### PR TITLE
Keep shared provider keys out of tenant secrets

### DIFF
--- a/saas-platform/platform-backend/src/backend/routes/provisioner.py
+++ b/saas-platform/platform-backend/src/backend/routes/provisioner.py
@@ -17,9 +17,6 @@ from uuid import UUID
 
 import anyio
 from backend.config import (
-    ANTHROPIC_API_KEY,
-    DEEPSEEK_API_KEY,
-    GOOGLE_API_KEY,
     INSTANCE_BASE_DOMAIN,
     INSTANCE_CREDENTIALS_ENCRYPTION_SECRET,
     INSTANCE_IMAGE_PULL_SECRET_NAMES,
@@ -46,7 +43,6 @@ from backend.config import (
     INSTANCE_TRUSTED_UPSTREAM_MATRIX_USER_ID_HEADER,
     INSTANCE_TRUSTED_UPSTREAM_REQUIRE_JWT,
     INSTANCE_TRUSTED_UPSTREAM_USER_ID_HEADER,
-    OPENAI_API_KEY,
     OPENROUTER_PROVISIONING_API_KEY,
     PLATFORM_DOMAIN,
     PROVISIONER_API_KEY,
@@ -630,12 +626,13 @@ async def provision_instance(  # noqa: C901, PLR0912, PLR0915
             existing_instance_row=existing_instance_row,
             namespace=namespace,
         )
+        # User BYOK credentials live in tenant storage; hosted budgets use only a scoped OpenRouter key.
         instance_secret_data = {
-            "openai_key": OPENAI_API_KEY or "",
-            "anthropic_key": ANTHROPIC_API_KEY or "",
+            "openai_key": "",
+            "anthropic_key": "",
             "openrouter_key": openrouter_key,
-            "google_key": GOOGLE_API_KEY or "",
-            "deepseek_key": DEEPSEEK_API_KEY or "",
+            "google_key": "",
+            "deepseek_key": "",
             "supabase_service_key": SUPABASE_SERVICE_KEY or "",
             "sandbox_proxy_token": sandbox_proxy_token,
             "credentials_encryption_key": credentials_encryption_key,

--- a/saas-platform/platform-backend/tests/test_provisioner.py
+++ b/saas-platform/platform-backend/tests/test_provisioner.py
@@ -1,6 +1,7 @@
 """Comprehensive HTTP API tests for provisioner endpoints."""
 
 import base64
+import inspect
 import logging
 from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
 
@@ -50,6 +51,18 @@ def _assert_helm_uses_external_instance_secret(helm_args: list[str]) -> None:
     assert "instanceSecrets.hash" in set_string_args
     assert "credentials_encryption_key" not in set_args
     assert "credentials_encryption_key" not in set_file_args
+
+
+def _applied_instance_secret_data(apply_secret: AsyncMock) -> dict[str, str]:
+    """Return the Secret payload passed to _apply_instance_secret."""
+    from backend.routes.provisioner import _apply_instance_secret
+
+    apply_secret.assert_awaited()
+    bound = inspect.signature(_apply_instance_secret).bind(
+        *apply_secret.await_args.args,
+        **apply_secret.await_args.kwargs,
+    )
+    return bound.arguments["secret_data"]
 
 
 def test_owner_matrix_user_id_from_email_matches_synapse_oidc_template() -> None:
@@ -350,7 +363,7 @@ class TestProvisionerEndpoints:
             )
 
         assert response.status_code == 200
-        secret_data = apply_secret.call_args.args[2]
+        secret_data = _applied_instance_secret_data(apply_secret)
         assert secret_data["openrouter_key"] == ""
         create_key.assert_not_called()
 
@@ -377,7 +390,7 @@ class TestProvisionerEndpoints:
             )
 
         assert response.status_code == 200
-        secret_data = apply_secret.call_args.args[2]
+        secret_data = _applied_instance_secret_data(apply_secret)
         assert secret_data["openai_key"] == ""
         assert secret_data["anthropic_key"] == ""
         assert secret_data["google_key"] == ""
@@ -417,7 +430,7 @@ class TestProvisionerEndpoints:
             )
 
         assert response.status_code == 200
-        secret_data = apply_secret.call_args.args[2]
+        secret_data = _applied_instance_secret_data(apply_secret)
         assert secret_data["openrouter_key"] == "sk-or-v1-hobby-customer"
         assert secret_data["openai_key"] == ""
         assert secret_data["anthropic_key"] == ""
@@ -463,7 +476,7 @@ class TestProvisionerEndpoints:
         plan = create_key.call_args.kwargs["plan"]
         assert plan.monthly_limit_usd == 15
         assert plan.name == "MindRoom hobby account acc_test_123 instance 123"
-        secret_data = apply_secret.call_args.args[2]
+        secret_data = _applied_instance_secret_data(apply_secret)
         assert secret_data["openrouter_key"] == "sk-or-v1-hobby-customer"
         update_payloads = [call_.args[0] for call_ in mock_supabase.table().update.call_args_list if call_.args]
         assert any(payload.get("openrouter_key_hash") == "hobby_hash" for payload in update_payloads)
@@ -506,7 +519,7 @@ class TestProvisionerEndpoints:
             )
 
         assert response.status_code == 200
