### PR TITLE
Update MindRoom release metadata to v2026.6.12

### DIFF
--- a/Casks/mindroom.rb
+++ b/Casks/mindroom.rb
@@ -1,6 +1,6 @@
 cask "mindroom" do
-  version "2026.6.9"
-  sha256 "8294f897f80e0cc7ee65d00478f72c71b64aafb252ee8a24563a24375a7f3646"
+  version "2026.6.12"
+  sha256 "3b34478db31b27eb0fa4669ed24f6320da1cb6ec5f77e518c41451d288646afa"
 
   url "https://github.com/mindroom-ai/mindroom/releases/download/v#{version}/MindRoom.dmg"
   name "MindRoom"

--- a/macos/appcast.xml
+++ b/macos/appcast.xml
@@ -5,6 +5,32 @@
         <link>https://github.com/mindroom-ai/mindroom</link>
         <description>Signed MindRoom macOS app updates.</description>
         <item>
+            <title>2026.6.12</title>
+            <pubDate>Tue, 02 Jun 2026 16:05:52 +0000</pubDate>
+            <link>https://github.com/mindroom-ai/mindroom</link>
+            <sparkle:version>645</sparkle:version>
+            <sparkle:shortVersionString>2026.6.12</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+            <description sparkle:format="markdown"><![CDATA[# Release 2026.6.12
+
+## 📊 Statistics
+- 📦 **1** commits
+- 👥 **1** contributors
+
+## 📝 Changes
+
+- [Replace per-bundle toolkits with per-tool lazy loading (#1124)](https://github.com/mindroom-ai/mindroom/commit/e9209ec4) by @basnijholt
+## 👥 Contributors
+@basnijholt
+
+
+---
+🙏 Thank you for using this project! Please report any issues or feedback on the GitHub repository.
+]]></description>
+            <enclosure url="https://github.com/mindroom-ai/mindroom/releases/download/v2026.6.12/MindRoom.zip" length="23510987" type="application/octet-stream" sparkle:edSignature="xBiuVdAD2ARkdKu3jmh5S5Y6rxb0HqJhUY4gTu7/bOjfORP+lR1Klg4YALL246wwb1dO+SUR2w5BeLpYST8TBA=="/>
+        </item>
+        <item>
             <title>2026.6.9</title>
             <pubDate>Tue, 02 Jun 2026 06:32:43 +0000</pubDate>
             <link>https://github.com/mindroom-ai/mindroom</link>


### PR DESCRIPTION
Updates release metadata generated by the v2026.6.12 macOS release workflow.

This includes:
- Homebrew cask version and SHA256
- Sparkle appcast entry and signature

## Summary by Sourcery

Update macOS release metadata for the 2026.6.12 MindRoom release.

New Features:
- Add a new Sparkle appcast entry for the 2026.6.12 macOS release of MindRoom.

Enhancements:
- Bump the Homebrew cask to version 2026.6.12 with the corresponding release checksum.