### PR TITLE
Derive Stripe price mode from secret key

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -120,9 +120,9 @@ Start MindRoom with your configuration.
 │                                          ERROR)                                        │
 │                                          [env var: LOG_LEVEL]                          │
 │                                          [default: INFO]                               │
-│ --config        -c              PATH     Use this config file path. Defaults storage   │
-│                                          beside the selected config unless             │
-│                                          --storage-path is set.                        │
+│ --config        -c              PATH     Use this config file path. Defaults the       │
+│                                          storage location to the selected config       │
+│                                          directory unless --storage-path is set.       │
 │ --storage-path  -s              PATH     Base directory for persistent MindRoom data   │
 │                                          (state, sessions, tracking)                   │
 │ --api               --no-api             Start the bundled dashboard/API server        │

--- a/saas-platform/platform-backend/src/backend/pricing.py
+++ b/saas-platform/platform-backend/src/backend/pricing.py
@@ -132,9 +132,10 @@ def load_pricing_config_model() -> PricingConfig:
 
 
 def _stripe_mode() -> Literal["test", "live"]:
+    # Server-side price IDs must match the secret key used for Stripe API calls.
     secret_key = os.getenv("STRIPE_SECRET_KEY", "")
-    if secret_key.startswith(("sk_live_", "rk_live_")):
-        return "live"
+    if secret_key:
+        return "live" if secret_key.startswith(("sk_live_", "rk_live_")) else "test"
 
     secret_file = os.getenv("STRIPE_SECRET_KEY_FILE", "")
     if secret_file:

--- a/saas-platform/platform-backend/src/backend/pricing.py
+++ b/saas-platform/platform-backend/src/backend/pricing.py
@@ -132,10 +132,6 @@ def load_pricing_config_model() -> PricingConfig:
 
 
 def _stripe_mode() -> Literal["test", "live"]:
-    publishable_key = os.getenv("STRIPE_PUBLISHABLE_KEY", "")
-    if publishable_key.startswith("pk_live_"):
-        return "live"
-
     secret_key = os.getenv("STRIPE_SECRET_KEY", "")
     if secret_key.startswith(("sk_live_", "rk_live_")):
         return "live"

--- a/saas-platform/platform-backend/tests/test_pricing.py
+++ b/saas-platform/platform-backend/tests/test_pricing.py
@@ -16,6 +16,14 @@ from backend.pricing import (
 )
 
 
+@pytest.fixture(autouse=True)
+def clear_stripe_mode_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep pricing mode tests isolated from host Stripe configuration."""
+    monkeypatch.delenv("STRIPE_SECRET_KEY", raising=False)
+    monkeypatch.delenv("STRIPE_SECRET_KEY_FILE", raising=False)
+    monkeypatch.delenv("STRIPE_PUBLISHABLE_KEY", raising=False)
+
+
 class TestPricingConfig:
     """Test pricing configuration loading and validation."""
 
@@ -199,10 +207,20 @@ class TestPricingHelperFunctions:
         """Production file-mounted secrets select live price IDs."""
         secret_file = tmp_path / "stripe_secret_key"
         secret_file.write_text("sk_live_mock", encoding="utf-8")
-        monkeypatch.delenv("STRIPE_SECRET_KEY", raising=False)
         monkeypatch.setenv("STRIPE_SECRET_KEY_FILE", str(secret_file))
 
         assert get_stripe_price_id("starter", "monthly") == "price_1TZQHw3GVsrZHuzXeXWd2f3Z"
+
+    def test_stripe_secret_env_takes_precedence_over_secret_file(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Environment secret precedence matches backend.config._get_secret."""
+        secret_file = tmp_path / "stripe_secret_key"
+        secret_file.write_text("sk_live_mock", encoding="utf-8")
+        monkeypatch.setenv("STRIPE_SECRET_KEY", "sk_test_mock")
+        monkeypatch.setenv("STRIPE_SECRET_KEY_FILE", str(secret_file))
+
+        assert get_stripe_price_id("starter", "monthly") == "price_1S6FvF3GVsrZHuzXrDZ5H7EW"
 
     def test_get_plan_details(self) -> None:
         """Test getting plan details."""

