### PR TITLE
Keep tenant secrets out of Helm release values

### DIFF
--- a/cluster/k8s/instance/templates/_helpers.tpl
+++ b/cluster/k8s/instance/templates/_helpers.tpl
@@ -1,3 +1,27 @@
+{{- define "mindroom.instanceSecretName" -}}
+{{- $instanceSecrets := .instanceSecrets | default (dict) -}}
+{{- $instanceSecrets.name | default (printf "mindroom-api-keys-%s" .customer) -}}
+{{- end }}
+
+{{- define "mindroom.instanceSecretsCreate" -}}
+{{- $instanceSecrets := .instanceSecrets | default (dict) -}}
+{{- $create := true -}}
+{{- if hasKey $instanceSecrets "create" -}}
+{{- $createValue := lower (toString $instanceSecrets.create) -}}
+{{- $create = has $createValue (list "1" "true" "yes" "on") -}}
+{{- end -}}
+{{- $create -}}
+{{- end }}
+
+{{- define "mindroom.instanceSecretHash" -}}
+{{- $instanceSecrets := .instanceSecrets | default (dict) -}}
+{{- if $instanceSecrets.hash -}}
+{{- $instanceSecrets.hash -}}
+{{- else -}}
+{{- printf "%s|%s|%s|%s|%s|%s|%s|%s|%s" (.openai_key | default "") (.anthropic_key | default "") (.openrouter_key | default "") (.google_key | default "") (.deepseek_key | default "") (.supabaseServiceKey | default "") (.sandbox_proxy_token | default "") (.credentials_encryption_key | default "") (.matrixOidc.clientSecret | default "") | sha256sum -}}
+{{- end -}}
+{{- end }}
+
 {{- define "mindroom.workerBackendEnv" -}}
 {{- $workerBackend := .workerBackend -}}
 {{- $instanceNamespace := .instanceNamespace -}}
@@ -67,15 +91,13 @@
   - name: MINDROOM_SANDBOX_PROXY_TOKEN
     valueFrom:
       secretKeyRef:
-        name: mindroom-api-keys-{{ $values.customer }}
+        name: {{ include "mindroom.instanceSecretName" $values }}
         key: sandbox_proxy_token
-  {{- if $values.credentials_encryption_key }}
   - name: MINDROOM_CREDENTIALS_ENCRYPTION_KEY
     valueFrom:
       secretKeyRef:
-        name: mindroom-api-keys-{{ $values.customer }}
+        name: {{ include "mindroom.instanceSecretName" $values }}
         key: credentials_encryption_key
-  {{- end }}
   - name: MINDROOM_CONFIG_PATH
     value: "/app/config.yaml"
   - name: MINDROOM_STORAGE_PATH

--- a/cluster/k8s/instance/templates/_helpers.tpl
+++ b/cluster/k8s/instance/templates/_helpers.tpl
@@ -1,6 +1,6 @@
 {{- define "mindroom.instanceSecretName" -}}
 {{- $instanceSecrets := .instanceSecrets | default (dict) -}}
-{{- $instanceSecrets.name | default (printf "mindroom-api-keys-%s" .customer) -}}
+{{- $instanceSecrets.name | default (printf "mindroom-api-keys-%s" (toString .customer)) -}}
 {{- end }}
 
 {{- define "mindroom.instanceSecretsCreate" -}}

--- a/cluster/k8s/instance/templates/deployment-mindroom.yaml
+++ b/cluster/k8s/instance/templates/deployment-mindroom.yaml
@@ -11,6 +11,9 @@
 {{- $trustedUpstreamAuthEnabled := has $trustedUpstreamAuthEnabledValue (list "1" "true" "yes" "on") -}}
 {{- $trustedUpstreamRequireJwtValue := lower (toString ($trustedUpstreamAuth.requireJwt | default false)) -}}
 {{- $trustedUpstreamRequireJwt := has $trustedUpstreamRequireJwtValue (list "1" "true" "yes" "on") -}}
+{{- $instanceSecretName := include "mindroom.instanceSecretName" .Values -}}
+{{- $instanceSecretHash := include "mindroom.instanceSecretHash" .Values -}}
+{{- $configHash := printf "%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s" (.Values.customer | toString) (.Values.baseDomain | toString) (.Values.accountId | default "" | toString) (.Values.storagePath | toString) (.Values.workerBackend | default "static_runner" | toString) (.Values.supabaseUrl | default "" | toString) (.Values.supabaseAnonKey | default "" | toString) ($trustedUpstreamAuth.enabled | default "" | toString) ($trustedUpstreamAuth.userIdHeader | default "" | toString) ($trustedUpstreamAuth.emailHeader | default "" | toString) ($trustedUpstreamAuth.matrixUserIdHeader | default "" | toString) ($trustedUpstreamAuth.emailToMatrixUserIdTemplate | default "" | toString) ($trustedUpstreamAuth.requireJwt | default "" | toString) ($trustedUpstreamAuth.jwtHeader | default "" | toString) ($trustedUpstreamAuth.jwksUrl | default "" | toString) ($trustedUpstreamAuth.jwtAudience | default "" | toString) ($trustedUpstreamAuth.jwtIssuer | default "" | toString) ($trustedUpstreamAuth.jwtEmailClaim | default "email" | toString) ($trustedUpstreamAuth.jwtUserIdClaim | default "" | toString) ($trustedUpstreamAuth.jwtMatrixUserIdClaim | default "" | toString) | sha256sum -}}
 {{- if and (eq $workerBackend "kubernetes") (ne $storageAccessMode "ReadWriteMany") (eq $controlPlaneNodeName "") -}}
 {{- fail "workerBackend=kubernetes with shared storage requires either storageAccessMode=ReadWriteMany or controlPlaneNodeName to keep the control plane and workers on one node" -}}
 {{- end -}}
