### PR TITLE
Address late AI review follow-ups

### DIFF
--- a/saas-platform/platform-backend/tests/test_pricing.py
+++ b/saas-platform/platform-backend/tests/test_pricing.py
@@ -112,10 +112,10 @@ class TestPricingConfig:
             assert plan.stripe_price_id_monthly.startswith("price_")
             assert plan.stripe_price_id_yearly is not None
             assert plan.stripe_price_id_yearly.startswith("price_")
-
-        byok = model.plans["byok"]
-        assert byok.stripe_price_id_monthly_live == "price_1TZQHw3GVsrZHuzXeXWd2f3Z"
-        assert byok.stripe_price_id_yearly_live == "price_1TZQJK3GVsrZHuzXuazROiIy"
+            assert plan.stripe_price_id_monthly_live is not None
+            assert plan.stripe_price_id_monthly_live.startswith("price_")
+            assert plan.stripe_price_id_yearly_live is not None
+            assert plan.stripe_price_id_yearly_live.startswith("price_")
 
         # Free and Enterprise should not have Stripe IDs
         assert model.plans["free"].stripe_price_id_monthly is None
@@ -199,14 +199,13 @@ class TestPricingHelperFunctions:
 
     def test_get_live_stripe_price_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test getting live Stripe price IDs in live mode."""
+        config = load_pricing_config_model()
         monkeypatch.setenv("STRIPE_SECRET_KEY", "sk_live_mock")
 
-        assert get_stripe_price_id("byok", "monthly") == "price_1TZQHw3GVsrZHuzXeXWd2f3Z"
-        assert get_stripe_price_id("byok", "yearly") == "price_1TZQJK3GVsrZHuzXuazROiIy"
-        assert get_stripe_price_id("hobby", "monthly") == "price_1TZRzu3GVsrZHuzXUXJEQ6Ng"
-        assert get_stripe_price_id("hobby", "yearly") == "price_1TZRzu3GVsrZHuzX77678390"
-        assert get_stripe_price_id("pro", "monthly") == "price_1TZRzv3GVsrZHuzXFRd9cUgz"
-        assert get_stripe_price_id("pro", "yearly") == "price_1TZRzv3GVsrZHuzXrXOhvBy0"
+        for plan_key in ("byok", "hobby", "pro"):
+            plan = config.plans[plan_key]
+            assert get_stripe_price_id(plan_key, "monthly") == plan.stripe_price_id_monthly_live
+            assert get_stripe_price_id(plan_key, "yearly") == plan.stripe_price_id_yearly_live
 
     def test_publishable_key_does_not_determine_stripe_price_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Server-side Stripe price IDs must match the server-side secret key."""
@@ -236,15 +235,21 @@ class TestPricingHelperFunctions:
 
     def test_get_stripe_price_match_uses_configured_test_and_live_ids(self) -> None:
         """Configured Stripe price IDs map back to canonical plan metadata."""
-        test_match = get_stripe_price_match("price_1TZQNK3GVsrZHuzX6EWO8kgD")
-        assert test_match is not None
-        assert test_match.tier == "byok"
-        assert test_match.billing_cycle == "monthly"
+        config = load_pricing_config_model()
 
-        live_match = get_stripe_price_match("price_1TZQJK3GVsrZHuzXuazROiIy")
-        assert live_match is not None
-        assert live_match.tier == "byok"
-        assert live_match.billing_cycle == "yearly"
+        for plan_key in ("byok", "hobby", "pro"):
+            plan = config.plans[plan_key]
+            price_ids = (
+                (plan.stripe_price_id_monthly, "monthly"),
+                (plan.stripe_price_id_monthly_live, "monthly"),
+                (plan.stripe_price_id_yearly, "yearly"),
+                (plan.stripe_price_id_yearly_live, "yearly"),
+            )
+            for price_id, billing_cycle in price_ids:
+                match = get_stripe_price_match(price_id)
+                assert match is not None
+                assert match.tier == plan_key
+                assert match.billing_cycle == billing_cycle
 
         assert get_stripe_price_match("price_unknown") is None
 

