### PR TITLE
Add MindRoom macOS menu bar app

### DIFF
--- a/.github/scripts/normalize_appcast.py
+++ b/.github/scripts/normalize_appcast.py
@@ -1,0 +1,25 @@
+"""Normalize generated Sparkle appcast files for repository hooks."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def normalize_appcast_file(path: Path) -> None:
+    """Use LF line endings and exactly one final newline."""
+    text = path.read_text(encoding="utf-8")
+    path.write_text(text.rstrip("\n") + "\n", encoding="utf-8", newline="\n")
+
+
+def main() -> None:
+    """Run the command-line appcast normalizer."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("appcast", type=Path, help="Path to the generated appcast XML.")
+    args = parser.parse_args()
+
+    normalize_appcast_file(args.appcast)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/update_mindroom_cask.py
+++ b/.github/scripts/update_mindroom_cask.py
@@ -34,8 +34,15 @@ def update_cask_text(text: str, *, version: str, sha256: str) -> str:
     sha256_count = 0
     lines: list[str] = []
     for source_line in text.splitlines(keepends=True):
-        newline = "\n" if source_line.endswith("\n") else ""
-        content = source_line.removesuffix("\n")
+        if source_line.endswith("\r\n"):
+            newline = "\r\n"
+            content = source_line.removesuffix("\r\n")
+        elif source_line.endswith("\n"):
+            newline = "\n"
+            content = source_line.removesuffix("\n")
+        else:
+            newline = ""
+            content = source_line
 
         if match := VERSION_RE.match(content):
             output_line = f'{match.group("indent")}version "{version}"{newline}'

--- a/.github/scripts/update_mindroom_cask.py
+++ b/.github/scripts/update_mindroom_cask.py
@@ -1,0 +1,85 @@
+"""Update the MindRoom Homebrew cask version and checksum."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+VERSION_RE = re.compile(r'^(?P<indent>\s*)version "[^"]+"$')
+SHA256_RE = re.compile(r'^(?P<indent>\s*)sha256 "[0-9a-f]{64}"$')
+
+
+def _validate_sha256(value: str) -> str:
+    if not re.fullmatch(r"[0-9a-f]{64}", value):
+        msg = "sha256 must be 64 lowercase hexadecimal characters"
+        raise ValueError(msg)
+    return value
+
+
+def _validate_version(value: str) -> str:
+    value = value.removeprefix("v")
+    if not re.fullmatch(r"\d+(?:\.\d+)*(?:[-,._A-Za-z0-9]+)?", value):
+        msg = f"unsupported cask version: {value}"
+        raise ValueError(msg)
+    return value
+
+
+def update_cask_text(text: str, *, version: str, sha256: str) -> str:
+    """Replace the single version and sha256 stanzas in a cask."""
+    version = _validate_version(version)
+    sha256 = _validate_sha256(sha256)
+
+    version_count = 0
+    sha256_count = 0
+    lines: list[str] = []
+    for source_line in text.splitlines(keepends=True):
+        newline = "\n" if source_line.endswith("\n") else ""
+        content = source_line.removesuffix("\n")
+
+        if match := VERSION_RE.match(content):
+            output_line = f'{match.group("indent")}version "{version}"{newline}'
+            version_count += 1
+        elif match := SHA256_RE.match(content):
+            output_line = f'{match.group("indent")}sha256 "{sha256}"{newline}'
+            sha256_count += 1
+        else:
+            output_line = source_line
+        lines.append(output_line)
+
+    if version_count != 1:
+        msg = f"expected exactly one version stanza, found {version_count}"
+        raise ValueError(msg)
+    if sha256_count != 1:
+        msg = f"expected exactly one sha256 stanza, found {sha256_count}"
+        raise ValueError(msg)
+
+    return "".join(lines)
+
+
+def update_cask_file(path: Path, *, version: str, sha256: str) -> None:
+    """Update a cask file in place."""
+    path.write_text(
+        update_cask_text(path.read_text(), version=version, sha256=sha256),
+        encoding="utf-8",
+    )
+
+
+def main() -> None:
+    """Run the command-line cask updater."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--cask",
+        type=Path,
+        default=Path("Casks/mindroom.rb"),
+        help="Path to the cask file to update.",
+    )
+    parser.add_argument("--version", required=True, help="Release version, with or without v prefix.")
+    parser.add_argument("--sha256", required=True, help="SHA-256 checksum for the release DMG.")
+    args = parser.parse_args()
+
+    update_cask_file(args.cask, version=args.version, sha256=args.sha256)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
           ref: ${{ inputs.release_ref }}
           fetch-depth: 0
           lfs: true
+          persist-credentials: false
       - name: Fetch Git LFS assets
         run: git lfs pull
       - name: Install uv
@@ -46,6 +47,7 @@ jobs:
           ref: ${{ inputs.release_ref }}
           fetch-depth: 0
           lfs: true
+          persist-credentials: false
       - name: Fetch Git LFS assets
         run: git lfs pull
       - name: Install uv
@@ -129,6 +131,7 @@ jobs:
           cp "$APPCAST_DIR/appcast.xml" macos/appcast.xml
       - name: Update Homebrew cask and Sparkle appcast
         env:
+          GH_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ inputs.release_ref }}
         run: |
           VERSION="${TAG_NAME#v}"
@@ -148,5 +151,5 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Casks/mindroom.rb macos/appcast.xml
           git commit -m "Update MindRoom release metadata to ${TAG_NAME}"
-          git pull --rebase origin main
-          git push origin HEAD:main
+          git pull --rebase "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" main
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,3 +33,120 @@ jobs:
         run: uv build
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  build_macos_app:
+    name: Build and publish macOS app
+    runs-on: macos-latest
+    timeout-minutes: 45
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.release_ref }}
+          fetch-depth: 0
+          lfs: true
+      - name: Fetch Git LFS assets
+        run: git lfs pull
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Import Developer ID certificate
+        uses: apple-actions/import-codesign-certs@v7
+        with:
+          p12-file-base64: ${{ secrets.MACOS_CODESIGN_CERTIFICATE_BASE64 }}
+          p12-password: ${{ secrets.MACOS_CODESIGN_CERTIFICATE_PASSWORD }}
+          keychain-password: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+      - name: Resolve Developer ID identity
+        id: codesign
+        run: |
+          IDENTITY=$(
+            security find-identity -v -p codesigning |
+              awk -F '"' '/Developer ID Application/ { print $2; exit }'
+          )
+          if [[ -z "$IDENTITY" ]]; then
+            echo "Developer ID Application signing identity not found." >&2
+            exit 1
+          fi
+          echo "identity=$IDENTITY" >> "$GITHUB_OUTPUT"
+      - name: Build notarized macOS DMG
+        env:
+          CODESIGN_IDENTITY: ${{ steps.codesign.outputs.identity }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APP_VERSION: ${{ inputs.release_ref }}
+          BUILD_VERSION: ${{ github.run_number }}
+          SPARKLE_PUBLIC_ED_KEY: ${{ vars.SPARKLE_PUBLIC_ED_KEY }}
+        run: |
+          if [[ -z "$SPARKLE_PUBLIC_ED_KEY" ]]; then
+            echo "SPARKLE_PUBLIC_ED_KEY repository variable is required to enable Sparkle updates." >&2
+            exit 1
+          fi
+          NOTARIZE=1 macos/build-macos-app.sh --dmg
+          ditto -c -k --keepParent dist/macos/MindRoom.app dist/macos/MindRoom.zip
+      - name: Upload macOS app to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ inputs.release_ref }}
+        run: gh release upload "$TAG_NAME" dist/macos/MindRoom.dmg dist/macos/MindRoom.zip --clobber
+      - name: Update Sparkle appcast
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ inputs.release_ref }}
+          SPARKLE_PRIVATE_ED_KEY: ${{ secrets.SPARKLE_PRIVATE_ED_KEY }}
+        run: |
+          git fetch origin main
+          git switch --force-create release-metadata origin/main
+
+          if [[ -z "$SPARKLE_PRIVATE_ED_KEY" ]]; then
+            echo "SPARKLE_PRIVATE_ED_KEY is required to sign Sparkle updates." >&2
+            exit 1
+          fi
+
+          SPARKLE_GENERATE_APPCAST="macos/MindRoom/.build/artifacts/sparkle/Sparkle/bin/generate_appcast"
+          if [[ ! -x "$SPARKLE_GENERATE_APPCAST" ]]; then
+            echo "Sparkle generate_appcast not found: $SPARKLE_GENERATE_APPCAST" >&2
+            exit 1
+          fi
+
+          APPCAST_DIR="$RUNNER_TEMP/mindroom-appcast"
+          rm -rf "$APPCAST_DIR"
+          mkdir -p "$APPCAST_DIR"
+          cp dist/macos/MindRoom.zip "$APPCAST_DIR/MindRoom.zip"
+          cp macos/appcast.xml "$APPCAST_DIR/appcast.xml"
+          gh release view "$TAG_NAME" --json body --jq .body >"$APPCAST_DIR/MindRoom.md"
+
+          printf '%s' "$SPARKLE_PRIVATE_ED_KEY" |
+            "$SPARKLE_GENERATE_APPCAST" \
+              --ed-key-file - \
+              --download-url-prefix "https://github.com/mindroom-ai/mindroom/releases/download/${TAG_NAME}/" \
+              --link "https://github.com/mindroom-ai/mindroom" \
+              --embed-release-notes \
+              --maximum-versions 10 \
+              -o "$APPCAST_DIR/appcast.xml" \
+              "$APPCAST_DIR"
+
+          cp "$APPCAST_DIR/appcast.xml" macos/appcast.xml
+      - name: Update Homebrew cask and Sparkle appcast
+        env:
+          TAG_NAME: ${{ inputs.release_ref }}
+        run: |
+          VERSION="${TAG_NAME#v}"
+          SHA256=$(shasum -a 256 dist/macos/MindRoom.dmg | awk '{ print $1 }')
+
+          python3 .github/scripts/update_mindroom_cask.py \
+            --version "$VERSION" \
+            --sha256 "$SHA256"
+          python3 .github/scripts/normalize_appcast.py macos/appcast.xml
+
+          if git diff --quiet -- Casks/mindroom.rb macos/appcast.xml; then
+            echo "Casks/mindroom.rb and macos/appcast.xml are already up to date."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Casks/mindroom.rb macos/appcast.xml
+          git commit -m "Update MindRoom release metadata to ${TAG_NAME}"
+          git pull --rebase origin main
+          git push origin HEAD:main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,8 +97,8 @@ jobs:
           TAG_NAME: ${{ inputs.release_ref }}
           SPARKLE_PRIVATE_ED_KEY: ${{ secrets.SPARKLE_PRIVATE_ED_KEY }}
         run: |
-          git fetch origin main
-          git switch --force-create release-metadata origin/main
+          git fetch "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" main
+          git switch --force-create release-metadata FETCH_HEAD
 
           if [[ -z "$SPARKLE_PRIVATE_ED_KEY" ]]; then
             echo "SPARKLE_PRIVATE_ED_KEY is required to sign Sparkle updates." >&2

--- a/Casks/mindroom.rb
+++ b/Casks/mindroom.rb
@@ -20,6 +20,7 @@ cask "mindroom" do
             quit:      "chat.mindroom.menubar"
 
   zap trash: [
+    "~/Library/LaunchAgents/chat.mindroom.local.plist",
     "~/Library/Logs/mindroom",
     "~/Library/Preferences/chat.mindroom.menubar.plist",
   ]

--- a/Casks/mindroom.rb
+++ b/Casks/mindroom.rb
@@ -1,0 +1,26 @@
+cask "mindroom" do
+  version "0.0.0"
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+
+  url "https://github.com/mindroom-ai/mindroom/releases/download/v#{version}/MindRoom.dmg"
+  name "MindRoom"
+  desc "Menu bar app for local MindRoom agent service management"
+  homepage "https://github.com/mindroom-ai/mindroom"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: :ventura
+
+  app "MindRoom.app"
+
+  uninstall launchctl: "chat.mindroom.local",
+            quit:      "chat.mindroom.menubar"
+
+  zap trash: [
+    "~/Library/Logs/mindroom",
+    "~/Library/Preferences/chat.mindroom.menubar.plist",
+  ]
+end

--- a/README.md
+++ b/README.md
@@ -158,6 +158,21 @@ Native Matrix tools include `matrix_message`, `matrix_room`, `thread_tags`, and 
 
 ## Quick Start
 