-        secret_data = apply_secret.call_args.args[2]
+        secret_data = _applied_instance_secret_data(apply_secret)
         assert secret_data["openrouter_key"] == "sk-or-v1-hobby-customer"
 
     def test_hobby_provisioning_missing_openrouter_management_key_returns_operator_error(
@@ -577,7 +590,7 @@ class TestProvisionerEndpoints:
         assert response.status_code == 200
         plan = create_key.call_args.kwargs["plan"]
         assert plan.monthly_limit_usd == 150
-        secret_data = apply_secret.call_args.args[2]
+        secret_data = _applied_instance_secret_data(apply_secret)
         assert secret_data["openrouter_key"] == "sk-or-v1-pro-customer"
         set_args = _helm_set_args(mock_helm.call_args.args[0])
         assert set_args["storage"] == "25Gi"

--- a/saas-platform/platform-backend/tests/test_provisioner.py
+++ b/saas-platform/platform-backend/tests/test_provisioner.py
@@ -274,7 +274,6 @@ class TestProvisionerEndpoints:
             PLATFORM_DOMAIN="mindroom.test",
             SUPABASE_URL="https://supabase.test",
             SUPABASE_ANON_KEY="test-anon-key",
-            OPENAI_API_KEY="test-openai",
         ):
             yield
 
@@ -354,6 +353,76 @@ class TestProvisionerEndpoints:
         secret_data = apply_secret.call_args.args[2]
         assert secret_data["openrouter_key"] == ""
         create_key.assert_not_called()
+
+    def test_byok_provisioning_does_not_inject_shared_platform_provider_keys(
+        self,
+        client: TestClient,
+        mock_supabase: MagicMock,
+        mock_kubectl: AsyncMock,
+        mock_helm: AsyncMock,
+        mock_wait_for_deployment: AsyncMock,
+        valid_auth_header: dict,
+        mock_config,
+    ):
+        """BYOK tenants should not receive shared platform model-provider keys."""
+        mock_supabase.table().insert().execute.return_value = Mock(data=[{"instance_id": "123"}])
+        mock_supabase.table().update().eq().execute.return_value = Mock()
+
+        with patch("backend.routes.provisioner._apply_instance_secret", new_callable=AsyncMock) as apply_secret:
+            apply_secret.return_value = "hash"
+            response = client.post(
+                "/system/provision",
+                json={"subscription_id": "sub_test_123", "account_id": "acc_test_123", "tier": "byok"},
+                headers=valid_auth_header,
+            )
+
+        assert response.status_code == 200
+        secret_data = apply_secret.call_args.args[2]
+        assert secret_data["openai_key"] == ""
+        assert secret_data["anthropic_key"] == ""
+        assert secret_data["google_key"] == ""
+        assert secret_data["deepseek_key"] == ""
+
+    def test_hobby_provisioning_only_injects_limited_openrouter_provider_key(
+        self,
+        client: TestClient,
+        mock_supabase: MagicMock,
+        mock_kubectl: AsyncMock,
+        mock_helm: AsyncMock,
+        mock_wait_for_deployment: AsyncMock,
+        valid_auth_header: dict,
+        mock_config,
+    ):
+        """Included-budget tenants should not receive shared direct provider keys."""
+        mock_supabase.table().insert().execute.return_value = Mock(data=[{"instance_id": "123"}])
+        mock_supabase.table().update().eq().execute.return_value = Mock()
+        created_key = CreatedOpenRouterKey(
+            key="sk-or-v1-hobby-customer",
+            hash="hobby_hash",
+            label="MindRoom hobby instance 123",
+            limit_usd=15,
+            limit_reset="monthly",
+        )
+
+        with (
+            patch("backend.routes.provisioner.OPENROUTER_PROVISIONING_API_KEY", "sk-or-v1-management", create=True),
+            patch("backend.routes.provisioner.create_openrouter_key", return_value=created_key, create=True),
+            patch("backend.routes.provisioner._apply_instance_secret", new_callable=AsyncMock) as apply_secret,
+        ):
+            apply_secret.return_value = "hash"
+            response = client.post(
+                "/system/provision",
+                json={"subscription_id": "sub_test_123", "account_id": "acc_test_123", "tier": "hobby"},
+                headers=valid_auth_header,
+            )
+
+        assert response.status_code == 200
+        secret_data = apply_secret.call_args.args[2]
+        assert secret_data["openrouter_key"] == "sk-or-v1-hobby-customer"
+        assert secret_data["openai_key"] == ""
+        assert secret_data["anthropic_key"] == ""
+        assert secret_data["google_key"] == ""
+        assert secret_data["deepseek_key"] == ""
 
     def test_hobby_provisioning_creates_monthly_limited_openrouter_key(
         self,


### PR DESCRIPTION
## Summary
- stop copying shared platform OpenAI/Anthropic/Google/DeepSeek keys into tenant instance Secrets
- keep hosted AI budgets scoped to per-tenant OpenRouter keys only
- add BYOK and Hobby regression coverage for provider-key isolation

## Validation
- uv run --directory saas-platform/platform-backend pytest -q
- PUPPETEER_SKIP_DOWNLOAD=1 uv run pre-commit run --all-files

## Live ops already applied
- upgraded instance-1 MindRoom containers to ghcr.io/mindroom-ai/mindroom:v2026.5.231
- blanked the live tenant model-provider keys in mindroom-api-keys-1
- verified https://1.mindroom.chat/api/health and /api/ready

## Summary by Sourcery

Enforce isolation of shared platform model provider credentials from tenant instance secrets and tighten provisioning behavior for BYOK and hobby tiers.

Enhancements:
- Stop injecting shared platform OpenAI, Anthropic, Google, and DeepSeek API keys into tenant instance secrets, ensuring hosted budgets rely only on scoped OpenRouter keys.

Tests:
- Add regression tests to verify BYOK tenants do not receive shared platform provider keys and hobby tenants only receive a limited OpenRouter key with no direct provider keys.