### PR TITLE
Update Opus defaults to 4.8

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Coding model training data often lags recent releases, so never trust memorized 
 | Provider | Use | Preferred model | Model string to use |
 | --- | --- | --- | --- |
 | Anthropic | Balanced default | Claude Sonnet 4.6 | `claude-sonnet-4-6` |
-| Anthropic | Max intelligence | Claude Opus 4.7 | `claude-opus-4-7` |
+| Anthropic | Max intelligence | Claude Opus 4.8 | `claude-opus-4-8` |
 | Anthropic | Fast / cheap | Claude Haiku 4.5 | `claude-haiku-4-5` |
 | OpenAI | Frontier default | GPT-5.5 | `gpt-5.5` |
 | OpenAI Codex subscription | Frontier via Codex CLI | GPT-5.5 | `gpt-5.5` |
@@ -30,9 +30,9 @@ Coding model training data often lags recent releases, so never trust memorized 
 | Google (Gemini API) | Image generation / editing | Nano Banana 2 Preview | `gemini-3.1-flash-image-preview` |
 | Google (Gemini API) | Embeddings for `google` | Gemini Embedding 2 Preview | `gemini-embedding-2-preview` |
 
-For `anthropic`, prefer `claude-sonnet-4-6`, `claude-opus-4-7`, and `claude-haiku-4-5` unless you intentionally need a pinned snapshot ID.
+For `anthropic`, prefer `claude-sonnet-4-6`, `claude-opus-4-8`, and `claude-haiku-4-5` unless you intentionally need a pinned snapshot ID.
 For `vertexai_claude`, use the current Vertex AI request name from the provider docs instead of assuming the Anthropic API ID carries over unchanged.
-Current docs list bare Vertex IDs for current Claude models such as `claude-sonnet-4-6` and `claude-opus-4-7`, while some other Vertex models are still documented as dated snapshot IDs such as `claude-haiku-4-5@20251001`.
+Current docs list bare Vertex IDs for current Claude models such as `claude-sonnet-4-6` and `claude-opus-4-8`, while some other Vertex models are still documented as dated snapshot IDs such as `claude-haiku-4-5@20251001`.
 Do not assume `@default` or dated `@...` suffixes are universally required for Vertex AI Claude.
 For Gemini API text and coding work, prefer `gemini-3.5-flash` as the standard stable model unless you intentionally need the cheaper Flash-Lite tier.
 Use `gemini-3.1-pro-preview` only when you need the highest Gemini API intelligence tier and accept a preview model.

--- a/cluster/k8s/instance/default-config.yaml
+++ b/cluster/k8s/instance/default-config.yaml
@@ -398,7 +398,7 @@ models:
     context_window: 400000
   opus:
     provider: openrouter
-    id: anthropic/claude-opus-4.7
+    id: anthropic/claude-opus-4.8
     context_window: 1000000
   sonnet:
     provider: openrouter

--- a/config.yaml
+++ b/config.yaml
@@ -469,7 +469,7 @@ models:
     id: claude-haiku-4-5
     provider: anthropic
   opus:
-    id: claude-opus-4-7
+    id: claude-opus-4-8
     provider: anthropic
   sonnet:
     id: claude-sonnet-4-6

--- a/src/mindroom/model_defaults.py
+++ b/src/mindroom/model_defaults.py
@@ -67,7 +67,7 @@ class ModelPreset:
         return config
 
 
-_ANTHROPIC_OPUS = "claude-opus-4-7"
+_ANTHROPIC_OPUS = "claude-opus-4-8"
 _ANTHROPIC_SONNET = "claude-sonnet-4-6"
 _ANTHROPIC_HAIKU = "claude-haiku-4-5"
 CODEX_GPT = "gpt-5.5"
@@ -83,7 +83,7 @@ GOOGLE_IMAGEN_FAST = "imagen-4.0-fast-generate-001"
 GOOGLE_IMAGEN_ULTRA = "imagen-4.0-ultra-generate-001"
 GOOGLE_VEO = "veo-2.0-generate-001"
 
-_OPENROUTER_CLAUDE_OPUS = "anthropic/claude-opus-4.7"
+_OPENROUTER_CLAUDE_OPUS = "anthropic/claude-opus-4.8"
 _OPENROUTER_CLAUDE_SONNET = "anthropic/claude-sonnet-4.6"
 _OPENROUTER_CLAUDE_HAIKU = "anthropic/claude-haiku-4.5"
 _OPENROUTER_GEMINI_FLASH = "google/gemini-3.5-flash"

