### PR TITLE
Preserve router relay provenance

### DIFF
--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -46,7 +46,7 @@ from mindroom.dispatch_handoff import (
     payload_metadata_from_source,
 )
 from mindroom.dispatch_replay_guard import has_newer_unresponded_cached_thread_event, has_newer_unresponded_in_thread
-from mindroom.dispatch_source import is_automation_source_kind, is_voice_event
+from mindroom.dispatch_source import SCHEDULED_SOURCE_KIND, is_automation_source_kind, is_voice_event
 from mindroom.entity_resolution import entity_identity_registry
 from mindroom.error_handling import get_user_friendly_error_message
 from mindroom.handled_turns import HandledTurnState
@@ -969,7 +969,12 @@ class TurnController:
             return None
 
         sender_agent_name = self._managed_entity_name_for_sender(requester_user_id)
-        if sender_agent_name and not context.am_i_mentioned and not ingress_policy.bypass_unmentioned_agent_gate:
+        if (
+            sender_agent_name
+            and envelope.source_kind != SCHEDULED_SOURCE_KIND
+            and not context.am_i_mentioned
+            and not ingress_policy.bypass_unmentioned_agent_gate
+        ):
             self.deps.logger.debug(
                 "ignore_unmentioned_agent_event",
                 agent=sender_agent_name,
@@ -1224,6 +1229,11 @@ class TurnController:
         )
         thread_event_id = resolved_target.resolved_thread_id
         routed_extra_content = dict(extra_content) if extra_content is not None else {}
+        if (
+            ORIGINAL_SENDER_KEY not in routed_extra_content
+            and self._managed_entity_name_for_sender(requester_user_id) is None
+        ):
+            routed_extra_content[ORIGINAL_SENDER_KEY] = requester_user_id
         routed_media_events = list(media_events or [])
         if not routed_media_events and is_matrix_media_dispatch_event(event):
             routed_media_events.append(event)

--- a/tests/test_bot_scheduling.py
+++ b/tests/test_bot_scheduling.py
@@ -17,6 +17,9 @@ from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig, RouterConfig
 from mindroom.constants import ORIGINAL_SENDER_KEY, ROUTER_AGENT_NAME, VOICE_PREFIX
 from mindroom.conversation_resolver import MessageContext
+from mindroom.dispatch_handoff import DispatchIngressMetadata
+from mindroom.dispatch_source import SCHEDULED_SOURCE_KIND
+from mindroom.handled_turns import HandledTurnState
 from mindroom.matrix.cache.thread_history_result import thread_history_result
 from mindroom.matrix.client import ResolvedVisibleMessage
 from mindroom.matrix.users import AgentMatrixUser
@@ -1108,6 +1111,77 @@ class TestCommandHandling:
         # Verify it was caught early by the agent message check
         debug_calls = [call[0][0] for call in bot.logger.debug.call_args_list]
         assert "ignore_unmentioned_agent_event" in debug_calls
