### PR TITLE
Preserve tenant PVC storage class on reprovision

### DIFF
--- a/saas-platform/platform-backend/src/backend/routes/provisioner.py
+++ b/saas-platform/platform-backend/src/backend/routes/provisioner.py
@@ -223,6 +223,33 @@ async def _provision_credentials_encryption_key(
     return ""
 
 
+async def _existing_instance_storage_class_name(instance_id: str, namespace: str) -> str | None:
+    """Return the bound PVC storage class for an existing instance."""
+    pvc_names = [f"mindroom-storage-{instance_id}", f"synapse-storage-{instance_id}"]
+    code, out, err = await run_kubectl(
+        ["get", "pvc", *pvc_names, "--ignore-not-found", "-o", "json"],
+        namespace=namespace,
+    )
+    if code != 0:
+        msg = f"Failed to inspect existing PVC storage class for instance {instance_id}: {err or out}"
+        raise HTTPException(status_code=500, detail=msg)
+    if not out.strip():
+        return None
+
+    payload = json.loads(out)
+    storage_classes = {
+        item.get("spec", {}).get("storageClassName", "").strip()
+        for item in payload.get("items", [])
+        if item.get("spec", {}).get("storageClassName", "").strip()
+    }
+    if not storage_classes:
+        return None
+    if len(storage_classes) > 1:
+        msg = f"Instance {instance_id} has PVCs with different storage classes: {', '.join(sorted(storage_classes))}"
+        raise HTTPException(status_code=500, detail=msg)
+    return storage_classes.pop()
+
+
 @router.post("/system/provision", response_model=ProvisionResponse)
 @limiter.limit("5/minute")
 async def provision_instance(  # noqa: C901, PLR0912, PLR0915
@@ -329,6 +356,11 @@ async def provision_instance(  # noqa: C901, PLR0912, PLR0915
     credentials_encryption_key = await _provision_credentials_encryption_key(
         customer_id=customer_id, existing_instance_id=existing_instance_id, data=data, namespace=namespace
     )
+    storage_class_name = INSTANCE_STORAGE_CLASS_NAME
+    if existing_instance_id:
+        storage_class_name = (
+            await _existing_instance_storage_class_name(customer_id, namespace)
+        ) or INSTANCE_STORAGE_CLASS_NAME
     instance_secret_data = {
         "openai_key": OPENAI_API_KEY or "",
         "anthropic_key": ANTHROPIC_API_KEY or "",
@@ -369,8 +401,8 @@ async def provision_instance(  # noqa: C901, PLR0912, PLR0915
             "--set-string",
             f"instanceSecrets.hash={instance_secret_hash}",
         ]
-        if INSTANCE_STORAGE_CLASS_NAME:
-            helm_args += ["--set", f"storageClassName={INSTANCE_STORAGE_CLASS_NAME}"]
+        if storage_class_name:
+            helm_args += ["--set", f"storageClassName={storage_class_name}"]
         if INSTANCE_MINDROOM_IMAGE:
             helm_args += ["--set", f"mindroom_image={INSTANCE_MINDROOM_IMAGE}"]
         if INSTANCE_MINDROOM_IMAGE_PULL_POLICY:

--- a/saas-platform/platform-backend/tests/test_provisioner.py
+++ b/saas-platform/platform-backend/tests/test_provisioner.py
@@ -53,6 +53,8 @@ def _assert_helm_uses_external_instance_secret(helm_args: list[str]) -> None:
 async def _kubectl_without_credentials_encryption_secret(args: list[str], namespace: str | None = None):
     """Return an empty response for a missing existing instance API key Secret."""
     _ = namespace
+    if args[:2] == ["get", "pvc"]:
+        return (0, '{"items":[]}', "")
     if args[:3] == ["get", "secret", "mindroom-api-keys-456"]:
         assert "--ignore-not-found" in args
         return (0, "", "")
@@ -62,6 +64,8 @@ async def _kubectl_without_credentials_encryption_secret(args: list[str], namesp
 async def _kubectl_with_credentials_encryption_secret(args: list[str], namespace: str | None = None):
     """Return a non-empty existing credential encryption key for the instance API key Secret."""
     _ = namespace
+    if args[:2] == ["get", "pvc"]:
+        return (0, '{"items":[]}', "")
     if args[:3] == ["get", "secret", "mindroom-api-keys-456"]:
         assert "--ignore-not-found" in args
         existing_key = base64.urlsafe_b64encode(b"1" * 32).decode("ascii").rstrip("=")
@@ -72,6 +76,8 @@ async def _kubectl_with_credentials_encryption_secret(args: list[str], namespace
 async def _kubectl_credentials_encryption_secret_lookup_fails(args: list[str], namespace: str | None = None):
     """Return a real kubectl failure for the existing instance API key Secret lookup."""
     _ = namespace
+    if args[:2] == ["get", "pvc"]:
+        return (0, '{"items":[]}', "")
     if args[:3] == ["get", "secret", "mindroom-api-keys-456"]:
         assert "--ignore-not-found" in args
         return (1, "", "Forbidden")

--- a/saas-platform/platform-backend/tests/test_provisioner_integration.py
+++ b/saas-platform/platform-backend/tests/test_provisioner_integration.py
@@ -295,6 +295,8 @@ class TestProvisionerIntegration:
             with patch("backend.routes.provisioner.run_kubectl") as mock_kubectl:
 
                 async def kubectl_side_effect(args, **kwargs):
+                    if args[:2] == ["get", "pvc"]:
+                        return (0, '{"items":[]}', "")
                     if args[:2] == ["get", "secret"]:
                         return (0, "", "")
                     return (0, "Success", "")

--- a/saas-platform/platform-backend/tests/test_provisioner_real.py
+++ b/saas-platform/platform-backend/tests/test_provisioner_real.py
@@ -224,6 +224,7 @@ class TestProvisionerCommandValidation:
             ),
             patch("backend.routes.provisioner.run_helm", side_effect=capture_helm_command),
             patch("backend.routes.provisioner.run_kubectl", side_effect=capture_kubectl_command),
+            patch("backend.routes.provisioner.wait_for_deployment_ready", return_value=True),
             patch("backend.routes.provisioner.ensure_supabase") as mock_sb,
         ):
             mock_sb.return_value.table().insert().execute.return_value = Mock(data=[{"instance_id": "123"}])
@@ -281,6 +282,64 @@ class TestProvisionerCommandValidation:
         assert "matrix-client-secret" not in " ".join(helm_args)
         assert set_file_args == {}
         assert captured_secret_manifests[0]["stringData"]["matrix_oidc_client_secret"] == "matrix-client-secret"
+
+    @pytest.mark.asyncio
+    async def test_reprovision_preserves_existing_pvc_storage_class(self):
+        """Re-provisioning must not try to mutate bound PVC storage classes."""
+        from backend.routes.provisioner import provision_instance
+
+        captured_helm_args = []
+
+        async def capture_helm_command(args):
+            captured_helm_args.append(args)
+            return (0, "Success", "")
+
+        async def capture_kubectl_command(args, namespace=None):
+            if args[:2] == ["get", "pvc"]:
+                return (
+                    0,
+                    json.dumps(
+                        {
+                            "items": [
+                                {
+                                    "metadata": {"name": "mindroom-storage-1"},
+                                    "spec": {"storageClassName": "local-path"},
+                                },
+                                {"metadata": {"name": "synapse-storage-1"}, "spec": {"storageClassName": "local-path"}},
+                            ]
+                        }
+                    ),
+                    "",
+                )
+            return (0, "", "")
+
+        with (
+            patch.multiple(
+                "backend.routes.provisioner",
+                PROVISIONER_API_KEY="test-key",
+                INSTANCE_STORAGE_CLASS_NAME="hcloud-volumes",
+            ),
+            patch("backend.routes.provisioner.run_helm", side_effect=capture_helm_command),
+            patch("backend.routes.provisioner.run_kubectl", side_effect=capture_kubectl_command),
+            patch("backend.routes.provisioner.wait_for_deployment_ready", return_value=True),
+            patch("backend.routes.provisioner.ensure_supabase") as mock_sb,
+        ):
+            mock_sb.return_value.table().update().eq().execute.return_value = Mock(data=[{"instance_id": "1"}])
+
+            await provision_instance(
+                None,
+                {"subscription_id": "sub-123", "account_id": "acc-123", "tier": "free", "instance_id": "1"},
+                "Bearer test-key",
+                None,
+            )
+
+        set_args = {}
+        for i, arg in enumerate(captured_helm_args[0]):
+            if arg == "--set":
+                key, value = captured_helm_args[0][i + 1].split("=", 1)
+                set_args[key] = value
+
+        assert set_args["storageClassName"] == "local-path"
 
     @pytest.mark.asyncio
     async def test_kubectl_scale_command_uses_correct_syntax(self):


### PR DESCRIPTION
## Summary
- preserve existing tenant PVC storageClassName during reprovisioning
- keep new tenant provisioning on the configured storage class
- add regression coverage for existing local-path PVCs when the platform default is hcloud-volumes

## Verification
- cd saas-platform/platform-backend && uv run pytest -q
- uv run pre-commit run --all-files

## Summary by Sourcery

Preserve existing tenant PVC storage classes during instance reprovisioning while keeping new instances on the configured default storage class.

New Features:
- Determine and reuse the storage class of existing bound PVCs when reprovisioning an instance, falling back to the configured default when none is found.

Tests:
- Add regression coverage to ensure reprovisioning preserves existing PVC storage classes and adapt kubectl test helpers to handle PVC lookups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Instances being re-provisioned now preserve their existing storage class configuration instead of reverting to defaults. The system intelligently detects and maintains the original storage class, preventing unintended configuration changes when updating instances.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1059?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->