### PR TITLE
Add room-specific thread summary models

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ defaults:
 Add the `thread_summary` tool to an agent when you want it to write or refresh the one-line summary shown for a Matrix thread.
 `set_thread_summary` uses the current resolved thread context by default.
 Outside a resolved thread context, pass `thread_id` explicitly.
+Use `room_thread_summary_models` when automatic summaries in a specific room should use a different model from `defaults.thread_summary_model`.
 
 `compress_tool_results` now defaults to `false`.
 On Anthropic and Vertex Claude models, enabling it can mutate replayed tool messages and invalidate prompt-cache prefixes.

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -312,6 +312,8 @@ defaults:
 MindRoom uses `defaults.thread_summary_temperature` for automatic thread summaries on providers that support runtime temperature overrides.
 Set it to `null` to omit the field and use provider defaults.
 MindRoom always omits temperature for Vertex Claude thread summaries because the provider rejects that field on this path.
+Use `room_thread_summary_models` when automatic summaries in a specific room should use a different model from `defaults.thread_summary_model`.
+Keys can be managed room aliases such as `lobby` or raw Matrix room IDs such as `!room:example.org`.
 
 `defaults.worker_grantable_credentials` is a list of credential service names.
 Use built-in names like `openai`, `azure`, `anthropic`, `google`, `openrouter`, `deepseek`, `cerebras`, `groq`, `ollama`, and `github_private`, or custom shared credential service names you saved through the dashboard or API.
@@ -451,6 +453,11 @@ rooms:
 # Keys are room aliases, values are model names from the models section.
 # Example: room_models: {dev: sonnet, lobby: gpt4o}
 room_models: {}
+
+# Room-specific automatic thread summary model overrides (optional)
+# Keys are room aliases or raw Matrix room IDs, values are model names from the models section.
+# Example: room_thread_summary_models: {lobby: haiku}
+room_thread_summary_models: {}
 
 # Non-MindRoom bot accounts to exclude from multi-human detection (optional)
 # These accounts won't trigger the mention requirement in threads