@@ -53,10 +56,9 @@ spec:
       labels:
         app: mindroom
         customer: {{ .Values.customer | quote }}
-      {{- if .Values.credentials_encryption_key }}
       annotations:
-        mindroom.ai/credentials-encryption-key-hash: {{ .Values.credentials_encryption_key | sha256sum | quote }}
-      {{- end }}
+        mindroom.ai/config-hash: {{ $configHash | quote }}
+        mindroom.ai/instance-secret-hash: {{ $instanceSecretHash | quote }}
     spec:
       {{- if $controlPlaneNodeName }}
       nodeName: {{ $controlPlaneNodeName }}
@@ -128,15 +130,13 @@ spec:
         - name: MINDROOM_SANDBOX_PROXY_TOKEN
           valueFrom:
             secretKeyRef:
-              name: mindroom-api-keys-{{ .Values.customer }}
+              name: {{ $instanceSecretName }}
               key: sandbox_proxy_token
-        {{- if .Values.credentials_encryption_key }}
         - name: MINDROOM_CREDENTIALS_ENCRYPTION_KEY
           valueFrom:
             secretKeyRef:
-              name: mindroom-api-keys-{{ .Values.customer }}
+              name: {{ $instanceSecretName }}
               key: credentials_encryption_key
-        {{- end }}
         - name: MINDROOM_SANDBOX_EXECUTION_MODE
           value: "selective"
         - name: MINDROOM_SANDBOX_PROXY_TOOLS
@@ -250,7 +250,7 @@ spec:
           name: mindroom-config-{{ .Values.customer }}
       - name: api-keys
         secret:
-          secretName: mindroom-api-keys-{{ .Values.customer }}
+          secretName: {{ $instanceSecretName }}
           defaultMode: 0400
       {{- if eq $workerBackend "static_runner" }}
 {{ include "mindroom.staticRunnerVolume" . | nindent 6 }}

