### PR TITLE
Update MindRoom release metadata to v2026.6.9

### DIFF
--- a/Casks/mindroom.rb
+++ b/Casks/mindroom.rb
@@ -1,6 +1,6 @@
 cask "mindroom" do
-  version "0.0.0"
-  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+  version "2026.6.9"
+  sha256 "8294f897f80e0cc7ee65d00478f72c71b64aafb252ee8a24563a24375a7f3646"
 
   url "https://github.com/mindroom-ai/mindroom/releases/download/v#{version}/MindRoom.dmg"
   name "MindRoom"

--- a/macos/appcast.xml
+++ b/macos/appcast.xml
@@ -4,5 +4,31 @@
         <title>MindRoom Updates</title>
         <link>https://github.com/mindroom-ai/mindroom</link>
         <description>Signed MindRoom macOS app updates.</description>
+        <item>
+            <title>2026.6.9</title>
+            <pubDate>Tue, 02 Jun 2026 06:32:43 +0000</pubDate>
+            <link>https://github.com/mindroom-ai/mindroom</link>
+            <sparkle:version>642</sparkle:version>
+            <sparkle:shortVersionString>2026.6.9</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+            <description sparkle:format="markdown"><![CDATA[# Release 2026.6.9
+
+## 📊 Statistics
+- 📦 **1** commits
+- 👥 **1** contributors
+
+## 📝 Changes
+
+- [Fix macOS release metadata workflow (#1126)](https://github.com/mindroom-ai/mindroom/commit/04fbf0cf) by @basnijholt
+## 👥 Contributors
+@basnijholt
+
+
+---
+🙏 Thank you for using this project! Please report any issues or feedback on the GitHub repository.
+]]></description>
+            <enclosure url="https://github.com/mindroom-ai/mindroom/releases/download/v2026.6.9/MindRoom.zip" length="23511011" type="application/octet-stream" sparkle:edSignature="bhCBZwZZ7/Ka11hIXDzahzRBj199cxT3UzPsz64qGpanJ0+L2WB/PiErX1pacKNxeKZoOx2o6cSRiUc+qqQLCg=="/>
+        </item>
     </channel>
 </rss>


### PR DESCRIPTION
Updates release metadata generated by the v2026.6.9 macOS release workflow.

This includes:
- Homebrew cask version and SHA256
- Sparkle appcast entry and signature

## Summary by Sourcery

Update macOS release metadata to reference the new 2026.6.9 build.

Enhancements:
- Add a new Sparkle appcast entry for the 2026.6.9 macOS release, including metadata and download link.

Build:
- Bump the Homebrew cask version to 2026.6.9 and update its SHA256 checksum to match the new DMG.