### PR TITLE
Emit room-member join hooks for prev-less live joins

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -93,7 +93,6 @@ from .matrix.client_room_admin import get_joined_rooms
 from .matrix.client_session import PermanentMatrixStartupError
 from .matrix.room_member_joins import (
     RoomMemberJoin,
-    record_room_member_joins_from_sync_state_seen,
     room_member_join_from_event,
     room_member_joins_from_sync_state,
     room_member_joins_from_sync_timeline,
@@ -1135,15 +1134,7 @@ class AgentBot:
         if room_member_join_hook_plan.emit_state:
             await self._emit_room_member_joined_sync_state_hooks(response)
         if room_member_join_hook_plan.record_state_seen:
-            client = self.client
-            if client is not None:
-                record_room_member_joins_from_sync_state_seen(
-                    response,
-                    rooms=client.rooms,
-                    config=self.config,
-                    runtime_paths=self.runtime_paths,
-                    storage_root=self.runtime_paths.storage_root,
-                )
+            await self._emit_room_member_joined_sync_state_hooks(response, record_only=True)
 
         if first_sync_response:
             self._register_room_member_callback_after_initial_sync()
@@ -1621,11 +1612,16 @@ class AgentBot:
 
         await self._emit_room_member_joined_hooks(join)
 
-    async def _emit_room_member_joined_sync_state_hooks(self, response: nio.SyncResponse) -> None:
-        """Expose human joins that matrix-nio delivers through sync room state."""
+    async def _emit_room_member_joined_sync_state_hooks(
+        self,
+        response: nio.SyncResponse,
+        *,
+        record_only: bool = False,
+    ) -> None:
+        """Expose or record human joins that matrix-nio delivers through sync room state."""
         if self.agent_name != ROUTER_AGENT_NAME or not self._first_sync_done or not self._room_member_join_hooks_armed:
             return
-        if not self.hook_registry.has_hooks(EVENT_ROOM_MEMBER_JOINED):
+        if not record_only and not self.hook_registry.has_hooks(EVENT_ROOM_MEMBER_JOINED):
             return
         client = self.client
         if client is None:
@@ -1637,6 +1633,7 @@ class AgentBot:
             config=self.config,
             runtime_paths=self.runtime_paths,
             storage_root=self.runtime_paths.storage_root,
+            record_only=record_only,
         ):
             await self._emit_room_member_joined_hooks(join)
 

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -93,6 +93,7 @@ from .matrix.client_room_admin import get_joined_rooms
 from .matrix.client_session import PermanentMatrixStartupError
 from .matrix.room_member_joins import (
     RoomMemberJoin,
+    record_room_member_joins_from_sync_state_seen,
     room_member_join_from_event,
     room_member_joins_from_sync_state,
     room_member_joins_from_sync_timeline,
@@ -148,6 +149,7 @@ class _RoomMemberJoinSyncHookPlan:
     arm_after_response: bool = True
     emit_state: bool = False
     emit_timeline: bool = False
+    record_state_seen: bool = False
 
 
 def _create_task_wrapper(
@@ -1117,6 +1119,7 @@ class AgentBot:
             arm_after_response=True,
             emit_state=emit_certified_state,
             emit_timeline=restored_token_first_sync_response,
+            record_state_seen=decision.state is SyncTrustState.CERTIFIED and not emit_certified_state,
         )
 
     async def _run_sync_response_side_effects(
@@ -1131,6 +1134,16 @@ class AgentBot:
             await self._emit_room_member_joined_sync_timeline_hooks(response)
         if room_member_join_hook_plan.emit_state:
             await self._emit_room_member_joined_sync_state_hooks(response)
+        if room_member_join_hook_plan.record_state_seen:
+            client = self.client
+            if client is not None:
+                record_room_member_joins_from_sync_state_seen(
+                    response,
+                    rooms=client.rooms,
+                    config=self.config,
+                    runtime_paths=self.runtime_paths,
+                    storage_root=self.runtime_paths.storage_root,
+                )
 
         if first_sync_response:
             self._register_room_member_callback_after_initial_sync()

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -1129,12 +1129,12 @@ class AgentBot:
         room_member_join_hook_plan: _RoomMemberJoinSyncHookPlan,
     ) -> None:
         """Run sync-response side effects that must poison certification on failure."""
+        if room_member_join_hook_plan.record_state_seen:
+            await self._emit_room_member_joined_sync_state_hooks(response, record_only=True)
         if room_member_join_hook_plan.emit_timeline:
             await self._emit_room_member_joined_sync_timeline_hooks(response)
         if room_member_join_hook_plan.emit_state:
             await self._emit_room_member_joined_sync_state_hooks(response)
-        if room_member_join_hook_plan.record_state_seen:
-            await self._emit_room_member_joined_sync_state_hooks(response, record_only=True)
 
         if first_sync_response:
             self._register_room_member_callback_after_initial_sync()

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -1600,6 +1600,8 @@ class AgentBot:
             config=self.config,
             runtime_paths=self.runtime_paths,
             storage_root=self.runtime_paths.storage_root,
+            # Live callbacks are armed only after startup sync; prev_content may be absent.
+            require_previous_membership=False,
         )
         if join is None:
             return

