### PR TITLE
Extract coalescing order book

### DIFF
--- a/src/mindroom/coalescing.py
+++ b/src/mindroom/coalescing.py
@@ -21,6 +21,7 @@ from .coalescing_cleanup import (
     close_pending_event_metadata_once,
     close_ready_task_result_metadata,
 )
+from .coalescing_order import CoalescingOrderBook, IngressOrderReservation
 from .coalescing_policy import (
     QueueKind,
     is_coalescing_exempt_source_kind,
@@ -85,29 +86,6 @@ class _QueuedEvent:
             msg = "Queued admission has not resolved to a pending event"
             raise RuntimeError(msg)
         return self.ready_result.pending_event
-
-
-@dataclass
-class IngressOrderReservation:
-    """Receive-order placeholder for ingress that must resolve its canonical key first."""
-
-    room_id: str
-    requester_user_id: str
-    received_order: int
-    receipt_time: float
-    released: bool = False
-    settled: asyncio.Event = field(default_factory=asyncio.Event, repr=False, compare=False)
-    _release: Callable[[IngressOrderReservation], None] | None = field(default=None, repr=False, compare=False)
-
-    def release(self) -> None:
-        """Release this reservation if it will not be admitted."""
-        if self._release is None:
-            if self.released:
-                return
-            self.released = True
-            self.settled.set()
-            return
-        self._release(self)
 
 
 @dataclass(frozen=True)
@@ -240,9 +218,8 @@ class CoalescingGate:
         self._upload_grace_seconds = upload_grace_seconds
         self._is_shutting_down = is_shutting_down
         self._gates: dict[CoalescingKey, _GateEntry] = {}
-        self._order_reservations: list[IngressOrderReservation] = []
+        self._order_book = CoalescingOrderBook()
         self._in_flight_buffered_max_order: dict[CoalescingKey, int] = {}
-        self._next_received_order = 0
         self._active_drain_context: _DrainContext | None = None
 
     def _remove_gate(self, key: CoalescingKey) -> None:
@@ -274,14 +251,6 @@ class CoalescingGate:
     def _same_owner(left: CoalescingKey, right: CoalescingKey) -> bool:
         return left.room_id == right.room_id and left.requester_user_id == right.requester_user_id
 
-    @staticmethod
-    def _reservation_matches_key(reservation: IngressOrderReservation, key: CoalescingKey) -> bool:
-        return reservation.room_id == key.room_id and reservation.requester_user_id == key.requester_user_id
-
-    def _next_order(self) -> int:
-        self._next_received_order += 1
-        return self._next_received_order
-
     def _wake_owner(self, room_id: str, requester_user_id: str) -> None:
         for gate_key, gate in self._gates.items():
             if gate_key.room_id == room_id and gate_key.requester_user_id == requester_user_id:
@@ -291,20 +260,6 @@ class CoalescingGate:
         for other_key, other_gate in self._gates.items():
             if other_key != key and self._same_owner(other_key, key):
                 self._wake(other_gate)
-
-    def _older_owner_reservations(
-        self,
-        key: CoalescingKey,
-        *,
-        before_order: int,
-    ) -> list[IngressOrderReservation]:
-        return [
-            reservation
-            for reservation in self._order_reservations
-            if not reservation.released
-            and self._reservation_matches_key(reservation, key)
-            and reservation.received_order < before_order
-        ]
 
     def _older_owner_root_gates(
         self,
@@ -332,14 +287,6 @@ class CoalescingGate:
             )
         ]
 
