### PR TITLE
Include direct built-ins in MCP function collision checks

### DIFF
--- a/src/mindroom/mcp/manager.py
+++ b/src/mindroom/mcp/manager.py
@@ -29,7 +29,7 @@ from mindroom.mcp.transports import build_transport_handle
 from mindroom.mcp.types import MCPDiscoveredTool, MCPServerCatalog, MCPServerState
 from mindroom.oauth.providers import OAuthConnectionRequired, OAuthProviderError
 from mindroom.oauth.service import build_oauth_connect_instruction, oauth_connect_url, oauth_credentials_usable
-from mindroom.tool_system.catalog import ensure_tool_registry_loaded, get_tool_by_name
+from mindroom.tool_system.catalog import TOOL_METADATA, ensure_tool_registry_loaded, get_tool_by_name
 from mindroom.tool_system.dynamic_toolkits import visible_tool_surface
 
 if TYPE_CHECKING:
@@ -908,15 +908,28 @@ class MCPServerManager:
         return local_tool_configs, {server_id: tuple(configs) for server_id, configs in mcp_tool_configs.items()}
 
     @staticmethod
-    def _special_tool_function_names(tool_names: set[str]) -> set[str]:
-        """Return provider-visible function names for special control-plane tools."""
+    def _metadata_only_tool_function_names(tool_name: str, *, config: Config, agent_name: str) -> set[str]:
+        """Return provider-visible names for context-built tools declared in metadata."""
+        metadata = TOOL_METADATA.get(tool_name)
+        if metadata is None or metadata.factory is not None:
+            return set()
+        if tool_name == "memory" and config.get_agent_memory_backend(agent_name) == "none":
+            return set()
+        return set(metadata.function_names)
+
+    def _metadata_only_tool_function_names_for_surface(
+        self,
+        tool_names: set[str],
+        *,
+        config: Config,
+        agent_name: str,
+    ) -> set[str]:
+        """Return provider-visible function names for metadata-only configured tools."""
         function_names: set[str] = set()
-        if "delegate" in tool_names:
-            function_names.add("delegate_task")
-        if "self_config" in tool_names:
-            function_names.update({"get_own_config", "update_own_config"})
-        if "dynamic_tools" in tool_names:
-            function_names.update({"list_tools", "load_tool", "unload_tool", "tool_search"})
+        for tool_name in sorted(tool_names):
+            function_names.update(
+                self._metadata_only_tool_function_names(tool_name, config=config, agent_name=agent_name),
+            )
         return function_names
 
     def _tool_function_names_for_local_tools(
@@ -961,13 +974,21 @@ class MCPServerManager:
             self._configured_tool_configs(agent_name, loaded_tools=loaded_tools),
         )
         local_tool_names = {entry.name for entry in local_tool_configs}
-        function_names = self._special_tool_function_names(local_tool_names)
+        function_names = self._metadata_only_tool_function_names_for_surface(
+            local_tool_names,
+            config=config,
+            agent_name=agent_name,
+        )
         function_names.update(
             self._tool_function_names_for_local_tools(
                 [
                     entry
                     for entry in local_tool_configs
-                    if entry.name not in {"delegate", "self_config", "dynamic_tools"}
+                    if not self._metadata_only_tool_function_names(
+                        entry.name,
+                        config=config,
+                        agent_name=agent_name,
+                    )
                 ],
                 get_tool_by_name=get_tool_by_name,
             ),

--- a/src/mindroom/tools/compact_context.py
+++ b/src/mindroom/tools/compact_context.py
@@ -26,5 +26,6 @@ register_builtin_tool_metadata(
         icon_color="text-amber-500",
         config_fields=[],
         dependencies=[],
+        function_names=("compact_context",),
     ),
 )

--- a/src/mindroom/tools/delegate.py
+++ b/src/mindroom/tools/delegate.py
@@ -26,5 +26,6 @@ register_builtin_tool_metadata(
         icon_color="text-blue-500",
         config_fields=[],
         dependencies=[],
+        function_names=("delegate_task",),
     ),
 )

