### PR TITLE
Support hosted Synapse bot registration

### DIFF
--- a/cluster/k8s/instance/templates/_helpers.tpl
+++ b/cluster/k8s/instance/templates/_helpers.tpl
@@ -18,7 +18,7 @@
 {{- if $instanceSecrets.hash -}}
 {{- $instanceSecrets.hash -}}
 {{- else -}}
-{{- printf "%s|%s|%s|%s|%s|%s|%s|%s|%s" (.openai_key | default "") (.anthropic_key | default "") (.openrouter_key | default "") (.google_key | default "") (.deepseek_key | default "") (.supabaseServiceKey | default "") (.sandbox_proxy_token | default "") (.credentials_encryption_key | default "") (.matrixOidc.clientSecret | default "") | sha256sum -}}
+{{- printf "%s|%s|%s|%s|%s|%s|%s|%s|%s|%s" (.openai_key | default "") (.anthropic_key | default "") (.openrouter_key | default "") (.google_key | default "") (.deepseek_key | default "") (.supabaseServiceKey | default "") (.sandbox_proxy_token | default "") (.credentials_encryption_key | default "") (.matrixOidc.clientSecret | default "") (.matrixRegistrationSharedSecret | default .matrix_admin_password | default "") | sha256sum -}}
 {{- end -}}
 {{- end }}
 

--- a/cluster/k8s/instance/templates/configmap-synapse.yaml
+++ b/cluster/k8s/instance/templates/configmap-synapse.yaml
@@ -35,13 +35,12 @@ data:
     enable_registration: false
     enable_registration_without_verification: false
     password_config:
-      enabled: false
+      enabled: true
 {{- else }}
     enable_registration: true
     enable_registration_without_verification: true
 {{- end }}
-    # If not provided, fallback to a strong random value
-    registration_shared_secret: "{{ .Values.matrix_admin_password | default (randAlphaNum 32) }}"
+    registration_shared_secret_path: /etc/mindroom-secrets/matrix_registration_shared_secret
 {{- if eq (toString .Values.matrixOidc.enabled) "true" }}
 
     oidc_providers:

--- a/cluster/k8s/instance/templates/deployment-mindroom.yaml
+++ b/cluster/k8s/instance/templates/deployment-mindroom.yaml
@@ -145,6 +145,8 @@ spec:
           value: "http://synapse-{{ .Values.customer }}:8008"
         - name: MATRIX_SERVER_NAME
           value: "{{ .Values.customer }}.{{ .Values.baseDomain }}"
+        - name: MATRIX_REGISTRATION_SHARED_SECRET_FILE
+          value: "/etc/secrets/matrix_registration_shared_secret"
         - name: MINDROOM_MATRIX_HOMESERVER_STARTUP_TIMEOUT_SECONDS
           value: {{ .Values.matrixHomeserverStartupTimeoutSeconds | quote }}
         - name: SUPABASE_URL

--- a/cluster/k8s/instance/templates/secret-api-keys.yaml
+++ b/cluster/k8s/instance/templates/secret-api-keys.yaml
@@ -15,4 +15,5 @@ stringData:
   sandbox_proxy_token: {{ .Values.sandbox_proxy_token | default "" | quote }}
   credentials_encryption_key: {{ .Values.credentials_encryption_key | default "" | quote }}
   matrix_oidc_client_secret: {{ .Values.matrixOidc.clientSecret | default "" | quote }}
+  matrix_registration_shared_secret: {{ .Values.matrixRegistrationSharedSecret | default .Values.matrix_admin_password | default (randAlphaNum 48) | quote }}
 {{- end }}

--- a/cluster/k8s/instance/values.yaml
+++ b/cluster/k8s/instance/values.yaml
@@ -71,6 +71,7 @@ openrouter_key: ""
 deepseek_key: ""
 sandbox_proxy_token: ""
 credentials_encryption_key: ""
+matrixRegistrationSharedSecret: ""
 
 # Supabase (shared auth)
 supabaseUrl: ""

--- a/saas-platform/platform-backend/src/backend/routes/provisioner.py
+++ b/saas-platform/platform-backend/src/backend/routes/provisioner.py
@@ -126,12 +126,24 @@ def _require_provisioner_auth(authorization: str | None) -> None:
 
 def _instance_credentials_encryption_key(instance_id: str) -> str:
     """Derive a stable per-instance credential encryption key."""
