### PR TITLE
Wire live Stripe pricing

### DIFF
--- a/saas-platform/platform-backend/src/backend/pricing.py
+++ b/saas-platform/platform-backend/src/backend/pricing.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Any, Literal
 
@@ -52,6 +53,8 @@ class Plan(BaseModel):
     limits: PlanLimits
     stripe_price_id_monthly: str | None = None
     stripe_price_id_yearly: str | None = None
+    stripe_price_id_monthly_live: str | None = None
+    stripe_price_id_yearly_live: str | None = None
     recommended: bool = False
     price_model: Literal["per_user"] | None = None
 
@@ -128,6 +131,24 @@ def load_pricing_config_model() -> PricingConfig:
     return PricingConfig(**config_dict)
 
 
+def _stripe_mode() -> Literal["test", "live"]:
+    publishable_key = os.getenv("STRIPE_PUBLISHABLE_KEY", "")
+    if publishable_key.startswith("pk_live_"):
+        return "live"
+
+    secret_key = os.getenv("STRIPE_SECRET_KEY", "")
+    if secret_key.startswith(("sk_live_", "rk_live_")):
+        return "live"
+
+    secret_file = os.getenv("STRIPE_SECRET_KEY_FILE", "")
+    if secret_file:
+        path = Path(secret_file)
+        if path.exists() and path.read_text(encoding="utf-8").strip().startswith(("sk_live_", "rk_live_")):
+            return "live"
+
+    return "test"
+
+
 def get_stripe_price_id(plan: str, billing_cycle: str = "monthly") -> str | None:
     """Get Stripe price ID for a specific plan and billing cycle.
 
@@ -145,6 +166,12 @@ def get_stripe_price_id(plan: str, billing_cycle: str = "monthly") -> str | None
     if not plan_obj:
         return None
 
+    mode = _stripe_mode()
+
+    if billing_cycle == "monthly" and mode == "live":
+        return plan_obj.stripe_price_id_monthly_live
+    if billing_cycle == "yearly" and mode == "live":
+        return plan_obj.stripe_price_id_yearly_live
     if billing_cycle == "monthly":
         return plan_obj.stripe_price_id_monthly
     if billing_cycle == "yearly":

--- a/saas-platform/platform-backend/src/backend/routes/admin.py
+++ b/saas-platform/platform-backend/src/backend/routes/admin.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from typing import Annotated, Any
 
-from backend.config import PROVISIONER_API_KEY, logger
+from backend.config import PROVISIONER_API_KEY, logger, stripe
 from pydantic import BaseModel
 from backend.deps import ensure_supabase, limiter, verify_admin
 from backend.utils.audit import create_audit_log
@@ -588,11 +588,6 @@ async def admin_delete_account_complete(
     # 3. Cancel any active Stripe subscriptions
     if account.get("stripe_customer_id"):
         try:
-            import stripe
-            from backend.config import STRIPE_API_KEY
-
-            stripe.api_key = STRIPE_API_KEY
-
             # List and cancel all subscriptions for this customer
             subscriptions = stripe.Subscription.list(customer=account["stripe_customer_id"], status="active")
             for subscription in subscriptions.data:

--- a/saas-platform/platform-backend/src/backend/routes/pricing.py
+++ b/saas-platform/platform-backend/src/backend/routes/pricing.py
@@ -53,9 +53,8 @@ async def get_pricing_config() -> dict[str, Any]:
             "features": plan_data.features,
             "limits": plan_data.limits.model_dump(),
             "recommended": plan_data.recommended,
-            # Include Stripe price IDs if available
-            "stripe_price_id_monthly": plan_data.stripe_price_id_monthly,
-            "stripe_price_id_yearly": plan_data.stripe_price_id_yearly,
+            "stripe_price_id_monthly": get_stripe_price_id(plan_key, "monthly"),
+            "stripe_price_id_yearly": get_stripe_price_id(plan_key, "yearly"),
         }
 
     return config

--- a/saas-platform/platform-backend/tests/test_pricing.py
+++ b/saas-platform/platform-backend/tests/test_pricing.py
@@ -86,11 +86,15 @@ class TestPricingConfig:
         starter = model.plans["starter"]
         assert starter.stripe_price_id_monthly == "price_1S6FvF3GVsrZHuzXrDZ5H7EW"
         assert starter.stripe_price_id_yearly == "price_1S6FvF3GVsrZHuzXDjv76gwE"
+        assert starter.stripe_price_id_monthly_live == "price_1TZQHw3GVsrZHuzXeXWd2f3Z"
+        assert starter.stripe_price_id_yearly_live == "price_1TZQJK3GVsrZHuzXuazROiIy"
 
         # Professional plan IDs
         professional = model.plans["professional"]
         assert professional.stripe_price_id_monthly == "price_1S6FvG3GVsrZHuzXBwljASJB"
         assert professional.stripe_price_id_yearly == "price_1S6FvG3GVsrZHuzXQV9y2VEo"
+        assert professional.stripe_price_id_monthly_live == "price_1TZQJL3GVsrZHuzXSzAgw8U4"
+        assert professional.stripe_price_id_yearly_live == "price_1TZQJL3GVsrZHuzXO0WBASeh"
 
         # Free and Enterprise should not have Stripe IDs
         assert model.plans["free"].stripe_price_id_monthly is None
@@ -149,8 +153,10 @@ class TestPricingConfig:
 class TestPricingHelperFunctions:
     """Test pricing helper functions."""
 
-    def test_get_stripe_price_id(self) -> None:
+    def test_get_stripe_price_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test getting Stripe price IDs."""
+        monkeypatch.setenv("STRIPE_PUBLISHABLE_KEY", "pk_test_mock")
+
         # Starter monthly
         assert get_stripe_price_id("starter", "monthly") == "price_1S6FvF3GVsrZHuzXrDZ5H7EW"
 
