### PR TITLE
Resolve generated Matrix localpart mentions

### DIFF
--- a/src/mindroom/matrix/mentions.py
+++ b/src/mindroom/matrix/mentions.py
@@ -10,6 +10,7 @@ from mindroom.constants import ROUTER_AGENT_NAME
 from mindroom.entity_resolution import entity_identity_registry
 from mindroom.matrix.identity import MatrixID, parse_current_matrix_user_id
 from mindroom.matrix.message_builder import build_message_content, markdown_to_html
+from mindroom.matrix_identifiers import unnamespaced_agent_name_from_username_localpart
 from mindroom.tool_system.events import build_tool_trace_content, ensure_visible_tool_marker_spacing
 
 if TYPE_CHECKING:
@@ -301,9 +302,24 @@ def _find_matching_entity_name_for_localpart(
     config: Config,
 ) -> str | None:
     """Return the configured agent or team name matched by one localpart string, if any."""
-    lower_localpart = localpart.lower()
+    entities = [*config.agents, *config.teams]
 
-    for entity_name in [*config.agents, *config.teams]:
+    if entity_name := _find_matching_entity_name(localpart, entities):
+        return entity_name
+
+    generated_name = unnamespaced_agent_name_from_username_localpart(localpart)
+    if generated_name is None or generated_name.lower().startswith("user_"):
+        return None
+    return _find_matching_entity_name(generated_name, entities)
+
+
+def _find_matching_entity_name(
+    localpart: str,
+    entities: list[str],
+) -> str | None:
+    """Return the configured entity name matched by one localpart candidate."""
+    lower_localpart = localpart.lower()
+    for entity_name in entities:
         if entity_name == ROUTER_AGENT_NAME:
             continue
         if entity_name.lower() == lower_localpart:

