### PR TITLE
Require authenticated checkout sessions

### DIFF
--- a/saas-platform/platform-backend/src/backend/routes/stripe_routes.py
+++ b/saas-platform/platform-backend/src/backend/routes/stripe_routes.py
@@ -3,7 +3,7 @@
 from typing import Annotated, Any
 
 from backend.config import PLATFORM_DOMAIN, logger, stripe
-from backend.deps import ensure_supabase, limiter, verify_user, verify_user_optional
+from backend.deps import ensure_supabase, limiter, verify_user
 from backend.models import UrlResponse
 from backend.pricing import get_stripe_price_id, get_trial_days, is_trial_enabled_for_plan
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -25,7 +25,7 @@ class CheckoutRequest(BaseModel):
 async def create_checkout_session(
     request: Request,  # noqa: ARG001
     payload: CheckoutRequest,
-    user: Annotated[dict | None, Depends(verify_user_optional)],
+    user: Annotated[dict, Depends(verify_user)],
 ) -> dict[str, Any]:
     """Create Stripe checkout session for subscription."""
     if not stripe.api_key:
@@ -36,33 +36,28 @@ async def create_checkout_session(
     if not price_id:
         raise HTTPException(status_code=400, detail=f"No price found for {payload.tier} ({payload.billing_cycle})")
 
-    customer_id: str | None = None
-
-    if user:
-        sb = ensure_supabase()
-        result = sb.table("accounts").select("stripe_customer_id").eq("id", user["account_id"]).single().execute()
-        if result.data and result.data.get("stripe_customer_id"):
-            customer_id = result.data["stripe_customer_id"]
-        else:
-            customer = stripe.Customer.create(email=user["email"], metadata={"supabase_user_id": user["account_id"]})
-            customer_id = customer.id
-            sb.table("accounts").update({"stripe_customer_id": customer_id}).eq("id", user["account_id"]).execute()
+    sb = ensure_supabase()
+    result = sb.table("accounts").select("stripe_customer_id").eq("id", user["account_id"]).single().execute()
+    if result.data and result.data.get("stripe_customer_id"):
+        customer_id = result.data["stripe_customer_id"]
+    else:
+        customer = stripe.Customer.create(email=user["email"], metadata={"supabase_user_id": user["account_id"]})
+        customer_id = customer.id
+        sb.table("accounts").update({"stripe_customer_id": customer_id}).eq("id", user["account_id"]).execute()
 
     # Check if customer already has an active subscription
-    if customer_id:
-        # Check for existing active subscriptions
-        subscriptions = stripe.Subscription.list(customer=customer_id, status="all", limit=10)
-        for sub in subscriptions.data:
-            if sub.status in ["active", "trialing"]:
-                # Customer already has a subscription - they should use the portal to manage it
-                logger.warning(
-                    "Customer %s already has an active subscription %s, redirecting to portal", customer_id, sub.id
-                )
-                # Create a portal session instead
-                portal_session = stripe.billing_portal.Session.create(
-                    customer=customer_id, return_url=f"https://app.{PLATFORM_DOMAIN}/dashboard/billing"
-                )
-                return {"url": portal_session.url}
+    subscriptions = stripe.Subscription.list(customer=customer_id, status="all", limit=10)
+    for sub in subscriptions.data:
+        if sub.status in ["active", "trialing"]:
+            # Customer already has a subscription - they should use the portal to manage it
+            logger.warning(
+                "Customer %s already has an active subscription %s, redirecting to portal", customer_id, sub.id
+            )
+            # Create a portal session instead
+            portal_session = stripe.billing_portal.Session.create(
+                customer=customer_id, return_url=f"https://app.{PLATFORM_DOMAIN}/dashboard/billing"
+            )
+            return {"url": portal_session.url}
 
     # Use quantity for professional plan (per-user pricing)
     quantity = payload.quantity if payload.tier == "professional" else 1
@@ -79,7 +74,7 @@ async def create_checkout_session(
                 "tier": payload.tier,
                 "billing_cycle": payload.billing_cycle,
                 "quantity": str(quantity),
-                "supabase_user_id": user["account_id"] if user else "",
+                "supabase_user_id": user["account_id"],
             }
         },
     }