--- a/src/mindroom/tools/dynamic_tools.py
+++ b/src/mindroom/tools/dynamic_tools.py
@@ -25,5 +25,6 @@ register_builtin_tool_metadata(
         icon_color="text-sky-500",
         config_fields=[],
         dependencies=[],
+        function_names=("list_tools", "load_tool", "unload_tool", "tool_search"),
     ),
 )

--- a/src/mindroom/tools/memory.py
+++ b/src/mindroom/tools/memory.py
@@ -26,5 +26,13 @@ register_builtin_tool_metadata(
         icon_color="text-violet-500",
         config_fields=[],
         dependencies=[],
+        function_names=(
+            "add_memory",
+            "delete_memory",
+            "get_memory",
+            "list_memories",
+            "search_memories",
+            "update_memory",
+        ),
     ),
 )

--- a/src/mindroom/tools/self_config.py
+++ b/src/mindroom/tools/self_config.py
@@ -26,5 +26,6 @@ register_builtin_tool_metadata(
         icon_color="text-indigo-500",
         config_fields=[],
         dependencies=[],
+        function_names=("get_own_config", "update_own_config"),
     ),
 )

--- a/src/mindroom/tools_metadata.json
+++ b/src/mindroom/tools_metadata.json
@@ -2533,7 +2533,12 @@
       "description": "Load and unload deferred tools for the current session",
       "display_name": "Dynamic Tools",
       "docs_url": null,
-      "function_names": [],
+      "function_names": [
+        "list_tools",
+        "load_tool",
+        "unload_tool",
+        "tool_search"
+      ],
       "helper_text": null,
       "icon": "PackagePlus",
       "icon_color": "text-sky-500",
@@ -5468,7 +5473,10 @@
       "description": "Allow an agent to read and modify its own configuration",
       "display_name": "Self Config",
       "docs_url": null,
-      "function_names": [],
+      "function_names": [
+        "get_own_config",
+        "update_own_config"
+      ],
       "helper_text": null,
       "icon": "Settings",
       "icon_color": "text-indigo-500",
@@ -6948,7 +6956,9 @@
       "description": "Request context compaction before the next reply in this conversation scope",
       "display_name": "Context Compaction",
       "docs_url": null,
-      "function_names": [],
+      "function_names": [
+        "compact_context"
+      ],
       "helper_text": null,
       "icon": "Minimize2",
       "icon_color": "text-amber-500",
@@ -7100,7 +7110,9 @@
       "description": "Delegate tasks to other configured agents",
       "display_name": "Agent Delegation",
       "docs_url": null,
-      "function_names": [],
+      "function_names": [
+        "delegate_task"
+      ],
       "helper_text": null,
       "icon": "Users",
       "icon_color": "text-blue-500",
@@ -7511,7 +7523,14 @@
       "description": "Explicitly store and search agent memories on demand",
       "display_name": "Agent Memory",
       "docs_url": null,
