### PR TITLE
test(interactive): update selection fixtures

### DIFF
--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -4554,7 +4554,9 @@ class TestAgentBot:
         event = self._make_handler_event("reaction", sender="@user:localhost", event_id="$reaction")
         selection = interactive.InteractiveSelection(
             question_event_id="$question",
+            question_text="Choose one",
             selection_key="1",
+            selected_label="Selected",
             selected_value="Selected",
             thread_id="$thread-root",
         )
@@ -4591,7 +4593,9 @@ class TestAgentBot:
         event.key = "✅"
         selection = interactive.InteractiveSelection(
             question_event_id="$question",
+            question_text="Approve?",
             selection_key="✅",
+            selected_label="Approved",
             selected_value="Approved",
             thread_id="$thread-root",
         )


### PR DESCRIPTION
Cherry-picks `a8fd3eafa57c4da18ef2c300d4ee74c76ff72676` from `gitea/main` onto `origin/main`.

Skipped `6ee8e68fe` per request. Existing open PRs already cover `08cf97152` (#1004), `3b2fd0caa` (#1009), and `44fdca303` (#1114).

## Summary by Sourcery

Tests:
- Extend multi-agent interactive reaction selection tests to assert question text and selected label fields are populated.