+### macOS Menu Bar App
+
+MindRoom also ships as a macOS menu bar app for running the local MindRoom service without keeping a terminal open.
+The app bundles `uv`, installs the `mindroom` CLI with `uv tool install`, uses `~/.mindroom` for normal config and state, and manages the existing `mindroom service` launchd service.
+
+```bash
+brew install --cask mindroom
+```
+
+Open **MindRoom** from `/Applications` or Spotlight.
+Use the menu bar item to install the MindRoom runtime, initialize the hosted `chat.mindroom.chat` config, pair with a code from the hosted chat UI, install the service, and open the dashboard.
+Self-hosted config and local-stack setup remain available from the same menu.
+
+See [macOS app guide](docs/installation/macos-app.md) for setup, updates, and uninstall instructions.
+
 ### Prerequisites
 - Python 3.12+
 - [uv](https://github.com/astral-sh/uv) for Python package management

--- a/docs/installation/macos-app.md
+++ b/docs/installation/macos-app.md
@@ -12,7 +12,7 @@ MindRoom config, secrets, and runtime state stay in `~/.mindroom`, so the app an
 
 ## Install
 
-Install the signed app release with Homebrew:
+Install the signed app release with Homebrew.
 
 ```bash
 brew install --cask mindroom
@@ -45,7 +45,7 @@ Configuration is available through **Open Config Folder** at `~/.mindroom`.
 
 Use **Update MindRoom Runtime** to run `uv tool install --managed-python --python 3.13 --force mindroom`.
 Use **Check for App Updates...** to update the signed macOS app through Sparkle.
-Homebrew users can also update with:
+Homebrew users can also update with Homebrew.
 
 ```bash
 brew update
@@ -58,7 +58,7 @@ brew upgrade --cask mindroom
 brew uninstall --cask mindroom
 ```
 
-To remove app preferences and logs:
+Use Homebrew zap to remove app preferences and logs.
 
 ```bash
 brew uninstall --zap --cask mindroom

--- a/docs/installation/macos-app.md
+++ b/docs/installation/macos-app.md
@@ -1,0 +1,68 @@
+# macOS Menu Bar App
+
+MindRoom ships as a native macOS menu bar app for running the local MindRoom service without using terminal commands.
+The app bundles `uv`, installs the `mindroom` CLI through `uv tool install`, and manages the existing launchd service through `mindroom service`.
+MindRoom config, secrets, and runtime state stay in `~/.mindroom`, so the app and CLI use the same files.
+
+## Requirements
+
+- macOS 13 Ventura or later.
+- Network access for installing the `mindroom` package and pairing with hosted MindRoom.
+- A model provider credential in `~/.mindroom/.env`, unless you configure a local or subscription-backed provider.
+
+## Install
+
+Install the signed app release with Homebrew:
+
+```bash
+brew install --cask mindroom
+```
+
+Open **MindRoom** from `/Applications` or Spotlight.
+
+## First Launch
+
+Use **Install MindRoom Runtime** to install the CLI runtime with bundled `uv`.
+Use **Initialize Hosted Config** for the default `chat.mindroom.chat` profile.
+Open `https://chat.mindroom.chat`, generate a local MindRoom pair code, and use **Pair Hosted MindRoom...** in the menu.
+Use **Install/Ensure Service** to run `mindroom service install --no-confirm`.
+Use **Open Dashboard** to open `http://localhost:8765`.
+
+## Other Setup Modes
+
+Use **Initialize Self-Hosted Config** when you want to connect to your own Matrix homeserver.
+Use **Run Local Stack Setup** when you want the local Matrix stack flow.
+These actions still write to `~/.mindroom`.
+
+## Service Controls
+
+The menu exposes **Start Service**, **Stop Service**, **Restart Service**, and **Refresh Status**.
+The service is managed by launchd, so MindRoom keeps running after the menu bar app quits.
+Logs are available through **Open Logs Folder** at `~/Library/Logs/mindroom`.
+Configuration is available through **Open Config Folder** at `~/.mindroom`.
+
+## Updates
+
+Use **Update MindRoom Runtime** to run `uv tool install --managed-python --python 3.13 --force mindroom`.
+Use **Check for App Updates...** to update the signed macOS app through Sparkle.
+Homebrew users can also update with:
+
+```bash
+brew update
+brew upgrade --cask mindroom
+```
+
+## Uninstall
+
+```bash
+brew uninstall --cask mindroom
+```
+
+To remove app preferences and logs:
+
+```bash
+brew uninstall --zap --cask mindroom
+```
+
+The zap command intentionally does not delete `~/.mindroom`.
+Remove that directory manually only when you want to delete MindRoom config, credentials, and persistent agent data.

--- a/docs/superpowers/plans/2026-05-29-mindroom-macos-menu-bar-app.md
+++ b/docs/superpowers/plans/2026-05-29-mindroom-macos-menu-bar-app.md
@@ -10,9 +10,11 @@
 
 ---
 
+## Implementation Tasks
+
 ### Task 1: Swift Package Skeleton And Runtime Tests
 
-**Files:**
+**Files.**
 - Create: `macos/MindRoom/Package.swift`
 - Create: `macos/MindRoom/Sources/MindRoom/AppMetadata.swift`
 - Create: `macos/MindRoom/Sources/MindRoom/MindRoomRuntime.swift`
@@ -27,8 +29,8 @@ Add tests that assert the app uses `~/.mindroom`, constructs `uv tool install` f
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `swift test --package-path macos/MindRoom`
-Expected: FAIL because the Swift package and runtime types do not exist.
+Run `swift test --package-path macos/MindRoom`.
+Expected result is FAIL because the Swift package and runtime types do not exist.
 
 - [ ] **Step 3: Add minimal package and runtime types**
 
@@ -36,16 +38,16 @@ Add a Swift package with Sparkle dependency, a `CommandResult` struct, and a `Mi
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `swift test --package-path macos/MindRoom`
-Expected: PASS.
+Run `swift test --package-path macos/MindRoom`.
+Expected result is PASS.
 
 - [ ] **Step 5: Commit**
 
-Run: `git add macos/MindRoom/Package.swift macos/MindRoom/Sources/MindRoom/AppMetadata.swift macos/MindRoom/Sources/MindRoom/MindRoomRuntime.swift macos/MindRoom/Sources/MindRoom/CommandResult.swift macos/MindRoom/Tests/MindRoomTests/MindRoomRuntimeTests.swift macos/MindRoom/Resources/Info.plist macos/MindRoom/Resources/MindRoom.entitlements && git commit -m "Add MindRoom macOS runtime package"`
+Run `git add macos/MindRoom/Package.swift macos/MindRoom/Sources/MindRoom/AppMetadata.swift macos/MindRoom/Sources/MindRoom/MindRoomRuntime.swift macos/MindRoom/Sources/MindRoom/CommandResult.swift macos/MindRoom/Tests/MindRoomTests/MindRoomRuntimeTests.swift macos/MindRoom/Resources/Info.plist macos/MindRoom/Resources/MindRoom.entitlements && git commit -m "Add MindRoom macOS runtime package"`.
 
 ### Task 2: Command Runner And Service Status Tests
 
-**Files:**
+**Files.**
 - Create: `macos/MindRoom/Sources/MindRoom/MindRoomCommand.swift`
 - Create: `macos/MindRoom/Sources/MindRoom/MindRoomCommandRunner.swift`
 - Create: `macos/MindRoom/Sources/MindRoom/ServiceStatus.swift`
@@ -57,8 +59,8 @@ Add tests for `running`, `installed but not running`, `not installed`, and missi
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `swift test --package-path macos/MindRoom`
-Expected: FAIL because status parser types do not exist.
+Run `swift test --package-path macos/MindRoom`.
+Expected result is FAIL because status parser types do not exist.
 
 - [ ] **Step 3: Add command and status code**
 
@@ -68,16 +70,16 @@ Add a service status parser that maps CLI output to menu status.
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `swift test --package-path macos/MindRoom`
-Expected: PASS.
+Run `swift test --package-path macos/MindRoom`.
+Expected result is PASS.
 
 - [ ] **Step 5: Commit**
 
-Run: `git add macos/MindRoom/Sources/MindRoom/MindRoomCommand.swift macos/MindRoom/Sources/MindRoom/MindRoomCommandRunner.swift macos/MindRoom/Sources/MindRoom/ServiceStatus.swift macos/MindRoom/Tests/MindRoomTests/ServiceStatusTests.swift && git commit -m "Add MindRoom macOS command runner"`
+Run `git add macos/MindRoom/Sources/MindRoom/MindRoomCommand.swift macos/MindRoom/Sources/MindRoom/MindRoomCommandRunner.swift macos/MindRoom/Sources/MindRoom/ServiceStatus.swift macos/MindRoom/Tests/MindRoomTests/ServiceStatusTests.swift && git commit -m "Add MindRoom macOS command runner"`.
 
 ### Task 3: Menu Bar App UI
 
-**Files:**
+**Files.**
 - Create: `macos/MindRoom/Sources/MindRoom/MindRoomApp.swift`
 - Create: `macos/MindRoom/Sources/MindRoom/AppDelegate.swift`
 - Create: `macos/MindRoom/Sources/MindRoom/StatusMenuController.swift`
@@ -91,16 +93,16 @@ The menu includes Install or Update Runtime, Ensure Service, Start, Stop, Restar
 
 - [ ] **Step 2: Run Swift tests and build**
 
-Run: `swift test --package-path macos/MindRoom && swift build -c release --package-path macos/MindRoom`
-Expected: PASS.
+Run `swift test --package-path macos/MindRoom && swift build -c release --package-path macos/MindRoom`.
+Expected result is PASS.
 
 - [ ] **Step 3: Commit**
 
-Run: `git add macos/MindRoom/Sources/MindRoom/MindRoomApp.swift macos/MindRoom/Sources/MindRoom/AppDelegate.swift macos/MindRoom/Sources/MindRoom/StatusMenuController.swift macos/MindRoom/Sources/MindRoom/AppUpdater.swift macos/MindRoom/Sources/MindRoom/LoginItemController.swift && git commit -m "Add MindRoom macOS menu app"`
+Run `git add macos/MindRoom/Sources/MindRoom/MindRoomApp.swift macos/MindRoom/Sources/MindRoom/AppDelegate.swift macos/MindRoom/Sources/MindRoom/StatusMenuController.swift macos/MindRoom/Sources/MindRoom/AppUpdater.swift macos/MindRoom/Sources/MindRoom/LoginItemController.swift && git commit -m "Add MindRoom macOS menu app"`.
 
 ### Task 4: Build Script, Appcast, Cask, And Release Workflow
 
-**Files:**
+**Files.**
 - Create: `macos/build-macos-app.sh`
 - Create: `macos/appcast.xml`
 - Create: `Casks/mindroom.rb`
@@ -121,18 +123,18 @@ Update the CalVer dispatcher so macOS app publishing runs with the existing rele
 
 - [ ] **Step 3: Run script self-test and metadata checks**
 
-Run: `SPARKLE_PUBLIC_ED_KEY=test macos/build-macos-app.sh`
-Expected: PASS on macOS and produce `dist/macos/MindRoom.app`.
-Run: `swift test --package-path macos/MindRoom`
-Expected: PASS.
+Run `SPARKLE_PUBLIC_ED_KEY=test macos/build-macos-app.sh`.
+Expected result is PASS on macOS and produce `dist/macos/MindRoom.app`.
+Run `swift test --package-path macos/MindRoom`.
+Expected result is PASS.
 
 - [ ] **Step 4: Commit**
 
-Run: `git add macos/build-macos-app.sh macos/appcast.xml Casks/mindroom.rb .github/scripts/update_mindroom_cask.py .github/scripts/normalize_appcast.py .github/workflows/release.yml .github/workflows/calver-auto-release.yml && git commit -m "Add MindRoom macOS release packaging"`
+Run `git add macos/build-macos-app.sh macos/appcast.xml Casks/mindroom.rb .github/scripts/update_mindroom_cask.py .github/scripts/normalize_appcast.py .github/workflows/release.yml .github/workflows/calver-auto-release.yml && git commit -m "Add MindRoom macOS release packaging"`.
 
 ### Task 5: Documentation And Final Verification
 
-**Files:**
+**Files.**
 - Modify: `README.md`
 - Create: `docs/installation/macos-app.md`
 
@@ -142,13 +144,13 @@ Document installing the cask, opening the app, installing runtime, initializing 
 
 - [ ] **Step 2: Run final verification**
 
-Run: `swift test --package-path macos/MindRoom`
-Expected: PASS.
-Run: `macos/build-macos-app.sh`
-Expected: PASS.
-Run: `uv run pytest tests/test_services.py -q`
-Expected: PASS.
+Run `swift test --package-path macos/MindRoom`.
+Expected result is PASS.
+Run `macos/build-macos-app.sh`.
+Expected result is PASS.
+Run `uv run pytest tests/test_services.py -q`.
+Expected result is PASS.
 
 - [ ] **Step 3: Commit**
 
-Run: `git add README.md docs/installation/macos-app.md && git commit -m "Document MindRoom macOS app"`
+Run `git add README.md docs/installation/macos-app.md && git commit -m "Document MindRoom macOS app"`.

--- a/docs/superpowers/plans/2026-05-29-mindroom-macos-menu-bar-app.md
+++ b/docs/superpowers/plans/2026-05-29-mindroom-macos-menu-bar-app.md
@@ -1,0 +1,154 @@
+# MindRoom macOS Menu Bar App Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a minimal macOS menu bar app that installs MindRoom through bundled `uv`, manages `mindroom service`, opens `~/.mindroom`, opens logs, opens the dashboard, and ships through AgentCLI-style Sparkle and Homebrew release metadata.
+
+**Architecture:** Add a focused Swift package in `macos/MindRoom` with small collaborators for runtime paths, command construction, process execution, service status parsing, and menu wiring. Add one build script and release metadata files by adapting AgentCLI's proven macOS packaging flow while keeping MindRoom config and storage in `~/.mindroom`.
+
+**Tech Stack:** Swift Package Manager, SwiftUI/AppKit menu bar APIs, Sparkle 2, bundled `uv`, existing Python `mindroom service` CLI, GitHub Actions, Homebrew cask.
+
+---
+
+### Task 1: Swift Package Skeleton And Runtime Tests
+
+**Files:**
+- Create: `macos/MindRoom/Package.swift`
+- Create: `macos/MindRoom/Sources/MindRoom/AppMetadata.swift`
+- Create: `macos/MindRoom/Sources/MindRoom/MindRoomRuntime.swift`
+- Create: `macos/MindRoom/Sources/MindRoom/CommandResult.swift`
+- Create: `macos/MindRoom/Tests/MindRoomTests/MindRoomRuntimeTests.swift`
+- Create: `macos/MindRoom/Resources/Info.plist`
+- Create: `macos/MindRoom/Resources/MindRoom.entitlements`
+
+- [ ] **Step 1: Write failing runtime tests**
+
+Add tests that assert the app uses `~/.mindroom`, constructs `uv tool install` for MindRoom, constructs `mindroom service install --no-confirm`, and prepends the bundled uv/tool paths without redirecting `MINDROOM_CONFIG_PATH`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path macos/MindRoom`
+Expected: FAIL because the Swift package and runtime types do not exist.
+
+- [ ] **Step 3: Add minimal package and runtime types**
+
+Add a Swift package with Sparkle dependency, a `CommandResult` struct, and a `MindRoomRuntime` struct with pure command-construction helpers.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path macos/MindRoom`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Run: `git add macos/MindRoom/Package.swift macos/MindRoom/Sources/MindRoom/AppMetadata.swift macos/MindRoom/Sources/MindRoom/MindRoomRuntime.swift macos/MindRoom/Sources/MindRoom/CommandResult.swift macos/MindRoom/Tests/MindRoomTests/MindRoomRuntimeTests.swift macos/MindRoom/Resources/Info.plist macos/MindRoom/Resources/MindRoom.entitlements && git commit -m "Add MindRoom macOS runtime package"`
+
+### Task 2: Command Runner And Service Status Tests
+
+**Files:**
+- Create: `macos/MindRoom/Sources/MindRoom/MindRoomCommand.swift`
+- Create: `macos/MindRoom/Sources/MindRoom/MindRoomCommandRunner.swift`
+- Create: `macos/MindRoom/Sources/MindRoom/ServiceStatus.swift`
+- Create: `macos/MindRoom/Tests/MindRoomTests/ServiceStatusTests.swift`
+
+- [ ] **Step 1: Write failing status parser tests**
+
+Add tests for `running`, `installed but not running`, `not installed`, and missing runtime output.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path macos/MindRoom`
+Expected: FAIL because status parser types do not exist.
+
+- [ ] **Step 3: Add command and status code**
+
+Add command enum cases for install runtime, update runtime, install service, lifecycle commands, config init, pairing, dashboard, logs, and config folder.
+Add a command runner that executes commands asynchronously and captures output.
+Add a service status parser that maps CLI output to menu status.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path macos/MindRoom`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Run: `git add macos/MindRoom/Sources/MindRoom/MindRoomCommand.swift macos/MindRoom/Sources/MindRoom/MindRoomCommandRunner.swift macos/MindRoom/Sources/MindRoom/ServiceStatus.swift macos/MindRoom/Tests/MindRoomTests/ServiceStatusTests.swift && git commit -m "Add MindRoom macOS command runner"`
+
+### Task 3: Menu Bar App UI
+
+**Files:**
+- Create: `macos/MindRoom/Sources/MindRoom/MindRoomApp.swift`
+- Create: `macos/MindRoom/Sources/MindRoom/AppDelegate.swift`
+- Create: `macos/MindRoom/Sources/MindRoom/StatusMenuController.swift`
+- Create: `macos/MindRoom/Sources/MindRoom/AppUpdater.swift`
+- Create: `macos/MindRoom/Sources/MindRoom/LoginItemController.swift`
+
+- [ ] **Step 1: Write compile-focused app shell**
+
+Add a minimal SwiftUI app delegate, menu controller, updater wrapper, and login item controller.
+The menu includes Install or Update Runtime, Ensure Service, Start, Stop, Restart, Initialize Hosted Config, Initialize Self-Hosted Config, Pair Hosted MindRoom, Open Dashboard, Open Config Folder, Open Logs Folder, Check for Updates, and Quit.
+
+- [ ] **Step 2: Run Swift tests and build**
+
+Run: `swift test --package-path macos/MindRoom && swift build -c release --package-path macos/MindRoom`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+Run: `git add macos/MindRoom/Sources/MindRoom/MindRoomApp.swift macos/MindRoom/Sources/MindRoom/AppDelegate.swift macos/MindRoom/Sources/MindRoom/StatusMenuController.swift macos/MindRoom/Sources/MindRoom/AppUpdater.swift macos/MindRoom/Sources/MindRoom/LoginItemController.swift && git commit -m "Add MindRoom macOS menu app"`
+
+### Task 4: Build Script, Appcast, Cask, And Release Workflow
+
+**Files:**
+- Create: `macos/build-macos-app.sh`
+- Create: `macos/appcast.xml`
+- Create: `Casks/mindroom.rb`
+- Create: `.github/scripts/update_mindroom_cask.py`
+- Create: `.github/scripts/normalize_appcast.py`
+- Modify: `.github/workflows/release.yml`
+- Modify: `.github/workflows/calver-auto-release.yml`
+
+- [ ] **Step 1: Add packaging files**
+
+Adapt AgentCLI's build script to build `MindRoom.app`, bundle `uv`, copy Sparkle, stamp versions, codesign, create a DMG, and optionally notarize.
+Add an initial empty Sparkle appcast and a Homebrew cask.
+
+- [ ] **Step 2: Add release workflow integration**
+
+Extend the release workflow with a macOS job that builds the DMG and zip, uploads both to the release, updates appcast, updates cask SHA256, and commits metadata to `main`.
+Update the CalVer dispatcher so macOS app publishing runs with the existing release publishers.
+
+- [ ] **Step 3: Run script self-test and metadata checks**
+
+Run: `SPARKLE_PUBLIC_ED_KEY=test macos/build-macos-app.sh`
+Expected: PASS on macOS and produce `dist/macos/MindRoom.app`.
+Run: `swift test --package-path macos/MindRoom`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+Run: `git add macos/build-macos-app.sh macos/appcast.xml Casks/mindroom.rb .github/scripts/update_mindroom_cask.py .github/scripts/normalize_appcast.py .github/workflows/release.yml .github/workflows/calver-auto-release.yml && git commit -m "Add MindRoom macOS release packaging"`
+
+### Task 5: Documentation And Final Verification
+
+**Files:**
+- Modify: `README.md`
+- Create: `docs/installation/macos-app.md`
+
+- [ ] **Step 1: Add docs**
+
+Document installing the cask, opening the app, installing runtime, initializing hosted config, pairing, installing the service, opening the dashboard, updating, and uninstalling.
+
+- [ ] **Step 2: Run final verification**
+
+Run: `swift test --package-path macos/MindRoom`
+Expected: PASS.
+Run: `macos/build-macos-app.sh`
+Expected: PASS.
+Run: `uv run pytest tests/test_services.py -q`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+Run: `git add README.md docs/installation/macos-app.md && git commit -m "Document MindRoom macOS app"`

--- a/docs/superpowers/specs/2026-05-29-mindroom-macos-menu-bar-app-design.md
+++ b/docs/superpowers/specs/2026-05-29-mindroom-macos-menu-bar-app-design.md
@@ -1,0 +1,91 @@
+# MindRoom macOS Menu Bar App Design
+
+## Context
+
+MindRoom currently supports command-line installation, `~/.mindroom` configuration, and a `mindroom service` command that installs a launchd user service on macOS.
+AgentCLI has a proven macOS menu bar app pattern that bundles `uv`, uses SwiftUI, ships through a signed and notarized DMG, self-updates with Sparkle, and updates Homebrew cask metadata through CI.
+MindRoom should adopt the same packaging and release shape without creating a separate app-private MindRoom configuration home.
+
+## Goals
+
+The app should let a non-terminal user install, configure, run, update, and inspect MindRoom from the macOS menu bar.
+The app should use `~/.mindroom` for config, environment, and persistent MindRoom state so CLI and app usage stay interoperable.
+The app should default to hosted `chat.mindroom.chat` setup while keeping self-hosted and local-stack setup visible.
+The app should manage the existing `mindroom service` lifecycle instead of duplicating launchd logic in Swift.
+The app should self-update the same way AgentCLI does.
+
+## Non-Goals
+
+The app will not embed the dashboard in a native webview.
+The app will not implement a custom service manager in Swift.
+The app will not maintain an app-private MindRoom config or storage tree.
+The app will not bundle a MindRoom wheel in the first version unless release constraints make that necessary.
+The app will not add a full setup wizard before the simpler menu flow has been tried.
+
+## Architecture
+
+Add a `macos/MindRoom` Swift package that builds a small LSUIElement menu bar app.
+The app bundles a `uv` binary under `Contents/Resources/bin/uv`.
+The app depends on Sparkle for app updates.
+The app runs CLI commands through a small command runner that injects an app-controlled PATH with the bundled `uv` and uv tool bin directory first.
+The app uses the default MindRoom runtime paths, so `mindroom` resolves `~/.mindroom/config.yaml`, `~/.mindroom/.env`, and `~/.mindroom/mindroom_data`.
+The app reads service state by running `mindroom service status` and displays a compact running, stopped, missing-runtime, or missing-config status row in the menu.
+
+## Runtime Installation
+
+On launch, the app checks whether `mindroom --version` succeeds through the uv tool environment.
+If the command is missing, the menu shows an install action instead of silently doing heavy work.
+The install action runs `uv tool install --managed-python --python 3.13 mindroom`.
+The update action runs `uv tool install --managed-python --python 3.13 --force mindroom`.
+The app should set uv directories only for the uv tool installation itself when needed, but it should not redirect MindRoom config or storage away from `~/.mindroom`.
+The app should surface command output in a troubleshooting menu and write app command failures to an app log file.
+
+## Service Lifecycle
+
+The primary start action runs `mindroom service install --no-confirm`.
+This creates or refreshes the launchd service and starts it.
+Start, stop, restart, and status actions call the existing `mindroom service start`, `mindroom service stop`, `mindroom service restart`, and `mindroom service status` commands.
+The app should not call `mindroom run` directly for normal operation.
+The app should rely on launchd to keep MindRoom running after the menu bar app quits.
+
+## Configuration Menu
+
+The configuration menu contains a default hosted setup action for `chat.mindroom.chat`.
+That action runs the current hosted-profile `mindroom config init` command that writes to `~/.mindroom`.
+The menu also exposes self-hosted config initialization and local-stack setup actions.
+The hosted pairing action opens a simple pair-code dialog and runs `mindroom connect --pair-code <code>`.
+The menu should also include a shortcut to open `https://chat.mindroom.chat` for pair-code generation.
+Config actions should avoid overwriting existing config without showing the same safety behavior the CLI already provides.
+
+## Utility Menu
+
+The app includes an Open Dashboard action that opens `http://localhost:8765`.
+The app includes Open Config Folder for `~/.mindroom`.
+The app includes Open Logs Folder for `~/Library/Logs/mindroom`.
+The app includes Runtime Status and Copy Last Output troubleshooting actions.
+The app includes Check for App Updates through Sparkle.
+The app includes Quit.
+
+## Release And CI
+
+Copy the AgentCLI release pattern into MindRoom with MindRoom-specific names, bundle IDs, appcast URL, and cask path.
+The release workflow should build a signed and notarized DMG on macOS.
+The workflow should upload the DMG and app zip to the GitHub release.
+The workflow should run Sparkle `generate_appcast` to update `macos/appcast.xml`.
+The workflow should update a Homebrew cask file with the new version and SHA256.
+The workflow should commit the appcast and cask metadata back to `main`.
+The existing CalVer release dispatcher should trigger this macOS app build alongside PyPI, Docker image, and Helm chart publishing.
+
+## Tests And Verification
+
+Swift tests should cover command construction, runtime-path behavior, and status parsing.
+The build script should include a self-test mode that verifies bundled `uv`, Sparkle metadata, icon resources, and command runner setup.
+CI should run the Swift package tests on macOS.
+CI should verify the DMG contains `MindRoom.app`, bundled `uv`, Sparkle framework, Info.plist metadata, and app icon resources.
+Manual verification should install the DMG, initialize hosted config, pair with `chat.mindroom.chat`, install the service, confirm launchd reports MindRoom running, open the dashboard, and confirm logs are accessible.
+
+## Open Decisions
+
+The exact hosted config command should match the current CLI surface at implementation time.
+The Homebrew tap location should be chosen before adding the cask update script.
+The app bundle identifier should be finalized before signing and Sparkle keys are generated.

--- a/macos/MindRoom/Package.resolved
+++ b/macos/MindRoom/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "6276ba2b404829d139c45ff98427cf90e2efc59b",
+        "version" : "2.9.2"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/macos/MindRoom/Package.swift
+++ b/macos/MindRoom/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "MindRoom",
+    platforms: [
+        .macOS(.v13),
+    ],
+    products: [
+        .executable(name: "MindRoom", targets: ["MindRoom"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/sparkle-project/Sparkle", exact: "2.9.2"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "MindRoom",
+            dependencies: [
+                .product(name: "Sparkle", package: "Sparkle"),
+            ],
+            path: "Sources/MindRoom"
+        ),
+        .testTarget(
+            name: "MindRoomTests",
+            dependencies: ["MindRoom"],
+            path: "Tests/MindRoomTests"
+        ),
+    ]
+)

--- a/macos/MindRoom/Resources/Info.plist
+++ b/macos/MindRoom/Resources/Info.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>MindRoom</string>
+	<key>CFBundleExecutable</key>
+	<string>MindRoom</string>
+	<key>CFBundleIdentifier</key>
+	<string>chat.mindroom.menubar</string>
+	<key>CFBundleIconFile</key>
+	<string>MindRoom</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>MindRoom</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>13.0</string>
+	<key>LSUIElement</key>
+	<true/>
+	<key>SUEnableInstallerLauncherService</key>
+	<true/>
+	<key>SUFeedURL</key>
+	<string>https://raw.githubusercontent.com/mindroom-ai/mindroom/main/macos/appcast.xml</string>
+</dict>
+</plist>

--- a/macos/MindRoom/Resources/MindRoom.entitlements
+++ b/macos/MindRoom/Resources/MindRoom.entitlements
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/macos/MindRoom/Sources/MindRoom/AppDelegate.swift
+++ b/macos/MindRoom/Sources/MindRoom/AppDelegate.swift
@@ -1,0 +1,18 @@
+import AppKit
+import Foundation
+
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        NSApp.setActivationPolicy(.accessory)
+        StatusMenuController.shared.start()
+        MindRoomCommandRunner.shared.refreshStatus()
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        StatusMenuController.shared.stop()
+    }
+
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        false
+    }
+}

