### PR TITLE
Bundle browser runtime packages in Docker image

### DIFF
--- a/local/instances/deploy/Dockerfile.mindroom
+++ b/local/instances/deploy/Dockerfile.mindroom
@@ -52,13 +52,13 @@ WORKDIR /app
 
 # Install runtime dependencies:
 # - curl for health checks
-# - git and git-lfs for remote knowledge base cloning/sync
+# - git, git-lfs, and openssh-client for remote knowledge base cloning/sync
 # - bash and tmux for shell tooling and detached interactive CLI flows
 # - tini to reap orphaned subprocesses when MindRoom runs as PID 1
 # - chromium, browser fonts, and ffmpeg for browser/voice-capable worker tools
 # - nodejs for agent workspace scripts that expect a standard JS runtime
 # - common small CLI utilities used by headless auth/install workflows
-RUN apt-get update && apt-get install -y --no-install-recommends bash bzip2 chromium curl ffmpeg fonts-liberation git git-lfs jq nano nodejs procps ripgrep tini tmux unzip \
+RUN apt-get update && apt-get install -y --no-install-recommends bash bzip2 chromium curl ffmpeg fonts-liberation git git-lfs jq nano nodejs openssh-client procps ripgrep tini tmux unzip \
     && printf 'set-option -g exit-empty off\n' > /etc/tmux.conf \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/local/instances/deploy/Dockerfile.mindroom
+++ b/local/instances/deploy/Dockerfile.mindroom
@@ -55,8 +55,10 @@ WORKDIR /app
 # - git and git-lfs for remote knowledge base cloning/sync
 # - bash and tmux for shell tooling and detached interactive CLI flows
 # - tini to reap orphaned subprocesses when MindRoom runs as PID 1
+# - chromium, browser fonts, and ffmpeg for browser/voice-capable worker tools
+# - nodejs for agent workspace scripts that expect a standard JS runtime
 # - common small CLI utilities used by headless auth/install workflows
-RUN apt-get update && apt-get install -y bash bzip2 curl git git-lfs jq nano procps ripgrep tini tmux unzip \
+RUN apt-get update && apt-get install -y --no-install-recommends bash bzip2 chromium curl ffmpeg fonts-liberation git git-lfs jq nano nodejs procps ripgrep tini tmux unzip \
     && printf 'set-option -g exit-empty off\n' > /etc/tmux.conf \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/tests/test_mindroom_dockerfiles.py
+++ b/tests/test_mindroom_dockerfiles.py
@@ -67,6 +67,18 @@ def test_full_mindroom_runtime_image_bundles_browser_runtime_packages() -> None:
     assert {"chromium", "ffmpeg", "fonts-liberation", "nodejs"} <= packages
 
 
+def test_mindroom_runtime_images_keep_git_ssh_support_when_disabling_recommends() -> None:
+    """Git-over-SSH needs an explicit SSH client when apt recommendations are disabled."""
+    for dockerfile in _MINDROOM_DOCKERFILES:
+        text = dockerfile.read_text(encoding="utf-8")
+        install_args_match = re.search(r"apt-get install -y (?P<args>.*?)\\\s*&&", text, re.DOTALL)
+        assert install_args_match is not None
+        install_args = install_args_match.group("args").split()
+
+        if "--no-install-recommends" in install_args:
+            assert "openssh-client" in _apt_install_packages(text)
+
+
 def test_kubernetes_command_overrides_run_under_tini() -> None:
     """Kubernetes command overrides bypass image entrypoints, so add tini explicitly."""
     runtime_template = _RUNTIME_DEPLOYMENT_TEMPLATE.read_text(encoding="utf-8")

--- a/tests/test_mindroom_dockerfiles.py
+++ b/tests/test_mindroom_dockerfiles.py
@@ -20,7 +20,7 @@ _SANDBOX_RUNNER_SCRIPT = _REPO_ROOT / "run-sandbox-runner.sh"
 def _apt_install_packages(dockerfile_text: str) -> set[str]:
     match = re.search(r"apt-get install -y (?P<packages>.*?)\\\s*&&", dockerfile_text, re.DOTALL)
     assert match is not None
-    return {package for package in match.group("packages").split() if not package.startswith("-")}
+    return {package for package in match.group("packages").split() if not package.startswith("-") and package != "\\"}
 
 
 def _assert_command_starts_with_tini(template_text: str, command: str) -> None:
@@ -29,6 +29,17 @@ def _assert_command_starts_with_tini(template_text: str, command: str) -> None:
     inline_list_pattern = rf"command:\s*\[\s*\"tini\"\s*,\s*\"--\"\s*,\s*\"{escaped_command}\""
 
     assert re.search(block_list_pattern, template_text) or re.search(inline_list_pattern, template_text)
+
+
+def test_apt_install_packages_ignores_flags_and_line_continuations() -> None:
+    """Dockerfile package parsing should tolerate multiline apt install formatting."""
+    text = """RUN apt-get update && apt-get install -y --no-install-recommends \\
+    bash \\
+    git \\
+    && apt-get clean
+"""
+
+    assert _apt_install_packages(text) == {"bash", "git"}
 
 
 def test_mindroom_runtime_images_run_under_tini() -> None:

--- a/tests/test_mindroom_dockerfiles.py
+++ b/tests/test_mindroom_dockerfiles.py
@@ -20,7 +20,7 @@ _SANDBOX_RUNNER_SCRIPT = _REPO_ROOT / "run-sandbox-runner.sh"
 def _apt_install_packages(dockerfile_text: str) -> set[str]:
     match = re.search(r"apt-get install -y (?P<packages>.*?)\\\s*&&", dockerfile_text, re.DOTALL)
     assert match is not None
-    return set(match.group("packages").split())
+    return {package for package in match.group("packages").split() if not package.startswith("-")}
 
 
 def _assert_command_starts_with_tini(template_text: str, command: str) -> None:
@@ -57,6 +57,14 @@ def test_mindroom_runtime_images_opt_into_dashboard_asset_build() -> None:
         assert "--reinstall-package mindroom" in builder_after_frontend
         assert "rm -rf frontend/node_modules" in builder_after_frontend
         assert "bun install --frozen-lockfile" not in text
+
+
+def test_full_mindroom_runtime_image_bundles_browser_runtime_packages() -> None:
+    """The full runtime image should support browser and media-capable worker tools."""
+    text = (_REPO_ROOT / "local/instances/deploy/Dockerfile.mindroom").read_text(encoding="utf-8")
+    packages = _apt_install_packages(text)
+
+    assert {"chromium", "ffmpeg", "fonts-liberation", "nodejs"} <= packages
 
 
 def test_kubernetes_command_overrides_run_under_tini() -> None:


### PR DESCRIPTION
## Summary
- Bundle Chromium, browser fonts, ffmpeg, and Node.js in the full MindRoom runtime image.
- Keep Git-over-SSH support explicit when apt recommendations are disabled.
- Add Dockerfile tests for browser/media runtime packages and SSH preservation.

## Test Plan
- uv run pytest tests/test_mindroom_dockerfiles.py -x -n 0 --no-cov -v
- uv run pre-commit run --all-files
- Container package probe confirming chromium, node, ffmpeg, ssh, git, and git-lfs are available with the updated apt install list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MindRoom runtime Docker image now includes browser automation, media and voice processing capabilities, SSH client for secure remote access, and Node.js for agent workspace scripting.

* **Tests**
  * Enhanced test suite to validate Docker image package installations and dependency configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->