### PR TITLE
Add config path option to mindroom run

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -120,6 +120,9 @@ Start MindRoom with your configuration.
 │                                          ERROR)                                        │
 │                                          [env var: LOG_LEVEL]                          │
 │                                          [default: INFO]                               │
+│ --config        -c              PATH     Use this config file path. Defaults storage   │
+│                                          beside the selected config unless             │
+│                                          --storage-path is set.                        │
 │ --storage-path  -s              PATH     Base directory for persistent MindRoom data   │
 │                                          (state, sessions, tracking)                   │
 │ --api               --no-api             Start the bundled dashboard/API server        │

--- a/skills/mindroom-docs/references/page__cli__index.md
+++ b/skills/mindroom-docs/references/page__cli__index.md
@@ -116,6 +116,9 @@ Start MindRoom with your configuration.
 │                                          ERROR)                                        │
 │                                          [env var: LOG_LEVEL]                          │
 │                                          [default: INFO]                               │
+│ --config        -c              PATH     Use this config file path. Defaults storage   │
+│                                          beside the selected config unless             │
+│                                          --storage-path is set.                        │
 │ --storage-path  -s              PATH     Base directory for persistent MindRoom data   │
 │                                          (state, sessions, tracking)                   │
 │ --api               --no-api             Start the bundled dashboard/API server        │

--- a/src/mindroom/cli/main.py
+++ b/src/mindroom/cli/main.py
@@ -88,6 +88,12 @@ def run(
         case_sensitive=False,
         envvar="LOG_LEVEL",
     ),
