### PR TITLE
Accept shell command strings

### DIFF
--- a/docs/tools/execution-and-coding.md
+++ b/docs/tools/execution-and-coding.md
@@ -138,12 +138,14 @@ save_file("temporary notes\n", "scratch/notes.txt")
 
 ## [`shell`]
 
-`shell` runs argv-style commands and is MindRoom's most configurable execution tool for sandboxed command-line work.
+`shell` runs command strings or argv-style commands and is MindRoom's most configurable execution tool for sandboxed command-line work.
 
 ### What It Does
 
 `shell` exposes `run_shell_command()`, `check_shell_command()`, and `kill_shell_command()`.
-`run_shell_command()` expects a list of arguments, not a shell-parsed string.
+`run_shell_command()` accepts either a natural shell command string or a list of argv strings.
+Plain command strings and single-item argv lists that look shell-like run through `bash -lc`.
+Explicit multi-item argv lists run directly without shell parsing.
 If the command exits within `timeout`, the tool returns the last `tail` lines of stdout, or stderr on non-zero exit.
 Shell output is also capped to the most recent 51200 bytes, with a truncation notice when older output is dropped.
 If the timeout is exceeded, the process keeps running in the background and the tool returns a `shell:...` handle.
@@ -179,6 +181,7 @@ agents:
 ```
 
 ```python
+run_shell_command("git status --short", tail=50)
 run_shell_command(["git", "status", "--short"], tail=50)
 run_shell_command(["bash", "-lc", "sleep 300 && echo done"], timeout=2)
 check_shell_command("shell:abcd1234")
@@ -189,6 +192,7 @@ kill_shell_command("shell:abcd1234")
 
 - `extra_env_passthrough` only affects sandboxed `shell` calls and matches exported process env, not config-adjacent `.env` entries.
   MindRoom forwards no committed runtime `.env` values by default; matched values pass through except credential seed declarations, Kubernetes worker backend config env names, runner control names including `MINDROOM_CREDENTIALS_ENCRYPTION_KEY`, and names starting with `MINDROOM_SANDBOX_`.
+- Use explicit argv lists for commands that need exact argument boundaries.
 - In authored YAML, `extra_env_passthrough` and `shell_path_prepend` can be written as lists, and MindRoom normalizes them to the tool's comma-or-newline form.
 - Background handles survive multiple requests to the same long-lived runner process, but they do not survive runner restarts.
 - `shell_path_prepend` deduplicates PATH entries and only changes subprocess PATH, not the main MindRoom process PATH.

--- a/src/mindroom/tools/shell.py
+++ b/src/mindroom/tools/shell.py
@@ -15,10 +15,9 @@ import uuid
 from collections import deque
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Annotated, cast
+from typing import cast
 
 from agno.tools.toolkit import Toolkit
