### PR TITLE
Gate hosted instances on active subscriptions

### DIFF
--- a/cluster/k8s/platform/values.yaml
+++ b/cluster/k8s/platform/values.yaml
@@ -41,7 +41,7 @@ autoscaling:
     targetCPUUtilizationPercentage: 65
 
 cleanupScheduler:
-  enabled: "false"
+  enabled: "true"
 
 # These should be overridden in values-staging.yaml and values-prod.yaml
 supabase:

--- a/saas-platform/platform-backend/src/backend/entitlements.py
+++ b/saas-platform/platform-backend/src/backend/entitlements.py
@@ -1,0 +1,82 @@
+"""Subscription entitlement checks for hosted infrastructure."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from fastapi import HTTPException
+
+PAID_TIERS = frozenset({"starter", "professional", "enterprise"})
+
+
+def _parse_timestamp(value: str | None) -> datetime | None:
+    if not value:
+        return None
+
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def is_subscription_service_active(subscription: dict[str, Any], *, now: datetime | None = None) -> bool:
+    """Return whether a subscription may run customer infrastructure."""
+    tier = str(subscription.get("tier") or "free")
+    if tier not in PAID_TIERS:
+        return False
+
+    status = str(subscription.get("status") or "")
+    if status == "active":
+        return True
+
+    if status != "trialing":
+        return False
+
+    trial_ends_at = _parse_timestamp(subscription.get("trial_ends_at"))
+    if trial_ends_at is None:
+        return False
+
+    reference_time = (now or datetime.now(UTC)).astimezone(UTC)
+    return trial_ends_at > reference_time
+
+
+def is_expired_trial(subscription: dict[str, Any], *, now: datetime | None = None) -> bool:
+    """Return whether a subscription is still marked trialing after its end timestamp."""
+    if str(subscription.get("status") or "") != "trialing":
+        return False
+
+    trial_ends_at = _parse_timestamp(subscription.get("trial_ends_at"))
+    if trial_ends_at is None:
+        return False
+
+    reference_time = (now or datetime.now(UTC)).astimezone(UTC)
+    return trial_ends_at <= reference_time
+
+
+def _entitlement_failure_detail(subscription: dict[str, Any], action: str) -> str:
+    tier = str(subscription.get("tier") or "free")
+    status = str(subscription.get("status") or "unknown")
+
+    if tier == "free":
+        return f"Upgrade to a paid plan or start a trial before you {action} a hosted MindRoom instance."
+
+    if status == "trialing":
+        return "Your MindRoom trial has expired. Add billing or choose a paid plan to continue using the instance."
+
+    if status == "past_due":
+        return "Payment is past due. Update billing before you run the MindRoom instance."
+
+    if status in {"cancelled", "paused"}:
+        return "This subscription is not active. Reactivate billing before you run the MindRoom instance."
+
+    return "This subscription is not entitled to run a hosted MindRoom instance."
+
+
+def assert_instance_entitlement(subscription: dict[str, Any], action: str) -> None:
+    """Raise when the subscription cannot run hosted instance infrastructure."""
+    if is_subscription_service_active(subscription):
+        return
+
+    raise HTTPException(status_code=402, detail=_entitlement_failure_detail(subscription, action))

--- a/saas-platform/platform-backend/src/backend/models.py
+++ b/saas-platform/platform-backend/src/backend/models.py
@@ -37,7 +37,7 @@ class SubscriptionOut(BaseModel):
     id: str
     account_id: str
     tier: Literal["free", "starter", "professional", "enterprise"]
-    status: Literal["active", "cancelled", "past_due", "trialing", "incomplete"]
+    status: Literal["active", "cancelled", "past_due", "trialing", "paused", "incomplete"]
     stripe_subscription_id: str | None = None
     stripe_customer_id: str | None = None
     current_period_start: str | None = None

--- a/saas-platform/platform-backend/src/backend/routes/instances.py
+++ b/saas-platform/platform-backend/src/backend/routes/instances.py
@@ -2,12 +2,13 @@
 
 import json
 import time
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
 from typing import Annotated, Any
 
 from backend.config import PROVISIONER_API_KEY, logger
 from backend.deps import ensure_supabase, limiter, verify_user
+from backend.entitlements import assert_instance_entitlement
 from backend.k8s import check_deployment_exists, instance_deployment_ref, run_kubectl
 from backend.models import ActionResult, InstancesResponse, ProvisionResponse
 from backend.routes.provisioner import (
@@ -22,6 +23,7 @@ router = APIRouter()
 
 # Track instances being synced to prevent duplicates
 _syncing_instances: set[str] = set()
+ProvisionerAction = Callable[[Request, int, str], Awaitable[dict[str, Any]]]
 
 
 async def _background_sync_instance_status(instance_id: str) -> None:
@@ -187,6 +189,8 @@ async def provision_user_instance(
     if not sub_result.data:
         raise HTTPException(status_code=404, detail="No subscription found")
     subscription = sub_result.data[0]
+    assert_instance_entitlement(subscription, "provision")
+
     inst_result = (
         sb.table("instances")
         .select("*")
@@ -239,14 +243,19 @@ async def provision_user_instance(
 
 # Helper function for user instance actions
 async def _verify_instance_ownership_and_proxy(
-    request: Request, instance_id: int, user: dict, provisioner_func: Callable
+    request: Request,
+    instance_id: int,
+    user: dict,
+    provisioner_func: ProvisionerAction,
+    *,
+    require_active_subscription: bool,
 ) -> dict[str, Any]:
     """Verify user owns instance and proxy to provisioner."""
     sb = ensure_supabase()
 
     result = (
         sb.table("instances")
-        .select("id")
+        .select("id,subscription_id")
         .eq("instance_id", instance_id)
         .eq("account_id", user["account_id"])
         .limit(1)
@@ -254,6 +263,13 @@ async def _verify_instance_ownership_and_proxy(
     )
     if not result.data:
         raise HTTPException(status_code=404, detail="Instance not found or access denied")
+
+    if require_active_subscription:
+        instance = result.data[0]
+        sub_result = sb.table("subscriptions").select("*").eq("id", instance["subscription_id"]).limit(1).execute()
+        if not sub_result.data:
+            raise HTTPException(status_code=404, detail="Subscription not found")
+        assert_instance_entitlement(sub_result.data[0], "run")
 
     return await provisioner_func(request, instance_id, f"Bearer {PROVISIONER_API_KEY}")
 
@@ -264,7 +280,9 @@ async def start_user_instance(
     request: Request, instance_id: int, user: Annotated[dict, Depends(verify_user)]
 ) -> dict[str, Any]:
     """Start user's instance."""