+    return _stable_instance_secret("instance-credentials", instance_id)
+
+
+def _instance_matrix_registration_shared_secret(instance_id: str) -> str:
+    """Derive a stable per-instance Synapse registration shared secret."""
+    return _stable_instance_secret("matrix-registration", instance_id)
+
+
+def _stable_instance_secret(purpose: str, instance_id: str) -> str:
+    """Derive one stable per-instance secret from the platform root secret."""
     root_secret = (INSTANCE_CREDENTIALS_ENCRYPTION_SECRET or PROVISIONER_API_KEY).strip()
     if not root_secret:
         msg = "INSTANCE_CREDENTIALS_ENCRYPTION_SECRET or PROVISIONER_API_KEY must be configured"
         raise HTTPException(status_code=500, detail=msg)
     digest = hmac.digest(
-        root_secret.encode("utf-8"), f"mindroom.instance-credentials.v1:{instance_id}".encode("utf-8"), hashlib.sha256
+        root_secret.encode("utf-8"),
+        f"mindroom.{purpose}.v1:{instance_id}".encode("utf-8"),
+        hashlib.sha256,
     )
     return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
 
@@ -371,6 +383,7 @@ async def provision_instance(  # noqa: C901, PLR0912, PLR0915
         "sandbox_proxy_token": sandbox_proxy_token,
         "credentials_encryption_key": credentials_encryption_key,
         "matrix_oidc_client_secret": INSTANCE_MATRIX_OIDC_CLIENT_SECRET or "",
+        "matrix_registration_shared_secret": _instance_matrix_registration_shared_secret(customer_id),
     }
 
     try:

--- a/saas-platform/platform-backend/tests/test_provisioner_real.py
+++ b/saas-platform/platform-backend/tests/test_provisioner_real.py
@@ -136,15 +136,17 @@ class TestProvisionerCommandValidation:
         assert "openai_key" not in set_args
         assert "sandbox_proxy_token" not in set_args
         assert "credentials_encryption_key" not in set_args
+        assert "matrix_registration_shared_secret" not in set_args
         assert set_file_args == {}
 
         secret_data = captured_secret_manifests[0]["stringData"]
         assert secret_data["sandbox_proxy_token"]
         assert secret_data["credentials_encryption_key"]
+        assert secret_data["matrix_registration_shared_secret"]
         assert operations == ["helm", "secret"]
 
