### PR TITLE
Make chat interface access prominent

### DIFF
--- a/saas-platform/platform-frontend/src/app/dashboard/instance/page.tsx
+++ b/saas-platform/platform-frontend/src/app/dashboard/instance/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { Loader2, RefreshCw, CheckCircle, AlertCircle, Clock, Play, Pause, ExternalLink, Server, Database, Globe } from 'lucide-react'
+import { Loader2, RefreshCw, CheckCircle, AlertCircle, Clock, Play, Pause, ExternalLink, Server, MessageCircle, Globe } from 'lucide-react'
 import { listInstances, startInstance, stopInstance, restartInstance as apiRestartInstance } from '@/lib/api'
 import { cache } from '@/lib/cache'
 import { buildCinnyLoginUrl } from '@/lib/cinny'
@@ -400,9 +400,9 @@ export default function InstancePage() {
             {instance.matrix_server_url && (
               <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 p-5 bg-gray-50 dark:bg-gray-700 rounded-2xl">
                 <div className="flex items-center gap-3">
-                  <Database className="w-5 h-5 text-gray-600 dark:text-gray-400" />
+                  <MessageCircle className="w-5 h-5 text-gray-600 dark:text-gray-400" />
                   <div>
-                    <p className="font-medium dark:text-white">Matrix Server</p>
+                    <p className="font-medium dark:text-white">Chat Interface</p>
                     <p className="text-sm text-gray-600 dark:text-gray-400">{instance.matrix_server_url}</p>
                   </div>
                 </div>
@@ -412,7 +412,7 @@ export default function InstancePage() {
                   rel="noopener noreferrer"
                   className="flex items-center justify-center gap-2 px-4 py-2 border border-gray-300 dark:border-gray-600 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors whitespace-nowrap"
                 >
-                  Open Chat
+                  Open Chat Interface
                   <ExternalLink className="w-4 h-4" />
                 </a>
               </div>

--- a/saas-platform/platform-frontend/src/components/dashboard/InstanceCard.tsx
+++ b/saas-platform/platform-frontend/src/components/dashboard/InstanceCard.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink, CheckCircle, AlertCircle, Loader2, XCircle, Rocket, Copy } from 'lucide-react'
+import { ExternalLink, CheckCircle, AlertCircle, Loader2, XCircle, Rocket, Copy, MessageCircle } from 'lucide-react'
 import Link from 'next/link'
 import { useState } from 'react'
 import type { Instance } from '@/hooks/useInstance'
@@ -208,7 +208,6 @@ export function InstanceCard({
 
   const frontendHost = getHostname(instance.frontend_url)
   const backendHost = getHostname(instance.backend_url)
-  const matrixHost = getHostname(instance.matrix_server_url)
   const cinnyLoginUrl = instance.matrix_server_url
     ? buildCinnyLoginUrl(instance.matrix_server_url)
     : null
@@ -319,22 +318,22 @@ export function InstanceCard({
           <span className="font-medium capitalize dark:text-gray-200">{instance.tier || 'Free'}</span>
         </div>
 
-        {/* Matrix Server */}
+        {/* Chat Interface */}
         {instance.matrix_server_url && (
           <div className="flex items-center justify-between">
-            <span className="text-gray-600 dark:text-gray-400">Matrix Server</span>
+            <span className="text-gray-600 dark:text-gray-400">Chat Interface</span>
             <div className="flex items-center gap-2">
               <Link
                 href={cinnyLoginUrl || instance.matrix_server_url}
                 target="_blank"
                 className="flex items-center gap-1 text-purple-600 hover:text-purple-700 dark:text-purple-400 dark:hover:text-purple-300 font-medium"
               >
-                {matrixHost || 'Connect'}
+                Open chat
                 <ExternalLink className="w-3 h-3" />
               </Link>
               <button
                 onClick={() => copyToClipboard(instance.matrix_server_url!)}
-                title="Copy Matrix URL"
+                title="Copy chat server URL"
                 className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
               >
                 <Copy className="w-4 h-4" />
@@ -361,15 +360,28 @@ export function InstanceCard({
       {/* Action Buttons */}
       {instance.status === 'running' && instance.frontend_url && (
         <div className="mt-6 pt-6 border-t dark:border-gray-700">
-          <Link
-            href={instance.frontend_url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="w-full inline-flex items-center justify-center gap-2 px-6 py-3 bg-gradient-to-r from-orange-500 to-orange-600 text-white rounded-xl font-semibold hover:shadow-lg hover:scale-105 transition-all"
-          >
-            <ExternalLink className="w-4 h-4" />
-            Open MindRoom
-          </Link>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Link
+              href={instance.frontend_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center justify-center gap-2 px-6 py-3 bg-gradient-to-r from-orange-500 to-orange-600 text-white rounded-xl font-semibold hover:shadow-lg hover:scale-105 transition-all"
+            >
+              <ExternalLink className="w-4 h-4" />
+              Open MindRoom
+            </Link>
+            {cinnyLoginUrl && (
+              <Link
+                href={cinnyLoginUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center gap-2 px-6 py-3 border border-purple-200 bg-purple-50 text-purple-700 rounded-xl font-semibold hover:bg-purple-100 dark:border-purple-800/50 dark:bg-purple-900/20 dark:text-purple-200 dark:hover:bg-purple-900/30 transition-colors"
+              >
+                <MessageCircle className="w-4 h-4" />
+                Open Chat Interface
+              </Link>
+            )}
+          </div>
         </div>
       )}
     </Card>

--- a/saas-platform/platform-frontend/src/components/dashboard/__tests__/InstanceCard.simple.test.tsx
+++ b/saas-platform/platform-frontend/src/components/dashboard/__tests__/InstanceCard.simple.test.tsx
@@ -103,7 +103,8 @@ describe('InstanceCard - Simplified Tests', () => {
       // Check URLs are displayed (use getAllByText since domain appears multiple times)
       expect(screen.getAllByText('customer.mindroom.chat')).toHaveLength(2) // Domain and Frontend
       expect(screen.getByText('customer.api.mindroom.chat')).toBeInTheDocument()
-      expect(screen.getByText('customer.matrix.mindroom.chat')).toBeInTheDocument()
+      expect(screen.getByText('Chat Interface')).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: /^Open chat$/i })).toBeInTheDocument()
 
       // Check tier (it's showing as 'pro' not 'Pro' due to capitalize class)
       expect(screen.getByText(/pro/i)).toBeInTheDocument()
@@ -138,6 +139,17 @@ describe('InstanceCard - Simplified Tests', () => {
       expect(openButton).toHaveAttribute('href', 'https://customer.mindroom.chat')
     })
 
+    it('should display Open Chat Interface button for running instances', () => {
+      render(<InstanceCard instance={mockInstance} />)
+
+      const openButton = screen.getByRole('link', { name: /Open Chat Interface/i })
+      expect(openButton).toBeInTheDocument()
+      expect(openButton).toHaveAttribute(
+        'href',
+        'https://chat.mindroom.chat/login/https%3A%2F%2Fcustomer.matrix.mindroom.chat/'
+      )
+    })
+
     it('should not display Open MindRoom button for stopped instances', () => {
       const stoppedInstance = { ...mockInstance, status: 'stopped' as Instance['status'] }
       render(<InstanceCard instance={stoppedInstance} />)
@@ -163,6 +175,7 @@ describe('InstanceCard - Simplified Tests', () => {
       expect(screen.queryByText('Domain')).not.toBeInTheDocument()
       expect(screen.queryByText('Frontend')).not.toBeInTheDocument()
       expect(screen.queryByText('API')).not.toBeInTheDocument()
+      expect(screen.queryByText('Chat Interface')).not.toBeInTheDocument()
     })
 
     it('should show default tier when not specified', () => {

--- a/saas-platform/platform-frontend/src/components/dashboard/__tests__/InstanceCard.test.tsx
+++ b/saas-platform/platform-frontend/src/components/dashboard/__tests__/InstanceCard.test.tsx
@@ -212,16 +212,17 @@ describe('InstanceCard', () => {
       expect(screen.getByText('Running')).toBeInTheDocument()
       expect(screen.getAllByText('customer.mindroom.chat').length).toBeGreaterThan(0)
       expect(screen.getByText('customer.api.mindroom.chat')).toBeInTheDocument()
-      expect(screen.getByText('customer.matrix.mindroom.chat')).toBeInTheDocument()
+      expect(screen.getByText('Chat Interface')).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: /^Open chat$/i })).toBeInTheDocument()
       expect(screen.getByText('pro')).toBeInTheDocument()
       expect(screen.getByText('#1')).toBeInTheDocument()
     })
 
-    it('should link Matrix access through Cinny with the homeserver prefilled', () => {
+    it('should link chat access through Cinny with the homeserver prefilled', () => {
       render(<InstanceCard instance={mockInstance} />)
 
-      const matrixLink = screen.getByRole('link', { name: /customer.matrix.mindroom.chat/i })
-      expect(matrixLink).toHaveAttribute(
+      const chatLink = screen.getByRole('link', { name: /Open Chat Interface/i })
+      expect(chatLink).toHaveAttribute(
         'href',
         'https://chat.mindroom.chat/login/https%3A%2F%2Fcustomer.matrix.mindroom.chat/'
       )
@@ -303,11 +304,24 @@ describe('InstanceCard', () => {
       expect(openButton).toHaveAttribute('target', '_blank')
     })
 
+    it('should show Open Chat Interface button for running instances', () => {
+      render(<InstanceCard instance={mockInstance} />)
+
+      const openButton = screen.getByRole('link', { name: /Open Chat Interface/i })
+      expect(openButton).toBeInTheDocument()
+      expect(openButton).toHaveAttribute(
+        'href',
+        'https://chat.mindroom.chat/login/https%3A%2F%2Fcustomer.matrix.mindroom.chat/'
+      )
+      expect(openButton).toHaveAttribute('target', '_blank')
+    })
+
     it('should not show Open MindRoom button for non-running instances', () => {
       const stoppedInstance = { ...mockInstance, status: 'stopped' as Instance['status'] }
       render(<InstanceCard instance={stoppedInstance} />)
 
       expect(screen.queryByRole('link', { name: /Open MindRoom/i })).not.toBeInTheDocument()
+      expect(screen.queryByRole('link', { name: /Open Chat Interface/i })).not.toBeInTheDocument()
     })
   })
 
@@ -351,10 +365,10 @@ describe('InstanceCard', () => {
       expect(mockClipboardWriteText).toHaveBeenCalledWith('https://customer.api.mindroom.chat')
     })
 
-    it('should copy Matrix URL to clipboard', async () => {
+    it('should copy chat server URL to clipboard', async () => {
       render(<InstanceCard instance={mockInstance} />)
 
-      const copyButton = screen.getByTitle('Copy Matrix URL')
+      const copyButton = screen.getByTitle('Copy chat server URL')
       await userEvent.click(copyButton)
 
       expect(mockClipboardWriteText).toHaveBeenCalledWith('https://customer.matrix.mindroom.chat')
@@ -394,7 +408,7 @@ describe('InstanceCard', () => {
       expect(screen.queryByText('Domain')).not.toBeInTheDocument()
       expect(screen.queryByText('Frontend')).not.toBeInTheDocument()
       expect(screen.queryByText('API')).not.toBeInTheDocument()
-      expect(screen.queryByText('Matrix Server')).not.toBeInTheDocument()
+      expect(screen.queryByText('Chat Interface')).not.toBeInTheDocument()
     })
 
     it('should handle unknown status gracefully', () => {


### PR DESCRIPTION
## Summary
- Add a prominent dashboard action to open the hosted chat interface through Cinny
- Rename user-facing Matrix access copy to Chat Interface
- Update dashboard card tests for the new chat link behavior

## Tests
- bun run test -- src/components/dashboard/__tests__/InstanceCard.test.tsx src/components/dashboard/__tests__/InstanceCard.simple.test.tsx --runInBand
- bun run build

## Summary by Sourcery

Make the hosted chat interface more prominent and reword Matrix-related UI copy to "Chat Interface" across the dashboard instance views.

New Features:
- Add a dedicated dashboard action button to open the Cinny-hosted chat interface for running instances.

Enhancements:
- Update dashboard instance cards and instance detail page to label Matrix access as "Chat Interface" and adjust link labels and icons for clearer chat access.

Tests:
- Extend and update InstanceCard dashboard tests to cover the new chat button, revised labels, and clipboard behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Renamed "Matrix Server" references to "Chat Interface" throughout the instance dashboard for improved terminology clarity.
  * Updated interface icons and refined action button labels for chat access.
  * Enhanced responsive grid layout for action buttons in instance card display.

* **Tests**
  * Updated test coverage to align with UI terminology changes and responsive layout adjustments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1076?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->