-    return await _verify_instance_ownership_and_proxy(request, instance_id, user, start_instance_provisioner)
+    return await _verify_instance_ownership_and_proxy(
+        request, instance_id, user, start_instance_provisioner, require_active_subscription=True
+    )
 
 
 @router.post("/my/instances/{instance_id}/stop", response_model=ActionResult)
@@ -273,7 +291,9 @@ async def stop_user_instance(
     request: Request, instance_id: int, user: Annotated[dict, Depends(verify_user)]
 ) -> dict[str, Any]:
     """Stop user's instance."""
-    return await _verify_instance_ownership_and_proxy(request, instance_id, user, stop_instance_provisioner)
+    return await _verify_instance_ownership_and_proxy(
+        request, instance_id, user, stop_instance_provisioner, require_active_subscription=False
+    )
 
 
 @router.post("/my/instances/{instance_id}/restart", response_model=ActionResult)
@@ -282,4 +302,6 @@ async def restart_user_instance(
     request: Request, instance_id: int, user: Annotated[dict, Depends(verify_user)]
 ) -> dict[str, Any]:
     """Restart user's instance."""
-    return await _verify_instance_ownership_and_proxy(request, instance_id, user, restart_instance_provisioner)
+    return await _verify_instance_ownership_and_proxy(
+        request, instance_id, user, restart_instance_provisioner, require_active_subscription=True
+    )

--- a/saas-platform/platform-backend/src/backend/tasks/cleanup.py
+++ b/saas-platform/platform-backend/src/backend/tasks/cleanup.py
@@ -7,8 +7,11 @@ from datetime import UTC, datetime, timedelta
 import logging
 
 from backend.deps import ensure_supabase
+from backend.entitlements import is_expired_trial, is_subscription_service_active
+from backend.k8s import instance_deployment_ref, run_kubectl
 
 logger = logging.getLogger(__name__)
+RUNNING_INSTANCE_STATUSES = ["running", "provisioning", "restarting"]
 
 
 def cleanup_soft_deleted_accounts(grace_period_days: int = 7) -> dict:
@@ -93,6 +96,66 @@ def cleanup_old_usage_metrics(retention_days: int = 365) -> dict:
     }
 
 