+
+    @pytest.mark.asyncio
+    async def test_scheduled_agent_event_with_router_requester_reaches_dispatch_policy(self) -> None:
+        """A deferred scheduled task authored by an agent may carry Router as requester."""
+        agent_user = AgentMatrixUser(
+            agent_name="general",
+            user_id="@mindroom_general:localhost",
+            display_name="General Agent",
+            password=TEST_PASSWORD,
+            access_token=TEST_ACCESS_TOKEN,
+        )
+        config = _runtime_bound_config(
+            Config(
+                agents={"general": AgentConfig(display_name="General Agent")},
+                router=RouterConfig(model="default"),
+            ),
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bot = AgentBot(
+                agent_user=agent_user,
+                storage_path=Path(tmpdir),
+                config=config,
+                runtime_paths=runtime_paths_for(config),
+                rooms=["!test:server"],
+            )
+            wrap_extracted_collaborators(bot)
+            bot.client = AsyncMock()
+            bot.client.user_id = "@mindroom_general:localhost"
+            sync_bot_runtime_state(bot)
+            bot.logger = MagicMock()
+            _sync_turn_policy_runtime(bot)
+
+            mock_context = _message_context(
+                am_i_mentioned=False,
+                is_thread=True,
+                thread_id="$thread123",
+            )
+            bot._conversation_resolver.extract_dispatch_context = AsyncMock(
+                return_value=dispatch_context_result(mock_context),
+            )
+
+            room = nio.MatrixRoom(room_id="!test:server", own_user_id=bot.client.user_id)
+            event = nio.RoomMessageText.from_dict(
+                {
+                    "event_id": "$scheduled_task",
+                    "sender": "@mindroom_general:localhost",
+                    "origin_server_ts": 1234567890,
+                    "content": {
+                        "msgtype": "m.text",
+                        "body": "⏰ [Automated Task]\nCheck the workloop status",
+                        "com.mindroom.source_kind": SCHEDULED_SOURCE_KIND,
+                        ORIGINAL_SENDER_KEY: "@mindroom_router:localhost",
+                    },
+                },
+            )
+
+            result = await bot._turn_controller._prepare_dispatch(
+                room,
+                event,
+                "@mindroom_router:localhost",
+                event_label="message",
+                handled_turn=HandledTurnState.from_source_event_id(event.event_id),
+                ingress_metadata=DispatchIngressMetadata(source_kind=SCHEDULED_SOURCE_KIND),
+            )
+
+        assert result is not None
+        assert result.dispatch.requester_user_id == "@mindroom_router:localhost"
+        assert result.dispatch.envelope.source_kind == SCHEDULED_SOURCE_KIND
+        debug_calls = [call[0][0] for call in bot.logger.debug.call_args_list]
+        assert "ignore_unmentioned_agent_event" not in debug_calls
 
     @pytest.mark.asyncio
     async def test_router_error_prevents_team_formation(self) -> None:

--- a/tests/test_routing_regression.py
+++ b/tests/test_routing_regression.py
@@ -548,6 +548,89 @@ class TestRoutingRegression:
         assert content[ORIGINAL_SENDER_KEY] == "@bob:localhost"
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("extra_content", "expected_original_sender"),
+        [
+            pytest.param(None, None, id="unset"),
+            pytest.param({ORIGINAL_SENDER_KEY: "@human:localhost"}, "@human:localhost", id="preserved"),
+        ],
+    )
+    @patch("mindroom.turn_controller.suggest_responder_for_message")
+    async def test_router_relay_does_not_stamp_managed_requester_as_original_sender(
+        self,
+        mock_suggest_responder: AsyncMock,
+        tmp_path: Path,
+        extra_content: dict[str, object] | None,
+        expected_original_sender: str | None,
+    ) -> None:
+        """Router relay provenance is human-origin metadata, not managed-agent identity."""
+        test_room_id = "!managed-requester:localhost"
+        test_config = _runtime_bound_config(
+            Config(
+                agents={
+                    "alpha": AgentConfig(display_name="AlphaAgent", rooms=[test_room_id]),
+                    "beta": AgentConfig(display_name="BetaAgent", rooms=[test_room_id]),
+                },
+                room_models={},
+                models={"default": ModelConfig(provider="test", id="test-model")},
+                router=RouterConfig(model="default"),
+                authorization={"default_room_access": True},
+            ),
+            tmp_path,
+        )
+        runtime_paths = runtime_paths_for(test_config)
+        ids = entity_ids(test_config, runtime_paths)
+        router_bot = setup_test_bot(
+            AgentMatrixUser(
+                agent_name="router",
+                password=TEST_PASSWORD,
+                display_name="RouterAgent",
+                user_id=ids["router"].full_id,
+            ),
+            tmp_path,
+            test_room_id,
+            config=test_config,
+        )
+
+        mock_suggest_responder.return_value = "beta"
+        mock_send_response = MagicMock()
+        mock_send_response.__class__ = nio.RoomSendResponse
+        mock_send_response.event_id = "$managed_requester_response"
+        router_bot.client.room_send.return_value = mock_send_response
+
+        mock_room = MagicMock()
+        mock_room.room_id = test_room_id
+        mock_room.users = {
+            ids["router"].full_id: MagicMock(),
+            ids["alpha"].full_id: MagicMock(),
+            ids["beta"].full_id: MagicMock(),
+        }
+        message_event = MagicMock(spec=nio.RoomMessageText)
+        message_event.sender = ids["alpha"].full_id
+        message_event.body = "Please route this"
+        message_event.event_id = "$managed_requester_message"
+        message_event.server_timestamp = 1000
+        message_event.source = {"content": {"body": "Please route this"}}
+
+        await router_bot._turn_controller._execute_router_relay(
+            mock_room,
+            message_event,
+            [],
+            None,
+            requester_user_id=ids["alpha"].full_id,
+            extra_content=extra_content,
+        )
+
+        router_bot.client.room_send.assert_awaited_once()
+        content = router_bot.client.room_send.await_args.kwargs["content"]
+        assert content["body"] == f"{ids['beta'].full_id} could you help with this?"
+        assert content["m.mentions"]["user_ids"] == [ids["beta"].full_id]
+        if expected_original_sender is None:
+            assert ORIGINAL_SENDER_KEY not in content
+        else:
+            assert content[ORIGINAL_SENDER_KEY] == expected_original_sender
+
+    @pytest.mark.asyncio
     @patch("mindroom.turn_controller.suggest_responder_for_message")
     async def test_router_relay_filters_configured_room_candidates_by_live_state(
         self,

--- a/tests/test_routing_regression.py
+++ b/tests/test_routing_regression.py
@@ -19,6 +19,7 @@ from mindroom.bot import AgentBot, TeamBot
 from mindroom.config.agent import AgentConfig, TeamConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig, RouterConfig
+from mindroom.constants import ORIGINAL_SENDER_KEY
 from mindroom.conversation_resolver import MessageContext
 from mindroom.hooks import MessageEnvelope
 from mindroom.knowledge.utils import _KnowledgeResolution
@@ -544,6 +545,7 @@ class TestRoutingRegression:
         content = router_bot.client.room_send.await_args.kwargs["content"]
         assert content["body"] == "@mindroom_news_oldns:localhost could you help with this?"
         assert content["m.mentions"]["user_ids"] == ["@mindroom_news_oldns:localhost"]
+        assert content[ORIGINAL_SENDER_KEY] == "@bob:localhost"
 
     @pytest.mark.asyncio
     @patch("mindroom.turn_controller.suggest_responder_for_message")
@@ -631,6 +633,7 @@ class TestRoutingRegression:
         content = router_bot.client.room_send.await_args.kwargs["content"]
         assert content["body"] == f"{ids['alpha'].full_id} could you help with this?"
         assert content["m.mentions"]["user_ids"] == [ids["alpha"].full_id]
+        assert content[ORIGINAL_SENDER_KEY] == "@user:localhost"
 
     @pytest.mark.asyncio
     async def test_direct_response_candidates_filter_configured_room_by_live_state(


### PR DESCRIPTION
## Summary
- Cherry-picks 2ac5994582f9416e8ace110ad51fa26e8db1e7b0 from gitea/main.
- Preserves router relay provenance while handing off to the selected agent.
- Adds regression coverage for scheduled/router relay provenance.

## Test Plan
- uv run --no-sync pytest tests/test_bot_scheduling.py tests/test_routing_regression.py -n 0 --no-cov -v
- uv run --no-sync pytest -n 0 --no-cov
- uv run --no-sync pre-commit run --files src/mindroom/turn_controller.py tests/test_bot_scheduling.py tests/test_routing_regression.py

Note: `uv run --no-sync pre-commit run --all-files` was also attempted; it fails on existing frontend tooling/environment issues unrelated to this cherry-pick: TypeScript rejects `frontend/tsconfig.json` ignoreDeprecations value `6.0`, and the bun-lock hook hits a broken local Puppeteer Chrome cache.

## Summary by Sourcery

Preserve router relay provenance and adjust dispatch gating for scheduled events.

New Features:
- Support scheduled agent events that retain router requester provenance through dispatch preparation.

Bug Fixes:
- Ensure router relay messages propagate the original sender field when missing so downstream logic can attribute provenance correctly.
- Allow scheduled router-authored events to bypass the unmentioned-agent gate while still respecting other dispatch policies.

Tests:
- Add regression coverage for scheduled router relay provenance and router relay original-sender propagation.