### PR TITLE
Preserve accepted invited rooms

### DIFF
--- a/src/mindroom/bot_room_lifecycle.py
+++ b/src/mindroom/bot_room_lifecycle.py
@@ -182,17 +182,7 @@ class BotRoomLifecycle:
             if root_space_id is not None:
                 configured_rooms.add(root_space_id)
 
-        rooms_to_leave = current_rooms - configured_rooms
-        if self.should_persist_invited_rooms() and rooms_to_leave:
-            self.invited_rooms.update(rooms_to_leave)
-            self.save_invited_rooms()
-            self._logger().info(
-                "backfilled_joined_invited_rooms",
-                room_count=len(rooms_to_leave),
-            )
-            return []
-
-        return list(rooms_to_leave)
+        return list(current_rooms - configured_rooms)
 
     async def send_welcome_message_if_empty(self, room_id: str, visible_to_sender_id: str | None = None) -> None:
         """Send the router welcome message only when the room has no other history."""

--- a/src/mindroom/bot_room_lifecycle.py
+++ b/src/mindroom/bot_room_lifecycle.py
@@ -182,7 +182,17 @@ class BotRoomLifecycle:
             if root_space_id is not None:
                 configured_rooms.add(root_space_id)
 
-        return list(current_rooms - configured_rooms)
+        rooms_to_leave = current_rooms - configured_rooms
+        if self.should_persist_invited_rooms() and rooms_to_leave:
+            self.invited_rooms.update(rooms_to_leave)
+            self.save_invited_rooms()
+            self._logger().info(
+                "backfilled_joined_invited_rooms",
+                room_count=len(rooms_to_leave),
+            )
+            return []
+
+        return list(rooms_to_leave)
 
     async def send_welcome_message_if_empty(self, room_id: str, visible_to_sender_id: str | None = None) -> None:
         """Send the router welcome message only when the room has no other history."""

--- a/tests/test_room_invites.py
+++ b/tests/test_room_invites.py
@@ -7,6 +7,7 @@ memberships. This test module verifies that behavior.
 from __future__ import annotations
 
 import asyncio
