### PR TITLE
Scale the full tenant stack during lifecycle actions

### DIFF
--- a/saas-platform/platform-backend/src/backend/k8s.py
+++ b/saas-platform/platform-backend/src/backend/k8s.py
@@ -16,6 +16,26 @@ def instance_deployment_ref(instance_id: str | int) -> str:
     return f"deployment/{instance_workload_name(instance_id)}"
 
 
+def synapse_workload_name(instance_id: str | int) -> str:
+    """Return the Kubernetes workload name for an instance homeserver."""
+    return f"synapse-{instance_id}"
+
+
+def synapse_deployment_ref(instance_id: str | int) -> str:
+    """Return the Kubernetes deployment reference for an instance homeserver."""
+    return f"deployment/{synapse_workload_name(instance_id)}"
+
+
+def tenant_start_deployment_refs(instance_id: str | int) -> tuple[str, str]:
+    """Return tenant deployments in startup order."""
+    return (synapse_deployment_ref(instance_id), instance_deployment_ref(instance_id))
+
+
+def tenant_stop_deployment_refs(instance_id: str | int) -> tuple[str, str]:
+    """Return tenant deployments in shutdown order."""
+    return (instance_deployment_ref(instance_id), synapse_deployment_ref(instance_id))
+
+
 async def check_deployment_exists(instance_id: str, namespace: str = "mindroom-instances") -> bool:
     """Check if a Kubernetes deployment exists for an instance."""
     try:

--- a/saas-platform/platform-backend/src/backend/routes/provisioner.py
+++ b/saas-platform/platform-backend/src/backend/routes/provisioner.py
@@ -49,7 +49,14 @@ from backend.config import (
 )
 from backend.db_utils import update_instance_status
 from backend.deps import _extract_bearer_token, ensure_supabase, limiter
-from backend.k8s import check_deployment_exists, instance_deployment_ref, run_kubectl, wait_for_deployment_ready
+from backend.k8s import (
+    check_deployment_exists,
+    instance_deployment_ref,
+    run_kubectl,
+    tenant_start_deployment_refs,
+    tenant_stop_deployment_refs,
+    wait_for_deployment_ready,
+)
 from backend.models import ActionResult, ProvisionResponse, SyncResult, SyncUpdateOut
 from backend.process import run_helm
 from fastapi import APIRouter, BackgroundTasks, Header, HTTPException, Request