--- a/tests/test_claude_agent_tool.py
+++ b/tests/test_claude_agent_tool.py
@@ -425,14 +425,14 @@ async def test_claude_send_tool_model_overrides_agent_model(
     fake_manager: claude_agent_module._ClaudeSessionManager,  # noqa: ARG001
 ) -> None:
     """Explicit tool-config model should override the calling agent model id."""
-    tools = claude_agent_module.ClaudeAgentTools(api_key="sk-test", model="claude-opus-4-6")
+    tools = claude_agent_module.ClaudeAgentTools(api_key="sk-test", model="claude-opus-4-8")
     run_context = RunContext(run_id="run-1", session_id="session-1")
     agent = SimpleNamespace(name="general", model=SimpleNamespace(id="claude-sonnet-4-5"))
 
     await tools.claude_send("hello", run_context=run_context, agent=agent)
 
     options = _FakeClaudeSDKClient.instances[0].options
-    assert options.model == "claude-opus-4-6"
+    assert options.model == "claude-opus-4-8"
 
 
 @pytest.mark.asyncio
@@ -687,7 +687,7 @@ async def test_gateway_probe_posts_to_v1_messages_and_reuses_sdk_session(
         api_key="sk-test",
         anthropic_base_url=fake_anthropic_gateway["base_url"],
         anthropic_auth_token="gateway-token",  # noqa: S106
-        model="claude-opus-4-6",
+        model="claude-opus-4-8",
         disable_experimental_betas=True,
     )
     run_context = RunContext(run_id="run-1", session_id="session-1")
@@ -723,7 +723,7 @@ async def test_gateway_probe_can_include_anthropic_beta_header_when_not_disabled
         api_key="sk-test",
         anthropic_base_url=fake_anthropic_gateway["base_url"],
         anthropic_auth_token="gateway-token",  # noqa: S106
-        model="claude-opus-4-6",
+        model="claude-opus-4-8",
         disable_experimental_betas=False,
     )
     run_context = RunContext(run_id="run-1", session_id="session-1")
@@ -749,7 +749,7 @@ async def test_gateway_probe_error_is_propagated_and_session_is_closed(
         api_key="sk-test",
         anthropic_base_url=fake_anthropic_gateway["base_url"],
         anthropic_auth_token="gateway-token",  # noqa: S106
-        model="claude-opus-4-6",
+        model="claude-opus-4-8",
         disable_experimental_betas=True,
     )
     run_context = RunContext(run_id="run-1", session_id="session-1")

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -420,7 +420,7 @@ def test_ai_run_metadata_bounds_context_cache_split_to_displayed_context(tmp_pat
             models={
                 "default": ModelConfig(
                     provider="vertexai_claude",
-                    id="claude-opus-4-7",
+                    id="claude-opus-4-8",
                     context_window=200_000,
                 ),
             },
@@ -435,7 +435,7 @@ def test_ai_run_metadata_bounds_context_cache_split_to_displayed_context(tmp_pat
         run_id="run-1",
         session_id="session-1",
         status="completed",
-        model="claude-opus-4-7",
+        model="claude-opus-4-8",
         model_provider="VertexAI",
         metrics={"input_tokens": 153_294, "cache_read_tokens": 281_264},
         context_input_tokens=153_294,

--- a/tests/test_extra_kwargs.py
+++ b/tests/test_extra_kwargs.py
@@ -186,7 +186,7 @@ def test_different_providers_with_extra_kwargs() -> None:
             },
             "anthropic_model": {
                 "provider": "anthropic",
-                "id": "claude-3-opus",
+                "id": "claude-opus-4-8",
                 "extra_kwargs": {
                     "temperature": 0.2,
                     "max_tokens": 2048,

--- a/tests/test_presence.py
+++ b/tests/test_presence.py
@@ -72,13 +72,13 @@ class TestBuildAgentStatusMessage:
                     model="claude",
                 ),
             },
-            models={"claude": ModelConfig(provider="anthropic", id="claude-3-opus")},
+            models={"claude": ModelConfig(provider="anthropic", id="claude-opus-4-8")},
             defaults={"tools": []},
         )
 
         status = build_agent_status_message("researcher", config)
 
