### PR TITLE
Opt into frontend asset build during Docker sync

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import time
@@ -11,6 +12,7 @@ from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 
 _BUN_INSTALL_MAX_ATTEMPTS = 3
 _BUN_INSTALL_RETRY_DELAY_SECONDS = 2.0
+_BUILD_FRONTEND_ENV = "MINDROOM_BUILD_FRONTEND"
 _GIT_LFS_POINTER_PREFIX = b"version https://git-lfs.github.com/spec/v1\n"
 
 
@@ -19,7 +21,8 @@ class FrontendBuildHook(BuildHookInterface):
 
     def initialize(self, version: str, build_data: dict[str, object]) -> None:
         """Build dashboard assets when the current build target needs them."""
-        if self.target_name != "wheel" or version != "standard":
+        should_build_editable = version == "editable" and _env_flag_enabled(_BUILD_FRONTEND_ENV)
+        if self.target_name != "wheel" or (version != "standard" and not should_build_editable):
             return
 
         frontend_dir = Path(self.root) / "frontend"
@@ -29,14 +32,14 @@ class FrontendBuildHook(BuildHookInterface):
 
         bun = shutil.which("bun")
         if bun is None:
-            msg = (
-                "bun is required to build the bundled frontend for wheel distributions. "
-                "Install bun or build from a prebuilt wheel instead."
-            )
+            msg = _missing_bun_message(version)
             raise RuntimeError(msg)
 
-        output_dir = _get_output_dir(self.directory)
+        output_dir = _get_output_dir(frontend_dir, self.directory, version)
         _build_frontend(frontend_dir, output_dir, bun)
+
+        if version == "editable":
+            return
 
         force_include = build_data.setdefault("force_include", {})
         if not isinstance(force_include, dict):
@@ -45,8 +48,24 @@ class FrontendBuildHook(BuildHookInterface):
         force_include[str(output_dir)] = "mindroom/_frontend"
 
 
-def _get_output_dir(build_directory: str) -> Path:
-    """Return the isolated frontend build output directory for wheel builds."""
+def _env_flag_enabled(name: str) -> bool:
+    """Return whether an environment flag has a truthy value."""
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _missing_bun_message(version: str) -> str:
+    if version == "editable":
+        return f"bun is required when {_BUILD_FRONTEND_ENV}=1. Install bun or unset {_BUILD_FRONTEND_ENV}."
+    return (
+        "bun is required to build the bundled frontend for wheel distributions. "
+        "Install bun or build from a prebuilt wheel instead."
+    )
+
+
+def _get_output_dir(frontend_dir: Path, build_directory: str, version: str) -> Path:
+    """Return the frontend build output directory for the requested build mode."""
+    if version == "editable":
+        return frontend_dir / "dist"
     return Path(build_directory).parent / ".frontend-build" / "frontend-dist"
 
 

--- a/local/instances/deploy/Dockerfile.mindroom
+++ b/local/instances/deploy/Dockerfile.mindroom
@@ -25,24 +25,19 @@ COPY avatars /app/avatars
 COPY skills /app/skills
 COPY frontend /app/frontend
 
-# Build dashboard assets for the runtime image. The final stage does not include
-# Bun, so `/app/frontend/dist` must already exist when MindRoom starts.
-ENV PUPPETEER_SKIP_DOWNLOAD=true
-WORKDIR /app/frontend
-RUN --mount=type=cache,target=/root/.bun/install/cache \
-    bun install --frozen-lockfile \
-    && bun run build \
-    && rm -rf node_modules
-WORKDIR /app
-
 # Install the project itself.
+# Opt into the editable-install frontend build so the final image has
+# `/app/frontend/dist` without carrying Bun into the runtime stage.
+ENV MINDROOM_BUILD_FRONTEND=1
+ENV PUPPETEER_SKIP_DOWNLOAD=true
 # Keep the sentence_transformers extra runtime-only so the full image doesn't
 # pull torch and CUDA wheels into the smoke-stack build.
 # Set pretend version for setuptools-scm (no .git in container)
 ARG VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-dev --all-extras --no-extra sentence_transformers
+    uv sync --locked --no-dev --all-extras --no-extra sentence_transformers --reinstall-package mindroom \
+    && rm -rf frontend/node_modules
 
 # Final production stage
 FROM public.ecr.aws/docker/library/python:3.13-slim AS final

