### PR TITLE
Fix numeric tenant Matrix auto-join aliases

### DIFF
--- a/cluster/k8s/instance/templates/configmap-synapse.yaml
+++ b/cluster/k8s/instance/templates/configmap-synapse.yaml
@@ -34,7 +34,7 @@ data:
 
     auto_join_rooms:
 {{- range $roomKey := $autoJoinRoomKeys }}
-      - {{ printf "#%s:%s.%s" $roomKey $.Values.customer $.Values.baseDomain | quote }}
+      - {{ printf "#%s:%s.%s" $roomKey ($.Values.customer | toString) ($.Values.baseDomain | toString) | quote }}
 {{- end }}
     autocreate_auto_join_rooms: false
 {{- end }}

--- a/tests/test_helm_instance_worker_isolation.py
+++ b/tests/test_helm_instance_worker_isolation.py
@@ -205,22 +205,22 @@ def test_instance_chart_configures_owner_room_access_for_oidc_tenants() -> None:
     """OIDC tenants should authorize and auto-join the platform owner to managed rooms."""
     docs = _render_chart(
         Path("cluster/k8s/instance"),
-        "customer=tenant42",
+        "customer=42",
         "baseDomain=example.test",
         "matrixOidc.enabled=true",
         "matrixOidc.issuer=https://api.example.test/matrix-oidc",
         "matrixRoomAccess.mode=multi_user",
         "matrixRoomAccess.reconcileExistingRooms=true",
         set_string_args=(
-            "authorizationGlobalUsers[0]=@owner:tenant42.example.test",
+            "authorizationGlobalUsers[0]=@owner:42.example.test",
             "matrixAutoJoinRoomKeys[0]=lobby",
             "matrixAutoJoinRoomKeys[1]=dev",
         ),
     )
-    mindroom_config = yaml.safe_load(_resource(docs, "ConfigMap", "mindroom-config-tenant42")["data"]["config.yaml"])
-    synapse_config = yaml.safe_load(_resource(docs, "ConfigMap", "synapse-config-tenant42")["data"]["homeserver.yaml"])
+    mindroom_config = yaml.safe_load(_resource(docs, "ConfigMap", "mindroom-config-42")["data"]["config.yaml"])
+    synapse_config = yaml.safe_load(_resource(docs, "ConfigMap", "synapse-config-42")["data"]["homeserver.yaml"])
 
-    assert mindroom_config["authorization"]["global_users"] == ["@owner:tenant42.example.test"]
+    assert mindroom_config["authorization"]["global_users"] == ["@owner:42.example.test"]
     assert mindroom_config["matrix_room_access"] == {
         "mode": "multi_user",
         "multi_user_join_rule": "public",
@@ -229,8 +229,8 @@ def test_instance_chart_configures_owner_room_access_for_oidc_tenants() -> None:
         "reconcile_existing_rooms": True,
     }
     assert synapse_config["auto_join_rooms"] == [
-        "#lobby:tenant42.example.test",
-        "#dev:tenant42.example.test",
+        "#lobby:42.example.test",
+        "#dev:42.example.test",
     ]
     assert synapse_config["autocreate_auto_join_rooms"] is False
 


### PR DESCRIPTION
## Summary
- stringify numeric Helm customer values when rendering Synapse auto_join_rooms
- make the owner-room-access Helm test render a numeric tenant ID, matching production instance IDs

## Validation
- uv run pre-commit run --all-files
- remote helm template with customer=42 produced #lobby:42.example.test and no %!s aliases
- live disposable tenant test exposed the failure before this patch: Synapse rejected #analysis:%!s(int64=14).mindroom.chat and crashed

## Summary by Sourcery

Ensure Synapse auto-join room aliases are rendered correctly for numeric tenants and update tests to reflect numeric customer IDs.

Bug Fixes:
- Prevent invalid Synapse auto-join room aliases when the Helm customer value is numeric by stringifying the value before formatting room aliases.

Tests:
- Adjust the owner-room-access Helm test to use and assert numeric tenant IDs consistent with production instance IDs.