### PR TITLE
Preserve history compaction progress across stale session writes

### DIFF
--- a/src/mindroom/history/compaction.py
+++ b/src/mindroom/history/compaction.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import Awaitable, Callable, Iterable, Sequence
 from copy import deepcopy
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
@@ -428,7 +428,8 @@ async def _rewrite_working_session_for_compaction(  # noqa: C901, PLR0912, PLR09
 ) -> _CompactionRewriteResult | None:
     final_summary_text = _current_summary_text(working_session) or ""
     total_compacted_run_count = 0
-    all_compacted_run_ids: set[str] = set()
+    all_compacted_run_ids: list[str] = []
+    all_compacted_run_id_set: set[str] = set()
     compacted_messages: list[Message] = []
     pending_selected_run_ids: set[str] | None = None
 
@@ -509,7 +510,7 @@ async def _rewrite_working_session_for_compaction(  # noqa: C901, PLR0912, PLR09
         if before_persist_callback is not None:
             await before_persist_callback(included_runs)
         final_summary_text = generated_summary.summary
-        compacted_run_ids = {run.run_id for run in included_runs if isinstance(run.run_id, str) and run.run_id}
+        compacted_run_ids = tuple(run.run_id for run in included_runs if isinstance(run.run_id, str) and run.run_id)
         compacted_seen_event_ids = sorted(seen_event_ids_for_runs(included_runs))
         working_session.summary = SessionSummary(summary=generated_summary.summary, updated_at=datetime.now(UTC))
         working_state = read_scope_state(working_session, scope)
@@ -522,7 +523,10 @@ async def _rewrite_working_session_for_compaction(  # noqa: C901, PLR0912, PLR09
             update_scope_seen_event_ids(working_session, scope, compacted_seen_event_ids)
         working_session.runs = remove_runs_by_id(working_session.runs or [], compacted_run_ids)
         total_compacted_run_count += len(included_runs)
-        all_compacted_run_ids.update(compacted_run_ids)
+        for run_id in compacted_run_ids:
+            if run_id not in all_compacted_run_id_set:
+                all_compacted_run_id_set.add(run_id)
+                all_compacted_run_ids.append(run_id)
         if collect_compaction_hook_messages:
             compacted_messages.extend(_messages_for_runs(included_runs, history_settings))
         if pending_selected_run_ids is not None:
@@ -632,7 +636,7 @@ def _persist_compaction_progress(
     storage: BaseDb,
     persisted_session: AgentSession | TeamSession,
     working_session: AgentSession | TeamSession,
-    compacted_run_ids: set[str],
+    compacted_run_ids: Iterable[str],
     sync_remaining_runs: bool = False,
 ) -> None:
     """Save one successful compaction chunk before attempting the next chunk."""

--- a/src/mindroom/history/compaction.py
+++ b/src/mindroom/history/compaction.py
@@ -31,8 +31,10 @@ from pydantic import BaseModel
 from mindroom.cancellation import request_task_cancel
 from mindroom.constants import MINDROOM_COMPACTION_CHUNK_TIMEOUT_SECONDS
 from mindroom.history.storage import (
+    compacted_run_ids_with,
     metadata_with_merged_seen_event_ids,
     read_scope_state,
+    remove_runs_by_id,
     seen_event_ids_for_runs,
     update_scope_seen_event_ids,
     write_scope_state,
@@ -73,6 +75,7 @@ _EXCERPT_METADATA_OMIT_KEYS = frozenset(
 )
 _STANDARD_HISTORY_ROLES = frozenset({"user", "assistant", "tool"})
 _COMPACTION_CANCEL_DRAIN_TIMEOUT_SECONDS = 1.0
+_MIN_RETRY_SUMMARY_INPUT_BUDGET = 1_000
 type _ToolDefinition = dict[str, object]
 
 
@@ -343,6 +346,7 @@ async def compact_scope_history(
         last_compacted_at=compacted_at,
         last_summary_model=_model_identifier(summary_model),
         last_compacted_run_count=rewrite_result.compacted_run_count,
+        compacted_run_ids=compacted_run_ids_with(state, rewrite_result.compacted_run_ids),
         force_compact_before_next_run=False,
     )
     write_scope_state(session, scope, new_state)
@@ -508,9 +512,15 @@ async def _rewrite_working_session_for_compaction(  # noqa: C901, PLR0912, PLR09
         compacted_run_ids = {run.run_id for run in included_runs if isinstance(run.run_id, str) and run.run_id}
         compacted_seen_event_ids = sorted(seen_event_ids_for_runs(included_runs))
         working_session.summary = SessionSummary(summary=generated_summary.summary, updated_at=datetime.now(UTC))
+        working_state = read_scope_state(working_session, scope)
+        write_scope_state(
+            working_session,
+            scope,
+            replace(working_state, compacted_run_ids=compacted_run_ids_with(working_state, compacted_run_ids)),
+        )
         if compacted_seen_event_ids:
             update_scope_seen_event_ids(working_session, scope, compacted_seen_event_ids)
-        working_session.runs = _remove_runs_by_id(working_session.runs or [], compacted_run_ids)
+        working_session.runs = remove_runs_by_id(working_session.runs or [], compacted_run_ids)
         total_compacted_run_count += len(included_runs)
         all_compacted_run_ids.update(compacted_run_ids)
         if collect_compaction_hook_messages:
@@ -635,7 +645,7 @@ def _persist_compaction_progress(
         target_session.metadata,
         working_session.metadata,
     )
-    target_session.runs = _remove_runs_by_id(target_session.runs or [], compacted_run_ids)
+    target_session.runs = remove_runs_by_id(target_session.runs or [], compacted_run_ids)
     if sync_remaining_runs:
         target_session.runs = _sync_remaining_runs_from_working(
             target_session.runs or [],
@@ -990,12 +1000,12 @@ async def _generate_compaction_summary_with_retry(
     summary_prompt: str,
     timing_scope: str | None = None,
 ) -> _GeneratedSummaryChunk:
-    """Generate one summary chunk, retrying once with a smaller input when safe."""
+    """Generate one summary chunk, retrying with progressively smaller input when safe."""
     summary_input = initial_summary_input
     included_runs = initial_included_runs
     budget = summary_input_budget
-    last_error: Exception | None = None
-    for attempt in (1, 2):
+    attempt = 1
+    while True:
         estimated_input_tokens = estimate_text_tokens(summary_input)
         started = asyncio.get_running_loop().time()
         logger.info(
@@ -1032,9 +1042,8 @@ async def _generate_compaction_summary_with_retry(
                 duration_ms=duration_ms,
                 error=str(exc) or type(exc).__name__,
             )
-            last_error = exc
-            retry_budget = max(1_000, budget // 2)
-            if attempt == 1 and retry_budget < budget and _should_retry_smaller_summary_chunk(exc):
+            retry_budget = max(_MIN_RETRY_SUMMARY_INPUT_BUDGET, budget // 2)
+            if retry_budget < budget and _should_retry_smaller_summary_chunk(exc):
                 rebuilt_input, rebuilt_runs = _build_summary_input(
                     previous_summary=previous_summary,
                     compacted_runs=compactable_runs,
@@ -1045,6 +1054,7 @@ async def _generate_compaction_summary_with_retry(
                     summary_input = rebuilt_input
                     included_runs = rebuilt_runs
                     budget = retry_budget
+                    attempt += 1
                     continue
             raise
         duration_ms = int((asyncio.get_running_loop().time() - started) * 1000)
@@ -1061,8 +1071,6 @@ async def _generate_compaction_summary_with_retry(
             duration_ms=duration_ms,
         )
         return _GeneratedSummaryChunk(summary=summary, included_runs=included_runs)
-    assert last_error is not None
-    raise last_error
 
 
 def _should_retry_smaller_summary_chunk(error: Exception) -> bool:
@@ -1646,36 +1654,6 @@ def _estimated_message_chars(message: Message) -> int:
     content_chars = len(_render_message_content(message))
     tool_call_chars = len(stable_serialize(message.tool_calls)) if message.tool_calls else 0
     return content_chars + tool_call_chars + _estimate_message_media_chars(message)
-
-
-def _remove_runs_by_id(
-    runs: Sequence[RunOutput | TeamRunOutput],
-    compacted_run_ids: set[str],
-) -> list[RunOutput | TeamRunOutput]:
-    if not compacted_run_ids:
-        return list(runs)
-
-    remove_ids = set(compacted_run_ids)
-    changed = True
-    while changed:
-        changed = False
-        for run in runs:
-            parent_run_id = run.parent_run_id
-            run_id = run.run_id
-            if not isinstance(parent_run_id, str) or not isinstance(run_id, str):
-                continue
-            if parent_run_id in remove_ids and run_id not in remove_ids:
-                remove_ids.add(run_id)
-                changed = True
-
-    return [
-        run
-        for run in runs
-        if not (
-            (isinstance(run.run_id, str) and run.run_id in remove_ids)
-            or (isinstance(run.parent_run_id, str) and run.parent_run_id in remove_ids)
-        )
-    ]
 
 
 def _estimate_message_media_chars(message: Message) -> int:

--- a/src/mindroom/history/runtime.py
+++ b/src/mindroom/history/runtime.py
@@ -40,6 +40,7 @@ from mindroom.history.policy import (
 from mindroom.history.storage import (
     clear_force_compaction_state,
     consume_pending_force_compaction_scope,
+    prune_compacted_runs_from_session,
     read_scope_state,
     set_force_compaction_state,
     write_scope_state,
@@ -1409,6 +1410,8 @@ def _prepare_scope_state_for_run(
     execution_plan: ResolvedHistoryExecutionPlan,
 ) -> HistoryScopeState:
     state = read_scope_state(session, scope)
+    if prune_compacted_runs_from_session(session, state):
+        storage.upsert_session(session)
     if consume_pending_force_compaction_scope(session, scope):
         state = set_force_compaction_state(session, scope, state, force=True)
         storage.upsert_session(session)

--- a/src/mindroom/history/storage.py
+++ b/src/mindroom/history/storage.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
 _COMPACTION_METADATA_VERSION = 2
 _MATRIX_HISTORY_METADATA_VERSION = 1
 _PENDING_COMPACTION_SCOPE_KEYS_SESSION_STATE_KEY = "mindroom_pending_compaction_scope_keys"
+_COMPACTED_RUN_ID_RETENTION_LIMIT = 1_024
 
 
 def read_scope_state(session: AgentSession | TeamSession, scope: HistoryScope) -> HistoryScopeState:
@@ -237,9 +238,7 @@ def _parse_state(raw_state: dict[str, Any]) -> HistoryScopeState:
         last_summary_model=summary_model if isinstance(summary_model, str) else None,
         last_compacted_run_count=compacted_run_count if isinstance(compacted_run_count, int) else None,
         compacted_run_ids=(
-            tuple(sorted({run_id for run_id in compacted_run_ids if isinstance(run_id, str) and run_id}))
-            if isinstance(compacted_run_ids, list)
-            else ()
+            _normalize_compacted_run_ids(compacted_run_ids) if isinstance(compacted_run_ids, list) else ()
         ),
         force_compact_before_next_run=bool(force_flag),
     )
@@ -256,7 +255,7 @@ def _state_to_metadata(state: HistoryScopeState) -> dict[str, object]:
     if state.last_compacted_run_count is not None:
         payload["last_compacted_run_count"] = state.last_compacted_run_count
     if state.compacted_run_ids:
-        payload["compacted_run_ids"] = list(state.compacted_run_ids)
+        payload["compacted_run_ids"] = list(_normalize_compacted_run_ids(state.compacted_run_ids))
     return payload
 
 
@@ -272,9 +271,7 @@ def _state_is_empty(state: HistoryScopeState) -> bool:
 
 def compacted_run_ids_with(state: HistoryScopeState, run_ids: Iterable[str]) -> tuple[str, ...]:
     """Return the state tombstone set with additional compacted run ids."""
-    merged = set(state.compacted_run_ids)
-    merged.update(run_id for run_id in run_ids if run_id)
-    return tuple(sorted(merged))
+    return _normalize_compacted_run_ids([*state.compacted_run_ids, *run_ids])
 
 
 def remove_runs_by_id(
@@ -287,17 +284,20 @@ def remove_runs_by_id(
         return list(runs)
 
     run_list = list(runs)
-    changed = True
-    while changed:
-        changed = False
-        for run in run_list:
-            parent_run_id = run.parent_run_id
-            run_id = run.run_id
-            if not isinstance(parent_run_id, str) or not isinstance(run_id, str):
-                continue
-            if parent_run_id in remove_ids and run_id not in remove_ids:
-                remove_ids.add(run_id)
-                changed = True
+    children_by_parent: dict[str, list[str]] = {}
+    for run in run_list:
+        parent_run_id = run.parent_run_id
+        run_id = run.run_id
+        if isinstance(parent_run_id, str) and parent_run_id and isinstance(run_id, str) and run_id:
+            children_by_parent.setdefault(parent_run_id, []).append(run_id)
+
+    stack = list(remove_ids)
+    while stack:
+        run_id = stack.pop()
+        for child_run_id in children_by_parent.get(run_id, []):
+            if child_run_id not in remove_ids:
+                remove_ids.add(child_run_id)
+                stack.append(child_run_id)
 
     return [
         run
@@ -307,6 +307,17 @@ def remove_runs_by_id(
             or (isinstance(run.parent_run_id, str) and run.parent_run_id in remove_ids)
         )
     ]
+
+
+def _normalize_compacted_run_ids(run_ids: Iterable[object]) -> tuple[str, ...]:
+    compacted_run_ids: list[str] = []
+    seen_run_ids: set[str] = set()
+    for run_id in run_ids:
+        if not isinstance(run_id, str) or not run_id or run_id in seen_run_ids:
+            continue
+        seen_run_ids.add(run_id)
+        compacted_run_ids.append(run_id)
+    return tuple(compacted_run_ids[-_COMPACTED_RUN_ID_RETENTION_LIMIT:])
 
 
 def prune_compacted_runs_from_session(

--- a/src/mindroom/history/storage.py
+++ b/src/mindroom/history/storage.py
@@ -230,11 +230,17 @@ def _parse_state(raw_state: dict[str, Any]) -> HistoryScopeState:
     compacted_at = raw_state.get("last_compacted_at")
     summary_model = raw_state.get("last_summary_model")
     compacted_run_count = raw_state.get("last_compacted_run_count")
+    compacted_run_ids = raw_state.get("compacted_run_ids")
     force_flag = raw_state.get("force_compact_before_next_run")
     return HistoryScopeState(
         last_compacted_at=compacted_at if isinstance(compacted_at, str) else None,
         last_summary_model=summary_model if isinstance(summary_model, str) else None,
         last_compacted_run_count=compacted_run_count if isinstance(compacted_run_count, int) else None,
+        compacted_run_ids=(
+            tuple(sorted({run_id for run_id in compacted_run_ids if isinstance(run_id, str) and run_id}))
+            if isinstance(compacted_run_ids, list)
+            else ()
+        ),
         force_compact_before_next_run=bool(force_flag),
     )
 
@@ -249,6 +255,8 @@ def _state_to_metadata(state: HistoryScopeState) -> dict[str, object]:
         payload["last_summary_model"] = state.last_summary_model
     if state.last_compacted_run_count is not None:
         payload["last_compacted_run_count"] = state.last_compacted_run_count
+    if state.compacted_run_ids:
+        payload["compacted_run_ids"] = list(state.compacted_run_ids)
     return payload
 
 
@@ -257,8 +265,63 @@ def _state_is_empty(state: HistoryScopeState) -> bool:
         state.last_compacted_at is None
         and state.last_summary_model is None
         and state.last_compacted_run_count is None
+        and not state.compacted_run_ids
         and not state.force_compact_before_next_run
     )
+
+
+def compacted_run_ids_with(state: HistoryScopeState, run_ids: Iterable[str]) -> tuple[str, ...]:
+    """Return the state tombstone set with additional compacted run ids."""
+    merged = set(state.compacted_run_ids)
+    merged.update(run_id for run_id in run_ids if run_id)
+    return tuple(sorted(merged))
+
+
+def remove_runs_by_id(
+    runs: Iterable[RunOutput | TeamRunOutput],
+    compacted_run_ids: Iterable[str],
+) -> list[RunOutput | TeamRunOutput]:
+    """Return runs with compacted run ids, and their child runs, removed."""
+    remove_ids = {run_id for run_id in compacted_run_ids if run_id}
+    if not remove_ids:
+        return list(runs)
+
+    run_list = list(runs)
+    changed = True
+    while changed:
+        changed = False
+        for run in run_list:
+            parent_run_id = run.parent_run_id
+            run_id = run.run_id
+            if not isinstance(parent_run_id, str) or not isinstance(run_id, str):
+                continue
+            if parent_run_id in remove_ids and run_id not in remove_ids:
+                remove_ids.add(run_id)
+                changed = True
+
+    return [
+        run
+        for run in run_list
+        if not (
+            (isinstance(run.run_id, str) and run.run_id in remove_ids)
+            or (isinstance(run.parent_run_id, str) and run.parent_run_id in remove_ids)
+        )
+    ]
+
+
+def prune_compacted_runs_from_session(
+    session: AgentSession | TeamSession,
+    state: HistoryScopeState,
+) -> bool:
+    """Remove any run that was already recorded as compacted in scope metadata."""
+    if not state.compacted_run_ids:
+        return False
+    runs = session.runs or []
+    pruned_runs = remove_runs_by_id(runs, state.compacted_run_ids)
+    if len(pruned_runs) == len(runs):
+        return False
+    session.runs = pruned_runs
+    return True
 
 
 def _read_preserved_scope_seen_event_ids(session: AgentSession | TeamSession, scope: HistoryScope) -> set[str]:

--- a/src/mindroom/history/types.py
+++ b/src/mindroom/history/types.py
@@ -89,6 +89,7 @@ class HistoryScopeState:
     last_compacted_at: str | None = None
     last_summary_model: str | None = None
     last_compacted_run_count: int | None = None
+    compacted_run_ids: tuple[str, ...] = field(default_factory=tuple)
     force_compact_before_next_run: bool = False
 
 

--- a/src/mindroom/prompts.py
+++ b/src/mindroom/prompts.py
@@ -287,6 +287,8 @@ Rules:
 - Preserve all still-relevant information from <previous_summary>.
 - Add only the new information from <new_conversation>.
 - Keep unchanged wording verbatim when it is still correct so future prompt prefixes remain stable.
+- The compacted runs may be only an older prefix of a longer conversation. Do not claim a goal, status, or next step
+  is current unless the compacted input explicitly shows that it remains current after that prefix.
 - Never paraphrase away exact technical details such as file paths, function names, class names, commands, Matrix IDs, model names, config keys, numeric thresholds, ports, URLs, or error text.
 - Preserve tool activity when it matters to current state, especially file edits, commands, and tool results.
 - Do not invent facts.

--- a/tests/test_agno_history.py
+++ b/tests/test_agno_history.py
@@ -85,8 +85,10 @@ from mindroom.history.runtime import (
     prepare_scope_history,
 )
 from mindroom.history.storage import (
+    compacted_run_ids_with,
     read_scope_seen_event_ids,
     read_scope_state,
+    remove_runs_by_id,
     set_force_compaction_state,
     update_scope_seen_event_ids,
     write_scope_state,
@@ -5915,6 +5917,57 @@ def test_scope_seen_event_ids_do_not_bleed_between_scopes(tmp_path: Path) -> Non
 
     assert read_scope_seen_event_ids(session, agent_scope) == {"agent-event"}
     assert read_scope_seen_event_ids(session, team_scope) == {"team-event", "preserved-team-event"}
+
+
+def test_compacted_run_ids_with_caps_tombstones_to_newest_ids() -> None:
+    existing_ids = tuple(f"old-{index}" for index in range(1_024))
+
+    compacted_run_ids = compacted_run_ids_with(
+        HistoryScopeState(compacted_run_ids=existing_ids),
+        ["new-1", "new-2"],
+    )
+
+    assert len(compacted_run_ids) == 1_024
+    assert compacted_run_ids[:2] == ("old-2", "old-3")
+    assert compacted_run_ids[-2:] == ("new-1", "new-2")
+    assert "old-0" not in compacted_run_ids
+
+
+def test_write_scope_state_caps_compacted_run_id_metadata() -> None:
+    scope = HistoryScope(kind="agent", scope_id="test_agent")
+    session = _session("session-1")
+
+    write_scope_state(
+        session,
+        scope,
+        HistoryScopeState(compacted_run_ids=tuple(f"run-{index}" for index in range(1_026))),
+    )
+
+    metadata = session.metadata or {}
+    raw_compaction = metadata[MINDROOM_COMPACTION_METADATA_KEY]
+    assert isinstance(raw_compaction, dict)
+    raw_states = raw_compaction["states"]
+    assert isinstance(raw_states, dict)
+    raw_state = raw_states[scope.key]
+    assert isinstance(raw_state, dict)
+    compacted_run_ids = raw_state["compacted_run_ids"]
+    assert isinstance(compacted_run_ids, list)
+    assert len(compacted_run_ids) == 1_024
+    assert compacted_run_ids[:2] == ["run-2", "run-3"]
+    assert compacted_run_ids[-2:] == ["run-1024", "run-1025"]
+
+
+def test_remove_runs_by_id_removes_descendants() -> None:
+    runs = [
+        RunOutput(run_id="unrelated", status=RunStatus.completed),
+        RunOutput(run_id="child", parent_run_id="root", status=RunStatus.completed),
+        RunOutput(run_id="grandchild", parent_run_id="child", status=RunStatus.completed),
+        RunOutput(run_id="root", status=RunStatus.completed),
+    ]
+
+    pruned_runs = remove_runs_by_id(runs, ["root"])
+
+    assert [run.run_id for run in pruned_runs] == ["unrelated"]
 
 
 def test_compaction_progress_preserves_newer_seen_event_ids(tmp_path: Path) -> None:

--- a/tests/test_agno_history.py
+++ b/tests/test_agno_history.py
@@ -749,12 +749,60 @@ async def test_prepare_history_for_run_forced_compaction_rewrites_session(tmp_pa
     state = read_scope_state(persisted, scope)
     assert state.last_summary_model == "summary-model"
     assert state.last_compacted_run_count == 4
+    assert state.compacted_run_ids == ("run-1", "run-2", "run-3", "run-4")
     assert state.force_compact_before_next_run is False
     assert state.last_compacted_at is not None
 
     assert prepared.replays_persisted_history is True
     assert len(prepared.compaction_outcomes) == 1
     assert prepared.compaction_outcomes[0].summary == "merged summary"
+
+
+@pytest.mark.asyncio
+async def test_prepare_history_for_run_prunes_reintroduced_compacted_runs(tmp_path: Path) -> None:
+    """Compacted run tombstones should win over a later stale session write."""
+    config, runtime_paths = _make_config(
+        tmp_path,
+        compaction=CompactionOverrideConfig(enabled=True),
+        context_window=64_000,
+    )
+    storage = create_session_storage("test_agent", config, runtime_paths, execution_identity=None)
+    scope = HistoryScope(kind="agent", scope_id="test_agent")
+    session = _session(
+        "session-1",
+        runs=[
+            _completed_run("run-1"),
+            _completed_run("run-2"),
+        ],
+    )
+    write_scope_state(
+        session,
+        scope,
+        HistoryScopeState(
+            last_compacted_at="2026-01-01T00:00:00Z",
+            last_summary_model="summary-model",
+            last_compacted_run_count=1,
+            compacted_run_ids=("run-1",),
+        ),
+    )
+    storage.upsert_session(session)
+
+    prepared = await prepare_history_for_run_for_test(
+        agent=_agent(db=storage),
+        agent_name="test_agent",
+        full_prompt="Current prompt",
+        session_id="session-1",
+        runtime_paths=runtime_paths,
+        config=config,
+        execution_identity=None,
+        storage=storage,
+        session=session,
+    )
+
+    persisted = get_agent_session(storage, "session-1")
+    assert persisted is not None
+    assert [run.run_id for run in persisted.runs or []] == ["run-2"]
+    assert prepared.replay_plan is not None
 
 
 @pytest.mark.asyncio
@@ -1223,6 +1271,66 @@ async def test_rewrite_retries_summary_with_smaller_chunk_after_timeout(tmp_path
 
     assert rewrite_result is not None
     assert len(summary_inputs) == 2
+    assert estimate_text_tokens(summary_inputs[1]) < estimate_text_tokens(summary_inputs[0])
+
+
+@pytest.mark.asyncio
+async def test_rewrite_keeps_shrinking_summary_chunks_after_repeated_timeouts(tmp_path: Path) -> None:
+    config, runtime_paths = _make_config(tmp_path)
+    storage = create_session_storage("test_agent", config, runtime_paths, execution_identity=None)
+    scope = HistoryScope(kind="agent", scope_id="test_agent")
+    working_session = _session(
+        "session-1",
+        runs=[
+            _completed_run(
+                "run-1",
+                messages=[
+                    Message(role="user", content="u" * 16_000),
+                    Message(role="assistant", content="a" * 16_000),
+                ],
+            ),
+        ],
+    )
+    summary_inputs: list[str] = []
+
+    async def fake_summary(*, summary_input: str, **_kwargs: object) -> SessionSummary:
+        summary_inputs.append(summary_input)
+        if len(summary_inputs) < 3:
+            msg = f"compaction summary timed out after {MINDROOM_COMPACTION_CHUNK_TIMEOUT_SECONDS}s"
+            raise RuntimeError(msg)
+        return SessionSummary(summary="merged summary", updated_at=datetime.now(UTC))
+
+    with patch(
+        "mindroom.history.compaction._generate_compaction_summary",
+        new=AsyncMock(side_effect=fake_summary),
+    ):
+        rewrite_result = await _rewrite_working_session_for_compaction(
+            storage=storage,
+            persisted_session=working_session,
+            working_session=working_session,
+            summary_model=FakeModel(id="summary-model", provider="fake"),
+            summary_model_name="summary-model",
+            session_id="session-1",
+            scope=scope,
+            state=HistoryScopeState(force_compact_before_next_run=True),
+            history_settings=ResolvedHistorySettings(
+                policy=HistoryPolicy(mode="all"),
+                max_tool_calls_from_history=None,
+            ),
+            available_history_budget=None,
+            summary_input_budget=16_000,
+            before_tokens=0,
+            runs_before=1,
+            threshold_tokens=None,
+            summary_prompt=COMPACTION_SUMMARY_PROMPT,
+            lifecycle_notice_event_id=None,
+            progress_callback=None,
+            collect_compaction_hook_messages=False,
+        )
+
+    assert rewrite_result is not None
+    assert len(summary_inputs) == 3
+    assert estimate_text_tokens(summary_inputs[2]) < estimate_text_tokens(summary_inputs[1])
     assert estimate_text_tokens(summary_inputs[1]) < estimate_text_tokens(summary_inputs[0])
 
 


### PR DESCRIPTION
Summary:
- Persist compacted run ids in history scope metadata and prune any reintroduced compacted runs before replay planning.
- Preserve chunk-level compaction progress so later stale session writes cannot bring already-summarized runs back into prompt history.
- Retry timed-out compaction summary chunks with progressively smaller budgets and clarify that summaries may cover only an older prefix.

Tests:
- uv run pytest tests/test_agno_history.py -q -n 0
- uv run ruff check src/mindroom/history/compaction.py src/mindroom/history/runtime.py src/mindroom/history/storage.py src/mindroom/history/types.py src/mindroom/prompts.py tests/test_agno_history.py
- pre-commit hooks from git commit

## Summary by Sourcery

Track compacted run IDs in history scope metadata and prune any already-compacted runs before planning or persisting history, while making compaction summaries more robust to timeouts and partial-prefix inputs.

Bug Fixes:
- Prevent stale or out-of-order session writes from reintroducing runs that have already been compacted into history summaries.

Enhancements:
- Persist compacted run IDs in scope state, including across compaction and persistence flows, and use them to prune runs and their descendants from sessions.
- Refine compaction summary retry logic to keep shrinking the summary input budget on repeated timeouts down to a minimum threshold.
- Clarify the compaction summary prompt to indicate that summarized runs may cover only an older prefix of the conversation so models avoid implying current state beyond that prefix.

Tests:
- Add tests covering pruning of reintroduced compacted runs and repeated shrinking of summary chunks after compaction timeouts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved history compaction reliability with enhanced retry logic for summary generation timeouts.
  * Fixed issue where previously compacted runs could reappear in conversation history.

* **Improvements**
  * Enhanced compaction summary accuracy when summarizing partial conversation context.
  * Better tracking and management of compacted run history.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1094?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->