### PR TITLE
Avoid repeated tool registry bootstrap during agent creation

### DIFF
--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -34,7 +34,12 @@ from mindroom.runtime_resolution import (
 )
 from mindroom.timing import timed
 from mindroom.tool_approval import tool_requires_approval_for_openai_compat
-from mindroom.tool_system.catalog import TOOL_METADATA, get_tool_by_name
+from mindroom.tool_system.catalog import (
+    TOOL_METADATA,
+    default_worker_routed_tools,
+    ensure_tool_registry_loaded,
+    get_tool_by_name,
+)
 from mindroom.tool_system.dynamic_toolkits import (
     VisibleToolSurface,
     deferred_tool_catalog_entries,
@@ -745,8 +750,6 @@ def _resolve_runtime_worker_tools(
     if configured is not None:
         return config.expand_tool_names(list(configured))
 
-    from mindroom.tool_system.catalog import default_worker_routed_tools, ensure_tool_registry_loaded  # noqa: PLC0415
-
     if not tool_registry_preloaded:
         ensure_tool_registry_loaded(runtime_paths, config)
     return default_worker_routed_tools(runtime_tool_names)
@@ -956,8 +959,6 @@ def _load_agent_plugins(config: Config, runtime_paths: constants.RuntimePaths) -
 
 @timed("system_prompt_assembly.agent_create.tool_registry_sync")
 def _sync_agent_tool_registry(config: Config, runtime_paths: constants.RuntimePaths) -> None:
-    from mindroom.tool_system.catalog import ensure_tool_registry_loaded  # noqa: PLC0415
-
     ensure_tool_registry_loaded(runtime_paths, config, load_plugin_tools=False)
 
 

--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -123,6 +123,13 @@ _PRIVATE_CULTURE_MANAGER_CACHE: WeakValueDictionary[
 ] = WeakValueDictionary()
 
 
+class _UnsetToolRuntimeOverrides:
+    """Sentinel for runtime overrides that have not been resolved yet."""
+
+
+_UNSET_TOOL_RUNTIME_OVERRIDES = _UnsetToolRuntimeOverrides()
+
+
 def show_tool_calls_for_agent(config: Config, agent_name: str) -> bool:
     """Resolve tool-call visibility for one agent from current config."""
     agent_config = config.agents.get(agent_name)
@@ -552,6 +559,7 @@ def build_agent_toolkit(  # noqa: C901, PLR0911
     session_id: str | None = None,
     delegation_depth: int = 0,
     refresh_scheduler: KnowledgeRefreshScheduler | None = None,
+    runtime_overrides: dict[str, object] | None | _UnsetToolRuntimeOverrides = _UNSET_TOOL_RUNTIME_OVERRIDES,
 ) -> Toolkit | None:
     """Build one configured toolkit for an agent.
 
@@ -677,6 +685,11 @@ def build_agent_toolkit(  # noqa: C901, PLR0911
         )
 
     worker_egress_broker = config.get_agent_worker_egress_broker(agent_name)
+    resolved_runtime_overrides = (
+        config.get_agent_tool_runtime_overrides(agent_name, tool_name, runtime_paths=runtime_paths)
+        if runtime_overrides is _UNSET_TOOL_RUNTIME_OVERRIDES
+        else cast("dict[str, object] | None", runtime_overrides)
+    )
     return _build_registered_agent_tool(
         tool_name,
         runtime_paths,
@@ -691,7 +704,7 @@ def build_agent_toolkit(  # noqa: C901, PLR0911
         config.defaults.tool_output_auto_save_threshold_bytes,
         agent_runtime.is_private,
         execution_identity,
-        config.get_agent_tool_runtime_overrides(agent_name, tool_name, runtime_paths=runtime_paths),
+        resolved_runtime_overrides,
         worker_egress_broker.execution_env if worker_egress_broker is not None else None,
     )
 
@@ -721,6 +734,8 @@ def _resolve_runtime_worker_tools(
     config: Config,
     runtime_paths: constants.RuntimePaths,
     runtime_tool_names: list[str],
+    *,
+    tool_registry_preloaded: bool = False,
 ) -> list[str]:
     """Return worker-routed tools for one concrete runtime tool selection."""
     agent_config = config.get_agent(agent_name)
@@ -732,7 +747,8 @@ def _resolve_runtime_worker_tools(
 
     from mindroom.tool_system.catalog import default_worker_routed_tools, ensure_tool_registry_loaded  # noqa: PLC0415
 
-    ensure_tool_registry_loaded(runtime_paths, config)
+    if not tool_registry_preloaded:
+        ensure_tool_registry_loaded(runtime_paths, config)
     return default_worker_routed_tools(runtime_tool_names)
 
 
@@ -936,6 +952,13 @@ def _resolve_agent_culture(
 @timed("system_prompt_assembly.agent_create.load_plugins")
 def _load_agent_plugins(config: Config, runtime_paths: constants.RuntimePaths) -> list[HookRegistryPlugin]:
     return cast("list[HookRegistryPlugin]", load_plugins(config, runtime_paths))
+
+
+@timed("system_prompt_assembly.agent_create.tool_registry_sync")
+def _sync_agent_tool_registry(config: Config, runtime_paths: constants.RuntimePaths) -> None:
+    from mindroom.tool_system.catalog import ensure_tool_registry_loaded  # noqa: PLC0415
+
+    ensure_tool_registry_loaded(runtime_paths, config, load_plugin_tools=False)
 
 
 @timed("system_prompt_assembly.agent_create.hook_bridge")
@@ -1146,6 +1169,7 @@ def create_agent(  # noqa: PLR0915, C901, PLR0912
     defaults = config.defaults
 
     plugins = _load_agent_plugins(config, runtime_paths)
+    _sync_agent_tool_registry(config, runtime_paths)
     tool_hook_bridge = _build_agent_tool_hook_bridge(
         hook_registry=hook_registry,
         plugins=plugins,
@@ -1183,11 +1207,13 @@ def create_agent(  # noqa: PLR0915, C901, PLR0912
         config,
         runtime_paths,
         list(resolved_tool_configs),
+        tool_registry_preloaded=True,
     )
     workspace = agent_runtime.workspace
     tools: list[Toolkit] = []
     for tool_name in resolved_tool_configs:
         try:
+            runtime_overrides = config.get_agent_tool_runtime_overrides(agent_name, tool_name)
             toolkit = build_agent_toolkit(
                 tool_name,
                 agent_name=agent_name,
@@ -1200,6 +1226,7 @@ def create_agent(  # noqa: PLR0915, C901, PLR0912
                 execution_identity=execution_identity,
                 delegation_depth=delegation_depth,
                 refresh_scheduler=refresh_scheduler,
+                runtime_overrides=runtime_overrides,
             )
             if toolkit:
                 toolkit = _prune_openai_approval_gated_tools(

--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -128,13 +128,6 @@ _PRIVATE_CULTURE_MANAGER_CACHE: WeakValueDictionary[
 ] = WeakValueDictionary()
 
 
-class _UnsetToolRuntimeOverrides:
-    """Sentinel for runtime overrides that have not been resolved yet."""
-
-
-_UNSET_TOOL_RUNTIME_OVERRIDES = _UnsetToolRuntimeOverrides()
-
-
 def show_tool_calls_for_agent(config: Config, agent_name: str) -> bool:
     """Resolve tool-call visibility for one agent from current config."""
     agent_config = config.agents.get(agent_name)
@@ -558,16 +551,17 @@ def build_agent_toolkit(  # noqa: C901, PLR0911
     config: Config,
     runtime_paths: constants.RuntimePaths,
     worker_tools: list[str],
+    runtime_overrides: dict[str, object] | None,
     agent_runtime: ResolvedAgentRuntime | None = None,
     tool_config_overrides: dict[str, object] | None = None,
     execution_identity: ToolExecutionIdentity | None,
     session_id: str | None = None,
     delegation_depth: int = 0,
     refresh_scheduler: KnowledgeRefreshScheduler | None = None,
-    runtime_overrides: dict[str, object] | None | _UnsetToolRuntimeOverrides = _UNSET_TOOL_RUNTIME_OVERRIDES,
 ) -> Toolkit | None:
     """Build one configured toolkit for an agent.
 
+    Callers own runtime override resolution before invoking this builder.
     Returns ``None`` when the configured tool should be skipped, such as an
     explicit ``delegate`` entry without valid delegation targets.
     """
@@ -690,11 +684,6 @@ def build_agent_toolkit(  # noqa: C901, PLR0911
         )
 
     worker_egress_broker = config.get_agent_worker_egress_broker(agent_name)
-    resolved_runtime_overrides = (
-        config.get_agent_tool_runtime_overrides(agent_name, tool_name, runtime_paths=runtime_paths)
-        if runtime_overrides is _UNSET_TOOL_RUNTIME_OVERRIDES
-        else cast("dict[str, object] | None", runtime_overrides)
-    )
     return _build_registered_agent_tool(
         tool_name,
         runtime_paths,
@@ -709,7 +698,7 @@ def build_agent_toolkit(  # noqa: C901, PLR0911
         config.defaults.tool_output_auto_save_threshold_bytes,
         agent_runtime.is_private,
         execution_identity,
-        resolved_runtime_overrides,
+        runtime_overrides,
         worker_egress_broker.execution_env if worker_egress_broker is not None else None,
     )
 
@@ -1221,13 +1210,13 @@ def create_agent(  # noqa: PLR0915, C901, PLR0912
                 config=config,
                 runtime_paths=runtime_paths,
                 worker_tools=worker_tools,
+                runtime_overrides=runtime_overrides,
                 agent_runtime=agent_runtime,
                 tool_config_overrides=resolved_tool_configs.get(tool_name),
                 session_id=session_id,
                 execution_identity=execution_identity,
                 delegation_depth=delegation_depth,
                 refresh_scheduler=refresh_scheduler,
-                runtime_overrides=runtime_overrides,
             )
             if toolkit:
                 toolkit = _prune_openai_approval_gated_tools(

--- a/src/mindroom/tool_system/bootstrap.py
+++ b/src/mindroom/tool_system/bootstrap.py
@@ -12,6 +12,8 @@ if TYPE_CHECKING:
 def ensure_tool_registry_loaded(
     runtime_paths: RuntimePaths,
     config: Config | None = None,
+    *,
+    load_plugin_tools: bool = True,
 ) -> None:
     """Ensure core, plugin, and MCP tool registrations are loaded for one runtime."""
     import mindroom.tools  # noqa: F401, PLC0415  # import here to avoid tools_metadata cycle
@@ -19,9 +21,10 @@ def ensure_tool_registry_loaded(
     if config is None:
         return
 
-    from mindroom.tool_system.plugins import load_plugins  # noqa: PLC0415
+    if load_plugin_tools:
+        from mindroom.tool_system.plugins import load_plugins  # noqa: PLC0415
 
-    load_plugins(config, runtime_paths, set_skill_roots=False)
+        load_plugins(config, runtime_paths, set_skill_roots=False)
 
     from mindroom.mcp.registry import sync_mcp_tool_registry  # noqa: PLC0415
 

--- a/src/mindroom/tool_system/bootstrap.py
+++ b/src/mindroom/tool_system/bootstrap.py
@@ -15,7 +15,7 @@ def ensure_tool_registry_loaded(
     *,
     load_plugin_tools: bool = True,
 ) -> None:
-    """Ensure core, plugin, and MCP tool registrations are loaded for one runtime."""
+    """Ensure core and MCP registrations are loaded, plus plugin tools when requested."""
     import mindroom.tools  # noqa: F401, PLC0415  # import here to avoid tools_metadata cycle
 
     if config is None:

--- a/src/mindroom/tool_system/bootstrap.py
+++ b/src/mindroom/tool_system/bootstrap.py
@@ -15,7 +15,7 @@ def ensure_tool_registry_loaded(
     *,
     load_plugin_tools: bool = True,
 ) -> None:
-    """Ensure core and MCP registrations are loaded, plus plugin tools when requested."""
+    """Load core tools, then sync MCP and optional plugin tools when config is provided."""
     import mindroom.tools  # noqa: F401, PLC0415  # import here to avoid tools_metadata cycle
 
     if config is None:

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -599,6 +599,25 @@ def test_create_agent_passes_merged_tool_config_overrides_to_registered_tools(
 
 @patch("mindroom.agents.get_tool_by_name")
 @patch("mindroom.agent_storage.SqliteDb")
+def test_create_agent_does_not_bootstrap_tool_registry_once_per_registered_tool(
+    mock_storage: MagicMock,  # noqa: ARG001
+    mock_get_tool_by_name: MagicMock,
+) -> None:
+    """Agent construction should not reload plugin/MCP registry state per toolkit."""
+    mock_get_tool_by_name.return_value = MagicMock()
+    config = _test_config()
+    config.agents["general"].tools = ["shell", "coding", "duckduckgo", "website"]
+    config.agents["general"].include_default_tools = False
+
+    with patch("mindroom.tool_system.catalog.ensure_tool_registry_loaded") as mock_ensure_registry:
+        _create_agent_for_test("general", config=config)
+
+    assert len(mock_get_tool_by_name.call_args_list) == 4
+    assert mock_ensure_registry.call_count <= 1
+
+
+@patch("mindroom.agents.get_tool_by_name")
+@patch("mindroom.agent_storage.SqliteDb")
 def test_create_agent_keeps_runtime_base_dir_separate_from_authored_tool_config(
     mock_storage: MagicMock,  # noqa: ARG001
     mock_get_tool_by_name: MagicMock,

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -613,7 +613,7 @@ def test_create_agent_does_not_bootstrap_tool_registry_once_per_registered_tool(
         _create_agent_for_test("general", config=config)
 
     assert len(mock_get_tool_by_name.call_args_list) == 4
-    assert mock_ensure_registry.call_count <= 1
+    assert mock_ensure_registry.call_count == 1
 
 
 @patch("mindroom.agents.get_tool_by_name")

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -599,7 +599,7 @@ def test_create_agent_passes_merged_tool_config_overrides_to_registered_tools(
 
 @patch("mindroom.agents.get_tool_by_name")
 @patch("mindroom.agent_storage.SqliteDb")
-def test_create_agent_does_not_bootstrap_tool_registry_once_per_registered_tool(
+def test_create_agent_bootstraps_tool_registry_once_for_multiple_tools(
     mock_storage: MagicMock,  # noqa: ARG001
     mock_get_tool_by_name: MagicMock,
 ) -> None:
@@ -609,7 +609,7 @@ def test_create_agent_does_not_bootstrap_tool_registry_once_per_registered_tool(
     config.agents["general"].tools = ["shell", "coding", "duckduckgo", "website"]
     config.agents["general"].include_default_tools = False
 
-    with patch("mindroom.tool_system.catalog.ensure_tool_registry_loaded") as mock_ensure_registry:
+    with patch("mindroom.agents.ensure_tool_registry_loaded") as mock_ensure_registry:
         _create_agent_for_test("general", config=config)
 
     assert len(mock_get_tool_by_name.call_args_list) == 4

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -826,6 +826,7 @@ def test_direct_agent_toolkit_exposes_output_redirect_for_workspace_agent(tmp_pa
         config=config,
         runtime_paths=runtime_paths,
         worker_tools=[],
+        runtime_overrides=None,
         agent_runtime=agent_runtime,
         execution_identity=None,
     )
@@ -856,6 +857,7 @@ def test_memory_toolkit_is_omitted_when_agent_memory_is_disabled(tmp_path: Path)
         config=config,
         runtime_paths=runtime_paths,
         worker_tools=[],
+        runtime_overrides=None,
         agent_runtime=agent_runtime,
         execution_identity=None,
     )

--- a/tests/test_worker_egress.py
+++ b/tests/test_worker_egress.py
@@ -193,6 +193,7 @@ def test_build_agent_toolkit_passes_worker_egress_env_to_registered_tools(
         config=config,
         runtime_paths=runtime_paths,
         worker_tools=["shell"],
+        runtime_overrides=config.get_agent_tool_runtime_overrides("code", "shell", runtime_paths=runtime_paths),
         execution_identity=None,
     )
 


### PR DESCRIPTION
## Summary
- Load plugin tools once during `create_agent`, then sync core/MCP registry state without reloading plugins per toolkit.
- Resolve runtime overrides before toolkit construction and pass them explicitly to `build_agent_toolkit`.
- Add a regression test covering multi-tool agent creation plus existing runtime override behavior.

## Test Plan
- `uv sync --all-extras`
- `uv run pytest tests/test_agents.py::test_create_agent_bootstraps_tool_registry_once_for_multiple_tools tests/test_agents.py::test_create_agent_passes_authored_shell_runtime_overrides tests/test_agents.py::test_create_agent_passes_merged_tool_config_overrides_to_registered_tools tests/test_agents.py::test_direct_agent_toolkit_exposes_output_redirect_for_workspace_agent tests/test_agents.py::test_memory_toolkit_is_omitted_when_agent_memory_is_disabled tests/test_worker_egress.py -x -n 0 --no-cov -v`
- `uv run ruff check src/mindroom/agents.py src/mindroom/tool_system/bootstrap.py tests/test_agents.py tests/test_worker_egress.py`
- `uv run tach check --dependencies --interfaces`
- `uv run pre-commit run --files src/mindroom/agents.py src/mindroom/tool_system/bootstrap.py tests/test_agents.py tests/test_worker_egress.py`
- `uv run pytest -q`