### PR TITLE
Fix config generation after API saves

### DIFF
--- a/src/mindroom/api/config_lifecycle.py
+++ b/src/mindroom/api/config_lifecycle.py
@@ -135,19 +135,18 @@ def _source_fingerprint(source: bytes | str) -> str:
     return hashlib.sha256(source_bytes).hexdigest()
 
 
-def _config_source_fingerprint(runtime_paths: constants.RuntimePaths) -> str:
-    """Return the raw source identity for the active config file."""
-    return _source_fingerprint(runtime_paths.config_path.read_bytes())
-
-
 def _load_config_result(
     runtime_paths: constants.RuntimePaths,
 ) -> tuple[ConfigLoadResult, dict[str, Any] | None, Config | None, str | None]:
     """Load and validate one config file without mutating shared app state."""
     source_fingerprint: str | None = None
     try:
-        source_fingerprint = _config_source_fingerprint(runtime_paths)
-        runtime_config = load_runtime_config_model(
+        source_bytes = runtime_paths.config_path.read_bytes()
+        source_fingerprint = _source_fingerprint(source_bytes)
+        source_text = source_bytes.decode("utf-8")
+        data = yaml.safe_load(source_text) or {}
+        runtime_config = Config.validate_with_runtime(
+            data,
             runtime_paths,
             tolerate_plugin_load_errors=True,
         )
@@ -174,6 +173,8 @@ def _load_config_result(
             source_fingerprint,
         )
     else:
+        logger.info("loaded_agent_configuration", path=str(runtime_paths.config_path))
+        logger.info("loaded_agent_configuration_count", agent_count=len(runtime_config.agents))
         logger.info("Loaded API config", config_path=str(runtime_paths.config_path))
         return ConfigLoadResult(success=True), validated_payload, runtime_config, source_fingerprint
 

--- a/src/mindroom/api/config_lifecycle.py
+++ b/src/mindroom/api/config_lifecycle.py
@@ -607,8 +607,15 @@ def load_config_into_app(runtime_paths: constants.RuntimePaths, api_app: FastAPI
                 active_config_path=str(current.runtime_paths.config_path),
             )
             return False
+        same_successful_config = (
+            result.success
+            and current.config_load_result is not None
+            and current.config_load_result.success
+            and validated_payload == current.config_data
+        )
         current_state.snapshot = _published_snapshot(
             current,
+            increment_generation=not same_successful_config,
             config_data=validated_payload if validated_payload is not None else current.config_data,
             runtime_config=runtime_config if runtime_config is not None else current.runtime_config,
             config_load_result=result,

--- a/src/mindroom/api/config_lifecycle.py
+++ b/src/mindroom/api/config_lifecycle.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import tempfile
 import threading
 import weakref
@@ -63,6 +64,7 @@ class ApiSnapshot:
     config_data: dict[str, Any]
     runtime_config: Config | None = None
     config_load_result: ConfigLoadResult | None = None
+    source_fingerprint: str | None = None
     auth_state: Any | None = None
 
 
@@ -127,11 +129,24 @@ def _config_error_detail(
     ]
 
 
+def _source_fingerprint(source: bytes | str) -> str:
+    """Return the stable identity used for raw config stale-write protection."""
+    source_bytes = source.encode("utf-8") if isinstance(source, str) else source
+    return hashlib.sha256(source_bytes).hexdigest()
+
+
+def _config_source_fingerprint(runtime_paths: constants.RuntimePaths) -> str:
+    """Return the raw source identity for the active config file."""
+    return _source_fingerprint(runtime_paths.config_path.read_bytes())
+
+
 def _load_config_result(
     runtime_paths: constants.RuntimePaths,
-) -> tuple[ConfigLoadResult, dict[str, Any] | None, Config | None]:
+) -> tuple[ConfigLoadResult, dict[str, Any] | None, Config | None, str | None]:
     """Load and validate one config file without mutating shared app state."""
+    source_fingerprint: str | None = None
     try:
+        source_fingerprint = _config_source_fingerprint(runtime_paths)
         runtime_config = load_runtime_config_model(
             runtime_paths,
             tolerate_plugin_load_errors=True,
@@ -144,17 +159,23 @@ def _load_config_result(
             config_path=str(runtime_paths.config_path),
             errors=detail,
         )
-        return ConfigLoadResult(success=False, error_status_code=422, error_detail=detail), None, None
+        return (
+            ConfigLoadResult(success=False, error_status_code=422, error_detail=detail),
+            None,
+            None,
+            source_fingerprint,
+        )
     except Exception:
         logger.exception("Failed to load API config", config_path=str(runtime_paths.config_path))
         return (
             ConfigLoadResult(success=False, error_status_code=500, error_detail="Failed to load configuration"),
             None,
             None,
+            source_fingerprint,
         )
     else:
         logger.info("Loaded API config", config_path=str(runtime_paths.config_path))
-        return ConfigLoadResult(success=True), validated_payload, runtime_config
+        return ConfigLoadResult(success=True), validated_payload, runtime_config, source_fingerprint
 
 
 def _raise_for_config_load_result(result: ConfigLoadResult | None) -> None:
@@ -175,30 +196,31 @@ def _raise_missing_loaded_config() -> None:
 def _save_config_to_file(
     config: dict[str, Any],
     runtime_paths: constants.RuntimePaths,
-) -> None:
+) -> str:
     """Save config to YAML file with deterministic ordering."""
     config_path = runtime_paths.config_path
     tmp_path = config_path.with_suffix(config_path.suffix + ".tmp")
-    with tmp_path.open("w", encoding="utf-8") as f:
-        yaml.dump(
-            config,
-            f,
-            default_flow_style=False,
-            sort_keys=True,
-            allow_unicode=True,
-        )
+    source = yaml.dump(
+        config,
+        default_flow_style=False,
+        sort_keys=True,
+        allow_unicode=True,
+    )
+    tmp_path.write_text(source, encoding="utf-8")
     constants.safe_replace(tmp_path, config_path)
+    return _source_fingerprint(source)
 
 
 def _save_raw_config_source_to_file(
     source: str,
     runtime_paths: constants.RuntimePaths,
-) -> None:
+) -> str:
     """Save raw config source text to the active config path."""
     config_path = runtime_paths.config_path
     tmp_path = config_path.with_suffix(config_path.suffix + ".tmp")
     tmp_path.write_text(source, encoding="utf-8")
     constants.safe_replace(tmp_path, config_path)
