### PR TITLE
Update MindRoom release metadata to v2026.6.168

### DIFF
--- a/macos/appcast.xml
+++ b/macos/appcast.xml
@@ -5,6 +5,32 @@
         <link>https://github.com/mindroom-ai/mindroom</link>
         <description>Signed MindRoom macOS app updates.</description>
         <item>
+            <title>2026.6.168</title>
+            <pubDate>Fri, 19 Jun 2026 19:20:03 +0000</pubDate>
+            <link>https://github.com/mindroom-ai/mindroom</link>
+            <sparkle:version>805</sparkle:version>
+            <sparkle:shortVersionString>2026.6.168</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+            <description sparkle:format="markdown"><![CDATA[# Release 2026.6.168
+
+## 📊 Statistics
+- 📦 **1** commits
+- 👥 **1** contributors
+
+## 📝 Changes
+
+- [Throttle background knowledge refreshes (#1314)](https://github.com/mindroom-ai/mindroom/commit/3af81a84) by @basnijholt
+## 👥 Contributors
+@basnijholt
+
+
+---
+🙏 Thank you for using this project! Please report any issues or feedback on the GitHub repository.
+]]></description>
+            <enclosure url="https://github.com/mindroom-ai/mindroom/releases/download/v2026.6.168/MindRoom.zip" length="23940324" type="application/octet-stream" sparkle:edSignature="5i40IMl0kvc4Oy72y4nQt/GMaGj07xoHClyirLCzi32MxS4RYbMWWC/WiJsTQ+PUt/owS/cqqUY5fYZjgr+7Dg=="/>
+        </item>
+        <item>
             <title>2026.6.38</title>
             <pubDate>Wed, 03 Jun 2026 23:10:41 +0000</pubDate>
             <link>https://github.com/mindroom-ai/mindroom</link>


### PR DESCRIPTION
Updates release metadata generated by the v2026.6.168 macOS release workflow.

This includes:
- Sparkle appcast entry and signature
