### PR TITLE
Update MindRoom release metadata to v2026.6.37

### DIFF
--- a/macos/appcast.xml
+++ b/macos/appcast.xml
@@ -5,6 +5,32 @@
         <link>https://github.com/mindroom-ai/mindroom</link>
         <description>Signed MindRoom macOS app updates.</description>
         <item>
+            <title>2026.6.37</title>
+            <pubDate>Wed, 03 Jun 2026 22:52:41 +0000</pubDate>
+            <link>https://github.com/mindroom-ai/mindroom</link>
+            <sparkle:version>670</sparkle:version>
+            <sparkle:shortVersionString>2026.6.37</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+            <description sparkle:format="markdown"><![CDATA[# Release 2026.6.37
+
+## 📊 Statistics
+- 📦 **1** commits
+- 👥 **1** contributors
+
+## 📝 Changes
+
+- [Move MindRoom cask to Homebrew tap (#1153)](https://github.com/mindroom-ai/mindroom/commit/50404e38) by @basnijholt
+## 👥 Contributors
+@basnijholt
+
+
+---
+🙏 Thank you for using this project! Please report any issues or feedback on the GitHub repository.
+]]></description>
+            <enclosure url="https://github.com/mindroom-ai/mindroom/releases/download/v2026.6.37/MindRoom.zip" length="23634452" type="application/octet-stream" sparkle:edSignature="s5eeczMwqwjcYKLWEBsX1Q1rRZDy3DmKfXF21RJbhW7fdU7eHxv+0vq+Hn//YlIzkM3VBIS/KzPYo/KoxJj3BA=="/>
+        </item>
+        <item>
             <title>2026.6.9</title>
             <pubDate>Tue, 02 Jun 2026 06:32:43 +0000</pubDate>
             <link>https://github.com/mindroom-ai/mindroom</link>


### PR DESCRIPTION
Updates release metadata generated by the v2026.6.37 macOS release workflow.

This includes:
- Sparkle appcast entry and signature
