### PR TITLE
Simplify active follow-up backlog handling

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -71,6 +71,7 @@ from .agents import create_agent, get_rooms_for_entity, show_tool_calls_for_agen
 from .authorization import is_authorized_sender
 from .background_tasks import create_background_task, wait_for_background_tasks
 from .coalescing import CoalescingGate
+from .coalescing_batch import CoalescingKey, is_active_follow_up_coalescing_key
 from .commands import config_confirmation
 from .constants import ROUTER_AGENT_NAME, RuntimePaths, resolve_avatar_path
 from .conversation_resolver import ConversationResolver, ConversationResolverDeps
@@ -372,6 +373,7 @@ class AgentBot:
             debounce_seconds=lambda: self.config.defaults.coalescing.debounce_ms / 1000,
             upload_grace_seconds=lambda: self.config.defaults.coalescing.upload_grace_ms / 1000,
             is_shutting_down=lambda: self._sync_shutting_down,
+            wait_until_dispatch_allowed=self._wait_until_coalesced_dispatch_allowed,
         )
         self._hook_context_support = HookContextSupport(
             runtime=self._runtime_view,
@@ -517,6 +519,12 @@ class AgentBot:
                 edit_regenerator=self._edit_regenerator,
             ),
         )
+
+    async def _wait_until_coalesced_dispatch_allowed(self, key: CoalescingKey) -> None:
+        """Hold active follow-up dispatch until the response lock for its target is idle."""
+        if not is_active_follow_up_coalescing_key(key):
+            return
+        await self._response_runner.wait_for_thread_response_idle(key.room_id, key.thread_id)
 
     def _rebuild_runtime_components_after_login_if_identity_changed(self, matrix_id_before_login: MatrixID) -> None:
         """Refresh startup collaborators when Matrix login authenticates as a different user."""

--- a/src/mindroom/coalescing.py
+++ b/src/mindroom/coalescing.py
@@ -14,6 +14,7 @@ from .coalescing_batch import (
     CoalescingKey,
     PendingEvent,
     build_coalesced_batch,
+    is_active_follow_up_coalescing_key,
 )
 from .coalescing_cleanup import (
     ClaimedSegmentOwner,
@@ -1380,6 +1381,44 @@ class CoalescingGate:
         if not gate.queue:
             gate.drain_all_requested = False
 
+    async def _dispatch_active_follow_up_backlog(self, key: CoalescingKey, gate: _GateEntry) -> bool:
+        """Dispatch the post-idle active-response backlog as one receive-ordered batch."""
+        if not is_active_follow_up_coalescing_key(key):
+            return False
+        front = gate.queue[0]
+        if self._queued_kind(front) is not QueueKind.NORMAL:
+            return False
+
+        backlog_max_order = self._order_book.next_received_order
+        backlog_reservations = self._order_book.unsettled_owner_reservations_in_window(
+            key,
+            after_order=front.received_order,
+            before_order=backlog_max_order + 1,
+            before_or_at_receipt_time=float("inf"),
+        )
+        if backlog_reservations:
+            await self._wait_for_reservations(gate, backlog_reservations)
+            return True
+
+        candidate_count = self._claimable_front_normal_run_length(
+            key,
+            gate,
+            coalesce_normal_events=True,
+            max_received_order=backlog_max_order,
+        )
+        if candidate_count == 0:
+            return False
+
+        claimed_admissions = self._claim_front_events(gate, candidate_count)
+        await self._dispatch_claim(
+            key,
+            gate,
+            claimed_admissions,
+            bypass_grace=True,
+            allow_upload_grace=False,
+        )
+        return True
+
     async def _drain_gate_iteration(self, key: CoalescingKey, gate: _GateEntry) -> None:
         front = gate.queue[0]
         await self._wait_until_front_claimable(key, gate, front_order=front.received_order)
@@ -1392,6 +1431,9 @@ class CoalescingGate:
 
         front = gate.queue[0]
         if await self._dispatch_front_barrier(key, gate, self._queued_kind(front)):
+            return
+
+        if await self._dispatch_active_follow_up_backlog(key, gate):
             return
 
         debounce_result = await self._wait_for_debounce(

--- a/src/mindroom/coalescing.py
+++ b/src/mindroom/coalescing.py
@@ -229,7 +229,7 @@ class CoalescingGate:
 
     def _remove_gate(self, key: CoalescingKey) -> None:
         self._gates.pop(key, None)
-        self._wake_owner_gates(key)
+        self._wake_related_gates(key)
 
     def _get_or_create_gate(self, key: CoalescingKey) -> _GateEntry:
         gate = self._gates.get(key)
@@ -266,6 +266,32 @@ class CoalescingGate:
             if other_key != key and self._same_owner(other_key, key):
                 self._wake(other_gate)
 
+    def _wake_room_gates(self, key: CoalescingKey) -> None:
+        for other_key, other_gate in self._gates.items():
+            if other_key != key and other_key.room_id == key.room_id:
+                self._wake(other_gate)
+
+    def _wake_related_gates(self, key: CoalescingKey) -> None:
+        self._wake_owner_gates(key)
+        if is_active_follow_up_coalescing_key(key):
+            self._wake_room_gates(key)
+
+    @staticmethod
+    def _gate_has_work_before(
+        gate: _GateEntry,
+        *,
+        before_order: int,
+        source_event_id: str | None = None,
+    ) -> bool:
+        def matches(queued: _QueuedEvent) -> bool:
+            return queued.received_order < before_order and (
+                source_event_id is None or queued.source_event_id == source_event_id
+            )
+
+        return any(matches(queued) for queued in gate.queue) or any(
+            matches(claimed) for claimed in gate.claimed_admissions
+        )
+
     def _older_owner_root_gates(
         self,
         key: CoalescingKey,
@@ -280,16 +306,28 @@ class CoalescingGate:
             if gate_key != key
             and self._same_owner(gate_key, key)
             and gate_key.thread_id is None
-            and (
-                any(
-                    queued.received_order < before_order and queued.source_event_id == key.thread_id
-                    for queued in gate.queue
-                )
-                or any(
-                    claimed.received_order < before_order and claimed.source_event_id == key.thread_id
-                    for claimed in gate.claimed_admissions
-                )
-            )
+            and self._gate_has_work_before(gate, before_order=before_order, source_event_id=key.thread_id)
+        ]
+
+    def _older_room_active_follow_up_gates(
+        self,
+        key: CoalescingKey,
+        *,
+        before_order: int,
+    ) -> list[_GateEntry]:
+        return [
+            gate
+            for gate_key, gate in self._gates.items()
+            if gate_key != key
+            and gate_key.room_id == key.room_id
+            and is_active_follow_up_coalescing_key(gate_key)
+            and self._gate_has_work_before(gate, before_order=before_order)
+        ]
+
+    def _older_gate_blockers(self, key: CoalescingKey, *, before_order: int) -> list[_GateEntry]:
+        return [
+            *self._older_owner_root_gates(key, before_order=before_order),
+            *self._older_room_active_follow_up_gates(key, before_order=before_order),
         ]
 
     async def _wait_until_front_claimable(
@@ -309,13 +347,13 @@ class CoalescingGate:
                 gate,
                 self._order_book.older_owner_reservations(key, before_order=front_order),
             )
-            older_gates = self._older_owner_root_gates(key, before_order=front_order)
-            if not older_gates:
+            blockers = self._older_gate_blockers(key, before_order=front_order)
+            if not blockers:
                 return
             wake_generation = gate.wake_generation
             gate.wake_event.clear()
-            older_gates = self._older_owner_root_gates(key, before_order=front_order)
-            if not older_gates or gate.wake_generation != wake_generation:
+            blockers = self._older_gate_blockers(key, before_order=front_order)
+            if not blockers or gate.wake_generation != wake_generation:
                 continue
             await gate.wake_event.wait()
 
@@ -753,7 +791,7 @@ class CoalescingGate:
         )
         self._insert_queued_event(gate, admission)
         self._schedule_drain(key, gate)
-        self._wake_owner_gates(key)
+        self._wake_related_gates(key)
         kind = self._queued_kind(admission)
         path = self._enqueue_path(kind)
         if ready_result is not None:
@@ -1188,7 +1226,7 @@ class CoalescingGate:
             gate.phase = GatePhase.DEBOUNCE
             gate.grace_deadline = None
             gate.deadline = None
-            self._wake_owner_gates(key)
+            self._wake_related_gates(key)
 
     async def _dispatch_claimed_events(
         self,
@@ -1327,7 +1365,7 @@ class CoalescingGate:
             raise
         finally:
             self._clear_claimed_admissions(gate, admissions)
-            self._wake_owner_gates(key)
+            self._wake_related_gates(key)
 
     async def _dispatch_front_barrier(
         self,
@@ -1395,11 +1433,10 @@ class CoalescingGate:
             return False
 
         backlog_max_order = self._order_book.next_received_order
-        backlog_reservations = self._order_book.unsettled_owner_reservations_in_window(
+        backlog_reservations = self._order_book.unsettled_room_reservations_in_window(
             key,
             after_order=front.received_order,
             before_order=backlog_max_order + 1,
-            before_or_at_receipt_time=float("inf"),
         )
         if backlog_reservations:
             await self._wait_for_reservations(gate, backlog_reservations)

--- a/src/mindroom/coalescing.py
+++ b/src/mindroom/coalescing.py
@@ -56,6 +56,10 @@ _COALESCING_FLUSH_WARNING_SECONDS = 5.0
 logger = get_logger(__name__)
 
 
+async def _allow_dispatch(_key: CoalescingKey) -> None:
+    return
+
+
 class GatePhase(enum.Enum):
     """Lifecycle phases for one coalescing gate."""
 
@@ -211,11 +215,13 @@ class CoalescingGate:
         debounce_seconds: Callable[[], float],
         upload_grace_seconds: Callable[[], float],
         is_shutting_down: Callable[[], bool],
+        wait_until_dispatch_allowed: Callable[[CoalescingKey], Awaitable[None]] | None = None,
     ) -> None:
         self._dispatch_batch = dispatch_batch
         self._debounce_seconds = debounce_seconds
         self._upload_grace_seconds = upload_grace_seconds
         self._is_shutting_down = is_shutting_down
+        self._wait_until_dispatch_allowed = wait_until_dispatch_allowed or _allow_dispatch
         self._gates: dict[CoalescingKey, _GateEntry] = {}
         self._order_book = CoalescingOrderBook()
         self._active_drain_context: _DrainContext | None = None
@@ -407,6 +413,14 @@ class CoalescingGate:
         )
         self._wake_owner(room_id, requester_user_id)
         return reservation
+
+    def retarget_order_reservation(self, reservation: IngressOrderReservation, *, requester_user_id: str) -> None:
+        """Move an unsettled receive-order reservation to another owner key."""
+        previous_requester_user_id = reservation.requester_user_id
+        if not self._order_book.retarget(reservation, requester_user_id=requester_user_id):
+            return
+        self._wake_owner(reservation.room_id, previous_requester_user_id)
+        self._wake_owner(reservation.room_id, requester_user_id)
 
     def release_order_reservation(self, reservation: IngressOrderReservation) -> None:
         """Release a receive-order reservation that will not become a queued admission."""
@@ -1369,6 +1383,10 @@ class CoalescingGate:
     async def _drain_gate_iteration(self, key: CoalescingKey, gate: _GateEntry) -> None:
         front = gate.queue[0]
         await self._wait_until_front_claimable(key, gate, front_order=front.received_order)
+        if not gate.queue:
+            return
+
+        await self._wait_until_dispatch_allowed(key)
         if not gate.queue:
             return
 

--- a/src/mindroom/coalescing.py
+++ b/src/mindroom/coalescing.py
@@ -1425,7 +1425,9 @@ class CoalescingGate:
         if not gate.queue:
             return
 
-        await self._wait_until_dispatch_allowed(key)
+        drain_context = self._current_drain_context(gate)
+        if not (self._is_shutting_down() or self._is_bounded_drain(drain_context)):
+            await self._wait_until_dispatch_allowed(key)
         if not gate.queue:
             return
 

--- a/src/mindroom/coalescing.py
+++ b/src/mindroom/coalescing.py
@@ -167,7 +167,6 @@ class _GateEntry:
     grace_deadline: float | None = None
     drain_all_requested: bool = False
     drain_context: _DrainContext | None = None
-    buffered_in_flight_max_order: int | None = None
 
 
 @dataclass(frozen=True)
@@ -219,7 +218,6 @@ class CoalescingGate:
         self._is_shutting_down = is_shutting_down
         self._gates: dict[CoalescingKey, _GateEntry] = {}
         self._order_book = CoalescingOrderBook()
-        self._in_flight_buffered_max_order: dict[CoalescingKey, int] = {}
         self._active_drain_context: _DrainContext | None = None
 
     def _remove_gate(self, key: CoalescingKey) -> None:
@@ -332,57 +330,6 @@ class CoalescingGate:
                 self._release_unsettled_reservations(unsettled, drain_context.result)
                 return
 
-    def _set_buffered_in_flight_max_order(
-        self,
-        key: CoalescingKey,
-        gate: _GateEntry,
-        *,
-        after_order: int,
-    ) -> None:
-        buffered_orders = [queued.received_order for queued in gate.queue if queued.received_order > after_order]
-        buffered_orders.extend(
-            self._order_book.unsettled_owner_reservation_orders_after(key, after_order=after_order),
-        )
-        gate.buffered_in_flight_max_order = max(buffered_orders, default=None)
-        if gate.buffered_in_flight_max_order is None:
-            self._in_flight_buffered_max_order.pop(key, None)
-        else:
-            self._in_flight_buffered_max_order[key] = gate.buffered_in_flight_max_order
-
-    def _set_related_root_followup_buffered_orders(
-        self,
-        key: CoalescingKey,
-        pending_events: list[PendingEvent],
-        *,
-        after_order: int,
-    ) -> None:
-        if key.thread_id is not None:
-            return
-        source_event_ids = {pending_event.event.event_id for pending_event in pending_events}
-        related_keys = {
-            CoalescingKey(key.room_id, source_event_id, key.requester_user_id) for source_event_id in source_event_ids
-        }
-        buffered_orders = self._order_book.unsettled_owner_reservation_orders_after(key, after_order=after_order)
-        if buffered_orders:
-            buffered_max_order = max(buffered_orders)
-            for related_key in related_keys:
-                existing_max_order = self._in_flight_buffered_max_order.get(related_key)
-                self._in_flight_buffered_max_order[related_key] = max(
-                    existing_max_order or buffered_max_order,
-                    buffered_max_order,
-                )
-        for other_key, other_gate in self._gates.items():
-            if other_key in related_keys:
-                self._set_buffered_in_flight_max_order(other_key, other_gate, after_order=after_order)
-
-    def _prune_in_flight_buffered_orders(self) -> None:
-        """Drop buffered markers whose reservations settled without creating that gate."""
-        for key, buffered_max_order in list(self._in_flight_buffered_max_order.items()):
-            if key in self._gates:
-                continue
-            if not self._order_book.has_unsettled_owner_reservation_at_or_before(key, buffered_max_order):
-                self._in_flight_buffered_max_order.pop(key, None)
-
     @staticmethod
     def _oldest_pending_age_ms(gate: _GateEntry) -> float | None:
         pending = [*gate.claimed_admissions, *gate.queue]
@@ -409,7 +356,6 @@ class CoalescingGate:
     @staticmethod
     def _claim_front_events(gate: _GateEntry, count: int) -> list[_QueuedEvent]:
         gate.claimed_admissions = [gate.queue.popleft() for _ in range(count)]
-        gate.buffered_in_flight_max_order = None
         return gate.claimed_admissions
 
     @staticmethod
@@ -465,7 +411,6 @@ class CoalescingGate:
     def release_order_reservation(self, reservation: IngressOrderReservation) -> None:
         """Release a receive-order reservation that will not become a queued admission."""
         self._release_order_reservation(reservation, wake=True)
-        self._prune_in_flight_buffered_orders()
 
     def _release_order_reservation(self, reservation: IngressOrderReservation, *, wake: bool) -> None:
         if not self._order_book.release(reservation):
@@ -483,7 +428,6 @@ class CoalescingGate:
                 continue
             self._release_order_reservation(reservation, wake=True)
             drain_result.released_reservation_count += 1
-        self._prune_in_flight_buffered_orders()
 
     async def _wait_for_order_reservations_for_drain(self, drain_context: _DrainContext) -> None:
         while True:
@@ -595,13 +539,10 @@ class CoalescingGate:
         latest_receipt_time = gate.queue[0].receipt_time
         if not coalesce_normal_events:
             return latest_receipt_time
-        buffered_in_flight_max_order = gate.buffered_in_flight_max_order
         for queued in list(gate.queue)[1:]:
             if CoalescingGate._queued_kind(queued) is not QueueKind.NORMAL:
                 break
-            if (
-                buffered_in_flight_max_order is None or queued.received_order > buffered_in_flight_max_order
-            ) and queued.receipt_time > latest_receipt_time + debounce_seconds:
+            if queued.receipt_time > latest_receipt_time + debounce_seconds:
                 break
             latest_receipt_time = queued.receipt_time
         return latest_receipt_time
@@ -780,12 +721,6 @@ class CoalescingGate:
             resolved_received_at = received_at if received_at is not None else time.time()
             receipt_time = order_reservation.receipt_time
             self._release_order_reservation(order_reservation, wake=False)
-        buffered_max_order = self._in_flight_buffered_max_order.get(key)
-        if buffered_max_order is not None and received_order <= buffered_max_order:
-            gate.buffered_in_flight_max_order = max(
-                gate.buffered_in_flight_max_order or buffered_max_order,
-                buffered_max_order,
-            )
         admission = _QueuedEvent(
             admission_key=key,
             received_order=received_order,
@@ -797,7 +732,6 @@ class CoalescingGate:
             ready_result=ready_result,
         )
         self._insert_queued_event(gate, admission)
-        self._prune_in_flight_buffered_orders()
         self._schedule_drain(key, gate)
         self._wake_owner_gates(key)
         kind = self._queued_kind(admission)
@@ -1181,9 +1115,8 @@ class CoalescingGate:
         *,
         bypass_grace: bool,
     ) -> str:
-        """Dispatch a claimed batch while buffering new ingress on the same gate."""
+        """Dispatch a claimed batch."""
         flush_start = time.monotonic()
-        in_flight_start_order = self._order_book.next_received_order
         gate.phase = GatePhase.IN_FLIGHT
         gate.deadline = None
         gate.grace_deadline = None
@@ -1233,8 +1166,6 @@ class CoalescingGate:
                 outcome=outcome,
             )
             gate.phase = GatePhase.DEBOUNCE
-            self._set_buffered_in_flight_max_order(key, gate, after_order=in_flight_start_order)
-            self._set_related_root_followup_buffered_orders(key, pending_events, after_order=in_flight_start_order)
             gate.grace_deadline = None
             gate.deadline = None
             self._wake_owner_gates(key)
@@ -1276,7 +1207,6 @@ class CoalescingGate:
             after_order=front.received_order,
             before_order=grace_result.before_order,
             before_or_at_receipt_time=grace_result.quiet_deadline,
-            buffered_in_flight_max_order=gate.buffered_in_flight_max_order,
         )
         if same_window_reservations:
             await self._wait_for_reservations(gate, same_window_reservations)
@@ -1409,7 +1339,6 @@ class CoalescingGate:
             after_order=front.received_order,
             before_order=debounce_result.before_order,
             before_or_at_receipt_time=debounce_result.quiet_deadline,
-            buffered_in_flight_max_order=gate.buffered_in_flight_max_order,
         )
         if same_window_reservations:
             await self._wait_for_reservations(gate, same_window_reservations)
@@ -1479,8 +1408,6 @@ class CoalescingGate:
                 current_gate.drain_task = None
             if self._gate_work_count(current_gate) == 0:
                 self._remove_gate(key)
-                if not self._order_book.unsettled_owner_reservation_orders_after(key, after_order=0):
-                    self._in_flight_buffered_max_order.pop(key, None)
             elif outcome in {"failed", "cancelled"} and not self._is_shutting_down():
                 self._ensure_drain_task(key, current_gate)
                 self._wake(current_gate)
@@ -1653,4 +1580,3 @@ class _CoalescingDrainCoordinator:
             self._clear_context()
             if drain_completed:
                 self.gate._gates.clear()
-                self.gate._in_flight_buffered_max_order.clear()

--- a/src/mindroom/coalescing.py
+++ b/src/mindroom/coalescing.py
@@ -256,6 +256,10 @@ class CoalescingGate:
     def _same_owner(left: CoalescingKey, right: CoalescingKey) -> bool:
         return left.room_id == right.room_id and left.requester_user_id == right.requester_user_id
 
+    @staticmethod
+    def _same_target(left: CoalescingKey, right: CoalescingKey) -> bool:
+        return left.room_id == right.room_id and left.thread_id == right.thread_id
+
     def _wake_owner(self, room_id: str, requester_user_id: str) -> None:
         for gate_key, gate in self._gates.items():
             if gate_key.room_id == room_id and gate_key.requester_user_id == requester_user_id:
@@ -266,15 +270,15 @@ class CoalescingGate:
             if other_key != key and self._same_owner(other_key, key):
                 self._wake(other_gate)
 
-    def _wake_room_gates(self, key: CoalescingKey) -> None:
+    def _wake_target_gates(self, key: CoalescingKey) -> None:
         for other_key, other_gate in self._gates.items():
-            if other_key != key and other_key.room_id == key.room_id:
+            if other_key != key and self._same_target(other_key, key):
                 self._wake(other_gate)
 
     def _wake_related_gates(self, key: CoalescingKey) -> None:
         self._wake_owner_gates(key)
         if is_active_follow_up_coalescing_key(key):
-            self._wake_room_gates(key)
+            self._wake_target_gates(key)
 
     @staticmethod
     def _gate_has_work_before(
@@ -309,17 +313,18 @@ class CoalescingGate:
             and self._gate_has_work_before(gate, before_order=before_order, source_event_id=key.thread_id)
         ]
 
-    def _older_room_active_follow_up_gates(
+    def _older_target_active_follow_up_gates(
         self,
         key: CoalescingKey,
         *,
         before_order: int,
     ) -> list[_GateEntry]:
+        """Return active follow-up gates that can block a resolved target."""
         return [
             gate
             for gate_key, gate in self._gates.items()
             if gate_key != key
-            and gate_key.room_id == key.room_id
+            and self._same_target(gate_key, key)
             and is_active_follow_up_coalescing_key(gate_key)
             and self._gate_has_work_before(gate, before_order=before_order)
         ]
@@ -327,7 +332,7 @@ class CoalescingGate:
     def _older_gate_blockers(self, key: CoalescingKey, *, before_order: int) -> list[_GateEntry]:
         return [
             *self._older_owner_root_gates(key, before_order=before_order),
-            *self._older_room_active_follow_up_gates(key, before_order=before_order),
+            *self._older_target_active_follow_up_gates(key, before_order=before_order),
         ]
 
     async def _wait_until_front_claimable(
@@ -339,6 +344,8 @@ class CoalescingGate:
     ) -> None:
         while True:
             if is_active_follow_up_coalescing_key(key):
+                # The target of older same-room reservations is still unknown, so wait
+                # room-wide here. Once admitted, gate blockers below are target-scoped.
                 await self._wait_for_reservations(
                     gate,
                     self._order_book.older_room_reservations(key, before_order=front_order),

--- a/src/mindroom/coalescing.py
+++ b/src/mindroom/coalescing.py
@@ -300,6 +300,11 @@ class CoalescingGate:
         front_order: int,
     ) -> None:
         while True:
+            if is_active_follow_up_coalescing_key(key):
+                await self._wait_for_reservations(
+                    gate,
+                    self._order_book.older_room_reservations(key, before_order=front_order),
+                )
             await self._wait_for_reservations(
                 gate,
                 self._order_book.older_owner_reservations(key, before_order=front_order),

--- a/src/mindroom/coalescing_batch.py
+++ b/src/mindroom/coalescing_batch.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, NamedTuple
+from xml.sax.saxutils import quoteattr as xml_quoteattr
 
 from .attachments import merge_attachment_ids, parse_attachment_ids_from_event_source
 from .constants import ORIGINAL_SENDER_KEY, VOICE_RAW_AUDIO_FALLBACK_KEY
@@ -16,7 +17,12 @@ from .dispatch_handoff import (
     event_content_dict,
     is_media_dispatch_event,
 )
-from .dispatch_source import IMAGE_SOURCE_KIND, MEDIA_SOURCE_KIND, VOICE_SOURCE_KIND
+from .dispatch_source import (
+    ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND,
+    IMAGE_SOURCE_KIND,
+    MEDIA_SOURCE_KIND,
+    VOICE_SOURCE_KIND,
+)
 
 if TYPE_CHECKING:
     import nio
@@ -30,6 +36,23 @@ class CoalescingKey(NamedTuple):
     requester_user_id: str
 
 
+_ACTIVE_FOLLOW_UP_OWNER_PREFIX = "__mindroom_active_follow_up__"
+
+
+def active_follow_up_coalescing_key(room_id: str, thread_id: str | None) -> CoalescingKey:
+    """Return the target-scoped key for follow-ups queued behind an active response."""
+    return CoalescingKey(
+        room_id,
+        thread_id,
+        f"{_ACTIVE_FOLLOW_UP_OWNER_PREFIX}:{thread_id or 'room'}",
+    )
+
+
+def is_active_follow_up_coalescing_key(key: CoalescingKey) -> bool:
+    """Return whether a coalescing key is target-scoped for an active response."""
+    return key.requester_user_id.startswith(f"{_ACTIVE_FOLLOW_UP_OWNER_PREFIX}:")
+
+
 @dataclass
 class PendingEvent:
     """One queued inbound event waiting to be coalesced."""
@@ -41,6 +64,7 @@ class PendingEvent:
     hook_source: str | None = None
     message_received_depth: int = 0
     trust_internal_payload_metadata: bool = False
+    requester_user_id: str | None = None
     enqueue_time: float = field(default_factory=time.time)
     dispatch_metadata: tuple[PendingDispatchMetadata, ...] = ()
 
@@ -81,6 +105,35 @@ def coalesced_prompt(message_bodies: list[str]) -> str:
         "The user sent the following messages in quick succession. "
         "Treat them as one turn and respond once:\n\n"
         f"{combined_body}"
+    )
+
+
+def _active_follow_up_message(pending_event: PendingEvent) -> str:
+    safe_body = dispatch_prompt_for_event(pending_event.event).replace("]]>", "]]]]><![CDATA[>")
+    sender = pending_event.requester_user_id or pending_event.event.sender
+    return (
+        f"<msg event_id={xml_quoteattr(pending_event.event.event_id)} "
+        f"from={xml_quoteattr(sender)}><![CDATA[{safe_body}]]></msg>"
+    )
+
+
+def _active_follow_up_prompt(pending_events: list[PendingEvent]) -> str:
+    rendered_messages = "\n".join(_active_follow_up_message(pending_event) for pending_event in pending_events)
+    return (
+        "Messages arrived while the previous response was still running. "
+        "They are in chat timeline order. Respond once to the combined context:\n\n"
+        f"<queued_messages>\n{rendered_messages}\n</queued_messages>"
+    )
+
+
+def _coalesced_prompt_for_events(ordered_pending_events: list[PendingEvent]) -> str:
+    if (
+        len(ordered_pending_events) > 1
+        and _batch_dispatch_policy_source_kind(ordered_pending_events) == ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND
+    ):
+        return _active_follow_up_prompt(ordered_pending_events)
+    return coalesced_prompt(
+        [dispatch_prompt_for_event(pending_event.event) for pending_event in ordered_pending_events],
     )
 
 
@@ -184,11 +237,9 @@ def build_coalesced_batch(
         coalescing_key=key,
         room=primary_pending_event.room,
         primary_event=primary_pending_event.event,
-        requester_user_id=key.requester_user_id,
+        requester_user_id=primary_pending_event.requester_user_id or key.requester_user_id,
         pending_events=tuple(ordered_pending_events),
-        prompt=coalesced_prompt(
-            [dispatch_prompt_for_event(pending_event.event) for pending_event in ordered_pending_events],
-        ),
+        prompt=_coalesced_prompt_for_events(ordered_pending_events),
         source_kind=_batch_source_kind(ordered_pending_events),
         dispatch_policy_source_kind=_batch_dispatch_policy_source_kind(ordered_pending_events),
         hook_source=_batch_hook_source(ordered_pending_events),

--- a/src/mindroom/coalescing_order.py
+++ b/src/mindroom/coalescing_order.py
@@ -94,6 +94,13 @@ class CoalescingOrderBook:
         reservation.settled.set()
         return True
 
+    def retarget(self, reservation: IngressOrderReservation, *, requester_user_id: str) -> bool:
+        """Move an unsettled reservation to a different owner key."""
+        if reservation.released or reservation.requester_user_id == requester_user_id:
+            return False
+        reservation.requester_user_id = requester_user_id
+        return True
+
     def unsettled(self) -> list[IngressOrderReservation]:
         """Return all currently unresolved reservations."""
         return list(self._reservations)

--- a/src/mindroom/coalescing_order.py
+++ b/src/mindroom/coalescing_order.py
@@ -129,7 +129,6 @@ class CoalescingOrderBook:
         after_order: int,
         before_order: int | None,
         before_or_at_receipt_time: float,
-        buffered_in_flight_max_order: int | None = None,
     ) -> list[IngressOrderReservation]:
         """Return unresolved same-owner reservations that belong to a claim window."""
         return [
@@ -138,31 +137,5 @@ class CoalescingOrderBook:
             if self.reservation_matches_key(reservation, key)
             and reservation.received_order > after_order
             and (before_order is None or reservation.received_order < before_order)
-            and (
-                reservation.receipt_time <= before_or_at_receipt_time
-                or (
-                    buffered_in_flight_max_order is not None
-                    and reservation.received_order <= buffered_in_flight_max_order
-                )
-            )
+            and reservation.receipt_time <= before_or_at_receipt_time
         ]
-
-    def unsettled_owner_reservation_orders_after(
-        self,
-        key: CoalescingKey,
-        *,
-        after_order: int,
-    ) -> list[int]:
-        """Return unresolved same-owner reservation orders after a receive order."""
-        return [
-            reservation.received_order
-            for reservation in self._reservations
-            if self.reservation_matches_key(reservation, key) and reservation.received_order > after_order
-        ]
-
-    def has_unsettled_owner_reservation_at_or_before(self, key: CoalescingKey, received_order: int) -> bool:
-        """Return whether an unresolved same-owner reservation exists at or before an order."""
-        return any(
-            self.reservation_matches_key(reservation, key) and reservation.received_order <= received_order
-            for reservation in self._reservations
-        )

--- a/src/mindroom/coalescing_order.py
+++ b/src/mindroom/coalescing_order.py
@@ -130,6 +130,22 @@ class CoalescingOrderBook:
             if reservation.room_id == key.room_id and reservation.received_order < before_order
         ]
 