--- a/saas-platform/platform-backend/tests/test_pricing.py
+++ b/saas-platform/platform-backend/tests/test_pricing.py
@@ -155,7 +155,7 @@ class TestPricingHelperFunctions:
 
     def test_get_stripe_price_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test getting Stripe price IDs."""
-        monkeypatch.setenv("STRIPE_PUBLISHABLE_KEY", "pk_test_mock")
+        monkeypatch.setenv("STRIPE_SECRET_KEY", "sk_test_mock")
 
         # Starter monthly
         assert get_stripe_price_id("starter", "monthly") == "price_1S6FvF3GVsrZHuzXrDZ5H7EW"
@@ -181,12 +181,28 @@ class TestPricingHelperFunctions:
 
     def test_get_live_stripe_price_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test getting live Stripe price IDs in live mode."""
-        monkeypatch.setenv("STRIPE_PUBLISHABLE_KEY", "pk_live_mock")
+        monkeypatch.setenv("STRIPE_SECRET_KEY", "sk_live_mock")
 
         assert get_stripe_price_id("starter", "monthly") == "price_1TZQHw3GVsrZHuzXeXWd2f3Z"
         assert get_stripe_price_id("starter", "yearly") == "price_1TZQJK3GVsrZHuzXuazROiIy"
         assert get_stripe_price_id("professional", "monthly") == "price_1TZQJL3GVsrZHuzXSzAgw8U4"
         assert get_stripe_price_id("professional", "yearly") == "price_1TZQJL3GVsrZHuzXO0WBASeh"
+
+    def test_publishable_key_does_not_determine_stripe_price_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Server-side Stripe price IDs must match the server-side secret key."""
+        monkeypatch.setenv("STRIPE_PUBLISHABLE_KEY", "pk_live_mock")
+        monkeypatch.setenv("STRIPE_SECRET_KEY", "sk_test_mock")
+
+        assert get_stripe_price_id("starter", "monthly") == "price_1S6FvF3GVsrZHuzXrDZ5H7EW"
+
+    def test_stripe_secret_file_determines_price_mode(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Production file-mounted secrets select live price IDs."""
+        secret_file = tmp_path / "stripe_secret_key"
+        secret_file.write_text("sk_live_mock", encoding="utf-8")
+        monkeypatch.delenv("STRIPE_SECRET_KEY", raising=False)
+        monkeypatch.setenv("STRIPE_SECRET_KEY_FILE", str(secret_file))
+
+        assert get_stripe_price_id("starter", "monthly") == "price_1TZQHw3GVsrZHuzXeXWd2f3Z"
 
     def test_get_plan_details(self) -> None:
         """Test getting plan details."""

--- a/saas-platform/platform-backend/tests/test_stripe_integration.py
+++ b/saas-platform/platform-backend/tests/test_stripe_integration.py
@@ -48,7 +48,9 @@ class TestStripeIntegration:
         """Test that MindRoom product exists in Stripe."""
         products = stripe.Product.list(limit=100)
 
-        mindroom_products = [p for p in products.data if "platform" in p.metadata and p.metadata["platform"] == "mindroom"]
+        mindroom_products = [
+            p for p in products.data if "platform" in p.metadata and p.metadata["platform"] == "mindroom"
+        ]
 
         assert len(mindroom_products) > 0, "No MindRoom product found in Stripe"
 

--- a/saas-platform/platform-backend/tests/test_stripe_utils.py
+++ b/saas-platform/platform-backend/tests/test_stripe_utils.py
@@ -37,7 +37,9 @@ class TestStripeDebugUtils:
         products = stripe.Product.list(limit=100)
 
         # Find MindRoom products