--- a/cluster/k8s/instance/templates/deployment-synapse.yaml
+++ b/cluster/k8s/instance/templates/deployment-synapse.yaml
@@ -1,3 +1,7 @@
+{{- $instanceSecretName := include "mindroom.instanceSecretName" .Values -}}
+{{- $instanceSecretHash := include "mindroom.instanceSecretHash" .Values -}}
+{{- $matrixOidc := .Values.matrixOidc | default (dict) -}}
+{{- $synapseConfigHash := printf "%s|%s|%s|%s|%s" (.Values.customer | toString) (.Values.baseDomain | toString) ($matrixOidc.enabled | default "" | toString) ($matrixOidc.issuer | default "" | toString) ($matrixOidc.clientId | default "" | toString) | sha256sum -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -17,6 +21,9 @@ spec:
       labels:
         app: synapse
         customer: {{ .Values.customer | quote }}
+      annotations:
+        mindroom.ai/synapse-config-hash: {{ $synapseConfigHash | quote }}
+        mindroom.ai/instance-secret-hash: {{ $instanceSecretHash | quote }}
     spec:
       containers:
       - name: synapse
@@ -80,4 +87,4 @@ spec:
           name: synapse-config-{{ .Values.customer }}
       - name: mindroom-secrets
         secret:
-          secretName: mindroom-api-keys-{{ .Values.customer }}
+          secretName: {{ $instanceSecretName }}

--- a/cluster/k8s/instance/templates/secret-api-keys.yaml
+++ b/cluster/k8s/instance/templates/secret-api-keys.yaml
@@ -1,7 +1,8 @@
+{{- if eq (include "mindroom.instanceSecretsCreate" .Values) "true" }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: mindroom-api-keys-{{ .Values.customer }}
+  name: {{ include "mindroom.instanceSecretName" .Values }}
   namespace: mindroom-instances
 type: Opaque
 stringData:
@@ -14,3 +15,4 @@ stringData:
   sandbox_proxy_token: {{ .Values.sandbox_proxy_token | default "" | quote }}
   credentials_encryption_key: {{ .Values.credentials_encryption_key | default "" | quote }}
   matrix_oidc_client_secret: {{ .Values.matrixOidc.clientSecret | default "" | quote }}
+{{- end }}

--- a/cluster/k8s/instance/values.yaml
+++ b/cluster/k8s/instance/values.yaml
@@ -58,7 +58,12 @@ kubernetesWorkerIdleTimeoutSeconds: 1800
 kubernetesWorkerEnableServiceLinks: false
 
 # API keys and secrets (referenced via Secret in deployment)
-# Provide values here or inject via a separate Secret overwrite.
+# Production provisioner deploys create this Secret outside Helm so secret values
+# do not land in Helm release history.
+instanceSecrets:
+  create: true
+  name: ""
+  hash: ""
 openai_key: ""
 anthropic_key: ""
 google_key: ""

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -255,6 +255,9 @@ env:
     value: "/etc/secrets/openrouter_key"
 ```
 
+For production SaaS instance provisioning, the platform backend creates `mindroom-api-keys-{instance_id}` directly with Kubernetes before running Helm.
+The instance chart is then rendered with `instanceSecrets.create=false`, `instanceSecrets.name`, and a non-secret `instanceSecrets.hash`, so tenant API keys and OIDC client secrets do not enter Helm release values or rendered Helm Secret manifests.
+
 ## Ingress
 
 Each instance gets three hosts:

--- a/saas-platform/platform-backend/src/backend/routes/provisioner.py
+++ b/saas-platform/platform-backend/src/backend/routes/provisioner.py
@@ -5,6 +5,7 @@ import binascii
 import contextlib
 import hashlib
 import hmac
+import json
 import os
 import secrets
 import tempfile
@@ -135,27 +136,7 @@ def _instance_credentials_encryption_key(instance_id: str) -> str:
     return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
 
 
-def _write_helm_secret_value_file(value: str) -> str:
-    """Write one Helm --set-file secret value to a private temporary file."""
-    fd, path = tempfile.mkstemp(prefix="mindroom-credentials-encryption-key-", text=True)
-    try:
-        os.write(fd, value.encode("utf-8"))
-    finally:
-        os.close(fd)
-    return path
-
-
-def _append_credentials_encryption_key_helm_args(helm_args: list[str], key: str) -> str | None:
-    """Append credential encryption key Helm args without putting key material in argv."""
-    if not key:
-        helm_args += ["--set", "credentials_encryption_key="]
-        return None
-    secret_file_path = _write_helm_secret_value_file(key)
-    helm_args += ["--set-file", f"credentials_encryption_key={secret_file_path}"]
-    return secret_file_path
-
-
-def _append_matrix_oidc_helm_args(helm_args: list[str]) -> str | None:
+def _append_matrix_oidc_helm_args(helm_args: list[str]) -> None:
     """Forward hosted Matrix OIDC settings to the instance chart."""
     if INSTANCE_MATRIX_OIDC_ENABLED:
         helm_args += ["--set", f"matrixOidc.enabled={INSTANCE_MATRIX_OIDC_ENABLED}"]
@@ -163,12 +144,6 @@ def _append_matrix_oidc_helm_args(helm_args: list[str]) -> str | None:
         helm_args += ["--set", f"matrixOidc.issuer={INSTANCE_MATRIX_OIDC_ISSUER}"]
     if INSTANCE_MATRIX_OIDC_CLIENT_ID:
         helm_args += ["--set", f"matrixOidc.clientId={INSTANCE_MATRIX_OIDC_CLIENT_ID}"]
-    if not INSTANCE_MATRIX_OIDC_CLIENT_SECRET:
-        return None
-
-    secret_file_path = _write_helm_secret_value_file(INSTANCE_MATRIX_OIDC_CLIENT_SECRET)
-    helm_args += ["--set-file", f"matrixOidc.clientSecret={secret_file_path}"]
-    return secret_file_path
 
 
 def _append_image_pull_secret_helm_args(helm_args: list[str], secret_names: str) -> None:
@@ -178,9 +153,44 @@ def _append_image_pull_secret_helm_args(helm_args: list[str], secret_names: str)
         helm_args += ["--set-string", f"imagePullSecrets[{index}].name={name}"]
 
 
+def _instance_secret_name(instance_id: str) -> str:
+    """Return the externally managed Secret name for an instance."""
+    return f"mindroom-api-keys-{instance_id}"
+
+
+def _instance_secret_hash(secret_data: dict[str, str]) -> str:
+    """Return a deterministic rollout hash for instance secret contents."""
+    encoded = json.dumps(secret_data, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+async def _apply_instance_secret(instance_id: str, namespace: str, secret_data: dict[str, str]) -> str:
+    """Apply instance secrets outside Helm so release values stay non-sensitive."""
+    secret_name = _instance_secret_name(instance_id)
+    manifest = {
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "metadata": {"name": secret_name, "namespace": namespace},
+        "type": "Opaque",
+        "stringData": secret_data,
+    }
+    fd, path = tempfile.mkstemp(prefix=f"{secret_name}-", suffix=".json", text=True)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(manifest, handle)
+        code, out, err = await run_kubectl(["apply", "-f", path], namespace=namespace)
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(path)
+    if code != 0:
+        msg = f"Failed to apply instance Secret {secret_name}: {err or out}"
+        raise RuntimeError(msg)
+    return _instance_secret_hash(secret_data)
+
+
 async def _existing_instance_credentials_encryption_key(instance_id: str, namespace: str) -> str | None:
     """Return the existing credential encryption key from an instance Secret when present."""
-    secret_name = f"mindroom-api-keys-{instance_id}"
+    secret_name = _instance_secret_name(instance_id)
     code, out, err = await run_kubectl(
         ["get", "secret", secret_name, "--ignore-not-found", "-o=jsonpath={.data.credentials_encryption_key}"],
         namespace=namespace,
@@ -319,8 +329,20 @@ async def provision_instance(  # noqa: C901, PLR0912, PLR0915
     credentials_encryption_key = await _provision_credentials_encryption_key(
         customer_id=customer_id, existing_instance_id=existing_instance_id, data=data, namespace=namespace
     )
+    instance_secret_data = {
+        "openai_key": OPENAI_API_KEY or "",
+        "anthropic_key": ANTHROPIC_API_KEY or "",
+        "openrouter_key": OPENROUTER_API_KEY or "",
+        "google_key": GOOGLE_API_KEY or "",
+        "deepseek_key": DEEPSEEK_API_KEY or "",
+        "supabase_service_key": SUPABASE_SERVICE_KEY or "",
+        "sandbox_proxy_token": sandbox_proxy_token,
+        "credentials_encryption_key": credentials_encryption_key,
+        "matrix_oidc_client_secret": INSTANCE_MATRIX_OIDC_CLIENT_SECRET or "",
+    }
 
     try:
+        instance_secret_hash = await _apply_instance_secret(customer_id, namespace, instance_secret_data)
         # Use upgrade --install to handle both new and re-provisioning cases
         helm_args = [
             "upgrade",
@@ -341,19 +363,11 @@ async def provision_instance(  # noqa: C901, PLR0912, PLR0915
             "--set",
             f"supabaseAnonKey={SUPABASE_ANON_KEY or ''}",
             "--set",
-            f"supabaseServiceKey={SUPABASE_SERVICE_KEY or ''}",
+            "instanceSecrets.create=false",
             "--set",
-            f"openai_key={OPENAI_API_KEY}",
-            "--set",
-            f"anthropic_key={ANTHROPIC_API_KEY}",
-            "--set",
-            f"google_key={GOOGLE_API_KEY}",
-            "--set",
-            f"openrouter_key={OPENROUTER_API_KEY}",
-            "--set",
-            f"deepseek_key={DEEPSEEK_API_KEY}",
-            "--set",
-            f"sandbox_proxy_token={sandbox_proxy_token}",
+            f"instanceSecrets.name={_instance_secret_name(customer_id)}",
+            "--set-string",
+            f"instanceSecrets.hash={instance_secret_hash}",
         ]
         if INSTANCE_STORAGE_CLASS_NAME:
             helm_args += ["--set", f"storageClassName={INSTANCE_STORAGE_CLASS_NAME}"]
@@ -410,19 +424,8 @@ async def provision_instance(  # noqa: C901, PLR0912, PLR0915
                 f"trustedUpstreamAuth.jwtMatrixUserIdClaim={INSTANCE_TRUSTED_UPSTREAM_JWT_MATRIX_USER_ID_CLAIM}",
             ]
 
-        matrix_oidc_client_secret_file_path = _append_matrix_oidc_helm_args(helm_args)
-        credentials_encryption_key_file_path = _append_credentials_encryption_key_helm_args(
-            helm_args, credentials_encryption_key
-        )
-        try:
-            code, stdout, stderr = await run_helm(helm_args)
-        finally:
-            if matrix_oidc_client_secret_file_path is not None:
-                with contextlib.suppress(FileNotFoundError):
-                    os.unlink(matrix_oidc_client_secret_file_path)
-            if credentials_encryption_key_file_path is not None:
-                with contextlib.suppress(FileNotFoundError):
-                    os.unlink(credentials_encryption_key_file_path)
+        _append_matrix_oidc_helm_args(helm_args)
+        code, stdout, stderr = await run_helm(helm_args)
         if code != 0:
             # Mark as error in DB
             try:

--- a/saas-platform/platform-backend/tests/test_provisioner.py
+++ b/saas-platform/platform-backend/tests/test_provisioner.py
@@ -1,7 +1,6 @@
 """Comprehensive HTTP API tests for provisioner endpoints."""
 
 import base64
-from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
 
 import pytest
@@ -26,6 +25,29 @@ def _helm_set_file_args(helm_args: list[str]) -> dict[str, str]:
             key, path = helm_args[i + 1].split("=", 1)
             set_file_args[key] = path
     return set_file_args
+
+
+def _helm_set_string_args(helm_args: list[str]) -> dict[str, str]:
+    """Return Helm --set-string key/value pairs from a captured command."""
+    set_string_args = {}
+    for i, arg in enumerate(helm_args):
+        if arg == "--set-string":
+            key, value = helm_args[i + 1].split("=", 1)
+            set_string_args[key] = value
+    return set_string_args
+
+
+def _assert_helm_uses_external_instance_secret(helm_args: list[str]) -> None:
+    """Assert Helm only receives the external instance Secret reference."""
+    set_args = _helm_set_args(helm_args)
+    set_file_args = _helm_set_file_args(helm_args)
+    set_string_args = _helm_set_string_args(helm_args)
+
+    assert set_args["instanceSecrets.create"] == "false"
+    assert set_args["instanceSecrets.name"].startswith("mindroom-api-keys-")
+    assert "instanceSecrets.hash" in set_string_args
+    assert "credentials_encryption_key" not in set_args
+    assert "credentials_encryption_key" not in set_file_args
 
 
 async def _kubectl_without_credentials_encryption_secret(args: list[str], namespace: str | None = None):
@@ -208,9 +230,8 @@ class TestProvisionerEndpoints:
         assert data["success"] is True
         assert data["customer_id"] == "456"
         helm_args = mock_helm.call_args.args[0]
-        set_args = _helm_set_args(helm_args)
-        assert set_args["credentials_encryption_key"] == ""
-        assert "credentials_encryption_key" not in _helm_set_file_args(helm_args)
+        _assert_helm_uses_external_instance_secret(helm_args)
+        assert any(call_.args[0][:2] == ["apply", "-f"] for call_ in mock_kubectl.call_args_list)
 
     def test_provision_re_provision_existing_preserves_credentials_encryption(
         self,
@@ -239,13 +260,10 @@ class TestProvisionerEndpoints:
 
         assert response.status_code == 200
         helm_args = mock_helm.call_args.args[0]
-        set_args = _helm_set_args(helm_args)
         expected_key = base64.urlsafe_b64encode(b"1" * 32).decode("ascii").rstrip("=")
-        assert "credentials_encryption_key" not in set_args
-        set_file_args = _helm_set_file_args(helm_args)
-        assert "credentials_encryption_key" in set_file_args
         assert expected_key not in " ".join(helm_args)
-        assert not Path(set_file_args["credentials_encryption_key"]).exists()
+        _assert_helm_uses_external_instance_secret(helm_args)
+        assert any(call_.args[0][:2] == ["apply", "-f"] for call_ in mock_kubectl.call_args_list)
 
     def test_provision_re_provision_existing_opt_in_preserves_existing_credentials_encryption_key(
         self,
@@ -275,13 +293,10 @@ class TestProvisionerEndpoints:
 
         assert response.status_code == 200
         helm_args = mock_helm.call_args.args[0]
-        set_args = _helm_set_args(helm_args)
         expected_key = base64.urlsafe_b64encode(b"1" * 32).decode("ascii").rstrip("=")
-        assert "credentials_encryption_key" not in set_args
-        set_file_args = _helm_set_file_args(helm_args)
-        assert "credentials_encryption_key" in set_file_args
         assert expected_key not in " ".join(helm_args)
-        assert not Path(set_file_args["credentials_encryption_key"]).exists()
+        _assert_helm_uses_external_instance_secret(helm_args)
+        assert any(call_.args[0][:2] == ["apply", "-f"] for call_ in mock_kubectl.call_args_list)
 
     def test_provision_re_provision_existing_can_opt_into_credentials_encryption(
         self,
@@ -311,11 +326,8 @@ class TestProvisionerEndpoints:
 
         assert response.status_code == 200
         helm_args = mock_helm.call_args.args[0]
-        set_args = _helm_set_args(helm_args)
-        assert "credentials_encryption_key" not in set_args
-        set_file_args = _helm_set_file_args(helm_args)
-        assert "credentials_encryption_key" in set_file_args
-        assert not Path(set_file_args["credentials_encryption_key"]).exists()
+        _assert_helm_uses_external_instance_secret(helm_args)
+        assert any(call_.args[0][:2] == ["apply", "-f"] for call_ in mock_kubectl.call_args_list)
 
     def test_provision_re_provision_existing_fails_when_existing_key_lookup_fails(
         self,

--- a/saas-platform/platform-backend/tests/test_provisioner_real.py
+++ b/saas-platform/platform-backend/tests/test_provisioner_real.py
@@ -2,8 +2,8 @@
 
 import base64
 import importlib
+import json
 import os
-import stat
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -72,36 +72,47 @@ class TestProvisionerCommandValidation:
         from backend.routes.provisioner import provision_instance
 
         captured_helm_args = []
+        captured_secret_manifests = []
 
         async def capture_helm_command(args):
             captured_helm_args.append(args)
             return (0, "Success", "")
 
+        async def capture_kubectl_command(args, namespace=None):
+            if args[:2] == ["apply", "-f"]:
+                captured_secret_manifests.append(json.loads(Path(args[2]).read_text(encoding="utf-8")))
+            return (0, "Success", "")
+
         with patch("backend.routes.provisioner.PROVISIONER_API_KEY", "test-key"):
             with patch("backend.routes.provisioner.run_helm", side_effect=capture_helm_command):
-                with patch("backend.routes.provisioner.ensure_supabase") as mock_sb:
-                    # Minimal mocking - just database
-                    mock_sb.return_value.table().insert().execute.return_value = Mock(data=[{"instance_id": "123"}])
+                with patch("backend.routes.provisioner.run_kubectl", side_effect=capture_kubectl_command):
+                    with patch("backend.routes.provisioner.ensure_supabase") as mock_sb:
+                        # Minimal mocking - just database
+                        mock_sb.return_value.table().insert().execute.return_value = Mock(data=[{"instance_id": "123"}])
 
-                    # Run actual provisioning
-                    await provision_instance(
-                        None,  # request
-                        {"subscription_id": "sub-123", "account_id": "acc-123", "tier": "professional"},
-                        "Bearer test-key",  # authorization
-                        None,  # background_tasks
-                    )
+                        # Run actual provisioning
+                        await provision_instance(
+                            None,  # request
+                            {"subscription_id": "sub-123", "account_id": "acc-123", "tier": "professional"},
+                            "Bearer test-key",  # authorization
+                            None,  # background_tasks
+                        )
 
         # Validate the ACTUAL helm command structure
         helm_args = captured_helm_args[0]
 
         # Critical: Verify --set arguments are correct
         set_args = {}
+        set_string_args = {}
         set_file_args = {}
         for i, arg in enumerate(helm_args):
             if arg == "--set":
                 key_value = helm_args[i + 1]
                 key, value = key_value.split("=", 1)
                 set_args[key] = value
+            if arg == "--set-string":
+                key, value = helm_args[i + 1].split("=", 1)
+                set_string_args[key] = value
             if arg == "--set-file":
                 key, value = helm_args[i + 1].split("=", 1)
                 set_file_args[key] = value
@@ -114,20 +125,18 @@ class TestProvisionerCommandValidation:
         assert set_args["baseDomain"] == "test.mindroom.chat"
         assert "supabaseUrl" in set_args
 
-        # Critical: Check we're not mixing up API keys
-        assert "openrouter_key" in set_args or "openrouter" in str(set_args)
-        assert "openai_key" in set_args or "openai" in str(set_args)
-        assert "sandbox_proxy_token" in set_args
-        assert set_args["sandbox_proxy_token"] != ""
+        assert set_args["instanceSecrets.create"] == "false"
+        assert set_args["instanceSecrets.name"] == "mindroom-api-keys-123"
+        assert "instanceSecrets.hash" in set_string_args
+        assert "openrouter_key" not in set_args
+        assert "openai_key" not in set_args
+        assert "sandbox_proxy_token" not in set_args
         assert "credentials_encryption_key" not in set_args
-        assert "credentials_encryption_key" in set_file_args
-        assert not Path(set_file_args["credentials_encryption_key"]).exists()
+        assert set_file_args == {}
 
-        # Verify we're not passing wrong values
-        # Skip check if both are empty (not set in env during tests)
-        if "openrouter_key" in set_args and "openai_key" in set_args:
-            if set_args["openrouter_key"] and set_args["openai_key"]:
-                assert set_args["openrouter_key"] != set_args["openai_key"]
+        secret_data = captured_secret_manifests[0]["stringData"]
+        assert secret_data["sandbox_proxy_token"]
+        assert secret_data["credentials_encryption_key"]
 
     def test_instance_credentials_encryption_key_is_stable_and_instance_scoped(self):
         """Provisioner-derived credential keys should be stable without sharing one key across instances."""
@@ -145,14 +154,27 @@ class TestProvisionerCommandValidation:
         assert first != other
         assert len(base64.urlsafe_b64decode(f"{first}=")) == 32
 
-    def test_credentials_encryption_key_helm_set_file_is_private(self):
-        """Provisioner should hand Helm secret values through private files, not argv."""
-        path = Path(provisioner._write_helm_secret_value_file("secret-key-value"))
-        try:
-            assert path.read_text(encoding="utf-8") == "secret-key-value"
-            assert stat.S_IMODE(path.stat().st_mode) == 0o600
-        finally:
-            path.unlink(missing_ok=True)
+    @pytest.mark.asyncio
+    async def test_instance_secret_apply_uses_private_manifest_file(self):
+        """Provisioner should apply Secret manifests from a private temporary file."""
+        captured = {}
+
+        async def capture_kubectl_command(args, namespace=None):
+            path = Path(args[2])
+            captured["mode"] = path.stat().st_mode & 0o777
+            captured["manifest"] = json.loads(path.read_text(encoding="utf-8"))
+            return (0, "Success", "")
+
+        with patch.object(provisioner, "run_kubectl", side_effect=capture_kubectl_command):
+            await provisioner._apply_instance_secret(
+                "123",
+                "mindroom-instances",
+                {"credentials_encryption_key": "secret-key-value"},
+            )
+
+        assert captured["mode"] == 0o600
+        assert captured["manifest"]["metadata"]["name"] == "mindroom-api-keys-123"
+        assert captured["manifest"]["stringData"]["credentials_encryption_key"] == "secret-key-value"
 
     @pytest.mark.asyncio
     async def test_helm_install_command_honors_instance_overrides(self):
@@ -160,14 +182,15 @@ class TestProvisionerCommandValidation:
         from backend.routes.provisioner import provision_instance
 
         captured_helm_args = []
-        captured_set_file_values = {}
+        captured_secret_manifests = []
 
         async def capture_helm_command(args):
             captured_helm_args.append(args)
-            for i, arg in enumerate(args):
-                if arg == "--set-file":
-                    key, value = args[i + 1].split("=", 1)
-                    captured_set_file_values[key] = Path(value).read_text(encoding="utf-8")
+            return (0, "Success", "")
+
+        async def capture_kubectl_command(args, namespace=None):
+            if args[:2] == ["apply", "-f"]:
+                captured_secret_manifests.append(json.loads(Path(args[2]).read_text(encoding="utf-8")))
             return (0, "Success", "")
 
         with (
@@ -200,6 +223,7 @@ class TestProvisionerCommandValidation:
                 INSTANCE_MATRIX_OIDC_CLIENT_SECRET="matrix-client-secret",
             ),
             patch("backend.routes.provisioner.run_helm", side_effect=capture_helm_command),
+            patch("backend.routes.provisioner.run_kubectl", side_effect=capture_kubectl_command),
             patch("backend.routes.provisioner.ensure_supabase") as mock_sb,
         ):
             mock_sb.return_value.table().insert().execute.return_value = Mock(data=[{"instance_id": "123"}])
@@ -251,9 +275,12 @@ class TestProvisionerCommandValidation:
         assert set_args["matrixOidc.enabled"] == "true"
         assert set_args["matrixOidc.issuer"] == "https://api.mindroom.chat/matrix-oidc"
         assert set_args["matrixOidc.clientId"] == "mindroom-synapse"
+        assert set_args["instanceSecrets.create"] == "false"
+        assert set_args["instanceSecrets.name"] == "mindroom-api-keys-123"
+        assert "instanceSecrets.hash" in set_string_args
         assert "matrix-client-secret" not in " ".join(helm_args)
-        assert captured_set_file_values["matrixOidc.clientSecret"] == "matrix-client-secret"
-        assert not Path(set_file_args["matrixOidc.clientSecret"]).exists()
+        assert set_file_args == {}
+        assert captured_secret_manifests[0]["stringData"]["matrix_oidc_client_secret"] == "matrix-client-secret"
 
     @pytest.mark.asyncio
     async def test_kubectl_scale_command_uses_correct_syntax(self):
@@ -611,7 +638,10 @@ class TestProvisionerRealScenarios:
                     "Error: failed to create resource: exceeded quota: compute-resources, requested: requests.cpu=2, used: requests.cpu=8, limited: requests.cpu=10",
                 )
 
-                with patch("backend.routes.provisioner.ensure_supabase") as mock_sb:
+                with (
+                    patch("backend.routes.provisioner.run_kubectl", return_value=(0, "Success", "")),
+                    patch("backend.routes.provisioner.ensure_supabase") as mock_sb,
+                ):
                     mock_sb.return_value.table().insert().execute.return_value = Mock(data=[{"instance_id": "123"}])
 
                     with pytest.raises(Exception) as exc_info:

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -15508,6 +15508,9 @@ env:
     value: "/etc/secrets/openrouter_key"
 ```
 
+For production SaaS instance provisioning, the platform backend creates `mindroom-api-keys-{instance_id}` directly with Kubernetes before running Helm.
+The instance chart is then rendered with `instanceSecrets.create=false`, `instanceSecrets.name`, and a non-secret `instanceSecrets.hash`, so tenant API keys and OIDC client secrets do not enter Helm release values or rendered Helm Secret manifests.
+
 ## Ingress
 
 Each instance gets three hosts:

--- a/skills/mindroom-docs/references/page__deployment__kubernetes__index.md
+++ b/skills/mindroom-docs/references/page__deployment__kubernetes__index.md
@@ -251,6 +251,9 @@ env:
     value: "/etc/secrets/openrouter_key"
 ```
 
+For production SaaS instance provisioning, the platform backend creates `mindroom-api-keys-{instance_id}` directly with Kubernetes before running Helm.
+The instance chart is then rendered with `instanceSecrets.create=false`, `instanceSecrets.name`, and a non-secret `instanceSecrets.hash`, so tenant API keys and OIDC client secrets do not enter Helm release values or rendered Helm Secret manifests.
+
 ## Ingress
 
 Each instance gets three hosts:

--- a/tests/test_helm_instance_worker_isolation.py
+++ b/tests/test_helm_instance_worker_isolation.py
@@ -349,6 +349,19 @@ def test_instance_chart_can_use_existing_secret_for_sensitive_values() -> None:
     assert synapse["spec"]["template"]["metadata"]["annotations"]["mindroom.ai/instance-secret-hash"] == "abc123"
 
 
+def test_instance_chart_numeric_customer_uses_valid_instance_secret_name() -> None:
+    """CI and production instance IDs are numeric and must still render valid Secret names."""
+    docs = _render_chart(
+        Path("cluster/k8s/instance"),
+        "customer=1",
+    )
+    secret = _resource(docs, "Secret", "mindroom-api-keys-1")
+    deployment = _resource(docs, "Deployment", "mindroom-1")
+
+    assert secret["metadata"]["name"] == "mindroom-api-keys-1"
+    assert deployment["spec"]["template"]["spec"]["volumes"][2]["secret"]["secretName"] == "mindroom-api-keys-1"
+
+
 def test_instance_chart_rejects_email_template_without_email_header() -> None:
     """Email-to-Matrix derivation requires the trusted email header name."""
     completed = _run_helm_template(

--- a/tests/test_helm_instance_worker_isolation.py
+++ b/tests/test_helm_instance_worker_isolation.py
@@ -108,6 +108,33 @@ def _env_by_name(container: dict[str, Any]) -> dict[str, dict[str, Any]]:
     return {env["name"]: env for env in container["env"]}
 
 
+def _instance_secret_hash(**overrides: str) -> str:
+    secret_data = {
+        "openai_key": "",
+        "anthropic_key": "",
+        "openrouter_key": "",
+        "google_key": "",
+        "deepseek_key": "",
+        "supabase_service_key": "",
+        "sandbox_proxy_token": "",
+        "credentials_encryption_key": "",
+        "matrix_oidc_client_secret": "",
+    }
+    secret_data.update(overrides)
+    ordered_values = [
+        secret_data["openai_key"],
+        secret_data["anthropic_key"],
+        secret_data["openrouter_key"],
+        secret_data["google_key"],
+        secret_data["deepseek_key"],
+        secret_data["supabase_service_key"],
+        secret_data["sandbox_proxy_token"],
+        secret_data["credentials_encryption_key"],
+        secret_data["matrix_oidc_client_secret"],
+    ]
+    return hashlib.sha256("|".join(ordered_values).encode("utf-8")).hexdigest()
+
+
 def test_instance_chart_worker_network_policy_allows_runner_ingress_only_from_control_plane() -> None:
     """Worker runner ingress should not allow every pod carrying the instance label."""
     docs = _render_instance_chart()
@@ -232,11 +259,8 @@ def test_instance_chart_static_runner_uses_shared_credentials_encryption_key_sec
 
     assert api_keys_secret["stringData"]["credentials_encryption_key"] == credentials_encryption_key
     assert credentials_encryption_key not in json.dumps(deployment)
-    assert (
-        annotations["mindroom.ai/credentials-encryption-key-hash"]
-        == hashlib.sha256(
-            credentials_encryption_key.encode("utf-8"),
-        ).hexdigest()
+    assert annotations["mindroom.ai/instance-secret-hash"] == _instance_secret_hash(
+        credentials_encryption_key=credentials_encryption_key,
     )
     assert _env_by_name(mindroom_container)["MINDROOM_CREDENTIALS_ENCRYPTION_KEY"] == {
         "name": "MINDROOM_CREDENTIALS_ENCRYPTION_KEY",
@@ -258,16 +282,26 @@ def test_instance_chart_static_runner_uses_shared_credentials_encryption_key_sec
     }
 
 
-def test_instance_chart_omits_credentials_encryption_env_when_key_is_unset() -> None:
-    """Instance runtime containers should not mount an empty credential encryption key."""
+def test_instance_chart_wires_credentials_encryption_env_when_key_is_unset() -> None:
+    """Instance runtime containers should consistently read the key from the shared Secret."""
     docs = _render_chart(Path("cluster/k8s/instance"))
     deployment = _resource(docs, "Deployment", "mindroom-demo")
     mindroom_container = _container(deployment, "mindroom")
     runner_container = _container(deployment, "sandbox-runner")
+    annotations = deployment["spec"]["template"]["metadata"]["annotations"]
 
-    assert "MINDROOM_CREDENTIALS_ENCRYPTION_KEY" not in _env_by_name(mindroom_container)
-    assert "MINDROOM_CREDENTIALS_ENCRYPTION_KEY" not in _env_by_name(runner_container)
-    assert "annotations" not in deployment["spec"]["template"]["metadata"]
+    expected_env = {
+        "name": "MINDROOM_CREDENTIALS_ENCRYPTION_KEY",
+        "valueFrom": {
+            "secretKeyRef": {
+                "name": "mindroom-api-keys-demo",
+                "key": "credentials_encryption_key",
+            },
+        },
+    }
+    assert _env_by_name(mindroom_container)["MINDROOM_CREDENTIALS_ENCRYPTION_KEY"] == expected_env
+    assert _env_by_name(runner_container)["MINDROOM_CREDENTIALS_ENCRYPTION_KEY"] == expected_env
+    assert annotations["mindroom.ai/instance-secret-hash"] == _instance_secret_hash()
 
 
 def test_instance_chart_credentials_encryption_key_rotation_changes_pod_template() -> None:
@@ -284,11 +318,35 @@ def test_instance_chart_credentials_encryption_key_rotation_changes_pod_template
     second_deployment = _resource(second_docs, "Deployment", "mindroom-demo")
 
     assert (
-        first_deployment["spec"]["template"]["metadata"]["annotations"]["mindroom.ai/credentials-encryption-key-hash"]
-        != second_deployment["spec"]["template"]["metadata"]["annotations"][
-            "mindroom.ai/credentials-encryption-key-hash"
-        ]
+        first_deployment["spec"]["template"]["metadata"]["annotations"]["mindroom.ai/instance-secret-hash"]
+        != second_deployment["spec"]["template"]["metadata"]["annotations"]["mindroom.ai/instance-secret-hash"]
     )
+
+
+def test_instance_chart_can_use_existing_secret_for_sensitive_values() -> None:
+    """Production instance deploys should keep secret material out of Helm manifests."""
+    docs = _render_chart(
+        Path("cluster/k8s/instance"),
+        "instanceSecrets.create=false",
+        "instanceSecrets.name=tenant-runtime-secrets",
+        "instanceSecrets.hash=abc123",
+        "credentials_encryption_key=must-not-render",
+        "matrixOidc.enabled=true",
+        "matrixOidc.issuer=https://api.mindroom.chat/matrix-oidc",
+        "matrixOidc.clientId=mindroom-synapse",
+        "matrixOidc.clientSecret=must-not-render-oidc",
+    )
+    mindroom = _resource(docs, "Deployment", "mindroom-demo")
+    synapse = _resource(docs, "Deployment", "synapse-demo")
+    rendered = json.dumps(docs)
+
+    assert not any(doc["kind"] == "Secret" and doc["metadata"]["name"] == "tenant-runtime-secrets" for doc in docs)
+    assert "must-not-render" not in rendered
+    assert "must-not-render-oidc" not in rendered
+    assert mindroom["spec"]["template"]["spec"]["volumes"][2]["secret"]["secretName"] == "tenant-runtime-secrets"
+    assert synapse["spec"]["template"]["spec"]["volumes"][2]["secret"]["secretName"] == "tenant-runtime-secrets"
+    assert mindroom["spec"]["template"]["metadata"]["annotations"]["mindroom.ai/instance-secret-hash"] == "abc123"
+    assert synapse["spec"]["template"]["metadata"]["annotations"]["mindroom.ai/instance-secret-hash"] == "abc123"
 
 
 def test_instance_chart_rejects_email_template_without_email_header() -> None:


### PR DESCRIPTION
## Summary
- create tenant instance API/OIDC secrets directly with Kubernetes before Helm upgrades
- render instance Helm releases with only an existing Secret name plus a rollout hash
- add chart/docs/tests for external tenant secrets

## Validation
- cd saas-platform/platform-backend && uv run pytest -q
- nix shell nixpkgs#kubernetes-helm -c uv run pytest tests/test_helm_instance_worker_isolation.py -q
- uv run pre-commit run --all-files

## Summary by Sourcery

Create and reference per-instance Kubernetes Secrets for tenant runtime configuration so that Helm releases only use non-sensitive secret metadata.

New Features:
- Support configuring the instance Helm chart to consume externally managed Secrets via instanceSecrets.create, instanceSecrets.name, and instanceSecrets.hash values.

Enhancements:
- Provision instance API/OIDC secrets directly with kubectl before Helm upgrades and reference them from releases using a deterministic hash for rollout.
- Update instance and Synapse deployments to consistently read credentials and OIDC secrets from the shared Secret and to annotate pods with config and secret hashes for controlled rollouts.
- Adjust the instance worker isolation tests and provisioning tests to validate the new external Secret wiring and hash-based rollout behavior.

Documentation:
- Document the production provisioning pattern where the backend pre-creates mindroom-api-keys-{instance_id} Secrets and the Helm chart is rendered to reference them without embedding secret values.

Tests:
- Add and update backend and chart tests to assert that sensitive values no longer appear in Helm --set/--set-file arguments or rendered manifests and that external Secrets are applied correctly.