@@ -71,6 +78,32 @@ async def _background_mark_running_when_ready(instance_id: str, namespace: str =
                 logger.warning("Background update: failed to mark instance %s as running", instance_id)
     except Exception:
         logger.exception("Background readiness wait failed for instance %s", instance_id)
+
+
+async def _run_kubectl_for_deployments(
+    kubectl_args_prefix: list[str], deployment_refs: tuple[str, ...], *, namespace: str
+) -> str:
+    """Run one kubectl command per deployment and fail on the first error."""
+    last_output = ""
+    for deployment_ref in deployment_refs:
+        code, out, err = await run_kubectl([*kubectl_args_prefix, deployment_ref], namespace=namespace)
+        if code != 0:
+            msg = f"kubectl command failed for {deployment_ref}: {err or out}"
+            raise RuntimeError(msg)
+        last_output = out
+    return last_output
+
+
+async def _scale_tenant_deployments(deployment_refs: tuple[str, ...], replicas: int, *, namespace: str) -> str:
+    """Scale each tenant deployment to the requested replica count."""
+    last_output = ""
+    for deployment_ref in deployment_refs:
+        code, out, err = await run_kubectl(["scale", deployment_ref, f"--replicas={replicas}"], namespace=namespace)
+        if code != 0:
+            msg = f"kubectl command failed for {deployment_ref}: {err or out}"
+            raise RuntimeError(msg)
+        last_output = out
+    return last_output
 
 
 def _require_provisioner_auth(authorization: str | None) -> None:
@@ -434,12 +467,9 @@ async def start_instance_provisioner(
         raise HTTPException(status_code=404, detail=error_msg)
 
     try:
-        code, out, err = await run_kubectl(
-            ["scale", instance_deployment_ref(instance_id), "--replicas=1"], namespace="mindroom-instances"
+        out = await _scale_tenant_deployments(
+            tenant_start_deployment_refs(instance_id), replicas=1, namespace="mindroom-instances"
         )
-        if code != 0:
-            msg = f"kubectl command failed: {err}"
-            raise RuntimeError(msg)  # noqa: TRY301
         logger.info("Started instance %s: %s", instance_id, out)
         # Reflect desired state in DB immediately
         if not update_instance_status(instance_id, "running"):
@@ -469,12 +499,9 @@ async def stop_instance_provisioner(
         raise HTTPException(status_code=404, detail=error_msg)
 
     try:
-        code, out, err = await run_kubectl(
-            ["scale", instance_deployment_ref(instance_id), "--replicas=0"], namespace="mindroom-instances"
+        out = await _scale_tenant_deployments(
+            tenant_stop_deployment_refs(instance_id), replicas=0, namespace="mindroom-instances"
         )
-        if code != 0:
-            msg = f"kubectl command failed: {err}"
-            raise RuntimeError(msg)  # noqa: TRY301
         logger.info("Stopped instance %s: %s", instance_id, out)
         # Reflect desired state in DB immediately
         if not update_instance_status(instance_id, "stopped"):
@@ -504,12 +531,9 @@ async def restart_instance_provisioner(
         raise HTTPException(status_code=404, detail=error_msg)
 
     try:
-        code, out, err = await run_kubectl(
-            ["rollout", "restart", instance_deployment_ref(instance_id)], namespace="mindroom-instances"
+        out = await _run_kubectl_for_deployments(
+            ["rollout", "restart"], tenant_start_deployment_refs(instance_id), namespace="mindroom-instances"
         )
-        if code != 0:
-            msg = f"kubectl command failed: {err}"
-            raise RuntimeError(msg)  # noqa: TRY301
         logger.info("Restarted instance %s: %s", instance_id, out)
     except Exception as e:
         logger.exception("Failed to restart instance %s", instance_id)

--- a/saas-platform/platform-backend/src/backend/tasks/cleanup.py
+++ b/saas-platform/platform-backend/src/backend/tasks/cleanup.py
@@ -8,10 +8,20 @@ import logging
 
 from backend.deps import ensure_supabase
 from backend.entitlements import is_expired_trial, is_subscription_service_active
-from backend.k8s import instance_deployment_ref, run_kubectl
+from backend.k8s import run_kubectl, tenant_stop_deployment_refs
 
 logger = logging.getLogger(__name__)
 RUNNING_INSTANCE_STATUSES = ["running", "provisioning", "restarting"]
+
+
+async def _stop_tenant_deployments(instance_id: str | int) -> str | None:
+    """Scale every deployment for a tenant to zero and return an error message on failure."""
+    for deployment_ref in tenant_stop_deployment_refs(instance_id):
+        code, out, err = await run_kubectl(["scale", deployment_ref, "--replicas=0"], namespace="mindroom-instances")
+        if code != 0:
+            message = (err or out).strip()
+            return message or f"kubectl scale failed for {deployment_ref}"
+    return None
 
 
 def cleanup_soft_deleted_accounts(grace_period_days: int = 7) -> dict:
@@ -124,10 +134,8 @@ async def cleanup_unentitled_instances() -> dict:
 
         for instance in instance_result.data or []:
             instance_id = instance["instance_id"]
-            code, out, err = await run_kubectl(
-                ["scale", instance_deployment_ref(instance_id), "--replicas=0"], namespace="mindroom-instances"
-            )
-            if code == 0:
+            error = await _stop_tenant_deployments(instance_id)
+            if not error:
                 sb.table("instances").update({"status": "stopped", "updated_at": now_iso}).eq(
                     "instance_id", instance_id
                 ).execute()
@@ -139,7 +147,7 @@ async def cleanup_unentitled_instances() -> dict:
                     "Failed to stop instance %s for inactive subscription %s: %s",
                     instance_id,
                     subscription["id"],
-                    err.strip() if err else out.strip(),
+                    error,
                 )
 
         if is_expired_trial(subscription, now=now):

--- a/saas-platform/platform-backend/tests/test_entitlements.py
+++ b/saas-platform/platform-backend/tests/test_entitlements.py
@@ -31,7 +31,9 @@ def test_unexpired_trial_can_run_instances() -> None:
     "subscription",
     [
         _subscription(tier="free", status="active"),
-        _subscription(tier="starter", status="trialing", trial_ends_at=(datetime.now(UTC) - timedelta(days=1)).isoformat()),
+        _subscription(
+            tier="starter", status="trialing", trial_ends_at=(datetime.now(UTC) - timedelta(days=1)).isoformat()
+        ),
         _subscription(tier="starter", status="past_due"),
         _subscription(tier="starter", status="cancelled"),
         _subscription(tier="starter", status="paused"),

--- a/saas-platform/platform-backend/tests/test_provisioner.py
+++ b/saas-platform/platform-backend/tests/test_provisioner.py
@@ -2,7 +2,7 @@
 
 import base64
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -445,10 +445,14 @@ class TestProvisionerEndpoints:
         assert data["success"] is True
         assert "started successfully" in data["message"]
 
-        # Verify kubectl was called with scale command
-        mock_kubectl.assert_called_with(
-            ["scale", "deployment/mindroom-123", "--replicas=1"], namespace="mindroom-instances"
+        # Verify the full tenant stack was started in dependency order.
+        mock_kubectl.assert_has_awaits(
+            [
+                call(["scale", "deployment/synapse-123", "--replicas=1"], namespace="mindroom-instances"),
+                call(["scale", "deployment/mindroom-123", "--replicas=1"], namespace="mindroom-instances"),
+            ]
         )
+        assert mock_kubectl.await_count == 2
         mock_update_status.assert_called_with(123, "running")
 
     def test_start_instance_not_found(
@@ -479,6 +483,32 @@ class TestProvisionerEndpoints:
         assert response.status_code == 500
         assert "Failed to start instance" in response.json()["detail"]
 
+    def test_start_instance_requires_full_stack_scale_success(
+        self,
+        client: TestClient,
+        mock_kubectl: AsyncMock,
+        mock_check_deployment: AsyncMock,
+        mock_update_status: Mock,
+        valid_auth_header: dict,
+    ):
+        """Test start only marks running after Synapse and MindRoom are both scaled."""
+        # Setup
+        mock_kubectl.side_effect = [(0, "synapse scaled", ""), (1, "", "mindroom error")]
+
+        # Make request
+        response = client.post("/system/instances/123/start", headers=valid_auth_header)
+
+        # Verify
+        assert response.status_code == 500
+        assert "Failed to start instance" in response.json()["detail"]
+        mock_kubectl.assert_has_awaits(
+            [
+                call(["scale", "deployment/synapse-123", "--replicas=1"], namespace="mindroom-instances"),
+                call(["scale", "deployment/mindroom-123", "--replicas=1"], namespace="mindroom-instances"),
+            ]
+        )
+        mock_update_status.assert_not_called()
+
     def test_stop_instance_success(
         self,
         client: TestClient,
@@ -497,10 +527,14 @@ class TestProvisionerEndpoints:
         assert data["success"] is True
         assert "stopped successfully" in data["message"]
 
-        # Verify kubectl was called with scale command
-        mock_kubectl.assert_called_with(
-            ["scale", "deployment/mindroom-123", "--replicas=0"], namespace="mindroom-instances"
+        # Verify the app stops before the homeserver to avoid reconnect churn.
+        mock_kubectl.assert_has_awaits(
+            [
+                call(["scale", "deployment/mindroom-123", "--replicas=0"], namespace="mindroom-instances"),
+                call(["scale", "deployment/synapse-123", "--replicas=0"], namespace="mindroom-instances"),
+            ]
         )
+        assert mock_kubectl.await_count == 2
         mock_update_status.assert_called_with(123, "stopped")
 
     def test_stop_instance_not_found(
@@ -530,10 +564,14 @@ class TestProvisionerEndpoints:
         assert data["success"] is True
         assert "restarted successfully" in data["message"]
 
-        # Verify kubectl was called with rollout restart command
-        mock_kubectl.assert_called_with(
-            ["rollout", "restart", "deployment/mindroom-123"], namespace="mindroom-instances"
+        # Verify both tenant deployments were restarted.
+        mock_kubectl.assert_has_awaits(
+            [
+                call(["rollout", "restart", "deployment/synapse-123"], namespace="mindroom-instances"),
+                call(["rollout", "restart", "deployment/mindroom-123"], namespace="mindroom-instances"),
+            ]
         )
+        assert mock_kubectl.await_count == 2
 
     def test_restart_instance_not_found(
         self, client: TestClient, mock_check_deployment: AsyncMock, valid_auth_header: dict

--- a/saas-platform/platform-backend/tests/test_provisioner_real.py
+++ b/saas-platform/platform-backend/tests/test_provisioner_real.py
@@ -252,17 +252,10 @@ class TestProvisionerCommandValidation:
                 with patch("backend.routes.provisioner.check_deployment_exists", return_value=True):
                     await stop_instance_provisioner(None, 123, "Bearer test-key")
 
-        args, namespace = captured_kubectl_args[0]
-
-        # Verify correct scale command syntax
-        assert args[0] == "scale"
-        assert args[1].startswith("deployment/")
-        assert "--replicas=0" in args
-        assert namespace == "mindroom-instances"
-
-        # Verify deployment name format
-        deployment = args[1].split("/")[1]
-        assert deployment == "mindroom-123"
+        assert captured_kubectl_args == [
+            (["scale", "deployment/mindroom-123", "--replicas=0"], "mindroom-instances"),
+            (["scale", "deployment/synapse-123", "--replicas=0"], "mindroom-instances"),
+        ]
 
 
 class TestProvisionerStateTransitions:

--- a/saas-platform/platform-backend/tests/test_subscription_lifecycle_cleanup.py
+++ b/saas-platform/platform-backend/tests/test_subscription_lifecycle_cleanup.py
@@ -1,7 +1,7 @@
 """Subscription lifecycle cleanup tests."""
 
 from datetime import UTC, datetime, timedelta
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
 
 import pytest
 
@@ -62,11 +62,80 @@ async def test_cleanup_stops_instances_for_expired_trials() -> None:
     assert result["instances_stopped"] == 1
     assert result["subscriptions_paused"] == 1
     assert result["errors"] == 0
-    kubectl.assert_awaited_once_with(
-        ["scale", "deployment/mindroom-123", "--replicas=0"],
-        namespace="mindroom-instances",
+    kubectl.assert_has_awaits(
+        [
+            call(["scale", "deployment/mindroom-123", "--replicas=0"], namespace="mindroom-instances"),
+            call(["scale", "deployment/synapse-123", "--replicas=0"], namespace="mindroom-instances"),
+        ]
     )
     instance_update.update.assert_called_once()
     assert instance_update.update.call_args[0][0]["status"] == "stopped"
+    subscription_update.update.assert_called_once()
+    assert subscription_update.update.call_args[0][0]["status"] == "paused"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_does_not_mark_instance_stopped_when_any_tenant_deployment_fails() -> None:
+    expired_trial = {
+        "id": "sub_expired",
+        "tier": "starter",
+        "status": "trialing",
+        "trial_ends_at": (datetime.now(UTC) - timedelta(days=1)).isoformat(),
+    }
+
+    subscription_query = MagicMock()
+    subscription_query.select.return_value = subscription_query
+    subscription_query.execute.return_value = Mock(data=[expired_trial])
+
+    instance_query = MagicMock()
+    instance_query.select.return_value = instance_query
+    instance_query.eq.return_value = instance_query
+    instance_query.in_.return_value = instance_query
+    instance_query.execute.return_value = Mock(data=[{"instance_id": 123, "status": "running"}])
+
+    instance_update = MagicMock()
+    instance_update.update.return_value = instance_update
+    instance_update.eq.return_value = instance_update
+    instance_update.execute.return_value = Mock(data=[])
+
+    subscription_update = MagicMock()
+    subscription_update.update.return_value = subscription_update
+    subscription_update.eq.return_value = subscription_update
+    subscription_update.execute.return_value = Mock(data=[])
+
+    table_calls = []
+
+    def table_side_effect(table_name: str) -> MagicMock:
+        table_calls.append(table_name)
+        if table_name == "subscriptions" and table_calls.count("subscriptions") == 1:
+            return subscription_query
+        if table_name == "instances" and table_calls.count("instances") == 1:
+            return instance_query
+        if table_name == "instances":
+            return instance_update
+        if table_name == "subscriptions":
+            return subscription_update
+        return MagicMock()
+
+    supabase = MagicMock()
+    supabase.table.side_effect = table_side_effect
+
+    with patch("backend.tasks.cleanup.ensure_supabase", return_value=supabase):
+        with patch(
+            "backend.tasks.cleanup.run_kubectl",
+            new=AsyncMock(side_effect=[(0, "", ""), (1, "", "synapse error")]),
+        ) as kubectl:
+            result = await cleanup_unentitled_instances()
+
+    assert result["instances_stopped"] == 0
+    assert result["subscriptions_paused"] == 1
+    assert result["errors"] == 1
+    kubectl.assert_has_awaits(
+        [
+            call(["scale", "deployment/mindroom-123", "--replicas=0"], namespace="mindroom-instances"),
+            call(["scale", "deployment/synapse-123", "--replicas=0"], namespace="mindroom-instances"),
+        ]
+    )
+    instance_update.update.assert_not_called()
     subscription_update.update.assert_called_once()
     assert subscription_update.update.call_args[0][0]["status"] == "paused"


### PR DESCRIPTION
## Summary
- Add explicit Synapse deployment helpers beside the existing MindRoom deployment helpers.
- Start/restart Synapse and MindRoom together, and stop MindRoom before Synapse.
- Stop both tenant deployments during entitlement cleanup and only mark the instance stopped after both scale-down operations succeed.

## Validation
- `uv run pytest -q` in `saas-platform/platform-backend`
- `uv run pre-commit run --all-files`

## Summary by Sourcery

Coordinate scaling of all tenant Kubernetes deployments (MindRoom and Synapse) during lifecycle operations and entitlement cleanup, ensuring instance state is updated only when the full stack transitions successfully.

Enhancements:
- Introduce shared helpers for computing tenant deployment references and running kubectl commands across multiple deployments in defined startup and shutdown order.
- Update provisioner start/stop/restart handlers to operate on both Synapse and MindRoom deployments, enforcing dependency-aware sequencing and consistent error handling.
- Adjust entitlement cleanup to scale down all tenant deployments before marking instances as stopped, returning structured error messages on partial failures.

Tests:
- Extend and add tests to cover multi-deployment start/stop/restart flows, error cases where only part of the tenant stack scales successfully, and real provisioner kubectl interactions for the full tenant stack.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved instance lifecycle operations to orchestrate multiple components consistently during start, stop, and restart actions.
  * Enhanced error handling in subscription cleanup to prevent partial state updates when deployment operations fail.

* **Refactor**
  * Reorganized internal deployment management logic for better reliability and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1055?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->