### PR TITLE
fix(workers): mount docker agent state at runtime root

### DIFF
--- a/src/mindroom/workers/backends/docker.py
+++ b/src/mindroom/workers/backends/docker.py
@@ -26,7 +26,7 @@ from mindroom.credentials import CredentialsManager, get_runtime_credentials_man
 from mindroom.redaction import redact_sensitive_text
 from mindroom.runtime_env_policy import SANDBOX_RUNTIME_ENV_BY_KEY, SHARED_CREDENTIALS_PATH_ENV
 from mindroom.tool_system.dependencies import ensure_optional_deps
-from mindroom.tool_system.worker_routing import worker_dir_name
+from mindroom.tool_system.worker_routing import worker_dir_name, worker_key_agent_name
 from mindroom.workers.backend import WorkerBackendError
 from mindroom.workers.backends._dedicated_worker_common import (
     build_dedicated_worker_runtime_paths,
@@ -116,7 +116,6 @@ _STARTUP_RUNTIME_PATHS_ENV = "MINDROOM_RUNTIME_PATHS_JSON"
 _DEDICATED_WORKER_KEY_ENV = SANDBOX_RUNTIME_ENV_BY_KEY["dedicated_worker_key"]
 _DEDICATED_WORKER_ROOT_ENV = SANDBOX_RUNTIME_ENV_BY_KEY["dedicated_worker_root"]
 _SHARED_STORAGE_ROOT_ENV = SANDBOX_RUNTIME_ENV_BY_KEY["shared_storage_root"]
-_CONTAINER_SHARED_STORAGE_ROOT = "/app/shared-storage"
 
 _LABEL_COMPONENT = "mindroom.ai/component"
 _LABEL_COMPONENT_VALUE = "worker"
@@ -664,7 +663,7 @@ class DockerWorkerBackend:
 
         if not self._container_env_matches(
             container,
-            expected_env=self._container_env(metadata.worker_key),
+            expected_env=self._container_env(metadata.worker_key, private_agent_names=private_agent_names),
         ):
             return False
 
@@ -704,7 +703,7 @@ class DockerWorkerBackend:
                 command=["/app/run-sandbox-runner.sh"],
                 name=metadata.container_name,
                 detach=True,
-                environment=self._container_env(metadata.worker_key),
+                environment=self._container_env(metadata.worker_key, private_agent_names=private_agent_names),
                 volumes=self._container_volumes(
                     paths,
                     worker_key=metadata.worker_key,
@@ -789,12 +788,22 @@ class DockerWorkerBackend:
         self._save_metadata(paths, metadata)
         return self._to_handle(metadata, container, now=now, paths=paths)
 
-    def _container_env(self, worker_key: str) -> dict[str, str]:
+    def _container_env(
+        self,
+        worker_key: str,
+        *,
+        private_agent_names: frozenset[str] | None,
+    ) -> dict[str, str]:
         dedicated_root = Path(self.config.storage_mount_path)
         startup_runtime_paths = self._worker_runtime_paths(
             worker_key=worker_key,
             dedicated_root=dedicated_root,
         )
+        # Docker bind-mounts canonical agent state under the same root used as
+        # MINDROOM_STORAGE_PATH. Keep the runner's shared-storage root aligned
+        # so agent workspaces resolve to mounted host files, not an empty worker
+        # state directory.
+        shared_storage_root = self.config.storage_mount_path
         env = {
             SANDBOX_RUNTIME_ENV_BY_KEY["runner_mode"]: "true",
             SANDBOX_RUNTIME_ENV_BY_KEY["runner_execution_mode"]: "subprocess",
@@ -805,11 +814,11 @@ class DockerWorkerBackend:
                 sort_keys=True,
             ),
             "MINDROOM_STORAGE_PATH": self.config.storage_mount_path,
-            _SHARED_STORAGE_ROOT_ENV: _CONTAINER_SHARED_STORAGE_ROOT,
+            _SHARED_STORAGE_ROOT_ENV: shared_storage_root,
             SHARED_CREDENTIALS_PATH_ENV: f"{self.config.storage_mount_path}/.shared_credentials",
             _DEDICATED_WORKER_KEY_ENV: worker_key,
             _DEDICATED_WORKER_ROOT_ENV: self.config.storage_mount_path,
-            "HOME": self.config.storage_mount_path,
+            "HOME": self._container_home_path(worker_key, private_agent_names=private_agent_names),
             _TOKEN_ENV_NAME: self.auth_token,
         }
         if self.config.host_config_path is not None:
@@ -857,9 +866,24 @@ class DockerWorkerBackend:
             config_path=self._worker_runtime_config_path(),
             dedicated_root=dedicated_root,
             worker_port=self.config.worker_port,
-            shared_storage_root=_CONTAINER_SHARED_STORAGE_ROOT,
+            shared_storage_root=self.config.storage_mount_path,
             extra_env=self.config.extra_env,
         )