@@ -88,8 +83,7 @@ async def create_checkout_session(
     if is_trial_enabled_for_plan(payload.tier):
         checkout_params["subscription_data"]["trial_period_days"] = get_trial_days()
 
-    if customer_id:
-        checkout_params["customer"] = customer_id
+    checkout_params["customer"] = customer_id
 
     try:
         session = stripe.checkout.Session.create(**checkout_params)

--- a/saas-platform/platform-backend/tests/test_stripe_integration.py
+++ b/saas-platform/platform-backend/tests/test_stripe_integration.py
@@ -89,6 +89,23 @@ class TestCheckoutEndpoint:
         return TestClient(app)
 
     @pytest.fixture(autouse=True)
+    def mock_auth_and_db(self):
+        """Authenticate checkout requests and provide a linked Stripe customer."""
+        from main import app  # noqa: PLC0415
+        from backend.deps import verify_user
+
+        def override_verify_user():
+            return {"account_id": "acc_test_123", "email": "test@example.com"}
+
+        app.dependency_overrides[verify_user] = override_verify_user
+        with patch("backend.routes.stripe_routes.ensure_supabase") as mock:
+            sb = Mock()
+            sb.table().select().eq().single().execute.return_value = Mock(data={"stripe_customer_id": "cus_test_123"})
+            mock.return_value = sb
+            yield sb
+        app.dependency_overrides.clear()
+
+    @pytest.fixture(autouse=True)
     def setup(self) -> None:
         """Set up Stripe API key."""
         if HAS_STRIPE_CREDENTIALS:

--- a/saas-platform/platform-backend/tests/test_stripe_routes.py
+++ b/saas-platform/platform-backend/tests/test_stripe_routes.py
@@ -225,30 +225,5 @@ class TestStripeRoutesEndpoints:
 
     def test_unauthorized_access(self, client: TestClient):
         """Test accessing endpoints without authentication."""
-        from main import app  # noqa: PLC0415
-        from backend.deps import verify_user_optional
-
-        # Mock pricing functions, user dependency, and Stripe
-        with (
-            patch("backend.routes.stripe_routes.get_stripe_price_id", return_value="price_test_123"),
-            patch("backend.routes.stripe_routes.is_trial_enabled_for_plan", return_value=False),
-            patch("backend.routes.stripe_routes.stripe") as mock_stripe,
-        ):
-            # Mock the checkout session creation
-            mock_checkout_session = Mock()
-            mock_checkout_session.url = "https://checkout.stripe.com/pay/cs_test_123"
-            mock_stripe.checkout.Session.create.return_value = mock_checkout_session
-
-            def override_verify_user_optional():
-                return None  # Return None to simulate no user
-
-            app.dependency_overrides[verify_user_optional] = override_verify_user_optional
-            try:
-                # When there's no authenticated user, checkout should still work
-                # as stripe_routes allows optional user for checkout
-                response = client.post("/stripe/checkout", json={"tier": "starter", "billing_cycle": "monthly"})
-                # The route actually allows unauthenticated access
-                assert response.status_code == 200
-                assert response.json()["url"] == "https://checkout.stripe.com/pay/cs_test_123"
-            finally:
-                app.dependency_overrides.clear()
+        response = client.post("/stripe/checkout", json={"tier": "starter", "billing_cycle": "monthly"})
+        assert response.status_code == 401


### PR DESCRIPTION
## Summary
- require a verified MindRoom account before creating Stripe checkout sessions
- always attach checkout sessions to a Stripe customer linked to the account
- remove the anonymous checkout path that produced subscriptions without account metadata

## Verification
- `cd saas-platform/platform-backend && uv run pytest tests/test_stripe_routes.py::TestStripeRoutesEndpoints::test_unauthorized_access -q`
- `cd saas-platform/platform-backend && uv run pytest tests/test_stripe_routes.py tests/test_stripe_integration.py -q`
- `cd saas-platform/platform-backend && uv run pytest -q`
- `uv run pre-commit run --all-files`

## Live finding
- production currently returns `200` for unauthenticated checkout; this PR changes that to `401` so payments cannot be detached from accounts.

## Summary by Sourcery

Require authentication for creating Stripe checkout sessions and always associate sessions with an account-linked Stripe customer.

Bug Fixes:
- Prevent creation of checkout sessions that are not associated with an authenticated account-linked Stripe customer.

Enhancements:
- Enforce mandatory user verification for the Stripe checkout route instead of allowing optional/anonymous users.
- Always resolve and attach a Stripe customer ID based on the requesting account and include the account ID in checkout metadata.

Tests:
- Update checkout unauthorized-access test to expect HTTP 401 for unauthenticated requests.
- Introduce an autouse test fixture that authenticates Stripe integration tests and mocks the account-to-customer lookup in Supabase.