### PR TITLE
Refactor trusted relay replay policy

### DIFF
--- a/src/mindroom/coalescing_policy.py
+++ b/src/mindroom/coalescing_policy.py
@@ -10,14 +10,11 @@ import nio
 from .commands.parsing import command_parser
 from .dispatch_handoff import DispatchEvent, PreparedTextEvent, is_media_dispatch_event
 from .dispatch_source import (
-    HOOK_DISPATCH_SOURCE_KIND,
-    HOOK_SOURCE_KIND,
     IMAGE_SOURCE_KIND,
     MEDIA_SOURCE_KIND,
-    SCHEDULED_SOURCE_KIND,
-    TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
     VOICE_SOURCE_KIND,
     is_voice_event,
+    source_kind_bypasses_coalescing,
 )
 
 if TYPE_CHECKING:
@@ -32,14 +29,6 @@ class QueueKind(enum.Enum):
     BYPASS = "bypass"
 
 
-_COALESCING_EXEMPT_SOURCE_KINDS: frozenset[str] = frozenset(
-    {
-        HOOK_SOURCE_KIND,
-        HOOK_DISPATCH_SOURCE_KIND,
-        SCHEDULED_SOURCE_KIND,
-        TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
-    },
-)
 _ROOM_SCOPE_BATCHING_SOURCE_KINDS: frozenset[str] = frozenset(
     {VOICE_SOURCE_KIND, IMAGE_SOURCE_KIND, MEDIA_SOURCE_KIND},
 )
@@ -61,7 +50,7 @@ def is_coalescing_exempt_source_kind(
     fallback_source_kind: str | None = None,
 ) -> bool:
     """Return True when coalescing should be skipped for this event."""
