### PR TITLE
Restart sync loop after unexpected clean return

### DIFF
--- a/src/mindroom/orchestration/runtime.py
+++ b/src/mindroom/orchestration/runtime.py
@@ -534,7 +534,15 @@ async def sync_forever_with_restart(bot: AgentBot | TeamBot, max_retries: int = 
                 await bot.prepare_for_sync_shutdown()
                 await iteration.cancel()
 
-        if not bot.running or (max_retries >= 0 and retry_count >= max_retries):
+        if not bot.running:
+            break
+        if max_retries >= 0 and retry_count >= max_retries:
+            logger.error(
+                "sync_loop_retries_exhausted",
+                agent=bot.agent_name,
+                retry_count=retry_count,
+                max_retries=max_retries,
+            )
             break
 
         wait_time = retry_delay_seconds(

--- a/src/mindroom/orchestration/runtime.py
+++ b/src/mindroom/orchestration/runtime.py
@@ -510,8 +510,15 @@ async def sync_forever_with_restart(bot: AgentBot | TeamBot, max_retries: int = 
             logger.info("starting_sync_loop", agent=bot.agent_name)
             iteration = _SyncIteration.start(bot)
             await iteration.wait()
-            # sync_forever returned normally, so the bot was stopped intentionally.
-            break
+            if not bot.running:
+                # sync_forever returned normally after an intentional stop.
+                break
+            retry_count += 1
+            logger.warning(
+                "sync_loop_returned_while_bot_running",
+                agent=bot.agent_name,
+                retry_count=retry_count,
+            )
         except asyncio.CancelledError:
             # Task cancellation is part of normal shutdown.
             logger.info("sync_task_cancelled", agent=bot.agent_name)

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -1251,6 +1251,32 @@ async def test_restart_resets_monotonic_clock(monkeypatch: pytest.MonkeyPatch) -
     assert bot.sync_calls == 2
 
 
+@pytest.mark.asyncio
+async def test_clean_sync_return_while_running_restarts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A clean sync_forever return is only a shutdown if the bot stopped.
+
+    nio can return from sync_forever without raising even though the bot is
+    still marked running. The supervisor must not treat that as intentional
+    shutdown, otherwise the entity stays present but stops syncing forever.
+    """
+    bot = _FakeBot()
+
+    async def return_once_then_stop() -> None:
+        bot.sync_calls += 1
+        if bot.sync_calls == 1:
+            return
+        bot.running = False
+
+    bot.sync_forever = return_once_then_stop
+
+    monkeypatch.setattr(runtime_helpers, "retry_delay_seconds", lambda *_args, **_kwargs: 0.0)
+
+    await sync_forever_with_restart(bot, max_retries=3)
+
+    assert bot.sync_calls == 2
+    assert bot.prepare_for_sync_shutdown_calls == 2
+
+
 # ---------------------------------------------------------------------------
 # R4 Fix 1: Immediate sync_forever() failure must retry, not exit cleanly
 # ---------------------------------------------------------------------------

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -1269,12 +1269,46 @@ async def test_clean_sync_return_while_running_restarts(monkeypatch: pytest.Monk
 
     bot.sync_forever = return_once_then_stop
 
-    monkeypatch.setattr(runtime_helpers, "retry_delay_seconds", lambda *_args, **_kwargs: 0.0)
+    retry_attempts: list[int] = []
+
+    def fake_retry_delay(attempt: int, **_kwargs: float) -> float:
+        retry_attempts.append(attempt)
+        return 0.0
+
+    monkeypatch.setattr(runtime_helpers, "retry_delay_seconds", fake_retry_delay)
 
     await sync_forever_with_restart(bot, max_retries=3)
 
     assert bot.sync_calls == 2
     assert bot.prepare_for_sync_shutdown_calls == 2
+    assert retry_attempts == [1]
+
+
+@pytest.mark.asyncio
+async def test_running_bot_logs_when_sync_retries_exhausted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Retry exhaustion should be visible if the bot is still logically running."""
+    bot = _FakeBot()
+
+    async def clean_return() -> None:
+        bot.sync_calls += 1
+
+    bot.sync_forever = clean_return
+    logger = MagicMock()
+
+    monkeypatch.setattr(runtime_helpers, "logger", logger)
+    monkeypatch.setattr(runtime_helpers, "retry_delay_seconds", lambda *_args, **_kwargs: 0.0)
+
+    await sync_forever_with_restart(bot, max_retries=2)
+
+    assert bot.running is True
+    assert bot.sync_calls == 2
+    assert bot.prepare_for_sync_shutdown_calls == 2
+    logger.error.assert_called_once_with(
+        "sync_loop_retries_exhausted",
+        agent="test_agent",
+        retry_count=2,
+        max_retries=2,
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Treat a clean Matrix sync loop return as intentional only after the bot has stopped
- Restart the sync loop when it returns while the bot is still marked running
- Add regression coverage for the stale running-but-not-syncing state

## Tests
- uv run pytest tests/test_sync_task_cancellation.py -q
- uv run ruff check src/mindroom/orchestration/runtime.py tests/test_sync_task_cancellation.py
- pre-commit hooks during commit

## Summary by Sourcery

Handle unexpected clean sync loop returns while the bot is still marked as running and add regression coverage for this scenario.

Bug Fixes:
- Prevent bots from remaining present but permanently stopping sync when the sync loop returns cleanly while still marked running.

Tests:
- Add regression test ensuring the sync loop restarts when sync_forever returns cleanly while the bot is still marked running.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sync restart behavior to correctly handle cases where the sync operation returns while the bot is still running.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1073?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->