### PR TITLE
Start Matrix sync before startup maintenance

### DIFF
--- a/src/mindroom/approval_transport.py
+++ b/src/mindroom/approval_transport.py
@@ -77,6 +77,10 @@ class ApprovalMatrixTransport:
     event_cache_provider: Callable[[], ConversationEventCache]
     _runtime_loop: asyncio.AbstractEventLoop | None = field(default=None, init=False, repr=False)
     _cache_write_tasks: set[asyncio.Task[None]] = field(default_factory=set, init=False, repr=False)
+    _startup_router_ready_for_cleanup: bool = field(default=False, init=False, repr=False)
+    _startup_runtime_support_ready_for_cleanup: bool = field(default=False, init=False, repr=False)
+    _startup_cleanup_done: bool = field(default=False, init=False, repr=False)
+    _startup_cleanup_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False, repr=False)
 
     def capture_runtime_loop(self) -> None:
         """Remember the runtime loop that owns Matrix client I/O."""
@@ -400,10 +404,43 @@ class ApprovalMatrixTransport:
         )
         return False
 
+    def reset_startup_cleanup_gate(self) -> None:
+        """Reset one-shot startup approval cleanup state for a fresh runtime start."""
+        self._startup_router_ready_for_cleanup = False
+        self._startup_runtime_support_ready_for_cleanup = False
+        self._startup_cleanup_done = False
+
+    async def mark_startup_runtime_support_ready(self) -> None:
+        """Record that approval runtime support can now perform startup cleanup."""
+        self._startup_runtime_support_ready_for_cleanup = True
+        await self._run_startup_cleanup_if_ready()
+
     async def handle_bot_ready(self, bot: _ApprovalTransportBot) -> None:
-        """Discard orphaned approval cards once the router finishes first sync."""
+        """Record router first sync and run startup approval cleanup once all gates are ready."""
         if bot.agent_name != ROUTER_AGENT_NAME or not bot.running or bot.client is None:
             return
+        self._startup_router_ready_for_cleanup = True
+        await self._run_startup_cleanup_if_ready()
+
+    async def _run_startup_cleanup_if_ready(self) -> None:
+        if (
+            self._startup_cleanup_done
+            or not self._startup_router_ready_for_cleanup
+            or not self._startup_runtime_support_ready_for_cleanup
+        ):
+            return
+        async with self._startup_cleanup_lock:
+            if (
+                self._startup_cleanup_done
+                or not self._startup_router_ready_for_cleanup
+                or not self._startup_runtime_support_ready_for_cleanup
+            ):
+                return
+            await self._discard_orphaned_approval_cards_on_startup()
+            self._startup_cleanup_done = True
+
+    async def _discard_orphaned_approval_cards_on_startup(self) -> None:
+        """Discard orphaned approval cards once startup approval gates are ready."""
         config = self.config_provider()
         if config is None:
             return

--- a/src/mindroom/matrix/stale_stream_cleanup.py
+++ b/src/mindroom/matrix/stale_stream_cleanup.py
@@ -55,10 +55,11 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 _ROOM_HISTORY_PAGE_SIZE = 100
-# Startup cleanup runs before this process starts its Matrix sync loop, so it cannot
-# clobber streams created by the same process. The remaining race is another
-# concurrently running instance cleaning up a message during a long provider/tool stall
-# where no new chunks arrive for a while, so keep a generous recency guard here.
+# Startup cleanup receives a pre-sync cutoff and ignores messages at or after
+# that timestamp, so post-sync cleanup cannot clobber streams created by this
+# process. The remaining race is another concurrently running instance cleaning
+# up a message during a long provider/tool stall where no new chunks arrive for
+# a while, so keep a generous recency guard here.
 _STALE_STREAM_RECENCY_GUARD_MS = 10_000
 # Restart cleanup should only touch messages from the current outage window.
 # Older interrupted replies are better left untouched than unexpectedly edited
@@ -142,6 +143,7 @@ async def cleanup_stale_streaming_messages(
     config: Config,
     runtime_paths: RuntimePaths,
     conversation_cache: ConversationCacheProtocol | None = None,
+    startup_cutoff_ms: int | None = None,
 ) -> tuple[int, list[InterruptedThread]]:
     """Clean stale in-progress bot messages across currently joined rooms."""
     joined_room_ids = await get_joined_rooms(client)
@@ -162,6 +164,7 @@ async def cleanup_stale_streaming_messages(
                 config=config,
                 runtime_paths=runtime_paths,
                 conversation_cache=conversation_cache,
+                startup_cutoff_ms=startup_cutoff_ms,
             )
             cleaned_count += room_cleaned_count
             interrupted_threads.extend(room_interrupted_threads)
@@ -247,6 +250,7 @@ async def _cleanup_room_stale_streaming_messages(
     config: Config,
     runtime_paths: RuntimePaths,
     conversation_cache: ConversationCacheProtocol | None = None,
+    startup_cutoff_ms: int | None = None,
 ) -> tuple[int, list[InterruptedThread]]:
     """Clean stale bot messages in one room."""
     current_time_ms = int(time.time() * 1000)