--- a/docs/tools/matrix-and-attachments.md
+++ b/docs/tools/matrix-and-attachments.md
@@ -273,6 +273,7 @@ matrix_message(action="reply", message="Sharing the plan here.", attachment_ids=
 
 Automatic thread summaries are still implemented in `src/mindroom/thread_summary.py` as bot runtime behavior.
 The summarizer posts one `m.notice` summary after a thread reaches the configured first threshold (one message by default), and then again every ten additional messages by default, using `defaults.thread_summary_model` or `default`.
+Set `room_thread_summary_models` to override the automatic summary model for a managed room alias or raw Matrix room ID.
 MindRoom uses `defaults.thread_summary_temperature` for automatic summaries when the provider supports runtime temperature overrides, and always omits temperature for Vertex Claude summaries.
 The `thread_summary` tool complements that automatic behavior by letting an agent publish a manual summary immediately and advance the stored summary baseline.
 

--- a/src/mindroom/config/main.py
+++ b/src/mindroom/config/main.py
@@ -118,6 +118,7 @@ _OPTIONAL_DICT_SECTION_NAMES = (
     "cultures",
     "rooms",
     "room_models",
+    "room_thread_summary_models",
     "toolkits",
     "knowledge_bases",
     "mcp_servers",
@@ -341,6 +342,10 @@ class Config(BaseModel):
     cultures: dict[str, CultureConfig] = Field(default_factory=dict, description="Culture configurations")
     rooms: dict[str, RoomConfig] = Field(default_factory=dict, description="Managed Matrix room metadata")
     room_models: dict[str, str] = Field(default_factory=dict, description="Room-specific model overrides")
+    room_thread_summary_models: dict[str, str] = Field(
+        default_factory=dict,
+        description="Room-specific model overrides for automatic thread summaries",
+    )
     toolkits: dict[str, ToolkitDefinition] = Field(
         default_factory=dict,
         description="Dynamically loadable tool bundles keyed by public toolkit name",

--- a/src/mindroom/entity_resolution.py
+++ b/src/mindroom/entity_resolution.py
@@ -15,7 +15,7 @@ from mindroom.matrix_identifiers import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Mapping
 
     from mindroom.config.agent import AgentConfig, TeamConfig
     from mindroom.config.main import Config
@@ -366,8 +366,22 @@ def effective_entity_model_name(
     """Return the effective model for one entity in one room context."""
     if entity_name not in config.agents and entity_name not in config.teams and entity_name != ROUTER_AGENT_NAME:
         return "default"
-    if room_id is not None:
-        room_alias = matrix_state.get_room_alias_from_id(room_id, runtime_paths)
-        if room_alias and room_alias in config.room_models:
-            return config.room_models[room_alias]
+    if room_override := resolve_room_scoped_model_override(config.room_models, room_id, runtime_paths):
+        return room_override
     return config.get_entity_model_name(entity_name)
+
+
+def resolve_room_scoped_model_override(
+    overrides: Mapping[str, str],
+    room_id: str | None,
+    runtime_paths: RuntimePaths,
+) -> str | None:
+    """Return a model override keyed by raw room ID or persisted room key."""
+    if room_id is None:
+        return None
+    if room_id in overrides:
+        return overrides[room_id]
+    room_alias = matrix_state.get_room_alias_from_id(room_id, runtime_paths)
+    if room_alias and room_alias in overrides:
+        return overrides[room_alias]
+    return None

--- a/src/mindroom/entity_resolution.py
+++ b/src/mindroom/entity_resolution.py
@@ -375,13 +375,18 @@ def resolve_room_scoped_model_override(
     overrides: Mapping[str, str],
     room_id: str | None,
     runtime_paths: RuntimePaths,
+    *,
+    allow_raw_room_id: bool = False,
 ) -> str | None:
-    """Return a model override keyed by raw room ID or persisted room key."""
-    if room_id is None:
+    """Return a model override keyed by persisted room key or alias."""
+    if room_id is None or not overrides:
         return None
-    if room_id in overrides:
+    if allow_raw_room_id and room_id in overrides:
         return overrides[room_id]
     room_alias = matrix_state.get_room_alias_from_id(room_id, runtime_paths)
     if room_alias and room_alias in overrides:
         return overrides[room_alias]
+    for room in matrix_state.matrix_state_for_runtime(runtime_paths).rooms.values():
+        if room.room_id == room_id and room.alias in overrides:
+            return overrides[room.alias]
     return None

--- a/src/mindroom/thread_summary.py
+++ b/src/mindroom/thread_summary.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel, Field
 
 from mindroom import model_loading
 from mindroom.ai_runtime import cached_agent_run
+from mindroom.entity_resolution import resolve_room_scoped_model_override
 from mindroom.logging_config import get_logger
 from mindroom.matrix.client_delivery import send_message_result
 from mindroom.matrix.message_builder import build_message_content
@@ -279,18 +280,31 @@ def _build_conversation_text(thread_history: Sequence[ResolvedVisibleMessage]) -
     return "\n".join(lines)
 
 
+def _resolve_thread_summary_model_name(
+    config: Config,
+    runtime_paths: RuntimePaths,
+    room_id: str | None,
+) -> str:
+    """Return the model name for automatic thread summaries in one room."""
+    if override := resolve_room_scoped_model_override(config.room_thread_summary_models, room_id, runtime_paths):
+        return override
+    return config.defaults.thread_summary_model or "default"
+
+
 async def _generate_summary(
     thread_history: Sequence[ResolvedVisibleMessage],
     config: Config,
     runtime_paths: RuntimePaths,
+    *,
+    model_name: str | None = None,
 ) -> str | None:
     """Generate a one-line summary of a thread conversation via LLM."""
-    model_name = config.defaults.thread_summary_model or "default"
-    model = model_loading.get_model_instance(config, runtime_paths, model_name)
+    resolved_model_name = model_name or config.defaults.thread_summary_model or "default"
+    model = model_loading.get_model_instance(config, runtime_paths, resolved_model_name)
     _configure_summary_model_temperature(
         model,
         summary_temperature=config.defaults.thread_summary_temperature,
-        model_name=model_name,
+        model_name=resolved_model_name,
     )
 
     conversation = _build_conversation_text(thread_history)
@@ -320,9 +334,11 @@ async def _timed_generate_summary(
     thread_history: Sequence[ResolvedVisibleMessage],
     config: Config,
     runtime_paths: RuntimePaths,
+    *,
+    model_name: str | None = None,
 ) -> str | None:
     """Run the summary generation attempt with timing instrumentation."""
-    return await _generate_summary(thread_history, config, runtime_paths)
+    return await _generate_summary(thread_history, config, runtime_paths, model_name=model_name)
 
 
 async def send_thread_summary_event(
@@ -489,8 +505,9 @@ async def maybe_generate_thread_summary(
             message_count = max(message_count, message_count_hint)
         if message_count < threshold:
             return
+        model_name = _resolve_thread_summary_model_name(config, runtime_paths, room_id)
         try:
-            summary = await _timed_generate_summary(thread_history, config, runtime_paths)
+            summary = await _timed_generate_summary(thread_history, config, runtime_paths, model_name=model_name)
         except Exception:
             logger.exception("Thread summary generation failed", room_id=room_id, thread_id=thread_id)
             # Record current count to prevent retry storms until next threshold
@@ -513,7 +530,6 @@ async def maybe_generate_thread_summary(
             update_last_summary_count(room_id, thread_id, message_count)
             return
 
-        model_name = config.defaults.thread_summary_model or "default"
         # Record count before sending — the LLM cost is already incurred, so don't
         # retry on Matrix send failure (avoids cost amplification loop).
         update_last_summary_count(room_id, thread_id, message_count)

--- a/src/mindroom/thread_summary.py
+++ b/src/mindroom/thread_summary.py
@@ -286,7 +286,12 @@ def _resolve_thread_summary_model_name(
     room_id: str | None,
 ) -> str:
     """Return the model name for automatic thread summaries in one room."""
-    if override := resolve_room_scoped_model_override(config.room_thread_summary_models, room_id, runtime_paths):
+    if override := resolve_room_scoped_model_override(
+        config.room_thread_summary_models,
+        room_id,
+        runtime_paths,
+        allow_raw_room_id=True,
+    ):
         return override
     return config.defaults.thread_summary_model or "default"
 
@@ -505,8 +510,8 @@ async def maybe_generate_thread_summary(
             message_count = max(message_count, message_count_hint)
         if message_count < threshold:
             return
-        model_name = _resolve_thread_summary_model_name(config, runtime_paths, room_id)
         try:
+            model_name = _resolve_thread_summary_model_name(config, runtime_paths, room_id)
             summary = await _timed_generate_summary(thread_history, config, runtime_paths, model_name=model_name)
         except Exception:
             logger.exception("Thread summary generation failed", room_id=room_id, thread_id=thread_id)

--- a/tach.toml
+++ b/tach.toml
@@ -2018,6 +2018,7 @@ depends_on = []
 path = "mindroom.thread_summary"
 depends_on = [
     "mindroom.ai_runtime",
+    "mindroom.entity_resolution",
     "mindroom.matrix.client_delivery",
     "mindroom.model_loading",
 ]

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -764,7 +764,7 @@ async def test_post_response_effects_queues_summary_with_stale_hint_inside_margi
         await asyncio.gather(*scheduled_tasks)
 
     mock_fetch.assert_awaited_once_with(conversation_cache, "!room:localhost", "$thread")
-    mock_generate.assert_awaited_once_with(thread_history, config, runtime_paths)
+    mock_generate.assert_awaited_once_with(thread_history, config, runtime_paths, model_name="default")
     mock_send.assert_awaited_once_with(
         client,
         "!room:localhost",

--- a/tests/test_thread_summary.py
+++ b/tests/test_thread_summary.py
@@ -16,6 +16,7 @@ from pydantic import ValidationError
 from mindroom.config.main import Config
 from mindroom.config.matrix import MatrixDeliveryConfig
 from mindroom.constants import RuntimePaths
+from mindroom.entity_resolution import resolve_room_scoped_model_override
 from mindroom.logging_config import setup_logging
 from mindroom.matrix.client import ResolvedVisibleMessage
 from mindroom.prompts import THREAD_SUMMARY_INSTRUCTIONS
@@ -357,6 +358,17 @@ def _mock_runtime_paths() -> MagicMock:
 class TestResolveThreadSummaryModelName:
     """Tests for room-specific automatic summary model selection."""
 
+    def test_empty_override_map_skips_room_state_lookup(self) -> None:
+        """Empty override maps should not touch persisted room state."""
+        config = _mock_config(model_name="haiku", room_thread_summary_models={})
+        rp = _mock_runtime_paths()
+
+        with patch("mindroom.entity_resolution.matrix_state.get_room_alias_from_id") as lookup:
+            result = _resolve_thread_summary_model_name(config, rp, "!dev:example")
+
+        assert result == "haiku"
+        lookup.assert_not_called()
+
     def test_uses_default_summary_model_without_room_override(self) -> None:
         """The global summary model remains the default when a room has no override."""
         config = _mock_config(model_name="haiku", room_thread_summary_models={"private": "qwen"})
@@ -377,6 +389,21 @@ class TestResolveThreadSummaryModelName:
 
         assert result == "qwen"
 
+    def test_uses_full_matrix_room_alias_override(self) -> None:
+        """Full Matrix aliases persisted in room state should resolve to overrides."""
+        config = _mock_config(model_name="haiku", room_thread_summary_models={"#private:example": "qwen"})
+        rp = _mock_runtime_paths()
+        room = MagicMock(room_id="!private:example", alias="#private:example")
+        state = MagicMock(rooms={"private": room})
+
+        with (
+            patch("mindroom.entity_resolution.matrix_state.get_room_alias_from_id", return_value=None),
+            patch("mindroom.entity_resolution.matrix_state.matrix_state_for_runtime", return_value=state),
+        ):
+            result = _resolve_thread_summary_model_name(config, rp, "!private:example")
+
+        assert result == "qwen"
+
     def test_uses_raw_room_id_override(self) -> None:
         """Unmanaged rooms can still be overridden by Matrix room ID."""
         config = _mock_config(model_name="haiku", room_thread_summary_models={"!external:example": "qwen"})
@@ -385,6 +412,18 @@ class TestResolveThreadSummaryModelName:
         result = _resolve_thread_summary_model_name(config, rp, "!external:example")
 
         assert result == "qwen"
+
+    def test_raw_room_id_override_requires_explicit_opt_in(self) -> None:
+        """Legacy room model overrides remain scoped to persisted room keys and aliases."""
+        rp = _mock_runtime_paths()
+
+        with (
+            patch("mindroom.entity_resolution.matrix_state.get_room_alias_from_id", return_value=None),
+            patch("mindroom.entity_resolution.matrix_state.matrix_state_for_runtime", return_value=MagicMock(rooms={})),
+        ):
+            result = resolve_room_scoped_model_override({"!external:example": "qwen"}, "!external:example", rp)
+
+        assert result is None
 
     def test_falls_back_to_default_model_without_global_summary_model(self) -> None:
         """The resolver should preserve the existing default-model fallback."""
@@ -606,6 +645,36 @@ class TestMaybeGenerateThreadSummary:
 
         mock_gen.assert_awaited_once()
         client.room_send.assert_awaited_once()
+        assert _last_summary_counts[_thread_summary_cache_key("!room:x", "$thread1")] == 5
+
+    async def test_model_resolution_failure_records_count(self) -> None:
+        """Room override lookup failures should not retry until the next threshold."""
+        client = _mock_client()
+        config = _mock_config(model_name="haiku", room_thread_summary_models={"private": "qwen"})
+        rp = _mock_runtime_paths()
+
+        with (
+            patch(
+                "mindroom.thread_summary._load_thread_history",
+                return_value=_make_thread_history(5),
+            ),
+            patch(
+                "mindroom.thread_summary._timed_generate_summary",
+                new=AsyncMock(return_value="Users discussed testing strategies"),
+            ) as mock_timed_gen,
+            patch(
+                "mindroom.thread_summary._recover_last_summary_count",
+                return_value=0,
+            ),
+            patch(
+                "mindroom.entity_resolution.matrix_state.get_room_alias_from_id",
+                side_effect=RuntimeError("state unavailable"),
+            ),
+        ):
+            await self._maybe_generate(client, config, rp)
+
+        mock_timed_gen.assert_not_awaited()
+        client.room_send.assert_not_awaited()
         assert _last_summary_counts[_thread_summary_cache_key("!room:x", "$thread1")] == 5
 
     async def test_room_specific_model_generates_and_records_metadata(self) -> None:

--- a/tests/test_thread_summary.py
+++ b/tests/test_thread_summary.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any
+from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import nio
@@ -31,6 +32,7 @@ from mindroom.thread_summary import (
     _next_thread_summary_threshold,
     _next_threshold,
     _recover_last_summary_count,
+    _resolve_thread_summary_model_name,
     _thread_locks,
     _thread_summary_cache_key,
     _ThreadSummary,
@@ -43,9 +45,6 @@ from mindroom.thread_summary import (
     update_last_summary_count,
 )
 from tests.conftest import make_matrix_client_mock
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 def _make_thread_history(count: int) -> list[ResolvedVisibleMessage]:
@@ -335,6 +334,7 @@ def _mock_config(
     first_threshold: int = 5,
     subsequent_interval: int = 10,
     summary_temperature: float | None = 0.2,
+    room_thread_summary_models: dict[str, str] | None = None,
 ) -> Config:
     return Config(
         defaults={
@@ -343,14 +343,57 @@ def _mock_config(
             "thread_summary_subsequent_interval": subsequent_interval,
             "thread_summary_temperature": summary_temperature,
         },
+        room_thread_summary_models=room_thread_summary_models or {},
         matrix_delivery=MatrixDeliveryConfig(),
     )
 
 
 def _mock_runtime_paths() -> MagicMock:
     rp = MagicMock()
-    rp.storage_root = "/var/empty/test_storage"
+    rp.storage_root = Path("/var/empty/test_storage")
     return rp
+
+
+class TestResolveThreadSummaryModelName:
+    """Tests for room-specific automatic summary model selection."""
+
+    def test_uses_default_summary_model_without_room_override(self) -> None:
+        """The global summary model remains the default when a room has no override."""
+        config = _mock_config(model_name="haiku", room_thread_summary_models={"private": "qwen"})
+        rp = _mock_runtime_paths()
+
+        with patch("mindroom.entity_resolution.matrix_state.get_room_alias_from_id", return_value="dev"):
+            result = _resolve_thread_summary_model_name(config, rp, "!dev:example")
+
+        assert result == "haiku"
+
+    def test_uses_room_specific_summary_model(self) -> None:
+        """A configured room summary model should override the global summary model."""
+        config = _mock_config(model_name="haiku", room_thread_summary_models={"private": "qwen"})
+        rp = _mock_runtime_paths()
+
+        with patch("mindroom.entity_resolution.matrix_state.get_room_alias_from_id", return_value="private"):
+            result = _resolve_thread_summary_model_name(config, rp, "!private:example")
+
+        assert result == "qwen"
+
+    def test_uses_raw_room_id_override(self) -> None:
+        """Unmanaged rooms can still be overridden by Matrix room ID."""
+        config = _mock_config(model_name="haiku", room_thread_summary_models={"!external:example": "qwen"})
+        rp = _mock_runtime_paths()
+
+        result = _resolve_thread_summary_model_name(config, rp, "!external:example")
+
+        assert result == "qwen"
+
+    def test_falls_back_to_default_model_without_global_summary_model(self) -> None:
+        """The resolver should preserve the existing default-model fallback."""
+        config = _mock_config(model_name=None)
+        rp = _mock_runtime_paths()
+
+        result = _resolve_thread_summary_model_name(config, rp, None)
+
+        assert result == "default"
 
 
 def _logging_runtime_paths(tmp_path: Path) -> RuntimePaths:
@@ -565,6 +608,40 @@ class TestMaybeGenerateThreadSummary:
         client.room_send.assert_awaited_once()
         assert _last_summary_counts[_thread_summary_cache_key("!room:x", "$thread1")] == 5
 
+    async def test_room_specific_model_generates_and_records_metadata(self) -> None:
+        """Room-specific summary model overrides should drive generation and event metadata."""
+        client = _mock_client()
+        client.room_send = AsyncMock(return_value=nio.RoomSendResponse(event_id="$summary1", room_id="!room:x"))
+        config = _mock_config(model_name="haiku", room_thread_summary_models={"private": "qwen"})
+        rp = _mock_runtime_paths()
+        thread_history = _make_thread_history(5)
+
+        with (
+            patch(
+                "mindroom.thread_summary._load_thread_history",
+                return_value=thread_history,
+            ),
+            patch(
+                "mindroom.thread_summary._generate_summary",
+                return_value="Users discussed testing strategies",
+            ) as mock_gen,
+            patch(
+                "mindroom.thread_summary._recover_last_summary_count",
+                return_value=0,
+            ),
+            patch("mindroom.entity_resolution.matrix_state.get_room_alias_from_id", return_value="private"),
+        ):
+            await self._maybe_generate(client, config, rp)
+
+        mock_gen.assert_awaited_once_with(
+            thread_history,
+            config,
+            rp,
+            model_name="qwen",
+        )
+        content = client.room_send.call_args.kwargs["content"]
+        assert content["io.mindroom.thread_summary"]["model"] == "qwen"
+
     @pytest.mark.parametrize(
         ("message_count", "should_generate"),
         [
@@ -638,7 +715,7 @@ class TestMaybeGenerateThreadSummary:
         generation_started = asyncio.Event()
         release_generation = asyncio.Event()
 
-        async def _blocked_generate(*_: object) -> str:
+        async def _blocked_generate(*_: object, **__: object) -> str:
             generation_started.set()
             await release_generation.wait()
             return "Users discussed testing strategies"
@@ -737,7 +814,7 @@ class TestMaybeGenerateThreadSummary:
             await self._maybe_generate(client, config, rp, message_count_hint=4)
 
         mock_fetch.assert_awaited_once_with(self.conversation_cache, "!room:x", "$thread1")
-        mock_gen.assert_awaited_once_with(thread_history, config, rp)
+        mock_gen.assert_awaited_once_with(thread_history, config, rp, model_name="default")
         client.room_send.assert_awaited_once()
 
     async def test_threshold_hint_fetches_on_boundary(self) -> None:
@@ -756,7 +833,7 @@ class TestMaybeGenerateThreadSummary:
             await self._maybe_generate(client, config, rp, message_count_hint=5)
 
         mock_fetch.assert_awaited_once_with(self.conversation_cache, "!room:x", "$thread1")
-        mock_gen.assert_awaited_once_with(thread_history, config, rp)
+        mock_gen.assert_awaited_once_with(thread_history, config, rp, model_name="default")
         client.room_send.assert_awaited_once()
 
     async def test_already_summarized_skips(self) -> None:
@@ -1430,6 +1507,25 @@ class TestGenerateSummary:
 
         assert result == "🧪 ISSUE-148 matrix cache invalidate-and-refetch live test"
         assert mock_model.temperature == 0.1
+
+    async def test_generate_summary_uses_explicit_model_name(self) -> None:
+        """Callers can pass the resolved room-specific summary model to generation."""
+        history = _make_thread_history(3)
+        config = _mock_config(model_name="haiku")
+        rp = _mock_runtime_paths()
+        mock_model = _TemperatureAwareModel()
+        mock_response = MagicMock()
+        mock_response.content = _ThreadSummary(summary="🧵 Room-specific summary model")
+
+        with (
+            patch("mindroom.model_loading.get_model_instance", return_value=mock_model) as mock_get_model,
+            patch("mindroom.thread_summary.Agent"),
+            patch("mindroom.thread_summary.cached_agent_run", new=AsyncMock(return_value=mock_response)),
+        ):
+            result = await _generate_summary(history, config, rp, model_name="qwen")
+
+        assert result == "🧵 Room-specific summary model"
+        mock_get_model.assert_called_once_with(config, rp, "qwen")
 
     async def test_generate_summary_can_disable_temperature_override(self) -> None:
         """A null summary temperature should clear any inherited model temperature."""


### PR DESCRIPTION
Cherry-picks `918d44be0c08771a25fdb2c1c9e55cd345c86070` from `gitea/main` onto `origin/main`.

Skipped `6ee8e68fe` per request. Existing open PRs already cover `08cf97152` (#1004), `3b2fd0caa` (#1009), and `44fdca303` (#1114).

## Summary by Sourcery

Add support for room-specific model selection for automatic thread summaries and share room-scoped model override resolution logic with existing entity model selection.

New Features:
- Allow configuring per-room model overrides for automatic thread summaries via room_thread_summary_models.
- Resolve and apply room-specific summary models when generating thread summaries, including recording the chosen model in event metadata.

Enhancements:
- Factor out shared room-scoped model override resolution into a reusable helper used by both entity and thread summary model selection.
- Extend summary generation to accept an explicit model name, enabling callers to pass resolved room-specific models.

Build:
- Update tach.toml module dependencies to include the entity resolution module for thread summary code.

Tests:
- Add unit tests for room-specific thread summary model resolution and for using explicit model names in summary generation.
- Update existing thread summary and queued message notification tests to cover the default model-name behavior under the new API.