### PR TITLE
fix: dedupe inline media replay payloads

### DIFF
--- a/src/mindroom/attachment_media.py
+++ b/src/mindroom/attachment_media.py
@@ -17,6 +17,30 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+def _inline_media_content_key(record: AttachmentRecord) -> tuple[str, ...]:
+    mime_type = record.mime_type or ""
+    if record.content_sha256:
+        return (record.kind, mime_type, record.content_sha256)
+    return (record.kind, mime_type, "filepath", str(record.local_path))
+
+
+def _partition_inline_media_by_content(
+    attachment_records: list[AttachmentRecord],
+    *,
+    current_attachment_ids: set[str],
+) -> list[AttachmentRecord]:
+    inline_records: list[AttachmentRecord] = []
+    seen_keys: set[tuple[str, ...]] = set()
+    current_records = [record for record in attachment_records if record.attachment_id in current_attachment_ids]
+    historical_records = [record for record in attachment_records if record.attachment_id not in current_attachment_ids]
+    for record in [*current_records, *historical_records]:
+        key = _inline_media_content_key(record)
+        if record.attachment_id in current_attachment_ids or key not in seen_keys:
+            inline_records.append(record)
+            seen_keys.add(key)
+    return inline_records
+
+
 def _attachment_records_to_media(
     attachment_records: list[AttachmentRecord],
 ) -> tuple[list[Audio], list[Image], list[File], list[Video]]:
