### PR TITLE
Warm semantic file memory indexes after writes

### DIFF
--- a/src/mindroom/memory/_file_backend.py
+++ b/src/mindroom/memory/_file_backend.py
@@ -208,6 +208,7 @@ def _schedule_agent_semantic_refresh(
     resolution: FileMemoryResolution,
     config: Config,
     runtime_paths: RuntimePaths,
+    execution_identity: ToolExecutionIdentity | None = None,
 ) -> None:
     search_config = config.get_agent_memory_search(agent_name)
     if search_config.mode != "semantic":
@@ -218,6 +219,26 @@ def _schedule_agent_semantic_refresh(
         config=config,
         runtime_paths=runtime_paths,
         search_config=search_config,
+        execution_identity=execution_identity,
+    )
+
+
+def _schedule_scope_semantic_refresh(
+    scope_user_id: str,
+    resolution: FileMemoryResolution,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    execution_identity: ToolExecutionIdentity | None = None,
+) -> None:
+    if (agent_name := agent_name_from_scope_user_id(scope_user_id)) is None:
+        return
+    _schedule_agent_semantic_refresh(
+        agent_name,
+        scope_user_id,
+        resolution,
+        config,
+        runtime_paths,
+        execution_identity=execution_identity,
     )
 
 
@@ -534,8 +555,9 @@ def _mutate_file_memory_targets(
     runtime_paths: RuntimePaths,
     anchor_result: MemoryResult,
     execution_identity: ToolExecutionIdentity | None = None,
-) -> tuple[str, int]:
+) -> tuple[str, int, list[FileMemoryResolution]]:
     updated_targets = 0