-from pydantic import BeforeValidator
 
 from mindroom.constants import (
     WORKSPACE_HOME_CONTRACT_ENV_NAMES,
@@ -114,6 +113,8 @@ def _normalize_shell_args(args: object) -> list[str]:
         try:
             args = json.loads(args)
         except json.JSONDecodeError as exc:
+            if any(char.isspace() for char in stripped):
+                return _normalize_shell_command_line(args)
             raise ValueError(_SHELL_ARGS_ERROR) from exc
 
     if not isinstance(args, list):
@@ -442,7 +443,7 @@ def shell_tools() -> type[Toolkit]:  # noqa: C901
 
         async def run_shell_command(
             self,
-            args: Annotated[list[str] | str, BeforeValidator(_normalize_shell_args)],
+            args: list[str] | str,
             tail: int = 100,
             timeout: int = 120,  # noqa: ASYNC109
         ) -> str:
@@ -464,9 +465,9 @@ def shell_tools() -> type[Toolkit]:  # noqa: C901
 
             """
             self._sweep_stale_records()
-            command_args = _normalize_shell_args(args)
 
             try:
+                command_args = _normalize_shell_args(args)
                 subprocess_env = _shell_subprocess_env(
                     self._runtime_env,
                     base_process_env=self._base_process_env,

--- a/src/mindroom/tools/shell.py
+++ b/src/mindroom/tools/shell.py
@@ -77,7 +77,10 @@ _MAX_OUTPUT_BYTES = 50 * 1024
 _STREAM_READ_CHUNK_BYTES = 8192
 _PROCESS_EXIT_POLL_INTERVAL_SECONDS = 0.05
 _POST_EXIT_READER_GRACE_SECONDS = 0.5
-_SHELL_ARGS_ERROR = '\'args\' must be a flat list of strings. Send args like ["bash", "-lc", "ls"].'
+_SHELL_ARGS_ERROR = (
+    '\'args\' must be a shell command string or a flat list of strings. Send args like "ls -la" or ["git", "status"].'
+)
+_SHELL_COMMAND_LINE_CHARS = frozenset("$|&;<>*?~`!(){}[]\n\r")
 
 # Module-level process registry shared across all MindRoomShellTools instances.
 # This ensures handles survive toolkit re-creation (e.g. in sandbox runner mode
@@ -85,9 +88,29 @@ _SHELL_ARGS_ERROR = '\'args\' must be a flat list of strings. Send args like ["b
 _process_registry: dict[str, _ProcessRecord] = {}
 
 
+def _normalize_shell_command_line(command: str) -> list[str]:
+    """Run natural shell command strings through bash."""
+    stripped = command.strip()
+    if not stripped:
+        raise ValueError(_SHELL_ARGS_ERROR)
+    return ["bash", "-lc", command]
+
+
+def _looks_like_shell_command_line(command: str) -> bool:
+    """Return whether a single argv item is probably a shell command line."""
+    if any(char.isspace() for char in command):
+        return True
+    return any(char in _SHELL_COMMAND_LINE_CHARS for char in command)
+
+
 def _normalize_shell_args(args: object) -> list[str]:
-    """Normalize stringified shell args while keeping the public schema as list[str]."""
+    """Normalize natural shell command strings and explicit argv lists."""
     if isinstance(args, str):
+        stripped = args.strip()
+        if not stripped:
+            raise ValueError(_SHELL_ARGS_ERROR)
+        if stripped[0] not in "[{":
+            return _normalize_shell_command_line(args)
         try:
             args = json.loads(args)
         except json.JSONDecodeError as exc:
@@ -99,7 +122,10 @@ def _normalize_shell_args(args: object) -> list[str]:
     if any(not isinstance(item, str) for item in args):
         raise ValueError(_SHELL_ARGS_ERROR)
 
-    return cast("list[str]", args)
+    normalized_args = cast("list[str]", args)
+    if len(normalized_args) == 1 and _looks_like_shell_command_line(normalized_args[0]):
+        return _normalize_shell_command_line(normalized_args[0])
+    return normalized_args
 
 
 def _shell_path_prepend_entries(shell_path_prepend: str | None) -> tuple[str, ...]:
@@ -416,7 +442,7 @@ def shell_tools() -> type[Toolkit]:  # noqa: C901
 
         async def run_shell_command(
             self,
-            args: Annotated[list[str], BeforeValidator(_normalize_shell_args)],
+            args: Annotated[list[str] | str, BeforeValidator(_normalize_shell_args)],
             tail: int = 100,
             timeout: int = 120,  # noqa: ASYNC109
         ) -> str:
@@ -429,7 +455,7 @@ def shell_tools() -> type[Toolkit]:  # noqa: C901
             ``check_shell_command`` or stopped with ``kill_shell_command``.
 
             Args:
-                args: The command to run as a list of strings.
+                args: The command to run as a shell command string or a list of argv strings.
                 tail: The number of lines to return from the output.
                 timeout: Maximum seconds to wait before backgrounding the command.
 
@@ -438,6 +464,7 @@ def shell_tools() -> type[Toolkit]:  # noqa: C901
 
             """
             self._sweep_stale_records()
+            command_args = _normalize_shell_args(args)
 
             try:
                 subprocess_env = _shell_subprocess_env(
@@ -446,7 +473,7 @@ def shell_tools() -> type[Toolkit]:  # noqa: C901
                     shell_path_prepend=self._shell_path_prepend,
                 )
                 process = await asyncio.create_subprocess_exec(
-                    *_shell_subprocess_args(args, subprocess_env),
+                    *_shell_subprocess_args(command_args, subprocess_env),
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                     cwd=str(self.base_dir) if self.base_dir else None,
@@ -482,7 +509,7 @@ def shell_tools() -> type[Toolkit]:  # noqa: C901
                         namespace=self._handle_namespace,
                         handle=handle,
                         pid=process.pid,
-                        args=args,
+                        args=command_args,
                         process=process,
                         stdout_buf=stdout_buf,
                         stderr_buf=stderr_buf,

--- a/tests/test_shell_async.py
+++ b/tests/test_shell_async.py
@@ -143,14 +143,38 @@ async def test_run_shell_command_bash_echo_returns_output(tmp_path: Path) -> Non
     assert result == "hello"
 
 
-def test_run_shell_command_schema_keeps_args_as_string_array(tmp_path: Path) -> None:
-    """The tool schema should expose args as array<string>, not anyOf."""
+@pytest.mark.asyncio
+async def test_run_shell_command_accepts_shell_command_string(tmp_path: Path) -> None:
+    """Natural shell command strings should execute through bash."""
+    tool = _get_toolkit(tmp_path)
+    entrypoint = tool.async_functions["run_shell_command"].entrypoint
+    assert entrypoint is not None
+
+    result = await entrypoint("echo $HOME")
+    assert result
+    assert not result.startswith("Error:")
+
+
+@pytest.mark.asyncio
+async def test_run_shell_command_accepts_single_item_shell_command_line(tmp_path: Path) -> None:
+    """LLMs often send one shell command line inside the argv array."""
+    tool = _get_toolkit(tmp_path)
+    entrypoint = tool.async_functions["run_shell_command"].entrypoint
+    assert entrypoint is not None
+
+    result = await entrypoint(["printf '%s' ok"])
+    assert result == "ok"
+
+
+def test_run_shell_command_schema_accepts_string_or_string_array(tmp_path: Path) -> None:
+    """The tool schema should expose both natural command strings and argv lists."""
     tool = _get_toolkit(tmp_path)
     args_schema = _get_run_shell_command_function(tool).parameters["properties"]["args"]
 
-    assert args_schema["type"] == "array"
-    assert args_schema["items"] == {"type": "string"}
-    assert "anyOf" not in args_schema
+    assert args_schema["anyOf"] == [
+        {"type": "array", "items": {"type": "string"}},
+        {"type": "string"},
+    ]
 
 
 @pytest.mark.asyncio
@@ -182,7 +206,6 @@ async def test_run_shell_command_parses_single_item_json_args(tmp_path: Path) ->
     [
         '["echo",',
         '{"cmd": "ls"}',
-        '"echo"',
         "",
         '["echo", 42]',
         '["bash", ["-c", "ls"]]',
@@ -196,7 +219,7 @@ async def test_run_shell_command_rejects_invalid_stringified_args(tmp_path: Path
 
     assert result.status == "failure"
     assert result.error is not None
-    assert "'args' must be a flat list of strings" in result.error
+    assert "'args' must be a shell command string or a flat list of strings" in result.error
 
 
 @pytest.mark.asyncio

--- a/tests/test_shell_async.py
+++ b/tests/test_shell_async.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
-from agno.tools.function import Function, FunctionCall, FunctionExecutionResult
+from agno.tools.function import Function
 
 from mindroom.constants import RuntimePaths, resolve_runtime_paths, workspace_home_identity_env
 from mindroom.tool_system.metadata import get_tool_by_name
@@ -112,10 +112,6 @@ def _get_run_shell_command_function(tool: Toolkit) -> Function:
     return tool.async_functions["run_shell_command"]
 
 
-async def _aexecute_run_shell_command(tool: Toolkit, args: object) -> FunctionExecutionResult:
-    return await FunctionCall(function=_get_run_shell_command_function(tool), arguments={"args": args}).aexecute()
-
-
 # ---------------------------------------------------------------------------
 # run_shell_command
 # ---------------------------------------------------------------------------
@@ -153,6 +149,26 @@ async def test_run_shell_command_accepts_shell_command_string(tmp_path: Path) ->
     result = await entrypoint("echo $HOME")
     assert result
     assert not result.startswith("Error:")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        ("[ 1 -eq 1 ] && echo ok", "ok"),
+        ("{ echo ok; }", "ok"),
+    ],
+)
+async def test_run_shell_command_accepts_bracketed_shell_command_strings(
+    tmp_path: Path, command: str, expected: str
+) -> None:
+    """Shell grammar that starts with JSON-like characters should still execute through bash."""
+    tool = _get_toolkit(tmp_path)
+    entrypoint = tool.async_functions["run_shell_command"].entrypoint
+    assert entrypoint is not None
+
+    result = await entrypoint(command)
+    assert result == expected
 
 
 @pytest.mark.asyncio
@@ -215,11 +231,12 @@ async def test_run_shell_command_parses_single_item_json_args(tmp_path: Path) ->
 async def test_run_shell_command_rejects_invalid_stringified_args(tmp_path: Path, args: str) -> None:
     """Malformed or non-flat stringified args should fail validation."""
     tool = _get_toolkit(tmp_path)
-    result = await _aexecute_run_shell_command(tool, args)
+    entrypoint = tool.async_functions["run_shell_command"].entrypoint
+    assert entrypoint is not None
 
-    assert result.status == "failure"
-    assert result.error is not None
-    assert "'args' must be a shell command string or a flat list of strings" in result.error
+    result = await entrypoint(args)
+    assert result.startswith("Error:")
+    assert "'args' must be a shell command string or a flat list of strings" in result
 
 
 @pytest.mark.asyncio
@@ -231,6 +248,19 @@ async def test_run_shell_command_empty_json_list_uses_existing_empty_behavior(tm
 
     result = await entrypoint("[]")
     assert result.startswith("Error:")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("args", ["", "   "])
+async def test_run_shell_command_entrypoint_returns_error_for_empty_string_args(tmp_path: Path, args: str) -> None:
+    """Direct entrypoint calls should return validation errors instead of raising."""
+    tool = _get_toolkit(tmp_path)
+    entrypoint = tool.async_functions["run_shell_command"].entrypoint
+    assert entrypoint is not None
+
+    result = await entrypoint(args)
+    assert result.startswith("Error:")
+    assert "'args' must be a shell command string or a flat list of strings" in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Cherry-picks `eb1a06da0cbf3864a7fbe36a36ec2f3a922a2683` from `gitea/main` onto `origin/main`.

Skipped `6ee8e68fe` per request. Existing open PRs already cover `08cf97152` (#1004), `3b2fd0caa` (#1009), and `44fdca303` (#1114).

## Summary by Sourcery

Allow the async shell tool to accept natural shell command strings in addition to argv-style argument lists.

New Features:
- Support passing shell commands as raw strings or single-item argv arrays that are executed via bash.

Enhancements:
- Improve shell argument normalization with heuristics to detect command-line-style inputs and route them through bash.
- Update shell tool argument validation error messaging to reflect support for both command strings and argv lists.

Tests:
- Add async tests verifying execution of raw shell command strings and single-item command-line arrays.
- Update schema tests to ensure the shell tool exposes args as either a string or an array of strings.