### PR TITLE
Fix drain reservation test race

### DIFF
--- a/tests/test_coalescing.py
+++ b/tests/test_coalescing.py
@@ -1066,19 +1066,16 @@ async def test_drain_all_waits_for_order_reservation_to_admit(monkeypatch: pytes
         receipt_time=1_000.0,
     )
     wait_entered = asyncio.Event()
-    original_wait_for_order_reservations = gate._wait_for_order_reservations_for_drain
 
-    async def wait_for_order_reservations_for_drain(drain_context: object) -> None:
+    original_settled_wait = reservation.settled.wait
+
+    async def wait_for_reservation_settled() -> bool:
         wait_entered.set()
-        await original_wait_for_order_reservations(drain_context)
+        return await original_settled_wait()
 
-    monkeypatch.setattr(
-        gate,
-        "_wait_for_order_reservations_for_drain",
-        wait_for_order_reservations_for_drain,
-    )
+    monkeypatch.setattr(reservation.settled, "wait", wait_for_reservation_settled)
 
-    drain_task = asyncio.create_task(gate.drain_all(ready_timeout_seconds=5.0))
+    drain_task = asyncio.create_task(gate.drain_all())
     await asyncio.wait_for(wait_entered.wait(), timeout=5.0)
     assert drain_task.done() is False
 

--- a/tests/test_coalescing.py
+++ b/tests/test_coalescing.py
@@ -1046,7 +1046,7 @@ async def test_bounded_shutdown_closes_metadata_for_abandoned_ready_work() -> No
 
 
 @pytest.mark.asyncio
-async def test_drain_all_waits_for_order_reservation_to_admit(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_drain_all_waits_for_order_reservation_to_admit() -> None:
     """Shutdown drains must treat receive-order reservations as pending ingress work."""
     batches: list[CoalescedBatch] = []
 
@@ -1055,7 +1055,7 @@ async def test_drain_all_waits_for_order_reservation_to_admit(monkeypatch: pytes
 
     gate = CoalescingGate(
         dispatch_batch=dispatch_batch,
-        debounce_seconds=lambda: 60.0,
+        debounce_seconds=lambda: 0.0,
         upload_grace_seconds=lambda: 0.0,
         is_shutting_down=lambda: True,
     )
@@ -1063,21 +1063,13 @@ async def test_drain_all_waits_for_order_reservation_to_admit(monkeypatch: pytes
     reservation = gate.reserve_order(
         room_id=key.room_id,
         requester_user_id=key.requester_user_id,
-        receipt_time=1_000.0,
+        receipt_time=time.monotonic(),
     )
-    wait_entered = asyncio.Event()
-
-    original_settled_wait = reservation.settled.wait
-
-    async def wait_for_reservation_settled() -> bool:
-        wait_entered.set()
-        return await original_settled_wait()
-
-    monkeypatch.setattr(reservation.settled, "wait", wait_for_reservation_settled)
 
     drain_task = asyncio.create_task(gate.drain_all())
-    await asyncio.wait_for(wait_entered.wait(), timeout=5.0)
+    await _wait_for(lambda: gate._active_drain_context is not None and not drain_task.done())
     assert drain_task.done() is False
+    assert reservation.released is False
 
     await gate.admit(
         key,


### PR DESCRIPTION
## Summary
- make `test_drain_all_waits_for_order_reservation_to_admit` synchronize on the reservation's actual settled wait
- remove the unrelated bounded-drain timeout from this wait/admit behavior test
- keep bounded reservation timeout coverage in the existing shutdown tests

## Root cause
The test signaled `wait_entered` before `drain_all()` actually awaited the reservation.
It also used `ready_timeout_seconds=5.0`, which belongs to a different bounded-shutdown invariant.
Under loaded CI, that made the test race against the timeout instead of only proving that drain waits for later admission.

## Verification
- `uv run pytest tests/test_coalescing.py::test_drain_all_waits_for_order_reservation_to_admit tests/test_matrix_sync_tokens.py::test_shutdown_drain_releases_stuck_pre_admission_reservation tests/test_matrix_sync_tokens.py::test_reserve_order_during_active_bounded_shutdown_returns_released_counted_reservation tests/test_matrix_sync_tokens.py::test_shutdown_timeout_reaches_already_running_same_window_reservation_wait -q -n 0 --no-cov -vv`
- `uv run pytest tests/test_coalescing.py -q -n auto --no-cov`
- `uv run pre-commit run --all-files`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored drain behavior test to remove external mocking dependencies and rely on direct state assertions instead. Updated test initialization parameters for improved clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->