### PR TITLE
fix(redaction): guard URL redaction against malformed IPv6 brackets

### DIFF
--- a/src/mindroom/redaction.py
+++ b/src/mindroom/redaction.py
@@ -172,7 +172,10 @@ def _redact_secret_assignment(match: re.Match[str]) -> str:
 
 
 def _redact_url(value: str) -> str:
-    parsed = urlparse(value)
+    try:
+        parsed = urlparse(value)
+    except ValueError:
+        return value
     if parsed.scheme not in {"http", "https"}:
         return value
 

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -123,3 +123,12 @@ def test_redact_sensitive_data_redacts_secret_before_truncated_bound() -> None:
     assert REDACTED in message
     assert "sk-test-secret" not in message
     assert len(message) <= 120
+
+
+def test_redact_sensitive_data_tolerates_malformed_ipv6_url() -> None:
+    """A URL-like token with an unbalanced IPv6 bracket must not crash redaction (ISSUE-230)."""
+    redacted = redact_sensitive_data({"message": 'see <a href="http://[">x</a> for details'})
+
+    message = redacted["message"]
+    assert isinstance(message, str)
+    assert "http://[" in message


### PR DESCRIPTION
_redact_url called urlparse() on every URL-shaped token matched in logged text. Under recent CPython, urlparse raises ValueError("Invalid IPv6 URL") on an unbalanced '[', which crashed redact_sensitive_data and aborted the agent run via the LLM-request-logging path (ISSUE-230, second call site). Catch ValueError and pass the unparseable token through unchanged.