--- a/macos/MindRoom/Sources/MindRoom/AppMetadata.swift
+++ b/macos/MindRoom/Sources/MindRoom/AppMetadata.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+struct SparkleConfiguration {
+    let feedURL: String?
+    let publicEdKey: String?
+
+    var isConfigured: Bool {
+        guard let feedURL, !feedURL.isEmpty else { return false }
+        guard let publicEdKey, !publicEdKey.isEmpty else { return false }
+        return true
+    }
+}
+
+enum AppMetadata {
+    static var sparkleConfiguration: SparkleConfiguration {
+        SparkleConfiguration(
+            feedURL: Bundle.main.object(forInfoDictionaryKey: "SUFeedURL") as? String,
+            publicEdKey: Bundle.main.object(forInfoDictionaryKey: "SUPublicEDKey") as? String
+        )
+    }
+}

--- a/macos/MindRoom/Sources/MindRoom/AppUpdater.swift
+++ b/macos/MindRoom/Sources/MindRoom/AppUpdater.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Sparkle
+
+@MainActor
+final class AppUpdater: ObservableObject {
+    static let shared = AppUpdater()
+
+    private let updaterController: SPUStandardUpdaterController?
+
+    var canCheckForUpdates: Bool {
+        updaterController != nil
+    }
+
+    private init(configuration: SparkleConfiguration = AppMetadata.sparkleConfiguration) {
+        guard configuration.isConfigured else {
+            updaterController = nil
+            return
+        }
+        updaterController = SPUStandardUpdaterController(
+            startingUpdater: true,
+            updaterDelegate: nil,
+            userDriverDelegate: nil
+        )
+    }
+
+    func checkForUpdates() {
+        guard let updaterController else {
+            MindRoomCommandRunner.shared.lastOutputForDisplay = "App updates are not configured for this build"
+            return
+        }
+        updaterController.checkForUpdates(nil)
+    }
+}

