### PR TITLE
Handle broken plugin tools during tolerant startup

### DIFF
--- a/src/mindroom/config/main.py
+++ b/src/mindroom/config/main.py
@@ -1250,6 +1250,7 @@ class Config(BaseModel):
                 config_path=config_path_prefix,
                 tool_name=entry.name,
             )
+            return
 
         validate_authored_tool_entry_overrides(
             entry.name,

--- a/src/mindroom/config/main.py
+++ b/src/mindroom/config/main.py
@@ -9,7 +9,16 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, ValidationInfo, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PrivateAttr,
+    ValidationError,
+    ValidationInfo,
+    field_validator,
+    model_validator,
+)
 
 from mindroom.agent_policy import (
     build_agent_policy_seeds,
@@ -327,6 +336,7 @@ class Config(BaseModel):
     """Complete configuration from YAML."""
 
     model_config = ConfigDict(extra="forbid")
+    _unavailable_plugin_tool_names: set[str] = PrivateAttr(default_factory=set)
 
     PRIVATE_KNOWLEDGE_BASE_ID_PREFIX: ClassVar[str] = "__agent_private__:"
     TOOL_PRESETS: ClassVar[dict[str, tuple[str, ...]]] = {
@@ -1230,9 +1240,16 @@ class Config(BaseModel):
             validate_authored_tool_entry_overrides,
         )
 
+        validation_info = tool_validation_snapshot.get(entry.name)
         if entry.name not in tool_validation_snapshot and not self.is_tool_preset(entry.name):
             msg = f"{config_path_prefix}.{entry.name}: Unknown tool '{entry.name}'."
             raise ToolConfigOverrideError(msg)
+        if validation_info is not None and validation_info.unavailable_due_to_plugin_load_error:
+            logger.warning(
+                "Plugin tool unavailable because plugin failed to load",
+                config_path=config_path_prefix,
+                tool_name=entry.name,
+            )
 
         validate_authored_tool_entry_overrides(
             entry.name,
@@ -1256,6 +1273,11 @@ class Config(BaseModel):
             self,
             tolerate_plugin_load_errors=tolerate_plugin_load_errors,
         )
+        self._unavailable_plugin_tool_names = {
+            tool_name
+            for tool_name, validation_info in tool_validation_snapshot.items()
+            if validation_info.unavailable_due_to_plugin_load_error
+        }
         self._validate_authored_tool_entries_with_snapshot(
             tool_validation_snapshot=tool_validation_snapshot,
         )
@@ -1289,7 +1311,9 @@ class Config(BaseModel):
                     )
                     raise ValueError(msg)
                 validation_info = tool_validation_snapshot.get(entry.name)
-                if validation_info is None or not validation_info.runtime_loadable:
+                if validation_info is None or (
+                    not validation_info.runtime_loadable and not validation_info.unavailable_due_to_plugin_load_error
+                ):
                     msg = (
                         f"{config_path_prefix}.{entry.name}: Toolkit tools must resolve through the normal "
                         f"tool registry; '{entry.name}' is not supported."
@@ -1313,6 +1337,7 @@ class Config(BaseModel):
                 tool_config_overrides=dict(merged_overrides.get(tool_name, {})),
             )
             for tool_name in self.expand_tool_names(toolkit.tool_names)
+            if tool_name not in self._unavailable_plugin_tool_names
         ]
 
     def get_agent_tool_configs(self, agent_name: str) -> list[ResolvedToolConfig]:
@@ -1338,6 +1363,7 @@ class Config(BaseModel):
                 tool_config_overrides=dict(merged_overrides.get(tool_name, {})),
             )
             for tool_name in self.expand_tool_names(explicit_names)
+            if tool_name not in self._unavailable_plugin_tool_names
         ]
 
     def get_agent_tools(self, agent_name: str) -> list[str]:

--- a/src/mindroom/tool_system/metadata.py
+++ b/src/mindroom/tool_system/metadata.py
@@ -1137,14 +1137,18 @@ def _unavailable_tool_metadata_from_failed_plugin(
     candidate_registrations: Mapping[str, dict[str, ToolMetadata]],
 ) -> dict[str, ToolMetadata]:
     """Return tools known to belong to one plugin that failed in tolerant startup mode."""
-    metadata_by_name = {
-        tool_name: metadata
-        for registrations in candidate_registrations.values()
-        for tool_name, metadata in registrations.items()
-    }
-    if metadata_by_name or plugin_base.tools_module_path is None:
-        return metadata_by_name
-    return _declared_tool_metadata_from_broken_plugin_source(plugin_base.tools_module_path)
+    metadata_by_name: dict[str, ToolMetadata] = {}
+    for module_path in (plugin_base.tools_module_path, plugin_base.hooks_module_path):
+        if module_path is not None:
+            metadata_by_name.update(_declared_tool_metadata_from_broken_plugin_source(module_path))
+    metadata_by_name.update(
+        {
+            tool_name: metadata
+            for registrations in candidate_registrations.values()
+            for tool_name, metadata in registrations.items()
+        },
+    )
+    return metadata_by_name
 
 
 def resolved_tool_validation_snapshot_for_runtime(

--- a/src/mindroom/tool_system/metadata.py
+++ b/src/mindroom/tool_system/metadata.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import functools
 import math
 import os
@@ -737,6 +738,7 @@ class ToolValidationInfo:
     agent_override_fields: tuple[ConfigField, ...] = ()
     authored_override_validator: ToolAuthoredOverrideValidator = ToolAuthoredOverrideValidator.DEFAULT
     runtime_loadable: bool = True
+    unavailable_due_to_plugin_load_error: bool = False
 
 
 @dataclass
@@ -931,7 +933,7 @@ def _resolved_tool_state_for_runtime(
     config: Config,
     *,
     tolerate_plugin_load_errors: bool = False,
-) -> tuple[dict[str, Callable[[], type[Toolkit]]], dict[str, ToolMetadata]]:
+) -> tuple[dict[str, Callable[[], type[Toolkit]]], dict[str, ToolMetadata], frozenset[str]]:
     """Return registry and metadata visible for one runtime config without mutating global state."""
     import mindroom.tools  # noqa: F401, PLC0415
     from mindroom.mcp.registry import resolved_mcp_tool_state  # noqa: PLC0415
