### PR TITLE
Fix router handoff follow-up policy

### DIFF
--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -40,7 +40,7 @@ from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.mentions import format_message_with_mentions, parse_mentions_in_text
 from mindroom.matrix.message_builder import build_message_content
 from mindroom.message_target import MessageTarget
-from mindroom.thread_utils import get_agents_in_thread
+from mindroom.thread_utils import filter_thread_agents_for_sender, get_agents_in_thread
 
 if TYPE_CHECKING:
     from mindroom.config.main import Config
@@ -1353,8 +1353,13 @@ async def schedule_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
                     caller_label="schedule_existing_thread",
                 ),
             )
-            thread_agents = get_agents_in_thread(thread_history, config, runtime_paths)
-            available_responders = [agent for agent in thread_agents if agent in sender_visible_room_responders]
+            available_responders = filter_thread_agents_for_sender(
+                get_agents_in_thread(thread_history, config, runtime_paths),
+                scheduled_by,
+                config,
+                runtime_paths,
+                available_responders_in_room=sender_visible_room_responders,
+            )
 
         if mentioned_agents:
             for mid in mentioned_agents:

--- a/src/mindroom/thread_utils.py
+++ b/src/mindroom/thread_utils.py
@@ -187,20 +187,38 @@ def thread_requires_explicit_agent_targeting(
     available_responders_in_room: Sequence[MatrixID] | None = None,
 ) -> bool:
     """Return whether a thread already has visible ownership or multiple human participants."""
