### PR TITLE
Keep unavailable plugin tools out of runtime metadata

### DIFF
--- a/src/mindroom/tool_system/metadata.py
+++ b/src/mindroom/tool_system/metadata.py
@@ -766,6 +766,15 @@ class ToolMetadata:
     factory: Callable | None = None  # Factory function to create tool instance
 
 
+@dataclass(frozen=True)
+class _ResolvedToolState:
+    """Runtime-visible tool state plus validation-only skipped-plugin metadata."""
+
+    tool_registry: dict[str, Callable[[], type[Toolkit]]]
+    tool_metadata: dict[str, ToolMetadata]
+    unavailable_tool_metadata: dict[str, ToolMetadata]
+
+
 def register_tool_with_metadata(
     *,
     name: str,
@@ -933,7 +942,7 @@ def _resolved_tool_state_for_runtime(
     config: Config,
     *,
     tolerate_plugin_load_errors: bool = False,
-) -> tuple[dict[str, Callable[[], type[Toolkit]]], dict[str, ToolMetadata], dict[str, ToolMetadata]]:
+) -> _ResolvedToolState:
     """Return registry and metadata visible for one runtime config without mutating global state."""
     import mindroom.tools  # noqa: F401, PLC0415
     from mindroom.mcp.registry import resolved_mcp_tool_state  # noqa: PLC0415
@@ -949,7 +958,7 @@ def _resolved_tool_state_for_runtime(
             mcp_registry,
             mcp_metadata,
         )