@@ -172,6 +178,15 @@ class TestPricingHelperFunctions:
 
         # Invalid billing cycle
         assert get_stripe_price_id("starter", "weekly") is None
+
+    def test_get_live_stripe_price_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test getting live Stripe price IDs in live mode."""
+        monkeypatch.setenv("STRIPE_PUBLISHABLE_KEY", "pk_live_mock")
+
+        assert get_stripe_price_id("starter", "monthly") == "price_1TZQHw3GVsrZHuzXeXWd2f3Z"
+        assert get_stripe_price_id("starter", "yearly") == "price_1TZQJK3GVsrZHuzXuazROiIy"
+        assert get_stripe_price_id("professional", "monthly") == "price_1TZQJL3GVsrZHuzXSzAgw8U4"
+        assert get_stripe_price_id("professional", "yearly") == "price_1TZQJL3GVsrZHuzXO0WBASeh"
 
     def test_get_plan_details(self) -> None:
         """Test getting plan details."""
@@ -306,3 +321,4 @@ class TestPricingIntegration:
         assert get_stripe_price_id("starter", "monthly") == starter_monthly_id
         assert config_model.plans["starter"].stripe_price_id_monthly == starter_monthly_id
         assert yaml_data["plans"]["starter"]["stripe_price_id_monthly"] == starter_monthly_id
+        assert yaml_data["plans"]["starter"]["stripe_price_id_monthly_live"] == "price_1TZQHw3GVsrZHuzXeXWd2f3Z"

--- a/saas-platform/platform-backend/tests/test_stripe_integration.py
+++ b/saas-platform/platform-backend/tests/test_stripe_integration.py
@@ -48,14 +48,14 @@ class TestStripeIntegration:
         """Test that MindRoom product exists in Stripe."""
         products = stripe.Product.list(limit=100)
 
-        mindroom_products = [p for p in products.data if p.metadata.get("platform") == "mindroom"]
+        mindroom_products = [p for p in products.data if "platform" in p.metadata and p.metadata["platform"] == "mindroom"]
 
         assert len(mindroom_products) > 0, "No MindRoom product found in Stripe"
 
         # Verify product details
         product = mindroom_products[0]
         assert product.name == "MindRoom Subscription"
-        assert product.metadata.get("platform") == "mindroom"
+        assert product.metadata["platform"] == "mindroom"
 
     @pytest.mark.skipif(not HAS_STRIPE_CREDENTIALS, reason="Requires real Stripe API credentials")
     def test_all_configured_prices_exist(self) -> None:

--- a/saas-platform/platform-backend/tests/test_stripe_utils.py
+++ b/saas-platform/platform-backend/tests/test_stripe_utils.py
@@ -37,7 +37,7 @@ class TestStripeDebugUtils:
         products = stripe.Product.list(limit=100)
 
         # Find MindRoom products
-        mindroom_products = [p for p in products.data if p.metadata.get("platform") == "mindroom"]
+        mindroom_products = [p for p in products.data if "platform" in p.metadata and p.metadata["platform"] == "mindroom"]
 
         # Should have at least one MindRoom product
         assert len(mindroom_products) > 0, "No MindRoom products found in Stripe"
@@ -46,7 +46,7 @@ class TestStripeDebugUtils:
         product = mindroom_products[0]
         assert product.name == "MindRoom Subscription", f"Product name mismatch: {product.name}"
         assert product.active, "MindRoom product is not active"
-        assert product.metadata.get("platform") == "mindroom", "Missing platform metadata"
+        assert product.metadata["platform"] == "mindroom", "Missing platform metadata"
 
     def _check_price(self, plan_name: str, price_id: str | None, yaml_price: int, billing_cycle: str) -> str | None:
         """Check a single price against Stripe. Returns error message if mismatch."""

--- a/saas-platform/pricing-config.yaml
+++ b/saas-platform/pricing-config.yaml
@@ -36,6 +36,8 @@ plans:
     description: Perfect for individuals
     stripe_price_id_monthly: price_1S6FvF3GVsrZHuzXrDZ5H7EW
     stripe_price_id_yearly: price_1S6FvF3GVsrZHuzXDjv76gwE
+    stripe_price_id_monthly_live: price_1TZQHw3GVsrZHuzXeXWd2f3Z
+    stripe_price_id_yearly_live: price_1TZQJK3GVsrZHuzXuazROiIy
     recommended: true
     features:
     - 100 AI Agents
@@ -67,6 +69,8 @@ plans:
     description: For teams and businesses
     stripe_price_id_monthly: price_1S6FvG3GVsrZHuzXBwljASJB
     stripe_price_id_yearly: price_1S6FvG3GVsrZHuzXQV9y2VEo
+    stripe_price_id_monthly_live: price_1TZQJL3GVsrZHuzXSzAgw8U4
+    stripe_price_id_yearly_live: price_1TZQJL3GVsrZHuzXO0WBASeh
     features:
     - Unlimited AI Agents
     - Unlimited messages


### PR DESCRIPTION
## Summary
- add live Stripe price IDs alongside existing test price IDs
- select Stripe price IDs based on configured Stripe mode
- expose effective price IDs through pricing config endpoint
- fix admin account deletion Stripe cancellation to use the configured shared client

## Test Plan
- uv run pytest tests/test_pricing.py tests/test_stripe_integration.py tests/test_stripe_utils.py -q --no-cov
- uv run ruff check saas-platform/platform-backend/src/backend/pricing.py saas-platform/platform-backend/src/backend/routes/pricing.py saas-platform/platform-backend/src/backend/routes/admin.py saas-platform/platform-backend/tests/test_pricing.py saas-platform/platform-backend/tests/test_stripe_integration.py saas-platform/platform-backend/tests/test_stripe_utils.py

## Summary by Sourcery

Wire Stripe pricing to use environment-driven test/live mode and expose mode-specific price IDs via the pricing config API.

New Features:
- Add separate live Stripe price IDs for each plan alongside existing test IDs and load them from the pricing configuration.
- Expose effective Stripe price IDs in the pricing config endpoint based on the current Stripe mode.

Bug Fixes:
- Use the shared, preconfigured Stripe client when cancelling subscriptions during admin account deletion to avoid redundant configuration.
- Make Stripe product metadata access in tests robust against missing keys to prevent runtime errors.

Tests:
- Extend pricing tests to cover live-mode Stripe price ID selection and ensure YAML pricing config consistency with new live IDs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System now automatically detects and applies production-ready payment processing when configured with live Stripe keys, with automatic fallback to test mode.

* **Chores**
  * Improved payment infrastructure to better separate test and production billing configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1079?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->