### PR TITLE
fix(orchestrator): disable entities with failed account setup

### DIFF
--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -789,7 +789,8 @@ class _MultiAgentOrchestrator:
         failed_entities: list[str] = []
         entity_names = tuple(entity_names)
         self._last_account_preparation_failed_entities = []
-        self._preflight_account_provisioning(config, entity_names=entity_names, include_internal_user=False)
+        if not allow_partial:
+            self._preflight_account_provisioning(config, entity_names=entity_names, include_internal_user=False)
 
         async def _prepare_accounts() -> None:
             nonlocal failed_entities, users
@@ -797,6 +798,12 @@ class _MultiAgentOrchestrator:
             permanently_failed_entities: list[str] = []
             for entity_name in entity_names:
                 try:
+                    if allow_partial:
+                        self._preflight_account_provisioning(
+                            config,
+                            entity_names=[entity_name],
+                            include_internal_user=False,
+                        )
                     prepared_users[entity_name] = await create_agent_user(
                         homeserver,
                         entity_name,
@@ -919,12 +926,11 @@ class _MultiAgentOrchestrator:
         active_teams = {
             team_name: team_config for team_name, team_config in config.teams.items() if team_name not in disabled_teams
         }
-        active_cultures = {
-            culture_name: culture_config.model_copy(
-                update={"agents": [agent_name for agent_name in culture_config.agents if agent_name in active_agents]},
-            )
-            for culture_name, culture_config in config.cultures.items()
-        }
+        active_cultures = {}
+        for culture_name, culture_config in config.cultures.items():
+            active_culture_agents = [agent_name for agent_name in culture_config.agents if agent_name in active_agents]
+            if active_culture_agents:
+                active_cultures[culture_name] = culture_config.model_copy(update={"agents": active_culture_agents})
         active_reply_permissions = {
             entity_name: user_ids
             for entity_name, user_ids in config.authorization.agent_reply_permissions.items()
@@ -1166,7 +1172,7 @@ class _MultiAgentOrchestrator:
         config = load_config(self.runtime_paths, tolerate_plugin_load_errors=True)
         hook_registry = self._build_hook_registry(config)
         entity_names = self._configured_entity_names(config)
-        self._preflight_account_provisioning(config, entity_names=entity_names, include_internal_user=True)
+        self._preflight_account_provisioning(config, entity_names=[], include_internal_user=True)
         await self._prepare_user_account(config, update_runtime_state=True)
         self._last_account_preparation_failed_entities = []
         entity_users = await self._prepare_entity_accounts(config, entity_names, allow_partial=True)
@@ -1391,7 +1397,7 @@ class _MultiAgentOrchestrator:
         """Handle config loading before the runtime has an active config."""
         self._preflight_account_provisioning(
             new_config,
-            entity_names=self._configured_entity_names(new_config),
+            entity_names=[],
             include_internal_user=True,
         )
         await self._prepare_user_account(new_config, update_runtime_state=not self.running)

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -24,6 +24,7 @@ from mindroom.entity_resolution import (
     configured_bot_user_ids_for_room,
     entity_identity_registry,
     is_configured_room,
+    mindroom_user_id,
 )
 from mindroom.hooks import (
     EVENT_CONFIG_RELOADED,
@@ -256,6 +257,14 @@ class _SignalAwareUvicornServer(uvicorn.Server):
         self.should_exit = True
 
 
+@dataclass(slots=True)
+class _FilteredRuntimeConfig:
+    """Runtime config after disabling entities unavailable during startup."""
+
+    config: Config
+    disabled_entities: set[str]
+
+
 @dataclass
 class _MultiAgentOrchestrator:
     """Orchestrates multiple agent bots."""
@@ -284,6 +293,8 @@ class _MultiAgentOrchestrator:
     hook_registry: HookRegistry = field(default_factory=HookRegistry.empty, init=False)
     _runtime_shutdown_event: asyncio.Event | None = field(default=None, init=False, repr=False)
     _approval_transport: ApprovalMatrixTransport = field(init=False, repr=False)
+    _last_account_preparation_failed_entities: list[str] = field(default_factory=list, init=False)
+    _account_preparation_failed_entities: set[str] = field(default_factory=set, init=False)
 
     def __post_init__(self) -> None:
         """Store canonical derived paths from the explicit runtime context."""
@@ -769,25 +780,44 @@ class _MultiAgentOrchestrator:
         self,
         config: Config,
         entity_names: Iterable[str],
+        *,
+        allow_partial: bool = False,
     ) -> dict[str, AgentMatrixUser]:
         """Ensure managed Matrix accounts exist before runtime bot construction."""
         homeserver = constants.runtime_matrix_homeserver(runtime_paths=self.runtime_paths)
         users: dict[str, AgentMatrixUser] = {}
+        failed_entities: list[str] = []
         entity_names = tuple(entity_names)
+        self._last_account_preparation_failed_entities = []
         self._preflight_account_provisioning(config, entity_names=entity_names, include_internal_user=False)
 
         async def _prepare_accounts() -> None:
-            nonlocal users
+            nonlocal failed_entities, users
             prepared_users: dict[str, AgentMatrixUser] = {}
+            permanently_failed_entities: list[str] = []
             for entity_name in entity_names:
-                prepared_users[entity_name] = await create_agent_user(
-                    homeserver,
-                    entity_name,
-                    self._entity_display_name(config, entity_name),
-                    runtime_paths=self.runtime_paths,
-                )
-            self._validate_entity_accounts(config)
+                try:
+                    prepared_users[entity_name] = await create_agent_user(
+                        homeserver,
+                        entity_name,
+                        self._entity_display_name(config, entity_name),
+                        runtime_paths=self.runtime_paths,
+                    )
+                except PermanentStartupError as exc:
+                    if not allow_partial or entity_name == ROUTER_AGENT_NAME:
+                        raise
+                    logger.error(  # noqa: TRY400
+                        "Managed Matrix account preparation failed permanently; leaving entity disabled",
+                        agent_name=entity_name,
+                        error=str(exc),
+                    )
+                    permanently_failed_entities.append(entity_name)
+            if permanently_failed_entities:
+                self._validate_prepared_entity_accounts(prepared_users, config)
+            else:
+                self._validate_entity_accounts(config)
             users = prepared_users
+            failed_entities = permanently_failed_entities
 
         await run_with_retry(
             "Preparing managed Matrix accounts",
@@ -795,7 +825,38 @@ class _MultiAgentOrchestrator:
             permanent_error_check=is_permanent_startup_error,
             update_runtime_state=not self.running,
         )
+        self._last_account_preparation_failed_entities = failed_entities
         return users
+
+    def _validate_prepared_entity_accounts(self, users: dict[str, AgentMatrixUser], config: Config) -> None:
+        """Validate prepared Matrix identities when some optional entities are disabled."""
+        owners_by_user_id: dict[str, str] = {}
+        duplicates: list[tuple[str, str, str]] = []
+        for entity_name, user in users.items():
+            previous_owner = owners_by_user_id.get(user.user_id)
+            if previous_owner is not None:
+                duplicates.append((user.user_id, previous_owner, entity_name))
+                continue
+            owners_by_user_id[user.user_id] = entity_name
+        if duplicates:
+            formatted = ", ".join(
+                f"{user_id} shared by {first_entity!r} and {second_entity!r}"
+                for user_id, first_entity, second_entity in duplicates
+            )
+            msg = f"Configured entities must have unique Matrix IDs: {formatted}"
+            raise PermanentStartupError(msg)
+
+        internal_user_id = mindroom_user_id(config, self.runtime_paths)
+        if internal_user_id is None:
+            return
+        matching_entity = owners_by_user_id.get(internal_user_id)
+        if matching_entity is None:
+            return
+        msg = (
+            "MindRoom internal user Matrix ID must not match a configured entity Matrix ID: "
+            f"{internal_user_id} is also used by {matching_entity!r}"
+        )
+        raise PermanentStartupError(msg)
 
     def _validate_entity_accounts(self, config: Config) -> None:
         """Validate persisted Matrix identities for all configured runtime entities."""
@@ -822,6 +883,70 @@ class _MultiAgentOrchestrator:
             )
         requests.extend(ManagedAccountProvisioningRequest(entity_name) for entity_name in entity_names)
         preflight_managed_account_provisioning(requests, self.runtime_paths)
+
+    def _filter_runtime_config_for_account_failures(
+        self,
+        config: Config,
+        failed_entities: Iterable[str],
+    ) -> _FilteredRuntimeConfig:
+        """Return a runtime config excluding entities whose accounts cannot be prepared."""
+        failed = set(failed_entities)
+        if not failed:
+            return _FilteredRuntimeConfig(config=config, disabled_entities=set())
+
+        disabled_agents = set(config.agents) & failed
+        disabled_teams = (set(config.teams) & failed) | {
+            team_name
+            for team_name, team_config in config.teams.items()
+            if any(agent_name in disabled_agents for agent_name in team_config.agents)
+        }
+        disabled_entities = disabled_agents | disabled_teams
+        if not disabled_entities:
+            return _FilteredRuntimeConfig(config=config, disabled_entities=set())
+
+        active_agents = {}
+        for agent_name, agent_config in config.agents.items():
+            if agent_name in disabled_agents:
+                continue
+            active_delegate_targets = [
+                delegate_name for delegate_name in agent_config.delegate_to if delegate_name not in disabled_agents
+            ]
+            if active_delegate_targets == agent_config.delegate_to:
+                active_agents[agent_name] = agent_config
+                continue
+            active_agents[agent_name] = agent_config.model_copy(update={"delegate_to": active_delegate_targets})
+
+        active_teams = {
+            team_name: team_config for team_name, team_config in config.teams.items() if team_name not in disabled_teams
+        }
+        active_cultures = {
+            culture_name: culture_config.model_copy(
+                update={"agents": [agent_name for agent_name in culture_config.agents if agent_name in active_agents]},
+            )
+            for culture_name, culture_config in config.cultures.items()
+        }
+        active_reply_permissions = {
+            entity_name: user_ids
+            for entity_name, user_ids in config.authorization.agent_reply_permissions.items()
+            if entity_name == "*" or entity_name not in disabled_entities
+        }
+        active_authorization = config.authorization.model_copy(
+            update={"agent_reply_permissions": active_reply_permissions},
+        )
+        runtime_config = config.model_copy(
+            update={
+                "agents": active_agents,
+                "teams": active_teams,
+                "cultures": active_cultures,
+                "authorization": active_authorization,
+            },
+        )
+        logger.warning(
+            "Configured entities disabled because Matrix account preparation failed",
+            entities=sorted(disabled_entities),
+            account_failed_entities=sorted(failed),
+        )
+        return _FilteredRuntimeConfig(config=runtime_config, disabled_entities=disabled_entities)
 
     def validate_managed_entity_identities(self) -> None:
         """Validate persisted managed Matrix identities for the live config."""
@@ -1043,7 +1168,15 @@ class _MultiAgentOrchestrator:
         entity_names = self._configured_entity_names(config)
         self._preflight_account_provisioning(config, entity_names=entity_names, include_internal_user=True)
         await self._prepare_user_account(config, update_runtime_state=True)
-        entity_users = await self._prepare_entity_accounts(config, entity_names)
+        self._last_account_preparation_failed_entities = []
+        entity_users = await self._prepare_entity_accounts(config, entity_names, allow_partial=True)
+        filtered_config = self._filter_runtime_config_for_account_failures(
+            config,
+            self._last_account_preparation_failed_entities,
+        )
+        config = filtered_config.config
+        self._account_preparation_failed_entities = filtered_config.disabled_entities
+        entity_names = self._configured_entity_names(config)
         self.config = config
         self._activate_hook_registry(hook_registry)
         await self._sync_mcp_manager(config)
@@ -1120,12 +1253,15 @@ class _MultiAgentOrchestrator:
     def _log_degraded_startup(self, failed_agents: list[str]) -> None:
         """Log degraded startup status for failed non-router bots."""
         if failed_agents:
+            failed_agent_names = set(failed_agents)
+            operational_agent_count = len([name for name in self.agent_bots if name not in failed_agent_names])
+            total_agent_count = len(self.agent_bots) + len(failed_agent_names - set(self.agent_bots))
             logger.warning(
                 "System starting in degraded mode",
                 failed_agents=failed_agents,
                 failed_agent_count=len(failed_agents),
-                operational_agent_count=len(self.agent_bots) - len(failed_agents),
-                total_agent_count=len(self.agent_bots),
+                operational_agent_count=operational_agent_count,
+                total_agent_count=total_agent_count,
             )
             return
         logger.info("All agent bots started successfully")
@@ -1212,7 +1348,11 @@ class _MultiAgentOrchestrator:
         )
         started_bots = [router_bot, *start_results.started_bots]
         self._log_degraded_startup(
-            [*start_results.retryable_entities, *start_results.permanently_failed_entities],
+            [
+                *sorted(self._account_preparation_failed_entities),
+                *start_results.retryable_entities,
+                *start_results.permanently_failed_entities,
+            ],
         )
 
         config = self._require_config()