+    updated_resolutions: list[FileMemoryResolution] = []
     scope_user_id = anchor_result["user_id"]
     for target_storage_path in storage_paths_for_scope_user_id(
         scope_user_id,
@@ -557,7 +579,8 @@ def _mutate_file_memory_targets(
         ):
             if _replace_scope_memory_entry(scope_user_id, target_id, content, resolution, config):
                 updated_targets += 1
-    return scope_user_id, updated_targets
+                updated_resolutions.append(resolution)
+    return scope_user_id, updated_targets, updated_resolutions
 
 
 def add_file_agent_memory(
@@ -578,7 +601,14 @@ def add_file_agent_memory(
     )
     scope_user_id = agent_scope_user_id(agent_name)
     _append_scope_memory_entry(scope_user_id, content, resolution, config)
-    _schedule_agent_semantic_refresh(agent_name, scope_user_id, resolution, config, runtime_paths)
+    _schedule_agent_semantic_refresh(
+        agent_name,
+        scope_user_id,
+        resolution,
+        config,
+        runtime_paths,
+        execution_identity=execution_identity,
+    )
     logger.info("File memory added", agent=agent_name)
 
 
@@ -611,7 +641,14 @@ def append_agent_daily_file_memory(
         config,
         target_relative_path=daily_relative_path,
     )
-    _schedule_agent_semantic_refresh(agent_name, scope_user_id, resolution, config, runtime_paths)
+    _schedule_agent_semantic_refresh(
+        agent_name,
+        scope_user_id,
+        resolution,
+        config,
+        runtime_paths,
+        execution_identity=execution_identity,
+    )
     logger.info("File daily memory added", agent=agent_name, date=current_date)
     return result
 
@@ -692,6 +729,7 @@ async def search_file_agent_memories(
                 runtime_paths=runtime_paths,
                 search_config=search_config,
                 limit=limit,
+                execution_identity=execution_identity,
                 timing_scope=timing_scope,
             )
         except SemanticFileMemoryIndexUnavailableError:
@@ -801,7 +839,7 @@ def update_file_agent_memory(
     ) is None:
         raise MemoryNotFoundError(memory_id)
 
-    scope_user_id, updated_targets = _mutate_file_memory_targets(
+    scope_user_id, updated_targets, updated_resolutions = _mutate_file_memory_targets(
         memory_id=memory_id,
         content=content,
         storage_path=storage_path,
@@ -811,6 +849,14 @@ def update_file_agent_memory(
         execution_identity=execution_identity,
     )
     if updated_targets > 0:
+        for resolution in updated_resolutions:
+            _schedule_scope_semantic_refresh(
+                scope_user_id,
+                resolution,
+                config,
+                runtime_paths,
+                execution_identity=execution_identity,
+            )
         logger.info(
             "File memory updated",
             memory_id=memory_id,
@@ -842,7 +888,7 @@ def delete_file_agent_memory(
     ) is None:
         raise MemoryNotFoundError(memory_id)
 
-    scope_user_id, deleted_targets = _mutate_file_memory_targets(
+    scope_user_id, deleted_targets, deleted_resolutions = _mutate_file_memory_targets(
         memory_id=memory_id,
         content=None,
         storage_path=storage_path,
@@ -852,6 +898,14 @@ def delete_file_agent_memory(
         execution_identity=execution_identity,
     )
     if deleted_targets > 0:
+        for resolution in deleted_resolutions:
+            _schedule_scope_semantic_refresh(
+                scope_user_id,
+                resolution,
+                config,
+                runtime_paths,
+                execution_identity=execution_identity,
+            )
         logger.info(
             "File memory deleted",
             memory_id=memory_id,
@@ -901,6 +955,15 @@ def store_file_conversation_memory(
             config,
             memory_id=team_memory_id,
         )
+        if isinstance(agent_name, str):
+            _schedule_agent_semantic_refresh(
+                agent_name,
+                scope_user_id,
+                resolution,
+                config,
+                runtime_paths,
+                execution_identity=execution_identity,
+            )
 
     if isinstance(agent_name, list):
         logger.info(

--- a/src/mindroom/memory/_file_backend.py
+++ b/src/mindroom/memory/_file_backend.py
@@ -21,7 +21,11 @@ from ._policy import (
     resolve_file_memory_resolution,
     storage_paths_for_scope_user_id,
 )
-from ._semantic_file_search import SemanticFileMemoryIndexUnavailableError, search_semantic_file_memories
+from ._semantic_file_search import (
+    SemanticFileMemoryIndexUnavailableError,
+    schedule_semantic_file_memory_refresh,
+    search_semantic_file_memories,
+)
 from ._shared import (
     FILE_MEMORY_DAILY_DIR,
     FILE_MEMORY_DEFAULT_DIRNAME,
@@ -196,6 +200,25 @@ def _match_score(query_tokens: set[str], text: str) -> float:
 def _format_entry_line(memory_id: str, content: str) -> str:
     normalized_content = " ".join(content.strip().split())
     return f"- [id={memory_id}] {normalized_content}"
+
+
+def _schedule_agent_semantic_refresh(
+    agent_name: str,
+    scope_user_id: str,
+    resolution: FileMemoryResolution,
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> None:
+    search_config = config.get_agent_memory_search(agent_name)
+    if search_config.mode != "semantic":
+        return
+    schedule_semantic_file_memory_refresh(
+        scope_user_id=scope_user_id,
+        root=_scope_dir(scope_user_id, resolution, config, create=False),
+        config=config,
+        runtime_paths=runtime_paths,
+        search_config=search_config,
+    )
 
 
 def _append_scope_memory_entry(
@@ -553,7 +576,9 @@ def add_file_agent_memory(
         agent_name=agent_name,
         execution_identity=execution_identity,
     )
-    _append_scope_memory_entry(agent_scope_user_id(agent_name), content, resolution, config)
+    scope_user_id = agent_scope_user_id(agent_name)
+    _append_scope_memory_entry(scope_user_id, content, resolution, config)
+    _schedule_agent_semantic_refresh(agent_name, scope_user_id, resolution, config, runtime_paths)
     logger.info("File memory added", agent=agent_name)
 
 
@@ -578,13 +603,15 @@ def append_agent_daily_file_memory(
     )
     current_date = datetime.now(ZoneInfo(config.timezone)).date().isoformat()
     daily_relative_path = f"{FILE_MEMORY_DAILY_DIR}/{current_date}.md"
+    scope_user_id = agent_scope_user_id(agent_name)
     result = _append_scope_memory_entry(
-        agent_scope_user_id(agent_name),
+        scope_user_id,
         content,
         resolution,
         config,
         target_relative_path=daily_relative_path,
     )
+    _schedule_agent_semantic_refresh(agent_name, scope_user_id, resolution, config, runtime_paths)
     logger.info("File daily memory added", agent=agent_name, date=current_date)
     return result
 

--- a/src/mindroom/memory/_semantic_file_search.py
+++ b/src/mindroom/memory/_semantic_file_search.py
@@ -75,6 +75,30 @@ def _memory_knowledge_config(
     return knowledge_config
 
 
+def schedule_semantic_file_memory_refresh(
+    *,
+    scope_user_id: str,
+    root: Path,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    search_config: MemorySearchConfig,
+) -> bool:
+    """Schedule a best-effort semantic refresh for one file-memory scope."""
+    base_id = _memory_knowledge_base_id(root, scope_user_id)
+    knowledge_config = _memory_knowledge_config(
+        config,
+        base_id=base_id,
+        root=root,
+        search_config=search_config,
+    )
+    try:
+        _memory_refresh_scheduler.schedule_refresh(base_id, config=knowledge_config, runtime_paths=runtime_paths)
+    except Exception:
+        logger.exception("Could not schedule semantic file-memory refresh")
+        return False
+    return True
+
+
 async def _list_memory_knowledge_files(config: Config, base_id: str, root: Path) -> list[Path]:
     return await asyncio.to_thread(list_knowledge_files, config, base_id, root)
 
@@ -141,13 +165,19 @@ async def search_semantic_file_memories(
 
     access_start = time.monotonic()
     resolution = resolve_knowledge_base_access(base_id, knowledge_config, runtime_paths)
-    _memory_refresh_scheduler.schedule_refresh(base_id, config=knowledge_config, runtime_paths=runtime_paths)
+    refresh_scheduled = schedule_semantic_file_memory_refresh(
+        scope_user_id=scope_user_id,
+        root=root,
+        config=config,
+        runtime_paths=runtime_paths,
+        search_config=search_config,
+    )
     emit_elapsed_timing(
         "system_prompt_assembly.memory_search.semantic.published_index_access",
         access_start,
         timing_scope=timing_scope,
         availability=resolution.availability.value,
-        refresh_scheduled=True,
+        refresh_scheduled=refresh_scheduled,
     )
     if resolution.knowledge is None:
         msg = "Semantic file-memory index is not ready"

--- a/src/mindroom/memory/_semantic_file_search.py
+++ b/src/mindroom/memory/_semantic_file_search.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     from mindroom.config.main import Config
     from mindroom.config.memory import MemorySearchConfig
     from mindroom.constants import RuntimePaths
+    from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
 logger = get_logger(__name__)
 _SOURCE_PATH_KEY = "source_path"
@@ -82,6 +83,7 @@ def schedule_semantic_file_memory_refresh(
     config: Config,
     runtime_paths: RuntimePaths,
     search_config: MemorySearchConfig,
+    execution_identity: ToolExecutionIdentity | None = None,
 ) -> bool:
     """Schedule a best-effort semantic refresh for one file-memory scope."""
     base_id = _memory_knowledge_base_id(root, scope_user_id)
@@ -92,7 +94,12 @@ def schedule_semantic_file_memory_refresh(
         search_config=search_config,
     )
     try:
-        _memory_refresh_scheduler.schedule_refresh(base_id, config=knowledge_config, runtime_paths=runtime_paths)
+        _memory_refresh_scheduler.schedule_refresh(
+            base_id,
+            config=knowledge_config,
+            runtime_paths=runtime_paths,
+            execution_identity=execution_identity,
+        )
     except Exception:
         logger.exception("Could not schedule semantic file-memory refresh")
         return False
@@ -139,6 +146,7 @@ async def search_semantic_file_memories(
     runtime_paths: RuntimePaths,
     search_config: MemorySearchConfig,
     limit: int,
+    execution_identity: ToolExecutionIdentity | None = None,
     timing_scope: str | None = None,
 ) -> list[MemoryResult]:
     """Search one file-memory scope through the published knowledge index pipeline."""
@@ -164,13 +172,19 @@ async def search_semantic_file_memories(
         return []
 
     access_start = time.monotonic()
-    resolution = resolve_knowledge_base_access(base_id, knowledge_config, runtime_paths)
+    resolution = resolve_knowledge_base_access(
+        base_id,
+        knowledge_config,
+        runtime_paths,
+        execution_identity=execution_identity,
+    )
     refresh_scheduled = schedule_semantic_file_memory_refresh(
         scope_user_id=scope_user_id,
         root=root,
         config=config,
         runtime_paths=runtime_paths,
         search_config=search_config,
+        execution_identity=execution_identity,
     )
     emit_elapsed_timing(
         "system_prompt_assembly.memory_search.semantic.published_index_access",

--- a/tests/test_memory_auto_flush.py
+++ b/tests/test_memory_auto_flush.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+import mindroom.memory._semantic_file_search as semantic_file_search
 from mindroom.config.agent import AgentConfig, AgentPrivateConfig
 from mindroom.config.main import Config
 from mindroom.constants import resolve_runtime_paths
@@ -335,6 +336,54 @@ async def test_worker_flush_unscoped_uses_canonical_agent_workspace_memory_path(
     assert "important decision" in canonical_daily_files[0].read_text(encoding="utf-8")
     assert not list((tmp_path / "shared-memory").rglob("*.md"))
     assert not list((tmp_path / "memory_files").rglob("*.md"))
+
+
+@pytest.mark.asyncio
+async def test_worker_daily_file_memory_schedules_semantic_refresh_when_semantic_search_enabled(
+    tmp_path: Path,
+    config: Config,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Auto-flush writes should warm the semantic file-memory index in the background."""
+    config.memory.search.mode = "semantic"
+    fake_session = _FakeSession(
+        updated_at=100,
+        messages=[_FakeMessage(role="user", content="remember this important decision")],
+    )
+    monkeypatch.setattr(
+        "mindroom.memory.auto_flush._load_agent_session",
+        lambda _config, _storage, _agent, _sid, **_kwargs: fake_session,
+    )
+    monkeypatch.setattr(
+        "mindroom.memory.auto_flush._extract_memory_summary",
+        _fake_extract_memory_summary,
+    )
+
+    scheduled: list[tuple[str, Config, object]] = []
+
+    class FakeScheduler:
+        def schedule_refresh(self, base_id: str, **kwargs: object) -> None:
+            scheduled.append((base_id, kwargs["config"], kwargs["runtime_paths"]))
+
+    monkeypatch.setattr(semantic_file_search, "_memory_refresh_scheduler", FakeScheduler())
+
+    worker = MemoryAutoFlushWorker(
+        storage_path=tmp_path,
+        runtime_paths=runtime_paths_for(config),
+        config_provider=lambda: config,
+    )
+    wrote_memory = await worker._flush_session(
+        config,
+        agent_name="general",
+        session_id="session-general",
+    )
+
+    workspace = agent_workspace_root_path(tmp_path, "general")
+    assert wrote_memory is True
+    assert len(scheduled) == 1
+    base_id, scheduled_config, scheduled_runtime_paths = scheduled[0]
+    assert scheduled_runtime_paths == runtime_paths_for(config)
+    assert scheduled_config.knowledge_bases[base_id].path == str(workspace.resolve())
 
 
 @pytest.mark.asyncio

--- a/tests/test_memory_auto_flush.py
+++ b/tests/test_memory_auto_flush.py
@@ -938,6 +938,7 @@ async def test_worker_flush_private_agent_uses_persisted_private_scope(
 ) -> None:
     """Private auto-flush should rebind the persisted requester scope for memory writes."""
     config = _private_auto_flush_config(tmp_path)
+    config.memory.search.mode = "semantic"
     alice_identity = ToolExecutionIdentity(
         channel="matrix",
         agent_name="mind",
@@ -977,6 +978,13 @@ async def test_worker_flush_private_agent_uses_persisted_private_scope(
         "mindroom.memory.auto_flush._extract_memory_summary",
         _fake_extract_memory_summary,
     )
+    scheduled_identities: list[object] = []
+
+    class FakeScheduler:
+        def schedule_refresh(self, _base_id: str, **kwargs: object) -> None:
+            scheduled_identities.append(kwargs["execution_identity"])
+
+    monkeypatch.setattr(semantic_file_search, "_memory_refresh_scheduler", FakeScheduler())
 
     worker = MemoryAutoFlushWorker(
         storage_path=tmp_path,
@@ -987,6 +995,7 @@ async def test_worker_flush_private_agent_uses_persisted_private_scope(
 
     assert seen_execution_identities
     assert all(identity == alice_identity for identity in seen_execution_identities)
+    assert scheduled_identities == [alice_identity]
 
     worker_key = resolve_worker_key("user", alice_identity, agent_name="mind")
     assert worker_key is not None

--- a/tests/test_memory_file_backend.py
+++ b/tests/test_memory_file_backend.py
@@ -609,6 +609,56 @@ async def test_file_backend_semantic_search_falls_back_to_keyword_on_index_error
 
 
 @pytest.mark.asyncio
+async def test_file_backend_add_schedules_semantic_refresh_when_semantic_search_enabled(
+    storage_path: Path,
+    config: Config,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config.memory.backend = "file"
+    config.memory.search.mode = "semantic"
+    config.agents["general"].memory_backend = "file"
+
+    scheduled: list[tuple[str, Config, object]] = []
+
+    class FakeScheduler:
+        def schedule_refresh(self, base_id: str, **kwargs: object) -> None:
+            scheduled.append((base_id, kwargs["config"], kwargs["runtime_paths"]))
+
+    monkeypatch.setattr(semantic_file_search, "_memory_refresh_scheduler", FakeScheduler())
+
+    await add_agent_memory("Semantic refresh memory", "general", storage_path, config)
+
+    workspace = agent_workspace_root_path(storage_path, "general")
+    assert len(scheduled) == 1
+    base_id, scheduled_config, scheduled_runtime_paths = scheduled[0]
+    assert scheduled_runtime_paths == runtime_paths_for(config)
+    assert scheduled_config.knowledge_bases[base_id].path == str(workspace.resolve())
+
+
+@pytest.mark.asyncio
+async def test_file_backend_add_skips_semantic_refresh_when_search_mode_is_keyword(
+    storage_path: Path,
+    config: Config,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config.memory.backend = "file"
+    config.memory.search.mode = "keyword"
+    config.agents["general"].memory_backend = "file"
+
+    scheduled: list[str] = []
+
+    class FakeScheduler:
+        def schedule_refresh(self, base_id: str, **_kwargs: object) -> None:
+            scheduled.append(base_id)
+
+    monkeypatch.setattr(semantic_file_search, "_memory_refresh_scheduler", FakeScheduler())
+
+    await add_agent_memory("Keyword mode memory", "general", storage_path, config)
+
+    assert scheduled == []
+
+
+@pytest.mark.asyncio
 async def test_file_backend_private_semantic_search_uses_requester_root(
     storage_path: Path,
     config: Config,

--- a/tests/test_memory_file_backend.py
+++ b/tests/test_memory_file_backend.py
@@ -281,7 +281,14 @@ async def test_semantic_memory_search_uses_knowledge_published_index(
 
     access_base_ids: list[str] = []
 
-    def resolve_access(base_id: str, access_config: Config, access_runtime_paths: object) -> object:
+    def resolve_access(
+        base_id: str,
+        access_config: Config,
+        access_runtime_paths: object,
+        *,
+        execution_identity: object = None,
+    ) -> object:
+        del execution_identity
         access_base_ids.append(base_id)
         assert access_runtime_paths == runtime_paths
         base_config = access_config.knowledge_bases[base_id]
@@ -617,21 +624,96 @@ async def test_file_backend_add_schedules_semantic_refresh_when_semantic_search_
     config.memory.backend = "file"
     config.memory.search.mode = "semantic"
     config.agents["general"].memory_backend = "file"
+    config.agents["general"].private = AgentPrivateConfig(per="user", root="mind_data")
+    identity = ToolExecutionIdentity(
+        channel="matrix",
+        agent_name="general",
+        requester_id="@alice:example.org",
+        room_id="!room:example.org",
+        thread_id=None,
+        resolved_thread_id=None,
+        session_id="session-alice",
+    )
 
-    scheduled: list[tuple[str, Config, object]] = []
+    scheduled: list[tuple[str, Config, object, object]] = []
 
     class FakeScheduler:
         def schedule_refresh(self, base_id: str, **kwargs: object) -> None:
-            scheduled.append((base_id, kwargs["config"], kwargs["runtime_paths"]))
+            scheduled.append((base_id, kwargs["config"], kwargs["runtime_paths"], kwargs["execution_identity"]))
 
     monkeypatch.setattr(semantic_file_search, "_memory_refresh_scheduler", FakeScheduler())
 
-    await add_agent_memory("Semantic refresh memory", "general", storage_path, config)
+    with tool_execution_identity(identity):
+        await add_agent_memory("Semantic refresh memory", "general", storage_path, config)
+
+    assert len(scheduled) == 1
+    base_id, scheduled_config, scheduled_runtime_paths, scheduled_identity = scheduled[0]
+    assert scheduled_runtime_paths == runtime_paths_for(config)
+    assert scheduled_identity == identity
+    scheduled_path = scheduled_config.knowledge_bases[base_id].path
+    assert "private_instances" in scheduled_path
+    assert scheduled_path.endswith("mind_data")
+
+
+@pytest.mark.asyncio
+async def test_file_backend_update_and_delete_schedule_semantic_refresh_when_semantic_search_enabled(
+    storage_path: Path,
+    config: Config,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config.memory.backend = "file"
+    config.memory.search.mode = "semantic"
+    config.agents["general"].memory_backend = "file"
+
+    scheduled: list[str] = []
+
+    class FakeScheduler:
+        def schedule_refresh(self, base_id: str, **_kwargs: object) -> None:
+            scheduled.append(base_id)
+
+    monkeypatch.setattr(semantic_file_search, "_memory_refresh_scheduler", FakeScheduler())
+
+    await add_agent_memory("Original semantic memory", "general", storage_path, config)
+    memory_id = (await list_all_agent_memories("general", storage_path, config))[0]["id"]
+
+    scheduled.clear()
+    await update_agent_memory(memory_id, "Updated semantic memory", "general", storage_path, config)
+    assert len(scheduled) == 1
+
+    scheduled.clear()
+    await delete_agent_memory(memory_id, "general", storage_path, config)
+    assert len(scheduled) == 1
+
+
+@pytest.mark.asyncio
+async def test_file_backend_store_conversation_memory_schedules_semantic_refresh_when_semantic_search_enabled(
+    storage_path: Path,
+    config: Config,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config.memory.backend = "file"
+    config.memory.search.mode = "semantic"
+    config.agents["general"].memory_backend = "file"
+
+    scheduled: list[tuple[str, Config]] = []
+
+    class FakeScheduler:
+        def schedule_refresh(self, base_id: str, **kwargs: object) -> None:
+            scheduled.append((base_id, kwargs["config"]))
+
+    monkeypatch.setattr(semantic_file_search, "_memory_refresh_scheduler", FakeScheduler())
+
+    await store_conversation_memory(
+        "Conversation semantic memory",
+        "general",
+        storage_path,
+        "session-general",
+        config,
+    )
 
     workspace = agent_workspace_root_path(storage_path, "general")
     assert len(scheduled) == 1
-    base_id, scheduled_config, scheduled_runtime_paths = scheduled[0]
-    assert scheduled_runtime_paths == runtime_paths_for(config)
+    base_id, scheduled_config = scheduled[0]
     assert scheduled_config.knowledge_bases[base_id].path == str(workspace.resolve())
 
 
@@ -706,6 +788,7 @@ async def test_file_backend_private_semantic_search_uses_requester_root(
     root = semantic_search.call_args.kwargs["root"]
     assert "private_instances" in str(root)
     assert str(root).endswith("mind_data")
+    assert semantic_search.call_args.kwargs["execution_identity"] == identity
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add a best-effort semantic file-memory refresh helper that reuses the synthetic knowledge-base ID/config logic from semantic search.
- Schedule background refresh after direct file-memory writes and auto-flush daily memory writes when semantic search is enabled.
- Keep keyword search mode as a no-op for refresh scheduling and preserve keyword fallback behavior.

## Test Plan
- [x] `uv sync --all-extras`
- [x] `uv run pytest tests/test_memory_file_backend.py tests/test_memory_auto_flush.py -q -n auto --no-cov`
- [x] `uv run ruff check src/mindroom/memory/_semantic_file_search.py src/mindroom/memory/_file_backend.py tests/test_memory_file_backend.py tests/test_memory_auto_flush.py`
- [x] `uv run ruff format --check src/mindroom/memory/_semantic_file_search.py src/mindroom/memory/_file_backend.py tests/test_memory_file_backend.py tests/test_memory_auto_flush.py`
- [x] `uv run tach check --dependencies --interfaces`
- [x] `uv run pytest -q -n auto --no-cov --tb=short`