@@ -32,6 +56,7 @@ def _attachment_records_to_media(
         if record.kind == "audio":
             audio.append(
                 Audio(
+                    id=record.attachment_id,
                     filepath=str(record.local_path),
                     mime_type=record.mime_type,
                 ),
@@ -39,6 +64,7 @@ def _attachment_records_to_media(
         elif record.kind == "image":
             images.append(
                 Image(
+                    id=record.attachment_id,
                     filepath=str(record.local_path),
                     mime_type=record.mime_type,
                 ),
@@ -46,6 +72,7 @@ def _attachment_records_to_media(
         elif record.kind == "file":
             try:
                 file_media = File(
+                    id=record.attachment_id,
                     filepath=str(record.local_path),
                     mime_type=record.mime_type,
                     filename=record.filename,
@@ -54,6 +81,7 @@ def _attachment_records_to_media(
                 # Agno validates file MIME types against a strict allow-list.
                 # Fall back to filepath+filename so arbitrary attachments still work.
                 file_media = File(
+                    id=record.attachment_id,
                     filepath=str(record.local_path),
                     filename=record.filename,
                 )
@@ -61,6 +89,7 @@ def _attachment_records_to_media(
         elif record.kind == "video":
             videos.append(
                 Video(
+                    id=record.attachment_id,
                     filepath=str(record.local_path),
                     mime_type=record.mime_type,
                 ),
@@ -75,6 +104,7 @@ def resolve_attachment_media(
     *,
     room_id: str | None = None,
     thread_id: str | None = None,
+    current_attachment_ids: set[str] | None = None,
 ) -> tuple[list[str], list[Audio], list[Image], list[File], list[Video]]:
     """Resolve attachment IDs into Agno media objects.
 
@@ -100,8 +130,13 @@ def resolve_attachment_media(
                 thread_id=thread_id,
             )
     resolved_attachment_ids = [record.attachment_id for record in attachment_records]
+    media_records = (
+        _partition_inline_media_by_content(attachment_records, current_attachment_ids=current_attachment_ids)
+        if current_attachment_ids is not None
+        else attachment_records
+    )
     attachment_audio, attachment_images, attachment_files, attachment_videos = _attachment_records_to_media(
-        attachment_records,
+        media_records,
     )
     emit_elapsed_timing(
         "response_payload.resolve_attachment_media",

--- a/src/mindroom/attachment_media.py
+++ b/src/mindroom/attachment_media.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+from collections import OrderedDict
 from typing import TYPE_CHECKING
 
 from agno.media import Audio, File, Image, Video
@@ -15,6 +16,23 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 logger = get_logger(__name__)
+
+_MAX_INLINE_MEDIA_RECORDS = 512
+_INLINE_MEDIA_RECORDS_BY_ID: OrderedDict[str, AttachmentRecord] = OrderedDict()
+_INLINE_MEDIA_RECORDS_BY_PATH: OrderedDict[str, AttachmentRecord] = OrderedDict()
+
+
+def _remember_attachment_record(record: AttachmentRecord) -> None:
+    _INLINE_MEDIA_RECORDS_BY_ID[record.attachment_id] = record
+    _INLINE_MEDIA_RECORDS_BY_ID.move_to_end(record.attachment_id)
+    while len(_INLINE_MEDIA_RECORDS_BY_ID) > _MAX_INLINE_MEDIA_RECORDS:
+        _INLINE_MEDIA_RECORDS_BY_ID.popitem(last=False)
+
+    path_key = str(record.local_path.resolve())
+    _INLINE_MEDIA_RECORDS_BY_PATH[path_key] = record
+    _INLINE_MEDIA_RECORDS_BY_PATH.move_to_end(path_key)
+    while len(_INLINE_MEDIA_RECORDS_BY_PATH) > _MAX_INLINE_MEDIA_RECORDS:
+        _INLINE_MEDIA_RECORDS_BY_PATH.popitem(last=False)
 
 
 def _inline_media_content_key(record: AttachmentRecord) -> tuple[str, ...]:
@@ -130,6 +148,8 @@ def resolve_attachment_media(
                 thread_id=thread_id,
             )
     resolved_attachment_ids = [record.attachment_id for record in attachment_records]
+    for record in attachment_records:
+        _remember_attachment_record(record)
     media_records = (
         _partition_inline_media_by_content(attachment_records, current_attachment_ids=current_attachment_ids)
         if current_attachment_ids is not None

--- a/src/mindroom/attachment_media.py
+++ b/src/mindroom/attachment_media.py
@@ -28,7 +28,7 @@ def _remember_attachment_record(record: AttachmentRecord) -> None:
     while len(_INLINE_MEDIA_RECORDS_BY_ID) > _MAX_INLINE_MEDIA_RECORDS:
         _INLINE_MEDIA_RECORDS_BY_ID.popitem(last=False)
 
-    path_key = str(record.local_path.resolve())
+    path_key = str(record.local_path.absolute())
     _INLINE_MEDIA_RECORDS_BY_PATH[path_key] = record
     _INLINE_MEDIA_RECORDS_BY_PATH.move_to_end(path_key)
     while len(_INLINE_MEDIA_RECORDS_BY_PATH) > _MAX_INLINE_MEDIA_RECORDS:

--- a/src/mindroom/attachments.py
+++ b/src/mindroom/attachments.py
@@ -416,11 +416,12 @@ def register_local_attachment(
         return None
 
     hasher = hashlib.sha256()
+    size_bytes = 0
     try:
         with local_path.open("rb") as fh:
             for chunk in iter(lambda: fh.read(65536), b""):
                 hasher.update(chunk)
-        size_bytes = local_path.stat().st_size
+                size_bytes += len(chunk)
     except OSError:
         logger.exception("Failed to hash attachment file", path=str(local_path))
         return None

--- a/src/mindroom/attachments.py
+++ b/src/mindroom/attachments.py
@@ -71,6 +71,7 @@ class AttachmentRecord:
     source_event_id: str | None = None
     sender: str | None = None
     size_bytes: int | None = None
+    content_sha256: str | None = None
     created_at: str | None = None
 
     def to_payload(self) -> dict[str, Any]:
@@ -86,6 +87,7 @@ class AttachmentRecord:
             "source_event_id": self.source_event_id,
             "sender": self.sender,
             "size_bytes": self.size_bytes,
+            "content_sha256": self.content_sha256,
             "created_at": self.created_at,
         }
 
@@ -413,11 +415,16 @@ def register_local_attachment(
         logger.warning("Attachment path does not exist", path=str(local_path), kind=kind)
         return None
 
+    hasher = hashlib.sha256()
     try:
+        with local_path.open("rb") as fh:
+            for chunk in iter(lambda: fh.read(65536), b""):
+                hasher.update(chunk)
         size_bytes = local_path.stat().st_size
     except OSError:
-        logger.exception("Failed to read attachment file metadata", path=str(local_path))
+        logger.exception("Failed to hash attachment file", path=str(local_path))
         return None
+    content_sha256 = hasher.hexdigest()
 
     resolved_attachment_id = attachment_id or f"att_{uuid4().hex[:16]}"
     normalized_attachment_id = normalize_attachment_id(resolved_attachment_id)
@@ -436,6 +443,7 @@ def register_local_attachment(
         source_event_id=source_event_id,
         sender=sender,
         size_bytes=size_bytes,
+        content_sha256=content_sha256,
         created_at=datetime.now(UTC).isoformat(),
     )
 
@@ -611,6 +619,7 @@ def load_attachment(storage_path: Path, attachment_id: str) -> AttachmentRecord 
     source_event_id = raw_payload.get("source_event_id")
     sender = raw_payload.get("sender")
     size_bytes = raw_payload.get("size_bytes")
+    content_sha256 = raw_payload.get("content_sha256")
     created_at = raw_payload.get("created_at")
 
     return AttachmentRecord(
@@ -624,6 +633,7 @@ def load_attachment(storage_path: Path, attachment_id: str) -> AttachmentRecord 
         source_event_id=source_event_id if isinstance(source_event_id, str) else None,
         sender=sender if isinstance(sender, str) else None,
         size_bytes=size_bytes if isinstance(size_bytes, int) else None,
+        content_sha256=content_sha256 if isinstance(content_sha256, str) else None,
         created_at=created_at if isinstance(created_at, str) else None,
     )
 

--- a/src/mindroom/attachments.py
+++ b/src/mindroom/attachments.py
@@ -495,7 +495,8 @@ async def _register_media_attachment(
     )
     if local_media_path is None:
         return None
-    return register_local_attachment(
+    return await asyncio.to_thread(
+        register_local_attachment,
         storage_path,
         local_media_path,
         kind=kind,

--- a/src/mindroom/history/__init__.py
+++ b/src/mindroom/history/__init__.py
@@ -1,5 +1,6 @@
 """Persisted history compaction helpers."""
 
+from mindroom.history import agno_team_patch
 from mindroom.history.compaction import (
     agent_tool_definition_payloads_for_logging,
     compute_prompt_token_breakdown,
@@ -56,6 +57,8 @@ from mindroom.history.types import (
     ResolvedHistorySettings,
     ResolvedReplayPlan,
 )
+
+agno_team_patch.apply_patch()
 
 __all__ = [
     "CompactionDecision",

--- a/src/mindroom/history/agno_team_patch.py
+++ b/src/mindroom/history/agno_team_patch.py
@@ -9,6 +9,7 @@ Team has the same upstream behavior.
 from __future__ import annotations
 
 import hashlib
+import threading
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar, cast
@@ -25,6 +26,7 @@ if TYPE_CHECKING:
     from agno.media import Audio, File, Image, Video
 
 _PATCHED = False
+_PATCH_LOCK = threading.Lock()
 type _RolefulInput = list[Message]
 type _RunMessagesBuilder = Callable[..., RunMessages]
 type _AsyncRunMessagesBuilder = Callable[..., Awaitable[RunMessages]]
@@ -67,8 +69,8 @@ def _media_content_key(kind: str, media: Image | Audio | Video | File) -> tuple[
         record = attachment_media._INLINE_MEDIA_RECORDS_BY_ID.get(media.id)
         if record is not None and record.kind == kind:
             key = attachment_media._inline_media_content_key(record)
-    if key is None and media.filepath is not None:
-        path = str(Path(media.filepath).resolve())
+    if key is None and media.filepath:
+        path = str(Path(media.filepath).absolute())
         record = attachment_media._INLINE_MEDIA_RECORDS_BY_PATH.get(path)
         if record is not None and record.kind == kind:
             key = attachment_media._inline_media_content_key(record)
@@ -145,6 +147,13 @@ def _messages_in_inline_media_dedupe_order(run_messages: RunMessages) -> list[Me
 
 
 def _dedupe_run_messages_inline_media(run_messages: RunMessages) -> RunMessages:
+    """Remove duplicate inline media from one provider-bound run in place.
+
+    Agno builds fresh per-run Message objects for persisted history before this
+    function runs, so clearing older duplicate media here affects the current
+    request payload rather than persisted session history. The first content key
+    in current, non-history, then history order wins.
+    """
     seen_images: set[tuple[str, ...]] = set()
     seen_audio: set[tuple[str, ...]] = set()
     seen_files: set[tuple[str, ...]] = set()
@@ -166,40 +175,43 @@ def apply_patch() -> None:
     global _PATCHED
     if _PATCHED:
         return
+    with _PATCH_LOCK:
+        if _PATCHED:
+            return
 
-    original_team_get_run_messages = cast("_RunMessagesBuilder", team_messages._get_run_messages)
-    original_team_aget_run_messages = cast("_AsyncRunMessagesBuilder", team_messages._aget_run_messages)
-    original_agent_get_run_messages = cast("_RunMessagesBuilder", agent_messages.get_run_messages)
-    original_agent_aget_run_messages = cast("_AsyncRunMessagesBuilder", agent_messages.aget_run_messages)
+        original_team_get_run_messages = cast("_RunMessagesBuilder", team_messages._get_run_messages)
+        original_team_aget_run_messages = cast("_AsyncRunMessagesBuilder", team_messages._aget_run_messages)
+        original_agent_get_run_messages = cast("_RunMessagesBuilder", agent_messages.get_run_messages)
+        original_agent_aget_run_messages = cast("_AsyncRunMessagesBuilder", agent_messages.aget_run_messages)
 
-    def _get_run_messages(*args: object, **kwargs: object) -> RunMessages:
-        input_message = kwargs.get("input_message")
-        if not _is_roleful_message_list(input_message):
-            return _dedupe_run_messages_inline_media(original_team_get_run_messages(*args, **kwargs))
+        def _get_run_messages(*args: object, **kwargs: object) -> RunMessages:
+            input_message = kwargs.get("input_message")
+            if not _is_roleful_message_list(input_message):
+                return _dedupe_run_messages_inline_media(original_team_get_run_messages(*args, **kwargs))
 
-        passthrough_kwargs = {**kwargs, "input_message": None}
-        run_messages = original_team_get_run_messages(*args, **passthrough_kwargs)
-        _append_input_messages(run_messages, cast("_RolefulInput", input_message))
-        return _dedupe_run_messages_inline_media(run_messages)
+            passthrough_kwargs = {**kwargs, "input_message": None}
+            run_messages = original_team_get_run_messages(*args, **passthrough_kwargs)
+            _append_input_messages(run_messages, cast("_RolefulInput", input_message))
+            return _dedupe_run_messages_inline_media(run_messages)
 
-    async def _aget_run_messages(*args: object, **kwargs: object) -> RunMessages:
-        input_message = kwargs.get("input_message")
-        if not _is_roleful_message_list(input_message):
-            return _dedupe_run_messages_inline_media(await original_team_aget_run_messages(*args, **kwargs))
+        async def _aget_run_messages(*args: object, **kwargs: object) -> RunMessages:
+            input_message = kwargs.get("input_message")
+            if not _is_roleful_message_list(input_message):
+                return _dedupe_run_messages_inline_media(await original_team_aget_run_messages(*args, **kwargs))
 
-        passthrough_kwargs = {**kwargs, "input_message": None}
-        run_messages = await original_team_aget_run_messages(*args, **passthrough_kwargs)
-        _append_input_messages(run_messages, cast("_RolefulInput", input_message))
-        return _dedupe_run_messages_inline_media(run_messages)
+            passthrough_kwargs = {**kwargs, "input_message": None}
+            run_messages = await original_team_aget_run_messages(*args, **passthrough_kwargs)
+            _append_input_messages(run_messages, cast("_RolefulInput", input_message))
+            return _dedupe_run_messages_inline_media(run_messages)
 
-    def _agent_get_run_messages(*args: object, **kwargs: object) -> RunMessages:
-        return _dedupe_run_messages_inline_media(original_agent_get_run_messages(*args, **kwargs))
+        def _agent_get_run_messages(*args: object, **kwargs: object) -> RunMessages:
+            return _dedupe_run_messages_inline_media(original_agent_get_run_messages(*args, **kwargs))
 
-    async def _agent_aget_run_messages(*args: object, **kwargs: object) -> RunMessages:
-        return _dedupe_run_messages_inline_media(await original_agent_aget_run_messages(*args, **kwargs))
+        async def _agent_aget_run_messages(*args: object, **kwargs: object) -> RunMessages:
+            return _dedupe_run_messages_inline_media(await original_agent_aget_run_messages(*args, **kwargs))
 
-    team_messages._get_run_messages = cast("Any", _get_run_messages)
-    team_messages._aget_run_messages = cast("Any", _aget_run_messages)
-    agent_messages.get_run_messages = cast("Any", _agent_get_run_messages)
-    agent_messages.aget_run_messages = cast("Any", _agent_aget_run_messages)
-    _PATCHED = True
+        team_messages._get_run_messages = cast("Any", _get_run_messages)
+        team_messages._aget_run_messages = cast("Any", _aget_run_messages)
+        agent_messages.get_run_messages = cast("Any", _agent_get_run_messages)
+        agent_messages.aget_run_messages = cast("Any", _agent_aget_run_messages)
+        _PATCHED = True

--- a/src/mindroom/history/agno_team_patch.py
+++ b/src/mindroom/history/agno_team_patch.py
@@ -1,0 +1,85 @@
+"""Vendored Agno Team roleful-input patch.
+
+Agno Agent preserves ``list[Message]`` input as roleful provider messages, while
+Agno Team currently flattens that same shape through ``get_text_from_message``.
+This throwaway monkey-patch mirrors the Agent message-builder path until Agno
+Team has the same upstream behavior.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any, cast
+
+from agno.models.message import Message
+from agno.run.messages import RunMessages
+from agno.team import _messages
+from agno.utils.log import log_warning
+
+_PATCHED = False
+type _RolefulInput = list[Message]
+type _RunMessagesBuilder = Callable[..., RunMessages]
+type _AsyncRunMessagesBuilder = Callable[..., Awaitable[RunMessages]]
+
+
+def _is_roleful_message_list(input_message: object) -> bool:
+    return isinstance(input_message, list) and bool(input_message) and isinstance(input_message[0], Message)
+
+
+def _append_input_messages(run_messages: RunMessages, input_messages: list[Any]) -> None:
+    roleful_messages: list[Message] = []
+    for input_message in input_messages:
+        if isinstance(input_message, Message):
+            message = input_message
+        else:
+            try:
+                message = Message.model_validate(input_message)
+            except Exception as exc:
+                log_warning(f"Failed to validate message: {exc}")
+                continue
+        roleful_messages.append(message)
+    if not roleful_messages:
+        return
+
+    additional_input = list(run_messages.extra_messages or [])
+    run_messages.messages.extend(roleful_messages)
+    if roleful_messages[-1].role == "user":
+        run_messages.user_message = roleful_messages[-1]
+        roleful_history = roleful_messages[:-1]
+    else:
+        roleful_history = roleful_messages
+    run_messages.extra_messages = [*roleful_history, *additional_input]
+
+
+def apply_patch() -> None:
+    """Patch Agno Team run-message builders once per interpreter."""
+    global _PATCHED
+    if _PATCHED:
+        return
+
+    original_get_run_messages = cast("_RunMessagesBuilder", _messages._get_run_messages)
+    original_aget_run_messages = cast("_AsyncRunMessagesBuilder", _messages._aget_run_messages)
+
+    def _get_run_messages(*args: object, **kwargs: object) -> RunMessages:
+        input_message = kwargs.get("input_message")
+        if not _is_roleful_message_list(input_message):
+            return original_get_run_messages(*args, **kwargs)
+
+        passthrough_kwargs = {**kwargs, "input_message": None}
+        run_messages = original_get_run_messages(*args, **passthrough_kwargs)
+        _append_input_messages(run_messages, cast("_RolefulInput", input_message))
+        return run_messages
+
+    async def _aget_run_messages(*args: object, **kwargs: object) -> RunMessages:
+        input_message = kwargs.get("input_message")
+        if not _is_roleful_message_list(input_message):
+            return await original_aget_run_messages(*args, **kwargs)
+
+        passthrough_kwargs = {**kwargs, "input_message": None}
+        run_messages = await original_aget_run_messages(*args, **passthrough_kwargs)
+        _append_input_messages(run_messages, cast("_RolefulInput", input_message))
+        return run_messages
+
+    _messages._get_run_messages = cast("Any", _get_run_messages)
+    _messages._aget_run_messages = cast("Any", _aget_run_messages)
+    _PATCHED = True

--- a/src/mindroom/history/agno_team_patch.py
+++ b/src/mindroom/history/agno_team_patch.py
@@ -8,18 +8,27 @@ Team has the same upstream behavior.
 
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Awaitable, Callable
-from typing import Any, cast
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
+from agno.agent import _messages as agent_messages
 from agno.models.message import Message
 from agno.run.messages import RunMessages
-from agno.team import _messages
+from agno.team import _messages as team_messages
 from agno.utils.log import log_warning
+
+from mindroom import attachment_media
+
+if TYPE_CHECKING:
+    from agno.media import Audio, File, Image, Video
 
 _PATCHED = False
 type _RolefulInput = list[Message]
 type _RunMessagesBuilder = Callable[..., RunMessages]
 type _AsyncRunMessagesBuilder = Callable[..., Awaitable[RunMessages]]
+_MediaT = TypeVar("_MediaT")
 
 
 def _is_roleful_message_list(input_message: object) -> bool:
@@ -51,35 +60,146 @@ def _append_input_messages(run_messages: RunMessages, input_messages: list[Any])
     run_messages.extra_messages = [*roleful_history, *additional_input]
 
 
+def _media_content_key(kind: str, media: Image | Audio | Video | File) -> tuple[str, ...] | None:
+    mime_type = media.mime_type or ""
+    key: tuple[str, ...] | None = None
+    if media.id and media.id.startswith("att_"):
+        record = attachment_media._INLINE_MEDIA_RECORDS_BY_ID.get(media.id)
+        if record is not None and record.kind == kind:
+            key = attachment_media._inline_media_content_key(record)
+    if key is None and media.filepath is not None:
+        path = str(Path(media.filepath).resolve())
+        record = attachment_media._INLINE_MEDIA_RECORDS_BY_PATH.get(path)
+        if record is not None and record.kind == kind:
+            key = attachment_media._inline_media_content_key(record)
+        else:
+            key = (kind, mime_type, "filepath", path)
+    if key is None and media.content is not None:
+        if isinstance(media.content, bytes):
+            content = media.content
+        elif isinstance(media.content, str):
+            content = media.content.encode("utf-8")
+        else:
+            content = None
+        if content is not None:
+            key = (kind, mime_type, hashlib.sha256(content).hexdigest())
+    if key is None and media.url is not None:
+        key = (kind, mime_type, "url", media.url)
+    return key
+
+
+def _image_content_key(image: Image) -> tuple[str, ...] | None:
+    return _media_content_key("image", image)
+
+
+def _audio_content_key(audio: Audio) -> tuple[str, ...] | None:
+    return _media_content_key("audio", audio)
+
+
+def _video_content_key(video: Video) -> tuple[str, ...] | None:
+    return _media_content_key("video", video)
+
+
+def _file_content_key(file: File) -> tuple[str, ...] | None:
+    return _media_content_key("file", file)
+
+
+def _keep_first_inline_media(
+    media: list[_MediaT],
+    seen: set[tuple[str, ...]],
+    key_for: Callable[[_MediaT], tuple[str, ...] | None],
+) -> list[_MediaT]:
+    kept: list[_MediaT] = []
+    for item in media:
+        key = key_for(item)
+        if key is None:
+            kept.append(item)
+        elif key not in seen:
+            seen.add(key)
+            kept.append(item)
+    return kept
+
+
+def _messages_in_inline_media_dedupe_order(run_messages: RunMessages) -> list[Message]:
+    current_message = run_messages.user_message
+    # Identity-based dedupe — Agno keeps the same Message instance in run_messages.messages and run_messages.user_message.
+    seen_message_ids: set[int] = set()
+    current_messages: list[Message] = []
+    non_history_messages: list[Message] = []
+    history_messages: list[Message] = []
+
+    if current_message is not None:
+        current_messages.append(current_message)
+        seen_message_ids.add(id(current_message))
+
+    for message in run_messages.messages:
+        if id(message) in seen_message_ids:
+            continue
+        seen_message_ids.add(id(message))
+        if message.from_history:
+            history_messages.append(message)
+        else:
+            non_history_messages.append(message)
+
+    return [*current_messages, *non_history_messages, *history_messages]
+
+
+def _dedupe_run_messages_inline_media(run_messages: RunMessages) -> RunMessages:
+    seen_images: set[tuple[str, ...]] = set()
+    seen_audio: set[tuple[str, ...]] = set()
+    seen_files: set[tuple[str, ...]] = set()
+    seen_videos: set[tuple[str, ...]] = set()
+    for message in _messages_in_inline_media_dedupe_order(run_messages):
+        if message.images:
+            message.images = _keep_first_inline_media(list(message.images), seen_images, _image_content_key)
+        if message.audio:
+            message.audio = _keep_first_inline_media(list(message.audio), seen_audio, _audio_content_key)
+        if message.files:
+            message.files = _keep_first_inline_media(list(message.files), seen_files, _file_content_key)
+        if message.videos:
+            message.videos = _keep_first_inline_media(list(message.videos), seen_videos, _video_content_key)
+    return run_messages
+
+
 def apply_patch() -> None:
     """Patch Agno Team run-message builders once per interpreter."""
     global _PATCHED
     if _PATCHED:
         return
 
-    original_get_run_messages = cast("_RunMessagesBuilder", _messages._get_run_messages)
-    original_aget_run_messages = cast("_AsyncRunMessagesBuilder", _messages._aget_run_messages)
+    original_team_get_run_messages = cast("_RunMessagesBuilder", team_messages._get_run_messages)
+    original_team_aget_run_messages = cast("_AsyncRunMessagesBuilder", team_messages._aget_run_messages)
+    original_agent_get_run_messages = cast("_RunMessagesBuilder", agent_messages.get_run_messages)
+    original_agent_aget_run_messages = cast("_AsyncRunMessagesBuilder", agent_messages.aget_run_messages)
 
     def _get_run_messages(*args: object, **kwargs: object) -> RunMessages:
         input_message = kwargs.get("input_message")
         if not _is_roleful_message_list(input_message):
-            return original_get_run_messages(*args, **kwargs)
+            return _dedupe_run_messages_inline_media(original_team_get_run_messages(*args, **kwargs))
 
         passthrough_kwargs = {**kwargs, "input_message": None}
-        run_messages = original_get_run_messages(*args, **passthrough_kwargs)
+        run_messages = original_team_get_run_messages(*args, **passthrough_kwargs)
         _append_input_messages(run_messages, cast("_RolefulInput", input_message))
-        return run_messages
+        return _dedupe_run_messages_inline_media(run_messages)
 
     async def _aget_run_messages(*args: object, **kwargs: object) -> RunMessages:
         input_message = kwargs.get("input_message")
         if not _is_roleful_message_list(input_message):
-            return await original_aget_run_messages(*args, **kwargs)
+            return _dedupe_run_messages_inline_media(await original_team_aget_run_messages(*args, **kwargs))
 
         passthrough_kwargs = {**kwargs, "input_message": None}
-        run_messages = await original_aget_run_messages(*args, **passthrough_kwargs)
+        run_messages = await original_team_aget_run_messages(*args, **passthrough_kwargs)
         _append_input_messages(run_messages, cast("_RolefulInput", input_message))
-        return run_messages
+        return _dedupe_run_messages_inline_media(run_messages)
 
-    _messages._get_run_messages = cast("Any", _get_run_messages)
-    _messages._aget_run_messages = cast("Any", _aget_run_messages)
+    def _agent_get_run_messages(*args: object, **kwargs: object) -> RunMessages:
+        return _dedupe_run_messages_inline_media(original_agent_get_run_messages(*args, **kwargs))
+
+    async def _agent_aget_run_messages(*args: object, **kwargs: object) -> RunMessages:
+        return _dedupe_run_messages_inline_media(await original_agent_aget_run_messages(*args, **kwargs))
+
+    team_messages._get_run_messages = cast("Any", _get_run_messages)
+    team_messages._aget_run_messages = cast("Any", _aget_run_messages)
+    agent_messages.get_run_messages = cast("Any", _agent_get_run_messages)
+    agent_messages.aget_run_messages = cast("Any", _agent_aget_run_messages)
     _PATCHED = True

--- a/src/mindroom/inbound_turn_normalizer.py
+++ b/src/mindroom/inbound_turn_normalizer.py
@@ -384,6 +384,7 @@ class InboundTurnNormalizer:
                 scoped_attachment_ids,
                 room_id=request.room_id,
                 thread_id=request.media_thread_id,
+                current_attachment_ids=set(request.current_attachment_ids),
             )
         )
         if trusted_current_attachment_ids:
@@ -403,9 +404,7 @@ class InboundTurnNormalizer:
             attachment_files = [*trusted_files, *attachment_files]
             attachment_videos = [*trusted_videos, *attachment_videos]
         if request.fallback_images:
-            attachment_images = (
-                [*attachment_images, *request.fallback_images] if attachment_images else list(request.fallback_images)
-            )
+            attachment_images = [*attachment_images, *request.fallback_images]
         attachment_prompt = format_attachment_ids_prompt(resolved_attachment_ids)
         return DispatchPayload(
             prompt=request.prompt,

--- a/tach.toml
+++ b/tach.toml
@@ -668,14 +668,27 @@ depends_on = [
 ]
 
 [[modules]]
+path = "mindroom.attachment_media"
+depends_on = [
+    "mindroom.attachments",
+    "mindroom.logging_config",
+    "mindroom.timing",
+]
+
+[[modules]]
 path = "mindroom.history"
 depends_on = [
+    "mindroom.history.agno_team_patch",
     "mindroom.history.compaction",
     "mindroom.history.policy",
     "mindroom.history.runtime",
     "mindroom.history.storage",
     "mindroom.history.types",
 ]
+
+[[modules]]
+path = "mindroom.history.agno_team_patch"
+depends_on = ["mindroom.attachment_media"]
 
 [[modules]]
 path = "mindroom.history.compaction"

--- a/tests/test_agno_team_patch.py
+++ b/tests/test_agno_team_patch.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 import pytest
+from agno.agent import _messages as agent_messages
+from agno.media import Image
 from agno.models.message import Message
 from agno.models.openai.chat import OpenAIChat
 from agno.models.response import ModelResponse
@@ -16,10 +18,28 @@ from agno.session.team import TeamSession
 from agno.team import Team, _messages
 from pydantic import BaseModel
 
+from mindroom.attachment_media import (
+    _INLINE_MEDIA_RECORDS_BY_ID,
+    _INLINE_MEDIA_RECORDS_BY_PATH,
+    resolve_attachment_media,
+)
+from mindroom.attachments import AttachmentRecord, register_local_attachment
 from mindroom.history import agno_team_patch
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
     from agno.run.messages import RunMessages
+
+
+@pytest.fixture(autouse=True)
+def _clear_inline_media_caches() -> Iterator[None]:
+    _INLINE_MEDIA_RECORDS_BY_ID.clear()
+    _INLINE_MEDIA_RECORDS_BY_PATH.clear()
+    yield
+    _INLINE_MEDIA_RECORDS_BY_ID.clear()
+    _INLINE_MEDIA_RECORDS_BY_PATH.clear()
 
 
 @dataclass
@@ -56,6 +76,33 @@ def _team(model: RecordingOpenAIChat) -> Team:
     )
 
 
+def _register_image_attachment(
+    tmp_path: Path,
+    attachment_id: str,
+    payload: bytes,
+) -> AttachmentRecord:
+    image_path = tmp_path / f"{attachment_id}.png"
+    image_path.write_bytes(payload)
+    record = register_local_attachment(
+        tmp_path,
+        image_path,
+        kind="image",
+        attachment_id=attachment_id,
+        filename=image_path.name,
+        mime_type="image/png",
+    )
+    assert record is not None
+    return record
+
+
+def _image(record: AttachmentRecord, *, image_id: str | None = None) -> Image:
+    return Image(
+        id=image_id if image_id is not None else record.attachment_id,
+        filepath=record.local_path,
+        mime_type=record.mime_type,
+    )
+
+
 async def _patched_run_messages(
     team: Team,
     input_message: list[Message],
@@ -88,6 +135,41 @@ def _conversation_messages(model: RecordingOpenAIChat) -> list[dict[str, Any]]:
         for message in model.formatted_messages
         if message["role"] in {"user", "assistant"} and message.get("content") != ""
     ]
+
+
+async def _patched_history_run_messages(
+    tmp_path: Path,
+    records: list[AttachmentRecord],
+    history_messages: list[Message],
+    current_images: list[Image],
+) -> RunMessages:
+    resolve_attachment_media(tmp_path, [record.attachment_id for record in records])
+    model = RecordingOpenAIChat(id="gpt-test", api_key="sk-test")
+    team = _team(model)
+    team.num_history_runs = len(history_messages)
+    session = TeamSession(
+        session_id="session",
+        runs=[
+            TeamRunOutput(
+                run_id=f"history-{index}",
+                session_id="session",
+                messages=[message],
+            )
+            for index, message in enumerate(history_messages)
+        ],
+    )
+    return await _messages._aget_run_messages(
+        team,
+        run_response=TeamRunOutput(run_id="run", session_id="session"),
+        run_context=RunContext(run_id="run", session_id="session"),
+        session=session,
+        add_history_to_context=True,
+        images=current_images,
+    )
+
+
+def _all_images(run_messages: RunMessages) -> list[Image]:
+    return [image for message in run_messages.messages for image in (message.images or [])]
 
 
 @pytest.mark.asyncio
@@ -127,6 +209,22 @@ async def test_team_list_message_patch_sets_user_message(use_async: bool) -> Non
     assert run_messages.user_message.content == "hi"
     assert run_messages.user_message in run_messages.messages
     assert run_messages.extra_messages == []
+
+
+def test_agno_team_builder_reuses_user_message_instance_in_messages() -> None:
+    model = RecordingOpenAIChat(id="gpt-test", api_key="sk-test")
+    team = _team(model)
+    input_message = Message(role="user", content="current")
+    run_messages = _messages._get_run_messages(
+        team,
+        run_response=TeamRunOutput(run_id="run", session_id="session"),
+        run_context=RunContext(run_id="run", session_id="session"),
+        session=TeamSession(session_id="session"),
+        input_message=input_message,
+    )
+
+    assert run_messages.user_message is input_message
+    assert run_messages.messages[-1] is run_messages.user_message
 
 
 @pytest.mark.parametrize("use_async", [False, True])
@@ -182,6 +280,123 @@ def test_team_list_message_patch_is_idempotent() -> None:
 
     assert _messages._get_run_messages is patched_sync
     assert _messages._aget_run_messages is patched_async
+
+
+@pytest.mark.asyncio
+async def test_cross_run_image_dedupe_collapses_22_replays_to_3_inlines(tmp_path: Path) -> None:
+    records = [
+        _register_image_attachment(tmp_path, "att_a", b"\x89PNG\r\n\x1a\na"),
+        _register_image_attachment(tmp_path, "att_b", b"\x89PNG\r\n\x1a\nb"),
+        _register_image_attachment(tmp_path, "att_c", b"\x89PNG\r\n\x1a\nc"),
+    ]
+    history_messages = [
+        Message(role="user", content=f"history {index}", images=[_image(record) for record in records])
+        for index in range(22)
+    ]
+
+    run_messages = await _patched_history_run_messages(
+        tmp_path,
+        records,
+        history_messages,
+        [_image(record) for record in records],
+    )
+
+    images = _all_images(run_messages)
+    history_user_messages = [
+        message for message in run_messages.messages if message.from_history and message.role == "user"
+    ]
+    assert len(images) == 3
+    assert {image.id for image in images} == {"att_a", "att_b", "att_c"}
+    assert len(history_user_messages) == 22
+    assert all((message.images or []) == [] for message in history_user_messages)
+    assert run_messages.user_message is not None
+    assert {image.id for image in (run_messages.user_message.images or [])} == {"att_a", "att_b", "att_c"}
+
+
+@pytest.mark.asyncio
+async def test_two_att_ids_with_identical_bytes_collapse_to_one(tmp_path: Path) -> None:
+    older = _register_image_attachment(tmp_path, "att_older", b"\x89PNG\r\n\x1a\nsame")
+    newer = _register_image_attachment(tmp_path, "att_newer", b"\x89PNG\r\n\x1a\nsame")
+    history_message = Message(role="user", content="history", images=[_image(older)])
+
+    run_messages = await _patched_history_run_messages(
+        tmp_path,
+        [older, newer],
+        [history_message],
+        [_image(newer)],
+    )
+
+    history_user_messages = [
+        message for message in run_messages.messages if message.from_history and message.role == "user"
+    ]
+    assert [image.id for image in _all_images(run_messages)] == ["att_newer"]
+    assert run_messages.user_message is not None
+    assert [image.id for image in (run_messages.user_message.images or [])] == ["att_newer"]
+    assert len(history_user_messages) == 1
+    assert history_user_messages[0].images == []
+
+
+@pytest.mark.asyncio
+async def test_current_image_wins_over_matching_history_image(tmp_path: Path) -> None:
+    record = _register_image_attachment(tmp_path, "att_same", b"\x89PNG\r\n\x1a\nsame")
+    history_message = Message(role="user", content="history", images=[_image(record)])
+
+    run_messages = await _patched_history_run_messages(
+        tmp_path,
+        [record],
+        [history_message],
+        [_image(record)],
+    )
+
+    history_user_messages = [
+        message for message in run_messages.messages if message.from_history and message.role == "user"
+    ]
+    assert [image.id for image in _all_images(run_messages)] == ["att_same"]
+    assert run_messages.user_message is not None
+    assert [image.id for image in (run_messages.user_message.images or [])] == ["att_same"]
+    assert len(history_user_messages) == 1
+    assert history_user_messages[0].images == []
+
+
+@pytest.mark.asyncio
+async def test_non_att_image_id_not_used_as_lookup_key(tmp_path: Path) -> None:
+    wrong_record = _register_image_attachment(tmp_path, "att_wrong", b"\x89PNG\r\n\x1a\nwrong")
+    filepath_record = _register_image_attachment(tmp_path, "att_filepath", b"\x89PNG\r\n\x1a\nfilepath")
+    random_id = "random-uuid-from-agno"
+    resolve_attachment_media(tmp_path, [wrong_record.attachment_id, filepath_record.attachment_id])
+    _INLINE_MEDIA_RECORDS_BY_ID[random_id] = wrong_record
+    history_message = Message(role="user", content="history", images=[_image(filepath_record, image_id=random_id)])
+
+    run_messages = await _patched_history_run_messages(
+        tmp_path,
+        [wrong_record, filepath_record],
+        [history_message],
+        [_image(filepath_record)],
+    )
+
+    history_user_messages = [
+        message for message in run_messages.messages if message.from_history and message.role == "user"
+    ]
+    assert [image.id for image in _all_images(run_messages)] == ["att_filepath"]
+    assert run_messages.user_message is not None
+    assert [image.id for image in (run_messages.user_message.images or [])] == ["att_filepath"]
+    assert len(history_user_messages) == 1
+    assert history_user_messages[0].images == []
+
+
+def test_apply_patch_is_idempotent() -> None:
+    patched_team_sync = _messages._get_run_messages
+    patched_team_async = _messages._aget_run_messages
+    patched_agent_sync = agent_messages.get_run_messages
+    patched_agent_async = agent_messages.aget_run_messages
+
+    agno_team_patch.apply_patch()
+    agno_team_patch.apply_patch()
+
+    assert _messages._get_run_messages is patched_team_sync
+    assert _messages._aget_run_messages is patched_team_async
+    assert agent_messages.get_run_messages is patched_agent_sync
+    assert agent_messages.aget_run_messages is patched_agent_async
 
 
 @pytest.mark.parametrize(

--- a/tests/test_agno_team_patch.py
+++ b/tests/test_agno_team_patch.py
@@ -1,0 +1,228 @@
+"""Integration tests for MindRoom's vendored Agno Team message patch."""
+# ruff: noqa: D101, D102, D103
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from agno.models.message import Message
+from agno.models.openai.chat import OpenAIChat
+from agno.models.response import ModelResponse
+from agno.run.base import RunContext
+from agno.run.team import TeamRunOutput
+from agno.session.team import TeamSession
+from agno.team import Team, _messages
+from pydantic import BaseModel
+
+from mindroom.history import agno_team_patch
+
+if TYPE_CHECKING:
+    from agno.run.messages import RunMessages
+
+
+@dataclass
+class RecordingOpenAIChat(OpenAIChat):
+    """OpenAI formatter-backed model that records provider-bound messages."""
+
+    formatted_messages: list[dict[str, Any]] = field(default_factory=list)
+    raw_messages: list[Message] = field(default_factory=list)
+
+    def _record(self, messages: list[Message], compress_tool_results: bool) -> None:
+        self.raw_messages = list(messages)
+        self.formatted_messages = self._format_all_messages(messages, compress_tool_results)
+
+    def invoke(self, messages: list[Message], *_args: object, **kwargs: object) -> ModelResponse:
+        self._record(messages, bool(kwargs.get("compress_tool_results", False)))
+        return ModelResponse(content="ok")
+
+    async def ainvoke(self, messages: list[Message], *_args: object, **kwargs: object) -> ModelResponse:
+        self._record(messages, bool(kwargs.get("compress_tool_results", False)))
+        return ModelResponse(content="ok")
+
+
+class ExampleInput(BaseModel):
+    value: str
+
+
+def _team(model: RecordingOpenAIChat) -> Team:
+    return Team(
+        name="patch-team",
+        model=model,
+        members=[],
+        markdown=False,
+        telemetry=False,
+    )
+
+
+async def _patched_run_messages(
+    team: Team,
+    input_message: list[Message],
+    *,
+    use_async: bool,
+) -> RunMessages:
+    run_response = TeamRunOutput(run_id="run", session_id="session")
+    run_context = RunContext(run_id="run", session_id="session")
+    session = TeamSession(session_id="session")
+    if use_async:
+        return await _messages._aget_run_messages(
+            team,
+            run_response=run_response,
+            run_context=run_context,
+            session=session,
+            input_message=input_message,
+        )
+    return _messages._get_run_messages(
+        team,
+        run_response=run_response,
+        run_context=run_context,
+        session=session,
+        input_message=input_message,
+    )
+
+
+def _conversation_messages(model: RecordingOpenAIChat) -> list[dict[str, Any]]:
+    return [
+        message
+        for message in model.formatted_messages
+        if message["role"] in {"user", "assistant"} and message.get("content") != ""
+    ]
+
+
+@pytest.mark.asyncio
+async def test_team_list_message_patch_preserves_roleful_input_through_formatter() -> None:
+    model = RecordingOpenAIChat(id="gpt-test", api_key="sk-test")
+    team = _team(model)
+    historical_answer = Message(role="assistant", content="persisted answer", from_history=True)
+
+    response = await team.arun(
+        [
+            Message(role="user", content="stored question", from_history=True),
+            historical_answer,
+            Message(role="user", content="current question"),
+        ],
+    )
+
+    assert response.content == "ok"
+    assert _conversation_messages(model) == [
+        {"role": "user", "content": "stored question"},
+        {"role": "assistant", "content": "persisted answer"},
+        {"role": "user", "content": "current question"},
+    ]
+    assert historical_answer in model.raw_messages
+    assert historical_answer.from_history is True
+
+
+@pytest.mark.parametrize("use_async", [False, True])
+@pytest.mark.asyncio
+async def test_team_list_message_patch_sets_user_message(use_async: bool) -> None:
+    model = RecordingOpenAIChat(id="gpt-test", api_key="sk-test")
+    team = _team(model)
+    input_message = Message(role="user", content="hi")
+
+    run_messages = await _patched_run_messages(team, [input_message], use_async=use_async)
+
+    assert run_messages.user_message is not None
+    assert run_messages.user_message.content == "hi"
+    assert run_messages.user_message in run_messages.messages
+    assert run_messages.extra_messages == []
+
+
+@pytest.mark.parametrize("use_async", [False, True])
+@pytest.mark.asyncio
+async def test_team_list_message_patch_get_input_messages_includes_roleful_history(use_async: bool) -> None:
+    model = RecordingOpenAIChat(id="gpt-test", api_key="sk-test")
+    team = _team(model)
+    old_question = Message(role="user", content="old")
+    old_answer = Message(role="assistant", content="old")
+    current_question = Message(role="user", content="current")
+
+    run_messages = await _patched_run_messages(
+        team,
+        [old_question, old_answer, current_question],
+        use_async=use_async,
+    )
+
+    assert run_messages.system_message is not None
+    assert run_messages.user_message is current_question
+    assert run_messages.extra_messages == [old_question, old_answer]
+    assert run_messages.get_input_messages() == [
+        run_messages.system_message,
+        current_question,
+        old_question,
+        old_answer,
+    ]
+
+
+@pytest.mark.parametrize("use_async", [False, True])
+@pytest.mark.asyncio
+async def test_team_list_message_patch_preserves_additional_input_separately(use_async: bool) -> None:
+    model = RecordingOpenAIChat(id="gpt-test", api_key="sk-test")
+    additional_input = Message(role="user", content="older context")
+    team = _team(model)
+    team.additional_input = [additional_input]
+    historical_input = Message(role="assistant", content="previous")
+    input_message = Message(role="user", content="current")
+
+    run_messages = await _patched_run_messages(team, [historical_input, input_message], use_async=use_async)
+
+    assert run_messages.user_message is input_message
+    assert input_message in run_messages.messages
+    assert input_message not in run_messages.extra_messages
+    assert run_messages.extra_messages == [historical_input, additional_input]
+
+
+def test_team_list_message_patch_is_idempotent() -> None:
+    patched_sync = _messages._get_run_messages
+    patched_async = _messages._aget_run_messages
+
+    agno_team_patch.apply_patch()
+    agno_team_patch.apply_patch()
+
+    assert _messages._get_run_messages is patched_sync
+    assert _messages._aget_run_messages is patched_async
+
+
+@pytest.mark.parametrize(
+    ("input_message", "expected_content"),
+    [
+        ("plain text", "plain text"),
+        ({"role": "user", "content": "dict text"}, "dict text"),
+        (Message(role="user", content="message text"), "message text"),
+        (ExampleInput(value="model text"), '{\n  "value": "model text"\n}'),
+        ([{"type": "text", "text": "multipart text"}], [{"type": "text", "text": "multipart text"}]),
+    ],
+)
+@pytest.mark.asyncio
+async def test_team_patch_keeps_non_roleful_inputs_on_original_path(
+    input_message: object,
+    expected_content: object,
+) -> None:
+    model = RecordingOpenAIChat(id="gpt-test", api_key="sk-test")
+    team = _team(model)
+
+    await team.arun(input_message)
+
+    conversation = _conversation_messages(model)
+    assert len(conversation) == 1
+    assert conversation[0] == {"role": "user", "content": expected_content}
+
+
+@pytest.mark.asyncio
+async def test_team_patch_produces_separate_provider_blocks_not_flattened_text() -> None:
+    model = RecordingOpenAIChat(id="gpt-test", api_key="sk-test")
+    team = _team(model)
+
+    await team.arun(
+        [
+            Message(role="user", content="first"),
+            Message(role="assistant", content="second"),
+        ],
+    )
+
+    conversation = _conversation_messages(model)
+    assert len(conversation) == 2
+    assert conversation[0]["role"] == "user"
+    assert conversation[1]["role"] == "assistant"
+    assert "second" not in conversation[0]["content"]

--- a/tests/test_agno_team_patch.py
+++ b/tests/test_agno_team_patch.py
@@ -399,6 +399,10 @@ def test_apply_patch_is_idempotent() -> None:
     assert agent_messages.aget_run_messages is patched_agent_async
 
 
+def test_media_content_key_ignores_empty_filepath() -> None:
+    assert agno_team_patch._media_content_key("image", Image(filepath="")) is None
+
+
 @pytest.mark.parametrize(
     ("input_message", "expected_content"),
     [

--- a/tests/test_attachment_media.py
+++ b/tests/test_attachment_media.py
@@ -1,0 +1,125 @@
+"""Regression tests for attachment media conversion."""
+# ruff: noqa: D103
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from agno.media import Image
+from agno.models.message import Message
+from agno.run.messages import RunMessages
+
+from mindroom.attachment_media import (
+    _INLINE_MEDIA_RECORDS_BY_ID,
+    _INLINE_MEDIA_RECORDS_BY_PATH,
+    _MAX_INLINE_MEDIA_RECORDS,
+    _remember_attachment_record,
+    resolve_attachment_media,
+)
+from mindroom.attachments import AttachmentRecord, register_local_attachment
+from mindroom.history.agno_team_patch import _dedupe_run_messages_inline_media
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _clear_inline_media_caches() -> Iterator[None]:
+    _INLINE_MEDIA_RECORDS_BY_ID.clear()
+    _INLINE_MEDIA_RECORDS_BY_PATH.clear()
+    yield
+    _INLINE_MEDIA_RECORDS_BY_ID.clear()
+    _INLINE_MEDIA_RECORDS_BY_PATH.clear()
+
+
+def test_inline_media_record_caches_evict_oldest_entries(tmp_path: Path) -> None:
+    for index in range(_MAX_INLINE_MEDIA_RECORDS + 50):
+        _remember_attachment_record(
+            AttachmentRecord(
+                attachment_id=f"att_{index}",
+                local_path=tmp_path / f"{index}.png",
+                kind="image",
+            ),
+        )
+
+    assert len(_INLINE_MEDIA_RECORDS_BY_ID) == _MAX_INLINE_MEDIA_RECORDS
+    assert len(_INLINE_MEDIA_RECORDS_BY_PATH) == _MAX_INLINE_MEDIA_RECORDS
+    assert list(_INLINE_MEDIA_RECORDS_BY_ID) == [f"att_{index}" for index in range(50, _MAX_INLINE_MEDIA_RECORDS + 50)]
+    assert set(_INLINE_MEDIA_RECORDS_BY_ID).isdisjoint({f"att_{index}" for index in range(50)})
+    assert all(str((tmp_path / f"{index}.png").resolve()) not in _INLINE_MEDIA_RECORDS_BY_PATH for index in range(50))
+
+
+def test_resolve_attachment_media_caches_records_before_partition(tmp_path: Path) -> None:
+    old_path = tmp_path / "old.png"
+    new_path = tmp_path / "new.png"
+    image_bytes = b"\x89PNG\r\n\x1a\nsame"
+    old_path.write_bytes(image_bytes)
+    new_path.write_bytes(image_bytes)
+    old_record = register_local_attachment(
+        tmp_path,
+        old_path,
+        kind="image",
+        attachment_id="att_old_duplicate",
+        mime_type="image/png",
+    )
+    new_record = register_local_attachment(
+        tmp_path,
+        new_path,
+        kind="image",
+        attachment_id="att_new_duplicate",
+        mime_type="image/png",
+    )
+    assert old_record is not None
+    assert new_record is not None
+
+    resolved_ids, _, images, _, _ = resolve_attachment_media(
+        tmp_path,
+        [old_record.attachment_id, new_record.attachment_id],
+        current_attachment_ids={new_record.attachment_id},
+    )
+
+    assert resolved_ids == [old_record.attachment_id, new_record.attachment_id]
+    assert [image.id for image in images] == [new_record.attachment_id]
+    assert _INLINE_MEDIA_RECORDS_BY_ID[old_record.attachment_id].local_path == old_record.local_path
+    assert _INLINE_MEDIA_RECORDS_BY_ID[new_record.attachment_id].local_path == new_record.local_path
+    assert _INLINE_MEDIA_RECORDS_BY_PATH[str(old_record.local_path.resolve())].attachment_id == old_record.attachment_id
+    assert _INLINE_MEDIA_RECORDS_BY_PATH[str(new_record.local_path.resolve())].attachment_id == new_record.attachment_id
+
+    old_message = Message(
+        role="user",
+        images=[
+            Image(
+                id=old_record.attachment_id,
+                filepath=old_record.local_path,
+                mime_type=old_record.mime_type,
+            ),
+        ],
+        from_history=True,
+    )
+    new_message = Message(
+        role="user",
+        images=[
+            Image(
+                id=new_record.attachment_id,
+                filepath=new_record.local_path,
+                mime_type=new_record.mime_type,
+            ),
+        ],
+    )
+    run_messages = RunMessages(
+        messages=[
+            old_message,
+            new_message,
+        ],
+        user_message=new_message,
+    )
+
+    _dedupe_run_messages_inline_media(run_messages)
+
+    assert [image.id for message in run_messages.messages for image in (message.images or [])] == [
+        new_record.attachment_id,
+    ]
+    assert old_message.images == []
+    assert [image.id for image in (new_message.images or [])] == [new_record.attachment_id]

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 from datetime import UTC, datetime, timedelta
@@ -111,6 +112,7 @@ def test_register_resolve_and_convert_attachment(tmp_path: Path) -> None:
     assert loaded is not None
     assert loaded.attachment_id == "att_payload"
     assert loaded.local_path == file_path.resolve()
+    assert loaded.content_sha256 == hashlib.sha256(file_path.read_bytes()).hexdigest()
 
     resolved = resolve_attachments(tmp_path, ["att_payload", "att_missing"])
     assert [record.attachment_id for record in resolved] == ["att_payload"]
@@ -118,6 +120,7 @@ def test_register_resolve_and_convert_attachment(tmp_path: Path) -> None:
     resolved_ids, _, _, files, videos = resolve_attachment_media(tmp_path, ["att_payload"])
     assert resolved_ids == ["att_payload"]
     assert len(files) == 1
+    assert files[0].id == "att_payload"
     assert files[0].filename == "payload.zip"
     assert str(files[0].filepath) == str(file_path.resolve())
     assert videos == []
@@ -174,6 +177,7 @@ def test_resolve_attachment_media_includes_images(tmp_path: Path) -> None:
     assert resolved_ids == ["att_image"]
     assert audio == []
     assert len(images) == 1
+    assert images[0].id == "att_image"
     assert str(images[0].filepath) == str(image_path.resolve())
     assert files == []
     assert videos == []

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import threading
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -14,8 +15,11 @@ import pytest
 
 from mindroom.attachment_media import resolve_attachment_media
 from mindroom.attachments import (
+    AttachmentRecord,
     _attachment_id_for_event,
+    _AttachmentKind,
     _register_image_attachment,
+    _register_media_attachment,
     filter_attachments_for_context,
     format_attachment_ids_prompt,
     load_attachment,
@@ -153,6 +157,56 @@ async def test_register_image_attachment_uses_detected_mime_type(tmp_path: Path)
     assert record is not None
     assert record.mime_type == "image/png"
     assert record.local_path.suffix == ".png"
+
+
+@pytest.mark.asyncio
+async def test_register_media_attachment_offloads_registration_work(tmp_path: Path) -> None:
+    """Matrix media registration should not hash files on the event loop."""
+    loop_thread_id = threading.get_ident()
+    registration_thread_ids: list[int] = []
+
+    def fake_register_local_attachment(
+        _storage_path: Path,
+        local_path: Path,
+        *,
+        kind: _AttachmentKind,
+        attachment_id: str | None = None,
+        filename: str | None = None,
+        mime_type: str | None = None,
+        room_id: str | None = None,
+        thread_id: str | None = None,
+        source_event_id: str | None = None,
+        sender: str | None = None,
+    ) -> AttachmentRecord:
+        registration_thread_ids.append(threading.get_ident())
+        return AttachmentRecord(
+            attachment_id=attachment_id or "att_generated",
+            local_path=local_path,
+            kind=kind,
+            filename=filename,
+            mime_type=mime_type,
+            room_id=room_id,
+            thread_id=thread_id,
+            source_event_id=source_event_id,
+            sender=sender,
+        )
+
+    with patch("mindroom.attachments.register_local_attachment", side_effect=fake_register_local_attachment):
+        record = await _register_media_attachment(
+            storage_path=tmp_path,
+            event_id="$media_event",
+            media_bytes=b"media-bytes",
+            mime_type="application/octet-stream",
+            room_id="!room:localhost",
+            thread_id="$thread",
+            sender="@user:localhost",
+            filename="payload.bin",
+            kind="file",
+        )
+
+    assert record is not None
+    assert registration_thread_ids
+    assert registration_thread_ids[0] != loop_thread_id
 
 
 def test_resolve_attachment_media_includes_images(tmp_path: Path) -> None:

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -112,6 +112,7 @@ def test_register_resolve_and_convert_attachment(tmp_path: Path) -> None:
     assert loaded is not None
     assert loaded.attachment_id == "att_payload"
     assert loaded.local_path == file_path.resolve()
+    assert loaded.size_bytes == len(b"PK\x03\x04")
     assert loaded.content_sha256 == hashlib.sha256(file_path.read_bytes()).hexdigest()
 
     resolved = resolve_attachments(tmp_path, ["att_payload", "att_missing"])

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -3559,6 +3559,9 @@ async def test_dispatch_payload_registers_unregistered_image_from_thread_history
         f"Available attachment IDs: {attachment_id}. Use tool calls to inspect or process them."
     )
     assert len(payload.media.images) == 1
+    assert payload.media.audio == ()
+    assert payload.media.files == ()
+    assert payload.media.videos == ()
     record = load_attachment(tmp_path, attachment_id)
     assert record is not None
     assert record.source_event_id == "$img-history"

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -12,7 +12,7 @@ from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass, replace
 from datetime import datetime
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any, Self, cast
+from typing import TYPE_CHECKING, Any, Literal, Self, cast
 from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
 from zoneinfo import ZoneInfo
 
@@ -776,6 +776,75 @@ def _visible_message(
         event_id=event_id,
         timestamp=timestamp,
         content=content,
+    )
+
+
+_MediaKind = Literal["audio", "image", "file", "video"]
+_MEDIA_MIME_TYPES: dict[_MediaKind, str] = {
+    "audio": "audio/wav",
+    "image": "image/png",
+    "file": "text/plain",
+    "video": "video/mp4",
+}
+
+
+def _payload_media_for_kind(payload: DispatchPayload, kind: _MediaKind) -> Sequence[Any]:
+    return {
+        "audio": payload.media.audio,
+        "image": payload.media.images,
+        "file": payload.media.files,
+        "video": payload.media.videos,
+    }[kind]
+
+
+def _register_payload_media_attachment(
+    storage_path: Path,
+    *,
+    kind: _MediaKind = "image",
+    attachment_id: str,
+    filename: str,
+    content: bytes | None = None,
+    local_path: Path | None = None,
+    room_id: str = "!test:localhost",
+    thread_id: str | None = "$thread",
+) -> str:
+    """Register one resolvable media attachment and return its local filepath."""
+    media_path = local_path or storage_path / filename
+    media_path.parent.mkdir(parents=True, exist_ok=True)
+    if local_path is None:
+        media_path.write_bytes(content or (b"media:" + attachment_id.encode("utf-8")))
+    record = register_local_attachment(
+        storage_path,
+        media_path,
+        kind=kind,
+        attachment_id=attachment_id,
+        filename=filename,
+        mime_type=_MEDIA_MIME_TYPES[kind],
+        room_id=room_id,
+        thread_id=thread_id,
+        source_event_id=f"${attachment_id}",
+        sender="@user:localhost",
+    )
+    assert record is not None
+    return str(record.local_path)
+
+
+def _register_payload_image_attachment(
+    storage_path: Path,
+    *,
+    attachment_id: str,
+    filename: str,
+    room_id: str = "!test:localhost",
+    thread_id: str | None = "$thread",
+) -> str:
+    return _register_payload_media_attachment(
+        storage_path,
+        kind="image",
+        attachment_id=attachment_id,
+        filename=filename,
+        content=b"\x89PNG\r\n\x1a\n" + attachment_id.encode("utf-8"),
+        room_id=room_id,
+        thread_id=thread_id,
     )
 
 
@@ -7811,20 +7880,21 @@ class TestAgentBot:
             ),
             patch(
                 "mindroom.inbound_turn_normalizer.resolve_attachment_media",
-                return_value=(
-                    [current_attachment_id, history_attachment_id],
-                    [],
-                    [image],
-                    [],
-                    [],
-                ),
+                return_value=([current_attachment_id, history_attachment_id], [], [image], [], []),
             ) as mock_resolve_media,
         ):
             await bot._on_media_message(room, event)
             await drain_coalescing(bot)
 
-        mock_resolve_media.assert_called_once()
-        assert mock_resolve_media.call_args.args[1] == [current_attachment_id, history_attachment_id]
+        assert mock_resolve_media.call_args_list == [
+            call(
+                tmp_path,
+                [current_attachment_id, history_attachment_id],
+                room_id="!test:localhost",
+                thread_id="$thread_root",
+                current_attachment_ids={current_attachment_id},
+            ),
+        ]
 
         bot._generate_response.assert_awaited_once()
         generate_kwargs = bot._generate_response.await_args.kwargs
@@ -7847,6 +7917,238 @@ class TestAgentBot:
             ),
         )
 
+    @pytest.mark.parametrize("kind", ["audio", "image", "file", "video"])
+    @pytest.mark.asyncio
+    async def test_dispatch_payload_inline_media_dedupes_same_content_across_history(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+        kind: _MediaKind,
+    ) -> None:
+        """Inline media should keep one copy while IDs stay thread/history-scoped."""
+        config = self._config_for_storage(tmp_path)
+        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        bot.client = _make_matrix_client_mock()
+        current_attachment_id = f"att_current_{kind}"
+        thread_attachment_id = f"att_thread_{kind}"
+        history_attachment_id = f"att_history_{kind}"
+        same_content = b"same media bytes"
+        current_path = _register_payload_media_attachment(
+            tmp_path,
+            kind=kind,
+            attachment_id=current_attachment_id,
+            filename=f"current-{kind}.bin",
+            content=same_content,
+        )
+        _register_payload_media_attachment(
+            tmp_path,
+            kind=kind,
+            attachment_id=thread_attachment_id,
+            filename=f"thread-{kind}.bin",
+            content=same_content,
+        )
+        _register_payload_media_attachment(
+            tmp_path,
+            kind=kind,
+            attachment_id=history_attachment_id,
+            filename=f"history-{kind}.bin",
+            content=same_content,
+        )
+        thread_history = [
+            _visible_message(
+                sender="@user:localhost",
+                event_id="$history",
+                content={ATTACHMENT_IDS_KEY: [history_attachment_id]},
+            ),
+        ]
+
+        with patch(
+            "mindroom.inbound_turn_normalizer.resolve_thread_attachment_ids",
+            new_callable=AsyncMock,
+            return_value=[thread_attachment_id],
+        ):
+            payload = await bot._inbound_turn_normalizer.build_dispatch_payload_with_attachments(
+                DispatchPayloadWithAttachmentsRequest(
+                    room_id="!test:localhost",
+                    prompt="describe this",
+                    current_attachment_ids=[current_attachment_id],
+                    thread_id="$thread",
+                    media_thread_id="$thread",
+                    thread_history=thread_history,
+                ),
+            )
+
+        inline_media = _payload_media_for_kind(payload, kind)
+        assert len(inline_media) == 1
+        assert inline_media[0].id == current_attachment_id
+        assert inline_media[0].filepath == current_path
+        assert payload.attachment_ids == [current_attachment_id, thread_attachment_id, history_attachment_id]
+
+    @pytest.mark.asyncio
+    async def test_dispatch_payload_inline_media_distinct_content_all_kept(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """Distinct images should each remain inline across current, thread, and history."""
+        config = self._config_for_storage(tmp_path)
+        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        bot.client = _make_matrix_client_mock()
+        current_attachment_id = "att_current_image"
+        thread_attachment_id = "att_thread_image"
+        history_attachment_id = "att_history_image"
+        current_path = _register_payload_image_attachment(
+            tmp_path,
+            attachment_id=current_attachment_id,
+            filename="current.png",
+        )
+        thread_path = _register_payload_image_attachment(
+            tmp_path,
+            attachment_id=thread_attachment_id,
+            filename="thread.png",
+        )
+        history_path = _register_payload_image_attachment(
+            tmp_path,
+            attachment_id=history_attachment_id,
+            filename="history.png",
+        )
+        thread_history = [
+            _visible_message(
+                sender="@user:localhost",
+                event_id="$history",
+                content={ATTACHMENT_IDS_KEY: [history_attachment_id]},
+            ),
+        ]
+
+        with patch(
+            "mindroom.inbound_turn_normalizer.resolve_thread_attachment_ids",
+            new_callable=AsyncMock,
+            return_value=[thread_attachment_id],
+        ):
+            payload = await bot._inbound_turn_normalizer.build_dispatch_payload_with_attachments(
+                DispatchPayloadWithAttachmentsRequest(
+                    room_id="!test:localhost",
+                    prompt="describe these",
+                    current_attachment_ids=[current_attachment_id],
+                    thread_id="$thread",
+                    media_thread_id="$thread",
+                    thread_history=thread_history,
+                ),
+            )
+
+        inline_image_paths = [image.filepath for image in payload.media.images]
+        assert inline_image_paths == [current_path, thread_path, history_path]
+        assert payload.attachment_ids == [current_attachment_id, thread_attachment_id, history_attachment_id]
+
+    @pytest.mark.asyncio
+    async def test_dispatch_payload_inline_media_current_event_wins_over_history_duplicate(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """The current event's media copy should be the inline representative for duplicates."""
+        config = self._config_for_storage(tmp_path)
+        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        bot.client = _make_matrix_client_mock()
+        current_attachment_id = "att_current_duplicate"
+        history_attachment_id = "att_history_duplicate"
+        same_content = b"\x89PNG\r\n\x1a\nsame"
+        current_path = _register_payload_media_attachment(
+            tmp_path,
+            kind="image",
+            attachment_id=current_attachment_id,
+            filename="current-wins.png",
+            content=same_content,
+        )
+        _register_payload_media_attachment(
+            tmp_path,
+            kind="image",
+            attachment_id=history_attachment_id,
+            filename="history-duplicate.png",
+            content=same_content,
+        )
+        thread_history = [
+            _visible_message(
+                sender="@user:localhost",
+                event_id="$history",
+                content={ATTACHMENT_IDS_KEY: [history_attachment_id]},
+            ),
+        ]
+
+        payload = await bot._inbound_turn_normalizer.build_dispatch_payload_with_attachments(
+            DispatchPayloadWithAttachmentsRequest(
+                room_id="!test:localhost",
+                prompt="describe this",
+                current_attachment_ids=[current_attachment_id],
+                thread_id=None,
+                media_thread_id="$thread",
+                thread_history=thread_history,
+            ),
+        )
+
+        assert len(payload.media.images) == 1
+        assert payload.media.images[0].id == current_attachment_id
+        assert payload.media.images[0].filepath == current_path
+        assert payload.attachment_ids == [current_attachment_id, history_attachment_id]
+
+    @pytest.mark.asyncio
+    async def test_dispatch_payload_inline_media_empty_when_no_attachments(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """Payloads without attachments should have empty inline media and no tool-visible IDs."""
+        config = self._config_for_storage(tmp_path)
+        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        bot.client = _make_matrix_client_mock()
+
+        payload = await bot._inbound_turn_normalizer.build_dispatch_payload_with_attachments(
+            DispatchPayloadWithAttachmentsRequest(
+                room_id="!test:localhost",
+                prompt="check in",
+                current_attachment_ids=[],
+                thread_id=None,
+                media_thread_id=None,
+                thread_history=[],
+            ),
+        )
+
+        assert payload.media.images == ()
+        assert payload.media.audio == ()
+        assert payload.media.files == ()
+        assert payload.media.videos == ()
+        assert payload.attachment_ids is None
+
+    @pytest.mark.asyncio
+    async def test_dispatch_payload_fallback_images_preserved(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """Fallback images should still populate inline media when no current IDs resolve."""
+        config = self._config_for_storage(tmp_path)
+        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        bot.client = _make_matrix_client_mock()
+        fallback_image = Image(content=b"\x89PNG\r\n\x1a\nfallback", mime_type="image/png")
+
+        payload = await bot._inbound_turn_normalizer.build_dispatch_payload_with_attachments(
+            DispatchPayloadWithAttachmentsRequest(
+                room_id="!test:localhost",
+                prompt="describe fallback",
+                current_attachment_ids=[],
+                thread_id=None,
+                media_thread_id=None,
+                thread_history=[],
+                fallback_images=[fallback_image],
+            ),
+        )
+
+        assert list(payload.media.images) == [fallback_image]
+        assert payload.media.audio == ()
+        assert payload.media.files == ()
+        assert payload.media.videos == ()
+        assert payload.attachment_ids is None
+
     @pytest.mark.asyncio
     async def test_build_dispatch_payload_merges_fallback_images_with_registered_attachments(
         self,
@@ -7857,8 +8159,8 @@ class TestAgentBot:
         config = self._config_for_storage(tmp_path)
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = _make_matrix_client_mock()
-        stored_image = MagicMock(spec=Image)
-        fallback_image = MagicMock(spec=Image)
+        stored_image = Image(content=b"\x89PNG\r\n\x1a\nstored", mime_type="image/png")
+        fallback_image = Image(content=b"\x89PNG\r\n\x1a\nfallback", mime_type="image/png")
 
         with (
             patch(
@@ -7900,7 +8202,7 @@ class TestAgentBot:
         config = self._config_for_storage(tmp_path)
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = _make_matrix_client_mock()
-        stored_image = MagicMock(spec=Image)
+        stored_image = Image(content=b"\x89PNG\r\n\x1a\nstored", mime_type="image/png")
 
         with (
             patch(


### PR DESCRIPTION
## Summary
- Cherry-pick ISSUE-222 inline media content dedupe scoped to current events
- Cherry-pick ISSUE-223 Agno run-message replay dedupe for team/history payloads

## Verification
- `uv sync --all-extras`
- `uv run pytest tests/test_agno_team_patch.py tests/test_attachment_media.py tests/test_attachments.py tests/test_multi_agent_bot.py tests/test_live_message_coalescing.py -q` (468 passed, 4 skipped)
- `uv run tach check --dependencies --interfaces`
- `uv run pytest` (7173 passed, 29 skipped)
- `uv run pre-commit run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline-media de-duplication with caching to avoid duplicate images/files across history; current event attachments take precedence.
  * Resolved media now include stable IDs for more reliable delivery.

* **Bug Fixes**
  * File-attachment fallback refined to avoid incorrect MIME handling.

* **Tests**
  * New and updated tests covering inline-media dedupe, caching, and patched history formatting/behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->