### PR TITLE
Derive admin MRR from pricing config

### DIFF
--- a/saas-platform/platform-backend/src/backend/routes/admin.py
+++ b/saas-platform/platform-backend/src/backend/routes/admin.py
@@ -22,7 +22,7 @@ from backend.models import (
     SyncResult,
     UpdateAccountStatusResponse,
 )
-from backend.pricing import load_pricing_config_model
+from backend.pricing import PRICING_CONFIG_MODEL
 from backend.routes.provisioner import (
     provision_instance,
     restart_instance_provisioner,
@@ -56,9 +56,8 @@ def audit_log_entry(
 
 def _monthly_plan_prices_usd() -> dict[str, int]:
     """Return configured monthly prices in dollars for automatic MRR estimates."""
-    pricing = load_pricing_config_model()
     prices: dict[str, int] = {}
-    for tier, plan in pricing.plans.items():
+    for tier, plan in PRICING_CONFIG_MODEL.plans.items():
         if isinstance(plan.price_monthly, int):
             prices[tier] = plan.price_monthly // 100
         else:

--- a/saas-platform/platform-backend/src/backend/routes/admin.py
+++ b/saas-platform/platform-backend/src/backend/routes/admin.py
@@ -6,9 +6,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Annotated, Any
 
 from backend.config import PROVISIONER_API_KEY, logger, stripe
-from pydantic import BaseModel
 from backend.deps import ensure_supabase, limiter, verify_admin
-from backend.utils.audit import create_audit_log
 from backend.models import (
     ActionResult,
     AdminAccountDetailsResponse,
@@ -24,6 +22,7 @@ from backend.models import (
     SyncResult,
     UpdateAccountStatusResponse,
 )
+from backend.pricing import load_pricing_config_model
 from backend.routes.provisioner import (
     provision_instance,
     restart_instance_provisioner,
@@ -32,7 +31,9 @@ from backend.routes.provisioner import (
     sync_instances,
     uninstall_instance,
 )
+from backend.utils.audit import create_audit_log
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
+from pydantic import BaseModel
 
 router = APIRouter()
 ALLOWED_RESOURCES = {"accounts", "subscriptions", "instances", "audit_logs", "usage_metrics"}
@@ -51,6 +52,18 @@ def audit_log_entry(
         details=details,
         success=True,  # Admin actions that reach this point are successful
     )
+
+
+def _monthly_plan_prices_usd() -> dict[str, int]:
+    """Return configured monthly prices in dollars for automatic MRR estimates."""
+    pricing = load_pricing_config_model()
+    prices: dict[str, int] = {}
+    for tier, plan in pricing.plans.items():
+        if isinstance(plan.price_monthly, int):
+            prices[tier] = plan.price_monthly // 100
+        else:
+            prices[tier] = 0
+    return prices
 
 
 @router.get("/admin/stats", response_model=AdminStatsOut)
@@ -325,7 +338,7 @@ async def get_dashboard_metrics(
         _ = sb.table("instances").select("*", count="exact", head=True).eq("status", "running").execute()
 
         subs_data = sb.table("subscriptions").select("tier").eq("status", "active").execute()
-        tier_prices = {"byok": 10, "hobby": 20, "pro": 200, "enterprise": 999, "free": 0}
+        tier_prices = _monthly_plan_prices_usd()
         mrr = sum(tier_prices.get(sub.get("tier", "free"), 0) for sub in (subs_data.data or []))
 
         seven_days_ago = (datetime.now(UTC) - timedelta(days=7)).isoformat()

--- a/saas-platform/platform-backend/tests/test_admin.py
+++ b/saas-platform/platform-backend/tests/test_admin.py
@@ -1,9 +1,11 @@
 """Comprehensive HTTP API tests for admin endpoints."""
 
 from datetime import UTC, datetime
+from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+import yaml
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
@@ -409,8 +411,24 @@ class TestAdminEndpoints:
         data = response.json()
         assert "data" in data
 
-    def test_admin_dashboard_metrics(self, client: TestClient, mock_supabase: MagicMock, mock_verify_admin: Mock):
+    def test_admin_dashboard_metrics(
+        self,
+        client: TestClient,
+        mock_supabase: MagicMock,
+        mock_verify_admin: Mock,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ):
         """Test admin dashboard metrics."""
+        from backend import pricing
+
+        pricing_config = pricing.load_pricing_config()
+        pricing_config["plans"]["byok"]["price_monthly"] = 3100
+        pricing_config["plans"]["pro"]["price_monthly"] = 9700
+        pricing_path = tmp_path / "pricing-config.yaml"
+        pricing_path.write_text(yaml.safe_dump(pricing_config), encoding="utf-8")
+        monkeypatch.setattr(pricing, "config_path", pricing_path)
+
         # Setup mock queries for each specific table call
         # Mock accounts query
         accounts_mock = MagicMock()
@@ -520,6 +538,7 @@ class TestAdminEndpoints:
         assert data["total_accounts"] == 100
         assert data["active_subscriptions"] == 70
         assert data["total_instances"] == 2  # We have 2 instances total in the mock
+        assert data["subscription_revenue"] == 128.0
 
     def test_admin_resource_not_in_allowlist(self, client: TestClient, mock_verify_admin: Mock):
         """Test admin accessing resource not in allowlist."""

--- a/saas-platform/platform-backend/tests/test_admin.py
+++ b/saas-platform/platform-backend/tests/test_admin.py
@@ -1,11 +1,9 @@
 """Comprehensive HTTP API tests for admin endpoints."""
 
 from datetime import UTC, datetime
-from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-import yaml
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
@@ -417,17 +415,15 @@ class TestAdminEndpoints:
         mock_supabase: MagicMock,
         mock_verify_admin: Mock,
         monkeypatch: pytest.MonkeyPatch,
-        tmp_path: Path,
     ):
         """Test admin dashboard metrics."""
         from backend import pricing
+        from backend.routes import admin
 
         pricing_config = pricing.load_pricing_config()
         pricing_config["plans"]["byok"]["price_monthly"] = 3100
         pricing_config["plans"]["pro"]["price_monthly"] = 9700
-        pricing_path = tmp_path / "pricing-config.yaml"
-        pricing_path.write_text(yaml.safe_dump(pricing_config), encoding="utf-8")
-        monkeypatch.setattr(pricing, "config_path", pricing_path)
+        monkeypatch.setattr(admin, "PRICING_CONFIG_MODEL", pricing.PricingConfig(**pricing_config))
 
         # Setup mock queries for each specific table call
         # Mock accounts query


### PR DESCRIPTION
## Summary
- derive admin dashboard MRR from `pricing-config.yaml` instead of a hard-coded tier price map
- treat free/custom monthly prices as zero in automatic MRR estimates
- add regression coverage proving dashboard MRR follows the pricing config

Closes #1084

## Verification
- `uv run pytest tests/test_admin.py::TestAdminEndpoints::test_admin_dashboard_metrics -q` red before the fix, then passed after the fix
- `uv run pytest tests/test_admin.py -q` passed: 20 passed
- `uv run ruff check src/backend/routes/admin.py tests/test_admin.py --fix && uv run ruff format src/backend/routes/admin.py tests/test_admin.py` passed
- `uv sync --all-extras && GIT_DIR=/Users/basnijholt/dev/mindroom/.git/worktrees/mindroom-admin-mrr-config GIT_WORK_TREE=/private/tmp/mindroom-admin-mrr-config uv run pre-commit run --all-files` passed

## Summary by Sourcery

Update admin dashboard MRR metrics to be derived from pricing configuration rather than hard-coded values and add regression coverage to ensure consistency.

New Features:
- Derive admin dashboard monthly recurring revenue from the pricing configuration model instead of an internal tier price map.

Bug Fixes:
- Treat non-numeric or free/custom monthly prices as zero when computing automatic MRR estimates to avoid inflating revenue metrics.

Tests:
- Extend admin dashboard metrics test to load and patch pricing configuration, verifying that subscription revenue reflects the configured plan prices.