@@ -276,7 +280,11 @@ async def _cleanup_room_stale_streaming_messages(
 
     for target_event_id, state in candidate_items:
         assert state.latest_body is not None  # guaranteed by filter above
-        if _is_outside_startup_cleanup_window(state.latest_timestamp, now_ms=current_time_ms):
+        if _is_outside_startup_cleanup_window(
+            state.latest_timestamp,
+            now_ms=current_time_ms,
+            startup_cutoff_ms=startup_cutoff_ms,
+        ):
             continue
 
         interrupted = None
@@ -1453,12 +1461,29 @@ def _is_cleanup_candidate(state: _MessageState) -> bool:
     return state.stream_status in {STREAM_STATUS_PENDING, STREAM_STATUS_STREAMING}
 
 
-def _is_outside_startup_cleanup_window(timestamp_ms: int, *, now_ms: int) -> bool:
+def _is_outside_startup_cleanup_window(
+    timestamp_ms: int,
+    *,
+    now_ms: int,
+    startup_cutoff_ms: int | None = None,
+) -> bool:
     """Return whether startup cleanup should ignore one event by age."""
-    return _is_recent_timestamp(timestamp_ms, now_ms=now_ms) or _is_older_than_cleanup_window(
-        timestamp_ms,
-        now_ms=now_ms,
+    return (
+        _is_at_or_after_startup_cutoff(timestamp_ms, startup_cutoff_ms=startup_cutoff_ms)
+        or _is_recent_timestamp(
+            timestamp_ms,
+            now_ms=now_ms,
+        )
+        or _is_older_than_cleanup_window(
+            timestamp_ms,
+            now_ms=now_ms,
+        )
     )
+
+
+def _is_at_or_after_startup_cutoff(timestamp_ms: int, *, startup_cutoff_ms: int | None) -> bool:
+    """Return whether a message may have been created by the current process."""
+    return startup_cutoff_ms is not None and timestamp_ms >= startup_cutoff_ms
 
 
 def _is_recent_timestamp(timestamp_ms: int, *, now_ms: int | None = None) -> bool:

--- a/src/mindroom/orchestration/runtime.py
+++ b/src/mindroom/orchestration/runtime.py
@@ -69,6 +69,8 @@ __all__ = [
     "is_sync_restart_cancel",
     "log_cancelled_response",
     "log_cancelled_response_source",
+    "log_startup_phase_finished",
+    "log_startup_phase_started",
     "matrix_sync_startup_timeout_seconds",
     "request_task_cancel",
     "retry_delay_seconds",
@@ -353,6 +355,22 @@ def create_logged_task(
     task = asyncio.create_task(coro, name=name)
     task.add_done_callback(partial(_log_detached_task_result, message=failure_message))
     return task
+
+
+def log_startup_phase_started(phase: str) -> float:
+    """Log and time one startup phase."""
+    logger.info("startup_phase_started", phase=phase)
+    return time.monotonic()
+
+
+def log_startup_phase_finished(phase: str, started_at: float, *, status: str = "completed") -> None:
+    """Log elapsed time for one startup phase."""
+    logger.info(
+        "startup_phase_finished",
+        phase=phase,
+        status=status,
+        elapsed_ms=round((time.monotonic() - started_at) * 1000, 1),
+    )
 
 
 async def run_with_retry(

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -99,6 +99,8 @@ from .orchestration.runtime import (
     cancel_task,
     create_logged_task,
     is_permanent_startup_error,
+    log_startup_phase_finished,
+    log_startup_phase_started,
     retry_delay_seconds,
     run_with_retry,
     stop_entities,
@@ -176,22 +178,6 @@ def _raise_orchestrator_exit(*, reason: str) -> NoReturn:
     logger.error("fatal_orchestrator_exit", reason=reason)
     msg = "MindRoom orchestrator exited unexpectedly"
     raise RuntimeError(msg)
-
-
-def _log_startup_phase_started(phase: str) -> float:
-    """Log and time one startup phase."""
-    logger.info("startup_phase_started", phase=phase)
-    return time.monotonic()
-
-
-def _log_startup_phase_finished(phase: str, started_at: float, *, status: str = "completed") -> None:
-    """Log elapsed time for one startup phase."""
-    logger.info(
-        "startup_phase_finished",
-        phase=phase,
-        status=status,
-        elapsed_ms=round((time.monotonic() - started_at) * 1000, 1),
-    )
 
 
 @dataclass
@@ -1268,26 +1254,26 @@ class _MultiAgentOrchestrator:
         """Run the startup sequence before handing off to the sync loops."""
         runtime_shutdown_event = self._reset_runtime_shutdown_event()
         self._approval_transport.reset_startup_cleanup_gate()
-        phase_started = _log_startup_phase_started("wait_for_matrix_homeserver")
+        phase_started = log_startup_phase_started("wait_for_matrix_homeserver")
         await wait_for_matrix_homeserver(runtime_paths=self.runtime_paths)
-        _log_startup_phase_finished("wait_for_matrix_homeserver", phase_started)
+        log_startup_phase_finished("wait_for_matrix_homeserver", phase_started)
 
         if not self.agent_bots:
-            phase_started = _log_startup_phase_started("initialize_runtime")
+            phase_started = log_startup_phase_started("initialize_runtime")
             await self.initialize()
-            _log_startup_phase_finished("initialize_runtime", phase_started)
+            log_startup_phase_finished("initialize_runtime", phase_started)
 
-        phase_started = _log_startup_phase_started("start_router_bot")
+        phase_started = log_startup_phase_started("start_router_bot")
         router_bot = await self._start_router_bot()
-        _log_startup_phase_finished("start_router_bot", phase_started)
+        log_startup_phase_finished("start_router_bot", phase_started)
 
         set_runtime_starting("Starting remaining Matrix bot accounts")
-        phase_started = _log_startup_phase_started("start_remaining_bots")
+        phase_started = log_startup_phase_started("start_remaining_bots")
         start_results = await self._start_entities_once(
             [entity_name for entity_name in self.agent_bots if entity_name != ROUTER_AGENT_NAME],
             start_sync_tasks=False,
         )
-        _log_startup_phase_finished("start_remaining_bots", phase_started)
+        log_startup_phase_finished("start_remaining_bots", phase_started)
 
         started_bots = [router_bot, *start_results.started_bots]
         self._log_degraded_startup(
@@ -1296,20 +1282,20 @@ class _MultiAgentOrchestrator:
 
         config = self._require_config()
         self._resolve_bot_room_aliases(started_bots, config)
-        phase_started = _log_startup_phase_started("bind_runtime_support")
+        phase_started = log_startup_phase_started("bind_runtime_support")
         self._bind_started_runtime_support_services(started_bots)
-        _log_startup_phase_finished("bind_runtime_support", phase_started)
+        log_startup_phase_finished("bind_runtime_support", phase_started)
 
         self.running = True
 
         # Create sync tasks for each bot with automatic restart on failure.
         set_runtime_starting("Starting Matrix sync loops")
         startup_cutoff_ms = int(time.time() * 1000)
-        phase_started = _log_startup_phase_started("start_matrix_sync_loops")
+        phase_started = log_startup_phase_started("start_matrix_sync_loops")
         for entity_name, bot in self.agent_bots.items():
             if bot.running:
                 self._start_sync_task(entity_name, bot)
-        _log_startup_phase_finished("start_matrix_sync_loops", phase_started)
+        log_startup_phase_finished("start_matrix_sync_loops", phase_started)
 
         self._startup_maintenance.start(started_bots, config, startup_cutoff_ms=startup_cutoff_ms)
 

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -274,6 +274,7 @@ class _MultiAgentOrchestrator:
     _config_reload_task: asyncio.Task | None = field(default=None, init=False)
     _config_reload_requested_at: float | None = field(default=None, init=False)
     _startup_maintenance_task: asyncio.Task | None = field(default=None, init=False)
+    _startup_cutoff_ms: int | None = field(default=None, init=False)
     _startup_router_ready_for_approval_cleanup: bool = field(default=False, init=False)
     _startup_runtime_support_ready_for_approval_cleanup: bool = field(default=False, init=False)
     _startup_approval_cleanup_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
@@ -472,11 +473,33 @@ class _MultiAgentOrchestrator:
         for entity_name in tuple(self._bot_start_tasks):
             await self._cancel_bot_start_task(entity_name)
 
-    async def _cancel_startup_maintenance_task(self) -> None:
+    async def _cancel_startup_maintenance_task(self) -> bool:
         """Cancel the detached initial startup maintenance task, if any."""
         task = self._startup_maintenance_task
         self._startup_maintenance_task = None
+        should_replay = task is not None and not task.done()
         await cancel_logged_task(task)
+        return should_replay
+
+    def _running_startup_maintenance_bots(self) -> list[AgentBot | TeamBot]:
+        """Return currently running bots in startup-maintenance order."""
+        router_bot = self.agent_bots.get(ROUTER_AGENT_NAME)
+        bots: list[AgentBot | TeamBot] = []
+        if router_bot is not None and router_bot.running:
+            bots.append(router_bot)
+        bots.extend(
+            bot for entity_name, bot in self.agent_bots.items() if entity_name != ROUTER_AGENT_NAME and bot.running
+        )
+        return bots
+
+    def _restart_startup_maintenance_after_config_reload(self, config: Config) -> None:
+        """Replay canceled initial startup maintenance after a config reload attempt."""
+        if self._startup_cutoff_ms is None or self._startup_maintenance_task is not None:
+            return
+        bots = self._running_startup_maintenance_bots()
+        if not bots:
+            return
+        self._start_startup_maintenance(bots, config, self._startup_cutoff_ms)
 
     def _reset_startup_approval_cleanup_state(self) -> None:
         """Reset one-shot approval cleanup gates for a fresh runtime start."""
@@ -1288,6 +1311,11 @@ class _MultiAgentOrchestrator:
             await self._approval_transport.handle_bot_ready(router_bot)
             self._startup_approval_cleanup_done = True
 
+    async def _mark_startup_runtime_support_ready_for_approval_cleanup(self) -> None:
+        """Mark runtime support ready and run startup approval cleanup if the router synced."""
+        self._startup_runtime_support_ready_for_approval_cleanup = True
+        await self._run_startup_approval_cleanup_if_ready()
+
     async def _run_startup_maintenance(
         self,
         started_bots: list[AgentBot | TeamBot],
@@ -1325,8 +1353,7 @@ class _MultiAgentOrchestrator:
             failure_message="Startup runtime support maintenance failed",
         )
         if runtime_support_ready:
-            self._startup_runtime_support_ready_for_approval_cleanup = True
-            await self._run_startup_approval_cleanup_if_ready()
+            await self._mark_startup_runtime_support_ready_for_approval_cleanup()
 
     def _start_startup_maintenance(
         self,
@@ -1389,6 +1416,7 @@ class _MultiAgentOrchestrator:
         # Create sync tasks for each bot with automatic restart on failure.
         set_runtime_starting("Starting Matrix sync loops")
         startup_cutoff_ms = int(time.time() * 1000)
+        self._startup_cutoff_ms = startup_cutoff_ms
         phase_started = self._log_startup_phase_started("start_matrix_sync_loops")
         for entity_name, bot in self.agent_bots.items():
             if bot.running:
@@ -1601,7 +1629,6 @@ class _MultiAgentOrchestrator:
 
     async def update_config(self) -> bool:
         """Reload configuration, restart affected entities, and reconcile room state."""
-        await self._cancel_startup_maintenance_task()
         new_config = load_config(self.runtime_paths, tolerate_plugin_load_errors=True)
 
         if not self.config:
@@ -1620,88 +1647,95 @@ class _MultiAgentOrchestrator:
             plan = replace(plan, entities_to_restart=plan.entities_to_restart | set(self.agent_bots))
 
         await self._prepare_accounts_for_config_update(new_config, plan)
+        replay_startup_maintenance = await self._cancel_startup_maintenance_task()
 
-        if plugin_changes:
-            pre_stopped_mcp_entities = await self._apply_plugin_changes_for_config_update(
-                current_config=current_config,
-                new_config=new_config,
-                changed_server_ids=plan.changed_mcp_servers,
+        try:
+            if plugin_changes:
+                pre_stopped_mcp_entities = await self._apply_plugin_changes_for_config_update(
+                    current_config=current_config,
+                    new_config=new_config,
+                    changed_server_ids=plan.changed_mcp_servers,
+                )
+            else:
+                pre_stopped_mcp_entities = await self._stop_entities_before_mcp_sync(
+                    current_config,
+                    new_config,
+                    plan.changed_mcp_servers,
+                )
+                # Only apply the new config after validation and account checks succeed.
+                self.config = new_config
+                self._sync_plugin_watch_roots(new_config)
+                self._activate_hook_registry(self.hook_registry)
+                clear_worker_validation_snapshot_cache()
+            changed_runtime_mcp_servers = await self._sync_mcp_manager(new_config)
+            await self._sync_event_cache_service(new_config)
+            logger.info(
+                "updating_config_authorization",
+                authorized_user_ids=new_config.authorization.global_users,
             )
-        else:
-            pre_stopped_mcp_entities = await self._stop_entities_before_mcp_sync(
-                current_config,
-                new_config,
-                plan.changed_mcp_servers,
-            )
-            # Only apply the new config after validation and account checks succeed.
-            self.config = new_config
-            self._sync_plugin_watch_roots(new_config)
-            self._activate_hook_registry(self.hook_registry)
-            clear_worker_validation_snapshot_cache()
-        changed_runtime_mcp_servers = await self._sync_mcp_manager(new_config)
-        await self._sync_event_cache_service(new_config)
-        logger.info(
-            "updating_config_authorization",
-            authorized_user_ids=new_config.authorization.global_users,
-        )
-        if changed_runtime_mcp_servers:
-            plan = replace(
+            if changed_runtime_mcp_servers:
+                plan = replace(
+                    plan,
+                    entities_to_restart=plan.entities_to_restart
+                    | new_config.get_entities_referencing_tools(
+                        {mcp_tool_name(server_id) for server_id in changed_runtime_mcp_servers},
+                    ),
+                )
+            await self._update_unchanged_bots(plan)
+
+            if plan.only_support_service_changes:
+                await self._sync_runtime_support_services(
+                    new_config,
+                    start_watcher=self.running,
+                    previous_config=current_config,
+                )
+                await self._mark_startup_runtime_support_ready_for_approval_cleanup()
+                await self._emit_config_reloaded(
+                    new_config=new_config,
+                    changed_entities=set(),
+                    added_entities=plan.added_entities,
+                    removed_entities=plan.removed_entities,
+                    plugin_changes=plugin_changes,
+                )
+                return False
+
+            changed_entities, retryable_entities, permanently_failed_entities = await self._restart_changed_entities(
                 plan,
-                entities_to_restart=plan.entities_to_restart
-                | new_config.get_entities_referencing_tools(
-                    {mcp_tool_name(server_id) for server_id in changed_runtime_mcp_servers},
-                ),
+                already_stopped_entities=pre_stopped_mcp_entities,
             )
-        await self._update_unchanged_bots(plan)
+            await self._reconcile_post_update_rooms(plan, changed_entities)
 
-        if plan.only_support_service_changes:
+            for entity_name in retryable_entities:
+                await self._schedule_bot_start_retry(entity_name)
+
+            if permanently_failed_entities:
+                logger.warning(
+                    "Configuration update left some bots disabled due to permanent startup errors",
+                    agent_names=permanently_failed_entities,
+                )
+
             await self._sync_runtime_support_services(
                 new_config,
                 start_watcher=self.running,
                 previous_config=current_config,
             )
+            await self._mark_startup_runtime_support_ready_for_approval_cleanup()
             await self._emit_config_reloaded(
                 new_config=new_config,
-                changed_entities=set(),
+                changed_entities=changed_entities,
                 added_entities=plan.added_entities,
                 removed_entities=plan.removed_entities,
                 plugin_changes=plugin_changes,
             )
-            return False
 
-        changed_entities, retryable_entities, permanently_failed_entities = await self._restart_changed_entities(
-            plan,
-            already_stopped_entities=pre_stopped_mcp_entities,
-        )
-        await self._reconcile_post_update_rooms(plan, changed_entities)
-
-        for entity_name in retryable_entities:
-            await self._schedule_bot_start_retry(entity_name)
-
-        if permanently_failed_entities:
-            logger.warning(
-                "Configuration update left some bots disabled due to permanent startup errors",
-                agent_names=permanently_failed_entities,
+            logger.info(
+                "configuration_update_complete",
+                affected_bot_count=len(plan.entities_to_restart) + len(plan.new_entities),
             )
-
-        await self._sync_runtime_support_services(
-            new_config,
-            start_watcher=self.running,
-            previous_config=current_config,
-        )
-        await self._emit_config_reloaded(
-            new_config=new_config,
-            changed_entities=changed_entities,
-            added_entities=plan.added_entities,
-            removed_entities=plan.removed_entities,
-            plugin_changes=plugin_changes,
-        )
-
-        logger.info(
-            "configuration_update_complete",
-            affected_bot_count=len(plan.entities_to_restart) + len(plan.new_entities),
-        )
-        return True
+            return True
+        finally:
+            if replay_startup_maintenance and self.running and self.config is not None:
+                self._restart_startup_maintenance_after_config_reload(self.config)
 
     def _router_bot(self) -> AgentBot | TeamBot | None:
         """Return the router bot when it exists and has an active client."""

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import signal
 import time
+from collections.abc import Awaitable, Callable
 from contextlib import suppress
 from dataclasses import dataclass, field, replace
 from functools import partial
@@ -272,6 +273,11 @@ class _MultiAgentOrchestrator:
     _memory_auto_flush_task: asyncio.Task | None = field(default=None, init=False)
     _config_reload_task: asyncio.Task | None = field(default=None, init=False)
     _config_reload_requested_at: float | None = field(default=None, init=False)
+    _startup_maintenance_task: asyncio.Task | None = field(default=None, init=False)
+    _startup_router_ready_for_approval_cleanup: bool = field(default=False, init=False)
+    _startup_runtime_support_ready_for_approval_cleanup: bool = field(default=False, init=False)
+    _startup_approval_cleanup_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
+    _startup_approval_cleanup_done: bool = field(default=False, init=False)
     _mcp_manager: MCPServerManager | None = field(default=None, init=False)
     _mcp_catalog_change_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
     _plugin_reload_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
@@ -380,6 +386,12 @@ class _MultiAgentOrchestrator:
         for bot in self.agent_bots.values():
             self._bind_runtime_support_services(bot)
 
+    def _bind_started_runtime_support_services(self, bots: list[AgentBot | TeamBot]) -> None:
+        """Bind current runtime support objects needed by live callbacks."""
+        for bot in bots:
+            self._bind_runtime_support_services(bot)
+        self._configure_approval_store_transport()
+
     async def _sync_event_cache_service(self, config: Config) -> None:
         """Ensure the runtime has one initialized shared event-cache service."""
         self._runtime_support = await sync_owned_runtime_support(
@@ -460,6 +472,34 @@ class _MultiAgentOrchestrator:
         for entity_name in tuple(self._bot_start_tasks):
             await self._cancel_bot_start_task(entity_name)
 
+    async def _cancel_startup_maintenance_task(self) -> None:
+        """Cancel the detached initial startup maintenance task, if any."""
+        task = self._startup_maintenance_task
+        self._startup_maintenance_task = None
+        await cancel_logged_task(task)
+
+    def _reset_startup_approval_cleanup_state(self) -> None:
+        """Reset one-shot approval cleanup gates for a fresh runtime start."""
+        self._startup_router_ready_for_approval_cleanup = False
+        self._startup_runtime_support_ready_for_approval_cleanup = False
+        self._startup_approval_cleanup_done = False
+
+    @staticmethod
+    def _log_startup_phase_started(phase: str) -> float:
+        """Log and time one startup phase."""
+        logger.info("startup_phase_started", phase=phase)
+        return time.monotonic()
+
+    @staticmethod
+    def _log_startup_phase_finished(phase: str, started_at: float, *, status: str = "completed") -> None:
+        """Log elapsed time for one startup phase."""
+        logger.info(
+            "startup_phase_finished",
+            phase=phase,
+            status=status,
+            elapsed_ms=round((time.monotonic() - started_at) * 1000, 1),
+        )
+
     def _start_sync_task(self, entity_name: str, bot: AgentBot | TeamBot) -> None:
         """Ensure one sync task exists for a running bot."""
         existing_task = self._sync_tasks.get(entity_name)
@@ -516,6 +556,11 @@ class _MultiAgentOrchestrator:
                 if start_status:
                     logger.info("Bot recovered after startup failure", agent_name=entity_name)
                     bots_to_setup = self._bots_to_setup_after_background_start(entity_name)
+                    self._bind_started_runtime_support_services([bot])
+                    config = self.config
+                    if config is not None:
+                        self._resolve_bot_room_aliases(bots_to_setup, config)
+                    self._start_sync_task(entity_name, bot)
                     if bots_to_setup:
                         await run_with_retry(
                             f"Updating Matrix room memberships for {entity_name}",
@@ -523,7 +568,6 @@ class _MultiAgentOrchestrator:
                             permanent_error_check=is_permanent_startup_error,
                             update_runtime_state=False,
                         )
-                    self._start_sync_task(entity_name, bot)
                     return
 
                 attempt += 1
@@ -1134,8 +1178,9 @@ class _MultiAgentOrchestrator:
         self,
         bots: list[AgentBot | TeamBot],
         config: Config,
+        startup_cutoff_ms: int | None = None,
     ) -> list[InterruptedThread]:
-        """Cleanup stale streams for started bots before sync loops begin."""
+        """Cleanup stale streams for started bots after restart."""
         bot_user_ids = {bot.agent_user.user_id for bot in bots if bot.client is not None and bot.agent_user.user_id}
         if not bot_user_ids:
             return []
@@ -1153,6 +1198,7 @@ class _MultiAgentOrchestrator:
                     config=config,
                     runtime_paths=self.runtime_paths,
                     conversation_cache=bot._conversation_cache,
+                    startup_cutoff_ms=startup_cutoff_ms,
                 )
                 cleaned_count += bot_cleaned_count
                 interrupted_threads.extend(bot_interrupted_threads)
@@ -1193,50 +1239,163 @@ class _MultiAgentOrchestrator:
         except Exception as exc:
             logger.warning("Could not auto-resume interrupted threads (non-critical)", error=str(exc))
 
+    def _resolve_bot_room_aliases(self, bots: list[AgentBot | TeamBot], config: Config) -> None:
+        """Resolve currently known room aliases into each bot's configured room IDs."""
+        for bot in bots:
+            room_aliases = get_rooms_for_entity(bot.agent_name, config)
+            bot.rooms = resolve_room_aliases(room_aliases, runtime_paths=self.runtime_paths)
+
+    async def _run_startup_maintenance_phase(
+        self,
+        phase: str,
+        operation: Callable[[], Awaitable[None]],
+        *,
+        failure_message: str,
+    ) -> bool:
+        """Run one post-sync startup maintenance phase without stopping sync loops."""
+        phase_started = self._log_startup_phase_started(phase)
+        try:
+            await operation()
+        except asyncio.CancelledError:
+            self._log_startup_phase_finished(phase, phase_started, status="cancelled")
+            raise
+        except Exception:
+            self._log_startup_phase_finished(phase, phase_started, status="failed")
+            logger.warning(failure_message, exc_info=True)
+            return False
+        else:
+            self._log_startup_phase_finished(phase, phase_started)
+            return True
+
+    async def _run_startup_approval_cleanup_if_ready(self) -> None:
+        """Run one-shot approval cleanup after router first sync and runtime support are ready."""
+        if (
+            self._startup_approval_cleanup_done
+            or not self._startup_router_ready_for_approval_cleanup
+            or not self._startup_runtime_support_ready_for_approval_cleanup
+        ):
+            return
+        async with self._startup_approval_cleanup_lock:
+            if (
+                self._startup_approval_cleanup_done
+                or not self._startup_router_ready_for_approval_cleanup
+                or not self._startup_runtime_support_ready_for_approval_cleanup
+            ):
+                return
+            router_bot = self.agent_bots.get(ROUTER_AGENT_NAME)
+            if router_bot is None:
+                return
+            await self._approval_transport.handle_bot_ready(router_bot)
+            self._startup_approval_cleanup_done = True
+
+    async def _run_startup_maintenance(
+        self,
+        started_bots: list[AgentBot | TeamBot],
+        config: Config,
+        startup_cutoff_ms: int,
+    ) -> None:
+        """Run slow restart maintenance after live Matrix sync has started."""
+        await self._run_startup_maintenance_phase(
+            "startup_maintenance.rooms_and_memberships",
+            lambda: run_with_retry(
+                "Setting up Matrix rooms and memberships",
+                lambda: self._setup_rooms_and_memberships(started_bots),
+                permanent_error_check=is_permanent_startup_error,
+                update_runtime_state=False,
+            ),
+            failure_message="Startup room and membership maintenance failed",
+        )
+
+        async def cleanup_and_resume() -> None:
+            interrupted_threads = await self._cleanup_stale_streams_after_restart(
+                started_bots,
+                config,
+                startup_cutoff_ms,
+            )
+            await self._auto_resume_after_restart(interrupted_threads, config)
+
+        await self._run_startup_maintenance_phase(
+            "startup_maintenance.stale_stream_cleanup",
+            cleanup_and_resume,
+            failure_message="Startup stale stream maintenance failed",
+        )
+        runtime_support_ready = await self._run_startup_maintenance_phase(
+            "startup_maintenance.runtime_support",
+            lambda: self._sync_runtime_support_services(config, start_watcher=True),
+            failure_message="Startup runtime support maintenance failed",
+        )
+        if runtime_support_ready:
+            self._startup_runtime_support_ready_for_approval_cleanup = True
+            await self._run_startup_approval_cleanup_if_ready()
+
+    def _start_startup_maintenance(
+        self,
+        started_bots: list[AgentBot | TeamBot],
+        config: Config,
+        startup_cutoff_ms: int,
+    ) -> None:
+        """Schedule detached startup maintenance."""
+        self._startup_maintenance_task = create_logged_task(
+            self._run_startup_maintenance(started_bots, config, startup_cutoff_ms),
+            name="startup_maintenance",
+            failure_message="Startup maintenance task failed",
+        )
+
     async def handle_bot_ready(self, bot: AgentBot | TeamBot) -> None:
         """Handle bot-ready notifications through the public runtime protocol."""
-        await self._approval_transport.handle_bot_ready(bot)
+        if bot.agent_name != ROUTER_AGENT_NAME:
+            return
+        self._startup_router_ready_for_approval_cleanup = True
+        await self._run_startup_approval_cleanup_if_ready()
 
     async def _start_runtime(self) -> None:
         """Run the startup sequence before handing off to the sync loops."""
         runtime_shutdown_event = self._reset_runtime_shutdown_event()
+        self._reset_startup_approval_cleanup_state()
+        phase_started = self._log_startup_phase_started("wait_for_matrix_homeserver")
         await wait_for_matrix_homeserver(runtime_paths=self.runtime_paths)
-        if not self.agent_bots:
-            await self.initialize()
+        self._log_startup_phase_finished("wait_for_matrix_homeserver", phase_started)
 
+        if not self.agent_bots:
+            phase_started = self._log_startup_phase_started("initialize_runtime")
+            await self.initialize()
+            self._log_startup_phase_finished("initialize_runtime", phase_started)
+
+        phase_started = self._log_startup_phase_started("start_router_bot")
         router_bot = await self._start_router_bot()
+        self._log_startup_phase_finished("start_router_bot", phase_started)
+
         set_runtime_starting("Starting remaining Matrix bot accounts")
+        phase_started = self._log_startup_phase_started("start_remaining_bots")
         start_results = await self._start_entities_once(
             [entity_name for entity_name in self.agent_bots if entity_name != ROUTER_AGENT_NAME],
             start_sync_tasks=False,
         )
+        self._log_startup_phase_finished("start_remaining_bots", phase_started)
+
         started_bots = [router_bot, *start_results.started_bots]
         self._log_degraded_startup(
             [*start_results.retryable_entities, *start_results.permanently_failed_entities],
         )
 
         config = self._require_config()
-
-        # Setup rooms and have all bots join them before potentially heavy
-        # knowledge indexing, so new rooms and invites are not delayed by embeddings.
-        await run_with_retry(
-            "Setting up Matrix rooms and memberships",
-            lambda: self._setup_rooms_and_memberships(started_bots),
-            permanent_error_check=is_permanent_startup_error,
-        )
-        interrupted_threads = await self._cleanup_stale_streams_after_restart(started_bots, config)
-        await self._auto_resume_after_restart(interrupted_threads, config)
+        self._resolve_bot_room_aliases(started_bots, config)
+        phase_started = self._log_startup_phase_started("bind_runtime_support")
+        self._bind_started_runtime_support_services(started_bots)
+        self._log_startup_phase_finished("bind_runtime_support", phase_started)
 
         self.running = True
 
-        set_runtime_starting("Starting background workers")
-        await self._sync_runtime_support_services(config, start_watcher=True)
-
         # Create sync tasks for each bot with automatic restart on failure.
         set_runtime_starting("Starting Matrix sync loops")
+        startup_cutoff_ms = int(time.time() * 1000)
+        phase_started = self._log_startup_phase_started("start_matrix_sync_loops")
         for entity_name, bot in self.agent_bots.items():
             if bot.running:
                 self._start_sync_task(entity_name, bot)
+        self._log_startup_phase_finished("start_matrix_sync_loops", phase_started)
+
+        self._start_startup_maintenance(started_bots, config, startup_cutoff_ms)
 
         for entity_name in start_results.retryable_entities:
             await self._schedule_bot_start_retry(entity_name)
@@ -1442,6 +1601,7 @@ class _MultiAgentOrchestrator:
 
     async def update_config(self) -> bool:
         """Reload configuration, restart affected entities, and reconcile room state."""
+        await self._cancel_startup_maintenance_task()
         new_config = load_config(self.runtime_paths, tolerate_plugin_load_errors=True)
 
         if not self.config:
@@ -1565,9 +1725,7 @@ class _MultiAgentOrchestrator:
 
         # Resolve room aliases now that any missing rooms have been created.
         config = self._require_config()
-        for bot in bots:
-            room_aliases = get_rooms_for_entity(bot.agent_name, config)
-            bot.rooms = resolve_room_aliases(room_aliases, runtime_paths=self.runtime_paths)
+        self._resolve_bot_room_aliases(bots, config)
 
         async def _ensure_internal_user_memberships() -> None:
             all_rooms = load_rooms(runtime_paths=self.runtime_paths)
@@ -1791,6 +1949,7 @@ class _MultiAgentOrchestrator:
             self._runtime_shutdown_event.set()
         await shutdown_approval_runtime()
         await self._cancel_config_reload_task()
+        await self._cancel_startup_maintenance_task()
         await self._stop_memory_auto_flush_worker()
         await self._knowledge_source_watcher.shutdown()
         await self._knowledge_refresh_scheduler.shutdown()

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -275,10 +275,6 @@ class _MultiAgentOrchestrator:
     _config_reload_requested_at: float | None = field(default=None, init=False)
     _startup_maintenance_task: asyncio.Task | None = field(default=None, init=False)
     _startup_cutoff_ms: int | None = field(default=None, init=False)
-    _startup_router_ready_for_approval_cleanup: bool = field(default=False, init=False)
-    _startup_runtime_support_ready_for_approval_cleanup: bool = field(default=False, init=False)
-    _startup_approval_cleanup_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
-    _startup_approval_cleanup_done: bool = field(default=False, init=False)
     _mcp_manager: MCPServerManager | None = field(default=None, init=False)
     _mcp_catalog_change_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
     _plugin_reload_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
@@ -500,12 +496,6 @@ class _MultiAgentOrchestrator:
         if not bots:
             return
         self._start_startup_maintenance(bots, config, self._startup_cutoff_ms)
-
-    def _reset_startup_approval_cleanup_state(self) -> None:
-        """Reset one-shot approval cleanup gates for a fresh runtime start."""
-        self._startup_router_ready_for_approval_cleanup = False
-        self._startup_runtime_support_ready_for_approval_cleanup = False
-        self._startup_approval_cleanup_done = False
 
     @staticmethod
     def _log_startup_phase_started(phase: str) -> float:
@@ -1290,32 +1280,6 @@ class _MultiAgentOrchestrator:
             self._log_startup_phase_finished(phase, phase_started)
             return True
 
-    async def _run_startup_approval_cleanup_if_ready(self) -> None:
-        """Run one-shot approval cleanup after router first sync and runtime support are ready."""
-        if (
-            self._startup_approval_cleanup_done
-            or not self._startup_router_ready_for_approval_cleanup
-            or not self._startup_runtime_support_ready_for_approval_cleanup
-        ):
-            return
-        async with self._startup_approval_cleanup_lock:
-            if (
-                self._startup_approval_cleanup_done
-                or not self._startup_router_ready_for_approval_cleanup
-                or not self._startup_runtime_support_ready_for_approval_cleanup
-            ):
-                return
-            router_bot = self.agent_bots.get(ROUTER_AGENT_NAME)
-            if router_bot is None:
-                return
-            await self._approval_transport.handle_bot_ready(router_bot)
-            self._startup_approval_cleanup_done = True
-
-    async def _mark_startup_runtime_support_ready_for_approval_cleanup(self) -> None:
-        """Mark runtime support ready and run startup approval cleanup if the router synced."""
-        self._startup_runtime_support_ready_for_approval_cleanup = True
-        await self._run_startup_approval_cleanup_if_ready()
-
     async def _run_startup_maintenance(
         self,
         started_bots: list[AgentBot | TeamBot],
@@ -1353,7 +1317,7 @@ class _MultiAgentOrchestrator:
             failure_message="Startup runtime support maintenance failed",
         )
         if runtime_support_ready:
-            await self._mark_startup_runtime_support_ready_for_approval_cleanup()
+            await self._approval_transport.mark_startup_runtime_support_ready()
 
     def _start_startup_maintenance(
         self,
@@ -1370,15 +1334,12 @@ class _MultiAgentOrchestrator:
 
     async def handle_bot_ready(self, bot: AgentBot | TeamBot) -> None:
         """Handle bot-ready notifications through the public runtime protocol."""
-        if bot.agent_name != ROUTER_AGENT_NAME:
-            return
-        self._startup_router_ready_for_approval_cleanup = True
-        await self._run_startup_approval_cleanup_if_ready()
+        await self._approval_transport.handle_bot_ready(bot)
 
     async def _start_runtime(self) -> None:
         """Run the startup sequence before handing off to the sync loops."""
         runtime_shutdown_event = self._reset_runtime_shutdown_event()
-        self._reset_startup_approval_cleanup_state()
+        self._approval_transport.reset_startup_cleanup_gate()
         phase_started = self._log_startup_phase_started("wait_for_matrix_homeserver")
         await wait_for_matrix_homeserver(runtime_paths=self.runtime_paths)
         self._log_startup_phase_finished("wait_for_matrix_homeserver", phase_started)
@@ -1689,7 +1650,7 @@ class _MultiAgentOrchestrator:
                     start_watcher=self.running,
                     previous_config=current_config,
                 )
-                await self._mark_startup_runtime_support_ready_for_approval_cleanup()
+                await self._approval_transport.mark_startup_runtime_support_ready()
                 await self._emit_config_reloaded(
                     new_config=new_config,
                     changed_entities=set(),
@@ -1719,7 +1680,7 @@ class _MultiAgentOrchestrator:
                 start_watcher=self.running,
                 previous_config=current_config,
             )
-            await self._mark_startup_runtime_support_ready_for_approval_cleanup()
+            await self._approval_transport.mark_startup_runtime_support_ready()
             await self._emit_config_reloaded(
                 new_config=new_config,
                 changed_entities=changed_entities,

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -63,6 +63,7 @@ from mindroom.memory import MemoryAutoFlushWorker, auto_flush_enabled
 from mindroom.runtime_state import reset_runtime_state, set_runtime_failed, set_runtime_ready, set_runtime_starting
 from mindroom.scheduling import set_scheduling_hook_registry
 from mindroom.startup_errors import PermanentStartupError
+from mindroom.startup_maintenance import StartupMaintenanceController
 from mindroom.tool_approval import shutdown_approval_runtime
 from mindroom.tool_system.plugins import (
     PluginReloadResult,
@@ -177,6 +178,22 @@ def _raise_orchestrator_exit(*, reason: str) -> NoReturn:
     raise RuntimeError(msg)
 
 
+def _log_startup_phase_started(phase: str) -> float:
+    """Log and time one startup phase."""
+    logger.info("startup_phase_started", phase=phase)
+    return time.monotonic()
+
+
+def _log_startup_phase_finished(phase: str, started_at: float, *, status: str = "completed") -> None:
+    """Log elapsed time for one startup phase."""
+    logger.info(
+        "startup_phase_finished",
+        phase=phase,
+        status=status,
+        elapsed_ms=round((time.monotonic() - started_at) * 1000, 1),
+    )
+
+
 @dataclass
 class _ConfigReloadDrainState:
     """Track response-drain state for a queued config reload."""
@@ -273,8 +290,6 @@ class _MultiAgentOrchestrator:
     _memory_auto_flush_task: asyncio.Task | None = field(default=None, init=False)
     _config_reload_task: asyncio.Task | None = field(default=None, init=False)
     _config_reload_requested_at: float | None = field(default=None, init=False)
-    _startup_maintenance_task: asyncio.Task | None = field(default=None, init=False)
-    _startup_cutoff_ms: int | None = field(default=None, init=False)
     _mcp_manager: MCPServerManager | None = field(default=None, init=False)
     _mcp_catalog_change_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
     _plugin_reload_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
@@ -287,6 +302,7 @@ class _MultiAgentOrchestrator:
     hook_registry: HookRegistry = field(default_factory=HookRegistry.empty, init=False)
     _runtime_shutdown_event: asyncio.Event | None = field(default=None, init=False, repr=False)
     _approval_transport: ApprovalMatrixTransport = field(init=False, repr=False)
+    _startup_maintenance: StartupMaintenanceController = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
         """Store canonical derived paths from the explicit runtime context."""
@@ -304,6 +320,25 @@ class _MultiAgentOrchestrator:
             bot_provider=lambda agent_name: self.agent_bots.get(agent_name),
             config_provider=lambda: self.config,
             event_cache_provider=lambda: self._runtime_support.event_cache,
+        )
+        self._startup_maintenance = StartupMaintenanceController(
+            setup_rooms_and_memberships=lambda bots: run_with_retry(
+                "Setting up Matrix rooms and memberships",
+                lambda: self._setup_rooms_and_memberships(bots),
+                permanent_error_check=is_permanent_startup_error,
+                update_runtime_state=False,
+            ),
+            cleanup_stale_streams=lambda bots, config, startup_cutoff_ms: self._cleanup_stale_streams_after_restart(
+                bots,
+                config,
+                startup_cutoff_ms,
+            ),
+            auto_resume=lambda interrupted_threads, config: self._auto_resume_after_restart(
+                interrupted_threads,
+                config,
+            ),
+            sync_runtime_support=lambda config: self._sync_runtime_support_services(config, start_watcher=True),
+            mark_runtime_support_ready=lambda: self._approval_transport.mark_startup_runtime_support_ready(),
         )
 
     @property
@@ -469,14 +504,6 @@ class _MultiAgentOrchestrator:
         for entity_name in tuple(self._bot_start_tasks):
             await self._cancel_bot_start_task(entity_name)
 
-    async def _cancel_startup_maintenance_task(self) -> bool:
-        """Cancel the detached initial startup maintenance task, if any."""
-        task = self._startup_maintenance_task
-        self._startup_maintenance_task = None
-        should_replay = task is not None and not task.done()
-        await cancel_logged_task(task)
-        return should_replay
-
     def _running_startup_maintenance_bots(self) -> list[AgentBot | TeamBot]:
         """Return currently running bots in startup-maintenance order."""
         router_bot = self.agent_bots.get(ROUTER_AGENT_NAME)
@@ -487,31 +514,6 @@ class _MultiAgentOrchestrator:
             bot for entity_name, bot in self.agent_bots.items() if entity_name != ROUTER_AGENT_NAME and bot.running
         )
         return bots
-
-    def _restart_startup_maintenance_after_config_reload(self, config: Config) -> None:
-        """Replay canceled initial startup maintenance after a config reload attempt."""
-        if self._startup_cutoff_ms is None or self._startup_maintenance_task is not None:
-            return
-        bots = self._running_startup_maintenance_bots()
-        if not bots:
-            return
-        self._start_startup_maintenance(bots, config, self._startup_cutoff_ms)
-
-    @staticmethod
-    def _log_startup_phase_started(phase: str) -> float:
-        """Log and time one startup phase."""
-        logger.info("startup_phase_started", phase=phase)
-        return time.monotonic()
-
-    @staticmethod
-    def _log_startup_phase_finished(phase: str, started_at: float, *, status: str = "completed") -> None:
-        """Log elapsed time for one startup phase."""
-        logger.info(
-            "startup_phase_finished",
-            phase=phase,
-            status=status,
-            elapsed_ms=round((time.monotonic() - started_at) * 1000, 1),
-        )
 
     def _start_sync_task(self, entity_name: str, bot: AgentBot | TeamBot) -> None:
         """Ensure one sync task exists for a running bot."""
@@ -1258,80 +1260,6 @@ class _MultiAgentOrchestrator:
             room_aliases = get_rooms_for_entity(bot.agent_name, config)
             bot.rooms = resolve_room_aliases(room_aliases, runtime_paths=self.runtime_paths)
 
-    async def _run_startup_maintenance_phase(
-        self,
-        phase: str,
-        operation: Callable[[], Awaitable[None]],
-        *,
-        failure_message: str,
-    ) -> bool:
-        """Run one post-sync startup maintenance phase without stopping sync loops."""
-        phase_started = self._log_startup_phase_started(phase)
-        try:
-            await operation()
-        except asyncio.CancelledError:
-            self._log_startup_phase_finished(phase, phase_started, status="cancelled")
-            raise
-        except Exception:
-            self._log_startup_phase_finished(phase, phase_started, status="failed")
-            logger.warning(failure_message, exc_info=True)
-            return False
-        else:
-            self._log_startup_phase_finished(phase, phase_started)
-            return True
-
-    async def _run_startup_maintenance(
-        self,
-        started_bots: list[AgentBot | TeamBot],
-        config: Config,
-        startup_cutoff_ms: int,
-    ) -> None:
-        """Run slow restart maintenance after live Matrix sync has started."""
-        await self._run_startup_maintenance_phase(
-            "startup_maintenance.rooms_and_memberships",
-            lambda: run_with_retry(
-                "Setting up Matrix rooms and memberships",
-                lambda: self._setup_rooms_and_memberships(started_bots),
-                permanent_error_check=is_permanent_startup_error,
-                update_runtime_state=False,
-            ),
-            failure_message="Startup room and membership maintenance failed",
-        )
-
-        async def cleanup_and_resume() -> None:
-            interrupted_threads = await self._cleanup_stale_streams_after_restart(
-                started_bots,
-                config,
-                startup_cutoff_ms,
-            )
-            await self._auto_resume_after_restart(interrupted_threads, config)
-
-        await self._run_startup_maintenance_phase(
-            "startup_maintenance.stale_stream_cleanup",
-            cleanup_and_resume,
-            failure_message="Startup stale stream maintenance failed",
-        )
-        runtime_support_ready = await self._run_startup_maintenance_phase(
-            "startup_maintenance.runtime_support",
-            lambda: self._sync_runtime_support_services(config, start_watcher=True),
-            failure_message="Startup runtime support maintenance failed",
-        )
-        if runtime_support_ready:
-            await self._approval_transport.mark_startup_runtime_support_ready()
-
-    def _start_startup_maintenance(
-        self,
-        started_bots: list[AgentBot | TeamBot],
-        config: Config,
-        startup_cutoff_ms: int,
-    ) -> None:
-        """Schedule detached startup maintenance."""
-        self._startup_maintenance_task = create_logged_task(
-            self._run_startup_maintenance(started_bots, config, startup_cutoff_ms),
-            name="startup_maintenance",
-            failure_message="Startup maintenance task failed",
-        )
-
     async def handle_bot_ready(self, bot: AgentBot | TeamBot) -> None:
         """Handle bot-ready notifications through the public runtime protocol."""
         await self._approval_transport.handle_bot_ready(bot)
@@ -1340,26 +1268,26 @@ class _MultiAgentOrchestrator:
         """Run the startup sequence before handing off to the sync loops."""
         runtime_shutdown_event = self._reset_runtime_shutdown_event()
         self._approval_transport.reset_startup_cleanup_gate()
-        phase_started = self._log_startup_phase_started("wait_for_matrix_homeserver")
+        phase_started = _log_startup_phase_started("wait_for_matrix_homeserver")
         await wait_for_matrix_homeserver(runtime_paths=self.runtime_paths)
-        self._log_startup_phase_finished("wait_for_matrix_homeserver", phase_started)
+        _log_startup_phase_finished("wait_for_matrix_homeserver", phase_started)
 
         if not self.agent_bots:
-            phase_started = self._log_startup_phase_started("initialize_runtime")
+            phase_started = _log_startup_phase_started("initialize_runtime")
             await self.initialize()
-            self._log_startup_phase_finished("initialize_runtime", phase_started)
+            _log_startup_phase_finished("initialize_runtime", phase_started)
 
-        phase_started = self._log_startup_phase_started("start_router_bot")
+        phase_started = _log_startup_phase_started("start_router_bot")
         router_bot = await self._start_router_bot()
-        self._log_startup_phase_finished("start_router_bot", phase_started)
+        _log_startup_phase_finished("start_router_bot", phase_started)
 
         set_runtime_starting("Starting remaining Matrix bot accounts")
-        phase_started = self._log_startup_phase_started("start_remaining_bots")
+        phase_started = _log_startup_phase_started("start_remaining_bots")
         start_results = await self._start_entities_once(
             [entity_name for entity_name in self.agent_bots if entity_name != ROUTER_AGENT_NAME],
             start_sync_tasks=False,
         )
-        self._log_startup_phase_finished("start_remaining_bots", phase_started)
+        _log_startup_phase_finished("start_remaining_bots", phase_started)
 
         started_bots = [router_bot, *start_results.started_bots]
         self._log_degraded_startup(
@@ -1368,23 +1296,22 @@ class _MultiAgentOrchestrator:
 
         config = self._require_config()
         self._resolve_bot_room_aliases(started_bots, config)
-        phase_started = self._log_startup_phase_started("bind_runtime_support")
+        phase_started = _log_startup_phase_started("bind_runtime_support")
         self._bind_started_runtime_support_services(started_bots)
-        self._log_startup_phase_finished("bind_runtime_support", phase_started)
+        _log_startup_phase_finished("bind_runtime_support", phase_started)
 
         self.running = True
 
         # Create sync tasks for each bot with automatic restart on failure.
         set_runtime_starting("Starting Matrix sync loops")
         startup_cutoff_ms = int(time.time() * 1000)
-        self._startup_cutoff_ms = startup_cutoff_ms
-        phase_started = self._log_startup_phase_started("start_matrix_sync_loops")
+        phase_started = _log_startup_phase_started("start_matrix_sync_loops")
         for entity_name, bot in self.agent_bots.items():
             if bot.running:
                 self._start_sync_task(entity_name, bot)
-        self._log_startup_phase_finished("start_matrix_sync_loops", phase_started)
+        _log_startup_phase_finished("start_matrix_sync_loops", phase_started)
 
-        self._start_startup_maintenance(started_bots, config, startup_cutoff_ms)
+        self._startup_maintenance.start(started_bots, config, startup_cutoff_ms=startup_cutoff_ms)
 
         for entity_name in start_results.retryable_entities:
             await self._schedule_bot_start_retry(entity_name)
@@ -1608,7 +1535,7 @@ class _MultiAgentOrchestrator:
             plan = replace(plan, entities_to_restart=plan.entities_to_restart | set(self.agent_bots))
 
         await self._prepare_accounts_for_config_update(new_config, plan)
-        replay_startup_maintenance = await self._cancel_startup_maintenance_task()
+        replay_startup_maintenance = await self._startup_maintenance.cancel()
 
         try:
             if plugin_changes:
@@ -1696,7 +1623,10 @@ class _MultiAgentOrchestrator:
             return True
         finally:
             if replay_startup_maintenance and self.running and self.config is not None:
-                self._restart_startup_maintenance_after_config_reload(self.config)
+                self._startup_maintenance.restart_after_config_reload(
+                    config=self.config,
+                    running_bots=self._running_startup_maintenance_bots,
+                )
 
     def _router_bot(self) -> AgentBot | TeamBot | None:
         """Return the router bot when it exists and has an active client."""
@@ -1944,7 +1874,7 @@ class _MultiAgentOrchestrator:
             self._runtime_shutdown_event.set()
         await shutdown_approval_runtime()
         await self._cancel_config_reload_task()
-        await self._cancel_startup_maintenance_task()
+        await self._startup_maintenance.cancel()
         await self._stop_memory_auto_flush_worker()
         await self._knowledge_source_watcher.shutdown()
         await self._knowledge_refresh_scheduler.shutdown()

--- a/src/mindroom/startup_maintenance.py
+++ b/src/mindroom/startup_maintenance.py
@@ -3,13 +3,17 @@
 from __future__ import annotations
 
 import asyncio
-import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from mindroom.logging_config import get_logger
-from mindroom.orchestration.runtime import cancel_logged_task, create_logged_task
+from mindroom.orchestration.runtime import (
+    cancel_logged_task,
+    create_logged_task,
+    log_startup_phase_finished,
+    log_startup_phase_started,
+)
 
 if TYPE_CHECKING:
     from mindroom.bot import AgentBot, TeamBot
@@ -101,31 +105,15 @@ class StartupMaintenanceController:
         *,
         failure_message: str,
     ) -> bool:
-        phase_started = self._log_phase_started(phase)
+        phase_started = log_startup_phase_started(phase)
         try:
             await operation()
         except asyncio.CancelledError:
-            self._log_phase_finished(phase, phase_started, status="cancelled")
+            log_startup_phase_finished(phase, phase_started, status="cancelled")
             raise
         except Exception:
-            self._log_phase_finished(phase, phase_started, status="failed")
+            log_startup_phase_finished(phase, phase_started, status="failed")
             logger.warning(failure_message, exc_info=True)
             return False
-        self._log_phase_finished(phase, phase_started)
+        log_startup_phase_finished(phase, phase_started)
         return True
-
-    @staticmethod
-    def _log_phase_started(phase: str) -> float:
-        """Log and time one startup maintenance phase."""
-        logger.info("startup_phase_started", phase=phase)
-        return time.monotonic()
-
-    @staticmethod
-    def _log_phase_finished(phase: str, started_at: float, *, status: str = "completed") -> None:
-        """Log elapsed time for one startup maintenance phase."""
-        logger.info(
-            "startup_phase_finished",
-            phase=phase,
-            status=status,
-            elapsed_ms=round((time.monotonic() - started_at) * 1000, 1),
-        )

--- a/src/mindroom/startup_maintenance.py
+++ b/src/mindroom/startup_maintenance.py
@@ -1,0 +1,131 @@
+"""Detached startup maintenance lifecycle."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from mindroom.logging_config import get_logger
+from mindroom.orchestration.runtime import cancel_logged_task, create_logged_task
+
+if TYPE_CHECKING:
+    from mindroom.bot import AgentBot, TeamBot
+    from mindroom.config.main import Config
+    from mindroom.matrix.stale_stream_cleanup import InterruptedThread
+
+logger = get_logger(__name__)
+
+type _StartupBot = AgentBot | TeamBot
+type _SetupRooms = Callable[[list[_StartupBot]], Awaitable[None]]
+type _CleanupStaleStreams = Callable[[list[_StartupBot], Config, int], Awaitable[list[InterruptedThread]]]
+type _AutoResume = Callable[[list[InterruptedThread], Config], Awaitable[None]]
+type _SyncRuntimeSupport = Callable[[Config], Awaitable[None]]
+type _MarkRuntimeSupportReady = Callable[[], Awaitable[None]]
+type _RunningBots = Callable[[], list[_StartupBot]]
+
+
+@dataclass
+class StartupMaintenanceController:
+    """Own detached post-sync startup maintenance task lifecycle."""
+
+    setup_rooms_and_memberships: _SetupRooms
+    cleanup_stale_streams: _CleanupStaleStreams
+    auto_resume: _AutoResume
+    sync_runtime_support: _SyncRuntimeSupport
+    mark_runtime_support_ready: _MarkRuntimeSupportReady
+    task: asyncio.Task[None] | None = field(default=None, init=False)
+    startup_cutoff_ms: int | None = field(default=None, init=False)
+
+    def start(self, bots: list[_StartupBot], config: Config, *, startup_cutoff_ms: int) -> None:
+        """Schedule detached startup maintenance for one startup generation."""
+        self.startup_cutoff_ms = startup_cutoff_ms
+        self.task = create_logged_task(
+            self._run(bots, config, startup_cutoff_ms),
+            name="startup_maintenance",
+            failure_message="Startup maintenance task failed",
+        )
+
+    async def cancel(self) -> bool:
+        """Cancel detached startup maintenance and report whether unfinished work was interrupted."""
+        task = self.task
+        self.task = None
+        should_replay = task is not None and not task.done()
+        await cancel_logged_task(task)
+        return should_replay
+
+    def restart_after_config_reload(
+        self,
+        *,
+        config: Config,
+        running_bots: _RunningBots,
+    ) -> None:
+        """Replay canceled startup maintenance after config reload completes."""
+        if self.startup_cutoff_ms is None or self.task is not None:
+            return
+        bots = running_bots()
+        if not bots:
+            return
+        self.start(bots, config, startup_cutoff_ms=self.startup_cutoff_ms)
+
+    async def _run(self, bots: list[_StartupBot], config: Config, startup_cutoff_ms: int) -> None:
+        await self._run_phase(
+            "startup_maintenance.rooms_and_memberships",
+            lambda: self.setup_rooms_and_memberships(bots),
+            failure_message="Startup room and membership maintenance failed",
+        )
+
+        async def cleanup_and_resume() -> None:
+            interrupted_threads = await self.cleanup_stale_streams(bots, config, startup_cutoff_ms)
+            await self.auto_resume(interrupted_threads, config)
+
+        await self._run_phase(
+            "startup_maintenance.stale_stream_cleanup",
+            cleanup_and_resume,
+            failure_message="Startup stale stream maintenance failed",
+        )
+        runtime_support_ready = await self._run_phase(
+            "startup_maintenance.runtime_support",
+            lambda: self.sync_runtime_support(config),
+            failure_message="Startup runtime support maintenance failed",
+        )
+        if runtime_support_ready:
+            await self.mark_runtime_support_ready()
+
+    async def _run_phase(
+        self,
+        phase: str,
+        operation: Callable[[], Awaitable[None]],
+        *,
+        failure_message: str,
+    ) -> bool:
+        phase_started = self._log_phase_started(phase)
+        try:
+            await operation()
+        except asyncio.CancelledError:
+            self._log_phase_finished(phase, phase_started, status="cancelled")
+            raise
+        except Exception:
+            self._log_phase_finished(phase, phase_started, status="failed")
+            logger.warning(failure_message, exc_info=True)
+            return False
+        self._log_phase_finished(phase, phase_started)
+        return True
+
+    @staticmethod
+    def _log_phase_started(phase: str) -> float:
+        """Log and time one startup maintenance phase."""
+        logger.info("startup_phase_started", phase=phase)
+        return time.monotonic()
+
+    @staticmethod
+    def _log_phase_finished(phase: str, started_at: float, *, status: str = "completed") -> None:
+        """Log elapsed time for one startup maintenance phase."""
+        logger.info(
+            "startup_phase_finished",
+            phase=phase,
+            status=status,
+            elapsed_ms=round((time.monotonic() - started_at) * 1000, 1),
+        )

--- a/tests/test_config_reload.py
+++ b/tests/test_config_reload.py
@@ -28,7 +28,7 @@ from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
 from mindroom.orchestration.config_updates import ConfigUpdatePlan, _get_changed_agents, build_config_update_plan
 from mindroom.orchestration.plugin_watch import _drop_unconfigured_plugin_root_snapshots, watch_plugins_task
-from mindroom.orchestration.runtime import create_logged_task
+from mindroom.orchestration.runtime import create_logged_task, log_startup_phase_finished, log_startup_phase_started
 from mindroom.orchestrator import _ConfigReloadDrainState, _MultiAgentOrchestrator, _watch_skills_task
 from mindroom.startup_errors import PermanentStartupError
 from mindroom.tool_system.plugins import PluginReloadResult
@@ -59,6 +59,25 @@ def setup_test_bot(bot: AgentBot, mock_client: AsyncMock) -> None:
     bot.client = mock_client
     bot.event_cache = make_event_cache_mock()
     bot.event_cache_write_coordinator = make_event_cache_write_coordinator_mock()
+
+
+def test_startup_phase_logging_helpers_emit_structured_timing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Startup phase logging helpers should emit one stable structured event pair."""
+    logger_mock = MagicMock()
+    monkeypatch.setattr("mindroom.orchestration.runtime.logger", logger_mock)
+
+    with patch("mindroom.orchestration.runtime.time.monotonic", side_effect=[10.0, 10.1234]):
+        started_at = log_startup_phase_started("phase.name")
+        log_startup_phase_finished("phase.name", started_at, status="failed")
+
+    assert started_at == 10.0
+    logger_mock.info.assert_any_call("startup_phase_started", phase="phase.name")
+    logger_mock.info.assert_any_call(
+        "startup_phase_finished",
+        phase="phase.name",
+        status="failed",
+        elapsed_ms=123.4,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -640,7 +640,7 @@ async def test_room_root_text_and_image_coalesce_into_single_dispatch(tmp_path: 
 @pytest.mark.asyncio
 async def test_text_first_image_during_debounce_dispatches_without_upload_grace_delay(tmp_path: Path) -> None:
     """Do not add upload-grace delay once media already joined during debounce."""
-    bot = _make_bot(tmp_path, debounce_ms=20, upload_grace_ms=10_000)
+    bot = _make_bot(tmp_path, debounce_ms=200, upload_grace_ms=10_000)
     room = _make_room()
     text_event = _text_event(event_id="$m1", body="describe this", server_timestamp=1000, thread_id="$thread")
     image_event = _image_event(event_id="$img1", server_timestamp=1001, thread_id="$thread")
@@ -665,7 +665,6 @@ async def test_text_first_image_during_debounce_dispatches_without_upload_grace_
             source_kind="message",
             requester_user_id="@user:localhost",
         )
-        await asyncio.sleep(0.005)
         await _enqueue_for_dispatch(
             bot,
             image_event,
@@ -673,7 +672,7 @@ async def test_text_first_image_during_debounce_dispatches_without_upload_grace_
             source_kind="image",
             requester_user_id="@user:localhost",
         )
-        await _wait_for(lambda: calls == [(["$m1", "$img1"], 1)], deadline_seconds=0.5)
+        await _wait_for(lambda: calls == [(["$m1", "$img1"], 1)], deadline_seconds=1.0)
 
     assert _coalescing_gate_is_idle(bot._coalescing_gate)
 

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -15004,6 +15004,7 @@ class TestMultiAgentOrchestrator:
         orchestrator.agent_bots = {"router": bot}
 
         call_order: list[str] = []
+        startup_discarded = asyncio.Event()
 
         async def _wait_for_homeserver(*_args: object, **_kwargs: object) -> None:
             call_order.append("wait_for_homeserver")
@@ -15017,6 +15018,7 @@ class TestMultiAgentOrchestrator:
         async def _discard_pending_on_startup(*, lookback_hours: int) -> int:
             assert lookback_hours == 240
             call_order.append("startup_discard")
+            startup_discarded.set()
             return 2
 
         async def _sync_forever_with_restart(started_bot: object) -> None:
@@ -15034,6 +15036,7 @@ class TestMultiAgentOrchestrator:
             patch("mindroom.orchestrator.sync_forever_with_restart", side_effect=_sync_forever_with_restart),
         ):
             await _run_orchestrator_start_until_ready(orchestrator)
+            await asyncio.wait_for(startup_discarded.wait(), timeout=1.0)
 
         assert call_order == [
             "wait_for_homeserver",
@@ -15064,6 +15067,124 @@ class TestMultiAgentOrchestrator:
             await orchestrator.handle_bot_ready(bot)
 
         expire_orphaned_approval_cards_on_startup.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_approval_transport_waits_for_runtime_support_before_startup_discard(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Router first sync alone must not discard startup approval cards before runtime support is ready."""
+        orchestrator = _MultiAgentOrchestrator(runtime_paths=TestAgentBot._runtime_paths(tmp_path))
+        orchestrator.config = MagicMock()
+        orchestrator.config.tool_approval.timeout_days = 7.0
+        orchestrator.config.tool_approval.rules = [SimpleNamespace(timeout_days=10.0)]
+
+        bot = MagicMock()
+        bot.agent_name = "router"
+        bot.running = True
+        bot.client = make_matrix_client_mock(user_id="@mindroom_router:localhost")
+        orchestrator.agent_bots = {"router": bot}
+
+        with patch(
+            "mindroom.approval_transport.expire_orphaned_approval_cards_on_startup",
+            new=AsyncMock(return_value=1),
+        ) as expire_orphaned_approval_cards_on_startup:
+            orchestrator._approval_transport.reset_startup_cleanup_gate()
+            await orchestrator.handle_bot_ready(bot)
+            expire_orphaned_approval_cards_on_startup.assert_not_awaited()
+
+            await orchestrator._approval_transport.mark_startup_runtime_support_ready()
+
+        expire_orphaned_approval_cards_on_startup.assert_awaited_once_with(lookback_hours=240)
+
+    @pytest.mark.asyncio
+    async def test_approval_transport_waits_for_router_ready_before_startup_discard(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Runtime support readiness alone must not discard startup approval cards before router first sync."""
+        orchestrator = _MultiAgentOrchestrator(runtime_paths=TestAgentBot._runtime_paths(tmp_path))
+        orchestrator.config = MagicMock()
+        orchestrator.config.tool_approval.timeout_days = 7.0
+        orchestrator.config.tool_approval.rules = [SimpleNamespace(timeout_days=10.0)]
+
+        bot = MagicMock()
+        bot.agent_name = "router"
+        bot.running = True
+        bot.client = make_matrix_client_mock(user_id="@mindroom_router:localhost")
+        orchestrator.agent_bots = {"router": bot}
+
+        with patch(
+            "mindroom.approval_transport.expire_orphaned_approval_cards_on_startup",
+            new=AsyncMock(return_value=1),
+        ) as expire_orphaned_approval_cards_on_startup:
+            orchestrator._approval_transport.reset_startup_cleanup_gate()
+            await orchestrator._approval_transport.mark_startup_runtime_support_ready()
+            expire_orphaned_approval_cards_on_startup.assert_not_awaited()
+
+            await orchestrator.handle_bot_ready(bot)
+
+        expire_orphaned_approval_cards_on_startup.assert_awaited_once_with(lookback_hours=240)
+
+    @pytest.mark.asyncio
+    async def test_approval_transport_concurrent_startup_gates_discard_once(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Router-ready and runtime-ready races must still run startup discard once."""
+        orchestrator = _MultiAgentOrchestrator(runtime_paths=TestAgentBot._runtime_paths(tmp_path))
+        orchestrator.config = MagicMock()
+        orchestrator.config.tool_approval.timeout_days = 7.0
+        orchestrator.config.tool_approval.rules = []
+
+        bot = MagicMock()
+        bot.agent_name = "router"
+        bot.running = True
+        bot.client = make_matrix_client_mock(user_id="@mindroom_router:localhost")
+        orchestrator.agent_bots = {"router": bot}
+
+        with patch(
+            "mindroom.approval_transport.expire_orphaned_approval_cards_on_startup",
+            new=AsyncMock(return_value=1),
+        ) as expire_orphaned_approval_cards_on_startup:
+            orchestrator._approval_transport.reset_startup_cleanup_gate()
+            await asyncio.gather(
+                orchestrator.handle_bot_ready(bot),
+                orchestrator._approval_transport.mark_startup_runtime_support_ready(),
+            )
+
+        expire_orphaned_approval_cards_on_startup.assert_awaited_once_with(lookback_hours=168)
+
+    @pytest.mark.asyncio
+    async def test_approval_transport_reset_allows_fresh_startup_discard(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A fresh runtime start must be able to run startup discard after the previous run did."""
+        orchestrator = _MultiAgentOrchestrator(runtime_paths=TestAgentBot._runtime_paths(tmp_path))
+        orchestrator.config = MagicMock()
+        orchestrator.config.tool_approval.timeout_days = 7.0
+        orchestrator.config.tool_approval.rules = []
+
+        bot = MagicMock()
+        bot.agent_name = "router"
+        bot.running = True
+        bot.client = make_matrix_client_mock(user_id="@mindroom_router:localhost")
+        orchestrator.agent_bots = {"router": bot}
+
+        with patch(
+            "mindroom.approval_transport.expire_orphaned_approval_cards_on_startup",
+            new=AsyncMock(return_value=1),
+        ) as expire_orphaned_approval_cards_on_startup:
+            orchestrator._approval_transport.reset_startup_cleanup_gate()
+            await orchestrator.handle_bot_ready(bot)
+            await orchestrator._approval_transport.mark_startup_runtime_support_ready()
+
+            orchestrator._approval_transport.reset_startup_cleanup_gate()
+            await orchestrator._approval_transport.mark_startup_runtime_support_ready()
+            await orchestrator.handle_bot_ready(bot)
+
+        assert expire_orphaned_approval_cards_on_startup.await_count == 2
 
     @pytest.mark.asyncio
     async def test_orchestrator_waits_for_homeserver_before_initialize(self, tmp_path: Path) -> None:

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -2248,8 +2248,8 @@ async def test_auto_resume_cap_uses_timestamps_not_room_iteration_order(tmp_path
 
 
 @pytest.mark.asyncio
-async def test_orchestrator_runs_cleanup_and_resume_before_sync_loops(tmp_path: Path) -> None:
-    """Startup should clean stale streams and queue resumes before sync loops begin."""
+async def test_orchestrator_runs_cleanup_and_resume_after_sync_loops(tmp_path: Path) -> None:
+    """Startup should clean stale streams and queue resumes in post-sync maintenance."""
     config = _make_config(tmp_path)
     config.defaults.auto_resume_after_restart = True
     orchestrator = _MultiAgentOrchestrator(runtime_paths=runtime_paths_for(config))
@@ -2272,7 +2272,8 @@ async def test_orchestrator_runs_cleanup_and_resume_before_sync_loops(tmp_path: 
     async def _setup_rooms(_: list[object]) -> None:
         call_order.append("setup")
 
-    async def _cleanup(_: list[object], __: Config) -> list[InterruptedThread]:
+    async def _cleanup(_: list[object], __: Config, startup_cutoff_ms: int | None = None) -> list[InterruptedThread]:
+        assert startup_cutoff_ms is not None
         call_order.append("cleanup")
         return [
             InterruptedThread(
@@ -2292,18 +2293,25 @@ async def test_orchestrator_runs_cleanup_and_resume_before_sync_loops(tmp_path: 
     def _mark_ready() -> None:
         ready.set()
 
+    def _start_sync_task(_: str, __: object) -> None:
+        call_order.append("sync")
+
     with (
         patch("mindroom.orchestrator.wait_for_matrix_homeserver", side_effect=_wait_for_homeserver),
         patch.object(orchestrator, "_setup_rooms_and_memberships", side_effect=_setup_rooms),
         patch.object(orchestrator, "_cleanup_stale_streams_after_restart", side_effect=_cleanup),
         patch.object(orchestrator, "_auto_resume_after_restart", side_effect=_resume),
         patch.object(orchestrator, "_sync_runtime_support_services", new=AsyncMock()),
-        patch("mindroom.orchestrator.sync_forever_with_restart", new=AsyncMock()),
+        patch.object(orchestrator, "_start_sync_task", side_effect=_start_sync_task),
         patch("mindroom.orchestrator.set_runtime_ready", side_effect=_mark_ready),
     ):
         runtime_task = asyncio.create_task(orchestrator.start())
         try:
             await asyncio.wait_for(ready.wait(), timeout=1.0)
+            for _ in range(50):
+                if "resume" in call_order:
+                    break
+                await asyncio.sleep(0.01)
             await orchestrator.stop()
             await asyncio.wait_for(runtime_task, timeout=1.0)
         finally:
@@ -2312,7 +2320,7 @@ async def test_orchestrator_runs_cleanup_and_resume_before_sync_loops(tmp_path: 
                 with suppress(asyncio.CancelledError):
                     await runtime_task
 
-    assert call_order == ["wait", "setup", "cleanup", "resume"]
+    assert call_order == ["wait", "sync", "setup", "cleanup", "resume"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -2265,6 +2265,7 @@ async def test_orchestrator_runs_cleanup_and_resume_after_sync_loops(tmp_path: P
     orchestrator.agent_bots = {ROUTER_AGENT_NAME: router_bot}
 
     call_order: list[str] = []
+    resume_finished = asyncio.Event()
 
     async def _wait_for_homeserver(*_args: object, **_kwargs: object) -> None:
         call_order.append("wait")
@@ -2287,6 +2288,7 @@ async def test_orchestrator_runs_cleanup_and_resume_after_sync_loops(tmp_path: P
 
     async def _resume(_: list[InterruptedThread], __: Config) -> None:
         call_order.append("resume")
+        resume_finished.set()
 
     ready = asyncio.Event()
 
@@ -2308,10 +2310,7 @@ async def test_orchestrator_runs_cleanup_and_resume_after_sync_loops(tmp_path: P
         runtime_task = asyncio.create_task(orchestrator.start())
         try:
             await asyncio.wait_for(ready.wait(), timeout=1.0)
-            for _ in range(50):
-                if "resume" in call_order:
-                    break
-                await asyncio.sleep(0.01)
+            await asyncio.wait_for(resume_finished.wait(), timeout=1.0)
             await orchestrator.stop()
             await asyncio.wait_for(runtime_task, timeout=1.0)
         finally:

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -195,6 +195,7 @@ async def _run_cleanup(
     joined_rooms: list[str],
     bot_user_ids: set[str] | None = None,
     now_ms: int = NOW_MS,
+    startup_cutoff_ms: int | None = None,
 ) -> tuple[int, list[InterruptedThread]]:
     client.user_id = BOT_USER_ID
     with (
@@ -210,6 +211,7 @@ async def _run_cleanup(
             bot_user_ids={BOT_USER_ID} if bot_user_ids is None else bot_user_ids,
             config=config,
             runtime_paths=runtime_paths_for(config),
+            startup_cutoff_ms=startup_cutoff_ms,
         )
 
 
@@ -486,6 +488,54 @@ async def test_cleanup_skips_messages_older_than_restart_window(tmp_path: Path) 
     assert cleaned == 0
     assert interrupted == []
     mock_edit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_skips_streaming_messages_at_or_after_startup_cutoff(tmp_path: Path) -> None:
+    """Post-sync cleanup must ignore messages that could have been created by this process."""
+    config = _make_config(tmp_path)
+    client = AsyncMock(spec=nio.AsyncClient)
+    startup_cutoff_ms = NOW_MS - 120_000
+    before_cutoff_message = _make_message_event(
+        event_id="$before-cutoff",
+        body="Previous process partial",
+        timestamp_ms=startup_cutoff_ms - 1,
+        extra_content={STREAM_STATUS_KEY: "streaming"},
+    )
+    at_cutoff_message = _make_message_event(
+        event_id="$at-cutoff",
+        body="Current process partial",
+        timestamp_ms=startup_cutoff_ms,
+        extra_content={STREAM_STATUS_KEY: "streaming"},
+    )
+    after_cutoff_message = _make_message_event(
+        event_id="$after-cutoff",
+        body="Current process newer partial",
+        timestamp_ms=startup_cutoff_ms + 1,
+        extra_content={STREAM_STATUS_KEY: "streaming"},
+    )
+    client.room_messages.return_value = _room_messages_response(
+        before_cutoff_message,
+        at_cutoff_message,
+        after_cutoff_message,
+    )
+    client.room_get_event_relations = MagicMock(return_value=_aiter())
+
+    with patch(
+        "mindroom.matrix.stale_stream_cleanup.edit_message_result",
+        new=AsyncMock(side_effect=delivered_matrix_side_effect("$edit")),
+    ) as mock_edit:
+        cleaned, interrupted = await _run_cleanup(
+            client,
+            config,
+            joined_rooms=[ROOM_ID],
+            startup_cutoff_ms=startup_cutoff_ms,
+        )
+
+    assert cleaned == 1
+    assert interrupted == []
+    assert mock_edit.await_count == 1
+    assert mock_edit.await_args.args[2] == "$before-cutoff"
 
 
 @pytest.mark.asyncio

--- a/tests/test_startup_maintenance.py
+++ b/tests/test_startup_maintenance.py
@@ -1,0 +1,183 @@
+"""Startup maintenance controller tests."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mindroom.startup_maintenance import StartupMaintenanceController
+
+
+async def _wait_for_controller(controller: StartupMaintenanceController) -> None:
+    task = controller.task
+    assert task is not None
+    await task
+
+
+@pytest.mark.asyncio
+async def test_startup_maintenance_runs_phases_in_order_and_passes_cutoff() -> None:
+    """Maintenance phases run in order and pass cutoff into stale cleanup."""
+    call_order: list[str] = []
+    bots = [MagicMock()]
+    config = MagicMock()
+    interrupted_threads = [MagicMock()]
+
+    async def setup_rooms(started_bots: list[object]) -> None:
+        assert started_bots == bots
+        call_order.append("setup")
+
+    async def cleanup_stale(started_bots: list[object], cleanup_config: object, startup_cutoff_ms: int) -> list[object]:
+        assert started_bots == bots
+        assert cleanup_config is config
+        assert startup_cutoff_ms == 123456
+        call_order.append("cleanup")
+        return interrupted_threads
+
+    async def auto_resume(cleaned_threads: list[object], resume_config: object) -> None:
+        assert cleaned_threads == interrupted_threads
+        assert resume_config is config
+        call_order.append("resume")
+
+    async def sync_runtime_support(sync_config: object) -> None:
+        assert sync_config is config
+        call_order.append("support")
+
+    async def mark_runtime_support_ready() -> None:
+        call_order.append("approval_ready")
+
+    controller = StartupMaintenanceController(
+        setup_rooms_and_memberships=setup_rooms,
+        cleanup_stale_streams=cleanup_stale,
+        auto_resume=auto_resume,
+        sync_runtime_support=sync_runtime_support,
+        mark_runtime_support_ready=mark_runtime_support_ready,
+    )
+
+    controller.start(bots, config, startup_cutoff_ms=123456)
+    await _wait_for_controller(controller)
+
+    assert call_order == ["setup", "cleanup", "resume", "support", "approval_ready"]
+
+
+@pytest.mark.asyncio
+async def test_startup_maintenance_continues_after_failed_room_setup() -> None:
+    """Later phases still run after room setup fails."""
+    call_order: list[str] = []
+
+    async def setup_rooms(_: list[object]) -> None:
+        call_order.append("setup")
+        msg = "room setup failed"
+        raise RuntimeError(msg)
+
+    async def cleanup_stale(_: list[object], __: object, ___: int) -> list[object]:
+        call_order.append("cleanup")
+        return []
+
+    async def auto_resume(_: list[object], __: object) -> None:
+        call_order.append("resume")
+
+    async def sync_runtime_support(_: object) -> None:
+        call_order.append("support")
+
+    async def mark_runtime_support_ready() -> None:
+        call_order.append("approval_ready")
+
+    controller = StartupMaintenanceController(
+        setup_rooms_and_memberships=setup_rooms,
+        cleanup_stale_streams=cleanup_stale,
+        auto_resume=auto_resume,
+        sync_runtime_support=sync_runtime_support,
+        mark_runtime_support_ready=mark_runtime_support_ready,
+    )
+
+    controller.start([MagicMock()], MagicMock(), startup_cutoff_ms=123456)
+    await _wait_for_controller(controller)
+
+    assert call_order == ["setup", "cleanup", "resume", "support", "approval_ready"]
+
+
+@pytest.mark.asyncio
+async def test_startup_maintenance_cancel_reports_unfinished_and_replays_with_running_bots() -> None:
+    """Canceling unfinished maintenance reports replay and reuses fresh running bots."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def setup_rooms(_: list[object]) -> None:
+        started.set()
+        await release.wait()
+
+    controller = StartupMaintenanceController(
+        setup_rooms_and_memberships=setup_rooms,
+        cleanup_stale_streams=AsyncMock(return_value=[]),
+        auto_resume=AsyncMock(),
+        sync_runtime_support=AsyncMock(),
+        mark_runtime_support_ready=AsyncMock(),
+    )
+
+    controller.start([MagicMock()], MagicMock(), startup_cutoff_ms=123456)
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    should_replay = await controller.cancel()
+
+    assert should_replay is True
+
+    running_bot = MagicMock()
+
+    def running_bots() -> list[object]:
+        return [running_bot]
+
+    replay_config = MagicMock()
+    with patch.object(controller, "start") as start:
+        controller.restart_after_config_reload(
+            config=replay_config,
+            running_bots=running_bots,
+        )
+
+    start.assert_called_once_with([running_bot], replay_config, startup_cutoff_ms=123456)
+    release.set()
+
+
+@pytest.mark.asyncio
+async def test_startup_maintenance_cancel_completed_task_returns_false() -> None:
+    """Canceling completed maintenance does not request replay."""
+    controller = StartupMaintenanceController(
+        setup_rooms_and_memberships=AsyncMock(),
+        cleanup_stale_streams=AsyncMock(return_value=[]),
+        auto_resume=AsyncMock(),
+        sync_runtime_support=AsyncMock(),
+        mark_runtime_support_ready=AsyncMock(),
+    )
+
+    controller.start([MagicMock()], MagicMock(), startup_cutoff_ms=123456)
+    await _wait_for_controller(controller)
+
+    should_replay = await controller.cancel()
+
+    assert should_replay is False
+    with patch.object(controller, "start") as start:
+        if should_replay:
+            controller.restart_after_config_reload(config=MagicMock(), running_bots=lambda: [MagicMock()])
+    start.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_startup_maintenance_runtime_support_failure_skips_approval_ready_marker() -> None:
+    """Runtime-support failure prevents approval cleanup ready marker."""
+    mark_runtime_support_ready = AsyncMock()
+
+    async def sync_runtime_support(_: object) -> None:
+        msg = "support failed"
+        raise RuntimeError(msg)
+
+    controller = StartupMaintenanceController(
+        setup_rooms_and_memberships=AsyncMock(),
+        cleanup_stale_streams=AsyncMock(return_value=[]),
+        auto_resume=AsyncMock(),
+        sync_runtime_support=sync_runtime_support,
+        mark_runtime_support_ready=mark_runtime_support_ready,
+    )
+
+    controller.start([MagicMock()], MagicMock(), startup_cutoff_ms=123456)
+    await _wait_for_controller(controller)
+
+    mark_runtime_support_ready.assert_not_awaited()

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -912,6 +912,76 @@ async def test_start_runtime_waits_for_shutdown_after_initial_sync_generation_ex
 
 
 @pytest.mark.asyncio
+async def test_start_runtime_starts_sync_before_startup_maintenance_completes(tmp_path: Path) -> None:
+    """Initial sync loops must not wait for room reconciliation or restart maintenance."""
+    orchestrator = _MultiAgentOrchestrator(runtime_paths=orchestrator_runtime_paths(tmp_path))
+
+    config = MagicMock(spec=Config)
+    config.agents = {"general": MagicMock()}
+    config.teams = {}
+    config.mcp_servers = {}
+    config.cache = MagicMock()
+    config.cache.resolve_db_path.return_value = tmp_path / "event_cache.db"
+    orchestrator.config = config
+
+    router_bot = AsyncMock()
+    router_bot.agent_name = "router"
+    router_bot.running = True
+    router_bot.stop = AsyncMock()
+
+    general_bot = AsyncMock()
+    general_bot.agent_name = "general"
+    general_bot.running = True
+    general_bot.stop = AsyncMock()
+
+    orchestrator.agent_bots = {"router": router_bot, "general": general_bot}
+
+    setup_started = asyncio.Event()
+    setup_can_finish = asyncio.Event()
+    sync_started = asyncio.Event()
+    call_order: list[str] = []
+
+    async def blocked_setup(_: list[object]) -> None:
+        call_order.append("setup_started")
+        setup_started.set()
+        await setup_can_finish.wait()
+        call_order.append("setup_finished")
+
+    def start_sync_task(entity_name: str, _bot: object) -> None:
+        call_order.append(f"sync_started:{entity_name}")
+        sync_started.set()
+
+    with (
+        patch("mindroom.orchestrator.wait_for_matrix_homeserver", new=AsyncMock()),
+        patch.object(orchestrator, "_start_router_bot", new=AsyncMock(return_value=router_bot)),
+        patch.object(
+            orchestrator,
+            "_start_entities_once",
+            new=AsyncMock(return_value=EntityStartResults(started_bots=[general_bot])),
+        ),
+        patch.object(orchestrator, "_setup_rooms_and_memberships", side_effect=blocked_setup),
+        patch.object(orchestrator, "_cleanup_stale_streams_after_restart", new=AsyncMock(return_value=[])),
+        patch.object(orchestrator, "_auto_resume_after_restart", new=AsyncMock()),
+        patch.object(orchestrator, "_sync_runtime_support_services", new=AsyncMock()),
+        patch.object(orchestrator, "_start_sync_task", side_effect=start_sync_task),
+    ):
+        runtime_task = asyncio.create_task(orchestrator._start_runtime())
+        try:
+            await asyncio.wait_for(setup_started.wait(), timeout=1.0)
+            await asyncio.wait_for(sync_started.wait(), timeout=0.1)
+
+            assert "setup_finished" not in call_order
+            assert any(item.startswith("sync_started:") for item in call_order)
+        finally:
+            setup_can_finish.set()
+            await orchestrator.stop()
+            if not runtime_task.done():
+                runtime_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await asyncio.wait_for(runtime_task, timeout=1.0)
+
+
+@pytest.mark.asyncio
 @pytest.mark.requires_matrix  # Requires real Matrix server for sync task management
 @pytest.mark.timeout(10)  # Add timeout to prevent hanging on real server connection
 async def test_orchestrator_update_config_cancels_old_tasks(tmp_path: Path) -> None:

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -939,7 +939,10 @@ async def test_start_runtime_starts_sync_before_startup_maintenance_completes(tm
 
     setup_started = asyncio.Event()
     setup_can_finish = asyncio.Event()
-    sync_started = asyncio.Event()
+    sync_started_by_entity = {
+        "router": asyncio.Event(),
+        "general": asyncio.Event(),
+    }
     call_order: list[str] = []
 
     async def blocked_setup(_: list[object]) -> None:
@@ -950,7 +953,7 @@ async def test_start_runtime_starts_sync_before_startup_maintenance_completes(tm
 
     def start_sync_task(entity_name: str, _bot: object) -> None:
         call_order.append(f"sync_started:{entity_name}")
-        sync_started.set()
+        sync_started_by_entity[entity_name].set()
 
     with (
         patch("mindroom.orchestrator.wait_for_matrix_homeserver", new=AsyncMock()),
@@ -969,10 +972,13 @@ async def test_start_runtime_starts_sync_before_startup_maintenance_completes(tm
         runtime_task = asyncio.create_task(orchestrator._start_runtime())
         try:
             await asyncio.wait_for(setup_started.wait(), timeout=1.0)
-            await asyncio.wait_for(sync_started.wait(), timeout=0.1)
+            await asyncio.wait_for(
+                asyncio.gather(*(event.wait() for event in sync_started_by_entity.values())),
+                timeout=1.0,
+            )
 
             assert "setup_finished" not in call_order
-            assert any(item.startswith("sync_started:") for item in call_order)
+            assert {"sync_started:router", "sync_started:general"} <= set(call_order)
         finally:
             setup_can_finish.set()
             await orchestrator.stop()
@@ -1019,34 +1025,41 @@ async def test_update_config_replays_cancelled_startup_maintenance_and_runs_appr
         await maintenance_released.wait()
 
     old_maintenance_task = asyncio.create_task(blocked_startup_maintenance())
-    orchestrator._startup_maintenance.task = old_maintenance_task
-    await asyncio.wait_for(maintenance_started.wait(), timeout=1.0)
+    try:
+        orchestrator._startup_maintenance.task = old_maintenance_task
+        await asyncio.wait_for(maintenance_started.wait(), timeout=1.0)
 
-    def replay_startup_maintenance(bots: list[object], config: object, *, startup_cutoff_ms: int) -> None:
-        replayed.append((bots, config, startup_cutoff_ms))
+        def replay_startup_maintenance(bots: list[object], config: object, *, startup_cutoff_ms: int) -> None:
+            replayed.append((bots, config, startup_cutoff_ms))
 
-    with (
-        patch("mindroom.orchestrator.load_config", return_value=new_config),
-        patch("mindroom.orchestrator.build_config_update_plan", return_value=plan),
-        patch.object(orchestrator, "_stop_entities_before_mcp_sync", new=AsyncMock(return_value=set())),
-        patch.object(orchestrator, "_sync_mcp_manager", new=AsyncMock(return_value=set())),
-        patch.object(orchestrator, "_sync_event_cache_service", new=AsyncMock()),
-        patch.object(orchestrator, "_sync_runtime_support_services", new=AsyncMock()),
-        patch.object(orchestrator, "_update_unchanged_bots", new=AsyncMock()),
-        patch.object(orchestrator, "_emit_config_reloaded", new=AsyncMock()),
-        patch.object(orchestrator._startup_maintenance, "start", side_effect=replay_startup_maintenance),
-        patch.object(
-            orchestrator._approval_transport,
-            "mark_startup_runtime_support_ready",
-            new=AsyncMock(),
-        ) as mark_startup_runtime_support_ready,
-    ):
-        updated = await orchestrator.update_config()
+        with (
+            patch("mindroom.orchestrator.load_config", return_value=new_config),
+            patch("mindroom.orchestrator.build_config_update_plan", return_value=plan),
+            patch.object(orchestrator, "_stop_entities_before_mcp_sync", new=AsyncMock(return_value=set())),
+            patch.object(orchestrator, "_sync_mcp_manager", new=AsyncMock(return_value=set())),
+            patch.object(orchestrator, "_sync_event_cache_service", new=AsyncMock()),
+            patch.object(orchestrator, "_sync_runtime_support_services", new=AsyncMock()),
+            patch.object(orchestrator, "_update_unchanged_bots", new=AsyncMock()),
+            patch.object(orchestrator, "_emit_config_reloaded", new=AsyncMock()),
+            patch.object(orchestrator._startup_maintenance, "start", side_effect=replay_startup_maintenance),
+            patch.object(
+                orchestrator._approval_transport,
+                "mark_startup_runtime_support_ready",
+                new=AsyncMock(),
+            ) as mark_startup_runtime_support_ready,
+        ):
+            updated = await orchestrator.update_config()
 
-    assert updated is False
-    assert old_maintenance_task.cancelled()
-    assert replayed == [([router_bot], new_config, 123456)]
-    mark_startup_runtime_support_ready.assert_awaited_once()
+        assert updated is False
+        assert old_maintenance_task.cancelled()
+        assert replayed == [([router_bot], new_config, 123456)]
+        mark_startup_runtime_support_ready.assert_awaited_once()
+    finally:
+        maintenance_released.set()
+        if not old_maintenance_task.done():
+            old_maintenance_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await old_maintenance_task
 
 
 def test_running_startup_maintenance_bots_returns_router_first(tmp_path: Path) -> None:

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -1049,6 +1049,26 @@ async def test_update_config_replays_cancelled_startup_maintenance_and_runs_appr
     mark_startup_runtime_support_ready.assert_awaited_once()
 
 
+def test_running_startup_maintenance_bots_returns_router_first(tmp_path: Path) -> None:
+    """Startup maintenance replay should keep router before other running bots."""
+    orchestrator = _MultiAgentOrchestrator(runtime_paths=orchestrator_runtime_paths(tmp_path))
+
+    router_bot = MagicMock()
+    router_bot.running = True
+    general_bot = MagicMock()
+    general_bot.running = True
+    stopped_bot = MagicMock()
+    stopped_bot.running = False
+
+    orchestrator.agent_bots = {
+        "general": general_bot,
+        "stopped": stopped_bot,
+        "router": router_bot,
+    }
+
+    assert orchestrator._running_startup_maintenance_bots() == [router_bot, general_bot]
+
+
 @pytest.mark.asyncio
 @pytest.mark.requires_matrix  # Requires real Matrix server for sync task management
 @pytest.mark.timeout(10)  # Add timeout to prevent hanging on real server connection

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -17,6 +17,7 @@ from mindroom.config.main import Config
 from mindroom.constants import RuntimePaths
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.orchestration import runtime as runtime_helpers
+from mindroom.orchestration.config_updates import ConfigUpdatePlan
 from mindroom.orchestration.runtime import (
     EntityStartResults,
     _MatrixSyncStalledError,
@@ -874,8 +875,12 @@ async def test_start_runtime_waits_for_shutdown_after_initial_sync_generation_ex
     async def completed_sync_supervisor() -> None:
         return None
 
+    sync_tasks_started = asyncio.Event()
+
     def start_completed_sync_task(entity_name: str, _bot: object) -> None:
         orchestrator._sync_tasks[entity_name] = asyncio.create_task(completed_sync_supervisor())
+        if set(orchestrator._sync_tasks) == {"router", "general"}:
+            sync_tasks_started.set()
 
     with (
         patch("mindroom.orchestrator.wait_for_matrix_homeserver", new=AsyncMock()),
@@ -893,11 +898,7 @@ async def test_start_runtime_waits_for_shutdown_after_initial_sync_generation_ex
     ):
         runtime_task = asyncio.create_task(orchestrator._start_runtime())
         try:
-            for _ in range(50):
-                if set(orchestrator._sync_tasks) == {"router", "general"}:
-                    break
-                await asyncio.sleep(0.01)
-
+            await asyncio.wait_for(sync_tasks_started.wait(), timeout=1.0)
             assert set(orchestrator._sync_tasks) == {"router", "general"}
             await asyncio.sleep(0)
             assert not runtime_task.done()
@@ -979,6 +980,70 @@ async def test_start_runtime_starts_sync_before_startup_maintenance_completes(tm
                 runtime_task.cancel()
             with suppress(asyncio.CancelledError):
                 await asyncio.wait_for(runtime_task, timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_update_config_replays_cancelled_startup_maintenance_and_runs_approval_cleanup(tmp_path: Path) -> None:
+    """Hot reload during startup maintenance must not lose one-shot restart cleanup."""
+    orchestrator = _MultiAgentOrchestrator(runtime_paths=orchestrator_runtime_paths(tmp_path))
+    current_config = Config()
+    new_config = Config()
+
+    plan = ConfigUpdatePlan(
+        new_config=new_config,
+        changed_mcp_servers=set(),
+        configured_entities=set(),
+        entities_to_restart=set(),
+        new_entities=set(),
+        removed_entities=set(),
+        mindroom_user_changed=False,
+        matrix_room_access_changed=False,
+        matrix_space_changed=False,
+        authorization_changed=False,
+    )
+
+    router_bot = MagicMock()
+    router_bot.agent_name = "router"
+    router_bot.running = True
+    orchestrator.agent_bots = {"router": router_bot}
+    orchestrator.config = current_config
+    orchestrator.running = True
+    orchestrator._startup_cutoff_ms = 123456
+    orchestrator._startup_router_ready_for_approval_cleanup = True
+
+    maintenance_started = asyncio.Event()
+    maintenance_released = asyncio.Event()
+    replayed: list[tuple[list[object], object, int]] = []
+
+    async def blocked_startup_maintenance() -> None:
+        maintenance_started.set()
+        await maintenance_released.wait()
+
+    old_maintenance_task = asyncio.create_task(blocked_startup_maintenance())
+    orchestrator._startup_maintenance_task = old_maintenance_task
+    await asyncio.wait_for(maintenance_started.wait(), timeout=1.0)
+
+    def replay_startup_maintenance(bots: list[object], config: object, startup_cutoff_ms: int) -> None:
+        replayed.append((bots, config, startup_cutoff_ms))
+
+    with (
+        patch("mindroom.orchestrator.load_config", return_value=new_config),
+        patch("mindroom.orchestrator.build_config_update_plan", return_value=plan),
+        patch.object(orchestrator, "_stop_entities_before_mcp_sync", new=AsyncMock(return_value=set())),
+        patch.object(orchestrator, "_sync_mcp_manager", new=AsyncMock(return_value=set())),
+        patch.object(orchestrator, "_sync_event_cache_service", new=AsyncMock()),
+        patch.object(orchestrator, "_sync_runtime_support_services", new=AsyncMock()),
+        patch.object(orchestrator, "_update_unchanged_bots", new=AsyncMock()),
+        patch.object(orchestrator, "_emit_config_reloaded", new=AsyncMock()),
+        patch.object(orchestrator, "_start_startup_maintenance", side_effect=replay_startup_maintenance),
+        patch.object(orchestrator._approval_transport, "handle_bot_ready", new=AsyncMock()) as handle_bot_ready,
+    ):
+        updated = await orchestrator.update_config()
+
+    assert updated is False
+    assert old_maintenance_task.cancelled()
+    assert replayed == [([router_bot], new_config, 123456)]
+    handle_bot_ready.assert_awaited_once_with(router_bot)
 
 
 @pytest.mark.asyncio

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -1008,8 +1008,7 @@ async def test_update_config_replays_cancelled_startup_maintenance_and_runs_appr
     orchestrator.agent_bots = {"router": router_bot}
     orchestrator.config = current_config
     orchestrator.running = True
-    orchestrator._startup_cutoff_ms = 123456
-    orchestrator._startup_router_ready_for_approval_cleanup = True
+    orchestrator._startup_maintenance.startup_cutoff_ms = 123456
 
     maintenance_started = asyncio.Event()
     maintenance_released = asyncio.Event()
@@ -1020,10 +1019,10 @@ async def test_update_config_replays_cancelled_startup_maintenance_and_runs_appr
         await maintenance_released.wait()
 
     old_maintenance_task = asyncio.create_task(blocked_startup_maintenance())
-    orchestrator._startup_maintenance_task = old_maintenance_task
+    orchestrator._startup_maintenance.task = old_maintenance_task
     await asyncio.wait_for(maintenance_started.wait(), timeout=1.0)
 
-    def replay_startup_maintenance(bots: list[object], config: object, startup_cutoff_ms: int) -> None:
+    def replay_startup_maintenance(bots: list[object], config: object, *, startup_cutoff_ms: int) -> None:
         replayed.append((bots, config, startup_cutoff_ms))
 
     with (
@@ -1035,15 +1034,19 @@ async def test_update_config_replays_cancelled_startup_maintenance_and_runs_appr
         patch.object(orchestrator, "_sync_runtime_support_services", new=AsyncMock()),
         patch.object(orchestrator, "_update_unchanged_bots", new=AsyncMock()),
         patch.object(orchestrator, "_emit_config_reloaded", new=AsyncMock()),
-        patch.object(orchestrator, "_start_startup_maintenance", side_effect=replay_startup_maintenance),
-        patch.object(orchestrator._approval_transport, "handle_bot_ready", new=AsyncMock()) as handle_bot_ready,
+        patch.object(orchestrator._startup_maintenance, "start", side_effect=replay_startup_maintenance),
+        patch.object(
+            orchestrator._approval_transport,
+            "mark_startup_runtime_support_ready",
+            new=AsyncMock(),
+        ) as mark_startup_runtime_support_ready,
     ):
         updated = await orchestrator.update_config()
 
     assert updated is False
     assert old_maintenance_task.cancelled()
     assert replayed == [([router_bot], new_config, 123456)]
-    handle_bot_ready.assert_awaited_once_with(router_bot)
+    mark_startup_runtime_support_ready.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- start Matrix sync loops once bots have minimal runtime bindings, before room reconciliation and other slow maintenance
- move room setup, stale stream cleanup, auto-resume, and runtime background services into detached startup maintenance
- add a startup cutoff to stale-stream cleanup so post-sync cleanup ignores messages created by the current process

## Test Plan
- uv run pytest tests/test_stale_stream_cleanup.py -n auto
- uv run pytest -n auto
- uv run pre-commit run --all-files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Startup cleanup now ignores messages created at-or-after a startup cutoff to avoid editing streams produced during startup.
  * Startup maintenance and recovery sequencing made more robust to prevent premature cleanup or missed recoveries; approval discard is gated to avoid running too early.

* **New Features**
  * One-shot gated startup discard for orphaned approval cards, with resettable gates for subsequent restarts.

* **Tests**
  * Added and adjusted tests for startup cutoff behavior, startup ordering, approval-gating, and timing-sensitive message coalescing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->