-    def test_instance_credentials_encryption_key_is_stable_and_instance_scoped(self):
-        """Provisioner-derived credential keys should be stable without sharing one key across instances."""
+    def test_instance_secrets_are_stable_and_instance_scoped(self):
+        """Provisioner-derived instance secrets should be stable without being shared across tenants."""
         provisioner_module = importlib.import_module("backend.routes.provisioner")
         with patch.multiple(
             provisioner_module,
@@ -154,10 +156,13 @@ class TestProvisionerCommandValidation:
             first = provisioner_module._instance_credentials_encryption_key("123")
             second = provisioner_module._instance_credentials_encryption_key("123")
             other = provisioner_module._instance_credentials_encryption_key("456")
+            registration_secret = provisioner_module._instance_matrix_registration_shared_secret("123")
 
         assert first == second
         assert first != other
+        assert first != registration_secret
         assert len(base64.urlsafe_b64decode(f"{first}=")) == 32
+        assert len(base64.urlsafe_b64decode(f"{registration_secret}=")) == 32
 
     @pytest.mark.asyncio
     async def test_instance_secret_apply_uses_private_manifest_file(self):
@@ -287,6 +292,7 @@ class TestProvisionerCommandValidation:
         assert "matrix-client-secret" not in " ".join(helm_args)
         assert set_file_args == {}
         assert captured_secret_manifests[0]["stringData"]["matrix_oidc_client_secret"] == "matrix-client-secret"
+        assert captured_secret_manifests[0]["stringData"]["matrix_registration_shared_secret"]
 
     @pytest.mark.asyncio
     async def test_reprovision_preserves_existing_pvc_storage_class(self):

--- a/src/mindroom/matrix/provisioning.py
+++ b/src/mindroom/matrix/provisioning.py
@@ -7,7 +7,7 @@ from typing import Literal
 
 import httpx
 
-from mindroom.constants import RuntimePaths, runtime_matrix_ssl_verify
+from mindroom.constants import RuntimePaths, runtime_env_path, runtime_matrix_ssl_verify
 from mindroom.matrix.client_session import matrix_startup_error
 from mindroom.matrix.identity import parse_current_matrix_user_id
 
@@ -22,6 +22,22 @@ def registration_token_from_env(runtime_paths: RuntimePaths) -> str | None:
     """Get MATRIX_REGISTRATION_TOKEN from environment if configured."""
     token = (runtime_paths.env_value("MATRIX_REGISTRATION_TOKEN") or "").strip()
     return token or None
+
+
+def registration_shared_secret_from_env(runtime_paths: RuntimePaths) -> str | None:
+    """Get Synapse shared-secret registration credentials from env or file."""
+    secret = (runtime_paths.env_value("MATRIX_REGISTRATION_SHARED_SECRET") or "").strip()
+    if secret:
+        return secret
+
+    file_path = runtime_env_path(runtime_paths, "MATRIX_REGISTRATION_SHARED_SECRET_FILE")
+    if file_path is None:
+        return None
+    try:
+        return file_path.read_text(encoding="utf-8").strip() or None
+    except OSError as exc:
+        msg = f"MATRIX_REGISTRATION_SHARED_SECRET_FILE is not readable: {file_path}"
+        raise matrix_startup_error(msg, permanent=True) from exc
 
 
 def _local_provisioning_client_credentials_from_env(

--- a/src/mindroom/matrix/users.py
+++ b/src/mindroom/matrix/users.py
@@ -1,5 +1,7 @@
 """Matrix user account management for agents."""
 
+import hashlib
+import hmac
 import secrets
 from dataclasses import dataclass
 from functools import cached_property
@@ -375,6 +377,100 @@ async def _register_user_with_token(
     )
 
 
+def _synapse_shared_secret_registration_mac(
+    *,
+    shared_secret: str,
+    nonce: str,
+    username: str,
+    password: str,
+    admin: bool = False,
+) -> str:
+    mac = hmac.new(key=shared_secret.encode("utf-8"), digestmod=hashlib.sha1)
+    for index, value in enumerate((nonce, username, password, "admin" if admin else "notadmin")):
+        if index:
+            mac.update(b"\x00")
+        mac.update(value.encode("utf-8"))
+    return mac.hexdigest()
+
+
+def _synapse_shared_secret_nonce(response: httpx.Response) -> str:
+    if not response.is_success:
+        detail, _ = _registration_http_error_details(response)
+        msg = f"Synapse shared-secret registration nonce request failed: HTTP {response.status_code}: {detail}"
+        raise matrix_startup_error(msg, permanent=response.status_code in {400, 401, 403, 404})
+    try:
+        body = response.json()
+    except ValueError as exc:
+        msg = "Synapse shared-secret registration nonce response missing valid JSON."
+        raise matrix_startup_error(msg, permanent=True) from exc
+    if not isinstance(body, dict):
+        msg = "Synapse shared-secret registration nonce response payload must be an object."
+        raise matrix_startup_error(msg, permanent=True)
+    nonce = body.get("nonce")
+    if not isinstance(nonce, str) or not nonce.strip():
+        msg = "Synapse shared-secret registration nonce response missing nonce."
+        raise matrix_startup_error(msg, permanent=True)
+    return nonce.strip()
+
+
+async def _register_user_with_synapse_shared_secret(
+    *,
+    homeserver: str,
+    user_id: str,
+    username: str,
+    password: str,
+    display_name: str,
+    shared_secret: str,
+    runtime_paths: RuntimePaths,
+) -> str:
+    """Register a user with Synapse's shared-secret admin registration API."""
+    register_url = f"{homeserver.rstrip('/')}/_synapse/admin/v1/register"
+    try:
+        async with httpx.AsyncClient(
+            timeout=10,
+            verify=runtime_matrix_ssl_verify(runtime_paths=runtime_paths),
+        ) as client:
+            nonce = _synapse_shared_secret_nonce(await client.get(register_url))
+            response = await client.post(
+                register_url,
+                json={
+                    "nonce": nonce,
+                    "username": username,
+                    "password": password,
+                    "admin": False,
+                    "mac": _synapse_shared_secret_registration_mac(
+                        shared_secret=shared_secret,
+                        nonce=nonce,
+                        username=username,
+                        password=password,
+                    ),
+                    "displayname": display_name,
+                },
+            )
+    except httpx.HTTPError as exc:
+        msg = f"Could not reach Synapse shared-secret registration endpoint ({homeserver}): {exc}"
+        raise matrix_startup_error(msg) from exc
+
+    detail, errcode = _registration_http_error_details(response)
+    if response.is_success:
+        actual_user_id = _direct_registration_success_user_id(response)
+        logger.info("matrix_user_registered_with_synapse_shared_secret", user_id=actual_user_id)
+    elif errcode == "M_USER_IN_USE":
+        actual_user_id = user_id
+        logger.info("matrix_user_already_exists", user_id=user_id)
+    else:
+        msg = f"Synapse shared-secret registration failed for user {username}: {detail}"
+        raise matrix_startup_error(msg, permanent=response.status_code in {400, 401, 403, 404})
+
+    return await _login_existing_user_or_raise_collision(
+        homeserver=homeserver,
+        user_id=actual_user_id,
+        password=password,
+        display_name=display_name,
+        runtime_paths=runtime_paths,
+    )
+
+
 def _validated_returned_user_id(raw_user_id: object, *, source: str) -> str:
     if not isinstance(raw_user_id, str) or not raw_user_id.strip():
         msg = f"{source} response missing user_id"
@@ -662,6 +758,7 @@ async def _register_user(
     server_name = extract_server_name_from_homeserver(homeserver, runtime_paths=runtime_paths)
     user_id = MatrixID.from_username(username, server_name).full_id
     registration_token = provisioning.registration_token_from_env(runtime_paths=runtime_paths)
+    registration_shared_secret = provisioning.registration_shared_secret_from_env(runtime_paths=runtime_paths)
 
     provisioning_result = await _register_user_via_provisioning_if_configured(
         homeserver=homeserver,
@@ -673,6 +770,16 @@ async def _register_user(
     )
     if provisioning_result is not None:
         return provisioning_result
+    if registration_shared_secret:
+        return await _register_user_with_synapse_shared_secret(
+            homeserver=homeserver,
+            user_id=user_id,
+            username=username,
+            password=password,
+            display_name=display_name,
+            shared_secret=registration_shared_secret,
+            runtime_paths=runtime_paths,
+        )
     if registration_token:
         return await _register_user_with_token(
             homeserver=homeserver,

--- a/tests/test_helm_instance_worker_isolation.py
+++ b/tests/test_helm_instance_worker_isolation.py
@@ -119,6 +119,7 @@ def _instance_secret_hash(**overrides: str) -> str:
         "sandbox_proxy_token": "",
         "credentials_encryption_key": "",
         "matrix_oidc_client_secret": "",
+        "matrix_registration_shared_secret": "",
     }
     secret_data.update(overrides)
     ordered_values = [
@@ -131,6 +132,7 @@ def _instance_secret_hash(**overrides: str) -> str:
         secret_data["sandbox_proxy_token"],
         secret_data["credentials_encryption_key"],
         secret_data["matrix_oidc_client_secret"],
+        secret_data["matrix_registration_shared_secret"],
     ]
     return hashlib.sha256("|".join(ordered_values).encode("utf-8")).hexdigest()
 
@@ -335,18 +337,29 @@ def test_instance_chart_can_use_existing_secret_for_sensitive_values() -> None:
         "matrixOidc.issuer=https://api.mindroom.chat/matrix-oidc",
         "matrixOidc.clientId=mindroom-synapse",
         "matrixOidc.clientSecret=must-not-render-oidc",
+        "matrixRegistrationSharedSecret=must-not-render-registration",
     )
     mindroom = _resource(docs, "Deployment", "mindroom-demo")
     synapse = _resource(docs, "Deployment", "synapse-demo")
+    synapse_config = _resource(docs, "ConfigMap", "synapse-config-demo")["data"]["homeserver.yaml"]
     rendered = json.dumps(docs)
+    mindroom_container = _container(mindroom, "mindroom")
+    mindroom_env = {env["name"]: env.get("value") for env in mindroom_container["env"]}
 
     assert not any(doc["kind"] == "Secret" and doc["metadata"]["name"] == "tenant-runtime-secrets" for doc in docs)
     assert "must-not-render" not in rendered
     assert "must-not-render-oidc" not in rendered
+    assert "must-not-render-registration" not in rendered
     assert mindroom["spec"]["template"]["spec"]["volumes"][2]["secret"]["secretName"] == "tenant-runtime-secrets"
     assert synapse["spec"]["template"]["spec"]["volumes"][2]["secret"]["secretName"] == "tenant-runtime-secrets"
     assert mindroom["spec"]["template"]["metadata"]["annotations"]["mindroom.ai/instance-secret-hash"] == "abc123"
     assert synapse["spec"]["template"]["metadata"]["annotations"]["mindroom.ai/instance-secret-hash"] == "abc123"
+    assert mindroom_env["MATRIX_REGISTRATION_SHARED_SECRET_FILE"] == (
+        "/etc/secrets/matrix_registration_shared_secret"  # noqa: S105
+    )
+    assert "registration_shared_secret_path: /etc/mindroom-secrets/matrix_registration_shared_secret" in synapse_config
+    assert "registration_shared_secret:" not in synapse_config
+    assert "password_config:\n      enabled: true" in synapse_config
 
 
 def test_instance_chart_numeric_customer_uses_valid_instance_secret_name() -> None:
@@ -359,6 +372,7 @@ def test_instance_chart_numeric_customer_uses_valid_instance_secret_name() -> No
     deployment = _resource(docs, "Deployment", "mindroom-1")
 
     assert secret["metadata"]["name"] == "mindroom-api-keys-1"
+    assert secret["stringData"]["matrix_registration_shared_secret"]
     assert deployment["spec"]["template"]["spec"]["volumes"][2]["secret"]["secretName"] == "mindroom-api-keys-1"
 
 

--- a/tests/test_matrix_agent_manager.py
+++ b/tests/test_matrix_agent_manager.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import hmac
 import os
 from typing import TYPE_CHECKING, Self
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -92,10 +94,44 @@ def _recording_httpx_async_client(
     return _FakeAsyncClient
 
 
+def _recording_httpx_sequence_client(
+    captured_requests: list[tuple[str, str, dict[str, object] | None]],
+    responses: list[httpx.Response],
+) -> type[object]:
+    """Build a minimal AsyncClient replacement that records GET and POST requests."""
+
+    class _FakeAsyncClient:
+        def __init__(self, *_: object, **__: object) -> None:
+            pass
+
+        async def __aenter__(self) -> Self:
+            return self
+
+        async def __aexit__(self, *_: object) -> None:
+            return None
+
+        async def get(self, url: str, **_: object) -> httpx.Response:
+            captured_requests.append(("GET", url, None))
+            return responses.pop(0)
+
+        async def post(
+            self,
+            url: str,
+            json: dict[str, object],
+            **_: object,
+        ) -> httpx.Response:
+            captured_requests.append(("POST", url, json))
+            return responses.pop(0)
+
+    return _FakeAsyncClient
+
+
 @pytest.fixture(autouse=True)
 def _clear_matrix_registration_token(monkeypatch: pytest.MonkeyPatch) -> None:
     """Keep matrix registration tests deterministic unless explicitly overridden."""
     monkeypatch.delenv("MATRIX_REGISTRATION_TOKEN", raising=False)
+    monkeypatch.delenv("MATRIX_REGISTRATION_SHARED_SECRET", raising=False)
+    monkeypatch.delenv("MATRIX_REGISTRATION_SHARED_SECRET_FILE", raising=False)
     monkeypatch.delenv("MINDROOM_PROVISIONING_URL", raising=False)
     monkeypatch.delenv("MINDROOM_LOCAL_CLIENT_ID", raising=False)
     monkeypatch.delenv("MINDROOM_LOCAL_CLIENT_SECRET", raising=False)
@@ -496,6 +532,74 @@ class TestMatrixRegistration:
                 "Test User",
                 runtime_paths=runtime_paths,
             )
+
+    @pytest.mark.asyncio
+    async def test_register_user_uses_synapse_shared_secret_file_when_configured(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Hosted Synapse instances can create bot accounts with shared-secret registration."""
+        test_pass = "test_pass"  # noqa: S105
+        shared_secret_path = tmp_path / "matrix-registration-secret"
+        shared_secret_path.write_text("shared-secret-value\n", encoding="utf-8")
+        runtime_paths = _runtime_paths(
+            tmp_path,
+            MATRIX_REGISTRATION_SHARED_SECRET_FILE=str(shared_secret_path),
+        )
+        mock_client = AsyncMock()
+        mock_client.login.return_value = nio.LoginResponse(
+            user_id="@test_user:localhost",
+            device_id="TEST_DEVICE",
+            access_token=TEST_ACCESS_TOKEN,
+        )
+        mock_client.set_displayname.return_value = AsyncMock()
+        captured_requests: list[tuple[str, str, dict[str, object] | None]] = []
+
+        with (
+            patch(
+                "mindroom.matrix.users.httpx.AsyncClient",
+                _recording_httpx_sequence_client(
+                    captured_requests,
+                    [
+                        httpx.Response(200, json={"nonce": "nonce-123"}),
+                        httpx.Response(200, json={"user_id": "@test_user:localhost"}),
+                    ],
+                ),
+            ),
+            patch("mindroom.matrix.users.matrix_client") as mock_matrix_client,
+        ):
+            mock_matrix_client.return_value.__aenter__.return_value = mock_client
+
+            user_id = await _register_user(
+                "http://localhost:8008",
+                "test_user",
+                test_pass,
+                "Test User",
+                runtime_paths=runtime_paths,
+            )
+
+        assert user_id == "@test_user:localhost"
+        assert captured_requests[0] == ("GET", "http://localhost:8008/_synapse/admin/v1/register", None)
+        assert captured_requests[1][0:2] == ("POST", "http://localhost:8008/_synapse/admin/v1/register")
+        payload = captured_requests[1][2]
+        assert payload is not None
+        expected_mac = hmac.new(
+            b"shared-secret-value",
+            b"\x00".join([b"nonce-123", b"test_user", test_pass.encode("utf-8"), b"notadmin"]),
+            hashlib.sha1,
+        ).hexdigest()
+        assert payload == {
+            "nonce": "nonce-123",
+            "username": "test_user",
+            "password": test_pass,
+            "admin": False,
+            "mac": expected_mac,
+            "displayname": "Test User",
+        }
+        mock_client.register.assert_not_called()
+        mock_client.register_with_token.assert_not_called()
+        mock_client.login.assert_called_once_with(test_pass)
+        mock_client.set_displayname.assert_called_once_with("Test User")
 
     @pytest.mark.asyncio
     async def test_register_user_uses_provisioning_service_register_agent_when_configured(


### PR DESCRIPTION
## Summary
- create a stable per-instance Synapse registration shared secret in the provisioner-managed Secret
- mount that secret into Synapse and MindRoom and use Synapse shared-secret registration for managed bot accounts
- keep public registration disabled while allowing password login for the internal bot accounts MindRoom creates

## Validation
- uv run pytest tests/test_matrix_agent_manager.py -q -n 0 --no-cov
- cd saas-platform/platform-backend && uv run pytest tests/test_provisioner.py tests/test_provisioner_real.py -q --no-cov
- uv run pre-commit run --all-files
- remote helm template render on 46.62.174.103 verified registration_shared_secret_path and MATRIX_REGISTRATION_SHARED_SECRET_FILE

## Summary by Sourcery

Introduce per-instance Synapse shared-secret registration for managed Matrix bot accounts and wire it through the provisioner, runtime configuration, and Helm charts.

New Features:
- Support Matrix user registration via Synapse shared-secret admin API when a shared secret is configured.
- Provision a stable per-instance Synapse registration shared secret and expose it to MindRoom and Synapse via Kubernetes secrets and config.

Enhancements:
- Extend instance secret derivation to support multiple independent per-instance secrets from a common root key.
- Update Synapse configuration to use a shared-secret file and enable password logins while keeping public registration disabled.

Tests:
- Add tests covering Synapse shared-secret registration flow and MAC calculation for hosted instances.
- Extend provisioner and Helm rendering tests to validate inclusion, stability, and non-leakage of the new registration shared secret in manifests and hashes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Matrix shared-secret registration support as an alternative user registration method.

* **Configuration**
  * Added `matrixRegistrationSharedSecret` configuration parameter with environment variable and file-based secret support.
  * Updated Synapse password configuration to activate when OIDC authentication is enabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1065?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->