### PR TITLE
fix(memory): keep semantic file indexing off request path

### DIFF
--- a/src/mindroom/config/knowledge.py
+++ b/src/mindroom/config/knowledge.py
@@ -4,9 +4,15 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator, model_validator
+
+from mindroom.path_globs import validate_safe_relative_pattern
 
 KnowledgeBaseMode = Literal["semantic", "files"]
+
+
+def _validate_relative_patterns(value: list[str], *, field_name: str) -> list[str]:
+    return [validate_safe_relative_pattern(pattern, field_name=field_name) for pattern in value]
 
 
 class KnowledgeGitConfig(BaseModel):
@@ -47,6 +53,12 @@ class KnowledgeGitConfig(BaseModel):
         description="Optional root-anchored glob patterns to exclude after include filtering",
     )
 
+    @field_validator("include_patterns", "exclude_patterns")
+    @classmethod
+    def validate_include_patterns(cls, value: list[str], info: ValidationInfo) -> list[str]:
+        """Validate include and exclude patterns stay inside the knowledge root."""
+        return _validate_relative_patterns(value, field_name=f"knowledge_bases.git.{info.field_name}")
+
 
 class KnowledgeBaseConfig(BaseModel):
     """Knowledge base configuration."""
@@ -85,10 +97,24 @@ class KnowledgeBaseConfig(BaseModel):
         default_factory=list,
         description="Optional file extensions to exclude from indexing after include filtering",
     )
+    include_patterns: list[str] = Field(
+        default_factory=list,
+        description="Optional root-anchored glob patterns to include before extension filtering",
+    )
+    exclude_patterns: list[str] = Field(
+        default_factory=list,
+        description="Optional root-anchored glob patterns to exclude after include filtering",
+    )
     git: KnowledgeGitConfig | None = Field(
         default=None,
         description="Optional Git sync configuration for this knowledge base",
     )
+
+    @field_validator("include_patterns", "exclude_patterns")
+    @classmethod
+    def validate_include_patterns(cls, value: list[str], info: ValidationInfo) -> list[str]:
+        """Validate include and exclude patterns stay inside the knowledge root."""
+        return _validate_relative_patterns(value, field_name=f"knowledge_bases.{info.field_name}")
 
     @field_validator("include_extensions", "exclude_extensions")
     @classmethod

--- a/src/mindroom/knowledge/__init__.py
+++ b/src/mindroom/knowledge/__init__.py
@@ -2,20 +2,26 @@
 
 # ruff: noqa: RUF022
 
+from mindroom.knowledge.manager import list_knowledge_files
 from mindroom.knowledge.refresh_scheduler import KnowledgeRefreshScheduler
 from mindroom.knowledge.status import reconcile_knowledge_mode_transition_states
 from mindroom.knowledge.utils import (
     KnowledgeAccessSupport,
     KnowledgeAvailabilityDetail,
+    KnowledgeBaseAccessResolution,
     format_knowledge_availability_notice,
     resolve_agent_knowledge_access,
+    resolve_knowledge_base_access,
 )
 
 __all__ = [
     "KnowledgeAccessSupport",
+    "KnowledgeBaseAccessResolution",
     "KnowledgeAvailabilityDetail",
     "format_knowledge_availability_notice",
     "KnowledgeRefreshScheduler",
+    "list_knowledge_files",
     "reconcile_knowledge_mode_transition_states",
     "resolve_agent_knowledge_access",
+    "resolve_knowledge_base_access",
 ]

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -71,6 +71,7 @@ _INDEXING_STATUSES = {
     _INDEXING_STATUS_COMPLETE,
 }
 _INDEXING_MODES: set[str] = {"semantic", "files"}
+_GLOB_CHARS = frozenset("*?[")
 _TEXT_LIKE_EXTENSIONS = {
     ".md",
     ".markdown",
@@ -148,13 +149,15 @@ class IndexingSettings:
     git_skip_hidden: str
     git_include_patterns: str
     git_exclude_patterns: str
+    include_patterns: str
+    exclude_patterns: str
     include_extensions: str
     exclude_extensions: str
 
     @classmethod
     def from_metadata(cls, settings: Mapping[str, str]) -> IndexingSettings | None:
         """Build typed settings from the persisted JSON object."""
-        if set(settings) != {
+        required_keys = {
             "base_id",
             "storage_root",
             "knowledge_path",
@@ -173,7 +176,9 @@ class IndexingSettings:
             "git_exclude_patterns",
             "include_extensions",
             "exclude_extensions",
-        }:
+        }
+        optional_keys = {"include_patterns", "exclude_patterns"}
+        if not required_keys.issubset(settings) or set(settings) - required_keys - optional_keys:
             return None
         mode = settings["mode"]
         if mode not in _INDEXING_MODES:
@@ -195,6 +200,8 @@ class IndexingSettings:
             git_skip_hidden=settings["git_skip_hidden"],
             git_include_patterns=settings["git_include_patterns"],
             git_exclude_patterns=settings["git_exclude_patterns"],
+            include_patterns=settings.get("include_patterns", ""),
+            exclude_patterns=settings.get("exclude_patterns", ""),
             include_extensions=settings["include_extensions"],
             exclude_extensions=settings["exclude_extensions"],
         )
@@ -218,6 +225,8 @@ class IndexingSettings:
             "git_skip_hidden": self.git_skip_hidden,
             "git_include_patterns": self.git_include_patterns,
             "git_exclude_patterns": self.git_exclude_patterns,
+            "include_patterns": self.include_patterns,
+            "exclude_patterns": self.exclude_patterns,
             "include_extensions": self.include_extensions,
             "exclude_extensions": self.exclude_extensions,
         }
@@ -235,7 +244,9 @@ class IndexingSettings:
             self.embedder_dimensions,
         )
 
-    def corpus_compatibility_key(self) -> tuple[str, str, str, str, str, str, str, str, str, str, str, str]:
+    def corpus_compatibility_key(
+        self,
+    ) -> tuple[str, str, str, str, str, str, str, str, str, str, str, str, str, str]:
         """Return fields that must match for safe source-corpus reuse."""
         return (
             self.base_id,
@@ -248,6 +259,8 @@ class IndexingSettings:
             self.git_skip_hidden,
             self.git_include_patterns,
             self.git_exclude_patterns,
+            self.include_patterns,
+            self.exclude_patterns,
             self.include_extensions,
             self.exclude_extensions,
         )