@@ -947,7 +949,7 @@ def _resolved_tool_state_for_runtime(
             mcp_registry,
             mcp_metadata,
         )
-        return builtin_registry, builtin_metadata
+        return builtin_registry, builtin_metadata, frozenset()
 
     plugin_bases = plugin_module._collect_plugin_bases(
         plugin_entries,
@@ -958,6 +960,7 @@ def _resolved_tool_state_for_runtime(
     plugin_module._reject_duplicate_plugin_manifest_names(plugin_bases)
 
     validation_registrations: dict[str, dict[str, ToolMetadata]] = {}
+    unavailable_tool_metadata: dict[str, ToolMetadata] = {}
     active_plugins: list[tuple[str, str]] = []
     for plugin_base, plugin_entry, _ in plugin_bases:
         candidate_registrations: dict[str, dict[str, ToolMetadata]] = {}
@@ -997,6 +1000,9 @@ def _resolved_tool_state_for_runtime(
             if not tolerate_plugin_load_errors:
                 raise
             plugin_module._log_skipped_plugin_entry(plugin_entry.path, plugin_base.root, exc)
+            unavailable_tool_metadata.update(
+                _unavailable_tool_metadata_from_failed_plugin(plugin_base, candidate_registrations),
+            )
             continue
 
         validation_registrations.update(candidate_registrations)
@@ -1010,7 +1016,28 @@ def _resolved_tool_state_for_runtime(
         mcp_registry,
         mcp_metadata,
     )
-    return desired_registry, desired_metadata
+    unavailable_tool_metadata = _unavailable_tool_metadata_without_resolved_tools(
+        unavailable_tool_metadata,
+        desired_registry,
+        desired_metadata,
+    )
+    desired_metadata.update(unavailable_tool_metadata)
+    unavailable_plugin_tool_names = frozenset(unavailable_tool_metadata)
+    return desired_registry, desired_metadata, unavailable_plugin_tool_names
+
+
+def _unavailable_tool_metadata_without_resolved_tools(
+    unavailable_tool_metadata: Mapping[str, ToolMetadata],
+    tool_registry: Mapping[str, Callable[[], type[Toolkit]]],
+    tool_metadata: Mapping[str, ToolMetadata],
+) -> dict[str, ToolMetadata]:
+    """Drop skipped-plugin declarations that collide with available runtime tools."""
+    resolved_tool_names = {*tool_registry, *tool_metadata}
+    return {
+        tool_name: metadata
+        for tool_name, metadata in unavailable_tool_metadata.items()
+        if tool_name not in resolved_tool_names
+    }
 
 
 def _merge_mcp_tool_state(
@@ -1035,7 +1062,7 @@ def resolved_tool_metadata_for_runtime(
     tolerate_plugin_load_errors: bool = False,
 ) -> dict[str, ToolMetadata]:
     """Return tool metadata visible for one runtime config without mutating global state."""
-    _, desired_metadata = _resolved_tool_state_for_runtime(
+    _, desired_metadata, _ = _resolved_tool_state_for_runtime(
         runtime_paths,
         config,
         tolerate_plugin_load_errors=tolerate_plugin_load_errors,
@@ -1046,6 +1073,8 @@ def resolved_tool_metadata_for_runtime(
 def _tool_validation_snapshot_from_state(
     tool_registry: Mapping[str, Callable[[], type[Toolkit]]],
     tool_metadata: Mapping[str, ToolMetadata],
+    *,
+    unavailable_plugin_tool_names: frozenset[str] = frozenset(),
 ) -> dict[str, ToolValidationInfo]:
     """Project runtime tool state into a validation-only snapshot."""
     return {
@@ -1055,9 +1084,67 @@ def _tool_validation_snapshot_from_state(
             agent_override_fields=tuple(metadata.agent_override_fields or ()),
             authored_override_validator=metadata.authored_override_validator,
             runtime_loadable=tool_name in tool_registry,
+            unavailable_due_to_plugin_load_error=tool_name in unavailable_plugin_tool_names,
         )
         for tool_name, metadata in tool_metadata.items()
     }
+
+
+def _declared_tool_metadata_from_broken_plugin_source(module_path: Path) -> dict[str, ToolMetadata]:
+    """Return literal tool declarations from a plugin module that failed before registration."""
+    try:
+        module_tree = ast.parse(module_path.read_text(encoding="utf-8"), filename=str(module_path))
+    except (OSError, SyntaxError, UnicodeError):
+        return {}
+
+    metadata_by_name: dict[str, ToolMetadata] = {}
+    for node in ast.walk(module_tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not _is_register_tool_with_metadata_call(node.func):
+            continue
+        tool_name = _literal_string_keyword(node, "name")
+        if tool_name is None:
+            continue
+        metadata_by_name[tool_name] = ToolMetadata(
+            name=tool_name,
+            display_name=_literal_string_keyword(node, "display_name") or tool_name,
+            description=_literal_string_keyword(node, "description") or "Unavailable plugin tool",
+            category=ToolCategory.INTEGRATIONS,
+        )
+    return metadata_by_name
+
+
+def _is_register_tool_with_metadata_call(node: ast.expr) -> bool:
+    if isinstance(node, ast.Name):
+        return node.id == "register_tool_with_metadata"
+    if isinstance(node, ast.Attribute):
+        return node.attr == "register_tool_with_metadata"
+    return False
+
+
+def _literal_string_keyword(node: ast.Call, keyword_name: str) -> str | None:
+    for keyword in node.keywords:
+        if keyword.arg != keyword_name:
+            continue
+        if isinstance(keyword.value, ast.Constant) and isinstance(keyword.value.value, str):
+            return keyword.value.value
+    return None
+
+
+def _unavailable_tool_metadata_from_failed_plugin(
+    plugin_base: plugin_module._PluginBase,
+    candidate_registrations: Mapping[str, dict[str, ToolMetadata]],
+) -> dict[str, ToolMetadata]:
+    """Return tools known to belong to one plugin that failed in tolerant startup mode."""
+    metadata_by_name = {
+        tool_name: metadata
+        for registrations in candidate_registrations.values()
+        for tool_name, metadata in registrations.items()
+    }
+    if metadata_by_name or plugin_base.tools_module_path is None:
+        return metadata_by_name
+    return _declared_tool_metadata_from_broken_plugin_source(plugin_base.tools_module_path)
 
 
 def resolved_tool_validation_snapshot_for_runtime(
@@ -1067,12 +1154,16 @@ def resolved_tool_validation_snapshot_for_runtime(
     tolerate_plugin_load_errors: bool = False,
 ) -> dict[str, ToolValidationInfo]:
     """Return validation-only tool state visible for one runtime config."""
-    tool_registry, desired_metadata = _resolved_tool_state_for_runtime(
+    tool_registry, desired_metadata, unavailable_plugin_tool_names = _resolved_tool_state_for_runtime(
         runtime_paths,
         config,
         tolerate_plugin_load_errors=tolerate_plugin_load_errors,
     )
-    return _tool_validation_snapshot_from_state(tool_registry, desired_metadata)
+    return _tool_validation_snapshot_from_state(
+        tool_registry,
+        desired_metadata,
+        unavailable_plugin_tool_names=unavailable_plugin_tool_names,
+    )
 
 
 def serialize_tool_validation_snapshot(
@@ -1085,6 +1176,7 @@ def serialize_tool_validation_snapshot(
             "agent_override_fields": [asdict(field) for field in info.agent_override_fields],
             "authored_override_validator": info.authored_override_validator.value,
             "runtime_loadable": info.runtime_loadable,
+            "unavailable_due_to_plugin_load_error": info.unavailable_due_to_plugin_load_error,
         }
         for tool_name, info in sorted(tool_validation_snapshot.items())
     }
@@ -1138,6 +1230,13 @@ def deserialize_tool_validation_snapshot(payload: object) -> dict[str, ToolValid
         if not isinstance(raw_runtime_loadable, bool):
             msg = f"Tool validation snapshot entry for '{tool_name}' must set runtime_loadable to a boolean."
             raise TypeError(msg)
+        raw_unavailable_due_to_plugin_load_error = raw_info_mapping.get("unavailable_due_to_plugin_load_error", False)
+        if not isinstance(raw_unavailable_due_to_plugin_load_error, bool):
+            msg = (
+                f"Tool validation snapshot entry for '{tool_name}' must set "
+                "unavailable_due_to_plugin_load_error to a boolean."
+            )
+            raise TypeError(msg)
         snapshot[tool_name] = ToolValidationInfo(
             name=tool_name,
             config_fields=_deserialize_tool_validation_fields(
@@ -1150,6 +1249,7 @@ def deserialize_tool_validation_snapshot(payload: object) -> dict[str, ToolValid
             ),
             authored_override_validator=authored_override_validator,
             runtime_loadable=raw_runtime_loadable,
+            unavailable_due_to_plugin_load_error=raw_unavailable_due_to_plugin_load_error,
         )
     return snapshot
 

--- a/src/mindroom/workers/runtime.py
+++ b/src/mindroom/workers/runtime.py
@@ -85,6 +85,7 @@ def serialized_kubernetes_worker_validation_snapshot(
             snapshot = resolved_tool_validation_snapshot_for_runtime(
                 runtime_paths,
                 config,
+                tolerate_plugin_load_errors=True,
             )
             cached_snapshot = serialize_tool_validation_snapshot(snapshot)
             _WORKER_VALIDATION_SNAPSHOT_CACHE[cache_key] = cached_snapshot

--- a/src/mindroom/workers/runtime.py
+++ b/src/mindroom/workers/runtime.py
@@ -69,7 +69,7 @@ def serialized_kubernetes_worker_validation_snapshot(
     if runtime_config is None:
         from mindroom.config.main import load_config  # noqa: PLC0415
 
-        config = load_config(runtime_paths)
+        config = load_config(runtime_paths, tolerate_plugin_load_errors=True)
     else:
         config = runtime_config
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -55,6 +55,60 @@ def _minimal_runtime_paths(tmp_path: Path) -> RuntimePaths:
     )
 
 
+def _write_broken_tool_plugin(plugin_root: Path, tool_name: str = "broken_plugin_tool") -> None:
+    plugin_root.mkdir(parents=True)
+    (plugin_root / "mindroom.plugin.json").write_text(
+        json.dumps({"name": "broken_plugin", "tools_module": "tools.py", "skills": []}),
+        encoding="utf-8",
+    )
+    (plugin_root / "tools.py").write_text(
+        "from agno.tools import Toolkit\n"
+        "from mindroom.tool_system.metadata import ToolCategory, register_tool_with_metadata\n"
+        "\n"
+        "class BrokenTool(Toolkit):\n"
+        "    def __init__(self) -> None:\n"
+        "        super().__init__(name='broken', tools=[])\n"
+        "\n"
+        "@register_tool_with_metadata(\n"
+        f"    name={tool_name!r},\n"
+        "    display_name='Broken Plugin Tool',\n"
+        "    description='Tool declared by a plugin that fails after registration',\n"
+        "    category=ToolCategory.DEVELOPMENT,\n"
+        ")\n"
+        "def broken_plugin_tools():\n"
+        "    return BrokenTool\n"
+        "\n"
+        "raise ImportError('missing optional plugin dependency')\n",
+        encoding="utf-8",
+    )
+
+
+def _write_working_tool_plugin(plugin_root: Path, *, plugin_name: str, tool_name: str) -> None:
+    plugin_root.mkdir(parents=True)
+    (plugin_root / "mindroom.plugin.json").write_text(
+        json.dumps({"name": plugin_name, "tools_module": "tools.py", "skills": []}),
+        encoding="utf-8",
+    )
+    (plugin_root / "tools.py").write_text(
+        "from agno.tools import Toolkit\n"
+        "from mindroom.tool_system.metadata import ToolCategory, register_tool_with_metadata\n"
+        "\n"
+        "class WorkingTool(Toolkit):\n"
+        "    def __init__(self) -> None:\n"
+        "        super().__init__(name='working', tools=[])\n"
+        "\n"
+        "@register_tool_with_metadata(\n"
+        f"    name={tool_name!r},\n"
+        "    display_name='Working Plugin Tool',\n"
+        "    description='Tool declared by a working plugin',\n"
+        "    category=ToolCategory.DEVELOPMENT,\n"
+        ")\n"
+        "def working_plugin_tools():\n"
+        "    return WorkingTool\n",
+        encoding="utf-8",
+    )
+
+
 @contextmanager
 def _preserved_plugin_loader_state(*, module_prefixes: tuple[str, ...] = ()) -> Iterator[None]:
     original_plugin_roots = _get_plugin_skill_roots()
@@ -1629,6 +1683,272 @@ def test_load_config_tolerates_missing_and_broken_plugins_on_startup(
         set_plugin_skill_roots(original_plugin_roots)
 
 
+def test_load_config_tolerates_agent_reference_to_tool_declared_by_broken_plugin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Startup config loads should allow unavailable tools only from skipped broken plugins."""
+    plugin_root = tmp_path / "plugins" / "broken"
+    _write_broken_tool_plugin(plugin_root)
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        (
+            "models:\n"
+            "  default:\n"
+            "    provider: openai\n"
+            "    id: gpt-5.4\n"
+            "router:\n"
+            "  model: default\n"
+            "agents:\n"
+            "  assistant:\n"
+            "    display_name: Assistant\n"
+            "    role: test\n"
+            "    tools:\n"
+            "      - shell\n"
+            "      - broken_plugin_tool\n"
+            "plugins:\n"
+            "  - ./plugins/broken\n"
+        ),
+        encoding="utf-8",
+    )
+    runtime_paths = resolve_runtime_paths(
+        config_path=config_path,
+        storage_path=config_path.parent / "mindroom_data",
+        process_env={
+            "MATRIX_HOMESERVER": "http://localhost:8008",
+            "MINDROOM_NAMESPACE": "",
+        },
+    )
+    mock_logger = MagicMock()
+    monkeypatch.setattr("mindroom.config.main.logger", mock_logger)
+
+    with _preserved_plugin_loader_state():
+        config = load_config(runtime_paths, tolerate_plugin_load_errors=True)
+
+        assert "broken_plugin_tool" not in config.get_agent_tools("assistant")
+        assert config.get_agent_tools("assistant") == ["shell", "scheduler"]
+        assert any(
+            call.args == ("Plugin tool unavailable because plugin failed to load",)
+            and call.kwargs["tool_name"] == "broken_plugin_tool"
+            and call.kwargs["config_path"] == "agents.assistant.tools[1]"
+            for call in mock_logger.warning.call_args_list
+        )
+
+
+def test_load_config_tolerates_toolkit_reference_to_tool_declared_by_broken_plugin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tolerant startup should drop unavailable skipped-plugin tools from dynamic toolkits."""
+    plugin_root = tmp_path / "plugins" / "broken"
+    _write_broken_tool_plugin(plugin_root)
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        (
+            "models:\n"
+            "  default:\n"
+            "    provider: openai\n"
+            "    id: gpt-5.4\n"
+            "router:\n"
+            "  model: default\n"
+            "toolkits:\n"
+            "  sleepy:\n"
+            "    tools:\n"
+            "      - broken_plugin_tool\n"
+            "agents:\n"
+            "  assistant:\n"
+            "    display_name: Assistant\n"
+            "    role: test\n"
+            "    allowed_toolkits:\n"
+            "      - sleepy\n"
+            "    initial_toolkits:\n"
+            "      - sleepy\n"
+            "plugins:\n"
+            "  - ./plugins/broken\n"
+        ),
+        encoding="utf-8",
+    )
+    runtime_paths = resolve_runtime_paths(
+        config_path=config_path,
+        storage_path=config_path.parent / "mindroom_data",
+        process_env={
+            "MATRIX_HOMESERVER": "http://localhost:8008",
+            "MINDROOM_NAMESPACE": "",
+        },
+    )
+    mock_logger = MagicMock()
+    monkeypatch.setattr("mindroom.config.main.logger", mock_logger)
+
+    with _preserved_plugin_loader_state():
+        config = load_config(runtime_paths, tolerate_plugin_load_errors=True)
+
+        assert config.get_toolkit_tool_configs("sleepy") == []
+        assert config.get_agent_tools("assistant") == ["scheduler"]
+        assert any(
+            call.args == ("Plugin tool unavailable because plugin failed to load",)
+            and call.kwargs["tool_name"] == "broken_plugin_tool"
+            and call.kwargs["config_path"] == "toolkits.sleepy.tools[0]"
+            for call in mock_logger.warning.call_args_list
+        )
+
+
+def test_broken_plugin_unavailable_tool_does_not_shadow_builtin_tool(tmp_path: Path) -> None:
+    """A skipped plugin declaration must not make a built-in tool unavailable."""
+    plugin_root = tmp_path / "plugins" / "broken"
+    _write_broken_tool_plugin(plugin_root, tool_name="shell")
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        (
+            "models:\n"
+            "  default:\n"
+            "    provider: openai\n"
+            "    id: gpt-5.4\n"
+            "router:\n"
+            "  model: default\n"
+            "agents:\n"
+            "  assistant:\n"
+            "    display_name: Assistant\n"
+            "    role: test\n"
+            "    tools:\n"
+            "      - shell\n"
+            "plugins:\n"
+            "  - ./plugins/broken\n"
+        ),
+        encoding="utf-8",
+    )
+    runtime_paths = resolve_runtime_paths(
+        config_path=config_path,
+        storage_path=config_path.parent / "mindroom_data",
+        process_env={
+            "MATRIX_HOMESERVER": "http://localhost:8008",
+            "MINDROOM_NAMESPACE": "",
+        },
+    )
+
+    with _preserved_plugin_loader_state():
+        config = load_config(runtime_paths, tolerate_plugin_load_errors=True)
+
+        assert config.get_agent_tools("assistant") == ["shell", "scheduler"]
+
+
+def test_broken_plugin_unavailable_tool_does_not_shadow_healthy_plugin_tool(tmp_path: Path) -> None:
+    """A later skipped plugin declaration must not make a healthy plugin tool unavailable."""
+    good_root = tmp_path / "plugins" / "good"
+    broken_root = tmp_path / "plugins" / "broken"
+    _write_working_tool_plugin(good_root, plugin_name="good_plugin", tool_name="healthy_plugin_tool")
+    _write_broken_tool_plugin(broken_root, tool_name="healthy_plugin_tool")
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        (
+            "models:\n"
+            "  default:\n"
+            "    provider: openai\n"
+            "    id: gpt-5.4\n"
+            "router:\n"
+            "  model: default\n"
+            "agents:\n"
+            "  assistant:\n"
+            "    display_name: Assistant\n"
+            "    role: test\n"
+            "    tools:\n"
+            "      - healthy_plugin_tool\n"
+            "plugins:\n"
+            "  - ./plugins/good\n"
+            "  - ./plugins/broken\n"
+        ),
+        encoding="utf-8",
+    )
+    runtime_paths = resolve_runtime_paths(
+        config_path=config_path,
+        storage_path=config_path.parent / "mindroom_data",
+        process_env={
+            "MATRIX_HOMESERVER": "http://localhost:8008",
+            "MINDROOM_NAMESPACE": "",
+        },
+    )
+
+    with _preserved_plugin_loader_state():
+        config = load_config(runtime_paths, tolerate_plugin_load_errors=True)
+
+        assert config.get_agent_tools("assistant") == ["healthy_plugin_tool", "scheduler"]
+
+
+def test_load_config_still_rejects_unknown_tool_without_broken_plugin_explanation(tmp_path: Path) -> None:
+    """Tolerant startup should not convert ordinary unknown tools into warnings."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        (
+            "models:\n"
+            "  default:\n"
+            "    provider: openai\n"
+            "    id: gpt-5.4\n"
+            "router:\n"
+            "  model: default\n"
+            "agents:\n"
+            "  assistant:\n"
+            "    display_name: Assistant\n"
+            "    role: test\n"
+            "    tools:\n"
+            "      - typo_plugin_tool\n"
+        ),
+        encoding="utf-8",
+    )
+    runtime_paths = resolve_runtime_paths(
+        config_path=config_path,
+        storage_path=config_path.parent / "mindroom_data",
+        process_env={
+            "MATRIX_HOMESERVER": "http://localhost:8008",
+            "MINDROOM_NAMESPACE": "",
+        },
+    )
+
+    with pytest.raises(ConfigRuntimeValidationError, match="Unknown tool 'typo_plugin_tool'"):
+        load_config(runtime_paths, tolerate_plugin_load_errors=True)
+
+
+def test_load_config_still_rejects_unknown_toolkit_tool_without_broken_plugin_explanation(tmp_path: Path) -> None:
+    """Tolerant startup should not allow ordinary unknown tools in dynamic toolkits."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        (
+            "models:\n"
+            "  default:\n"
+            "    provider: openai\n"
+            "    id: gpt-5.4\n"
+            "router:\n"
+            "  model: default\n"
+            "toolkits:\n"
+            "  sleepy:\n"
+            "    tools:\n"
+            "      - typo_plugin_tool\n"
+            "agents:\n"
+            "  assistant:\n"
+            "    display_name: Assistant\n"
+            "    role: test\n"
+            "    allowed_toolkits:\n"
+            "      - sleepy\n"
+            "    initial_toolkits:\n"
+            "      - sleepy\n"
+        ),
+        encoding="utf-8",
+    )
+    runtime_paths = resolve_runtime_paths(
+        config_path=config_path,
+        storage_path=config_path.parent / "mindroom_data",
+        process_env={
+            "MATRIX_HOMESERVER": "http://localhost:8008",
+            "MINDROOM_NAMESPACE": "",
+        },
+    )
+
+    with pytest.raises(ValueError, match="'typo_plugin_tool' is not supported"):
+        load_config(runtime_paths, tolerate_plugin_load_errors=True)
+
+
 def test_load_plugins_skips_later_broken_plugin_and_keeps_earlier_tools(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -2266,6 +2586,69 @@ def test_reload_plugins_raises_when_configured_plugin_becomes_invalid(tmp_path: 
         with pytest.raises(plugin_module.PluginValidationError, match="Plugin hooks module not found"):
             reload_plugins(config, runtime_paths_for(config))
     finally:
+        plugin_module._PLUGIN_CACHE.clear()
+        plugin_module._PLUGIN_CACHE.update(original_plugin_cache)
+        plugin_module._MODULE_IMPORT_CACHE.clear()
+        plugin_module._MODULE_IMPORT_CACHE.update(original_module_cache)
+        set_plugin_skill_roots(original_plugin_roots)
+        for module_name in set(sys.modules) - original_modules:
+            if module_name.startswith("mindroom_plugin_"):
+                sys.modules.pop(module_name, None)
+
+
+def test_failed_strict_tool_plugin_reload_preserves_previous_live_registry(tmp_path: Path) -> None:
+    """A failed strict reload should leave the previous working tool registration usable."""
+    plugin_root = tmp_path / "plugins" / "reload-tool"
+    plugin_root.mkdir(parents=True)
+    (plugin_root / "mindroom.plugin.json").write_text(
+        json.dumps({"name": "reload_tool", "tools_module": "tools.py", "skills": []}),
+        encoding="utf-8",
+    )
+    tools_path = plugin_root / "tools.py"
+    tools_path.write_text(
+        "from agno.tools import Toolkit\n"
+        "from mindroom.tool_system.metadata import ToolCategory, register_tool_with_metadata\n"
+        "\n"
+        "class ReloadTool(Toolkit):\n"
+        "    def __init__(self) -> None:\n"
+        "        super().__init__(name='reload', tools=[])\n"
+        "\n"
+        "@register_tool_with_metadata(\n"
+        "    name='reload_plugin_tool',\n"
+        "    display_name='Reload Plugin Tool',\n"
+        "    description='Tool that starts healthy then breaks on reload',\n"
+        "    category=ToolCategory.DEVELOPMENT,\n"
+        ")\n"
+        "def reload_plugin_tools():\n"
+        "    return ReloadTool\n",
+        encoding="utf-8",
+    )
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("agents: {}", encoding="utf-8")
+    config = _bind_runtime_paths(Config(plugins=["./plugins/reload-tool"]), config_path)
+
+    original_registry = TOOL_REGISTRY.copy()
+    original_metadata = TOOL_METADATA.copy()
+    original_plugin_roots = _get_plugin_skill_roots()
+    original_plugin_cache = plugin_module._PLUGIN_CACHE.copy()
+    original_module_cache = plugin_module._MODULE_IMPORT_CACHE.copy()
+    original_modules = set(sys.modules)
+    try:
+        initial = reload_plugins(config, runtime_paths_for(config))
+        assert initial.active_plugin_names == ("reload_tool",)
+        assert get_tool_by_name("reload_plugin_tool", runtime_paths_for(config), worker_target=None).name == "reload"
+
+        tools_path.write_text("raise ImportError('reload failure')\n", encoding="utf-8")
+
+        with pytest.raises(plugin_module.PluginValidationError, match="reload failure"):
+            reload_plugins(config, runtime_paths_for(config))
+
+        assert get_tool_by_name("reload_plugin_tool", runtime_paths_for(config), worker_target=None).name == "reload"
+    finally:
+        TOOL_REGISTRY.clear()
+        TOOL_REGISTRY.update(original_registry)
+        TOOL_METADATA.clear()
+        TOOL_METADATA.update(original_metadata)
         plugin_module._PLUGIN_CACHE.clear()
         plugin_module._PLUGIN_CACHE.update(original_plugin_cache)
         plugin_module._MODULE_IMPORT_CACHE.clear()

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -83,6 +83,33 @@ def _write_broken_tool_plugin(plugin_root: Path, tool_name: str = "broken_plugin
     )
 
 
+def _write_pre_registration_broken_tool_plugin(plugin_root: Path, tool_name: str = "broken_plugin_tool") -> None:
+    plugin_root.mkdir(parents=True)
+    (plugin_root / "mindroom.plugin.json").write_text(
+        json.dumps({"name": "broken_plugin", "tools_module": "tools.py", "skills": []}),
+        encoding="utf-8",
+    )
+    (plugin_root / "tools.py").write_text(
+        "from definitely_missing_plugin_dependency import broken\n"
+        "from agno.tools import Toolkit\n"
+        "from mindroom.tool_system.metadata import ToolCategory, register_tool_with_metadata\n"
+        "\n"
+        "class BrokenTool(Toolkit):\n"
+        "    def __init__(self) -> None:\n"
+        "        super().__init__(name='broken', tools=[])\n"
+        "\n"
+        "@register_tool_with_metadata(\n"
+        f"    name={tool_name!r},\n"
+        "    display_name='Broken Plugin Tool',\n"
+        "    description='Tool declared by a plugin that fails before registration',\n"
+        "    category=ToolCategory.DEVELOPMENT,\n"
+        ")\n"
+        "def broken_plugin_tools():\n"
+        "    return BrokenTool\n",
+        encoding="utf-8",
+    )
+
+
 def _write_working_tool_plugin(plugin_root: Path, *, plugin_name: str, tool_name: str) -> None:
     plugin_root.mkdir(parents=True)
     (plugin_root / "mindroom.plugin.json").write_text(
@@ -1732,6 +1759,58 @@ def test_load_config_tolerates_agent_reference_to_tool_declared_by_broken_plugin
             call.args == ("Plugin tool unavailable because plugin failed to load",)
             and call.kwargs["tool_name"] == "broken_plugin_tool"
             and call.kwargs["config_path"] == "agents.assistant.tools[1]"
+            for call in mock_logger.warning.call_args_list
+        )
+
+
+def test_load_config_tolerates_unavailable_ast_plugin_tool_with_authored_overrides(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Overrides for filtered unavailable plugin tools should not block tolerant startup."""
+    plugin_root = tmp_path / "plugins" / "broken"
+    _write_pre_registration_broken_tool_plugin(plugin_root)
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        (
+            "models:\n"
+            "  default:\n"
+            "    provider: openai\n"
+            "    id: gpt-5.4\n"
+            "router:\n"
+            "  model: default\n"
+            "agents:\n"
+            "  assistant:\n"
+            "    display_name: Assistant\n"
+            "    role: test\n"
+            "    tools:\n"
+            "      - broken_plugin_tool:\n"
+            "          unreachable_option: ignored\n"
+            "plugins:\n"
+            "  - ./plugins/broken\n"
+        ),
+        encoding="utf-8",
+    )
+    runtime_paths = resolve_runtime_paths(
+        config_path=config_path,
+        storage_path=config_path.parent / "mindroom_data",
+        process_env={
+            "MATRIX_HOMESERVER": "http://localhost:8008",
+            "MINDROOM_NAMESPACE": "",
+        },
+    )
+    mock_logger = MagicMock()
+    monkeypatch.setattr("mindroom.config.main.logger", mock_logger)
+
+    with _preserved_plugin_loader_state():
+        config = load_config(runtime_paths, tolerate_plugin_load_errors=True)
+
+        assert config.get_agent_tools("assistant") == ["scheduler"]
+        assert any(
+            call.args == ("Plugin tool unavailable because plugin failed to load",)
+            and call.kwargs["tool_name"] == "broken_plugin_tool"
+            and call.kwargs["config_path"] == "agents.assistant.tools[0]"
             for call in mock_logger.warning.call_args_list
         )
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -110,6 +110,43 @@ def _write_pre_registration_broken_tool_plugin(plugin_root: Path, tool_name: str
     )
 
 
+def _write_mid_registration_broken_tool_plugin(plugin_root: Path) -> None:
+    plugin_root.mkdir(parents=True)
+    (plugin_root / "mindroom.plugin.json").write_text(
+        json.dumps({"name": "broken_plugin", "tools_module": "tools.py", "skills": []}),
+        encoding="utf-8",
+    )
+    (plugin_root / "tools.py").write_text(
+        "from agno.tools import Toolkit\n"
+        "from mindroom.tool_system.metadata import ToolCategory, register_tool_with_metadata\n"
+        "\n"
+        "class BrokenTool(Toolkit):\n"
+        "    def __init__(self) -> None:\n"
+        "        super().__init__(name='broken', tools=[])\n"
+        "\n"
+        "@register_tool_with_metadata(\n"
+        "    name='registered_before_failure',\n"
+        "    display_name='Registered Before Failure',\n"
+        "    description='Tool declared before failure',\n"
+        "    category=ToolCategory.DEVELOPMENT,\n"
+        ")\n"
+        "def registered_before_failure_tools():\n"
+        "    return BrokenTool\n"
+        "\n"
+        "raise ImportError('missing optional plugin dependency')\n"
+        "\n"
+        "@register_tool_with_metadata(\n"
+        "    name='declared_after_failure',\n"
+        "    display_name='Declared After Failure',\n"
+        "    description='Tool declared after failure',\n"
+        "    category=ToolCategory.DEVELOPMENT,\n"
+        ")\n"
+        "def declared_after_failure_tools():\n"
+        "    return BrokenTool\n",
+        encoding="utf-8",
+    )
+
+
 def _write_working_tool_plugin(plugin_root: Path, *, plugin_name: str, tool_name: str) -> None:
     plugin_root.mkdir(parents=True)
     (plugin_root / "mindroom.plugin.json").write_text(
@@ -138,6 +175,8 @@ def _write_working_tool_plugin(plugin_root: Path, *, plugin_name: str, tool_name
 
 @contextmanager
 def _preserved_plugin_loader_state(*, module_prefixes: tuple[str, ...] = ()) -> Iterator[None]:
+    original_registry = TOOL_REGISTRY.copy()
+    original_metadata = TOOL_METADATA.copy()
     original_plugin_roots = _get_plugin_skill_roots()
     original_plugin_cache = plugin_module._PLUGIN_CACHE.copy()
     original_module_cache = plugin_module._MODULE_IMPORT_CACHE.copy()
@@ -146,6 +185,10 @@ def _preserved_plugin_loader_state(*, module_prefixes: tuple[str, ...] = ()) -> 
     try:
         yield
     finally:
+        TOOL_REGISTRY.clear()
+        TOOL_REGISTRY.update(original_registry)
+        TOOL_METADATA.clear()
+        TOOL_METADATA.update(original_metadata)
         plugin_module._PLUGIN_CACHE.clear()
         plugin_module._PLUGIN_CACHE.update(original_plugin_cache)
         plugin_module._MODULE_IMPORT_CACHE.clear()
@@ -1810,6 +1853,57 @@ def test_load_config_tolerates_unavailable_ast_plugin_tool_with_authored_overrid
         assert any(
             call.args == ("Plugin tool unavailable because plugin failed to load",)
             and call.kwargs["tool_name"] == "broken_plugin_tool"
+            and call.kwargs["config_path"] == "agents.assistant.tools[0]"
+            for call in mock_logger.warning.call_args_list
+        )
+
+
+def test_load_config_tolerates_tool_declared_after_broken_plugin_registration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Partial plugin registration should not hide later literal tool declarations."""
+    plugin_root = tmp_path / "plugins" / "broken"
+    _write_mid_registration_broken_tool_plugin(plugin_root)
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        (
+            "models:\n"
+            "  default:\n"
+            "    provider: openai\n"
+            "    id: gpt-5.4\n"
+            "router:\n"
+            "  model: default\n"
+            "agents:\n"
+            "  assistant:\n"
+            "    display_name: Assistant\n"
+            "    role: test\n"
+            "    tools:\n"
+            "      - declared_after_failure\n"
+            "plugins:\n"
+            "  - ./plugins/broken\n"
+        ),
+        encoding="utf-8",
+    )
+    runtime_paths = resolve_runtime_paths(
+        config_path=config_path,
+        storage_path=config_path.parent / "mindroom_data",
+        process_env={
+            "MATRIX_HOMESERVER": "http://localhost:8008",
+            "MINDROOM_NAMESPACE": "",
+        },
+    )
+    mock_logger = MagicMock()
+    monkeypatch.setattr("mindroom.config.main.logger", mock_logger)
+
+    with _preserved_plugin_loader_state():
+        config = load_config(runtime_paths, tolerate_plugin_load_errors=True)
+
+        assert config.get_agent_tools("assistant") == ["scheduler"]
+        assert any(
+            call.args == ("Plugin tool unavailable because plugin failed to load",)
+            and call.kwargs["tool_name"] == "declared_after_failure"
             and call.kwargs["config_path"] == "agents.assistant.tools[0]"
             for call in mock_logger.warning.call_args_list
         )

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -90,6 +90,43 @@ def test_serialized_kubernetes_worker_validation_snapshot_tolerates_plugin_load_
     assert tolerate_values == [True]
 
 
+def test_serialized_kubernetes_worker_validation_snapshot_loads_config_tolerantly(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The default config-loading branch should match tolerant startup behavior."""
+    runtime_paths = _runtime_paths(tmp_path)
+    runtime_paths.config_path.write_text(
+        (
+            "models:\n"
+            "  default:\n"
+            "    provider: openai\n"
+            "    id: gpt-5.4\n"
+            "router:\n"
+            "  model: default\n"
+            "agents: {}\n"
+            "plugins:\n"
+            "  - ./plugins/missing\n"
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_resolver(*_args: object, **_kwargs: object) -> dict[str, ToolValidationInfo]:
+        return {
+            "fake": ToolValidationInfo(name="fake"),
+            "scheduler": ToolValidationInfo(name="scheduler"),
+        }
+
+    monkeypatch.setattr(
+        "mindroom.tool_system.catalog.resolved_tool_validation_snapshot_for_runtime",
+        fake_resolver,
+    )
+
+    snapshot = workers_runtime_module.serialized_kubernetes_worker_validation_snapshot(runtime_paths)
+
+    assert set(snapshot) == {"fake", "scheduler"}
+
+
 def test_serialized_kubernetes_worker_validation_snapshot_clear_recomputes(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -64,6 +64,32 @@ def test_serialized_kubernetes_worker_validation_snapshot_reuses_cached_resolver
     assert first_snapshot == second_snapshot
 
 
+def test_serialized_kubernetes_worker_validation_snapshot_tolerates_plugin_load_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Worker validation snapshots should match the tolerant primary startup path."""
+    runtime_paths = _runtime_paths(tmp_path)
+    runtime_config = Config(plugins=[{"path": "plugins/broken"}])
+    tolerate_values: list[object] = []
+
+    def fake_resolver(*_args: object, **kwargs: object) -> dict[str, ToolValidationInfo]:
+        tolerate_values.append(kwargs.get("tolerate_plugin_load_errors"))
+        return {"fake": ToolValidationInfo(name="fake")}
+
+    monkeypatch.setattr(
+        "mindroom.tool_system.catalog.resolved_tool_validation_snapshot_for_runtime",
+        fake_resolver,
+    )
+
+    workers_runtime_module.serialized_kubernetes_worker_validation_snapshot(
+        runtime_paths,
+        runtime_config=runtime_config,
+    )
+
+    assert tolerate_values == [True]
+
+
 def test_serialized_kubernetes_worker_validation_snapshot_clear_recomputes(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- Treat tools declared by skipped broken plugins as known-but-unavailable during tolerant runtime validation.
- Filter unavailable skipped-plugin tools from effective agent/toolkit tool configs so agents start without them.
- Preserve strict unknown-tool validation for normal typos and strict plugin validation paths.

## Test Plan
- [x] `.venv/bin/python -m pytest tests/test_plugins.py tests/test_config_manager_consolidated.py::TestConsolidatedConfigManager::test_validate_with_runtime_rejects_unknown_tool_names tests/test_tools_metadata.py -q -n 0 --no-cov`
- [x] `.venv/bin/python -m pytest -q -n 0 --no-cov`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Warns with exact config path when a referenced tool is unavailable due to plugin load failures.
  * Excludes tools from failed plugins from agent and dynamic toolkit configs to prevent resolution errors.

* **Enhancements**
  * Startup can tolerate plugin load failures by tracking unavailable plugin tools and deriving metadata for failed plugins so launch can continue.
  * Kubernetes worker validation snapshots now tolerate plugin load errors.
  * Strict plugin reload failures preserve previously registered tools.

* **Tests**
  * Added extensive tests for tolerant startup, broken-plugin scenarios, toolkit interactions, and regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->