### PR TITLE
Fix live hosted plan Stripe price IDs

### DIFF
--- a/saas-platform/platform-backend/tests/test_pricing.py
+++ b/saas-platform/platform-backend/tests/test_pricing.py
@@ -203,8 +203,10 @@ class TestPricingHelperFunctions:
 
         assert get_stripe_price_id("byok", "monthly") == "price_1TZQHw3GVsrZHuzXeXWd2f3Z"
         assert get_stripe_price_id("byok", "yearly") == "price_1TZQJK3GVsrZHuzXuazROiIy"
-        assert get_stripe_price_id("hobby", "monthly") is None
-        assert get_stripe_price_id("pro", "monthly") is None
+        assert get_stripe_price_id("hobby", "monthly") == "price_1TZRzu3GVsrZHuzXUXJEQ6Ng"
+        assert get_stripe_price_id("hobby", "yearly") == "price_1TZRzu3GVsrZHuzX77678390"
+        assert get_stripe_price_id("pro", "monthly") == "price_1TZRzv3GVsrZHuzXFRd9cUgz"
+        assert get_stripe_price_id("pro", "yearly") == "price_1TZRzv3GVsrZHuzXrXOhvBy0"
 
     def test_publishable_key_does_not_determine_stripe_price_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Server-side Stripe price IDs must match the server-side secret key."""

--- a/saas-platform/pricing-config.yaml
+++ b/saas-platform/pricing-config.yaml
@@ -99,6 +99,8 @@ plans:
       custom_development: false
       on_premise: false
       dedicated_infrastructure: false
+    stripe_price_id_monthly_live: price_1TZRzu3GVsrZHuzXUXJEQ6Ng
+    stripe_price_id_yearly_live: price_1TZRzu3GVsrZHuzX77678390
   pro:
     name: Pro
     price_monthly: 20000
@@ -132,6 +134,8 @@ plans:
       custom_development: false
       on_premise: false
       dedicated_infrastructure: false
+    stripe_price_id_monthly_live: price_1TZRzv3GVsrZHuzXFRd9cUgz
+    stripe_price_id_yearly_live: price_1TZRzv3GVsrZHuzXrXOhvBy0
   enterprise:
     name: Enterprise
     price_monthly: custom


### PR DESCRIPTION
## Summary
- add live Stripe price IDs for Hobby and Pro plans
- update pricing test expectations for live mode

## Test Plan
- uv run pytest tests/test_pricing.py::TestPricingHelperFunctions::test_get_live_stripe_price_id tests/test_pricing.py::TestPricingHelperFunctions::test_get_stripe_price_match_uses_configured_test_and_live_ids tests/test_pricing.py::TestPricingConfig::test_stripe_price_ids -q
- uv run pre-commit run --all-files

## Deployment note
- Live Stripe prices were created for the configured Hobby/Pro monthly and yearly amounts; only public price IDs are committed.

## Summary by Sourcery

Update Stripe live price configuration and tests for Hobby and Pro plans.

Bug Fixes:
- Configure live Stripe price IDs for Hobby and Pro plans so they resolve correctly in production pricing lookups.

Tests:
- Adjust pricing helper tests to expect configured live Stripe price IDs for Hobby and Pro monthly and yearly plans.