### PR TITLE
Fix agent file-memory knowledge base paths

### DIFF
--- a/src/mindroom/runtime_resolution.py
+++ b/src/mindroom/runtime_resolution.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from mindroom.agent_policy import (
@@ -27,8 +28,6 @@ from mindroom.workspaces import (
 )
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from mindroom.config.main import Config
     from mindroom.tool_system.worker_routing import ToolExecutionIdentity, WorkerScope
 
@@ -86,6 +85,73 @@ def _knowledge_refresh_enabled(
 ) -> bool:
     """Return whether a knowledge base has any refresh mechanism available."""
     return file_watch_enabled or has_git_sync
+
+
+def _relative_literal_path_parts(path_text: str | None) -> tuple[str, ...] | None:
+    """Return normalized relative path parts for non-env literal config paths."""
+    if path_text is None or "$" in path_text:
+        return None
+    path = Path(path_text).expanduser()
+    if path.is_absolute() or ".." in path.parts:
+        return None
+    return tuple(part for part in path.parts if part != ".")
+
+
+def _shared_knowledge_path_uses_agent_file_memory(
+    agent_name: str,
+    base_id: str,
+    config: Config,
+) -> bool:
+    """Return whether a shared base points at the configured file-memory folder."""
+    if base_id not in config.get_agent(agent_name).knowledge_bases:
+        return False
+    if config.get_agent_memory_backend(agent_name) != "file":
+        return False
+    knowledge_path_parts = _relative_literal_path_parts(config.get_knowledge_base_config(base_id).path)
+    file_memory_path_parts = _relative_literal_path_parts(config.memory.file.path)
+    return knowledge_path_parts is not None and knowledge_path_parts == file_memory_path_parts
+
+
+def _resolve_agent_file_memory_knowledge_path_from_runtime(
+    agent_runtime: ResolvedAgentRuntime,
+    base_id: str,
+    config: Config,
+) -> Path | None:
+    """Resolve a shared file-memory knowledge base against an already-resolved workspace."""
+    if not _shared_knowledge_path_uses_agent_file_memory(agent_runtime.agent_name, base_id, config):
+        return None
+    if agent_runtime.workspace is None:
+        return None
+    return resolve_workspace_relative_path(
+        agent_runtime.workspace.root,
+        config.get_knowledge_base_config(base_id).path,
+        field_name=f"knowledge base '{base_id}' path",
+    )
+
+
+def _resolve_agent_file_memory_knowledge_binding(
+    agent_name: str,
+    base_id: str,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    execution_identity: ToolExecutionIdentity | None,
+    *,
+    create: bool,
+) -> tuple[ResolvedAgentRuntime, Path] | None:
+    """Resolve a shared file-memory knowledge base against the active agent workspace."""
+    if not _shared_knowledge_path_uses_agent_file_memory(agent_name, base_id, config):
+        return None
+    agent_runtime = resolve_agent_runtime(
+        agent_name,
+        config,
+        runtime_paths,
+        execution_identity=execution_identity,
+        create=create,
+    )
+    knowledge_path = _resolve_agent_file_memory_knowledge_path_from_runtime(agent_runtime, base_id, config)
+    if knowledge_path is None:
+        return None
+    return agent_runtime, knowledge_path
 
 
 def _resolve_private_scope_root(
@@ -228,7 +294,14 @@ def resolve_agent_runtime(
         for base_id in config.get_agent_knowledge_base_ids(agent_name):
             base_config = config.get_knowledge_base_config(base_id)
             if config.get_private_knowledge_base_agent(base_id) is None:
-                knowledge_paths[base_id] = resolve_config_relative_path(base_config.path, runtime_paths).resolve()
+                if _shared_knowledge_path_uses_agent_file_memory(agent_name, base_id, config):
+                    knowledge_paths[base_id] = resolve_workspace_relative_path(
+                        workspace.root,
+                        base_config.path,
+                        field_name=f"knowledge base '{base_id}' path",
+                    )
+                else:
+                    knowledge_paths[base_id] = resolve_config_relative_path(base_config.path, runtime_paths).resolve()
             else:
                 knowledge_paths[base_id] = resolve_workspace_relative_path(
                     workspace.root,
@@ -279,6 +352,23 @@ def resolve_knowledge_binding(
         private_knowledge_base_id_prefix=config.PRIVATE_KNOWLEDGE_BASE_ID_PREFIX,
     )
     if effective_agent_name is None:
+        if execution_identity is not None and execution_identity.agent_name in config.agents:
+            agent_memory_binding = _resolve_agent_file_memory_knowledge_binding(
+                execution_identity.agent_name,
+                base_id,
+                config,
+                runtime_paths,
+                execution_identity,
+                create=create,
+            )
+            if agent_memory_binding is not None:
+                agent_runtime, knowledge_path = agent_memory_binding
+                return ResolvedKnowledgeBinding(
+                    base_id=base_id,
+                    storage_root=agent_runtime.state_root,
+                    knowledge_path=knowledge_path,
+                    incremental_sync_on_access=base_config.watch and base_config.git is None and not start_watchers,
+                )
         knowledge_path = resolve_config_relative_path(base_config.path, runtime_paths).resolve()
         return ResolvedKnowledgeBinding(
             base_id=base_id,

--- a/src/mindroom/runtime_resolution.py
+++ b/src/mindroom/runtime_resolution.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -30,6 +31,8 @@ from mindroom.workspaces import (
 if TYPE_CHECKING:
     from mindroom.config.main import Config
     from mindroom.tool_system.worker_routing import ToolExecutionIdentity, WorkerScope
+
+_PATH_PLACEHOLDER_PATTERN = re.compile(r"\$(?:\{[A-Z0-9_]+\}|[A-Z0-9_]+)")
 
 
 @dataclass(frozen=True)
@@ -89,7 +92,7 @@ def _knowledge_refresh_enabled(
 
 def _relative_literal_path_parts(path_text: str | None) -> tuple[str, ...] | None:
     """Return normalized relative path parts for non-env literal config paths."""
-    if path_text is None or "$" in path_text:
+    if path_text is None or _PATH_PLACEHOLDER_PATTERN.search(path_text):
         return None
     path = Path(path_text).expanduser()
     if path.is_absolute() or ".." in path.parts:
@@ -118,8 +121,6 @@ def _resolve_agent_file_memory_knowledge_path_from_runtime(
     config: Config,
 ) -> Path | None:
     """Resolve a shared file-memory knowledge base against an already-resolved workspace."""
-    if not _shared_knowledge_path_uses_agent_file_memory(agent_runtime.agent_name, base_id, config):
-        return None
     if agent_runtime.workspace is None:
         return None
     return resolve_workspace_relative_path(

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -258,10 +258,10 @@ def _refresh_state_for_key(key: knowledge_registry.PublishedIndexKey) -> str:
     )
 
 
-def _identity(requester_id: str) -> ToolExecutionIdentity:
+def _identity(requester_id: str, *, agent_name: str = "helper") -> ToolExecutionIdentity:
     return ToolExecutionIdentity(
         channel="matrix",
-        agent_name="helper",
+        agent_name=agent_name,
         requester_id=requester_id,
         room_id="!room:localhost",
         thread_id=None,
@@ -4398,6 +4398,161 @@ def test_index_key_is_per_binding_not_raw_base_id(tmp_path: Path) -> None:
 
     assert key_a.base_id == key_b.base_id == "docs"
     assert key_a != key_b
+
+
+def test_shared_relative_knowledge_base_uses_requesting_agent_workspace(tmp_path: Path) -> None:
+    """Shared knowledge over the configured file-memory path should bind per agent workspace."""
+    runtime_paths = test_runtime_paths(tmp_path)
+    config = Config(
+        agents={
+            "openclaw": AgentConfig(
+                display_name="OpenClaw",
+                memory_backend="file",
+                knowledge_bases=["daily_memory"],
+            ),
+            "mindroom_spouse": AgentConfig(
+                display_name="MindRoom Spouse",
+                memory_backend="file",
+                knowledge_bases=["daily_memory"],
+            ),
+        },
+        models={},
+        knowledge_bases={"daily_memory": KnowledgeBaseConfig(path="./memory")},
+        memory={"backend": "file", "file": {"path": "./memory"}},
+    )
+    config = bind_runtime_paths(config, runtime_paths)
+
+    openclaw_key = resolve_published_index_key(
+        "daily_memory",
+        config=config,
+        runtime_paths=runtime_paths,
+        execution_identity=_identity("@alice:localhost", agent_name="openclaw"),
+        create=True,
+    )
+    spouse_key = resolve_published_index_key(
+        "daily_memory",
+        config=config,
+        runtime_paths=runtime_paths,
+        execution_identity=_identity("@alice:localhost", agent_name="mindroom_spouse"),
+        create=True,
+    )
+
+    assert (
+        Path(openclaw_key.knowledge_path) == runtime_paths.storage_root / "agents" / "openclaw" / "workspace" / "memory"
+    )
+    assert (
+        Path(spouse_key.knowledge_path)
+        == runtime_paths.storage_root / "agents" / "mindroom_spouse" / "workspace" / "memory"
+    )
+    assert openclaw_key != spouse_key
+
+
+def test_shared_relative_knowledge_base_keeps_non_memory_path_config_relative(tmp_path: Path) -> None:
+    """Ordinary shared relative knowledge paths should stay config-relative."""
+    runtime_paths = test_runtime_paths(tmp_path)
+    config = Config(
+        agents={
+            "helper": AgentConfig(
+                display_name="Helper",
+                memory_backend="file",
+                knowledge_bases=["docs"],
+            ),
+        },
+        models={},
+        knowledge_bases={"docs": KnowledgeBaseConfig(path="./knowledge_docs")},
+        memory={"backend": "file", "file": {"path": "./memory"}},
+    )
+    config = bind_runtime_paths(config, runtime_paths)
+
+    key = resolve_published_index_key(
+        "docs",
+        config=config,
+        runtime_paths=runtime_paths,
+        execution_identity=_identity("@alice:localhost"),
+        create=True,
+    )
+
+    assert Path(key.knowledge_path) == runtime_paths.config_dir / "knowledge_docs"
+
+
+@pytest.mark.asyncio
+async def test_file_memory_knowledge_search_uses_requesting_agent_workspace(tmp_path: Path) -> None:
+    """Search should query the file-memory workspace for the active agent binding."""
+    runtime_paths = test_runtime_paths(tmp_path)
+    config = bind_runtime_paths(
+        Config(
+            agents={
+                "openclaw": AgentConfig(
+                    display_name="OpenClaw",
+                    memory_backend="file",
+                    knowledge_bases=["daily_memory"],
+                ),
+                "mindroom_spouse": AgentConfig(
+                    display_name="MindRoom Spouse",
+                    memory_backend="file",
+                    knowledge_bases=["daily_memory"],
+                ),
+            },
+            models={},
+            knowledge_bases={"daily_memory": KnowledgeBaseConfig(path="./memory")},
+            memory={"backend": "file", "file": {"path": "./memory"}},
+        ),
+        runtime_paths,
+    )
+    openclaw_identity = _identity("@alice:localhost", agent_name="openclaw")
+    spouse_identity = _identity("@alice:localhost", agent_name="mindroom_spouse")
+    openclaw_key = resolve_published_index_key(
+        "daily_memory",
+        config=config,
+        runtime_paths=runtime_paths,
+        execution_identity=openclaw_identity,
+        create=True,
+    )
+    spouse_key = resolve_published_index_key(
+        "daily_memory",
+        config=config,
+        runtime_paths=runtime_paths,
+        execution_identity=spouse_identity,
+        create=True,
+    )
+    Path(openclaw_key.knowledge_path).mkdir(parents=True, exist_ok=True)
+    Path(spouse_key.knowledge_path).mkdir(parents=True, exist_ok=True)
+    (Path(openclaw_key.knowledge_path) / "note.md").write_text("openclaw unique note", encoding="utf-8")
+    (Path(spouse_key.knowledge_path) / "note.md").write_text("spouse unique note", encoding="utf-8")
+
+    await refresh_knowledge_binding(
+        "daily_memory",
+        config=config,
+        runtime_paths=runtime_paths,
+        execution_identity=openclaw_identity,
+    )
+    await refresh_knowledge_binding(
+        "daily_memory",
+        config=config,
+        runtime_paths=runtime_paths,
+        execution_identity=spouse_identity,
+    )
+    openclaw_knowledge = resolve_agent_knowledge_access(
+        "openclaw",
+        config,
+        runtime_paths,
+        execution_identity=openclaw_identity,
+    ).knowledge
+    spouse_knowledge = resolve_agent_knowledge_access(
+        "mindroom_spouse",
+        config,
+        runtime_paths,
+        execution_identity=spouse_identity,
+    ).knowledge
+
+    assert openclaw_knowledge is not None
+    assert spouse_knowledge is not None
+    assert [document.content for document in openclaw_knowledge.search("unique", max_results=5)] == [
+        "openclaw unique note",
+    ]
+    assert [document.content for document in spouse_knowledge.search("unique", max_results=5)] == [
+        "spouse unique note",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -4475,6 +4475,62 @@ def test_shared_relative_knowledge_base_keeps_non_memory_path_config_relative(tm
     assert Path(key.knowledge_path) == runtime_paths.config_dir / "knowledge_docs"
 
 
+def test_shared_file_memory_path_accepts_literal_dollar_in_path(tmp_path: Path) -> None:
+    """Literal dollar signs in path names should not disable file-memory binding."""
+    runtime_paths = test_runtime_paths(tmp_path)
+    config = Config(
+        agents={
+            "helper": AgentConfig(
+                display_name="Helper",
+                memory_backend="file",
+                knowledge_bases=["daily_memory"],
+            ),
+        },
+        models={},
+        knowledge_bases={"daily_memory": KnowledgeBaseConfig(path="./notes$archive")},
+        memory={"backend": "file", "file": {"path": "./notes$archive"}},
+    )
+    config = bind_runtime_paths(config, runtime_paths)
+
+    key = resolve_published_index_key(
+        "daily_memory",
+        config=config,
+        runtime_paths=runtime_paths,
+        execution_identity=_identity("@alice:localhost"),
+        create=True,
+    )
+
+    assert Path(key.knowledge_path) == runtime_paths.storage_root / "agents" / "helper" / "workspace" / "notes$archive"
+
+
+def test_file_memory_agent_without_configured_file_path_keeps_shared_base_config_relative(tmp_path: Path) -> None:
+    """Agent-level file memory does not make arbitrary shared paths workspace-relative."""
+    runtime_paths = test_runtime_paths(tmp_path)
+    config = Config(
+        agents={
+            "helper": AgentConfig(
+                display_name="Helper",
+                memory_backend="file",
+                knowledge_bases=["daily_memory"],
+            ),
+        },
+        models={},
+        knowledge_bases={"daily_memory": KnowledgeBaseConfig(path="./memory")},
+        memory={"backend": "mem0"},
+    )
+    config = bind_runtime_paths(config, runtime_paths)
+
+    key = resolve_published_index_key(
+        "daily_memory",
+        config=config,
+        runtime_paths=runtime_paths,
+        execution_identity=_identity("@alice:localhost"),
+        create=True,
+    )
+
+    assert Path(key.knowledge_path) == runtime_paths.config_dir / "memory"
+
+
 @pytest.mark.asyncio
 async def test_file_memory_knowledge_search_uses_requesting_agent_workspace(tmp_path: Path) -> None:
     """Search should query the file-memory workspace for the active agent binding."""


### PR DESCRIPTION
## Summary
- Resolve shared knowledge bases that point at the configured file-memory path against the requesting file-memory agent's workspace.
- Keep ordinary shared relative knowledge-base paths config-relative.
- Add regression coverage for per-agent index keys and search isolation.

## Test Plan
- [x] uv sync --all-extras
- [x] uv run pytest tests/test_knowledge_manager.py::test_shared_relative_knowledge_base_uses_requesting_agent_workspace tests/test_knowledge_manager.py::test_shared_relative_knowledge_base_keeps_non_memory_path_config_relative tests/test_knowledge_manager.py::test_file_memory_knowledge_search_uses_requesting_agent_workspace -q
- [x] uv run pre-commit run --files src/mindroom/runtime_resolution.py tests/test_knowledge_manager.py
- [x] uv run pytest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Knowledge base paths targeting per-agent file-memory directories now resolve correctly to the requesting agent's workspace, enabling proper per-agent knowledge isolation and workspace-relative binding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->