### PR TITLE
Extract prompt ingress reservation owner

### DIFF
--- a/src/mindroom/prompt_ingress_reservation.py
+++ b/src/mindroom/prompt_ingress_reservation.py
@@ -1,0 +1,93 @@
+"""Prompt-ingress reservation ownership."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from mindroom.coalescing import (
+    CoalescingGate,
+    IngressOrderReservation,
+    ReadyPendingEvent,
+    close_ready_task_result_metadata,
+)
+
+if TYPE_CHECKING:
+    from mindroom.coalescing_batch import CoalescingKey
+
+
+@dataclass
+class PromptIngressReservationOwner:
+    """Own one prompt ingress reservation until it is admitted or released."""
+
+    gate: CoalescingGate
+    reservation: IngressOrderReservation
+    admitted: bool = False
+    ready_task: asyncio.Task[ReadyPendingEvent | None] | None = None
+
+    @staticmethod
+    def _close_late_ready_task_result(task: asyncio.Task[ReadyPendingEvent | None]) -> None:
+        try:
+            result = task.result()
+        except BaseException:
+            return
+        close_ready_task_result_metadata(result)
+
+    async def admit(
+        self,
+        key: CoalescingKey,
+        *,
+        source_event_id: str | None,
+        source_kind: str,
+        ready_result: ReadyPendingEvent | None = None,
+        ready_task: asyncio.Task[ReadyPendingEvent | None] | None = None,
+    ) -> None:
+        """Transfer this reservation and any ready metadata to the coalescing gate."""
+        if ready_task is not None:
+            self.ready_task = ready_task
+        metadata_transferred = False
+        try:
+            await self.gate.admit(
+                key,
+                ready_result=ready_result,
+                ready_task=ready_task,
+                source_event_id=source_event_id,
+                source_kind=source_kind,
+                order_reservation=self.reservation,
+            )
+            metadata_transferred = True
+        except BaseException:
+            await self.cancel_ready_task()
+            if ready_result is not None and not metadata_transferred:
+                close_ready_task_result_metadata(ready_result)
+            raise
+        self.admitted = True
+        self.ready_task = None
+
+    async def cancel_ready_task(self) -> None:
+        """Cancel or collect the owned ready task once."""
+        if self.ready_task is None:
+            return
+        ready_task = self.ready_task
+        self.ready_task = None
+        if not ready_task.done():
+            ready_task.cancel()
+        try:
+            result = await asyncio.gather(ready_task, return_exceptions=True)
+        except asyncio.CancelledError:
+            if ready_task.done():
+                self._close_late_ready_task_result(ready_task)
+            else:
+                ready_task.add_done_callback(self._close_late_ready_task_result)
+            raise
+        close_ready_task_result_metadata(result[0])
+
+    async def release(self) -> None:
+        """Release this reservation if admission did not transfer ownership."""
+        if self.admitted:
+            return
+        try:
+            await self.cancel_ready_task()
+        finally:
+            self.gate.release_order_reservation(self.reservation)

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -16,9 +16,7 @@ from mindroom.authorization import get_effective_sender_id_for_reply_permissions
 from mindroom.coalescing import (
     CoalescingGate,
     IngressAdmissionClosedError,
-    IngressOrderReservation,
     ReadyPendingEvent,
-    close_ready_task_result_metadata,
 )
 from mindroom.coalescing_batch import CoalescedBatch, CoalescingKey, PendingEvent, close_pending_event_metadata
 from mindroom.commands.handler import CommandHandlerContext, handle_command
@@ -97,6 +95,7 @@ from mindroom.matrix.media import (
 )
 from mindroom.matrix.message_content import is_v2_sidecar_text_preview
 from mindroom.matrix.rooms import is_dm_room
+from mindroom.prompt_ingress_reservation import PromptIngressReservationOwner as _PromptIngressReservationOwner
 from mindroom.response_runner import PostLockRequestPreparationError, ResponseRequest
 from mindroom.routing import suggest_responder_for_message
 from mindroom.thread_utils import (
@@ -259,82 +258,6 @@ class _PrecheckedEvent[T]:
 
     event: T
     requester_user_id: str
-
-
-@dataclass
-class _PromptIngressReservationOwner:
-    """Own one prompt ingress reservation until it is admitted or released."""
-
-    gate: CoalescingGate
-    reservation: IngressOrderReservation
-    admitted: bool = False
-    ready_task: asyncio.Task[ReadyPendingEvent | None] | None = None
-
-    @staticmethod
-    def _close_late_ready_task_result(task: asyncio.Task[ReadyPendingEvent | None]) -> None:
-        try:
-            result = task.result()
-        except BaseException:
-            return
-        close_ready_task_result_metadata(result)
-
-    async def admit(
-        self,
-        key: CoalescingKey,
-        *,
-        source_event_id: str | None,
-        source_kind: str,
-        ready_result: ReadyPendingEvent | None = None,
-        ready_task: asyncio.Task[ReadyPendingEvent | None] | None = None,
-    ) -> None:
-        """Transfer this reservation and any ready metadata to the coalescing gate."""
-        if ready_task is not None:
-            self.ready_task = ready_task
-        metadata_transferred = False
-        try:
-            await self.gate.admit(
-                key,
-                ready_result=ready_result,
-                ready_task=ready_task,
-                source_event_id=source_event_id,
-                source_kind=source_kind,
-                order_reservation=self.reservation,
-            )
-            metadata_transferred = True
-        except BaseException:
-            await self.cancel_ready_task()
-            if ready_result is not None and not metadata_transferred:
-                close_ready_task_result_metadata(ready_result)
-            raise
-        self.admitted = True
-        self.ready_task = None
-
-    async def cancel_ready_task(self) -> None:
-        """Cancel or collect the owned ready task once."""
-        if self.ready_task is None:
-            return
-        ready_task = self.ready_task
-        self.ready_task = None
-        if not ready_task.done():
-            ready_task.cancel()
-        try:
-            result = await asyncio.gather(ready_task, return_exceptions=True)
-        except asyncio.CancelledError:
-            if ready_task.done():
-                self._close_late_ready_task_result(ready_task)
-            else:
-                ready_task.add_done_callback(self._close_late_ready_task_result)
-            raise
-        close_ready_task_result_metadata(result[0])
-
-    async def release(self) -> None:
-        """Release this reservation if admission did not transfer ownership."""
-        if self.admitted:
-            return
-        try:
-            await self.cancel_ready_task()
-        finally:
-            self.gate.release_order_reservation(self.reservation)
 
 
 type _PrecheckedTextDispatchEvent = _PrecheckedEvent[TextDispatchEvent]

--- a/tach.toml
+++ b/tach.toml
@@ -2072,6 +2072,11 @@ depends_on = [
 ]
 
 [[modules]]
+path = "mindroom.prompt_ingress_reservation"
+depends_on = ["mindroom.coalescing"]
+visibility = ["mindroom.turn_controller"]
+
+[[modules]]
 path = "mindroom.turn_controller"
 depends_on = [
     "mindroom.commands.handler",
@@ -2089,6 +2094,7 @@ depends_on = [
     "mindroom.matrix.event_info",
     "mindroom.matrix.message_content",
     "mindroom.matrix.rooms",
+    "mindroom.prompt_ingress_reservation",
     "mindroom.response_runner",
     "mindroom.routing",
     "mindroom.turn_store",

--- a/tests/test_turn_controller.py
+++ b/tests/test_turn_controller.py
@@ -21,8 +21,8 @@ from mindroom.dispatch_handoff import PendingDispatchMetadata, PreparedTextEvent
 from mindroom.dispatch_source import MESSAGE_SOURCE_KIND
 from mindroom.matrix.cache.thread_history_result import thread_history_result
 from mindroom.matrix.users import AgentMatrixUser
+from mindroom.prompt_ingress_reservation import PromptIngressReservationOwner
 from mindroom.streaming import send_streaming_response
-from mindroom.turn_controller import _PromptIngressReservationOwner
 from tests.conftest import (
     bind_runtime_paths,
     delivered_matrix_side_effect,
@@ -120,7 +120,7 @@ async def test_late_admit_rejection_closes_completed_ready_task_metadata_once() 
         received_order=1,
         receipt_time=1.0,
     )
-    owner = _PromptIngressReservationOwner(gate=RejectingGate(), reservation=reservation)
+    owner = PromptIngressReservationOwner(gate=RejectingGate(), reservation=reservation)
     ready_task = asyncio.create_task(ready())
     await ready_task
 
@@ -171,7 +171,7 @@ async def test_owner_cancel_ready_task_closes_ready_result_returned_during_cance
         is_shutting_down=lambda: False,
     )
     reservation = gate.reserve_order(room_id="!room:localhost", requester_user_id="@user:localhost")
-    owner = _PromptIngressReservationOwner(gate=gate, reservation=reservation)
+    owner = PromptIngressReservationOwner(gate=gate, reservation=reservation)
     owner.ready_task = asyncio.create_task(ready())
     await asyncio.sleep(0)
 
@@ -198,7 +198,7 @@ async def test_owner_release_settles_reservation_when_cancelled_during_ready_tas
         is_shutting_down=lambda: False,
     )
     reservation = gate.reserve_order(room_id="!room:localhost", requester_user_id="@user:localhost")
-    owner = _PromptIngressReservationOwner(gate=gate, reservation=reservation)
+    owner = PromptIngressReservationOwner(gate=gate, reservation=reservation)
     ready_task = asyncio.create_task(never_ready())
     owner.ready_task = ready_task
 


### PR DESCRIPTION
## Summary
- Move prompt-ingress reservation ownership out of `turn_controller.py` into `prompt_ingress_reservation.py`.
- Keep controller behavior unchanged by importing the extracted owner under the existing local name.
- Update owner-focused tests to import the new module directly.

## Test Plan
- `uv run ruff check src/mindroom/prompt_ingress_reservation.py src/mindroom/turn_controller.py tests/test_turn_controller.py`
- `uv run ty check src/mindroom/prompt_ingress_reservation.py tests/test_turn_controller.py`
- `uv run pytest tests/test_turn_controller.py -q -n auto --no-cov`
- `uv run pre-commit run --all-files`