### PR TITLE
fix(workers): project mapping-style plugin paths

### DIFF
--- a/src/mindroom/workers/backends/docker_projection.py
+++ b/src/mindroom/workers/backends/docker_projection.py
@@ -641,23 +641,40 @@ class DockerProjectionManager:
 
         plugins = cast("list[object]", raw_plugins)
         for index, raw_plugin in enumerate(plugins):
-            if not isinstance(raw_plugin, str) or not _plugin_uses_filesystem_path(
-                raw_plugin,
+            raw_plugin_path = self._plugin_path_value(raw_plugin)
+            if raw_plugin_path is None or not _plugin_uses_filesystem_path(
+                raw_plugin_path,
                 runtime_paths=self._runtime_paths,
             ):
                 continue
-            host_path = config_relative_path(raw_plugin, self._runtime_paths)
-            plugins[index] = self._projected_path_value(
+            host_path = config_relative_path(raw_plugin_path, self._runtime_paths)
+            projected_path = self._projected_path_value(
                 host_path,
                 PurePosixPath(
                     _PROJECTED_ASSETS_DIRNAME,
                     "plugins",
-                    f"{index:02d}-{_projection_display_name(host_path, fallback=raw_plugin)}",
+                    f"{index:02d}-{_projection_display_name(host_path, fallback=raw_plugin_path)}",
                 ),
                 asset_paths_by_host=asset_paths_by_host,
                 host_paths_by_relative_asset_path=host_paths_by_relative_asset_path,
                 assets=assets,
             )
+            # Config accepts either `- ./plugin` or `- path: ./plugin`.
+            # Keep mapping metadata intact, but make the worker-visible path point
+            # at the copied projection so plugin validation can run in the worker.
+            if isinstance(raw_plugin, dict):
+                cast("dict[str, object]", raw_plugin)["path"] = projected_path
+            else:
+                plugins[index] = projected_path
+
+    @staticmethod
+    def _plugin_path_value(raw_plugin: object) -> str | None:
+        if isinstance(raw_plugin, str):
+            return raw_plugin
+        if not isinstance(raw_plugin, dict):
+            return None
+        raw_path = cast("dict[str, object]", raw_plugin).get("path")
+        return raw_path if isinstance(raw_path, str) else None
 
     def _rewrite_projected_knowledge_paths(
         self,

--- a/tests/test_docker_worker_backend.py
+++ b/tests/test_docker_worker_backend.py
@@ -484,6 +484,44 @@ def _assert_projected_config_snapshot(projection_root: Path, tmp_path: Path) -> 
     ).is_dir()
 
 
+def test_docker_worker_projection_rewrites_mapping_plugin_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Mapping-style plugin entries must be copied into the worker projection."""
+    plugin_root = tmp_path / "plugins" / "mapped-plugin"
+    plugin_root.mkdir(parents=True)
+    (plugin_root / "plugin.py").write_text("PLUGIN_VERSION = 'mapped'\n", encoding="utf-8")
+    config_text = """
+plugins:
+  - path: ./plugins/mapped-plugin
+    enabled: true
+agents: {}
+models:
+  default:
+    provider: openai
+    id: test-model
+router:
+  model: default
+""".lstrip()
+
+    backend, _fake_client, _credential_sync_calls = _backend(
+        monkeypatch,
+        tmp_path,
+        config_text=config_text,
+    )
+    projection = backend._projection_manager.projected_config(
+        local_worker_state_paths_for_root(tmp_path / "workers" / "mapped-plugin"),
+        materialize=True,
+    )
+
+    projected_config = (projection.root / "config.yaml").read_text(encoding="utf-8")
+    assert "path: ./.mindroom-worker-assets/plugins/00-mapped-plugin" in projected_config
+    assert "enabled: true" in projected_config
+    projected_plugin_path = projection.root / ".mindroom-worker-assets" / "plugins" / "00-mapped-plugin" / "plugin.py"
+    assert projected_plugin_path.read_text(encoding="utf-8") == "PLUGIN_VERSION = 'mapped'\n"
+
+
 def _backend(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
Docker workers project a sanitized config snapshot into /app/config-host before starting the sandbox runner. The projection already copied plugin paths when config used bare string entries, but it missed the common mapping form used by runtime configs: `plugins: [{path: ...}]`.

That left paths like `plugins/location-enrich` pointing at files that were not mounted into the worker, so the published GHCR worker image exited during startup with `Configured plugin path does not exist`.

Handle both plugin entry shapes, preserve mapping metadata such as `enabled`, and add regression coverage for the mapping form.

Validation: `uv run ty check src/mindroom/workers/backends/docker_projection.py tests/test_docker_worker_backend.py`; `uv run pytest tests/test_docker_worker_backend.py -k 'mapping_plugin_paths or projected_config' -n auto --no-cov -q`; live Docker worker smoke using ghcr.io/mindroom-ai/mindroom:latest reached ready and executed `pwd && hostname` inside /app/worker/workspace. Full pre-commit was attempted and is blocked by an unrelated existing src/mindroom/ai.py ty error.