### PR TITLE
Build dashboard assets in MindRoom Docker image

### DIFF
--- a/local/instances/deploy/Dockerfile.mindroom
+++ b/local/instances/deploy/Dockerfile.mindroom
@@ -6,7 +6,7 @@ FROM oven/bun:1 AS bun
 FROM public.ecr.aws/docker/library/python:3.13-slim AS builder
 # Copy uv from the uv image
 COPY --from=uv /uv /uvx /bin/
-# Copy bun for frontend builds triggered by the editable install hook
+# Copy bun for explicit frontend builds in the builder stage
 COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
 COPY --from=bun /usr/local/bin/bunx /usr/local/bin/bunx
 
@@ -24,6 +24,16 @@ COPY src /app/src
 COPY avatars /app/avatars
 COPY skills /app/skills
 COPY frontend /app/frontend
+
+# Build dashboard assets for the runtime image. The final stage does not include
+# Bun, so `/app/frontend/dist` must already exist when MindRoom starts.
+ENV PUPPETEER_SKIP_DOWNLOAD=true
+WORKDIR /app/frontend
+RUN --mount=type=cache,target=/root/.bun/install/cache \
+    bun install --frozen-lockfile \
+    && bun run build \
+    && rm -rf node_modules
+WORKDIR /app
 
 # Install the project itself.
 # Keep the sentence_transformers extra runtime-only so the full image doesn't

--- a/tests/test_mindroom_dockerfiles.py
+++ b/tests/test_mindroom_dockerfiles.py
@@ -10,6 +10,7 @@ _MINDROOM_DOCKERFILES = (
     _REPO_ROOT / "local/instances/deploy/Dockerfile.mindroom",
     _REPO_ROOT / "local/instances/deploy/Dockerfile.mindroom-minimal",
 )
+_MINDROOM_DOCKERFILE = _REPO_ROOT / "local/instances/deploy/Dockerfile.mindroom"
 _RUNTIME_DEPLOYMENT_TEMPLATE = _REPO_ROOT / "cluster/k8s/runtime/templates/deployment.yaml"
 _INSTANCE_HELPERS_TEMPLATE = _REPO_ROOT / "cluster/k8s/instance/templates/_helpers.tpl"
 _PLATFORM_BACKEND_DOCKERFILE = _REPO_ROOT / "saas-platform/Dockerfile.platform-backend"
@@ -39,6 +40,19 @@ def test_mindroom_runtime_images_run_under_tini() -> None:
         assert "tini" in _apt_install_packages(text)
         assert 'ENTRYPOINT ["tini", "--"]' in text
         assert 'CMD ["/app/.venv/bin/mindroom", "run"]' in text
+
+
+def test_mindroom_runtime_image_builds_dashboard_assets_explicitly() -> None:
+    """The runtime image should ship dashboard assets without runtime Bun."""
+    text = _MINDROOM_DOCKERFILE.read_text(encoding="utf-8")
+    frontend_copy_index = text.index("COPY frontend /app/frontend")
+    final_stage_index = text.index("FROM public.ecr.aws/docker/library/python:3.13-slim AS final")
+    builder_after_frontend = text[frontend_copy_index:final_stage_index]
+
+    assert "PUPPETEER_SKIP_DOWNLOAD=true" in builder_after_frontend
+    assert "bun install --frozen-lockfile" in builder_after_frontend
+    assert "bun run build" in builder_after_frontend
+    assert "rm -rf node_modules" in builder_after_frontend
 
 
 def test_kubernetes_command_overrides_run_under_tini() -> None:

--- a/tests/test_mindroom_dockerfiles.py
+++ b/tests/test_mindroom_dockerfiles.py
@@ -46,7 +46,7 @@ def test_mindroom_runtime_image_builds_dashboard_assets_explicitly() -> None:
     """The runtime image should ship dashboard assets without runtime Bun."""
     text = _MINDROOM_DOCKERFILE.read_text(encoding="utf-8")
     frontend_copy_index = text.index("COPY frontend /app/frontend")
-    final_stage_index = text.index("FROM public.ecr.aws/docker/library/python:3.13-slim AS final")
+    final_stage_index = text.index(" AS final")
     builder_after_frontend = text[frontend_copy_index:final_stage_index]
 
     assert "PUPPETEER_SKIP_DOWNLOAD=true" in builder_after_frontend


### PR DESCRIPTION
## Summary
- Build the MindRoom dashboard explicitly in the Docker builder stage after copying `frontend`.
- Keep runtime image Bun-free while shipping `/app/frontend/dist`.
- Add a Dockerfile regression check for explicit dashboard asset builds.

## Test Plan
- `uv run pytest tests/test_hatch_build.py tests/test_init.py -q`
- `uv run pytest tests/test_mindroom_dockerfiles.py -q`
- `uv sync --all-extras`
- `uv run pre-commit run --all-files`
- `docker build -t ghcr.io/mindroom-ai/mindroom:latest -f local/instances/deploy/Dockerfile.mindroom .`
- `docker run --rm ghcr.io/mindroom-ai/mindroom:latest sh -lc 'test -f /app/frontend/dist/index.html || test -f /app/src/mindroom/_frontend/index.html'`
- API-only container root `/` contains `MindRoom`