+    return _source_fingerprint(source)
 
 
 def _persist_runtime_validated_config(
@@ -221,13 +243,14 @@ def _persist_runtime_validated_config(
                 continue
             locked_snapshots.append((state, snapshot))
 
-        _save_config_to_file(validated_payload, runtime_paths=runtime_paths)
+        source_fingerprint = _save_config_to_file(validated_payload, runtime_paths=runtime_paths)
         for state, snapshot in locked_snapshots:
             state.snapshot = _published_snapshot(
                 snapshot,
                 config_data=deepcopy(validated_payload),
                 runtime_config=runtime_config,
                 config_load_result=ConfigLoadResult(success=True),
+                source_fingerprint=source_fingerprint,
             )
 
 
@@ -307,6 +330,7 @@ def _published_snapshot(
     config_data: dict[str, Any] | None = None,
     runtime_config: Config | None | object = _UNSET,
     config_load_result: ConfigLoadResult | None | object = _UNSET,
+    source_fingerprint: str | None | object = _UNSET,
     auth_state: object = _UNSET,
 ) -> ApiSnapshot:
     """Return one new published snapshot with an incremented generation."""
@@ -320,6 +344,9 @@ def _published_snapshot(
         if config_load_result is _UNSET
         else cast("ConfigLoadResult | None", config_load_result)
     )
+    updated_source_fingerprint = (
+        snapshot.source_fingerprint if source_fingerprint is _UNSET else cast("str | None", source_fingerprint)
+    )
     updated_auth_state = snapshot.auth_state if auth_state is _UNSET else auth_state
     return replace(
         snapshot,
@@ -328,6 +355,7 @@ def _published_snapshot(
         config_data=updated_config_data,
         runtime_config=updated_runtime_config,
         config_load_result=updated_load_result,
+        source_fingerprint=updated_source_fingerprint,
         auth_state=updated_auth_state,
     )
 
@@ -390,12 +418,13 @@ def _commit_mutated_snapshot[T](
         if current.generation != expected_generation or current.runtime_paths != runtime_paths:
             _raise_for_config_load_result(current.config_load_result)
             raise _stale_snapshot_error()
-        _save_config_to_file(validated_payload, runtime_paths=runtime_paths)
+        source_fingerprint = _save_config_to_file(validated_payload, runtime_paths=runtime_paths)
         current_state.snapshot = _published_snapshot(
             current,
             config_data=validated_payload,
             runtime_config=validated_config,
             config_load_result=ConfigLoadResult(success=True),
+            source_fingerprint=source_fingerprint,
         )
         return result
 
@@ -446,12 +475,13 @@ def _commit_replaced_snapshot(
         current = current_state.snapshot
         if current.generation != expected_generation or current.runtime_paths != runtime_paths:
             raise _stale_snapshot_error()
-        _save_config_to_file(validated_payload, runtime_paths=runtime_paths)
+        source_fingerprint = _save_config_to_file(validated_payload, runtime_paths=runtime_paths)
         current_state.snapshot = _published_snapshot(
             current,
             config_data=validated_payload,
             runtime_config=validated_config,
             config_load_result=ConfigLoadResult(success=True),
+            source_fingerprint=source_fingerprint,
         )
         return current_state.snapshot.generation
 
@@ -472,12 +502,13 @@ def _commit_raw_replaced_snapshot(
         current = current_state.snapshot
         if current.generation != expected_generation or current.runtime_paths != runtime_paths:
             raise _stale_snapshot_error()
-        _save_raw_config_source_to_file(source, runtime_paths=runtime_paths)
+        source_fingerprint = _save_raw_config_source_to_file(source, runtime_paths=runtime_paths)
         current_state.snapshot = _published_snapshot(
             current,
             config_data=validated_payload,
             runtime_config=validated_config,
             config_load_result=ConfigLoadResult(success=True),
+            source_fingerprint=source_fingerprint,
         )
         return current_state.snapshot.generation
 
@@ -596,7 +627,7 @@ def load_config_into_app(runtime_paths: constants.RuntimePaths, api_app: FastAPI
     """Load config from disk into one API app's committed config cache."""
     initial_state = require_api_state(api_app)
     snapshot = initial_state.snapshot
-    result, validated_payload, runtime_config = _load_config_result(runtime_paths)
+    result, validated_payload, runtime_config, source_fingerprint = _load_config_result(runtime_paths)
     with initial_state.config_lock:
         current_state = require_api_state(api_app)
         current = current_state.snapshot
@@ -607,18 +638,14 @@ def load_config_into_app(runtime_paths: constants.RuntimePaths, api_app: FastAPI
                 active_config_path=str(current.runtime_paths.config_path),
             )
             return False
-        same_successful_config = (
-            result.success
-            and current.config_load_result is not None
-            and current.config_load_result.success
-            and validated_payload == current.config_data
-        )
+        same_source = source_fingerprint is not None and source_fingerprint == current.source_fingerprint
         current_state.snapshot = _published_snapshot(
             current,
-            increment_generation=not same_successful_config,
+            increment_generation=not same_source,
             config_data=validated_payload if validated_payload is not None else current.config_data,
             runtime_config=runtime_config if runtime_config is not None else current.runtime_config,
             config_load_result=result,
+            source_fingerprint=source_fingerprint,
         )
     return result.success
 

--- a/src/mindroom/api/main.py
+++ b/src/mindroom/api/main.py
@@ -306,6 +306,9 @@ def initialize_api_app(api_app: FastAPI, runtime_paths: constants.RuntimePaths) 
         config_load_result = (
             current_snapshot.config_load_result if current_snapshot.runtime_paths == runtime_paths else None
         )
+        source_fingerprint = (
+            current_snapshot.source_fingerprint if current_snapshot.runtime_paths == runtime_paths else None
+        )
         previous_state.snapshot = config_lifecycle._published_snapshot(
             current_snapshot,
             runtime_paths=runtime_paths,
@@ -313,6 +316,7 @@ def initialize_api_app(api_app: FastAPI, runtime_paths: constants.RuntimePaths) 
             runtime_config=runtime_config,
             auth_state=auth_state,
             config_load_result=config_load_result,
+            source_fingerprint=source_fingerprint,
         )
     config_lifecycle.register_api_app(api_app)
 

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -180,6 +180,7 @@ def test_config_lifecycle_published_snapshot_owns_optional_runtime_fields(tmp_pa
         config_data={"agents": {"old": {"display_name": "Old"}}},
         runtime_config=runtime_config,
         config_load_result=load_result,
+        source_fingerprint="old-source",
         auth_state=auth_state,
     )
 
@@ -190,6 +191,7 @@ def test_config_lifecycle_published_snapshot_owns_optional_runtime_fields(tmp_pa
     assert preserved.config_data is snapshot.config_data
     assert preserved.runtime_config is runtime_config
     assert preserved.config_load_result is load_result
+    assert preserved.source_fingerprint == "old-source"
     assert preserved.auth_state is auth_state
 
     cleared = config_lifecycle._published_snapshot(
@@ -198,6 +200,7 @@ def test_config_lifecycle_published_snapshot_owns_optional_runtime_fields(tmp_pa
         config_data={},
         runtime_config=None,
         config_load_result=None,
+        source_fingerprint=None,
         auth_state=None,
     )
 
@@ -206,6 +209,7 @@ def test_config_lifecycle_published_snapshot_owns_optional_runtime_fields(tmp_pa
     assert cleared.config_data == {}
     assert cleared.runtime_config is None
     assert cleared.config_load_result is None
+    assert cleared.source_fingerprint is None
     assert cleared.auth_state is None
 
 
@@ -570,10 +574,12 @@ def test_initialize_api_app_clears_config_cache_when_config_path_changes(tmp_pat
     main.initialize_api_app(fresh_app, first_runtime)
     config_lifecycle.load_config_into_app(first_runtime, fresh_app)
     assert set(main._app_context(fresh_app).config_data["agents"]) == {"first"}
+    assert main._app_context(fresh_app).source_fingerprint is not None
 
     main.initialize_api_app(fresh_app, second_runtime)
 
     assert main._app_context(fresh_app).config_data == {}
+    assert main._app_context(fresh_app).source_fingerprint is None
 
 
 def test_initialize_api_app_clears_config_cache_when_runtime_changes(tmp_path: Path) -> None:
@@ -595,10 +601,12 @@ def test_initialize_api_app_clears_config_cache_when_runtime_changes(tmp_path: P
     main.initialize_api_app(fresh_app, runtime_one)
     config_lifecycle.load_config_into_app(runtime_one, fresh_app)
     assert set(main._app_context(fresh_app).config_data["agents"]) == {"first"}
+    assert main._app_context(fresh_app).source_fingerprint is not None
 
     main.initialize_api_app(fresh_app, runtime_two)
 
     assert main._app_context(fresh_app).config_data == {}
+    assert main._app_context(fresh_app).source_fingerprint is None
 
 
 def test_load_config_into_app_discards_stale_results_after_runtime_swap(tmp_path: Path) -> None:
@@ -612,6 +620,8 @@ def test_load_config_into_app_discards_stale_results_after_runtime_swap(tmp_path
         config_path=tmp_path / "second.yaml",
         process_env={},
     )
+    first_runtime.config_path.write_text("agents: {}\n", encoding="utf-8")
+    second_runtime.config_path.write_text("agents: {}\n", encoding="utf-8")
     started = threading.Event()
     allow_finish = threading.Event()
     original_loader = config_lifecycle.load_runtime_config_model
@@ -2703,6 +2713,36 @@ def test_config_reload_after_api_save_keeps_returned_generation(test_client: Tes
         json=_authored_config_payload("second"),
     )
     assert second_save_response.status_code == 200
+    assert int(second_save_response.headers[config_lifecycle.CONFIG_GENERATION_HEADER]) > first_save_generation
+
+
+def test_external_raw_config_reload_advances_generation_for_same_authored_config(
+    test_client: TestClient,
+    temp_config_file: Path,
+) -> None:
+    """External raw-only edits should still make older raw editor drafts stale."""
+    initial_raw_response = test_client.get("/api/config/raw")
+    assert initial_raw_response.status_code == 200
+    initial_generation = int(initial_raw_response.headers[config_lifecycle.CONFIG_GENERATION_HEADER])
+    initial_source = initial_raw_response.json()["source"]
+
+    externally_edited_source = f"# external operator note\n{initial_source}"
+    temp_config_file.write_text(externally_edited_source, encoding="utf-8")
+
+    assert config_lifecycle.load_config_into_app(main._app_runtime_paths(test_client.app), main.app) is True
+
+    reloaded_raw_response = test_client.get("/api/config/raw")
+    assert reloaded_raw_response.status_code == 200
+    assert int(reloaded_raw_response.headers[config_lifecycle.CONFIG_GENERATION_HEADER]) > initial_generation
+    assert reloaded_raw_response.json() == {"source": externally_edited_source}
+
+    stale_save_response = test_client.put(
+        "/api/config/raw",
+        headers={config_lifecycle.CONFIG_GENERATION_HEADER: str(initial_generation)},
+        json={"source": initial_source},
+    )
+    assert stale_save_response.status_code == 409
+    assert temp_config_file.read_text(encoding="utf-8") == externally_edited_source
 
 
 def test_first_party_config_writers_advance_generation_before_watcher_reload(

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -2677,6 +2677,34 @@ def test_config_generation_headers_protect_full_and_raw_save_endpoints(
     assert stale_raw_save_response.status_code == 409
 
 
+def test_config_reload_after_api_save_keeps_returned_generation(test_client: TestClient) -> None:
+    """The file watcher should not make an API save response immediately stale."""
+    initial_load = test_client.post("/api/config/load")
+    assert initial_load.status_code == 200
+    initial_generation = int(initial_load.headers[config_lifecycle.CONFIG_GENERATION_HEADER])
+
+    first_save_response = test_client.put(
+        "/api/config/save",
+        headers={config_lifecycle.CONFIG_GENERATION_HEADER: str(initial_generation)},
+        json=_authored_config_payload("first"),
+    )
+    assert first_save_response.status_code == 200
+    first_save_generation = int(first_save_response.headers[config_lifecycle.CONFIG_GENERATION_HEADER])
+
+    assert config_lifecycle.load_config_into_app(main._app_runtime_paths(test_client.app), main.app) is True
+
+    reloaded_config_response = test_client.post("/api/config/load")
+    assert reloaded_config_response.status_code == 200
+    assert int(reloaded_config_response.headers[config_lifecycle.CONFIG_GENERATION_HEADER]) == first_save_generation
+
+    second_save_response = test_client.put(
+        "/api/config/save",
+        headers={config_lifecycle.CONFIG_GENERATION_HEADER: str(first_save_generation)},
+        json=_authored_config_payload("second"),
+    )
+    assert second_save_response.status_code == 200
+
+
 def test_first_party_config_writers_advance_generation_before_watcher_reload(
     test_client: TestClient,
 ) -> None:

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -621,44 +621,41 @@ def test_load_config_into_app_discards_stale_results_after_runtime_swap(tmp_path
         process_env={},
     )
     first_runtime.config_path.write_text("agents: {}\n", encoding="utf-8")
-    second_runtime.config_path.write_text("agents: {}\n", encoding="utf-8")
+    second_runtime.config_path.write_text(
+        yaml.safe_dump(
+            {
+                "models": {"default": {"provider": "openai", "id": "gpt-5.4"}},
+                "router": {"model": "default"},
+                "agents": {"second": {"display_name": "Second", "role": "valid", "rooms": []}},
+            },
+        ),
+        encoding="utf-8",
+    )
     started = threading.Event()
     allow_finish = threading.Event()
-    original_loader = config_lifecycle.load_runtime_config_model
+    original_load_result = config_lifecycle._load_config_result
 
-    def _fake_loader(
+    def _fake_load_result(
         runtime_paths: constants.RuntimePaths,
-        *,
-        tolerate_plugin_load_errors: bool = False,
-    ) -> Config:
+    ) -> tuple[config_lifecycle.ConfigLoadResult, dict[str, Any] | None, Config | None, str | None]:
         if runtime_paths == first_runtime:
             started.set()
             allow_finish.wait(timeout=1)
-            message = "invalid old config"
-            raise yaml.YAMLError(message)
-        if runtime_paths == second_runtime:
-            return Config.validate_with_runtime(
-                {
-                    "models": {"default": {"provider": "openai", "id": "gpt-5.4"}},
-                    "router": {"model": "default"},
-                    "agents": {
-                        "second": {
-                            "display_name": "Second",
-                            "role": "valid",
-                            "rooms": [],
-                        },
-                    },
-                },
-                second_runtime,
+            return (
+                config_lifecycle.ConfigLoadResult(
+                    success=False,
+                    error_status_code=422,
+                    error_detail="invalid old config",
+                ),
+                None,
+                None,
+                "stale-old-source",
             )
-        return original_loader(
-            runtime_paths,
-            tolerate_plugin_load_errors=tolerate_plugin_load_errors,
-        )
+        return original_load_result(runtime_paths)
 
-    with patch.object(config_lifecycle, "load_runtime_config_model", side_effect=_fake_loader):
-        main.initialize_api_app(fresh_app, first_runtime)
+    main.initialize_api_app(fresh_app, first_runtime)
 
+    with patch.object(config_lifecycle, "_load_config_result", side_effect=_fake_load_result):
         stale_thread = threading.Thread(
             target=config_lifecycle.load_config_into_app,
             args=(first_runtime, fresh_app),
@@ -2743,6 +2740,53 @@ def test_external_raw_config_reload_advances_generation_for_same_authored_config
     )
     assert stale_save_response.status_code == 409
     assert temp_config_file.read_text(encoding="utf-8") == externally_edited_source
+
+
+def test_config_reload_uses_source_fingerprint_from_validated_source(
+    test_client: TestClient,
+    temp_config_file: Path,
+) -> None:
+    """A file edit during reload should not publish new config under the old source identity."""
+    initial_response = test_client.post("/api/config/load")
+    assert initial_response.status_code == 200
+    initial_generation = int(initial_response.headers[config_lifecycle.CONFIG_GENERATION_HEADER])
+    initial_agents = initial_response.json()["agents"]
+
+    interleaved_source = yaml.safe_dump(_authored_config_payload("interleaved"), sort_keys=True)
+    original_read_bytes = Path.read_bytes
+    mutated = False
+
+    def _read_then_mutate(path: Path) -> bytes:
+        nonlocal mutated
+        source = original_read_bytes(path)
+        if path == temp_config_file and not mutated:
+            mutated = True
+            temp_config_file.write_text(interleaved_source, encoding="utf-8")
+        return source
+
+    with patch.object(Path, "read_bytes", autospec=True, side_effect=_read_then_mutate):
+        assert config_lifecycle.load_config_into_app(main._app_runtime_paths(test_client.app), main.app) is True
+
+    reloaded_response = test_client.post("/api/config/load")
+    assert reloaded_response.status_code == 200
+    assert reloaded_response.json()["agents"] == initial_agents
+    assert int(reloaded_response.headers[config_lifecycle.CONFIG_GENERATION_HEADER]) == initial_generation
+
+    assert config_lifecycle.load_config_into_app(main._app_runtime_paths(test_client.app), main.app) is True
+    interleaved_response = test_client.post("/api/config/load")
+    assert interleaved_response.status_code == 200
+    assert list(interleaved_response.json()["agents"]) == ["interleaved"]
+    assert int(interleaved_response.headers[config_lifecycle.CONFIG_GENERATION_HEADER]) > initial_generation
+
+    stale_save_response = test_client.put(
+        "/api/config/save",
+        headers={config_lifecycle.CONFIG_GENERATION_HEADER: str(initial_generation)},
+        json=_authored_config_payload("stale"),
+    )
+    assert stale_save_response.status_code == 409
+    assert yaml.safe_load(temp_config_file.read_text(encoding="utf-8"))["agents"] == {
+        "interleaved": {"display_name": "Interleaved", "role": "valid", "rooms": []},
+    }
 
 
 def test_first_party_config_writers_advance_generation_before_watcher_reload(


### PR DESCRIPTION
## Summary
- Prevent identical successful config reloads from advancing the API config generation.
- Add a regression for API save, watcher-style reload, then another save with the returned generation.

## Test Plan
- uv run pytest tests/api/test_api.py::test_config_generation_headers_protect_full_and_raw_save_endpoints tests/api/test_api.py::test_config_reload_after_api_save_keeps_returned_generation tests/api/test_api.py::test_first_party_config_writers_advance_generation_before_watcher_reload tests/api/test_api.py::test_load_config_into_app_discards_stale_results_after_runtime_swap tests/api/test_api.py::test_load_config_into_app_ignores_runtime_mismatches_after_api_runtime_swap -q
- git diff --check
- commit hooks

## Summary by Sourcery

Adjust config reload behavior to avoid advancing the config generation on identical successful reloads and add regression coverage around API save and watcher-driven reload interactions.

Bug Fixes:
- Prevent config generation from advancing when a watcher-triggered reload successfully reapplies an unchanged configuration, so API save responses are not made immediately stale.

Tests:
- Add regression test ensuring config reload after an API save preserves the returned generation and allows a subsequent save using that generation.