-        mindroom_products = [p for p in products.data if "platform" in p.metadata and p.metadata["platform"] == "mindroom"]
+        mindroom_products = [
+            p for p in products.data if "platform" in p.metadata and p.metadata["platform"] == "mindroom"
+        ]
 
         # Should have at least one MindRoom product
         assert len(mindroom_products) > 0, "No MindRoom products found in Stripe"

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -15768,9 +15768,9 @@ Start MindRoom with your configuration.
 │                                          ERROR)                                        │
 │                                          [env var: LOG_LEVEL]                          │
 │                                          [default: INFO]                               │
-│ --config        -c              PATH     Use this config file path. Defaults storage   │
-│                                          beside the selected config unless             │
-│                                          --storage-path is set.                        │
+│ --config        -c              PATH     Use this config file path. Defaults the       │
+│                                          storage location to the selected config       │
+│                                          directory unless --storage-path is set.       │
 │ --storage-path  -s              PATH     Base directory for persistent MindRoom data   │
 │                                          (state, sessions, tracking)                   │
 │ --api               --no-api             Start the bundled dashboard/API server        │

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -15768,6 +15768,9 @@ Start MindRoom with your configuration.
 │                                          ERROR)                                        │
 │                                          [env var: LOG_LEVEL]                          │
 │                                          [default: INFO]                               │
+│ --config        -c              PATH     Use this config file path. Defaults storage   │
+│                                          beside the selected config unless             │
+│                                          --storage-path is set.                        │
 │ --storage-path  -s              PATH     Base directory for persistent MindRoom data   │
 │                                          (state, sessions, tracking)                   │
 │ --api               --no-api             Start the bundled dashboard/API server        │

--- a/skills/mindroom-docs/references/page__cli__index.md
+++ b/skills/mindroom-docs/references/page__cli__index.md
@@ -116,9 +116,9 @@ Start MindRoom with your configuration.
 │                                          ERROR)                                        │
 │                                          [env var: LOG_LEVEL]                          │
 │                                          [default: INFO]                               │
-│ --config        -c              PATH     Use this config file path. Defaults storage   │
-│                                          beside the selected config unless             │
-│                                          --storage-path is set.                        │
+│ --config        -c              PATH     Use this config file path. Defaults the       │
+│                                          storage location to the selected config       │
+│                                          directory unless --storage-path is set.       │
 │ --storage-path  -s              PATH     Base directory for persistent MindRoom data   │
 │                                          (state, sessions, tracking)                   │
 │ --api               --no-api             Start the bundled dashboard/API server        │

--- a/src/mindroom/cli/main.py
+++ b/src/mindroom/cli/main.py
@@ -92,7 +92,7 @@ def run(
         None,
         "--config",
         "-c",
-        help="Use this config file path. Defaults storage beside the selected config unless --storage-path is set.",
+        help="Use this config file path. Defaults the storage location to the selected config directory unless --storage-path is set.",
     ),
     storage_path: Path | None = typer.Option(  # noqa: B008
         None,


### PR DESCRIPTION
## Summary
- derive Stripe test/live price selection from the server-side secret key only
- add regression coverage for live publishable key with test secret key
- add coverage for production file-mounted Stripe secrets
- include formatter/generated docs updates required by pre-commit

## Test Plan
- uv run pytest tests/test_pricing.py -q --no-cov
- uv run pytest tests/test_pricing.py tests/test_stripe_integration.py tests/test_stripe_utils.py -q --no-cov
- uv run ruff check saas-platform/platform-backend/src/backend/pricing.py saas-platform/platform-backend/tests/test_pricing.py
- uv run pre-commit run --all-files

## Summary by Sourcery

Derive Stripe pricing mode solely from the server-side secret key to correctly select test vs live prices and align with production secret handling.

Enhancements:
- Remove reliance on the publishable key for determining Stripe test/live mode, using only the Stripe secret key (including live restricted keys).

Tests:
- Extend pricing tests to cover secret-key-based mode selection, including mismatched publishable/secret keys and file-mounted Stripe secret key configuration.
- Reformat Stripe integration and utilities tests to satisfy the code formatter without changing behavior.