### PR TITLE
Learn model media fallback capabilities

### DIFF
--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -989,7 +989,7 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                 turn_recorder.set_run_metadata(metadata)
 
             response: RunOutput | None = None
-            media_route = build_model_media_route(agent.model)
+            media_route = build_model_media_route(agent.model) if media_inputs.has_any() else None
             media_filter = filter_media_inputs_for_route(media_route, media_inputs)
             attempt_prompt = (
                 ai_runtime.append_inline_media_fallback_to_run_input(
@@ -1510,7 +1510,7 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
             if turn_recorder is not None:
                 turn_recorder.set_run_metadata(metadata)
 
-            media_route = build_model_media_route(agent.model)
+            media_route = build_model_media_route(agent.model) if media_inputs.has_any() else None
             media_filter = filter_media_inputs_for_route(media_route, media_inputs)
             attempt_prompt = (
                 ai_runtime.append_inline_media_fallback_to_run_input(

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -418,7 +418,12 @@ def _request_stream_retry(
     if retried_after_media_fallback or _stream_attempt_has_progress(state):
         # Once any stream content is emitted, retrying would duplicate partial output.
         return False
-    retry_decision = retry_media_inputs_after_failure(media_route, error, media_inputs)
+    retry_decision = retry_media_inputs_after_failure(
+        media_route,
+        error,
+        media_inputs,
+        learn_route_capability=True,
+    )
     if not retry_decision.should_retry:
         return False
     state.media_fallback_retry_requested = True
@@ -1034,6 +1039,7 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                             media_route,
                             e,
                             attempt_media_inputs,
+                            learn_route_capability=True,
                         )
                         if not retried_after_media_fallback and retry_decision.should_retry:
                             logger.warning(
@@ -1059,6 +1065,7 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                             media_route,
                             error_text,
                             attempt_media_inputs,
+                            learn_route_capability=True,
                         )
                         if not retried_after_media_fallback and retry_decision.should_retry:
                             logger.warning(
@@ -1077,8 +1084,7 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
 
                         logger.warning("AI response returned errored run output", agent=agent_name, error=error_text)
 
-                    if response.status is not RunStatus.cancelled:
-                        break
+                    break
 
                 assert response is not None
             finally:

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -65,7 +65,13 @@ from mindroom.llm_request_logging import (
     stream_with_llm_request_log_context,
 )
 from mindroom.logging_config import get_logger
-from mindroom.media_fallback import should_retry_without_inline_media
+from mindroom.media_fallback import (
+    ModelMediaRoute,
+    build_model_media_route,
+    filter_media_inputs_for_route,
+    retry_media_inputs_after_failure,
+    should_retry_without_inline_media,
+)
 from mindroom.media_inputs import MediaInputs
 from mindroom.memory import MemoryPromptParts, build_memory_prompt_parts, strip_user_turn_time_prefix
 from mindroom.metadata_merge import deep_merge_metadata
@@ -93,6 +99,7 @@ __all__ = [
     "ai_response",
     "build_matrix_run_metadata",
     "resolve_run_correlation_id",
+    "should_retry_without_inline_media",
     "stream_agent_response",
 ]
 AIStreamChunk = str | RunContentEvent | RunCompletedEvent | ToolCallStartedEvent | ToolCallCompletedEvent
@@ -213,6 +220,7 @@ class _StreamingAttemptState:
     first_token_latency: float | None = None
     first_token_logged: bool = False
     retry_requested: bool = False
+    retry_media_inputs: MediaInputs | None = None
     user_error: Exception | None = None
     stream_exception: Exception | None = None
 
@@ -402,6 +410,7 @@ def _request_stream_retry(
     state: _StreamingAttemptState,
     *,
     retried_without_inline_media: bool,
+    media_route: ModelMediaRoute | None,
     media_inputs: MediaInputs,
     error: Exception | str,
     log_message: str,
@@ -411,13 +420,16 @@ def _request_stream_retry(
     if retried_without_inline_media or _stream_attempt_has_progress(state):
         # Once any stream content is emitted, retrying would duplicate partial output.
         return False
-    if not should_retry_without_inline_media(error, media_inputs):
+    retry_decision = retry_media_inputs_after_failure(media_route, error, media_inputs)
+    if not retry_decision.should_retry:
         return False
     state.retry_requested = True
+    state.retry_media_inputs = retry_decision.media_inputs
     logger.warning(
         log_message,
         agent=agent_name,
         error=str(error),
+        removed_media_kinds=sorted(retry_decision.removed_kinds),
     )
     return True
 
@@ -975,8 +987,17 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                 turn_recorder.set_run_metadata(metadata)
 
             response: RunOutput | None = None
-            attempt_prompt = ai_runtime.copy_run_input(run_input)
-            attempt_media_inputs = media_inputs
+            media_route = build_model_media_route(agent.model)
+            media_filter = filter_media_inputs_for_route(media_route, media_inputs)
+            attempt_prompt = (
+                ai_runtime.append_inline_media_fallback_to_run_input(
+                    run_input,
+                    fallback_prompt=inline_media_fallback_prompt,
+                )
+                if media_filter.removed_kinds
+                else ai_runtime.copy_run_input(run_input)
+            )
+            attempt_media_inputs = media_filter.media_inputs
 
             try:
                 for retried_without_inline_media in (False, True):
@@ -1011,20 +1032,23 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                                 timing_scope=timing_scope,
                             )
                     except Exception as e:
-                        if not retried_without_inline_media and should_retry_without_inline_media(
+                        retry_decision = retry_media_inputs_after_failure(
+                            media_route,
                             e,
                             attempt_media_inputs,
-                        ):
+                        )
+                        if not retried_without_inline_media and retry_decision.should_retry:
                             logger.warning(
-                                "Retrying AI response without inline media after validation error",
+                                "Retrying AI response after inline media validation error",
                                 agent=agent_name,
                                 error=str(e),
+                                removed_media_kinds=sorted(retry_decision.removed_kinds),
                             )
                             attempt_prompt = ai_runtime.append_inline_media_fallback_to_run_input(
                                 run_input,
                                 fallback_prompt=inline_media_fallback_prompt,
                             )
-                            attempt_media_inputs = MediaInputs()
+                            attempt_media_inputs = retry_decision.media_inputs
                             attempt_run_id = ai_runtime.next_retry_run_id(run_id)
                             continue
 
@@ -1033,20 +1057,23 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
 
                     if response.status == RunStatus.error:
                         error_text = str(response.content or "Unknown agent error")
-                        if not retried_without_inline_media and should_retry_without_inline_media(
+                        retry_decision = retry_media_inputs_after_failure(
+                            media_route,
                             error_text,
                             attempt_media_inputs,
-                        ):
+                        )
+                        if not retried_without_inline_media and retry_decision.should_retry:
                             logger.warning(
-                                "Retrying AI response without inline media after errored run output",
+                                "Retrying AI response after inline media errored run output",
                                 agent=agent_name,
                                 error=error_text,
+                                removed_media_kinds=sorted(retry_decision.removed_kinds),
                             )
                             attempt_prompt = ai_runtime.append_inline_media_fallback_to_run_input(
                                 run_input,
                                 fallback_prompt=inline_media_fallback_prompt,
                             )
-                            attempt_media_inputs = MediaInputs()
+                            attempt_media_inputs = retry_decision.media_inputs
                             attempt_run_id = ai_runtime.next_retry_run_id(run_id)
                             continue
 
@@ -1186,6 +1213,7 @@ async def _process_stream_events(  # noqa: C901, PLR0912, PLR0915
     media_inputs: MediaInputs,
     retried_without_inline_media: bool,
     timing_scope: str,
+    media_route: ModelMediaRoute | None = None,
     state_updated: Callable[[], None] | None = None,
     pipeline_timing: DispatchPipelineTiming | None = None,
 ) -> AsyncGenerator[AIStreamChunk, None]:
@@ -1263,9 +1291,10 @@ async def _process_stream_events(  # noqa: C901, PLR0912, PLR0915
                 if _request_stream_retry(
                     state,
                     retried_without_inline_media=retried_without_inline_media,
+                    media_route=media_route,
                     media_inputs=media_inputs,
                     error=error_text,
-                    log_message="Retrying streaming AI response without inline media after run error",
+                    log_message="Retrying streaming AI response after inline media run error",
                     agent_name=agent_name,
                 ):
                     return
@@ -1278,9 +1307,10 @@ async def _process_stream_events(  # noqa: C901, PLR0912, PLR0915
         if _request_stream_retry(
             state,
             retried_without_inline_media=retried_without_inline_media,
+            media_route=media_route,
             media_inputs=media_inputs,
             error=e,
-            log_message="Retrying streaming AI response without inline media after stream exception",
+            log_message="Retrying streaming AI response after inline media stream exception",
             agent_name=agent_name,
         ):
             return
@@ -1479,8 +1509,17 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
             if turn_recorder is not None:
                 turn_recorder.set_run_metadata(metadata)
 
-            attempt_prompt = ai_runtime.copy_run_input(run_input)
-            attempt_media_inputs = media_inputs
+            media_route = build_model_media_route(agent.model)
+            media_filter = filter_media_inputs_for_route(media_route, media_inputs)
+            attempt_prompt = (
+                ai_runtime.append_inline_media_fallback_to_run_input(
+                    run_input,
+                    fallback_prompt=inline_media_fallback_prompt,
+                )
+                if media_filter.removed_kinds
+                else ai_runtime.copy_run_input(run_input)
+            )
+            attempt_media_inputs = media_filter.media_inputs
             state = _StreamingAttemptState()
 
             def _sync_live_turn_recorder() -> None:
@@ -1537,6 +1576,7 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                             state=state,
                             show_tool_calls=show_tool_calls,
                             agent_name=agent_name,
+                            media_route=media_route,
                             media_inputs=attempt_media_inputs,
                             retried_without_inline_media=retried_without_inline_media,
                             timing_scope=timing_scope,
@@ -1548,16 +1588,17 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                         if _request_stream_retry(
                             state,
                             retried_without_inline_media=retried_without_inline_media,
+                            media_route=media_route,
                             media_inputs=attempt_media_inputs,
                             error=e,
-                            log_message="Retrying streaming AI response without inline media after validation error",
+                            log_message="Retrying streaming AI response after inline media validation error",
                             agent_name=agent_name,
                         ):
                             attempt_prompt = ai_runtime.append_inline_media_fallback_to_run_input(
                                 run_input,
                                 fallback_prompt=inline_media_fallback_prompt,
                             )
-                            attempt_media_inputs = MediaInputs()
+                            attempt_media_inputs = state.retry_media_inputs or MediaInputs()
                             attempt_run_id = ai_runtime.next_retry_run_id(run_id)
                             continue
                         logger.exception("Error starting streaming AI response")
@@ -1569,7 +1610,7 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                             run_input,
                             fallback_prompt=inline_media_fallback_prompt,
                         )
-                        attempt_media_inputs = MediaInputs()
+                        attempt_media_inputs = state.retry_media_inputs or MediaInputs()
                         attempt_run_id = ai_runtime.next_retry_run_id(run_id)
                         continue
 

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -70,7 +70,6 @@ from mindroom.media_fallback import (
     build_model_media_route,
     filter_media_inputs_for_route,
     retry_media_inputs_after_failure,
-    should_retry_without_inline_media,
 )
 from mindroom.media_inputs import MediaInputs
 from mindroom.memory import MemoryPromptParts, build_memory_prompt_parts, strip_user_turn_time_prefix
@@ -99,7 +98,6 @@ __all__ = [
     "ai_response",
     "build_matrix_run_metadata",
     "resolve_run_correlation_id",
-    "should_retry_without_inline_media",
     "stream_agent_response",
 ]
 AIStreamChunk = str | RunContentEvent | RunCompletedEvent | ToolCallStartedEvent | ToolCallCompletedEvent
@@ -219,8 +217,8 @@ class _StreamingAttemptState:
     request_metric_totals: dict[str, int] = field(default_factory=empty_request_metric_totals)
     first_token_latency: float | None = None
     first_token_logged: bool = False
-    retry_requested: bool = False
-    retry_media_inputs: MediaInputs | None = None
+    media_fallback_retry_requested: bool = False
+    media_fallback_retry_inputs: MediaInputs | None = None
     user_error: Exception | None = None
     stream_exception: Exception | None = None
 
@@ -409,7 +407,7 @@ def resolve_run_correlation_id(
 def _request_stream_retry(
     state: _StreamingAttemptState,
     *,
-    retried_without_inline_media: bool,
+    retried_after_media_fallback: bool,
     media_route: ModelMediaRoute | None,
     media_inputs: MediaInputs,
     error: Exception | str,
@@ -417,14 +415,14 @@ def _request_stream_retry(
     agent_name: str,
 ) -> bool:
     """Set retry flag when inline-media fallback should be attempted."""
-    if retried_without_inline_media or _stream_attempt_has_progress(state):
+    if retried_after_media_fallback or _stream_attempt_has_progress(state):
         # Once any stream content is emitted, retrying would duplicate partial output.
         return False
     retry_decision = retry_media_inputs_after_failure(media_route, error, media_inputs)
     if not retry_decision.should_retry:
         return False
-    state.retry_requested = True
-    state.retry_media_inputs = retry_decision.media_inputs
+    state.media_fallback_retry_requested = True
+    state.media_fallback_retry_inputs = retry_decision.media_inputs
     logger.warning(
         log_message,
         agent=agent_name,
@@ -1000,7 +998,7 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
             attempt_media_inputs = media_filter.media_inputs
 
             try:
-                for retried_without_inline_media in (False, True):
+                for retried_after_media_fallback in (False, True):
                     response = None
                     try:
                         if pipeline_timing is not None:
@@ -1037,7 +1035,7 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                             e,
                             attempt_media_inputs,
                         )
-                        if not retried_without_inline_media and retry_decision.should_retry:
+                        if not retried_after_media_fallback and retry_decision.should_retry:
                             logger.warning(
                                 "Retrying AI response after inline media validation error",
                                 agent=agent_name,
@@ -1062,7 +1060,7 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                             error_text,
                             attempt_media_inputs,
                         )
-                        if not retried_without_inline_media and retry_decision.should_retry:
+                        if not retried_after_media_fallback and retry_decision.should_retry:
                             logger.warning(
                                 "Retrying AI response after inline media errored run output",
                                 agent=agent_name,
@@ -1211,7 +1209,7 @@ async def _process_stream_events(  # noqa: C901, PLR0912, PLR0915
     show_tool_calls: bool,
     agent_name: str,
     media_inputs: MediaInputs,
-    retried_without_inline_media: bool,
+    retried_after_media_fallback: bool,
     timing_scope: str,
     media_route: ModelMediaRoute | None = None,
     state_updated: Callable[[], None] | None = None,
@@ -1290,7 +1288,7 @@ async def _process_stream_events(  # noqa: C901, PLR0912, PLR0915
                 error_text = event.content or "Unknown agent error"
                 if _request_stream_retry(
                     state,
-                    retried_without_inline_media=retried_without_inline_media,
+                    retried_after_media_fallback=retried_after_media_fallback,
                     media_route=media_route,
                     media_inputs=media_inputs,
                     error=error_text,
@@ -1306,7 +1304,7 @@ async def _process_stream_events(  # noqa: C901, PLR0912, PLR0915
     except Exception as e:
         if _request_stream_retry(
             state,
-            retried_without_inline_media=retried_without_inline_media,
+            retried_after_media_fallback=retried_after_media_fallback,
             media_route=media_route,
             media_inputs=media_inputs,
             error=e,
@@ -1533,7 +1531,7 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                 )
 
             try:
-                for retried_without_inline_media in (False, True):
+                for retried_after_media_fallback in (False, True):
                     state = _StreamingAttemptState()
 
                     try:
@@ -1578,7 +1576,7 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                             agent_name=agent_name,
                             media_route=media_route,
                             media_inputs=attempt_media_inputs,
-                            retried_without_inline_media=retried_without_inline_media,
+                            retried_after_media_fallback=retried_after_media_fallback,
                             timing_scope=timing_scope,
                             state_updated=_sync_live_turn_recorder,
                             pipeline_timing=pipeline_timing,
@@ -1587,7 +1585,7 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                     except Exception as e:
                         if _request_stream_retry(
                             state,
-                            retried_without_inline_media=retried_without_inline_media,
+                            retried_after_media_fallback=retried_after_media_fallback,
                             media_route=media_route,
                             media_inputs=attempt_media_inputs,
                             error=e,
@@ -1598,19 +1596,19 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                                 run_input,
                                 fallback_prompt=inline_media_fallback_prompt,
                             )
-                            attempt_media_inputs = state.retry_media_inputs or MediaInputs()
+                            attempt_media_inputs = state.media_fallback_retry_inputs or MediaInputs()
                             attempt_run_id = ai_runtime.next_retry_run_id(run_id)
                             continue
                         logger.exception("Error starting streaming AI response")
                         yield get_user_friendly_error_message(e, agent_name)
                         return
 
-                    if state.retry_requested:
+                    if state.media_fallback_retry_requested:
                         attempt_prompt = ai_runtime.append_inline_media_fallback_to_run_input(
                             run_input,
                             fallback_prompt=inline_media_fallback_prompt,
                         )
-                        attempt_media_inputs = state.retry_media_inputs or MediaInputs()
+                        attempt_media_inputs = state.media_fallback_retry_inputs or MediaInputs()
                         attempt_run_id = ai_runtime.next_retry_run_id(run_id)
                         continue
 

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -422,7 +422,6 @@ def _request_stream_retry(
         media_route,
         error,
         media_inputs,
-        learn_route_capability=True,
     )
     if not retry_decision.should_retry:
         return False
@@ -1039,7 +1038,6 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                             media_route,
                             e,
                             attempt_media_inputs,
-                            learn_route_capability=True,
                         )
                         if not retried_after_media_fallback and retry_decision.should_retry:
                             logger.warning(
@@ -1065,7 +1063,6 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                             media_route,
                             error_text,
                             attempt_media_inputs,
-                            learn_route_capability=True,
                         )
                         if not retried_after_media_fallback and retry_decision.should_retry:
                             logger.warning(

--- a/src/mindroom/media_fallback.py
+++ b/src/mindroom/media_fallback.py
@@ -63,6 +63,7 @@ class _MediaRetryDecision:
     removed_kinds: frozenset[_MediaKind]
 
 
+# Intentional process-lifetime pessimism: learned negative capability state is cleared by restart.
 _UNSUPPORTED_MEDIA_KINDS_BY_ROUTE: dict[ModelMediaRoute, set[_MediaKind]] = {}
 
 
@@ -78,13 +79,14 @@ def build_model_media_route(model: object | str | None) -> ModelMediaRoute | Non
             base_url=None,
         )
 
-    model_vars = vars(model)
-    provider = _route_text(model_vars.get("provider")) or _model_provider_method_text(model) or model.__class__.__name__
-    model_id = _route_text(model_vars.get("id")) or model.__class__.__name__
+    provider = (
+        _route_text(_route_value(model, "provider")) or _model_provider_method_text(model) or model.__class__.__name__
+    )
+    model_id = _route_text(_route_value(model, "id")) or model.__class__.__name__
     return ModelMediaRoute(
         provider=provider.lower(),
         model_id=model_id,
-        base_url=_route_endpoint(model_vars),
+        base_url=_route_endpoint(model),
     )
 
 
@@ -191,14 +193,18 @@ def _unsupported_media_kinds_from_error(error_text: str) -> frozenset[_MediaKind
     kinds: set[_MediaKind] = set()
     for pattern in _INLINE_MEDIA_UNSUPPORTED_PATTERNS:
         for match in pattern.finditer(lowered_error_text):
-            kinds.add(_canonical_media_kind(match.group("kind")))
+            kind = _canonical_media_kind(match.group("kind"))
+            if kind is not None:
+                kinds.add(kind)
     return frozenset(kinds)
 
 
 def _media_validation_kinds_from_error(error_text: str) -> frozenset[_MediaKind]:
     lowered_error_text = error_text.lower()
     kinds = {
-        _canonical_media_kind(match.group("kind")) for match in _INLINE_MEDIA_FIELD_PATTERN.finditer(lowered_error_text)
+        kind
+        for match in _INLINE_MEDIA_FIELD_PATTERN.finditer(lowered_error_text)
+        if (kind := _canonical_media_kind(match.group("kind"))) is not None
     }
     if _INLINE_MEDIA_MIME_MISMATCH_PATTERN.search(lowered_error_text):
         kinds.add("image")
@@ -209,7 +215,7 @@ def _is_ambiguous_media_error(error_text: str) -> bool:
     return bool(_INLINE_MEDIA_GENERIC_UNSUPPORTED_PATTERN.search(error_text.lower()))
 
 
-def _canonical_media_kind(provider_kind: str) -> _MediaKind:
+def _canonical_media_kind(provider_kind: str) -> _MediaKind | None:
     if provider_kind == "document":
         return "file"
     if provider_kind == "audio":
@@ -220,8 +226,7 @@ def _canonical_media_kind(provider_kind: str) -> _MediaKind:
         return "file"
     if provider_kind == "video":
         return "video"
-    msg = f"Unknown media kind: {provider_kind}"
-    raise ValueError(msg)
+    return None
 
 
 def _media_kinds_present(media_inputs: MediaInputs) -> frozenset[_MediaKind]:
@@ -246,13 +251,13 @@ def _without_media_kinds(media_inputs: MediaInputs, kinds: frozenset[_MediaKind]
     )
 
 
-def _route_endpoint(model_vars: dict[str, object]) -> str | None:
+def _route_endpoint(model: object) -> str | None:
     for field_name in ("base_url", "host", "azure_endpoint"):
-        endpoint = _route_text(model_vars.get(field_name))
+        endpoint = _route_text(_route_value(model, field_name))
         if endpoint:
             return endpoint.rstrip("/")
 
-    client_params = model_vars.get("client_params")
+    client_params = _route_value(model, "client_params")
     if not isinstance(client_params, Mapping):
         return None
     client_params_by_name = cast("Mapping[str, object]", client_params)
@@ -264,17 +269,18 @@ def _route_endpoint(model_vars: dict[str, object]) -> str | None:
 
 
 def _model_provider_method_text(model: object) -> str | None:
-    for cls in model.__class__.__mro__:
-        method = cls.__dict__.get("get_provider")
-        if callable(method):
-            return _route_text(method(model))
-    return None
+    method = getattr(model, "get_provider", None)
+    if not callable(method):
+        return None
+    return _route_text(method())
 
 
 def _route_text(value: object) -> str | None:
-    if value is None or callable(value):
+    if not isinstance(value, str):
         return None
-    if value.__class__.__module__ == "unittest.mock":
-        return None
-    text = str(value).strip()
+    text = value.strip()
     return text or None
+
+
+def _route_value(model: object, field_name: str) -> object:
+    return getattr(model, field_name, None)

--- a/src/mindroom/media_fallback.py
+++ b/src/mindroom/media_fallback.py
@@ -16,7 +16,6 @@ __all__ = [
     "filter_media_inputs_for_route",
     "reset_model_media_capability_cache",
     "retry_media_inputs_after_failure",
-    "should_retry_without_inline_media",
 ]
 
 _INLINE_MEDIA_FALLBACK_MARKER = "[Inline media unavailable for this model]"
@@ -138,11 +137,6 @@ def retry_media_inputs_after_failure(
         )
 
     return _no_media_retry_decision(media_inputs)
-
-
-def should_retry_without_inline_media(error: Exception | str, media_inputs: MediaInputs) -> bool:
-    """Return whether this run should retry once after dropping some inline media."""
-    return retry_media_inputs_after_failure(None, error, media_inputs).should_retry
 
 
 def reset_model_media_capability_cache() -> None:

--- a/src/mindroom/media_fallback.py
+++ b/src/mindroom/media_fallback.py
@@ -3,11 +3,25 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Literal, cast
+from typing import TYPE_CHECKING, Literal
+
+from agno.models.anthropic import Claude
+from agno.models.azure.openai_chat import AzureOpenAI
+from agno.models.base import Model
+from agno.models.cerebras import Cerebras
+from agno.models.deepseek import DeepSeek
+from agno.models.google import Gemini
+from agno.models.groq import Groq
+from agno.models.ollama import Ollama
+from agno.models.openai import OpenAIChat, OpenAIResponses
+from agno.models.openrouter import OpenRouter
+from agno.models.vertexai.claude import Claude as VertexAIClaude
 
 from mindroom.media_inputs import MediaInputs
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 __all__ = [
     "ModelMediaRoute",
@@ -66,7 +80,7 @@ class _MediaRetryDecision:
 _UNSUPPORTED_MEDIA_KINDS_BY_ROUTE: dict[ModelMediaRoute, set[_MediaKind]] = {}
 
 
-def build_model_media_route(model: object | str | None) -> ModelMediaRoute | None:
+def build_model_media_route(model: Model | str | None) -> ModelMediaRoute | None:
     """Return a process-cache key for one effective model route."""
     if model is None:
         return None
@@ -77,11 +91,11 @@ def build_model_media_route(model: object | str | None) -> ModelMediaRoute | Non
             model_id=model_id or provider,
             base_url=None,
         )
+    if not isinstance(model, Model):
+        return None
 
-    provider = (
-        _route_text(_route_value(model, "provider")) or _model_provider_method_text(model) or model.__class__.__name__
-    )
-    model_id = _route_text(_route_value(model, "id")) or model.__class__.__name__
+    provider = _route_text(model.provider) or model.__class__.__name__
+    model_id = _route_text(model.id) or model.__class__.__name__
     return ModelMediaRoute(
         provider=provider.lower(),
         model_id=model_id,
@@ -110,8 +124,15 @@ def retry_media_inputs_after_failure(
     route: ModelMediaRoute | None,
     error: Exception | str,
     media_inputs: MediaInputs,
+    *,
+    learn_route_capability: bool = False,
 ) -> _MediaRetryDecision:
-    """Decide whether and how one media-bearing request should retry."""
+    """Decide whether and how one media-bearing request should retry.
+
+    Only callers that just sent inline media to a model should set
+    ``learn_route_capability``; otherwise explicit media-kind errors retry once
+    without poisoning the process-local route cache.
+    """
     if not media_inputs.has_any():
         return _no_media_retry_decision(media_inputs)
 
@@ -121,7 +142,7 @@ def retry_media_inputs_after_failure(
         return _media_retry_decision_for_kinds(
             media_inputs,
             unsupported_kinds,
-            cache_route=route,
+            cache_route=route if learn_route_capability else None,
         )
 
     validation_kinds = _media_validation_kinds_from_error(error_text)
@@ -245,36 +266,64 @@ def _without_media_kinds(media_inputs: MediaInputs, kinds: frozenset[_MediaKind]
     )
 
 
-def _route_endpoint(model: object) -> str | None:
-    for field_name in ("base_url", "host", "azure_endpoint"):
-        endpoint = _route_text(_route_value(model, field_name))
-        if endpoint:
-            return endpoint.rstrip("/")
+def _route_endpoint(model: Model) -> str | None:
+    if isinstance(model, AzureOpenAI):
+        return _route_endpoint_text(
+            model.azure_endpoint,
+            model.base_url,
+            _client_params_endpoint(model.client_params),
+        )
+    if isinstance(model, Ollama):
+        return _route_endpoint_text(
+            model.host,
+            _client_params_endpoint(model.client_params),
+        )
+    if isinstance(model, VertexAIClaude):
+        return _route_endpoint_text(
+            str(model.base_url) if model.base_url is not None else None,
+            _client_params_endpoint(model.client_params),
+        )
+    if isinstance(
+        model,
+        (
+            Cerebras,
+            DeepSeek,
+            Groq,
+            OpenAIChat,
+            OpenAIResponses,
+            OpenRouter,
+        ),
+    ):
+        return _route_endpoint_text(
+            str(model.base_url) if model.base_url is not None else None,
+            _client_params_endpoint(model.client_params),
+        )
+    if isinstance(model, (Claude, Gemini)):
+        return _client_params_endpoint(model.client_params)
+    return None
 
-    client_params = _route_value(model, "client_params")
-    if not isinstance(client_params, Mapping):
+
+def _client_params_endpoint(client_params: Mapping[str, object] | None) -> str | None:
+    if client_params is None:
         return None
-    client_params_by_name = cast("Mapping[str, object]", client_params)
     for field_name in ("base_url", "host", "azure_endpoint"):
-        endpoint = _route_text(client_params_by_name.get(field_name))
+        candidate = client_params.get(field_name)
+        endpoint = _route_text(candidate) if isinstance(candidate, str) else None
         if endpoint:
             return endpoint.rstrip("/")
     return None
 
 
-def _model_provider_method_text(model: object) -> str | None:
-    method = getattr(model, "get_provider", None)
-    if not callable(method):
-        return None
-    return _route_text(method())
+def _route_endpoint_text(*values: str | None) -> str | None:
+    for value in values:
+        endpoint = _route_text(value)
+        if endpoint:
+            return endpoint.rstrip("/")
+    return None
 
 
-def _route_text(value: object) -> str | None:
-    if not isinstance(value, str):
+def _route_text(value: str | None) -> str | None:
+    if value is None:
         return None
     text = value.strip()
     return text or None
-
-
-def _route_value(model: object, field_name: str) -> object:
-    return getattr(model, field_name, None)

--- a/src/mindroom/media_fallback.py
+++ b/src/mindroom/media_fallback.py
@@ -1,40 +1,151 @@
-"""Shared inline-media fallback detection and prompt helpers."""
+"""Shared inline-media fallback detection and model capability helpers."""
 
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Literal, cast
 
-if TYPE_CHECKING:
-    from mindroom.media_inputs import MediaInputs
+from mindroom.media_inputs import MediaInputs
+
+__all__ = [
+    "ModelMediaRoute",
+    "append_inline_media_fallback_prompt",
+    "build_model_media_route",
+    "filter_media_inputs_for_route",
+    "reset_model_media_capability_cache",
+    "retry_media_inputs_after_failure",
+    "should_retry_without_inline_media",
+]
 
 _INLINE_MEDIA_FALLBACK_MARKER = "[Inline media unavailable for this model]"
-_INLINE_MEDIA_FIELD_PATTERN = re.compile(r"(?:document|image|audio|video)\.source\.base64(?:\.media_type)?")
+_INLINE_MEDIA_FIELD_PATTERN = re.compile(
+    r"(?P<kind>document|image|audio|video)\.source\.base64(?:\.media_type)?",
+)
 _INLINE_MEDIA_MIME_MISMATCH_PATTERN = re.compile(r"image was specified using the .* media type")
-_INLINE_MEDIA_UNSUPPORTED_PATTERN = re.compile(
-    r"(?:"
-    r"(?:audio|image|video|file|document) input is not supported"
-    r"|support input (?:audio|image|video|file|document)"
-    r"|at most 0 (?:audio|image|video|file|document)\(s\) may be provided"
-    r")",
+_INLINE_MEDIA_GENERIC_UNSUPPORTED_PATTERN = re.compile(r"(?:inline media|media input) is not supported")
+_MEDIA_KIND_PATTERN = r"audio|image|video|file|document"
+_INLINE_MEDIA_UNSUPPORTED_PATTERNS = (
+    re.compile(rf"(?P<kind>{_MEDIA_KIND_PATTERN}) input is not supported"),
+    re.compile(rf"(?P<kind>{_MEDIA_KIND_PATTERN}) inputs are not supported"),
+    re.compile(rf"does not support (?P<kind>{_MEDIA_KIND_PATTERN}) input"),
+    re.compile(rf"support input (?P<kind>{_MEDIA_KIND_PATTERN})"),
+    re.compile(rf"at most 0 (?P<kind>{_MEDIA_KIND_PATTERN})\(s\) may be provided"),
 )
 
+type _MediaKind = Literal["audio", "image", "file", "video"]
 
-def _is_media_validation_error_text(error_text: str) -> bool:
-    """Return whether provider error text indicates inline-media validation/capability failure."""
-    lowered_error_text = error_text.lower()
-    return bool(
-        _INLINE_MEDIA_FIELD_PATTERN.search(lowered_error_text)
-        or _INLINE_MEDIA_MIME_MISMATCH_PATTERN.search(lowered_error_text)
-        or _INLINE_MEDIA_UNSUPPORTED_PATTERN.search(lowered_error_text),
+
+@dataclass(frozen=True, slots=True)
+class ModelMediaRoute:
+    """Concrete model route used for process-local media capability learning."""
+
+    provider: str
+    model_id: str
+    base_url: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _MediaFilterResult:
+    """Media inputs after route capability filtering."""
+
+    media_inputs: MediaInputs
+    removed_kinds: frozenset[_MediaKind]
+
+
+@dataclass(frozen=True, slots=True)
+class _MediaRetryDecision:
+    """Retry policy after one provider media failure."""
+
+    should_retry: bool
+    media_inputs: MediaInputs
+    removed_kinds: frozenset[_MediaKind]
+
+
+_UNSUPPORTED_MEDIA_KINDS_BY_ROUTE: dict[ModelMediaRoute, set[_MediaKind]] = {}
+
+
+def build_model_media_route(model: object | str | None) -> ModelMediaRoute | None:
+    """Return a process-cache key for one effective model route."""
+    if model is None:
+        return None
+    if isinstance(model, str):
+        provider, separator, model_id = model.partition(":")
+        return ModelMediaRoute(
+            provider=provider.lower() if separator else "unknown",
+            model_id=model_id or provider,
+            base_url=None,
+        )
+
+    model_vars = vars(model)
+    provider = _route_text(model_vars.get("provider")) or _model_provider_method_text(model) or model.__class__.__name__
+    model_id = _route_text(model_vars.get("id")) or model.__class__.__name__
+    return ModelMediaRoute(
+        provider=provider.lower(),
+        model_id=model_id,
+        base_url=_route_endpoint(model_vars),
     )
 
 
-def should_retry_without_inline_media(error: Exception | str, media_inputs: MediaInputs) -> bool:
-    """Return whether this run should retry once without inline media."""
+def filter_media_inputs_for_route(
+    route: ModelMediaRoute | None,
+    media_inputs: MediaInputs,
+) -> _MediaFilterResult:
+    """Omit learned-unsupported media kinds before a model request."""
+    unsupported_kinds = (
+        frozenset(_UNSUPPORTED_MEDIA_KINDS_BY_ROUTE.get(route, set())) if route is not None else frozenset()
+    )
+    removed_kinds = unsupported_kinds & _media_kinds_present(media_inputs)
+    if not removed_kinds:
+        return _MediaFilterResult(media_inputs=media_inputs, removed_kinds=frozenset())
+    return _MediaFilterResult(
+        media_inputs=_without_media_kinds(media_inputs, removed_kinds),
+        removed_kinds=removed_kinds,
+    )
+
+
+def retry_media_inputs_after_failure(
+    route: ModelMediaRoute | None,
+    error: Exception | str,
+    media_inputs: MediaInputs,
+) -> _MediaRetryDecision:
+    """Decide whether and how one media-bearing request should retry."""
     if not media_inputs.has_any():
-        return False
-    return _is_media_validation_error_text(str(error))
+        return _no_media_retry_decision(media_inputs)
+
+    error_text = str(error)
+    unsupported_kinds = _unsupported_media_kinds_from_error(error_text)
+    if unsupported_kinds:
+        return _media_retry_decision_for_kinds(
+            media_inputs,
+            unsupported_kinds,
+            cache_route=route,
+        )
+
+    validation_kinds = _media_validation_kinds_from_error(error_text)
+    if validation_kinds:
+        return _media_retry_decision_for_kinds(media_inputs, validation_kinds)
+
+    if _is_ambiguous_media_error(error_text):
+        removed_kinds = _media_kinds_present(media_inputs)
+        return _MediaRetryDecision(
+            should_retry=True,
+            media_inputs=_without_media_kinds(media_inputs, removed_kinds),
+            removed_kinds=removed_kinds,
+        )
+
+    return _no_media_retry_decision(media_inputs)
+
+
+def should_retry_without_inline_media(error: Exception | str, media_inputs: MediaInputs) -> bool:
+    """Return whether this run should retry once after dropping some inline media."""
+    return retry_media_inputs_after_failure(None, error, media_inputs).should_retry
+
+
+def reset_model_media_capability_cache() -> None:
+    """Clear process-local learned model media capabilities."""
+    _UNSUPPORTED_MEDIA_KINDS_BY_ROUTE.clear()
 
 
 def append_inline_media_fallback_prompt(
@@ -47,3 +158,123 @@ def append_inline_media_fallback_prompt(
         return full_prompt
 
     return f"{full_prompt.rstrip()}\n\n{_INLINE_MEDIA_FALLBACK_MARKER}\n{fallback_prompt}"
+
+
+def _media_retry_decision_for_kinds(
+    media_inputs: MediaInputs,
+    kinds: frozenset[_MediaKind],
+    *,
+    cache_route: ModelMediaRoute | None = None,
+) -> _MediaRetryDecision:
+    removed_kinds = kinds & _media_kinds_present(media_inputs)
+    if not removed_kinds:
+        return _no_media_retry_decision(media_inputs)
+    if cache_route is not None:
+        _UNSUPPORTED_MEDIA_KINDS_BY_ROUTE.setdefault(cache_route, set()).update(removed_kinds)
+    return _MediaRetryDecision(
+        should_retry=True,
+        media_inputs=_without_media_kinds(media_inputs, removed_kinds),
+        removed_kinds=removed_kinds,
+    )
+
+
+def _no_media_retry_decision(media_inputs: MediaInputs) -> _MediaRetryDecision:
+    return _MediaRetryDecision(
+        should_retry=False,
+        media_inputs=media_inputs,
+        removed_kinds=frozenset(),
+    )
+
+
+def _unsupported_media_kinds_from_error(error_text: str) -> frozenset[_MediaKind]:
+    lowered_error_text = error_text.lower()
+    kinds: set[_MediaKind] = set()
+    for pattern in _INLINE_MEDIA_UNSUPPORTED_PATTERNS:
+        for match in pattern.finditer(lowered_error_text):
+            kinds.add(_canonical_media_kind(match.group("kind")))
+    return frozenset(kinds)
+
+
+def _media_validation_kinds_from_error(error_text: str) -> frozenset[_MediaKind]:
+    lowered_error_text = error_text.lower()
+    kinds = {
+        _canonical_media_kind(match.group("kind")) for match in _INLINE_MEDIA_FIELD_PATTERN.finditer(lowered_error_text)
+    }
+    if _INLINE_MEDIA_MIME_MISMATCH_PATTERN.search(lowered_error_text):
+        kinds.add("image")
+    return frozenset(kinds)
+
+
+def _is_ambiguous_media_error(error_text: str) -> bool:
+    return bool(_INLINE_MEDIA_GENERIC_UNSUPPORTED_PATTERN.search(error_text.lower()))
+
+
+def _canonical_media_kind(provider_kind: str) -> _MediaKind:
+    if provider_kind == "document":
+        return "file"
+    if provider_kind == "audio":
+        return "audio"
+    if provider_kind == "image":
+        return "image"
+    if provider_kind == "file":
+        return "file"
+    if provider_kind == "video":
+        return "video"
+    msg = f"Unknown media kind: {provider_kind}"
+    raise ValueError(msg)
+
+
+def _media_kinds_present(media_inputs: MediaInputs) -> frozenset[_MediaKind]:
+    kinds: set[_MediaKind] = set()
+    if media_inputs.audio:
+        kinds.add("audio")
+    if media_inputs.images:
+        kinds.add("image")
+    if media_inputs.files:
+        kinds.add("file")
+    if media_inputs.videos:
+        kinds.add("video")
+    return frozenset(kinds)
+
+
+def _without_media_kinds(media_inputs: MediaInputs, kinds: frozenset[_MediaKind]) -> MediaInputs:
+    return MediaInputs(
+        audio=() if "audio" in kinds else media_inputs.audio,
+        images=() if "image" in kinds else media_inputs.images,
+        files=() if "file" in kinds else media_inputs.files,
+        videos=() if "video" in kinds else media_inputs.videos,
+    )
+
+
+def _route_endpoint(model_vars: dict[str, object]) -> str | None:
+    for field_name in ("base_url", "host", "azure_endpoint"):
+        endpoint = _route_text(model_vars.get(field_name))
+        if endpoint:
+            return endpoint.rstrip("/")
+
+    client_params = model_vars.get("client_params")
+    if not isinstance(client_params, Mapping):
+        return None
+    client_params_by_name = cast("Mapping[str, object]", client_params)
+    for field_name in ("base_url", "host", "azure_endpoint"):
+        endpoint = _route_text(client_params_by_name.get(field_name))
+        if endpoint:
+            return endpoint.rstrip("/")
+    return None
+
+
+def _model_provider_method_text(model: object) -> str | None:
+    for cls in model.__class__.__mro__:
+        method = cls.__dict__.get("get_provider")
+        if callable(method):
+            return _route_text(method(model))
+    return None
+
+
+def _route_text(value: object) -> str | None:
+    if value is None or callable(value):
+        return None
+    if value.__class__.__module__ == "unittest.mock":
+        return None
+    text = str(value).strip()
+    return text or None

--- a/src/mindroom/media_fallback.py
+++ b/src/mindroom/media_fallback.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Literal
 
 from agno.models.anthropic import Claude
 from agno.models.azure.openai_chat import AzureOpenAI
-from agno.models.base import Model
 from agno.models.cerebras import Cerebras
 from agno.models.deepseek import DeepSeek
 from agno.models.google import Gemini
@@ -22,6 +21,8 @@ from mindroom.media_inputs import MediaInputs
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+
+    from agno.models.base import Model
 
 __all__ = [
     "ModelMediaRoute",
@@ -48,6 +49,15 @@ _INLINE_MEDIA_UNSUPPORTED_PATTERNS = (
 )
 
 type _MediaKind = Literal["audio", "image", "file", "video"]
+
+# Provider error vocabulary -> our MediaInputs kind (providers say "document" for files).
+_PROVIDER_MEDIA_KINDS: dict[str, _MediaKind] = {
+    "audio": "audio",
+    "image": "image",
+    "video": "video",
+    "file": "file",
+    "document": "file",
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -80,18 +90,9 @@ class _MediaRetryDecision:
 _UNSUPPORTED_MEDIA_KINDS_BY_ROUTE: dict[ModelMediaRoute, set[_MediaKind]] = {}
 
 
-def build_model_media_route(model: Model | str | None) -> ModelMediaRoute | None:
+def build_model_media_route(model: Model | None) -> ModelMediaRoute | None:
     """Return a process-cache key for one effective model route."""
     if model is None:
-        return None
-    if isinstance(model, str):
-        provider, separator, model_id = model.partition(":")
-        return ModelMediaRoute(
-            provider=provider.lower() if separator else "unknown",
-            model_id=model_id or provider,
-            base_url=None,
-        )
-    if not isinstance(model, Model):
         return None
 
     provider = _route_text(model.provider) or model.__class__.__name__
@@ -124,14 +125,13 @@ def retry_media_inputs_after_failure(
     route: ModelMediaRoute | None,
     error: Exception | str,
     media_inputs: MediaInputs,
-    *,
-    learn_route_capability: bool = False,
 ) -> _MediaRetryDecision:
     """Decide whether and how one media-bearing request should retry.
 
-    Only callers that just sent inline media to a model should set
-    ``learn_route_capability``; otherwise explicit media-kind errors retry once
-    without poisoning the process-local route cache.
+    Explicit "kind is not supported" errors teach the route cache so later
+    requests pre-drop that kind; validation and ambiguous media errors retry
+    once without poisoning the cache. A kind can only be learned when it was
+    actually present in ``media_inputs``.
     """
     if not media_inputs.has_any():
         return _no_media_retry_decision(media_inputs)
@@ -142,7 +142,7 @@ def retry_media_inputs_after_failure(
         return _media_retry_decision_for_kinds(
             media_inputs,
             unsupported_kinds,
-            cache_route=route if learn_route_capability else None,
+            cache_route=route,
         )
 
     validation_kinds = _media_validation_kinds_from_error(error_text)
@@ -231,17 +231,7 @@ def _is_ambiguous_media_error(error_text: str) -> bool:
 
 
 def _canonical_media_kind(provider_kind: str) -> _MediaKind | None:
-    if provider_kind == "document":
-        return "file"
-    if provider_kind == "audio":
-        return "audio"
-    if provider_kind == "image":
-        return "image"
-    if provider_kind == "file":
-        return "file"
-    if provider_kind == "video":
-        return "video"
-    return None
+    return _PROVIDER_MEDIA_KINDS.get(provider_kind)
 
 
 def _media_kinds_present(media_inputs: MediaInputs) -> frozenset[_MediaKind]:
@@ -278,14 +268,12 @@ def _route_endpoint(model: Model) -> str | None:
             model.host,
             _client_params_endpoint(model.client_params),
         )
-    if isinstance(model, VertexAIClaude):
-        return _route_endpoint_text(
-            str(model.base_url) if model.base_url is not None else None,
-            _client_params_endpoint(model.client_params),
-        )
+    # VertexAIClaude subclasses the Anthropic Claude model but exposes a base_url,
+    # so it must be matched here, before the Claude/Gemini branch below.
     if isinstance(
         model,
         (
+            VertexAIClaude,
             Cerebras,
             DeepSeek,
             Groq,

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -1671,7 +1671,7 @@ async def team_response(  # noqa: C901, PLR0912, PLR0915
             )
             attempt_media_inputs = media_filter.media_inputs
             try:
-                for retried_without_inline_media in (False, True):
+                for retried_after_media_fallback in (False, True):
                     response = None
                     cleaned_response = None
                     try:
@@ -1682,7 +1682,7 @@ async def team_response(  # noqa: C901, PLR0912, PLR0915
                             e,
                             attempt_media_inputs,
                         )
-                        if not retried_without_inline_media and retry_decision.should_retry:
+                        if not retried_after_media_fallback and retry_decision.should_retry:
                             logger.warning(
                                 "Retrying team response after inline media validation error",
                                 agents=agent_list,
@@ -1713,7 +1713,7 @@ async def team_response(  # noqa: C901, PLR0912, PLR0915
                             error_text,
                             attempt_media_inputs,
                         )
-                        if not retried_without_inline_media and retry_decision.should_retry:
+                        if not retried_after_media_fallback and retry_decision.should_retry:
                             logger.warning(
                                 "Retrying team response after inline media errored run output",
                                 agents=agent_list,
@@ -2201,7 +2201,7 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
                 )
 
             try:
-                for retried_without_inline_media in (False, True):
+                for retried_after_media_fallback in (False, True):
                     canonical_per_member = dict.fromkeys(display_names, "")
                     visible_per_member = dict.fromkeys(display_names, "")
                     canonical_consensus = ""
@@ -2212,7 +2212,7 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
                     next_tool_index = 1
                     pending_tools = tool_tracker.pending_tools
                     emitted_output = False
-                    retry_requested = False
+                    media_fallback_retry_requested = False
 
                     ai_runtime.note_attempt_run_id(run_id_callback, attempt_run_id)
 
@@ -2274,7 +2274,7 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
                                     attempt_media_inputs,
                                 )
                                 if (
-                                    not retried_without_inline_media
+                                    not retried_after_media_fallback
                                     and not (emitted_output or pending_tools or completed_tools)
                                     and retry_decision.should_retry
                                 ):
@@ -2294,7 +2294,7 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
                                     )
                                     attempt_media_inputs = retry_decision.media_inputs
                                     attempt_run_id = ai_runtime.next_retry_run_id(run_id)
-                                    retry_requested = True
+                                    media_fallback_retry_requested = True
                                     break
                                 yield get_user_friendly_error_message(Exception(error_text), team_label)
                                 return
@@ -2325,7 +2325,7 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
                                 attempt_media_inputs,
                             )
                             if (
-                                not retried_without_inline_media
+                                not retried_after_media_fallback
                                 and not (emitted_output or pending_tools or completed_tools)
                                 and retry_decision.should_retry
                             ):
@@ -2345,7 +2345,7 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
                                 )
                                 attempt_media_inputs = retry_decision.media_inputs
                                 attempt_run_id = ai_runtime.next_retry_run_id(run_id)
-                                retry_requested = True
+                                media_fallback_retry_requested = True
                                 break
                             yield get_user_friendly_error_message(Exception(error_text), team_label)
                             return
@@ -2414,7 +2414,7 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
                             chunk_tool_trace = tool_trace.copy() if show_tool_calls and tool_trace else None
                             yield StructuredStreamChunk(content=header + full_text, tool_trace=chunk_tool_trace)
 
-                    if retry_requested:
+                    if media_fallback_retry_requested:
                         continue
                     if emitted_output and reply_to_event_id:
                         _persist_bound_seen_event_ids(

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -1659,7 +1659,7 @@ async def team_response(  # noqa: C901, PLR0912, PLR0915
             response: object | None = None
             cleaned_response: RunOutput | TeamRunOutput | None = None
             inline_media_fallback_prompt = orchestrator.config.get_prompt("INLINE_MEDIA_FALLBACK_PROMPT")
-            media_route = build_model_media_route(team.model)
+            media_route = build_model_media_route(team.model) if media_inputs.has_any() else None
             media_filter = filter_media_inputs_for_route(media_route, media_inputs)
             attempt_prompt = (
                 append_inline_media_fallback_prompt(
@@ -2045,7 +2045,7 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
             logger.info("team_streaming_setup", agents=agent_names, display_names=display_names)
             media_inputs = media or MediaInputs()
             inline_media_fallback_prompt = orchestrator.config.get_prompt("INLINE_MEDIA_FALLBACK_PROMPT")
-            media_route = build_model_media_route(team.model)
+            media_route = build_model_media_route(team.model) if media_inputs.has_any() else None
             media_filter = filter_media_inputs_for_route(media_route, media_inputs)
             attempt_prompt = (
                 append_inline_media_fallback_prompt(

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -63,7 +63,12 @@ from mindroom.llm_request_logging import (
 )
 from mindroom.logging_config import get_logger
 from mindroom.matrix.state import get_room_alias_from_id
-from mindroom.media_fallback import append_inline_media_fallback_prompt, should_retry_without_inline_media
+from mindroom.media_fallback import (
+    append_inline_media_fallback_prompt,
+    build_model_media_route,
+    filter_media_inputs_for_route,
+    retry_media_inputs_after_failure,
+)
 from mindroom.media_inputs import MediaInputs
 from mindroom.metadata_merge import deep_merge_metadata
 from mindroom.team_exact_members import (
@@ -1653,9 +1658,18 @@ async def team_response(  # noqa: C901, PLR0912, PLR0915
 
             response: object | None = None
             cleaned_response: RunOutput | TeamRunOutput | None = None
-            attempt_prompt = prompt
-            attempt_media_inputs = media_inputs
             inline_media_fallback_prompt = orchestrator.config.get_prompt("INLINE_MEDIA_FALLBACK_PROMPT")
+            media_route = build_model_media_route(team.model)
+            media_filter = filter_media_inputs_for_route(media_route, media_inputs)
+            attempt_prompt = (
+                append_inline_media_fallback_prompt(
+                    prompt,
+                    fallback_prompt=inline_media_fallback_prompt,
+                )
+                if media_filter.removed_kinds
+                else prompt
+            )
+            attempt_media_inputs = media_filter.media_inputs
             try:
                 for retried_without_inline_media in (False, True):
                     response = None
@@ -1663,14 +1677,17 @@ async def team_response(  # noqa: C901, PLR0912, PLR0915
                     try:
                         response = await _run(attempt_prompt, attempt_media_inputs, attempt_run_id)
                     except Exception as e:
-                        if not retried_without_inline_media and should_retry_without_inline_media(
+                        retry_decision = retry_media_inputs_after_failure(
+                            media_route,
                             e,
                             attempt_media_inputs,
-                        ):
+                        )
+                        if not retried_without_inline_media and retry_decision.should_retry:
                             logger.warning(
-                                "Retrying team response without inline media after validation error",
+                                "Retrying team response after inline media validation error",
                                 agents=agent_list,
                                 error=str(e),
+                                removed_media_kinds=sorted(retry_decision.removed_kinds),
                             )
                             _scrub_team_retry_notice_state(
                                 scope_context=scope_context,
@@ -1680,7 +1697,7 @@ async def team_response(  # noqa: C901, PLR0912, PLR0915
                                 prompt,
                                 fallback_prompt=inline_media_fallback_prompt,
                             )
-                            attempt_media_inputs = MediaInputs()
+                            attempt_media_inputs = retry_decision.media_inputs
                             attempt_run_id = ai_runtime.next_retry_run_id(run_id)
                             continue
 
@@ -1691,14 +1708,17 @@ async def team_response(  # noqa: C901, PLR0912, PLR0915
                         cleaned_response = response
                     if isinstance(response, (TeamRunOutput, RunOutput)) and is_errored_run_output(response):
                         error_text = str(response.content or "Unknown team error")
-                        if not retried_without_inline_media and should_retry_without_inline_media(
+                        retry_decision = retry_media_inputs_after_failure(
+                            media_route,
                             error_text,
                             attempt_media_inputs,
-                        ):
+                        )
+                        if not retried_without_inline_media and retry_decision.should_retry:
                             logger.warning(
-                                "Retrying team response without inline media after errored run output",
+                                "Retrying team response after inline media errored run output",
                                 agents=agent_list,
                                 error=error_text,
+                                removed_media_kinds=sorted(retry_decision.removed_kinds),
                             )
                             _cleanup_team_notice_state(
                                 run_output=response,
@@ -1714,7 +1734,7 @@ async def team_response(  # noqa: C901, PLR0912, PLR0915
                                 prompt,
                                 fallback_prompt=inline_media_fallback_prompt,
                             )
-                            attempt_media_inputs = MediaInputs()
+                            attempt_media_inputs = retry_decision.media_inputs
                             attempt_run_id = ai_runtime.next_retry_run_id(run_id)
                             continue
                         logger.warning("Team response returned errored run output", agents=agent_list, error=error_text)
@@ -2024,9 +2044,18 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
             turn_recorder.set_run_metadata(run_metadata)
             logger.info("team_streaming_setup", agents=agent_names, display_names=display_names)
             media_inputs = media or MediaInputs()
-            attempt_prompt = prepared_prompt
-            attempt_media_inputs = media_inputs
             inline_media_fallback_prompt = orchestrator.config.get_prompt("INLINE_MEDIA_FALLBACK_PROMPT")
+            media_route = build_model_media_route(team.model)
+            media_filter = filter_media_inputs_for_route(media_route, media_inputs)
+            attempt_prompt = (
+                append_inline_media_fallback_prompt(
+                    prepared_prompt,
+                    fallback_prompt=inline_media_fallback_prompt,
+                )
+                if media_filter.removed_kinds
+                else prepared_prompt
+            )
+            attempt_media_inputs = media_filter.media_inputs
 
             visible_per_member: dict[str, str] = {}
             visible_consensus: str = ""
@@ -2239,15 +2268,21 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
 
                             if is_errored_run_output(event):
                                 error_text = str(event.content or "Unknown team error")
+                                retry_decision = retry_media_inputs_after_failure(
+                                    media_route,
+                                    error_text,
+                                    attempt_media_inputs,
+                                )
                                 if (
                                     not retried_without_inline_media
                                     and not (emitted_output or pending_tools or completed_tools)
-                                    and should_retry_without_inline_media(error_text, attempt_media_inputs)
+                                    and retry_decision.should_retry
                                 ):
                                     logger.warning(
-                                        "Retrying team streaming without inline media after errored run output",
+                                        "Retrying team streaming after inline media errored run output",
                                         agents=", ".join(agent_names),
                                         error=error_text,
+                                        removed_media_kinds=sorted(retry_decision.removed_kinds),
                                     )
                                     _scrub_team_retry_notice_state(
                                         scope_context=scope_context,
@@ -2257,7 +2292,7 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
                                         prepared_prompt,
                                         fallback_prompt=inline_media_fallback_prompt,
                                     )
-                                    attempt_media_inputs = MediaInputs()
+                                    attempt_media_inputs = retry_decision.media_inputs
                                     attempt_run_id = ai_runtime.next_retry_run_id(run_id)
                                     retry_requested = True
                                     break
@@ -2284,15 +2319,21 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
 
                         if isinstance(event, TeamRunErrorEvent):
                             error_text = event.content or "Unknown team error"
+                            retry_decision = retry_media_inputs_after_failure(
+                                media_route,
+                                error_text,
+                                attempt_media_inputs,
+                            )
                             if (
                                 not retried_without_inline_media
                                 and not (emitted_output or pending_tools or completed_tools)
-                                and should_retry_without_inline_media(error_text, attempt_media_inputs)
+                                and retry_decision.should_retry
                             ):
                                 logger.warning(
-                                    "Retrying team streaming without inline media after team error",
+                                    "Retrying team streaming after inline media team error",
                                     agents=", ".join(agent_names),
                                     error=error_text,
+                                    removed_media_kinds=sorted(retry_decision.removed_kinds),
                                 )
                                 _scrub_team_retry_notice_state(
                                     scope_context=scope_context,
@@ -2302,7 +2343,7 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
                                     prepared_prompt,
                                     fallback_prompt=inline_media_fallback_prompt,
                                 )
-                                attempt_media_inputs = MediaInputs()
+                                attempt_media_inputs = retry_decision.media_inputs
                                 attempt_run_id = ai_runtime.next_retry_run_id(run_id)
                                 retry_requested = True
                                 break

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -1681,6 +1681,7 @@ async def team_response(  # noqa: C901, PLR0912, PLR0915
                             media_route,
                             e,
                             attempt_media_inputs,
+                            learn_route_capability=True,
                         )
                         if not retried_after_media_fallback and retry_decision.should_retry:
                             logger.warning(
@@ -1712,6 +1713,7 @@ async def team_response(  # noqa: C901, PLR0912, PLR0915
                             media_route,
                             error_text,
                             attempt_media_inputs,
+                            learn_route_capability=True,
                         )
                         if not retried_after_media_fallback and retry_decision.should_retry:
                             logger.warning(
@@ -2252,7 +2254,7 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
                                 run_output=event,
                                 scope_context=scope_context,
                                 session_id=session_id,
-                                entity_name=team_label,
+                                entity_name=configured_team_name or team_label,
                             )
 
                             if is_cancelled_run_output(event):
@@ -2272,6 +2274,7 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
                                     media_route,
                                     error_text,
                                     attempt_media_inputs,
+                                    learn_route_capability=True,
                                 )
                                 if (
                                     not retried_after_media_fallback
@@ -2286,7 +2289,7 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
                                     )
                                     _scrub_team_retry_notice_state(
                                         scope_context=scope_context,
-                                        entity_name=team_label,
+                                        entity_name=configured_team_name or team_label,
                                     )
                                     attempt_prompt = append_inline_media_fallback_prompt(
                                         prepared_prompt,
@@ -2323,6 +2326,7 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
                                 media_route,
                                 error_text,
                                 attempt_media_inputs,
+                                learn_route_capability=True,
                             )
                             if (
                                 not retried_after_media_fallback
@@ -2337,7 +2341,7 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
                                 )
                                 _scrub_team_retry_notice_state(
                                     scope_context=scope_context,
-                                    entity_name=team_label,
+                                    entity_name=configured_team_name or team_label,
                                 )
                                 attempt_prompt = append_inline_media_fallback_prompt(
                                     prepared_prompt,
@@ -2439,7 +2443,7 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
                     run_output=None,
                     scope_context=scope_context,
                     session_id=session_id,
-                    entity_name=team_label,
+                    entity_name=configured_team_name or team_label,
                 )
     except asyncio.CancelledError:
         turn_recorder.record_interrupted(

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -1681,7 +1681,6 @@ async def team_response(  # noqa: C901, PLR0912, PLR0915
                             media_route,
                             e,
                             attempt_media_inputs,
-                            learn_route_capability=True,
                         )
                         if not retried_after_media_fallback and retry_decision.should_retry:
                             logger.warning(
@@ -1713,7 +1712,6 @@ async def team_response(  # noqa: C901, PLR0912, PLR0915
                             media_route,
                             error_text,
                             attempt_media_inputs,
-                            learn_route_capability=True,
                         )
                         if not retried_after_media_fallback and retry_decision.should_retry:
                             logger.warning(
@@ -2274,7 +2272,6 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
                                     media_route,
                                     error_text,
                                     attempt_media_inputs,
-                                    learn_route_capability=True,
                                 )
                                 if (
                                     not retried_after_media_fallback
@@ -2326,7 +2323,6 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
                                 media_route,
                                 error_text,
                                 attempt_media_inputs,
-                                learn_route_capability=True,
                             )
                             if (
                                 not retried_after_media_fallback

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,7 @@ from mindroom.matrix.client_delivery import build_edit_event_content
 from mindroom.matrix.conversation_cache import ConversationCacheProtocol
 from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.thread_diagnostics import is_thread_history_degraded
+from mindroom.media_fallback import reset_model_media_capability_cache
 from mindroom.message_target import MessageTarget
 from mindroom.response_runner import PostLockRequestPreparationError, ResponseRequest, ResponseRunner
 from mindroom.runtime_support import StartupThreadPrewarmRegistry
@@ -1145,6 +1146,14 @@ def _reset_runtime_paths() -> Generator[None, None, None]:
     os.environ.update(original_env)
     _TEST_RUNTIME_PATHS_BY_CONFIG_ID.clear()
     _TEST_RUNTIME_PATHS_BY_CONFIG_ID.update(original_bound_configs)
+
+
+@pytest.fixture(autouse=True)
+def _reset_model_media_capabilities() -> Generator[None, None, None]:
+    """Keep process-local learned media support isolated per test."""
+    reset_model_media_capability_cache()
+    yield
+    reset_model_media_capability_cache()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -91,7 +91,7 @@ from mindroom.knowledge.availability import KnowledgeAvailability
 from mindroom.knowledge.utils import KnowledgeAvailabilityDetail, _KnowledgeResolution
 from mindroom.llm_request_logging import install_llm_request_logging, stream_with_llm_request_log_context
 from mindroom.matrix.cache.thread_history_result import thread_history_result
-from mindroom.media_fallback import append_inline_media_fallback_prompt
+from mindroom.media_fallback import append_inline_media_fallback_prompt, reset_model_media_capability_cache
 from mindroom.media_inputs import MediaInputs
 from mindroom.memory import MemoryPromptParts
 from mindroom.message_target import MessageTarget
@@ -5210,6 +5210,71 @@ class TestUserIdPassthrough:
         assert "Inline media unavailable for this model" in str(second_prompt[-1].content)
 
     @pytest.mark.asyncio
+    async def test_ai_response_learns_audio_unsupported_for_same_model_route(self, tmp_path: Path) -> None:
+        """Audio-only capability failure should omit audio on later calls to the same concrete route."""
+        reset_model_media_capability_cache()
+        mock_agent = MagicMock()
+        mock_agent.model = MagicMock()
+        mock_agent.model.id = "qwen-local"
+        mock_agent.model.provider = "OpenAI"
+        mock_agent.model.base_url = "http://localhost:9292/v1"
+        mock_agent.name = "GeneralAgent"
+        mock_agent.add_history_to_context = False
+
+        first_success = MagicMock()
+        first_success.content = "Recovered response"
+        first_success.tools = None
+        second_success = MagicMock()
+        second_success.content = "Cached response"
+        second_success.tools = None
+        mock_agent.arun = AsyncMock(
+            side_effect=[
+                Exception("audio input is not supported - hint: you may need to provide the mmproj"),
+                first_success,
+                second_success,
+            ],
+        )
+
+        audio_input = MagicMock(name="audio_input")
+        image_input = MagicMock(name="image_input")
+
+        with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
+            mock_prepare.return_value = _prepared_prompt_result(mock_agent)
+            first_response = await ai_response(
+                agent_name="general",
+                prompt="test",
+                session_id="session1",
+                runtime_paths=_runtime_paths(tmp_path),
+                config=_config(),
+                media=MediaInputs(audio=[audio_input], images=[image_input]),
+            )
+            second_response = await ai_response(
+                agent_name="general",
+                prompt="test again",
+                session_id="session1",
+                runtime_paths=_runtime_paths(tmp_path),
+                config=_config(),
+                media=MediaInputs(audio=[audio_input], images=[image_input]),
+            )
+
+        assert first_response == "Recovered response"
+        assert second_response == "Cached response"
+        assert mock_agent.arun.await_count == 3
+        first_prompt = mock_agent.arun.await_args_list[0].args[0]
+        retry_prompt = mock_agent.arun.await_args_list[1].args[0]
+        cached_prompt = mock_agent.arun.await_args_list[2].args[0]
+        assert isinstance(first_prompt, list)
+        assert isinstance(retry_prompt, list)
+        assert isinstance(cached_prompt, list)
+        assert first_prompt[-1].audio == [audio_input]
+        assert first_prompt[-1].images == [image_input]
+        assert retry_prompt[-1].audio == ()
+        assert retry_prompt[-1].images == [image_input]
+        assert cached_prompt[-1].audio == ()
+        assert cached_prompt[-1].images == [image_input]
+        reset_model_media_capability_cache()
+
+    @pytest.mark.asyncio
     async def test_ai_response_rebuilds_request_log_context_for_retry(self, tmp_path: Path) -> None:
         """Non-streaming retries should log the actual prompt sent on each attempt."""
         mock_agent = MagicMock()
@@ -5768,7 +5833,13 @@ class TestUserIdPassthrough:
     )
     def test_should_retry_without_inline_media_error_matching(self, error_text: str, expected: bool) -> None:
         """Retry matcher should target inline-media validation and unsupported-input failures."""
-        assert should_retry_without_inline_media(error_text, MediaInputs(images=(object(),))) is expected
+        media_inputs = MediaInputs(
+            audio=(object(),),
+            images=(object(),),
+            files=(object(),),
+            videos=(object(),),
+        )
+        assert should_retry_without_inline_media(error_text, media_inputs) is expected
 
     def test_append_inline_media_fallback_prompt_is_idempotent(self) -> None:
         """Fallback marker should only be appended once across retries."""

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -5266,6 +5266,10 @@ class TestUserIdPassthrough:
         assert isinstance(first_prompt, list)
         assert isinstance(retry_prompt, list)
         assert isinstance(cached_prompt, list)
+        fallback_marker = "Inline media unavailable for this model"
+        assert fallback_marker not in str(first_prompt[-1].content)
+        assert fallback_marker in str(retry_prompt[-1].content)
+        assert fallback_marker in str(cached_prompt[-1].content)
         assert first_prompt[-1].audio == [audio_input]
         assert first_prompt[-1].images == [image_input]
         assert retry_prompt[-1].audio == ()
@@ -5840,6 +5844,10 @@ class TestUserIdPassthrough:
             videos=(object(),),
         )
         assert should_retry_without_inline_media(error_text, media_inputs) is expected
+
+    def test_should_retry_without_inline_media_ignores_media_errors_without_media(self) -> None:
+        """Media-shaped errors should not trigger retry when no media was sent."""
+        assert should_retry_without_inline_media("audio input is not supported", MediaInputs()) is False
 
     def test_append_inline_media_fallback_prompt_is_idempotent(self) -> None:
         """Fallback marker should only be appended once across retries."""

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -17,6 +17,7 @@ from agno.db.base import SessionType
 from agno.media import File
 from agno.models.message import Message
 from agno.models.metrics import Metrics
+from agno.models.openai import OpenAIChat
 from agno.models.response import ToolExecution
 from agno.models.vertexai.claude import Claude as VertexAIClaude
 from agno.run.agent import (
@@ -4773,7 +4774,11 @@ class TestUserIdPassthrough:
 
         with (
             patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare,
-            patch("mindroom.ai_runtime.cached_agent_run", new_callable=AsyncMock, return_value=mock_run_output),
+            patch(
+                "mindroom.ai_runtime.cached_agent_run",
+                new_callable=AsyncMock,
+                return_value=mock_run_output,
+            ) as run_mock,
         ):
             mock_prepare.return_value = _prepared_prompt_result(mock_agent)
 
@@ -4785,6 +4790,7 @@ class TestUserIdPassthrough:
                     runtime_paths=_runtime_paths(tmp_path),
                     config=_config(),
                 )
+            run_mock.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_ai_response_persists_interrupted_replay_for_cancelled_runs(self, tmp_path: Path) -> None:
@@ -5216,13 +5222,16 @@ class TestUserIdPassthrough:
     async def test_ai_response_learns_audio_unsupported_for_same_model_route(self, tmp_path: Path) -> None:
         """Audio-only capability failure should omit audio on later calls to the same concrete route."""
         reset_model_media_capability_cache()
-        mock_agent = MagicMock()
-        mock_agent.model = MagicMock()
-        mock_agent.model.id = "qwen-local"
-        mock_agent.model.provider = "OpenAI"
-        mock_agent.model.base_url = "http://localhost:9292/v1"
-        mock_agent.name = "GeneralAgent"
-        mock_agent.add_history_to_context = False
+
+        def build_agent() -> MagicMock:
+            agent = MagicMock()
+            agent.model = OpenAIChat(id="qwen-local", base_url="http://localhost:9292/v1")
+            agent.name = "GeneralAgent"
+            agent.add_history_to_context = False
+            return agent
+
+        first_agent = build_agent()
+        second_agent = build_agent()
 
         first_success = MagicMock()
         first_success.content = "Recovered response"
@@ -5230,19 +5239,22 @@ class TestUserIdPassthrough:
         second_success = MagicMock()
         second_success.content = "Cached response"
         second_success.tools = None
-        mock_agent.arun = AsyncMock(
+        first_agent.arun = AsyncMock(
             side_effect=[
                 Exception("audio input is not supported - hint: you may need to provide the mmproj"),
                 first_success,
-                second_success,
             ],
         )
+        second_agent.arun = AsyncMock(return_value=second_success)
 
         audio_input = MagicMock(name="audio_input")
         image_input = MagicMock(name="image_input")
 
         with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
-            mock_prepare.return_value = _prepared_prompt_result(mock_agent)
+            mock_prepare.side_effect = [
+                _prepared_prompt_result(first_agent),
+                _prepared_prompt_result(second_agent),
+            ]
             first_response = await ai_response(
                 agent_name="general",
                 prompt="test",
@@ -5262,10 +5274,11 @@ class TestUserIdPassthrough:
 
         assert first_response == "Recovered response"
         assert second_response == "Cached response"
-        assert mock_agent.arun.await_count == 3
-        first_prompt = mock_agent.arun.await_args_list[0].args[0]
-        retry_prompt = mock_agent.arun.await_args_list[1].args[0]
-        cached_prompt = mock_agent.arun.await_args_list[2].args[0]
+        assert first_agent.arun.await_count == 2
+        assert second_agent.arun.await_count == 1
+        first_prompt = first_agent.arun.await_args_list[0].args[0]
+        retry_prompt = first_agent.arun.await_args_list[1].args[0]
+        cached_prompt = second_agent.arun.await_args_list[0].args[0]
         assert isinstance(first_prompt, list)
         assert isinstance(retry_prompt, list)
         assert isinstance(cached_prompt, list)

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -43,7 +43,6 @@ from mindroom.ai import (
     _StreamingAttemptState,
     ai_response,
     build_matrix_run_metadata,
-    should_retry_without_inline_media,
     stream_agent_response,
 )
 from mindroom.ai_run_metadata import _serialize_metrics
@@ -91,7 +90,11 @@ from mindroom.knowledge.availability import KnowledgeAvailability
 from mindroom.knowledge.utils import KnowledgeAvailabilityDetail, _KnowledgeResolution
 from mindroom.llm_request_logging import install_llm_request_logging, stream_with_llm_request_log_context
 from mindroom.matrix.cache.thread_history_result import thread_history_result
-from mindroom.media_fallback import append_inline_media_fallback_prompt, reset_model_media_capability_cache
+from mindroom.media_fallback import (
+    append_inline_media_fallback_prompt,
+    reset_model_media_capability_cache,
+    retry_media_inputs_after_failure,
+)
 from mindroom.media_inputs import MediaInputs
 from mindroom.memory import MemoryPromptParts
 from mindroom.message_target import MessageTarget
@@ -5835,19 +5838,21 @@ class TestUserIdPassthrough:
             ("Rate limit exceeded", False),
         ],
     )
-    def test_should_retry_without_inline_media_error_matching(self, error_text: str, expected: bool) -> None:
-        """Retry matcher should target inline-media validation and unsupported-input failures."""
+    def test_retry_media_inputs_after_failure_error_matching(self, error_text: str, expected: bool) -> None:
+        """Retry decision should target inline-media validation and unsupported-input failures."""
         media_inputs = MediaInputs(
             audio=(object(),),
             images=(object(),),
             files=(object(),),
             videos=(object(),),
         )
-        assert should_retry_without_inline_media(error_text, media_inputs) is expected
+        assert retry_media_inputs_after_failure(None, error_text, media_inputs).should_retry is expected
 
-    def test_should_retry_without_inline_media_ignores_media_errors_without_media(self) -> None:
+    def test_retry_media_inputs_after_failure_ignores_media_errors_without_media(self) -> None:
         """Media-shaped errors should not trigger retry when no media was sent."""
-        assert should_retry_without_inline_media("audio input is not supported", MediaInputs()) is False
+        assert (
+            retry_media_inputs_after_failure(None, "audio input is not supported", MediaInputs()).should_retry is False
+        )
 
     def test_append_inline_media_fallback_prompt_is_idempotent(self) -> None:
         """Fallback marker should only be appended once across retries."""

--- a/tests/test_dispatch_timing_instrumentation.py
+++ b/tests/test_dispatch_timing_instrumentation.py
@@ -60,7 +60,7 @@ async def test_stream_processing_marks_tool_call_started() -> None:
                 show_tool_calls=True,
                 agent_name="code",
                 media_inputs=MediaInputs(),
-                retried_without_inline_media=False,
+                retried_after_media_fallback=False,
                 timing_scope="test",
             )
         ]

--- a/tests/test_media_fallback.py
+++ b/tests/test_media_fallback.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+from agno.models.openai import OpenAIChat
+
 from mindroom.media_fallback import (
     ModelMediaRoute,
     build_model_media_route,
@@ -27,18 +29,7 @@ def test_unknown_model_route_sends_all_media() -> None:
 
 def test_model_route_includes_provider_model_and_base_url() -> None:
     """Route construction should key learned support by concrete model endpoint."""
-    model = _RouteModel(provider="OpenAI", model_id="qwen-local", base_url="http://localhost:9292/v1/")
-
-    assert build_model_media_route(model) == ModelMediaRoute(
-        provider="openai",
-        model_id="qwen-local",
-        base_url="http://localhost:9292/v1",
-    )
-
-
-def test_model_route_supports_slotted_models() -> None:
-    """Route construction should not require model objects to expose __dict__."""
-    model = _SlottedRouteModel(provider="OpenAI", model_id="qwen-local", base_url="http://localhost:9292/v1/")
+    model = OpenAIChat(id="qwen-local", base_url="http://localhost:9292/v1/")
 
     assert build_model_media_route(model) == ModelMediaRoute(
         provider="openai",
@@ -57,6 +48,7 @@ def test_audio_unsupported_error_records_audio_only() -> None:
         route,
         RuntimeError("audio input is not supported - hint: you may need to provide the mmproj"),
         media,
+        learn_route_capability=True,
     )
 
     assert decision.should_retry is True
@@ -78,7 +70,12 @@ def test_image_remains_enabled_when_only_audio_failed() -> None:
     media = _media_inputs()
     route = _route()
 
-    retry_media_inputs_after_failure(route, "Error code: 400 - at most 0 audio(s) may be provided", media)
+    retry_media_inputs_after_failure(
+        route,
+        "Error code: 400 - at most 0 audio(s) may be provided",
+        media,
+        learn_route_capability=True,
+    )
 
     filtered = filter_media_inputs_for_route(route, media)
     assert filtered.media_inputs.audio == ()
@@ -92,7 +89,12 @@ def test_different_base_url_does_not_inherit_negative_cache() -> None:
     first_route = _route(base_url="http://localhost:9292/v1")
     second_route = _route(base_url="http://localhost:9293/v1")
 
-    retry_media_inputs_after_failure(first_route, "audio input is not supported", media)
+    retry_media_inputs_after_failure(
+        first_route,
+        "audio input is not supported",
+        media,
+        learn_route_capability=True,
+    )
 
     filtered = filter_media_inputs_for_route(second_route, media)
     assert filtered.removed_kinds == frozenset()
@@ -128,12 +130,26 @@ def test_generic_media_error_retries_without_caching() -> None:
     assert filtered.media_inputs == media
 
 
+def test_unsupported_media_retry_does_not_cache_without_learning_signal() -> None:
+    """Callers must opt in before explicit unsupported-kind failures teach a route."""
+    reset_model_media_capability_cache()
+    media = _media_inputs()
+    route = _route()
+
+    decision = retry_media_inputs_after_failure(route, "audio input is not supported", media)
+
+    assert decision.should_retry is True
+    assert decision.removed_kinds == frozenset({"audio"})
+    filtered = filter_media_inputs_for_route(route, media)
+    assert filtered.media_inputs == media
+
+
 def test_cache_can_be_reset() -> None:
     """Tests need explicit access to clear process-local learned state."""
     media = _media_inputs()
     route = _route()
 
-    retry_media_inputs_after_failure(route, "image input is not supported", media)
+    retry_media_inputs_after_failure(route, "image input is not supported", media, learn_route_capability=True)
     assert filter_media_inputs_for_route(route, media).media_inputs.images == ()
 
     reset_model_media_capability_cache()
@@ -152,22 +168,3 @@ def _media_inputs() -> MediaInputs:
         files=(MagicMock(name="file"),),
         videos=(MagicMock(name="video"),),
     )
-
-
-class _RouteModel:
-    def __init__(self, *, provider: str, model_id: str, base_url: str) -> None:
-        self.provider = provider
-        self.id = model_id
-        self.base_url = base_url
-
-    def get_provider(self) -> str:
-        return self.provider
-
-
-class _SlottedRouteModel:
-    __slots__ = ("base_url", "id", "provider")
-
-    def __init__(self, *, provider: str, model_id: str, base_url: str) -> None:
-        self.provider = provider
-        self.id = model_id
-        self.base_url = base_url

--- a/tests/test_media_fallback.py
+++ b/tests/test_media_fallback.py
@@ -1,0 +1,153 @@
+"""Tests for learned model media capability fallback policy."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from mindroom.media_fallback import (
+    ModelMediaRoute,
+    build_model_media_route,
+    filter_media_inputs_for_route,
+    reset_model_media_capability_cache,
+    retry_media_inputs_after_failure,
+)
+from mindroom.media_inputs import MediaInputs
+
+
+def test_unknown_model_route_sends_all_media() -> None:
+    """Unknown route should optimistically keep every supplied media kind."""
+    reset_model_media_capability_cache()
+    media = _media_inputs()
+
+    filtered = filter_media_inputs_for_route(_route(), media)
+
+    assert filtered.media_inputs == media
+    assert filtered.removed_kinds == frozenset()
+
+
+def test_model_route_includes_provider_model_and_base_url() -> None:
+    """Route construction should key learned support by concrete model endpoint."""
+    model = _RouteModel(provider="OpenAI", model_id="qwen-local", base_url="http://localhost:9292/v1/")
+
+    assert build_model_media_route(model) == ModelMediaRoute(
+        provider="openai",
+        model_id="qwen-local",
+        base_url="http://localhost:9292/v1",
+    )
+
+
+def test_audio_unsupported_error_records_audio_only() -> None:
+    """Audio unsupported errors should disable only audio for the route."""
+    reset_model_media_capability_cache()
+    media = _media_inputs()
+    route = _route()
+
+    decision = retry_media_inputs_after_failure(
+        route,
+        RuntimeError("audio input is not supported - hint: you may need to provide the mmproj"),
+        media,
+    )
+
+    assert decision.should_retry is True
+    assert decision.removed_kinds == frozenset({"audio"})
+    assert decision.media_inputs.audio == ()
+    assert decision.media_inputs.images == media.images
+    assert decision.media_inputs.files == media.files
+    assert decision.media_inputs.videos == media.videos
+
+    filtered = filter_media_inputs_for_route(route, media)
+    assert filtered.removed_kinds == frozenset({"audio"})
+    assert filtered.media_inputs.audio == ()
+    assert filtered.media_inputs.images == media.images
+
+
+def test_image_remains_enabled_when_only_audio_failed() -> None:
+    """Negative cache should track kinds independently."""
+    reset_model_media_capability_cache()
+    media = _media_inputs()
+    route = _route()
+
+    retry_media_inputs_after_failure(route, "Error code: 400 - at most 0 audio(s) may be provided", media)
+
+    filtered = filter_media_inputs_for_route(route, media)
+    assert filtered.media_inputs.audio == ()
+    assert filtered.media_inputs.images == media.images
+
+
+def test_different_base_url_does_not_inherit_negative_cache() -> None:
+    """Effective route should include endpoint, not just provider/model."""
+    reset_model_media_capability_cache()
+    media = _media_inputs()
+    first_route = _route(base_url="http://localhost:9292/v1")
+    second_route = _route(base_url="http://localhost:9293/v1")
+
+    retry_media_inputs_after_failure(first_route, "audio input is not supported", media)
+
+    filtered = filter_media_inputs_for_route(second_route, media)
+    assert filtered.removed_kinds == frozenset()
+    assert filtered.media_inputs.audio == media.audio
+
+
+def test_generic_errors_do_not_update_cache() -> None:
+    """Transient or unrelated failures should not teach media capability."""
+    reset_model_media_capability_cache()
+    media = _media_inputs()
+    route = _route()
+
+    decision = retry_media_inputs_after_failure(route, "Rate limit exceeded", media)
+
+    assert decision.should_retry is False
+    filtered = filter_media_inputs_for_route(route, media)
+    assert filtered.media_inputs == media
+
+
+def test_generic_media_error_retries_without_caching() -> None:
+    """Ambiguous media errors should preserve old drop-all retry without teaching cache."""
+    reset_model_media_capability_cache()
+    media = _media_inputs()
+    route = _route()
+
+    decision = retry_media_inputs_after_failure(route, "inline media input is not supported", media)
+
+    assert decision.should_retry is True
+    assert decision.removed_kinds == frozenset({"audio", "image", "file", "video"})
+    assert decision.media_inputs == MediaInputs()
+
+    filtered = filter_media_inputs_for_route(route, media)
+    assert filtered.media_inputs == media
+
+
+def test_cache_can_be_reset() -> None:
+    """Tests need explicit access to clear process-local learned state."""
+    media = _media_inputs()
+    route = _route()
+
+    retry_media_inputs_after_failure(route, "image input is not supported", media)
+    assert filter_media_inputs_for_route(route, media).media_inputs.images == ()
+
+    reset_model_media_capability_cache()
+
+    assert filter_media_inputs_for_route(route, media).media_inputs.images == media.images
+
+
+def _route(base_url: str = "http://localhost:9292/v1") -> ModelMediaRoute:
+    return ModelMediaRoute(provider="openai", model_id="qwen-local", base_url=base_url)
+
+
+def _media_inputs() -> MediaInputs:
+    return MediaInputs(
+        audio=(MagicMock(name="audio"),),
+        images=(MagicMock(name="image"),),
+        files=(MagicMock(name="file"),),
+        videos=(MagicMock(name="video"),),
+    )
+
+
+class _RouteModel:
+    def __init__(self, *, provider: str, model_id: str, base_url: str) -> None:
+        self.provider = provider
+        self.id = model_id
+        self.base_url = base_url
+
+    def get_provider(self) -> str:
+        return self.provider

--- a/tests/test_media_fallback.py
+++ b/tests/test_media_fallback.py
@@ -36,6 +36,17 @@ def test_model_route_includes_provider_model_and_base_url() -> None:
     )
 
 
+def test_model_route_supports_slotted_models() -> None:
+    """Route construction should not require model objects to expose __dict__."""
+    model = _SlottedRouteModel(provider="OpenAI", model_id="qwen-local", base_url="http://localhost:9292/v1/")
+
+    assert build_model_media_route(model) == ModelMediaRoute(
+        provider="openai",
+        model_id="qwen-local",
+        base_url="http://localhost:9292/v1",
+    )
+
+
 def test_audio_unsupported_error_records_audio_only() -> None:
     """Audio unsupported errors should disable only audio for the route."""
     reset_model_media_capability_cache()
@@ -151,3 +162,12 @@ class _RouteModel:
 
     def get_provider(self) -> str:
         return self.provider
+
+
+class _SlottedRouteModel:
+    __slots__ = ("base_url", "id", "provider")
+
+    def __init__(self, *, provider: str, model_id: str, base_url: str) -> None:
+        self.provider = provider
+        self.id = model_id
+        self.base_url = base_url

--- a/tests/test_media_fallback.py
+++ b/tests/test_media_fallback.py
@@ -48,7 +48,6 @@ def test_audio_unsupported_error_records_audio_only() -> None:
         route,
         RuntimeError("audio input is not supported - hint: you may need to provide the mmproj"),
         media,
-        learn_route_capability=True,
     )
 
     assert decision.should_retry is True
@@ -74,7 +73,6 @@ def test_image_remains_enabled_when_only_audio_failed() -> None:
         route,
         "Error code: 400 - at most 0 audio(s) may be provided",
         media,
-        learn_route_capability=True,
     )
 
     filtered = filter_media_inputs_for_route(route, media)
@@ -93,7 +91,6 @@ def test_different_base_url_does_not_inherit_negative_cache() -> None:
         first_route,
         "audio input is not supported",
         media,
-        learn_route_capability=True,
     )
 
     filtered = filter_media_inputs_for_route(second_route, media)
@@ -130,26 +127,12 @@ def test_generic_media_error_retries_without_caching() -> None:
     assert filtered.media_inputs == media
 
 
-def test_unsupported_media_retry_does_not_cache_without_learning_signal() -> None:
-    """Callers must opt in before explicit unsupported-kind failures teach a route."""
-    reset_model_media_capability_cache()
-    media = _media_inputs()
-    route = _route()
-
-    decision = retry_media_inputs_after_failure(route, "audio input is not supported", media)
-
-    assert decision.should_retry is True
-    assert decision.removed_kinds == frozenset({"audio"})
-    filtered = filter_media_inputs_for_route(route, media)
-    assert filtered.media_inputs == media
-
-
 def test_cache_can_be_reset() -> None:
     """Tests need explicit access to clear process-local learned state."""
     media = _media_inputs()
     route = _route()
 
-    retry_media_inputs_after_failure(route, "image input is not supported", media, learn_route_capability=True)
+    retry_media_inputs_after_failure(route, "image input is not supported", media)
     assert filter_media_inputs_for_route(route, media).media_inputs.images == ()
 
     reset_model_media_capability_cache()

--- a/tests/test_team_media_fallback.py
+++ b/tests/test_team_media_fallback.py
@@ -27,7 +27,7 @@ from agno.team._run import _cleanup_and_store
 from agno.utils.message import get_text_from_message
 
 from mindroom.agents import create_agent
-from mindroom.config.agent import AgentConfig, AgentPrivateConfig
+from mindroom.config.agent import AgentConfig, AgentPrivateConfig, TeamConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
 from mindroom.constants import AI_RUN_METADATA_KEY, ROUTER_AGENT_NAME
@@ -2902,6 +2902,11 @@ async def test_team_response_stream_tracks_retry_run_id_after_hard_cancellation(
 async def test_team_response_stream_retry_scrubs_queued_notice_before_second_attempt() -> None:
     """Streaming retries should scrub queued notices from the loaded team session before retrying."""
     config = _build_test_config()
+    config.teams["super_team"] = TeamConfig(
+        display_name="Super Team",
+        role="Configured test team",
+        agents=["general"],
+    )
     runtime_paths = runtime_paths_for(config)
     orchestrator = MagicMock()
     orchestrator.config = config
@@ -2915,6 +2920,7 @@ async def test_team_response_stream_retry_scrubs_queued_notice_before_second_att
         runtime_paths=runtime_paths,
         config=config,
         execution_identity=None,
+        team_name="super_team",
         create_session_if_missing=True,
     ) as scope_context:
         assert scope_context is not None
@@ -2940,6 +2946,7 @@ async def test_team_response_stream_retry_scrubs_queued_notice_before_second_att
         mock_team.db = prepared_scope_context.storage
         team_id = prepared_scope_context.session.team_id
         assert team_id is not None
+        assert team_id == "super_team"
         if attempts == 1:
             errored_output = TeamRunOutput(
                 run_id="run-1",
@@ -2983,6 +2990,7 @@ async def test_team_response_stream_retry_scrubs_queued_notice_before_second_att
                 execution_identity=None,
                 session_id="session-stream-retry-clean",
                 media=MediaInputs(audio=[MagicMock(name="audio_input")]),
+                configured_team_name="super_team",
             )
         ]
 


### PR DESCRIPTION
## Summary
- Add process-local negative media capability cache keyed by provider, model id, and base URL.
- Filter unsupported media kinds before model calls and retry only the failed kind when provider errors identify it.
- Wire learned media fallback through agent and team response paths, with focused helper and integration tests.
- Also fixes cancelled non-streaming runs so a cancelled response stops the retry loop instead of issuing another provider call.

## Test Plan
- uv run pre-commit run --all-files
- uv run pytest -q

## Summary by Sourcery

Learn and cache per-model media capabilities so subsequent calls automatically omit unsupported media kinds and adjust retry behavior for inline media failures.

Enhancements:
- Introduce a process-local cache of unsupported media kinds keyed by concrete model route and base URL, and use it to filter media inputs and drive targeted retry decisions across agents and teams.
- Extend AI and team response flows (including streaming) to reuse learned media capabilities, log removed media kinds on retries, and selectively drop only failing media types instead of all inline media.
- Improve model route detection and media error parsing to distinguish specific media validation errors from generic or transient failures.

Tests:
- Add focused unit tests for media capability routing, caching, and retry decisions as well as integration-style tests verifying agents and teams reuse learned media behavior across calls.
- Add an autouse pytest fixture to reset the process-local media capability cache between tests to keep test state isolated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-model route-aware media fallback: builds route-specific decisions and selectively retries with compatible media.

* **Bug Fixes**
  * Improved inline-media retry logic for both streaming and non-streaming responses; learned unsupported media kinds are respected to avoid repeated failures.
  * Added ability to reset learned media-capability cache for predictable behavior.

* **Tests**
  * Added extensive tests covering media-fallback behavior, caching, and streaming retry scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->