### PR TITLE
Use tier metadata for Stripe webhooks

### DIFF
--- a/cluster/scripts/sync-stripe-prices.py
+++ b/cluster/scripts/sync-stripe-prices.py
@@ -84,7 +84,7 @@ def find_or_create_price(product_id, plan_key, plan_data, billing_cycle):
     prices = stripe.Price.list(product=product_id, limit=100)
     for price in prices.data:
         metadata = price.metadata or {}
-        if metadata.get("plan") == plan_key and metadata.get("billing_cycle") == billing_cycle:
+        if metadata.get("tier") == plan_key and metadata.get("billing_cycle") == billing_cycle:
             print(f"  Found existing price for {plan_key} ({billing_cycle}): {price.id}")
             return price.id
 
@@ -101,7 +101,7 @@ def find_or_create_price(product_id, plan_key, plan_data, billing_cycle):
         },
         "nickname": f"{plan_data['name']} ({billing_cycle.capitalize()})",
         "metadata": {
-            "plan": plan_key,
+            "tier": plan_key,
             "billing_cycle": billing_cycle,
             "platform": "mindroom",
         },

--- a/saas-platform/platform-backend/src/backend/routes/webhooks.py
+++ b/saas-platform/platform-backend/src/backend/routes/webhooks.py
@@ -25,10 +25,10 @@ def _maybe_timestamp_to_iso(timestamp: float | None) -> str | None:
 def _get_tier_from_price(price: dict) -> str:
     """Extract tier from price metadata.
 
-    Our sync-stripe-prices.py script sets metadata.plan with the tier name.
+    Our sync-stripe-prices.py script sets metadata.tier with the tier name.
     """
-    if (metadata := price.get("metadata", {})) and (plan := metadata.get("plan")):
-        return plan
+    if (metadata := price.get("metadata", {})) and (tier := metadata.get("tier")):
+        return tier
 
     msg = (
         f"Unable to determine tier from price. "

--- a/saas-platform/platform-backend/tests/test_webhooks.py
+++ b/saas-platform/platform-backend/tests/test_webhooks.py
@@ -58,7 +58,7 @@ class TestWebhookEndpoints:
                     {
                         "price": {
                             "id": f"price_{tier}_{billing_cycle}",
-                            "metadata": {"plan": tier, "billing_cycle": billing_cycle},
+                            "metadata": {"tier": tier, "billing_cycle": billing_cycle},
                         },
                         "quantity": quantity,
                     }
@@ -521,13 +521,13 @@ class TestWebhookEndpoints:
         assert result["received"] is True
         assert "error" in result or "Unable to determine tier" in str(result)
 
-    def test_price_metadata_requires_plan(
+    def test_price_metadata_requires_tier(
         self, client: TestClient, mock_stripe_signature: Mock, mock_supabase: MagicMock
     ):
-        """Stripe price metadata must use the current plan field."""
+        """Stripe price metadata must use the current tier field."""
         subscription_data = self._create_subscription_data()
         subscription_data["items"]["data"][0]["price"]["metadata"] = {
-            "tier": "starter",
+            "plan": "starter",
             "billing_cycle": "monthly",
         }
         event = self._create_stripe_event("customer.subscription.created", subscription_data)


### PR DESCRIPTION
## Summary
- read Stripe price metadata from `tier` in webhook subscription handling
- keep the Stripe price sync script aligned with the live price metadata shape
- update webhook tests to reject stale `plan` metadata

## Validation
- `uv sync --all-extras`
- `uv run pre-commit run --all-files`
- `cd saas-platform/platform-backend && uv run pytest -q`

## Summary by Sourcery

Align Stripe webhook tier extraction and price sync metadata with the new tier-based metadata field.

Bug Fixes:
- Ensure webhook tier resolution reads the tier field from Stripe price metadata instead of the deprecated plan field.

Enhancements:
- Update the Stripe price sync script to write and match against tier metadata rather than plan for consistency across systems.

Tests:
- Adjust webhook tests to expect tier metadata and to reject stale plan-based price metadata.