+async def cleanup_unentitled_instances() -> dict:
+    """
+    Stop hosted instances whose subscription no longer allows infrastructure.
+    Expired trials are marked paused so they do not get processed repeatedly.
+    """
+    sb = ensure_supabase()
+    now = datetime.now(UTC)
+    now_iso = now.isoformat()
+    sub_result = sb.table("subscriptions").select("id,tier,status,trial_ends_at").execute()
+
+    instances_stopped = 0
+    subscriptions_paused = 0
+    errors = 0
+
+    for subscription in sub_result.data or []:
+        if is_subscription_service_active(subscription, now=now):
+            continue
+
+        instance_result = (
+            sb.table("instances")
+            .select("instance_id,status")
+            .eq("subscription_id", subscription["id"])
+            .in_("status", RUNNING_INSTANCE_STATUSES)
+            .execute()
+        )
+
+        for instance in instance_result.data or []:
+            instance_id = instance["instance_id"]
+            code, out, err = await run_kubectl(
+                ["scale", instance_deployment_ref(instance_id), "--replicas=0"], namespace="mindroom-instances"
+            )
+            if code == 0:
+                sb.table("instances").update({"status": "stopped", "updated_at": now_iso}).eq(
+                    "instance_id", instance_id
+                ).execute()
+                instances_stopped += 1
+                logger.info("Stopped instance %s because subscription %s is inactive", instance_id, subscription["id"])
+            else:
+                errors += 1
+                logger.warning(
+                    "Failed to stop instance %s for inactive subscription %s: %s",
+                    instance_id,
+                    subscription["id"],
+                    err.strip() if err else out.strip(),
+                )
+
+        if is_expired_trial(subscription, now=now):
+            sb.table("subscriptions").update({"status": "paused", "updated_at": now_iso}).eq(
+                "id", subscription["id"]
+            ).execute()
+            subscriptions_paused += 1
+
+    return {
+        "instances_stopped": instances_stopped,
+        "subscriptions_paused": subscriptions_paused,
+        "errors": errors,
+        "timestamp": now_iso,
+    }
+
+
 def run_all_cleanup_tasks() -> dict:
     """
     Run all cleanup tasks.
@@ -107,7 +170,9 @@ def run_all_cleanup_tasks() -> dict:
 
 if __name__ == "__main__":
     # Can be run directly for testing
+    import asyncio
     import json
 
     results = run_all_cleanup_tasks()
+    results["subscription_lifecycle"] = asyncio.run(cleanup_unentitled_instances())
     print(json.dumps(results, indent=2))

--- a/saas-platform/platform-backend/src/main.py
+++ b/saas-platform/platform-backend/src/main.py
@@ -18,7 +18,7 @@ from backend.config import ALLOWED_ORIGINS, ENABLE_CLEANUP_SCHEDULER, ENVIRONMEN
 from backend.metrics import instrument_app
 from backend.deps import limiter
 from backend.middleware.audit_logging import AuditLoggingMiddleware
-from backend.tasks.cleanup import run_all_cleanup_tasks
+from backend.tasks.cleanup import cleanup_unentitled_instances, run_all_cleanup_tasks
 from backend.routes import (
     accounts,
     admin,
@@ -47,10 +47,11 @@ if TYPE_CHECKING:
     from starlette.responses import Response as StarletteResponse
 
 
-def _run_cleanup_job() -> None:
+async def _run_cleanup_job() -> None:
     """Execute periodic cleanup tasks with logging."""
     try:
         result = run_all_cleanup_tasks()
+        result["subscription_lifecycle"] = await cleanup_unentitled_instances()
         logger = logging.getLogger("mindroom.cleanup")
         logger.info("Cleanup job completed", extra={"result": result})
     except Exception:  # noqa: BLE001

--- a/saas-platform/platform-backend/tests/test_entitlements.py
+++ b/saas-platform/platform-backend/tests/test_entitlements.py
@@ -1,0 +1,46 @@
+"""Subscription entitlement rules for hosted instances."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi import HTTPException
+
+from backend.entitlements import assert_instance_entitlement, is_subscription_service_active
+
+
+def _subscription(*, tier: str, status: str, trial_ends_at: str | None = None) -> dict:
+    return {"id": "sub_123", "tier": tier, "status": status, "trial_ends_at": trial_ends_at}
+
+
+def test_active_paid_subscription_can_run_instances() -> None:
+    subscription = _subscription(tier="starter", status="active")
+
+    assert is_subscription_service_active(subscription)
+    assert_instance_entitlement(subscription, "start")
+
+
+def test_unexpired_trial_can_run_instances() -> None:
+    trial_end = datetime.now(UTC) + timedelta(days=2)
+    subscription = _subscription(tier="starter", status="trialing", trial_ends_at=trial_end.isoformat())
+
+    assert is_subscription_service_active(subscription)
+    assert_instance_entitlement(subscription, "provision")
+
+
+@pytest.mark.parametrize(
+    "subscription",
+    [
+        _subscription(tier="free", status="active"),
+        _subscription(tier="starter", status="trialing", trial_ends_at=(datetime.now(UTC) - timedelta(days=1)).isoformat()),
+        _subscription(tier="starter", status="past_due"),
+        _subscription(tier="starter", status="cancelled"),
+        _subscription(tier="starter", status="paused"),
+    ],
+)
+def test_inactive_or_free_subscription_cannot_run_instances(subscription: dict) -> None:
+    assert not is_subscription_service_active(subscription)
+
+    with pytest.raises(HTTPException) as exc:
+        assert_instance_entitlement(subscription, "start")
+
+    assert exc.value.status_code == 402

--- a/saas-platform/platform-backend/tests/test_instances.py
+++ b/saas-platform/platform-backend/tests/test_instances.py
@@ -181,7 +181,7 @@ class TestInstancesEndpoints:
     ):
         """Test provisioning a new instance for user."""
         # Setup
-        subscription = {"id": "sub_123", "account_id": "acc_test_123", "tier": "starter"}
+        subscription = {"id": "sub_123", "account_id": "acc_test_123", "tier": "starter", "status": "active"}
 
         # Setup mock chains for different queries
         subscription_mock = MagicMock()