@@ -1255,7 +1395,18 @@ class _MultiAgentOrchestrator:
             include_internal_user=True,
         )
         await self._prepare_user_account(new_config, update_runtime_state=not self.running)
-        await self._prepare_entity_accounts(new_config, self._configured_entity_names(new_config))
+        self._last_account_preparation_failed_entities = []
+        await self._prepare_entity_accounts(
+            new_config,
+            self._configured_entity_names(new_config),
+            allow_partial=True,
+        )
+        filtered_config = self._filter_runtime_config_for_account_failures(
+            new_config,
+            self._last_account_preparation_failed_entities,
+        )
+        new_config = filtered_config.config
+        self._account_preparation_failed_entities = filtered_config.disabled_entities
         self.config = new_config
         self._activate_hook_registry(hook_registry)
         await self._sync_mcp_manager(new_config)

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -891,6 +891,19 @@ class _MultiAgentOrchestrator:
         requests.extend(ManagedAccountProvisioningRequest(entity_name) for entity_name in entity_names)
         preflight_managed_account_provisioning(requests, self.runtime_paths)
 
+    def _preflight_internal_user_entity_collisions(self, config: Config) -> None:
+        """Reject generated internal-user/entity localpart collisions before account writes."""
+        if config.mindroom_user is None:
+            return
+        requests = [
+            ManagedAccountProvisioningRequest(
+                INTERNAL_USER_AGENT_NAME,
+                username=config.mindroom_user.username,
+            ),
+            *(ManagedAccountProvisioningRequest(entity_name) for entity_name in self._configured_entity_names(config)),
+        ]
+        preflight_managed_account_provisioning(requests, self.runtime_paths)
+
     def _filter_runtime_config_for_account_failures(
         self,
         config: Config,
@@ -1172,6 +1185,7 @@ class _MultiAgentOrchestrator:
         config = load_config(self.runtime_paths, tolerate_plugin_load_errors=True)
         hook_registry = self._build_hook_registry(config)
         entity_names = self._configured_entity_names(config)
+        self._preflight_internal_user_entity_collisions(config)
         self._preflight_account_provisioning(config, entity_names=[], include_internal_user=True)
         await self._prepare_user_account(config, update_runtime_state=True)
         self._last_account_preparation_failed_entities = []
@@ -1395,6 +1409,7 @@ class _MultiAgentOrchestrator:
 
     async def _load_initial_config(self, new_config: Config, hook_registry: HookRegistry) -> bool:
         """Handle config loading before the runtime has an active config."""
+        self._preflight_internal_user_entity_collisions(new_config)
         self._preflight_account_provisioning(
             new_config,
             entity_names=[],
@@ -1585,6 +1600,8 @@ class _MultiAgentOrchestrator:
     async def _prepare_accounts_for_config_update(self, new_config: Config, plan: ConfigUpdatePlan) -> None:
         """Prepare or validate managed Matrix accounts before publishing a reloaded config."""
         entities_requiring_account_check = plan.added_entities | (plan.entities_to_restart & plan.configured_entities)
+        if plan.mindroom_user_changed:
+            self._preflight_internal_user_entity_collisions(new_config)
         self._preflight_account_provisioning(
             new_config,
             entity_names=entities_requiring_account_check,

--- a/tests/test_config_reload.py
+++ b/tests/test_config_reload.py
@@ -1059,6 +1059,9 @@ async def test_initialize_disables_non_router_entity_when_account_provisioning_f
                     "model": "default",
                 },
             },
+            cultures={
+                "flash_only": {"description": "Flash only", "agents": ["mind_flash"], "mode": "automatic"},
+            },
             models={"default": {"provider": "test", "id": "test-model"}},
         ),
         tmp_path,
