### PR TITLE
Update MindRoom release metadata to v2026.6.38

### DIFF
--- a/macos/appcast.xml
+++ b/macos/appcast.xml
@@ -5,6 +5,33 @@
         <link>https://github.com/mindroom-ai/mindroom</link>
         <description>Signed MindRoom macOS app updates.</description>
         <item>
+            <title>2026.6.38</title>
+            <pubDate>Wed, 03 Jun 2026 23:10:41 +0000</pubDate>
+            <link>https://github.com/mindroom-ai/mindroom</link>
+            <sparkle:version>671</sparkle:version>
+            <sparkle:shortVersionString>2026.6.38</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+            <description sparkle:format="markdown"><![CDATA[# Release 2026.6.38
+
+## 📊 Statistics
+- 📦 **2** commits
+- 👥 **1** contributors
+
+## 📝 Changes
+
+- [fix(ai): persist partial work when a streaming run errors mid-flight (#1154)](https://github.com/mindroom-ai/mindroom/commit/87e5c489) by @basnijholt
+- [Update MindRoom release metadata to v2026.6.37 (#1136)](https://github.com/mindroom-ai/mindroom/commit/4c555310) by @basnijholt
+## 👥 Contributors
+@basnijholt
+
+
+---
+🙏 Thank you for using this project! Please report any issues or feedback on the GitHub repository.
+]]></description>
+            <enclosure url="https://github.com/mindroom-ai/mindroom/releases/download/v2026.6.38/MindRoom.zip" length="23634404" type="application/octet-stream" sparkle:edSignature="MZEE8xua5SnvZ2bSuM+IVHowjPb2EwAJY0bPxBjbZAgbEcxWshzXnYDuDPiRyDNjrtpQQGKhn8jyROhfl7btBg=="/>
+        </item>
+        <item>
             <title>2026.6.37</title>
             <pubDate>Wed, 03 Jun 2026 22:52:41 +0000</pubDate>
             <link>https://github.com/mindroom-ai/mindroom</link>


### PR DESCRIPTION
Updates release metadata generated by the v2026.6.38 macOS release workflow.

This includes:
- Sparkle appcast entry and signature