+    def unsettled_room_reservations_in_window(
+        self,
+        key: CoalescingKey,
+        *,
+        after_order: int,
+        before_order: int | None,
+    ) -> list[IngressOrderReservation]:
+        """Return unresolved same-room reservations inside one receive-order window."""
+        return [
+            reservation
+            for reservation in self._reservations
+            if reservation.room_id == key.room_id
+            and reservation.received_order > after_order
+            and (before_order is None or reservation.received_order < before_order)
+        ]
+
     def has_older_unresolved_owner_reservation(self, key: CoalescingKey, received_order: int) -> bool:
         """Return whether older unresolved same-owner reservation blocks this order."""
         return any(

--- a/src/mindroom/coalescing_order.py
+++ b/src/mindroom/coalescing_order.py
@@ -122,6 +122,14 @@ class CoalescingOrderBook:
             if self.reservation_matches_key(reservation, key) and reservation.received_order < before_order
         ]
 
+    def older_room_reservations(self, key: CoalescingKey, *, before_order: int) -> list[IngressOrderReservation]:
+        """Return unresolved same-room reservations older than a receive order."""
+        return [
+            reservation
+            for reservation in self._reservations
+            if reservation.room_id == key.room_id and reservation.received_order < before_order
+        ]
+
     def has_older_unresolved_owner_reservation(self, key: CoalescingKey, received_order: int) -> bool:
         """Return whether older unresolved same-owner reservation blocks this order."""
         return any(

--- a/src/mindroom/prompt_ingress_reservation.py
+++ b/src/mindroom/prompt_ingress_reservation.py
@@ -65,6 +65,10 @@ class PromptIngressReservationOwner:
         self.admitted = True
         self.ready_task = None
 
+    def retarget(self, requester_user_id: str) -> None:
+        """Move this reservation to a different coalescing owner before admission."""
+        self.gate.retarget_order_reservation(self.reservation, requester_user_id=requester_user_id)
+
     async def cancel_ready_task(self) -> None:
         """Cancel or collect the owned ready task once."""
         if self.ready_task is None:

--- a/src/mindroom/prompt_ingress_reservation.py
+++ b/src/mindroom/prompt_ingress_reservation.py
@@ -23,6 +23,7 @@ class PromptIngressReservationOwner:
 
     gate: CoalescingGate
     reservation: IngressOrderReservation
+    active_response_thread_ids_at_receipt: frozenset[str | None] = frozenset()
     admitted: bool = False
     ready_task: asyncio.Task[ReadyPendingEvent | None] | None = None
 

--- a/src/mindroom/response_lifecycle.py
+++ b/src/mindroom/response_lifecycle.py
@@ -136,6 +136,15 @@ class ResponseLifecycleCoordinator:
         """Return whether one canonical conversation target already has an active turn."""
         return self._has_active_response_for_thread_key(self._thread_key(target))
 
+    def active_thread_ids_for_room(self, room_id: str) -> frozenset[str | None]:
+        """Return canonical thread IDs with active response lifecycles in one room."""
+        known_thread_keys = set(self._thread_queued_signals) | set(self._response_lifecycle_locks)
+        return frozenset(
+            thread_id
+            for known_room_id, thread_id in known_thread_keys
+            if known_room_id == room_id and self._has_active_response_for_thread_key((known_room_id, thread_id))
+        )
+
     def has_active_response_for_thread(self, room_id: str, thread_id: str | None) -> bool:
         """Return whether one canonical room/thread key has an active turn."""
         return self._has_active_response_for_thread_key((room_id, thread_id))

--- a/src/mindroom/response_lifecycle.py
+++ b/src/mindroom/response_lifecycle.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-from contextlib import contextmanager
-from contextvars import ContextVar
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, TypeVar, cast
 
@@ -17,13 +15,12 @@ from mindroom.post_response_effects import apply_post_response_effects
 from mindroom.tool_system.runtime_context import resolve_tool_runtime_hook_bindings
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable, Generator
+    from collections.abc import Awaitable, Callable
 
     from agno.db.base import BaseDb
     from structlog.stdlib import BoundLogger
 
     from mindroom.delivery_gateway import ResponseHookService
-    from mindroom.dispatch_handoff import MediaDispatchEvent
     from mindroom.final_delivery import FinalDeliveryOutcome
     from mindroom.history import HistoryScope
     from mindroom.hooks import MessageEnvelope
@@ -35,142 +32,48 @@ if TYPE_CHECKING:
 _LockedResponseResult = TypeVar("_LockedResponseResult")
 
 
-@dataclass(frozen=True, slots=True)
-class QueuedHumanMessage:
-    """Snapshot of one human message queued behind an active response."""
-
-    source_event_id: str
-    sender_id: str
-    body: str
-    attachment_ids: tuple[str, ...] = ()
-    trusted_attachment_ids: tuple[str, ...] = ()
-    media_event: MediaDispatchEvent | None = None
-
-
-_current_queued_human_messages_context: ContextVar[tuple[QueuedHumanMessage, ...]] = ContextVar(
-    "queued_human_messages_context",
-    default=(),
-)
-
-
-def _queued_human_message_from_envelope(response_envelope: MessageEnvelope) -> QueuedHumanMessage:
-    return QueuedHumanMessage(
-        source_event_id=response_envelope.source_event_id,
-        sender_id=response_envelope.requester_id,
-        body=response_envelope.body,
-    )
-
-
-@contextmanager
-def _queued_human_messages_context(messages: tuple[QueuedHumanMessage, ...]) -> Generator[None, None, None]:
-    """Bind active-thread backlog messages owned by this locked response."""
-    token = _current_queued_human_messages_context.set(messages)
-    try:
-        yield
-    finally:
-        _current_queued_human_messages_context.reset(token)
-
-
-def current_queued_human_messages() -> tuple[QueuedHumanMessage, ...]:
-    """Return active-thread backlog messages owned by the current locked response."""
-    return _current_queued_human_messages_context.get()
-
-
 @dataclass
 class _QueuedMessageState:
     """Track queued human ingress while one response lifecycle holds the lock."""
 
-    _pending_human_messages: list[QueuedHumanMessage] = field(default_factory=list)
-    _consumed_human_message_event_ids: set[str] = field(default_factory=set)
+    pending_human_message_event_ids: set[str] = field(default_factory=set)
     _active_response_turns: int = 0
     _event: asyncio.Event = field(default_factory=asyncio.Event)
+    _idle_event: asyncio.Event = field(default_factory=asyncio.Event)
+
+    def __post_init__(self) -> None:
+        self._idle_event.set()
 
     @property
     def pending_human_messages(self) -> int:
         """Return the number of distinct queued human events."""
-        return len(self._pending_human_messages)
-
-    @property
-    def pending_human_message_event_ids(self) -> tuple[str, ...]:
-        """Return pending human event ids in receive order."""
-        return tuple(message.source_event_id for message in self._pending_human_messages)
+        return len(self.pending_human_message_event_ids)
 
     def begin_response_turn(self) -> bool:
         existing_turn = self._active_response_turns > 0
         self._active_response_turns += 1
+        self._idle_event.clear()
         return existing_turn
 
     def finish_response_turn(self) -> None:
         if self._active_response_turns == 0:
             return
         self._active_response_turns -= 1
+        if self._active_response_turns == 0:
+            self._idle_event.set()
 
-    def add_waiting_human_message(self, message: QueuedHumanMessage) -> bool:
-        source_event_id = message.source_event_id
-        if (
-            source_event_id in self.pending_human_message_event_ids
-            or source_event_id in self._consumed_human_message_event_ids
-        ):
-            return False
-        self._pending_human_messages.append(message)
+    def add_waiting_human_message(self, source_event_id: str) -> bool:
+        previous_count = self.pending_human_messages
+        self.pending_human_message_event_ids.add(source_event_id)
         self._event.set()
-        return True
-
-    def update_waiting_human_message(self, message: QueuedHumanMessage) -> None:
-        for index, pending_message in enumerate(self._pending_human_messages):
-            if pending_message.source_event_id == message.source_event_id:
-                self._pending_human_messages[index] = message
-                return
+        return self.pending_human_messages != previous_count
 
     def consume_waiting_human_message(self, source_event_id: str) -> None:
         if source_event_id not in self.pending_human_message_event_ids:
             return
-        self._pending_human_messages = [
-            message for message in self._pending_human_messages if message.source_event_id != source_event_id
-        ]
+        self.pending_human_message_event_ids.remove(source_event_id)
         if self.pending_human_messages == 0:
             self._event.clear()
-
-    def claim_pending_human_messages(self) -> tuple[QueuedHumanMessage, ...]:
-        """Remove and return pending human messages for one follow-up response."""
-        messages = tuple(self._pending_human_messages)
-        if not messages:
-            return ()
-        self._pending_human_messages.clear()
-        self._event.clear()
-        return messages
-
-    def restore_pending_human_messages(self, messages: tuple[QueuedHumanMessage, ...]) -> None:
-        """Restore a failed backlog claim ahead of newer pending messages."""
-        if not messages:
-            return
-        existing_event_ids = set(self.pending_human_message_event_ids)
-        restored_messages = [
-            message
-            for message in messages
-            if message.source_event_id not in self._consumed_human_message_event_ids
-            and message.source_event_id not in existing_event_ids
-        ]
-        if not restored_messages:
-            return
-        self._pending_human_messages = [*restored_messages, *self._pending_human_messages]
-        self._event.set()
-
-    def commit_pending_human_messages(self, messages: tuple[QueuedHumanMessage, ...]) -> None:
-        """Mark one successfully answered backlog claim as consumed."""
-        if not messages:
-            return
-        event_ids = tuple(message.source_event_id for message in messages)
-        consumed_event_ids = set(event_ids)
-        self._pending_human_messages = [
-            message for message in self._pending_human_messages if message.source_event_id not in consumed_event_ids
-        ]
-        self._consumed_human_message_event_ids.update(event_ids)
-        if self.pending_human_messages == 0:
-            self._event.clear()
-
-    def has_consumed_human_message(self, source_event_id: str) -> bool:
-        return source_event_id in self._consumed_human_message_event_ids
 
     def has_pending_human_messages(self) -> bool:
         return self.pending_human_messages > 0
@@ -180,6 +83,9 @@ class _QueuedMessageState:
 
     async def wait(self) -> None:
         await self._event.wait()
+
+    async def wait_until_idle(self) -> None:
+        await self._idle_event.wait()
 
     def is_set(self) -> bool:
         return self._event.is_set()
@@ -202,16 +108,6 @@ class QueuedHumanNoticeReservation:
     def consume(self) -> None:
         """Mark the reservation as owned by the response lifecycle."""
         self._release_waiting_human_message()
-
-    def hand_off(self) -> None:
-        """Mark the reservation as owned while keeping its message in the backlog."""
-        self._active = False
-
-    def update_message(self, message: QueuedHumanMessage) -> None:
-        """Refresh the queued message snapshot while the reservation is active."""
-        if not self._active:
-            return
-        self._state.update_waiting_human_message(message)
 
     def cancel(self) -> None:
         """Release a reservation that will not reach response lifecycle ownership."""
@@ -239,6 +135,25 @@ class ResponseLifecycleCoordinator:
     def has_active_response_for_target(self, target: MessageTarget) -> bool:
         """Return whether one canonical conversation target already has an active turn."""
         return self._has_active_response_for_thread_key(self._thread_key(target))
+
+    def has_active_response_for_thread(self, room_id: str, thread_id: str | None) -> bool:
+        """Return whether one canonical room/thread key has an active turn."""
+        return self._has_active_response_for_thread_key((room_id, thread_id))
+
+    async def wait_for_thread_idle(self, room_id: str, thread_id: str | None) -> None:
+        """Wait until a response lifecycle lock is idle for one room/thread key."""
+        thread_key = (room_id, thread_id)
+        while self._has_active_response_for_thread_key(thread_key):
+            queued_signal = self._thread_queued_signals.get(thread_key)
+            if queued_signal is not None and queued_signal.has_active_response_turn():
+                await queued_signal.wait_until_idle()
+                continue
+            lifecycle_lock = self._response_lifecycle_locks.get(thread_key)
+            if lifecycle_lock is not None and lifecycle_lock.locked():
+                async with lifecycle_lock:
+                    pass
+                continue
+            return
 
     def _response_lifecycle_lock(self, target: MessageTarget) -> asyncio.Lock:
         """Return the per-target lock that serializes one response lifecycle."""
@@ -287,7 +202,6 @@ class ResponseLifecycleCoordinator:
         *,
         target: MessageTarget,
         response_envelope: MessageEnvelope,
-        queued_message: QueuedHumanMessage | None = None,
     ) -> QueuedHumanNoticeReservation | None:
         """Reserve an active-turn notice before queued dispatch owns the follow-up."""
         self._assert_target_matches_envelope(target, response_envelope)
@@ -297,8 +211,7 @@ class ResponseLifecycleCoordinator:
         if not self._has_active_response_for_thread_key(thread_key):
             return None
         queued_signal = self._get_or_create_queued_signal(target)
-        message = queued_message or _queued_human_message_from_envelope(response_envelope)
-        if not queued_signal.add_waiting_human_message(message):
+        if not queued_signal.add_waiting_human_message(response_envelope.source_event_id):
             return None
         return QueuedHumanNoticeReservation(queued_signal, response_envelope.source_event_id)
 
@@ -317,7 +230,7 @@ class ResponseLifecycleCoordinator:
             return None
         if not self._should_signal_queued_message(response_envelope):
             return None
-        if not queued_signal.add_waiting_human_message(_queued_human_message_from_envelope(response_envelope)):
+        if not queued_signal.add_waiting_human_message(response_envelope.source_event_id):
             return None
         return response_envelope.source_event_id
 
@@ -331,41 +244,6 @@ class ResponseLifecycleCoordinator:
             return
         queued_signal.consume_waiting_human_message(notice)
 
-    @staticmethod
-    def _claim_reserved_queued_messages(
-        *,
-        queued_signal: _QueuedMessageState,
-        queued_notice_reservation: QueuedHumanNoticeReservation | None,
-    ) -> tuple[QueuedHumanMessage, ...]:
-        if queued_notice_reservation is None:
-            return ()
-        queued_messages = queued_signal.claim_pending_human_messages()
-        queued_notice_reservation.hand_off()
-        return queued_messages
-
-    async def _run_with_queued_context(
-        self,
-        *,
-        target: MessageTarget,
-        queued_signal: _QueuedMessageState,
-        queued_messages: tuple[QueuedHumanMessage, ...],
-        queued_notice_reservation: QueuedHumanNoticeReservation | None,
-        locked_operation: Callable[[MessageTarget], Awaitable[_LockedResponseResult]],
-    ) -> _LockedResponseResult:
-        try:
-            with (
-                queued_message_signal_context(queued_signal),
-                _queued_human_messages_context(queued_messages),
-            ):
-                result = await locked_operation(target)
-        except BaseException:
-            if queued_notice_reservation is not None:
-                queued_signal.restore_pending_human_messages(queued_messages)
-            raise
-        if queued_notice_reservation is not None:
-            queued_signal.commit_pending_human_messages(queued_messages)
-        return result
-
     async def run_locked_response(
         self,
         *,
@@ -374,7 +252,7 @@ class ResponseLifecycleCoordinator:
         queued_notice_reservation: QueuedHumanNoticeReservation | None,
         pipeline_timing: DispatchPipelineTiming | None,
         locked_operation: Callable[[MessageTarget], Awaitable[_LockedResponseResult]],
-    ) -> _LockedResponseResult | None:
+    ) -> _LockedResponseResult:
         """Run one locked response operation with shared queued-message bookkeeping."""
         self._assert_target_matches_envelope(target, response_envelope)
         lifecycle_lock = self._response_lifecycle_lock(target)
@@ -386,6 +264,7 @@ class ResponseLifecycleCoordinator:
             queued_notice_reservation=queued_notice_reservation,
         )
         lock_acquired = False
+        reservation_consumed = False
         try:
             if pipeline_timing is not None:
                 pipeline_timing.mark("lock_wait_start")
@@ -394,34 +273,20 @@ class ResponseLifecycleCoordinator:
             if pipeline_timing is not None:
                 pipeline_timing.mark("lock_acquired")
             try:
-                if queued_signal.has_consumed_human_message(response_envelope.source_event_id):
-                    if queued_notice_reservation is not None:
-                        queued_notice_reservation.consume()
-                    notice = self._consume_queued_human_notice(
-                        notice=notice,
-                        queued_signal=queued_signal,
-                    )
-                    return None
-                queued_human_messages = self._claim_reserved_queued_messages(
-                    queued_signal=queued_signal,
-                    queued_notice_reservation=queued_notice_reservation,
-                )
+                if queued_notice_reservation is not None:
+                    queued_notice_reservation.consume()
+                    reservation_consumed = True
                 notice = self._consume_queued_human_notice(
                     notice=notice,
                     queued_signal=queued_signal,
                 )
-                return await self._run_with_queued_context(
-                    target=target,
-                    queued_signal=queued_signal,
-                    queued_messages=queued_human_messages,
-                    queued_notice_reservation=queued_notice_reservation,
-                    locked_operation=locked_operation,
-                )
+                with queued_message_signal_context(queued_signal):
+                    return await locked_operation(target)
             finally:
                 if lock_acquired:
                     lifecycle_lock.release()
         finally:
-            if queued_notice_reservation is not None:
+            if queued_notice_reservation is not None and not reservation_consumed:
                 queued_notice_reservation.cancel()
             self._consume_queued_human_notice(
                 notice=notice,

--- a/src/mindroom/response_lifecycle.py
+++ b/src/mindroom/response_lifecycle.py
@@ -145,10 +145,6 @@ class ResponseLifecycleCoordinator:
             if known_room_id == room_id and self._has_active_response_for_thread_key((known_room_id, thread_id))
         )
 
-    def has_active_response_for_thread(self, room_id: str, thread_id: str | None) -> bool:
-        """Return whether one canonical room/thread key has an active turn."""
-        return self._has_active_response_for_thread_key((room_id, thread_id))
-
     async def wait_for_thread_idle(self, room_id: str, thread_id: str | None) -> None:
         """Wait until a response lifecycle lock is idle for one room/thread key."""
         thread_key = (room_id, thread_id)

--- a/src/mindroom/response_lifecycle.py
+++ b/src/mindroom/response_lifecycle.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, TypeVar, cast
 
@@ -15,7 +17,7 @@ from mindroom.post_response_effects import apply_post_response_effects
 from mindroom.tool_system.runtime_context import resolve_tool_runtime_hook_bindings
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
+    from collections.abc import Awaitable, Callable, Generator
 
     from agno.db.base import BaseDb
     from structlog.stdlib import BoundLogger
@@ -32,18 +34,65 @@ if TYPE_CHECKING:
 _LockedResponseResult = TypeVar("_LockedResponseResult")
 
 
+@dataclass(frozen=True, slots=True)
+class QueuedHumanMessage:
+    """Snapshot of one human message queued behind an active response."""
+
+    source_event_id: str
+    sender_id: str
+    body: str
+    attachment_ids: tuple[str, ...] = ()
+    trusted_attachment_ids: tuple[str, ...] = ()
+    media_event: object | None = None
+
+
+_current_queued_human_messages_context: ContextVar[tuple[QueuedHumanMessage, ...]] = ContextVar(
+    "queued_human_messages_context",
+    default=(),
+)
+
+
+def _queued_human_message_from_envelope(response_envelope: MessageEnvelope) -> QueuedHumanMessage:
+    return QueuedHumanMessage(
+        source_event_id=response_envelope.source_event_id,
+        sender_id=response_envelope.requester_id,
+        body=response_envelope.body,
+    )
+
+
+@contextmanager
+def _queued_human_messages_context(messages: tuple[QueuedHumanMessage, ...]) -> Generator[None, None, None]:
+    """Bind active-thread backlog messages owned by this locked response."""
+    token = _current_queued_human_messages_context.set(messages)
+    try:
+        yield
+    finally:
+        _current_queued_human_messages_context.reset(token)
+
+
+def current_queued_human_messages() -> tuple[QueuedHumanMessage, ...]:
+    """Return active-thread backlog messages owned by the current locked response."""
+    return _current_queued_human_messages_context.get()
+
+
 @dataclass
 class _QueuedMessageState:
     """Track queued human ingress while one response lifecycle holds the lock."""
 
-    pending_human_message_event_ids: set[str] = field(default_factory=set)
+    _pending_human_messages: list[QueuedHumanMessage] = field(default_factory=list)
+    _consumed_human_message_event_ids: set[str] = field(default_factory=set)
     _active_response_turns: int = 0
     _event: asyncio.Event = field(default_factory=asyncio.Event)
 
     @property
     def pending_human_messages(self) -> int:
         """Return the number of distinct queued human events."""
-        return len(self.pending_human_message_event_ids)
+        return len(self._pending_human_messages)
+
+    @property
+    def pending_human_message_event_ids(self) -> tuple[str, ...]:
+        """Return pending human event ids in receive order."""
+        return tuple(message.source_event_id for message in self._pending_human_messages)
 
     def begin_response_turn(self) -> bool:
         existing_turn = self._active_response_turns > 0
@@ -55,18 +104,45 @@ class _QueuedMessageState:
             return
         self._active_response_turns -= 1
 
-    def add_waiting_human_message(self, source_event_id: str) -> bool:
-        previous_count = self.pending_human_messages
-        self.pending_human_message_event_ids.add(source_event_id)
+    def add_waiting_human_message(self, message: QueuedHumanMessage) -> bool:
+        source_event_id = message.source_event_id
+        if (
+            source_event_id in self.pending_human_message_event_ids
+            or source_event_id in self._consumed_human_message_event_ids
+        ):
+            return False
+        self._pending_human_messages.append(message)
         self._event.set()
-        return self.pending_human_messages != previous_count
+        return True
+
+    def update_waiting_human_message(self, message: QueuedHumanMessage) -> None:
+        for index, pending_message in enumerate(self._pending_human_messages):
+            if pending_message.source_event_id == message.source_event_id:
+                self._pending_human_messages[index] = message
+                return
 
     def consume_waiting_human_message(self, source_event_id: str) -> None:
         if source_event_id not in self.pending_human_message_event_ids:
             return
-        self.pending_human_message_event_ids.remove(source_event_id)
+        self._pending_human_messages = [
+            message for message in self._pending_human_messages if message.source_event_id != source_event_id
+        ]
         if self.pending_human_messages == 0:
             self._event.clear()
+
+    def consume_pending_human_messages(self) -> tuple[QueuedHumanMessage, ...]:
+        """Drain all pending human messages in receive order for one follow-up response."""
+        messages = tuple(self._pending_human_messages)
+        if not messages:
+            return ()
+        event_ids = tuple(message.source_event_id for message in messages)
+        self._pending_human_messages.clear()
+        self._consumed_human_message_event_ids.update(event_ids)
+        self._event.clear()
+        return messages
+
+    def has_consumed_human_message(self, source_event_id: str) -> bool:
+        return source_event_id in self._consumed_human_message_event_ids
 
     def has_pending_human_messages(self) -> bool:
         return self.pending_human_messages > 0
@@ -98,6 +174,12 @@ class QueuedHumanNoticeReservation:
     def consume(self) -> None:
         """Mark the reservation as owned by the response lifecycle."""
         self._release_waiting_human_message()
+
+    def update_message(self, message: QueuedHumanMessage) -> None:
+        """Refresh the queued message snapshot while the reservation is active."""
+        if not self._active:
+            return
+        self._state.update_waiting_human_message(message)
 
     def cancel(self) -> None:
         """Release a reservation that will not reach response lifecycle ownership."""
@@ -173,6 +255,7 @@ class ResponseLifecycleCoordinator:
         *,
         target: MessageTarget,
         response_envelope: MessageEnvelope,
+        queued_message: QueuedHumanMessage | None = None,
     ) -> QueuedHumanNoticeReservation | None:
         """Reserve an active-turn notice before queued dispatch owns the follow-up."""
         self._assert_target_matches_envelope(target, response_envelope)
@@ -182,7 +265,8 @@ class ResponseLifecycleCoordinator:
         if not self._has_active_response_for_thread_key(thread_key):
             return None
         queued_signal = self._get_or_create_queued_signal(target)
-        if not queued_signal.add_waiting_human_message(response_envelope.source_event_id):
+        message = queued_message or _queued_human_message_from_envelope(response_envelope)
+        if not queued_signal.add_waiting_human_message(message):
             return None
         return QueuedHumanNoticeReservation(queued_signal, response_envelope.source_event_id)
 
@@ -201,7 +285,7 @@ class ResponseLifecycleCoordinator:
             return None
         if not self._should_signal_queued_message(response_envelope):
             return None
-        if not queued_signal.add_waiting_human_message(response_envelope.source_event_id):
+        if not queued_signal.add_waiting_human_message(_queued_human_message_from_envelope(response_envelope)):
             return None
         return response_envelope.source_event_id
 
@@ -223,7 +307,7 @@ class ResponseLifecycleCoordinator:
         queued_notice_reservation: QueuedHumanNoticeReservation | None,
         pipeline_timing: DispatchPipelineTiming | None,
         locked_operation: Callable[[MessageTarget], Awaitable[_LockedResponseResult]],
-    ) -> _LockedResponseResult:
+    ) -> _LockedResponseResult | None:
         """Run one locked response operation with shared queued-message bookkeeping."""
         self._assert_target_matches_envelope(target, response_envelope)
         lifecycle_lock = self._response_lifecycle_lock(target)
@@ -244,6 +328,16 @@ class ResponseLifecycleCoordinator:
             if pipeline_timing is not None:
                 pipeline_timing.mark("lock_acquired")
             try:
+                if queued_signal.has_consumed_human_message(response_envelope.source_event_id):
+                    if queued_notice_reservation is not None:
+                        queued_notice_reservation.consume()
+                        reservation_consumed = True
+                    notice = self._consume_queued_human_notice(
+                        notice=notice,
+                        queued_signal=queued_signal,
+                    )
+                    return None
+                queued_human_messages = queued_signal.consume_pending_human_messages()
                 if queued_notice_reservation is not None:
                     queued_notice_reservation.consume()
                     reservation_consumed = True
@@ -251,7 +345,10 @@ class ResponseLifecycleCoordinator:
                     notice=notice,
                     queued_signal=queued_signal,
                 )
-                with queued_message_signal_context(queued_signal):
+                with (
+                    queued_message_signal_context(queued_signal),
+                    _queued_human_messages_context(queued_human_messages),
+                ):
                     return await locked_operation(target)
             finally:
                 if lock_acquired:

--- a/src/mindroom/response_lifecycle.py
+++ b/src/mindroom/response_lifecycle.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from structlog.stdlib import BoundLogger
 
     from mindroom.delivery_gateway import ResponseHookService
+    from mindroom.dispatch_handoff import MediaDispatchEvent
     from mindroom.final_delivery import FinalDeliveryOutcome
     from mindroom.history import HistoryScope
     from mindroom.hooks import MessageEnvelope
@@ -43,7 +44,7 @@ class QueuedHumanMessage:
     body: str
     attachment_ids: tuple[str, ...] = ()
     trusted_attachment_ids: tuple[str, ...] = ()
