### PR TITLE
Extract text ingress dispatch path

### DIFF
--- a/src/mindroom/text_ingress_dispatch.py
+++ b/src/mindroom/text_ingress_dispatch.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import time
-from typing import TYPE_CHECKING, Any
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal, Protocol
 
 from mindroom.attachments import merge_attachment_ids, parse_attachment_ids_from_event_source
 from mindroom.commands.parsing import command_parser
@@ -33,6 +34,7 @@ from mindroom.inbound_turn_normalizer import (
 from mindroom.matrix.media import is_audio_message_event, is_matrix_media_dispatch_event
 from mindroom.matrix.rooms import is_dm_room
 from mindroom.timing import (
+    DispatchPipelineTiming,
     attach_dispatch_pipeline_timing,
     event_timing_scope,
     get_dispatch_pipeline_timing,
@@ -40,14 +42,62 @@ from mindroom.timing import (
 from mindroom.timing import timing_scope as timing_scope_context
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     import nio
 
+    from mindroom.commands.parsing import Command
     from mindroom.conversation_resolver import MessageContext
+    from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
     from mindroom.response_lifecycle import QueuedHumanNoticeReservation
     from mindroom.turn_controller import TurnController
+    from mindroom.turn_policy import PreparedDispatch, ResponseAction
 
 
-async def dispatch_text_message(  # noqa: C901, PLR0912, PLR0915
+class _TurnPlan(Protocol):
+    kind: Literal["ignore", "route", "respond"]
+    response_action: ResponseAction | None
+    router_message: str | None
+    extra_content: dict[str, Any] | None
+    media_events: list[MediaDispatchEvent] | None
+    router_event: DispatchEvent | None
+    ignore_reason: Literal["router"] | None
+
+
+class _ReplayGuard(Protocol):
+    degraded: bool
+    history: Sequence[ResolvedVisibleMessage]
+    thread_id: str | None
+
+
+@dataclass(frozen=True)
+class _ResolvedTextDispatch:
+    event: TextDispatchEvent
+    payload_metadata: DispatchPayloadMetadata | None
+    handled_turn: HandledTurnState
+    command: Command | None
+    dispatch_started_at: float
+
+
+@dataclass(frozen=True)
+class _PreparedTextDispatch:
+    event: TextDispatchEvent
+    payload_metadata: DispatchPayloadMetadata | None
+    handled_turn: HandledTurnState
+    command: Command | None
+    dispatch: PreparedDispatch
+    replay_guard: _ReplayGuard
+    dispatch_started_at: float
+
+
+@dataclass(frozen=True)
+class _AttachmentContext:
+    message_attachment_ids: list[str]
+    trusted_current_attachment_ids: list[str]
+    router_extra_content: dict[str, Any]
+
+
+async def dispatch_text_message(
     controller: TurnController,
     room: nio.MatrixRoom,
     raw_event: TextDispatchEvent,
@@ -61,250 +111,67 @@ async def dispatch_text_message(  # noqa: C901, PLR0912, PLR0915
     trust_hydrated_internal_metadata: bool | None = None,
 ) -> None:
     """Run the normal text or command dispatch pipeline for a prepared text event."""
-    router_event: DispatchEvent = raw_event
     reservation = queued_notice_reservation
     timing_scope_token = None
     try:
-        event = await controller.deps.normalizer.resolve_text_event(
-            TextNormalizationRequest(event=raw_event),
-        )
-        trust_internal_payload_metadata = (
-            controller._should_trust_internal_payload_metadata(event)
-            if trust_hydrated_internal_metadata is None
-            else trust_hydrated_internal_metadata
-        )
-        hydrated_payload_metadata = payload_metadata_from_source(
-            event.source,
-            trust_internal_metadata=trust_internal_payload_metadata,
-        )
-        payload_metadata = (
-            hydrated_payload_metadata
-            if payload_metadata is None
-            else merge_payload_metadata(
-                payload_metadata,
-                hydrated_payload_metadata,
-                trust_hydrated_internal_metadata=trust_internal_payload_metadata,
-            )
-        )
         dispatch_timing = get_dispatch_pipeline_timing(raw_event.source)
-        attach_dispatch_pipeline_timing(event.source, dispatch_timing)
-        timing_scope_token = timing_scope_context.set(event_timing_scope(event.event_id))
-        if dispatch_timing is not None:
-            dispatch_timing.mark("dispatch_start")
-        dispatch_started_at = time.monotonic()
-        if handled_turn is None:
-            handled_turn = HandledTurnState.from_source_event_id(event.event_id)
-        elif raw_event is not event and event.event_id in handled_turn.source_event_ids:
-            refreshed_prompts = dict(handled_turn.source_event_prompts or {})
-            refreshed_prompts[event.event_id] = event.body
-            handled_turn = handled_turn.with_source_event_prompts(refreshed_prompts)
-
-        if dispatch_timing is not None:
-            dispatch_timing.mark("dispatch_prepare_start")
-        command = None
-        event_is_voice_dispatch = (
-            (ingress_metadata is not None and ingress_metadata.source_kind == VOICE_SOURCE_KIND)
-            or is_audio_message_event(event)
-            or is_voice_event(event, sender_is_trusted=controller._sender_is_trusted_for_ingress_metadata)
-        )
-        if not media_events and not event_is_voice_dispatch:
-            command = command_parser.parse(event.body)
-        prepared_dispatch = await controller._prepare_dispatch(
-            room,
-            event,
-            requester_user_id,
-            event_label="message",
+        resolved = await _resolve_text_dispatch(
+            controller,
+            raw_event,
+            media_events=media_events,
             handled_turn=handled_turn,
             ingress_metadata=ingress_metadata,
             payload_metadata=payload_metadata,
-            use_command_context=command is not None,
+            trust_hydrated_internal_metadata=trust_hydrated_internal_metadata,
+            dispatch_timing=dispatch_timing,
         )
-        if dispatch_timing is not None:
-            dispatch_timing.mark("dispatch_prepare_ready")
-        if prepared_dispatch is None:
-            return
-        dispatch = prepared_dispatch.dispatch
-        replay_guard = prepared_dispatch.replay_guard
-        handled_turn = handled_turn.with_request_context(
-            requester_id=dispatch.requester_user_id,
-            correlation_id=dispatch.correlation_id,
+        event = resolved.event
+        timing_scope_token = timing_scope_context.set(event_timing_scope(event.event_id))
+        prepared = await _prepare_text_dispatch(
+            controller,
+            room,
+            resolved,
+            requester_user_id,
+            ingress_metadata=ingress_metadata,
+            dispatch_timing=dispatch_timing,
         )
-
-        if command is not None and dispatch.envelope.source_kind == VOICE_SOURCE_KIND:
-            command = None
-        if command:
-            if controller.deps.agent_name == ROUTER_AGENT_NAME:
-                await controller._execute_command(
-                    room=room,
-                    event=event,
-                    requester_user_id=requester_user_id,
-                    command=command,
-                    target=dispatch.target,
-                )
+        if prepared is None:
             return
-        if controller._should_skip_deep_synthetic_full_dispatch(
-            event_id=event.event_id,
-            envelope=dispatch.envelope,
+        if await _command_or_suppression_consumed_turn(
+            controller,
+            room,
+            prepared,
+            requester_user_id=requester_user_id,
         ):
             return
-        message_attachment_ids = (
-            list(payload_metadata.attachment_ids)
-            if payload_metadata is not None and payload_metadata.attachment_ids is not None
-            else parse_attachment_ids_from_event_source(event.source)
-        )
-        trusted_current_attachment_ids = (
-            list(payload_metadata.attachment_ids)
-            if payload_metadata is not None and payload_metadata.attachment_ids is not None
-            else []
-        )
-        message_extra_content: dict[str, Any] = {}
-        if message_attachment_ids:
-            message_extra_content[ATTACHMENT_IDS_KEY] = message_attachment_ids
-        if payload_metadata is not None and payload_metadata.original_sender is not None:
-            message_extra_content[ORIGINAL_SENDER_KEY] = payload_metadata.original_sender
-        if payload_metadata is not None and payload_metadata.raw_audio_fallback:
-            message_extra_content[VOICE_RAW_AUDIO_FALLBACK_KEY] = True
-        router_extra_content = dict(message_extra_content)
-        if media_events and ORIGINAL_SENDER_KEY not in router_extra_content:
-            router_extra_content[ORIGINAL_SENDER_KEY] = requester_user_id
-        replay_guard_skips_turn = False
-        if replay_guard.degraded:
-            replay_guard_skips_turn = await controller._has_newer_unresponded_cached_thread_event(
-                room_id=room.room_id,
-                event=event,
-                requester_user_id=requester_user_id,
-                thread_id=replay_guard.thread_id,
-                source_kind=dispatch.envelope.source_kind,
-            )
-            if not replay_guard_skips_turn:
-                controller.deps.logger.warning(
-                    "Thread replay guard degraded; proceeding without negative newer-message proof",
-                    event_id=event.event_id,
-                    room_id=room.room_id,
-                    thread_id=replay_guard.thread_id,
-                    thread_read_degraded=True,
-                )
-        else:
-            replay_guard_skips_turn = controller._has_newer_unresponded_in_thread(
-                event,
-                requester_user_id,
-                replay_guard.history,
-                source_kind=dispatch.envelope.source_kind,
-            )
-        if replay_guard_skips_turn:
-            controller._mark_source_events_responded(handled_turn)
+        if await _replay_guard_skips_turn(controller, room, prepared, requester_user_id=requester_user_id):
             return
         if dispatch_timing is not None:
             dispatch_timing.mark("dispatch_plan_start")
+        attachments = _attachment_context(prepared, media_events=media_events, requester_user_id=requester_user_id)
         plan = await controller.deps.turn_policy.plan_turn(
             room,
-            event,
-            dispatch,
+            prepared.event,
+            prepared.dispatch,
             is_dm=await is_dm_room(controller._client(), room.room_id),
             has_active_response_for_target=controller.deps.response_runner.has_active_response_for_target,
-            extra_content=router_extra_content or None,
+            extra_content=attachments.router_extra_content or None,
             media_events=media_events,
-            router_event=media_events[0] if media_events and len(handled_turn.source_event_ids) == 1 else router_event,
+            router_event=media_events[0]
+            if media_events and len(prepared.handled_turn.source_event_ids) == 1
+            else raw_event,
         )
         if dispatch_timing is not None:
             dispatch_timing.mark("dispatch_plan_ready")
-        if plan.kind == "ignore":
-            if plan.ignore_reason == "router":
-                router_outcome = controller._router_handled_turn_outcome(handled_turn)
-                if router_outcome is not None:
-                    controller._mark_source_events_responded(router_outcome)
+        if await _non_response_plan_consumed_turn(controller, room, prepared, plan, media_events=media_events):
             return
-        if plan.kind == "route":
-            route_event = plan.router_event or event
-            tracked_route_handled_turn = (
-                handled_turn
-                if handled_turn.is_coalesced
-                or (handled_turn.source_event_ids and handled_turn.source_event_ids[0] != event.event_id)
-                else None
-            )
-            single_direct_media_route = (
-                is_matrix_media_dispatch_event(route_event)
-                and media_events == [route_event]
-                and handled_turn.source_event_ids == (event.event_id,)
-            )
-            routing_kwargs: dict[str, Any] = {
-                "message": event.body if media_events else plan.router_message,
-                "requester_user_id": dispatch.requester_user_id,
-                "extra_content": plan.extra_content,
-            }
-            if plan.media_events is not None and not single_direct_media_route:
-                routing_kwargs["media_events"] = plan.media_events
-            if (
-                tracked_route_handled_turn is not None
-                and list(tracked_route_handled_turn.source_event_ids) != [route_event.event_id]
-                and not single_direct_media_route
-            ):
-                routing_kwargs["handled_turn"] = controller.deps.turn_store.attach_response_context(
-                    tracked_route_handled_turn,
-                    history_scope=None,
-                    conversation_target=dispatch.target,
-                )
-            await controller._execute_router_relay(
-                room,
-                route_event,
-                dispatch.context.thread_history,
-                dispatch.target.resolved_thread_id,
-                **routing_kwargs,
-            )
-            return
-        assert plan.response_action is not None
-        response_history_scope = (
-            controller.deps.turn_store.response_history_scope(plan.response_action)
-            if plan.response_action.kind in {"individual", "team"}
-            else None
-        )
-        handled_turn = controller.deps.turn_store.attach_response_context(
-            handled_turn,
-            history_scope=response_history_scope,
-            conversation_target=dispatch.target,
-        )
-        matrix_run_metadata = controller.deps.turn_store.build_run_metadata(handled_turn)
-
-        async def build_payload(context: MessageContext) -> DispatchPayload:
-            effective_thread_id = dispatch.target.resolved_thread_id
-            media_attachment_ids: list[str] = []
-            fallback_images = None
-            if media_events:
-                media_result = await controller.deps.normalizer.register_batch_media_attachments(
-                    BatchMediaAttachmentRequest(
-                        room_id=room.room_id,
-                        thread_id=effective_thread_id,
-                        media_events=media_events,
-                    ),
-                )
-                media_attachment_ids = media_result.attachment_ids
-                fallback_images = media_result.fallback_images
-            return await controller.deps.normalizer.build_dispatch_payload_with_attachments(
-                DispatchPayloadWithAttachmentsRequest(
-                    room_id=room.room_id,
-                    prompt=event.body,
-                    current_attachment_ids=merge_attachment_ids(
-                        message_attachment_ids,
-                        media_attachment_ids,
-                    ),
-                    trusted_current_attachment_ids=trusted_current_attachment_ids,
-                    thread_id=context.thread_id,
-                    media_thread_id=effective_thread_id,
-                    thread_history=context.thread_history,
-                    fallback_images=fallback_images,
-                ),
-            )
-
-        await controller._execute_response_action(
+        await _execute_response_plan(
+            controller,
             room,
-            event,
-            dispatch,
-            plan.response_action,
-            build_payload,
-            processing_log="Processing",
-            dispatch_started_at=dispatch_started_at,
-            handled_turn=handled_turn,
-            matrix_run_metadata=matrix_run_metadata,
+            prepared,
+            plan,
+            attachments,
+            media_events=media_events,
             queued_notice_reservation=reservation,
         )
     finally:
@@ -312,3 +179,365 @@ async def dispatch_text_message(  # noqa: C901, PLR0912, PLR0915
             reservation.cancel()
         if timing_scope_token is not None:
             timing_scope_context.reset(timing_scope_token)
+
+
+async def _resolve_text_dispatch(
+    controller: TurnController,
+    raw_event: TextDispatchEvent,
+    *,
+    media_events: list[MediaDispatchEvent] | None,
+    handled_turn: HandledTurnState | None,
+    ingress_metadata: DispatchIngressMetadata | None,
+    payload_metadata: DispatchPayloadMetadata | None,
+    trust_hydrated_internal_metadata: bool | None,
+    dispatch_timing: DispatchPipelineTiming | None,
+) -> _ResolvedTextDispatch:
+    event = await controller.deps.normalizer.resolve_text_event(
+        TextNormalizationRequest(event=raw_event),
+    )
+    trust_internal_payload_metadata = (
+        controller._should_trust_internal_payload_metadata(event)
+        if trust_hydrated_internal_metadata is None
+        else trust_hydrated_internal_metadata
+    )
+    hydrated_payload_metadata = payload_metadata_from_source(
+        event.source,
+        trust_internal_metadata=trust_internal_payload_metadata,
+    )
+    merged_payload_metadata = (
+        hydrated_payload_metadata
+        if payload_metadata is None
+        else merge_payload_metadata(
+            payload_metadata,
+            hydrated_payload_metadata,
+            trust_hydrated_internal_metadata=trust_internal_payload_metadata,
+        )
+    )
+    attach_dispatch_pipeline_timing(event.source, dispatch_timing)
+    if dispatch_timing is not None:
+        dispatch_timing.mark("dispatch_start")
+    if handled_turn is None:
+        handled_turn = HandledTurnState.from_source_event_id(event.event_id)
+    elif raw_event is not event and event.event_id in handled_turn.source_event_ids:
+        refreshed_prompts = dict(handled_turn.source_event_prompts or {})
+        refreshed_prompts[event.event_id] = event.body
+        handled_turn = handled_turn.with_source_event_prompts(refreshed_prompts)
+    return _ResolvedTextDispatch(
+        event=event,
+        payload_metadata=merged_payload_metadata,
+        handled_turn=handled_turn,
+        command=_parsed_command_for_event(
+            controller,
+            event,
+            media_events=media_events,
+            ingress_metadata=ingress_metadata,
+        ),
+        dispatch_started_at=time.monotonic(),
+    )
+
+
+def _parsed_command_for_event(
+    controller: TurnController,
+    event: TextDispatchEvent,
+    *,
+    media_events: list[MediaDispatchEvent] | None,
+    ingress_metadata: DispatchIngressMetadata | None,
+) -> Command | None:
+    event_is_voice_dispatch = (
+        (ingress_metadata is not None and ingress_metadata.source_kind == VOICE_SOURCE_KIND)
+        or is_audio_message_event(event)
+        or is_voice_event(event, sender_is_trusted=controller._sender_is_trusted_for_ingress_metadata)
+    )
+    if media_events or event_is_voice_dispatch:
+        return None
+    return command_parser.parse(event.body)
+
+
+async def _prepare_text_dispatch(
+    controller: TurnController,
+    room: nio.MatrixRoom,
+    resolved: _ResolvedTextDispatch,
+    requester_user_id: str,
+    *,
+    ingress_metadata: DispatchIngressMetadata | None,
+    dispatch_timing: DispatchPipelineTiming | None,
+) -> _PreparedTextDispatch | None:
+    if dispatch_timing is not None:
+        dispatch_timing.mark("dispatch_prepare_start")
+    prepared_dispatch = await controller._prepare_dispatch(
+        room,
+        resolved.event,
+        requester_user_id,
+        event_label="message",
+        handled_turn=resolved.handled_turn,
+        ingress_metadata=ingress_metadata,
+        payload_metadata=resolved.payload_metadata,
+        use_command_context=resolved.command is not None,
+    )
+    if dispatch_timing is not None:
+        dispatch_timing.mark("dispatch_prepare_ready")
+    if prepared_dispatch is None:
+        return None
+    dispatch = prepared_dispatch.dispatch
+    command = resolved.command
+    if command is not None and dispatch.envelope.source_kind == VOICE_SOURCE_KIND:
+        command = None
+    return _PreparedTextDispatch(
+        event=resolved.event,
+        payload_metadata=resolved.payload_metadata,
+        handled_turn=resolved.handled_turn.with_request_context(
+            requester_id=dispatch.requester_user_id,
+            correlation_id=dispatch.correlation_id,
+        ),
+        command=command,
+        dispatch=dispatch,
+        replay_guard=prepared_dispatch.replay_guard,
+        dispatch_started_at=resolved.dispatch_started_at,
+    )
+
+
+async def _command_or_suppression_consumed_turn(
+    controller: TurnController,
+    room: nio.MatrixRoom,
+    prepared: _PreparedTextDispatch,
+    *,
+    requester_user_id: str,
+) -> bool:
+    if prepared.command is not None:
+        if controller.deps.agent_name == ROUTER_AGENT_NAME:
+            await controller._execute_command(
+                room=room,
+                event=prepared.event,
+                requester_user_id=requester_user_id,
+                command=prepared.command,
+                target=prepared.dispatch.target,
+            )
+        return True
+    return controller._should_skip_deep_synthetic_full_dispatch(
+        event_id=prepared.event.event_id,
+        envelope=prepared.dispatch.envelope,
+    )
+
+
+async def _replay_guard_skips_turn(
+    controller: TurnController,
+    room: nio.MatrixRoom,
+    prepared: _PreparedTextDispatch,
+    *,
+    requester_user_id: str,
+) -> bool:
+    if prepared.replay_guard.degraded:
+        skips_turn = await controller._has_newer_unresponded_cached_thread_event(
+            room_id=room.room_id,
+            event=prepared.event,
+            requester_user_id=requester_user_id,
+            thread_id=prepared.replay_guard.thread_id,
+            source_kind=prepared.dispatch.envelope.source_kind,
+        )
+        if not skips_turn:
+            controller.deps.logger.warning(
+                "Thread replay guard degraded; proceeding without negative newer-message proof",
+                event_id=prepared.event.event_id,
+                room_id=room.room_id,
+                thread_id=prepared.replay_guard.thread_id,
+                thread_read_degraded=True,
+            )
+    else:
+        skips_turn = controller._has_newer_unresponded_in_thread(
+            prepared.event,
+            requester_user_id,
+            prepared.replay_guard.history,
+            source_kind=prepared.dispatch.envelope.source_kind,
+        )
+    if skips_turn:
+        controller._mark_source_events_responded(prepared.handled_turn)
+    return skips_turn
+
+
+def _attachment_context(
+    prepared: _PreparedTextDispatch,
+    *,
+    media_events: list[MediaDispatchEvent] | None,
+    requester_user_id: str,
+) -> _AttachmentContext:
+    payload_metadata = prepared.payload_metadata
+    message_attachment_ids = (
+        list(payload_metadata.attachment_ids)
+        if payload_metadata is not None and payload_metadata.attachment_ids is not None
+        else parse_attachment_ids_from_event_source(prepared.event.source)
+    )
+    trusted_current_attachment_ids = (
+        list(payload_metadata.attachment_ids)
+        if payload_metadata is not None and payload_metadata.attachment_ids is not None
+        else []
+    )
+    message_extra_content: dict[str, Any] = {}
+    if message_attachment_ids:
+        message_extra_content[ATTACHMENT_IDS_KEY] = message_attachment_ids
+    if payload_metadata is not None and payload_metadata.original_sender is not None:
+        message_extra_content[ORIGINAL_SENDER_KEY] = payload_metadata.original_sender
+    if payload_metadata is not None and payload_metadata.raw_audio_fallback:
+        message_extra_content[VOICE_RAW_AUDIO_FALLBACK_KEY] = True
+    router_extra_content = dict(message_extra_content)
+    if media_events and ORIGINAL_SENDER_KEY not in router_extra_content:
+        router_extra_content[ORIGINAL_SENDER_KEY] = requester_user_id
+    return _AttachmentContext(
+        message_attachment_ids=message_attachment_ids,
+        trusted_current_attachment_ids=trusted_current_attachment_ids,
+        router_extra_content=router_extra_content,
+    )
+
+
+async def _non_response_plan_consumed_turn(
+    controller: TurnController,
+    room: nio.MatrixRoom,
+    prepared: _PreparedTextDispatch,
+    plan: _TurnPlan,
+    *,
+    media_events: list[MediaDispatchEvent] | None,
+) -> bool:
+    if plan.kind == "ignore":
+        if plan.ignore_reason == "router":
+            router_outcome = controller._router_handled_turn_outcome(prepared.handled_turn)
+            if router_outcome is not None:
+                controller._mark_source_events_responded(router_outcome)
+        return True
+    if plan.kind != "route":
+        return False
+    await _execute_route_plan(controller, room, prepared, plan, media_events=media_events)
+    return True
+
+
+async def _execute_route_plan(
+    controller: TurnController,
+    room: nio.MatrixRoom,
+    prepared: _PreparedTextDispatch,
+    plan: _TurnPlan,
+    *,
+    media_events: list[MediaDispatchEvent] | None,
+) -> None:
+    route_event = plan.router_event or prepared.event
+    tracked_route_handled_turn = (
+        prepared.handled_turn
+        if prepared.handled_turn.is_coalesced
+        or (
+            prepared.handled_turn.source_event_ids
+            and prepared.handled_turn.source_event_ids[0] != prepared.event.event_id
+        )
+        else None
+    )
+    single_direct_media_route = (
+        is_matrix_media_dispatch_event(route_event)
+        and media_events == [route_event]
+        and prepared.handled_turn.source_event_ids == (prepared.event.event_id,)
+    )
+    routing_kwargs: dict[str, Any] = {
+        "message": prepared.event.body if media_events else plan.router_message,
+        "requester_user_id": prepared.dispatch.requester_user_id,
+        "extra_content": plan.extra_content,
+    }
+    if plan.media_events is not None and not single_direct_media_route:
+        routing_kwargs["media_events"] = plan.media_events
+    if (
+        tracked_route_handled_turn is not None
+        and list(tracked_route_handled_turn.source_event_ids) != [route_event.event_id]
+        and not single_direct_media_route
+    ):
+        routing_kwargs["handled_turn"] = controller.deps.turn_store.attach_response_context(
+            tracked_route_handled_turn,
+            history_scope=None,
+            conversation_target=prepared.dispatch.target,
+        )
+    await controller._execute_router_relay(
+        room,
+        route_event,
+        prepared.dispatch.context.thread_history,
+        prepared.dispatch.target.resolved_thread_id,
+        **routing_kwargs,
+    )
+
+
+async def _execute_response_plan(
+    controller: TurnController,
+    room: nio.MatrixRoom,
+    prepared: _PreparedTextDispatch,
+    plan: _TurnPlan,
+    attachments: _AttachmentContext,
+    *,
+    media_events: list[MediaDispatchEvent] | None,
+    queued_notice_reservation: QueuedHumanNoticeReservation | None,
+) -> None:
+    assert plan.response_action is not None
+    response_history_scope = (
+        controller.deps.turn_store.response_history_scope(plan.response_action)
+        if plan.response_action.kind in {"individual", "team"}
+        else None
+    )
+    handled_turn = controller.deps.turn_store.attach_response_context(
+        prepared.handled_turn,
+        history_scope=response_history_scope,
+        conversation_target=prepared.dispatch.target,
+    )
+    matrix_run_metadata = controller.deps.turn_store.build_run_metadata(handled_turn)
+
+    async def build_payload(context: MessageContext) -> DispatchPayload:
+        return await _build_dispatch_payload(
+            controller,
+            room,
+            prepared,
+            attachments,
+            context=context,
+            media_events=media_events,
+        )
+
+    await controller._execute_response_action(
+        room,
+        prepared.event,
+        prepared.dispatch,
+        plan.response_action,
+        build_payload,
+        processing_log="Processing",
+        dispatch_started_at=prepared.dispatch_started_at,
+        handled_turn=handled_turn,
+        matrix_run_metadata=matrix_run_metadata,
+        queued_notice_reservation=queued_notice_reservation,
+    )
+
+
+async def _build_dispatch_payload(
+    controller: TurnController,
+    room: nio.MatrixRoom,
+    prepared: _PreparedTextDispatch,
+    attachments: _AttachmentContext,
+    *,
+    context: MessageContext,
+    media_events: list[MediaDispatchEvent] | None,
+) -> DispatchPayload:
+    effective_thread_id = prepared.dispatch.target.resolved_thread_id
+    media_attachment_ids: list[str] = []
+    fallback_images = None
+    if media_events:
+        media_result = await controller.deps.normalizer.register_batch_media_attachments(
+            BatchMediaAttachmentRequest(
+                room_id=room.room_id,
+                thread_id=effective_thread_id,
+                media_events=media_events,
+            ),
+        )
+        media_attachment_ids = media_result.attachment_ids
+        fallback_images = media_result.fallback_images
+    return await controller.deps.normalizer.build_dispatch_payload_with_attachments(
+        DispatchPayloadWithAttachmentsRequest(
+            room_id=room.room_id,
+            prompt=prepared.event.body,
+            current_attachment_ids=merge_attachment_ids(
+                attachments.message_attachment_ids,
+                media_attachment_ids,
+            ),
+            trusted_current_attachment_ids=attachments.trusted_current_attachment_ids,
+            thread_id=context.thread_id,
+            media_thread_id=effective_thread_id,
+            thread_history=context.thread_history,
+            fallback_images=fallback_images,
+        ),
+    )

--- a/src/mindroom/text_ingress_dispatch.py
+++ b/src/mindroom/text_ingress_dispatch.py
@@ -71,15 +71,6 @@ class _ReplayGuard(Protocol):
 
 
 @dataclass(frozen=True)
-class _ResolvedTextDispatch:
-    event: TextDispatchEvent
-    payload_metadata: DispatchPayloadMetadata | None
-    handled_turn: HandledTurnState
-    command: Command | None
-    dispatch_started_at: float
-
-
-@dataclass(frozen=True)
 class _PreparedTextDispatch:
     event: TextDispatchEvent
     payload_metadata: DispatchPayloadMetadata | None
@@ -88,13 +79,6 @@ class _PreparedTextDispatch:
     dispatch: PreparedDispatch
     replay_guard: _ReplayGuard
     dispatch_started_at: float
-
-
-@dataclass(frozen=True)
-class _AttachmentContext:
-    message_attachment_ids: list[str]
-    trusted_current_attachment_ids: list[str]
-    router_extra_content: dict[str, Any]
 
 
 async def dispatch_text_message(
@@ -111,13 +95,14 @@ async def dispatch_text_message(
     trust_hydrated_internal_metadata: bool | None = None,
 ) -> None:
     """Run the normal text or command dispatch pipeline for a prepared text event."""
-    reservation = queued_notice_reservation
     timing_scope_token = None
     try:
         dispatch_timing = get_dispatch_pipeline_timing(raw_event.source)
-        resolved = await _resolve_text_dispatch(
+        prepared = await _prepare_text_dispatch(
             controller,
+            room,
             raw_event,
+            requester_user_id,
             media_events=media_events,
             handled_turn=handled_turn,
             ingress_metadata=ingress_metadata,
@@ -125,37 +110,26 @@ async def dispatch_text_message(
             trust_hydrated_internal_metadata=trust_hydrated_internal_metadata,
             dispatch_timing=dispatch_timing,
         )
-        event = resolved.event
-        timing_scope_token = timing_scope_context.set(event_timing_scope(event.event_id))
-        prepared = await _prepare_text_dispatch(
-            controller,
-            room,
-            resolved,
-            requester_user_id,
-            ingress_metadata=ingress_metadata,
-            dispatch_timing=dispatch_timing,
-        )
         if prepared is None:
             return
-        if await _command_or_suppression_consumed_turn(
-            controller,
-            room,
+        timing_scope_token = timing_scope_context.set(event_timing_scope(prepared.event.event_id))
+        if await _blocked_before_plan(controller, room, prepared, requester_user_id=requester_user_id):
+            return
+
+        message_attachment_ids, trusted_attachment_ids, router_extra_content = _attachment_parts(
             prepared,
+            media_events=media_events,
             requester_user_id=requester_user_id,
-        ):
-            return
-        if await _replay_guard_skips_turn(controller, room, prepared, requester_user_id=requester_user_id):
-            return
+        )
         if dispatch_timing is not None:
             dispatch_timing.mark("dispatch_plan_start")
-        attachments = _attachment_context(prepared, media_events=media_events, requester_user_id=requester_user_id)
         plan = await controller.deps.turn_policy.plan_turn(
             room,
             prepared.event,
             prepared.dispatch,
             is_dm=await is_dm_room(controller._client(), room.room_id),
             has_active_response_for_target=controller.deps.response_runner.has_active_response_for_target,
-            extra_content=attachments.router_extra_content or None,
+            extra_content=router_extra_content or None,
             media_events=media_events,
             router_event=media_events[0]
             if media_events and len(prepared.handled_turn.source_event_ids) == 1
@@ -163,27 +137,28 @@ async def dispatch_text_message(
         )
         if dispatch_timing is not None:
             dispatch_timing.mark("dispatch_plan_ready")
-        if await _non_response_plan_consumed_turn(controller, room, prepared, plan, media_events=media_events):
-            return
-        await _execute_response_plan(
+        await _apply_turn_plan(
             controller,
             room,
             prepared,
             plan,
-            attachments,
+            message_attachment_ids=message_attachment_ids,
+            trusted_attachment_ids=trusted_attachment_ids,
             media_events=media_events,
-            queued_notice_reservation=reservation,
+            queued_notice_reservation=queued_notice_reservation,
         )
     finally:
-        if reservation is not None:
-            reservation.cancel()
+        if queued_notice_reservation is not None:
+            queued_notice_reservation.cancel()
         if timing_scope_token is not None:
             timing_scope_context.reset(timing_scope_token)
 
 
-async def _resolve_text_dispatch(
+async def _prepare_text_dispatch(
     controller: TurnController,
+    room: nio.MatrixRoom,
     raw_event: TextDispatchEvent,
+    requester_user_id: str,
     *,
     media_events: list[MediaDispatchEvent] | None,
     handled_turn: HandledTurnState | None,
@@ -191,48 +166,74 @@ async def _resolve_text_dispatch(
     payload_metadata: DispatchPayloadMetadata | None,
     trust_hydrated_internal_metadata: bool | None,
     dispatch_timing: DispatchPipelineTiming | None,
-) -> _ResolvedTextDispatch:
-    event = await controller.deps.normalizer.resolve_text_event(
-        TextNormalizationRequest(event=raw_event),
-    )
-    trust_internal_payload_metadata = (
-        controller._should_trust_internal_payload_metadata(event)
-        if trust_hydrated_internal_metadata is None
-        else trust_hydrated_internal_metadata
-    )
+) -> _PreparedTextDispatch | None:
+    event = await controller.deps.normalizer.resolve_text_event(TextNormalizationRequest(event=raw_event))
     hydrated_payload_metadata = payload_metadata_from_source(
         event.source,
-        trust_internal_metadata=trust_internal_payload_metadata,
+        trust_internal_metadata=(
+            controller._should_trust_internal_payload_metadata(event)
+            if trust_hydrated_internal_metadata is None
+            else trust_hydrated_internal_metadata
+        ),
     )
-    merged_payload_metadata = (
+    payload_metadata = (
         hydrated_payload_metadata
         if payload_metadata is None
         else merge_payload_metadata(
             payload_metadata,
             hydrated_payload_metadata,
-            trust_hydrated_internal_metadata=trust_internal_payload_metadata,
+            trust_hydrated_internal_metadata=trust_hydrated_internal_metadata
+            if trust_hydrated_internal_metadata is not None
+            else controller._should_trust_internal_payload_metadata(event),
         )
     )
     attach_dispatch_pipeline_timing(event.source, dispatch_timing)
     if dispatch_timing is not None:
         dispatch_timing.mark("dispatch_start")
+    dispatch_started_at = time.monotonic()
+
     if handled_turn is None:
         handled_turn = HandledTurnState.from_source_event_id(event.event_id)
     elif raw_event is not event and event.event_id in handled_turn.source_event_ids:
         refreshed_prompts = dict(handled_turn.source_event_prompts or {})
         refreshed_prompts[event.event_id] = event.body
         handled_turn = handled_turn.with_source_event_prompts(refreshed_prompts)
-    return _ResolvedTextDispatch(
-        event=event,
-        payload_metadata=merged_payload_metadata,
+
+    command = _parsed_command_for_event(
+        controller,
+        event,
+        media_events=media_events,
+        ingress_metadata=ingress_metadata,
+    )
+    if dispatch_timing is not None:
+        dispatch_timing.mark("dispatch_prepare_start")
+    prepared = await controller._prepare_dispatch(
+        room,
+        event,
+        requester_user_id,
+        event_label="message",
         handled_turn=handled_turn,
-        command=_parsed_command_for_event(
-            controller,
-            event,
-            media_events=media_events,
-            ingress_metadata=ingress_metadata,
+        ingress_metadata=ingress_metadata,
+        payload_metadata=payload_metadata,
+        use_command_context=command is not None,
+    )
+    if dispatch_timing is not None:
+        dispatch_timing.mark("dispatch_prepare_ready")
+    if prepared is None:
+        return None
+    if command is not None and prepared.dispatch.envelope.source_kind == VOICE_SOURCE_KIND:
+        command = None
+    return _PreparedTextDispatch(
+        event=event,
+        payload_metadata=payload_metadata,
+        handled_turn=handled_turn.with_request_context(
+            requester_id=prepared.dispatch.requester_user_id,
+            correlation_id=prepared.dispatch.correlation_id,
         ),
-        dispatch_started_at=time.monotonic(),
+        command=command,
+        dispatch=prepared.dispatch,
+        replay_guard=prepared.replay_guard,
+        dispatch_started_at=dispatch_started_at,
     )
 
 
@@ -243,60 +244,19 @@ def _parsed_command_for_event(
     media_events: list[MediaDispatchEvent] | None,
     ingress_metadata: DispatchIngressMetadata | None,
 ) -> Command | None:
-    event_is_voice_dispatch = (
-        (ingress_metadata is not None and ingress_metadata.source_kind == VOICE_SOURCE_KIND)
-        or is_audio_message_event(event)
-        or is_voice_event(event, sender_is_trusted=controller._sender_is_trusted_for_ingress_metadata)
-    )
-    if media_events or event_is_voice_dispatch:
+    if media_events:
+        return None
+    if ingress_metadata is not None and ingress_metadata.source_kind == VOICE_SOURCE_KIND:
+        return None
+    if is_audio_message_event(event) or is_voice_event(
+        event,
+        sender_is_trusted=controller._sender_is_trusted_for_ingress_metadata,
+    ):
         return None
     return command_parser.parse(event.body)
 
 
-async def _prepare_text_dispatch(
-    controller: TurnController,
-    room: nio.MatrixRoom,
-    resolved: _ResolvedTextDispatch,
-    requester_user_id: str,
-    *,
-    ingress_metadata: DispatchIngressMetadata | None,
-    dispatch_timing: DispatchPipelineTiming | None,
-) -> _PreparedTextDispatch | None:
-    if dispatch_timing is not None:
-        dispatch_timing.mark("dispatch_prepare_start")
-    prepared_dispatch = await controller._prepare_dispatch(
-        room,
-        resolved.event,
-        requester_user_id,
-        event_label="message",
-        handled_turn=resolved.handled_turn,
-        ingress_metadata=ingress_metadata,
-        payload_metadata=resolved.payload_metadata,
-        use_command_context=resolved.command is not None,
-    )
-    if dispatch_timing is not None:
-        dispatch_timing.mark("dispatch_prepare_ready")
-    if prepared_dispatch is None:
-        return None
-    dispatch = prepared_dispatch.dispatch
-    command = resolved.command
-    if command is not None and dispatch.envelope.source_kind == VOICE_SOURCE_KIND:
-        command = None
-    return _PreparedTextDispatch(
-        event=resolved.event,
-        payload_metadata=resolved.payload_metadata,
-        handled_turn=resolved.handled_turn.with_request_context(
-            requester_id=dispatch.requester_user_id,
-            correlation_id=dispatch.correlation_id,
-        ),
-        command=command,
-        dispatch=dispatch,
-        replay_guard=prepared_dispatch.replay_guard,
-        dispatch_started_at=resolved.dispatch_started_at,
-    )
-
-
-async def _command_or_suppression_consumed_turn(
+async def _blocked_before_plan(
     controller: TurnController,
     room: nio.MatrixRoom,
     prepared: _PreparedTextDispatch,
@@ -313,19 +273,12 @@ async def _command_or_suppression_consumed_turn(
                 target=prepared.dispatch.target,
             )
         return True
-    return controller._should_skip_deep_synthetic_full_dispatch(
+    if controller._should_skip_deep_synthetic_full_dispatch(
         event_id=prepared.event.event_id,
         envelope=prepared.dispatch.envelope,
-    )
+    ):
+        return True
 
-
-async def _replay_guard_skips_turn(
-    controller: TurnController,
-    room: nio.MatrixRoom,
-    prepared: _PreparedTextDispatch,
-    *,
-    requester_user_id: str,
-) -> bool:
     if prepared.replay_guard.degraded:
         skips_turn = await controller._has_newer_unresponded_cached_thread_event(
             room_id=room.room_id,
@@ -354,58 +307,107 @@ async def _replay_guard_skips_turn(
     return skips_turn
 
 
-def _attachment_context(
+def _attachment_parts(
     prepared: _PreparedTextDispatch,
     *,
     media_events: list[MediaDispatchEvent] | None,
     requester_user_id: str,
-) -> _AttachmentContext:
+) -> tuple[list[str], list[str], dict[str, Any]]:
     payload_metadata = prepared.payload_metadata
     message_attachment_ids = (
         list(payload_metadata.attachment_ids)
         if payload_metadata is not None and payload_metadata.attachment_ids is not None
         else parse_attachment_ids_from_event_source(prepared.event.source)
     )
-    trusted_current_attachment_ids = (
+    trusted_attachment_ids = (
         list(payload_metadata.attachment_ids)
         if payload_metadata is not None and payload_metadata.attachment_ids is not None
         else []
     )
-    message_extra_content: dict[str, Any] = {}
+    extra_content: dict[str, Any] = {}
     if message_attachment_ids:
-        message_extra_content[ATTACHMENT_IDS_KEY] = message_attachment_ids
+        extra_content[ATTACHMENT_IDS_KEY] = message_attachment_ids
     if payload_metadata is not None and payload_metadata.original_sender is not None:
-        message_extra_content[ORIGINAL_SENDER_KEY] = payload_metadata.original_sender
+        extra_content[ORIGINAL_SENDER_KEY] = payload_metadata.original_sender
     if payload_metadata is not None and payload_metadata.raw_audio_fallback:
-        message_extra_content[VOICE_RAW_AUDIO_FALLBACK_KEY] = True
-    router_extra_content = dict(message_extra_content)
-    if media_events and ORIGINAL_SENDER_KEY not in router_extra_content:
-        router_extra_content[ORIGINAL_SENDER_KEY] = requester_user_id
-    return _AttachmentContext(
-        message_attachment_ids=message_attachment_ids,
-        trusted_current_attachment_ids=trusted_current_attachment_ids,
-        router_extra_content=router_extra_content,
-    )
+        extra_content[VOICE_RAW_AUDIO_FALLBACK_KEY] = True
+    if media_events and ORIGINAL_SENDER_KEY not in extra_content:
+        extra_content[ORIGINAL_SENDER_KEY] = requester_user_id
+    return message_attachment_ids, trusted_attachment_ids, extra_content
 
 
-async def _non_response_plan_consumed_turn(
+async def _apply_turn_plan(
     controller: TurnController,
     room: nio.MatrixRoom,
     prepared: _PreparedTextDispatch,
     plan: _TurnPlan,
     *,
+    message_attachment_ids: list[str],
+    trusted_attachment_ids: list[str],
     media_events: list[MediaDispatchEvent] | None,
-) -> bool:
+    queued_notice_reservation: QueuedHumanNoticeReservation | None,
+) -> None:
     if plan.kind == "ignore":
         if plan.ignore_reason == "router":
             router_outcome = controller._router_handled_turn_outcome(prepared.handled_turn)
             if router_outcome is not None:
                 controller._mark_source_events_responded(router_outcome)
-        return True
-    if plan.kind != "route":
-        return False
-    await _execute_route_plan(controller, room, prepared, plan, media_events=media_events)
-    return True
+        return
+    if plan.kind == "route":
+        await _execute_route_plan(controller, room, prepared, plan, media_events=media_events)
+        return
+
+    assert plan.response_action is not None
+    response_history_scope = (
+        controller.deps.turn_store.response_history_scope(plan.response_action)
+        if plan.response_action.kind in {"individual", "team"}
+        else None
+    )
+    handled_turn = controller.deps.turn_store.attach_response_context(
+        prepared.handled_turn,
+        history_scope=response_history_scope,
+        conversation_target=prepared.dispatch.target,
+    )
+
+    async def build_payload(context: MessageContext) -> DispatchPayload:
+        effective_thread_id = prepared.dispatch.target.resolved_thread_id
+        media_attachment_ids: list[str] = []
+        fallback_images = None
+        if media_events:
+            media_result = await controller.deps.normalizer.register_batch_media_attachments(
+                BatchMediaAttachmentRequest(
+                    room_id=room.room_id,
+                    thread_id=effective_thread_id,
+                    media_events=media_events,
+                ),
+            )
+            media_attachment_ids = media_result.attachment_ids
+            fallback_images = media_result.fallback_images
+        return await controller.deps.normalizer.build_dispatch_payload_with_attachments(
+            DispatchPayloadWithAttachmentsRequest(
+                room_id=room.room_id,
+                prompt=prepared.event.body,
+                current_attachment_ids=merge_attachment_ids(message_attachment_ids, media_attachment_ids),
+                trusted_current_attachment_ids=trusted_attachment_ids,
+                thread_id=context.thread_id,
+                media_thread_id=effective_thread_id,
+                thread_history=context.thread_history,
+                fallback_images=fallback_images,
+            ),
+        )
+
+    await controller._execute_response_action(
+        room,
+        prepared.event,
+        prepared.dispatch,
+        plan.response_action,
+        build_payload,
+        processing_log="Processing",
+        dispatch_started_at=prepared.dispatch_started_at,
+        handled_turn=handled_turn,
+        matrix_run_metadata=controller.deps.turn_store.build_run_metadata(handled_turn),
+        queued_notice_reservation=queued_notice_reservation,
+    )
 
 
 async def _execute_route_plan(
@@ -417,15 +419,6 @@ async def _execute_route_plan(
     media_events: list[MediaDispatchEvent] | None,
 ) -> None:
     route_event = plan.router_event or prepared.event
-    tracked_route_handled_turn = (
-        prepared.handled_turn
-        if prepared.handled_turn.is_coalesced
-        or (
-            prepared.handled_turn.source_event_ids
-            and prepared.handled_turn.source_event_ids[0] != prepared.event.event_id
-        )
-        else None
-    )
     single_direct_media_route = (
         is_matrix_media_dispatch_event(route_event)
         and media_events == [route_event]
@@ -438,13 +431,14 @@ async def _execute_route_plan(
     }
     if plan.media_events is not None and not single_direct_media_route:
         routing_kwargs["media_events"] = plan.media_events
-    if (
-        tracked_route_handled_turn is not None
-        and list(tracked_route_handled_turn.source_event_ids) != [route_event.event_id]
-        and not single_direct_media_route
-    ):
+    tracked_turn = _tracked_route_turn(
+        prepared,
+        route_event=route_event,
+        single_direct_media_route=single_direct_media_route,
+    )
+    if tracked_turn is not None:
         routing_kwargs["handled_turn"] = controller.deps.turn_store.attach_response_context(
-            tracked_route_handled_turn,
+            tracked_turn,
             history_scope=None,
             conversation_target=prepared.dispatch.target,
         )
@@ -457,87 +451,19 @@ async def _execute_route_plan(
     )
 
 
-async def _execute_response_plan(
-    controller: TurnController,
-    room: nio.MatrixRoom,
+def _tracked_route_turn(
     prepared: _PreparedTextDispatch,
-    plan: _TurnPlan,
-    attachments: _AttachmentContext,
     *,
-    media_events: list[MediaDispatchEvent] | None,
-    queued_notice_reservation: QueuedHumanNoticeReservation | None,
-) -> None:
-    assert plan.response_action is not None
-    response_history_scope = (
-        controller.deps.turn_store.response_history_scope(plan.response_action)
-        if plan.response_action.kind in {"individual", "team"}
-        else None
-    )
-    handled_turn = controller.deps.turn_store.attach_response_context(
-        prepared.handled_turn,
-        history_scope=response_history_scope,
-        conversation_target=prepared.dispatch.target,
-    )
-    matrix_run_metadata = controller.deps.turn_store.build_run_metadata(handled_turn)
-
-    async def build_payload(context: MessageContext) -> DispatchPayload:
-        return await _build_dispatch_payload(
-            controller,
-            room,
-            prepared,
-            attachments,
-            context=context,
-            media_events=media_events,
-        )
-
-    await controller._execute_response_action(
-        room,
-        prepared.event,
-        prepared.dispatch,
-        plan.response_action,
-        build_payload,
-        processing_log="Processing",
-        dispatch_started_at=prepared.dispatch_started_at,
-        handled_turn=handled_turn,
-        matrix_run_metadata=matrix_run_metadata,
-        queued_notice_reservation=queued_notice_reservation,
-    )
-
-
-async def _build_dispatch_payload(
-    controller: TurnController,
-    room: nio.MatrixRoom,
-    prepared: _PreparedTextDispatch,
-    attachments: _AttachmentContext,
-    *,
-    context: MessageContext,
-    media_events: list[MediaDispatchEvent] | None,
-) -> DispatchPayload:
-    effective_thread_id = prepared.dispatch.target.resolved_thread_id
-    media_attachment_ids: list[str] = []
-    fallback_images = None
-    if media_events:
-        media_result = await controller.deps.normalizer.register_batch_media_attachments(
-            BatchMediaAttachmentRequest(
-                room_id=room.room_id,
-                thread_id=effective_thread_id,
-                media_events=media_events,
-            ),
-        )
-        media_attachment_ids = media_result.attachment_ids
-        fallback_images = media_result.fallback_images
-    return await controller.deps.normalizer.build_dispatch_payload_with_attachments(
-        DispatchPayloadWithAttachmentsRequest(
-            room_id=room.room_id,
-            prompt=prepared.event.body,
-            current_attachment_ids=merge_attachment_ids(
-                attachments.message_attachment_ids,
-                media_attachment_ids,
-            ),
-            trusted_current_attachment_ids=attachments.trusted_current_attachment_ids,
-            thread_id=context.thread_id,
-            media_thread_id=effective_thread_id,
-            thread_history=context.thread_history,
-            fallback_images=fallback_images,
-        ),
-    )
+    route_event: DispatchEvent,
+    single_direct_media_route: bool,
+) -> HandledTurnState | None:
+    if single_direct_media_route:
+        return None
+    if not prepared.handled_turn.is_coalesced and (
+        not prepared.handled_turn.source_event_ids
+        or prepared.handled_turn.source_event_ids[0] == prepared.event.event_id
+    ):
+        return None
+    if list(prepared.handled_turn.source_event_ids) == [route_event.event_id]:
+        return None
+    return prepared.handled_turn

--- a/src/mindroom/text_ingress_dispatch.py
+++ b/src/mindroom/text_ingress_dispatch.py
@@ -1,0 +1,314 @@
+"""Text ingress dispatch path used by TurnController."""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any
+
+from mindroom.attachments import merge_attachment_ids, parse_attachment_ids_from_event_source
+from mindroom.commands.parsing import command_parser
+from mindroom.constants import (
+    ATTACHMENT_IDS_KEY,
+    ORIGINAL_SENDER_KEY,
+    ROUTER_AGENT_NAME,
+    VOICE_RAW_AUDIO_FALLBACK_KEY,
+)
+from mindroom.dispatch_handoff import (
+    DispatchEvent,
+    DispatchIngressMetadata,
+    DispatchPayloadMetadata,
+    MediaDispatchEvent,
+    TextDispatchEvent,
+    merge_payload_metadata,
+    payload_metadata_from_source,
+)
+from mindroom.dispatch_source import VOICE_SOURCE_KIND, is_voice_event
+from mindroom.handled_turns import HandledTurnState
+from mindroom.inbound_turn_normalizer import (
+    BatchMediaAttachmentRequest,
+    DispatchPayload,
+    DispatchPayloadWithAttachmentsRequest,
+    TextNormalizationRequest,
+)
+from mindroom.matrix.media import is_audio_message_event, is_matrix_media_dispatch_event
+from mindroom.matrix.rooms import is_dm_room
+from mindroom.timing import (
+    attach_dispatch_pipeline_timing,
+    event_timing_scope,
+    get_dispatch_pipeline_timing,
+)
+from mindroom.timing import timing_scope as timing_scope_context
+
+if TYPE_CHECKING:
+    import nio
+
+    from mindroom.conversation_resolver import MessageContext
+    from mindroom.response_lifecycle import QueuedHumanNoticeReservation
+    from mindroom.turn_controller import TurnController
+
+
+async def dispatch_text_message(  # noqa: C901, PLR0912, PLR0915
+    controller: TurnController,
+    room: nio.MatrixRoom,
+    raw_event: TextDispatchEvent,
+    requester_user_id: str,
+    *,
+    media_events: list[MediaDispatchEvent] | None = None,
+    handled_turn: HandledTurnState | None = None,
+    queued_notice_reservation: QueuedHumanNoticeReservation | None = None,
+    ingress_metadata: DispatchIngressMetadata | None = None,
+    payload_metadata: DispatchPayloadMetadata | None = None,
+    trust_hydrated_internal_metadata: bool | None = None,
+) -> None:
+    """Run the normal text or command dispatch pipeline for a prepared text event."""
+    router_event: DispatchEvent = raw_event
+    reservation = queued_notice_reservation
+    timing_scope_token = None
+    try:
+        event = await controller.deps.normalizer.resolve_text_event(
+            TextNormalizationRequest(event=raw_event),
+        )
+        trust_internal_payload_metadata = (
+            controller._should_trust_internal_payload_metadata(event)
+            if trust_hydrated_internal_metadata is None
+            else trust_hydrated_internal_metadata
+        )
+        hydrated_payload_metadata = payload_metadata_from_source(
+            event.source,
+            trust_internal_metadata=trust_internal_payload_metadata,
+        )
+        payload_metadata = (
+            hydrated_payload_metadata
+            if payload_metadata is None
+            else merge_payload_metadata(
+                payload_metadata,
+                hydrated_payload_metadata,
+                trust_hydrated_internal_metadata=trust_internal_payload_metadata,
+            )
+        )
+        dispatch_timing = get_dispatch_pipeline_timing(raw_event.source)
+        attach_dispatch_pipeline_timing(event.source, dispatch_timing)
+        timing_scope_token = timing_scope_context.set(event_timing_scope(event.event_id))
+        if dispatch_timing is not None:
+            dispatch_timing.mark("dispatch_start")
+        dispatch_started_at = time.monotonic()
+        if handled_turn is None:
+            handled_turn = HandledTurnState.from_source_event_id(event.event_id)
+        elif raw_event is not event and event.event_id in handled_turn.source_event_ids:
+            refreshed_prompts = dict(handled_turn.source_event_prompts or {})
+            refreshed_prompts[event.event_id] = event.body
+            handled_turn = handled_turn.with_source_event_prompts(refreshed_prompts)
+
+        if dispatch_timing is not None:
+            dispatch_timing.mark("dispatch_prepare_start")
+        command = None
+        event_is_voice_dispatch = (
+            (ingress_metadata is not None and ingress_metadata.source_kind == VOICE_SOURCE_KIND)
+            or is_audio_message_event(event)
+            or is_voice_event(event, sender_is_trusted=controller._sender_is_trusted_for_ingress_metadata)
+        )
+        if not media_events and not event_is_voice_dispatch:
+            command = command_parser.parse(event.body)
+        prepared_dispatch = await controller._prepare_dispatch(
+            room,
+            event,
+            requester_user_id,
+            event_label="message",
+            handled_turn=handled_turn,
+            ingress_metadata=ingress_metadata,
+            payload_metadata=payload_metadata,
+            use_command_context=command is not None,
+        )
+        if dispatch_timing is not None:
+            dispatch_timing.mark("dispatch_prepare_ready")
+        if prepared_dispatch is None:
+            return
+        dispatch = prepared_dispatch.dispatch
+        replay_guard = prepared_dispatch.replay_guard
+        handled_turn = handled_turn.with_request_context(
+            requester_id=dispatch.requester_user_id,
+            correlation_id=dispatch.correlation_id,
+        )
+
+        if command is not None and dispatch.envelope.source_kind == VOICE_SOURCE_KIND:
+            command = None
+        if command:
+            if controller.deps.agent_name == ROUTER_AGENT_NAME:
+                await controller._execute_command(
+                    room=room,
+                    event=event,
+                    requester_user_id=requester_user_id,
+                    command=command,
+                    target=dispatch.target,
+                )
+            return
+        if controller._should_skip_deep_synthetic_full_dispatch(
+            event_id=event.event_id,
+            envelope=dispatch.envelope,
+        ):
+            return
+        message_attachment_ids = (
+            list(payload_metadata.attachment_ids)
+            if payload_metadata is not None and payload_metadata.attachment_ids is not None
+            else parse_attachment_ids_from_event_source(event.source)
+        )
+        trusted_current_attachment_ids = (
+            list(payload_metadata.attachment_ids)
+            if payload_metadata is not None and payload_metadata.attachment_ids is not None
+            else []
+        )
+        message_extra_content: dict[str, Any] = {}
+        if message_attachment_ids:
+            message_extra_content[ATTACHMENT_IDS_KEY] = message_attachment_ids
+        if payload_metadata is not None and payload_metadata.original_sender is not None:
+            message_extra_content[ORIGINAL_SENDER_KEY] = payload_metadata.original_sender
+        if payload_metadata is not None and payload_metadata.raw_audio_fallback:
+            message_extra_content[VOICE_RAW_AUDIO_FALLBACK_KEY] = True
+        router_extra_content = dict(message_extra_content)
+        if media_events and ORIGINAL_SENDER_KEY not in router_extra_content:
+            router_extra_content[ORIGINAL_SENDER_KEY] = requester_user_id
+        replay_guard_skips_turn = False
+        if replay_guard.degraded:
+            replay_guard_skips_turn = await controller._has_newer_unresponded_cached_thread_event(
+                room_id=room.room_id,
+                event=event,
+                requester_user_id=requester_user_id,
+                thread_id=replay_guard.thread_id,
+                source_kind=dispatch.envelope.source_kind,
+            )
+            if not replay_guard_skips_turn:
+                controller.deps.logger.warning(
+                    "Thread replay guard degraded; proceeding without negative newer-message proof",
+                    event_id=event.event_id,
+                    room_id=room.room_id,
+                    thread_id=replay_guard.thread_id,
+                    thread_read_degraded=True,
+                )
+        else:
+            replay_guard_skips_turn = controller._has_newer_unresponded_in_thread(
+                event,
+                requester_user_id,
+                replay_guard.history,
+                source_kind=dispatch.envelope.source_kind,
+            )
+        if replay_guard_skips_turn:
+            controller._mark_source_events_responded(handled_turn)
+            return
+        if dispatch_timing is not None:
+            dispatch_timing.mark("dispatch_plan_start")
+        plan = await controller.deps.turn_policy.plan_turn(
+            room,
+            event,
+            dispatch,
+            is_dm=await is_dm_room(controller._client(), room.room_id),
+            has_active_response_for_target=controller.deps.response_runner.has_active_response_for_target,
+            extra_content=router_extra_content or None,
+            media_events=media_events,
+            router_event=media_events[0] if media_events and len(handled_turn.source_event_ids) == 1 else router_event,
+        )
+        if dispatch_timing is not None:
+            dispatch_timing.mark("dispatch_plan_ready")
+        if plan.kind == "ignore":
+            if plan.ignore_reason == "router":
+                router_outcome = controller._router_handled_turn_outcome(handled_turn)
+                if router_outcome is not None:
+                    controller._mark_source_events_responded(router_outcome)
+            return
+        if plan.kind == "route":
+            route_event = plan.router_event or event
+            tracked_route_handled_turn = (
+                handled_turn
+                if handled_turn.is_coalesced
+                or (handled_turn.source_event_ids and handled_turn.source_event_ids[0] != event.event_id)
+                else None
+            )
+            single_direct_media_route = (
+                is_matrix_media_dispatch_event(route_event)
+                and media_events == [route_event]
+                and handled_turn.source_event_ids == (event.event_id,)
+            )
+            routing_kwargs: dict[str, Any] = {
+                "message": event.body if media_events else plan.router_message,
+                "requester_user_id": dispatch.requester_user_id,
+                "extra_content": plan.extra_content,
+            }
+            if plan.media_events is not None and not single_direct_media_route:
+                routing_kwargs["media_events"] = plan.media_events
+            if (
+                tracked_route_handled_turn is not None
+                and list(tracked_route_handled_turn.source_event_ids) != [route_event.event_id]
+                and not single_direct_media_route
+            ):
+                routing_kwargs["handled_turn"] = controller.deps.turn_store.attach_response_context(
+                    tracked_route_handled_turn,
+                    history_scope=None,
+                    conversation_target=dispatch.target,
+                )
+            await controller._execute_router_relay(
+                room,
+                route_event,
+                dispatch.context.thread_history,
+                dispatch.target.resolved_thread_id,
+                **routing_kwargs,
+            )
+            return
+        assert plan.response_action is not None
+        response_history_scope = (
+            controller.deps.turn_store.response_history_scope(plan.response_action)
+            if plan.response_action.kind in {"individual", "team"}
+            else None
+        )
+        handled_turn = controller.deps.turn_store.attach_response_context(
+            handled_turn,
+            history_scope=response_history_scope,
+            conversation_target=dispatch.target,
+        )
+        matrix_run_metadata = controller.deps.turn_store.build_run_metadata(handled_turn)
+
+        async def build_payload(context: MessageContext) -> DispatchPayload:
+            effective_thread_id = dispatch.target.resolved_thread_id
+            media_attachment_ids: list[str] = []
+            fallback_images = None
+            if media_events:
+                media_result = await controller.deps.normalizer.register_batch_media_attachments(
+                    BatchMediaAttachmentRequest(
+                        room_id=room.room_id,
+                        thread_id=effective_thread_id,
+                        media_events=media_events,
+                    ),
+                )
+                media_attachment_ids = media_result.attachment_ids
+                fallback_images = media_result.fallback_images
+            return await controller.deps.normalizer.build_dispatch_payload_with_attachments(
+                DispatchPayloadWithAttachmentsRequest(
+                    room_id=room.room_id,
+                    prompt=event.body,
+                    current_attachment_ids=merge_attachment_ids(
+                        message_attachment_ids,
+                        media_attachment_ids,
+                    ),
+                    trusted_current_attachment_ids=trusted_current_attachment_ids,
+                    thread_id=context.thread_id,
+                    media_thread_id=effective_thread_id,
+                    thread_history=context.thread_history,
+                    fallback_images=fallback_images,
+                ),
+            )
+
+        await controller._execute_response_action(
+            room,
+            event,
+            dispatch,
+            plan.response_action,
+            build_payload,
+            processing_log="Processing",
+            dispatch_started_at=dispatch_started_at,
+            handled_turn=handled_turn,
+            matrix_run_metadata=matrix_run_metadata,
+            queued_notice_reservation=reservation,
+        )
+    finally:
+        if reservation is not None:
+            reservation.cancel()
+        if timing_scope_token is not None:
+            timing_scope_context.reset(timing_scope_token)

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -46,7 +46,6 @@ from mindroom.dispatch_handoff import (
     PreparedTextEvent,
     TextDispatchEvent,
     build_dispatch_handoff,
-    merge_payload_metadata,
     payload_metadata_from_source,
 )
 from mindroom.dispatch_replay_guard import has_newer_unresponded_cached_thread_event, has_newer_unresponded_in_thread
@@ -60,7 +59,6 @@ from mindroom.dispatch_source import (
     SCHEDULED_SOURCE_KIND,
     TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
     VOICE_SOURCE_KIND,
-    is_voice_event,
     source_kind_from_content,
 )
 from mindroom.entity_resolution import entity_identity_registry
@@ -72,9 +70,7 @@ from mindroom.hooks import (
     hook_ingress_policy,
 )
 from mindroom.inbound_turn_normalizer import (
-    BatchMediaAttachmentRequest,
     DispatchPayload,
-    DispatchPayloadWithAttachmentsRequest,
     InboundTurnNormalizer,
     TextNormalizationRequest,
     VoiceNormalizationRequest,
@@ -94,10 +90,10 @@ from mindroom.matrix.media import (
     is_matrix_media_dispatch_event,
 )
 from mindroom.matrix.message_content import is_v2_sidecar_text_preview
-from mindroom.matrix.rooms import is_dm_room
 from mindroom.prompt_ingress_reservation import PromptIngressReservationOwner as _PromptIngressReservationOwner
 from mindroom.response_runner import PostLockRequestPreparationError, ResponseRequest
 from mindroom.routing import suggest_responder_for_message
+from mindroom.text_ingress_dispatch import dispatch_text_message
 from mindroom.thread_utils import (
     check_agent_mentioned,
     is_router_only_agent_mention,
@@ -112,7 +108,6 @@ from mindroom.timing import (
     event_timing_scope,
     get_dispatch_pipeline_timing,
 )
-from mindroom.timing import timing_scope as timing_scope_context
 from mindroom.turn_origin import (
     classify_turn_origin,
     original_sender_for_router_handoff,
@@ -124,7 +119,6 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Sequence
 
     import structlog
-    from agno.media import Image
 
     from mindroom.bot_runtime_view import BotRuntimeView
     from mindroom.commands.parsing import Command
@@ -2089,7 +2083,7 @@ class TurnController:
             if owns_reservation:
                 await reservation_owner.release()
 
-    async def _dispatch_text_message(  # noqa: C901, PLR0912, PLR0915
+    async def _dispatch_text_message(
         self,
         room: nio.MatrixRoom,
         event: TextDispatchEvent | _PrecheckedTextDispatchEvent,
@@ -2112,260 +2106,18 @@ class TurnController:
         if requester_user_id is None:
             msg = "requester_user_id is required when dispatching a raw event"
             raise TypeError(msg)
-        router_event: DispatchEvent = raw_event
-        reservation = queued_notice_reservation
-        dispatch: PreparedDispatch | None = None
-        timing_scope_token = None
-        try:
-            event = await self.deps.normalizer.resolve_text_event(
-                TextNormalizationRequest(event=raw_event),
-            )
-            trust_internal_payload_metadata = (
-                self._should_trust_internal_payload_metadata(event)
-                if trust_hydrated_internal_metadata is None
-                else trust_hydrated_internal_metadata
-            )
-            hydrated_payload_metadata = payload_metadata_from_source(
-                event.source,
-                trust_internal_metadata=trust_internal_payload_metadata,
-            )
-            payload_metadata = (
-                hydrated_payload_metadata
-                if payload_metadata is None
-                else merge_payload_metadata(
-                    payload_metadata,
-                    hydrated_payload_metadata,
-                    trust_hydrated_internal_metadata=trust_internal_payload_metadata,
-                )
-            )
-            dispatch_timing = get_dispatch_pipeline_timing(raw_event.source)
-            attach_dispatch_pipeline_timing(event.source, dispatch_timing)
-            timing_scope_token = timing_scope_context.set(event_timing_scope(event.event_id))
-            if dispatch_timing is not None:
-                dispatch_timing.mark("dispatch_start")
-            dispatch_started_at = time.monotonic()
-            if handled_turn is None:
-                handled_turn = HandledTurnState.from_source_event_id(event.event_id)
-            elif raw_event is not event and event.event_id in handled_turn.source_event_ids:
-                refreshed_prompts = dict(handled_turn.source_event_prompts or {})
-                refreshed_prompts[event.event_id] = event.body
-                handled_turn = handled_turn.with_source_event_prompts(refreshed_prompts)
-
-            if dispatch_timing is not None:
-                dispatch_timing.mark("dispatch_prepare_start")
-            command = None
-            event_is_voice_dispatch = (
-                (ingress_metadata is not None and ingress_metadata.source_kind == VOICE_SOURCE_KIND)
-                or is_audio_message_event(event)
-                or is_voice_event(event, sender_is_trusted=self._sender_is_trusted_for_ingress_metadata)
-            )
-            if not media_events and not event_is_voice_dispatch:
-                command = command_parser.parse(event.body)
-            prepared_dispatch = await self._prepare_dispatch(
-                room,
-                event,
-                requester_user_id,
-                event_label="message",
-                handled_turn=handled_turn,
-                ingress_metadata=ingress_metadata,
-                payload_metadata=payload_metadata,
-                use_command_context=command is not None,
-            )
-            if dispatch_timing is not None:
-                dispatch_timing.mark("dispatch_prepare_ready")
-            if prepared_dispatch is None:
-                return
-            dispatch = prepared_dispatch.dispatch
-            replay_guard = prepared_dispatch.replay_guard
-            handled_turn = handled_turn.with_request_context(
-                requester_id=dispatch.requester_user_id,
-                correlation_id=dispatch.correlation_id,
-            )
-
-            if command is not None and dispatch.envelope.source_kind == VOICE_SOURCE_KIND:
-                command = None
-            if command:
-                if self.deps.agent_name == ROUTER_AGENT_NAME:
-                    await self._execute_command(
-                        room=room,
-                        event=event,
-                        requester_user_id=requester_user_id,
-                        command=command,
-                        target=dispatch.target,
-                    )
-                return
-            if self._should_skip_deep_synthetic_full_dispatch(
-                event_id=event.event_id,
-                envelope=dispatch.envelope,
-            ):
-                return
-            message_attachment_ids = (
-                list(payload_metadata.attachment_ids)
-                if payload_metadata is not None and payload_metadata.attachment_ids is not None
-                else parse_attachment_ids_from_event_source(event.source)
-            )
-            trusted_current_attachment_ids = (
-                list(payload_metadata.attachment_ids)
-                if payload_metadata is not None and payload_metadata.attachment_ids is not None
-                else []
-            )
-            message_extra_content: dict[str, Any] = {}
-            if message_attachment_ids:
-                message_extra_content[ATTACHMENT_IDS_KEY] = message_attachment_ids
-            if payload_metadata is not None and payload_metadata.original_sender is not None:
-                message_extra_content[ORIGINAL_SENDER_KEY] = payload_metadata.original_sender
-            if payload_metadata is not None and payload_metadata.raw_audio_fallback:
-                message_extra_content[VOICE_RAW_AUDIO_FALLBACK_KEY] = True
-            router_extra_content = dict(message_extra_content)
-            if media_events and ORIGINAL_SENDER_KEY not in router_extra_content:
-                router_extra_content[ORIGINAL_SENDER_KEY] = requester_user_id
-            replay_guard_skips_turn = False
-            if replay_guard.degraded:
-                replay_guard_skips_turn = await self._has_newer_unresponded_cached_thread_event(
-                    room_id=room.room_id,
-                    event=event,
-                    requester_user_id=requester_user_id,
-                    thread_id=replay_guard.thread_id,
-                    source_kind=dispatch.envelope.source_kind,
-                )
-                if not replay_guard_skips_turn:
-                    self.deps.logger.warning(
-                        "Thread replay guard degraded; proceeding without negative newer-message proof",
-                        event_id=event.event_id,
-                        room_id=room.room_id,
-                        thread_id=replay_guard.thread_id,
-                        thread_read_degraded=True,
-                    )
-            else:
-                replay_guard_skips_turn = self._has_newer_unresponded_in_thread(
-                    event,
-                    requester_user_id,
-                    replay_guard.history,
-                    source_kind=dispatch.envelope.source_kind,
-                )
-            if replay_guard_skips_turn:
-                self._mark_source_events_responded(handled_turn)
-                return
-            if dispatch_timing is not None:
-                dispatch_timing.mark("dispatch_plan_start")
-            plan = await self.deps.turn_policy.plan_turn(
-                room,
-                event,
-                dispatch,
-                is_dm=await is_dm_room(self._client(), room.room_id),
-                has_active_response_for_target=self.deps.response_runner.has_active_response_for_target,
-                extra_content=router_extra_content or None,
-                media_events=media_events,
-                router_event=media_events[0]
-                if media_events and len(handled_turn.source_event_ids) == 1
-                else router_event,
-            )
-            if dispatch_timing is not None:
-                dispatch_timing.mark("dispatch_plan_ready")
-            if plan.kind == "ignore":
-                if plan.ignore_reason == "router":
-                    router_outcome = self._router_handled_turn_outcome(handled_turn)
-                    if router_outcome is not None:
-                        self._mark_source_events_responded(router_outcome)
-                return
-            if plan.kind == "route":
-                route_event = plan.router_event or event
-                tracked_route_handled_turn = (
-                    handled_turn
-                    if handled_turn.is_coalesced
-                    or (handled_turn.source_event_ids and handled_turn.source_event_ids[0] != event.event_id)
-                    else None
-                )
-                single_direct_media_route = (
-                    is_matrix_media_dispatch_event(route_event)
-                    and media_events == [route_event]
-                    and handled_turn.source_event_ids == (event.event_id,)
-                )
-                routing_kwargs: dict[str, Any] = {
-                    "message": event.body if media_events else plan.router_message,
-                    "requester_user_id": dispatch.requester_user_id,
-                    "extra_content": plan.extra_content,
-                }
-                if plan.media_events is not None and not single_direct_media_route:
-                    routing_kwargs["media_events"] = plan.media_events
-                if (
-                    tracked_route_handled_turn is not None
-                    and list(tracked_route_handled_turn.source_event_ids) != [route_event.event_id]
-                    and not single_direct_media_route
-                ):
-                    routing_kwargs["handled_turn"] = self.deps.turn_store.attach_response_context(
-                        tracked_route_handled_turn,
-                        history_scope=None,
-                        conversation_target=dispatch.target,
-                    )
-                await self._execute_router_relay(
-                    room,
-                    route_event,
-                    dispatch.context.thread_history,
-                    dispatch.target.resolved_thread_id,
-                    **routing_kwargs,
-                )
-                return
-            assert plan.response_action is not None
-            response_history_scope = (
-                self.deps.turn_store.response_history_scope(plan.response_action)
-                if plan.response_action.kind in {"individual", "team"}
-                else None
-            )
-            handled_turn = self.deps.turn_store.attach_response_context(
-                handled_turn,
-                history_scope=response_history_scope,
-                conversation_target=dispatch.target,
-            )
-            matrix_run_metadata = self.deps.turn_store.build_run_metadata(handled_turn)
-
-            async def build_payload(context: MessageContext) -> DispatchPayload:
-                effective_thread_id = dispatch.target.resolved_thread_id
-                media_attachment_ids: list[str] = []
-                fallback_images: list[Image] | None = None
-                if media_events:
-                    media_result = await self.deps.normalizer.register_batch_media_attachments(
-                        BatchMediaAttachmentRequest(
-                            room_id=room.room_id,
-                            thread_id=effective_thread_id,
-                            media_events=media_events,
-                        ),
-                    )
-                    media_attachment_ids = media_result.attachment_ids
-                    fallback_images = media_result.fallback_images
-                return await self.deps.normalizer.build_dispatch_payload_with_attachments(
-                    DispatchPayloadWithAttachmentsRequest(
-                        room_id=room.room_id,
-                        prompt=event.body,
-                        current_attachment_ids=merge_attachment_ids(
-                            message_attachment_ids,
-                            media_attachment_ids,
-                        ),
-                        trusted_current_attachment_ids=trusted_current_attachment_ids,
-                        thread_id=context.thread_id,
-                        media_thread_id=effective_thread_id,
-                        thread_history=context.thread_history,
-                        fallback_images=fallback_images,
-                    ),
-                )
-
-            await self._execute_response_action(
-                room,
-                event,
-                dispatch,
-                plan.response_action,
-                build_payload,
-                processing_log="Processing",
-                dispatch_started_at=dispatch_started_at,
-                handled_turn=handled_turn,
-                matrix_run_metadata=matrix_run_metadata,
-                queued_notice_reservation=reservation,
-            )
-        finally:
-            if reservation is not None:
-                reservation.cancel()
-            if timing_scope_token is not None:
-                timing_scope_context.reset(timing_scope_token)
+        await dispatch_text_message(
+            self,
+            room,
+            raw_event,
+            requester_user_id,
+            media_events=media_events,
+            handled_turn=handled_turn,
+            queued_notice_reservation=queued_notice_reservation,
+            ingress_metadata=ingress_metadata,
+            payload_metadata=payload_metadata,
+            trust_hydrated_internal_metadata=trust_hydrated_internal_metadata,
+        )
 
     async def handle_media_event(
         self,

--- a/tach.toml
+++ b/tach.toml
@@ -2077,6 +2077,22 @@ depends_on = ["mindroom.coalescing"]
 visibility = ["mindroom.turn_controller"]
 
 [[modules]]
+path = "mindroom.text_ingress_dispatch"
+depends_on = [
+    "mindroom.attachments",
+    "mindroom.commands.parsing",
+    "mindroom.constants",
+    "mindroom.dispatch_handoff",
+    "mindroom.dispatch_source",
+    "mindroom.handled_turns",
+    "mindroom.inbound_turn_normalizer",
+    "mindroom.matrix.media",
+    "mindroom.matrix.rooms",
+    "mindroom.timing",
+]
+visibility = ["mindroom.turn_controller"]
+
+[[modules]]
 path = "mindroom.turn_controller"
 depends_on = [
     "mindroom.commands.handler",
@@ -2097,6 +2113,7 @@ depends_on = [
     "mindroom.prompt_ingress_reservation",
     "mindroom.response_runner",
     "mindroom.routing",
+    "mindroom.text_ingress_dispatch",
     "mindroom.turn_store",
     "mindroom.turn_policy",
 ]

--- a/tests/test_bot_scheduling.py
+++ b/tests/test_bot_scheduling.py
@@ -856,7 +856,7 @@ class TestCommandHandling:
                     new_callable=AsyncMock,
                     return_value=None,
                 ),
-                patch("mindroom.turn_controller.is_dm_room", return_value=False),
+                patch("mindroom.text_ingress_dispatch.is_dm_room", return_value=False),
             ):
                 await bot._on_message(room, event)
                 await drain_coalescing(bot)

--- a/tests/test_dm_functionality.py
+++ b/tests/test_dm_functionality.py
@@ -356,7 +356,7 @@ class TestDMIntegration:
             patch("mindroom.conversation_resolver.check_agent_mentioned", return_value=([], False, False)),
             patch("mindroom.matrix.event_info.EventInfo.from_event") as mock_thread_info,
             patch("mindroom.conversation_resolver._should_skip_mentions", return_value=False),
-            patch("mindroom.turn_controller.is_dm_room", return_value=True),  # This is a DM room
+            patch("mindroom.text_ingress_dispatch.is_dm_room", return_value=True),  # This is a DM room
             patch("mindroom.turn_controller.interactive.handle_text_response", new=mock_handle),
         ):
             # Mock thread info to return no thread
@@ -453,7 +453,7 @@ class TestDMIntegration:
             patch("mindroom.conversation_resolver.check_agent_mentioned", return_value=([], False, False)),
             patch("mindroom.matrix.event_info.EventInfo.from_event") as mock_thread_info,
             patch("mindroom.conversation_resolver._should_skip_mentions", return_value=False),
-            patch("mindroom.turn_controller.is_dm_room", return_value=True),  # This is a DM room
+            patch("mindroom.text_ingress_dispatch.is_dm_room", return_value=True),  # This is a DM room
             patch("mindroom.turn_controller.interactive.handle_text_response", new=mock_handle),
         ):
             # Mock thread info to return no thread

--- a/tests/test_edit_response_regeneration.py
+++ b/tests/test_edit_response_regeneration.py
@@ -4267,7 +4267,7 @@ async def test_on_media_message_tracks_relay_event_id(tmp_path: Path) -> None:
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_handle_voice,
         patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
-        patch("mindroom.turn_controller.is_dm_room", new_callable=AsyncMock, return_value=False),
+        patch("mindroom.text_ingress_dispatch.is_dm_room", new_callable=AsyncMock, return_value=False),
     ):
         # Setup mocks
         bot._conversation_cache.get_thread_history = AsyncMock(
@@ -4383,7 +4383,7 @@ async def test_on_media_message_no_transcription_still_marks_relayed(tmp_path: P
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_handle_voice,
         patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
-        patch("mindroom.turn_controller.is_dm_room", new_callable=AsyncMock, return_value=False),
+        patch("mindroom.text_ingress_dispatch.is_dm_room", new_callable=AsyncMock, return_value=False),
     ):
         # Setup mocks
         bot._conversation_cache.get_thread_history = AsyncMock(

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -7197,7 +7197,7 @@ class TestAgentBot:
             patch("mindroom.bot.is_authorized_sender", return_value=True),
             patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
             patch.object(bot._turn_policy, "can_reply_to_sender", return_value=False),
-            patch("mindroom.turn_controller.is_dm_room", new_callable=AsyncMock, return_value=False),
+            patch("mindroom.text_ingress_dispatch.is_dm_room", new_callable=AsyncMock, return_value=False),
         ):
             await self._invoke_handler(bot, handler_name, room, event)
 
@@ -7253,7 +7253,7 @@ class TestAgentBot:
         with (
             patch("mindroom.bot.is_authorized_sender", return_value=True),
             patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
-            patch("mindroom.turn_controller.is_dm_room", new_callable=AsyncMock, return_value=False),
+            patch("mindroom.text_ingress_dispatch.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch(
                 "mindroom.turn_policy.decide_team_formation",
                 new_callable=AsyncMock,
@@ -7791,7 +7791,7 @@ class TestAgentBot:
         with (
             patch("mindroom.bot.is_authorized_sender", return_value=True),
             patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
-            patch("mindroom.turn_controller.is_dm_room", new_callable=AsyncMock, return_value=False),
+            patch("mindroom.text_ingress_dispatch.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch(
                 "mindroom.turn_policy.decide_team_formation",
                 new_callable=AsyncMock,
@@ -8016,7 +8016,7 @@ class TestAgentBot:
         with (
             patch("mindroom.bot.is_authorized_sender", return_value=True),
             patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
-            patch("mindroom.turn_controller.is_dm_room", new_callable=AsyncMock, return_value=False),
+            patch("mindroom.text_ingress_dispatch.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch(
                 "mindroom.turn_policy.decide_team_formation",
                 new_callable=AsyncMock,
@@ -8086,7 +8086,7 @@ class TestAgentBot:
         with (
             patch("mindroom.bot.is_authorized_sender", return_value=True),
             patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
-            patch("mindroom.turn_controller.is_dm_room", new_callable=AsyncMock, return_value=False),
+            patch("mindroom.text_ingress_dispatch.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch(
                 "mindroom.turn_policy.decide_team_formation",
                 new_callable=AsyncMock,
@@ -8179,7 +8179,7 @@ class TestAgentBot:
         with (
             patch("mindroom.bot.is_authorized_sender", return_value=True),
             patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
-            patch("mindroom.turn_controller.is_dm_room", new_callable=AsyncMock, return_value=False),
+            patch("mindroom.text_ingress_dispatch.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch(
                 "mindroom.turn_policy.decide_team_formation",
                 new_callable=AsyncMock,
@@ -8693,7 +8693,7 @@ class TestAgentBot:
         with (
             patch("mindroom.bot.is_authorized_sender", return_value=True),
             patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
-            patch("mindroom.turn_controller.is_dm_room", new_callable=AsyncMock, return_value=False),
+            patch("mindroom.text_ingress_dispatch.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch(
                 "mindroom.turn_policy.decide_team_formation",
                 new_callable=AsyncMock,
@@ -8786,7 +8786,7 @@ class TestAgentBot:
                 ],
             ),
             patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
-            patch("mindroom.turn_controller.is_dm_room", new_callable=AsyncMock, return_value=False),
+            patch("mindroom.text_ingress_dispatch.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch("mindroom.dispatch_handoff.extract_media_caption", return_value="[Attached image]"),
             patch(
                 "mindroom.turn_controller.interactive.handle_text_response",
@@ -8862,7 +8862,7 @@ class TestAgentBot:
                 return_value=[entity_ids(config, runtime_paths_for(config))["calculator"]],
             ),
             patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
-            patch("mindroom.turn_controller.is_dm_room", new_callable=AsyncMock, return_value=False),
+            patch("mindroom.text_ingress_dispatch.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch("mindroom.dispatch_handoff.extract_media_caption", return_value="[Attached image]"),
             patch(
                 "mindroom.turn_controller.interactive.handle_text_response",
@@ -8919,7 +8919,7 @@ class TestAgentBot:
 
         with (
             patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
-            patch("mindroom.turn_controller.is_dm_room", new_callable=AsyncMock, return_value=False),
+            patch("mindroom.text_ingress_dispatch.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch(
                 "mindroom.turn_controller.interactive.handle_text_response",
                 new_callable=AsyncMock,
@@ -8995,7 +8995,7 @@ class TestAgentBot:
                 new_callable=AsyncMock,
                 return_value=None,
             ),
-            patch("mindroom.turn_controller.is_dm_room", new_callable=AsyncMock, return_value=False),
+            patch("mindroom.text_ingress_dispatch.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch("mindroom.turn_policy.get_agents_in_thread", return_value=[]),
             patch("mindroom.turn_policy.responder_candidate_entities_for_room", return_value=[]),
             patch(
@@ -12422,7 +12422,7 @@ class TestAgentBot:
         with (
             patch("mindroom.bot.is_authorized_sender", return_value=True),
             patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
-            patch("mindroom.turn_controller.is_dm_room", new_callable=AsyncMock, return_value=False),
+            patch("mindroom.text_ingress_dispatch.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch(
                 "mindroom.turn_policy.decide_team_formation",
                 new_callable=AsyncMock,

--- a/tests/test_multi_agent_e2e.py
+++ b/tests/test_multi_agent_e2e.py
@@ -358,7 +358,7 @@ async def test_agent_responds_in_threads_based_on_participation(  # noqa: PLR091
             patch.object(bot._conversation_cache, "get_thread_history") as mock_fetch,
             patch.object(bot._conversation_cache, "get_dispatch_thread_snapshot") as mock_dispatch_snapshot,
             patch.object(bot._conversation_cache, "get_dispatch_thread_history") as mock_dispatch_history,
-            patch("mindroom.turn_controller.is_dm_room", return_value=False),  # Not a DM room
+            patch("mindroom.text_ingress_dispatch.is_dm_room", return_value=False),  # Not a DM room
             patch("mindroom.turn_controller.interactive.handle_text_response", new=AsyncMock(return_value=None)),
         ):
             # Only this agent in the thread
@@ -418,7 +418,7 @@ async def test_agent_responds_in_threads_based_on_participation(  # noqa: PLR091
             patch.object(bot._conversation_cache, "get_thread_history") as mock_fetch,
             patch.object(bot._conversation_cache, "get_dispatch_thread_snapshot") as mock_dispatch_snapshot,
             patch.object(bot._conversation_cache, "get_dispatch_thread_history") as mock_dispatch_history,
-            patch("mindroom.turn_controller.is_dm_room", return_value=False),  # Not a DM room
+            patch("mindroom.text_ingress_dispatch.is_dm_room", return_value=False),  # Not a DM room
             patch("mindroom.turn_controller.interactive.handle_text_response", new=AsyncMock(return_value=None)),
         ):
             # Multiple agents in the thread
@@ -500,7 +500,7 @@ async def test_agent_responds_in_threads_based_on_participation(  # noqa: PLR091
             patch.object(bot._conversation_cache, "get_dispatch_thread_snapshot") as mock_dispatch_snapshot,
             patch.object(bot._conversation_cache, "get_dispatch_thread_history") as mock_dispatch_history,
             patch.object(bot._conversation_resolver, "fetch_thread_history") as mock_refresh_history,
-            patch("mindroom.turn_controller.is_dm_room", return_value=False),  # Not a DM room
+            patch("mindroom.text_ingress_dispatch.is_dm_room", return_value=False),  # Not a DM room
             patch("mindroom.turn_controller.interactive.handle_text_response", new=AsyncMock(return_value=None)),
         ):
             thread_history = [

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -1709,7 +1709,7 @@ async def test_reserved_follow_up_cleanup_when_plan_ignores_before_response(tmp_
                 "_prepare_dispatch",
                 new=AsyncMock(return_value=prepared_dispatch_result(case.dispatch)),
             ),
-            patch("mindroom.turn_controller.is_dm_room", new=AsyncMock(return_value=False)),
+            patch("mindroom.text_ingress_dispatch.is_dm_room", new=AsyncMock(return_value=False)),
             patch(
                 "mindroom.turn_policy.TurnPolicy.plan_turn",
                 new=AsyncMock(return_value=_DispatchPlan(kind="ignore")),
@@ -1740,7 +1740,7 @@ async def test_reserved_follow_up_cleanup_when_route_returns_before_response(tmp
                 "_prepare_dispatch",
                 new=AsyncMock(return_value=prepared_dispatch_result(case.dispatch)),
             ),
-            patch("mindroom.turn_controller.is_dm_room", new=AsyncMock(return_value=False)),
+            patch("mindroom.text_ingress_dispatch.is_dm_room", new=AsyncMock(return_value=False)),
             patch(
                 "mindroom.turn_policy.TurnPolicy.plan_turn",
                 new=AsyncMock(return_value=_DispatchPlan(kind="route", router_message="route this")),
@@ -1773,7 +1773,7 @@ async def test_reserved_follow_up_cleanup_when_dispatch_raises_before_lifecycle(
                 "_prepare_dispatch",
                 new=AsyncMock(return_value=prepared_dispatch_result(case.dispatch)),
             ),
-            patch("mindroom.turn_controller.is_dm_room", new=AsyncMock(return_value=False)),
+            patch("mindroom.text_ingress_dispatch.is_dm_room", new=AsyncMock(return_value=False)),
             patch(
                 "mindroom.turn_policy.TurnPolicy.plan_turn",
                 new=AsyncMock(
@@ -1815,7 +1815,7 @@ async def test_reserved_follow_up_cleanup_when_dispatch_cancelled_before_lifecyc
                 "_prepare_dispatch",
                 new=AsyncMock(return_value=prepared_dispatch_result(case.dispatch)),
             ),
-            patch("mindroom.turn_controller.is_dm_room", new=AsyncMock(return_value=False)),
+            patch("mindroom.text_ingress_dispatch.is_dm_room", new=AsyncMock(return_value=False)),
             patch(
                 "mindroom.turn_policy.TurnPolicy.plan_turn",
                 new=AsyncMock(

--- a/tests/test_voice_bot_threading.py
+++ b/tests/test_voice_bot_threading.py
@@ -357,7 +357,7 @@ async def test_voice_message_in_main_room_creates_thread(mock_home_bot: AgentBot
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", return_value="🎤 what is the weather"),
         patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
-        patch("mindroom.turn_controller.is_dm_room", new_callable=AsyncMock, return_value=False),
+        patch("mindroom.text_ingress_dispatch.is_dm_room", new_callable=AsyncMock, return_value=False),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
         await bot._on_media_message(room, voice_event)
@@ -410,7 +410,7 @@ async def test_voice_message_in_thread_continues_thread(mock_home_bot: AgentBot)
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", return_value="🎤 show me the forecast"),
         patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
-        patch("mindroom.turn_controller.is_dm_room", new_callable=AsyncMock, return_value=False),
+        patch("mindroom.text_ingress_dispatch.is_dm_room", new_callable=AsyncMock, return_value=False),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
         await bot._on_media_message(room, voice_event)
@@ -468,7 +468,7 @@ async def test_voice_plain_reply_to_thread_message_stays_threaded_transitively(
             new=AsyncMock(return_value="$thread_root"),
         ),
         patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
-        patch("mindroom.turn_controller.is_dm_room", new_callable=AsyncMock, return_value=False),
+        patch("mindroom.text_ingress_dispatch.is_dm_room", new_callable=AsyncMock, return_value=False),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
         await bot._on_media_message(room, voice_event)

--- a/tests/test_voice_command_processing.py
+++ b/tests/test_voice_command_processing.py
@@ -213,7 +213,7 @@ async def test_router_processes_own_voice_transcriptions(tmp_path) -> None:  # n
     with (
         patch("mindroom.turn_controller.TurnController._execute_command", new_callable=AsyncMock) as mock_handle,
         patch("mindroom.turn_controller.interactive.handle_text_response", new_callable=AsyncMock, return_value=None),
-        patch("mindroom.turn_controller.is_dm_room", return_value=False),
+        patch("mindroom.text_ingress_dispatch.is_dm_room", return_value=False),
     ):
         bot.client = MagicMock()
         await bot._on_message(room, event)
@@ -254,7 +254,7 @@ async def test_router_ignores_non_voice_self_messages(tmp_path) -> None:  # noqa
     with (
         patch("mindroom.turn_controller.TurnController._execute_command", new_callable=AsyncMock) as mock_handle,
         patch("mindroom.turn_controller.interactive.handle_text_response", new_callable=AsyncMock, return_value=None),
-        patch("mindroom.turn_controller.is_dm_room", return_value=False),
+        patch("mindroom.text_ingress_dispatch.is_dm_room", return_value=False),
     ):
         bot.client = MagicMock()
         await bot._on_message(room, event)
@@ -810,7 +810,7 @@ async def test_agent_handles_audio_without_router_when_voice_disabled(tmp_path) 
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
         patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
-        patch("mindroom.turn_controller.is_dm_room", new_callable=AsyncMock, return_value=False),
+        patch("mindroom.text_ingress_dispatch.is_dm_room", new_callable=AsyncMock, return_value=False),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
         mock_voice.return_value = None
@@ -883,7 +883,7 @@ async def test_agent_handles_audio_with_router_present_in_single_agent_room(tmp_
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
         patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
-        patch("mindroom.turn_controller.is_dm_room", new_callable=AsyncMock, return_value=False),
+        patch("mindroom.text_ingress_dispatch.is_dm_room", new_callable=AsyncMock, return_value=False),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
         mock_voice.return_value = None
@@ -939,7 +939,7 @@ async def test_router_and_agent_share_audio_normalization_when_router_is_present
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
         patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
-        patch("mindroom.turn_controller.is_dm_room", new_callable=AsyncMock, return_value=False),
+        patch("mindroom.text_ingress_dispatch.is_dm_room", new_callable=AsyncMock, return_value=False),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
         mock_voice.return_value = f"{VOICE_PREFIX}turn on the lights"
@@ -1320,7 +1320,7 @@ async def test_transcribed_mentions_target_the_mentioned_agent_when_router_absen
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
         patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
-        patch("mindroom.turn_controller.is_dm_room", new_callable=AsyncMock, return_value=False),
+        patch("mindroom.text_ingress_dispatch.is_dm_room", new_callable=AsyncMock, return_value=False),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
         mock_voice.return_value = f"{VOICE_PREFIX}@research summarize this audio"
@@ -1394,7 +1394,7 @@ async def test_caption_mentions_still_target_agent_when_stt_drops_the_mention(tm
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
         patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
-        patch("mindroom.turn_controller.is_dm_room", new_callable=AsyncMock, return_value=False),
+        patch("mindroom.text_ingress_dispatch.is_dm_room", new_callable=AsyncMock, return_value=False),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
         mock_voice.return_value = f"{VOICE_PREFIX}summarize this audio"


### PR DESCRIPTION
## Summary
- Move the normal text/command dispatch pipeline out of `turn_controller.py` into `text_ingress_dispatch.py`.
- Keep `_dispatch_text_message` as a thin controller wrapper so existing callers keep the same entrypoint.
- Declare the new Tach boundary and update tests to patch `is_dm_room` at the new module owner.

## Test Plan
- `uv run ruff check src/mindroom/text_ingress_dispatch.py src/mindroom/turn_controller.py`
- `uv run ty check src/mindroom/text_ingress_dispatch.py src/mindroom/turn_controller.py`
- `uv run tach check --dependencies --interfaces`
- `uv run pytest tests/test_turn_controller.py -q -n auto --no-cov`
- targeted `_dispatch_text_message` tests across multi-agent, hook, queued-notice, and coalescing paths
- `uv run pre-commit run --all-files`