### PR TITLE
Apply tenant secret after Helm upgrade

### DIFF
--- a/saas-platform/platform-backend/src/backend/routes/provisioner.py
+++ b/saas-platform/platform-backend/src/backend/routes/provisioner.py
@@ -374,7 +374,7 @@ async def provision_instance(  # noqa: C901, PLR0912, PLR0915
     }
 
     try:
-        instance_secret_hash = await _apply_instance_secret(customer_id, namespace, instance_secret_data)
+        instance_secret_hash = _instance_secret_hash(instance_secret_data)
         # Use upgrade --install to handle both new and re-provisioning cases
         helm_args = [
             "upgrade",
@@ -384,6 +384,8 @@ async def provision_instance(  # noqa: C901, PLR0912, PLR0915
             "--namespace",
             namespace,
             "--create-namespace",
+            "--history-max",
+            "2",
             "--set",
             f"customer={customer_id}",
             "--set",
@@ -469,6 +471,9 @@ async def provision_instance(  # noqa: C901, PLR0912, PLR0915
             msg = f"Helm install failed: {stderr}"
             raise HTTPException(status_code=500, detail=msg)  # noqa: TRY301
         logger.info("Helm install output: %s", stdout)
+        # Older releases managed this Secret in Helm. Apply it after Helm so
+        # Helm's resource pruning cannot delete the externally managed Secret.
+        await _apply_instance_secret(customer_id, namespace, instance_secret_data)
     except HTTPException:
         raise
     except Exception as e:

--- a/saas-platform/platform-backend/tests/test_provisioner_real.py
+++ b/saas-platform/platform-backend/tests/test_provisioner_real.py
@@ -73,14 +73,17 @@ class TestProvisionerCommandValidation:
 
         captured_helm_args = []
         captured_secret_manifests = []
+        operations = []
 
         async def capture_helm_command(args):
             captured_helm_args.append(args)
+            operations.append("helm")
             return (0, "Success", "")
 
         async def capture_kubectl_command(args, namespace=None):
             if args[:2] == ["apply", "-f"]:
                 captured_secret_manifests.append(json.loads(Path(args[2]).read_text(encoding="utf-8")))
+                operations.append("secret")
             return (0, "Success", "")
 
         with patch("backend.routes.provisioner.PROVISIONER_API_KEY", "test-key"):
@@ -128,6 +131,7 @@ class TestProvisionerCommandValidation:
         assert set_args["instanceSecrets.create"] == "false"
         assert set_args["instanceSecrets.name"] == "mindroom-api-keys-123"
         assert "instanceSecrets.hash" in set_string_args
+        assert helm_args[helm_args.index("--history-max") + 1] == "2"
         assert "openrouter_key" not in set_args
         assert "openai_key" not in set_args
         assert "sandbox_proxy_token" not in set_args
@@ -137,6 +141,7 @@ class TestProvisionerCommandValidation:
         secret_data = captured_secret_manifests[0]["stringData"]
         assert secret_data["sandbox_proxy_token"]
         assert secret_data["credentials_encryption_key"]
+        assert operations == ["helm", "secret"]
 
     def test_instance_credentials_encryption_key_is_stable_and_instance_scoped(self):
         """Provisioner-derived credential keys should be stable without sharing one key across instances."""


### PR DESCRIPTION
## Summary
- compute the tenant Secret rollout hash before Helm without applying the Secret first
- apply the externally managed tenant Secret after Helm succeeds so Helm pruning cannot delete a previously Helm-owned Secret
- add a regression asserting Helm runs before the external Secret apply

## Verification
- `cd saas-platform/platform-backend && uv run pytest tests/test_provisioner_real.py::TestProvisionerCommandValidation::test_helm_install_command_validates_required_values -q`
- `cd saas-platform/platform-backend && uv run pytest tests/test_provisioner.py tests/test_provisioner_extended.py tests/test_provisioner_integration.py tests/test_provisioner_real.py -q`
- `cd saas-platform/platform-backend && uv run pytest -q`
- `uv run pre-commit run --all-files`

## Live notes
- manually restored tenant `mindroom-api-keys-1` after the old release Secret was pruned during reprovision
- verified tenant pods running and Matrix login advertises `m.login.sso`

## Summary by Sourcery

Adjust instance provisioning to compute the tenant secret hash before Helm and apply the external tenant Secret only after a successful Helm upgrade to avoid it being pruned from legacy releases.

Bug Fixes:
- Prevent externally managed tenant Secrets from being deleted by Helm resource pruning during instance reprovisioning.

Tests:
- Extend provisioner integration tests to assert Helm runs before the external Secret is applied and to validate the resulting Secret contents.