### PR TITLE
fix(ai): persist partial work when a streaming run errors mid-flight

### DIFF
--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -1649,12 +1649,31 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                         attempt_run_id = ai_runtime.next_retry_run_id(run_id)
                         continue
 
-                    if state.user_error is not None:
-                        yield get_user_friendly_error_message(state.user_error, agent_name)
-                        return
-
-                    if state.stream_exception is not None:
-                        yield get_user_friendly_error_message(state.stream_exception, agent_name)
+                    run_error = state.user_error or state.stream_exception
+                    if run_error is not None:
+                        if state.assistant_text or state.completed_tools or state.pending_tools:
+                            interrupted_tools = [pending.trace_entry for pending in state.pending_tools]
+                            if turn_recorder is not None:
+                                turn_recorder.record_interrupted(
+                                    run_metadata=metadata,
+                                    assistant_text=state.assistant_text,
+                                    completed_tools=state.completed_tools,
+                                    interrupted_tools=interrupted_tools,
+                                )
+                            elif not standalone_interrupted_replay_persisted:
+                                persist_interrupted_replay(
+                                    scope_context=scope_context,
+                                    session_id=session_id,
+                                    run_id=attempt_run_id or str(uuid4()),
+                                    user_message=prompt,
+                                    partial_text=state.assistant_text,
+                                    completed_tools=state.completed_tools,
+                                    interrupted_tools=interrupted_tools,
+                                    run_metadata=metadata,
+                                    is_team=False,
+                                )
+                                standalone_interrupted_replay_persisted = True
+                        yield get_user_friendly_error_message(run_error, agent_name)
                         return
 
                     if state.cancelled_run_event is not None:

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -1630,6 +1630,16 @@ class ResponseRunner:
                 )
                 if request.pipeline_timing is not None:
                     request.pipeline_timing.mark("streaming_complete")
+                if turn_recorder.outcome == "interrupted":
+                    self._persist_interrupted_recorder(
+                        recorder=turn_recorder,
+                        session_scope=self.deps.state_writer.history_scope(),
+                        session_id=runtime.session_id,
+                        execution_identity=runtime.tool_dispatch.execution_identity,
+                        run_id=run_id,
+                        is_team=False,
+                        response_event_id=request.existing_event_id,
+                    )
                 return transport_outcome
         except asyncio.CancelledError:
             self._persist_interrupted_recorder(

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -1382,6 +1382,79 @@ async def test_process_and_respond_streaming_persists_interrupted_history_when_d
     ]
 
 
+@pytest.mark.asyncio
+async def test_process_and_respond_streaming_persists_interrupted_history_when_model_stream_errors(
+    tmp_path: Path,
+) -> None:
+    """Model stream errors returned as text should still persist interrupted replay."""
+    runtime_paths = _runtime_paths(tmp_path)
+    config = bind_runtime_paths(_config(), runtime_paths)
+    bot = _make_bot(tmp_path, config=config, runtime_paths=runtime_paths)
+    storage = _SessionStorage()
+    mock_agent = MagicMock()
+    mock_agent.model = MagicMock()
+    mock_agent.model.__class__.__name__ = "OpenAIChat"
+    mock_agent.model.id = "test-model"
+    mock_agent.name = "GeneralAgent"
+    mock_agent.add_history_to_context = False
+
+    completed_tool = ToolExecution(
+        tool_call_id="call-1",
+        tool_name="run_shell_command",
+        tool_args={"cmd": "pwd"},
+        result="/app",
+    )
+
+    async def errored_agent_stream() -> AsyncIterator[object]:
+        yield RunContentEvent(content="Partial answer")
+        yield ToolCallStartedEvent(tool=completed_tool)
+        yield ToolCallCompletedEvent(tool=completed_tool)
+        yield RunErrorEvent(content="Error code: 500 - provider exploded")
+
+    mock_agent.arun = MagicMock(return_value=errored_agent_stream())
+
+    with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
+        mock_prepare.return_value = _prepared_prompt_result(mock_agent)
+        coordinator = _build_response_runner(
+            bot,
+            config=config,
+            runtime_paths=runtime_paths,
+            storage_path=tmp_path,
+            requester_id="@bob:localhost",
+            history_storage=storage,
+            message_target=MessageTarget.resolve("!test:localhost", "$thread-root", "$user_msg"),
+        )
+
+        async def consume_delivery(request: object) -> StreamTransportOutcome:
+            rendered = "".join([str(chunk) async for chunk in request.response_stream])
+            request.visible_event_id_callback("$streamed")
+            return _stream_outcome("$streamed", rendered)
+
+        coordinator.deps.delivery_gateway.deliver_stream.side_effect = consume_delivery
+
+        delivery = await coordinator.process_and_respond_streaming(
+            _response_request(prompt="Hello", user_id="@bob:localhost", thread_id="$thread-root"),
+            run_id="run-1",
+        )
+
+    assert delivery.event_id == "$streamed"
+    persisted_session = cast("AgentSession", storage.session)
+    assert persisted_session is not None
+    assert persisted_session.runs is not None
+    persisted_run = cast("RunOutput", persisted_session.runs[0])
+    assert persisted_run.run_id == "run-1"
+    assert persisted_run.metadata is not None
+    assert persisted_run.metadata["matrix_response_event_id"] == "$streamed"
+    assert persisted_run.messages is not None
+    assert [(message.role, message.content) for message in persisted_run.messages] == [
+        ("user", "Hello"),
+        (
+            "assistant",
+            "Partial answer\n\n[tool:run_shell_command completed]\n  args: cmd=pwd\n  result: /app\n\n[interrupted]",
+        ),
+    ]
+
+
 def test_strip_visible_tool_markers_handles_blank_lined_markers() -> None:
     """The tool-marker stripper should leave bodies intact when markers are followed by blank lines."""
     text = "Intro\n\n🔧 `run_shell_command` [1]\n\n---\n\nBody"


### PR DESCRIPTION
When an agent's streaming run fails partway through (e.g. the model backend returns a 500 on a tool call), the RunErrorEvent is converted into a user-friendly error string, yielded, and the generator returns. The visible Matrix message already preserves the partial output: the streamed content/tool traces accumulated before the error and the error note is simply appended.

The problem is session memory, not the visible message. This error path returned *normally* (no exception), so neither turn_recorder.record_completed (skipped by the early return) nor the owner's except CancelledError / except StreamingDeliveryError persistence blocks ever ran. Agno does not persist aborted runs either. Net effect: the agent's session history recorded nothing for the turn, so on the next turn it had no memory of the (sometimes many minutes of) partial work it had already done - re-running tools and losing context.

This mirrors the existing cancellation salvage path, which already persists partial state via the interrupted-replay machinery. We now do the same on the error path:

- ai.py: in the run-error branch, record the partial turn via turn_recorder.record_interrupted(...) when a recorder is present (it already carries run_id + visible event id populated during streaming), falling back to a standalone persist_interrupted_replay only when there is no recorder. This makes the branch structurally symmetric with the cancelled_run_event branch directly below it.
- response_runner: the error-as-text path returns normally, so the existing except-block flush never fires. After deliver_stream returns we now flush the recorder iff outcome == "interrupted", reusing _persist_interrupted_recorder. The outcome guard leaves successful turns untouched and claim_interrupted_persistence() dedupes against any later flush.

Scope: single-agent streaming path (matches the observed incident). The team streaming path has the same theoretical gap via a different code path and is intentionally left for a follow-up.