--- a/local/instances/deploy/Dockerfile.mindroom-minimal
+++ b/local/instances/deploy/Dockerfile.mindroom-minimal
@@ -8,7 +8,7 @@ FROM oven/bun:1 AS bun
 FROM public.ecr.aws/docker/library/python:3.13-slim AS builder
 # Copy uv from the uv image
 COPY --from=uv /uv /uvx /bin/
-# Copy bun for frontend builds triggered by the editable install hook
+# Copy bun for explicit frontend builds in the builder stage
 COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
 COPY --from=bun /usr/local/bin/bunx /usr/local/bin/bunx
 
@@ -28,11 +28,16 @@ COPY skills /app/skills
 COPY frontend /app/frontend
 
 # Install the project itself (base only, no extras)
+# Opt into the editable-install frontend build so the final image has
+# `/app/frontend/dist` without carrying Bun into the runtime stage.
+ENV MINDROOM_BUILD_FRONTEND=1
+ENV PUPPETEER_SKIP_DOWNLOAD=true
 # Set pretend version for setuptools-scm (no .git in container)
 ARG VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-dev
+    uv sync --locked --no-dev --reinstall-package mindroom \
+    && rm -rf frontend/node_modules
 
 # Final production stage
 FROM public.ecr.aws/docker/library/python:3.13-slim AS final

