### PR TITLE
Update MindRoom release metadata to v2026.6.11

### DIFF
--- a/Casks/mindroom.rb
+++ b/Casks/mindroom.rb
@@ -1,6 +1,6 @@
 cask "mindroom" do
-  version "2026.6.9"
-  sha256 "8294f897f80e0cc7ee65d00478f72c71b64aafb252ee8a24563a24375a7f3646"
+  version "2026.6.11"
+  sha256 "03019f9fcc1d34b920809567d2c8546291475c9874639fe9bbd4347dca9f11a1"
 
   url "https://github.com/mindroom-ai/mindroom/releases/download/v#{version}/MindRoom.dmg"
   name "MindRoom"

--- a/macos/appcast.xml
+++ b/macos/appcast.xml
@@ -5,6 +5,32 @@
         <link>https://github.com/mindroom-ai/mindroom</link>
         <description>Signed MindRoom macOS app updates.</description>
         <item>
+            <title>2026.6.11</title>
+            <pubDate>Tue, 02 Jun 2026 16:04:38 +0000</pubDate>
+            <link>https://github.com/mindroom-ai/mindroom</link>
+            <sparkle:version>644</sparkle:version>
+            <sparkle:shortVersionString>2026.6.11</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+            <description sparkle:format="markdown"><![CDATA[# Release 2026.6.11
+
+## 📊 Statistics
+- 📦 **1** commits
+- 👥 **1** contributors
+
+## 📝 Changes
+
+- [Refactor trusted relay replay policy (#1130)](https://github.com/mindroom-ai/mindroom/commit/c019b46e) by @basnijholt
+## 👥 Contributors
+@basnijholt
+
+
+---
+🙏 Thank you for using this project! Please report any issues or feedback on the GitHub repository.
+]]></description>
+            <enclosure url="https://github.com/mindroom-ai/mindroom/releases/download/v2026.6.11/MindRoom.zip" length="23511042" type="application/octet-stream" sparkle:edSignature="MGf40WWNv7jlqwUjbQ5wf4kGQGQKvNoYVwy3lvFn7MkF4bUAcUX/hXMiTmjTGHqgNGDu5cCxo0ZZIIJ0hqrIAw=="/>
+        </item>
+        <item>
             <title>2026.6.9</title>
             <pubDate>Tue, 02 Jun 2026 06:32:43 +0000</pubDate>
             <link>https://github.com/mindroom-ai/mindroom</link>


### PR DESCRIPTION
Updates release metadata generated by the v2026.6.11 macOS release workflow.

This includes:
- Homebrew cask version and SHA256
- Sparkle appcast entry and signature

## Summary by Sourcery

Update macOS release metadata for the latest MindRoom version.

New Features:
- Publish a new Sparkle appcast entry for the 2026.6.11 macOS release, including metadata and release notes.

Enhancements:
- Bump the Homebrew cask to version 2026.6.11 with the corresponding SHA256 checksum.