+import json
 from pathlib import Path  # noqa: TC003
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
@@ -636,11 +637,11 @@ async def test_router_ignores_invite_when_accept_invites_disabled(
 
 
 @pytest.mark.asyncio
-async def test_router_leave_unconfigured_rooms_backfills_joined_invited_rooms(
+async def test_router_leave_unconfigured_rooms_preserves_persisted_invited_rooms(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Router cleanup should preserve and backfill accepted invited rooms."""
+    """Router cleanup should preserve persisted invited rooms and leave unrelated rooms."""
     config = bind_runtime_paths(
         Config(router=RouterConfig(model="default", accept_invites=True)),
         test_runtime_paths(tmp_path),
@@ -680,14 +681,9 @@ async def test_router_leave_unconfigured_rooms_backfills_joined_invited_rooms(
 
     await bot.leave_unconfigured_rooms()
 
-    assert bot._room_lifecycle.invited_rooms == {
-        "!old-room:localhost",
-        "!router-invited:localhost",
-    }
-    assert invited_rooms_path.read_text(encoding="utf-8") == (
-        '[\n  "!old-room:localhost",\n  "!router-invited:localhost"\n]\n'
-    )
-    assert left_room_ids == []
+    assert bot._room_lifecycle.invited_rooms == {"!router-invited:localhost"}
+    assert json.loads(invited_rooms_path.read_text(encoding="utf-8")) == ["!router-invited:localhost"]
+    assert left_room_ids == ["!old-room:localhost"]
 
 
 @pytest.mark.asyncio
@@ -818,8 +814,8 @@ async def test_router_preserves_root_space_when_leaving_unconfigured_rooms(
 
     await bot.leave_unconfigured_rooms()
 
-    assert left_room_ids == []
-    assert bot._room_lifecycle.invited_rooms == {"!room2:localhost"}
+    assert left_room_ids == ["!room2:localhost"]
+    assert bot._room_lifecycle.invited_rooms == set()
     assert "!space:localhost" not in left_room_ids
 
 
@@ -1145,11 +1141,11 @@ async def test_agent_invite_does_not_auto_add_router_to_ad_hoc_room(
 
 
 @pytest.mark.asyncio
-async def test_leave_unconfigured_rooms_backfills_joined_invited_rooms(
+async def test_leave_unconfigured_rooms_preserves_persisted_invited_rooms(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Cleanup should preserve and backfill accepted invited non-DM rooms."""
+    """Cleanup should preserve persisted invited non-DM rooms and leave unrelated rooms."""
     agent_user = AgentMatrixUser(
         agent_name="agent1",
         user_id="@mindroom_agent1:localhost",
@@ -1200,14 +1196,9 @@ async def test_leave_unconfigured_rooms_backfills_joined_invited_rooms(
 
     await bot.leave_unconfigured_rooms()
 
-    assert bot._room_lifecycle.invited_rooms == {
-        "!invited-room:localhost",
-        "!old-room:localhost",
-    }
-    assert invited_rooms_path.read_text(encoding="utf-8") == (
-        '[\n  "!invited-room:localhost",\n  "!old-room:localhost"\n]\n'
-    )
-    assert left_room_ids == []
+    assert bot._room_lifecycle.invited_rooms == {"!invited-room:localhost"}
+    assert json.loads(invited_rooms_path.read_text(encoding="utf-8")) == ["!invited-room:localhost"]
+    assert left_room_ids == ["!old-room:localhost"]
 
 
 def test_load_invited_rooms_returns_empty_set_for_invalid_utf8(tmp_path: Path) -> None:

--- a/tests/test_room_invites.py
+++ b/tests/test_room_invites.py
@@ -636,11 +636,11 @@ async def test_router_ignores_invite_when_accept_invites_disabled(
 
 
 @pytest.mark.asyncio
-async def test_router_leave_unconfigured_rooms_preserves_persisted_invited_room(
+async def test_router_leave_unconfigured_rooms_backfills_joined_invited_rooms(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Router cleanup should preserve a previously accepted invited room."""
+    """Router cleanup should preserve and backfill accepted invited rooms."""
     config = bind_runtime_paths(
         Config(router=RouterConfig(model="default", accept_invites=True)),
         test_runtime_paths(tmp_path),
@@ -680,8 +680,14 @@ async def test_router_leave_unconfigured_rooms_preserves_persisted_invited_room(
 
     await bot.leave_unconfigured_rooms()
 
-    assert bot._room_lifecycle.invited_rooms == {"!router-invited:localhost"}
-    assert left_room_ids == ["!old-room:localhost"]
+    assert bot._room_lifecycle.invited_rooms == {
+        "!old-room:localhost",
+        "!router-invited:localhost",
+    }
+    assert invited_rooms_path.read_text(encoding="utf-8") == (
+        '[\n  "!old-room:localhost",\n  "!router-invited:localhost"\n]\n'
+    )
+    assert left_room_ids == []
 
 
 @pytest.mark.asyncio
@@ -812,7 +818,8 @@ async def test_router_preserves_root_space_when_leaving_unconfigured_rooms(
 
     await bot.leave_unconfigured_rooms()
 
-    assert set(left_room_ids) == {"!room2:localhost"}
+    assert left_room_ids == []
+    assert bot._room_lifecycle.invited_rooms == {"!room2:localhost"}
     assert "!space:localhost" not in left_room_ids
 
 
@@ -1138,11 +1145,11 @@ async def test_agent_invite_does_not_auto_add_router_to_ad_hoc_room(
 
 
 @pytest.mark.asyncio
-async def test_leave_unconfigured_rooms_preserves_persisted_invited_room(
+async def test_leave_unconfigured_rooms_backfills_joined_invited_rooms(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Cleanup should preserve one previously invited non-DM room."""
+    """Cleanup should preserve and backfill accepted invited non-DM rooms."""
     agent_user = AgentMatrixUser(
         agent_name="agent1",
         user_id="@mindroom_agent1:localhost",
@@ -1193,8 +1200,14 @@ async def test_leave_unconfigured_rooms_preserves_persisted_invited_room(
 
     await bot.leave_unconfigured_rooms()
 
-    assert bot._room_lifecycle.invited_rooms == {"!invited-room:localhost"}
-    assert left_room_ids == ["!old-room:localhost"]
+    assert bot._room_lifecycle.invited_rooms == {
+        "!invited-room:localhost",
+        "!old-room:localhost",
+    }
+    assert invited_rooms_path.read_text(encoding="utf-8") == (
+        '[\n  "!invited-room:localhost",\n  "!old-room:localhost"\n]\n'
+    )
+    assert left_room_ids == []
 
 
 def test_load_invited_rooms_returns_empty_set_for_invalid_utf8(tmp_path: Path) -> None:


### PR DESCRIPTION
Cherry-picks `19488a3babbb4dc670eacac0ffe09c5a43ffe3c7` from `gitea/main` onto `origin/main`.

Skipped `6ee8e68fe` per request. Existing open PRs already cover `08cf97152` (#1004), `3b2fd0caa` (#1009), and `44fdca303` (#1114).

## Summary by Sourcery

Preserve and backfill accepted invited rooms during router cleanup instead of leaving them.

Enhancements:
- Persist newly detected unconfigured rooms as invited rooms when invite persistence is enabled, and skip leaving them in that case.

Tests:
- Update router and agent invite cleanup tests to assert that accepted invited rooms are backfilled, persisted on disk, and not left during cleanup.