@@ -228,7 +228,7 @@ class TestInstancesEndpoints:
     ):
         """Test provisioning when instance already exists."""
         # Setup
-        subscription = {"id": "sub_123", "account_id": "acc_test_123", "tier": "starter"}
+        subscription = {"id": "sub_123", "account_id": "acc_test_123", "tier": "starter", "status": "active"}
         existing_instance = {
             "id": 1,
             "instance_id": "456",
@@ -288,7 +288,7 @@ class TestInstancesEndpoints:
     ):
         """Test reprovisioning a deprovisioned instance."""
         # Setup
-        subscription = {"id": "sub_123", "account_id": "acc_test_123", "tier": "professional"}
+        subscription = {"id": "sub_123", "account_id": "acc_test_123", "tier": "professional", "status": "active"}
         deprovisioned_instance = {
             "id": 1,
             "instance_id": "789",
@@ -354,6 +354,43 @@ class TestInstancesEndpoints:
         assert response.status_code == 404
         assert response.json()["detail"] == "No subscription found"
 
+    def test_provision_user_instance_rejects_free_subscription(
+        self,
+        client: TestClient,
+        mock_supabase: MagicMock,
+        mock_verify_user: Mock,
+        mock_provision_instance: Mock,
+        mock_provisioner_api_key,
+    ):
+        """Test free accounts cannot provision hosted infrastructure."""
+        subscription = {"id": "sub_123", "account_id": "acc_test_123", "tier": "free", "status": "active"}
+
+        subscription_mock = MagicMock()
+        subscription_mock.select.return_value = subscription_mock
+        subscription_mock.eq.return_value = subscription_mock
+        subscription_mock.execute.return_value = Mock(data=[subscription])
+
+        instance_mock = MagicMock()
+        instance_mock.select.return_value = instance_mock
+        instance_mock.eq.return_value = instance_mock
+        instance_mock.limit.return_value = instance_mock
+        instance_mock.execute.return_value = Mock(data=[])
+
+        def table_side_effect(table_name):
+            if table_name == "subscriptions":
+                return subscription_mock
+            if table_name == "instances":
+                return instance_mock
+            return MagicMock()
+
+        mock_supabase.table = Mock(side_effect=table_side_effect)
+
+        response = client.post("/my/instances/provision")
+
+        assert response.status_code == 402
+        assert "Upgrade" in response.json()["detail"]
+        mock_provision_instance.assert_not_called()
+
     def test_start_user_instance_success(
         self,
         client: TestClient,
@@ -363,8 +400,26 @@ class TestInstancesEndpoints:
         mock_provisioner_api_key,
     ):
         """Test starting user's instance successfully."""
-        # Setup
-        mock_supabase.table().select().eq().eq().limit().execute.return_value = Mock(data=[{"id": 1}])
+        instance_mock = MagicMock()
+        instance_mock.select.return_value = instance_mock
+        instance_mock.eq.return_value = instance_mock
+        instance_mock.limit.return_value = instance_mock
+        instance_mock.execute.return_value = Mock(data=[{"id": 1, "subscription_id": "sub_123"}])
+
+        subscription_mock = MagicMock()
+        subscription_mock.select.return_value = subscription_mock
+        subscription_mock.eq.return_value = subscription_mock
+        subscription_mock.limit.return_value = subscription_mock
+        subscription_mock.execute.return_value = Mock(data=[{"id": "sub_123", "tier": "starter", "status": "active"}])
+
+        def table_side_effect(table_name):
+            if table_name == "instances":
+                return instance_mock
+            if table_name == "subscriptions":
+                return subscription_mock
+            return MagicMock()
+
+        mock_supabase.table = Mock(side_effect=table_side_effect)
 
         # Make request
         response = client.post("/my/instances/123/start")
@@ -377,6 +432,50 @@ class TestInstancesEndpoints:
 
         # Verify start_instance_provisioner was called
         mock_start_instance.assert_called_once_with(ANY, 123, "Bearer test-api-key")
+
+    def test_start_user_instance_rejects_expired_trial(
+        self,
+        client: TestClient,
+        mock_supabase: MagicMock,
+        mock_verify_user: Mock,
+        mock_start_instance: Mock,
+        mock_provisioner_api_key,
+    ):
+        """Test expired trials cannot start hosted infrastructure."""
+        expired_trial = {
+            "id": "sub_123",
+            "account_id": "acc_test_123",
+            "tier": "starter",
+            "status": "trialing",
+            "trial_ends_at": (datetime.now(UTC) - timedelta(days=1)).isoformat(),
+        }
+
+        instance_mock = MagicMock()
+        instance_mock.select.return_value = instance_mock
+        instance_mock.eq.return_value = instance_mock
+        instance_mock.limit.return_value = instance_mock
+        instance_mock.execute.return_value = Mock(data=[{"id": 1, "subscription_id": "sub_123"}])
+
+        subscription_mock = MagicMock()
+        subscription_mock.select.return_value = subscription_mock
+        subscription_mock.eq.return_value = subscription_mock
+        subscription_mock.limit.return_value = subscription_mock
+        subscription_mock.execute.return_value = Mock(data=[expired_trial])
+
+        def table_side_effect(table_name):
+            if table_name == "instances":
+                return instance_mock
+            if table_name == "subscriptions":
+                return subscription_mock
+            return MagicMock()
+
+        mock_supabase.table = Mock(side_effect=table_side_effect)
+
+        response = client.post("/my/instances/123/start")
+
+        assert response.status_code == 402
+        assert "trial" in response.json()["detail"].lower()
+        mock_start_instance.assert_not_called()
 
     def test_start_user_instance_not_owned(self, client: TestClient, mock_supabase: MagicMock, mock_verify_user: Mock):
         """Test starting instance not owned by user."""
@@ -423,8 +522,26 @@ class TestInstancesEndpoints:
         mock_provisioner_api_key,
     ):
         """Test restarting user's instance successfully."""
