### PR TITLE
Retry media fallback for zero-audio limits

### DIFF
--- a/src/mindroom/media_fallback.py
+++ b/src/mindroom/media_fallback.py
@@ -15,6 +15,7 @@ _INLINE_MEDIA_UNSUPPORTED_PATTERN = re.compile(
     r"(?:"
     r"(?:audio|image|video|file|document) input is not supported"
     r"|support input (?:audio|image|video|file|document)"
+    r"|at most 0 (?:audio|image|video|file|document)\(s\) may be provided"
     r")",
 )
 

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -5744,6 +5744,7 @@ class TestUserIdPassthrough:
             ),
             ("Error code: 500 - audio input is not supported", True),
             ("Error code: 404 - No endpoints found that support input audio", True),
+            ("[openclaw] Error: At most 0 audio(s) may be provided in one prompt.", True),
             ("invalid_request_error: max_tokens must be <= 4096", False),
             ("Rate limit exceeded", False),
         ],


### PR DESCRIPTION
## Summary
- recognize provider errors that cap inline media at zero, including OpenClaw `At most 0 audio(s) may be provided in one prompt`
- route those errors through the existing retry-without-inline-media fallback
- add regression coverage next to the OpenRouter audio fallback matcher from #1035

## Tests
- uv run pytest tests/test_ai_user_id.py::TestUserIdPassthrough::test_should_retry_without_inline_media_error_matching tests/test_team_media_fallback.py -q -n 0 --no-cov
- uv run pre-commit run --all-files
- uv run pytest -q

## Summary by Sourcery

Handle provider errors that enforce a zero inline-media limit by reusing the existing retry-without-inline-media fallback path.

Bug Fixes:
- Treat provider messages that state at most zero audio/image/video/file/document items may be provided as inline-media errors eligible for fallback retry.

Tests:
- Extend media fallback tests to cover OpenClaw zero-audio limit errors and ensure they trigger the retry-without-inline-media behavior.