-        return builtin_registry, builtin_metadata, {}
+        return _ResolvedToolState(builtin_registry, builtin_metadata, {})
 
     plugin_bases = plugin_module._collect_plugin_bases(
         plugin_entries,
@@ -1021,7 +1030,7 @@ def _resolved_tool_state_for_runtime(
         desired_registry,
         desired_metadata,
     )
-    return desired_registry, desired_metadata, unavailable_tool_metadata
+    return _ResolvedToolState(desired_registry, desired_metadata, unavailable_tool_metadata)
 
 
 def _unavailable_tool_metadata_without_resolved_tools(
@@ -1060,12 +1069,12 @@ def resolved_tool_metadata_for_runtime(
     tolerate_plugin_load_errors: bool = False,
 ) -> dict[str, ToolMetadata]:
     """Return tool metadata visible for one runtime config without mutating global state."""
-    _, desired_metadata, _ = _resolved_tool_state_for_runtime(
+    resolved_state = _resolved_tool_state_for_runtime(
         runtime_paths,
         config,
         tolerate_plugin_load_errors=tolerate_plugin_load_errors,
     )
-    return desired_metadata
+    return resolved_state.tool_metadata
 
 
 def _tool_validation_snapshot_from_state(
@@ -1156,19 +1165,19 @@ def resolved_tool_validation_snapshot_for_runtime(
     tolerate_plugin_load_errors: bool = False,
 ) -> dict[str, ToolValidationInfo]:
     """Return validation-only tool state visible for one runtime config."""
-    tool_registry, desired_metadata, unavailable_tool_metadata = _resolved_tool_state_for_runtime(
+    resolved_state = _resolved_tool_state_for_runtime(
         runtime_paths,
         config,
         tolerate_plugin_load_errors=tolerate_plugin_load_errors,
     )
     validation_metadata = {
-        **desired_metadata,
-        **unavailable_tool_metadata,
+        **resolved_state.tool_metadata,
+        **resolved_state.unavailable_tool_metadata,
     }
     return _tool_validation_snapshot_from_state(
-        tool_registry,
+        resolved_state.tool_registry,
         validation_metadata,
-        unavailable_plugin_tool_names=frozenset(unavailable_tool_metadata),
+        unavailable_plugin_tool_names=frozenset(resolved_state.unavailable_tool_metadata),
     )
 
 

--- a/src/mindroom/tool_system/metadata.py
+++ b/src/mindroom/tool_system/metadata.py
@@ -933,7 +933,7 @@ def _resolved_tool_state_for_runtime(
     config: Config,
     *,
     tolerate_plugin_load_errors: bool = False,
-) -> tuple[dict[str, Callable[[], type[Toolkit]]], dict[str, ToolMetadata], frozenset[str]]:
+) -> tuple[dict[str, Callable[[], type[Toolkit]]], dict[str, ToolMetadata], dict[str, ToolMetadata]]:
     """Return registry and metadata visible for one runtime config without mutating global state."""
     import mindroom.tools  # noqa: F401, PLC0415
     from mindroom.mcp.registry import resolved_mcp_tool_state  # noqa: PLC0415
@@ -949,7 +949,7 @@ def _resolved_tool_state_for_runtime(
             mcp_registry,
             mcp_metadata,
         )
-        return builtin_registry, builtin_metadata, frozenset()
+        return builtin_registry, builtin_metadata, {}
 
     plugin_bases = plugin_module._collect_plugin_bases(
         plugin_entries,
@@ -1021,9 +1021,7 @@ def _resolved_tool_state_for_runtime(
         desired_registry,
         desired_metadata,
     )
-    desired_metadata.update(unavailable_tool_metadata)
-    unavailable_plugin_tool_names = frozenset(unavailable_tool_metadata)
-    return desired_registry, desired_metadata, unavailable_plugin_tool_names
+    return desired_registry, desired_metadata, unavailable_tool_metadata
 
 
 def _unavailable_tool_metadata_without_resolved_tools(
@@ -1158,15 +1156,19 @@ def resolved_tool_validation_snapshot_for_runtime(
     tolerate_plugin_load_errors: bool = False,
 ) -> dict[str, ToolValidationInfo]:
     """Return validation-only tool state visible for one runtime config."""
-    tool_registry, desired_metadata, unavailable_plugin_tool_names = _resolved_tool_state_for_runtime(
+    tool_registry, desired_metadata, unavailable_tool_metadata = _resolved_tool_state_for_runtime(
         runtime_paths,
         config,
         tolerate_plugin_load_errors=tolerate_plugin_load_errors,
     )
+    validation_metadata = {
+        **desired_metadata,
+        **unavailable_tool_metadata,
+    }
     return _tool_validation_snapshot_from_state(
         tool_registry,
-        desired_metadata,
-        unavailable_plugin_tool_names=unavailable_plugin_tool_names,
+        validation_metadata,
+        unavailable_plugin_tool_names=frozenset(unavailable_tool_metadata),
     )
 
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1858,6 +1858,58 @@ def test_load_config_tolerates_unavailable_ast_plugin_tool_with_authored_overrid
         )
 
 
+def test_unavailable_plugin_tool_is_validation_only_not_runtime_metadata(tmp_path: Path) -> None:
+    """Skipped plugin tools should not appear in public runtime tool metadata."""
+    plugin_root = tmp_path / "plugins" / "broken"
+    _write_pre_registration_broken_tool_plugin(plugin_root)
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        (
+            "models:\n"
+            "  default:\n"
+            "    provider: openai\n"
+            "    id: gpt-5.4\n"
+            "router:\n"
+            "  model: default\n"
+            "agents:\n"
+            "  assistant:\n"
+            "    display_name: Assistant\n"
+            "    role: test\n"
+            "    tools:\n"
+            "      - broken_plugin_tool\n"
+            "plugins:\n"
+            "  - ./plugins/broken\n"
+        ),
+        encoding="utf-8",
+    )
+    runtime_paths = resolve_runtime_paths(
+        config_path=config_path,
+        storage_path=config_path.parent / "mindroom_data",
+        process_env={
+            "MATRIX_HOMESERVER": "http://localhost:8008",
+            "MINDROOM_NAMESPACE": "",
+        },
+    )
+    config = Config(plugins=["./plugins/broken"])
+
+    with _preserved_plugin_loader_state():
+        runtime_metadata = metadata_module.resolved_tool_metadata_for_runtime(
+            runtime_paths,
+            config,
+            tolerate_plugin_load_errors=True,
+        )
+        validation_snapshot = metadata_module.resolved_tool_validation_snapshot_for_runtime(
+            runtime_paths,
+            config,
+            tolerate_plugin_load_errors=True,
+        )
+
+        assert "broken_plugin_tool" not in runtime_metadata
+        assert validation_snapshot["broken_plugin_tool"].runtime_loadable is False
+        assert validation_snapshot["broken_plugin_tool"].unavailable_due_to_plugin_load_error is True
+
+
 def test_load_config_tolerates_tool_declared_after_broken_plugin_registration(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- Keep skipped broken-plugin tool metadata out of public runtime/catalog metadata.
- Preserve unavailable skipped-plugin tools only in validation snapshots so tolerant config validation can still filter and warn.
- Add a regression for a pre-registration broken plugin tool being validation-only.

## Test Plan
- [x] Focused broken-plugin metadata regression passed.
- [x] Ruff and pre-commit checks passed.
- [x] Broader plugin/tool metadata tests passed.
- [x] API/facade tool metadata slice passed.
- [ ] Full suite was started serially and interrupted by request; future full runs should use `-n auto`.

## Summary by Sourcery

Ensure unavailable plugin tools are excluded from public runtime tool metadata while remaining visible for validation snapshots.

Enhancements:
- Adjust runtime tool state resolution so tools from broken or unavailable plugins are no longer included in runtime tool metadata but are tracked separately as unavailable metadata.
- Update validation snapshot construction to merge unavailable plugin tool metadata back into validation-only state while still marking them as unavailable.

Tests:
- Add a regression test verifying that a pre-registration broken plugin tool is omitted from runtime metadata but present and correctly flagged in validation metadata.