--- a/src/mindroom/matrix/room_member_joins.py
+++ b/src/mindroom/matrix/room_member_joins.py
@@ -16,7 +16,7 @@ from mindroom.entity_resolution import entity_identity_registry, mindroom_user_i
 from mindroom.logging_config import get_logger
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Iterator, Mapping
     from pathlib import Path
 
     from mindroom.config.main import Config
@@ -120,16 +120,27 @@ def _mark_room_member_join_seen(storage_root: Path, *, room_id: str, user_id: st
         return _save_room_member_joins(path, seen)
 
 
-def _is_ignored_room_member_user(user_id: str, *, config: Config, runtime_paths: RuntimePaths) -> bool:
-    """Return whether a membership event belongs to a managed/bot user."""
-    return (
+def _human_join_user_id(
+    event: nio.RoomMemberEvent,
+    *,
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> str | None:
+    """Return the joined human user ID for one membership event, or None."""
+    if event.membership != "join":
+        return None
+
+    user_id = event.state_key
+    if (
         entity_identity_registry(config, runtime_paths).is_managed_user_id(user_id)
         or user_id in config.bot_accounts
         or user_id == mindroom_user_id(config, runtime_paths)
-    )
+    ):
+        return None
+    return user_id
 
 
-def _mark_room_member_join_seen_from_event(
+def _record_room_member_join_seen_from_event(
     room: nio.MatrixRoom,
     event: nio.RoomMemberEvent,
     *,
@@ -138,11 +149,8 @@ def _mark_room_member_join_seen_from_event(
     storage_root: Path,
 ) -> bool:
     """Record one human room-member join event without emitting hook payload data."""
-    if event.membership != "join":
-        return False
-
-    user_id = event.state_key
-    if _is_ignored_room_member_user(user_id, config=config, runtime_paths=runtime_paths):
+    user_id = _human_join_user_id(event, config=config, runtime_paths=runtime_paths)
+    if user_id is None:
         return False
 
     return _mark_room_member_join_seen(storage_root, room_id=room.room_id, user_id=user_id)
@@ -163,17 +171,11 @@ def room_member_join_from_event(
     if require_previous_membership and event.prev_membership is None:
         return None
 
-    user_id = event.state_key
-    if _is_ignored_room_member_user(user_id, config=config, runtime_paths=runtime_paths):
+    user_id = _human_join_user_id(event, config=config, runtime_paths=runtime_paths)
+    if user_id is None:
         return None
 
-    if not _mark_room_member_join_seen_from_event(
-        room,
-        event,
-        config=config,
-        runtime_paths=runtime_paths,
-        storage_root=storage_root,
-    ):
+    if not _mark_room_member_join_seen(storage_root, room_id=room.room_id, user_id=user_id):
         return None
 
     return RoomMemberJoin(
@@ -188,6 +190,21 @@ def room_member_join_from_event(
     )
 
 
+def _room_member_events_from_sync_state(
+    response: nio.SyncResponse,
+    *,
+    rooms: Mapping[str, nio.MatrixRoom],
+) -> Iterator[tuple[nio.MatrixRoom, nio.RoomMemberEvent]]:
+    """Yield room-member events from sync state with their resolved room."""
+    for room_id, join_info in response.rooms.join.items():
+        room = rooms.get(room_id)
+        if room is None:
+            continue
+        for event in join_info.state:
+            if isinstance(event, nio.RoomMemberEvent):
+                yield room, event
+
+
 def room_member_joins_from_sync_state(
     response: nio.SyncResponse,
     *,
@@ -195,60 +212,40 @@ def room_member_joins_from_sync_state(
     config: Config,
     runtime_paths: RuntimePaths,
     storage_root: Path,
+    record_only: bool = False,
 ) -> tuple[RoomMemberJoin, ...]:
     """Return hook payloads for human joins delivered through sync room state."""
     joins: list[RoomMemberJoin] = []
-    for room_id, join_info in response.rooms.join.items():
-        room = rooms.get(room_id)
-        if room is None:
-            continue
-        for event in join_info.state:
-            if not isinstance(event, nio.RoomMemberEvent):
-                continue
-            join = room_member_join_from_event(
+    for room, event in _room_member_events_from_sync_state(response, rooms=rooms):
+        if record_only:
+            _record_room_member_join_seen_from_event(
                 room,
                 event,
                 config=config,
                 runtime_paths=runtime_paths,
                 storage_root=storage_root,
-                require_previous_membership=True,
             )
-            if join is not None:
-                joins.append(join)
-            elif event.membership == "join" and event.prev_membership in {None, "join"}:
-                _mark_room_member_join_seen_from_event(
-                    room,
-                    event,
-                    config=config,
-                    runtime_paths=runtime_paths,
-                    storage_root=storage_root,
-                )
+            continue
+
+        join = room_member_join_from_event(
+            room,
+            event,
+            config=config,
+            runtime_paths=runtime_paths,
+            storage_root=storage_root,
+            require_previous_membership=True,
+        )
+        if join is not None:
+            joins.append(join)
+        elif event.prev_membership in {None, "join"}:
+            _record_room_member_join_seen_from_event(
+                room,
+                event,
+                config=config,
+                runtime_paths=runtime_paths,
+                storage_root=storage_root,
+            )
     return tuple(joins)
-
-
-def record_room_member_joins_from_sync_state_seen(
-    response: nio.SyncResponse,
-    *,
-    rooms: Mapping[str, nio.MatrixRoom],
-    config: Config,
-    runtime_paths: RuntimePaths,
-    storage_root: Path,
-) -> None:
-    """Record human join state snapshots so later profile updates do not emit join hooks."""
-    for room_id, join_info in response.rooms.join.items():
-        room = rooms.get(room_id)
-        if room is None:
-            continue
-        for event in join_info.state:
-            if not isinstance(event, nio.RoomMemberEvent):
-                continue
-            _mark_room_member_join_seen_from_event(
-                room,
-                event,
-                config=config,
-                runtime_paths=runtime_paths,
-                storage_root=storage_root,
-            )
 
 
 def room_member_joins_from_sync_timeline(

--- a/src/mindroom/matrix/room_member_joins.py
+++ b/src/mindroom/matrix/room_member_joins.py
@@ -211,6 +211,8 @@ def room_member_joins_from_sync_timeline(
                 config=config,
                 runtime_paths=runtime_paths,
                 storage_root=storage_root,
+                # Timeline events are a live event stream, not a full-state snapshot.
+                require_previous_membership=False,
             )
             if join is not None:
                 joins.append(join)

--- a/src/mindroom/matrix/room_member_joins.py
+++ b/src/mindroom/matrix/room_member_joins.py
@@ -120,6 +120,34 @@ def _mark_room_member_join_seen(storage_root: Path, *, room_id: str, user_id: st
         return _save_room_member_joins(path, seen)
 
 
+def _is_ignored_room_member_user(user_id: str, *, config: Config, runtime_paths: RuntimePaths) -> bool:
+    """Return whether a membership event belongs to a managed/bot user."""
+    return (
+        entity_identity_registry(config, runtime_paths).is_managed_user_id(user_id)
+        or user_id in config.bot_accounts
+        or user_id == mindroom_user_id(config, runtime_paths)
+    )
+
+
+def _mark_room_member_join_seen_from_event(
+    room: nio.MatrixRoom,
+    event: nio.RoomMemberEvent,
+    *,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    storage_root: Path,
+) -> bool:
+    """Record one human room-member join event without emitting hook payload data."""
+    if event.membership != "join":
+        return False
+
+    user_id = event.state_key
+    if _is_ignored_room_member_user(user_id, config=config, runtime_paths=runtime_paths):
+        return False
+
+    return _mark_room_member_join_seen(storage_root, room_id=room.room_id, user_id=user_id)
+
+
 def room_member_join_from_event(
     room: nio.MatrixRoom,
     event: nio.RoomMemberEvent,
@@ -136,14 +164,16 @@ def room_member_join_from_event(
         return None
 
     user_id = event.state_key
-    if (
-        entity_identity_registry(config, runtime_paths).is_managed_user_id(user_id)
-        or user_id in config.bot_accounts
-        or user_id == mindroom_user_id(config, runtime_paths)
-    ):
+    if _is_ignored_room_member_user(user_id, config=config, runtime_paths=runtime_paths):
         return None
 
-    if not _mark_room_member_join_seen(storage_root, room_id=room.room_id, user_id=user_id):
+    if not _mark_room_member_join_seen_from_event(
+        room,
+        event,
+        config=config,
+        runtime_paths=runtime_paths,
+        storage_root=storage_root,
+    ):
         return None
 
     return RoomMemberJoin(
@@ -185,7 +215,40 @@ def room_member_joins_from_sync_state(
             )
             if join is not None:
                 joins.append(join)
+            elif event.membership == "join" and event.prev_membership in {None, "join"}:
+                _mark_room_member_join_seen_from_event(
+                    room,
+                    event,
+                    config=config,
+                    runtime_paths=runtime_paths,
+                    storage_root=storage_root,
+                )
     return tuple(joins)
+
+
+def record_room_member_joins_from_sync_state_seen(
+    response: nio.SyncResponse,
+    *,
+    rooms: Mapping[str, nio.MatrixRoom],
+    config: Config,
+    runtime_paths: RuntimePaths,
+    storage_root: Path,
+) -> None:
+    """Record human join state snapshots so later profile updates do not emit join hooks."""
+    for room_id, join_info in response.rooms.join.items():
+        room = rooms.get(room_id)
+        if room is None:
+            continue
+        for event in join_info.state:
+            if not isinstance(event, nio.RoomMemberEvent):
+                continue
+            _mark_room_member_join_seen_from_event(
+                room,
+                event,
+                config=config,
+                runtime_paths=runtime_paths,
+                storage_root=storage_root,
+            )
 
 
 def room_member_joins_from_sync_timeline(

--- a/tests/test_room_member_hooks.py
+++ b/tests/test_room_member_hooks.py
@@ -213,20 +213,22 @@ async def test_room_member_joined_supports_router_agent_scope(tmp_path: Path) ->
 
 
 @pytest.mark.asyncio
-async def test_router_ignores_live_room_member_join_without_previous_membership(tmp_path: Path) -> None:
-    """Live member events without previous membership are ambiguous snapshots."""
-    seen: list[str] = []
+async def test_router_emits_live_room_member_join_without_previous_membership(tmp_path: Path) -> None:
+    """Live member joins can omit unsigned previous membership."""
+    seen: list[RoomMemberJoinedContext] = []
 
     @hook(EVENT_ROOM_MEMBER_JOINED)
     async def joined(ctx: RoomMemberJoinedContext) -> None:
-        seen.append(ctx.event_id)
+        seen.append(ctx)
 
     bot = _router_bot(tmp_path)
     bot.hook_registry = HookRegistry.from_plugins([_plugin("onboarding", [joined])])
 
-    await bot._on_room_member(_room(), _room_member_event(event_id="$profile-update", prev_membership=None))
+    await bot._on_room_member(_room(), _room_member_event(event_id="$sso-autojoin", prev_membership=None))
 
-    assert seen == []
+    assert len(seen) == 1
+    assert seen[0].event_id == "$sso-autojoin"
+    assert seen[0].prev_membership is None
 
 
 @pytest.mark.asyncio
@@ -289,7 +291,7 @@ async def test_router_emits_room_member_joined_from_first_restored_token_sync_ti
         _sync_response_with_state(
             room.room_id,
             [],
-            timeline_events=[_room_member_event(event_id="$catchup-join")],
+            timeline_events=[_room_member_event(event_id="$catchup-join", prev_membership=None)],
         ),
     )
 

--- a/tests/test_room_member_hooks.py
+++ b/tests/test_room_member_hooks.py
@@ -345,6 +345,46 @@ async def test_router_ignores_restored_token_first_sync_full_state_member_snapsh
 
 
 @pytest.mark.asyncio
+async def test_router_ignores_restored_token_timeline_profile_update_for_existing_member(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Restored-token timeline member updates should not onboard users already in state."""
+    seen: list[str] = []
+
+    @hook(EVENT_ROOM_MEMBER_JOINED)
+    async def joined(ctx: RoomMemberJoinedContext) -> None:
+        seen.append(ctx.event_id)
+
+    bot = _router_bot(tmp_path)
+    room = _room()
+    bot._first_sync_done = False
+    bot._room_member_join_hooks_armed = False
+    bot._sync_trust_state = SyncTrustState.PENDING
+    bot.client.rooms = {room.room_id: room}
+    bot.client.next_batch = "s_restored"
+    bot.hook_registry = HookRegistry.from_plugins([_plugin("onboarding", [joined])])
+    bot._emit_agent_lifecycle_event = AsyncMock()
+    bot._maybe_start_startup_thread_prewarm = MagicMock()
+    bot._maybe_start_deferred_overdue_task_drain = MagicMock()
+    monkeypatch.setattr(
+        bot,
+        "_sync_cache_result_for_certification",
+        AsyncMock(return_value=SyncCacheWriteResult(complete=True)),
+    )
+
+    await bot._on_sync_response(
+        _sync_response_with_state(
+            room.room_id,
+            [_room_member_event(event_id="$existing-member", prev_membership=None)],
+            timeline_events=[_room_member_event(event_id="$profile-update", prev_membership=None)],
+        ),
+    )
+
+    assert seen == []
+
+
+@pytest.mark.asyncio
 async def test_router_ignores_sync_state_member_snapshot_without_previous_membership(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_room_member_hooks.py
+++ b/tests/test_room_member_hooks.py
@@ -336,6 +336,13 @@ async def test_router_ignores_restored_token_first_sync_full_state_member_snapsh
 
     assert seen == []
 
+    await bot._on_room_member(
+        room,
+        _room_member_event(event_id="$profile-update", prev_membership=None),
+    )
+
+    assert seen == []
+
 
 @pytest.mark.asyncio
 async def test_router_ignores_sync_state_member_snapshot_without_previous_membership(
@@ -364,6 +371,13 @@ async def test_router_ignores_sync_state_member_snapshot_without_previous_member
             room.room_id,
             [_room_member_event(event_id="$snapshot-join", prev_membership=None)],
         ),
+    )
+
+    assert seen == []
+
+    await bot._on_room_member(
+        room,
+        _room_member_event(event_id="$profile-update", prev_membership=None),
     )
 
     assert seen == []


### PR DESCRIPTION
## Summary
- emit room-member join hooks for live Matrix member events even when `unsigned.prev_content` is absent
- apply the same behavior to restored-token timeline catch-up events
- keep full-state sync snapshots guarded by previous membership so existing members are not replayed as new joins

## Tests
- `uv run pytest tests/test_room_member_hooks.py -q`