-      "function_names": [],
+      "function_names": [
+        "add_memory",
+        "delete_memory",
+        "get_memory",
+        "list_memories",
+        "search_memories",
+        "update_memory"
+      ],
       "helper_text": null,
       "icon": "Brain",
       "icon_color": "text-violet-500",

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -1020,6 +1020,47 @@ async def test_mcp_manager_marks_local_function_name_collisions_as_failed(
 
 
 @pytest.mark.asyncio
+async def test_mcp_manager_marks_direct_builtin_function_name_collisions_as_failed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Reject MCP functions that collide with direct built-in tool functions."""
+    _patch_manager(monkeypatch)
+    _FakeClientSession.tool_list = [_tool("memory")]
+    runtime_paths = _runtime_paths(tmp_path)
+    config = Config.validate_with_runtime(
+        {
+            "mcp_servers": {
+                "demo": {
+                    "transport": "stdio",
+                    "command": "npx",
+                    "tool_prefix": "add",
+                },
+            },
+            "agents": {
+                "code": {
+                    "display_name": "Code",
+                    "role": "Write code",
+                    "tools": ["memory", "mcp_demo"],
+                    "memory_backend": "file",
+                },
+            },
+        },
+        runtime_paths,
+    )
+    manager = MCPServerManager(runtime_paths)
+
+    changed = await manager.sync_servers(config)
+
+    assert changed == set()
+    assert manager.failed_server_ids() == {"demo"}
+    error = manager._states["demo"].last_error
+    assert isinstance(error, MCPProtocolError)
+    assert "add_memory" in str(error)
+    assert "existing MindRoom tool function" in str(error)
+
+
+@pytest.mark.asyncio
 async def test_mcp_manager_ignores_deferred_unloaded_local_function_collisions_at_startup(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -1061,6 +1061,83 @@ async def test_mcp_manager_marks_direct_builtin_function_name_collisions_as_fail
 
 
 @pytest.mark.asyncio
+async def test_mcp_manager_allows_memory_mcp_function_when_memory_backend_none(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Do not reserve memory function names when the agent memory backend is disabled."""
+    _patch_manager(monkeypatch)
+    _FakeClientSession.tool_list = [_tool("memory")]
+    runtime_paths = _runtime_paths(tmp_path)
+    config = Config.validate_with_runtime(
+        {
+            "mcp_servers": {
+                "demo": {
+                    "transport": "stdio",
+                    "command": "npx",
+                    "tool_prefix": "add",
+                },
+            },
+            "agents": {
+                "code": {
+                    "display_name": "Code",
+                    "role": "Write code",
+                    "tools": ["memory", "mcp_demo"],
+                    "memory_backend": "none",
+                },
+            },
+        },
+        runtime_paths,
+    )
+    manager = MCPServerManager(runtime_paths)
+
+    changed = await manager.sync_servers(config)
+
+    assert changed == {"demo"}
+    assert manager.failed_server_ids() == set()
+
+
+@pytest.mark.asyncio
+async def test_mcp_manager_marks_compact_context_function_name_collisions_as_failed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Reject MCP functions that collide with compact-context direct built-in functions."""
+    _patch_manager(monkeypatch)
+    _FakeClientSession.tool_list = [_tool("context")]
+    runtime_paths = _runtime_paths(tmp_path)
+    config = Config.validate_with_runtime(
+        {
+            "mcp_servers": {
+                "demo": {
+                    "transport": "stdio",
+                    "command": "npx",
+                    "tool_prefix": "compact",
+                },
+            },
+            "agents": {
+                "code": {
+                    "display_name": "Code",
+                    "role": "Write code",
+                    "tools": ["compact_context", "mcp_demo"],
+                },
+            },
+        },
+        runtime_paths,
+    )
+    manager = MCPServerManager(runtime_paths)
+
+    changed = await manager.sync_servers(config)
+
+    assert changed == set()
+    assert manager.failed_server_ids() == {"demo"}
+    error = manager._states["demo"].last_error
+    assert isinstance(error, MCPProtocolError)
+    assert "compact_context" in str(error)
+    assert "existing MindRoom tool function" in str(error)
+
+
+@pytest.mark.asyncio
 async def test_mcp_manager_ignores_deferred_unloaded_local_function_collisions_at_startup(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- declare provider-visible function names on metadata-only built-in tools
- include metadata-only built-ins in MCP function-name collision validation
- cover memory tool collisions with a regression test

## Tests
- uv run pytest tests/test_mcp_manager.py -q --no-cov
- uv run pytest tests/test_plugins.py -k metadata_only -q --no-cov
- uv run ruff check src/mindroom/mcp/manager.py src/mindroom/tools/memory.py src/mindroom/tools/compact_context.py src/mindroom/tools/delegate.py src/mindroom/tools/dynamic_tools.py src/mindroom/tools/self_config.py tests/test_mcp_manager.py
- uv run ruff format --check src/mindroom/mcp/manager.py src/mindroom/tools/memory.py src/mindroom/tools/compact_context.py src/mindroom/tools/delegate.py src/mindroom/tools/dynamic_tools.py src/mindroom/tools/self_config.py tests/test_mcp_manager.py

Note: local pre-commit type checking was skipped because the temporary worktree environment did not include optional packages used elsewhere in the repository.