--- a/saas-platform/platform-frontend/src/components/dashboard/InstanceCard.tsx
+++ b/saas-platform/platform-frontend/src/components/dashboard/InstanceCard.tsx
@@ -208,10 +208,9 @@ export function InstanceCard({
 
   const frontendHost = getHostname(instance.frontend_url)
   const backendHost = getHostname(instance.backend_url)
-  const cinnyLoginUrl = instance.matrix_server_url
+  const chatInterfaceUrl = instance.matrix_server_url
     ? buildCinnyLoginUrl(instance.matrix_server_url)
     : null
-  const chatInterfaceUrl = cinnyLoginUrl || instance.matrix_server_url
   const lastSynced = instance.kubernetes_synced_at
     ? formatRelativeTime(instance.kubernetes_synced_at)
     : null

--- a/saas-platform/platform-frontend/src/components/dashboard/InstanceCard.tsx
+++ b/saas-platform/platform-frontend/src/components/dashboard/InstanceCard.tsx
@@ -211,6 +211,7 @@ export function InstanceCard({
   const cinnyLoginUrl = instance.matrix_server_url
     ? buildCinnyLoginUrl(instance.matrix_server_url)
     : null
+  const chatInterfaceUrl = cinnyLoginUrl || instance.matrix_server_url
   const lastSynced = instance.kubernetes_synced_at
     ? formatRelativeTime(instance.kubernetes_synced_at)
     : null
@@ -319,12 +320,12 @@ export function InstanceCard({
         </div>
 
         {/* Chat Interface */}
-        {instance.matrix_server_url && (
+        {chatInterfaceUrl && (
           <div className="flex items-center justify-between">
             <span className="text-gray-600 dark:text-gray-400">Chat Interface</span>
             <div className="flex items-center gap-2">
               <Link
-                href={cinnyLoginUrl || instance.matrix_server_url}
+                href={chatInterfaceUrl}
                 target="_blank"
                 className="flex items-center gap-1 text-purple-600 hover:text-purple-700 dark:text-purple-400 dark:hover:text-purple-300 font-medium"
               >
@@ -360,22 +361,22 @@ export function InstanceCard({
       {/* Action Buttons */}
       {instance.status === 'running' && instance.frontend_url && (
         <div className="mt-6 pt-6 border-t dark:border-gray-700">
-          <div className="grid gap-3 sm:grid-cols-2">
+          <div className={`grid gap-3 ${chatInterfaceUrl ? 'sm:grid-cols-2' : ''}`}>
             <Link
               href={instance.frontend_url}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center justify-center gap-2 px-6 py-3 bg-gradient-to-r from-orange-500 to-orange-600 text-white rounded-xl font-semibold hover:shadow-lg hover:scale-105 transition-all"
+              className="w-full inline-flex items-center justify-center gap-2 px-6 py-3 bg-gradient-to-r from-orange-500 to-orange-600 text-white rounded-xl font-semibold hover:shadow-lg hover:scale-105 transition-all"
             >
               <ExternalLink className="w-4 h-4" />
               Open MindRoom
             </Link>
-            {cinnyLoginUrl && (
+            {chatInterfaceUrl && (
               <Link
-                href={cinnyLoginUrl}
+                href={chatInterfaceUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center justify-center gap-2 px-6 py-3 border border-purple-200 bg-purple-50 text-purple-700 rounded-xl font-semibold hover:bg-purple-100 dark:border-purple-800/50 dark:bg-purple-900/20 dark:text-purple-200 dark:hover:bg-purple-900/30 transition-colors"
+                className="w-full inline-flex items-center justify-center gap-2 px-6 py-3 border border-purple-200 bg-purple-50 text-purple-700 rounded-xl font-semibold hover:bg-purple-100 dark:border-purple-800/50 dark:bg-purple-900/20 dark:text-purple-200 dark:hover:bg-purple-900/30 transition-colors"
               >
                 <MessageCircle className="w-4 h-4" />
                 Open Chat Interface

--- a/saas-platform/platform-frontend/src/components/dashboard/__tests__/InstanceCard.test.tsx
+++ b/saas-platform/platform-frontend/src/components/dashboard/__tests__/InstanceCard.test.tsx
@@ -302,6 +302,7 @@ describe('InstanceCard', () => {
       expect(openButton).toBeInTheDocument()
       expect(openButton).toHaveAttribute('href', mockInstance.frontend_url)
       expect(openButton).toHaveAttribute('target', '_blank')
+      expect(openButton).toHaveClass('w-full')
     })
 
     it('should show Open Chat Interface button for running instances', () => {
@@ -314,6 +315,16 @@ describe('InstanceCard', () => {
         'https://chat.mindroom.chat/login/https%3A%2F%2Fcustomer.matrix.mindroom.chat/'
       )
       expect(openButton).toHaveAttribute('target', '_blank')
+      expect(openButton).toHaveClass('w-full')
+    })
+
+    it('should keep the MindRoom action full-width when chat is unavailable', () => {
+      render(<InstanceCard instance={{ ...mockInstance, matrix_server_url: null }} />)
+
+      const openButton = screen.getByRole('link', { name: /Open MindRoom/i })
+      expect(openButton).toHaveClass('w-full')
+      expect(openButton.parentElement).not.toHaveClass('sm:grid-cols-2')
+      expect(screen.queryByRole('link', { name: /Open Chat Interface/i })).not.toBeInTheDocument()
     })
 
     it('should not show Open MindRoom button for non-running instances', () => {


### PR DESCRIPTION
## Summary
- cover configured test and live Stripe price IDs for BYOK, Hobby, and Pro in pricing tests
- keep live price selection tests tied to the parsed pricing config instead of duplicating literal IDs
- make dashboard instance action buttons full-width and only use two columns when a chat action exists

## Review follow-ups
- Addresses #1083 test coverage comments for newly added Hobby/Pro live price IDs.
- Addresses #1076 InstanceCard action button layout comments.
- Verified the #1083 Greptile P1 numeric live price ID concern against live Stripe; the ID exists, is active, and matches the intended 12-month billing interval.

## Tests
- `uv run pytest tests/test_pricing.py -q --no-cov`
- `bun run test src/components/dashboard/__tests__/InstanceCard.test.tsx --runInBand`
- `bun run build`
- `uv run pre-commit run --all-files`

## Summary by Sourcery

Tighten Stripe pricing coverage and align dashboard instance action layout with chat availability.

Bug Fixes:
- Ensure live Stripe price ID tests use configured pricing metadata instead of hard-coded IDs.
- Fix dashboard chat interface link handling to prefer the Cinny login URL when available and fall back to the Matrix server URL.

Enhancements:
- Unify computation of chat interface URLs for instances and conditionally use a two-column layout only when a chat action exists.

Tests:
- Expand pricing tests to cover configured test and live Stripe price IDs for BYOK, Hobby, and Pro plans and assert live IDs follow Stripe format.
- Extend dashboard InstanceCard tests to verify full-width action buttons and grid behavior when chat is present or absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Streamlined chat interface display logic for more consistent behavior on the instance dashboard, improving layout responsiveness when the chat interface is available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1086?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->