--- a/src/mindroom/matrix/mentions.py
+++ b/src/mindroom/matrix/mentions.py
@@ -49,6 +49,8 @@ def parse_mentions_in_text(
     text: str,
     config: Config,
     runtime_paths: RuntimePaths,
+    *,
+    allow_generated_agent_localparts: bool = True,
 ) -> tuple[str, list[str], str]:
     """Parse text for agent/team mentions and return processed text with user IDs.
 
@@ -56,6 +58,7 @@ def parse_mentions_in_text(
         text: Text that may contain @entity_name mentions
         config: Application configuration
         runtime_paths: Explicit runtime context for namespace-aware mention resolution
+        allow_generated_agent_localparts: Whether generated localparts like @mindroom_agent are aliases
 
     Returns:
         Tuple of (plain_text, list_of_mentioned_user_ids, markdown_text_with_links)
@@ -70,6 +73,7 @@ def parse_mentions_in_text(
         tokens,
         registry=registry,
         config=config,
+        allow_generated_agent_localparts=allow_generated_agent_localparts,
     )
 
     return (
@@ -94,6 +98,7 @@ def resolve_mentioned_user_ids_from_text(
         tokens,
         registry=registry,
         config=config,
+        allow_generated_agent_localparts=False,
     )
     return _mentioned_user_ids_from_replacements(replacements)
 
@@ -170,6 +175,7 @@ def _resolve_mention_tokens(
     *,
     registry: EntityIdentityRegistry,
     config: Config,
+    allow_generated_agent_localparts: bool,
 ) -> list[_MentionReplacement]:
     """Resolve scanned tokens into render-ready replacements."""
     replacements: list[_MentionReplacement] = []
@@ -178,6 +184,7 @@ def _resolve_mention_tokens(
             token,
             registry=registry,
             config=config,
+            allow_generated_agent_localparts=allow_generated_agent_localparts,
         )
         if resolution is None:
             continue
@@ -198,6 +205,7 @@ def _resolve_mention_token(
     *,
     registry: EntityIdentityRegistry,
     config: Config,
+    allow_generated_agent_localparts: bool,
 ) -> _MentionResolution | None:
     """Resolve one scanned mention token into an entity or literal-user target."""
     if token.explicit_user_id is not None:
@@ -211,6 +219,7 @@ def _resolve_mention_token(
         has_server_name=token.has_server_name,
         registry=registry,
         config=config,
+        allow_generated_agent_localparts=allow_generated_agent_localparts,
     )
 
 
@@ -241,11 +250,16 @@ def _resolve_entity_alias_token(
     has_server_name: bool,
     registry: EntityIdentityRegistry,
     config: Config,
+    allow_generated_agent_localparts: bool,
 ) -> _MentionResolution | None:
     """Resolve one alias-style token to a local configured agent or team, if any."""
     if has_server_name:
         return None
-    if entity_name := _find_matching_entity_name_for_localpart(localpart, config):
+    if entity_name := _find_matching_entity_name_for_localpart(
+        localpart,
+        config,
+        allow_generated_agent_localparts=allow_generated_agent_localparts,
+    ):
         return _entity_mention_resolution(
             entity_name,
             registry=registry,
@@ -300,12 +314,17 @@ def _is_valid_explicit_matrix_user_id(candidate: str) -> bool:
 def _find_matching_entity_name_for_localpart(
     localpart: str,
     config: Config,
+    *,
+    allow_generated_agent_localparts: bool,
 ) -> str | None:
     """Return the configured agent or team name matched by one localpart string, if any."""
     entities = [*config.agents, *config.teams]
 
     if entity_name := _find_matching_entity_name(localpart, entities):
         return entity_name
+
+    if not allow_generated_agent_localparts:
+        return None
 
     generated_name = unnamespaced_agent_name_from_username_localpart(localpart)
     if generated_name is None or generated_name.lower().startswith("user_"):
@@ -330,11 +349,14 @@ def _find_matching_entity_name(
 def resolve_entity_name_for_mention_localpart(
     localpart: str,
     config: Config,
+    *,
+    allow_generated_agent_localparts: bool = True,
 ) -> str | None:
     """Return the configured agent or team name matched by one Matrix mention localpart."""
     return _find_matching_entity_name_for_localpart(
         localpart,
         config,
+        allow_generated_agent_localparts=allow_generated_agent_localparts,
     )
 
 

--- a/src/mindroom/matrix_identifiers.py
+++ b/src/mindroom/matrix_identifiers.py
@@ -36,6 +36,14 @@ def agent_username_localpart(agent_name: str, runtime_paths: RuntimePaths) -> st
     return f"{_AGENT_USERNAME_PREFIX}{agent_name}"
 
 
+def unnamespaced_agent_name_from_username_localpart(username_localpart: str) -> str | None:
+    """Extract an unnamespaced generated agent name from a Matrix username localpart."""
+    if not username_localpart.lower().startswith(_AGENT_USERNAME_PREFIX):
+        return None
+    agent_name = username_localpart[len(_AGENT_USERNAME_PREFIX) :]
+    return agent_name or None
+
+
 def managed_room_alias_localpart(room_key: str, runtime_paths: RuntimePaths) -> str:
     """Build the managed room alias localpart for a room key."""
     namespace = _mindroom_namespace(runtime_paths)

--- a/src/mindroom/voice_handler.py
+++ b/src/mindroom/voice_handler.py
@@ -663,4 +663,8 @@ def _voice_mention_entity_name(
             return None
         return registry.current_entity_name_for_user_id(user_id, include_router=False)
 
-    return resolve_entity_name_for_mention_localpart(localpart, config)
+    return resolve_entity_name_for_mention_localpart(
+        localpart,
+        config,
+        allow_generated_agent_localparts=False,
+    )

--- a/tests/test_matrix_identity.py
+++ b/tests/test_matrix_identity.py
@@ -23,7 +23,7 @@ from mindroom.matrix.identity import (
     try_parse_historical_matrix_user_id,
 )
 from mindroom.matrix.state import MatrixState
-from mindroom.matrix_identifiers import agent_username_localpart
+from mindroom.matrix_identifiers import agent_username_localpart, unnamespaced_agent_name_from_username_localpart
 from tests.conftest import bind_runtime_paths, runtime_paths_for, test_runtime_paths
 from tests.identity_helpers import entity_ids, persist_entity_accounts
 
@@ -238,6 +238,13 @@ class TestMatrixID:
 
         assert _entity_name(f"@actual_calculator:{domain}", config, runtime_paths) == "calculator"
         assert _entity_name(f"@mindroom_calculator:{domain}", config, runtime_paths) is None
+
+    def test_unnamespaced_agent_name_from_username_localpart(self) -> None:
+        """Generated unnamespaced agent localparts can be inverted."""
+        assert unnamespaced_agent_name_from_username_localpart("mindroom_calculator") == "calculator"
+        assert unnamespaced_agent_name_from_username_localpart("MINDROOM_calculator") == "calculator"
+        assert unnamespaced_agent_name_from_username_localpart("calculator") is None
+        assert unnamespaced_agent_name_from_username_localpart("mindroom_") is None
 
 
 class TestThreadStateKey:

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -109,15 +109,15 @@ class TestMentionParsing:
         assert set(mentions) == {"@actual_calculator:localhost", "@actual_general:localhost"}
         assert len(mentions) == 2
 
-    def test_parse_with_generated_looking_localpart_does_not_resolve(self) -> None:
-        """Generated-looking localparts are not aliases unless configured exactly."""
+    def test_parse_with_generated_looking_localpart_resolves_entity_alias(self) -> None:
+        """Generated Matrix localparts also work as stable entity aliases."""
         config = _make_config(_default_runtime_paths())
 
         text = "Ask @mindroom_calculator for help"
         processed, mentions, _markdown = _parse_mentions_in_text(text, config)
 
-        assert processed == "Ask @mindroom_calculator for help"
-        assert mentions == []
+        assert processed == "Ask @actual_calculator:localhost for help"
+        assert mentions == ["@actual_calculator:localhost"]
 
     def test_parse_with_generated_looking_full_mxid_stays_literal(self) -> None:
         """Generated-looking full MXIDs are preserved as explicit literal users."""
@@ -316,8 +316,8 @@ class TestMentionParsing:
         assert content["body"] == "@actual_general_live:localhost could you help with this?"
         assert content["m.mentions"]["user_ids"] == ["@actual_general_live:localhost"]
 
-    def test_format_message_rejects_stale_generated_username_after_drift(self, tmp_path: Path) -> None:
-        """After username drift, stale generated localparts should not retarget the live account."""
+    def test_format_message_resolves_generated_alias_after_username_drift(self, tmp_path: Path) -> None:
+        """Generated aliases target the current account even after username drift."""
         runtime_paths = constants_mod.resolve_runtime_paths(
             config_path=tmp_path / "config.yaml",
             storage_path=tmp_path / "mindroom_data",
@@ -336,8 +336,8 @@ class TestMentionParsing:
             "@mindroom_general could you help with this?",
         )
 
-        assert content["body"] == "@mindroom_general could you help with this?"
-        assert "m.mentions" not in content
+        assert content["body"] == "@actual_general_live:localhost could you help with this?"
+        assert content["m.mentions"]["user_ids"] == ["@actual_general_live:localhost"]
 
     def test_format_message_rejects_stale_generated_full_mxid_after_drift(self, tmp_path: Path) -> None:
         """After username drift, stale generated full MXIDs should stay literal."""
@@ -717,8 +717,8 @@ class TestMentionParsing:
         assert mentions == ["@actual_mindroom_dev:localhost"]
         assert processed == "@actual_mindroom_dev:localhost can you look at this?"
 
-    def test_generated_localpart_for_prefixed_agent_key_does_not_resolve(self) -> None:
-        """Generated-looking localparts are not aliases for prefixed config keys."""
+    def test_generated_localpart_for_prefixed_agent_key_resolves(self) -> None:
+        """Generated aliases also work for entity keys that start with mindroom_."""
         runtime_paths = _default_runtime_paths()
         config = _bind_config(
             runtime_paths,
@@ -730,8 +730,8 @@ class TestMentionParsing:
         text = "@mindroom_mindroom_dev help"
         processed, mentions, _markdown = _parse_mentions_in_text(text, config)
 
-        assert mentions == []
-        assert processed == "@mindroom_mindroom_dev help"
+        assert mentions == ["@actual_mindroom_dev:localhost"]
+        assert processed == "@actual_mindroom_dev:localhost help"
 
     def test_prefixed_agent_key_alias_survives_persisted_username_drift(self, tmp_path: Path) -> None:
         """Configured entity keys remain stable mention aliases after username drift."""
@@ -801,14 +801,14 @@ class TestMentionParsing:
         assert mentions == ["@actual_mindroom_calculator:localhost"]
         assert processed == "@actual_mindroom_calculator:localhost help"
 
-    def test_uppercase_generated_looking_mentions_do_not_resolve_without_exact_alias(self) -> None:
-        """Generated-looking aliases do not resolve through prefix stripping."""
+    def test_uppercase_generated_looking_mentions_resolve_case_insensitively(self) -> None:
+        """Generated aliases resolve with the same case-insensitive matching as direct aliases."""
         config = _make_config(_default_runtime_paths())
 
         processed, mentions, _markdown = _parse_mentions_in_text("@MINDROOM_calculator help", config)
 
-        assert mentions == []
-        assert processed == "@MINDROOM_calculator help"
+        assert mentions == ["@actual_calculator:localhost"]
+        assert processed == "@actual_calculator:localhost help"
 
     def test_case_insensitive_mentions(self) -> None:
         """Test that mentions are case-insensitive."""


### PR DESCRIPTION
## Summary
- resolve bare `@mindroom_<entity>` mention aliases to the current configured entity account when no exact entity alias exists
- keep exact configured aliases first, so a configured `mindroom_*` entity still wins
- keep full Matrix IDs literal unless they match the current managed account
- keep generated localpart parsing in the shared Matrix identifier helpers instead of duplicating the prefix in mention parsing

## Tests
- `uv run pytest tests/test_mentions.py tests/test_matrix_identity.py tests/test_agent_response_logic.py tests/test_bot_scheduling.py -q -n 0 --no-cov`
- `uv run ruff check src/mindroom/matrix_identifiers.py src/mindroom/matrix/mentions.py tests/test_mentions.py tests/test_matrix_identity.py`
- `uv run ruff format --check src/mindroom/matrix_identifiers.py src/mindroom/matrix/mentions.py tests/test_mentions.py tests/test_matrix_identity.py`
- commit hook suite (`ruff`, `ty`, `vulture`, Tach checks)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced mention resolution to support generated agent localparts with flexible control over resolution behavior
  * Improved case-insensitive mention matching for agent references

* **Bug Fixes**
  * Fixed mention resolution to correctly handle generated-style agent mentions and username drift scenarios
  * Corrected uppercase mention handling to resolve case-insensitively

<!-- end of auto-generated comment: release notes by coderabbit.ai -->