### PR TITLE
Use PAT for macOS release metadata PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,6 @@ jobs:
     timeout-minutes: 45
     permissions:
       contents: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -132,7 +131,7 @@ jobs:
           cp "$APPCAST_DIR/appcast.xml" macos/appcast.xml
       - name: Update Homebrew cask and Sparkle appcast
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
+          GH_TOKEN: ${{ secrets.RELEASE_METADATA_PAT || secrets.PAT }}
           TAG_NAME: ${{ inputs.release_ref }}
         run: |
           VERSION="${TAG_NAME#v}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,7 @@ jobs:
           cp "$APPCAST_DIR/appcast.xml" macos/appcast.xml
       - name: Update Homebrew cask and Sparkle appcast
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PAT }}
           TAG_NAME: ${{ inputs.release_ref }}
         run: |
           VERSION="${TAG_NAME#v}"


### PR DESCRIPTION
## Summary
- Use the existing PAT secret for the release metadata branch push and PR creation step.

## Why
The v2026.6.9 release built, notarized, uploaded DMG/ZIP, and generated appcast successfully, but the final metadata PR creation failed because this repo does not allow GitHub Actions to create pull requests with GITHUB_TOKEN.

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "ok release.yml"'

## Current release state
- v2026.6.9 has MindRoom.dmg and MindRoom.zip uploaded.
- Opened #1127 manually for the generated v2026.6.9 cask/appcast metadata.

## Summary by Sourcery

Build:
- Update the release workflow to use a PAT secret instead of GITHUB_TOKEN for pushing and creating PRs for macOS release metadata.