### PR TITLE
Revoke superseded OpenRouter keys

### DIFF
--- a/saas-platform/platform-backend/src/backend/openrouter.py
+++ b/saas-platform/platform-backend/src/backend/openrouter.py
@@ -55,7 +55,7 @@ def _default_http_post(url: str, headers: dict[str, str], body: bytes) -> tuple[
 
 
 def _default_http_delete(url: str, headers: dict[str, str]) -> tuple[int, bytes]:
-    request = urllib.request.Request(url, headers=headers, method="DELETE")
+    request = urllib.request.Request(url, data=b"{}", headers=headers, method="DELETE")
     try:
         with urllib.request.urlopen(request, timeout=20) as response:  # noqa: S310
             return response.status, response.read()
@@ -127,16 +127,24 @@ def delete_openrouter_key(
     http_delete: HttpDelete = _default_http_delete,
 ) -> None:
     """Delete an OpenRouter API key by hash."""
-    if not management_api_key.strip():
+    if not isinstance(management_api_key, str):
+        msg = "OPENROUTER_PROVISIONING_API_KEY must be a string"
+        raise OpenRouterConfigurationError(msg)
+    management_api_key = management_api_key.strip()
+    if not management_api_key:
         msg = "OPENROUTER_PROVISIONING_API_KEY is required to delete OpenRouter keys"
         raise OpenRouterConfigurationError(msg)
-    if not key_hash.strip():
+    if not isinstance(key_hash, str):
+        msg = "OpenRouter key_hash must be a string"
+        raise OpenRouterError(msg)
+    key_hash = key_hash.strip()
+    if not key_hash:
         msg = "OpenRouter key_hash is required to delete OpenRouter keys"
         raise OpenRouterError(msg)
 
-    quoted_hash = urllib.parse.quote(key_hash.strip(), safe="")
+    quoted_hash = urllib.parse.quote(key_hash, safe="")
     headers = {
-        "Authorization": f"Bearer {management_api_key.strip()}",
+        "Authorization": f"Bearer {management_api_key}",
         "Content-Type": "application/json",
     }
     status, response_body = http_delete(f"{OPENROUTER_KEYS_URL}/{quoted_hash}", headers)
@@ -145,11 +153,15 @@ def delete_openrouter_key(
         msg = f"OpenRouter key deletion failed with status {status}: {error_detail}"
         raise OpenRouterError(msg)
 
+    decoded_body = response_body.decode("utf-8", errors="replace")
     try:
-        payload = json.loads(response_body.decode("utf-8"))
-    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
-        msg = "Failed to decode OpenRouter key deletion response"
+        payload = json.loads(decoded_body)
+    except json.JSONDecodeError as exc:
+        msg = f"OpenRouter key deletion response is invalid JSON: {decoded_body}"
         raise OpenRouterError(msg) from exc
+    if not isinstance(payload, dict):
+        msg = f"OpenRouter key deletion response has invalid response type: {decoded_body}"
+        raise OpenRouterError(msg)
     if payload.get("deleted") is not True:
-        msg = "OpenRouter key deletion response did not confirm deletion"
+        msg = f"OpenRouter key deletion response did not confirm deletion: {decoded_body}"
         raise OpenRouterError(msg)

--- a/saas-platform/platform-backend/src/backend/openrouter.py
+++ b/saas-platform/platform-backend/src/backend/openrouter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import urllib.error
+import urllib.parse
 import urllib.request
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -11,6 +12,7 @@ from dataclasses import dataclass
 OPENROUTER_KEYS_URL = "https://openrouter.ai/api/v1/keys"
 
 HttpPost = Callable[[str, dict[str, str], bytes], tuple[int, bytes]]
+HttpDelete = Callable[[str, dict[str, str]], tuple[int, bytes]]
 
 
 class OpenRouterError(RuntimeError):
@@ -49,6 +51,18 @@ def _default_http_post(url: str, headers: dict[str, str], body: bytes) -> tuple[
         return exc.code, exc.read()
     except urllib.error.URLError as exc:
         msg = "OpenRouter key creation failed before receiving a response"
+        raise OpenRouterError(msg) from exc
+
+
+def _default_http_delete(url: str, headers: dict[str, str]) -> tuple[int, bytes]:
+    request = urllib.request.Request(url, headers=headers, method="DELETE")
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:  # noqa: S310
+            return response.status, response.read()
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read()
+    except urllib.error.URLError as exc:
+        msg = "OpenRouter key deletion failed before receiving a response"
         raise OpenRouterError(msg) from exc
 
 
@@ -104,3 +118,38 @@ def create_openrouter_key(
     except (TypeError, ValueError) as exc:
         msg = "OpenRouter key creation response has invalid field values"
         raise OpenRouterError(msg) from exc
+
+
+def delete_openrouter_key(
+    *,
+    management_api_key: str,
+    key_hash: str,
+    http_delete: HttpDelete = _default_http_delete,
+) -> None:
+    """Delete an OpenRouter API key by hash."""
+    if not management_api_key.strip():
+        msg = "OPENROUTER_PROVISIONING_API_KEY is required to delete OpenRouter keys"
+        raise OpenRouterConfigurationError(msg)
+    if not key_hash.strip():
+        msg = "OpenRouter key_hash is required to delete OpenRouter keys"
+        raise OpenRouterError(msg)
+
+    quoted_hash = urllib.parse.quote(key_hash.strip(), safe="")
+    headers = {
+        "Authorization": f"Bearer {management_api_key.strip()}",
+        "Content-Type": "application/json",
+    }
+    status, response_body = http_delete(f"{OPENROUTER_KEYS_URL}/{quoted_hash}", headers)
+    if status != 200:
+        error_detail = response_body.decode("utf-8", errors="replace")
+        msg = f"OpenRouter key deletion failed with status {status}: {error_detail}"
+        raise OpenRouterError(msg)
+
+    try:
+        payload = json.loads(response_body.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        msg = "Failed to decode OpenRouter key deletion response"
+        raise OpenRouterError(msg) from exc
+    if payload.get("deleted") is not True:
+        msg = "OpenRouter key deletion response did not confirm deletion"
+        raise OpenRouterError(msg)

--- a/saas-platform/platform-backend/src/backend/routes/provisioner.py
+++ b/saas-platform/platform-backend/src/backend/routes/provisioner.py
@@ -73,6 +73,7 @@ from backend.openrouter import (
     OpenRouterError,
     OpenRouterKeyPlan,
     create_openrouter_key,
+    delete_openrouter_key,
 )
 from backend.pricing import get_plan_details
 from backend.process import run_helm
@@ -399,6 +400,16 @@ def _matching_openrouter_metadata(row: Mapping[str, Any] | None, monthly_limit_u
     )
 
 
+def _stored_openrouter_key_hash(row: Mapping[str, Any] | None) -> str | None:
+    """Return a stored OpenRouter key hash when it is usable for lifecycle cleanup."""
+    if not row:
+        return None
+    key_hash = row.get("openrouter_key_hash")
+    if isinstance(key_hash, str) and key_hash.strip():
+        return key_hash.strip()
+    return None
+
+
 def _persist_openrouter_key_metadata(sb: Any, instance_id: str, created_key: CreatedOpenRouterKey) -> None:
     """Persist non-secret OpenRouter key metadata for reuse and audit."""
     sb.table("instances").update(
@@ -443,6 +454,7 @@ async def _provision_openrouter_key(
         if existing_key:
             return existing_key
 
+    superseded_key_hash = _stored_openrouter_key_hash(existing_instance_row)
     create_key = partial(
         create_openrouter_key,
         management_api_key=OPENROUTER_PROVISIONING_API_KEY,
@@ -458,6 +470,7 @@ async def _provision_openrouter_key(
     except OpenRouterError as exc:
         raise HTTPException(status_code=502, detail=str(exc)) from exc
 
+    metadata_persisted = False
     try:
         await anyio.to_thread.run_sync(
             partial(
@@ -467,8 +480,25 @@ async def _provision_openrouter_key(
                 created_key,
             )
         )
+        metadata_persisted = True
     except Exception:
         logger.exception("Failed to persist OpenRouter key metadata for instance %s", instance_id)
+    if metadata_persisted and superseded_key_hash and superseded_key_hash != created_key.hash:
+        try:
+            await anyio.to_thread.run_sync(
+                partial(
+                    delete_openrouter_key,
+                    management_api_key=OPENROUTER_PROVISIONING_API_KEY,
+                    key_hash=superseded_key_hash,
+                )
+            )
+        except OpenRouterError:
+            logger.warning(
+                "Failed to revoke superseded OpenRouter key %s for instance %s",
+                superseded_key_hash,
+                instance_id,
+                exc_info=True,
+            )
     return created_key.key
 
 

--- a/saas-platform/platform-backend/tests/test_openrouter.py
+++ b/saas-platform/platform-backend/tests/test_openrouter.py
@@ -178,6 +178,39 @@ def test_delete_openrouter_key_sends_management_delete_request() -> None:
     assert captured["headers"]["Authorization"] == "Bearer sk-or-v1-management"
 
 
+def test_delete_openrouter_key_default_transport_sends_empty_json_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    """OpenRouter's delete endpoint expects an explicit empty JSON request body."""
+    captured: dict[str, Any] = {}
+
+    class FakeResponse:
+        status = 200
+
+        def __enter__(self) -> "FakeResponse":
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return b'{"deleted":true}'
+
+    def urlopen(request: Any, timeout: int) -> FakeResponse:
+        captured["url"] = request.full_url
+        captured["data"] = request.data
+        captured["timeout"] = timeout
+        return FakeResponse()
+
+    monkeypatch.setattr("backend.openrouter.urllib.request.urlopen", urlopen)
+
+    delete_openrouter_key(management_api_key="sk-or-v1-management", key_hash="hash_123")
+
+    assert captured == {
+        "url": "https://openrouter.ai/api/v1/keys/hash_123",
+        "data": b"{}",
+        "timeout": 20,
+    }
+
+
 def test_delete_openrouter_key_reports_openrouter_failures() -> None:
     """Failed OpenRouter key revocation should surface an operator-readable error."""
 
@@ -185,6 +218,56 @@ def test_delete_openrouter_key_reports_openrouter_failures() -> None:
         return 404, b'{"error":{"message":"Key not found"}}'
 
     with pytest.raises(OpenRouterError, match='OpenRouter key deletion failed with status 404: {"error"'):
+        delete_openrouter_key(
+            management_api_key="sk-or-v1-management",
+            key_hash="hash_123",
+            http_delete=http_delete,
+        )
+
+
+@pytest.mark.parametrize(
+    ("management_api_key", "expected_error"),
+    [(None, "OPENROUTER_PROVISIONING_API_KEY must be a string"), ("", "OPENROUTER_PROVISIONING_API_KEY is required")],
+)
+def test_delete_openrouter_key_rejects_invalid_management_key(management_api_key: object, expected_error: str) -> None:
+    """Local delete configuration errors should fail before making an OpenRouter request."""
+
+    def http_delete(url: str, headers: dict[str, str]) -> tuple[int, bytes]:  # noqa: ARG001
+        raise AssertionError("delete request should not be sent")
+
+    with pytest.raises(OpenRouterConfigurationError, match=expected_error):
+        delete_openrouter_key(
+            management_api_key=management_api_key,  # type: ignore[arg-type]
+            key_hash="hash_123",
+            http_delete=http_delete,
+        )
+
+
+@pytest.mark.parametrize(
+    ("key_hash", "expected_error"),
+    [(None, "OpenRouter key_hash must be a string"), ("", "OpenRouter key_hash is required")],
+)
+def test_delete_openrouter_key_rejects_invalid_key_hash(key_hash: object, expected_error: str) -> None:
+    """Delete input errors should be reported separately from management-key configuration errors."""
+
+    def http_delete(url: str, headers: dict[str, str]) -> tuple[int, bytes]:  # noqa: ARG001
+        raise AssertionError("delete request should not be sent")
+
+    with pytest.raises(OpenRouterError, match=expected_error):
+        delete_openrouter_key(
+            management_api_key="sk-or-v1-management",
+            key_hash=key_hash,  # type: ignore[arg-type]
+            http_delete=http_delete,
+        )
+
+
+def test_delete_openrouter_key_rejects_malformed_success_response() -> None:
+    """Malformed delete responses should include enough context for operator debugging."""
+
+    def http_delete(url: str, headers: dict[str, str]) -> tuple[int, bytes]:  # noqa: ARG001
+        return 200, b"[]"
+
+    with pytest.raises(OpenRouterError, match=r"invalid response.*\[\]"):
         delete_openrouter_key(
             management_api_key="sk-or-v1-management",
             key_hash="hash_123",

--- a/saas-platform/platform-backend/tests/test_openrouter.py
+++ b/saas-platform/platform-backend/tests/test_openrouter.py
@@ -11,6 +11,7 @@ from backend.openrouter import (
     OpenRouterError,
     OpenRouterKeyPlan,
     create_openrouter_key,
+    delete_openrouter_key,
 )
 
 
@@ -155,4 +156,37 @@ def test_create_openrouter_key_rejects_invalid_limit_value() -> None:
             management_api_key="sk-or-v1-management",
             plan=OpenRouterKeyPlan(name="MindRoom instance 42", monthly_limit_usd=15),
             http_post=http_post,
+        )
+
+
+def test_delete_openrouter_key_sends_management_delete_request() -> None:
+    """OpenRouter provisioning should revoke superseded customer keys by hash."""
+    captured: dict[str, Any] = {}
+
+    def http_delete(url: str, headers: dict[str, str]) -> tuple[int, bytes]:
+        captured["url"] = url
+        captured["headers"] = headers
+        return 200, b'{"deleted":true}'
+
+    delete_openrouter_key(
+        management_api_key="sk-or-v1-management",
+        key_hash="hash_123",
+        http_delete=http_delete,
+    )
+
+    assert captured["url"] == "https://openrouter.ai/api/v1/keys/hash_123"
+    assert captured["headers"]["Authorization"] == "Bearer sk-or-v1-management"
+
+
+def test_delete_openrouter_key_reports_openrouter_failures() -> None:
+    """Failed OpenRouter key revocation should surface an operator-readable error."""
+
+    def http_delete(url: str, headers: dict[str, str]) -> tuple[int, bytes]:  # noqa: ARG001
+        return 404, b'{"error":{"message":"Key not found"}}'
+
+    with pytest.raises(OpenRouterError, match='OpenRouter key deletion failed with status 404: {"error"'):
+        delete_openrouter_key(
+            management_api_key="sk-or-v1-management",
+            key_hash="hash_123",
+            http_delete=http_delete,
         )

--- a/saas-platform/platform-backend/tests/test_provisioner.py
+++ b/saas-platform/platform-backend/tests/test_provisioner.py
@@ -1,10 +1,11 @@
 """Comprehensive HTTP API tests for provisioner endpoints."""
 
 import base64
+import logging
 from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
 
 import pytest
-from backend.openrouter import CreatedOpenRouterKey
+from backend.openrouter import CreatedOpenRouterKey, OpenRouterError
 from fastapi.testclient import TestClient
 
 
@@ -89,6 +90,85 @@ def test_matching_openrouter_metadata_treats_invalid_stored_limit_as_cache_miss(
         )
         is False
     )
+
+
+@pytest.mark.asyncio
+async def test_provision_openrouter_key_revokes_superseded_stored_hash() -> None:
+    """Replacing a stored OpenRouter key should revoke the superseded key hash."""
+    from backend.routes.provisioner import _provision_openrouter_key
+
+    sb = MagicMock()
+    sb.table().update().eq().execute.return_value = Mock()
+    created_key = CreatedOpenRouterKey(
+        key="sk-or-v1-new-customer",
+        hash="new_hash",
+        label="MindRoom hobby instance 123",
+        limit_usd=15,
+        limit_reset="monthly",
+    )
+
+    with (
+        patch("backend.routes.provisioner.OPENROUTER_PROVISIONING_API_KEY", "sk-or-v1-management", create=True),
+        patch("backend.routes.provisioner.create_openrouter_key", return_value=created_key, create=True),
+        patch("backend.routes.provisioner.delete_openrouter_key", create=True) as delete_key,
+    ):
+        result = await _provision_openrouter_key(
+            sb=sb,
+            account_id="acc_123",
+            instance_id="123",
+            tier="hobby",
+            existing_instance_row={
+                "openrouter_key_hash": "old_hash",
+                "openrouter_key_limit_usd": 10,
+                "openrouter_key_limit_reset": "monthly",
+            },
+            namespace="mindroom-instances",
+        )
+
+    assert result == "sk-or-v1-new-customer"
+    delete_key.assert_called_once_with(management_api_key="sk-or-v1-management", key_hash="old_hash")
+
+
+@pytest.mark.asyncio
+async def test_provision_openrouter_key_logs_superseded_hash_revoke_failure(caplog: pytest.LogCaptureFixture) -> None:
+    """Superseded key deletion failure should be visible but not lose the replacement key."""
+    from backend.routes.provisioner import _provision_openrouter_key
+
+    sb = MagicMock()
+    sb.table().update().eq().execute.return_value = Mock()
+    created_key = CreatedOpenRouterKey(
+        key="sk-or-v1-new-customer",
+        hash="new_hash",
+        label="MindRoom hobby instance 123",
+        limit_usd=15,
+        limit_reset="monthly",
+    )
+
+    with (
+        caplog.at_level(logging.WARNING),
+        patch("backend.routes.provisioner.OPENROUTER_PROVISIONING_API_KEY", "sk-or-v1-management", create=True),
+        patch("backend.routes.provisioner.create_openrouter_key", return_value=created_key, create=True),
+        patch(
+            "backend.routes.provisioner.delete_openrouter_key",
+            side_effect=OpenRouterError("OpenRouter key deletion failed"),
+            create=True,
+        ),
+    ):
+        result = await _provision_openrouter_key(
+            sb=sb,
+            account_id="acc_123",
+            instance_id="123",
+            tier="hobby",
+            existing_instance_row={
+                "openrouter_key_hash": "old_hash",
+                "openrouter_key_limit_usd": 10,
+                "openrouter_key_limit_reset": "monthly",
+            },
+            namespace="mindroom-instances",
+        )
+
+    assert result == "sk-or-v1-new-customer"
+    assert "Failed to revoke superseded OpenRouter key old_hash for instance 123" in caplog.text
 
 
 async def _kubectl_without_credentials_encryption_secret(args: list[str], namespace: str | None = None):


### PR DESCRIPTION
## Summary
- add an OpenRouter Management API delete wrapper for key hashes
- revoke a stored old tenant key hash after replacement key metadata is successfully persisted
- keep provisioning usable if old-key revocation fails, while logging the failed hash for operator audit
- add regression coverage for delete requests, delete failures, successful revocation, and logged revocation failures

Closes #1085

Reference: https://openrouter.ai/docs/api/api-reference/api-keys/delete-keys

## Verification
- `uv run pytest tests/test_openrouter.py::test_delete_openrouter_key_sends_management_delete_request tests/test_openrouter.py::test_delete_openrouter_key_reports_openrouter_failures tests/test_provisioner.py::test_provision_openrouter_key_revokes_superseded_stored_hash tests/test_provisioner.py::test_provision_openrouter_key_logs_superseded_hash_revoke_failure -q` red before the fix, then passed after the fix
- `uv run pytest tests/test_openrouter.py tests/test_provisioner.py -q` passed: 51 passed
- `uv run ruff check src/backend/openrouter.py src/backend/routes/provisioner.py tests/test_openrouter.py tests/test_provisioner.py --fix && uv run ruff format src/backend/openrouter.py src/backend/routes/provisioner.py tests/test_openrouter.py tests/test_provisioner.py` passed
- `uv sync --all-extras && GIT_DIR=/Users/basnijholt/dev/mindroom/.git/worktrees/mindroom-openrouter-revoke GIT_WORK_TREE=/private/tmp/mindroom-openrouter-revoke uv run pre-commit run --all-files` passed

## Summary by Sourcery

Revoke superseded OpenRouter API keys when provisioning replacement keys while ensuring provisioning remains resilient to revocation failures.

New Features:
- Add support for deleting OpenRouter API keys via the Management API by key hash.
- Revoke previously stored OpenRouter key hashes after successfully persisting metadata for newly provisioned keys.

Bug Fixes:
- Ensure failed OpenRouter key revocations surface clear operator-facing errors and logs without aborting key provisioning.

Enhancements:
- Refine OpenRouter provisioning to only revoke valid, non-empty stored key hashes and log revocation failures with instance context.

Tests:
- Add unit tests covering OpenRouter key deletion requests, failure handling, superseded key revocation during provisioning, and logging of revocation failures.