+
+    def _container_home_path(
+        self,
+        worker_key: str,
+        *,
+        private_agent_names: frozenset[str] | None,
+    ) -> str:
+        agent_name = worker_key_agent_name(worker_key)
+        if agent_name is None:
+            return self.config.storage_mount_path
+        if private_agent_names is not None and agent_name in private_agent_names:
+            # Private workspaces can be renamed in config, so the request
+            # preparation layer remains the source of truth for the command cwd.
+            return self.config.storage_mount_path
+        return str(Path(self.config.storage_mount_path) / "agents" / agent_name / "workspace")
 
     def _container_volumes(
         self,
@@ -902,7 +926,7 @@ class DockerWorkerBackend:
             for planned_root in plan_scoped_visible_state_roots(
                 worker_key=worker_key,
                 local_shared_storage_root=self._storage_path,
-                worker_visible_shared_storage_root=Path(_CONTAINER_SHARED_STORAGE_ROOT),
+                worker_visible_shared_storage_root=Path(self.config.storage_mount_path),
                 private_agent_names=private_agent_names,
                 allow_unknown_worker_key=False,
                 resolved_agent_policies=self._projection_manager.current_resolved_agent_policies(),

--- a/src/mindroom/workers/backends/docker.py
+++ b/src/mindroom/workers/backends/docker.py
@@ -26,7 +26,7 @@ from mindroom.credentials import CredentialsManager, get_runtime_credentials_man
 from mindroom.redaction import redact_sensitive_text
 from mindroom.runtime_env_policy import SANDBOX_RUNTIME_ENV_BY_KEY, SHARED_CREDENTIALS_PATH_ENV
 from mindroom.tool_system.dependencies import ensure_optional_deps
-from mindroom.tool_system.worker_routing import worker_dir_name, worker_key_agent_name
+from mindroom.tool_system.worker_routing import resolved_worker_key_scope, worker_dir_name, worker_key_agent_name
 from mindroom.workers.backend import WorkerBackendError
 from mindroom.workers.backends._dedicated_worker_common import (
     build_dedicated_worker_runtime_paths,
@@ -663,7 +663,7 @@ class DockerWorkerBackend:
 
         if not self._container_env_matches(
             container,
-            expected_env=self._container_env(metadata.worker_key, private_agent_names=private_agent_names),
+            expected_env=self._container_env(metadata.worker_key),
         ):
             return False
 
@@ -703,7 +703,7 @@ class DockerWorkerBackend:
                 command=["/app/run-sandbox-runner.sh"],
                 name=metadata.container_name,
                 detach=True,
-                environment=self._container_env(metadata.worker_key, private_agent_names=private_agent_names),
+                environment=self._container_env(metadata.worker_key),
                 volumes=self._container_volumes(
                     paths,
                     worker_key=metadata.worker_key,
@@ -788,12 +788,7 @@ class DockerWorkerBackend:
         self._save_metadata(paths, metadata)
         return self._to_handle(metadata, container, now=now, paths=paths)
 
-    def _container_env(
-        self,
-        worker_key: str,
-        *,
-        private_agent_names: frozenset[str] | None,
-    ) -> dict[str, str]:
+    def _container_env(self, worker_key: str) -> dict[str, str]:
         dedicated_root = Path(self.config.storage_mount_path)
         startup_runtime_paths = self._worker_runtime_paths(
             worker_key=worker_key,
@@ -818,7 +813,7 @@ class DockerWorkerBackend:
             SHARED_CREDENTIALS_PATH_ENV: f"{self.config.storage_mount_path}/.shared_credentials",
             _DEDICATED_WORKER_KEY_ENV: worker_key,
             _DEDICATED_WORKER_ROOT_ENV: self.config.storage_mount_path,
-            "HOME": self._container_home_path(worker_key, private_agent_names=private_agent_names),
+            "HOME": self._container_home_path(worker_key),
             _TOKEN_ENV_NAME: self.auth_token,
         }
         if self.config.host_config_path is not None:
@@ -870,16 +865,11 @@ class DockerWorkerBackend:
             extra_env=self.config.extra_env,
         )
 
-    def _container_home_path(
-        self,
-        worker_key: str,
-        *,
-        private_agent_names: frozenset[str] | None,
-    ) -> str:
+    def _container_home_path(self, worker_key: str) -> str:
         agent_name = worker_key_agent_name(worker_key)
         if agent_name is None:
             return self.config.storage_mount_path
-        if private_agent_names is not None and agent_name in private_agent_names:
+        if resolved_worker_key_scope(worker_key) == "user_agent":
             # Private workspaces can be renamed in config, so the request
             # preparation layer remains the source of truth for the command cwd.
             return self.config.storage_mount_path

--- a/tests/test_docker_worker_backend.py
+++ b/tests/test_docker_worker_backend.py
@@ -2735,6 +2735,32 @@ def test_docker_backend_user_agent_requires_explicit_private_visibility(
         backend.ensure_worker(WorkerSpec(worker_key), now=10.0)
 
 
+def test_docker_backend_user_agent_home_is_neutral_without_visibility(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """User-agent HOME should come from worker-key scope, not visibility metadata."""
+    config_text, _projected_paths = _private_user_agent_projected_config_fixture(tmp_path)
+    backend, _fake_client, _sync_calls = _backend(monkeypatch, tmp_path, config_text=config_text)
+    worker_key = resolve_worker_key(
+        "user_agent",
+        ToolExecutionIdentity(
+            channel="matrix",
+            agent_name="alpha",
+            requester_id="@alice:example.org",
+            room_id="!room:example.org",
+            thread_id=None,
+            resolved_thread_id=None,
+            session_id=None,
+            tenant_id="tenant-123",
+        ),
+        agent_name="alpha",
+    )
+
+    assert worker_key is not None
+    assert backend._container_env(worker_key)["HOME"] == "/app/worker"
+
+
 def test_docker_backend_rejects_unknown_worker_keys_for_scoped_mounts(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_docker_worker_backend.py
+++ b/tests/test_docker_worker_backend.py
@@ -1103,9 +1103,10 @@ def test_docker_backend_ensures_worker_container_and_bind_mount(
     assert env["MINDROOM_SANDBOX_PROXY_TOKEN"] == _TEST_AUTH_TOKEN
     assert env["MINDROOM_SANDBOX_DEDICATED_WORKER_KEY"] == _TEST_UNSCOPED_WORKER_KEY
     assert env["MINDROOM_SANDBOX_DEDICATED_WORKER_ROOT"] == "/app/worker"
-    assert env["MINDROOM_SANDBOX_SHARED_STORAGE_ROOT"] == "/app/shared-storage"
+    assert env["MINDROOM_SANDBOX_SHARED_STORAGE_ROOT"] == "/app/worker"
     assert env["MINDROOM_SHARED_CREDENTIALS_PATH"] == "/app/worker/.shared_credentials"
     assert env["MINDROOM_CONFIG_PATH"] == "/app/config-host/config.yaml"
+    assert env["HOME"] == "/app/worker/agents/code/workspace"
     assert env["EXTRA_ENV"] == "present"
 
     volumes = run_call["volumes"]
@@ -2322,7 +2323,7 @@ def test_docker_backend_recreates_container_when_extra_stale_mount_is_present(
         {
             "Type": "bind",
             "Source": str((tmp_path / "agents" / "beta").resolve()),
-            "Destination": "/app/shared-storage/agents/beta",
+            "Destination": "/app/worker/agents/beta",
             "Mode": "rw",
             "RW": True,
         },
@@ -2700,9 +2701,12 @@ def test_docker_backend_shared_worker_mounts_canonical_agent_root(
     assert isinstance(volumes, dict)
     expected_agent_root = (tmp_path / "agents" / "alpha").resolve()
     assert volumes[str(expected_agent_root)] == {
-        "bind": "/app/shared-storage/agents/alpha",
+        "bind": "/app/worker/agents/alpha",
         "mode": "rw",
     }
+    env = fake_client.containers.run_calls[0]["environment"]
+    assert isinstance(env, dict)
+    assert env["HOME"] == "/app/worker/agents/alpha/workspace"
 
 
 def test_docker_backend_user_agent_requires_explicit_private_visibility(
@@ -2977,10 +2981,13 @@ def test_docker_backend_user_agent_mounts_private_root_from_worker_spec(
     assert isinstance(volumes, dict)
     expected_private_root = (tmp_path / "private_instances" / worker_dir_name(worker_key) / "alpha").resolve()
     assert volumes[str(expected_private_root)] == {
-        "bind": f"/app/shared-storage/private_instances/{worker_dir_name(worker_key)}/alpha",
+        "bind": f"/app/worker/private_instances/{worker_dir_name(worker_key)}/alpha",
         "mode": "rw",
     }
-    assert all(spec["bind"] != "/app/shared-storage/agents/alpha" for spec in volumes.values())
+    assert all(spec["bind"] != "/app/worker/agents/alpha" for spec in volumes.values())
+    env = fake_client.containers.run_calls[0]["environment"]
+    assert isinstance(env, dict)
+    assert env["HOME"] == "/app/worker"
 
 
 def test_docker_backend_rejects_private_user_agent_container_without_target_visibility(
@@ -3015,7 +3022,7 @@ def test_docker_backend_rejects_private_user_agent_container_without_target_visi
     assert isinstance(second_volumes, dict)
     expected_private_root = (tmp_path / "private_instances" / worker_dir_name(worker_key) / "alpha").resolve()
     assert second_volumes[str(expected_private_root)] == {
-        "bind": f"/app/shared-storage/private_instances/{worker_dir_name(worker_key)}/alpha",
+        "bind": f"/app/worker/private_instances/{worker_dir_name(worker_key)}/alpha",
         "mode": "rw",
     }
     assert handle.status == "ready"


### PR DESCRIPTION
Docker workers were mounting canonical agent state under /app/shared-storage while the runner and tools resolved workspaces from MINDROOM_STORAGE_PATH under /app/worker. That left agent commands in an empty worker-local workspace even though the host workspace was mounted elsewhere.

Mount scoped durable state under the Docker storage mount path, set the runner shared-storage root to the same path, and use the normal agent workspace as HOME for non-private agent-scoped workers. Private user-agent workers keep a neutral HOME because their private workspace root is config-dependent and request preparation remains the source of truth for cwd.

Tests cover shared, unscoped, private user-agent, stale-mount, and projected-context paths.