--- a/macos/MindRoom/Sources/MindRoom/AppUpdater.swift
+++ b/macos/MindRoom/Sources/MindRoom/AppUpdater.swift
@@ -1,6 +1,17 @@
 import Foundation
 import Sparkle
 
+enum AppUpdaterError: LocalizedError {
+    case updatesNotConfigured
+
+    var errorDescription: String? {
+        switch self {
+        case .updatesNotConfigured:
+            return "App updates are not configured for this build"
+        }
+    }
+}
+
 @MainActor
 final class AppUpdater: ObservableObject {
     static let shared = AppUpdater()
@@ -23,10 +34,9 @@ final class AppUpdater: ObservableObject {
         )
     }
 
-    func checkForUpdates() {
+    func checkForUpdates() throws {
         guard let updaterController else {
-            MindRoomCommandRunner.shared.lastOutputForDisplay = "App updates are not configured for this build"
-            return
+            throw AppUpdaterError.updatesNotConfigured
         }
         updaterController.checkForUpdates(nil)
     }

--- a/macos/MindRoom/Sources/MindRoom/CommandResult.swift
+++ b/macos/MindRoom/Sources/MindRoom/CommandResult.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct CommandResult: Equatable {
+    let exitCode: Int32
+    let output: String
+}

--- a/macos/MindRoom/Sources/MindRoom/LoginItemController.swift
+++ b/macos/MindRoom/Sources/MindRoom/LoginItemController.swift
@@ -8,7 +8,14 @@ final class LoginItemController {
     private init() {}
 
     var canToggle: Bool {
-        true
+        switch SMAppService.mainApp.status {
+        case .enabled, .notRegistered:
+            return true
+        case .requiresApproval, .notFound:
+            return false
+        @unknown default:
+            return false
+        }
     }
 
     var isEnabled: Bool {
@@ -16,7 +23,18 @@ final class LoginItemController {
     }
 
     var menuTitle: String {
-        isEnabled ? "Start at Login: On" : "Start at Login: Off"
+        switch SMAppService.mainApp.status {
+        case .enabled:
+            return "Start at Login: On"
+        case .notRegistered:
+            return "Start at Login: Off"
+        case .requiresApproval:
+            return "Start at Login: Needs Approval"
+        case .notFound:
+            return "Start at Login: Unavailable"
+        @unknown default:
+            return "Start at Login: Unknown"
+        }
     }
 
     func toggle() {

--- a/macos/MindRoom/Sources/MindRoom/LoginItemController.swift
+++ b/macos/MindRoom/Sources/MindRoom/LoginItemController.swift
@@ -1,0 +1,33 @@
+import Foundation
+import ServiceManagement
+
+@MainActor
+final class LoginItemController {
+    static let shared = LoginItemController()
+
+    private init() {}
+
+    var canToggle: Bool {
+        true
+    }
+
+    var isEnabled: Bool {
+        SMAppService.mainApp.status == .enabled
+    }
+
+    var menuTitle: String {
+        isEnabled ? "Start at Login: On" : "Start at Login: Off"
+    }
+
+    func toggle() {
+        do {
+            if isEnabled {
+                try SMAppService.mainApp.unregister()
+            } else {
+                try SMAppService.mainApp.register()
+            }
+        } catch {
+            MindRoomCommandRunner.shared.lastOutputForDisplay = error.localizedDescription
+        }
+    }
+}

--- a/macos/MindRoom/Sources/MindRoom/MindRoomApp.swift
+++ b/macos/MindRoom/Sources/MindRoom/MindRoomApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct MindRoomApp: App {
+    var body: some Scene {
+        Settings {
+            EmptyView()
+        }
+    }
+}

--- a/macos/MindRoom/Sources/MindRoom/MindRoomApp.swift
+++ b/macos/MindRoom/Sources/MindRoom/MindRoomApp.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 @main
 struct MindRoomApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+
     var body: some Scene {
         Settings {
             EmptyView()

--- a/macos/MindRoom/Sources/MindRoom/MindRoomCommand.swift
+++ b/macos/MindRoom/Sources/MindRoom/MindRoomCommand.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+enum MindRoomCommand: Equatable {
+    case installRuntime
+    case updateRuntime
+    case installService
+    case startService
+    case stopService
+    case restartService
+    case serviceStatus
+    case initializeHostedConfig
+    case initializeSelfHostedConfig
+    case localStackSetup
+    case pairHosted(pairCode: String)
+    case openDashboard
+    case openHostedChat
+    case openConfigFolder
+    case openLogsFolder
+
+    var title: String {
+        switch self {
+        case .installRuntime:
+            return "Install MindRoom Runtime"
+        case .updateRuntime:
+            return "Update MindRoom Runtime"
+        case .installService:
+            return "Install/Ensure Service"
+        case .startService:
+            return "Start Service"
+        case .stopService:
+            return "Stop Service"
+        case .restartService:
+            return "Restart Service"
+        case .serviceStatus:
+            return "Refresh Status"
+        case .initializeHostedConfig:
+            return "Initialize Hosted Config"
+        case .initializeSelfHostedConfig:
+            return "Initialize Self-Hosted Config"
+        case .localStackSetup:
+            return "Run Local Stack Setup"
+        case .pairHosted:
+            return "Pair Hosted MindRoom..."
+        case .openDashboard:
+            return "Open Dashboard"
+        case .openHostedChat:
+            return "Open chat.mindroom.chat"
+        case .openConfigFolder:
+            return "Open Config Folder"
+        case .openLogsFolder:
+            return "Open Logs Folder"
+        }
+    }
+
+    var runtimeAction: MindRoomRuntimeAction? {
+        switch self {
+        case .installRuntime:
+            return .installRuntime
+        case .updateRuntime:
+            return .updateRuntime
+        case .installService:
+            return .installService
+        case .startService:
+            return .startService
+        case .stopService:
+            return .stopService
+        case .restartService:
+            return .restartService
+        case .serviceStatus:
+            return .serviceStatus
+        case .initializeHostedConfig:
+            return .initializeHostedConfig
+        case .initializeSelfHostedConfig:
+            return .initializeSelfHostedConfig
+        case .localStackSetup:
+            return .localStackSetup
+        case let .pairHosted(pairCode):
+            return .pairHosted(pairCode: pairCode.trimmingCharacters(in: .whitespacesAndNewlines).uppercased())
+        case .openDashboard, .openHostedChat, .openConfigFolder, .openLogsFolder:
+            return nil
+        }
+    }
+}

--- a/macos/MindRoom/Sources/MindRoom/MindRoomCommandRunner.swift
+++ b/macos/MindRoom/Sources/MindRoom/MindRoomCommandRunner.swift
@@ -29,6 +29,11 @@ final class MindRoomCommandRunner: ObservableObject {
         runRuntimeAction(.serviceStatus, updateStatusFromOutput: true)
     }
 
+    var lastOutputForDisplay: String {
+        get { lastOutput }
+        set { lastOutput = newValue }
+    }
+
     func run(_ command: MindRoomCommand) {
         switch command {
         case .openDashboard:

--- a/macos/MindRoom/Sources/MindRoom/MindRoomCommandRunner.swift
+++ b/macos/MindRoom/Sources/MindRoom/MindRoomCommandRunner.swift
@@ -1,0 +1,87 @@
+import AppKit
+import Foundation
+
+typealias MindRoomProcessRunner = (MindRoomCommandInvocation) -> CommandResult
+
+@MainActor
+final class MindRoomCommandRunner: ObservableObject {
+    static let shared = MindRoomCommandRunner()
+
+    @Published private(set) var serviceStatus = MindRoomServiceStatus(
+        state: .unknown,
+        message: "MindRoom status is unknown"
+    )
+    @Published private(set) var isRunningCommand = false
+    @Published private(set) var lastOutput = ""
+
+    private let runtime: MindRoomRuntime
+    private let processRunner: MindRoomProcessRunner
+
+    init(
+        runtime: MindRoomRuntime = MindRoomRuntime(),
+        processRunner: @escaping MindRoomProcessRunner = MindRoomCommandRunner.runProcess
+    ) {
+        self.runtime = runtime
+        self.processRunner = processRunner
+    }
+
+    func refreshStatus() {
+        runRuntimeAction(.serviceStatus, updateStatusFromOutput: true)
+    }
+
+    func run(_ command: MindRoomCommand) {
+        switch command {
+        case .openDashboard:
+            NSWorkspace.shared.open(URL(string: "http://localhost:8765")!)
+        case .openHostedChat:
+            NSWorkspace.shared.open(URL(string: "https://chat.mindroom.chat")!)
+        case .openConfigFolder:
+            NSWorkspace.shared.open(runtime.configDirectoryURL)
+        case .openLogsFolder:
+            NSWorkspace.shared.open(runtime.logsDirectoryURL)
+        default:
+            guard let action = command.runtimeAction else { return }
+            runRuntimeAction(action, updateStatusFromOutput: action == .serviceStatus)
+        }
+    }
+
+    private func runRuntimeAction(_ action: MindRoomRuntimeAction, updateStatusFromOutput: Bool = false) {
+        isRunningCommand = true
+        let invocation = runtime.command(for: action)
+        let processRunner = processRunner
+        DispatchQueue.global(qos: .userInitiated).async {
+            let result = processRunner(invocation)
+            DispatchQueue.main.async {
+                self.isRunningCommand = false
+                self.lastOutput = result.output
+                if updateStatusFromOutput {
+                    self.serviceStatus = MindRoomServiceStatus.parse(result.output)
+                } else if result.exitCode == 0 {
+                    self.refreshStatus()
+                }
+            }
+        }
+    }
+
+    nonisolated static func runProcess(_ invocation: MindRoomCommandInvocation) -> CommandResult {
+        let process = Process()
+        process.executableURL = invocation.executableURL
+        process.arguments = invocation.arguments
+        process.environment = invocation.environment
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return CommandResult(exitCode: 127, output: error.localizedDescription)
+        }
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: data, encoding: .utf8) ?? ""
+        return CommandResult(exitCode: process.terminationStatus, output: output)
+    }
+}

--- a/macos/MindRoom/Sources/MindRoom/MindRoomCommandRunner.swift
+++ b/macos/MindRoom/Sources/MindRoom/MindRoomCommandRunner.swift
@@ -51,10 +51,7 @@ final class MindRoomCommandRunner: ObservableObject {
     }
 
     private func runRuntimeAction(_ action: MindRoomRuntimeAction, updateStatusFromOutput: Bool = false) {
-        guard !isRunningCommand else {
-            lastOutput = "Another MindRoom command is already running."
-            return
-        }
+        guard !isRunningCommand else { return }
         isRunningCommand = true
         let invocation = runtime.command(for: action)
         let processRunner = processRunner
@@ -62,11 +59,13 @@ final class MindRoomCommandRunner: ObservableObject {
             let result = processRunner(invocation)
             DispatchQueue.main.async {
                 self.isRunningCommand = false
-                self.lastOutput = result.output
                 if updateStatusFromOutput {
                     self.serviceStatus = MindRoomServiceStatus.parse(result.output)
-                } else if result.exitCode == 0 {
-                    self.refreshStatus()
+                } else {
+                    self.lastOutput = result.output
+                    if result.exitCode == 0 {
+                        self.refreshStatus()
+                    }
                 }
             }
         }

--- a/macos/MindRoom/Sources/MindRoom/MindRoomCommandRunner.swift
+++ b/macos/MindRoom/Sources/MindRoom/MindRoomCommandRunner.swift
@@ -51,6 +51,10 @@ final class MindRoomCommandRunner: ObservableObject {
     }
 
     private func runRuntimeAction(_ action: MindRoomRuntimeAction, updateStatusFromOutput: Bool = false) {
+        guard !isRunningCommand else {
+            lastOutput = "Another MindRoom command is already running."
+            return
+        }
         isRunningCommand = true
         let invocation = runtime.command(for: action)
         let processRunner = processRunner
@@ -80,12 +84,12 @@ final class MindRoomCommandRunner: ObservableObject {
 
         do {
             try process.run()
-            process.waitUntilExit()
         } catch {
             return CommandResult(exitCode: 127, output: error.localizedDescription)
         }
 
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
         let output = String(data: data, encoding: .utf8) ?? ""
         return CommandResult(exitCode: process.terminationStatus, output: output)
     }

--- a/macos/MindRoom/Sources/MindRoom/MindRoomRuntime.swift
+++ b/macos/MindRoom/Sources/MindRoom/MindRoomRuntime.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum MindRoomRuntimeAction {
+enum MindRoomRuntimeAction: Equatable {
     case installRuntime
     case updateRuntime
     case installService

--- a/macos/MindRoom/Sources/MindRoom/MindRoomRuntime.swift
+++ b/macos/MindRoom/Sources/MindRoom/MindRoomRuntime.swift
@@ -1,0 +1,130 @@
+import Foundation
+
+enum MindRoomRuntimeAction {
+    case installRuntime
+    case updateRuntime
+    case installService
+    case startService
+    case stopService
+    case restartService
+    case serviceStatus
+    case initializeHostedConfig
+    case initializeSelfHostedConfig
+    case localStackSetup
+    case pairHosted(pairCode: String)
+}
+
+struct MindRoomCommandInvocation: Equatable {
+    let executableURL: URL
+    let arguments: [String]
+    let environment: [String: String]
+}
+
+struct MindRoomRuntime {
+    private static let bundledUVRelativePath = "Contents/Resources/bin/uv"
+    private let homeURL: URL
+    private let bundleURL: URL
+    private let baseEnvironment: [String: String]
+
+    init(
+        homeURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+        bundleURL: URL = Bundle.main.bundleURL,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) {
+        self.homeURL = homeURL
+        self.bundleURL = bundleURL
+        self.baseEnvironment = environment
+    }
+
+    var bundledUVURL: URL {
+        bundleURL.appendingPathComponent(Self.bundledUVRelativePath)
+    }
+
+    var configDirectoryURL: URL {
+        homeURL.appendingPathComponent(".mindroom", isDirectory: true)
+    }
+
+    var configPathURL: URL {
+        configDirectoryURL.appendingPathComponent("config.yaml")
+    }
+
+    var envPathURL: URL {
+        configDirectoryURL.appendingPathComponent(".env")
+    }
+
+    var logsDirectoryURL: URL {
+        homeURL
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Logs", isDirectory: true)
+            .appendingPathComponent("mindroom", isDirectory: true)
+    }
+
+    func command(for action: MindRoomRuntimeAction) -> MindRoomCommandInvocation {
+        switch action {
+        case .installRuntime:
+            return uvCommand(arguments: ["tool", "install", "--managed-python", "--python", "3.13", "mindroom"])
+        case .updateRuntime:
+            return uvCommand(arguments: ["tool", "install", "--managed-python", "--python", "3.13", "--force", "mindroom"])
+        case .installService:
+            return mindroomCommand(arguments: ["service", "install", "--no-confirm"])
+        case .startService:
+            return mindroomCommand(arguments: ["service", "start"])
+        case .stopService:
+            return mindroomCommand(arguments: ["service", "stop"])
+        case .restartService:
+            return mindroomCommand(arguments: ["service", "restart"])
+        case .serviceStatus:
+            return mindroomCommand(arguments: ["service", "status", "--logs", "0"])
+        case .initializeHostedConfig:
+            return mindroomCommand(arguments: ["config", "init", "--profile", "public"])
+        case .initializeSelfHostedConfig:
+            return mindroomCommand(arguments: ["config", "init", "--matrix-server", "self-hosted"])
+        case .localStackSetup:
+            return mindroomCommand(arguments: ["local-stack-setup"])
+        case let .pairHosted(pairCode):
+            return mindroomCommand(arguments: ["connect", "--pair-code", pairCode])
+        }
+    }
+
+    private func uvCommand(arguments: [String]) -> MindRoomCommandInvocation {
+        MindRoomCommandInvocation(
+            executableURL: bundledUVURL,
+            arguments: arguments,
+            environment: commandEnvironment()
+        )
+    }
+
+    private func mindroomCommand(arguments: [String]) -> MindRoomCommandInvocation {
+        MindRoomCommandInvocation(
+            executableURL: URL(fileURLWithPath: "/usr/bin/env"),
+            arguments: ["mindroom"] + arguments,
+            environment: commandEnvironment()
+        )
+    }
+
+    func commandEnvironment() -> [String: String] {
+        var environment = baseEnvironment
+        environment["PATH"] = commandPath(existingPATH: environment["PATH"] ?? "/usr/bin:/bin:/usr/sbin:/sbin")
+        environment["UV_NO_PROGRESS"] = "1"
+        environment["NO_COLOR"] = "1"
+        environment["TERM"] = "dumb"
+        return environment
+    }
+
+    func commandPath(existingPATH: String) -> String {
+        let entries = [
+            homeURL.appendingPathComponent(".local/bin", isDirectory: true).path,
+            bundledUVURL.deletingLastPathComponent().path,
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            existingPATH,
+        ]
+
+        var seen = Set<String>()
+        return entries
+            .flatMap { $0.split(separator: ":").map(String.init) }
+            .filter { !$0.isEmpty }
+            .filter { seen.insert($0).inserted }
+            .joined(separator: ":")
+    }
+}

--- a/macos/MindRoom/Sources/MindRoom/MindRoomRuntime.swift
+++ b/macos/MindRoom/Sources/MindRoom/MindRoomRuntime.swift
@@ -76,7 +76,7 @@ struct MindRoomRuntime {
         case .serviceStatus:
             return mindroomCommand(arguments: ["service", "status", "--logs", "0"])
         case .initializeHostedConfig:
-            return mindroomCommand(arguments: ["config", "init", "--profile", "public"])
+            return mindroomCommand(arguments: ["config", "init", "--matrix-server", "mindroom.chat"])
         case .initializeSelfHostedConfig:
             return mindroomCommand(arguments: ["config", "init", "--matrix-server", "self-hosted"])
         case .localStackSetup:

--- a/macos/MindRoom/Sources/MindRoom/ServiceStatus.swift
+++ b/macos/MindRoom/Sources/MindRoom/ServiceStatus.swift
@@ -31,6 +31,18 @@ struct MindRoomServiceStatus: Equatable {
         if normalized.isEmpty {
             return MindRoomServiceStatus(state: .unknown, message: "MindRoom status is unknown")
         }
-        return MindRoomServiceStatus(state: .unknown, message: normalized)
+        return MindRoomServiceStatus(state: .unknown, message: sanitizedUnknownMessage(normalized))
+    }
+
+    private static func sanitizedUnknownMessage(_ output: String) -> String {
+        let collapsed = output
+            .split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        if collapsed.count <= 200 {
+            return collapsed
+        }
+        return String(collapsed.prefix(197)) + "..."
     }
 }

--- a/macos/MindRoom/Sources/MindRoom/ServiceStatus.swift
+++ b/macos/MindRoom/Sources/MindRoom/ServiceStatus.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+enum MindRoomServiceState: Equatable {
+    case running
+    case stopped
+    case notInstalled
+    case runtimeMissing
+    case unknown
+}
+
+struct MindRoomServiceStatus: Equatable {
+    let state: MindRoomServiceState
+    let message: String
+
+    static func parse(_ output: String) -> MindRoomServiceStatus {
+        let normalized = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lowercased = normalized.lowercased()
+
+        if lowercased.contains("no such file") || lowercased.contains("command not found") {
+            return MindRoomServiceStatus(state: .runtimeMissing, message: "MindRoom runtime is not installed")
+        }
+        if lowercased.contains("service: running") {
+            return MindRoomServiceStatus(state: .running, message: "MindRoom is running")
+        }
+        if lowercased.contains("installed but not running") {
+            return MindRoomServiceStatus(state: .stopped, message: "MindRoom is installed but stopped")
+        }
+        if lowercased.contains("not installed") {
+            return MindRoomServiceStatus(state: .notInstalled, message: "MindRoom service is not installed")
+        }
+        if normalized.isEmpty {
+            return MindRoomServiceStatus(state: .unknown, message: "MindRoom status is unknown")
+        }
+        return MindRoomServiceStatus(state: .unknown, message: normalized)
+    }
+}

--- a/macos/MindRoom/Sources/MindRoom/StatusMenuController.swift
+++ b/macos/MindRoom/Sources/MindRoom/StatusMenuController.swift
@@ -1,0 +1,222 @@
+import AppKit
+import Foundation
+
+@MainActor
+final class StatusMenuController: NSObject, NSMenuDelegate {
+    static let shared = StatusMenuController()
+
+    private let runner = MindRoomCommandRunner.shared
+    private let appUpdater = AppUpdater.shared
+    private let loginItemController = LoginItemController.shared
+    private let menu = NSMenu()
+    private var statusItem: NSStatusItem?
+    private var statusRefreshTimer: Timer?
+
+    private override init() {
+        super.init()
+        menu.delegate = self
+    }
+
+    func start() {
+        guard statusItem == nil else { return }
+        let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        item.menu = menu
+        statusItem = item
+        rebuildMenu()
+        refreshStatusIcon()
+        startStatusRefreshTimer()
+    }
+
+    func stop() {
+        statusRefreshTimer?.invalidate()
+        statusRefreshTimer = nil
+        if let statusItem {
+            NSStatusBar.system.removeStatusItem(statusItem)
+        }
+        statusItem = nil
+    }
+
+    func menuNeedsUpdate(_ menu: NSMenu) {
+        rebuildMenu()
+        refreshStatusIcon()
+    }
+
+    private func rebuildMenu() {
+        menu.removeAllItems()
+
+        menu.addItem(disabledItem("Status: \(runner.serviceStatus.message)"))
+        if runner.isRunningCommand {
+            menu.addItem(disabledItem("Running command..."))
+        }
+        menu.addItem(.separator())
+
+        menu.addItem(actionItem(MindRoomCommand.installRuntime.title, symbolName: "arrow.down.circle", action: #selector(installRuntime)))
+        menu.addItem(actionItem(MindRoomCommand.updateRuntime.title, symbolName: "arrow.triangle.2.circlepath", action: #selector(updateRuntime)))
+        menu.addItem(.separator())
+
+        menu.addItem(actionItem(MindRoomCommand.installService.title, symbolName: "checkmark.circle", action: #selector(installService)))
+        menu.addItem(actionItem(MindRoomCommand.startService.title, symbolName: "play.circle", action: #selector(startService)))
+        menu.addItem(actionItem(MindRoomCommand.stopService.title, symbolName: "stop.circle", action: #selector(stopService)))
+        menu.addItem(actionItem(MindRoomCommand.restartService.title, symbolName: "arrow.clockwise.circle", action: #selector(restartService)))
+        menu.addItem(actionItem(MindRoomCommand.serviceStatus.title, symbolName: "waveform.path.ecg", action: #selector(refreshStatus)))
+        menu.addItem(.separator())
+
+        menu.addItem(actionItem(MindRoomCommand.initializeHostedConfig.title, symbolName: "person.2.wave.2", action: #selector(initializeHostedConfig)))
+        menu.addItem(actionItem(MindRoomCommand.initializeSelfHostedConfig.title, symbolName: "server.rack", action: #selector(initializeSelfHostedConfig)))
+        menu.addItem(actionItem(MindRoomCommand.localStackSetup.title, symbolName: "shippingbox", action: #selector(localStackSetup)))
+        menu.addItem(actionItem(MindRoomCommand.pairHosted(pairCode: "").title, symbolName: "link", action: #selector(pairHosted)))
+        menu.addItem(actionItem(MindRoomCommand.openHostedChat.title, symbolName: "safari", action: #selector(openHostedChat)))
+        menu.addItem(.separator())
+
+        menu.addItem(actionItem(MindRoomCommand.openDashboard.title, symbolName: "rectangle.3.group", action: #selector(openDashboard)))
+        menu.addItem(actionItem(MindRoomCommand.openConfigFolder.title, symbolName: "folder", action: #selector(openConfigFolder)))
+        menu.addItem(actionItem(MindRoomCommand.openLogsFolder.title, symbolName: "doc.text.magnifyingglass", action: #selector(openLogsFolder)))
+        if !runner.lastOutput.isEmpty {
+            menu.addItem(actionItem("Copy Last Output", symbolName: "doc.on.doc", action: #selector(copyLastOutput)))
+        }
+        menu.addItem(.separator())
+
+        let loginItem = actionItem(loginItemController.menuTitle, symbolName: loginItemController.isEnabled ? "checkmark.circle" : "circle", action: #selector(toggleStartAtLogin))
+        loginItem.isEnabled = loginItemController.canToggle
+        menu.addItem(loginItem)
+
+        let updateItem = actionItem("Check for App Updates...", symbolName: "arrow.down.circle", action: #selector(checkForUpdates))
+        updateItem.isEnabled = appUpdater.canCheckForUpdates
+        menu.addItem(updateItem)
+        menu.addItem(.separator())
+        menu.addItem(actionItem("Quit", symbolName: "power", action: #selector(quit)))
+    }
+
+    private func startStatusRefreshTimer() {
+        guard statusRefreshTimer == nil else { return }
+        let timer = Timer(timeInterval: 5, repeats: true) { _ in
+            Task { @MainActor in
+                MindRoomCommandRunner.shared.refreshStatus()
+                self.refreshStatusIcon()
+            }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        statusRefreshTimer = timer
+    }
+
+    private func refreshStatusIcon() {
+        guard let button = statusItem?.button else { return }
+        button.image = NSImage(systemSymbolName: iconName, accessibilityDescription: "MindRoom")
+        button.imagePosition = .imageOnly
+        button.toolTip = runner.serviceStatus.message
+    }
+
+    private var iconName: String {
+        switch runner.serviceStatus.state {
+        case .running:
+            return "brain.head.profile"
+        case .stopped, .notInstalled:
+            return "brain"
+        case .runtimeMissing:
+            return "exclamationmark.triangle"
+        case .unknown:
+            return "questionmark.circle"
+        }
+    }
+
+    private func actionItem(_ title: String, symbolName: String, action: Selector) -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
+        item.target = self
+        item.image = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)
+        return item
+    }
+
+    private func disabledItem(_ title: String) -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+        item.isEnabled = false
+        return item
+    }
+
+    @objc private func installRuntime() {
+        runner.run(.installRuntime)
+    }
+
+    @objc private func updateRuntime() {
+        runner.run(.updateRuntime)
+    }
+
+    @objc private func installService() {
+        runner.run(.installService)
+    }
+
+    @objc private func startService() {
+        runner.run(.startService)
+    }
+
+    @objc private func stopService() {
+        runner.run(.stopService)
+    }
+
+    @objc private func restartService() {
+        runner.run(.restartService)
+    }
+
+    @objc private func refreshStatus() {
+        runner.refreshStatus()
+    }
+
+    @objc private func initializeHostedConfig() {
+        runner.run(.initializeHostedConfig)
+    }
+
+    @objc private func initializeSelfHostedConfig() {
+        runner.run(.initializeSelfHostedConfig)
+    }
+
+    @objc private func localStackSetup() {
+        runner.run(.localStackSetup)
+    }
+
+    @objc private func pairHosted() {
+        let alert = NSAlert()
+        alert.messageText = "Pair Hosted MindRoom"
+        alert.informativeText = "Enter the pair code from chat.mindroom.chat."
+        let textField = NSTextField(frame: NSRect(x: 0, y: 0, width: 220, height: 24))
+        textField.placeholderString = "ABCD-EFGH"
+        alert.accessoryView = textField
+        alert.addButton(withTitle: "Pair")
+        alert.addButton(withTitle: "Cancel")
+
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        runner.run(.pairHosted(pairCode: textField.stringValue))
+    }
+
+    @objc private func openDashboard() {
+        runner.run(.openDashboard)
+    }
+
+    @objc private func openHostedChat() {
+        runner.run(.openHostedChat)
+    }
+
+    @objc private func openConfigFolder() {
+        runner.run(.openConfigFolder)
+    }
+
+    @objc private func openLogsFolder() {
+        runner.run(.openLogsFolder)
+    }
+
+    @objc private func copyLastOutput() {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(runner.lastOutput, forType: .string)
+    }
+
+    @objc private func toggleStartAtLogin() {
+        loginItemController.toggle()
+        rebuildMenu()
+    }
+
+    @objc private func checkForUpdates() {
+        appUpdater.checkForUpdates()
+    }
+
+    @objc private func quit() {
+        NSApp.terminate(nil)
+    }
+}

--- a/macos/MindRoom/Sources/MindRoom/StatusMenuController.swift
+++ b/macos/MindRoom/Sources/MindRoom/StatusMenuController.swift
@@ -89,10 +89,11 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
 
     private func startStatusRefreshTimer() {
         guard statusRefreshTimer == nil else { return }
-        let timer = Timer(timeInterval: 5, repeats: true) { _ in
+        let runner = runner
+        let timer = Timer(timeInterval: 5, repeats: true) { [weak self] _ in
             Task { @MainActor in
-                MindRoomCommandRunner.shared.refreshStatus()
-                self.refreshStatusIcon()
+                runner.refreshStatus()
+                self?.refreshStatusIcon()
             }
         }
         RunLoop.main.add(timer, forMode: .common)
@@ -183,7 +184,12 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
         alert.addButton(withTitle: "Cancel")
 
         guard alert.runModal() == .alertFirstButtonReturn else { return }
-        runner.run(.pairHosted(pairCode: textField.stringValue))
+        let pairCode = textField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !pairCode.isEmpty else {
+            runner.lastOutputForDisplay = "Pair code cannot be empty."
+            return
+        }
+        runner.run(.pairHosted(pairCode: pairCode))
     }
 
     @objc private func openDashboard() {
@@ -213,7 +219,11 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
     }
 
     @objc private func checkForUpdates() {
-        appUpdater.checkForUpdates()
+        do {
+            try appUpdater.checkForUpdates()
+        } catch {
+            runner.lastOutputForDisplay = error.localizedDescription
+        }
     }
 
     @objc private func quit() {

--- a/macos/MindRoom/Tests/MindRoomTests/MindRoomRuntimeTests.swift
+++ b/macos/MindRoom/Tests/MindRoomTests/MindRoomRuntimeTests.swift
@@ -62,6 +62,6 @@ final class MindRoomRuntimeTests: XCTestCase {
         )
 
         let command = runtime.command(for: .initializeHostedConfig)
-        XCTAssertEqual(command.arguments, ["mindroom", "config", "init", "--profile", "public"])
+        XCTAssertEqual(command.arguments, ["mindroom", "config", "init", "--matrix-server", "mindroom.chat"])
     }
 }

--- a/macos/MindRoom/Tests/MindRoomTests/MindRoomRuntimeTests.swift
+++ b/macos/MindRoom/Tests/MindRoomTests/MindRoomRuntimeTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+@testable import MindRoom
+
+final class MindRoomRuntimeTests: XCTestCase {
+    func testDefaultPathsUseHomeMindroom() {
+        let runtime = MindRoomRuntime(
+            homeURL: URL(fileURLWithPath: "/Users/example", isDirectory: true),
+            bundleURL: URL(fileURLWithPath: "/Applications/MindRoom.app", isDirectory: true),
+            environment: ["PATH": "/usr/bin:/bin"]
+        )
+
+        XCTAssertEqual(runtime.configDirectoryURL.path, "/Users/example/.mindroom")
+        XCTAssertEqual(runtime.configPathURL.path, "/Users/example/.mindroom/config.yaml")
+        XCTAssertEqual(runtime.envPathURL.path, "/Users/example/.mindroom/.env")
+        XCTAssertEqual(runtime.logsDirectoryURL.path, "/Users/example/Library/Logs/mindroom")
+    }
+
+    func testRuntimeInstallUsesBundledUVAndDoesNotRedirectMindRoomConfig() {
+        let runtime = MindRoomRuntime(
+            homeURL: URL(fileURLWithPath: "/Users/example", isDirectory: true),
+            bundleURL: URL(fileURLWithPath: "/Applications/MindRoom.app", isDirectory: true),
+            environment: ["PATH": "/usr/bin:/bin"]
+        )
+
+        let command = runtime.command(for: .installRuntime)
+        XCTAssertEqual(command.executableURL.path, "/Applications/MindRoom.app/Contents/Resources/bin/uv")
+        XCTAssertEqual(command.arguments, ["tool", "install", "--managed-python", "--python", "3.13", "mindroom"])
+        XCTAssertNil(command.environment["MINDROOM_CONFIG_PATH"])
+        XCTAssertNil(command.environment["MINDROOM_STORAGE_PATH"])
+        XCTAssertEqual(command.environment["UV_NO_PROGRESS"], "1")
+        XCTAssertTrue(command.environment["PATH"]?.hasPrefix("/Users/example/.local/bin:/Applications/MindRoom.app/Contents/Resources/bin:") == true)
+    }
+
+    func testRuntimeUpdateForcesLatestMindRoomInstall() {
+        let runtime = MindRoomRuntime(
+            homeURL: URL(fileURLWithPath: "/Users/example", isDirectory: true),
+            bundleURL: URL(fileURLWithPath: "/Applications/MindRoom.app", isDirectory: true),
+            environment: ["PATH": "/usr/bin:/bin"]
+        )
+
+        let command = runtime.command(for: .updateRuntime)
+        XCTAssertEqual(command.arguments, ["tool", "install", "--managed-python", "--python", "3.13", "--force", "mindroom"])
+    }
+
+    func testServiceInstallUsesMindRoomServiceInstallNoConfirm() {
+        let runtime = MindRoomRuntime(
+            homeURL: URL(fileURLWithPath: "/Users/example", isDirectory: true),
+            bundleURL: URL(fileURLWithPath: "/Applications/MindRoom.app", isDirectory: true),
+            environment: ["PATH": "/usr/bin:/bin"]
+        )
+
+        let command = runtime.command(for: .installService)
+        XCTAssertEqual(command.executableURL.path, "/usr/bin/env")
+        XCTAssertEqual(command.arguments, ["mindroom", "service", "install", "--no-confirm"])
+    }
+
+    func testHostedConfigCommandUsesPublicProfile() {
+        let runtime = MindRoomRuntime(
+            homeURL: URL(fileURLWithPath: "/Users/example", isDirectory: true),
+            bundleURL: URL(fileURLWithPath: "/Applications/MindRoom.app", isDirectory: true),
+            environment: ["PATH": "/usr/bin:/bin"]
+        )
+
+        let command = runtime.command(for: .initializeHostedConfig)
+        XCTAssertEqual(command.arguments, ["mindroom", "config", "init", "--profile", "public"])
+    }
+}

--- a/macos/MindRoom/Tests/MindRoomTests/ServiceStatusTests.swift
+++ b/macos/MindRoom/Tests/MindRoomTests/ServiceStatusTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+@testable import MindRoom
+
+final class ServiceStatusTests: XCTestCase {
+    func testParsesRunningServiceStatus() {
+        let status = MindRoomServiceStatus.parse("MindRoom service: running (pid 12345)")
+
+        XCTAssertEqual(status.state, .running)
+        XCTAssertEqual(status.message, "MindRoom is running")
+    }
+
+    func testParsesStoppedServiceStatus() {
+        let status = MindRoomServiceStatus.parse("MindRoom service: installed but not running")
+
+        XCTAssertEqual(status.state, .stopped)
+        XCTAssertEqual(status.message, "MindRoom is installed but stopped")
+    }
+
+    func testParsesNotInstalledServiceStatus() {
+        let status = MindRoomServiceStatus.parse("MindRoom service: not installed")
+
+        XCTAssertEqual(status.state, .notInstalled)
+        XCTAssertEqual(status.message, "MindRoom service is not installed")
+    }
+
+    func testParsesMissingRuntimeStatus() {
+        let status = MindRoomServiceStatus.parse("env: mindroom: No such file or directory")
+
+        XCTAssertEqual(status.state, .runtimeMissing)
+        XCTAssertEqual(status.message, "MindRoom runtime is not installed")
+    }
+
+    func testParsesUnknownStatusWithTrimmedOutput() {
+        let status = MindRoomServiceStatus.parse("\nUnexpected output\n")
+
+        XCTAssertEqual(status.state, .unknown)
+        XCTAssertEqual(status.message, "Unexpected output")
+    }
+}
+
+final class MindRoomCommandTests: XCTestCase {
+    func testPairCodeIsUppercasedAndTrimmed() {
+        let command = MindRoomCommand.pairHosted(pairCode: " abcd-efgh ")
+
+        XCTAssertEqual(command.runtimeAction, .pairHosted(pairCode: "ABCD-EFGH"))
+    }
+
+    func testMenuCommandsExposeTitles() {
+        XCTAssertEqual(MindRoomCommand.installRuntime.title, "Install MindRoom Runtime")
+        XCTAssertEqual(MindRoomCommand.openDashboard.title, "Open Dashboard")
+        XCTAssertEqual(MindRoomCommand.openConfigFolder.title, "Open Config Folder")
+        XCTAssertEqual(MindRoomCommand.openLogsFolder.title, "Open Logs Folder")
+    }
+}

--- a/macos/MindRoom/Tests/MindRoomTests/ServiceStatusTests.swift
+++ b/macos/MindRoom/Tests/MindRoomTests/ServiceStatusTests.swift
@@ -36,6 +36,16 @@ final class ServiceStatusTests: XCTestCase {
         XCTAssertEqual(status.state, .unknown)
         XCTAssertEqual(status.message, "Unexpected output")
     }
+
+    func testParsesUnknownStatusWithCollapsedAndTruncatedOutput() {
+        let status = MindRoomServiceStatus.parse(
+            String(repeating: "Unexpected output line\n", count: 20)
+        )
+
+        XCTAssertEqual(status.state, .unknown)
+        XCTAssertLessThanOrEqual(status.message.count, 200)
+        XCTAssertFalse(status.message.contains("\n"))
+    }
 }
 
 final class MindRoomCommandTests: XCTestCase {

--- a/macos/appcast.xml
+++ b/macos/appcast.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+    <channel>
+        <title>MindRoom Updates</title>
+        <link>https://github.com/mindroom-ai/mindroom</link>
+        <description>Signed MindRoom macOS app updates.</description>
+    </channel>
+</rss>

--- a/macos/build-macos-app.sh
+++ b/macos/build-macos-app.sh
@@ -1,0 +1,333 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+APP_NAME="MindRoom"
+DISPLAY_NAME="MindRoom"
+INSTALL=false
+CREATE_DMG=false
+
+usage() {
+    cat <<'EOF'
+Usage: macos/build-macos-app.sh [--install] [--dmg]
+
+Build the native macOS menu bar app for MindRoom.
+
+Options:
+  --install   Copy the built app to /Applications and open it.
+  --dmg       Create dist/macos/MindRoom.dmg.
+  -h, --help  Show this help text.
+
+Environment:
+  CODESIGN_IDENTITY  Codesign identity to use. Defaults to ad-hoc signing (-).
+  APP_VERSION        CFBundleShortVersionString to stamp into the app.
+                     Defaults to the current package version when available.
+  BUILD_VERSION      CFBundleVersion to stamp into the app. Defaults to
+                     GITHUB_RUN_NUMBER, then the git commit count.
+  SPARKLE_PUBLIC_ED_KEY
+                     Public EdDSA key for Sparkle updates. If unset, the app
+                     builds without enabling Sparkle update checks.
+  UV_BINARY          uv binary to bundle. Defaults to the uv found on PATH.
+  INSTALL_DIR        Install destination. Defaults to /Applications.
+  MINDROOM_SKIP_OPEN Set to 1 to skip opening the app after --install.
+  NOTARIZE           Set to 1 to notarize and staple the DMG. Requires --dmg.
+  APPLE_ID           Apple ID email used for notarization.
+  APPLE_APP_SPECIFIC_PASSWORD
+                     App-specific password used by xcrun notarytool.
+  APPLE_TEAM_ID      Apple Developer Team ID used for notarization.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --install)
+            INSTALL=true
+            shift
+            ;;
+        --dmg)
+            CREATE_DMG=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+PACKAGE_DIR="$ROOT_DIR/macos/$APP_NAME"
+DIST_DIR="$ROOT_DIR/dist/macos"
+APP_DIR="$DIST_DIR/$APP_NAME.app"
+DMG_STAGING_DIR="$DIST_DIR/dmg-staging"
+DMG_RW_PATH="$DIST_DIR/$APP_NAME-rw.dmg"
+INFO_PLIST="$PACKAGE_DIR/Resources/Info.plist"
+ENTITLEMENTS_PLIST="$PACKAGE_DIR/Resources/MindRoom.entitlements"
+ICON_SOURCE_PNG="$ROOT_DIR/frontend/public/logo-square.png"
+ICONSET_DIR="$DIST_DIR/MindRoom.iconset"
+APP_ICON_ICNS="$DIST_DIR/MindRoom.icns"
+CODESIGN_IDENTITY=${CODESIGN_IDENTITY:--}
+APP_VERSION=${APP_VERSION:-}
+BUILD_VERSION=${BUILD_VERSION:-${GITHUB_RUN_NUMBER:-}}
+UV_BINARY=${UV_BINARY:-$(command -v uv || true)}
+INSTALL_DIR=${INSTALL_DIR:-/Applications}
+NOTARIZE=${NOTARIZE:-0}
+SPARKLE_PUBLIC_ED_KEY=${SPARKLE_PUBLIC_ED_KEY:-}
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "This script builds a macOS .app bundle and must run on macOS." >&2
+    exit 1
+fi
+
+for required_tool in swift sips iconutil; do
+    if ! command -v "$required_tool" >/dev/null 2>&1; then
+        echo "$required_tool is required to build the MindRoom app." >&2
+        exit 1
+    fi
+done
+
+if [[ -z "$UV_BINARY" || ! -x "$UV_BINARY" ]]; then
+    echo "uv is required so it can be bundled into the app. Set UV_BINARY or install uv." >&2
+    exit 1
+fi
+
+if [[ ! -f "$INFO_PLIST" ]]; then
+    echo "Info.plist is missing: $INFO_PLIST" >&2
+    exit 1
+fi
+
+if [[ ! -f "$ENTITLEMENTS_PLIST" ]]; then
+    echo "Entitlements plist is missing: $ENTITLEMENTS_PLIST" >&2
+    exit 1
+fi
+
+if [[ ! -f "$ICON_SOURCE_PNG" ]]; then
+    echo "MindRoom icon source is missing: $ICON_SOURCE_PNG" >&2
+    exit 1
+fi
+
+if [[ "$NOTARIZE" == "1" && "$CREATE_DMG" != true ]]; then
+    echo "NOTARIZE=1 requires --dmg so there is a distributable artifact to notarize." >&2
+    exit 1
+fi
+
+codesign_args() {
+    printf '%s\0' --force --sign "$CODESIGN_IDENTITY"
+    if [[ "$CODESIGN_IDENTITY" != "-" ]]; then
+        printf '%s\0' --timestamp --options runtime
+    fi
+}
+
+sign_executable() {
+    local target="$1"
+    local args=()
+    while IFS= read -r -d '' arg; do
+        args+=("$arg")
+    done < <(codesign_args)
+    codesign "${args[@]}" "$target"
+}
+
+sign_app() {
+    local target="$1"
+    local args=()
+    while IFS= read -r -d '' arg; do
+        args+=("$arg")
+    done < <(codesign_args)
+    codesign --deep --entitlements "$ENTITLEMENTS_PLIST" "${args[@]}" "$target"
+}
+
+resolve_app_version() {
+    local raw_version="$APP_VERSION"
+    if [[ -z "$raw_version" ]]; then
+        raw_version=$(uv version --short 2>/dev/null || true)
+    fi
+    if [[ -z "$raw_version" ]]; then
+        raw_version="0.1.0"
+    fi
+    raw_version="${raw_version#v}"
+    if [[ "$raw_version" =~ ^[0-9]+([.][0-9]+){0,2} ]]; then
+        printf '%s\n' "${BASH_REMATCH[0]}"
+        return
+    fi
+    echo "Could not derive a macOS app version from: $raw_version" >&2
+    exit 1
+}
+
+resolve_build_version() {
+    local build_version="$BUILD_VERSION"
+    if [[ -z "$build_version" ]]; then
+        build_version=$(git -C "$ROOT_DIR" rev-list --count HEAD 2>/dev/null || true)
+    fi
+    if [[ -z "$build_version" ]]; then
+        build_version=$(date +%Y%m%d%H%M%S)
+    fi
+    build_version=$(printf '%s' "$build_version" | tr -cd '0-9.')
+    if [[ -z "$build_version" || ! "$build_version" =~ ^[0-9]+([.][0-9]+)*$ ]]; then
+        echo "Could not derive a numeric macOS app build version from: ${BUILD_VERSION:-unset}" >&2
+        exit 1
+    fi
+    printf '%s\n' "$build_version"
+}
+
+stamp_info_plist() {
+    local app_version
+    local build_version
+    app_version=$(resolve_app_version)
+    build_version=$(resolve_build_version)
+
+    /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $app_version" "$APP_DIR/Contents/Info.plist"
+    /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $build_version" "$APP_DIR/Contents/Info.plist"
+    if [[ -n "$SPARKLE_PUBLIC_ED_KEY" ]]; then
+        /usr/libexec/PlistBuddy -c "Delete :SUPublicEDKey" "$APP_DIR/Contents/Info.plist" >/dev/null 2>&1 || true
+        /usr/libexec/PlistBuddy -c "Add :SUPublicEDKey string $SPARKLE_PUBLIC_ED_KEY" "$APP_DIR/Contents/Info.plist"
+    fi
+    echo "Stamped app bundle version $app_version ($build_version)"
+}
+
+build_app_icon() {
+    rm -rf "$ICONSET_DIR" "$APP_ICON_ICNS"
+    mkdir -p "$ICONSET_DIR"
+    sips -z 16 16 "$ICON_SOURCE_PNG" --out "$ICONSET_DIR/icon_16x16.png" >/dev/null
+    sips -z 32 32 "$ICON_SOURCE_PNG" --out "$ICONSET_DIR/icon_16x16@2x.png" >/dev/null
+    sips -z 32 32 "$ICON_SOURCE_PNG" --out "$ICONSET_DIR/icon_32x32.png" >/dev/null
+    sips -z 64 64 "$ICON_SOURCE_PNG" --out "$ICONSET_DIR/icon_32x32@2x.png" >/dev/null
+    sips -z 128 128 "$ICON_SOURCE_PNG" --out "$ICONSET_DIR/icon_128x128.png" >/dev/null
+    sips -z 256 256 "$ICON_SOURCE_PNG" --out "$ICONSET_DIR/icon_128x128@2x.png" >/dev/null
+    sips -z 256 256 "$ICON_SOURCE_PNG" --out "$ICONSET_DIR/icon_256x256.png" >/dev/null
+    sips -z 512 512 "$ICON_SOURCE_PNG" --out "$ICONSET_DIR/icon_256x256@2x.png" >/dev/null
+    sips -z 512 512 "$ICON_SOURCE_PNG" --out "$ICONSET_DIR/icon_512x512.png" >/dev/null
+    sips -z 1024 1024 "$ICON_SOURCE_PNG" --out "$ICONSET_DIR/icon_512x512@2x.png" >/dev/null
+    iconutil -c icns "$ICONSET_DIR" -o "$APP_ICON_ICNS"
+    rm -rf "$ICONSET_DIR"
+}
+
+require_notarization_env() {
+    if [[ "$CODESIGN_IDENTITY" == "-" ]]; then
+        echo "A Developer ID signing identity is required when NOTARIZE=1." >&2
+        exit 1
+    fi
+    for variable in APPLE_ID APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID; do
+        if [[ -z "${!variable:-}" ]]; then
+            echo "$variable is required when NOTARIZE=1." >&2
+            exit 1
+        fi
+    done
+}
+
+notarize_dmg() {
+    local dmg_path="$1"
+    require_notarization_env
+    xcrun notarytool submit "$dmg_path" \
+        --apple-id "$APPLE_ID" \
+        --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+        --team-id "$APPLE_TEAM_ID" \
+        --wait
+    xcrun stapler staple "$dmg_path"
+    xcrun stapler validate "$dmg_path"
+}
+
+create_drag_install_dmg() {
+    local dmg_path="$1"
+    local staging_size_kb
+    local image_size_mb
+    hdiutil detach "/Volumes/$DISPLAY_NAME" >/dev/null 2>&1 || true
+    rm -rf "$DMG_STAGING_DIR" "$DMG_RW_PATH" "$dmg_path"
+    mkdir -p "$DMG_STAGING_DIR"
+    ditto "$APP_DIR" "$DMG_STAGING_DIR/$APP_NAME.app"
+    ln -s /Applications "$DMG_STAGING_DIR/Applications"
+    staging_size_kb=$(du -sk "$DMG_STAGING_DIR" | awk '{ print $1 }')
+    image_size_mb=$((staging_size_kb / 1024 + 64))
+    hdiutil create "$DMG_RW_PATH" -volname "$DISPLAY_NAME" -size "${image_size_mb}m" -fs HFS+ -ov
+    local attach_output
+    attach_output=$(hdiutil attach "$DMG_RW_PATH" -nobrowse -noautoopen)
+    local volume_path
+    volume_path=$(printf '%s\n' "$attach_output" | awk -F '\t' '/\/Volumes\// { mount=$NF } END { if (mount) print mount; else exit 1 }')
+    ditto "$DMG_STAGING_DIR" "$volume_path"
+    sync
+    hdiutil detach "$volume_path" -force >/dev/null
+    hdiutil convert "$DMG_RW_PATH" -format UDZO -imagekey zlib-level=9 -o "$dmg_path"
+    rm -rf "$DMG_STAGING_DIR" "$DMG_RW_PATH"
+}
+
+quit_running_app() {
+    if ! pgrep -x "$APP_NAME" >/dev/null 2>&1; then
+        return
+    fi
+    osascript -e "quit app \"$APP_NAME\"" >/dev/null 2>&1 || true
+    for _ in {1..20}; do
+        if ! pgrep -x "$APP_NAME" >/dev/null 2>&1; then
+            return
+        fi
+        sleep 0.2
+    done
+    pkill -x "$APP_NAME" >/dev/null 2>&1 || true
+}
+
+echo "Building $DISPLAY_NAME..."
+swift build -c release --package-path "$PACKAGE_DIR"
+BIN_DIR=$(swift build -c release --package-path "$PACKAGE_DIR" --show-bin-path)
+BINARY="$BIN_DIR/$APP_NAME"
+
+if [[ ! -x "$BINARY" ]]; then
+    echo "Built binary not found: $BINARY" >&2
+    exit 1
+fi
+
+echo "Building app icon..."
+build_app_icon
+
+rm -rf "$APP_DIR"
+mkdir -p "$APP_DIR/Contents/MacOS" "$APP_DIR/Contents/Frameworks" "$APP_DIR/Contents/Resources/bin"
+
+SPARKLE_FRAMEWORK="$BIN_DIR/Sparkle.framework"
+if [[ ! -d "$SPARKLE_FRAMEWORK" ]]; then
+    echo "Built Sparkle framework not found: $SPARKLE_FRAMEWORK" >&2
+    exit 1
+fi
+
+cp "$BINARY" "$APP_DIR/Contents/MacOS/$APP_NAME"
+cp "$INFO_PLIST" "$APP_DIR/Contents/Info.plist"
+ditto "$SPARKLE_FRAMEWORK" "$APP_DIR/Contents/Frameworks/Sparkle.framework"
+cp "$UV_BINARY" "$APP_DIR/Contents/Resources/bin/uv"
+cp "$APP_ICON_ICNS" "$APP_DIR/Contents/Resources/MindRoom.icns"
+chmod 755 "$APP_DIR/Contents/MacOS/$APP_NAME" "$APP_DIR/Contents/Resources/bin/uv"
+
+if ! otool -l "$APP_DIR/Contents/MacOS/$APP_NAME" | grep -q '@executable_path/../Frameworks'; then
+    install_name_tool -add_rpath "@executable_path/../Frameworks" "$APP_DIR/Contents/MacOS/$APP_NAME"
+fi
+
+stamp_info_plist
+sign_executable "$APP_DIR/Contents/Resources/bin/uv"
+sign_app "$APP_DIR"
+
+echo "Built $APP_DIR"
+
+if [[ "$CREATE_DMG" == true ]]; then
+    DMG_PATH="$DIST_DIR/$APP_NAME.dmg"
+    create_drag_install_dmg "$DMG_PATH"
+    if [[ "$CODESIGN_IDENTITY" != "-" ]]; then
+        codesign --force --sign "$CODESIGN_IDENTITY" --timestamp "$DMG_PATH"
+    fi
+    if [[ "$NOTARIZE" == "1" ]]; then
+        notarize_dmg "$DMG_PATH"
+    fi
+    echo "Built $DMG_PATH"
+fi
+
+if [[ "$INSTALL" == true ]]; then
+    INSTALL_PATH="$INSTALL_DIR/$APP_NAME.app"
+    mkdir -p "$INSTALL_DIR"
+    quit_running_app
+    rm -rf "$INSTALL_PATH"
+    ditto "$APP_DIR" "$INSTALL_PATH"
+    codesign --verify --deep --strict "$INSTALL_PATH"
+    if [[ "${MINDROOM_SKIP_OPEN:-0}" != "1" ]]; then
+        open "$INSTALL_PATH"
+    fi
+    echo "Installed $INSTALL_PATH"
+fi

--- a/macos/build-macos-app.sh
+++ b/macos/build-macos-app.sh
@@ -144,7 +144,16 @@ sign_app() {
 resolve_app_version() {
     local raw_version="$APP_VERSION"
     if [[ -z "$raw_version" ]]; then
-        raw_version=$(uv version --short 2>/dev/null || true)
+        raw_version=$(
+            PYPROJECT_PATH="$ROOT_DIR/pyproject.toml" python3 <<'PY' 2>/dev/null || true
+import os
+import pathlib
+import tomllib
+
+pyproject = pathlib.Path(os.environ["PYPROJECT_PATH"])
+print(tomllib.loads(pyproject.read_text())["project"]["version"])
+PY
+        )
     fi
     if [[ -z "$raw_version" ]]; then
         raw_version="0.1.0"
@@ -221,12 +230,15 @@ require_notarization_env() {
 
 notarize_dmg() {
     local dmg_path="$1"
+    local app_path="$2"
     require_notarization_env
     xcrun notarytool submit "$dmg_path" \
         --apple-id "$APPLE_ID" \
         --password "$APPLE_APP_SPECIFIC_PASSWORD" \
         --team-id "$APPLE_TEAM_ID" \
         --wait
+    xcrun stapler staple "$app_path"
+    xcrun stapler validate "$app_path"
     xcrun stapler staple "$dmg_path"
     xcrun stapler validate "$dmg_path"
 }
@@ -269,7 +281,6 @@ quit_running_app() {
 }
 
 echo "Building $DISPLAY_NAME..."
-swift build -c release --package-path "$PACKAGE_DIR"
 BIN_DIR=$(swift build -c release --package-path "$PACKAGE_DIR" --show-bin-path)
 BINARY="$BIN_DIR/$APP_NAME"
 
@@ -314,7 +325,7 @@ if [[ "$CREATE_DMG" == true ]]; then
         codesign --force --sign "$CODESIGN_IDENTITY" --timestamp "$DMG_PATH"
     fi
     if [[ "$NOTARIZE" == "1" ]]; then
-        notarize_dmg "$DMG_PATH"
+        notarize_dmg "$DMG_PATH" "$APP_DIR"
     fi
     echo "Built $DMG_PATH"
 fi


### PR DESCRIPTION
## Summary
- Add a native Swift/AppKit MindRoom menu bar app that bundles `uv`, installs the latest `mindroom` runtime, uses `~/.mindroom`, and manages `mindroom service` lifecycle commands.
- Add macOS packaging and release plumbing: build script, Sparkle appcast, Homebrew cask, and release workflow metadata updates.
- Document the macOS app install, hosted/self-hosted setup flows, service controls, updates, and uninstall behavior.

## Test Plan
- [x] `swift test --package-path macos/MindRoom`
- [x] `SPARKLE_PUBLIC_ED_KEY=test macos/build-macos-app.sh`
- [x] `uv run pytest` (`6912 passed, 92 skipped`)
- [x] `uv run pre-commit run --all-files`

## Summary by Sourcery

Add a native Swift-based macOS menu bar application for managing the MindRoom runtime and service, with accompanying packaging, release automation, and user documentation.

New Features:
- Introduce a macOS menu bar app that installs and manages the MindRoom runtime and launchd service using bundled uv and existing CLI commands.
- Expose menu actions for hosted/self-hosted configuration, local-stack setup, pairing, dashboard and log access, and app/service status display.
- Add a Sparkle-driven in-app update mechanism and login-item support for starting the app at login.

Enhancements:
- Add a Swift package for the macOS app with runtime command construction, process execution, and service status parsing logic.
- Provide a macOS build script that assembles, signs, optionally notarizes, and packages the app into a DMG and ZIP, including bundled uv and Sparkle framework.
- Introduce helper scripts to update the Homebrew cask and normalize the Sparkle appcast XML in release automation.

CI:
- Extend the release workflow to build, sign, notarize, and publish the macOS app artifacts, then update the Sparkle appcast and Homebrew cask metadata on new releases.

Documentation:
- Document installation, configuration flows, service controls, updates, and uninstall steps for the macOS menu bar app, and reference it from the main README.
- Add internal design and implementation plan docs describing the macOS menu bar app architecture, behaviors, and release flow.

Tests:
- Add Swift unit tests for runtime path/command construction, service status parsing, and command metadata for the macOS app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Native macOS menu bar app for controlling MindRoom service and runtime
  * Homebrew installation support via `brew install mindroom`
  * Automatic app updates via Sparkle
  * Service status monitoring and control from menu bar
  * Hosted MindRoom pairing integration

* **Documentation**
  * Added macOS app installation, setup, and operation guide
  * Updated README with quick-start instructions for macOS menu bar app

* **Chores**
  * Added macOS build and release automation workflows
  * Added Homebrew cask metadata management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->