### PR TITLE
fix(ISSUE-220): allow sole visible responder on degraded planning history

### DIFF
--- a/src/mindroom/turn_policy.py
+++ b/src/mindroom/turn_policy.py
@@ -26,7 +26,6 @@ from mindroom.hooks import (
     render_enrichment_block,
 )
 from mindroom.inbound_turn_normalizer import DispatchPayload
-from mindroom.matrix.thread_diagnostics import is_thread_history_degraded
 from mindroom.responder_availability import (
     filter_materializable_responders,
     live_responder_entity_names,
@@ -654,9 +653,7 @@ class TurnPolicy:
                 )
             )
             single_visible_self = (
-                not is_thread_history_degraded(context.thread_history)
-                and len(available_responders_in_room) == 1
-                and available_responders_in_room[0] == agent_matrix_id
+                len(available_responders_in_room) == 1 and available_responders_in_room[0] == agent_matrix_id
             )
             if should_continue_active_thread or single_visible_self:
                 return ResponseAction(kind="individual")

--- a/tests/test_agent_response_logic.py
+++ b/tests/test_agent_response_logic.py
@@ -15,12 +15,20 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from mindroom.config.agent import AgentConfig, TeamConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
+from mindroom.conversation_resolver import MessageContext
+from mindroom.matrix.cache.thread_history_result import thread_history_result
 from mindroom.matrix.client import ResolvedVisibleMessage
+from mindroom.matrix.thread_diagnostics import (
+    THREAD_HISTORY_DEGRADED_DIAGNOSTIC,
+    THREAD_HISTORY_ERROR_DIAGNOSTIC,
+)
 from mindroom.teams import TeamIntent, TeamOutcome, TeamResolution
 from mindroom.thread_utils import should_agent_respond
 from mindroom.turn_policy import ResponseAction, TurnPolicy, TurnPolicyDeps
@@ -175,6 +183,72 @@ class TestAgentResponseLogic:
         assert action is not None
         assert action.kind == "reject"
         assert action.rejection_message == "Team request includes no available members."
+
+    @pytest.mark.asyncio
+    async def test_single_visible_responder_replies_when_planning_history_degraded(self) -> None:
+        """A degraded dispatch read must not silence the sole visible responder in a thread."""
+        room = create_mock_room("!room:localhost", ["calculator", "general"], self.config)
+        runtime = MagicMock()
+        runtime.client = None
+        runtime.config = self.config
+        runtime.orchestrator = None
+        policy = TurnPolicy(
+            TurnPolicyDeps(
+                runtime=runtime,
+                logger=MagicMock(),
+                runtime_paths=self.runtime_paths,
+                agent_name="calculator",
+                matrix_id=entity_ids(self.config, self.runtime_paths)["calculator"],
+            ),
+        )
+        context = MessageContext(
+            am_i_mentioned=False,
+            is_thread=True,
+            thread_id="$thread-root:localhost",
+            thread_history=thread_history_result(
+                [],
+                is_full_history=False,
+                diagnostics={
+                    THREAD_HISTORY_DEGRADED_DIAGNOSTIC: True,
+                    THREAD_HISTORY_ERROR_DIAGNOSTIC: "dispatch_read_timeout",
+                },
+            ),
+            mentioned_agents=[],
+            has_non_agent_mentions=False,
+        )
+        assert context.planning_thread_history_unavailable is True
+
+        candidate_ids = entity_ids(self.config, self.runtime_paths)
+        with patch(
+            "mindroom.turn_policy.responder_candidate_entities_for_room",
+            new=AsyncMock(return_value=[candidate_ids["calculator"], candidate_ids["general"]]),
+        ):
+            multiple_visible_action = await policy.resolve_response_action(
+                context,
+                room,
+                self.sender,
+                "continue",
+                False,
+            )
+
+        assert multiple_visible_action.kind == "skip"
+
+        with patch(
+            "mindroom.turn_policy.responder_candidate_entities_for_room",
+            new=AsyncMock(return_value=[candidate_ids["calculator"]]),
+        ):
+            single_visible_action = await policy.resolve_response_action(
+                context,
+                room,
+                self.sender,
+                "continue",
+                False,
+            )
+
+        assert single_visible_action.kind != "skip", (
+            "degraded planning history should still dispatch the sole visible responder"
+        )
+        assert single_visible_action.kind == "individual"
 
     def test_effective_response_action_does_not_convert_reject_to_configured_team(self) -> None:
         """Configured-team execution only upgrades individual actions."""

--- a/tests/test_agent_response_logic.py
+++ b/tests/test_agent_response_logic.py
@@ -245,9 +245,6 @@ class TestAgentResponseLogic:
                 False,
             )
 
-        assert single_visible_action.kind != "skip", (
-            "degraded planning history should still dispatch the sole visible responder"
-        )
         assert single_visible_action.kind == "individual"
 
     def test_effective_response_action_does_not_convert_reject_to_configured_team(self) -> None:

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -9897,11 +9897,11 @@ class TestAgentBot:
         mock_should_respond.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_resolve_response_action_skips_unmentioned_thread_when_policy_history_degraded(
+    async def test_resolve_response_action_allows_sole_responder_when_policy_history_degraded(
         self,
         tmp_path: Path,
     ) -> None:
-        """Unavailable policy history should fail closed instead of behaving like an empty thread."""
+        """Unavailable policy history should not silence the sole visible responder."""
         config = _runtime_bound_config(
             Config(
                 agents={
@@ -9958,7 +9958,7 @@ class TestAgentBot:
                 False,
             )
 
-        assert action.kind == "skip"
+        assert action.kind == "individual"
         mock_should_respond.assert_not_called()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Allows the sole visible responder in a thread to reply even when planning thread history is degraded.
- Keeps multi-responder degraded-history cases skipped to avoid ambiguous dispatch.
- Adds regression coverage for degraded planning history with one versus multiple visible responders.

## Test Plan
- [ ] `uv run pytest tests/test_agent_response_logic.py -x -n 0 --no-cov -v`
- [ ] `uv run pytest`

## Summary by Sourcery

Allow an agent that is the sole visible responder in a thread to reply even when planning thread history is degraded, while keeping multi-responder degraded cases skipped.

Bug Fixes:
- Ensure degraded planning history does not suppress replies when there is exactly one visible responder in the room.

Tests:
- Add regression test covering degraded planning history behavior for single versus multiple visible responders in a thread.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined bot response decision-making when thread history is unavailable or degraded. Single visible responder now correctly proceeds with replies in these conditions, while still appropriately skipping when multiple responders are present.

* **Tests**
  * Added comprehensive test coverage for response behavior in thread history degradation scenarios, ensuring proper handling across different responder configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1068?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->