@@ -307,6 +320,12 @@ class _PersistedIndexState:
 @dataclass
 class _CandidatePublishState:
     index_published: bool = False
+
+
+@dataclass(frozen=True)
+class _ListingTarget:
+    path: Path
+    mode: Literal["file", "dir", "walk"]
 
 
 def _raise_cancelled() -> NoReturn:
@@ -387,6 +406,48 @@ def _filter_settings_key(values: Iterable[str]) -> str:
     return str(tuple(sorted(values)))
 
 
+def _split_pattern_parts(pattern: str) -> tuple[str, ...]:
+    normalized = pattern.replace("\\", "/").strip().removeprefix("./").strip("/")
+    if not normalized:
+        return ()
+    return tuple(part for part in normalized.split("/") if part and part != ".")
+
+
+def _part_has_glob(part: str) -> bool:
+    return any(char in part for char in _GLOB_CHARS)
+
+
+def _listing_targets_for_pattern(resolved_root: Path, pattern: str) -> list[_ListingTarget]:
+    parts = _split_pattern_parts(pattern)
+    if not parts:
+        return []
+    first_glob_index = next((index for index, part in enumerate(parts) if _part_has_glob(part)), len(parts))
+    if first_glob_index == len(parts):
+        return [_ListingTarget(resolved_root.joinpath(*parts), "file")]
+
+    base = resolved_root.joinpath(*parts[:first_glob_index]) if first_glob_index else resolved_root
+    remaining_parts = parts[first_glob_index:]
+    if len(remaining_parts) == 1 and remaining_parts[0] != "**":
+        return [_ListingTarget(base, "dir")]
+    return [_ListingTarget(base, "walk")]
+
+
+def _listing_targets(resolved_root: Path, patterns: list[str]) -> list[_ListingTarget]:
+    if not patterns:
+        return [_ListingTarget(resolved_root, "walk")]
+
+    deduped: list[_ListingTarget] = []
+    seen: set[tuple[Path, str]] = set()
+    for pattern in patterns:
+        for target in _listing_targets_for_pattern(resolved_root, pattern):
+            key = (target.path, target.mode)
+            if key in seen:
+                continue
+            seen.add(key)
+            deduped.append(target)
+    return deduped
+
+
 def _indexing_settings_key(config: Config, storage_path: Path, base_id: str, knowledge_path: Path) -> IndexingSettings:
     base_config = config.get_knowledge_base_config(base_id)
     git_config = base_config.git
@@ -430,6 +491,8 @@ def _indexing_settings_key(config: Config, storage_path: Path, base_id: str, kno
         git_skip_hidden=str(git_config.skip_hidden) if git_config is not None else "",
         git_include_patterns=_filter_settings_key(git_config.include_patterns) if git_config is not None else "",
         git_exclude_patterns=_filter_settings_key(git_config.exclude_patterns) if git_config is not None else "",
+        include_patterns=_filter_settings_key(base_config.include_patterns),
+        exclude_patterns=_filter_settings_key(base_config.exclude_patterns),
         include_extensions=include_extensions,
         exclude_extensions=exclude_extensions,
     )