-    media_event: object | None = None
+    media_event: MediaDispatchEvent | None = None
 
 
 _current_queued_human_messages_context: ContextVar[tuple[QueuedHumanMessage, ...]] = ContextVar(
@@ -130,16 +131,43 @@ class _QueuedMessageState:
         if self.pending_human_messages == 0:
             self._event.clear()
 
-    def consume_pending_human_messages(self) -> tuple[QueuedHumanMessage, ...]:
-        """Drain all pending human messages in receive order for one follow-up response."""
+    def claim_pending_human_messages(self) -> tuple[QueuedHumanMessage, ...]:
+        """Remove and return pending human messages for one follow-up response."""
         messages = tuple(self._pending_human_messages)
         if not messages:
             return ()
-        event_ids = tuple(message.source_event_id for message in messages)
         self._pending_human_messages.clear()
-        self._consumed_human_message_event_ids.update(event_ids)
         self._event.clear()
         return messages
+
+    def restore_pending_human_messages(self, messages: tuple[QueuedHumanMessage, ...]) -> None:
+        """Restore a failed backlog claim ahead of newer pending messages."""
+        if not messages:
+            return
+        existing_event_ids = set(self.pending_human_message_event_ids)
+        restored_messages = [
+            message
+            for message in messages
+            if message.source_event_id not in self._consumed_human_message_event_ids
+            and message.source_event_id not in existing_event_ids
+        ]
+        if not restored_messages:
+            return
+        self._pending_human_messages = [*restored_messages, *self._pending_human_messages]
+        self._event.set()
+
+    def commit_pending_human_messages(self, messages: tuple[QueuedHumanMessage, ...]) -> None:
+        """Mark one successfully answered backlog claim as consumed."""
+        if not messages:
+            return
+        event_ids = tuple(message.source_event_id for message in messages)
+        consumed_event_ids = set(event_ids)
+        self._pending_human_messages = [
+            message for message in self._pending_human_messages if message.source_event_id not in consumed_event_ids
+        ]
+        self._consumed_human_message_event_ids.update(event_ids)
+        if self.pending_human_messages == 0:
+            self._event.clear()
 
     def has_consumed_human_message(self, source_event_id: str) -> bool:
         return source_event_id in self._consumed_human_message_event_ids
@@ -174,6 +202,10 @@ class QueuedHumanNoticeReservation:
     def consume(self) -> None:
         """Mark the reservation as owned by the response lifecycle."""
         self._release_waiting_human_message()
+
+    def hand_off(self) -> None:
+        """Mark the reservation as owned while keeping its message in the backlog."""
+        self._active = False
 
     def update_message(self, message: QueuedHumanMessage) -> None:
         """Refresh the queued message snapshot while the reservation is active."""
@@ -299,6 +331,41 @@ class ResponseLifecycleCoordinator:
             return
         queued_signal.consume_waiting_human_message(notice)
 
+    @staticmethod
+    def _claim_reserved_queued_messages(
+        *,
+        queued_signal: _QueuedMessageState,
+        queued_notice_reservation: QueuedHumanNoticeReservation | None,
+    ) -> tuple[QueuedHumanMessage, ...]:
+        if queued_notice_reservation is None:
+            return ()
+        queued_messages = queued_signal.claim_pending_human_messages()
+        queued_notice_reservation.hand_off()
+        return queued_messages
+
+    async def _run_with_queued_context(
+        self,
+        *,
+        target: MessageTarget,
+        queued_signal: _QueuedMessageState,
+        queued_messages: tuple[QueuedHumanMessage, ...],
+        queued_notice_reservation: QueuedHumanNoticeReservation | None,
+        locked_operation: Callable[[MessageTarget], Awaitable[_LockedResponseResult]],
+    ) -> _LockedResponseResult:
+        try:
+            with (
+                queued_message_signal_context(queued_signal),
+                _queued_human_messages_context(queued_messages),
+            ):
+                result = await locked_operation(target)
+        except BaseException:
+            if queued_notice_reservation is not None:
+                queued_signal.restore_pending_human_messages(queued_messages)
+            raise
+        if queued_notice_reservation is not None:
+            queued_signal.commit_pending_human_messages(queued_messages)
+        return result
+
     async def run_locked_response(
         self,
         *,
@@ -319,7 +386,6 @@ class ResponseLifecycleCoordinator:
             queued_notice_reservation=queued_notice_reservation,
         )
         lock_acquired = False
-        reservation_consumed = False
         try:
             if pipeline_timing is not None:
                 pipeline_timing.mark("lock_wait_start")
@@ -331,30 +397,31 @@ class ResponseLifecycleCoordinator:
                 if queued_signal.has_consumed_human_message(response_envelope.source_event_id):
                     if queued_notice_reservation is not None:
                         queued_notice_reservation.consume()
-                        reservation_consumed = True
                     notice = self._consume_queued_human_notice(
                         notice=notice,
                         queued_signal=queued_signal,
                     )
                     return None
-                queued_human_messages = queued_signal.consume_pending_human_messages()
-                if queued_notice_reservation is not None:
-                    queued_notice_reservation.consume()
-                    reservation_consumed = True
+                queued_human_messages = self._claim_reserved_queued_messages(
+                    queued_signal=queued_signal,
+                    queued_notice_reservation=queued_notice_reservation,
+                )
                 notice = self._consume_queued_human_notice(
                     notice=notice,
                     queued_signal=queued_signal,
                 )
-                with (
-                    queued_message_signal_context(queued_signal),
-                    _queued_human_messages_context(queued_human_messages),
-                ):
-                    return await locked_operation(target)
+                return await self._run_with_queued_context(
+                    target=target,
+                    queued_signal=queued_signal,
+                    queued_messages=queued_human_messages,
+                    queued_notice_reservation=queued_notice_reservation,
+                    locked_operation=locked_operation,
+                )
             finally:
                 if lock_acquired:
                     lifecycle_lock.release()
         finally:
-            if queued_notice_reservation is not None and not reservation_consumed:
+            if queued_notice_reservation is not None:
                 queued_notice_reservation.cancel()
             self._consume_queued_human_notice(
                 notice=notice,

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -68,7 +68,6 @@ from .delivery_gateway import (
 )
 from .media_inputs import MediaInputs
 from .response_lifecycle import (
-    QueuedHumanMessage,
     QueuedHumanNoticeReservation,
     ResponseLifecycle,
     ResponseLifecycleCoordinator,
@@ -520,18 +519,24 @@ class ResponseRunner:
         """Return whether one canonical conversation target already has an active turn."""
         return self._lifecycle_coordinator.has_active_response_for_target(target)
 
+    def has_active_response_for_thread(self, room_id: str, thread_id: str | None) -> bool:
+        """Return whether one canonical room/thread already has an active turn."""
+        return self._lifecycle_coordinator.has_active_response_for_thread(room_id, thread_id)
+
+    async def wait_for_thread_response_idle(self, room_id: str, thread_id: str | None) -> None:
+        """Wait until one canonical room/thread has no active response turn."""
+        await self._lifecycle_coordinator.wait_for_thread_idle(room_id, thread_id)
+
     def reserve_waiting_human_message(
         self,
         *,
         target: MessageTarget,
         response_envelope: MessageEnvelope,
-        queued_message: QueuedHumanMessage | None = None,
     ) -> QueuedHumanNoticeReservation | None:
         """Reserve a queued-human notice for an active response before dispatch owns ingress."""
         return self._lifecycle_coordinator.reserve_waiting_human_message(
             target=target,
             response_envelope=response_envelope,
-            queued_message=queued_message,
         )
 
     async def _run_in_tool_context(

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -519,6 +519,10 @@ class ResponseRunner:
         """Return whether one canonical conversation target already has an active turn."""
         return self._lifecycle_coordinator.has_active_response_for_target(target)
 
+    def active_thread_ids_for_room(self, room_id: str) -> frozenset[str | None]:
+        """Return canonical thread IDs with active response lifecycles in one room."""
+        return self._lifecycle_coordinator.active_thread_ids_for_room(room_id)
+
     def has_active_response_for_thread(self, room_id: str, thread_id: str | None) -> bool:
         """Return whether one canonical room/thread already has an active turn."""
         return self._lifecycle_coordinator.has_active_response_for_thread(room_id, thread_id)

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -523,10 +523,6 @@ class ResponseRunner:
         """Return canonical thread IDs with active response lifecycles in one room."""
         return self._lifecycle_coordinator.active_thread_ids_for_room(room_id)
 
-    def has_active_response_for_thread(self, room_id: str, thread_id: str | None) -> bool:
-        """Return whether one canonical room/thread already has an active turn."""
-        return self._lifecycle_coordinator.has_active_response_for_thread(room_id, thread_id)
-
     async def wait_for_thread_response_idle(self, room_id: str, thread_id: str | None) -> None:
         """Wait until one canonical room/thread has no active response turn."""
         await self._lifecycle_coordinator.wait_for_thread_idle(room_id, thread_id)

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -68,6 +68,7 @@ from .delivery_gateway import (
 )
 from .media_inputs import MediaInputs
 from .response_lifecycle import (
+    QueuedHumanMessage,
     QueuedHumanNoticeReservation,
     ResponseLifecycle,
     ResponseLifecycleCoordinator,
@@ -524,11 +525,13 @@ class ResponseRunner:
         *,
         target: MessageTarget,
         response_envelope: MessageEnvelope,
+        queued_message: QueuedHumanMessage | None = None,
     ) -> QueuedHumanNoticeReservation | None:
         """Reserve a queued-human notice for an active response before dispatch owns ingress."""
         return self._lifecycle_coordinator.reserve_waiting_human_message(
             target=target,
             response_envelope=response_envelope,
+            queued_message=queued_message,
         )
 
     async def _run_in_tool_context(

--- a/src/mindroom/text_ingress_dispatch.py
+++ b/src/mindroom/text_ingress_dispatch.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal, Protocol, cast
+from typing import TYPE_CHECKING, Any, Literal, Protocol
 
 from mindroom.attachments import merge_attachment_ids, parse_attachment_ids_from_event_source
 from mindroom.commands.parsing import command_parser
@@ -106,11 +106,7 @@ def _active_follow_up_payload_extras(
     queued_messages: Sequence[QueuedHumanMessage],
 ) -> _ActiveFollowUpPayloadExtras:
     media_events = _dedupe_media_events(
-        tuple(
-            cast("MediaDispatchEvent", message.media_event)
-            for message in queued_messages
-            if message.media_event is not None
-        ),
+        tuple(message.media_event for message in queued_messages if message.media_event is not None),
     )
     return _ActiveFollowUpPayloadExtras(
         attachment_ids=tuple(merge_attachment_ids(*(list(message.attachment_ids) for message in queued_messages))),

--- a/src/mindroom/text_ingress_dispatch.py
+++ b/src/mindroom/text_ingress_dispatch.py
@@ -23,7 +23,7 @@ from mindroom.dispatch_handoff import (
     merge_payload_metadata,
     payload_metadata_from_source,
 )
-from mindroom.dispatch_source import ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND, VOICE_SOURCE_KIND, is_voice_event
+from mindroom.dispatch_source import VOICE_SOURCE_KIND, is_voice_event
 from mindroom.handled_turns import HandledTurnState
 from mindroom.inbound_turn_normalizer import (
     BatchMediaAttachmentRequest,
@@ -33,7 +33,6 @@ from mindroom.inbound_turn_normalizer import (
 )
 from mindroom.matrix.media import is_audio_message_event, is_matrix_media_dispatch_event
 from mindroom.matrix.rooms import is_dm_room
-from mindroom.response_lifecycle import QueuedHumanMessage, current_queued_human_messages
 from mindroom.timing import (
     DispatchPipelineTiming,
     attach_dispatch_pipeline_timing,
@@ -80,41 +79,6 @@ class _PreparedTextDispatch:
     dispatch: PreparedDispatch
     replay_guard: _ReplayGuard
     dispatch_started_at: float
-
-
-@dataclass(frozen=True)
-class _ActiveFollowUpPayloadExtras:
-    """Attachments/media from queued follow-ups owned by one combined response."""
-
-    attachment_ids: tuple[str, ...] = ()
-    trusted_attachment_ids: tuple[str, ...] = ()
-    media_events: tuple[MediaDispatchEvent, ...] = ()
-
-
-def _dedupe_media_events(media_events: Sequence[MediaDispatchEvent]) -> tuple[MediaDispatchEvent, ...]:
-    seen: set[str] = set()
-    ordered: list[MediaDispatchEvent] = []
-    for media_event in media_events:
-        if media_event.event_id in seen:
-            continue
-        seen.add(media_event.event_id)
-        ordered.append(media_event)
-    return tuple(ordered)
-
-
-def _active_follow_up_payload_extras(
-    queued_messages: Sequence[QueuedHumanMessage],
-) -> _ActiveFollowUpPayloadExtras:
-    media_events = _dedupe_media_events(
-        tuple(message.media_event for message in queued_messages if message.media_event is not None),
-    )
-    return _ActiveFollowUpPayloadExtras(
-        attachment_ids=tuple(merge_attachment_ids(*(list(message.attachment_ids) for message in queued_messages))),
-        trusted_attachment_ids=tuple(
-            merge_attachment_ids(*(list(message.trusted_attachment_ids) for message in queued_messages)),
-        ),
-        media_events=media_events,
-    )
 
 
 async def dispatch_text_message(
@@ -409,23 +373,12 @@ async def _apply_turn_plan(
         effective_thread_id = prepared.dispatch.target.resolved_thread_id
         media_attachment_ids: list[str] = []
         fallback_images = None
-        queued_payload_extras = (
-            _active_follow_up_payload_extras(current_queued_human_messages())
-            if prepared.dispatch.envelope.dispatch_policy_source_kind == ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND
-            else _ActiveFollowUpPayloadExtras()
-        )
-        payload_media_events = _dedupe_media_events(
-            (
-                *(media_events or ()),
-                *queued_payload_extras.media_events,
-            ),
-        )
-        if payload_media_events:
+        if media_events:
             media_result = await controller.deps.normalizer.register_batch_media_attachments(
                 BatchMediaAttachmentRequest(
                     room_id=room.room_id,
                     thread_id=effective_thread_id,
-                    media_events=list(payload_media_events),
+                    media_events=media_events,
                 ),
             )
             media_attachment_ids = media_result.attachment_ids
@@ -437,12 +390,8 @@ async def _apply_turn_plan(
                 current_attachment_ids=merge_attachment_ids(
                     message_attachment_ids,
                     media_attachment_ids,
-                    list(queued_payload_extras.attachment_ids),
                 ),
-                trusted_current_attachment_ids=merge_attachment_ids(
-                    trusted_attachment_ids,
-                    list(queued_payload_extras.trusted_attachment_ids),
-                ),
+                trusted_current_attachment_ids=trusted_attachment_ids,
                 thread_id=context.thread_id,
                 media_thread_id=effective_thread_id,
                 thread_history=context.thread_history,

--- a/src/mindroom/text_ingress_dispatch.py
+++ b/src/mindroom/text_ingress_dispatch.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal, Protocol
+from typing import TYPE_CHECKING, Any, Literal, Protocol, cast
 
 from mindroom.attachments import merge_attachment_ids, parse_attachment_ids_from_event_source
 from mindroom.commands.parsing import command_parser
@@ -23,7 +23,7 @@ from mindroom.dispatch_handoff import (
     merge_payload_metadata,
     payload_metadata_from_source,
 )
-from mindroom.dispatch_source import VOICE_SOURCE_KIND, is_voice_event
+from mindroom.dispatch_source import ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND, VOICE_SOURCE_KIND, is_voice_event
 from mindroom.handled_turns import HandledTurnState
 from mindroom.inbound_turn_normalizer import (
     BatchMediaAttachmentRequest,
@@ -33,6 +33,7 @@ from mindroom.inbound_turn_normalizer import (
 )
 from mindroom.matrix.media import is_audio_message_event, is_matrix_media_dispatch_event
 from mindroom.matrix.rooms import is_dm_room
+from mindroom.response_lifecycle import QueuedHumanMessage, current_queued_human_messages
 from mindroom.timing import (
     DispatchPipelineTiming,
     attach_dispatch_pipeline_timing,
@@ -79,6 +80,45 @@ class _PreparedTextDispatch:
     dispatch: PreparedDispatch
     replay_guard: _ReplayGuard
     dispatch_started_at: float
+
+
+@dataclass(frozen=True)
+class _ActiveFollowUpPayloadExtras:
+    """Attachments/media from queued follow-ups owned by one combined response."""
+
+    attachment_ids: tuple[str, ...] = ()
+    trusted_attachment_ids: tuple[str, ...] = ()
+    media_events: tuple[MediaDispatchEvent, ...] = ()
+
+
+def _dedupe_media_events(media_events: Sequence[MediaDispatchEvent]) -> tuple[MediaDispatchEvent, ...]:
+    seen: set[str] = set()
+    ordered: list[MediaDispatchEvent] = []
+    for media_event in media_events:
+        if media_event.event_id in seen:
+            continue
+        seen.add(media_event.event_id)
+        ordered.append(media_event)
+    return tuple(ordered)
+
+
+def _active_follow_up_payload_extras(
+    queued_messages: Sequence[QueuedHumanMessage],
+) -> _ActiveFollowUpPayloadExtras:
+    media_events = _dedupe_media_events(
+        tuple(
+            cast("MediaDispatchEvent", message.media_event)
+            for message in queued_messages
+            if message.media_event is not None
+        ),
+    )
+    return _ActiveFollowUpPayloadExtras(
+        attachment_ids=tuple(merge_attachment_ids(*(list(message.attachment_ids) for message in queued_messages))),
+        trusted_attachment_ids=tuple(
+            merge_attachment_ids(*(list(message.trusted_attachment_ids) for message in queued_messages)),
+        ),
+        media_events=media_events,
+    )
 
 
 async def dispatch_text_message(
@@ -373,12 +413,23 @@ async def _apply_turn_plan(
         effective_thread_id = prepared.dispatch.target.resolved_thread_id
         media_attachment_ids: list[str] = []
         fallback_images = None
-        if media_events:
+        queued_payload_extras = (
+            _active_follow_up_payload_extras(current_queued_human_messages())
+            if prepared.dispatch.envelope.dispatch_policy_source_kind == ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND
+            else _ActiveFollowUpPayloadExtras()
+        )
+        payload_media_events = _dedupe_media_events(
+            (
+                *(media_events or ()),
+                *queued_payload_extras.media_events,
+            ),
+        )
+        if payload_media_events:
             media_result = await controller.deps.normalizer.register_batch_media_attachments(
                 BatchMediaAttachmentRequest(
                     room_id=room.room_id,
                     thread_id=effective_thread_id,
-                    media_events=media_events,
+                    media_events=list(payload_media_events),
                 ),
             )
             media_attachment_ids = media_result.attachment_ids
@@ -387,8 +438,15 @@ async def _apply_turn_plan(
             DispatchPayloadWithAttachmentsRequest(
                 room_id=room.room_id,
                 prompt=prepared.event.body,
-                current_attachment_ids=merge_attachment_ids(message_attachment_ids, media_attachment_ids),
-                trusted_current_attachment_ids=trusted_attachment_ids,
+                current_attachment_ids=merge_attachment_ids(
+                    message_attachment_ids,
+                    media_attachment_ids,
+                    list(queued_payload_extras.attachment_ids),
+                ),
+                trusted_current_attachment_ids=merge_attachment_ids(
+                    trusted_attachment_ids,
+                    list(queued_payload_extras.trusted_attachment_ids),
+                ),
                 thread_id=context.thread_id,
                 media_thread_id=effective_thread_id,
                 thread_history=context.thread_history,

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -365,6 +365,7 @@ class TurnController:
                 requester_user_id=requester_user_id,
                 receipt_time=receipt_time,
             ),
+            active_response_thread_ids_at_receipt=self.deps.response_runner.active_thread_ids_for_room(room.room_id),
         )
 
     def _sender_is_trusted_for_ingress_metadata(self, sender_id: str) -> bool:
@@ -611,12 +612,13 @@ class TurnController:
         self,
         *,
         envelope: MessageEnvelope,
+        active_response_thread_ids_at_receipt: frozenset[str | None] | None = None,
     ) -> bool:
-        """Return whether one human thread follow-up should carry active-response policy."""
-        if envelope.target.resolved_thread_id is None:
-            return False
+        """Return whether one human follow-up should carry active-response policy."""
         if not envelope.origin.may_answer_interactive_prompt:
             return False
+        if active_response_thread_ids_at_receipt is not None:
+            return envelope.target.resolved_thread_id in active_response_thread_ids_at_receipt
         return self.deps.response_runner.has_active_response_for_target(envelope.target)
 
     @staticmethod
@@ -631,6 +633,7 @@ class TurnController:
         target: MessageTarget,
         envelope: MessageEnvelope,
         queued_notice_reservation: QueuedHumanNoticeReservation | None,
+        active_response_thread_ids_at_receipt: frozenset[str | None] | None,
     ) -> tuple[bool, QueuedHumanNoticeReservation | None]:
         """Return active-follow-up policy and the reservation for a voice target."""
         if queued_notice_reservation is not None and (
@@ -642,12 +645,15 @@ class TurnController:
         ):
             queued_notice_reservation.cancel()
             queued_notice_reservation = None
-        if queued_notice_reservation is not None:
-            return True, queued_notice_reservation
-        active_follow_up = (
-            envelope.origin.may_answer_interactive_prompt
-            and self.deps.response_runner.has_active_response_for_target(target)
+        active_follow_up = self._should_apply_active_thread_follow_up_policy(
+            envelope=envelope,
+            active_response_thread_ids_at_receipt=active_response_thread_ids_at_receipt,
         )
+        if queued_notice_reservation is not None:
+            if active_follow_up:
+                return True, queued_notice_reservation
+            queued_notice_reservation.cancel()
+            return False, None
         if not active_follow_up:
             return False, None
         return True, self.deps.response_runner.reserve_waiting_human_message(
@@ -729,6 +735,7 @@ class TurnController:
         )
         if self._should_apply_active_thread_follow_up_policy(
             envelope=envelope,
+            active_response_thread_ids_at_receipt=reservation_owner.active_response_thread_ids_at_receipt,
         ):
             await self._enqueue_active_thread_follow_up(
                 room=room,
@@ -794,6 +801,7 @@ class TurnController:
         )
         if self._should_apply_active_thread_follow_up_policy(
             envelope=envelope,
+            active_response_thread_ids_at_receipt=reservation_owner.active_response_thread_ids_at_receipt,
         ):
             await self._enqueue_active_thread_follow_up(
                 room=room,
@@ -2251,6 +2259,7 @@ class TurnController:
             event_info=event_info,
             requester_user_id=prechecked_event.requester_user_id,
             dispatch_timing=dispatch_timing,
+            active_response_thread_ids_at_receipt=reservation_owner.active_response_thread_ids_at_receipt,
         )
 
         ready_task = asyncio.create_task(
@@ -2259,6 +2268,7 @@ class TurnController:
                 prechecked_event=prechecked_event,
                 voice_target=voice_target,
                 dispatch_timing=dispatch_timing,
+                active_response_thread_ids_at_receipt=reservation_owner.active_response_thread_ids_at_receipt,
             ),
             name=f"voice_ready:{room.room_id}:{event.event_id}",
         )
@@ -2278,6 +2288,7 @@ class TurnController:
         event_info: EventInfo,
         requester_user_id: str,
         dispatch_timing: DispatchPipelineTiming | None,
+        active_response_thread_ids_at_receipt: frozenset[str | None],
     ) -> tuple[MessageTarget, CoalescingKey]:
         await self._append_live_event_with_timing(
             room.room_id,
@@ -2292,7 +2303,17 @@ class TurnController:
             reply_to_event_id=event.event_id,
             event_source=event.source,
         )
-        if self.deps.response_runner.has_active_response_for_target(voice_target):
+        envelope = self.deps.resolver.build_ingress_envelope(
+            room_id=room.room_id,
+            event=cast("DispatchEvent", event),
+            requester_user_id=requester_user_id,
+            target=voice_target,
+            source_kind=VOICE_SOURCE_KIND,
+        )
+        if self._should_apply_active_thread_follow_up_policy(
+            envelope=envelope,
+            active_response_thread_ids_at_receipt=active_response_thread_ids_at_receipt,
+        ):
             admission_key = active_follow_up_coalescing_key(room.room_id, coalescing_thread_id)
         else:
             admission_key = CoalescingKey(room.room_id, coalescing_thread_id, requester_user_id)
@@ -2305,6 +2326,7 @@ class TurnController:
         prechecked_event: _PrecheckedEvent[AudioMessageEvent],
         voice_target: MessageTarget,
         dispatch_timing: DispatchPipelineTiming | None,
+        active_response_thread_ids_at_receipt: frozenset[str | None],
     ) -> ReadyPendingEvent | None:
         """Normalize a raw voice event after its conversation key is fixed."""
         event = prechecked_event.event
@@ -2318,10 +2340,14 @@ class TurnController:
                 target=voice_target,
                 source_kind=VOICE_SOURCE_KIND,
             )
-            queued_notice_reservation = self.deps.response_runner.reserve_waiting_human_message(
-                target=voice_target,
-                response_envelope=envelope,
-            )
+            if self._should_apply_active_thread_follow_up_policy(
+                envelope=envelope,
+                active_response_thread_ids_at_receipt=active_response_thread_ids_at_receipt,
+            ):
+                queued_notice_reservation = self.deps.response_runner.reserve_waiting_human_message(
+                    target=voice_target,
+                    response_envelope=envelope,
+                )
             normalized_event, effective_thread_id = await self._normalize_voice_event_or_fallback(
                 room=room,
                 event=event,
@@ -2367,6 +2393,7 @@ class TurnController:
                 target=normalized_target,
                 envelope=envelope,
                 queued_notice_reservation=queued_notice_reservation,
+                active_response_thread_ids_at_receipt=active_response_thread_ids_at_receipt,
             )
             reservation_released_or_handed_off = True
             return ReadyPendingEvent(
@@ -2399,6 +2426,7 @@ class TurnController:
                 thread_id=voice_target.resolved_thread_id,
                 dispatch_timing=dispatch_timing,
                 error=exc,
+                active_response_thread_ids_at_receipt=active_response_thread_ids_at_receipt,
             )
         finally:
             if not reservation_released_or_handed_off and queued_notice_reservation is not None:
@@ -2441,6 +2469,7 @@ class TurnController:
         thread_id: str | None,
         dispatch_timing: DispatchPipelineTiming | None,
         error: Exception,
+        active_response_thread_ids_at_receipt: frozenset[str | None],
     ) -> ReadyPendingEvent:
         """Return a raw-audio fallback when voice readiness fails before STT."""
         self.deps.logger.warning(
@@ -2476,6 +2505,7 @@ class TurnController:
                 target=target,
                 envelope=envelope,
                 queued_notice_reservation=None,
+                active_response_thread_ids_at_receipt=active_response_thread_ids_at_receipt,
             )
             dispatch_policy_source_kind = (
                 ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND if active_follow_up else envelope.dispatch_policy_source_kind

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -7,6 +7,7 @@ import time
 from dataclasses import dataclass, replace
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Protocol, cast
+from xml.sax.saxutils import quoteattr as xml_quoteattr
 
 import nio
 
@@ -46,6 +47,7 @@ from mindroom.dispatch_handoff import (
     PreparedTextEvent,
     TextDispatchEvent,
     build_dispatch_handoff,
+    dispatch_prompt_for_event,
     payload_metadata_from_source,
 )
 from mindroom.dispatch_replay_guard import has_newer_unresponded_cached_thread_event, has_newer_unresponded_in_thread
@@ -90,7 +92,9 @@ from mindroom.matrix.media import (
     is_matrix_media_dispatch_event,
 )
 from mindroom.matrix.message_content import is_v2_sidecar_text_preview
+from mindroom.metadata_merge import deep_merge_metadata
 from mindroom.prompt_ingress_reservation import PromptIngressReservationOwner as _PromptIngressReservationOwner
+from mindroom.response_lifecycle import QueuedHumanMessage, current_queued_human_messages
 from mindroom.response_runner import PostLockRequestPreparationError, ResponseRequest
 from mindroom.routing import suggest_responder_for_message
 from mindroom.text_ingress_dispatch import dispatch_text_message
@@ -136,6 +140,87 @@ if TYPE_CHECKING:
 type _DispatchPayloadBuilder = Callable[[MessageContext], Awaitable[DispatchPayload]]
 
 _QUEUED_NOTICE_METADATA_KIND = "queued_notice_reservation"
+
+
+@dataclass(frozen=True)
+class _ActiveFollowUpBacklog:
+    """Model-facing backlog for human messages queued behind one active response."""
+
+    source_event_ids: tuple[str, ...]
+    prompt: str
+    thread_history: tuple[ResolvedVisibleMessage, ...]
+    source_event_prompts: dict[str, str]
+
+
+def _matched_visible_event_id(message: ResolvedVisibleMessage, event_ids: set[str]) -> str | None:
+    candidates = (
+        (message.event_id,)
+        if message.latest_event_id == message.event_id
+        else (
+            message.event_id,
+            message.latest_event_id,
+        )
+    )
+    for candidate in candidates:
+        if candidate in event_ids:
+            return candidate
+    return None
+
+
+def _render_active_follow_up_message(message: QueuedHumanMessage) -> str:
+    safe_body = message.body.replace("]]>", "]]]]><![CDATA[>")
+    return (
+        f"<msg event_id={xml_quoteattr(message.source_event_id)} "
+        f"from={xml_quoteattr(message.sender_id)}><![CDATA[{safe_body}]]></msg>"
+    )
+
+
+def _render_active_follow_up_prompt(messages: Sequence[QueuedHumanMessage]) -> str:
+    rendered_messages = "\n".join(_render_active_follow_up_message(message) for message in messages)
+    return (
+        "Messages arrived while the previous response was still running. "
+        "They are in chat timeline order. Respond once to the combined context:\n\n"
+        f"<queued_messages>\n{rendered_messages}\n</queued_messages>"
+    )
+
+
+def _active_follow_up_backlog(
+    *,
+    queued_messages: Sequence[QueuedHumanMessage],
+    thread_history: Sequence[ResolvedVisibleMessage],
+) -> _ActiveFollowUpBacklog | None:
+    source_event_ids = tuple(message.source_event_id for message in queued_messages)
+    if len(source_event_ids) <= 1:
+        return None
+
+    backlog_source_id_set = set(source_event_ids)
+    filtered_history = tuple(
+        message for message in thread_history if _matched_visible_event_id(message, backlog_source_id_set) is None
+    )
+    return _ActiveFollowUpBacklog(
+        source_event_ids=source_event_ids,
+        prompt=_render_active_follow_up_prompt(queued_messages),
+        thread_history=filtered_history,
+        source_event_prompts={message.source_event_id: message.body for message in queued_messages},
+    )
+
+
+def _queued_human_message_for_event(
+    *,
+    event: DispatchEvent,
+    envelope: MessageEnvelope,
+    trust_internal_payload_metadata: bool | None,
+) -> QueuedHumanMessage:
+    attachment_ids = envelope.attachment_ids if trust_internal_payload_metadata else ()
+    media_event = event if is_matrix_media_dispatch_event(event) else None
+    return QueuedHumanMessage(
+        source_event_id=envelope.source_event_id,
+        sender_id=envelope.requester_id,
+        body=dispatch_prompt_for_event(event),
+        attachment_ids=attachment_ids,
+        trusted_attachment_ids=attachment_ids,
+        media_event=media_event,
+    )
 
 
 def _room_level_context_event(event: TextDispatchEvent) -> TextDispatchEvent:
@@ -630,9 +715,15 @@ class TurnController:
         preliminary_target: MessageTarget | None,
         target: MessageTarget,
         envelope: MessageEnvelope,
+        event: DispatchEvent,
         queued_notice_reservation: QueuedHumanNoticeReservation | None,
     ) -> tuple[bool, QueuedHumanNoticeReservation | None]:
         """Return active-follow-up policy and the reservation for a voice target."""
+        queued_message = _queued_human_message_for_event(
+            event=event,
+            envelope=envelope,
+            trust_internal_payload_metadata=True,
+        )
         if queued_notice_reservation is not None and (
             preliminary_target is None
             or not self._same_response_lifecycle_target(
@@ -643,6 +734,7 @@ class TurnController:
             queued_notice_reservation.cancel()
             queued_notice_reservation = None
         if queued_notice_reservation is not None:
+            queued_notice_reservation.update_message(queued_message)
             return True, queued_notice_reservation
         active_follow_up = (
             envelope.origin.may_answer_interactive_prompt
@@ -653,6 +745,7 @@ class TurnController:
         return True, self.deps.response_runner.reserve_waiting_human_message(
             target=target,
             response_envelope=envelope,
+            queued_message=queued_message,
         )
 
     async def _enqueue_active_thread_follow_up(
@@ -673,6 +766,11 @@ class TurnController:
             queued_notice_reservation = self.deps.response_runner.reserve_waiting_human_message(
                 target=target,
                 response_envelope=envelope,
+                queued_message=_queued_human_message_for_event(
+                    event=event,
+                    envelope=envelope,
+                    trust_internal_payload_metadata=trust_internal_payload_metadata,
+                ),
             )
         try:
             await self._enqueue_for_dispatch(
@@ -1775,6 +1873,8 @@ class TurnController:
 
                 async def prepare_request_after_lock(request: ResponseRequest) -> ResponseRequest:
                     nonlocal dispatch
+                    nonlocal handled_turn
+                    nonlocal matrix_run_metadata
                     nonlocal payload_ready_monotonic
                     if dispatch_timing is not None:
                         dispatch_timing.mark("response_payload_start")
@@ -1799,6 +1899,31 @@ class TurnController:
                             thread_id=request.thread_id,
                             outcome=payload_builder_outcome,
                         )
+                    backlog: _ActiveFollowUpBacklog | None = None
+                    queued_messages = current_queued_human_messages()
+                    if (
+                        queued_messages
+                        and dispatch.envelope.dispatch_policy_source_kind == ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND
+                    ):
+                        backlog = _active_follow_up_backlog(
+                            queued_messages=queued_messages,
+                            thread_history=request.thread_history,
+                        )
+                        if backlog is not None:
+                            handled_turn = replace(
+                                handled_turn,
+                                source_event_ids=backlog.source_event_ids,
+                                source_event_prompts=backlog.source_event_prompts,
+                            )
+                            matrix_run_metadata = deep_merge_metadata(
+                                matrix_run_metadata,
+                                self.deps.turn_store.build_run_metadata(handled_turn),
+                            )
+                            payload = replace(payload, prompt=backlog.prompt, model_prompt=None)
+                            dispatch = replace(
+                                dispatch,
+                                envelope=replace(dispatch.envelope, body=backlog.prompt),
+                            )
                     prepared_payload = await self.deps.ingress_hook_runner.apply_message_enrichment(
                         dispatch,
                         payload,
@@ -1829,7 +1954,7 @@ class TurnController:
                         thread_history=request.thread_history,
                     )
                     return ResponseRequest(
-                        thread_history=request.thread_history,
+                        thread_history=backlog.thread_history if backlog is not None else request.thread_history,
                         prompt=prepared_payload.payload.prompt,
                         model_prompt=prepared_payload.payload.model_prompt,
                         existing_event_id=request.existing_event_id,
@@ -2364,6 +2489,7 @@ class TurnController:
                 preliminary_target=voice_target,
                 target=normalized_target,
                 envelope=envelope,
+                event=normalized_event,
                 queued_notice_reservation=queued_notice_reservation,
             )
             reservation_released_or_handed_off = True
@@ -2472,6 +2598,7 @@ class TurnController:
                 preliminary_target=target,
                 target=target,
                 envelope=envelope,
+                event=fallback_event,
                 queued_notice_reservation=None,
             )
             dispatch_policy_source_kind = (

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -209,7 +209,7 @@ def _queued_human_message_for_event(
     *,
     event: DispatchEvent,
     envelope: MessageEnvelope,
-    trust_internal_payload_metadata: bool | None,
+    trust_internal_payload_metadata: bool,
 ) -> QueuedHumanMessage:
     attachment_ids = envelope.attachment_ids if trust_internal_payload_metadata else ()
     media_event = event if is_matrix_media_dispatch_event(event) else None
@@ -277,7 +277,11 @@ def _queued_notice_reservation_from_metadata(
     )
     for item in reservation_items:
         if item is not selected_item:
-            cast("QueuedHumanNoticeReservation", item.payload).consume()
+            reservation = cast("QueuedHumanNoticeReservation", item.payload)
+            if item.target_key == target_key:
+                reservation.hand_off()
+            else:
+                reservation.consume()
     if selected_item is None:
         return None
     return cast("QueuedHumanNoticeReservation", selected_item.payload)
@@ -762,6 +766,11 @@ class TurnController:
         queued_notice_reservation: QueuedHumanNoticeReservation | None = None,
     ) -> _IngressAdmissionOutcome:
         """Queue an active-thread follow-up while preserving its mid-turn notice."""
+        resolved_trust_internal_payload_metadata = (
+            self._should_trust_internal_payload_metadata(event)
+            if trust_internal_payload_metadata is None
+            else trust_internal_payload_metadata
+        )
         if queued_notice_reservation is None:
             queued_notice_reservation = self.deps.response_runner.reserve_waiting_human_message(
                 target=target,
@@ -769,7 +778,7 @@ class TurnController:
                 queued_message=_queued_human_message_for_event(
                     event=event,
                     envelope=envelope,
-                    trust_internal_payload_metadata=trust_internal_payload_metadata,
+                    trust_internal_payload_metadata=resolved_trust_internal_payload_metadata,
                 ),
             )
         try:
@@ -785,7 +794,7 @@ class TurnController:
                 coalescing_key=CoalescingKey(room.room_id, coalescing_thread_id, requester_user_id),
                 queued_notice_reservation=queued_notice_reservation,
                 queued_notice_target=target,
-                trust_internal_payload_metadata=trust_internal_payload_metadata,
+                trust_internal_payload_metadata=resolved_trust_internal_payload_metadata,
             )
         except asyncio.CancelledError:
             if queued_notice_reservation is not None:
@@ -823,7 +832,7 @@ class TurnController:
         ):
             await self._enqueue_active_thread_follow_up(
                 room=room,
-                event=dispatch_event,
+                event=prepared_event,
                 target=target,
                 envelope=envelope,
                 coalescing_thread_id=coalescing_thread_id,
@@ -1919,7 +1928,7 @@ class TurnController:
                                 matrix_run_metadata,
                                 self.deps.turn_store.build_run_metadata(handled_turn),
                             )
-                            payload = replace(payload, prompt=backlog.prompt, model_prompt=None)
+                            payload = replace(payload, prompt=backlog.prompt)
                             dispatch = replace(
                                 dispatch,
                                 envelope=replace(dispatch.envelope, body=backlog.prompt),

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -7,7 +7,6 @@ import time
 from dataclasses import dataclass, replace
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Protocol, cast
-from xml.sax.saxutils import quoteattr as xml_quoteattr
 
 import nio
 
@@ -19,7 +18,13 @@ from mindroom.coalescing import (
     IngressAdmissionClosedError,
     ReadyPendingEvent,
 )
-from mindroom.coalescing_batch import CoalescedBatch, CoalescingKey, PendingEvent, close_pending_event_metadata
+from mindroom.coalescing_batch import (
+    CoalescedBatch,
+    CoalescingKey,
+    PendingEvent,
+    active_follow_up_coalescing_key,
+    close_pending_event_metadata,
+)
 from mindroom.commands.handler import CommandHandlerContext, handle_command
 from mindroom.commands.parsing import command_parser
 from mindroom.constants import (
@@ -47,7 +52,6 @@ from mindroom.dispatch_handoff import (
     PreparedTextEvent,
     TextDispatchEvent,
     build_dispatch_handoff,
-    dispatch_prompt_for_event,
     payload_metadata_from_source,
 )
 from mindroom.dispatch_replay_guard import has_newer_unresponded_cached_thread_event, has_newer_unresponded_in_thread
@@ -92,9 +96,7 @@ from mindroom.matrix.media import (
     is_matrix_media_dispatch_event,
 )
 from mindroom.matrix.message_content import is_v2_sidecar_text_preview
-from mindroom.metadata_merge import deep_merge_metadata
 from mindroom.prompt_ingress_reservation import PromptIngressReservationOwner as _PromptIngressReservationOwner
-from mindroom.response_lifecycle import QueuedHumanMessage, current_queued_human_messages
 from mindroom.response_runner import PostLockRequestPreparationError, ResponseRequest
 from mindroom.routing import suggest_responder_for_message
 from mindroom.text_ingress_dispatch import dispatch_text_message
@@ -142,87 +144,6 @@ type _DispatchPayloadBuilder = Callable[[MessageContext], Awaitable[DispatchPayl
 _QUEUED_NOTICE_METADATA_KIND = "queued_notice_reservation"
 
 
-@dataclass(frozen=True)
-class _ActiveFollowUpBacklog:
-    """Model-facing backlog for human messages queued behind one active response."""
-
-    source_event_ids: tuple[str, ...]
-    prompt: str
-    thread_history: tuple[ResolvedVisibleMessage, ...]
-    source_event_prompts: dict[str, str]
-
-
-def _matched_visible_event_id(message: ResolvedVisibleMessage, event_ids: set[str]) -> str | None:
-    candidates = (
-        (message.event_id,)
-        if message.latest_event_id == message.event_id
-        else (
-            message.event_id,
-            message.latest_event_id,
-        )
-    )
-    for candidate in candidates:
-        if candidate in event_ids:
-            return candidate
-    return None
-
-
-def _render_active_follow_up_message(message: QueuedHumanMessage) -> str:
-    safe_body = message.body.replace("]]>", "]]]]><![CDATA[>")
-    return (
-        f"<msg event_id={xml_quoteattr(message.source_event_id)} "
-        f"from={xml_quoteattr(message.sender_id)}><![CDATA[{safe_body}]]></msg>"
-    )
-
-
-def _render_active_follow_up_prompt(messages: Sequence[QueuedHumanMessage]) -> str:
-    rendered_messages = "\n".join(_render_active_follow_up_message(message) for message in messages)
-    return (
-        "Messages arrived while the previous response was still running. "
-        "They are in chat timeline order. Respond once to the combined context:\n\n"
-        f"<queued_messages>\n{rendered_messages}\n</queued_messages>"
-    )
-
-
-def _active_follow_up_backlog(
-    *,
-    queued_messages: Sequence[QueuedHumanMessage],
-    thread_history: Sequence[ResolvedVisibleMessage],
-) -> _ActiveFollowUpBacklog | None:
-    source_event_ids = tuple(message.source_event_id for message in queued_messages)
-    if len(source_event_ids) <= 1:
-        return None
-
-    backlog_source_id_set = set(source_event_ids)
-    filtered_history = tuple(
-        message for message in thread_history if _matched_visible_event_id(message, backlog_source_id_set) is None
-    )
-    return _ActiveFollowUpBacklog(
-        source_event_ids=source_event_ids,
-        prompt=_render_active_follow_up_prompt(queued_messages),
-        thread_history=filtered_history,
-        source_event_prompts={message.source_event_id: message.body for message in queued_messages},
-    )
-
-
-def _queued_human_message_for_event(
-    *,
-    event: DispatchEvent,
-    envelope: MessageEnvelope,
-    trust_internal_payload_metadata: bool,
-) -> QueuedHumanMessage:
-    attachment_ids = envelope.attachment_ids if trust_internal_payload_metadata else ()
-    media_event = event if is_matrix_media_dispatch_event(event) else None
-    return QueuedHumanMessage(
-        source_event_id=envelope.source_event_id,
-        sender_id=envelope.requester_id,
-        body=dispatch_prompt_for_event(event),
-        attachment_ids=attachment_ids,
-        trusted_attachment_ids=attachment_ids,
-        media_event=media_event,
-    )
-
-
 def _room_level_context_event(event: TextDispatchEvent) -> TextDispatchEvent:
     """Return an event view that cannot pull dispatch context through Matrix relations."""
     if not isinstance(event.source, dict):
@@ -263,28 +184,18 @@ def _queued_notice_dispatch_metadata(
     )
 
 
-def _queued_notice_reservation_from_metadata(
+def _consume_queued_notice_reservations_from_metadata(
     dispatch_metadata: tuple[PendingDispatchMetadata, ...],
     *,
     target_key: tuple[str, str | None],
-) -> QueuedHumanNoticeReservation | None:
+) -> None:
     reservation_items = [item for item in dispatch_metadata if item.kind == _QUEUED_NOTICE_METADATA_KIND]
-    if not reservation_items:
-        return None
-    selected_item = next(
-        (item for item in reversed(reservation_items) if item.target_key == target_key),
-        None,
-    )
     for item in reservation_items:
-        if item is not selected_item:
-            reservation = cast("QueuedHumanNoticeReservation", item.payload)
-            if item.target_key == target_key:
-                reservation.hand_off()
-            else:
-                reservation.consume()
-    if selected_item is None:
-        return None
-    return cast("QueuedHumanNoticeReservation", selected_item.payload)
+        reservation = cast("QueuedHumanNoticeReservation", item.payload)
+        if item.target_key == target_key:
+            reservation.consume()
+        else:
+            reservation.cancel()
 
 
 def _raw_voice_fallback_event(event: AudioMessageEvent, *, thread_id: str | None) -> PreparedTextEvent:
@@ -719,15 +630,9 @@ class TurnController:
         preliminary_target: MessageTarget | None,
         target: MessageTarget,
         envelope: MessageEnvelope,
-        event: DispatchEvent,
         queued_notice_reservation: QueuedHumanNoticeReservation | None,
     ) -> tuple[bool, QueuedHumanNoticeReservation | None]:
         """Return active-follow-up policy and the reservation for a voice target."""
-        queued_message = _queued_human_message_for_event(
-            event=event,
-            envelope=envelope,
-            trust_internal_payload_metadata=True,
-        )
         if queued_notice_reservation is not None and (
             preliminary_target is None
             or not self._same_response_lifecycle_target(
@@ -738,7 +643,6 @@ class TurnController:
             queued_notice_reservation.cancel()
             queued_notice_reservation = None
         if queued_notice_reservation is not None:
-            queued_notice_reservation.update_message(queued_message)
             return True, queued_notice_reservation
         active_follow_up = (
             envelope.origin.may_answer_interactive_prompt
@@ -749,7 +653,6 @@ class TurnController:
         return True, self.deps.response_runner.reserve_waiting_human_message(
             target=target,
             response_envelope=envelope,
-            queued_message=queued_message,
         )
 
     async def _enqueue_active_thread_follow_up(
@@ -775,12 +678,9 @@ class TurnController:
             queued_notice_reservation = self.deps.response_runner.reserve_waiting_human_message(
                 target=target,
                 response_envelope=envelope,
-                queued_message=_queued_human_message_for_event(
-                    event=event,
-                    envelope=envelope,
-                    trust_internal_payload_metadata=resolved_trust_internal_payload_metadata,
-                ),
             )
+        coalescing_key = active_follow_up_coalescing_key(room.room_id, coalescing_thread_id)
+        reservation_owner.retarget(coalescing_key.requester_user_id)
         try:
             await self._enqueue_for_dispatch(
                 event,
@@ -791,7 +691,7 @@ class TurnController:
                 message_received_depth=envelope.message_received_depth,
                 requester_user_id=requester_user_id,
                 reservation_owner=reservation_owner,
-                coalescing_key=CoalescingKey(room.room_id, coalescing_thread_id, requester_user_id),
+                coalescing_key=coalescing_key,
                 queued_notice_reservation=queued_notice_reservation,
                 queued_notice_target=target,
                 trust_internal_payload_metadata=resolved_trust_internal_payload_metadata,
@@ -1142,6 +1042,7 @@ class TurnController:
         pending_event = PendingEvent(
             event=event,
             room=room,
+            requester_user_id=requester_user_id,
             source_kind=source_kind,
             dispatch_policy_source_kind=dispatch_policy_source_kind,
             hook_source=hook_source,
@@ -1882,8 +1783,6 @@ class TurnController:
 
                 async def prepare_request_after_lock(request: ResponseRequest) -> ResponseRequest:
                     nonlocal dispatch
-                    nonlocal handled_turn
-                    nonlocal matrix_run_metadata
                     nonlocal payload_ready_monotonic
                     if dispatch_timing is not None:
                         dispatch_timing.mark("response_payload_start")
@@ -1908,31 +1807,6 @@ class TurnController:
                             thread_id=request.thread_id,
                             outcome=payload_builder_outcome,
                         )
-                    backlog: _ActiveFollowUpBacklog | None = None
-                    queued_messages = current_queued_human_messages()
-                    if (
-                        queued_messages
-                        and dispatch.envelope.dispatch_policy_source_kind == ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND
-                    ):
-                        backlog = _active_follow_up_backlog(
-                            queued_messages=queued_messages,
-                            thread_history=request.thread_history,
-                        )
-                        if backlog is not None:
-                            handled_turn = replace(
-                                handled_turn,
-                                source_event_ids=backlog.source_event_ids,
-                                source_event_prompts=backlog.source_event_prompts,
-                            )
-                            matrix_run_metadata = deep_merge_metadata(
-                                matrix_run_metadata,
-                                self.deps.turn_store.build_run_metadata(handled_turn),
-                            )
-                            payload = replace(payload, prompt=backlog.prompt)
-                            dispatch = replace(
-                                dispatch,
-                                envelope=replace(dispatch.envelope, body=backlog.prompt),
-                            )
                     prepared_payload = await self.deps.ingress_hook_runner.apply_message_enrichment(
                         dispatch,
                         payload,
@@ -1963,7 +1837,7 @@ class TurnController:
                         thread_history=request.thread_history,
                     )
                     return ResponseRequest(
-                        thread_history=backlog.thread_history if backlog is not None else request.thread_history,
+                        thread_history=request.thread_history,
                         prompt=prepared_payload.payload.prompt,
                         model_prompt=prepared_payload.payload.model_prompt,
                         existing_event_id=request.existing_event_id,
@@ -2029,42 +1903,35 @@ class TurnController:
 
     async def handle_coalesced_batch(self, batch: CoalescedBatch) -> None:
         """Dispatch one flushed batch through the normal text pipeline."""
-        reservation: QueuedHumanNoticeReservation | None = None
         try:
-            try:
-                handoff = build_dispatch_handoff(batch)
-            except BaseException:
-                close_pending_event_metadata(list(batch.pending_events))
-                raise
-            reservation = _queued_notice_reservation_from_metadata(
-                handoff.dispatch_metadata,
-                target_key=self._queued_notice_target_key_for_handoff(handoff),
+            handoff = build_dispatch_handoff(batch)
+        except BaseException:
+            close_pending_event_metadata(list(batch.pending_events))
+            raise
+        _consume_queued_notice_reservations_from_metadata(
+            handoff.dispatch_metadata,
+            target_key=self._queued_notice_target_key_for_handoff(handoff),
+        )
+        timing_scope = event_timing_scope(handoff.event.event_id)
+        dispatch_timing = get_dispatch_pipeline_timing(handoff.event.source)
+        if dispatch_timing is not None:
+            dispatch_timing.mark("gate_exit")
+        async with self.deps.resolver.turn_thread_cache_scope():
+            dispatch_start = time.monotonic()
+            handled_turn = HandledTurnState.create(
+                handoff.source_event_ids,
+                source_event_prompts=dict(handoff.source_event_prompts),
             )
-            timing_scope = event_timing_scope(handoff.event.event_id)
-            dispatch_timing = get_dispatch_pipeline_timing(handoff.event.source)
-            if dispatch_timing is not None:
-                dispatch_timing.mark("gate_exit")
-            async with self.deps.resolver.turn_thread_cache_scope():
-                dispatch_start = time.monotonic()
-                handled_turn = HandledTurnState.create(
-                    handoff.source_event_ids,
-                    source_event_prompts=dict(handoff.source_event_prompts),
-                )
-                await self._dispatch_handoff(
-                    handoff,
-                    handled_turn=handled_turn,
-                    queued_notice_reservation=reservation,
-                )
-                reservation = None
-                emit_elapsed_timing(
-                    "coalescing.handle_batch.dispatch_text_message",
-                    dispatch_start,
-                    source_event_count=len(batch.source_event_ids),
-                    timing_scope=timing_scope,
-                )
-        finally:
-            if reservation is not None:
-                reservation.cancel()
+            await self._dispatch_handoff(
+                handoff,
+                handled_turn=handled_turn,
+            )
+            emit_elapsed_timing(
+                "coalescing.handle_batch.dispatch_text_message",
+                dispatch_start,
+                source_event_count=len(batch.source_event_ids),
+                timing_scope=timing_scope,
+            )
 
     def _queued_notice_target_key_for_handoff(self, handoff: DispatchHandoff) -> tuple[str, str | None]:
         coalescing_key = handoff.ingress.coalescing_key
@@ -2084,17 +1951,14 @@ class TurnController:
         handoff: DispatchHandoff,
         *,
         handled_turn: HandledTurnState,
-        queued_notice_reservation: QueuedHumanNoticeReservation | None,
     ) -> None:
         """Dispatch one coalesced handoff and own opaque metadata cleanup."""
-        reservation = queued_notice_reservation
         await self._dispatch_text_message(
             handoff.room,
             handoff.event,
             handoff.requester_user_id,
             media_events=list(handoff.media_events) or None,
             handled_turn=handled_turn,
-            queued_notice_reservation=reservation,
             ingress_metadata=handoff.ingress,
             payload_metadata=handoff.payload,
             trust_hydrated_internal_metadata=handoff.trust_hydrated_internal_metadata,
@@ -2398,6 +2262,7 @@ class TurnController:
             ),
             name=f"voice_ready:{room.room_id}:{event.event_id}",
         )
+        reservation_owner.retarget(admission_key.requester_user_id)
         await reservation_owner.admit(
             admission_key,
             ready_task=ready_task,
@@ -2427,7 +2292,10 @@ class TurnController:
             reply_to_event_id=event.event_id,
             event_source=event.source,
         )
-        admission_key = CoalescingKey(room.room_id, coalescing_thread_id, requester_user_id)
+        if self.deps.response_runner.has_active_response_for_target(voice_target):
+            admission_key = active_follow_up_coalescing_key(room.room_id, coalescing_thread_id)
+        else:
+            admission_key = CoalescingKey(room.room_id, coalescing_thread_id, requester_user_id)
         return voice_target, admission_key
 
     async def _ready_voice_event(
@@ -2498,7 +2366,6 @@ class TurnController:
                 preliminary_target=voice_target,
                 target=normalized_target,
                 envelope=envelope,
-                event=normalized_event,
                 queued_notice_reservation=queued_notice_reservation,
             )
             reservation_released_or_handed_off = True
@@ -2507,6 +2374,7 @@ class TurnController:
                     event=normalized_event,
                     room=room,
                     source_kind=envelope.source_kind,
+                    requester_user_id=prechecked_event.requester_user_id,
                     dispatch_policy_source_kind=(
                         ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND
                         if active_follow_up
@@ -2607,7 +2475,6 @@ class TurnController:
                 preliminary_target=target,
                 target=target,
                 envelope=envelope,
-                event=fallback_event,
                 queued_notice_reservation=None,
             )
             dispatch_policy_source_kind = (
@@ -2628,6 +2495,7 @@ class TurnController:
                 event=fallback_event,
                 room=room,
                 source_kind=VOICE_SOURCE_KIND,
+                requester_user_id=requester_user_id,
                 dispatch_policy_source_kind=dispatch_policy_source_kind,
                 hook_source=hook_source,
                 message_received_depth=message_received_depth,

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -610,16 +610,26 @@ class TurnController:
 
     def _should_apply_active_thread_follow_up_policy(
         self,
-        *,
         envelope: MessageEnvelope,
-        active_response_thread_ids_at_receipt: frozenset[str | None] | None = None,
+        active_response_thread_ids_at_receipt: frozenset[str | None],
     ) -> bool:
         """Return whether one human follow-up should carry active-response policy."""
         if not envelope.origin.may_answer_interactive_prompt:
             return False
-        if active_response_thread_ids_at_receipt is not None:
-            return envelope.target.resolved_thread_id in active_response_thread_ids_at_receipt
-        return self.deps.response_runner.has_active_response_for_target(envelope.target)
+        return envelope.target.resolved_thread_id in active_response_thread_ids_at_receipt
+
+    def _coalescing_key_for_ingress(
+        self,
+        room_id: str,
+        coalescing_thread_id: str | None,
+        requester_user_id: str,
+        envelope: MessageEnvelope,
+        active_response_thread_ids_at_receipt: frozenset[str | None],
+    ) -> tuple[bool, CoalescingKey]:
+        """Return whether ingress is an active follow-up and its physical queue key."""
+        if self._should_apply_active_thread_follow_up_policy(envelope, active_response_thread_ids_at_receipt):
+            return True, active_follow_up_coalescing_key(room_id, coalescing_thread_id)
+        return False, CoalescingKey(room_id, coalescing_thread_id, requester_user_id)
 
     @staticmethod
     def _same_response_lifecycle_target(left: MessageTarget, right: MessageTarget) -> bool:
@@ -633,7 +643,7 @@ class TurnController:
         target: MessageTarget,
         envelope: MessageEnvelope,
         queued_notice_reservation: QueuedHumanNoticeReservation | None,
-        active_response_thread_ids_at_receipt: frozenset[str | None] | None,
+        active_response_thread_ids_at_receipt: frozenset[str | None],
     ) -> tuple[bool, QueuedHumanNoticeReservation | None]:
         """Return active-follow-up policy and the reservation for a voice target."""
         if queued_notice_reservation is not None and (
@@ -646,8 +656,8 @@ class TurnController:
             queued_notice_reservation.cancel()
             queued_notice_reservation = None
         active_follow_up = self._should_apply_active_thread_follow_up_policy(
-            envelope=envelope,
-            active_response_thread_ids_at_receipt=active_response_thread_ids_at_receipt,
+            envelope,
+            active_response_thread_ids_at_receipt,
         )
         if queued_notice_reservation is not None:
             if active_follow_up:
@@ -668,9 +678,9 @@ class TurnController:
         event: DispatchEvent,
         target: MessageTarget,
         envelope: MessageEnvelope,
-        coalescing_thread_id: str | None,
         requester_user_id: str,
         reservation_owner: _PromptIngressReservationOwner,
+        coalescing_key: CoalescingKey,
         trust_internal_payload_metadata: bool | None = None,
         queued_notice_reservation: QueuedHumanNoticeReservation | None = None,
     ) -> _IngressAdmissionOutcome:
@@ -685,7 +695,6 @@ class TurnController:
                 target=target,
                 response_envelope=envelope,
             )
-        coalescing_key = active_follow_up_coalescing_key(room.room_id, coalescing_thread_id)
         reservation_owner.retarget(coalescing_key.requester_user_id)
         try:
             await self._enqueue_for_dispatch(
@@ -733,18 +742,22 @@ class TurnController:
             reply_to_event_id=prepared_event.event_id,
             event_source=prepared_event.source,
         )
-        if self._should_apply_active_thread_follow_up_policy(
-            envelope=envelope,
-            active_response_thread_ids_at_receipt=reservation_owner.active_response_thread_ids_at_receipt,
-        ):
+        active_follow_up, coalescing_key = self._coalescing_key_for_ingress(
+            room.room_id,
+            coalescing_thread_id,
+            requester_user_id,
+            envelope,
+            reservation_owner.active_response_thread_ids_at_receipt,
+        )
+        if active_follow_up:
             await self._enqueue_active_thread_follow_up(
                 room=room,
                 event=prepared_event,
                 target=target,
                 envelope=envelope,
-                coalescing_thread_id=coalescing_thread_id,
                 requester_user_id=requester_user_id,
                 reservation_owner=reservation_owner,
+                coalescing_key=coalescing_key,
                 trust_internal_payload_metadata=trust_internal_payload_metadata,
                 queued_notice_reservation=queued_notice_reservation,
             )
@@ -759,7 +772,7 @@ class TurnController:
                 message_received_depth=envelope.message_received_depth,
                 requester_user_id=requester_user_id,
                 reservation_owner=reservation_owner,
-                coalescing_key=CoalescingKey(room.room_id, coalescing_thread_id, requester_user_id),
+                coalescing_key=coalescing_key,
                 queued_notice_reservation=queued_notice_reservation,
                 queued_notice_target=target,
                 trust_internal_payload_metadata=trust_internal_payload_metadata,
@@ -799,18 +812,22 @@ class TurnController:
             target=target,
             source_kind=source_kind,
         )
-        if self._should_apply_active_thread_follow_up_policy(
-            envelope=envelope,
-            active_response_thread_ids_at_receipt=reservation_owner.active_response_thread_ids_at_receipt,
-        ):
+        active_follow_up, coalescing_key = self._coalescing_key_for_ingress(
+            room.room_id,
+            coalescing_thread_id,
+            requester_user_id,
+            envelope,
+            reservation_owner.active_response_thread_ids_at_receipt,
+        )
+        if active_follow_up:
             await self._enqueue_active_thread_follow_up(
                 room=room,
                 event=event,
                 target=target,
                 envelope=envelope,
-                coalescing_thread_id=coalescing_thread_id,
                 requester_user_id=requester_user_id,
                 reservation_owner=reservation_owner,
+                coalescing_key=coalescing_key,
             )
             return _IngressAdmissionOutcome.ADMITTED
         await self._enqueue_for_dispatch(
@@ -819,7 +836,7 @@ class TurnController:
             source_kind=envelope.source_kind,
             requester_user_id=requester_user_id,
             reservation_owner=reservation_owner,
-            coalescing_key=CoalescingKey(room.room_id, coalescing_thread_id, requester_user_id),
+            coalescing_key=coalescing_key,
         )
         return _IngressAdmissionOutcome.ADMITTED
 
@@ -2253,7 +2270,7 @@ class TurnController:
         """Resolve the audio conversation key once, then defer voice normalization."""
         event = prechecked_event.event
 
-        voice_target, admission_key = await self._resolve_ready_voice_target(
+        voice_target, admission_key, preliminary_active_follow_up = await self._resolve_ready_voice_target(
             room,
             event,
             event_info=event_info,
@@ -2268,6 +2285,7 @@ class TurnController:
                 prechecked_event=prechecked_event,
                 voice_target=voice_target,
                 dispatch_timing=dispatch_timing,
+                preliminary_active_follow_up=preliminary_active_follow_up,
                 active_response_thread_ids_at_receipt=reservation_owner.active_response_thread_ids_at_receipt,
             ),
             name=f"voice_ready:{room.room_id}:{event.event_id}",
@@ -2289,7 +2307,7 @@ class TurnController:
         requester_user_id: str,
         dispatch_timing: DispatchPipelineTiming | None,
         active_response_thread_ids_at_receipt: frozenset[str | None],
-    ) -> tuple[MessageTarget, CoalescingKey]:
+    ) -> tuple[MessageTarget, CoalescingKey, bool]:
         await self._append_live_event_with_timing(
             room.room_id,
             event,
@@ -2310,14 +2328,14 @@ class TurnController:
             target=voice_target,
             source_kind=VOICE_SOURCE_KIND,
         )
-        if self._should_apply_active_thread_follow_up_policy(
-            envelope=envelope,
-            active_response_thread_ids_at_receipt=active_response_thread_ids_at_receipt,
-        ):
-            admission_key = active_follow_up_coalescing_key(room.room_id, coalescing_thread_id)
-        else:
-            admission_key = CoalescingKey(room.room_id, coalescing_thread_id, requester_user_id)
-        return voice_target, admission_key
+        active_follow_up, admission_key = self._coalescing_key_for_ingress(
+            room.room_id,
+            coalescing_thread_id,
+            requester_user_id,
+            envelope,
+            active_response_thread_ids_at_receipt,
+        )
+        return voice_target, admission_key, active_follow_up
 
     async def _ready_voice_event(
         self,
@@ -2326,6 +2344,7 @@ class TurnController:
         prechecked_event: _PrecheckedEvent[AudioMessageEvent],
         voice_target: MessageTarget,
         dispatch_timing: DispatchPipelineTiming | None,
+        preliminary_active_follow_up: bool,
         active_response_thread_ids_at_receipt: frozenset[str | None],
     ) -> ReadyPendingEvent | None:
         """Normalize a raw voice event after its conversation key is fixed."""
@@ -2340,10 +2359,7 @@ class TurnController:
                 target=voice_target,
                 source_kind=VOICE_SOURCE_KIND,
             )
-            if self._should_apply_active_thread_follow_up_policy(
-                envelope=envelope,
-                active_response_thread_ids_at_receipt=active_response_thread_ids_at_receipt,
-            ):
+            if preliminary_active_follow_up:
                 queued_notice_reservation = self.deps.response_runner.reserve_waiting_human_message(
                     target=voice_target,
                     response_envelope=envelope,

--- a/tach.toml
+++ b/tach.toml
@@ -927,7 +927,11 @@ depends_on = [
     "mindroom.post_response_effects",
     "mindroom.tool_system.runtime_context",
 ]
-visibility = ["mindroom.response_runner"]
+visibility = [
+    "mindroom.response_runner",
+    "mindroom.text_ingress_dispatch",
+    "mindroom.turn_controller",
+]
 
 [[modules]]
 path = "mindroom.response_attempt"
@@ -2088,6 +2092,7 @@ depends_on = [
     "mindroom.inbound_turn_normalizer",
     "mindroom.matrix.media",
     "mindroom.matrix.rooms",
+    "mindroom.response_lifecycle",
     "mindroom.timing",
 ]
 visibility = ["mindroom.turn_controller"]
@@ -2110,7 +2115,9 @@ depends_on = [
     "mindroom.matrix.event_info",
     "mindroom.matrix.message_content",
     "mindroom.matrix.rooms",
+    "mindroom.metadata_merge",
     "mindroom.prompt_ingress_reservation",
+    "mindroom.response_lifecycle",
     "mindroom.response_runner",
     "mindroom.routing",
     "mindroom.text_ingress_dispatch",

--- a/tests/test_coalescing.py
+++ b/tests/test_coalescing.py
@@ -847,6 +847,75 @@ async def test_active_follow_up_backlog_ignores_debounce_gaps_after_idle() -> No
 
 
 @pytest.mark.asyncio
+async def test_later_normal_gate_waits_behind_older_active_backlog() -> None:
+    """A resolved later normal key must not overtake an older same-room active backlog."""
+    batches: list[list[str]] = []
+    first_active_wait = asyncio.Event()
+    release_first_active_wait = asyncio.Event()
+    second_active_wait = asyncio.Event()
+    release_second_active_wait = asyncio.Event()
+    active_wait_count = 0
+    active_key = active_follow_up_coalescing_key("!room:localhost", "$thread:localhost")
+    normal_key = CoalescingKey("!room:localhost", "$other-thread:localhost", "@bob:localhost")
+
+    async def dispatch_batch(batch: CoalescedBatch) -> None:
+        batches.append(list(batch.source_event_ids))
+
+    async def wait_until_dispatch_allowed(wait_key: CoalescingKey) -> None:
+        nonlocal active_wait_count
+        if wait_key != active_key:
+            return
+        active_wait_count += 1
+        if active_wait_count == 1:
+            first_active_wait.set()
+            await release_first_active_wait.wait()
+            return
+        second_active_wait.set()
+        await release_second_active_wait.wait()
+
+    gate = CoalescingGate(
+        dispatch_batch=dispatch_batch,
+        debounce_seconds=lambda: 0.0,
+        upload_grace_seconds=lambda: 0.0,
+        is_shutting_down=lambda: False,
+        wait_until_dispatch_allowed=wait_until_dispatch_allowed,
+    )
+
+    await _admit_ready(
+        gate,
+        active_key,
+        PendingEvent(
+            event=_text_event("$active:localhost", "queued while active", 1_000_000),
+            room=nio.MatrixRoom("!room:localhost", "@mindroom:localhost"),
+            source_kind=MESSAGE_SOURCE_KIND,
+            requester_user_id="@alice:localhost",
+            dispatch_policy_source_kind=ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND,
+        ),
+    )
+    await first_active_wait.wait()
+
+    later_reservation = gate.reserve_order(room_id=normal_key.room_id, requester_user_id=normal_key.requester_user_id)
+    release_first_active_wait.set()
+    await asyncio.sleep(0)
+
+    await gate.admit(
+        normal_key,
+        ready_result=ReadyPendingEvent(
+            pending_event=_pending(_text_event("$normal:localhost", "later normal", 1_000_001)),
+        ),
+        order_reservation=later_reservation,
+    )
+    await _wait_for(lambda: second_active_wait.is_set() or batches)
+
+    assert batches == []
+
+    release_second_active_wait.set()
+    await gate.drain_all()
+
+    assert batches == [["$active:localhost"], ["$normal:localhost"]]
+
+
+@pytest.mark.asyncio
 async def test_unresolved_reservation_wait_keeps_debounce_gaps() -> None:
     """Events queued before dispatch starts must still obey debounce gaps after the blocker resolves."""
     batches: list[CoalescedBatch] = []

--- a/tests/test_coalescing.py
+++ b/tests/test_coalescing.py
@@ -1079,6 +1079,57 @@ async def test_bounded_shutdown_times_out_stuck_in_flight_dispatch() -> None:
 
 
 @pytest.mark.asyncio
+async def test_bounded_drain_does_not_wait_forever_on_external_dispatch_gate() -> None:
+    """A bounded drain must not wait indefinitely for an active-follow-up idle gate."""
+    calls: list[list[str]] = []
+    dispatch_wait_started = asyncio.Event()
+    release_dispatch_wait = asyncio.Event()
+    key = active_follow_up_coalescing_key("!room:localhost", "$thread:localhost")
+
+    async def wait_until_dispatch_allowed(wait_key: CoalescingKey) -> None:
+        if wait_key == key:
+            dispatch_wait_started.set()
+            await release_dispatch_wait.wait()
+
+    async def dispatch_batch(batch: CoalescedBatch) -> None:
+        calls.append(list(batch.source_event_ids))
+
+    gate = CoalescingGate(
+        dispatch_batch=dispatch_batch,
+        debounce_seconds=lambda: 0.0,
+        upload_grace_seconds=lambda: 0.0,
+        is_shutting_down=lambda: False,
+        wait_until_dispatch_allowed=wait_until_dispatch_allowed,
+    )
+    await _admit_ready(
+        gate,
+        key,
+        PendingEvent(
+            event=_text_event("$text:localhost", "typed", 1_000_000),
+            room=nio.MatrixRoom("!room:localhost", "@mindroom:localhost"),
+            source_kind=MESSAGE_SOURCE_KIND,
+            requester_user_id="@user:localhost",
+            dispatch_policy_source_kind=ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND,
+        ),
+    )
+    await dispatch_wait_started.wait()
+
+    drain_task = asyncio.create_task(gate.drain_all(ready_timeout_seconds=0.01))
+    try:
+        result = await asyncio.wait_for(asyncio.shield(drain_task), timeout=0.2)
+    except TimeoutError:  # pragma: no cover - documents the failure mode on regression
+        pytest.fail("bounded drain hung behind external dispatch gate")
+    finally:
+        release_dispatch_wait.set()
+        if not drain_task.done():
+            drain_task.cancel()
+            await asyncio.gather(drain_task, return_exceptions=True)
+
+    assert result.completed is True
+    assert calls == [["$text:localhost"]]
+
+
+@pytest.mark.asyncio
 async def test_bounded_shutdown_closes_metadata_for_abandoned_ready_work() -> None:
     """Gate-owned metadata must close before bounded shutdown discards failed queued work."""
     close_count = 0

--- a/tests/test_coalescing.py
+++ b/tests/test_coalescing.py
@@ -17,7 +17,12 @@ from mindroom.coalescing import (
     ReadyPendingEvent,
     is_coalescing_exempt_source_kind,
 )
-from mindroom.coalescing_batch import CoalescingKey, PendingEvent, build_coalesced_batch
+from mindroom.coalescing_batch import (
+    CoalescingKey,
+    PendingEvent,
+    active_follow_up_coalescing_key,
+    build_coalesced_batch,
+)
 from mindroom.dispatch_handoff import PendingDispatchMetadata, PreparedTextEvent, build_dispatch_handoff
 from mindroom.dispatch_source import (
     ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND,
@@ -780,6 +785,65 @@ async def test_threaded_debounce_uses_trailing_quiet_time() -> None:
     await _wait_for(
         lambda: [batch.source_event_ids for batch in batches] == [["$first:localhost", "$second:localhost"]],
     )
+
+
+@pytest.mark.asyncio
+async def test_active_follow_up_backlog_ignores_debounce_gaps_after_idle() -> None:
+    """Same-target follow-ups queued behind one active response flush as one ordered backlog."""
+    calls: list[tuple[list[str], str]] = []
+    idle = asyncio.Event()
+    key = active_follow_up_coalescing_key("!room:localhost", "$thread:localhost")
+
+    async def dispatch_batch(batch: CoalescedBatch) -> None:
+        calls.append((list(batch.source_event_ids), batch.prompt))
+
+    async def wait_until_dispatch_allowed(wait_key: CoalescingKey) -> None:
+        if wait_key == key:
+            await idle.wait()
+
+    gate = CoalescingGate(
+        dispatch_batch=dispatch_batch,
+        debounce_seconds=lambda: 0.01,
+        upload_grace_seconds=lambda: 0.0,
+        is_shutting_down=lambda: False,
+        wait_until_dispatch_allowed=wait_until_dispatch_allowed,
+    )
+
+    for event_id, body, requester_user_id in (
+        ("$a1:localhost", "first follow-up", "@alice:localhost"),
+        ("$b1:localhost", "extra context", "@bob:localhost"),
+        ("$a2:localhost", "reply to bob", "@alice:localhost"),
+    ):
+        await _admit_ready(
+            gate,
+            key,
+            PendingEvent(
+                event=_text_event(event_id, body, 1_000_000),
+                room=nio.MatrixRoom("!room:localhost", "@mindroom:localhost"),
+                source_kind=MESSAGE_SOURCE_KIND,
+                requester_user_id=requester_user_id,
+                dispatch_policy_source_kind=ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND,
+            ),
+        )
+        await asyncio.sleep(0.03)
+
+    assert calls == []
+
+    idle.set()
+    await _wait_for(lambda: calls != [])
+
+    assert calls == [
+        (
+            ["$a1:localhost", "$b1:localhost", "$a2:localhost"],
+            "Messages arrived while the previous response was still running. "
+            "They are in chat timeline order. Respond once to the combined context:\n\n"
+            "<queued_messages>\n"
+            '<msg event_id="$a1:localhost" from="@alice:localhost"><![CDATA[first follow-up]]></msg>\n'
+            '<msg event_id="$b1:localhost" from="@bob:localhost"><![CDATA[extra context]]></msg>\n'
+            '<msg event_id="$a2:localhost" from="@alice:localhost"><![CDATA[reply to bob]]></msg>\n'
+            "</queued_messages>",
+        ),
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_coalescing.py
+++ b/tests/test_coalescing.py
@@ -776,7 +776,7 @@ async def test_threaded_debounce_uses_trailing_quiet_time() -> None:
     key = CoalescingKey("!room:localhost", "$thread:localhost", "@user:localhost")
 
     await _admit_ready(gate, key, _pending(_text_event("$first:localhost", "first", 1_000_000)))
-    await asyncio.sleep(0.04)
+    await asyncio.sleep(0.01)
     await _admit_ready(gate, key, _pending(_text_event("$second:localhost", "second", 1_000_040)))
     await asyncio.sleep(0.02)
 

--- a/tests/test_coalescing.py
+++ b/tests/test_coalescing.py
@@ -847,8 +847,8 @@ async def test_active_follow_up_backlog_ignores_debounce_gaps_after_idle() -> No
 
 
 @pytest.mark.asyncio
-async def test_later_normal_gate_waits_behind_older_active_backlog() -> None:
-    """A resolved later normal key must not overtake an older same-room active backlog."""
+async def test_same_target_normal_gate_waits_behind_older_active_backlog() -> None:
+    """A resolved later normal key must not overtake an older active backlog for that target."""
     batches: list[list[str]] = []
     first_active_wait = asyncio.Event()
     release_first_active_wait = asyncio.Event()
@@ -856,7 +856,7 @@ async def test_later_normal_gate_waits_behind_older_active_backlog() -> None:
     release_second_active_wait = asyncio.Event()
     active_wait_count = 0
     active_key = active_follow_up_coalescing_key("!room:localhost", "$thread:localhost")
-    normal_key = CoalescingKey("!room:localhost", "$other-thread:localhost", "@bob:localhost")
+    normal_key = CoalescingKey("!room:localhost", "$thread:localhost", "@bob:localhost")
 
     async def dispatch_batch(batch: CoalescedBatch) -> None:
         batches.append(list(batch.source_event_ids))
@@ -913,6 +913,71 @@ async def test_later_normal_gate_waits_behind_older_active_backlog() -> None:
     await gate.drain_all()
 
     assert batches == [["$active:localhost"], ["$normal:localhost"]]
+
+
+@pytest.mark.asyncio
+async def test_different_thread_normal_gate_does_not_wait_behind_older_active_backlog() -> None:
+    """Resolved gates in other threads must not wait behind an active backlog for this target."""
+    batches: list[list[str]] = []
+    first_active_wait = asyncio.Event()
+    release_first_active_wait = asyncio.Event()
+    release_second_active_wait = asyncio.Event()
+    active_wait_count = 0
+    active_key = active_follow_up_coalescing_key("!room:localhost", "$thread:localhost")
+    normal_key = CoalescingKey("!room:localhost", "$other-thread:localhost", "@bob:localhost")
+
+    async def dispatch_batch(batch: CoalescedBatch) -> None:
+        batches.append(list(batch.source_event_ids))
+
+    async def wait_until_dispatch_allowed(wait_key: CoalescingKey) -> None:
+        nonlocal active_wait_count
+        if wait_key != active_key:
+            return
+        active_wait_count += 1
+        if active_wait_count == 1:
+            first_active_wait.set()
+            await release_first_active_wait.wait()
+            return
+        await release_second_active_wait.wait()
+
+    gate = CoalescingGate(
+        dispatch_batch=dispatch_batch,
+        debounce_seconds=lambda: 0.0,
+        upload_grace_seconds=lambda: 0.0,
+        is_shutting_down=lambda: False,
+        wait_until_dispatch_allowed=wait_until_dispatch_allowed,
+    )
+
+    await _admit_ready(
+        gate,
+        active_key,
+        PendingEvent(
+            event=_text_event("$active:localhost", "queued while active", 1_000_000),
+            room=nio.MatrixRoom("!room:localhost", "@mindroom:localhost"),
+            source_kind=MESSAGE_SOURCE_KIND,
+            requester_user_id="@alice:localhost",
+            dispatch_policy_source_kind=ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND,
+        ),
+    )
+    await first_active_wait.wait()
+
+    later_reservation = gate.reserve_order(room_id=normal_key.room_id, requester_user_id=normal_key.requester_user_id)
+    release_first_active_wait.set()
+    await asyncio.sleep(0)
+
+    await gate.admit(
+        normal_key,
+        ready_result=ReadyPendingEvent(
+            pending_event=_pending(_text_event("$normal:localhost", "later normal", 1_000_001)),
+        ),
+        order_reservation=later_reservation,
+    )
+    await _wait_for(lambda: batches == [["$normal:localhost"]])
+
+    release_second_active_wait.set()
+    await gate.drain_all()
+
+    assert batches == [["$normal:localhost"], ["$active:localhost"]]
 
 
 @pytest.mark.asyncio

--- a/tests/test_coalescing.py
+++ b/tests/test_coalescing.py
@@ -783,7 +783,7 @@ async def test_threaded_debounce_uses_trailing_quiet_time() -> None:
 
 
 @pytest.mark.asyncio
-async def test_unresolved_reservation_wait_does_not_mark_queued_events_as_in_flight_buffered() -> None:
+async def test_unresolved_reservation_wait_keeps_debounce_gaps() -> None:
     """Events queued before dispatch starts must still obey debounce gaps after the blocker resolves."""
     batches: list[CoalescedBatch] = []
 
@@ -824,8 +824,8 @@ async def test_unresolved_reservation_wait_does_not_mark_queued_events_as_in_fli
 
 
 @pytest.mark.asyncio
-async def test_in_flight_unresolved_reservations_stay_buffered_after_admission() -> None:
-    """Reservations created during dispatch should stay in the in-flight follow-up window."""
+async def test_in_flight_unresolved_reservations_obey_debounce_after_admission() -> None:
+    """Reservations created during dispatch should still obey their receive-time debounce gaps."""
     batches: list[CoalescedBatch] = []
     release_dispatch = asyncio.Event()
 
@@ -855,6 +855,9 @@ async def test_in_flight_unresolved_reservations_stay_buffered_after_admission()
         ready_result=ReadyPendingEvent(pending_event=_pending(_text_event("$second:localhost", "second", 1_000_001))),
         order_reservation=second_reservation,
     )
+    await _wait_for(
+        lambda: [batch.source_event_ids for batch in batches] == [["$first:localhost"], ["$second:localhost"]],
+    )
     await gate.admit(
         key,
         ready_result=ReadyPendingEvent(pending_event=_pending(_text_event("$third:localhost", "third", 1_000_002))),
@@ -864,7 +867,8 @@ async def test_in_flight_unresolved_reservations_stay_buffered_after_admission()
 
     assert [batch.source_event_ids for batch in batches] == [
         ["$first:localhost"],
-        ["$second:localhost", "$third:localhost"],
+        ["$second:localhost"],
+        ["$third:localhost"],
     ]
 
 
@@ -1671,101 +1675,8 @@ async def test_multi_segment_claim_remains_visible_until_last_segment_finishes()
 
 
 @pytest.mark.asyncio
-async def test_root_in_flight_buffers_late_reservation_followups_for_child_key() -> None:
-    """Reservations made during a root response should buffer after resolving to that root's child key."""
-    first_dispatch_started = asyncio.Event()
-    release_first_dispatch = asyncio.Event()
-    batches: list[list[str]] = []
-
-    async def dispatch_batch(batch: CoalescedBatch) -> None:
-        batches.append(batch.source_event_ids)
-        if batch.source_event_ids == ["$root:localhost"]:
-            first_dispatch_started.set()
-            await release_first_dispatch.wait()
-
-    gate = CoalescingGate(
-        dispatch_batch=dispatch_batch,
-        debounce_seconds=lambda: 0.01,
-        upload_grace_seconds=lambda: 0.0,
-        is_shutting_down=lambda: False,
-    )
-    root_key = CoalescingKey("!room:localhost", None, "@user:localhost")
-    child_key = CoalescingKey("!room:localhost", "$root:localhost", "@user:localhost")
-
-    await _admit_ready(gate, root_key, _pending(_text_event("$root:localhost", "root", 1_000_000)))
-    await _wait_for(first_dispatch_started.is_set)
-    first_reservation = gate.reserve_order(room_id=root_key.room_id, requester_user_id=root_key.requester_user_id)
-    await asyncio.sleep(0.03)
-    second_reservation = gate.reserve_order(room_id=root_key.room_id, requester_user_id=root_key.requester_user_id)
-
-    release_first_dispatch.set()
-    await _wait_for(lambda: child_key in gate._in_flight_buffered_max_order)
-    await gate.admit(
-        child_key,
-        ready_result=ReadyPendingEvent(
-            pending_event=_pending(_text_event("$follow1:localhost", "follow 1", 1_000_001)),
-        ),
-        order_reservation=first_reservation,
-    )
-    await gate.admit(
-        child_key,
-        ready_result=ReadyPendingEvent(
-            pending_event=_pending(_text_event("$follow2:localhost", "follow 2", 1_000_002)),
-        ),
-        order_reservation=second_reservation,
-    )
-    await gate.drain_all()
-
-    assert batches == [["$root:localhost"], ["$follow1:localhost", "$follow2:localhost"]]
-
-
-@pytest.mark.asyncio
-async def test_root_in_flight_buffer_entries_clear_when_reservation_admits_elsewhere() -> None:
-    """Synthetic root-follow-up buffering should not leak after reservation admission elsewhere."""
-    first_dispatch_started = asyncio.Event()
-    release_first_dispatch = asyncio.Event()
-    batches: list[list[str]] = []
-
-    async def dispatch_batch(batch: CoalescedBatch) -> None:
-        batches.append(batch.source_event_ids)
-        if batch.source_event_ids == ["$root:localhost"]:
-            first_dispatch_started.set()
-            await release_first_dispatch.wait()
-
-    gate = CoalescingGate(
-        dispatch_batch=dispatch_batch,
-        debounce_seconds=lambda: 0.01,
-        upload_grace_seconds=lambda: 0.0,
-        is_shutting_down=lambda: False,
-    )
-    root_key = CoalescingKey("!room:localhost", None, "@user:localhost")
-    child_key = CoalescingKey("!room:localhost", "$root:localhost", "@user:localhost")
-    other_key = CoalescingKey("!room:localhost", "$other:localhost", "@user:localhost")
-
-    await _admit_ready(gate, root_key, _pending(_text_event("$root:localhost", "root", 1_000_000)))
-    await _wait_for(first_dispatch_started.is_set)
-    reservation = gate.reserve_order(room_id=root_key.room_id, requester_user_id=root_key.requester_user_id)
-
-    release_first_dispatch.set()
-    await _wait_for(lambda: child_key in gate._in_flight_buffered_max_order)
-    await gate.admit(
-        other_key,
-        ready_result=ReadyPendingEvent(
-            pending_event=_pending(_text_event("$other:localhost", "other", 1_000_001)),
-        ),
-        order_reservation=reservation,
-    )
-    await gate.drain_all()
-
-    assert batches == [["$root:localhost"], ["$other:localhost"]]
-    assert root_key not in gate._in_flight_buffered_max_order
-    assert child_key not in gate._in_flight_buffered_max_order
-    assert gate._in_flight_buffered_max_order == {}
-
-
-@pytest.mark.asyncio
-async def test_in_flight_buffered_reservations_ignore_debounce_gap_after_partial_admit() -> None:
-    """Buffered reservations should still batch when only the first one admits before debounce expires."""
+async def test_root_in_flight_child_followup_reservations_obey_debounce() -> None:
+    """Reservations made during a root response should not get a special post-dispatch batch window."""
     first_dispatch_started = asyncio.Event()
     release_first_dispatch = asyncio.Event()
     batches: list[list[str]] = []
@@ -1800,10 +1711,7 @@ async def test_in_flight_buffered_reservations_ignore_debounce_gap_after_partial
         ),
         order_reservation=first_reservation,
     )
-    await asyncio.sleep(0.03)
-
-    assert batches == [["$root:localhost"]]
-
+    await _wait_for(lambda: batches == [["$root:localhost"], ["$follow1:localhost"]])
     await gate.admit(
         child_key,
         ready_result=ReadyPendingEvent(
@@ -1813,4 +1721,4 @@ async def test_in_flight_buffered_reservations_ignore_debounce_gap_after_partial
     )
     await gate.drain_all()
 
-    assert batches == [["$root:localhost"], ["$follow1:localhost", "$follow2:localhost"]]
+    assert batches == [["$root:localhost"], ["$follow1:localhost"], ["$follow2:localhost"]]

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -1535,8 +1535,7 @@ async def test_active_follow_up_owner_includes_later_media_payload(tmp_path: Pat
             attachment_ids=list(request.current_attachment_ids),
         )
 
-    async def fake_generate_response_locked(_self: object, request: object, *, resolved_target: MessageTarget) -> str:
-        del resolved_target
+    async def fake_generate_response_locked(_self: object, request: object, **_kwargs: object) -> str:
         prepared_request = await response_runner._prepare_request_after_lock(request)
         captured_requests.append(prepared_request)
         return "$response"
@@ -1594,6 +1593,7 @@ async def test_active_follow_up_owner_includes_later_media_payload(tmp_path: Pat
             lifecycle_lock.release()
             await bot._coalescing_gate.drain_all()
     finally:
+        queued_signal.finish_response_turn()
         if lifecycle_lock.locked():
             lifecycle_lock.release()
 
@@ -4327,7 +4327,7 @@ async def test_turn_store_marks_all_batch_event_ids(tmp_path: Path) -> None:
             source_kind="message",
             requester_user_id="@user:localhost",
         )
-        await _wait_for(lambda: bot._turn_store.is_handled("$m1"))
+        await _wait_for(lambda: bot._turn_store.is_handled("$m1"), deadline_seconds=1.0)
 
     assert bot._turn_store.is_handled("$m1")
     assert bot._turn_store.is_handled("$m2")

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -1479,6 +1479,94 @@ async def test_active_follow_ups_share_target_gate_across_requesters(tmp_path: P
 
 
 @pytest.mark.asyncio
+async def test_slow_thread_lookup_active_follow_up_stays_before_later_follow_up(tmp_path: Path) -> None:
+    """A slow older lookup received during an active turn must stay in the same active backlog."""
+    bot = _make_bot(tmp_path, debounce_ms=0)
+    room = _make_room()
+    second = _text_event(
+        event_id="$m2",
+        body="second",
+        sender="@alice:localhost",
+        server_timestamp=1001,
+        thread_id="$thread",
+    )
+    third = _text_event(
+        event_id="$m3",
+        body="third",
+        sender="@bob:localhost",
+        server_timestamp=1002,
+        thread_id="$thread",
+    )
+    response_runner = unwrap_extracted_collaborator(bot._response_runner)
+    lifecycle = response_runner._lifecycle_coordinator
+    target = MessageTarget.resolve(room.room_id, "$thread", "$response")
+    lifecycle_lock = lifecycle._response_lifecycle_lock(target)
+    queued_signal = lifecycle._get_or_create_queued_signal(target)
+    second_lookup_started = asyncio.Event()
+    release_second_lookup = asyncio.Event()
+    calls: list[list[str]] = []
+
+    async def coalescing_thread_id(_room: nio.MatrixRoom, event: nio.Event | PreparedTextEvent) -> str | None:
+        if event.event_id == "$m2":
+            second_lookup_started.set()
+            await release_second_lookup.wait()
+        return "$thread"
+
+    async def record_dispatch(
+        _room: nio.MatrixRoom,
+        _dispatched_event: nio.RoomMessageText,
+        _requester_user_id: str,
+        *,
+        media_events: list[object] | None = None,
+        handled_turn: HandledTurnState | None = None,
+        **_metadata: object,
+    ) -> None:
+        _ = media_events
+        calls.append(_handled_turn_source_event_ids(handled_turn))
+
+    await lifecycle_lock.acquire()
+    queued_signal.begin_response_turn()
+    second_task: asyncio.Task[None] | None = None
+    third_task: asyncio.Task[None] | None = None
+    try:
+        with (
+            patch.object(
+                bot._conversation_resolver,
+                "coalescing_thread_id",
+                new=AsyncMock(side_effect=coalescing_thread_id),
+            ),
+            patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)),
+            patch("mindroom.turn_controller.interactive.handle_text_response", new=AsyncMock(return_value=None)),
+        ):
+            second_task = asyncio.create_task(bot._turn_controller.handle_text_event(room, second))
+            await second_lookup_started.wait()
+
+            third_task = asyncio.create_task(bot._turn_controller.handle_text_event(room, third))
+            await asyncio.wait_for(third_task, timeout=0.5)
+
+            queued_signal.finish_response_turn()
+            lifecycle_lock.release()
+            await asyncio.sleep(0.05)
+            assert calls == []
+
+            release_second_lookup.set()
+            await asyncio.wait_for(second_task, timeout=0.5)
+            await _wait_for(lambda: calls == [["$m2", "$m3"]])
+    finally:
+        release_second_lookup.set()
+        queued_signal.finish_response_turn()
+        if lifecycle_lock.locked():
+            lifecycle_lock.release()
+        pending_tasks = [task for task in (second_task, third_task) if task is not None and not task.done()]
+        for task in pending_tasks:
+            task.cancel()
+        if pending_tasks:
+            await asyncio.gather(*pending_tasks, return_exceptions=True)
+
+    assert calls == [["$m2", "$m3"]]
+
+
+@pytest.mark.asyncio
 async def test_active_follow_up_owner_includes_later_media_payload(tmp_path: Path) -> None:
     """The first queued follow-up owner should carry later media before skipping its duplicate run."""
     bot = _make_bot(tmp_path, debounce_ms=0)

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -19,7 +19,12 @@ from mindroom.coalescing import (
     ReadyPendingEvent,
     is_coalescing_exempt_source_kind,
 )
-from mindroom.coalescing_batch import CoalescedBatch, CoalescingKey, PendingEvent, build_coalesced_batch
+from mindroom.coalescing_batch import (
+    CoalescedBatch,
+    CoalescingKey,
+    PendingEvent,
+    build_coalesced_batch,
+)
 from mindroom.config.agent import AgentConfig
 from mindroom.config.auth import AuthorizationConfig
 from mindroom.config.main import Config
@@ -1339,8 +1344,8 @@ async def test_already_queued_command_barrier_flushes_normal_without_debounce() 
 
 
 @pytest.mark.asyncio
-async def test_messages_during_active_response_wait_and_dispatch_after_completion(tmp_path: Path) -> None:
-    """Hold threaded follow-ups while the first-turn dispatch is in flight, then drain them normally."""
+async def test_messages_during_active_response_wait_and_batch_after_completion(tmp_path: Path) -> None:
+    """Hold all threaded follow-ups while the first-turn response is in flight, then batch them."""
     bot = _make_bot(tmp_path, debounce_ms=10)
     room = _make_room()
     first = _text_event(event_id="$m1", body="first", server_timestamp=1000)
@@ -1349,6 +1354,34 @@ async def test_messages_during_active_response_wait_and_dispatch_after_completio
     entered_first_dispatch = asyncio.Event()
     release_first_dispatch = asyncio.Event()
     calls: list[list[str]] = []
+
+    async def wait_for_thread_response_idle(room_id: str, thread_id: str | None) -> None:
+        assert room_id == room.room_id
+        assert thread_id == "$m1"
+        await release_first_dispatch.wait()
+
+    async def enqueue_active_follow_up(event: nio.RoomMessageText) -> None:
+        target = MessageTarget.resolve(room.room_id, "$m1", event.event_id)
+        envelope = bot._conversation_resolver.build_ingress_envelope(
+            room_id=room.room_id,
+            event=event,
+            requester_user_id="@user:localhost",
+            target=target,
+            source_kind=MESSAGE_SOURCE_KIND,
+        )
+        reservation_owner = bot._turn_controller._reserve_prompt_ingress_order(room, "@user:localhost")
+        try:
+            await bot._turn_controller._enqueue_active_thread_follow_up(
+                room=room,
+                event=event,
+                target=target,
+                envelope=envelope,
+                coalescing_thread_id="$m1",
+                requester_user_id="@user:localhost",
+                reservation_owner=reservation_owner,
+            )
+        finally:
+            await reservation_owner.release()
 
     async def record_dispatch(
         _room: nio.MatrixRoom,
@@ -1365,7 +1398,14 @@ async def test_messages_during_active_response_wait_and_dispatch_after_completio
             entered_first_dispatch.set()
             await release_first_dispatch.wait()
 
-    with patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+    with (
+        patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)),
+        patch.object(
+            bot._response_runner,
+            "wait_for_thread_response_idle",
+            new=AsyncMock(side_effect=wait_for_thread_response_idle),
+        ),
+    ):
         await _enqueue_for_dispatch(
             bot,
             first,
@@ -1376,29 +1416,17 @@ async def test_messages_during_active_response_wait_and_dispatch_after_completio
         await asyncio.sleep(0.03)
         await entered_first_dispatch.wait()
 
-        await _enqueue_for_dispatch(
-            bot,
-            second,
-            room,
-            source_kind="message",
-            requester_user_id="@user:localhost",
-        )
+        await enqueue_active_follow_up(second)
         await asyncio.sleep(0.03)
-        await _enqueue_for_dispatch(
-            bot,
-            third,
-            room,
-            source_kind="message",
-            requester_user_id="@user:localhost",
-        )
+        await enqueue_active_follow_up(third)
         await asyncio.sleep(0.03)
 
         assert calls == [["$m1"]]
 
         release_first_dispatch.set()
-        await _wait_for(lambda: calls == [["$m1"], ["$m2"], ["$m3"]])
+        await _wait_for(lambda: calls == [["$m1"], ["$m2", "$m3"]])
 
-    assert calls == [["$m1"], ["$m2"], ["$m3"]]
+    assert calls == [["$m1"], ["$m2", "$m3"]]
 
 
 @pytest.mark.asyncio

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -44,6 +44,7 @@ from mindroom.dispatch_handoff import (
 )
 from mindroom.dispatch_source import (
     ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND,
+    IMAGE_SOURCE_KIND,
     MESSAGE_SOURCE_KIND,
     TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
     VOICE_SOURCE_KIND,
@@ -82,6 +83,7 @@ from tests.conftest import (
     replace_turn_controller_deps,
     runtime_paths_for,
     test_runtime_paths,
+    unwrap_extracted_collaborator,
     wrap_extracted_collaborators,
 )
 
@@ -1337,8 +1339,8 @@ async def test_already_queued_command_barrier_flushes_normal_without_debounce() 
 
 
 @pytest.mark.asyncio
-async def test_messages_during_active_response_wait_and_batch_after_completion(tmp_path: Path) -> None:
-    """Hold all threaded follow-ups while the first-turn response is in flight, then batch them."""
+async def test_messages_during_active_response_wait_and_dispatch_after_completion(tmp_path: Path) -> None:
+    """Hold threaded follow-ups while the first-turn dispatch is in flight, then drain them normally."""
     bot = _make_bot(tmp_path, debounce_ms=10)
     room = _make_room()
     first = _text_event(event_id="$m1", body="first", server_timestamp=1000)
@@ -1394,9 +1396,137 @@ async def test_messages_during_active_response_wait_and_batch_after_completion(t
         assert calls == [["$m1"]]
 
         release_first_dispatch.set()
-        await _wait_for(lambda: calls == [["$m1"], ["$m2", "$m3"]])
+        await _wait_for(lambda: calls == [["$m1"], ["$m2"], ["$m3"]])
 
-    assert calls == [["$m1"], ["$m2", "$m3"]]
+    assert calls == [["$m1"], ["$m2"], ["$m3"]]
+
+
+@pytest.mark.asyncio
+async def test_active_follow_up_owner_includes_later_media_payload(tmp_path: Path) -> None:
+    """The first queued follow-up owner should carry later media before skipping its duplicate run."""
+    bot = _make_bot(tmp_path, debounce_ms=0)
+    room = _make_room()
+    text_event = _text_event(
+        event_id="$text",
+        body="text follow-up",
+        sender="@alice:localhost",
+        server_timestamp=1000,
+        thread_id="$thread",
+    )
+    image_event = _image_event(
+        event_id="$img",
+        sender="@bob:localhost",
+        server_timestamp=1001,
+        thread_id="$thread",
+    )
+    target = MessageTarget.resolve(room.room_id, "$thread", "$text")
+    response_runner = unwrap_extracted_collaborator(bot._response_runner)
+    lifecycle = response_runner._lifecycle_coordinator
+    lifecycle_lock = lifecycle._response_lifecycle_lock(target)
+    queued_signal = lifecycle._get_or_create_queued_signal(target)
+    captured_requests = []
+    payload_requests = []
+    registered_media_event_ids = []
+
+    async def fake_prepare_dispatch(
+        _room: nio.MatrixRoom,
+        event: DispatchEvent,
+        requester_user_id: str,
+        **_kwargs: object,
+    ) -> object:
+        dispatch = _prepared_dispatch(
+            event_id=event.event_id,
+            requester_user_id=requester_user_id,
+            body=event.body,
+            thread_id="$thread",
+            dispatch_policy_source_kind=ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND,
+        )
+        dispatch.context.am_i_mentioned = True
+        return prepared_dispatch_result(dispatch)
+
+    async def fake_register_batch_media_attachments(
+        request: BatchMediaAttachmentRequest,
+    ) -> _BatchMediaAttachmentResult:
+        registered_media_event_ids.append([media_event.event_id for media_event in request.media_events])
+        return _BatchMediaAttachmentResult(attachment_ids=["img-attachment"])
+
+    async def fake_build_payload(request: DispatchPayloadWithAttachmentsRequest) -> DispatchPayload:
+        payload_requests.append(request)
+        return DispatchPayload(prompt=request.prompt, attachment_ids=list(request.current_attachment_ids))
+
+    async def fake_generate_response_locked(_self: object, request: object, *, resolved_target: MessageTarget) -> str:
+        del resolved_target
+        prepared_request = await response_runner._prepare_request_after_lock(request)
+        captured_requests.append(prepared_request)
+        return "$response"
+
+    await lifecycle_lock.acquire()
+    queued_signal.begin_response_turn()
+    try:
+        with (
+            patch.object(bot._turn_controller, "_prepare_dispatch", new=fake_prepare_dispatch),
+            patch.object(bot._turn_policy, "plan_turn", new=AsyncMock(return_value=_respond_dispatch_plan())),
+            patch.object(
+                bot._inbound_turn_normalizer,
+                "register_batch_media_attachments",
+                new=fake_register_batch_media_attachments,
+            ),
+            patch.object(
+                bot._inbound_turn_normalizer,
+                "build_dispatch_payload_with_attachments",
+                new=fake_build_payload,
+            ),
+            patch.object(bot._turn_controller, "_has_newer_unresponded_in_thread", return_value=False),
+            patch.object(bot._turn_controller, "_log_dispatch_latency"),
+            patch(
+                "mindroom.response_runner.ResponseRunner.generate_response_locked",
+                new=fake_generate_response_locked,
+            ),
+        ):
+            for event, requester_user_id in (
+                (text_event, "@alice:localhost"),
+                (image_event, "@bob:localhost"),
+            ):
+                event_target = MessageTarget.resolve(room.room_id, "$thread", event.event_id)
+                envelope = bot._conversation_resolver.build_ingress_envelope(
+                    room_id=room.room_id,
+                    event=event,
+                    requester_user_id=requester_user_id,
+                    target=event_target,
+                    source_kind=IMAGE_SOURCE_KIND if event.event_id == "$img" else MESSAGE_SOURCE_KIND,
+                )
+                reservation_owner = bot._turn_controller._reserve_prompt_ingress_order(room, requester_user_id)
+                try:
+                    await bot._turn_controller._enqueue_active_thread_follow_up(
+                        room=room,
+                        event=event,
+                        target=event_target,
+                        envelope=envelope,
+                        coalescing_thread_id="$thread",
+                        requester_user_id=requester_user_id,
+                        reservation_owner=reservation_owner,
+                    )
+                finally:
+                    await reservation_owner.release()
+
+            queued_signal.finish_response_turn()
+            lifecycle_lock.release()
+            await bot._coalescing_gate.drain_all()
+    finally:
+        if lifecycle_lock.locked():
+            lifecycle_lock.release()
+
+    assert registered_media_event_ids == [["$img"]]
+    assert payload_requests[0].current_attachment_ids == ["img-attachment"]
+    assert captured_requests[0].attachment_ids == ("img-attachment",)
+    assert captured_requests[0].prompt == (
+        "Messages arrived while the previous response was still running. "
+        "They are in chat timeline order. Respond once to the combined context:\n\n"
+        "<queued_messages>\n"
+        '<msg event_id="$text" from="@alice:localhost"><![CDATA[text follow-up]]></msg>\n'
+        '<msg event_id="$img" from="@bob:localhost"><![CDATA[[Attached image]]]></msg>\n'
+        "</queued_messages>"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -1402,6 +1402,55 @@ async def test_messages_during_active_response_wait_and_dispatch_after_completio
 
 
 @pytest.mark.asyncio
+async def test_active_follow_ups_share_target_gate_across_requesters(tmp_path: Path) -> None:
+    """Active-response follow-ups should queue by target while preserving the actual requester."""
+    bot = _make_bot(tmp_path, debounce_ms=0)
+    room = _make_room()
+    first = _text_event(event_id="$a", body="first", sender="@alice:localhost", thread_id="$thread")
+    second = _text_event(event_id="$b", body="second", sender="@bob:localhost", thread_id="$thread")
+    admitted: list[tuple[CoalescingKey, PendingEvent]] = []
+
+    async def record_admit(key: CoalescingKey, **kwargs: object) -> None:
+        ready_result = cast("ReadyPendingEvent", kwargs["ready_result"])
+        admitted.append((key, ready_result.pending_event))
+        bot._coalescing_gate.release_order_reservation(kwargs["order_reservation"])
+
+    with (
+        patch.object(bot._coalescing_gate, "admit", new=AsyncMock(side_effect=record_admit)),
+        patch.object(bot._response_runner, "has_active_response_for_target", return_value=True),
+        patch.object(bot._response_runner, "reserve_waiting_human_message", return_value=MagicMock()),
+    ):
+        for event, requester_user_id in ((first, "@alice:localhost"), (second, "@bob:localhost")):
+            target = MessageTarget.resolve(room.room_id, "$thread", event.event_id)
+            envelope = bot._conversation_resolver.build_ingress_envelope(
+                room_id=room.room_id,
+                event=event,
+                requester_user_id=requester_user_id,
+                target=target,
+                source_kind=MESSAGE_SOURCE_KIND,
+            )
+            reservation_owner = bot._turn_controller._reserve_prompt_ingress_order(room, requester_user_id)
+            try:
+                await bot._turn_controller._enqueue_active_thread_follow_up(
+                    room=room,
+                    event=event,
+                    target=target,
+                    envelope=envelope,
+                    coalescing_thread_id="$thread",
+                    requester_user_id=requester_user_id,
+                    reservation_owner=reservation_owner,
+                )
+            finally:
+                await reservation_owner.release()
+
+    assert len({key for key, _pending_event in admitted}) == 1
+    assert [pending_event.requester_user_id for _key, pending_event in admitted] == [
+        "@alice:localhost",
+        "@bob:localhost",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_active_follow_up_owner_includes_later_media_payload(tmp_path: Path) -> None:
     """The first queued follow-up owner should carry later media before skipping its duplicate run."""
     bot = _make_bot(tmp_path, debounce_ms=0)

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -1539,7 +1539,7 @@ async def test_slow_thread_lookup_active_follow_up_stays_before_later_follow_up(
             patch("mindroom.turn_controller.interactive.handle_text_response", new=AsyncMock(return_value=None)),
         ):
             second_task = asyncio.create_task(bot._turn_controller.handle_text_event(room, second))
-            await second_lookup_started.wait()
+            await asyncio.wait_for(second_lookup_started.wait(), timeout=0.5)
 
             third_task = asyncio.create_task(bot._turn_controller.handle_text_event(room, third))
             await asyncio.wait_for(third_task, timeout=0.5)
@@ -1630,7 +1630,7 @@ async def test_later_slow_thread_lookup_active_follow_up_joins_open_backlog(tmp_
             await asyncio.wait_for(first_task, timeout=0.5)
 
             second_task = asyncio.create_task(bot._turn_controller.handle_text_event(room, second))
-            await second_lookup_started.wait()
+            await asyncio.wait_for(second_lookup_started.wait(), timeout=0.5)
 
             queued_signal.finish_response_turn()
             lifecycle_lock.release()

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -23,6 +23,7 @@ from mindroom.coalescing_batch import (
     CoalescedBatch,
     CoalescingKey,
     PendingEvent,
+    active_follow_up_coalescing_key,
     build_coalesced_batch,
 )
 from mindroom.config.agent import AgentConfig
@@ -1376,9 +1377,9 @@ async def test_messages_during_active_response_wait_and_batch_after_completion(t
                 event=event,
                 target=target,
                 envelope=envelope,
-                coalescing_thread_id="$m1",
                 requester_user_id="@user:localhost",
                 reservation_owner=reservation_owner,
+                coalescing_key=active_follow_up_coalescing_key(room.room_id, "$m1"),
             )
         finally:
             await reservation_owner.release()
@@ -1445,7 +1446,6 @@ async def test_active_follow_ups_share_target_gate_across_requesters(tmp_path: P
 
     with (
         patch.object(bot._coalescing_gate, "admit", new=AsyncMock(side_effect=record_admit)),
-        patch.object(bot._response_runner, "has_active_response_for_target", return_value=True),
         patch.object(bot._response_runner, "reserve_waiting_human_message", return_value=MagicMock()),
     ):
         for event, requester_user_id in ((first, "@alice:localhost"), (second, "@bob:localhost")):
@@ -1464,9 +1464,9 @@ async def test_active_follow_ups_share_target_gate_across_requesters(tmp_path: P
                     event=event,
                     target=target,
                     envelope=envelope,
-                    coalescing_thread_id="$thread",
                     requester_user_id=requester_user_id,
                     reservation_owner=reservation_owner,
+                    coalescing_key=active_follow_up_coalescing_key(room.room_id, "$thread"),
                 )
             finally:
                 await reservation_owner.release()
@@ -1564,6 +1564,94 @@ async def test_slow_thread_lookup_active_follow_up_stays_before_later_follow_up(
             await asyncio.gather(*pending_tasks, return_exceptions=True)
 
     assert calls == [["$m2", "$m3"]]
+
+
+@pytest.mark.asyncio
+async def test_later_slow_thread_lookup_active_follow_up_joins_open_backlog(tmp_path: Path) -> None:
+    """A later lookup received during an active turn must not miss the active backlog freeze."""
+    bot = _make_bot(tmp_path, debounce_ms=0)
+    room = _make_room()
+    first = _text_event(
+        event_id="$m1",
+        body="first",
+        sender="@alice:localhost",
+        server_timestamp=1001,
+        thread_id="$thread",
+    )
+    second = _text_event(
+        event_id="$m2",
+        body="second",
+        sender="@bob:localhost",
+        server_timestamp=1002,
+        thread_id="$thread",
+    )
+    response_runner = unwrap_extracted_collaborator(bot._response_runner)
+    lifecycle = response_runner._lifecycle_coordinator
+    target = MessageTarget.resolve(room.room_id, "$thread", "$response")
+    lifecycle_lock = lifecycle._response_lifecycle_lock(target)
+    queued_signal = lifecycle._get_or_create_queued_signal(target)
+    second_lookup_started = asyncio.Event()
+    release_second_lookup = asyncio.Event()
+    calls: list[list[str]] = []
+
+    async def coalescing_thread_id(_room: nio.MatrixRoom, event: nio.Event | PreparedTextEvent) -> str | None:
+        if event.event_id == "$m2":
+            second_lookup_started.set()
+            await release_second_lookup.wait()
+        return "$thread"
+
+    async def record_dispatch(
+        _room: nio.MatrixRoom,
+        _dispatched_event: nio.RoomMessageText,
+        _requester_user_id: str,
+        *,
+        media_events: list[object] | None = None,
+        handled_turn: HandledTurnState | None = None,
+        **_metadata: object,
+    ) -> None:
+        _ = media_events
+        calls.append(_handled_turn_source_event_ids(handled_turn))
+
+    await lifecycle_lock.acquire()
+    queued_signal.begin_response_turn()
+    first_task: asyncio.Task[None] | None = None
+    second_task: asyncio.Task[None] | None = None
+    try:
+        with (
+            patch.object(
+                bot._conversation_resolver,
+                "coalescing_thread_id",
+                new=AsyncMock(side_effect=coalescing_thread_id),
+            ),
+            patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)),
+            patch("mindroom.turn_controller.interactive.handle_text_response", new=AsyncMock(return_value=None)),
+        ):
+            first_task = asyncio.create_task(bot._turn_controller.handle_text_event(room, first))
+            await asyncio.wait_for(first_task, timeout=0.5)
+
+            second_task = asyncio.create_task(bot._turn_controller.handle_text_event(room, second))
+            await second_lookup_started.wait()
+
+            queued_signal.finish_response_turn()
+            lifecycle_lock.release()
+            await asyncio.sleep(0.05)
+            assert calls == []
+
+            release_second_lookup.set()
+            await asyncio.wait_for(second_task, timeout=0.5)
+            await _wait_for(lambda: calls == [["$m1", "$m2"]])
+    finally:
+        release_second_lookup.set()
+        queued_signal.finish_response_turn()
+        if lifecycle_lock.locked():
+            lifecycle_lock.release()
+        pending_tasks = [task for task in (first_task, second_task) if task is not None and not task.done()]
+        for task in pending_tasks:
+            task.cancel()
+        if pending_tasks:
+            await asyncio.gather(*pending_tasks, return_exceptions=True)
+
+    assert calls == [["$m1", "$m2"]]
 
 
 @pytest.mark.asyncio
@@ -1670,9 +1758,9 @@ async def test_active_follow_up_owner_includes_later_media_payload(tmp_path: Pat
                         event=event,
                         target=event_target,
                         envelope=envelope,
-                        coalescing_thread_id="$thread",
                         requester_user_id=requester_user_id,
                         reservation_owner=reservation_owner,
+                        coalescing_key=active_follow_up_coalescing_key(room.room_id, "$thread"),
                     )
                 finally:
                     await reservation_owner.release()

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -1452,7 +1452,11 @@ async def test_active_follow_up_owner_includes_later_media_payload(tmp_path: Pat
 
     async def fake_build_payload(request: DispatchPayloadWithAttachmentsRequest) -> DispatchPayload:
         payload_requests.append(request)
-        return DispatchPayload(prompt=request.prompt, attachment_ids=list(request.current_attachment_ids))
+        return DispatchPayload(
+            prompt=request.prompt,
+            model_prompt="attachment guidance",
+            attachment_ids=list(request.current_attachment_ids),
+        )
 
     async def fake_generate_response_locked(_self: object, request: object, *, resolved_target: MessageTarget) -> str:
         del resolved_target
@@ -1519,6 +1523,7 @@ async def test_active_follow_up_owner_includes_later_media_payload(tmp_path: Pat
     assert registered_media_event_ids == [["$img"]]
     assert payload_requests[0].current_attachment_ids == ["img-attachment"]
     assert captured_requests[0].attachment_ids == ("img-attachment",)
+    assert captured_requests[0].model_prompt == "attachment guidance"
     assert captured_requests[0].prompt == (
         "Messages arrived while the previous response was still running. "
         "They are in chat timeline order. Respond once to the combined context:\n\n"
@@ -4207,7 +4212,7 @@ async def test_upload_grace_hard_cap_prevents_indefinite_extension(tmp_path: Pat
 @pytest.mark.asyncio
 async def test_turn_store_marks_all_batch_event_ids(tmp_path: Path) -> None:
     """Mark every source event ID from a coalesced batch as responded."""
-    bot = _make_bot(tmp_path)
+    bot = _make_bot(tmp_path, debounce_ms=250)
     room = _make_room()
     first = _text_event(event_id="$m1", body="first", server_timestamp=1000, thread_id="$thread")
     second = _text_event(event_id="$m2", body="second", server_timestamp=1001, thread_id="$thread")

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -41,7 +41,7 @@ from mindroom.attachments import _attachment_id_for_event, register_local_attach
 from mindroom.authorization import is_authorized_sender as is_authorized_sender_for_test
 from mindroom.bot import AgentBot, TeamBot
 from mindroom.coalescing import CoalescingGate, IngressOrderReservation, ReadyPendingEvent
-from mindroom.coalescing_batch import CoalescedBatch, CoalescingKey, PendingEvent
+from mindroom.coalescing_batch import CoalescedBatch, CoalescingKey, PendingEvent, active_follow_up_coalescing_key
 from mindroom.config.agent import AgentConfig, AgentPrivateConfig, TeamConfig
 from mindroom.config.auth import AuthorizationConfig
 from mindroom.config.knowledge import KnowledgeBaseConfig
@@ -11825,8 +11825,9 @@ class TestAgentBot:
         ready_result = mock_admit.await_args.kwargs["ready_result"]
         assert isinstance(ready_result, ReadyPendingEvent)
         pending_event = ready_result.pending_event
-        assert key == CoalescingKey(room.room_id, "$thread_root", "@user:localhost")
+        assert key == active_follow_up_coalescing_key(room.room_id, "$thread_root")
         assert isinstance(pending_event, PendingEvent)
+        assert pending_event.requester_user_id == "@user:localhost"
         assert pending_event.event is prepared_event
         assert pending_event.source_kind == MESSAGE_SOURCE_KIND
         assert pending_event.dispatch_policy_source_kind == ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND
@@ -11966,7 +11967,7 @@ class TestAgentBot:
             )
             mock_admit.assert_awaited_once()
             key = mock_admit.await_args.args[0]
-            assert key == CoalescingKey(room.room_id, "$thread_root", "@user:localhost")
+            assert key == active_follow_up_coalescing_key(room.room_id, "$thread_root")
             ready_event = await mock_admit.await_args.kwargs["ready_task"]
 
         assert isinstance(ready_event, ReadyPendingEvent)
@@ -11978,6 +11979,7 @@ class TestAgentBot:
         assert reserved_envelope.source_kind == VOICE_SOURCE_KIND
         pending_event = ready_event.pending_event
         assert isinstance(pending_event, PendingEvent)
+        assert pending_event.requester_user_id == "@user:localhost"
         assert pending_event.event is prepared_event
         assert pending_event.source_kind == VOICE_SOURCE_KIND
         assert pending_event.dispatch_policy_source_kind == ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND
@@ -12079,8 +12081,9 @@ class TestAgentBot:
         ready_result = mock_admit.await_args.kwargs["ready_result"]
         assert isinstance(ready_result, ReadyPendingEvent)
         pending_event = ready_result.pending_event
-        assert key == CoalescingKey(room.room_id, "$thread_root", "@user:localhost")
+        assert key == active_follow_up_coalescing_key(room.room_id, "$thread_root")
         assert isinstance(pending_event, PendingEvent)
+        assert pending_event.requester_user_id == "@user:localhost"
         assert pending_event.event is prepared_event
         assert pending_event.source_kind == MESSAGE_SOURCE_KIND
 
@@ -12187,8 +12190,9 @@ class TestAgentBot:
         ready_result = mock_admit.await_args.kwargs["ready_result"]
         assert isinstance(ready_result, ReadyPendingEvent)
         pending_event = ready_result.pending_event
-        assert key == CoalescingKey(room.room_id, "$thread_root", "@user:localhost")
+        assert key == active_follow_up_coalescing_key(room.room_id, "$thread_root")
         assert isinstance(pending_event, PendingEvent)
+        assert pending_event.requester_user_id == "@user:localhost"
         assert pending_event.event is prepared_event
         assert pending_event.source_kind == MESSAGE_SOURCE_KIND
         assert pending_event.dispatch_policy_source_kind == ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -11795,9 +11795,9 @@ class TestAgentBot:
             patch("mindroom.turn_controller.interactive.handle_text_response", new=AsyncMock(return_value=None)),
             patch.object(
                 bot._response_runner,
-                "has_active_response_for_target",
-                return_value=True,
-            ) as mock_has_active_response,
+                "active_thread_ids_for_room",
+                return_value=frozenset({"$thread_root"}),
+            ) as mock_active_thread_ids,
             patch.object(
                 bot._response_runner,
                 "reserve_waiting_human_message",
@@ -11812,9 +11812,7 @@ class TestAgentBot:
         ):
             await asyncio.wait_for(bot._on_message(room, event), timeout=0.05)
 
-        mock_has_active_response.assert_called_once()
-        active_target = mock_has_active_response.call_args.args[0]
-        assert active_target.resolved_thread_id == target.resolved_thread_id
+        mock_active_thread_ids.assert_called_once_with(room.room_id)
         mock_reserve_waiting_human_message.assert_called_once()
         signal_target = mock_reserve_waiting_human_message.call_args.kwargs["target"]
         assert signal_target.resolved_thread_id == target.resolved_thread_id
@@ -11942,8 +11940,8 @@ class TestAgentBot:
             patch.object(bot._turn_controller, "_maybe_send_visible_voice_echo", new=AsyncMock()) as mock_echo,
             patch.object(
                 bot._response_runner,
-                "has_active_response_for_target",
-                return_value=True,
+                "active_thread_ids_for_room",
+                return_value=frozenset({"$thread_root"}),
             ),
             patch.object(
                 bot._response_runner,
@@ -12163,8 +12161,8 @@ class TestAgentBot:
             ),
             patch.object(
                 bot._response_runner,
-                "has_active_response_for_target",
-                return_value=True,
+                "active_thread_ids_for_room",
+                return_value=frozenset({"$thread_root"}),
             ),
             patch.object(
                 bot._response_runner,

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -12081,7 +12081,7 @@ class TestAgentBot:
         ready_result = mock_admit.await_args.kwargs["ready_result"]
         assert isinstance(ready_result, ReadyPendingEvent)
         pending_event = ready_result.pending_event
-        assert key == active_follow_up_coalescing_key(room.room_id, "$thread_root")
+        assert key == CoalescingKey(room.room_id, "$thread_root", "@user:localhost")
         assert isinstance(pending_event, PendingEvent)
         assert pending_event.requester_user_id == "@user:localhost"
         assert pending_event.event is prepared_event

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -7509,6 +7509,7 @@ class TestAgentBot:
                     event_source=voice_event.source,
                 ),
                 CoalescingKey(room.room_id, "$thread-root", "@user:localhost"),
+                False,
             ),
         )
         bot._turn_controller._ready_voice_event = AsyncMock(

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -11827,7 +11827,7 @@ class TestAgentBot:
         pending_event = ready_result.pending_event
         assert key == CoalescingKey(room.room_id, "$thread_root", "@user:localhost")
         assert isinstance(pending_event, PendingEvent)
-        assert pending_event.event is event
+        assert pending_event.event is prepared_event
         assert pending_event.source_kind == MESSAGE_SOURCE_KIND
         assert pending_event.dispatch_policy_source_kind == ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND
         assert len(pending_event.dispatch_metadata) == 1

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -469,6 +469,50 @@ def test_active_follow_up_backlog_uses_queued_receive_order() -> None:
     )
 
 
+def test_same_target_batch_reservation_keeps_all_pending_messages(tmp_path: Path) -> None:
+    """Selecting one coalesced reservation must not drop earlier messages on the same target."""
+    bot = _bot(tmp_path)
+    target = MessageTarget.resolve("!room:localhost", "$thread", "$a1")
+    coordinator = unwrap_extracted_collaborator(bot._response_runner)
+    lifecycle = coordinator._lifecycle_coordinator
+    queued_signal = lifecycle._get_or_create_queued_signal(target)
+    queued_signal.begin_response_turn()
+    try:
+        first_reservation = lifecycle.reserve_waiting_human_message(
+            target=target,
+            response_envelope=_envelope(source_event_id="$a1", target=target),
+        )
+        second_reservation = lifecycle.reserve_waiting_human_message(
+            target=target,
+            response_envelope=_envelope(source_event_id="$b1", target=target),
+        )
+        assert first_reservation is not None
+        assert second_reservation is not None
+
+        selected = turn_controller._queued_notice_reservation_from_metadata(
+            (
+                PendingDispatchMetadata(
+                    kind="queued_notice_reservation",
+                    payload=first_reservation,
+                    close=first_reservation.cancel,
+                    target_key=(target.room_id, target.resolved_thread_id),
+                ),
+                PendingDispatchMetadata(
+                    kind="queued_notice_reservation",
+                    payload=second_reservation,
+                    close=second_reservation.cancel,
+                    target_key=(target.room_id, target.resolved_thread_id),
+                ),
+            ),
+            target_key=(target.room_id, target.resolved_thread_id),
+        )
+
+        assert selected is second_reservation
+        assert queued_signal.pending_human_message_event_ids == ("$a1", "$b1")
+    finally:
+        queued_signal.finish_response_turn()
+
+
 @contextmanager
 def _open_scope(storage: _FakeStorage) -> object:
     yield SimpleNamespace(storage=storage, session=storage.session)
@@ -920,9 +964,9 @@ async def test_generate_response_detects_active_turn_before_lock_is_held(tmp_pat
         second_result = await second_task
         first_result = await first_task
 
-    assert second_result is None
+    assert second_result == "second"
     assert first_result == "first"
-    assert observed_backlog == {"first": ("$second",)}
+    assert observed_backlog == {"first": (), "second": ()}
 
 
 @pytest.mark.asyncio
@@ -1421,8 +1465,8 @@ async def test_generate_team_response_helper_sets_queued_signal(tmp_path: Path) 
 
 
 @pytest.mark.asyncio
-async def test_generate_response_drains_later_queued_human_message(tmp_path: Path) -> None:
-    """The first queued owner should drain later human messages that were already queued."""
+async def test_generate_response_without_reservation_does_not_drain_human_backlog(tmp_path: Path) -> None:
+    """Unreserved direct responses should serialize normally instead of owning active follow-up backlog."""
     bot = _bot(tmp_path)
     response_envelope_b = _envelope(source_event_id="$event-b")
     response_envelope_c = _envelope(source_event_id="$event-c")
@@ -1472,23 +1516,24 @@ async def test_generate_response_drains_later_queued_human_message(tmp_path: Pat
 
             lifecycle_lock.release()
             await asyncio.wait_for(second_turn_started.wait(), timeout=0.2)
-            assert observed_pending == [False]
-            assert observed_backlogs == [("$event-b", "$event-c")]
+            assert observed_pending == [True]
+            assert observed_backlogs == [()]
 
             allow_turns_to_finish.set()
             assert await task_b == "$response-1"
-            assert await task_c is None
+            assert await task_c == "$response-2"
     finally:
         if lifecycle_lock.locked():
             lifecycle_lock.release()
 
-    assert observed_pending == [False]
+    assert observed_pending == [True, False]
+    assert observed_backlogs == [(), ()]
     assert not queued_signal.is_set()
 
 
 @pytest.mark.asyncio
-async def test_generate_team_response_drains_later_queued_human_message(tmp_path: Path) -> None:
-    """Team queue notices should also drain already queued human messages once."""
+async def test_generate_team_response_without_reservation_does_not_drain_human_backlog(tmp_path: Path) -> None:
+    """Unreserved direct team responses should serialize without owning active follow-up backlog."""
     bot = _bot(tmp_path)
     response_envelope_b = _envelope(source_event_id="$team-event-b")
     response_envelope_c = _envelope(source_event_id="$team-event-c")
@@ -1542,17 +1587,18 @@ async def test_generate_team_response_drains_later_queued_human_message(tmp_path
 
             lifecycle_lock.release()
             await asyncio.wait_for(second_turn_started.wait(), timeout=0.2)
-            assert observed_pending == [False]
-            assert observed_backlogs == [("$team-event-b", "$team-event-c")]
+            assert observed_pending == [True]
+            assert observed_backlogs == [()]
 
             allow_turns_to_finish.set()
             assert await task_b == "$team-response-1"
-            assert await task_c is None
+            assert await task_c == "$team-response-2"
     finally:
         if lifecycle_lock.locked():
             lifecycle_lock.release()
 
-    assert observed_pending == [False]
+    assert observed_pending == [True, False]
+    assert observed_backlogs == [(), ()]
     assert not queued_signal.is_set()
 
 
@@ -1692,6 +1738,168 @@ async def test_response_lifecycle_consumes_active_backlog_once(tmp_path: Path) -
     assert await active_task == "$active-response"
     assert await asyncio.gather(*follow_up_tasks) == ["$response-$a1", None, None]
     assert follow_up_calls == ["$a1"]
+
+
+@pytest.mark.asyncio
+async def test_non_human_lock_owner_does_not_drain_pending_human_backlog(tmp_path: Path) -> None:
+    """Scheduled or hook turns sharing the target lock must not consume human follow-up backlog."""
+    bot = _bot(tmp_path)
+    coordinator = unwrap_extracted_collaborator(bot._response_runner)
+    lifecycle = coordinator._lifecycle_coordinator
+    target = MessageTarget.resolve("!room:localhost", "$thread", "$active")
+    active_envelope = _envelope(source_event_id="$active", target=target)
+    human_envelope = _envelope(
+        source_event_id="$human",
+        target=target,
+        dispatch_policy_source_kind=ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND,
+    )
+    scheduled_envelope = _envelope(
+        source_event_id="$scheduled",
+        target=target,
+        source_kind=SCHEDULED_SOURCE_KIND,
+    )
+    active_started = asyncio.Event()
+    release_active = asyncio.Event()
+    observed_scheduled_backlog: list[tuple[str, ...]] = []
+    observed_human_backlog: list[tuple[str, ...]] = []
+
+    async def active_operation(_target: MessageTarget) -> str:
+        active_started.set()
+        await release_active.wait()
+        return "$active-response"
+
+    async def scheduled_operation(_target: MessageTarget) -> str:
+        observed_scheduled_backlog.append(_current_queued_human_event_ids())
+        return "$scheduled-response"
+
+    async def human_operation(_target: MessageTarget) -> str:
+        observed_human_backlog.append(_current_queued_human_event_ids())
+        return "$human-response"
+
+    active_task = asyncio.create_task(
+        lifecycle.run_locked_response(
+            target=target,
+            response_envelope=active_envelope,
+            queued_notice_reservation=None,
+            pipeline_timing=None,
+            locked_operation=active_operation,
+        ),
+    )
+    await asyncio.wait_for(active_started.wait(), timeout=0.2)
+
+    human_reservation = lifecycle.reserve_waiting_human_message(target=target, response_envelope=human_envelope)
+    assert human_reservation is not None
+    scheduled_task = asyncio.create_task(
+        lifecycle.run_locked_response(
+            target=target,
+            response_envelope=scheduled_envelope,
+            queued_notice_reservation=None,
+            pipeline_timing=None,
+            locked_operation=scheduled_operation,
+        ),
+    )
+    await asyncio.sleep(0)
+
+    release_active.set()
+    assert await active_task == "$active-response"
+    assert await scheduled_task == "$scheduled-response"
+    assert observed_scheduled_backlog == [()]
+    assert lifecycle._get_or_create_queued_signal(target).pending_human_message_event_ids == ("$human",)
+
+    assert (
+        await lifecycle.run_locked_response(
+            target=target,
+            response_envelope=human_envelope,
+            queued_notice_reservation=human_reservation,
+            pipeline_timing=None,
+            locked_operation=human_operation,
+        )
+        == "$human-response"
+    )
+    assert observed_human_backlog == [("$human",)]
+
+
+@pytest.mark.asyncio
+async def test_failed_active_follow_up_owner_leaves_backlog_for_next_owner(tmp_path: Path) -> None:
+    """Backlog consumption should commit only after the owning response finishes successfully."""
+    bot = _bot(tmp_path)
+    coordinator = unwrap_extracted_collaborator(bot._response_runner)
+    lifecycle = coordinator._lifecycle_coordinator
+    target = MessageTarget.resolve("!room:localhost", "$thread", "$active")
+    active_envelope = _envelope(source_event_id="$active", target=target)
+    first_envelope = _envelope(
+        source_event_id="$a1",
+        target=target,
+        dispatch_policy_source_kind=ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND,
+    )
+    second_envelope = _envelope(
+        source_event_id="$b1",
+        target=target,
+        dispatch_policy_source_kind=ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND,
+    )
+    active_started = asyncio.Event()
+    release_active = asyncio.Event()
+    observed_failed_owner_backlog: list[tuple[str, ...]] = []
+    observed_next_owner_backlog: list[tuple[str, ...]] = []
+
+    async def active_operation(_target: MessageTarget) -> str:
+        active_started.set()
+        await release_active.wait()
+        return "$active-response"
+
+    async def failing_owner_operation(_target: MessageTarget) -> str:
+        observed_failed_owner_backlog.append(_current_queued_human_event_ids())
+        msg = "payload failed"
+        raise RuntimeError(msg)
+
+    async def next_owner_operation(_target: MessageTarget) -> str:
+        observed_next_owner_backlog.append(_current_queued_human_event_ids())
+        return "$next-response"
+
+    active_task = asyncio.create_task(
+        lifecycle.run_locked_response(
+            target=target,
+            response_envelope=active_envelope,
+            queued_notice_reservation=None,
+            pipeline_timing=None,
+            locked_operation=active_operation,
+        ),
+    )
+    await asyncio.wait_for(active_started.wait(), timeout=0.2)
+
+    first_reservation = lifecycle.reserve_waiting_human_message(target=target, response_envelope=first_envelope)
+    second_reservation = lifecycle.reserve_waiting_human_message(target=target, response_envelope=second_envelope)
+    assert first_reservation is not None
+    assert second_reservation is not None
+
+    first_task = asyncio.create_task(
+        lifecycle.run_locked_response(
+            target=target,
+            response_envelope=first_envelope,
+            queued_notice_reservation=first_reservation,
+            pipeline_timing=None,
+            locked_operation=failing_owner_operation,
+        ),
+    )
+    await asyncio.sleep(0)
+
+    release_active.set()
+    assert await active_task == "$active-response"
+    with pytest.raises(RuntimeError, match="payload failed"):
+        await first_task
+
+    assert observed_failed_owner_backlog == [("$a1", "$b1")]
+    assert (
+        await lifecycle.run_locked_response(
+            target=target,
+            response_envelope=second_envelope,
+            queued_notice_reservation=second_reservation,
+            pipeline_timing=None,
+            locked_operation=next_owner_operation,
+        )
+        == "$next-response"
+    )
+    assert observed_next_owner_backlog == [("$a1", "$b1")]
 
 
 @pytest.mark.asyncio

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -2418,9 +2418,9 @@ async def test_active_follow_up_reservation_cancelled_when_enqueue_is_cancelled(
                     event=event,
                     target=target,
                     envelope=envelope,
-                    coalescing_thread_id="$thread",
                     requester_user_id="@user:localhost",
                     reservation_owner=reservation_owner,
+                    coalescing_key=active_follow_up_coalescing_key(room.room_id, "$thread"),
                 )
         finally:
             await reservation_owner.release()

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -20,6 +20,7 @@ from agno.run.team import TeamRunOutput
 from agno.session.agent import AgentSession
 from agno.session.team import TeamSession
 
+from mindroom import turn_controller
 from mindroom.ai import _PreparedAgentRun, ai_response, stream_agent_response
 from mindroom.ai_runtime import (
     cleanup_queued_notice_state,
@@ -59,7 +60,7 @@ from mindroom.post_response_effects import (
     apply_post_response_effects,
 )
 from mindroom.prompts import QUEUED_MESSAGE_NOTICE_TEXT
-from mindroom.response_lifecycle import _QueuedMessageState
+from mindroom.response_lifecycle import QueuedHumanMessage, _QueuedMessageState, current_queued_human_messages
 from mindroom.response_runner import PostLockRequestPreparationError, ResponseRequest, ResponseRunner
 from mindroom.teams import TeamMode, _create_team_instance
 from mindroom.turn_controller import _PrecheckedEvent
@@ -85,6 +86,10 @@ if TYPE_CHECKING:
 
     from mindroom.delivery_gateway import FinalDeliveryRequest
     from mindroom.turn_origin import TurnOrigin
+
+
+def _current_queued_human_event_ids() -> tuple[str, ...]:
+    return tuple(message.source_event_id for message in current_queued_human_messages())
 
 
 class _ReservationLike(Protocol):
@@ -383,9 +388,10 @@ class _StaticQueuedState:
 def test_queued_message_state_tracks_source_event_ids_idempotently() -> None:
     """Queued-message state should track distinct source events, not anonymous increments."""
     state = _QueuedMessageState()
+    message = QueuedHumanMessage(source_event_id="$event", sender_id="@user:localhost", body="hello")
 
-    assert state.add_waiting_human_message("$event")
-    assert not state.add_waiting_human_message("$event")
+    assert state.add_waiting_human_message(message)
+    assert not state.add_waiting_human_message(message)
 
     assert state.has_pending_human_messages()
     assert state.pending_human_messages == 1
@@ -400,6 +406,67 @@ def test_queued_message_state_tracks_source_event_ids_idempotently() -> None:
     assert not state.has_pending_human_messages()
     assert state.pending_human_messages == 0
     assert not state.is_set()
+
+
+def test_active_follow_up_backlog_uses_queued_receive_order() -> None:
+    """An active-stream backlog should render queued human messages once, even across senders."""
+    thread_history = [
+        ResolvedVisibleMessage.synthetic(
+            sender="@alice:localhost",
+            body="A first",
+            event_id="$a1",
+            timestamp=1,
+            thread_id="$thread",
+        ),
+        ResolvedVisibleMessage.synthetic(
+            sender="@bob:localhost",
+            body="B <context> & more",
+            event_id="$b1",
+            timestamp=2,
+            thread_id="$thread",
+        ),
+        ResolvedVisibleMessage.synthetic(
+            sender="@alice:localhost",
+            body="A follow-up",
+            event_id="$a2",
+            timestamp=3,
+            thread_id="$thread",
+        ),
+        ResolvedVisibleMessage.synthetic(
+            sender="@mindroom_general:localhost",
+            body="Previous partial",
+            event_id="$agent",
+            timestamp=4,
+            thread_id="$thread",
+        ),
+    ]
+
+    backlog = turn_controller._active_follow_up_backlog(
+        queued_messages=(
+            QueuedHumanMessage(source_event_id="$a1", sender_id="@alice:localhost", body="A first"),
+            QueuedHumanMessage(source_event_id="$b1", sender_id="@bob:localhost", body="B <context> & more"),
+            QueuedHumanMessage(source_event_id="$a2", sender_id="@alice:localhost", body="A follow-up"),
+        ),
+        thread_history=thread_history,
+    )
+
+    assert backlog is not None
+    assert backlog.source_event_ids == ("$a1", "$b1", "$a2")
+    assert [message.event_id for message in backlog.thread_history] == ["$agent"]
+    assert backlog.source_event_prompts == {
+        "$a1": "A first",
+        "$b1": "B <context> & more",
+        "$a2": "A follow-up",
+    }
+    assert backlog.prompt == (
+        "Messages arrived while the previous response was still running. "
+        "They are in chat timeline order. Respond once to the combined context:\n\n"
+        "<queued_messages>\n"
+        '<msg event_id="$a1" from="@alice:localhost"><![CDATA[A first]]></msg>\n'
+        '<msg event_id="$b1" from="@bob:localhost"><![CDATA[B <context> & more]]></msg>\n'
+        '<msg event_id="$a2" from="@alice:localhost"><![CDATA[A follow-up]]></msg>\n'
+        "</queued_messages>"
+    )
 
 
 @contextmanager
@@ -811,9 +878,9 @@ async def test_generate_response_detects_active_turn_before_lock_is_held(tmp_pat
     bot = _bot(tmp_path)
     coordinator = unwrap_extracted_collaborator(bot._response_runner)
     lock = _PrelockBarrierLock()
-    response_envelope = _envelope()
-    response_target = response_envelope.target
-    observed_pending: dict[str, int] = {}
+    first_envelope = _envelope(source_event_id="$first")
+    second_envelope = _envelope(source_event_id="$second")
+    observed_backlog: dict[str, tuple[str, ...]] = {}
 
     async def fake_generate_response_locked(
         _self: ResponseRunner,
@@ -823,8 +890,7 @@ async def test_generate_response_detects_active_turn_before_lock_is_held(tmp_pat
     ) -> str:
         del resolved_target
         user_id = str(request.user_id)
-        queued_signal = coordinator._lifecycle_coordinator._get_or_create_queued_signal(response_target)
-        observed_pending[user_id] = queued_signal.pending_human_messages
+        observed_backlog[user_id] = _current_queued_human_event_ids()
         return user_id
 
     with (
@@ -836,7 +902,7 @@ async def test_generate_response_detects_active_turn_before_lock_is_held(tmp_pat
                 prompt="hello",
                 thread_history=[],
                 user_id="first",
-                response_envelope=response_envelope,
+                response_envelope=first_envelope,
             ),
         )
         await lock.first_waiting.wait()
@@ -846,7 +912,7 @@ async def test_generate_response_detects_active_turn_before_lock_is_held(tmp_pat
                 prompt="stop",
                 thread_history=[],
                 user_id="second",
-                response_envelope=response_envelope,
+                response_envelope=second_envelope,
             ),
         )
 
@@ -854,9 +920,9 @@ async def test_generate_response_detects_active_turn_before_lock_is_held(tmp_pat
         second_result = await second_task
         first_result = await first_task
 
-    assert second_result == "second"
+    assert second_result is None
     assert first_result == "first"
-    assert observed_pending["first"] == 1
+    assert observed_backlog == {"first": ("$second",)}
 
 
 @pytest.mark.asyncio
@@ -1355,8 +1421,8 @@ async def test_generate_team_response_helper_sets_queued_signal(tmp_path: Path) 
 
 
 @pytest.mark.asyncio
-async def test_generate_response_preserves_later_queued_human_message(tmp_path: Path) -> None:
-    """The next active turn must still see any later human messages that were already queued."""
+async def test_generate_response_drains_later_queued_human_message(tmp_path: Path) -> None:
+    """The first queued owner should drain later human messages that were already queued."""
     bot = _bot(tmp_path)
     response_envelope_b = _envelope(source_event_id="$event-b")
     response_envelope_c = _envelope(source_event_id="$event-c")
@@ -1366,11 +1432,13 @@ async def test_generate_response_preserves_later_queued_human_message(tmp_path: 
     lifecycle_lock = lifecycle._response_lifecycle_lock(response_target)
     queued_signal = lifecycle._get_or_create_queued_signal(response_target)
     observed_pending: list[bool] = []
+    observed_backlogs: list[tuple[str, ...]] = []
     second_turn_started = asyncio.Event()
     allow_turns_to_finish = asyncio.Event()
 
     async def fake_locked(_self: ResponseRunner, *_args: object, **_kwargs: object) -> str:
         observed_pending.append(queued_signal.has_pending_human_messages())
+        observed_backlogs.append(_current_queued_human_event_ids())
         if len(observed_pending) == 1:
             second_turn_started.set()
         await allow_turns_to_finish.wait()
@@ -1404,22 +1472,23 @@ async def test_generate_response_preserves_later_queued_human_message(tmp_path: 
 
             lifecycle_lock.release()
             await asyncio.wait_for(second_turn_started.wait(), timeout=0.2)
-            assert observed_pending == [True]
+            assert observed_pending == [False]
+            assert observed_backlogs == [("$event-b", "$event-c")]
 
             allow_turns_to_finish.set()
             assert await task_b == "$response-1"
-            assert await task_c == "$response-2"
+            assert await task_c is None
     finally:
         if lifecycle_lock.locked():
             lifecycle_lock.release()
 
-    assert observed_pending == [True, False]
+    assert observed_pending == [False]
     assert not queued_signal.is_set()
 
 
 @pytest.mark.asyncio
-async def test_generate_team_response_preserves_later_queued_human_message(tmp_path: Path) -> None:
-    """Team queue notices must also survive when more than one human turn is waiting."""
+async def test_generate_team_response_drains_later_queued_human_message(tmp_path: Path) -> None:
+    """Team queue notices should also drain already queued human messages once."""
     bot = _bot(tmp_path)
     response_envelope_b = _envelope(source_event_id="$team-event-b")
     response_envelope_c = _envelope(source_event_id="$team-event-c")
@@ -1429,11 +1498,13 @@ async def test_generate_team_response_preserves_later_queued_human_message(tmp_p
     lifecycle_lock = lifecycle._response_lifecycle_lock(response_target)
     queued_signal = lifecycle._get_or_create_queued_signal(response_target)
     observed_pending: list[bool] = []
+    observed_backlogs: list[tuple[str, ...]] = []
     second_turn_started = asyncio.Event()
     allow_turns_to_finish = asyncio.Event()
 
     async def fake_locked(_self: ResponseRunner, *_args: object, **_kwargs: object) -> str:
         observed_pending.append(queued_signal.has_pending_human_messages())
+        observed_backlogs.append(_current_queued_human_event_ids())
         if len(observed_pending) == 1:
             second_turn_started.set()
         await allow_turns_to_finish.wait()
@@ -1471,16 +1542,17 @@ async def test_generate_team_response_preserves_later_queued_human_message(tmp_p
 
             lifecycle_lock.release()
             await asyncio.wait_for(second_turn_started.wait(), timeout=0.2)
-            assert observed_pending == [True]
+            assert observed_pending == [False]
+            assert observed_backlogs == [("$team-event-b", "$team-event-c")]
 
             allow_turns_to_finish.set()
             assert await task_b == "$team-response-1"
-            assert await task_c == "$team-response-2"
+            assert await task_c is None
     finally:
         if lifecycle_lock.locked():
             lifecycle_lock.release()
 
-    assert observed_pending == [True, False]
+    assert observed_pending == [False]
     assert not queued_signal.is_set()
 
 
@@ -1548,6 +1620,78 @@ async def test_reserved_human_follow_up_reaches_active_turn_before_dispatch(tmp_
 
     assert follow_up_observed_pending == [False]
     assert not queued_signal.is_set()
+
+
+@pytest.mark.asyncio
+async def test_response_lifecycle_consumes_active_backlog_once(tmp_path: Path) -> None:
+    """Only one queued turn should answer the human messages that arrived during an active reply."""
+    bot = _bot(tmp_path)
+    coordinator = unwrap_extracted_collaborator(bot._response_runner)
+    lifecycle = coordinator._lifecycle_coordinator
+    target = MessageTarget.resolve("!room:localhost", "$thread", "$active")
+    active_envelope = _envelope(source_event_id="$active", target=target)
+    active_started = asyncio.Event()
+    release_active = asyncio.Event()
+    follow_up_calls: list[str] = []
+
+    async def active_operation(_target: MessageTarget) -> str:
+        active_started.set()
+        await release_active.wait()
+        return "$active-response"
+
+    async def follow_up_operation(source_event_id: str, _target: MessageTarget) -> str:
+        follow_up_calls.append(source_event_id)
+        return f"$response-{source_event_id}"
+
+    active_task = asyncio.create_task(
+        lifecycle.run_locked_response(
+            target=target,
+            response_envelope=active_envelope,
+            queued_notice_reservation=None,
+            pipeline_timing=None,
+            locked_operation=active_operation,
+        ),
+    )
+    await asyncio.wait_for(active_started.wait(), timeout=0.2)
+
+    queued_items = []
+    for source_event_id, sender_id in (
+        ("$a1", "@alice:localhost"),
+        ("$b1", "@bob:localhost"),
+        ("$a2", "@alice:localhost"),
+    ):
+        envelope = _envelope(
+            source_event_id=source_event_id,
+            target=target,
+            requester_id=sender_id,
+            sender_id=sender_id,
+        )
+        reservation = lifecycle.reserve_waiting_human_message(target=target, response_envelope=envelope)
+        assert reservation is not None
+        queued_items.append((source_event_id, envelope, reservation))
+
+    follow_up_tasks = [
+        asyncio.create_task(
+            lifecycle.run_locked_response(
+                target=target,
+                response_envelope=envelope,
+                queued_notice_reservation=reservation,
+                pipeline_timing=None,
+                locked_operation=lambda locked_target, source_event_id=source_event_id: follow_up_operation(
+                    source_event_id,
+                    locked_target,
+                ),
+            ),
+        )
+        for source_event_id, envelope, reservation in queued_items
+    ]
+    await asyncio.sleep(0)
+    assert follow_up_calls == []
+
+    release_active.set()
+    assert await active_task == "$active-response"
+    assert await asyncio.gather(*follow_up_tasks) == ["$response-$a1", None, None]
+    assert follow_up_calls == ["$a1"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -29,7 +29,12 @@ from mindroom.ai_runtime import (
 )
 from mindroom.bot import AgentBot
 from mindroom.bot_runtime_view import BotRuntimeState
-from mindroom.coalescing_batch import CoalescingKey, PendingEvent, build_coalesced_batch
+from mindroom.coalescing_batch import (
+    CoalescingKey,
+    PendingEvent,
+    active_follow_up_coalescing_key,
+    build_coalesced_batch,
+)
 from mindroom.config.agent import AgentConfig
 from mindroom.config.auth import AuthorizationConfig
 from mindroom.config.main import Config
@@ -60,7 +65,7 @@ from mindroom.post_response_effects import (
     apply_post_response_effects,
 )
 from mindroom.prompts import QUEUED_MESSAGE_NOTICE_TEXT
-from mindroom.response_lifecycle import QueuedHumanMessage, _QueuedMessageState, current_queued_human_messages
+from mindroom.response_lifecycle import _QueuedMessageState
 from mindroom.response_runner import PostLockRequestPreparationError, ResponseRequest, ResponseRunner
 from mindroom.teams import TeamMode, _create_team_instance
 from mindroom.turn_controller import _PrecheckedEvent
@@ -86,10 +91,6 @@ if TYPE_CHECKING:
 
     from mindroom.delivery_gateway import FinalDeliveryRequest
     from mindroom.turn_origin import TurnOrigin
-
-
-def _current_queued_human_event_ids() -> tuple[str, ...]:
-    return tuple(message.source_event_id for message in current_queued_human_messages())
 
 
 class _ReservationLike(Protocol):
@@ -388,10 +389,9 @@ class _StaticQueuedState:
 def test_queued_message_state_tracks_source_event_ids_idempotently() -> None:
     """Queued-message state should track distinct source events, not anonymous increments."""
     state = _QueuedMessageState()
-    message = QueuedHumanMessage(source_event_id="$event", sender_id="@user:localhost", body="hello")
 
-    assert state.add_waiting_human_message(message)
-    assert not state.add_waiting_human_message(message)
+    assert state.add_waiting_human_message("$event")
+    assert not state.add_waiting_human_message("$event")
 
     assert state.has_pending_human_messages()
     assert state.pending_human_messages == 1
@@ -408,57 +408,65 @@ def test_queued_message_state_tracks_source_event_ids_idempotently() -> None:
     assert not state.is_set()
 
 
-def test_active_follow_up_backlog_uses_queued_receive_order() -> None:
-    """An active-stream backlog should render queued human messages once, even across senders."""
-    thread_history = [
-        ResolvedVisibleMessage.synthetic(
-            sender="@alice:localhost",
-            body="A first",
-            event_id="$a1",
-            timestamp=1,
-            thread_id="$thread",
+def test_active_follow_up_batch_prompt_uses_queued_receive_order() -> None:
+    """Target-scoped active follow-up batches should preserve timeline order and senders."""
+    room = MagicMock(spec=nio.MatrixRoom)
+    room.room_id = "!room:localhost"
+    pending_events = [
+        PendingEvent(
+            event=PreparedTextEvent(
+                sender="@alice:localhost",
+                event_id="$a1",
+                body="A first",
+                source={"content": {"body": "A first"}},
+                server_timestamp=1,
+            ),
+            room=room,
+            requester_user_id="@alice:localhost",
+            source_kind=MESSAGE_SOURCE_KIND,
+            dispatch_policy_source_kind=ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND,
         ),
-        ResolvedVisibleMessage.synthetic(
-            sender="@bob:localhost",
-            body="B <context> & more",
-            event_id="$b1",
-            timestamp=2,
-            thread_id="$thread",
+        PendingEvent(
+            event=PreparedTextEvent(
+                sender="@bob:localhost",
+                event_id="$b1",
+                body="B <context> & more",
+                source={"content": {"body": "B <context> & more"}},
+                server_timestamp=2,
+            ),
+            room=room,
+            requester_user_id="@bob:localhost",
+            source_kind=MESSAGE_SOURCE_KIND,
+            dispatch_policy_source_kind=ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND,
         ),
-        ResolvedVisibleMessage.synthetic(
-            sender="@alice:localhost",
-            body="A follow-up",
-            event_id="$a2",
-            timestamp=3,
-            thread_id="$thread",
-        ),
-        ResolvedVisibleMessage.synthetic(
-            sender="@mindroom_general:localhost",
-            body="Previous partial",
-            event_id="$agent",
-            timestamp=4,
-            thread_id="$thread",
+        PendingEvent(
+            event=PreparedTextEvent(
+                sender="@alice:localhost",
+                event_id="$a2",
+                body="A follow-up",
+                source={"content": {"body": "A follow-up"}},
+                server_timestamp=3,
+            ),
+            room=room,
+            requester_user_id="@alice:localhost",
+            source_kind=MESSAGE_SOURCE_KIND,
+            dispatch_policy_source_kind=ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND,
         ),
     ]
 
-    backlog = turn_controller._active_follow_up_backlog(
-        queued_messages=(
-            QueuedHumanMessage(source_event_id="$a1", sender_id="@alice:localhost", body="A first"),
-            QueuedHumanMessage(source_event_id="$b1", sender_id="@bob:localhost", body="B <context> & more"),
-            QueuedHumanMessage(source_event_id="$a2", sender_id="@alice:localhost", body="A follow-up"),
-        ),
-        thread_history=thread_history,
+    batch = build_coalesced_batch(
+        active_follow_up_coalescing_key(room.room_id, "$thread"),
+        pending_events,
     )
 
-    assert backlog is not None
-    assert backlog.source_event_ids == ("$a1", "$b1", "$a2")
-    assert [message.event_id for message in backlog.thread_history] == ["$agent"]
-    assert backlog.source_event_prompts == {
+    assert batch.source_event_ids == ["$a1", "$b1", "$a2"]
+    assert batch.requester_user_id == "@alice:localhost"
+    assert batch.source_event_prompts == {
         "$a1": "A first",
         "$b1": "B <context> & more",
         "$a2": "A follow-up",
     }
-    assert backlog.prompt == (
+    assert batch.prompt == (
         "Messages arrived while the previous response was still running. "
         "They are in chat timeline order. Respond once to the combined context:\n\n"
         "<queued_messages>\n"
@@ -469,8 +477,8 @@ def test_active_follow_up_backlog_uses_queued_receive_order() -> None:
     )
 
 
-def test_same_target_batch_reservation_keeps_all_pending_messages(tmp_path: Path) -> None:
-    """Selecting one coalesced reservation must not drop earlier messages on the same target."""
+def test_same_target_batch_reservation_consumes_all_pending_messages(tmp_path: Path) -> None:
+    """A coalesced target batch should consume every matching queued-human notice."""
     bot = _bot(tmp_path)
     target = MessageTarget.resolve("!room:localhost", "$thread", "$a1")
     coordinator = unwrap_extracted_collaborator(bot._response_runner)
@@ -489,7 +497,7 @@ def test_same_target_batch_reservation_keeps_all_pending_messages(tmp_path: Path
         assert first_reservation is not None
         assert second_reservation is not None
 
-        selected = turn_controller._queued_notice_reservation_from_metadata(
+        turn_controller._consume_queued_notice_reservations_from_metadata(
             (
                 PendingDispatchMetadata(
                     kind="queued_notice_reservation",
@@ -507,8 +515,7 @@ def test_same_target_batch_reservation_keeps_all_pending_messages(tmp_path: Path
             target_key=(target.room_id, target.resolved_thread_id),
         )
 
-        assert selected is second_reservation
-        assert queued_signal.pending_human_message_event_ids == ("$a1", "$b1")
+        assert queued_signal.pending_human_message_event_ids == set()
     finally:
         queued_signal.finish_response_turn()
 
@@ -924,7 +931,6 @@ async def test_generate_response_detects_active_turn_before_lock_is_held(tmp_pat
     lock = _PrelockBarrierLock()
     first_envelope = _envelope(source_event_id="$first")
     second_envelope = _envelope(source_event_id="$second")
-    observed_backlog: dict[str, tuple[str, ...]] = {}
 
     async def fake_generate_response_locked(
         _self: ResponseRunner,
@@ -933,9 +939,7 @@ async def test_generate_response_detects_active_turn_before_lock_is_held(tmp_pat
         resolved_target: MessageTarget,
     ) -> str:
         del resolved_target
-        user_id = str(request.user_id)
-        observed_backlog[user_id] = _current_queued_human_event_ids()
-        return user_id
+        return str(request.user_id)
 
     with (
         patch.object(coordinator._lifecycle_coordinator, "_response_lifecycle_lock", return_value=lock),
@@ -966,7 +970,6 @@ async def test_generate_response_detects_active_turn_before_lock_is_held(tmp_pat
 
     assert second_result == "second"
     assert first_result == "first"
-    assert observed_backlog == {"first": (), "second": ()}
 
 
 @pytest.mark.asyncio
@@ -1476,13 +1479,11 @@ async def test_generate_response_without_reservation_does_not_drain_human_backlo
     lifecycle_lock = lifecycle._response_lifecycle_lock(response_target)
     queued_signal = lifecycle._get_or_create_queued_signal(response_target)
     observed_pending: list[bool] = []
-    observed_backlogs: list[tuple[str, ...]] = []
     second_turn_started = asyncio.Event()
     allow_turns_to_finish = asyncio.Event()
 
     async def fake_locked(_self: ResponseRunner, *_args: object, **_kwargs: object) -> str:
         observed_pending.append(queued_signal.has_pending_human_messages())
-        observed_backlogs.append(_current_queued_human_event_ids())
         if len(observed_pending) == 1:
             second_turn_started.set()
         await allow_turns_to_finish.wait()
@@ -1517,7 +1518,6 @@ async def test_generate_response_without_reservation_does_not_drain_human_backlo
             lifecycle_lock.release()
             await asyncio.wait_for(second_turn_started.wait(), timeout=0.2)
             assert observed_pending == [True]
-            assert observed_backlogs == [()]
 
             allow_turns_to_finish.set()
             assert await task_b == "$response-1"
@@ -1527,7 +1527,6 @@ async def test_generate_response_without_reservation_does_not_drain_human_backlo
             lifecycle_lock.release()
 
     assert observed_pending == [True, False]
-    assert observed_backlogs == [(), ()]
     assert not queued_signal.is_set()
 
 
@@ -1543,13 +1542,11 @@ async def test_generate_team_response_without_reservation_does_not_drain_human_b
     lifecycle_lock = lifecycle._response_lifecycle_lock(response_target)
     queued_signal = lifecycle._get_or_create_queued_signal(response_target)
     observed_pending: list[bool] = []
-    observed_backlogs: list[tuple[str, ...]] = []
     second_turn_started = asyncio.Event()
     allow_turns_to_finish = asyncio.Event()
 
     async def fake_locked(_self: ResponseRunner, *_args: object, **_kwargs: object) -> str:
         observed_pending.append(queued_signal.has_pending_human_messages())
-        observed_backlogs.append(_current_queued_human_event_ids())
         if len(observed_pending) == 1:
             second_turn_started.set()
         await allow_turns_to_finish.wait()
@@ -1588,7 +1585,6 @@ async def test_generate_team_response_without_reservation_does_not_drain_human_b
             lifecycle_lock.release()
             await asyncio.wait_for(second_turn_started.wait(), timeout=0.2)
             assert observed_pending == [True]
-            assert observed_backlogs == [()]
 
             allow_turns_to_finish.set()
             assert await task_b == "$team-response-1"
@@ -1598,7 +1594,6 @@ async def test_generate_team_response_without_reservation_does_not_drain_human_b
             lifecycle_lock.release()
 
     assert observed_pending == [True, False]
-    assert observed_backlogs == [(), ()]
     assert not queued_signal.is_set()
 
 
@@ -1669,8 +1664,8 @@ async def test_reserved_human_follow_up_reaches_active_turn_before_dispatch(tmp_
 
 
 @pytest.mark.asyncio
-async def test_response_lifecycle_consumes_active_backlog_once(tmp_path: Path) -> None:
-    """Only one queued turn should answer the human messages that arrived during an active reply."""
+async def test_response_lifecycle_reservations_clear_individual_notices(tmp_path: Path) -> None:
+    """Lifecycle reservations only own queued-message notices, not coalesced follow-up batching."""
     bot = _bot(tmp_path)
     coordinator = unwrap_extracted_collaborator(bot._response_runner)
     lifecycle = coordinator._lifecycle_coordinator
@@ -1736,13 +1731,17 @@ async def test_response_lifecycle_consumes_active_backlog_once(tmp_path: Path) -
 
     release_active.set()
     assert await active_task == "$active-response"
-    assert await asyncio.gather(*follow_up_tasks) == ["$response-$a1", None, None]
-    assert follow_up_calls == ["$a1"]
+    assert await asyncio.gather(*follow_up_tasks) == [
+        "$response-$a1",
+        "$response-$b1",
+        "$response-$a2",
+    ]
+    assert follow_up_calls == ["$a1", "$b1", "$a2"]
 
 
 @pytest.mark.asyncio
-async def test_non_human_lock_owner_does_not_drain_pending_human_backlog(tmp_path: Path) -> None:
-    """Scheduled or hook turns sharing the target lock must not consume human follow-up backlog."""
+async def test_non_human_lock_owner_does_not_clear_pending_human_notice(tmp_path: Path) -> None:
+    """Scheduled or hook turns sharing the target lock must not clear human follow-up notices."""
     bot = _bot(tmp_path)
     coordinator = unwrap_extracted_collaborator(bot._response_runner)
     lifecycle = coordinator._lifecycle_coordinator
@@ -1760,8 +1759,8 @@ async def test_non_human_lock_owner_does_not_drain_pending_human_backlog(tmp_pat
     )
     active_started = asyncio.Event()
     release_active = asyncio.Event()
-    observed_scheduled_backlog: list[tuple[str, ...]] = []
-    observed_human_backlog: list[tuple[str, ...]] = []
+    observed_scheduled_pending: list[set[str]] = []
+    observed_human_pending: list[set[str]] = []
 
     async def active_operation(_target: MessageTarget) -> str:
         active_started.set()
@@ -1769,11 +1768,15 @@ async def test_non_human_lock_owner_does_not_drain_pending_human_backlog(tmp_pat
         return "$active-response"
 
     async def scheduled_operation(_target: MessageTarget) -> str:
-        observed_scheduled_backlog.append(_current_queued_human_event_ids())
+        observed_scheduled_pending.append(
+            set(lifecycle._get_or_create_queued_signal(target).pending_human_message_event_ids),
+        )
         return "$scheduled-response"
 
     async def human_operation(_target: MessageTarget) -> str:
-        observed_human_backlog.append(_current_queued_human_event_ids())
+        observed_human_pending.append(
+            set(lifecycle._get_or_create_queued_signal(target).pending_human_message_event_ids),
+        )
         return "$human-response"
 
     active_task = asyncio.create_task(
@@ -1803,8 +1806,8 @@ async def test_non_human_lock_owner_does_not_drain_pending_human_backlog(tmp_pat
     release_active.set()
     assert await active_task == "$active-response"
     assert await scheduled_task == "$scheduled-response"
-    assert observed_scheduled_backlog == [()]
-    assert lifecycle._get_or_create_queued_signal(target).pending_human_message_event_ids == ("$human",)
+    assert observed_scheduled_pending == [{"$human"}]
+    assert lifecycle._get_or_create_queued_signal(target).pending_human_message_event_ids == {"$human"}
 
     assert (
         await lifecycle.run_locked_response(
@@ -1816,90 +1819,7 @@ async def test_non_human_lock_owner_does_not_drain_pending_human_backlog(tmp_pat
         )
         == "$human-response"
     )
-    assert observed_human_backlog == [("$human",)]
-
-
-@pytest.mark.asyncio
-async def test_failed_active_follow_up_owner_leaves_backlog_for_next_owner(tmp_path: Path) -> None:
-    """Backlog consumption should commit only after the owning response finishes successfully."""
-    bot = _bot(tmp_path)
-    coordinator = unwrap_extracted_collaborator(bot._response_runner)
-    lifecycle = coordinator._lifecycle_coordinator
-    target = MessageTarget.resolve("!room:localhost", "$thread", "$active")
-    active_envelope = _envelope(source_event_id="$active", target=target)
-    first_envelope = _envelope(
-        source_event_id="$a1",
-        target=target,
-        dispatch_policy_source_kind=ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND,
-    )
-    second_envelope = _envelope(
-        source_event_id="$b1",
-        target=target,
-        dispatch_policy_source_kind=ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND,
-    )
-    active_started = asyncio.Event()
-    release_active = asyncio.Event()
-    observed_failed_owner_backlog: list[tuple[str, ...]] = []
-    observed_next_owner_backlog: list[tuple[str, ...]] = []
-
-    async def active_operation(_target: MessageTarget) -> str:
-        active_started.set()
-        await release_active.wait()
-        return "$active-response"
-
-    async def failing_owner_operation(_target: MessageTarget) -> str:
-        observed_failed_owner_backlog.append(_current_queued_human_event_ids())
-        msg = "payload failed"
-        raise RuntimeError(msg)
-
-    async def next_owner_operation(_target: MessageTarget) -> str:
-        observed_next_owner_backlog.append(_current_queued_human_event_ids())
-        return "$next-response"
-
-    active_task = asyncio.create_task(
-        lifecycle.run_locked_response(
-            target=target,
-            response_envelope=active_envelope,
-            queued_notice_reservation=None,
-            pipeline_timing=None,
-            locked_operation=active_operation,
-        ),
-    )
-    await asyncio.wait_for(active_started.wait(), timeout=0.2)
-
-    first_reservation = lifecycle.reserve_waiting_human_message(target=target, response_envelope=first_envelope)
-    second_reservation = lifecycle.reserve_waiting_human_message(target=target, response_envelope=second_envelope)
-    assert first_reservation is not None
-    assert second_reservation is not None
-
-    first_task = asyncio.create_task(
-        lifecycle.run_locked_response(
-            target=target,
-            response_envelope=first_envelope,
-            queued_notice_reservation=first_reservation,
-            pipeline_timing=None,
-            locked_operation=failing_owner_operation,
-        ),
-    )
-    await asyncio.sleep(0)
-
-    release_active.set()
-    assert await active_task == "$active-response"
-    with pytest.raises(RuntimeError, match="payload failed"):
-        await first_task
-
-    assert observed_failed_owner_backlog == [("$a1", "$b1")]
-    assert (
-        await lifecycle.run_locked_response(
-            target=target,
-            response_envelope=second_envelope,
-            queued_notice_reservation=second_reservation,
-            pipeline_timing=None,
-            locked_operation=next_owner_operation,
-        )
-        == "$next-response"
-    )
-    assert observed_next_owner_backlog == [("$a1", "$b1")]
+    assert observed_human_pending == [set()]
 
 
 @pytest.mark.asyncio
@@ -2324,8 +2244,8 @@ async def test_reserved_follow_up_cleanup_when_handle_coalesced_batch_fails_befo
 
 
 @pytest.mark.asyncio
-async def test_coalesced_batch_uses_queued_notice_for_batch_thread(tmp_path: Path) -> None:
-    """A mixed batch should keep the reservation for its single coalescing target."""
+async def test_coalesced_batch_consumes_queued_notice_for_batch_thread(tmp_path: Path) -> None:
+    """A mixed batch should consume the notices for its single coalescing target before dispatch."""
     bot = _bot(tmp_path)
     room = MagicMock(spec=nio.MatrixRoom)
     room.room_id = "!room:localhost"
@@ -2352,15 +2272,13 @@ async def test_coalesced_batch_uses_queued_notice_for_batch_thread(tmp_path: Pat
         body="🎤 voice transcript",
         source_kind_override=VOICE_SOURCE_KIND,
     )
-    captured_reservations: list[object] = []
+    captured_dispatches: list[str] = []
 
     async def capture_dispatch(*_args: object, **kwargs: object) -> None:
+        del kwargs
         assert pre_signal.pending_human_messages == 0
-        assert post_signal.pending_human_messages == 1
-        reservation = kwargs["queued_notice_reservation"]
-        captured_reservations.append(reservation)
-        assert reservation is post_reservation
-        reservation.consume()
+        assert post_signal.pending_human_messages == 0
+        captured_dispatches.append("dispatched")
 
     pre_signal.begin_response_turn()
     post_signal.begin_response_turn()
@@ -2395,7 +2313,7 @@ async def test_coalesced_batch_uses_queued_notice_for_batch_thread(tmp_path: Pat
         pre_signal.finish_response_turn()
         post_signal.finish_response_turn()
 
-    assert captured_reservations == [post_reservation]
+    assert captured_dispatches == ["dispatched"]
     assert pre_signal.pending_human_messages == 0
     assert post_signal.pending_human_messages == 0
     assert not pre_signal.is_set()
@@ -2403,8 +2321,8 @@ async def test_coalesced_batch_uses_queued_notice_for_batch_thread(tmp_path: Pat
 
 
 @pytest.mark.asyncio
-async def test_room_scoped_root_voice_uses_final_target_for_queued_notice(tmp_path: Path) -> None:
-    """A room-scoped voice root should select the reservation for its final target root."""
+async def test_room_scoped_root_voice_consumes_final_target_queued_notice(tmp_path: Path) -> None:
+    """A room-scoped voice root should consume the notice for its final target root before dispatch."""
     bot = _bot(tmp_path)
     room = MagicMock(spec=nio.MatrixRoom)
     room.room_id = "!room:localhost"
@@ -2429,14 +2347,12 @@ async def test_room_scoped_root_voice_uses_final_target_for_queued_notice(tmp_pa
     coordinator = unwrap_extracted_collaborator(bot._response_runner)
     lifecycle = coordinator._lifecycle_coordinator
     queued_signal = lifecycle._get_or_create_queued_signal(target)
-    captured_reservations: list[object] = []
+    captured_dispatches: list[str] = []
 
     async def capture_dispatch(*_args: object, **kwargs: object) -> None:
-        assert queued_signal.pending_human_messages == 1
-        reservation = kwargs["queued_notice_reservation"]
-        captured_reservations.append(reservation)
-        assert reservation is voice_reservation
-        reservation.consume()
+        del kwargs
+        assert queued_signal.pending_human_messages == 0
+        captured_dispatches.append("dispatched")
 
     queued_signal.begin_response_turn()
     try:
@@ -2460,7 +2376,7 @@ async def test_room_scoped_root_voice_uses_final_target_for_queued_notice(tmp_pa
     finally:
         queued_signal.finish_response_turn()
 
-    assert captured_reservations == [voice_reservation]
+    assert captured_dispatches == ["dispatched"]
     assert queued_signal.pending_human_messages == 0
     assert not queued_signal.is_set()
 

--- a/tests/test_voice_bot_threading.py
+++ b/tests/test_voice_bot_threading.py
@@ -559,6 +559,7 @@ async def test_voice_message_signals_active_turn_before_stt(mock_home_bot: Agent
         prepare_started.set()
         await allow_prepare.wait()
 
+    turn_active = True
     queued_signal.begin_response_turn()
     task: asyncio.Task[None] | None = None
     try:
@@ -575,13 +576,16 @@ async def test_voice_message_signals_active_turn_before_stt(mock_home_bot: Agent
             assert queued_signal.pending_human_messages == 1
             allow_prepare.set()
             await task
+            queued_signal.finish_response_turn()
+            turn_active = False
             await drain_coalescing(bot)
     finally:
         if task is not None and not task.done():
             task.cancel()
             with suppress(asyncio.CancelledError):
                 await task
-        queued_signal.finish_response_turn()
+        if turn_active:
+            queued_signal.finish_response_turn()
 
     assert queued_signal.pending_human_messages == 0
     assert not queued_signal.is_set()
@@ -641,6 +645,7 @@ async def test_voice_message_clears_active_turn_signal_when_post_stt_echo_fails(
         assert queued_signal.pending_human_messages == 1
         raise echo_error
 
+    turn_active = True
     queued_signal.begin_response_turn()
     try:
         with (
@@ -657,9 +662,12 @@ async def test_voice_message_clears_active_turn_signal_when_post_stt_echo_fails(
             patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
         ):
             await bot._on_media_message(room, voice_event)
+            queued_signal.finish_response_turn()
+            turn_active = False
             await drain_coalescing(bot)
     finally:
-        queued_signal.finish_response_turn()
+        if turn_active:
+            queued_signal.finish_response_turn()
 
     assert queued_signal.pending_human_messages == 0
     assert not queued_signal.is_set()
@@ -769,16 +777,16 @@ async def test_voice_message_uses_canonical_target_for_queued_notice_before_stt(
     lifecycle = unwrap_extracted_collaborator(bot._response_runner)._lifecycle_coordinator
     pre_stt_signal = lifecycle._get_or_create_queued_signal(pre_stt_target)
     alternate_signal = lifecycle._get_or_create_queued_signal(alternate_target)
-    captured_reservations: list[object] = []
+    dispatch_count = 0
 
-    async def capture_dispatch(*_args: object, **kwargs: object) -> None:
-        assert pre_stt_signal.pending_human_messages == 1
+    async def capture_dispatch(*_args: object, **_kwargs: object) -> None:
+        nonlocal dispatch_count
+        dispatch_count += 1
+        assert pre_stt_signal.pending_human_messages == 0
         assert alternate_signal.pending_human_messages == 0
-        reservation = kwargs["queued_notice_reservation"]
-        assert reservation is not None
-        captured_reservations.append(reservation)
-        reservation.consume()
 
+    pre_stt_turn_active = True
+    alternate_turn_active = True
     pre_stt_signal.begin_response_turn()
     alternate_signal.begin_response_turn()
     try:
@@ -798,12 +806,18 @@ async def test_voice_message_uses_canonical_target_for_queued_notice_before_stt(
             patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
         ):
             await bot._on_media_message(room, voice_event)
+            pre_stt_signal.finish_response_turn()
+            pre_stt_turn_active = False
+            alternate_signal.finish_response_turn()
+            alternate_turn_active = False
             await drain_coalescing(bot)
     finally:
-        pre_stt_signal.finish_response_turn()
-        alternate_signal.finish_response_turn()
+        if pre_stt_turn_active:
+            pre_stt_signal.finish_response_turn()
+        if alternate_turn_active:
+            alternate_signal.finish_response_turn()
 
-    assert len(captured_reservations) == 1
+    assert dispatch_count == 1
     assert pre_stt_signal.pending_human_messages == 0
     assert alternate_signal.pending_human_messages == 0
     assert not pre_stt_signal.is_set()
@@ -852,7 +866,7 @@ async def test_room_mode_voice_notice_survives_until_queued_dispatch_owns_it(
     )
     lifecycle = unwrap_extracted_collaborator(bot._response_runner)._lifecycle_coordinator
     queued_signal = lifecycle._get_or_create_queued_signal(target)
-    captured_reservations: list[object] = []
+    dispatch_count = 0
     prepare_started = asyncio.Event()
     allow_prepare = asyncio.Event()
 
@@ -864,13 +878,12 @@ async def test_room_mode_voice_notice_survives_until_queued_dispatch_owns_it(
         await allow_prepare.wait()
         return normalized_voice
 
-    async def capture_dispatch(*_args: object, **kwargs: object) -> None:
-        assert queued_signal.pending_human_messages == 1
-        reservation = kwargs["queued_notice_reservation"]
-        assert reservation is not None
-        captured_reservations.append(reservation)
-        reservation.consume()
+    async def capture_dispatch(*_args: object, **_kwargs: object) -> None:
+        nonlocal dispatch_count
+        dispatch_count += 1
+        assert queued_signal.pending_human_messages == 0
 
+    turn_active = True
     queued_signal.begin_response_turn()
     task: asyncio.Task[None] | None = None
     try:
@@ -889,15 +902,18 @@ async def test_room_mode_voice_notice_survives_until_queued_dispatch_owns_it(
             assert queued_signal.pending_human_messages == 1
             allow_prepare.set()
             await task
+            queued_signal.finish_response_turn()
+            turn_active = False
             await drain_coalescing(bot)
     finally:
         if task is not None and not task.done():
             task.cancel()
             with suppress(asyncio.CancelledError):
                 await task
-        queued_signal.finish_response_turn()
+        if turn_active:
+            queued_signal.finish_response_turn()
 
-    assert len(captured_reservations) == 1
+    assert dispatch_count == 1
     assert queued_signal.pending_human_messages == 0
     assert not queued_signal.is_set()
 


### PR DESCRIPTION
## Summary
- Remove in-flight buffered-order bookkeeping from the coalescing gate and order tracker.
- Drain active-thread follow-up backlogs once through response lifecycle snapshots, preserving sender/body/media/attachments in receive order.
- Render queued follow-up prompts as XML-like tagged messages and update Tach boundaries for the intentional lifecycle/metadata dependencies.

## Test Plan
- uv run pre-commit run --all-files
- uv run pytest tests/test_coalescing.py tests/test_queued_message_notify.py tests/test_live_message_coalescing.py -q
- uv run pytest -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Follow-up messages sent into an active thread now wait until that thread is idle before dispatch and are emitted as a single ordered follow-up batch preserving sender identity, receive order, and included media/attachments.
  * Added thread-level idle checks so callers can wait for a room/thread to become fully idle before proceeding.

* **Bug Fixes**
  * Improved dispatch/drain behavior so shutdowns and bounded drains complete when external dispatch gating is used and active-follow-up backlogs preserve correct ordering.

* **Tests**
  * Expanded test coverage for active-follow-up batching, queuing, voice/thread lifecycles, prompt/media composition, and drain scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->