-    return _effective_source_kind(event, fallback_source_kind) in _COALESCING_EXEMPT_SOURCE_KINDS
+    return source_kind_bypasses_coalescing(_effective_source_kind(event, fallback_source_kind))
 
 
 def _is_command_event(

--- a/src/mindroom/dispatch_replay_guard.py
+++ b/src/mindroom/dispatch_replay_guard.py
@@ -7,10 +7,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from mindroom.commands.parsing import command_parser
-from mindroom.dispatch_source import (
-    is_visible_router_voice_echo_content,
-    is_voice_event,
-)
+from mindroom.dispatch_source import is_voice_event
 from mindroom.matrix.event_info import EventInfo
 
 if TYPE_CHECKING:
@@ -21,6 +18,7 @@ if TYPE_CHECKING:
 
 type _RequesterResolver = Callable[[str, object], str]
 type _HandledLookup = Callable[[str], bool]
+type _VisibleRouterVoiceEchoLookup = Callable[[str, object], bool]
 type _RecentRoomEventsLookup = Callable[..., Awaitable[Sequence[dict[str, Any]]]]
 # Implementations fail open by returning None after logging lookup failures.
 type _ThreadIdForEventLookup = Callable[[str, str], Awaitable[str | None]]
@@ -41,6 +39,7 @@ def has_newer_unresponded_in_thread(
     *,
     may_be_superseded_by_newer_requester_turn: bool,
     requester_user_id_for_event: _RequesterResolver,
+    is_visible_router_voice_echo: _VisibleRouterVoiceEchoLookup,
     sender_is_trusted_for_ingress_metadata: Callable[[str], bool],
     is_handled: _HandledLookup,
     logger: structlog.stdlib.BoundLogger,
@@ -52,9 +51,7 @@ def has_newer_unresponded_in_thread(
     if event_ts is None or not thread_history:
         return False
     for message in thread_history:
-        if sender_is_trusted_for_ingress_metadata(message.sender) and is_visible_router_voice_echo_content(
-            message.content,
-        ):
+        if is_visible_router_voice_echo(message.sender, message.content):
             continue
         if (
             requester_user_id_for_event(
@@ -111,6 +108,7 @@ def _unresponded_requester_event_id(
     skipped_event_id: str,
     requester_user_id: str,
     requester_user_id_for_event: _RequesterResolver,
+    is_visible_router_voice_echo: _VisibleRouterVoiceEchoLookup,
     sender_is_trusted_for_ingress_metadata: Callable[[str], bool],
     is_handled: _HandledLookup,
 ) -> str | None:
@@ -123,8 +121,9 @@ def _unresponded_requester_event_id(
         return None
     content = event_source.get("content")
     if (
-        sender_is_trusted_for_ingress_metadata(sender) and is_visible_router_voice_echo_content(content)
-    ) or requester_user_id_for_event(sender, event_source) != requester_user_id:
+        is_visible_router_voice_echo(sender, content)
+        or requester_user_id_for_event(sender, event_source) != requester_user_id
+    ):
         return None
     if is_handled(event_id):
         return None
@@ -149,6 +148,7 @@ async def _newer_unresponded_cached_thread_event_id(
     thread_id: str,
     get_thread_id_for_event: _ThreadIdForEventLookup | None,
     requester_user_id_for_event: _RequesterResolver,
+    is_visible_router_voice_echo: _VisibleRouterVoiceEchoLookup,
     sender_is_trusted_for_ingress_metadata: Callable[[str], bool],
     is_handled: _HandledLookup,
 ) -> str | None:
@@ -170,6 +170,7 @@ async def _newer_unresponded_cached_thread_event_id(
             skipped_event_id=skipped_event_id,
             requester_user_id=requester_user_id,
             requester_user_id_for_event=requester_user_id_for_event,
+            is_visible_router_voice_echo=is_visible_router_voice_echo,
             sender_is_trusted_for_ingress_metadata=sender_is_trusted_for_ingress_metadata,
             is_handled=is_handled,
         )
@@ -188,6 +189,7 @@ async def has_newer_unresponded_cached_thread_event(
     get_recent_room_events: _RecentRoomEventsLookup | None,
     get_thread_id_for_event: _ThreadIdForEventLookup | None,
     requester_user_id_for_event: _RequesterResolver,
+    is_visible_router_voice_echo: _VisibleRouterVoiceEchoLookup,
     sender_is_trusted_for_ingress_metadata: Callable[[str], bool],
     is_handled: _HandledLookup,
     logger: structlog.stdlib.BoundLogger,
@@ -222,6 +224,7 @@ async def has_newer_unresponded_cached_thread_event(
         thread_id=thread_id,
         get_thread_id_for_event=get_thread_id_for_event,
         requester_user_id_for_event=requester_user_id_for_event,
+        is_visible_router_voice_echo=is_visible_router_voice_echo,
         sender_is_trusted_for_ingress_metadata=sender_is_trusted_for_ingress_metadata,
         is_handled=is_handled,
     )

--- a/src/mindroom/dispatch_replay_guard.py
+++ b/src/mindroom/dispatch_replay_guard.py
@@ -7,7 +7,10 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from mindroom.commands.parsing import command_parser
-from mindroom.dispatch_source import is_automation_source_kind, is_voice_event
+from mindroom.dispatch_source import (
+    is_visible_router_voice_echo_content,
+    is_voice_event,
+)
 from mindroom.matrix.event_info import EventInfo
 
 if TYPE_CHECKING:
@@ -36,19 +39,23 @@ def has_newer_unresponded_in_thread(
     requester_user_id: str,
     thread_history: Sequence[ResolvedVisibleMessage],
     *,
-    source_kind: str | None,
+    may_be_superseded_by_newer_requester_turn: bool,
     requester_user_id_for_event: _RequesterResolver,
     sender_is_trusted_for_ingress_metadata: Callable[[str], bool],
     is_handled: _HandledLookup,
     logger: structlog.stdlib.BoundLogger,
 ) -> bool:
     """Return True when full thread history proves a newer unhandled requester turn exists."""
-    if is_automation_source_kind(source_kind or ""):
+    if not may_be_superseded_by_newer_requester_turn:
         return False
     event_ts = event.server_timestamp
     if event_ts is None or not thread_history:
         return False
     for message in thread_history:
+        if sender_is_trusted_for_ingress_metadata(message.sender) and is_visible_router_voice_echo_content(
+            message.content,
+        ):
+            continue
         if (
             requester_user_id_for_event(
                 message.sender,
@@ -114,11 +121,13 @@ def _unresponded_requester_event_id(
     sender = event_source.get("sender")
     if not isinstance(event_id, str) or event_id == skipped_event_id or not isinstance(sender, str):
         return None
-    if requester_user_id_for_event(sender, event_source) != requester_user_id:
+    content = event_source.get("content")
+    if (
+        sender_is_trusted_for_ingress_metadata(sender) and is_visible_router_voice_echo_content(content)
+    ) or requester_user_id_for_event(sender, event_source) != requester_user_id:
         return None
     if is_handled(event_id):
         return None
-    content = event_source.get("content")
     body = content.get("body") if isinstance(content, dict) else None
     event_view = _CachedEventView(sender=sender, source=event_source)
     if (
@@ -175,7 +184,7 @@ async def has_newer_unresponded_cached_thread_event(
     event: TextDispatchEvent,
     requester_user_id: str,
     thread_id: str | None,
-    source_kind: str | None,
+    may_be_superseded_by_newer_requester_turn: bool,
     get_recent_room_events: _RecentRoomEventsLookup | None,
     get_thread_id_for_event: _ThreadIdForEventLookup | None,
     requester_user_id_for_event: _RequesterResolver,
@@ -184,8 +193,7 @@ async def has_newer_unresponded_cached_thread_event(
     logger: structlog.stdlib.BoundLogger,
 ) -> bool:
     """Return positive cached-event proof for degraded dispatch replay history."""
-    # Automation backlog replay should not suppress older automation turns by scanning raw cached room events.
-    if thread_id is None or event.server_timestamp is None or is_automation_source_kind(source_kind or ""):
+    if thread_id is None or event.server_timestamp is None or not may_be_superseded_by_newer_requester_turn:
         return False
     if get_recent_room_events is None:
         return False

--- a/src/mindroom/dispatch_source.py
+++ b/src/mindroom/dispatch_source.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping
 from typing import Any, Protocol, cast, runtime_checkable
 
-from mindroom.constants import SOURCE_KIND_KEY
+from mindroom.constants import SOURCE_KIND_KEY, VISIBLE_ROUTER_VOICE_ECHO_KEY
 
 MESSAGE_SOURCE_KIND = "message"
 VOICE_SOURCE_KIND = "voice"
@@ -35,6 +35,27 @@ _AUTOMATION_SOURCE_KINDS: frozenset[str] = frozenset(
         SCHEDULED_SOURCE_KIND,
         HOOK_SOURCE_KIND,
         HOOK_DISPATCH_SOURCE_KIND,
+    },
+)
+_COALESCING_BYPASS_SOURCE_KINDS: frozenset[str] = _AUTOMATION_SOURCE_KINDS | frozenset(
+    {
+        TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
+    },
+)
+_TRUSTED_ORIGINAL_SENDER_SOURCE_KINDS: frozenset[str] = frozenset(
+    {
+        HOOK_DISPATCH_SOURCE_KIND,
+        HOOK_SOURCE_KIND,
+        SCHEDULED_SOURCE_KIND,
+        TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
+        VOICE_SOURCE_KIND,
+    },
+)
+_INTERNAL_RELAY_DETECTION_SOURCE_KINDS: frozenset[str] = frozenset(
+    {
+        "",
+        MESSAGE_SOURCE_KIND,
+        TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
     },
 )
 
@@ -69,6 +90,21 @@ def is_automation_source_kind(source_kind: str) -> bool:
     return source_kind in _AUTOMATION_SOURCE_KINDS
 
 
+def source_kind_bypasses_coalescing(source_kind: str | None) -> bool:
+    """Return whether one source kind must dispatch as a FIFO barrier."""
+    return source_kind in _COALESCING_BYPASS_SOURCE_KINDS
+
+
+def source_kind_allows_trusted_original_sender(source_kind: str | None) -> bool:
+    """Return whether trusted senders may promote original-sender metadata for this source kind."""
+    return source_kind in _TRUSTED_ORIGINAL_SENDER_SOURCE_KINDS
+
+
+def source_kind_allows_internal_relay_detection(source_kind: str | None) -> bool:
+    """Return whether content metadata may promote this event to a trusted internal relay."""
+    return source_kind in _INTERNAL_RELAY_DETECTION_SOURCE_KINDS
+
+
 def _source_kind_from_value(value: object) -> str | None:
     """Return a canonical source kind from arbitrary metadata."""
     return value if isinstance(value, str) and value in _KNOWN_SOURCE_KINDS else None
@@ -78,6 +114,13 @@ def source_kind_from_content(content: Mapping[str, Any]) -> str | None:
     """Return canonical source-kind metadata from Matrix content."""
     source_kind = content.get(SOURCE_KIND_KEY)
     return _source_kind_from_value(source_kind)
+
+
+def is_visible_router_voice_echo_content(content: object) -> bool:
+    """Return whether Matrix content is a visible router voice transcript echo."""
+    if not isinstance(content, Mapping):
+        return False
+    return cast("Mapping[str, object]", content).get(VISIBLE_ROUTER_VOICE_ECHO_KEY) is True
 
 
 def _trusted_source_kind_from_event_content(

--- a/src/mindroom/text_ingress_dispatch.py
+++ b/src/mindroom/text_ingress_dispatch.py
@@ -279,13 +279,14 @@ async def _blocked_before_plan(
     ):
         return True
 
+    may_be_superseded = prepared.dispatch.envelope.origin.may_be_superseded_by_newer_requester_turn
     if prepared.replay_guard.degraded:
         skips_turn = await controller._has_newer_unresponded_cached_thread_event(
             room_id=room.room_id,
             event=prepared.event,
             requester_user_id=requester_user_id,
             thread_id=prepared.replay_guard.thread_id,
-            source_kind=prepared.dispatch.envelope.source_kind,
+            may_be_superseded_by_newer_requester_turn=may_be_superseded,
         )
         if not skips_turn:
             controller.deps.logger.warning(
@@ -300,7 +301,7 @@ async def _blocked_before_plan(
             prepared.event,
             requester_user_id,
             prepared.replay_guard.history,
-            source_kind=prepared.dispatch.envelope.source_kind,
+            may_be_superseded_by_newer_requester_turn=may_be_superseded,
         )
     if skips_turn:
         controller._mark_source_events_responded(prepared.handled_turn)

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -460,6 +460,22 @@ class TurnController:
         sender_agent_name = self._managed_entity_name_for_sender(event.sender)
         return sender_agent_name == ROUTER_AGENT_NAME
 
+    def _is_trusted_router_visible_voice_echo_content(self, sender: str, content: object) -> bool:
+        """Return whether replay history content is a display-only router voice echo."""
+        if self._managed_entity_name_for_sender(sender) != ROUTER_AGENT_NAME:
+            return False
+        if not is_visible_router_voice_echo_content(content) or not isinstance(content, dict):
+            return False
+        content_dict = cast("dict[str, Any]", content)
+        return (
+            self._trusted_human_original_sender(
+                sender=sender,
+                content=content_dict,
+                source_kind=source_kind_from_content(content_dict),
+            )
+            is not None
+        )
+
     def _should_use_trusted_router_relay_context(
         self,
         event: DispatchEvent,
@@ -556,6 +572,7 @@ class TurnController:
                 sender=sender,
                 source=source,
             ),
+            is_visible_router_voice_echo=self._is_trusted_router_visible_voice_echo_content,
             sender_is_trusted_for_ingress_metadata=self._sender_is_trusted_for_ingress_metadata,
             is_handled=self.deps.turn_store.is_handled,
             logger=self.deps.logger,
@@ -584,6 +601,7 @@ class TurnController:
                 sender=sender,
                 source=source,
             ),
+            is_visible_router_voice_echo=self._is_trusted_router_visible_voice_echo_content,
             sender_is_trusted_for_ingress_metadata=self._sender_is_trusted_for_ingress_metadata,
             is_handled=self.deps.turn_store.is_handled,
             logger=self.deps.logger,

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -58,13 +58,14 @@ from mindroom.dispatch_replay_guard import has_newer_unresponded_cached_thread_e
 from mindroom.dispatch_source import (
     ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND,
     HOOK_DISPATCH_SOURCE_KIND,
-    HOOK_SOURCE_KIND,
     IMAGE_SOURCE_KIND,
     MEDIA_SOURCE_KIND,
     MESSAGE_SOURCE_KIND,
-    SCHEDULED_SOURCE_KIND,
     TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
     VOICE_SOURCE_KIND,
+    is_visible_router_voice_echo_content,
+    source_kind_allows_internal_relay_detection,
+    source_kind_allows_trusted_original_sender,
     source_kind_from_content,
 )
 from mindroom.entity_resolution import entity_identity_registry
@@ -393,13 +394,7 @@ class TurnController:
         sender_agent_name = self._managed_entity_name_for_sender(sender)
         if sender_agent_name is None and not sender_is_own_entity:
             return False
-        return source_kind in {
-            HOOK_DISPATCH_SOURCE_KIND,
-            HOOK_SOURCE_KIND,
-            SCHEDULED_SOURCE_KIND,
-            TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
-            VOICE_SOURCE_KIND,
-        }
+        return source_kind_allows_trusted_original_sender(source_kind)
 
     @staticmethod
     def _event_source_kind(event: DispatchEvent, content: dict[str, Any]) -> str | None:
@@ -549,14 +544,14 @@ class TurnController:
         requester_user_id: str,
         thread_history: Sequence[ResolvedVisibleMessage],
         *,
-        source_kind: str | None = None,
+        may_be_superseded_by_newer_requester_turn: bool,
     ) -> bool:
         """Return True when a newer unresponded message from the same requester exists."""
         return has_newer_unresponded_in_thread(
             event,
             requester_user_id,
             thread_history,
-            source_kind=source_kind,
+            may_be_superseded_by_newer_requester_turn=may_be_superseded_by_newer_requester_turn,
             requester_user_id_for_event=lambda sender, source: self._requester_user_id(
                 sender=sender,
                 source=source,
@@ -573,7 +568,7 @@ class TurnController:
         event: TextDispatchEvent,
         requester_user_id: str,
         thread_id: str | None,
-        source_kind: str | None = None,
+        may_be_superseded_by_newer_requester_turn: bool,
     ) -> bool:
         """Return positive replay proof from raw cached room events when thread history degraded."""
         event_cache = self.deps.runtime.event_cache
@@ -582,7 +577,7 @@ class TurnController:
             event=event,
             requester_user_id=requester_user_id,
             thread_id=thread_id,
-            source_kind=source_kind,
+            may_be_superseded_by_newer_requester_turn=may_be_superseded_by_newer_requester_turn,
             get_recent_room_events=event_cache.get_recent_room_events if event_cache is not None else None,
             get_thread_id_for_event=self.deps.conversation_cache.get_thread_id_for_event,
             requester_user_id_for_event=lambda sender, source: self._requester_user_id(
@@ -974,11 +969,7 @@ class TurnController:
         original_sender = self._trusted_human_original_sender_for_event(prepared_event)
         content = prepared_event.source.get("content") if isinstance(prepared_event.source, dict) else None
         prepared_source_kind = self._event_source_kind(prepared_event, content) if isinstance(content, dict) else None
-        if (
-            isinstance(content, dict)
-            and content.get(VISIBLE_ROUTER_VOICE_ECHO_KEY) is True
-            and self._is_trusted_router_relay_event(prepared_event)
-        ):
+        if is_visible_router_voice_echo_content(content) and self._is_trusted_router_relay_event(prepared_event):
             self._mark_source_events_responded(HandledTurnState.from_source_event_id(prepared_event.event_id))
             return _IngressAdmissionOutcome.CONSUMED
         trusted_user_relay = original_sender is not None and prepared_source_kind in {
@@ -1046,12 +1037,7 @@ class TurnController:
             dispatch_timing.mark("gate_enter")
         enqueue_start = time.monotonic()
         timing_scope = event_timing_scope(event.event_id)
-        source_kind_allows_relay_detection = source_kind in {
-            "",
-            MESSAGE_SOURCE_KIND,
-            TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
-        }
-        if source_kind_allows_relay_detection and self._is_trusted_internal_relay_event(event):
+        if source_kind_allows_internal_relay_detection(source_kind) and self._is_trusted_internal_relay_event(event):
             if dispatch_timing is not None:
                 dispatch_timing.note(coalescing_bypassed=True, coalescing_bypass_reason="trusted_internal_relay")
             source_kind = TRUSTED_INTERNAL_RELAY_SOURCE_KIND

--- a/src/mindroom/turn_origin.py
+++ b/src/mindroom/turn_origin.py
@@ -79,6 +79,11 @@ class TurnOrigin:
             TurnIntent.TRUSTED_INTERNAL_RELAY,
         }
 
+    @property
+    def may_be_superseded_by_newer_requester_turn(self) -> bool:
+        """Return whether replay guards may skip this turn when a newer requester prompt exists."""
+        return self.may_answer_interactive_prompt
+
 
 def classify_turn_origin(
     *,

--- a/tests/test_dispatch_source.py
+++ b/tests/test_dispatch_source.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from mindroom.constants import VISIBLE_ROUTER_VOICE_ECHO_KEY
 from mindroom.dispatch_source import (
     HOOK_DISPATCH_SOURCE_KIND,
     HOOK_SOURCE_KIND,
@@ -11,6 +12,7 @@ from mindroom.dispatch_source import (
     SCHEDULED_SOURCE_KIND,
     TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
     VOICE_SOURCE_KIND,
+    is_visible_router_voice_echo_content,
     source_kind_allows_internal_relay_detection,
     source_kind_allows_trusted_original_sender,
     source_kind_bypasses_coalescing,
@@ -109,3 +111,29 @@ def test_source_kind_allows_internal_relay_detection_rejects_specialized_turns(
 ) -> None:
     """Specialized source kinds should not be reclassified as generic trusted relays."""
     assert not source_kind_allows_internal_relay_detection(source_kind)
+
+
+@pytest.mark.parametrize("content", [None, [], "visible echo"])
+def test_visible_router_voice_echo_content_rejects_non_mappings(content: object) -> None:
+    """Only Matrix content mappings can carry the visible voice echo marker."""
+    assert not is_visible_router_voice_echo_content(content)
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        {},
+        {VISIBLE_ROUTER_VOICE_ECHO_KEY: False},
+        {VISIBLE_ROUTER_VOICE_ECHO_KEY: "true"},
+    ],
+)
+def test_visible_router_voice_echo_content_rejects_missing_or_non_true_marker(
+    content: dict[str, object],
+) -> None:
+    """Only the explicit True marker identifies display-only router voice echoes."""
+    assert not is_visible_router_voice_echo_content(content)
+
+
+def test_visible_router_voice_echo_content_accepts_true_marker() -> None:
+    """The visible router voice echo marker is a strict boolean metadata flag."""
+    assert is_visible_router_voice_echo_content({VISIBLE_ROUTER_VOICE_ECHO_KEY: True})

--- a/tests/test_dispatch_source.py
+++ b/tests/test_dispatch_source.py
@@ -1,0 +1,111 @@
+"""Tests for shared dispatch source-kind policy predicates."""
+
+import pytest
+
+from mindroom.dispatch_source import (
+    HOOK_DISPATCH_SOURCE_KIND,
+    HOOK_SOURCE_KIND,
+    IMAGE_SOURCE_KIND,
+    MEDIA_SOURCE_KIND,
+    MESSAGE_SOURCE_KIND,
+    SCHEDULED_SOURCE_KIND,
+    TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
+    VOICE_SOURCE_KIND,
+    source_kind_allows_internal_relay_detection,
+    source_kind_allows_trusted_original_sender,
+    source_kind_bypasses_coalescing,
+)
+
+
+@pytest.mark.parametrize(
+    "source_kind",
+    [
+        HOOK_SOURCE_KIND,
+        HOOK_DISPATCH_SOURCE_KIND,
+        SCHEDULED_SOURCE_KIND,
+        TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
+    ],
+)
+def test_source_kind_bypasses_coalescing_for_synthetic_and_relay_turns(source_kind: str) -> None:
+    """Synthetic fires and trusted relay turns are FIFO barriers."""
+    assert source_kind_bypasses_coalescing(source_kind)
+
+
+@pytest.mark.parametrize(
+    "source_kind",
+    [
+        MESSAGE_SOURCE_KIND,
+        VOICE_SOURCE_KIND,
+        IMAGE_SOURCE_KIND,
+        MEDIA_SOURCE_KIND,
+        None,
+        "",
+    ],
+)
+def test_source_kind_bypasses_coalescing_rejects_interactive_and_unknown_turns(source_kind: str | None) -> None:
+    """Interactive user turns and unknown source kinds use normal coalescing."""
+    assert not source_kind_bypasses_coalescing(source_kind)
+
+
+@pytest.mark.parametrize(
+    "source_kind",
+    [
+        HOOK_SOURCE_KIND,
+        HOOK_DISPATCH_SOURCE_KIND,
+        SCHEDULED_SOURCE_KIND,
+        TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
+        VOICE_SOURCE_KIND,
+    ],
+)
+def test_source_kind_allows_trusted_original_sender_for_internal_provenance(source_kind: str) -> None:
+    """Only internally generated source kinds may promote original-sender metadata."""
+    assert source_kind_allows_trusted_original_sender(source_kind)
+
+
+@pytest.mark.parametrize(
+    "source_kind",
+    [
+        MESSAGE_SOURCE_KIND,
+        IMAGE_SOURCE_KIND,
+        MEDIA_SOURCE_KIND,
+        None,
+        "",
+    ],
+)
+def test_source_kind_allows_trusted_original_sender_rejects_plain_turns(source_kind: str | None) -> None:
+    """Plain user-controlled source kinds must not promote original-sender metadata."""
+    assert not source_kind_allows_trusted_original_sender(source_kind)
+
+
+@pytest.mark.parametrize(
+    "source_kind",
+    [
+        "",
+        MESSAGE_SOURCE_KIND,
+        TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
+    ],
+)
+def test_source_kind_allows_internal_relay_detection_for_plain_text_handoff_candidates(
+    source_kind: str,
+) -> None:
+    """Only plain text and already-relay candidates are promoted after trusted metadata inspection."""
+    assert source_kind_allows_internal_relay_detection(source_kind)
+
+
+@pytest.mark.parametrize(
+    "source_kind",
+    [
+        HOOK_SOURCE_KIND,
+        HOOK_DISPATCH_SOURCE_KIND,
+        SCHEDULED_SOURCE_KIND,
+        VOICE_SOURCE_KIND,
+        IMAGE_SOURCE_KIND,
+        MEDIA_SOURCE_KIND,
+        None,
+    ],
+)
+def test_source_kind_allows_internal_relay_detection_rejects_specialized_turns(
+    source_kind: str | None,
+) -> None:
+    """Specialized source kinds should not be reclassified as generic trusted relays."""
+    assert not source_kind_allows_internal_relay_detection(source_kind)

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -4881,6 +4881,47 @@ def test_replay_guard_does_not_supersede_non_interactive_origin_turns() -> None:
     assert not should_skip
 
 
+def test_full_history_replay_guard_ignores_visible_router_voice_echo() -> None:
+    """Visible router voice echoes must not suppress the canonical voice turn in full history."""
+    older_event = PreparedTextEvent(
+        sender="@user:localhost",
+        event_id="$voice",
+        body="check my calendar",
+        source={"content": {"msgtype": "m.text", "body": "check my calendar", SOURCE_KIND_KEY: "voice"}},
+        server_timestamp=1000,
+    )
+    visible_echo = ResolvedVisibleMessage(
+        sender="@mindroom_router:localhost",
+        body="check my calendar",
+        timestamp=2000,
+        event_id="$visible_echo",
+        content={
+            "msgtype": "m.text",
+            "body": "check my calendar",
+            SOURCE_KIND_KEY: TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
+            ORIGINAL_SENDER_KEY: "@user:localhost",
+            VISIBLE_ROUTER_VOICE_ECHO_KEY: True,
+        },
+        thread_id="$thread",
+        latest_event_id="$visible_echo",
+    )
+
+    should_skip = has_newer_unresponded_in_thread(
+        older_event,
+        "@user:localhost",
+        [visible_echo],
+        may_be_superseded_by_newer_requester_turn=True,
+        requester_user_id_for_event=lambda sender, source: (
+            source["content"].get(ORIGINAL_SENDER_KEY) if sender == "@mindroom_router:localhost" else sender
+        ),
+        sender_is_trusted_for_ingress_metadata=lambda sender: sender == "@mindroom_router:localhost",
+        is_handled=lambda _event_id: False,
+        logger=MagicMock(),
+    )
+
+    assert not should_skip
+
+
 @pytest.mark.asyncio
 async def test_backlog_replay_degraded_thread_history_ignores_visible_router_voice_echo(tmp_path: Path) -> None:
     """Router transcript echoes must not suppress the canonical voice turn they represent."""
@@ -4925,16 +4966,24 @@ async def test_backlog_replay_degraded_thread_history_ignores_visible_router_voi
     bot.event_cache.get_recent_room_events.return_value = [visible_echo_source]
 
     action_mock = AsyncMock(return_value=_DispatchPlan(kind="ignore"))
+    history_guard = MagicMock(wraps=bot._turn_controller._has_newer_unresponded_in_thread)
     with (
         patch.object(
             bot._turn_controller,
             "_prepare_dispatch",
             new=AsyncMock(return_value=prepared_dispatch_result(dispatch)),
         ),
+        patch.object(bot._turn_controller, "_has_newer_unresponded_in_thread", new=history_guard),
         patch.object(bot._turn_policy, "plan_turn", new=action_mock),
     ):
         await bot._turn_controller._dispatch_text_message(room, older_event, "@user:localhost")
 
+    history_guard.assert_not_called()
+    bot.event_cache.get_recent_room_events.assert_awaited_once_with(
+        room.room_id,
+        event_type="m.room.message",
+        since_ts_ms=1000,
+    )
     action_mock.assert_awaited_once()
     assert not bot._turn_store.is_handled("$voice")
 

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -36,6 +36,7 @@ from mindroom.constants import (
     ORIGINAL_SENDER_KEY,
     SKIP_MENTIONS_KEY,
     SOURCE_KIND_KEY,
+    VISIBLE_ROUTER_VOICE_ECHO_KEY,
     VOICE_RAW_AUDIO_FALLBACK_KEY,
 )
 from mindroom.conversation_resolver import MessageContext
@@ -48,6 +49,7 @@ from mindroom.dispatch_handoff import (
     _build_batch_dispatch_event,
     build_dispatch_handoff,
 )
+from mindroom.dispatch_replay_guard import has_newer_unresponded_in_thread
 from mindroom.dispatch_source import (
     ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND,
     IMAGE_SOURCE_KIND,
@@ -4844,6 +4846,97 @@ async def test_backlog_replay_degraded_thread_history_counts_trusted_voice_comma
 
     action_mock.assert_not_awaited()
     assert bot._turn_store.is_handled("$m1")
+
+
+def test_replay_guard_does_not_supersede_non_interactive_origin_turns() -> None:
+    """Replay suppression is gated by turn-origin policy, not just sender/timestamp matching."""
+    older_event = PreparedTextEvent(
+        sender="@mindroom_general:localhost",
+        event_id="$managed",
+        body="internal status",
+        source={"content": {"msgtype": "m.text", "body": "internal status"}},
+        server_timestamp=1000,
+    )
+    newer_msg = ResolvedVisibleMessage(
+        sender="@mindroom_general:localhost",
+        body="newer internal status",
+        timestamp=2000,
+        event_id="$managed-newer",
+        content={"body": "newer internal status"},
+        thread_id="$thread",
+        latest_event_id="$managed-newer",
+    )
+
+    should_skip = has_newer_unresponded_in_thread(
+        older_event,
+        "@mindroom_general:localhost",
+        [newer_msg],
+        may_be_superseded_by_newer_requester_turn=False,
+        requester_user_id_for_event=lambda sender, _source: sender,
+        sender_is_trusted_for_ingress_metadata=lambda _sender: True,
+        is_handled=lambda _event_id: False,
+        logger=MagicMock(),
+    )
+
+    assert not should_skip
+
+
+@pytest.mark.asyncio
+async def test_backlog_replay_degraded_thread_history_ignores_visible_router_voice_echo(tmp_path: Path) -> None:
+    """Router transcript echoes must not suppress the canonical voice turn they represent."""
+    bot = _make_bot(tmp_path)
+    room = _make_room()
+    older_event = PreparedTextEvent(
+        sender="@user:localhost",
+        event_id="$voice",
+        body="check my calendar",
+        source={"content": {"msgtype": "m.text", "body": "check my calendar", SOURCE_KIND_KEY: "voice"}},
+        server_timestamp=1000,
+    )
+    dispatch = _prepared_dispatch(event_id="$voice", body="check my calendar", thread_id="$thread")
+    degraded_history = ThreadHistoryResult(
+        [],
+        is_full_history=False,
+        diagnostics={
+            THREAD_HISTORY_SOURCE_DIAGNOSTIC: THREAD_HISTORY_SOURCE_DEGRADED,
+            THREAD_HISTORY_DEGRADED_DIAGNOSTIC: True,
+            THREAD_HISTORY_ERROR_DIAGNOSTIC: "cache_coordinator_timeout",
+        },
+    )
+    dispatch.context.am_i_mentioned = False
+    dispatch.context.thread_history = degraded_history
+    dispatch.context.replay_guard_history = degraded_history
+    dispatch.context.requires_model_history_refresh = True
+    visible_echo_source = {
+        "event_id": "$visible_echo",
+        "sender": bot.agent_user.user_id,
+        "origin_server_ts": 2000,
+        "room_id": room.room_id,
+        "type": "m.room.message",
+        "content": {
+            "msgtype": "m.text",
+            "body": "check my calendar",
+            SOURCE_KIND_KEY: TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
+            ORIGINAL_SENDER_KEY: "@user:localhost",
+            VISIBLE_ROUTER_VOICE_ECHO_KEY: True,
+            "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread"},
+        },
+    }
+    bot.event_cache.get_recent_room_events.return_value = [visible_echo_source]
+
+    action_mock = AsyncMock(return_value=_DispatchPlan(kind="ignore"))
+    with (
+        patch.object(
+            bot._turn_controller,
+            "_prepare_dispatch",
+            new=AsyncMock(return_value=prepared_dispatch_result(dispatch)),
+        ),
+        patch.object(bot._turn_policy, "plan_turn", new=action_mock),
+    ):
+        await bot._turn_controller._dispatch_text_message(room, older_event, "@user:localhost")
+
+    action_mock.assert_awaited_once()
+    assert not bot._turn_store.is_handled("$voice")
 
 
 @pytest.mark.asyncio

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -4873,6 +4873,7 @@ def test_replay_guard_does_not_supersede_non_interactive_origin_turns() -> None:
         [newer_msg],
         may_be_superseded_by_newer_requester_turn=False,
         requester_user_id_for_event=lambda sender, _source: sender,
+        is_visible_router_voice_echo=lambda _sender, _content: False,
         sender_is_trusted_for_ingress_metadata=lambda _sender: True,
         is_handled=lambda _event_id: False,
         logger=MagicMock(),
@@ -4914,12 +4915,61 @@ def test_full_history_replay_guard_ignores_visible_router_voice_echo() -> None:
         requester_user_id_for_event=lambda sender, source: (
             source["content"].get(ORIGINAL_SENDER_KEY) if sender == "@mindroom_router:localhost" else sender
         ),
+        is_visible_router_voice_echo=lambda sender, content: (
+            sender == "@mindroom_router:localhost"
+            and isinstance(content, dict)
+            and content.get(VISIBLE_ROUTER_VOICE_ECHO_KEY) is True
+        ),
         sender_is_trusted_for_ingress_metadata=lambda sender: sender == "@mindroom_router:localhost",
         is_handled=lambda _event_id: False,
         logger=MagicMock(),
     )
 
     assert not should_skip
+
+
+def test_full_history_replay_guard_counts_non_router_visible_echo_marker() -> None:
+    """Only router voice echoes are display-only; other trusted relay turns still suppress older turns."""
+    older_event = PreparedTextEvent(
+        sender="@user:localhost",
+        event_id="$voice",
+        body="check my calendar",
+        source={"content": {"msgtype": "m.text", "body": "check my calendar", SOURCE_KIND_KEY: "voice"}},
+        server_timestamp=1000,
+    )
+    marked_helper_relay = ResolvedVisibleMessage(
+        sender="@mindroom_helper:localhost",
+        body="check my calendar",
+        timestamp=2000,
+        event_id="$helper_relay",
+        content={
+            "msgtype": "m.text",
+            "body": "check my calendar",
+            SOURCE_KIND_KEY: TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
+            ORIGINAL_SENDER_KEY: "@user:localhost",
+            VISIBLE_ROUTER_VOICE_ECHO_KEY: True,
+        },
+        thread_id="$thread",
+        latest_event_id="$helper_relay",
+    )
+
+    should_skip = has_newer_unresponded_in_thread(
+        older_event,
+        "@user:localhost",
+        [marked_helper_relay],
+        may_be_superseded_by_newer_requester_turn=True,
+        requester_user_id_for_event=lambda sender, _source: (
+            "@user:localhost" if sender == "@mindroom_helper:localhost" else sender
+        ),
+        is_visible_router_voice_echo=lambda sender, _content: sender == "@mindroom_router:localhost",
+        sender_is_trusted_for_ingress_metadata=lambda sender: (
+            sender in {"@mindroom_helper:localhost", "@mindroom_router:localhost"}
+        ),
+        is_handled=lambda _event_id: False,
+        logger=MagicMock(),
+    )
+
+    assert should_skip
 
 
 @pytest.mark.asyncio
@@ -4950,7 +5000,7 @@ async def test_backlog_replay_degraded_thread_history_ignores_visible_router_voi
     dispatch.context.requires_model_history_refresh = True
     visible_echo_source = {
         "event_id": "$visible_echo",
-        "sender": bot.agent_user.user_id,
+        "sender": "@mindroom_router:localhost",
         "origin_server_ts": 2000,
         "room_id": room.room_id,
         "type": "m.room.message",
@@ -4986,6 +5036,72 @@ async def test_backlog_replay_degraded_thread_history_ignores_visible_router_voi
     )
     action_mock.assert_awaited_once()
     assert not bot._turn_store.is_handled("$voice")
+
+
+@pytest.mark.asyncio
+async def test_backlog_replay_degraded_thread_history_counts_non_router_visible_echo_marker(tmp_path: Path) -> None:
+    """Only router transcript echoes are replay noise; other marked relays still count as newer turns."""
+    bot = _make_bot(tmp_path)
+    room = _make_room()
+    older_event = PreparedTextEvent(
+        sender="@user:localhost",
+        event_id="$voice",
+        body="check my calendar",
+        source={"content": {"msgtype": "m.text", "body": "check my calendar", SOURCE_KIND_KEY: "voice"}},
+        server_timestamp=1000,
+    )
+    dispatch = _prepared_dispatch(event_id="$voice", body="check my calendar", thread_id="$thread")
+    degraded_history = ThreadHistoryResult(
+        [],
+        is_full_history=False,
+        diagnostics={
+            THREAD_HISTORY_SOURCE_DIAGNOSTIC: THREAD_HISTORY_SOURCE_DEGRADED,
+            THREAD_HISTORY_DEGRADED_DIAGNOSTIC: True,
+            THREAD_HISTORY_ERROR_DIAGNOSTIC: "cache_coordinator_timeout",
+        },
+    )
+    dispatch.context.am_i_mentioned = False
+    dispatch.context.thread_history = degraded_history
+    dispatch.context.replay_guard_history = degraded_history
+    dispatch.context.requires_model_history_refresh = True
+    marked_helper_relay_source = {
+        "event_id": "$helper_relay",
+        "sender": bot.agent_user.user_id,
+        "origin_server_ts": 2000,
+        "room_id": room.room_id,
+        "type": "m.room.message",
+        "content": {
+            "msgtype": "m.text",
+            "body": "check my calendar",
+            SOURCE_KIND_KEY: TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
+            ORIGINAL_SENDER_KEY: "@user:localhost",
+            VISIBLE_ROUTER_VOICE_ECHO_KEY: True,
+            "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread"},
+        },
+    }
+    bot.event_cache.get_recent_room_events.return_value = [marked_helper_relay_source]
+
+    action_mock = AsyncMock()
+    history_guard = MagicMock(wraps=bot._turn_controller._has_newer_unresponded_in_thread)
+    with (
+        patch.object(
+            bot._turn_controller,
+            "_prepare_dispatch",
+            new=AsyncMock(return_value=prepared_dispatch_result(dispatch)),
+        ),
+        patch.object(bot._turn_controller, "_has_newer_unresponded_in_thread", new=history_guard),
+        patch.object(bot._turn_policy, "plan_turn", new=action_mock),
+    ):
+        await bot._turn_controller._dispatch_text_message(room, older_event, "@user:localhost")
+
+    history_guard.assert_not_called()
+    bot.event_cache.get_recent_room_events.assert_awaited_once_with(
+        room.room_id,
+        event_type="m.room.message",
+        since_ts_ms=1000,
+    )
+    action_mock.assert_not_awaited()
+    assert bot._turn_store.is_handled("$voice")
 
 
 @pytest.mark.asyncio

--- a/tests/test_turn_origin.py
+++ b/tests/test_turn_origin.py
@@ -221,6 +221,71 @@ def test_human_requested_messages_answer_interactive_prompts() -> None:
     assert origin.may_answer_interactive_prompt
 
 
+def test_replay_guard_supersedable_policy_tracks_interactive_requester_turns() -> None:
+    """Only interactive requester turns should be skipped by newer requester prompts."""
+    human_message = classify_turn_origin(
+        transport_sender_id="@human:localhost",
+        requester_id="@human:localhost",
+        sender_entity_name=None,
+        requester_entity_name=None,
+        source_kind="message",
+        original_sender=None,
+        trusted_user_relay=False,
+    )
+    router_handoff = classify_turn_origin(
+        transport_sender_id="@mindroom_router:localhost",
+        requester_id="@human:localhost",
+        sender_entity_name="router",
+        requester_entity_name=None,
+        source_kind=TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
+        original_sender="@human:localhost",
+        trusted_user_relay=True,
+    )
+    trusted_relay = classify_turn_origin(
+        transport_sender_id="@mindroom_helper:localhost",
+        requester_id="@human:localhost",
+        sender_entity_name="helper",
+        requester_entity_name=None,
+        source_kind=TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
+        original_sender="@human:localhost",
+        trusted_user_relay=True,
+    )
+    scheduled_fire = classify_turn_origin(
+        transport_sender_id="@mindroom_general:localhost",
+        requester_id="@mindroom_router:localhost",
+        sender_entity_name="general",
+        requester_entity_name="router",
+        source_kind=SCHEDULED_SOURCE_KIND,
+        original_sender="@mindroom_router:localhost",
+        trusted_user_relay=False,
+    )
+    hook_dispatch = classify_turn_origin(
+        transport_sender_id="@mindroom_general:localhost",
+        requester_id="@human:localhost",
+        sender_entity_name="general",
+        requester_entity_name=None,
+        source_kind=HOOK_DISPATCH_SOURCE_KIND,
+        original_sender="@human:localhost",
+        trusted_user_relay=False,
+    )
+    managed_chatter = classify_turn_origin(
+        transport_sender_id="@mindroom_general:localhost",
+        requester_id="@mindroom_general:localhost",
+        sender_entity_name="general",
+        requester_entity_name="general",
+        source_kind="message",
+        original_sender=None,
+        trusted_user_relay=False,
+    )
+
+    assert human_message.may_be_superseded_by_newer_requester_turn
+    assert router_handoff.may_be_superseded_by_newer_requester_turn
+    assert trusted_relay.may_be_superseded_by_newer_requester_turn
+    assert not scheduled_fire.may_be_superseded_by_newer_requester_turn
+    assert not hook_dispatch.may_be_superseded_by_newer_requester_turn
+    assert not managed_chatter.may_be_superseded_by_newer_requester_turn
+
+
 def test_router_handoff_original_sender_only_for_human_targeted_handoff() -> None:
     """Router handoff metadata is stamped only on real targeted human requests."""
     assert (


### PR DESCRIPTION
## Summary

- Centralizes reusable source-kind policy predicates in `dispatch_source`.
- Moves replay suppression eligibility to `TurnOrigin.may_be_superseded_by_newer_requester_turn` so replay guards consume origin policy instead of maintaining their own source-kind exception list.
- Reuses a shared visible router voice echo predicate in both live ingress and replay guard paths.
- Adds regression coverage for non-interactive turns, trusted relay policy, coalescing bypass policy, and visible voice transcript echoes in degraded replay history.

## Investigation

The dispatch stack had several duplicated policy surfaces that were all trying to answer adjacent questions about trusted, synthetic, and relayed turns:

- `coalescing_policy` had a local set of source kinds that bypass coalescing.
- `turn_controller` had a separate source-kind set for trusted original-sender metadata.
- `turn_controller` also had an inline set deciding which text events may be promoted to trusted relay events after metadata inspection.
- `dispatch_replay_guard` accepted a raw `source_kind` and maintained its own automation exception for newer-message suppression.
- Visible router voice transcript echoes were identified by direct content-marker checks in one ingress path, while replay scans had to rediscover that display-only event shape separately.

Those duplicated surfaces made it easy for related origins to drift. In particular, replay suppression is not really a source-kind question: it should only skip an older turn when the older turn represents an interactive requester prompt that can be superseded by a newer requester prompt. Synthetic fires, hook dispatches, and managed chatter should not be suppressed just because a later event has the same requester identity.

## Refactor Plan

1. Keep pre-origin source-kind gates in `dispatch_source`, where the source-kind vocabulary already lives.
2. Add named predicates for the three source-kind policy gates that still happen before full origin classification: coalescing bypass, trusted original-sender promotion, and trusted relay detection candidates.
3. Add `TurnOrigin.may_be_superseded_by_newer_requester_turn` as the single replay-suppression invariant.
4. Change both full-history and degraded-cache replay guards to consume that invariant instead of accepting raw source-kind metadata.
5. Treat visible router voice transcript echoes as display-only content metadata and filter them in replay guard scans using a shared content predicate.
6. Add focused tests that pin the source-kind predicates, turn-origin replay policy, non-interactive replay behavior, and visible echo handling.

## Tests

- `uv run ruff check src/mindroom/dispatch_source.py src/mindroom/coalescing_policy.py src/mindroom/dispatch_replay_guard.py src/mindroom/turn_origin.py src/mindroom/turn_controller.py src/mindroom/text_ingress_dispatch.py tests/test_dispatch_source.py tests/test_turn_origin.py tests/test_live_message_coalescing.py tests/test_voice_bot_threading.py tests/test_voice_command_processing.py` passed.
- `uv run ty check src/mindroom/dispatch_source.py src/mindroom/dispatch_replay_guard.py src/mindroom/turn_controller.py` passed.
- `uv run pytest tests/test_dispatch_source.py tests/test_turn_origin.py tests/test_live_message_coalescing.py -k 'replay_guard or backlog_replay_degraded_thread_history or scheduled_event_not_suppressed or hook_event_not_suppressed or multiple_scheduled_fires_not_suppressed' -q` passed: `12 passed`.
- `uv run pytest tests/test_dispatch_source.py tests/test_turn_origin.py tests/test_voice_bot_threading.py::test_trusted_router_visible_voice_echo_is_display_only tests/test_voice_bot_threading.py::test_forged_visible_voice_echo_marker_still_dispatches tests/test_voice_command_processing.py::test_router_visible_voice_echo_is_not_duplicated_when_handoff_retries -q` passed: `48 passed`.
- `uv run pytest tests/test_coalescing.py tests/test_live_message_coalescing.py::test_automation_source_kinds_are_coalescing_exempt tests/test_live_message_coalescing.py::test_automation_and_relay_source_kinds_dispatch_solo_with_human_neighbor tests/test_hook_ingress.py::test_automation_source_kinds_do_not_answer_interactive_prompts -q` passed: `57 passed`.

## Privacy

This PR is written as a generic product/runtime refactor. It does not include deployment-specific logs, room IDs, hostnames, user identities, or environment details.

## Summary by Sourcery

Refine dispatch replay, coalescing, and relay policies around source kinds and turn origins to ensure only interactive requester turns are superseded and router voice transcript echoes remain display-only.

Enhancements:
- Centralize reusable source-kind policy predicates in dispatch_source and reuse them across coalescing, relay detection, and trusted original-sender handling.
- Change replay guards to rely on TurnOrigin.may_be_superseded_by_newer_requester_turn rather than raw source kinds, and ignore visible router voice transcript echoes when scanning history.
- Adjust text ingress and turn controller logic to use the new origin-based replay policy and shared visible-echo detection predicate.

Tests:
- Add unit tests for source-kind policy predicates, replay supersedable turn-origin behavior, non-interactive replay handling, and visible router voice echo behavior under degraded history and live coalescing paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved message replay guard behavior to correctly handle newer requester interactions and visible voice transcripts.

* **Refactor**
  * Reorganized internal dispatch policy logic for more maintainable source-kind classification.

* **Tests**
  * Added test coverage for dispatch source policies and replay suppression scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->