@@ -1103,7 +1106,72 @@ async def test_initialize_disables_non_router_entity_when_account_provisioning_f
     assert created_bots == [ROUTER_AGENT_NAME, "general"]
     assert set(orchestrator.config.agents) == {"general"}
     assert orchestrator.config.teams == {}
+    assert orchestrator.config.cultures == {}
     assert orchestrator._account_preparation_failed_entities == {"mind_flash", "flash_team"}
+
+
+@pytest.mark.asyncio
+async def test_initialize_disables_non_router_entity_when_account_preflight_fails(tmp_path: Path) -> None:
+    """Per-entity preflight failures should be handled by partial startup."""
+    config = _runtime_bound_config(
+        Config(
+            agents={
+                "general": {"display_name": "GeneralAgent", "model": "default"},
+                "mind_flash": {"display_name": "MindFlash", "model": "default"},
+            },
+            models={"default": {"provider": "test", "id": "test-model"}},
+        ),
+        tmp_path,
+    )
+    orchestrator = _MultiAgentOrchestrator(runtime_paths_for(config))
+    created_bots: list[str] = []
+
+    def preflight(
+        _config: Config,
+        entity_names: Iterable[str],
+        *,
+        include_internal_user: bool,
+    ) -> None:
+        del _config, include_internal_user
+        if "mind_flash" in entity_names:
+            msg = "preflight rejected"
+            raise PermanentStartupError(msg)
+
+    async def create_user(
+        _homeserver: str,
+        entity_name: str,
+        display_name: str,
+        *,
+        runtime_paths: object,
+        username: str | None = None,
+    ) -> AgentMatrixUser:
+        del runtime_paths, username
+        return AgentMatrixUser(
+            agent_name=entity_name,
+            user_id=f"@actual_{entity_name}:localhost",
+            display_name=display_name,
+            password=TEST_PASSWORD,
+        )
+
+    def create_bot(entity_name: str, *_args: object, **_kwargs: object) -> MagicMock:
+        created_bots.append(entity_name)
+        return MagicMock()
+
+    with (
+        patch("mindroom.orchestrator.load_config", return_value=config),
+        patch("mindroom.orchestrator.load_plugins", return_value=[]),
+        patch("mindroom.orchestrator.create_agent_user", new=create_user),
+        patch.object(orchestrator, "_preflight_account_provisioning", new=preflight),
+        patch.object(orchestrator, "_prepare_user_account", new=AsyncMock()),
+        patch.object(orchestrator, "_sync_mcp_manager", new=AsyncMock(return_value=set())),
+        patch.object(orchestrator, "_sync_event_cache_service", new=AsyncMock()),
+        patch("mindroom.orchestrator.create_bot_for_entity", side_effect=create_bot),
+    ):
+        await orchestrator.initialize()
+
+    assert created_bots == [ROUTER_AGENT_NAME, "general"]
+    assert set(orchestrator.config.agents) == {"general"}
+    assert orchestrator._account_preparation_failed_entities == {"mind_flash"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_config_reload.py
+++ b/tests/test_config_reload.py
@@ -157,8 +157,10 @@ async def _noop_prepare_entity_accounts(
     self: _MultiAgentOrchestrator,
     config: Config,
     entity_names: Iterable[str],
+    *,
+    allow_partial: bool = False,
 ) -> dict[str, AgentMatrixUser]:
-    del self
+    del self, allow_partial
     return {
         entity_name: AgentMatrixUser(
             agent_name=entity_name,
@@ -1038,6 +1040,70 @@ async def test_initialize_keeps_config_unpublished_when_entity_account_preparati
         await orchestrator.initialize()
 
     assert orchestrator.config is None
+
+
+@pytest.mark.asyncio
+async def test_initialize_disables_non_router_entity_when_account_provisioning_fails(tmp_path: Path) -> None:
+    """A new optional account that cannot be provisioned must not prevent existing bots from starting."""
+    config = _runtime_bound_config(
+        Config(
+            agents={
+                "general": {"display_name": "GeneralAgent", "model": "default"},
+                "mind_flash": {"display_name": "MindFlash", "model": "default"},
+            },
+            teams={
+                "flash_team": {
+                    "display_name": "FlashTeam",
+                    "role": "Uses the flash twin",
+                    "agents": ["general", "mind_flash"],
+                    "model": "default",
+                },
+            },
+            models={"default": {"provider": "test", "id": "test-model"}},
+        ),
+        tmp_path,
+    )
+    orchestrator = _MultiAgentOrchestrator(runtime_paths_for(config))
+    created_bots: list[str] = []
+
+    async def create_user(
+        _homeserver: str,
+        entity_name: str,
+        display_name: str,
+        *,
+        runtime_paths: object,
+        username: str | None = None,
+    ) -> AgentMatrixUser:
+        del runtime_paths, username
+        if entity_name == "mind_flash":
+            msg = "provisioning rejected"
+            raise PermanentStartupError(msg)
+        return AgentMatrixUser(
+            agent_name=entity_name,
+            user_id=f"@actual_{entity_name}:localhost",
+            display_name=display_name,
+            password=TEST_PASSWORD,
+        )
+
+    def create_bot(entity_name: str, *_args: object, **_kwargs: object) -> MagicMock:
+        created_bots.append(entity_name)
+        return MagicMock()
+
+    with (
+        patch("mindroom.orchestrator.load_config", return_value=config),
+        patch("mindroom.orchestrator.load_plugins", return_value=[]),
+        patch("mindroom.orchestrator.create_agent_user", new=create_user),
+        patch.object(orchestrator, "_prepare_user_account", new=AsyncMock()),
+        patch.object(orchestrator, "_sync_mcp_manager", new=AsyncMock(return_value=set())),
+        patch.object(orchestrator, "_sync_event_cache_service", new=AsyncMock()),
+        patch("mindroom.orchestrator.create_bot_for_entity", side_effect=create_bot),
+    ):
+        await orchestrator.initialize()
+
+    assert created_bots == [ROUTER_AGENT_NAME, "general"]
+    assert set(orchestrator.config.agents) == {"general"}
+    assert orchestrator.config.teams == {}
+    assert orchestrator._account_preparation_failed_entities == {"mind_flash", "flash_team"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Cherry-picks `016ca881a9ebe385f5d78b36cc092dbe494ee407` from `gitea/main` onto `origin/main`.

Skipped `6ee8e68fe` per request. Existing open PRs already cover `08cf97152` (#1004), `3b2fd0caa` (#1009), and `44fdca303` (#1114).

## Summary by Sourcery

Allow orchestrator to start in degraded mode by disabling entities whose Matrix account setup fails during initialization or config reload.

Bug Fixes:
- Prevent optional non-router entities with permanently failing account provisioning from blocking orchestrator startup.
- Ensure degraded-startup logging correctly reports operational and total agent counts when some entities are disabled before bot creation.

Enhancements:
- Filter runtime configuration to remove agents, teams, cultures, and reply permissions referencing entities whose account setup failed, keeping remaining entities operational.
- Track entities whose account provisioning failed and include them in degraded-mode status reporting.

Tests:
- Add a regression test verifying that an entity with permanently failing account provisioning is disabled, its dependent team is removed, and remaining bots still start successfully on initialize.