### PR TITLE
Update latest model examples

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -475,11 +475,11 @@ models:
     id: claude-sonnet-4-6
     provider: anthropic
   # --- OpenAI ---
-  gpt52:
-    id: gpt-5.2
+  gpt55:
+    id: gpt-5.5
     provider: openai
   gpt5mini:
-    id: gpt-5-mini
+    id: gpt-5.4-mini
     provider: openai
   # --- Google ---
   gemini_flash:

--- a/docs/chat-commands.md
+++ b/docs/chat-commands.md
@@ -160,7 +160,7 @@ Changes are validated against the Pydantic config schema before applying.
 
 ```
 !config set agents.analyst.display_name "Research Expert"
-!config set models.default.id gpt-5.4
+!config set models.default.id gpt-5.5
 !config set defaults.markdown false
 !config set timezone America/New_York
 ```

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -51,7 +51,7 @@ models:
   # OpenAI
   gpt:
     provider: openai
-    id: gpt-5.4
+    id: gpt-5.5
 
   # Azure OpenAI
   azure:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -203,7 +203,7 @@ agents:
 models:
   default:
     provider: openai
-    id: gpt-5.4
+    id: gpt-5.5
 
 defaults:
   tools: [scheduler]

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,7 +75,7 @@ agents:
 models:
   default:
     provider: openai
-    id: gpt-5.4
+    id: gpt-5.5
 
 defaults:
   tools: [scheduler]

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -77,7 +77,7 @@ agents:
 models:
   default:
     provider: openai
-    id: gpt-5.4
+    id: gpt-5.5
 
 defaults:
   tools: [scheduler]
@@ -387,7 +387,7 @@ agents:
 models:
   default:
     provider: openai
-    id: gpt-5.4
+    id: gpt-5.5
 
 defaults:
   tools: [scheduler]
@@ -2104,7 +2104,7 @@ models:
   # OpenAI
   gpt:
     provider: openai
-    id: gpt-5.4
+    id: gpt-5.5
 
   # Azure OpenAI
   azure:
@@ -12528,7 +12528,7 @@ Changes are validated against the Pydantic config schema before applying.
 
 ```
 !config set agents.analyst.display_name "Research Expert"
-!config set models.default.id gpt-5.4
+!config set models.default.id gpt-5.5
 !config set defaults.markdown false
 !config set timezone America/New_York
 ```

--- a/skills/mindroom-docs/references/page__chat-commands__index.md
+++ b/skills/mindroom-docs/references/page__chat-commands__index.md
@@ -156,7 +156,7 @@ Changes are validated against the Pydantic config schema before applying.
 
 ```
 !config set agents.analyst.display_name "Research Expert"
-!config set models.default.id gpt-5.4
+!config set models.default.id gpt-5.5
 !config set defaults.markdown false
 !config set timezone America/New_York
 ```

--- a/skills/mindroom-docs/references/page__configuration__models__index.md
+++ b/skills/mindroom-docs/references/page__configuration__models__index.md
@@ -47,7 +47,7 @@ models:
   # OpenAI
   gpt:
     provider: openai
-    id: gpt-5.4
+    id: gpt-5.5
 
   # Azure OpenAI
   azure:

--- a/skills/mindroom-docs/references/page__getting-started__index.md
+++ b/skills/mindroom-docs/references/page__getting-started__index.md
@@ -199,7 +199,7 @@ agents:
 models:
   default:
     provider: openai
-    id: gpt-5.4
+    id: gpt-5.5
 
 defaults:
   tools: [scheduler]

--- a/skills/mindroom-docs/references/page__index.md
+++ b/skills/mindroom-docs/references/page__index.md
@@ -71,7 +71,7 @@ agents:
 models:
   default:
     provider: openai
-    id: gpt-5.4
+    id: gpt-5.5
 
 defaults:
   tools: [scheduler]


### PR DESCRIPTION
## Summary
- Update sample OpenAI model aliases from older GPT IDs to gpt-5.5 / gpt-5.4-mini.
- Refresh model examples in public docs and generated mindroom-docs references.
- Keep current Anthropic/OpenRouter Claude Sonnet 4.6 identifiers unchanged.

## Test Plan
- uv sync --all-extras
- uv run pytest tests/test_model_defaults.py tests/test_docs_frontmatter.py tests/test_cli_config.py -q
- uv run pre-commit run --all-files
- uv run pytest

## Summary by Sourcery

Update OpenAI model defaults and examples to use the latest gpt-5.5 / gpt-5.4-mini aliases across configuration and documentation.

Enhancements:
- Update OpenAI model aliases in the main configuration to point to gpt-5.5 and gpt-5.4-mini instead of older GPT model IDs.

Documentation:
- Refresh configuration and getting-started docs to use gpt-5.5 as the default OpenAI model in examples.
- Regenerate mindroom-docs reference pages to reflect the new gpt-5.5 model ID in config snippets.