--- a/tests/test_hatch_build.py
+++ b/tests/test_hatch_build.py
@@ -36,7 +36,7 @@ def test_get_output_dir_for_standard_build_stays_out_of_dist(
     """Wheel builds should not leave non-package artifacts in the publish directory."""
     build_dir = tmp_path / "dist"
 
-    output_dir = hatch_build_module._get_output_dir(str(build_dir))
+    output_dir = hatch_build_module._get_output_dir(tmp_path / "frontend", str(build_dir), "standard")
 
     assert output_dir == tmp_path / ".frontend-build" / "frontend-dist"
     assert output_dir.parent != build_dir
@@ -69,6 +69,57 @@ def test_editable_build_skips_frontend_build_even_when_bun_is_available(
     hook.initialize("editable", {})
 
     assert build_calls == []
+
+
+def test_editable_build_env_opt_in_builds_repo_frontend_dist(
+    hatch_build_module: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Editable installs should build frontend/dist when explicitly requested."""
+    frontend_dir = tmp_path / "frontend"
+    frontend_dir.mkdir()
+    hook = hatch_build_module.FrontendBuildHook()
+    hook.target_name = "wheel"
+    hook.root = str(tmp_path)
+    hook.directory = str(tmp_path / "dist")
+    build_calls: list[tuple[Path, Path, str]] = []
+    build_data: dict[str, object] = {}
+
+    def fake_build_frontend(frontend: Path, output: Path, bun: str) -> None:
+        build_calls.append((frontend, output, bun))
+
+    monkeypatch.setenv(hatch_build_module._BUILD_FRONTEND_ENV, "1")
+    monkeypatch.setattr(
+        hatch_build_module.shutil,
+        "which",
+        lambda name: "/usr/local/bin/bun" if name == "bun" else None,
+    )
+    monkeypatch.setattr(hatch_build_module, "_build_frontend", fake_build_frontend)
+
+    hook.initialize("editable", build_data)
+
+    assert build_calls == [(frontend_dir, frontend_dir / "dist", "/usr/local/bin/bun")]
+    assert build_data == {}
+
+
+def test_editable_build_env_opt_in_requires_bun(
+    hatch_build_module: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """An explicit editable frontend build should fail rather than skip missing Bun."""
+    (tmp_path / "frontend").mkdir()
+    hook = hatch_build_module.FrontendBuildHook()
+    hook.target_name = "wheel"
+    hook.root = str(tmp_path)
+    hook.directory = str(tmp_path / "dist")
+
+    monkeypatch.setenv(hatch_build_module._BUILD_FRONTEND_ENV, "1")
+    monkeypatch.setattr(hatch_build_module.shutil, "which", lambda _name: None)
+
+    with pytest.raises(RuntimeError, match="MINDROOM_BUILD_FRONTEND=1"):
+        hook.initialize("editable", {})
 
 
 def test_run_command_retries_once_before_succeeding(

--- a/tests/test_mindroom_dockerfiles.py
+++ b/tests/test_mindroom_dockerfiles.py
@@ -10,7 +10,6 @@ _MINDROOM_DOCKERFILES = (
     _REPO_ROOT / "local/instances/deploy/Dockerfile.mindroom",
     _REPO_ROOT / "local/instances/deploy/Dockerfile.mindroom-minimal",
 )
-_MINDROOM_DOCKERFILE = _REPO_ROOT / "local/instances/deploy/Dockerfile.mindroom"
 _RUNTIME_DEPLOYMENT_TEMPLATE = _REPO_ROOT / "cluster/k8s/runtime/templates/deployment.yaml"
 _INSTANCE_HELPERS_TEMPLATE = _REPO_ROOT / "cluster/k8s/instance/templates/_helpers.tpl"
 _PLATFORM_BACKEND_DOCKERFILE = _REPO_ROOT / "saas-platform/Dockerfile.platform-backend"
@@ -42,17 +41,22 @@ def test_mindroom_runtime_images_run_under_tini() -> None:
         assert 'CMD ["/app/.venv/bin/mindroom", "run"]' in text
 
 
-def test_mindroom_runtime_image_builds_dashboard_assets_explicitly() -> None:
+def test_mindroom_runtime_images_opt_into_dashboard_asset_build() -> None:
     """The runtime image should ship dashboard assets without runtime Bun."""
-    text = _MINDROOM_DOCKERFILE.read_text(encoding="utf-8")
-    frontend_copy_index = text.index("COPY frontend /app/frontend")
-    final_stage_index = text.index(" AS final")
-    builder_after_frontend = text[frontend_copy_index:final_stage_index]
+    for dockerfile in _MINDROOM_DOCKERFILES:
+        text = dockerfile.read_text(encoding="utf-8")
+        frontend_copy_index = text.index("COPY frontend /app/frontend")
+        final_stage_index = text.index(" AS final")
+        builder_after_frontend = text[frontend_copy_index:final_stage_index]
+        frontend_build_env_index = builder_after_frontend.index("ENV MINDROOM_BUILD_FRONTEND=1")
+        project_install_index = builder_after_frontend.index("uv sync --locked --no-dev")
 
-    assert "PUPPETEER_SKIP_DOWNLOAD=true" in builder_after_frontend
-    assert "bun install --frozen-lockfile" in builder_after_frontend
-    assert "bun run build" in builder_after_frontend
-    assert "rm -rf node_modules" in builder_after_frontend
+        assert frontend_build_env_index < project_install_index
+        assert "MINDROOM_BUILD_FRONTEND=1" in builder_after_frontend
+        assert "PUPPETEER_SKIP_DOWNLOAD=true" in builder_after_frontend
+        assert "--reinstall-package mindroom" in builder_after_frontend
+        assert "rm -rf frontend/node_modules" in builder_after_frontend
+        assert "bun install --frozen-lockfile" not in text
 
 
 def test_kubernetes_command_overrides_run_under_tini() -> None:


### PR DESCRIPTION
## Summary
- add MINDROOM_BUILD_FRONTEND as an opt-in editable-install frontend build flag
- have both MindRoom runtime Dockerfiles set the flag during project uv sync and force reinstall mindroom so the build hook cannot be skipped by uv cache
- remove frontend node_modules after the build and assert both runtime Dockerfiles opt into the asset build

## Verification
- git lfs pull
- uv run pytest tests/test_hatch_build.py tests/test_init.py tests/test_mindroom_dockerfiles.py -q
- uv run pre-commit run --all-files
- docker build -t ghcr.io/mindroom-ai/mindroom:latest -f local/instances/deploy/Dockerfile.mindroom .
- docker run --rm ghcr.io/mindroom-ai/mindroom:latest sh -lc 'test -f /app/frontend/dist/index.html && ! command -v bun && test ! -d /app/frontend/node_modules'
- docker build -t ghcr.io/mindroom-ai/mindroom-minimal:latest -f local/instances/deploy/Dockerfile.mindroom-minimal .
- docker run --rm ghcr.io/mindroom-ai/mindroom-minimal:latest sh -lc 'test -f /app/frontend/dist/index.html && ! command -v bun && test ! -d /app/frontend/node_modules'
- docker run -d --name mindroom-dashboard-check -p 127.0.0.1:18766:8765 ghcr.io/mindroom-ai/mindroom:latest, then curl / and confirmed MindRoom