### PR TITLE
Speed up pytest startup

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -19,7 +19,7 @@ class FrontendBuildHook(BuildHookInterface):
 
     def initialize(self, version: str, build_data: dict[str, object]) -> None:
         """Build dashboard assets when the current build target needs them."""
-        if self.target_name != "wheel" or version not in {"standard", "editable"}:
+        if self.target_name != "wheel" or version != "standard":
             return
 
         frontend_dir = Path(self.root) / "frontend"
@@ -29,29 +29,24 @@ class FrontendBuildHook(BuildHookInterface):
 
         bun = shutil.which("bun")
         if bun is None:
-            if version == "editable":
-                return
             msg = (
                 "bun is required to build the bundled frontend for wheel distributions. "
                 "Install bun or build from a prebuilt wheel instead."
             )
             raise RuntimeError(msg)
 
-        output_dir = _get_output_dir(frontend_dir, self.directory, version)
+        output_dir = _get_output_dir(self.directory)
         _build_frontend(frontend_dir, output_dir, bun)
 
-        if version == "standard":
-            force_include = build_data.setdefault("force_include", {})
-            if not isinstance(force_include, dict):
-                msg = "Wheel build data force_include must be a dictionary"
-                raise TypeError(msg)
-            force_include[str(output_dir)] = "mindroom/_frontend"
+        force_include = build_data.setdefault("force_include", {})
+        if not isinstance(force_include, dict):
+            msg = "Wheel build data force_include must be a dictionary"
+            raise TypeError(msg)
+        force_include[str(output_dir)] = "mindroom/_frontend"
 
 
-def _get_output_dir(frontend_dir: Path, build_directory: str, version: str) -> Path:
-    """Return the frontend build output directory for the requested build mode."""
-    if version == "editable":
-        return frontend_dir / "dist"
+def _get_output_dir(build_directory: str) -> Path:
+    """Return the isolated frontend build output directory for wheel builds."""
     return Path(build_directory).parent / ".frontend-build" / "frontend-dist"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -533,6 +533,7 @@ python_files = "test_*.py"
 asyncio_mode = "auto"
 pythonpath = [ "src" ]
 addopts = """
+    -p no:tach
     -vvv
     -n auto
     --cov=mindroom

--- a/tests/test_hatch_build.py
+++ b/tests/test_hatch_build.py
@@ -34,25 +34,41 @@ def test_get_output_dir_for_standard_build_stays_out_of_dist(
     tmp_path: Path,
 ) -> None:
     """Wheel builds should not leave non-package artifacts in the publish directory."""
-    frontend_dir = tmp_path / "frontend"
     build_dir = tmp_path / "dist"
 
-    output_dir = hatch_build_module._get_output_dir(frontend_dir, str(build_dir), "standard")
+    output_dir = hatch_build_module._get_output_dir(str(build_dir))
 
     assert output_dir == tmp_path / ".frontend-build" / "frontend-dist"
     assert output_dir.parent != build_dir
 
 
-def test_get_output_dir_for_editable_build_uses_repo_frontend_dist(
+def test_editable_build_skips_frontend_build_even_when_bun_is_available(
     hatch_build_module: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Editable installs should still write to the repo frontend dist directory."""
+    """Editable installs should not build bundled dashboard assets."""
     frontend_dir = tmp_path / "frontend"
+    frontend_dir.mkdir()
+    hook = hatch_build_module.FrontendBuildHook()
+    hook.target_name = "wheel"
+    hook.root = str(tmp_path)
+    hook.directory = str(tmp_path / "dist")
+    build_calls: list[tuple[Path, Path, str]] = []
 
-    output_dir = hatch_build_module._get_output_dir(frontend_dir, str(tmp_path / "dist"), "editable")
+    def fake_build_frontend(frontend: Path, output: Path, bun: str) -> None:
+        build_calls.append((frontend, output, bun))
 
-    assert output_dir == frontend_dir / "dist"
+    monkeypatch.setattr(
+        hatch_build_module.shutil,
+        "which",
+        lambda name: "/usr/local/bin/bun" if name == "bun" else None,
+    )
+    monkeypatch.setattr(hatch_build_module, "_build_frontend", fake_build_frontend)
+
+    hook.initialize("editable", {})
+
+    assert build_calls == []
 
 
 def test_run_command_retries_once_before_succeeding(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,7 +5,9 @@ import json
 import os
 import subprocess
 import sys
+import tomllib
 import types
+from pathlib import Path
 
 import pytest
 
@@ -128,3 +130,14 @@ if missing:
     )
 
     assert result.returncode == 0, result.stderr
+
+
+def test_default_pytest_options_disable_tach_plugin() -> None:
+    """Plain pytest should not run Tach impact analysis unless explicitly requested."""
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    data = tomllib.loads(pyproject.read_text())
+
+    addopts = data["tool"]["pytest"]["ini_options"]["addopts"].split()
+
+    assert "-p" in addopts
+    assert "no:tach" in addopts

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import tomllib
 import types
+from itertools import pairwise
 from pathlib import Path
 
 import pytest
@@ -138,6 +139,6 @@ def test_default_pytest_options_disable_tach_plugin() -> None:
     data = tomllib.loads(pyproject.read_text())
 
     addopts = data["tool"]["pytest"]["ini_options"]["addopts"].split()
+    addopts_pairs = pairwise(addopts)
 
-    assert "-p" in addopts
-    assert "no:tach" in addopts
+    assert ("-p", "no:tach") in addopts_pairs


### PR DESCRIPTION
## Summary
- Skip bundled frontend builds during editable wheel installs so `uv run pytest` does not run `bun install`/Vite before tests.
- Disable the Tach pytest plugin for plain pytest runs; explicit Tach checks still work with `pytest -p tach --tach`.
- Add regression coverage for editable build skipping and default pytest options.

## Test Plan
- [x] `uv sync --all-extras`
- [x] `uv run pre-commit run --all-files`
- [x] `uv run pytest` (`7361 passed, 59 skipped`)
- [x] `/usr/bin/time -p uv run pytest --collect-only -q -n 0 --no-cov` (`7420 tests collected in 1.59s`, wall `5.97s`)

No lazy import changes included.