-        # Setup
-        mock_supabase.table().select().eq().eq().limit().execute.return_value = Mock(data=[{"id": 1}])
+        instance_mock = MagicMock()
+        instance_mock.select.return_value = instance_mock
+        instance_mock.eq.return_value = instance_mock
+        instance_mock.limit.return_value = instance_mock
+        instance_mock.execute.return_value = Mock(data=[{"id": 1, "subscription_id": "sub_123"}])
+
+        subscription_mock = MagicMock()
+        subscription_mock.select.return_value = subscription_mock
+        subscription_mock.eq.return_value = subscription_mock
+        subscription_mock.limit.return_value = subscription_mock
+        subscription_mock.execute.return_value = Mock(data=[{"id": "sub_123", "tier": "starter", "status": "active"}])
+
+        def table_side_effect(table_name):
+            if table_name == "instances":
+                return instance_mock
+            if table_name == "subscriptions":
+                return subscription_mock
+            return MagicMock()
+
+        mock_supabase.table = Mock(side_effect=table_side_effect)
 
         # Make request
         response = client.post("/my/instances/456/restart")
@@ -518,7 +635,7 @@ class TestInstancesEndpoints:
     ):
         """Test provisioning when instance is already provisioning."""
         # Setup
-        subscription = {"id": "sub_123", "account_id": "acc_test_123", "tier": "starter"}
+        subscription = {"id": "sub_123", "account_id": "acc_test_123", "tier": "starter", "status": "active"}
         provisioning_instance = {
             "id": 1,
             "instance_id": "456",

--- a/saas-platform/platform-backend/tests/test_subscription_lifecycle_cleanup.py
+++ b/saas-platform/platform-backend/tests/test_subscription_lifecycle_cleanup.py
@@ -1,0 +1,72 @@
+"""Subscription lifecycle cleanup tests."""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+from backend.tasks.cleanup import cleanup_unentitled_instances
+
+
+@pytest.mark.asyncio
+async def test_cleanup_stops_instances_for_expired_trials() -> None:
+    expired_trial = {
+        "id": "sub_expired",
+        "tier": "starter",
+        "status": "trialing",
+        "trial_ends_at": (datetime.now(UTC) - timedelta(days=1)).isoformat(),
+    }
+    active_subscription = {"id": "sub_active", "tier": "starter", "status": "active", "trial_ends_at": None}
+
+    subscription_query = MagicMock()
+    subscription_query.select.return_value = subscription_query
+    subscription_query.execute.return_value = Mock(data=[expired_trial, active_subscription])
+
+    instance_query = MagicMock()
+    instance_query.select.return_value = instance_query
+    instance_query.eq.return_value = instance_query
+    instance_query.in_.return_value = instance_query
+    instance_query.execute.return_value = Mock(data=[{"instance_id": 123, "status": "running"}])
+
+    instance_update = MagicMock()
+    instance_update.update.return_value = instance_update
+    instance_update.eq.return_value = instance_update
+    instance_update.execute.return_value = Mock(data=[])
+
+    subscription_update = MagicMock()
+    subscription_update.update.return_value = subscription_update
+    subscription_update.eq.return_value = subscription_update
+    subscription_update.execute.return_value = Mock(data=[])
+
+    table_calls = []
+
+    def table_side_effect(table_name: str) -> MagicMock:
+        table_calls.append(table_name)
+        if table_name == "subscriptions" and table_calls.count("subscriptions") == 1:
+            return subscription_query
+        if table_name == "instances" and table_calls.count("instances") == 1:
+            return instance_query
+        if table_name == "instances":
+            return instance_update
+        if table_name == "subscriptions":
+            return subscription_update
+        return MagicMock()
+
+    supabase = MagicMock()
+    supabase.table.side_effect = table_side_effect
+
+    with patch("backend.tasks.cleanup.ensure_supabase", return_value=supabase):
+        with patch("backend.tasks.cleanup.run_kubectl", new=AsyncMock(return_value=(0, "", ""))) as kubectl:
+            result = await cleanup_unentitled_instances()
+
+    assert result["instances_stopped"] == 1
+    assert result["subscriptions_paused"] == 1
+    assert result["errors"] == 0
+    kubectl.assert_awaited_once_with(
+        ["scale", "deployment/mindroom-123", "--replicas=0"],
+        namespace="mindroom-instances",
+    )
+    instance_update.update.assert_called_once()
+    assert instance_update.update.call_args[0][0]["status"] == "stopped"
+    subscription_update.update.assert_called_once()
+    assert subscription_update.update.call_args[0][0]["status"] == "paused"

--- a/saas-platform/platform-frontend/src/app/dashboard/instance/page.tsx
+++ b/saas-platform/platform-frontend/src/app/dashboard/instance/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { Loader2, RefreshCw, CheckCircle, AlertCircle, Clock, Play, Pause, ExternalLink, Server, Database, Globe } from 'lucide-react'
 import { listInstances, startInstance, stopInstance, restartInstance as apiRestartInstance } from '@/lib/api'
 import { cache } from '@/lib/cache'
+import { buildCinnyLoginUrl } from '@/lib/cinny'
 import { getRuntimeConfig } from '@/lib/runtime-config'
 import { logger } from '@/lib/logger'
 import { Card, CardHeader, CardSection } from '@/components/ui/Card'
@@ -405,6 +406,15 @@ export default function InstancePage() {
                     <p className="text-sm text-gray-600 dark:text-gray-400">{instance.matrix_server_url}</p>
                   </div>
                 </div>
+                <a
+                  href={buildCinnyLoginUrl(instance.matrix_server_url)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center justify-center gap-2 px-4 py-2 border border-gray-300 dark:border-gray-600 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors whitespace-nowrap"
+                >
+                  Open Chat
+                  <ExternalLink className="w-4 h-4" />
+                </a>
               </div>
             )}
           </div>

--- a/saas-platform/platform-frontend/src/app/dashboard/page.tsx
+++ b/saas-platform/platform-frontend/src/app/dashboard/page.tsx
@@ -97,7 +97,7 @@ export default function DashboardPage() {
 
       {/* Instance Status and Quick Actions */}
       <div className="grid lg:grid-cols-2 gap-6">
-        <InstanceCard instance={instance} />
+        <InstanceCard instance={instance} subscription={subscription} />
         <QuickActions instance={instance} subscription={subscription} />
       </div>
 

--- a/saas-platform/platform-frontend/src/components/dashboard/InstanceCard.tsx
+++ b/saas-platform/platform-frontend/src/components/dashboard/InstanceCard.tsx
@@ -2,11 +2,29 @@ import { ExternalLink, CheckCircle, AlertCircle, Loader2, XCircle, Rocket, Copy 
 import Link from 'next/link'
 import { useState } from 'react'
 import type { Instance } from '@/hooks/useInstance'
+import type { Subscription } from '@/hooks/useSubscription'
 import { provisionInstance } from '@/lib/api'
+import { buildCinnyLoginUrl } from '@/lib/cinny'
 import { Card, CardHeader } from '@/components/ui/Card'
 import { logger } from '@/lib/logger'
 
-export function InstanceCard({ instance }: { instance: Instance | null }) {
+const INFRASTRUCTURE_TIERS = new Set(['starter', 'professional', 'enterprise'])
+
+function subscriptionCanRunInfrastructure(subscription: Subscription | null | undefined) {
+  if (subscription === undefined) return true
+  if (!subscription || !INFRASTRUCTURE_TIERS.has(subscription.tier)) return false
+  if (subscription.status === 'active') return true
+  if (subscription.status !== 'trialing' || !subscription.trial_ends_at) return false
+  return new Date(subscription.trial_ends_at).getTime() > Date.now()
+}
+
+export function InstanceCard({
+  instance,
+  subscription,
+}: {
+  instance: Instance | null
+  subscription?: Subscription | null
+}) {
   const [isProvisioning, setIsProvisioning] = useState(false)
   const copyToClipboard = async (text: string) => {
     try {
@@ -78,28 +96,46 @@ export function InstanceCard({ instance }: { instance: Instance | null }) {
 
   // No instance yet - show provision card
   if (!instance) {
+    const canProvision = subscriptionCanRunInfrastructure(subscription)
+
     return (
       <Card>
         <CardHeader>MindRoom Instance</CardHeader>
         <div className="text-center py-8">
           <Rocket className="w-16 h-16 text-gray-400 dark:text-gray-500 mx-auto mb-4" />
-          <p className="text-gray-600 dark:text-gray-400 mb-6">
-            No instance provisioned yet. Click below to create your MindRoom instance.
-          </p>
-          <button
-            onClick={handleProvision}
-            disabled={isProvisioning}
-            className="px-6 py-3 bg-gradient-to-r from-orange-500 to-orange-600 text-white rounded-xl font-semibold hover:shadow-lg hover:scale-105 transition-all disabled:bg-gray-400 disabled:cursor-not-allowed"
-          >
-            {isProvisioning ? (
-              <>
-                <Loader2 className="inline-block w-5 h-5 mr-2 animate-spin" />
-                Provisioning...
-              </>
-            ) : (
-              'Provision Instance'
-            )}
-          </button>
+          {canProvision ? (
+            <>
+              <p className="text-gray-600 dark:text-gray-400 mb-6">
+                No instance provisioned yet. Click below to create your MindRoom instance.
+              </p>
+              <button
+                onClick={handleProvision}
+                disabled={isProvisioning}
+                className="px-6 py-3 bg-gradient-to-r from-orange-500 to-orange-600 text-white rounded-xl font-semibold hover:shadow-lg hover:scale-105 transition-all disabled:bg-gray-400 disabled:cursor-not-allowed"
+              >
+                {isProvisioning ? (
+                  <>
+                    <Loader2 className="inline-block w-5 h-5 mr-2 animate-spin" />
+                    Provisioning...
+                  </>
+                ) : (
+                  'Provision Instance'
+                )}
+              </button>
+            </>
+          ) : (
+            <>
+              <p className="text-gray-600 dark:text-gray-400 mb-6">
+                Hosted instances require an active trial or paid plan.
+              </p>
+              <Link
+                href="/dashboard/billing/upgrade"
+                className="inline-flex items-center justify-center px-6 py-3 bg-gradient-to-r from-orange-500 to-orange-600 text-white rounded-xl font-semibold hover:shadow-lg hover:scale-105 transition-all"
+              >
+                Start Trial
+              </Link>
+            </>
+          )}
         </div>
       </Card>
     )
@@ -156,6 +192,9 @@ export function InstanceCard({ instance }: { instance: Instance | null }) {
   const frontendHost = getHostname(instance.frontend_url)
   const backendHost = getHostname(instance.backend_url)
   const matrixHost = getHostname(instance.matrix_server_url)
+  const cinnyLoginUrl = instance.matrix_server_url
+    ? buildCinnyLoginUrl(instance.matrix_server_url)
+    : null
   const lastSynced = instance.kubernetes_synced_at
     ? formatRelativeTime(instance.kubernetes_synced_at)
     : null
@@ -269,7 +308,7 @@ export function InstanceCard({ instance }: { instance: Instance | null }) {
             <span className="text-gray-600 dark:text-gray-400">Matrix Server</span>
             <div className="flex items-center gap-2">
               <Link
-                href={instance.matrix_server_url}
+                href={cinnyLoginUrl || instance.matrix_server_url}
                 target="_blank"
                 className="flex items-center gap-1 text-purple-600 hover:text-purple-700 dark:text-purple-400 dark:hover:text-purple-300 font-medium"
               >

--- a/saas-platform/platform-frontend/src/components/dashboard/__tests__/InstanceCard.test.tsx
+++ b/saas-platform/platform-frontend/src/components/dashboard/__tests__/InstanceCard.test.tsx
@@ -39,6 +39,24 @@ Object.defineProperty(navigator, 'clipboard', {
 })
 
 describe('InstanceCard', () => {
+  const freeSubscription = {
+    id: 'sub-free',
+    account_id: 'acc-123',
+    tier: 'free' as const,
+    status: 'active' as const,
+    stripe_subscription_id: null,
+    stripe_customer_id: null,
+    current_period_start: null,
+    current_period_end: null,
+    trial_ends_at: null,
+    cancelled_at: null,
+    max_agents: 1,
+    max_messages_per_day: 100,
+    max_storage_gb: 1,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  }
+
   beforeEach(() => {
     jest.clearAllMocks()
     mockClipboardWriteText.mockResolvedValue(undefined)
@@ -127,6 +145,16 @@ describe('InstanceCard', () => {
       // Should not show alert for aborted requests
       expect(mockAlert).not.toHaveBeenCalled()
     })
+
+    it('should send free users to billing instead of provisioning infrastructure', async () => {
+      render(<InstanceCard instance={null} subscription={freeSubscription} />)
+
+      expect(screen.queryByRole('button', { name: /Provision Instance/i })).not.toBeInTheDocument()
+      expect(screen.getByRole('link', { name: /Start Trial/i })).toHaveAttribute(
+        'href',
+        '/dashboard/billing/upgrade'
+      )
+    })
   })
 
   describe('Instance Display', () => {
@@ -152,6 +180,16 @@ describe('InstanceCard', () => {
       expect(screen.getByText('customer.matrix.mindroom.chat')).toBeInTheDocument()
       expect(screen.getByText('pro')).toBeInTheDocument()
       expect(screen.getByText('#1')).toBeInTheDocument()
+    })
+
+    it('should link Matrix access through Cinny with the homeserver prefilled', () => {
+      render(<InstanceCard instance={mockInstance} />)
+
+      const matrixLink = screen.getByRole('link', { name: /customer.matrix.mindroom.chat/i })
+      expect(matrixLink).toHaveAttribute(
+        'href',
+        'https://chat.mindroom.chat/login/https%3A%2F%2Fcustomer.matrix.mindroom.chat/'
+      )
     })
 
     it('should show correct status indicators', () => {

--- a/saas-platform/platform-frontend/src/hooks/useSubscription.ts
+++ b/saas-platform/platform-frontend/src/hooks/useSubscription.ts
@@ -10,7 +10,7 @@ export interface Subscription {
   id: string
   account_id: string
   tier: 'free' | 'starter' | 'professional' | 'enterprise'
-  status: 'active' | 'cancelled' | 'past_due' | 'trialing'
+  status: 'active' | 'cancelled' | 'past_due' | 'trialing' | 'paused' | 'incomplete'
   stripe_subscription_id: string | null
   stripe_customer_id: string | null
   current_period_start: string | null

--- a/saas-platform/platform-frontend/src/lib/__tests__/cinny.test.ts
+++ b/saas-platform/platform-frontend/src/lib/__tests__/cinny.test.ts
@@ -1,0 +1,15 @@
+import { buildCinnyLoginUrl } from '../cinny'
+
+describe('buildCinnyLoginUrl', () => {
+  it('builds a MindRoom Chat login URL with the homeserver encoded in the route', () => {
+    expect(buildCinnyLoginUrl('https://1.matrix.mindroom.chat')).toBe(
+      'https://chat.mindroom.chat/login/https%3A%2F%2F1.matrix.mindroom.chat/'
+    )
+  })
+
+  it('normalizes trailing slashes on the chat origin and homeserver URL', () => {
+    expect(buildCinnyLoginUrl('https://1.matrix.mindroom.chat/', 'https://chat.mindroom.chat/')).toBe(
+      'https://chat.mindroom.chat/login/https%3A%2F%2F1.matrix.mindroom.chat/'
+    )
+  })
+})

--- a/saas-platform/platform-frontend/src/lib/cinny.ts
+++ b/saas-platform/platform-frontend/src/lib/cinny.ts
@@ -1,0 +1,11 @@
+const DEFAULT_CINNY_ORIGIN = 'https://chat.mindroom.chat'
+
+function stripTrailingSlashes(value: string): string {
+  return value.replace(/\/+$/, '')
+}
+
+export function buildCinnyLoginUrl(matrixServerUrl: string, cinnyOrigin = DEFAULT_CINNY_ORIGIN): string {
+  const origin = stripTrailingSlashes(cinnyOrigin.trim())
+  const homeserver = stripTrailingSlashes(matrixServerUrl.trim())
+  return `${origin}/login/${encodeURIComponent(homeserver)}/`
+}


### PR DESCRIPTION
## Summary
- Add backend entitlement checks so only active paid subscriptions or unexpired paid trials can provision/start/restart hosted instances.
- Add scheduled cleanup for inactive subscriptions: expired trials are marked `paused` and their MindRoom deployment is scaled to zero.
- Enable the platform cleanup scheduler by default in the Helm values.
- Route Matrix access links through MindRoom Cinny login URLs with the homeserver prefilled.
- Send free dashboard accounts to billing instead of showing a provision-infrastructure CTA.

## Validation
- `uv run pytest -q` in `saas-platform/platform-backend` -> 315 passed, 5 skipped.
- `bun run test -- --runInBand` in `saas-platform/platform-frontend` -> 200 passed.
- `SUPABASE_URL=https://example.supabase.co SUPABASE_ANON_KEY=test NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=test PLATFORM_DOMAIN=mindroom.chat bun run build` -> passed.
- `nix-shell -p kubernetes-helm --run 'helm template platform cluster/k8s/platform >/tmp/mindroom-platform-render.yaml'` -> passed.
- `nix-shell -p kubernetes-helm --run 'helm template instance cluster/k8s/instance >/tmp/mindroom-instance-render.yaml'` -> passed.
- `uv run pre-commit run --all-files` -> passed.

## Notes
This does not implement the larger Matrix identity redesign yet.
Current per-customer homeservers still use Synapse password auth; the PR only fixes subscription lifecycle enforcement and Cinny homeserver handoff links.

## Summary by Sourcery

Enforce subscription-based entitlements for hosted instances across backend, frontend, and cleanup workflows, and improve Matrix access links via Cinny.

New Features:
- Add centralized subscription entitlement checks to gate provisioning and lifecycle actions for hosted instances.
- Route Matrix server access through Cinny login URLs with the homeserver prefilled from the instance configuration.

Enhancements:
- Introduce an async cleanup task that scales down instances backed by inactive or expired trial subscriptions and pauses those subscriptions.
- Extend subscription models to handle paused and incomplete states and apply them consistently in entitlement logic.
- Update dashboard instance UI to respect subscription entitlements, directing free users to billing instead of provisioning infrastructure.

Deployment:
- Enable the platform cleanup scheduler by default in Helm values to ensure periodic subscription lifecycle enforcement runs in production.

Tests:
- Add backend tests for subscription entitlement rules and cleanup of unentitled instances, including Kubernetes scaling behavior.
- Expand instance and dashboard frontend tests to cover free-plan gating and Cinny-based Matrix login links.