-        assert "🤖 Model: anthropic/claude-3-opus" in status
+        assert "🤖 Model: anthropic/claude-opus-4-8" in status
         assert "💼 Research specialist focused on finding information" in status
         assert "🔧 4 tools available" in status
 

--- a/tests/test_prompt_cache_review.py
+++ b/tests/test_prompt_cache_review.py
@@ -33,8 +33,8 @@ def test_load_request_rows_handles_concatenated_json_objects(tmp_path: Path) -> 
     module = _load_prompt_cache_review_module()
     jsonl_path = tmp_path / "requests.jsonl"
     jsonl_path.write_text(
-        '{"timestamp":"2026-04-11T11:00:00-07:00","agent_name":"opus","model_id":"claude-opus-4-6","system_prompt":"S","messages":[{"role":"user","content":"a"}],"message_count":1}'
-        '{"timestamp":"2026-04-11T11:00:01-07:00","agent_name":"opus","model_id":"claude-opus-4-6","system_prompt":"S","messages":[{"role":"user","content":"b"}],"message_count":1}\n',
+        '{"timestamp":"2026-04-11T11:00:00-07:00","agent_name":"opus","model_id":"claude-opus-4-8","system_prompt":"S","messages":[{"role":"user","content":"a"}],"message_count":1}'
+        '{"timestamp":"2026-04-11T11:00:01-07:00","agent_name":"opus","model_id":"claude-opus-4-8","system_prompt":"S","messages":[{"role":"user","content":"b"}],"message_count":1}\n',
         encoding="utf-8",
     )
 
@@ -55,7 +55,7 @@ def test_build_session_reviews_detects_prefix_extension_with_two_appended_messag
             session_id="room:$thread",
             room_id="room",
             agent_name="opus",
-            model_id="claude-opus-4-6",
+            model_id="claude-opus-4-8",
             system_prompt="S",
             message_count=2,
             message_blobs=("m1", "m2"),
@@ -67,7 +67,7 @@ def test_build_session_reviews_detects_prefix_extension_with_two_appended_messag
             session_id="room:$thread",
             room_id="room",
             agent_name="opus",
-            model_id="claude-opus-4-6",
+            model_id="claude-opus-4-8",
             system_prompt="S",
             message_count=4,
             message_blobs=("m1", "m2", "m3", "m4"),
@@ -96,7 +96,7 @@ def test_prefix_extension_ignores_moving_cache_control_marker() -> None:
             session_id="room:$thread",
             room_id="room",
             agent_name="opus",
-            model_id="claude-opus-4-6",
+            model_id="claude-opus-4-8",
             system_prompt="S",
             message_count=1,
             message_blobs=('{"content":[{"text":"a","cache_control":{"type":"ephemeral"}}],"role":"user"}',),
@@ -108,7 +108,7 @@ def test_prefix_extension_ignores_moving_cache_control_marker() -> None:
             session_id="room:$thread",
             room_id="room",
             agent_name="opus",
-            model_id="claude-opus-4-6",
+            model_id="claude-opus-4-8",
             system_prompt="S",
             message_count=2,
             message_blobs=(
@@ -136,7 +136,7 @@ def test_raw_prefix_extension_detects_moving_cache_control_marker() -> None:
         session_id="room:$thread",
         room_id="room",
         agent_name="opus",
-        model_id="claude-opus-4-6",
+        model_id="claude-opus-4-8",
         system_prompt="S",
         message_count=1,
         message_blobs=('{"content":[{"text":"a","cache_control":{"type":"ephemeral"}}],"role":"user"}',),
@@ -148,7 +148,7 @@ def test_raw_prefix_extension_detects_moving_cache_control_marker() -> None:
         session_id="room:$thread",
         room_id="room",
         agent_name="opus",
-        model_id="claude-opus-4-6",
+        model_id="claude-opus-4-8",
         system_prompt="S",
         message_count=2,
         message_blobs=(


### PR DESCRIPTION
## Summary
- Update Anthropic Opus guidance and configured defaults to Claude Opus 4.8.
- Update OpenRouter Opus defaults to anthropic/claude-opus-4.8.
- Refresh tests and fixtures that referenced older Opus model IDs.

## Test Plan
- [x] uv run pytest tests/test_claude_agent_tool.py tests/test_compaction.py tests/test_prompt_cache_review.py tests/test_presence.py tests/test_extra_kwargs.py -q
- [x] uv run pytest