+    config_path: Path | None = typer.Option(  # noqa: B008
+        None,
+        "--config",
+        "-c",
+        help="Use this config file path. Defaults storage beside the selected config unless --storage-path is set.",
+    ),
     storage_path: Path | None = typer.Option(  # noqa: B008
         None,
         "--storage-path",
@@ -121,6 +127,7 @@ def run(
     asyncio.run(
         _run(
             log_level=log_level.upper(),
+            config_path=config_path,
             storage_path=storage_path,
             api=api,
             api_port=api_port,
@@ -155,6 +162,7 @@ def _load_active_config_or_exit(runtime_paths: RuntimePaths) -> Config:
 
 async def _run(
     log_level: str,
+    config_path: Path | None,
     storage_path: Path | None,
     *,
     api: bool,
@@ -164,7 +172,7 @@ async def _run(
     """Run the multi-agent system with friendly error handling."""
     from mindroom.startup_errors import PermanentStartupError  # noqa: PLC0415
 
-    runtime_paths = activate_cli_runtime(storage_path=storage_path)
+    runtime_paths = activate_cli_runtime(config_path, storage_path=storage_path)
     config = _load_active_config_or_exit(runtime_paths)
 
     # Check for missing API keys

--- a/src/mindroom/cli/main.py
+++ b/src/mindroom/cli/main.py
@@ -172,7 +172,7 @@ async def _run(
     """Run the multi-agent system with friendly error handling."""
     from mindroom.startup_errors import PermanentStartupError  # noqa: PLC0415
 
-    runtime_paths = activate_cli_runtime(config_path, storage_path=storage_path)
+    runtime_paths = activate_cli_runtime(path=config_path, storage_path=storage_path)
     config = _load_active_config_or_exit(runtime_paths)
 
     # Check for missing API keys

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -1484,6 +1484,8 @@ class TestRunApiFlags:
         result = runner.invoke(app, ["run", "--help"])
         assert result.exit_code == 0
         output = normalize_console_output(result.output)
+        assert "--config" in output
+        assert "-c" in output
         assert "--api" in output
         assert "--no-api" in output
         assert "--api-port" in output
@@ -1539,6 +1541,72 @@ class TestRunApiFlags:
         assert mock_main.call_args.kwargs["api_port"] == 9000
         assert mock_main.call_args.kwargs["api_host"] == "127.0.0.1"
 
+    def test_run_config_path_updates_runtime_paths(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Run should let an explicit config path own the implicit storage root."""
+        ambient_config = tmp_path / "ambient" / "config.yaml"
+        ambient_config.parent.mkdir()
+        ambient_config.write_text("agents: {}\nmodels: {}\n", encoding="utf-8")
+        config_dir = tmp_path / "selected"
+        cfg = config_dir / "config.yaml"
+        config_dir.mkdir()
+        cfg.write_text(
+            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
+            "agents:\n  a:\n    display_name: A\n    model: default\n"
+            "router:\n  model: default\n"
+            "matrix_space:\n  enabled: false\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("MINDROOM_CONFIG_PATH", str(ambient_config))
+        monkeypatch.delenv("MINDROOM_STORAGE_PATH", raising=False)
+
+        async def _fake_main(**kwargs: object) -> None:
+            runtime_paths = kwargs["runtime_paths"]
+            assert isinstance(runtime_paths, constants_module.RuntimePaths)
+            assert runtime_paths.config_path == cfg.resolve()
+            assert runtime_paths.storage_root == config_dir.resolve() / "mindroom_data"
+            assert runtime_paths.process_env["MINDROOM_CONFIG_PATH"] == str(cfg.resolve())
+            assert runtime_paths.process_env["MINDROOM_STORAGE_PATH"] == str(
+                config_dir.resolve() / "mindroom_data",
+            )
+
+        with patch("mindroom.orchestrator.main", AsyncMock(side_effect=_fake_main)) as mock_main:
+            result = runner.invoke(app, ["run", "--config", str(cfg)])
+
+        assert result.exit_code == 0
+        mock_main.assert_awaited_once()
+
+    def test_run_config_short_flag_updates_runtime_paths(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Run should expose `-c` as the short form for explicit config selection."""
+        config_dir = tmp_path / "selected"
+        cfg = config_dir / "config.yaml"
+        config_dir.mkdir()
+        cfg.write_text(
+            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
+            "agents:\n  a:\n    display_name: A\n    model: default\n"
+            "router:\n  model: default\n"
+            "matrix_space:\n  enabled: false\n",
+            encoding="utf-8",
+        )
+
+        async def _fake_main(**kwargs: object) -> None:
+            runtime_paths = kwargs["runtime_paths"]
+            assert isinstance(runtime_paths, constants_module.RuntimePaths)
+            assert runtime_paths.config_path == cfg.resolve()
+            assert runtime_paths.storage_root == config_dir.resolve() / "mindroom_data"
+
+        with patch("mindroom.orchestrator.main", AsyncMock(side_effect=_fake_main)) as mock_main:
+            result = runner.invoke(app, ["run", "-c", str(cfg)])
+
+        assert result.exit_code == 0
+        mock_main.assert_awaited_once()
+
     def test_run_storage_path_updates_runtime_paths(
         self,
         tmp_path: Path,
@@ -1571,6 +1639,31 @@ class TestRunApiFlags:
 
         with patch("mindroom.orchestrator.main", AsyncMock(side_effect=_fake_main)) as mock_main:
             result = _invoke_with_runtime(["run", "--storage-path", str(runtime_storage)], cfg)
+
+        assert result.exit_code == 0
+        mock_main.assert_awaited_once()
+
+    def test_run_short_config_path_keeps_storage_path_override(self, tmp_path: Path) -> None:
+        """Run should allow `-c` with an explicit storage override."""
+        config_dir = tmp_path / "profile"
+        config_dir.mkdir()
+        cfg = config_dir / "config.yaml"
+        cfg.write_text(
+            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
+            "agents:\n  a:\n    display_name: A\n    model: default\n"
+            "router:\n  model: default\n"
+            "matrix_space:\n  enabled: false\n",
+        )
+        storage_root = tmp_path / "explicit-storage"
+
+        async def _fake_main(**kwargs: object) -> None:
+            runtime_paths = kwargs["runtime_paths"]
+            assert isinstance(runtime_paths, constants_module.RuntimePaths)
+            assert runtime_paths.config_path == cfg.resolve()
+            assert runtime_paths.storage_root == storage_root.resolve()
+
+        with patch("mindroom.orchestrator.main", AsyncMock(side_effect=_fake_main)) as mock_main:
+            result = runner.invoke(app, ["run", "-c", str(cfg), "--storage-path", str(storage_root)])
 
         assert result.exit_code == 0
         mock_main.assert_awaited_once()

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -1479,6 +1479,16 @@ class TestVersionAndHelp:
 class TestRunApiFlags:
     """Tests for --api/--no-api, --api-port, --api-host flags."""
 
+    @staticmethod
+    def _write_minimal_config(path: Path) -> None:
+        path.write_text(
+            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
+            "agents:\n  a:\n    display_name: A\n    model: default\n"
+            "router:\n  model: default\n"
+            "matrix_space:\n  enabled: false\n",
+            encoding="utf-8",
+        )
+
     def test_run_help_shows_api_flags(self) -> None:
         """Run --help lists the new API server flags."""
         result = runner.invoke(app, ["run", "--help"])
@@ -1553,13 +1563,7 @@ class TestRunApiFlags:
         config_dir = tmp_path / "selected"
         cfg = config_dir / "config.yaml"
         config_dir.mkdir()
-        cfg.write_text(
-            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
-            "agents:\n  a:\n    display_name: A\n    model: default\n"
-            "router:\n  model: default\n"
-            "matrix_space:\n  enabled: false\n",
-            encoding="utf-8",
-        )
+        self._write_minimal_config(cfg)
         monkeypatch.setenv("MINDROOM_CONFIG_PATH", str(ambient_config))
         monkeypatch.delenv("MINDROOM_STORAGE_PATH", raising=False)
 
@@ -1587,13 +1591,7 @@ class TestRunApiFlags:
         config_dir = tmp_path / "selected"
         cfg = config_dir / "config.yaml"
         config_dir.mkdir()
-        cfg.write_text(
-            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
-            "agents:\n  a:\n    display_name: A\n    model: default\n"
-            "router:\n  model: default\n"
-            "matrix_space:\n  enabled: false\n",
-            encoding="utf-8",
-        )
+        self._write_minimal_config(cfg)
 
         async def _fake_main(**kwargs: object) -> None:
             runtime_paths = kwargs["runtime_paths"]
@@ -1648,12 +1646,7 @@ class TestRunApiFlags:
         config_dir = tmp_path / "profile"
         config_dir.mkdir()
         cfg = config_dir / "config.yaml"
-        cfg.write_text(
-            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
-            "agents:\n  a:\n    display_name: A\n    model: default\n"
-            "router:\n  model: default\n"
-            "matrix_space:\n  enabled: false\n",
-        )
+        self._write_minimal_config(cfg)
         storage_root = tmp_path / "explicit-storage"
 
         async def _fake_main(**kwargs: object) -> None:


### PR DESCRIPTION
## Summary
- Add `--config` / `-c` to `mindroom run`.
- Route the selected config path through CLI runtime activation so implicit storage defaults beside that config.
- Cover help output, long/short config flags, and explicit `--storage-path` precedence.

## Test Plan
- [x] `PUPPETEER_SKIP_DOWNLOAD=true PYTHONPATH=/tmp/mindroom-run-config-pr/src /Users/basnijholt/.codex/worktrees/20f6/mindroom/.venv/bin/python -m pytest tests/test_cli_config.py -q --no-cov -n 0`
- [x] `uv run --python 3.13 pytest --no-cov`
- [x] `uv run ruff check src/mindroom/cli/main.py tests/test_cli_config.py`
- [x] `uv run ruff format --check src/mindroom/cli/main.py tests/test_cli_config.py`
- [x] `uv run pre-commit run --files src/mindroom/cli/main.py tests/test_cli_config.py`

## Summary by Sourcery

Add support for specifying a config file for `mindroom run` and route it through CLI runtime activation.

New Features:
- Introduce a `--config` / `-c` option to `mindroom run` to select an explicit config file, defaulting storage beside that config when no storage path override is provided.

Tests:
- Extend CLI integration tests to cover help output, config path handling, short flag support, and precedence of explicit storage-path overrides when a config is specified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--config` (`-c`) option to `mindroom run` command, enabling users to specify a custom config file path.

* **Documentation**
  * Updated CLI help and reference documentation to document the new `--config` option and its behavior.

* **Tests**
  * Added comprehensive test coverage for the new config path selection functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1077?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->