-    def _has_older_unresolved_owner_reservation(self, key: CoalescingKey, received_order: int) -> bool:
-        return any(
-            not reservation.released
-            and self._reservation_matches_key(reservation, key)
-            and reservation.received_order < received_order
-            for reservation in self._order_reservations
-        )
-
     async def _wait_until_front_claimable(
         self,
         key: CoalescingKey,
@@ -350,7 +297,7 @@ class CoalescingGate:
         while True:
             await self._wait_for_reservations(
                 gate,
-                self._older_owner_reservations(key, before_order=front_order),
+                self._order_book.older_owner_reservations(key, before_order=front_order),
             )
             older_gates = self._older_owner_root_gates(key, before_order=front_order)
             if not older_gates:
@@ -385,45 +332,6 @@ class CoalescingGate:
                 self._release_unsettled_reservations(unsettled, drain_context.result)
                 return
 
-    def _unsettled_owner_reservations_in_window(
-        self,
-        key: CoalescingKey,
-        *,
-        after_order: int,
-        before_order: int | None,
-        before_or_at_receipt_time: float,
-        buffered_in_flight_max_order: int | None = None,
-    ) -> list[IngressOrderReservation]:
-        return [
-            reservation
-            for reservation in self._order_reservations
-            if not reservation.released
-            and self._reservation_matches_key(reservation, key)
-            and reservation.received_order > after_order
-            and (before_order is None or reservation.received_order < before_order)
-            and (
-                reservation.receipt_time <= before_or_at_receipt_time
-                or (
-                    buffered_in_flight_max_order is not None
-                    and reservation.received_order <= buffered_in_flight_max_order
-                )
-            )
-        ]
-
-    def _unsettled_owner_reservation_orders_after(
-        self,
-        key: CoalescingKey,
-        *,
-        after_order: int,
-    ) -> list[int]:
-        return [
-            reservation.received_order
-            for reservation in self._order_reservations
-            if not reservation.released
-            and self._reservation_matches_key(reservation, key)
-            and reservation.received_order > after_order
-        ]
-
     def _set_buffered_in_flight_max_order(
         self,
         key: CoalescingKey,
@@ -433,7 +341,7 @@ class CoalescingGate:
     ) -> None:
         buffered_orders = [queued.received_order for queued in gate.queue if queued.received_order > after_order]
         buffered_orders.extend(
-            self._unsettled_owner_reservation_orders_after(key, after_order=after_order),
+            self._order_book.unsettled_owner_reservation_orders_after(key, after_order=after_order),
         )
         gate.buffered_in_flight_max_order = max(buffered_orders, default=None)
         if gate.buffered_in_flight_max_order is None:
@@ -454,7 +362,7 @@ class CoalescingGate:
         related_keys = {
             CoalescingKey(key.room_id, source_event_id, key.requester_user_id) for source_event_id in source_event_ids
         }
-        buffered_orders = self._unsettled_owner_reservation_orders_after(key, after_order=after_order)
+        buffered_orders = self._order_book.unsettled_owner_reservation_orders_after(key, after_order=after_order)
         if buffered_orders:
             buffered_max_order = max(buffered_orders)
             for related_key in related_keys:
@@ -472,13 +380,7 @@ class CoalescingGate:
         for key, buffered_max_order in list(self._in_flight_buffered_max_order.items()):
             if key in self._gates:
                 continue
-            has_unsettled_owner_reservation = any(
-                not reservation.released
-                and self._reservation_matches_key(reservation, key)
-                and reservation.received_order <= buffered_max_order
-                for reservation in self._order_reservations
-            )
-            if not has_unsettled_owner_reservation:
+            if not self._order_book.has_unsettled_owner_reservation_at_or_before(key, buffered_max_order):
                 self._in_flight_buffered_max_order.pop(key, None)
 
     @staticmethod
@@ -541,26 +443,22 @@ class CoalescingGate:
         drain_context = self._active_drain_context
         if self._is_bounded_drain(drain_context):
             assert drain_context is not None
-            reservation = IngressOrderReservation(
+            reservation = self._order_book.reserve(
                 room_id=room_id,
                 requester_user_id=requester_user_id,
-                received_order=self._next_order(),
-                receipt_time=receipt_time if receipt_time is not None else time.monotonic(),
+                receipt_time=receipt_time,
+                release=self.release_order_reservation,
                 released=True,
-                _release=self.release_order_reservation,
             )
-            reservation.settled.set()
             drain_context.result.released_reservation_count += 1
             self._wake_owner(room_id, requester_user_id)
             return reservation
-        reservation = IngressOrderReservation(
+        reservation = self._order_book.reserve(
             room_id=room_id,
             requester_user_id=requester_user_id,
-            received_order=self._next_order(),
-            receipt_time=receipt_time if receipt_time is not None else time.monotonic(),
-            _release=self.release_order_reservation,
+            receipt_time=receipt_time,
+            release=self.release_order_reservation,
         )
-        self._order_reservations.append(reservation)
         self._wake_owner(room_id, requester_user_id)
         return reservation
 
@@ -570,14 +468,8 @@ class CoalescingGate:
         self._prune_in_flight_buffered_orders()
 
     def _release_order_reservation(self, reservation: IngressOrderReservation, *, wake: bool) -> None:
-        if reservation.released:
+        if not self._order_book.release(reservation):
             return
-        reservation.released = True
-        for index, current_reservation in enumerate(self._order_reservations):
-            if current_reservation is reservation:
-                del self._order_reservations[index]
-                break
-        reservation.settled.set()
         if wake:
             self._wake_owner(reservation.room_id, reservation.requester_user_id)
 
@@ -595,7 +487,7 @@ class CoalescingGate:
 
     async def _wait_for_order_reservations_for_drain(self, drain_context: _DrainContext) -> None:
         while True:
-            reservations = [reservation for reservation in self._order_reservations if not reservation.released]
+            reservations = self._order_book.unsettled()
             if not reservations:
                 return
             if not self._is_bounded_drain(drain_context):
@@ -648,7 +540,7 @@ class CoalescingGate:
         )
         claimable_count = 0
         for queued in list(gate.queue)[:base_count]:
-            if self._has_older_unresolved_owner_reservation(key, queued.received_order):
+            if self._order_book.has_older_unresolved_owner_reservation(key, queued.received_order):
                 break
             claimable_count += 1
         return claimable_count
@@ -926,7 +818,7 @@ class CoalescingGate:
             return True
         if active_pending:
             return False
-        return not any(not reservation.released for reservation in self._order_reservations)
+        return self._order_book.all_settled()
 
     @staticmethod
     def _wake(gate: _GateEntry) -> None:
@@ -987,11 +879,11 @@ class CoalescingGate:
         enqueue_start = time.monotonic()
         gate = self._get_or_create_gate(key)
         if order_reservation is None:
-            received_order = self._next_order()
+            received_order = self._order_book.next_order()
             resolved_received_at = received_at if received_at is not None else time.time()
             receipt_time = time.monotonic()
         else:
-            if not self._reservation_matches_key(order_reservation, key):
+            if not self._order_book.reservation_matches_key(order_reservation, key):
                 msg = "Ingress order reservation owner must match admitted coalescing key"
                 raise ValueError(msg)
             received_order = order_reservation.received_order
@@ -1418,7 +1310,7 @@ class CoalescingGate:
     ) -> str:
         """Dispatch a claimed batch while buffering new ingress on the same gate."""
         flush_start = time.monotonic()
-        in_flight_start_order = self._next_received_order
+        in_flight_start_order = self._order_book.next_received_order
         gate.phase = GatePhase.IN_FLIGHT
         gate.deadline = None
         gate.grace_deadline = None
@@ -1506,7 +1398,7 @@ class CoalescingGate:
             return
 
         front = gate.queue[0]
-        same_window_reservations = self._unsettled_owner_reservations_in_window(
+        same_window_reservations = self._order_book.unsettled_owner_reservations_in_window(
             key,
             after_order=front.received_order,
             before_order=grace_result.before_order,
@@ -1521,7 +1413,7 @@ class CoalescingGate:
             key,
             gate,
             coalesce_normal_events=self._should_coalesce_normal_events(key, gate),
-            max_received_order=self._next_received_order,
+            max_received_order=self._order_book.next_received_order,
         )
         candidate_count = min(grace_result.candidate_count, claimable_count)
         if candidate_count <= 0:
@@ -1656,7 +1548,7 @@ class CoalescingGate:
                 if not gate.queue:
                     continue
                 front = gate.queue[0]
-                same_window_reservations = self._unsettled_owner_reservations_in_window(
+                same_window_reservations = self._order_book.unsettled_owner_reservations_in_window(
                     key,
                     after_order=front.received_order,
                     before_order=debounce_result.before_order,
@@ -1666,7 +1558,7 @@ class CoalescingGate:
                 if same_window_reservations:
                     await self._wait_for_reservations(gate, same_window_reservations)
                     continue
-                claim_max_received_order = self._next_received_order
+                claim_max_received_order = self._order_book.next_received_order
                 bypass_grace = self._is_shutting_down() or gate.drain_all_requested
                 use_upload_grace = not bypass_grace and self._upload_grace_seconds() > 0
                 coalesce_normal_events = self._should_coalesce_normal_events(key, gate)
@@ -1708,7 +1600,7 @@ class CoalescingGate:
                     current_gate.drain_task = None
                 if self._gate_work_count(current_gate) == 0:
                     self._remove_gate(key)
-                    if not self._unsettled_owner_reservation_orders_after(key, after_order=0):
+                    if not self._order_book.unsettled_owner_reservation_orders_after(key, after_order=0):
                         self._in_flight_buffered_max_order.pop(key, None)
                 elif outcome in {"failed", "cancelled"} and not self._is_shutting_down():
                     self._ensure_drain_task(key, current_gate)

--- a/src/mindroom/coalescing_order.py
+++ b/src/mindroom/coalescing_order.py
@@ -1,0 +1,177 @@
+"""Receive-order reservation bookkeeping for coalescing ingress."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from .coalescing_batch import CoalescingKey
+
+
+@dataclass
+class IngressOrderReservation:
+    """Receive-order placeholder for ingress that must resolve its canonical key first."""
+
+    room_id: str
+    requester_user_id: str
+    received_order: int
+    receipt_time: float
+    released: bool = False
+    settled: asyncio.Event = field(default_factory=asyncio.Event, repr=False, compare=False)
+    _release: Callable[[IngressOrderReservation], None] | None = field(default=None, repr=False, compare=False)
+
+    def release(self) -> None:
+        """Release this reservation if it will not be admitted."""
+        if self._release is None:
+            if self.released:
+                return
+            self.released = True
+            self.settled.set()
+            return
+        self._release(self)
+
+
+class CoalescingOrderBook:
+    """Own receive-order reservation state for one coalescing gate."""
+
+    def __init__(self) -> None:
+        self._reservations: list[IngressOrderReservation] = []
+        self._next_received_order = 0
+
+    @property
+    def next_received_order(self) -> int:
+        """Return the highest receive order assigned so far."""
+        return self._next_received_order
+
+    def next_order(self) -> int:
+        """Return the next monotonic receive order."""
+        self._next_received_order += 1
+        return self._next_received_order
+
+    def reserve(
+        self,
+        *,
+        room_id: str,
+        requester_user_id: str,
+        receipt_time: float | None,
+        release: Callable[[IngressOrderReservation], None],
+        released: bool = False,
+    ) -> IngressOrderReservation:
+        """Create a reservation and track it until release unless already closed."""
+        reservation = IngressOrderReservation(
+            room_id=room_id,
+            requester_user_id=requester_user_id,
+            received_order=self.next_order(),
+            receipt_time=receipt_time if receipt_time is not None else time.monotonic(),
+            released=released,
+            _release=release,
+        )
+        if released:
+            reservation.settled.set()
+        else:
+            self._reservations.append(reservation)
+        return reservation
+
+    @staticmethod
+    def reservation_matches_key(reservation: IngressOrderReservation, key: CoalescingKey) -> bool:
+        """Return whether a reservation belongs to the same room requester as a key."""
+        return reservation.room_id == key.room_id and reservation.requester_user_id == key.requester_user_id
+
+    def release(self, reservation: IngressOrderReservation) -> bool:
+        """Release a tracked reservation, returning whether it changed state."""
+        if reservation.released:
+            return False
+        reservation.released = True
+        for index, current_reservation in enumerate(self._reservations):
+            if current_reservation is reservation:
+                del self._reservations[index]
+                break
+        reservation.settled.set()
+        return True
+
+    def unsettled(self) -> list[IngressOrderReservation]:
+        """Return all currently unresolved reservations."""
+        return [reservation for reservation in self._reservations if not reservation.released]
+
+    def all_settled(self) -> bool:
+        """Return whether there are no unresolved reservations."""
+        return not self.unsettled()
+
+    def older_owner_reservations(
+        self,
+        key: CoalescingKey,
+        *,
+        before_order: int,
+    ) -> list[IngressOrderReservation]:
+        """Return unresolved same-owner reservations older than a receive order."""
+        return [
+            reservation
+            for reservation in self._reservations
+            if not reservation.released
+            and self.reservation_matches_key(reservation, key)
+            and reservation.received_order < before_order
+        ]
+
+    def has_older_unresolved_owner_reservation(self, key: CoalescingKey, received_order: int) -> bool:
+        """Return whether older unresolved same-owner reservation blocks this order."""
+        return any(
+            not reservation.released
+            and self.reservation_matches_key(reservation, key)
+            and reservation.received_order < received_order
+            for reservation in self._reservations
+        )
+
+    def unsettled_owner_reservations_in_window(
+        self,
+        key: CoalescingKey,
+        *,
+        after_order: int,
+        before_order: int | None,
+        before_or_at_receipt_time: float,
+        buffered_in_flight_max_order: int | None = None,
+    ) -> list[IngressOrderReservation]:
+        """Return unresolved same-owner reservations that belong to a claim window."""
+        return [
+            reservation
+            for reservation in self._reservations
+            if not reservation.released
+            and self.reservation_matches_key(reservation, key)
+            and reservation.received_order > after_order
+            and (before_order is None or reservation.received_order < before_order)
+            and (
+                reservation.receipt_time <= before_or_at_receipt_time
+                or (
+                    buffered_in_flight_max_order is not None
+                    and reservation.received_order <= buffered_in_flight_max_order
+                )
+            )
+        ]
+
+    def unsettled_owner_reservation_orders_after(
+        self,
+        key: CoalescingKey,
+        *,
+        after_order: int,
+    ) -> list[int]:
+        """Return unresolved same-owner reservation orders after a receive order."""
+        return [
+            reservation.received_order
+            for reservation in self._reservations
+            if not reservation.released
+            and self.reservation_matches_key(reservation, key)
+            and reservation.received_order > after_order
+        ]
+
+    def has_unsettled_owner_reservation_at_or_before(self, key: CoalescingKey, received_order: int) -> bool:
+        """Return whether an unresolved same-owner reservation exists at or before an order."""
+        return any(
+            not reservation.released
+            and self.reservation_matches_key(reservation, key)
+            and reservation.received_order <= received_order
+            for reservation in self._reservations
+        )

--- a/src/mindroom/coalescing_order.py
+++ b/src/mindroom/coalescing_order.py
@@ -96,11 +96,11 @@ class CoalescingOrderBook:
 
     def unsettled(self) -> list[IngressOrderReservation]:
         """Return all currently unresolved reservations."""
-        return [reservation for reservation in self._reservations if not reservation.released]
+        return list(self._reservations)
 
     def all_settled(self) -> bool:
         """Return whether there are no unresolved reservations."""
-        return not self.unsettled()
+        return not self._reservations
 
     def older_owner_reservations(
         self,
@@ -112,17 +112,13 @@ class CoalescingOrderBook:
         return [
             reservation
             for reservation in self._reservations
-            if not reservation.released
-            and self.reservation_matches_key(reservation, key)
-            and reservation.received_order < before_order
+            if self.reservation_matches_key(reservation, key) and reservation.received_order < before_order
         ]
 
     def has_older_unresolved_owner_reservation(self, key: CoalescingKey, received_order: int) -> bool:
         """Return whether older unresolved same-owner reservation blocks this order."""
         return any(
-            not reservation.released
-            and self.reservation_matches_key(reservation, key)
-            and reservation.received_order < received_order
+            self.reservation_matches_key(reservation, key) and reservation.received_order < received_order
             for reservation in self._reservations
         )
 
@@ -139,8 +135,7 @@ class CoalescingOrderBook:
         return [
             reservation
             for reservation in self._reservations
-            if not reservation.released
-            and self.reservation_matches_key(reservation, key)
+            if self.reservation_matches_key(reservation, key)
             and reservation.received_order > after_order
             and (before_order is None or reservation.received_order < before_order)
             and (
@@ -162,16 +157,12 @@ class CoalescingOrderBook:
         return [
             reservation.received_order
             for reservation in self._reservations
-            if not reservation.released
-            and self.reservation_matches_key(reservation, key)
-            and reservation.received_order > after_order
+            if self.reservation_matches_key(reservation, key) and reservation.received_order > after_order
         ]
 
     def has_unsettled_owner_reservation_at_or_before(self, key: CoalescingKey, received_order: int) -> bool:
         """Return whether an unresolved same-owner reservation exists at or before an order."""
         return any(
-            not reservation.released
-            and self.reservation_matches_key(reservation, key)
-            and reservation.received_order <= received_order
+            self.reservation_matches_key(reservation, key) and reservation.received_order <= received_order
             for reservation in self._reservations
         )

--- a/tests/test_coalescing.py
+++ b/tests/test_coalescing.py
@@ -212,12 +212,12 @@ def test_release_order_removes_unadmitted_reservation_from_owner_work() -> None:
     key = CoalescingKey("!room:localhost", "$thread:localhost", "@user:localhost")
     reservation = gate.reserve_order(room_id=key.room_id, requester_user_id=key.requester_user_id)
 
-    assert gate._older_owner_reservations(key, before_order=reservation.received_order + 1) == [reservation]
+    assert gate._order_book.older_owner_reservations(key, before_order=reservation.received_order + 1) == [reservation]
 
     reservation.release()
     reservation.release()
 
-    assert gate._older_owner_reservations(key, before_order=reservation.received_order + 1) == []
+    assert gate._order_book.older_owner_reservations(key, before_order=reservation.received_order + 1) == []
     assert reservation.released
     assert reservation.settled.is_set()
 

--- a/tests/test_edit_event_handling.py
+++ b/tests/test_edit_event_handling.py
@@ -197,7 +197,7 @@ async def test_edit_event_reserves_prompt_order_while_regenerating(tmp_path: Pat
 
     async def handle_edit(*_args: object) -> None:
         edit_started.set()
-        assert [reservation for reservation in bot._coalescing_gate._order_reservations if not reservation.released]
+        assert bot._coalescing_gate._order_book.unsettled()
         await release_edit.wait()
 
     with (
@@ -213,7 +213,7 @@ async def test_edit_event_reserves_prompt_order_while_regenerating(tmp_path: Pat
         release_edit.set()
         await edit_task
 
-    assert bot._coalescing_gate._order_reservations == []
+    assert bot._coalescing_gate._order_book.all_settled()
 
 
 @pytest.mark.asyncio

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -4469,7 +4469,7 @@ class TestAgentBot:
 
         async def handle_selection(*_args: object, **_kwargs: object) -> None:
             selection_started.set()
-            assert [reservation for reservation in bot._coalescing_gate._order_reservations if not reservation.released]
+            assert bot._coalescing_gate._order_book.unsettled()
 
         with (
             patch("mindroom.bot.interactive.handle_reaction", new=AsyncMock(return_value=selection)),
@@ -4478,7 +4478,7 @@ class TestAgentBot:
             await bot._on_reaction(room, event)
 
         await asyncio.wait_for(selection_started.wait(), timeout=0.5)
-        assert bot._coalescing_gate._order_reservations == []
+        assert bot._coalescing_gate._order_book.all_settled()
 
     @pytest.mark.asyncio
     async def test_checkmark_interactive_reaction_reserves_before_tool_approval_lookup(
@@ -4518,9 +4518,7 @@ class TestAgentBot:
             reaction_task = asyncio.create_task(bot._on_reaction(room, event))
             await asyncio.wait_for(approval_started.wait(), timeout=0.5)
             try:
-                reaction_reservations = [
-                    reservation for reservation in bot._coalescing_gate._order_reservations if not reservation.released
-                ]
+                reaction_reservations = bot._coalescing_gate._order_book.unsettled()
                 assert reaction_reservations
                 later_owner = bot._turn_controller._reserve_prompt_ingress_order(room, "@user:localhost")
                 try:
@@ -4531,7 +4529,7 @@ class TestAgentBot:
                 release_approval.set()
                 await reaction_task
 
-        assert bot._coalescing_gate._order_reservations == []
+        assert bot._coalescing_gate._order_book.all_settled()
 
     @pytest.mark.asyncio
     async def test_checkmark_tool_approval_bypasses_conversation_reply_permission(
@@ -4561,7 +4559,7 @@ class TestAgentBot:
 
         approval_handler.assert_awaited_once()
         interactive_handler.assert_not_awaited()
-        assert bot._coalescing_gate._order_reservations == []
+        assert bot._coalescing_gate._order_book.all_settled()
 
     @pytest.mark.asyncio
     async def test_unknown_tool_approval_response_with_approval_id_and_denial_reason_resolves_live_waiter(
@@ -7458,7 +7456,7 @@ class TestAgentBot:
         with pytest.raises(asyncio.CancelledError):
             await bot._turn_controller._handle_media_message_inner(room, event)
 
-        assert bot._coalescing_gate._order_reservations == []
+        assert bot._coalescing_gate._order_book.all_settled()
 
     @pytest.mark.asyncio
     async def test_text_reserves_receive_order_before_thread_lookup(


### PR DESCRIPTION
## Summary
- move receive-order reservation bookkeeping into CoalescingOrderBook
- keep CoalescingGate focused on wakeups, drain accounting, and dispatch lifecycle
- update white-box tests to inspect the order book directly

## Verification
- uv run ruff check src/mindroom/coalescing.py src/mindroom/coalescing_order.py tests/test_coalescing.py tests/test_multi_agent_bot.py tests/test_edit_event_handling.py
- uv run pytest tests/test_coalescing.py tests/test_live_message_coalescing.py tests/test_multi_agent_bot.py::TestAgentBot::test_interactive_reaction_selection_reserves_prompt_order tests/test_multi_agent_bot.py::TestAgentBot::test_checkmark_interactive_reaction_reserves_before_tool_approval_lookup tests/test_multi_agent_bot.py::TestAgentBot::test_checkmark_tool_approval_bypasses_conversation_reply_permission tests/test_multi_agent_bot.py::TestAgentBot::test_audio_dispatch_releases_receive_order_when_target_resolution_is_cancelled tests/test_edit_event_handling.py::test_edit_event_reserves_prompt_order_while_regenerating -q -n auto --no-cov
- uv run pre-commit run --all-files

Review notes: two subagents reviewed. Code-quality reviewer approved. Spec reviewer only flagged the pre-existing untracked plan file, which is not staged or part of this PR.