### PR TITLE
Limit startup thread prewarm concurrency

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -717,17 +717,16 @@ class AgentBot:
 
     async def _prewarm_claimed_startup_thread_room(self, room_id: str) -> None:
         """Prewarm one claimed room and release the claim unless the room-level pass finishes."""
+        completed = False
         try:
             async with self.startup_thread_prewarm_registry.room_slot():
                 completed = await self._conversation_cache.prewarm_recent_room_threads(
                     room_id,
                     is_shutting_down=lambda: self._sync_shutting_down,
                 )
-        except asyncio.CancelledError:
-            await self.startup_thread_prewarm_registry.release(room_id)
-            raise
-        if not completed:
-            await self.startup_thread_prewarm_registry.release(room_id)
+        finally:
+            if not completed:
+                await self.startup_thread_prewarm_registry.release(room_id)
 
     async def _run_startup_thread_prewarm(self) -> None:
         """Prewarm recent thread snapshots per joined room without blocking live dispatch behind cache seeding."""

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -718,10 +718,11 @@ class AgentBot:
     async def _prewarm_claimed_startup_thread_room(self, room_id: str) -> None:
         """Prewarm one claimed room and release the claim unless the room-level pass finishes."""
         try:
-            completed = await self._conversation_cache.prewarm_recent_room_threads(
-                room_id,
-                is_shutting_down=lambda: self._sync_shutting_down,
-            )
+            async with self.startup_thread_prewarm_registry.room_slot():
+                completed = await self._conversation_cache.prewarm_recent_room_threads(
+                    room_id,
+                    is_shutting_down=lambda: self._sync_shutting_down,
+                )
         except asyncio.CancelledError:
             await self.startup_thread_prewarm_registry.release(room_id)
             raise

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -78,7 +78,7 @@ __all__ = [
 
 
 _STARTUP_PREWARM_THREAD_LIMIT = 32
-_STARTUP_PREWARM_THREAD_CONCURRENCY = 32
+_STARTUP_PREWARM_THREAD_CONCURRENCY = 4
 type _StartupThreadPrewarmOutcome = Literal["warmed", "failed", "aborted"]
 
 

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -78,7 +78,7 @@ __all__ = [
 
 
 _STARTUP_PREWARM_THREAD_LIMIT = 32
-_STARTUP_PREWARM_THREAD_CONCURRENCY = 4
+_STARTUP_PREWARM_THREAD_CONCURRENCY = 8
 type _StartupThreadPrewarmOutcome = Literal["warmed", "failed", "aborted"]
 
 

--- a/src/mindroom/runtime_support.py
+++ b/src/mindroom/runtime_support.py
@@ -52,11 +52,8 @@ class StartupThreadPrewarmRegistry:
     @asynccontextmanager
     async def room_slot(self) -> AsyncIterator[None]:
         """Limit concurrent room-level startup prewarm work across all bots."""
-        await self._room_slots.acquire()
-        try:
+        async with self._room_slots:
             yield
-        finally:
-            self._room_slots.release()
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/mindroom/runtime_support.py
+++ b/src/mindroom/runtime_support.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from importlib import import_module
 from typing import TYPE_CHECKING, cast
@@ -15,7 +16,10 @@ from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
 from mindroom.matrix.cache.write_coordinator import EventCacheWriteCoordinator
 from mindroom.tool_system.dependencies import ensure_optional_deps
 
+_STARTUP_PREWARM_ROOM_CONCURRENCY = 1
+
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
     from pathlib import Path
 
     import structlog
@@ -27,9 +31,10 @@ if TYPE_CHECKING:
 class StartupThreadPrewarmRegistry:
     """Track one startup-wave claim set for room-level thread prewarm."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, room_concurrency: int = _STARTUP_PREWARM_ROOM_CONCURRENCY) -> None:
         self._lock = asyncio.Lock()
         self._claimed_room_ids: set[str] = set()
+        self._room_slots = asyncio.Semaphore(max(1, room_concurrency))
 
     async def try_claim(self, room_id: str) -> bool:
         """Claim one room for this startup wave unless another bot already did."""
@@ -43,6 +48,15 @@ class StartupThreadPrewarmRegistry:
         """Release one room claim so another bot may retry during the same startup wave."""
         async with self._lock:
             self._claimed_room_ids.discard(room_id)
+
+    @asynccontextmanager
+    async def room_slot(self) -> AsyncIterator[None]:
+        """Limit concurrent room-level startup prewarm work across all bots."""
+        await self._room_slots.acquire()
+        try:
+            yield
+        finally:
+            self._room_slots.release()
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_bot_ready_hook.py
+++ b/tests/test_bot_ready_hook.py
@@ -29,6 +29,7 @@ from mindroom.hooks import (
 from mindroom.matrix.cache import ThreadHistoryResult, thread_history_result
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.orchestrator import _MultiAgentOrchestrator
+from mindroom.runtime_support import StartupThreadPrewarmRegistry
 from tests.conftest import (
     TEST_PASSWORD,
     bind_runtime_paths,
@@ -664,6 +665,7 @@ async def test_startup_thread_prewarm_refreshes_threads_concurrently(tmp_path: P
     bot = _agent_bot(tmp_path)
     bot._conversation_cache.logger = MagicMock()
     thread_ids = [f"$thread-{index}:localhost" for index in range(40)]
+    expected_concurrency = 4
     all_concurrent_refreshes_started = asyncio.Event()
     release_refreshes = asyncio.Event()
     started_thread_ids: list[str] = []
@@ -676,7 +678,7 @@ async def test_startup_thread_prewarm_refreshes_threads_concurrently(tmp_path: P
         active_refreshes += 1
         max_active_refreshes = max(max_active_refreshes, active_refreshes)
         started_thread_ids.append(thread_id)
-        if len(started_thread_ids) == 32:
+        if len(started_thread_ids) == expected_concurrency:
             all_concurrent_refreshes_started.set()
         await release_refreshes.wait()
         active_refreshes -= 1
@@ -698,7 +700,7 @@ async def test_startup_thread_prewarm_refreshes_threads_concurrently(tmp_path: P
         )
         try:
             await asyncio.wait_for(all_concurrent_refreshes_started.wait(), timeout=1.0)
-            assert started_thread_ids == thread_ids[:32]
+            assert started_thread_ids == thread_ids[:expected_concurrency]
             release_refreshes.set()
             assert await prewarm_task
         finally:
@@ -706,7 +708,7 @@ async def test_startup_thread_prewarm_refreshes_threads_concurrently(tmp_path: P
             await asyncio.gather(prewarm_task, return_exceptions=True)
 
     assert started_thread_ids == thread_ids
-    assert max_active_refreshes == 32
+    assert max_active_refreshes == expected_concurrency
     bot._conversation_cache.logger.info.assert_any_call(
         "startup_thread_prewarm_complete",
         room_id="!room:localhost",
@@ -714,6 +716,50 @@ async def test_startup_thread_prewarm_refreshes_threads_concurrently(tmp_path: P
         threads_failed=0,
         elapsed_ms=ANY,
     )
+
+
+@pytest.mark.asyncio
+async def test_startup_thread_prewarm_limits_room_work_across_bots(tmp_path: Path) -> None:
+    """Startup prewarm should not let many enabled bots warm different rooms at the same time."""
+    first_bot = _agent_bot(tmp_path, agent_name="router")
+    second_bot = _agent_bot(tmp_path, agent_name="research")
+    shared_registry = StartupThreadPrewarmRegistry()
+    first_bot.startup_thread_prewarm_registry = shared_registry
+    second_bot.startup_thread_prewarm_registry = shared_registry
+    first_bot._get_startup_thread_prewarm_joined_rooms = AsyncMock(return_value=["!first:localhost"])
+    second_bot._get_startup_thread_prewarm_joined_rooms = AsyncMock(return_value=["!second:localhost"])
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    active_rooms = 0
+    max_active_rooms = 0
+    warmed_rooms: list[str] = []
+
+    async def prewarm_room(room_id: str, *, is_shutting_down: object) -> bool:
+        nonlocal active_rooms, max_active_rooms
+        del is_shutting_down
+        active_rooms += 1
+        max_active_rooms = max(max_active_rooms, active_rooms)
+        warmed_rooms.append(room_id)
+        if room_id == "!first:localhost":
+            first_started.set()
+            await release_first.wait()
+        active_rooms -= 1
+        return True
+
+    first_bot._conversation_cache.prewarm_recent_room_threads = AsyncMock(side_effect=prewarm_room)
+    second_bot._conversation_cache.prewarm_recent_room_threads = AsyncMock(side_effect=prewarm_room)
+
+    first_task = asyncio.create_task(first_bot._run_startup_thread_prewarm())
+    await asyncio.wait_for(first_started.wait(), timeout=1.0)
+    second_task = asyncio.create_task(second_bot._run_startup_thread_prewarm())
+    await asyncio.sleep(0.05)
+
+    assert warmed_rooms == ["!first:localhost"]
+    release_first.set()
+    await asyncio.gather(first_task, second_task)
+
+    assert warmed_rooms == ["!first:localhost", "!second:localhost"]
+    assert max_active_rooms == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_bot_ready_hook.py
+++ b/tests/test_bot_ready_hook.py
@@ -665,7 +665,7 @@ async def test_startup_thread_prewarm_refreshes_threads_concurrently(tmp_path: P
     bot = _agent_bot(tmp_path)
     bot._conversation_cache.logger = MagicMock()
     thread_ids = [f"$thread-{index}:localhost" for index in range(40)]
-    expected_concurrency = 4
+    expected_concurrency = 8
     all_concurrent_refreshes_started = asyncio.Event()
     release_refreshes = asyncio.Event()
     started_thread_ids: list[str] = []

--- a/tests/test_bot_ready_hook.py
+++ b/tests/test_bot_ready_hook.py
@@ -730,9 +730,22 @@ async def test_startup_thread_prewarm_limits_room_work_across_bots(tmp_path: Pat
     second_bot._get_startup_thread_prewarm_joined_rooms = AsyncMock(return_value=["!second:localhost"])
     first_started = asyncio.Event()
     release_first = asyncio.Event()
+    second_waiting_for_slot = asyncio.Event()
     active_rooms = 0
     max_active_rooms = 0
+    room_slot_attempts = 0
     warmed_rooms: list[str] = []
+
+    original_room_slot = shared_registry.room_slot
+
+    @asynccontextmanager
+    async def observed_room_slot() -> AsyncIterator[None]:
+        nonlocal room_slot_attempts
+        room_slot_attempts += 1
+        if room_slot_attempts == 2:
+            second_waiting_for_slot.set()
+        async with original_room_slot():
+            yield
 
     async def prewarm_room(room_id: str, *, is_shutting_down: object) -> bool:
         nonlocal active_rooms, max_active_rooms
@@ -748,11 +761,12 @@ async def test_startup_thread_prewarm_limits_room_work_across_bots(tmp_path: Pat
 
     first_bot._conversation_cache.prewarm_recent_room_threads = AsyncMock(side_effect=prewarm_room)
     second_bot._conversation_cache.prewarm_recent_room_threads = AsyncMock(side_effect=prewarm_room)
+    shared_registry.room_slot = observed_room_slot
 
     first_task = asyncio.create_task(first_bot._run_startup_thread_prewarm())
     await asyncio.wait_for(first_started.wait(), timeout=1.0)
     second_task = asyncio.create_task(second_bot._run_startup_thread_prewarm())
-    await asyncio.sleep(0.05)
+    await asyncio.wait_for(second_waiting_for_slot.wait(), timeout=1.0)
 
     assert warmed_rooms == ["!first:localhost"]
     release_first.set()
@@ -760,6 +774,22 @@ async def test_startup_thread_prewarm_limits_room_work_across_bots(tmp_path: Pat
 
     assert warmed_rooms == ["!first:localhost", "!second:localhost"]
     assert max_active_rooms == 1
+
+
+@pytest.mark.asyncio
+async def test_startup_thread_prewarm_releases_room_claim_after_failure(tmp_path: Path) -> None:
+    """Unexpected room prewarm errors should release the claim so another bot can retry."""
+    bot = _agent_bot(tmp_path)
+    room_id = "!room:localhost"
+    registry = StartupThreadPrewarmRegistry()
+    bot.startup_thread_prewarm_registry = registry
+    assert await registry.try_claim(room_id)
+    bot._conversation_cache.prewarm_recent_room_threads = AsyncMock(side_effect=RuntimeError("boom"))
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await bot._prewarm_claimed_startup_thread_room(room_id)
+
+    assert await registry.try_claim(room_id)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add a shared room-level semaphore so startup thread prewarm does not warm multiple rooms concurrently across bots.
- Reduce per-room startup thread refresh fanout from 32 to 4 so advisory warming does not saturate Matrix/history reads.
- Add regression coverage for cross-bot room prewarm limiting and the lower per-room thread concurrency.

## Test Plan
- `uv run pytest -q tests/test_bot_ready_hook.py`
- `uv run ruff check src/mindroom/runtime_support.py src/mindroom/bot.py src/mindroom/matrix/conversation_cache.py tests/test_bot_ready_hook.py`