### PR TITLE
fix(matrix): guard markdown URL sanitizer against malformed IPv6 brackets

### DIFF
--- a/src/mindroom/matrix/message_builder.py
+++ b/src/mindroom/matrix/message_builder.py
@@ -235,7 +235,10 @@ def _sanitize_url_attribute(value: str) -> str | None:
     normalized = "".join(char for char in candidate if not char.isspace())
     if normalized.startswith(("#", "/", "//")):
         return candidate
-    scheme = urlsplit(normalized).scheme.lower()
+    try:
+        scheme = urlsplit(normalized).scheme.lower()
+    except ValueError:
+        return None
     if scheme in _ALLOWED_URL_SCHEMES:
         return candidate
     if not scheme and ":" not in normalized:

--- a/tests/test_markdown_to_html.py
+++ b/tests/test_markdown_to_html.py
@@ -355,6 +355,15 @@ def test_data_uri_attributes_are_stripped() -> None:
     assert 'href="data:' not in html
 
 
+def test_malformed_ipv6_url_attribute_is_dropped_without_crashing() -> None:
+    """A URL with an unbalanced IPv6 bracket must not abort the whole render (ISSUE-230)."""
+    html = markdown_to_html('<a href="http://[">x</a>\n<img src="http://[" alt="safe">')
+    assert "<a>x</a>" in html
+    assert 'href="http://["' not in html
+    assert 'alt="safe"' in html
+    assert 'src="http://["' not in html
+
+
 @pytest.mark.parametrize(
     ("raw_html", "expected_fragment", "forbidden_fragment"),
     [


### PR DESCRIPTION
urlsplit() in _sanitize_url_attribute now validates IPv6 brackets eagerly on .scheme access under recent CPython, raising ValueError("Invalid IPv6 URL") on an unbalanced '[' in a raw HTML href/src. That uncaught error aborted the entire outgoing-message render, bricking agents whose replies emitted such a token (ISSUE-230). Catch ValueError and drop the attribute, matching the existing javascript:/data: rejection path.