@@ -568,6 +631,13 @@ def _include_knowledge_relative_path(config: Config, base_id: str, relative_path
         return False
 
     base_config = config.get_knowledge_base_config(base_id)
+    if base_config.include_patterns and not any(
+        matches_root_glob(relative_path, pattern) for pattern in base_config.include_patterns
+    ):
+        return False
+    if any(matches_root_glob(relative_path, pattern) for pattern in base_config.exclude_patterns):
+        return False
+
     git_config = base_config.git
     if git_config is not None and git_config.skip_hidden and _is_hidden_relative_path(path_obj):
         return False
@@ -575,12 +645,11 @@ def _include_knowledge_relative_path(config: Config, base_id: str, relative_path
     if git_config is None:
         return True
 
-    if git_config.include_patterns and not any(
+    git_included = not git_config.include_patterns or any(
         matches_root_glob(relative_path, pattern) for pattern in git_config.include_patterns
-    ):
-        return False
-
-    return not any(matches_root_glob(relative_path, pattern) for pattern in git_config.exclude_patterns)
+    )
+    git_excluded = any(matches_root_glob(relative_path, pattern) for pattern in git_config.exclude_patterns)
+    return git_included and not git_excluded
 
 
 def include_semantic_knowledge_relative_path(config: Config, base_id: str, relative_path: str) -> bool:
@@ -641,6 +710,53 @@ def _include_knowledge_file(config: Config, base_id: str, knowledge_root: Path, 
     return include_knowledge_relative_path(config, base_id, relative_path.as_posix())
 
 
+def _add_listed_knowledge_file(
+    config: Config,
+    base_id: str,
+    root: Path,
+    path: Path,
+    *,
+    files: list[Path],
+    seen_paths: set[Path],
+) -> None:
+    if not _include_knowledge_file(config, base_id, root, path):
+        return
+    resolved_path = path.resolve()
+    if resolved_path in seen_paths:
+        return
+    seen_paths.add(resolved_path)
+    files.append(resolved_path)
+
+
+def _collect_listing_target_files(
+    config: Config,
+    base_id: str,
+    root: Path,
+    target: _ListingTarget,
+    *,
+    files: list[Path],
+    seen_paths: set[Path],
+) -> None:
+    def add_file(path: Path) -> None:
+        _add_listed_knowledge_file(config, base_id, root, path, files=files, seen_paths=seen_paths)
+
+    if target.mode == "file":
+        add_file(target.path)
+        return
+    if not target.path.is_dir() or _path_is_symlink_or_under_symlink(root, target.path):
+        return
+    if target.mode == "dir":
+        for path in target.path.iterdir():
+            if path.is_file():
+                add_file(path)
+        return
+    for dirpath, dirnames, filenames in os.walk(target.path, followlinks=False):
+        current_dir = Path(dirpath)
+        dirnames[:] = [dirname for dirname in dirnames if not (current_dir / dirname).is_symlink()]
+        for filename in filenames:
+            add_file(current_dir / filename)
+
+
 def list_knowledge_files(config: Config, base_id: str, knowledge_root: Path) -> list[Path]:
     """List managed files without constructing a knowledge manager."""
     root = knowledge_root.resolve()
@@ -648,13 +764,10 @@ def list_knowledge_files(config: Config, base_id: str, knowledge_root: Path) -> 
         return []
 
     files: list[Path] = []
-    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
-        current_dir = Path(dirpath)
-        dirnames[:] = [dirname for dirname in dirnames if not (current_dir / dirname).is_symlink()]
-        for filename in filenames:
-            path = current_dir / filename
-            if _include_knowledge_file(config, base_id, root, path):
-                files.append(path)
+    seen_paths: set[Path] = set()
+    include_patterns = config.get_knowledge_base_config(base_id).include_patterns
+    for target in _listing_targets(root, include_patterns):
+        _collect_listing_target_files(config, base_id, root, target, files=files, seen_paths=seen_paths)
     return sorted(files)
 
 

--- a/src/mindroom/knowledge/utils.py
+++ b/src/mindroom/knowledge/utils.py
@@ -60,6 +60,14 @@ class _KnowledgeResolution:
     unavailable: Mapping[str, KnowledgeAvailabilityDetail] = field(default_factory=dict)
 
 
+@dataclass(frozen=True)
+class KnowledgeBaseAccessResolution:
+    """Resolved access for one configured knowledge base."""
+
+    knowledge: Knowledge | None
+    availability: KnowledgeAvailability
+
+
 class _KnowledgeVectorDb(Protocol):
     """Subset of vector DB interface this module requires."""
 
@@ -428,6 +436,29 @@ def resolve_agent_knowledge_access(
         missing=tuple(missing_base_ids),
         unavailable=unavailable_bases,
     )
+
+
+def resolve_knowledge_base_access(
+    base_id: str,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    *,
+    execution_identity: ToolExecutionIdentity | None = None,
+) -> KnowledgeBaseAccessResolution:
+    """Resolve one knowledge base without going through an agent assignment."""
+    lookup = _lookup_knowledge_for_base(
+        base_id,
+        config=config,
+        runtime_paths=runtime_paths,
+        execution_identity=execution_identity,
+    )
+    availability = lookup.availability if lookup is not None else KnowledgeAvailability.INITIALIZING
+    if lookup is not None and availability is KnowledgeAvailability.READY:
+        availability = _ready_index_effective_availability(lookup, config)
+    knowledge = lookup.index.knowledge if lookup is not None and lookup.index is not None else None
+    if knowledge is not None:
+        _apply_knowledge_metadata(base_id, knowledge, config)
+    return KnowledgeBaseAccessResolution(knowledge=knowledge, availability=availability)
 
 
 def _stale_availability_notice(base_id: str, *, search_available: bool) -> str:

--- a/src/mindroom/memory/_file_backend.py
+++ b/src/mindroom/memory/_file_backend.py
@@ -21,7 +21,7 @@ from ._policy import (
     resolve_file_memory_resolution,
     storage_paths_for_scope_user_id,
 )
-from ._semantic_file_search import search_semantic_file_memories
+from ._semantic_file_search import SemanticFileMemoryIndexUnavailableError, search_semantic_file_memories
 from ._shared import (
     FILE_MEMORY_DAILY_DIR,
     FILE_MEMORY_DEFAULT_DIRNAME,
@@ -665,7 +665,11 @@ async def search_file_agent_memories(
                 runtime_paths=runtime_paths,
                 search_config=search_config,
                 limit=limit,
+                timing_scope=timing_scope,
             )
+        except SemanticFileMemoryIndexUnavailableError:
+            logger.debug("File-memory semantic index unavailable; falling back to keyword search", agent=agent_name)
+            results = keyword_results()
         except Exception:
             logger.exception("File-memory semantic search failed; falling back to keyword search", agent=agent_name)
             results = keyword_results()

--- a/src/mindroom/memory/_semantic_file_search.py
+++ b/src/mindroom/memory/_semantic_file_search.py
@@ -4,47 +4,34 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
-import json
-import os
-from copy import deepcopy
-from dataclasses import dataclass
-from pathlib import Path
-from typing import TYPE_CHECKING, cast
+import time
+from typing import TYPE_CHECKING
 
-from agno.knowledge.knowledge import Knowledge
-from agno.knowledge.reader import ReaderFactory
-from agno.knowledge.reader.markdown_reader import MarkdownReader
-from agno.knowledge.reader.text_reader import TextReader
-from agno.vectordb.chroma import ChromaDb
-
-from mindroom.chunking import SafeFixedSizeChunking
-from mindroom.embedding_factory import create_configured_embedder
-from mindroom.file_locks import async_exclusive_file_lock
+from mindroom.config.knowledge import KnowledgeBaseConfig
+from mindroom.knowledge import KnowledgeRefreshScheduler, list_knowledge_files, resolve_knowledge_base_access
 from mindroom.logging_config import get_logger
 from mindroom.memory._shared import MemoryResult
-from mindroom.path_globs import matches_root_glob
+from mindroom.timing import emit_elapsed_timing
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from agno.knowledge.document.base import Document
-    from agno.knowledge.reader.base import Reader
 
     from mindroom.config.main import Config
     from mindroom.config.memory import MemorySearchConfig
     from mindroom.constants import RuntimePaths
 
 logger = get_logger(__name__)
-_COLLECTION_PREFIX = "mindroom_memory"
 _SOURCE_PATH_KEY = "source_path"
 _CHUNK_SIZE = 5000
 _CHUNK_OVERLAP = 0
+_MEMORY_KNOWLEDGE_PREFIX = "file_memory"
+_memory_refresh_scheduler = KnowledgeRefreshScheduler()
 
 
-@dataclass(frozen=True)
-class _IndexedFile:
-    path: Path
-    relative_path: str
-    mtime_ns: int
-    size: int
+class SemanticFileMemoryIndexUnavailableError(RuntimeError):
+    """Raised when semantic file memory should use keyword fallback for this request."""
 
 
 def _safe_identifier(value: str) -> str:
@@ -52,257 +39,51 @@ def _safe_identifier(value: str) -> str:
     return sanitized or "default"
 
 
-def _index_file_lock_path(index_path: Path) -> Path:
-    return index_path / ".semantic-memory-index.lock"
-
-
-def _path_is_symlink_or_under_symlink(root: Path, path: Path) -> bool:
-    try:
-        relative_path = path.relative_to(root)
-    except ValueError:
-        return True
-    current = root
-    for part in relative_path.parts:
-        current = current / part
-        if current.is_symlink():
-            return True
-    return False
-
-
-def _include_relative_path(relative_path: str, search_config: MemorySearchConfig) -> bool:
-    if relative_path == "MEMORY.md":
-        return search_config.include_entrypoint
-    return any(matches_root_glob(relative_path, pattern) for pattern in search_config.include)
-
-
-def _list_indexed_files(root: Path, search_config: MemorySearchConfig) -> list[_IndexedFile]:
-    if not root.is_dir():
-        return []
-    resolved_root = root.resolve()
-    files: list[_IndexedFile] = []
-    for dirpath, dirnames, filenames in os.walk(resolved_root, followlinks=False):
-        current_dir = Path(dirpath)
-        dirnames[:] = [dirname for dirname in dirnames if not (current_dir / dirname).is_symlink()]
-        for filename in filenames:
-            path = current_dir / filename
-            if path.suffix.lower() != ".md" or _path_is_symlink_or_under_symlink(resolved_root, path):
-                continue
-            try:
-                resolved_path = path.resolve(strict=True)
-                resolved_path.relative_to(resolved_root)
-                relative_path = resolved_path.relative_to(resolved_root).as_posix()
-                if not _include_relative_path(relative_path, search_config):
-                    continue
-                stat = resolved_path.stat()
-                files.append(
-                    _IndexedFile(
-                        path=resolved_path,
-                        relative_path=relative_path,
-                        mtime_ns=stat.st_mtime_ns,
-                        size=stat.st_size,
-                    ),
-                )
-            except (OSError, ValueError):
-                continue
-    return sorted(files, key=lambda item: item.relative_path)
-
-
-def _settings_signature(config: Config, search_config: MemorySearchConfig, root: Path) -> str:
-    embedder_config = config.memory.embedder.config
-    payload = repr(
-        (
-            str(root.resolve()),
-            config.memory.embedder.provider,
-            embedder_config.model,
-            embedder_config.host,
-            embedder_config.dimensions,
-            tuple(search_config.include),
-            search_config.include_entrypoint,
-            _CHUNK_SIZE,
-            _CHUNK_OVERLAP,
-        ),
-    )
-    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
-
-
 def _scope_digest(root: Path, scope_user_id: str) -> str:
     return hashlib.sha256(f"{scope_user_id}:{root.resolve()}".encode()).hexdigest()[:16]
 
 
-def _index_storage_path(runtime_paths: RuntimePaths, root: Path, scope_user_id: str) -> Path:
-    name = f"{_safe_identifier(scope_user_id)}_{_scope_digest(root, scope_user_id)}"
-    return runtime_paths.storage_root / "memory_search_db" / name
+def _memory_knowledge_base_id(root: Path, scope_user_id: str) -> str:
+    return f"{_MEMORY_KNOWLEDGE_PREFIX}_{_safe_identifier(scope_user_id)}_{_scope_digest(root, scope_user_id)}"
 
 
-def _collection_name(root: Path, scope_user_id: str) -> str:
-    return f"{_COLLECTION_PREFIX}_{_safe_identifier(scope_user_id)}_{_scope_digest(root, scope_user_id)}"
+def _memory_include_patterns(search_config: MemorySearchConfig) -> list[str]:
+    patterns = list(search_config.include)
+    if search_config.include_entrypoint:
+        patterns.append("MEMORY.md")
+    return patterns
 
 
-def _state_path(index_path: Path) -> Path:
-    return index_path / "index_state.json"
-
-
-def _file_state(files: list[_IndexedFile]) -> dict[str, dict[str, int]]:
-    return {file.relative_path: {"mtime_ns": file.mtime_ns, "size": file.size} for file in files}
-
-
-def _load_state(index_path: Path) -> dict[str, object] | None:
-    try:
-        payload = json.loads(_state_path(index_path).read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return None
-    return payload if isinstance(payload, dict) else None
-
-
-def _write_state(
-    index_path: Path,
+def _memory_knowledge_config(
+    config: Config,
     *,
-    settings_signature: str,
-    collection_name: str,
-    files: list[_IndexedFile],
-) -> None:
-    _state_path(index_path).write_text(
-        json.dumps(
-            {
-                "settings_signature": settings_signature,
-                "collection": collection_name,
-                "files": _file_state(files),
-            },
-            indent=2,
-            sort_keys=True,
-        )
-        + "\n",
-        encoding="utf-8",
+    base_id: str,
+    root: Path,
+    search_config: MemorySearchConfig,
+) -> Config:
+    knowledge_config = config.model_copy(deep=True)
+    knowledge_config.knowledge_bases[base_id] = KnowledgeBaseConfig(
+        mode="semantic",
+        description="File-backed memory search index",
+        path=str(root.resolve()),
+        watch=False,
+        chunk_size=_CHUNK_SIZE,
+        chunk_overlap=_CHUNK_OVERLAP,
+        include_extensions=[".md"],
+        include_patterns=_memory_include_patterns(search_config),
     )
+    return knowledge_config
 
 
-def _write_resetting_state(index_path: Path, *, settings_signature: str, collection_name: str) -> None:
-    _state_path(index_path).write_text(
-        json.dumps(
-            {
-                "settings_signature": settings_signature,
-                "collection": collection_name,
-                "resetting": True,
-            },
-            indent=2,
-            sort_keys=True,
-        )
-        + "\n",
-        encoding="utf-8",
-    )
+async def _list_memory_knowledge_files(config: Config, base_id: str, root: Path) -> list[Path]:
+    return await asyncio.to_thread(list_knowledge_files, config, base_id, root)
 
 
-def _build_reader(file_path: Path) -> Reader:
-    reader = ReaderFactory.get_reader_for_extension(file_path.suffix.lower())
-    if not isinstance(reader, (TextReader, MarkdownReader)):
-        return reader
-    configured_reader = deepcopy(reader)
-    configured_reader.chunk = True
-    configured_reader.chunk_size = _CHUNK_SIZE
-    configured_reader.chunking_strategy = SafeFixedSizeChunking(chunk_size=_CHUNK_SIZE, overlap=_CHUNK_OVERLAP)
-    return configured_reader
-
-
-def _indexed_file_changed(saved: object, current: _IndexedFile) -> bool:
-    if not isinstance(saved, dict):
-        return True
-    saved_file = cast("dict[str, object]", saved)
-    return saved_file.get("mtime_ns") != current.mtime_ns or saved_file.get("size") != current.size
-
-
-def _vector_db(knowledge: Knowledge) -> ChromaDb:
-    return cast("ChromaDb", knowledge.vector_db)
-
-
-def _reset_collection(knowledge: Knowledge) -> None:
-    vector_db = _vector_db(knowledge)
-    if vector_db.exists():
-        vector_db.delete()
-    vector_db.create()
-
-
-def _insert_file(knowledge: Knowledge, indexed_file: _IndexedFile) -> None:
-    knowledge.insert(
-        path=str(indexed_file.path),
-        metadata={_SOURCE_PATH_KEY: indexed_file.relative_path},
-        upsert=True,
-        reader=_build_reader(indexed_file.path),
-    )
-
-
-def _ensure_index_current(
-    knowledge: Knowledge,
-    files: list[_IndexedFile],
-    index_path: Path,
-    collection_name: str,
-    settings_signature: str,
-) -> None:
-    state = _load_state(index_path)
-    saved_files = state.get("files") if isinstance(state, dict) else None
-    needs_reset = (
-        not _vector_db(knowledge).exists()
-        or state is None
-        or state.get("settings_signature") != settings_signature
-        or state.get("collection") != collection_name
-        or not isinstance(saved_files, dict)
-    )
-
-    if needs_reset:
-        _write_resetting_state(index_path, settings_signature=settings_signature, collection_name=collection_name)
-        _reset_collection(knowledge)
-        for indexed_file in files:
-            _insert_file(knowledge, indexed_file)
-    else:
-        current_by_path = {file.relative_path: file for file in files}
-        saved_by_path = cast("dict[str, object]", saved_files)
-        for relative_path in sorted(set(saved_by_path) - set(current_by_path)):
-            knowledge.remove_vectors_by_metadata({_SOURCE_PATH_KEY: relative_path})
-        for relative_path, indexed_file in current_by_path.items():
-            if _indexed_file_changed(saved_by_path.get(relative_path), indexed_file):
-                knowledge.remove_vectors_by_metadata({_SOURCE_PATH_KEY: relative_path})
-                _insert_file(knowledge, indexed_file)
-
-    _write_state(index_path, settings_signature=settings_signature, collection_name=collection_name, files=files)
-
-
-async def search_semantic_file_memories(
-    query: str,
+def _memory_results_from_documents(
+    documents: list[Document],
     *,
     scope_user_id: str,
-    root: Path,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    search_config: MemorySearchConfig,
-    limit: int,
 ) -> list[MemoryResult]:
-    """Search one file-memory scope with an embedding-backed index."""
-    index_path = _index_storage_path(runtime_paths, root, scope_user_id)
-    index_path.mkdir(parents=True, exist_ok=True)
-    collection_name = _collection_name(root, scope_user_id)
-    files = await asyncio.to_thread(_list_indexed_files, root, search_config)
-    if not files:
-        return []
-
-    knowledge = Knowledge(
-        vector_db=ChromaDb(
-            collection=collection_name,
-            path=str(index_path),
-            persistent_client=True,
-            embedder=create_configured_embedder(config, runtime_paths),
-        ),
-    )
-    # One advisory file lock serializes index build + search per scope across both
-    # coroutines (flock contends across separate open descriptions) and processes.
-    async with async_exclusive_file_lock(_index_file_lock_path(index_path)):
-        await asyncio.to_thread(
-            _ensure_index_current,
-            knowledge,
-            files,
-            index_path,
-            collection_name,
-            _settings_signature(config, search_config, root),
-        )
-        documents: list[Document] = await asyncio.to_thread(knowledge.search, query=query, max_results=limit)
     results: list[MemoryResult] = []
     for rank, document in enumerate(documents, start=1):
         metadata = dict(document.meta_data)
@@ -323,3 +104,61 @@ async def search_semantic_file_memories(
             ),
         )
     return results
+
+
+async def search_semantic_file_memories(
+    query: str,
+    *,
+    scope_user_id: str,
+    root: Path,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    search_config: MemorySearchConfig,
+    limit: int,
+    timing_scope: str | None = None,
+) -> list[MemoryResult]:
+    """Search one file-memory scope through the published knowledge index pipeline."""
+    base_id = _memory_knowledge_base_id(root, scope_user_id)
+    knowledge_config = _memory_knowledge_config(
+        config,
+        base_id=base_id,
+        root=root,
+        search_config=search_config,
+    )
+
+    list_start = time.monotonic()
+    files = await _list_memory_knowledge_files(knowledge_config, base_id, root)
+    emit_elapsed_timing(
+        "system_prompt_assembly.memory_search.semantic.file_listing",
+        list_start,
+        timing_scope=timing_scope,
+        file_count=len(files),
+        include_pattern_count=len(search_config.include),
+        include_entrypoint=search_config.include_entrypoint,
+    )
+    if not files:
+        return []
+
+    access_start = time.monotonic()
+    resolution = resolve_knowledge_base_access(base_id, knowledge_config, runtime_paths)
+    _memory_refresh_scheduler.schedule_refresh(base_id, config=knowledge_config, runtime_paths=runtime_paths)
+    emit_elapsed_timing(
+        "system_prompt_assembly.memory_search.semantic.published_index_access",
+        access_start,
+        timing_scope=timing_scope,
+        availability=resolution.availability.value,
+        refresh_scheduled=True,
+    )
+    if resolution.knowledge is None:
+        msg = "Semantic file-memory index is not ready"
+        raise SemanticFileMemoryIndexUnavailableError(msg)
+
+    query_start = time.monotonic()
+    documents: list[Document] = await asyncio.to_thread(resolution.knowledge.search, query=query, max_results=limit)
+    emit_elapsed_timing(
+        "system_prompt_assembly.memory_search.semantic.vector_query",
+        query_start,
+        timing_scope=timing_scope,
+        availability=resolution.availability.value,
+    )
+    return _memory_results_from_documents(documents, scope_user_id=scope_user_id)

--- a/tach.toml
+++ b/tach.toml
@@ -1171,11 +1171,10 @@ visibility = ["mindroom.memory.functions"]
 [[modules]]
 path = "mindroom.memory._semantic_file_search"
 depends_on = [
-    "mindroom.chunking",
-    "mindroom.embedding_factory",
+    "mindroom.knowledge",
     "mindroom.logging_config",
     "mindroom.memory._shared",
-    "mindroom.path_globs",
+    "mindroom.timing",
 ]
 visibility = ["mindroom.memory._file_backend"]
 
@@ -2460,6 +2459,7 @@ from = ["mindroom.model_loading"]
 [[interfaces]]
 expose = [
     "KnowledgeAccessSupport",
+    "KnowledgeBaseAccessResolution",
     "KnowledgeManager",
     "KnowledgeRefreshScheduler",
     "format_knowledge_availability_notice",
@@ -2467,10 +2467,12 @@ expose = [
     "KnowledgeAvailability",
     "KnowledgeAvailabilityDetail",
     "KnowledgeResolution",
+    "list_knowledge_files",
     "OrchestratorKnowledgeRefreshScheduler",
     "PerBindingKnowledgeRefreshScheduler",
     "reconcile_knowledge_mode_transition_states",
     "resolve_agent_knowledge_access",
+    "resolve_knowledge_base_access",
     "StandaloneKnowledgeRefreshScheduler",
 ]
 from = ["mindroom.knowledge"]

--- a/tests/test_delegate_tools.py
+++ b/tests/test_delegate_tools.py
@@ -68,6 +68,8 @@ def _fake_indexing_settings(base_id: str) -> IndexingSettings:
         git_skip_hidden="",
         git_include_patterns="",
         git_exclude_patterns="",
+        include_patterns="",
+        exclude_patterns="",
         include_extensions="",
         exclude_extensions="()",
     )

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -238,6 +238,8 @@ def _test_indexing_settings(base_id: str = "docs") -> knowledge_manager_module.I
         git_skip_hidden="",
         git_include_patterns="",
         git_exclude_patterns="",
+        include_patterns="",
+        exclude_patterns="",
         include_extensions="",
         exclude_extensions="()",
     )
@@ -1362,6 +1364,42 @@ def test_knowledge_file_listing_rejects_symlinked_directory_escape(tmp_path: Pat
     config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
 
     assert list_knowledge_files(config, "docs", docs_path) == []
+
+
+def test_local_knowledge_file_listing_prunes_literal_include_prefixes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Local include globs should avoid walking unrelated source trees."""
+    docs_path = tmp_path / "workspace"
+    memory_dir = docs_path / "memory"
+    unrelated_dir = docs_path / "docs" / "deep"
+    memory_dir.mkdir(parents=True)
+    unrelated_dir.mkdir(parents=True)
+    memory_file = memory_dir / "2026-06-02.md"
+    unrelated_file = unrelated_dir / "runbook.md"
+    memory_file.write_text("Indexed memory.\n", encoding="utf-8")
+    unrelated_file.write_text("Unrelated markdown.\n", encoding="utf-8")
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+    config.knowledge_bases["docs"] = KnowledgeBaseConfig(
+        path=str(docs_path),
+        include_extensions=[".md"],
+        include_patterns=["memory/**/*.md"],
+    )
+
+    walked_roots: list[Path] = []
+    original_walk = knowledge_manager_module.os.walk
+
+    def recording_walk(top: object, *args: object, **kwargs: object) -> object:
+        walked_roots.append(Path(top))
+        return original_walk(top, *args, **kwargs)
+
+    monkeypatch.setattr(knowledge_manager_module.os, "walk", recording_walk)
+
+    files = list_knowledge_files(config, "docs", docs_path)
+
+    assert files == [memory_file.resolve()]
+    assert walked_roots == [memory_dir.resolve()]
 
 
 @pytest.mark.asyncio

--- a/tests/test_memory_file_backend.py
+++ b/tests/test_memory_file_backend.py
@@ -3,10 +3,7 @@
 
 from __future__ import annotations
 
-import asyncio
-import json
-import time
-from threading import Lock
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -17,6 +14,7 @@ import mindroom.memory.functions as memory_functions
 from mindroom.config.agent import AgentConfig, AgentPrivateConfig
 from mindroom.config.main import Config
 from mindroom.constants import resolve_runtime_paths
+from mindroom.knowledge.availability import KnowledgeAvailability
 from mindroom.memory import MemoryPromptParts
 from mindroom.memory import add_agent_memory as public_add_agent_memory
 from mindroom.memory import build_memory_enhanced_prompt as public_build_memory_enhanced_prompt
@@ -27,7 +25,6 @@ from mindroom.memory import list_all_agent_memories as public_list_all_agent_mem
 from mindroom.memory import search_agent_memories as public_search_agent_memories
 from mindroom.memory import store_conversation_memory as public_store_conversation_memory
 from mindroom.memory import update_agent_memory as public_update_agent_memory
-from mindroom.memory._semantic_file_search import _ensure_index_current, _IndexedFile
 from mindroom.runtime_resolution import resolve_agent_runtime
 from mindroom.tool_system.worker_routing import (
     ToolExecutionIdentity,
@@ -256,6 +253,110 @@ def storage_path(tmp_path: Path) -> Path:
 @pytest.fixture
 def config(storage_path: Path) -> Config:
     return _test_config(storage_path)
+
+
+@pytest.mark.asyncio
+async def test_semantic_memory_search_uses_knowledge_published_index(
+    storage_path: Path,
+    config: Config,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = storage_path / "memory-root"
+    memory_file = root / "memory" / "2026-06-02.md"
+    memory_file.parent.mkdir(parents=True)
+    memory_file.write_text("Published semantic memory.\n", encoding="utf-8")
+    runtime_paths = runtime_paths_for(config)
+
+    class FakeKnowledge:
+        def search(self, *, query: str, max_results: int) -> list[object]:
+            assert query == "semantic memory"
+            assert max_results == 5
+            return [
+                SimpleNamespace(
+                    content="Published semantic memory.",
+                    meta_data={"source_path": "memory/2026-06-02.md"},
+                    reranking_score=0.8,
+                ),
+            ]
+
+    access_base_ids: list[str] = []
+
+    def resolve_access(base_id: str, access_config: Config, access_runtime_paths: object) -> object:
+        access_base_ids.append(base_id)
+        assert access_runtime_paths == runtime_paths
+        base_config = access_config.knowledge_bases[base_id]
+        assert base_config.path == str(root.resolve())
+        assert base_config.include_patterns == ["memory/**/*.md"]
+        assert base_config.include_extensions == [".md"]
+        return SimpleNamespace(knowledge=FakeKnowledge(), availability=KnowledgeAvailability.READY)
+
+    scheduled_base_ids: list[str] = []
+
+    class FakeScheduler:
+        def schedule_refresh(self, base_id: str, **_kwargs: object) -> None:
+            scheduled_base_ids.append(base_id)
+
+    def list_files(*_args: object, **_kwargs: object) -> list[Path]:
+        return [memory_file.resolve()]
+
+    monkeypatch.setattr(semantic_file_search, "list_knowledge_files", list_files)
+    monkeypatch.setattr(semantic_file_search, "resolve_knowledge_base_access", resolve_access, raising=False)
+    monkeypatch.setattr(semantic_file_search, "_memory_refresh_scheduler", FakeScheduler(), raising=False)
+
+    results = await semantic_file_search.search_semantic_file_memories(
+        "semantic memory",
+        scope_user_id="agent_general",
+        root=root,
+        config=config,
+        runtime_paths=runtime_paths,
+        search_config=config.memory.search,
+        limit=5,
+    )
+
+    assert results[0]["memory"] == "Published semantic memory."
+    assert access_base_ids
+    assert scheduled_base_ids == access_base_ids
+
+
+@pytest.mark.asyncio
+async def test_semantic_memory_missing_knowledge_index_schedules_refresh_and_raises_fallback(
+    storage_path: Path,
+    config: Config,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = storage_path / "memory-root"
+    memory_file = root / "memory" / "2026-06-02.md"
+    memory_file.parent.mkdir(parents=True)
+    memory_file.write_text("Serialized semantic memory.\n", encoding="utf-8")
+
+    scheduled_base_ids: list[str] = []
+
+    class FakeScheduler:
+        def schedule_refresh(self, base_id: str, **_kwargs: object) -> None:
+            scheduled_base_ids.append(base_id)
+
+    def list_files(*_args: object, **_kwargs: object) -> list[Path]:
+        return [memory_file.resolve()]
+
+    def resolve_access(*_args: object, **_kwargs: object) -> object:
+        return SimpleNamespace(knowledge=None, availability=KnowledgeAvailability.INITIALIZING)
+
+    monkeypatch.setattr(semantic_file_search, "list_knowledge_files", list_files)
+    monkeypatch.setattr(semantic_file_search, "resolve_knowledge_base_access", resolve_access)
+    monkeypatch.setattr(semantic_file_search, "_memory_refresh_scheduler", FakeScheduler())
+
+    with pytest.raises(semantic_file_search.SemanticFileMemoryIndexUnavailableError):
+        await semantic_file_search.search_semantic_file_memories(
+            "semantic memory",
+            scope_user_id="agent_general",
+            root=root,
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            search_config=config.memory.search,
+            limit=5,
+        )
+
+    assert scheduled_base_ids
 
 
 @pytest.mark.asyncio
@@ -555,236 +656,6 @@ async def test_file_backend_private_semantic_search_uses_requester_root(
     root = semantic_search.call_args.kwargs["root"]
     assert "private_instances" in str(root)
     assert str(root).endswith("mind_data")
-
-
-def test_semantic_memory_index_updates_changed_files_incrementally(tmp_path: Path) -> None:
-    class FakeVectorDb:
-        collection_name = "memory_collection"
-
-        def __init__(self) -> None:
-            self.deleted = False
-            self.created = False
-
-        def exists(self) -> bool:
-            return True
-
-        def delete(self) -> None:
-            self.deleted = True
-
-        def create(self) -> None:
-            self.created = True
-
-    class FakeKnowledge:
-        def __init__(self) -> None:
-            self.vector_db = FakeVectorDb()
-            self.removed: list[dict[str, str]] = []
-            self.inserted: list[str] = []
-
-        def remove_vectors_by_metadata(self, metadata: dict[str, str]) -> None:
-            self.removed.append(metadata)
-
-        def insert(self, *, path: str, metadata: dict[str, object], upsert: bool, reader: object) -> None:
-            assert upsert is True
-            assert metadata["source_path"] == "memory/2026-06-02.md"
-            assert reader is not None
-            self.inserted.append(path.rsplit("/", 1)[-1])
-
-    memory_root = tmp_path / "memory-root"
-    memory_root.mkdir()
-    changed_file = memory_root / "memory" / "2026-06-02.md"
-    changed_file.parent.mkdir()
-    changed_file.write_text("changed", encoding="utf-8")
-    current_file = _IndexedFile(
-        path=changed_file,
-        relative_path="memory/2026-06-02.md",
-        mtime_ns=2,
-        size=7,
-    )
-    index_path = tmp_path / "index"
-    index_path.mkdir()
-    (index_path / "index_state.json").write_text(
-        json.dumps(
-            {
-                "settings_signature": "same-settings",
-                "collection": "memory_collection",
-                "files": {
-                    "memory/2026-06-02.md": {"mtime_ns": 1, "size": 3},
-                    "memory/deleted.md": {"mtime_ns": 1, "size": 3},
-                },
-            },
-        ),
-        encoding="utf-8",
-    )
-    knowledge = FakeKnowledge()
-
-    _ensure_index_current(
-        knowledge,
-        [current_file],
-        index_path,
-        "memory_collection",
-        "same-settings",
-    )
-
-    assert knowledge.vector_db.deleted is False
-    assert knowledge.vector_db.created is False
-    assert knowledge.removed == [
-        {"source_path": "memory/deleted.md"},
-        {"source_path": "memory/2026-06-02.md"},
-    ]
-    assert knowledge.inserted == ["2026-06-02.md"]
-
-
-def test_semantic_memory_failed_reset_forces_next_reset(tmp_path: Path) -> None:
-    class FakeVectorDb:
-        collection_name = "memory_collection"
-
-        def __init__(self, *, exists_before: bool) -> None:
-            self.exists_before = exists_before
-            self.deleted = False
-            self.created = False
-
-        def exists(self) -> bool:
-            return self.exists_before
-
-        def delete(self) -> None:
-            self.deleted = True
-
-        def create(self) -> None:
-            self.created = True
-
-    class FakeKnowledge:
-        def __init__(self, *, exists_before: bool, fail_insert: bool) -> None:
-            self.vector_db = FakeVectorDb(exists_before=exists_before)
-            self.fail_insert = fail_insert
-            self.inserted: list[str] = []
-
-        def insert(self, *, path: str, metadata: dict[str, object], upsert: bool, reader: object) -> None:
-            assert upsert is True
-            assert metadata["source_path"] == "memory/2026-06-02.md"
-            assert reader is not None
-            if self.fail_insert:
-                msg = "embedder failed"
-                raise RuntimeError(msg)
-            self.inserted.append(path.rsplit("/", 1)[-1])
-
-    memory_root = tmp_path / "memory-root"
-    memory_root.mkdir()
-    memory_file = memory_root / "memory" / "2026-06-02.md"
-    memory_file.parent.mkdir()
-    memory_file.write_text("current", encoding="utf-8")
-    current_file = _IndexedFile(
-        path=memory_file,
-        relative_path="memory/2026-06-02.md",
-        mtime_ns=1,
-        size=7,
-    )
-    index_path = tmp_path / "index"
-    index_path.mkdir()
-    (index_path / "index_state.json").write_text(
-        json.dumps(
-            {
-                "settings_signature": "same-settings",
-                "collection": "memory_collection",
-                "files": {"memory/2026-06-02.md": {"mtime_ns": 1, "size": 7}},
-            },
-        ),
-        encoding="utf-8",
-    )
-
-    failing_knowledge = FakeKnowledge(exists_before=False, fail_insert=True)
-    with pytest.raises(RuntimeError, match="embedder failed"):
-        _ensure_index_current(
-            failing_knowledge,
-            [current_file],
-            index_path,
-            "memory_collection",
-            "same-settings",
-        )
-
-    incomplete_state = json.loads((index_path / "index_state.json").read_text(encoding="utf-8"))
-    assert "files" not in incomplete_state
-
-    succeeding_knowledge = FakeKnowledge(exists_before=True, fail_insert=False)
-    _ensure_index_current(
-        succeeding_knowledge,
-        [current_file],
-        index_path,
-        "memory_collection",
-        "same-settings",
-    )
-
-    assert succeeding_knowledge.vector_db.deleted is True
-    assert succeeding_knowledge.vector_db.created is True
-    assert succeeding_knowledge.inserted == ["2026-06-02.md"]
-
-
-@pytest.mark.asyncio
-async def test_semantic_memory_index_refresh_and_search_are_serialized(storage_path: Path, config: Config) -> None:
-    root = storage_path / "memory-root"
-    memory_file = root / "memory" / "2026-06-02.md"
-    memory_file.parent.mkdir(parents=True)
-    memory_file.write_text("Serialized semantic memory.\n", encoding="utf-8")
-
-    active_sections = 0
-    max_active_sections = 0
-    section_lock = Lock()
-
-    def run_blocking_index_section() -> None:
-        nonlocal active_sections, max_active_sections
-        with section_lock:
-            active_sections += 1
-            max_active_sections = max(max_active_sections, active_sections)
-        try:
-            time.sleep(0.1)
-        finally:
-            with section_lock:
-                active_sections -= 1
-
-    def fake_ensure_index_current(*_args: object, **_kwargs: object) -> None:
-        run_blocking_index_section()
-
-    class FakeKnowledge:
-        def __init__(self, *, vector_db: object) -> None:
-            self.vector_db = vector_db
-
-        def search(self, *, query: str, max_results: int) -> list[object]:
-            assert query == "semantic memory"
-            assert max_results == 5
-            run_blocking_index_section()
-            return []
-
-    class FakeChromaDb:
-        def __init__(self, **_kwargs: object) -> None:
-            pass
-
-    with (
-        patch.object(semantic_file_search, "Knowledge", FakeKnowledge),
-        patch.object(semantic_file_search, "ChromaDb", FakeChromaDb),
-        patch.object(semantic_file_search, "create_configured_embedder", return_value=object()),
-        patch.object(semantic_file_search, "_ensure_index_current", fake_ensure_index_current),
-    ):
-        await asyncio.gather(
-            semantic_file_search.search_semantic_file_memories(
-                "semantic memory",
-                scope_user_id="agent_general",
-                root=root,
-                config=config,
-                runtime_paths=runtime_paths_for(config),
-                search_config=config.memory.search,
-                limit=5,
-            ),
-            semantic_file_search.search_semantic_file_memories(
-                "semantic memory",
-                scope_user_id="agent_general",
-                root=root,
-                config=config,
-                runtime_paths=runtime_paths_for(config),
-                search_config=config.memory.search,
-                limit=5,
-            ),
-        )
-
-    assert max_active_sections == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -513,6 +513,8 @@ def _fake_indexing_settings(base_id: str) -> IndexingSettings:
         git_skip_hidden="",
         git_include_patterns="",
         git_exclude_patterns="",
+        include_patterns="",
+        exclude_patterns="",
         include_extensions="",
         exclude_extensions="()",
     )

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -112,6 +112,8 @@ def _fake_indexing_settings(base_id: str) -> IndexingSettings:
         git_skip_hidden="",
         git_include_patterns="",
         git_exclude_patterns="",
+        include_patterns="",
+        exclude_patterns="",
         include_extensions="",
         exclude_extensions="()",
     )


### PR DESCRIPTION
## Summary
- Replace the standalone semantic file-memory indexer with the existing knowledge published-index pipeline.
- Add local knowledge include/exclude patterns and include-aware file listing so `memory/**/*.md` prunes to the `memory/` subtree instead of walking unrelated workspace trees.
- Semantic file-memory search now queries the last-known-good published index, schedules refresh in the background, and falls back to keyword search when no published index is available.
- Add request-path timing for file listing, published-index access/scheduling, and vector search.

## Test Plan
- `uv run pytest -n auto --no-cov` (`7610 passed, 60 skipped`)
- `uv run pre-commit run --all-files`
- `uv run tach check --dependencies --interfaces`