### PR TITLE
Preserve requester metadata on visible router voice echoes

### DIFF
--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -905,7 +905,7 @@ class TurnController:
         text: str,
         thread_id: str | None,
     ) -> str | None:
-        """Optionally post a display-only router echo for normalized audio."""
+        """Optionally post a visible router echo for normalized audio."""
         if self.deps.agent_name != ROUTER_AGENT_NAME or not self.deps.runtime.config.voice.visible_router_echo:
             return None
 
@@ -924,6 +924,10 @@ class TurnController:
                 target=target,
                 response_text=text,
                 skip_mentions=True,
+                extra_content={
+                    ORIGINAL_SENDER_KEY: event.sender,
+                    "com.mindroom.source_kind": COALESCING_BYPASS_TRUSTED_INTERNAL_RELAY,
+                },
             ),
         )
         if visible_echo_event_id is not None:

--- a/tests/test_voice_command_processing.py
+++ b/tests/test_voice_command_processing.py
@@ -12,6 +12,7 @@ from agno.media import Audio
 
 from mindroom.attachments import _attachment_id_for_event, load_attachment
 from mindroom.bot import AgentBot
+from mindroom.coalescing import COALESCING_BYPASS_TRUSTED_INTERNAL_RELAY
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.constants import (
@@ -970,6 +971,10 @@ async def test_router_posts_visible_voice_echo_when_enabled(tmp_path) -> None:  
     assert request.response_text == f"{VOICE_PREFIX}@home turn on the lights"
     assert request.target.resolved_thread_id == "$voice_event"
     assert request.skip_mentions is True
+    assert request.extra_content == {
+        ORIGINAL_SENDER_KEY: "@alice:example.com",
+        "com.mindroom.source_kind": COALESCING_BYPASS_TRUSTED_INTERNAL_RELAY,
+    }
 
 
 @pytest.mark.asyncio
@@ -1053,7 +1058,10 @@ async def test_router_visible_voice_echo_keeps_multi_agent_handoff(tmp_path) -> 
     assert echo_request.target.reply_to_event_id == "$voice_event"
     assert echo_request.response_text == f"{VOICE_PREFIX}summarize this audio"
     assert echo_request.skip_mentions is True
-    assert echo_request.extra_content is None
+    assert echo_request.extra_content == {
+        ORIGINAL_SENDER_KEY: "@alice:example.com",
+        "com.mindroom.source_kind": COALESCING_BYPASS_TRUSTED_INTERNAL_RELAY,
+    }
     assert handoff_request.target.reply_to_event_id == "$voice_event"
     assert handoff_request.response_text == "@home could you help with this?"
     assert handoff_request.extra_content == {


### PR DESCRIPTION
## Summary
- stamp visible router voice echoes with the original requester metadata
- mark those echoes as trusted internal relays so downstream dispatch uses the relay origin consistently
- update voice routing tests to assert the emitted metadata

## Tests
- `uv run pytest tests/test_voice_command_processing.py -q`
- `uv run ruff check src/mindroom/turn_controller.py tests/test_voice_command_processing.py`

## Summary by Sourcery

Preserve and propagate original requester metadata on visible router voice echoes and mark them as trusted internal relays.

Enhancements:
- Attach original sender metadata and trusted internal relay source kind to visible router voice echo events so downstream routing uses consistent relay origin.
- Clarify the router echo helper docstring to describe visible voice echoes more accurately.

Tests:
- Extend voice routing tests to assert requester metadata and relay source flags on visible router echo events.