-    sender_visible_responders = authorization.filter_responders_by_sender_permissions(
+    sender_visible_responders = filter_thread_agents_for_sender(
         get_agents_in_thread(thread_history, config, runtime_paths),
         sender_id,
         config,
         runtime_paths,
+        available_responders_in_room=available_responders_in_room,
     )
-    if available_responders_in_room is not None:
-        available_responder_ids = {responder.full_id for responder in available_responders_in_room}
-        sender_visible_responders = [
-            responder for responder in sender_visible_responders if responder.full_id in available_responder_ids
-        ]
     if sender_visible_responders:
         return True
     return has_multiple_non_agent_users_in_thread(thread_history, config, runtime_paths)
+
+
+def filter_thread_agents_for_sender(
+    agents_in_thread: Sequence[MatrixID],
+    sender_id: str,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    *,
+    available_responders_in_room: Sequence[MatrixID] | None = None,
+) -> list[MatrixID]:
+    """Return participating agents that may reply within the sender and room responder boundary."""
+    sender_visible_agents = authorization.filter_responders_by_sender_permissions(
+        agents_in_thread,
+        sender_id,
+        config,
+        runtime_paths,
+    )
+    if available_responders_in_room is None:
+        return sender_visible_agents
+
+    available_responder_ids = {responder.full_id for responder in available_responders_in_room}
+    return [agent for agent in sender_visible_agents if agent.full_id in available_responder_ids]
 
 
 def get_all_mentioned_agents_in_thread(
@@ -294,14 +312,13 @@ def should_agent_respond(  # noqa: PLR0911
 
     # For threads, continue only if we're the single participating agent
     # that may reply to this sender within this room's responder boundary.
-    agents_in_thread = get_agents_in_thread(thread_history, config, runtime_paths)
-    agents_in_thread = authorization.filter_responders_by_sender_permissions(
-        agents_in_thread,
+    agents_in_thread = filter_thread_agents_for_sender(
+        get_agents_in_thread(thread_history, config, runtime_paths),
         sender_id,
         config,
         runtime_paths,
+        available_responders_in_room=available_responders,
     )
-    agents_in_thread = [agent for agent in agents_in_thread if agent.full_id in available_responder_ids]
     if agents_in_thread:
         return len(agents_in_thread) == 1 and agents_in_thread[0] == agent_matrix_id
 

--- a/src/mindroom/thread_utils.py
+++ b/src/mindroom/thread_utils.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, cast
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal, cast
 
 from mindroom import authorization
 from mindroom.constants import ROUTER_AGENT_NAME
@@ -26,6 +27,25 @@ if TYPE_CHECKING:
 # Accepts both single and double quotes (mautrix bridges use single quotes).
 # Requires @localpart:domain format to avoid feeding malformed IDs to MatrixID.parse.
 _MATRIX_PILL_RE = re.compile(r"""href=["']https://matrix\.to/#/(@[^"':]+:[^"']+)["']""")
+
+_AgentResponseSkipReason = Literal[
+    "sender_not_allowed",
+    "agent_not_available",
+    "other_explicit_mention",
+    "multiple_non_agent_users_in_thread",
+    "multiple_agents_in_thread",
+    "different_agent_in_thread",
+    "not_single_responder",
+]
+
+
+@dataclass(frozen=True)
+class AgentResponseDecision:
+    """Individual response decision plus the policy branch that produced a skip."""
+
+    should_respond: bool
+    skip_reason: _AgentResponseSkipReason | None = None
+    sender_visible_thread_agents: tuple[MatrixID, ...] = ()
 
 
 def _extract_mentioned_user_ids(
@@ -246,7 +266,51 @@ def get_all_mentioned_agents_in_thread(
     return mentioned_agents
 
 
-def should_agent_respond(  # noqa: PLR0911
+def _decide_thread_agent_response(
+    *,
+    agent_matrix_id: MatrixID,
+    sender_id: str,
+    thread_history: Sequence[ResolvedVisibleMessage],
+    config: Config,
+    runtime_paths: RuntimePaths,
+    available_responders: Sequence[MatrixID],
+    agents_in_thread: Sequence[MatrixID] | None,
+) -> AgentResponseDecision:
+    """Decide unmentioned thread continuation for an available agent."""
+    if has_multiple_non_agent_users_in_thread(thread_history, config, runtime_paths):
+        return AgentResponseDecision(False, "multiple_non_agent_users_in_thread")
+
+    thread_agents = agents_in_thread
+    if thread_agents is None:
+        thread_agents = get_agents_in_thread(thread_history, config, runtime_paths)
+    sender_visible_thread_agents = filter_thread_agents_for_sender(
+        thread_agents,
+        sender_id,
+        config,
+        runtime_paths,
+        available_responders_in_room=available_responders,
+    )
+    if sender_visible_thread_agents:
+        if len(sender_visible_thread_agents) == 1 and sender_visible_thread_agents[0] == agent_matrix_id:
+            return AgentResponseDecision(True, sender_visible_thread_agents=tuple(sender_visible_thread_agents))
+        reason: _AgentResponseSkipReason = (
+            "multiple_agents_in_thread" if len(sender_visible_thread_agents) > 1 else "different_agent_in_thread"
+        )
+        return AgentResponseDecision(
+            False,
+            reason,
+            tuple(sender_visible_thread_agents),
+        )
+
+    # No agents in thread yet: respond if we're the only visible responder.
+    should_respond = len(available_responders) == 1 and available_responders[0] == agent_matrix_id
+    return AgentResponseDecision(
+        should_respond,
+        None if should_respond else "not_single_responder",
+    )
+
+
+def decide_agent_response(
     agent_name: str,
     am_i_mentioned: bool,
     is_thread: bool,
@@ -259,8 +323,9 @@ def should_agent_respond(  # noqa: PLR0911
     *,
     sender_id: str,
     available_responders_in_room: list[MatrixID] | None = None,
-) -> bool:
-    """Determine if an agent should respond to a message individually.
+    agents_in_thread: Sequence[MatrixID] | None = None,
+) -> AgentResponseDecision:
+    """Decide if an agent should respond to a message individually.
 
     Team formation is handled elsewhere - this just determines individual responses.
 
@@ -276,10 +341,11 @@ def should_agent_respond(  # noqa: PLR0911
         has_non_agent_mentions: True when the message explicitly tags a non-agent user
         sender_id: Sender Matrix ID used for per-agent reply permissions
         available_responders_in_room: Optional precomputed sender-visible responders for the room
+        agents_in_thread: Optional precomputed agents that have participated in the thread
 
     """
     if not authorization.is_sender_allowed_for_agent_reply(sender_id, agent_name, config, runtime_paths):
-        return False
+        return AgentResponseDecision(False, "sender_not_allowed")
 
     available_responders = available_responders_in_room
     if available_responders is None:
@@ -292,35 +358,30 @@ def should_agent_respond(  # noqa: PLR0911
     agent_matrix_id = entity_identity_registry(config, runtime_paths).current_id(agent_name)
     available_responder_ids = {responder.full_id for responder in available_responders}
     if agent_matrix_id.full_id not in available_responder_ids:
-        return False
+        return AgentResponseDecision(False, "agent_not_available")
 
     # Always respond if mentioned
     if am_i_mentioned:
-        return True
+        return AgentResponseDecision(True)
 
     # Never respond if anyone else is explicitly mentioned (agent or not)
     if mentioned_agents or has_non_agent_mentions:
-        return False
+        return AgentResponseDecision(False, "other_explicit_mention")
 
     # Non-thread messages: auto-respond if we're the only visible responder in the room.
     if not is_thread:
-        return len(available_responders) == 1 and available_responders[0] == agent_matrix_id
+        should_respond = len(available_responders) == 1 and available_responders[0] == agent_matrix_id
+        return AgentResponseDecision(
+            should_respond,
+            None if should_respond else "not_single_responder",
+        )
 
-    # In threads with multiple human participants, always require explicit mention.
-    if has_multiple_non_agent_users_in_thread(thread_history, config, runtime_paths):
-        return False
-
-    # For threads, continue only if we're the single participating agent
-    # that may reply to this sender within this room's responder boundary.
-    agents_in_thread = filter_thread_agents_for_sender(
-        get_agents_in_thread(thread_history, config, runtime_paths),
-        sender_id,
-        config,
-        runtime_paths,
-        available_responders_in_room=available_responders,
+    return _decide_thread_agent_response(
+        agent_matrix_id=agent_matrix_id,
+        sender_id=sender_id,
+        thread_history=thread_history,
+        config=config,
+        runtime_paths=runtime_paths,
+        available_responders=available_responders,
+        agents_in_thread=agents_in_thread,
     )
-    if agents_in_thread:
-        return len(agents_in_thread) == 1 and agents_in_thread[0] == agent_matrix_id
-
-    # No agents in thread yet: respond if we're the only visible responder.
-    return len(available_responders) == 1 and available_responders[0] == agent_matrix_id

--- a/src/mindroom/turn_policy.py
+++ b/src/mindroom/turn_policy.py
@@ -6,11 +6,7 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
-from mindroom.authorization import (
-    filter_responders_by_sender_permissions,
-    is_sender_allowed_for_agent_reply,
-    responder_candidate_entities_for_room,
-)
+from mindroom.authorization import is_sender_allowed_for_agent_reply, responder_candidate_entities_for_room
 from mindroom.constants import ROUTER_AGENT_NAME, RuntimePaths
 from mindroom.dispatch_source import ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND
 from mindroom.entity_resolution import entity_identity_registry
@@ -45,6 +41,7 @@ from mindroom.teams import (
     resolve_configured_team,
 )
 from mindroom.thread_utils import (
+    filter_thread_agents_for_sender,
     get_agents_in_thread,
     get_all_mentioned_agents_in_thread,
     has_multiple_non_agent_users_in_thread,
@@ -729,14 +726,13 @@ class TurnPolicy:
         if not context.is_thread or context.mentioned_agents or context.has_non_agent_mentions:
             return
 
-        available_responder_ids = {responder.full_id for responder in available_responders_in_room}
-        sender_visible_agents = filter_responders_by_sender_permissions(
+        sender_visible_agents = filter_thread_agents_for_sender(
             agents_in_thread,
             requester_user_id,
             self.deps.runtime.config,
             self.deps.runtime_paths,
+            available_responders_in_room=available_responders_in_room,
         )
-        sender_visible_agents = [agent for agent in sender_visible_agents if agent.full_id in available_responder_ids]
         if len(sender_visible_agents) < 2:
             return
 

--- a/src/mindroom/turn_policy.py
+++ b/src/mindroom/turn_policy.py
@@ -6,7 +6,11 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
-from mindroom.authorization import is_sender_allowed_for_agent_reply, responder_candidate_entities_for_room
+from mindroom.authorization import (
+    filter_responders_by_sender_permissions,
+    is_sender_allowed_for_agent_reply,
+    responder_candidate_entities_for_room,
+)
 from mindroom.constants import ROUTER_AGENT_NAME, RuntimePaths
 from mindroom.dispatch_source import ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND
 from mindroom.entity_resolution import entity_identity_registry
@@ -703,9 +707,45 @@ class TurnPolicy:
                 has_active_response_for_target=has_active_response_for_target,
             ):
                 return ResponseAction(kind="individual")
+            if agent_is_responder_candidate:
+                self._log_multi_agent_thread_skip(
+                    context,
+                    requester_user_id,
+                    agents_in_thread,
+                    available_responders_in_room,
+                )
             return ResponseAction(kind="skip")
 
         return ResponseAction(kind="individual")
+
+    def _log_multi_agent_thread_skip(
+        self,
+        context: MessageContext,
+        requester_user_id: str,
+        agents_in_thread: list[MatrixID],
+        available_responders_in_room: list[MatrixID],
+    ) -> None:
+        """Log the ambiguous multi-agent thread branch after router participants are filtered out."""
+        if not context.is_thread or context.mentioned_agents or context.has_non_agent_mentions:
+            return
+
+        available_responder_ids = {responder.full_id for responder in available_responders_in_room}
+        sender_visible_agents = filter_responders_by_sender_permissions(
+            agents_in_thread,
+            requester_user_id,
+            self.deps.runtime.config,
+            self.deps.runtime_paths,
+        )
+        sender_visible_agents = [agent for agent in sender_visible_agents if agent.full_id in available_responder_ids]
+        if len(sender_visible_agents) < 2:
+            return
+
+        self.deps.logger.info(
+            "Skipping response: multiple agents in thread require explicit mention",
+            agent_name=self.deps.agent_name,
+            thread_id=context.thread_id,
+            agents_in_thread=[agent.full_id for agent in sender_visible_agents],
+        )
 
     def _should_queue_follow_up_in_active_response_thread(
         self,

--- a/src/mindroom/turn_policy.py
+++ b/src/mindroom/turn_policy.py
@@ -725,6 +725,12 @@ class TurnPolicy:
         """Log the ambiguous multi-agent thread branch after router participants are filtered out."""
         if not context.is_thread or context.mentioned_agents or context.has_non_agent_mentions:
             return
+        if has_multiple_non_agent_users_in_thread(
+            context.planning_thread_history,
+            self.deps.runtime.config,
+            self.deps.runtime_paths,
+        ):
+            return
 
         sender_visible_agents = filter_thread_agents_for_sender(
             agents_in_thread,

--- a/src/mindroom/turn_policy.py
+++ b/src/mindroom/turn_policy.py
@@ -41,12 +41,12 @@ from mindroom.teams import (
     resolve_configured_team,
 )
 from mindroom.thread_utils import (
-    filter_thread_agents_for_sender,
+    AgentResponseDecision,
+    decide_agent_response,
     get_agents_in_thread,
     get_all_mentioned_agents_in_thread,
     has_multiple_non_agent_users_in_thread,
     is_router_only_agent_mention,
-    should_agent_respond,
     thread_requires_explicit_agent_targeting,
 )
 from mindroom.timing import emit_elapsed_timing, timed
@@ -684,7 +684,7 @@ class TurnPolicy:
         if team_action is not None:
             return team_action
 
-        if not should_agent_respond(
+        agent_response_decision = decide_agent_response(
             agent_name=self.deps.agent_name,
             am_i_mentioned=context.am_i_mentioned,
             is_thread=context.is_thread,
@@ -696,7 +696,9 @@ class TurnPolicy:
             has_non_agent_mentions=context.has_non_agent_mentions,
             sender_id=requester_user_id,
             available_responders_in_room=available_responders_in_room,
-        ):
+            agents_in_thread=agents_in_thread,
+        )
+        if not agent_response_decision.should_respond:
             if agent_is_responder_candidate and self._should_queue_follow_up_in_active_response_thread(
                 context=context,
                 target=dispatch.target,
@@ -707,9 +709,7 @@ class TurnPolicy:
             if agent_is_responder_candidate:
                 self._log_multi_agent_thread_skip(
                     context,
-                    requester_user_id,
-                    agents_in_thread,
-                    available_responders_in_room,
+                    agent_response_decision,
                 )
             return ResponseAction(kind="skip")
 
@@ -718,35 +718,21 @@ class TurnPolicy:
     def _log_multi_agent_thread_skip(
         self,
         context: MessageContext,
-        requester_user_id: str,
-        agents_in_thread: list[MatrixID],
-        available_responders_in_room: list[MatrixID],
+        agent_response_decision: AgentResponseDecision,
     ) -> None:
-        """Log the ambiguous multi-agent thread branch after router participants are filtered out."""
-        if not context.is_thread or context.mentioned_agents or context.has_non_agent_mentions:
-            return
-        if has_multiple_non_agent_users_in_thread(
-            context.planning_thread_history,
-            self.deps.runtime.config,
-            self.deps.runtime_paths,
-        ):
+        """Log the multi-agent thread branch selected by individual response policy."""
+        if agent_response_decision.skip_reason != "multiple_agents_in_thread":
             return
 
-        sender_visible_agents = filter_thread_agents_for_sender(
-            agents_in_thread,
-            requester_user_id,
-            self.deps.runtime.config,
-            self.deps.runtime_paths,
-            available_responders_in_room=available_responders_in_room,
-        )
-        if len(sender_visible_agents) < 2:
+        agents_in_thread = agent_response_decision.sender_visible_thread_agents
+        if len(agents_in_thread) < 2:
             return
 
         self.deps.logger.info(
             "Skipping response: multiple agents in thread require explicit mention",
             agent_name=self.deps.agent_name,
             thread_id=context.thread_id,
-            agents_in_thread=[agent.full_id for agent in sender_visible_agents],
+            agents_in_thread=[agent.full_id for agent in agents_in_thread],
         )
 
     def _should_queue_follow_up_in_active_response_thread(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 import time
 import uuid
-from collections.abc import AsyncGenerator, Awaitable, Callable, Generator, Iterator, Mapping, MutableMapping
+from collections.abc import AsyncGenerator, Awaitable, Callable, Generator, Iterator, Mapping, MutableMapping, Sequence
 from contextlib import ExitStack, contextmanager
 from dataclasses import replace
 from itertools import count
@@ -38,10 +38,12 @@ from mindroom.matrix.cache.write_coordinator import EventCacheWriteCoordinator
 from mindroom.matrix.client import DeliveredMatrixEvent, ResolvedVisibleMessage
 from mindroom.matrix.client_delivery import build_edit_event_content
 from mindroom.matrix.conversation_cache import ConversationCacheProtocol
+from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.thread_diagnostics import is_thread_history_degraded
 from mindroom.message_target import MessageTarget
 from mindroom.response_runner import PostLockRequestPreparationError, ResponseRequest, ResponseRunner
 from mindroom.runtime_support import StartupThreadPrewarmRegistry
+from mindroom.thread_utils import decide_agent_response
 from mindroom.turn_controller import TurnController, _DispatchPreparation, _ReplayGuardContext
 from mindroom.turn_origin import TurnOrigin, classify_turn_origin
 from mindroom.turn_policy import PreparedDispatch, TurnPolicy
@@ -55,6 +57,7 @@ __all__ = [
     "TEST_ACCESS_TOKEN",
     "TEST_PASSWORD",
     "FakeCredentialsManager",
+    "agent_response_should_respond",
     "aioresponse",
     "bind_mock_config_cache",
     "bind_runtime_paths",
@@ -123,6 +126,38 @@ def prepared_dispatch_result(dispatch: PreparedDispatch) -> _DispatchPreparation
             thread_id=dispatch.target.resolved_thread_id,
         ),
     )
+
+
+def agent_response_should_respond(
+    agent_name: str,
+    am_i_mentioned: bool,
+    is_thread: bool,
+    room: nio.MatrixRoom,
+    thread_history: Sequence[ResolvedVisibleMessage],
+    config: Config,
+    runtime_paths: RuntimePaths,
+    mentioned_agents: list[MatrixID] | None = None,
+    has_non_agent_mentions: bool = False,
+    *,
+    sender_id: str,
+    available_responders_in_room: list[MatrixID] | None = None,
+    agents_in_thread: Sequence[MatrixID] | None = None,
+) -> bool:
+    """Return the boolean projection of the agent response decision for tests."""
+    return decide_agent_response(
+        agent_name,
+        am_i_mentioned,
+        is_thread,
+        room,
+        thread_history,
+        config,
+        runtime_paths,
+        mentioned_agents,
+        has_non_agent_mentions,
+        sender_id=sender_id,
+        available_responders_in_room=available_responders_in_room,
+        agents_in_thread=agents_in_thread,
+    ).should_respond
 
 
 def message_origin(

--- a/tests/test_agent_response_logic.py
+++ b/tests/test_agent_response_logic.py
@@ -33,9 +33,9 @@ from mindroom.message_target import MessageTarget
 from mindroom.teams import TeamIntent, TeamOutcome, TeamResolution
 from mindroom.thread_utils import (
     check_agent_mentioned,
+    decide_agent_response,
     get_agents_in_thread,
     is_router_only_agent_mention,
-    should_agent_respond,
 )
 from mindroom.turn_policy import PreparedDispatch, ResponseAction, TurnPolicy, TurnPolicyDeps
 from tests.conftest import bind_runtime_paths, create_mock_room, request_envelope, runtime_paths_for, test_runtime_paths
@@ -47,6 +47,11 @@ def _bind_runtime_config(config: Config, runtime_root: Path | None = None) -> Co
     bound_config = bind_runtime_paths(config, runtime_paths)
     persist_entity_accounts(bound_config, runtime_paths_for(bound_config))
     return bound_config
+
+
+def should_agent_respond(*args: Any, **kwargs: Any) -> bool:  # noqa: ANN401
+    """Return the boolean result for legacy response-policy assertions."""
+    return decide_agent_response(*args, **kwargs).should_respond
 
 
 def _message(

--- a/tests/test_agent_response_logic.py
+++ b/tests/test_agent_response_logic.py
@@ -33,12 +33,18 @@ from mindroom.message_target import MessageTarget
 from mindroom.teams import TeamIntent, TeamOutcome, TeamResolution
 from mindroom.thread_utils import (
     check_agent_mentioned,
-    decide_agent_response,
     get_agents_in_thread,
     is_router_only_agent_mention,
 )
 from mindroom.turn_policy import PreparedDispatch, ResponseAction, TurnPolicy, TurnPolicyDeps
-from tests.conftest import bind_runtime_paths, create_mock_room, request_envelope, runtime_paths_for, test_runtime_paths
+from tests.conftest import (
+    agent_response_should_respond,
+    bind_runtime_paths,
+    create_mock_room,
+    request_envelope,
+    runtime_paths_for,
+    test_runtime_paths,
+)
 from tests.identity_helpers import entity_ids, persist_entity_accounts
 
 
@@ -47,11 +53,6 @@ def _bind_runtime_config(config: Config, runtime_root: Path | None = None) -> Co
     bound_config = bind_runtime_paths(config, runtime_paths)
     persist_entity_accounts(bound_config, runtime_paths_for(bound_config))
     return bound_config
-
-
-def should_agent_respond(*args: Any, **kwargs: Any) -> bool:  # noqa: ANN401
-    """Return the boolean result for legacy response-policy assertions."""
-    return decide_agent_response(*args, **kwargs).should_respond
 
 
 def _message(
@@ -70,7 +71,7 @@ def _message(
 
 
 class TestAgentResponseLogic:
-    """Test the should_agent_respond logic."""
+    """Test the agent response decision logic."""
 
     def setup_method(self) -> None:
         """Set up test config."""
@@ -98,7 +99,7 @@ class TestAgentResponseLogic:
 
     def test_mentioned_agent_always_responds(self) -> None:
         """If an agent is mentioned, it should always respond."""
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="calculator",
             am_i_mentioned=True,
             is_thread=True,
@@ -115,7 +116,7 @@ class TestAgentResponseLogic:
         self.config.authorization.agent_reply_permissions = {
             "calculator": [f"@alice:{self.domain}"],
         }
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="calculator",
             am_i_mentioned=True,
             is_thread=False,
@@ -135,7 +136,7 @@ class TestAgentResponseLogic:
             "calculator": [canonical_user],
         }
         self.config.authorization.aliases = {canonical_user: [alias_user]}
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="calculator",
             am_i_mentioned=True,
             is_thread=False,
@@ -561,7 +562,7 @@ class TestAgentResponseLogic:
         self.config.authorization.agent_reply_permissions = {
             "calculator": [f"*:{self.domain}"],
         }
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="calculator",
             am_i_mentioned=True,
             is_thread=False,
@@ -583,7 +584,7 @@ class TestAgentResponseLogic:
         }
         room = create_mock_room("!room:localhost", ["calculator", "general"], self.config)
 
-        should_respond_calculator = should_agent_respond(
+        should_respond_calculator = agent_response_should_respond(
             agent_name="calculator",
             am_i_mentioned=False,
             is_thread=False,
@@ -593,7 +594,7 @@ class TestAgentResponseLogic:
             runtime_paths=self.runtime_paths,
             sender_id=f"@alice:{self.domain}",
         )
-        should_respond_general = should_agent_respond(
+        should_respond_general = agent_response_should_respond(
             agent_name="general",
             am_i_mentioned=False,
             is_thread=False,
@@ -614,7 +615,7 @@ class TestAgentResponseLogic:
             _message(sender="@user:localhost", body="What about 3+3?"),
         ]
 
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="calculator",
             am_i_mentioned=False,
             is_thread=True,
@@ -634,7 +635,7 @@ class TestAgentResponseLogic:
             _message(sender=f"@user:{self.domain}", body="What about 3+3?"),
         ]
 
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="calculator",
             am_i_mentioned=False,
             is_thread=True,
@@ -649,7 +650,7 @@ class TestAgentResponseLogic:
     def test_invited_agent_behaves_like_native_agent(self) -> None:
         """Invited agents should follow the same rules as native agents."""
         # Test 1: Invited agent with no agents in thread - router decides (multiple agents)
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="calculator",
             am_i_mentioned=False,
             is_thread=True,
@@ -666,7 +667,7 @@ class TestAgentResponseLogic:
             _message(sender=self.agent_id("calculator"), body="2+2=4"),
             _message(sender="@user:localhost", body="What about 3+3?"),
         ]
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="calculator",
             am_i_mentioned=False,
             is_thread=True,
@@ -684,7 +685,7 @@ class TestAgentResponseLogic:
             _message(sender=self.agent_id("general"), body="Let me help"),
             _message(sender="@user:localhost", body="What about 3+3?"),
         ]
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="calculator",
             am_i_mentioned=False,
             is_thread=True,
@@ -699,7 +700,7 @@ class TestAgentResponseLogic:
     def test_only_agent_with_access_responds_when_no_history(self) -> None:
         """When no agents have spoken yet, router decides who responds if multiple agents available."""
         # Multiple agents with access - router should decide
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="general",
             am_i_mentioned=False,
             is_thread=True,
@@ -713,7 +714,7 @@ class TestAgentResponseLogic:
 
         # Agent in room but not configured - should not respond when multiple agents available
         # (router decides) but CAN respond if mentioned
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="calculator",
             am_i_mentioned=False,
             is_thread=True,
@@ -726,7 +727,7 @@ class TestAgentResponseLogic:
         assert should_respond is False  # Router decides when multiple agents available
 
         # But if mentioned, agent in room can respond even if not configured
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="calculator",
             am_i_mentioned=True,
             is_thread=True,
@@ -740,7 +741,7 @@ class TestAgentResponseLogic:
 
     def test_no_agents_in_thread_uses_router(self) -> None:
         """If no agents have participated, router decides who responds (multiple agents available)."""
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="calculator",
             am_i_mentioned=False,
             is_thread=True,
@@ -760,7 +761,7 @@ class TestAgentResponseLogic:
             _message(sender="@user:localhost", body="What about 3+3?"),
         ]
 
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="calculator",
             am_i_mentioned=False,
             is_thread=True,
@@ -793,7 +794,7 @@ class TestAgentResponseLogic:
 
         assert [agent.full_id for agent in agents_in_thread] == [self.agent_id("general")]
         assert (
-            should_agent_respond(
+            agent_response_should_respond(
                 agent_name="general",
                 am_i_mentioned=False,
                 is_thread=True,
@@ -832,7 +833,7 @@ class TestAgentResponseLogic:
             self.agent_id("calculator"),
         ]
         assert (
-            should_agent_respond(
+            agent_response_should_respond(
                 agent_name="general",
                 am_i_mentioned=False,
                 is_thread=True,
@@ -845,7 +846,7 @@ class TestAgentResponseLogic:
             is False
         )
         assert (
-            should_agent_respond(
+            agent_response_should_respond(
                 agent_name="calculator",
                 am_i_mentioned=False,
                 is_thread=True,
@@ -903,7 +904,7 @@ class TestAgentResponseLogic:
         mentioned_agents = [entity_ids(self.config, self.runtime_paths)["general"]]
 
         assert (
-            should_agent_respond(
+            agent_response_should_respond(
                 agent_name="general",
                 am_i_mentioned=True,
                 is_thread=True,
@@ -929,7 +930,7 @@ class TestAgentResponseLogic:
             _message(sender=f"@alice:{self.domain}", body="What about 3+3?"),
         ]
 
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="calculator",
             am_i_mentioned=False,
             is_thread=True,
@@ -968,7 +969,7 @@ class TestAgentResponseLogic:
             _message(sender=f"@bob:{self.domain}", body="continue"),
         ]
 
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="calculator",
             am_i_mentioned=False,
             is_thread=True,
@@ -997,7 +998,7 @@ class TestAgentResponseLogic:
         persist_entity_accounts(config, runtime_paths_for(config))
         runtime_paths = runtime_paths_for(config)
 
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="calculator",
             am_i_mentioned=True,
             is_thread=False,
@@ -1012,7 +1013,7 @@ class TestAgentResponseLogic:
 
     def test_not_in_thread_uses_router(self) -> None:
         """If not in a thread, use router to determine response."""
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="calculator",
             am_i_mentioned=False,
             is_thread=False,
@@ -1026,7 +1027,7 @@ class TestAgentResponseLogic:
 
     def test_agent_not_in_room_no_response(self) -> None:
         """If agent is not in room (native or invited), don't respond."""
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="calculator",
             am_i_mentioned=False,
             is_thread=True,
@@ -1040,7 +1041,7 @@ class TestAgentResponseLogic:
 
     def test_mentioned_outside_thread_responds(self) -> None:
         """Agents respond when mentioned in room (will create thread)."""
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="calculator",
             am_i_mentioned=True,
             is_thread=False,
@@ -1066,7 +1067,7 @@ class TestAgentResponseLogic:
         ]
 
         # Non-mentioned agent should not respond
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="general",
             am_i_mentioned=False,
             is_thread=True,
@@ -1081,7 +1082,7 @@ class TestAgentResponseLogic:
     def test_router_selection_scenarios(self) -> None:
         """Test various scenarios where router should be used."""
         # Scenario 1: Empty thread, native agent
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="calculator",
             am_i_mentioned=False,
             is_thread=True,
@@ -1098,7 +1099,7 @@ class TestAgentResponseLogic:
             _message(sender="@user:localhost", body="I need help with math"),
             _message(sender="@user:localhost", body="Can someone help?"),
         ]
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="calculator",
             am_i_mentioned=False,
             is_thread=True,
@@ -1112,7 +1113,7 @@ class TestAgentResponseLogic:
 
     def test_room_message_no_access_no_response(self) -> None:
         """Agent without room access doesn't respond to room messages."""
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="calculator",
             am_i_mentioned=False,
             is_thread=False,
@@ -1127,7 +1128,7 @@ class TestAgentResponseLogic:
     def test_edge_case_empty_configured_rooms(self) -> None:
         """Test agent with no configured rooms but invited to thread."""
         # Should behave same as native agent when invited
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="calculator",
             am_i_mentioned=False,
             is_thread=True,
@@ -1151,7 +1152,7 @@ class TestAgentResponseLogic:
         ]
 
         # Multiple agents present, nobody should respond without mention
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="calculator",
             am_i_mentioned=False,
             is_thread=True,
@@ -1166,7 +1167,7 @@ class TestAgentResponseLogic:
     def test_router_disabled_when_any_agent_mentioned(self) -> None:
         """Test that router is disabled when any agent is mentioned, not just the current one."""
         # Room message scenario - agent1 is NOT mentioned but agent2 IS mentioned
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="agent1",
             am_i_mentioned=False,
             is_thread=False,
@@ -1180,7 +1181,7 @@ class TestAgentResponseLogic:
         assert not should_respond
 
         # Now test when no agents are mentioned - router should be used
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="agent1",
             am_i_mentioned=False,
             is_thread=False,
@@ -1195,7 +1196,7 @@ class TestAgentResponseLogic:
         assert not should_respond
 
         # Test when current agent is mentioned
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="agent1",
             am_i_mentioned=True,
             is_thread=True,
@@ -1212,7 +1213,7 @@ class TestAgentResponseLogic:
         """When an ad-hoc room has one agent with access to an empty thread, it takes ownership."""
         room = create_mock_room("!adhoc:localhost", ["calculator"], self.config)
 
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="calculator",
             am_i_mentioned=False,
             is_thread=True,
@@ -1229,7 +1230,7 @@ class TestAgentResponseLogic:
             _message(sender="@user:localhost", body="I need help"),
             _message(sender="@user:localhost", body="Anyone there?"),
         ]
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="calculator",
             am_i_mentioned=False,
             is_thread=True,
@@ -1251,7 +1252,7 @@ class TestAgentResponseLogic:
             _message(sender="@bob:localhost", body="I also need help"),
         ]
         assert (
-            should_agent_respond(
+            agent_response_should_respond(
                 agent_name="calculator",
                 am_i_mentioned=False,
                 is_thread=True,
@@ -1266,7 +1267,7 @@ class TestAgentResponseLogic:
 
         # Same thread but agent is explicitly mentioned → respond
         assert (
-            should_agent_respond(
+            agent_response_should_respond(
                 agent_name="calculator",
                 am_i_mentioned=True,
                 is_thread=True,
@@ -1284,7 +1285,7 @@ class TestAgentResponseLogic:
             _message(sender="@alice:localhost", body="Can someone help?"),
         ]
         assert (
-            should_agent_respond(
+            agent_response_should_respond(
                 agent_name="calculator",
                 am_i_mentioned=False,
                 is_thread=True,
@@ -1305,7 +1306,7 @@ class TestAgentResponseLogic:
             _message(sender="@alice:localhost", body="Can you continue?"),
         ]
         assert (
-            should_agent_respond(
+            agent_response_should_respond(
                 agent_name="calculator",
                 am_i_mentioned=False,
                 is_thread=True,
@@ -1323,7 +1324,7 @@ class TestAgentResponseLogic:
         room = create_mock_room("!room:localhost", ["calculator"], self.config)
 
         assert (
-            should_agent_respond(
+            agent_response_should_respond(
                 agent_name="calculator",
                 am_i_mentioned=False,
                 is_thread=False,
@@ -1344,7 +1345,7 @@ class TestAgentResponseLogic:
         room.users["@bob:localhost"] = None
 
         assert (
-            should_agent_respond(
+            agent_response_should_respond(
                 agent_name="calculator",
                 am_i_mentioned=False,
                 is_thread=False,
@@ -1378,7 +1379,7 @@ class TestAgentResponseLogic:
         ]
         # Only one real human — agent should auto-respond
         assert (
-            should_agent_respond(
+            agent_response_should_respond(
                 agent_name="calculator",
                 am_i_mentioned=False,
                 is_thread=True,
@@ -1405,7 +1406,7 @@ class TestAgentResponseLogic:
         ]
 
         # GeneralAgent should NOT respond because ResearchAgent is mentioned
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="general",
             am_i_mentioned=False,  # GeneralAgent is NOT mentioned
             is_thread=True,
@@ -1421,7 +1422,7 @@ class TestAgentResponseLogic:
         assert should_respond is False  # Should NOT respond when another agent is mentioned
 
         # But if no agents are mentioned, general should continue the conversation
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="general",
             am_i_mentioned=False,
             is_thread=True,

--- a/tests/test_agent_response_logic.py
+++ b/tests/test_agent_response_logic.py
@@ -31,7 +31,12 @@ from mindroom.matrix.thread_diagnostics import (
 )
 from mindroom.message_target import MessageTarget
 from mindroom.teams import TeamIntent, TeamOutcome, TeamResolution
-from mindroom.thread_utils import should_agent_respond
+from mindroom.thread_utils import (
+    check_agent_mentioned,
+    get_agents_in_thread,
+    is_router_only_agent_mention,
+    should_agent_respond,
+)
 from mindroom.turn_policy import PreparedDispatch, ResponseAction, TurnPolicy, TurnPolicyDeps
 from tests.conftest import bind_runtime_paths, create_mock_room, request_envelope, runtime_paths_for, test_runtime_paths
 from tests.identity_helpers import entity_ids, persist_entity_accounts
@@ -263,6 +268,162 @@ class TestAgentResponseLogic:
             )
 
         assert single_visible_action.kind == "individual"
+
+    @pytest.mark.asyncio
+    async def test_response_policy_logs_multi_agent_thread_skip(self) -> None:
+        """A multi-agent thread skip should leave a useful policy diagnostic."""
+        room = create_mock_room("!room:localhost", ["calculator", "general"], self.config)
+        runtime = MagicMock()
+        runtime.client = None
+        runtime.config = self.config
+        runtime.orchestrator = None
+        logger = MagicMock()
+        policy = TurnPolicy(
+            TurnPolicyDeps(
+                runtime=runtime,
+                logger=logger,
+                runtime_paths=self.runtime_paths,
+                agent_name="calculator",
+                matrix_id=entity_ids(self.config, self.runtime_paths)["calculator"],
+            ),
+        )
+        context = MessageContext(
+            am_i_mentioned=False,
+            is_thread=True,
+            thread_id="$thread-root:localhost",
+            thread_history=thread_history_result(
+                [
+                    _message(sender=self.agent_id("general"), body="I can help."),
+                    _message(sender=self.agent_id("calculator"), body="I can also help."),
+                    _message(sender=self.sender, body="What next?"),
+                ],
+                is_full_history=True,
+            ),
+            mentioned_agents=[],
+            has_non_agent_mentions=False,
+        )
+        target = MessageTarget.resolve(room.room_id, context.thread_id, "$event")
+        dispatch = PreparedDispatch(
+            requester_user_id=self.sender,
+            context=context,
+            target=target,
+            correlation_id="$event",
+            envelope=request_envelope(
+                room_id=room.room_id,
+                reply_to_event_id="$event",
+                thread_id=context.thread_id,
+                prompt="continue",
+                user_id=self.sender,
+                target=target,
+                agent_name="calculator",
+            ),
+        )
+        candidate_ids = entity_ids(self.config, self.runtime_paths)
+
+        with (
+            patch(
+                "mindroom.turn_policy.responder_candidate_entities_for_room",
+                new=AsyncMock(return_value=[candidate_ids["calculator"], candidate_ids["general"]]),
+            ),
+            patch(
+                "mindroom.turn_policy.decide_team_formation",
+                new=AsyncMock(return_value=TeamResolution.none()),
+            ),
+        ):
+            action = await policy.resolve_response_action(
+                dispatch,
+                room,
+                "continue",
+                False,
+                has_active_response_for_target=lambda _target: False,
+            )
+
+        assert action.kind == "skip"
+        matching_calls = [
+            call
+            for call in logger.info.call_args_list
+            if call.args == ("Skipping response: multiple agents in thread require explicit mention",)
+        ]
+        assert matching_calls
+        assert matching_calls[0].kwargs["agent_name"] == "calculator"
+        assert matching_calls[0].kwargs["thread_id"] == "$thread-root:localhost"
+        assert matching_calls[0].kwargs["agents_in_thread"] == [
+            self.agent_id("general"),
+            self.agent_id("calculator"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_response_policy_continues_after_router_handoff(self) -> None:
+        """The main turn policy should ignore router handoff as conversational participation."""
+        room = create_mock_room("!room:localhost", ["calculator", "general"], self.config)
+        runtime = MagicMock()
+        runtime.client = None
+        runtime.config = self.config
+        runtime.orchestrator = None
+        policy = TurnPolicy(
+            TurnPolicyDeps(
+                runtime=runtime,
+                logger=MagicMock(),
+                runtime_paths=self.runtime_paths,
+                agent_name="general",
+                matrix_id=entity_ids(self.config, self.runtime_paths)["general"],
+            ),
+        )
+        context = MessageContext(
+            am_i_mentioned=False,
+            is_thread=True,
+            thread_id="$thread-root:localhost",
+            thread_history=thread_history_result(
+                [
+                    _message(sender=self.sender, body="Can someone help?"),
+                    _message(
+                        sender=self.agent_id("router"),
+                        body="@mindroom_general could you help?",
+                        content={
+                            "m.mentions": {
+                                "user_ids": [self.agent_id("general")],
+                            },
+                        },
+                    ),
+                    _message(sender=self.agent_id("general"), body="I can help."),
+                    _message(sender=self.sender, body="What is the next step?"),
+                ],
+                is_full_history=True,
+            ),
+            mentioned_agents=[],
+            has_non_agent_mentions=False,
+        )
+        target = MessageTarget.resolve(room.room_id, context.thread_id, "$event")
+        dispatch = PreparedDispatch(
+            requester_user_id=self.sender,
+            context=context,
+            target=target,
+            correlation_id="$event",
+            envelope=request_envelope(
+                room_id=room.room_id,
+                reply_to_event_id="$event",
+                thread_id=context.thread_id,
+                prompt="continue",
+                user_id=self.sender,
+                target=target,
+                agent_name="general",
+            ),
+        )
+        candidate_ids = entity_ids(self.config, self.runtime_paths)
+
+        with patch(
+            "mindroom.turn_policy.responder_candidate_entities_for_room",
+            new=AsyncMock(return_value=[candidate_ids["calculator"], candidate_ids["general"]]),
+        ):
+            action = await policy.resolve_response_action(
+                dispatch,
+                room,
+                "continue",
+                False,
+                has_active_response_for_target=lambda _target: False,
+            )
+
+        assert action.kind == "individual"
 
     def test_effective_response_action_does_not_convert_reject_to_configured_team(self) -> None:
         """Configured-team execution only upgrades individual actions."""
@@ -527,6 +688,151 @@ class TestAgentResponseLogic:
             sender_id=self.sender,
         )
         assert should_respond is False
+
+    def test_router_handoff_allows_target_agent_follow_up(self) -> None:
+        """Router handoff should not count as a second agent for untagged follow-ups."""
+        thread_history = [
+            _message(sender=self.sender, body="Can someone help?"),
+            _message(
+                sender=self.agent_id("router"),
+                body="@mindroom_general could you help?",
+                content={
+                    "m.mentions": {
+                        "user_ids": [self.agent_id("general")],
+                    },
+                },
+            ),
+            _message(sender=self.agent_id("general"), body="I can help."),
+            _message(sender=self.sender, body="What is the next step?"),
+        ]
+
+        agents_in_thread = get_agents_in_thread(thread_history, self.config, self.runtime_paths)
+
+        assert [agent.full_id for agent in agents_in_thread] == [self.agent_id("general")]
+        assert (
+            should_agent_respond(
+                agent_name="general",
+                am_i_mentioned=False,
+                is_thread=True,
+                room=create_mock_room("!room:localhost", ["calculator", "general", "agent1"], self.config),
+                thread_history=thread_history,
+                config=self.config,
+                runtime_paths=self.runtime_paths,
+                sender_id=self.sender,
+            )
+            is True
+        )
+
+    def test_router_handoff_still_requires_mention_after_second_real_agent_participates(self) -> None:
+        """Router handoff is ignored, but two real agent participants still suppress auto-follow-up."""
+        thread_history = [
+            _message(sender=self.sender, body="Can someone help?"),
+            _message(
+                sender=self.agent_id("router"),
+                body="@mindroom_general could you help?",
+                content={
+                    "m.mentions": {
+                        "user_ids": [self.agent_id("general")],
+                    },
+                },
+            ),
+            _message(sender=self.agent_id("general"), body="I can help."),
+            _message(sender=self.agent_id("calculator"), body="I can also help with numbers."),
+            _message(sender=self.sender, body="What is the next step?"),
+        ]
+        room = create_mock_room("!room:localhost", ["calculator", "general", "agent1"], self.config)
+
+        agents_in_thread = get_agents_in_thread(thread_history, self.config, self.runtime_paths)
+
+        assert [agent.full_id for agent in agents_in_thread] == [
+            self.agent_id("general"),
+            self.agent_id("calculator"),
+        ]
+        assert (
+            should_agent_respond(
+                agent_name="general",
+                am_i_mentioned=False,
+                is_thread=True,
+                room=room,
+                thread_history=thread_history,
+                config=self.config,
+                runtime_paths=self.runtime_paths,
+                sender_id=self.sender,
+            )
+            is False
+        )
+        assert (
+            should_agent_respond(
+                agent_name="calculator",
+                am_i_mentioned=False,
+                is_thread=True,
+                room=room,
+                thread_history=thread_history,
+                config=self.config,
+                runtime_paths=self.runtime_paths,
+                sender_id=self.sender,
+            )
+            is False
+        )
+
+    def test_explicit_router_mention_still_detected(self) -> None:
+        """Filtering router from participants must not hide explicit router mentions."""
+        router_id = entity_ids(self.config, self.runtime_paths)["router"]
+        event_source = {
+            "content": {
+                "body": "@mindroom_router route this",
+                "msgtype": "m.text",
+                "m.mentions": {
+                    "user_ids": [router_id.full_id],
+                },
+            },
+        }
+
+        mentioned_agents, am_i_mentioned, has_non_agent_mentions = check_agent_mentioned(
+            event_source,
+            router_id,
+            self.config,
+            self.runtime_paths,
+        )
+
+        assert mentioned_agents == [router_id]
+        assert am_i_mentioned is True
+        assert has_non_agent_mentions is False
+        assert (
+            is_router_only_agent_mention(
+                mentioned_agents,
+                has_non_agent_mentions=has_non_agent_mentions,
+                config=self.config,
+                runtime_paths=self.runtime_paths,
+            )
+            is True
+        )
+
+    def test_explicit_target_agent_mention_still_works_in_multi_agent_thread(self) -> None:
+        """Explicitly mentioning the target agent overrides multi-agent follow-up suppression."""
+        thread_history = [
+            _message(sender=self.sender, body="Can someone help?"),
+            _message(sender=self.agent_id("router"), body="@mindroom_general could you help?"),
+            _message(sender=self.agent_id("general"), body="I can help."),
+            _message(sender=self.agent_id("calculator"), body="I can also help with numbers."),
+            _message(sender=self.sender, body="@mindroom_general what next?"),
+        ]
+        mentioned_agents = [entity_ids(self.config, self.runtime_paths)["general"]]
+
+        assert (
+            should_agent_respond(
+                agent_name="general",
+                am_i_mentioned=True,
+                is_thread=True,
+                room=create_mock_room("!room:localhost", ["calculator", "general", "agent1"], self.config),
+                thread_history=thread_history,
+                config=self.config,
+                runtime_paths=self.runtime_paths,
+                mentioned_agents=mentioned_agents,
+                sender_id=self.sender,
+            )
+            is True
+        )
 
     def test_only_permitted_agent_in_thread_continues(self) -> None:
         """A permitted agent should continue when other thread participants are disallowed."""

--- a/tests/test_agent_response_logic.py
+++ b/tests/test_agent_response_logic.py
@@ -353,6 +353,78 @@ class TestAgentResponseLogic:
         ]
 
     @pytest.mark.asyncio
+    async def test_response_policy_does_not_log_multi_agent_skip_for_multi_human_thread(self) -> None:
+        """Multi-human thread suppression should not be misreported as multi-agent suppression."""
+        room = create_mock_room("!room:localhost", ["calculator", "general"], self.config)
+        runtime = MagicMock()
+        runtime.client = None
+        runtime.config = self.config
+        runtime.orchestrator = None
+        logger = MagicMock()
+        policy = TurnPolicy(
+            TurnPolicyDeps(
+                runtime=runtime,
+                logger=logger,
+                runtime_paths=self.runtime_paths,
+                agent_name="calculator",
+                matrix_id=entity_ids(self.config, self.runtime_paths)["calculator"],
+            ),
+        )
+        context = MessageContext(
+            am_i_mentioned=False,
+            is_thread=True,
+            thread_id="$thread-root:localhost",
+            thread_history=thread_history_result(
+                [
+                    _message(sender=self.agent_id("general"), body="I can help."),
+                    _message(sender="@other-human:localhost", body="I have context too."),
+                    _message(sender=self.agent_id("calculator"), body="I can also help."),
+                    _message(sender=self.sender, body="What next?"),
+                ],
+                is_full_history=True,
+            ),
+            mentioned_agents=[],
+            has_non_agent_mentions=False,
+        )
+        target = MessageTarget.resolve(room.room_id, context.thread_id, "$event")
+        dispatch = PreparedDispatch(
+            requester_user_id=self.sender,
+            context=context,
+            target=target,
+            correlation_id="$event",
+            envelope=request_envelope(
+                room_id=room.room_id,
+                reply_to_event_id="$event",
+                thread_id=context.thread_id,
+                prompt="continue",
+                user_id=self.sender,
+                target=target,
+                agent_name="calculator",
+            ),
+        )
+        candidate_ids = entity_ids(self.config, self.runtime_paths)
+
+        with patch(
+            "mindroom.turn_policy.responder_candidate_entities_for_room",
+            new=AsyncMock(return_value=[candidate_ids["calculator"], candidate_ids["general"]]),
+        ):
+            action = await policy.resolve_response_action(
+                dispatch,
+                room,
+                "continue",
+                False,
+                has_active_response_for_target=lambda _target: False,
+            )
+
+        assert action.kind == "skip"
+        matching_calls = [
+            call
+            for call in logger.info.call_args_list
+            if call.args == ("Skipping response: multiple agents in thread require explicit mention",)
+        ]
+        assert not matching_calls
+
+    @pytest.mark.asyncio
     async def test_response_policy_continues_after_router_handoff(self) -> None:
         """The main turn policy should ignore router handoff as conversational participation."""
         room = create_mock_room("!room:localhost", ["calculator", "general"], self.config)
@@ -411,9 +483,15 @@ class TestAgentResponseLogic:
         )
         candidate_ids = entity_ids(self.config, self.runtime_paths)
 
-        with patch(
-            "mindroom.turn_policy.responder_candidate_entities_for_room",
-            new=AsyncMock(return_value=[candidate_ids["calculator"], candidate_ids["general"]]),
+        with (
+            patch(
+                "mindroom.turn_policy.responder_candidate_entities_for_room",
+                new=AsyncMock(return_value=[candidate_ids["calculator"], candidate_ids["general"]]),
+            ),
+            patch(
+                "mindroom.turn_policy.decide_team_formation",
+                new=AsyncMock(return_value=TeamResolution.none()),
+            ),
         ):
             action = await policy.resolve_response_action(
                 dispatch,

--- a/tests/test_bot_scheduling.py
+++ b/tests/test_bot_scheduling.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import nio
@@ -24,7 +24,7 @@ from mindroom.matrix.cache.thread_history_result import thread_history_result
 from mindroom.matrix.client import ResolvedVisibleMessage
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
-from mindroom.thread_utils import should_agent_respond
+from mindroom.thread_utils import AgentResponseDecision, decide_agent_response
 from mindroom.turn_controller import _PrecheckedEvent
 from mindroom.turn_origin import TurnIntent
 from tests.conftest import (
@@ -50,6 +50,11 @@ from tests.identity_helpers import entity_ids, persist_entity_accounts
 
 if TYPE_CHECKING:
     from mindroom.matrix.identity import MatrixID
+
+
+def should_agent_respond(*args: Any, **kwargs: Any) -> bool:  # noqa: ANN401
+    """Return the boolean result for legacy response-policy assertions."""
+    return decide_agent_response(*args, **kwargs).should_respond
 
 
 def _runtime_bound_config(config: Config, runtime_root: Path | None = None) -> Config:
@@ -922,8 +927,8 @@ class TestCommandHandling:
             return_value=dispatch_context_result(mock_context),
         )
 
-        # Mock should_agent_respond to return True
-        with patch("mindroom.turn_policy.should_agent_respond", return_value=True):
+        # Mock decide_agent_response to return a positive decision
+        with patch("mindroom.turn_policy.decide_agent_response", return_value=AgentResponseDecision(True)):
             # Create a room and event with a regular message
             room = nio.MatrixRoom(room_id="!test:server", own_user_id=bot.client.user_id)
             event = nio.RoomMessageText.from_dict(

--- a/tests/test_bot_scheduling.py
+++ b/tests/test_bot_scheduling.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import nio
@@ -24,12 +24,13 @@ from mindroom.matrix.cache.thread_history_result import thread_history_result
 from mindroom.matrix.client import ResolvedVisibleMessage
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
-from mindroom.thread_utils import AgentResponseDecision, decide_agent_response
+from mindroom.thread_utils import AgentResponseDecision
 from mindroom.turn_controller import _PrecheckedEvent
 from mindroom.turn_origin import TurnIntent
 from tests.conftest import (
     TEST_ACCESS_TOKEN,
     TEST_PASSWORD,
+    agent_response_should_respond,
     bind_runtime_paths,
     create_mock_room,
     dispatch_context_result,
@@ -50,11 +51,6 @@ from tests.identity_helpers import entity_ids, persist_entity_accounts
 
 if TYPE_CHECKING:
     from mindroom.matrix.identity import MatrixID
-
-
-def should_agent_respond(*args: Any, **kwargs: Any) -> bool:  # noqa: ANN401
-    """Return the boolean result for legacy response-policy assertions."""
-    return decide_agent_response(*args, **kwargs).should_respond
 
 
 def _runtime_bound_config(config: Config, runtime_root: Path | None = None) -> Config:
@@ -1040,11 +1036,11 @@ class TestCommandHandling:
         ]
 
         # NOTE: In reality, when router sends an error without mentions,
-        # bot.py returns early and never calls should_agent_respond.
+        # bot.py returns early and never reaches individual response policy.
         # But we test what WOULD happen if it were called:
 
         # Test with single agent (finance only, router excluded from available_agents)
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="finance",
             am_i_mentioned=False,
             is_thread=True,
@@ -1059,7 +1055,7 @@ class TestCommandHandling:
         assert should_respond, "Single agent takes ownership after router error"
 
         # Test with multiple agents - nobody responds
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="finance",
             am_i_mentioned=False,
             is_thread=True,

--- a/tests/test_dm_functionality.py
+++ b/tests/test_dm_functionality.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import nio
@@ -16,9 +16,9 @@ from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.orchestrator import _MultiAgentOrchestrator
-from mindroom.thread_utils import decide_agent_response
 from tests.conftest import (
     TEST_PASSWORD,
+    agent_response_should_respond,
     bind_runtime_paths,
     drain_coalescing,
     install_generate_response_mock,
@@ -30,11 +30,6 @@ from tests.identity_helpers import entity_ids, persist_entity_accounts
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-
-def should_agent_respond(*args: Any, **kwargs: Any) -> bool:  # noqa: ANN401
-    """Return the boolean result for legacy response-policy assertions."""
-    return decide_agent_response(*args, **kwargs).should_respond
 
 
 def _bind_runtime_paths(config: Config, path: Path) -> Config:
@@ -67,7 +62,7 @@ class TestDMResponseLogic:
         room.users = {agent_matrix_id: None}
 
         # In DM mode, agent should respond when no one else has
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="test_agent",
             am_i_mentioned=False,  # Not mentioned
             is_thread=False,
@@ -98,7 +93,7 @@ class TestDMResponseLogic:
         room.users = {agent_matrix_id: None}
 
         # When mentioned, always respond
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="test_agent",
             am_i_mentioned=True,  # Mentioned
             is_thread=False,
@@ -131,7 +126,7 @@ class TestDMResponseLogic:
         room.users = {test_agent_id: None, other_agent_id: None}
 
         # Another agent is mentioned, not this one
-        should_respond = should_agent_respond(
+        should_respond = agent_response_should_respond(
             agent_name="test_agent",
             am_i_mentioned=False,
             is_thread=False,
@@ -167,7 +162,7 @@ class TestDMResponseLogic:
         room.users = {test_agent_id: None, other_agent_id: None}
 
         # No mentions - agents should not respond individually (team formation happens at a higher level)
-        should_respond_test = should_agent_respond(
+        should_respond_test = agent_response_should_respond(
             agent_name="test_agent",
             am_i_mentioned=False,
             is_thread=False,
@@ -179,7 +174,7 @@ class TestDMResponseLogic:
             sender_id="@user:localhost",
         )
 
-        should_respond_other = should_agent_respond(
+        should_respond_other = agent_response_should_respond(
             agent_name="other_agent",
             am_i_mentioned=False,
             is_thread=False,

--- a/tests/test_dm_functionality.py
+++ b/tests/test_dm_functionality.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import nio
@@ -16,7 +16,7 @@ from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.orchestrator import _MultiAgentOrchestrator
-from mindroom.thread_utils import should_agent_respond
+from mindroom.thread_utils import decide_agent_response
 from tests.conftest import (
     TEST_PASSWORD,
     bind_runtime_paths,
@@ -30,6 +30,11 @@ from tests.identity_helpers import entity_ids, persist_entity_accounts
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+def should_agent_respond(*args: Any, **kwargs: Any) -> bool:  # noqa: ANN401
+    """Return the boolean result for legacy response-policy assertions."""
+    return decide_agent_response(*args, **kwargs).should_respond
 
 
 def _bind_runtime_paths(config: Config, path: Path) -> Config:

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -133,6 +133,7 @@ from mindroom.startup_errors import PermanentStartupError
 from mindroom.streaming import StreamingDeliveryError
 from mindroom.teams import TeamIntent, TeamMemberStatus, TeamMode, TeamOutcome, TeamResolution, TeamResolutionMember
 from mindroom.thread_summary import thread_summary_message_count_hint
+from mindroom.thread_utils import AgentResponseDecision
 from mindroom.tool_approval import ApprovalActionResult, MatrixApprovalAction, _shutdown_approval_store
 from mindroom.tool_system.events import ToolTraceEntry
 from mindroom.tool_system.metadata import TOOL_METADATA
@@ -7366,7 +7367,7 @@ class TestAgentBot:
                 new_callable=AsyncMock,
                 return_value=TeamResolution.none(),
             ),
-            patch("mindroom.turn_policy.should_agent_respond", return_value=True),
+            patch("mindroom.turn_policy.decide_agent_response", return_value=AgentResponseDecision(True)),
             patch("mindroom.inbound_turn_normalizer.download_image", new_callable=AsyncMock, return_value=image),
             patch(
                 "mindroom.inbound_turn_normalizer.register_matrix_media_attachment",
@@ -7905,7 +7906,7 @@ class TestAgentBot:
                 new_callable=AsyncMock,
                 return_value=TeamResolution.none(),
             ),
-            patch("mindroom.turn_policy.should_agent_respond", return_value=True),
+            patch("mindroom.turn_policy.decide_agent_response", return_value=AgentResponseDecision(True)),
             patch("mindroom.inbound_turn_normalizer.download_image", new_callable=AsyncMock, return_value=image),
             patch(
                 "mindroom.inbound_turn_normalizer.register_matrix_media_attachment",
@@ -8363,7 +8364,7 @@ class TestAgentBot:
                 new_callable=AsyncMock,
                 return_value=TeamResolution.none(),
             ),
-            patch("mindroom.turn_policy.should_agent_respond", return_value=True),
+            patch("mindroom.turn_policy.decide_agent_response", return_value=AgentResponseDecision(True)),
             patch("mindroom.inbound_turn_normalizer.download_image", new_callable=AsyncMock, return_value=None),
         ):
             await bot._on_media_message(room, event)
@@ -8433,7 +8434,7 @@ class TestAgentBot:
                 new_callable=AsyncMock,
                 return_value=TeamResolution.none(),
             ),
-            patch("mindroom.turn_policy.should_agent_respond", return_value=True),
+            patch("mindroom.turn_policy.decide_agent_response", return_value=AgentResponseDecision(True)),
             patch(
                 "mindroom.inbound_turn_normalizer.register_matrix_media_attachment",
                 new_callable=AsyncMock,
@@ -8526,7 +8527,7 @@ class TestAgentBot:
                 new_callable=AsyncMock,
                 return_value=TeamResolution.none(),
             ),
-            patch("mindroom.turn_policy.should_agent_respond", return_value=True),
+            patch("mindroom.turn_policy.decide_agent_response", return_value=AgentResponseDecision(True)),
             patch(
                 "mindroom.inbound_turn_normalizer.register_matrix_media_attachment",
                 new_callable=AsyncMock,
@@ -9353,7 +9354,7 @@ class TestAgentBot:
                 new_callable=AsyncMock,
                 return_value=TeamResolution.none(),
             ),
-            patch("mindroom.turn_policy.should_agent_respond", return_value=True),
+            patch("mindroom.turn_policy.decide_agent_response", return_value=AgentResponseDecision(True)),
         ):
             await bot._on_message(room, event)
             await drain_coalescing(bot)
@@ -9473,7 +9474,10 @@ class TestAgentBot:
                     ),
                 ),
             ),
-            patch("mindroom.turn_policy.should_agent_respond", return_value=True) as mock_should_respond,
+            patch(
+                "mindroom.turn_policy.decide_agent_response",
+                return_value=AgentResponseDecision(True),
+            ) as mock_decide_agent_response,
         ):
             action = await bot._turn_policy.resolve_response_action(
                 _policy_dispatch(bot, room, context, "@user:localhost", "help me"),
@@ -9485,7 +9489,7 @@ class TestAgentBot:
 
         assert action.kind == "reject"
         assert "private agents cannot participate in teams yet" in action.rejection_message
-        mock_should_respond.assert_not_called()
+        mock_decide_agent_response.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_resolve_response_action_rejects_when_explicit_mentions_include_hidden_agent(
@@ -9530,7 +9534,10 @@ class TestAgentBot:
             has_non_agent_mentions=False,
         )
 
-        with patch("mindroom.turn_policy.should_agent_respond", return_value=True) as mock_should_respond:
+        with patch(
+            "mindroom.turn_policy.decide_agent_response",
+            return_value=AgentResponseDecision(True),
+        ) as mock_decide_agent_response:
             action = await bot._turn_policy.resolve_response_action(
                 _policy_dispatch(bot, room, context, "@alice:localhost", "calculator and general, help"),
                 room,
@@ -9543,7 +9550,7 @@ class TestAgentBot:
         assert action.rejection_message == (
             "Team request includes agent 'general' that is not available to you in this room."
         )
-        mock_should_respond.assert_not_called()
+        mock_decide_agent_response.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_resolve_response_action_rejects_when_only_unrequested_visible_bot_can_surface_reject(
@@ -9586,7 +9593,10 @@ class TestAgentBot:
             has_non_agent_mentions=False,
         )
 
-        with patch("mindroom.turn_policy.should_agent_respond", return_value=True) as mock_should_respond:
+        with patch(
+            "mindroom.turn_policy.decide_agent_response",
+            return_value=AgentResponseDecision(True),
+        ) as mock_decide_agent_response:
             action = await bot._turn_policy.resolve_response_action(
                 _policy_dispatch(bot, room, context, "@user:localhost", "general and research, help"),
                 room,
@@ -9599,7 +9609,7 @@ class TestAgentBot:
         assert action.rejection_message == (
             "Team request includes agents 'general', 'research' that could not be materialized for this request."
         )
-        mock_should_respond.assert_not_called()
+        mock_decide_agent_response.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_resolve_response_action_rejects_non_running_requested_member(
@@ -9643,7 +9653,10 @@ class TestAgentBot:
             has_non_agent_mentions=False,
         )
 
-        with patch("mindroom.turn_policy.should_agent_respond", return_value=True) as mock_should_respond:
+        with patch(
+            "mindroom.turn_policy.decide_agent_response",
+            return_value=AgentResponseDecision(True),
+        ) as mock_decide_agent_response:
             action = await bot._turn_policy.resolve_response_action(
                 _policy_dispatch(bot, room, context, "@user:localhost", "alpha and calculator, help"),
                 room,
@@ -9656,7 +9669,7 @@ class TestAgentBot:
         assert action.rejection_message == (
             "Team request includes agent 'alpha' that could not be materialized for this request."
         )
-        mock_should_respond.assert_not_called()
+        mock_decide_agent_response.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_resolve_response_action_skips_when_explicit_mentions_are_all_hidden(
@@ -9701,7 +9714,10 @@ class TestAgentBot:
             has_non_agent_mentions=False,
         )
 
-        with patch("mindroom.turn_policy.should_agent_respond", return_value=True) as mock_should_respond:
+        with patch(
+            "mindroom.turn_policy.decide_agent_response",
+            return_value=AgentResponseDecision(True),
+        ) as mock_decide_agent_response:
             action = await bot._turn_policy.resolve_response_action(
                 _policy_dispatch(bot, room, context, "@alice:localhost", "calculator and general, help"),
                 room,
@@ -9711,7 +9727,7 @@ class TestAgentBot:
             )
 
         assert action.kind == "skip"
-        mock_should_respond.assert_not_called()
+        mock_decide_agent_response.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_resolve_response_action_keeps_configured_room_boundary_for_direct_reply(
@@ -9936,7 +9952,10 @@ class TestAgentBot:
                     ),
                 ),
             ),
-            patch("mindroom.turn_policy.should_agent_respond", return_value=True) as mock_should_respond,
+            patch(
+                "mindroom.turn_policy.decide_agent_response",
+                return_value=AgentResponseDecision(True),
+            ) as mock_decide_agent_response,
         ):
             action = await bot._turn_policy.resolve_response_action(
                 _policy_dispatch(bot, room, context, "@user:localhost", "alpha and calculator, help"),
@@ -9948,7 +9967,7 @@ class TestAgentBot:
 
         assert action.kind == "reject"
         assert action.rejection_message == "Team request includes agent 'alpha' that is not available right now."
-        mock_should_respond.assert_not_called()
+        mock_decide_agent_response.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_resolve_response_action_ignores_unsupported_non_responders_for_reject_ownership(
@@ -10014,7 +10033,10 @@ class TestAgentBot:
                     ),
                 ),
             ),
-            patch("mindroom.turn_policy.should_agent_respond", return_value=True) as mock_should_respond,
+            patch(
+                "mindroom.turn_policy.decide_agent_response",
+                return_value=AgentResponseDecision(True),
+            ) as mock_decide_agent_response,
         ):
             action = await bot._turn_policy.resolve_response_action(
                 _policy_dispatch(bot, room, context, "@user:localhost", "alpha and calculator, help"),
@@ -10026,7 +10048,7 @@ class TestAgentBot:
 
         assert action.kind == "reject"
         assert "private agents cannot participate in teams yet" in action.rejection_message
-        mock_should_respond.assert_not_called()
+        mock_decide_agent_response.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_resolve_response_action_uses_actual_team_resolution_for_private_member_reject_ownership(
@@ -10070,7 +10092,10 @@ class TestAgentBot:
             has_non_agent_mentions=False,
         )
 
-        with patch("mindroom.turn_policy.should_agent_respond", return_value=True) as mock_should_respond:
+        with patch(
+            "mindroom.turn_policy.decide_agent_response",
+            return_value=AgentResponseDecision(True),
+        ) as mock_decide_agent_response:
             action = await bot._turn_policy.resolve_response_action(
                 _policy_dispatch(bot, room, context, "@user:localhost", "alpha and calculator, help"),
                 room,
@@ -10083,7 +10108,7 @@ class TestAgentBot:
         assert action.rejection_message == (
             "Team request includes private agent 'alpha'; private agents cannot participate in teams yet"
         )
-        mock_should_respond.assert_not_called()
+        mock_decide_agent_response.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_resolve_response_action_honors_single_agent_team_fallback(
@@ -10091,7 +10116,7 @@ class TestAgentBot:
         mock_agent_user: AgentMatrixUser,
         tmp_path: Path,
     ) -> None:
-        """Team formation may degrade to one responder without falling back through should_agent_respond."""
+        """Team formation may degrade to one responder without falling back through decide_agent_response."""
         config = _runtime_bound_config(
             Config(
                 agents={
@@ -10123,7 +10148,10 @@ class TestAgentBot:
                     ),
                 ),
             ),
-            patch("mindroom.turn_policy.should_agent_respond", return_value=False) as mock_should_respond,
+            patch(
+                "mindroom.turn_policy.decide_agent_response",
+                return_value=AgentResponseDecision(False),
+            ) as mock_decide_agent_response,
         ):
             action = await bot._turn_policy.resolve_response_action(
                 _policy_dispatch(bot, room, context, "@user:localhost", "help me"),
@@ -10134,7 +10162,7 @@ class TestAgentBot:
             )
 
         assert action.kind == "individual"
-        mock_should_respond.assert_not_called()
+        mock_decide_agent_response.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_resolve_response_action_keeps_human_follow_up_in_active_thread(
@@ -10213,7 +10241,10 @@ class TestAgentBot:
                 "mindroom.turn_policy.decide_team_formation",
                 new=AsyncMock(return_value=TeamResolution.none()),
             ),
-            patch("mindroom.turn_policy.should_agent_respond", return_value=False) as mock_should_respond,
+            patch(
+                "mindroom.turn_policy.decide_agent_response",
+                return_value=AgentResponseDecision(False),
+            ) as mock_decide_agent_response,
             patch.object(
                 bot._response_runner,
                 "has_active_response_for_target",
@@ -10235,7 +10266,7 @@ class TestAgentBot:
             )
 
         assert action.kind == "individual"
-        mock_should_respond.assert_called_once()
+        mock_decide_agent_response.assert_called_once()
         mock_has_active_response.assert_called_once_with(target)
 
     @pytest.mark.asyncio
@@ -10448,7 +10479,10 @@ class TestAgentBot:
                 "mindroom.turn_policy.decide_team_formation",
                 new=AsyncMock(return_value=TeamResolution.none()),
             ),
-            patch("mindroom.turn_policy.should_agent_respond", return_value=False) as mock_should_respond,
+            patch(
+                "mindroom.turn_policy.decide_agent_response",
+                return_value=AgentResponseDecision(False),
+            ) as mock_decide_agent_response,
             patch.object(
                 bot._response_runner,
                 "has_active_response_for_target",
@@ -10470,7 +10504,7 @@ class TestAgentBot:
             )
 
         assert action.kind == "individual"
-        mock_should_respond.assert_called_once()
+        mock_decide_agent_response.assert_called_once()
         mock_has_active_response.assert_not_called()
 
     @pytest.mark.asyncio
@@ -10533,7 +10567,10 @@ class TestAgentBot:
                 "mindroom.turn_policy.decide_team_formation",
                 new=AsyncMock(return_value=TeamResolution.none()),
             ),
-            patch("mindroom.turn_policy.should_agent_respond", return_value=False) as mock_should_respond,
+            patch(
+                "mindroom.turn_policy.decide_agent_response",
+                return_value=AgentResponseDecision(False),
+            ) as mock_decide_agent_response,
             patch.object(
                 bot._response_runner,
                 "has_active_response_for_target",
@@ -10556,7 +10593,7 @@ class TestAgentBot:
 
         assert action.kind == "individual"
         assert envelope.source_kind == VOICE_SOURCE_KIND
-        mock_should_respond.assert_called_once()
+        mock_decide_agent_response.assert_called_once()
         mock_has_active_response.assert_not_called()
 
     @pytest.mark.asyncio
@@ -10799,7 +10836,10 @@ class TestAgentBot:
                 "mindroom.turn_policy.decide_team_formation",
                 new=AsyncMock(side_effect=AssertionError("team formation should be skipped")),
             ) as mock_decide_team_formation,
-            patch("mindroom.turn_policy.should_agent_respond", return_value=False) as mock_should_respond,
+            patch(
+                "mindroom.turn_policy.decide_agent_response",
+                return_value=AgentResponseDecision(False),
+            ) as mock_decide_agent_response,
         ):
             action = await bot._turn_policy.resolve_response_action(
                 _policy_dispatch(bot, room, context, "@bas:localhost", "I fixed two issues"),
@@ -10811,7 +10851,7 @@ class TestAgentBot:
 
         assert action.kind == "skip"
         mock_decide_team_formation.assert_not_awaited()
-        mock_should_respond.assert_called_once()
+        mock_decide_agent_response.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_resolve_response_action_continues_single_agent_thread_when_policy_history_partial(
@@ -10932,7 +10972,10 @@ class TestAgentBot:
             requires_model_history_refresh=True,
         )
 
-        with patch("mindroom.turn_policy.should_agent_respond", return_value=True) as mock_should_respond:
+        with patch(
+            "mindroom.turn_policy.decide_agent_response",
+            return_value=AgentResponseDecision(True),
+        ) as mock_decide_agent_response:
             action = await bot._turn_policy.resolve_response_action(
                 _policy_dispatch(bot, room, context, "@bas:localhost", "Follow-up"),
                 room,
@@ -10942,7 +10985,7 @@ class TestAgentBot:
             )
 
         assert action.kind == "skip"
-        mock_should_respond.assert_not_called()
+        mock_decide_agent_response.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_resolve_response_action_allows_sole_responder_when_policy_history_degraded(
@@ -10997,7 +11040,10 @@ class TestAgentBot:
             has_non_agent_mentions=False,
         )
 
-        with patch("mindroom.turn_policy.should_agent_respond", return_value=True) as mock_should_respond:
+        with patch(
+            "mindroom.turn_policy.decide_agent_response",
+            return_value=AgentResponseDecision(True),
+        ) as mock_decide_agent_response:
             action = await bot._turn_policy.resolve_response_action(
                 _policy_dispatch(bot, room, context, "@bas:localhost", "Follow-up"),
                 room,
@@ -11007,7 +11053,7 @@ class TestAgentBot:
             )
 
         assert action.kind == "individual"
-        mock_should_respond.assert_not_called()
+        mock_decide_agent_response.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_router_skips_unmentioned_thread_when_policy_history_degraded(
@@ -12771,7 +12817,7 @@ class TestAgentBot:
                 new_callable=AsyncMock,
                 return_value=TeamResolution.none(),
             ),
-            patch("mindroom.turn_policy.should_agent_respond", return_value=True),
+            patch("mindroom.turn_policy.decide_agent_response", return_value=AgentResponseDecision(True)),
             patch("mindroom.inbound_turn_normalizer.download_image", new_callable=AsyncMock, return_value=None),
             patch.object(bot._turn_controller, "_log_dispatch_latency"),
         ):

--- a/tests/test_routing_regression.py
+++ b/tests/test_routing_regression.py
@@ -30,6 +30,7 @@ from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
 from mindroom.routing import suggest_responder_for_message
 from mindroom.teams import TeamOutcome, TeamResolution
+from mindroom.thread_utils import AgentResponseDecision
 from mindroom.turn_policy import PreparedDispatch, TurnPolicy, TurnPolicyDeps
 from tests.conftest import (
     TEST_PASSWORD,
@@ -1008,7 +1009,10 @@ class TestRoutingRegression:
                 "mindroom.turn_policy.decide_team_formation",
                 new=AsyncMock(return_value=TeamResolution.none()),
             ),
-            patch("mindroom.turn_policy.should_agent_respond", return_value=True) as mock_should_agent_respond,
+            patch(
+                "mindroom.turn_policy.decide_agent_response",
+                return_value=AgentResponseDecision(True),
+            ) as mock_decide_agent_response,
         ):
             action = await alpha_bot._turn_policy.resolve_response_action(
                 _policy_dispatch(
@@ -1027,7 +1031,7 @@ class TestRoutingRegression:
         assert action.kind == "individual"
         candidate_names = [
             entity_name_for_id(candidate, test_config, runtime_paths)
-            for candidate in mock_should_agent_respond.call_args.kwargs["available_responders_in_room"]
+            for candidate in mock_decide_agent_response.call_args.kwargs["available_responders_in_room"]
         ]
         assert candidate_names == ["alpha"]
 


### PR DESCRIPTION
## Summary
- Keep router handoff behavior covered so router participation is excluded from follow-up participant counting while explicit router and target-agent mentions still work.
- Return structured agent response decisions so multi-agent thread skips can be logged without duplicating response-policy logic.
- Reuse sender-visible thread responder filtering for scheduled existing-thread tasks.
- Replace duplicated local test response-policy wrappers with one typed shared test helper.

## Tests
- `uv run ruff check tests/conftest.py tests/test_agent_response_logic.py tests/test_bot_scheduling.py tests/test_dm_functionality.py`
- `uv run ruff format --check tests/conftest.py tests/test_agent_response_logic.py tests/test_bot_scheduling.py tests/test_dm_functionality.py`
- `uv run pytest tests/test_agent_response_logic.py tests/test_bot_scheduling.py tests/test_dm_functionality.py -n 0 --no-cov -v`
- `uv run pre-commit run --all-files`
- `uv run pytest tests/test_multi_agent_bot.py::TestMultiAgentOrchestrator::test_wait_for_matrix_homeserver_returns_when_versions tests/test_live_message_coalescing.py::test_text_first_multiple_images_during_grace_dispatch_once -n 0 --no-cov -v`
- `uv run pytest tests/test_tools_metadata.py::test_registered_tools_declare_managed_init_args_for_explicit_constructor_inputs -n 0 --no-cov -v`

## Full-suite note
- `uv run pytest -n auto --no-cov` was retried locally. The parallel runs failed only on unrelated xdist-sensitive tests that passed in the serial reruns listed above.
