### PR TITLE
fix(scheduling): preserve router requester for scheduled fires

### DIFF
--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -118,6 +118,7 @@ from mindroom.turn_origin import (
     classify_turn_origin,
     original_sender_for_router_handoff,
     original_sender_for_router_relay,
+    requester_id_from_trusted_original_sender,
 )
 from mindroom.turn_policy import IngressHookRunner, PreparedDispatch, ResponseAction, TurnPolicy
 
@@ -335,13 +336,17 @@ class TurnController:
                     self.deps.runtime_paths,
                 )
             source_kind = source_kind_from_content(content)
-            trusted_original_sender = self._trusted_human_original_sender(
-                sender=sender,
-                content=content,
+            trusted_requester = requester_id_from_trusted_original_sender(
+                original_sender=original_sender,
+                original_sender_entity_name=self._managed_entity_name_for_sender(original_sender),
                 source_kind=source_kind,
+                sender_trusts_original_sender=self._should_trust_original_sender_metadata(
+                    sender=sender,
+                    source_kind=source_kind,
+                ),
             )
-            if trusted_original_sender is not None:
-                return trusted_original_sender
+            if trusted_requester is not None:
+                return trusted_requester
             return sender
         return get_effective_sender_id_for_reply_permissions(
             sender,

--- a/src/mindroom/turn_origin.py
+++ b/src/mindroom/turn_origin.py
@@ -150,6 +150,23 @@ def original_sender_for_router_relay(
     return None
 
 
+def requester_id_from_trusted_original_sender(
+    *,
+    original_sender: str | None,
+    original_sender_entity_name: str | None,
+    source_kind: str | None,
+    sender_trusts_original_sender: bool,
+) -> str | None:
+    """Return original-sender metadata that may act as the dispatch requester."""
+    if not sender_trusts_original_sender or not original_sender:
+        return None
+    if original_sender_entity_name is None:
+        return original_sender
+    if source_kind == SCHEDULED_SOURCE_KIND:
+        return original_sender
+    return None
+
+
 def _turn_trust(
     *,
     sender_kind: SenderKind,

--- a/tests/test_bot_scheduling.py
+++ b/tests/test_bot_scheduling.py
@@ -1208,6 +1208,58 @@ class TestCommandHandling:
         assert "ignore_unmentioned_agent_event" not in debug_calls
 
     @pytest.mark.asyncio
+    async def test_scheduled_agent_event_with_router_requester_survives_ingress_precheck(self) -> None:
+        """Scheduled self-authored events must reach dispatch instead of the self-message guard."""
+        agent_user = AgentMatrixUser(
+            agent_name="general",
+            user_id="@mindroom_general:localhost",
+            display_name="General Agent",
+            password=TEST_PASSWORD,
+            access_token=TEST_ACCESS_TOKEN,
+        )
+        config = _runtime_bound_config(
+            Config(
+                agents={"general": AgentConfig(display_name="General Agent")},
+                router=RouterConfig(model="default"),
+            ),
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bot = AgentBot(
+                agent_user=agent_user,
+                storage_path=Path(tmpdir),
+                config=config,
+                runtime_paths=runtime_paths_for(config),
+                rooms=["!test:server"],
+            )
+            wrap_extracted_collaborators(bot)
+            bot.client = AsyncMock()
+            bot.client.user_id = "@mindroom_general:localhost"
+            sync_bot_runtime_state(bot)
+            bot.logger = MagicMock()
+            _sync_turn_policy_runtime(bot)
+
+            room = nio.MatrixRoom(room_id="!test:server", own_user_id=bot.client.user_id)
+            event = nio.RoomMessageText.from_dict(
+                {
+                    "event_id": "$scheduled_task",
+                    "sender": "@mindroom_general:localhost",
+                    "origin_server_ts": 1234567890,
+                    "content": {
+                        "msgtype": "m.text",
+                        "body": "⏰ [Automated Task]\nCheck the workloop status",
+                        SOURCE_KIND_KEY: SCHEDULED_SOURCE_KIND,
+                        ORIGINAL_SENDER_KEY: "@mindroom_router:localhost",
+                    },
+                },
+            )
+
+            result = bot._turn_controller._precheck_dispatch_event(room, event)
+
+        assert result is not None
+        assert result.requester_user_id == "@mindroom_router:localhost"
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "content_extra",
         [

--- a/tests/test_turn_origin.py
+++ b/tests/test_turn_origin.py
@@ -11,6 +11,7 @@ from mindroom.turn_origin import (
     classify_turn_origin,
     original_sender_for_router_handoff,
     original_sender_for_router_relay,
+    requester_id_from_trusted_original_sender,
 )
 
 
@@ -113,6 +114,45 @@ def test_plain_hook_with_managed_requester_still_requires_mention() -> None:
     assert origin.intent == TurnIntent.HOOK_MESSAGE
     assert not origin.may_dispatch_without_mention
     assert origin.blocks_unmentioned_managed_sender
+
+
+def test_requester_id_from_trusted_original_sender_accepts_human_metadata() -> None:
+    """Trusted human original-sender metadata may act as the requester."""
+    assert (
+        requester_id_from_trusted_original_sender(
+            original_sender="@human:localhost",
+            original_sender_entity_name=None,
+            source_kind=HOOK_DISPATCH_SOURCE_KIND,
+            sender_trusts_original_sender=True,
+        )
+        == "@human:localhost"
+    )
+
+
+def test_requester_id_from_trusted_original_sender_accepts_managed_scheduled_fires() -> None:
+    """Scheduled fires may preserve a managed requester such as the router."""
+    assert (
+        requester_id_from_trusted_original_sender(
+            original_sender="@mindroom_router:localhost",
+            original_sender_entity_name="router",
+            source_kind=SCHEDULED_SOURCE_KIND,
+            sender_trusts_original_sender=True,
+        )
+        == "@mindroom_router:localhost"
+    )
+
+
+def test_requester_id_from_trusted_original_sender_rejects_managed_plain_hooks() -> None:
+    """Managed original-sender metadata is only a requester for scheduled fires."""
+    assert (
+        requester_id_from_trusted_original_sender(
+            original_sender="@mindroom_router:localhost",
+            original_sender_entity_name="router",
+            source_kind=HOOK_SOURCE_KIND,
+            sender_trusts_original_sender=True,
+        )
+        is None
+    )
 
 
 def test_router_handoff_is_trusted_user_relay() -> None:

--- a/tests/test_turn_origin.py
+++ b/tests/test_turn_origin.py
@@ -155,6 +155,19 @@ def test_requester_id_from_trusted_original_sender_rejects_managed_plain_hooks()
     )
 
 
+def test_requester_id_from_trusted_original_sender_requires_original_sender() -> None:
+    """Trusted metadata without an original sender cannot act as a requester."""
+    assert (
+        requester_id_from_trusted_original_sender(
+            original_sender=None,
+            original_sender_entity_name=None,
+            source_kind=HOOK_DISPATCH_SOURCE_KIND,
+            sender_trusts_original_sender=True,
+        )
+        is None
+    )
+
+
 def test_router_handoff_is_trusted_user_relay() -> None:
     """Router handoffs are trusted relays of the original human author."""
     origin = classify_turn_origin(


### PR DESCRIPTION
Cherry-picks `d788a72e4d1e164a448da986d3e66e65b6fe9a74` from `gitea/main` onto `origin/main`.

Skipped `6ee8e68fe` per request. Existing open PRs already cover `08cf97152` (#1004), `3b2fd0caa` (#1009), and `44fdca303` (#1114).

## Summary by Sourcery

Preserve trusted original-sender metadata as the effective requester for scheduled events while keeping existing safeguards for other dispatch sources.

Enhancements:
- Introduce a helper to derive a trusted requester ID from original-sender metadata, allowing managed requesters to be preserved for scheduled fires but not for plain hooks.
- Update turn controller requester resolution to use the new trusted requester helper when original-sender metadata is present.

Tests:
- Add tests ensuring scheduled agent events authored by the router survive ingress precheck and retain the router as requester.
- Add unit tests covering requester derivation from trusted original-sender metadata for human senders, scheduled fires, and non-scheduled managed hooks.