### PR TITLE
Preserve broker env for dedicated shell workers

### DIFF
--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -822,11 +822,13 @@ def _prepared_shell_execution_env(
     request: SandboxRunnerExecuteRequest,
     runtime_paths: RuntimePaths,
     prepared: sandbox_worker_prep.PreparedWorkerRequest | None,
+    execution_env: dict[str, str],
 ) -> dict[str, str] | None:
     """Return the worker shell env when shell execution is bound to a prepared worker."""
     if request.tool_name != "shell" or prepared is None:
         return None
     worker_execution_env = sandbox_exec.worker_subprocess_env(prepared.paths)
+    worker_execution_env.update(execution_env)
     worker_execution_env.update(
         constants.shell_extra_env_values(
             extra_env_passthrough=request.extra_env_passthrough,
@@ -887,7 +889,7 @@ def _prepare_execute_request(
         prepared_worker=prepared_worker,
         runner_token=runner_token,
     )
-    execution_env = _prepared_shell_execution_env(request, runtime_paths, prepared) or execution_env
+    execution_env = _prepared_shell_execution_env(request, runtime_paths, prepared, execution_env) or execution_env
     config = config or _runtime_config_or_empty(runtime_paths)
     request_workspace = _resolve_request_workspace(request, prepared, runtime_paths=runtime_paths, config=config)
     try:

--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -828,13 +828,27 @@ def _prepared_shell_execution_env(
     if request.tool_name != "shell" or prepared is None:
         return None
     worker_execution_env = sandbox_exec.worker_subprocess_env(prepared.paths)
-    worker_execution_env.update(execution_env)
+    worker_base_path = worker_execution_env.get("PATH")
     worker_execution_env.update(
         constants.shell_extra_env_values(
             extra_env_passthrough=request.extra_env_passthrough,
             process_env=request.execution_env or runtime_paths.process_env,
         ),
     )
+    worker_execution_env.update(execution_env)
+    worker_path = constants.subprocess_path_with_prepends(
+        os.pathsep.join(
+            path
+            for path in (
+                worker_execution_env.get("PATH"),
+                worker_base_path,
+            )
+            if path
+        ),
+        prepend_entries=(str(prepared.paths.venv_dir / "bin"),),
+    )
+    if worker_path is not None:
+        worker_execution_env["PATH"] = worker_path
     return worker_execution_env
 
 

--- a/src/mindroom/workers/backends/_dedicated_worker_common.py
+++ b/src/mindroom/workers/backends/_dedicated_worker_common.py
@@ -8,11 +8,7 @@ from types import MappingProxyType
 from typing import TYPE_CHECKING, cast
 
 from mindroom.agent_policy import build_agent_policy_seeds, resolve_agent_policy_index
-from mindroom.constants import (
-    RuntimePaths,
-    deserialize_runtime_paths,
-    serialize_public_runtime_paths,
-)
+from mindroom.constants import RuntimePaths, deserialize_runtime_paths, serialize_public_runtime_paths
 from mindroom.runtime_env_policy import SANDBOX_RUNTIME_ENV_BY_KEY, SHARED_CREDENTIALS_PATH_ENV
 from mindroom.tool_system.worker_routing import (
     resolved_worker_key_scope,

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -1928,9 +1928,11 @@ def test_prepared_dedicated_shell_request_preserves_explicit_execution_env(tmp_p
         sandbox_runner_module.SandboxRunnerExecuteRequest(
             tool_name="shell",
             function_name="run_shell_command",
+            worker_key="v1:default:unscoped:code",
             execution_env={
                 "HTTP_PROXY": "http://agent-vault-adapter:18080",
                 "http_proxy": "http://agent-vault-adapter:18080",
+                "PATH": "/host/bin",
                 "MINDROOM_CONFIG_PATH": "/bad/config.yaml",
                 "MINDROOM_STORAGE_PATH": "/bad/storage",
                 SHARED_CREDENTIALS_PATH_ENV: "/bad/credentials",
@@ -1943,12 +1945,58 @@ def test_prepared_dedicated_shell_request_preserves_explicit_execution_env(tmp_p
 
     assert prepared_request.execution_env["HTTP_PROXY"] == "http://agent-vault-adapter:18080"
     assert prepared_request.execution_env["http_proxy"] == "http://agent-vault-adapter:18080"
+    assert prepared_request.execution_env["PATH"].startswith(str(worker_paths.venv_dir / "bin"))
+    assert "/host/bin" in prepared_request.execution_env["PATH"]
+    worker_path_entries = sandbox_exec_module.worker_subprocess_env(worker_paths)["PATH"].split(os.pathsep)
+    prepared_path_entries = prepared_request.execution_env["PATH"].split(os.pathsep)
+    assert all(entry in prepared_path_entries for entry in worker_path_entries)
     assert "MINDROOM_CONFIG_PATH" not in prepared_request.execution_env
     assert "MINDROOM_STORAGE_PATH" not in prepared_request.execution_env
     assert SHARED_CREDENTIALS_PATH_ENV not in prepared_request.execution_env
     assert subprocess_context.subprocess_env is not None
     assert subprocess_context.subprocess_env["HTTP_PROXY"] == "http://agent-vault-adapter:18080"
     assert subprocess_context.subprocess_env["http_proxy"] == "http://agent-vault-adapter:18080"
+    assert subprocess_context.subprocess_env["PATH"].startswith(str(worker_paths.venv_dir / "bin"))
+    assert "/host/bin" in subprocess_context.subprocess_env["PATH"]
+
+
+def test_prepared_shell_execution_env_resolved_env_wins_over_extra_passthrough(tmp_path: Path) -> None:
+    """Resolved broker env should not be shadowed by raw extra-env passthrough values."""
+    runtime_paths = resolve_primary_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path / "storage",
+        process_env={"HTTP_PROXY": "http://runtime-proxy:18080"},
+    )
+    worker_paths = local_workers_module.local_worker_state_paths_for_root(tmp_path / "worker-root")
+    prepared_worker = sandbox_runner_module.sandbox_worker_prep.PreparedWorkerRequest(
+        handle=WorkerHandle(
+            worker_id="worker-1",
+            worker_key="v1:default:unscoped:code",
+            endpoint="http://127.0.0.1:8766",
+            auth_token=SANDBOX_TOKEN,
+            status="ready",
+            backend_name="docker",
+            last_used_at=0.0,
+            created_at=0.0,
+        ),
+        paths=worker_paths,
+        runtime_overrides={},
+    )
+
+    execution_env = sandbox_runner_module._prepared_shell_execution_env(
+        sandbox_runner_module.SandboxRunnerExecuteRequest(
+            tool_name="shell",
+            function_name="run_shell_command",
+            execution_env={"HTTP_PROXY": "http://raw-request-proxy:18080"},
+            extra_env_passthrough="HTTP_PROXY",
+        ),
+        runtime_paths,
+        prepared_worker,
+        execution_env={"HTTP_PROXY": "http://resolved-broker-proxy:18080"},
+    )
+
+    assert execution_env is not None
+    assert execution_env["HTTP_PROXY"] == "http://resolved-broker-proxy:18080"
 
 
 def test_filter_runtime_tool_init_overrides_keeps_only_safe_declared_fields() -> None:

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -1889,6 +1889,68 @@ def test_prepare_execute_request_preserves_dedicated_worker_runtime_contract(
     assert "MINDROOM_STORAGE_PATH" not in subprocess_context.subprocess_env
 
 
+def test_prepared_dedicated_shell_request_preserves_explicit_execution_env(tmp_path: Path) -> None:
+    """Prepared Docker/Kubernetes shell workers must keep broker env passed by the primary runtime."""
+    config_path = tmp_path / "config.yaml"
+    _write_general_agent_config(config_path)
+    runtime_paths = resolve_primary_runtime_paths(
+        config_path=config_path,
+        storage_path=tmp_path / "storage",
+        process_env={},
+    )
+    worker_runtime = build_dedicated_worker_runtime_paths(
+        runtime_paths=runtime_paths,
+        backend_name="Docker",
+        worker_key="v1:default:unscoped:code",
+        config_path=Path("/app/config.yaml"),
+        dedicated_root=Path("/app/worker"),
+        worker_port=8766,
+        shared_storage_root="/app/shared-storage",
+        extra_env={},
+    )
+    worker_paths = local_workers_module.local_worker_state_paths_for_root(tmp_path / "worker-root")
+    prepared_worker = sandbox_runner_module.sandbox_worker_prep.PreparedWorkerRequest(
+        handle=WorkerHandle(
+            worker_id="worker-1",
+            worker_key="v1:default:unscoped:code",
+            endpoint="http://127.0.0.1:8766",
+            auth_token=SANDBOX_TOKEN,
+            status="ready",
+            backend_name="docker",
+            last_used_at=0.0,
+            created_at=0.0,
+        ),
+        paths=worker_paths,
+        runtime_overrides={},
+    )
+
+    prepared_request = sandbox_runner_module._prepare_execute_request(
+        sandbox_runner_module.SandboxRunnerExecuteRequest(
+            tool_name="shell",
+            function_name="run_shell_command",
+            execution_env={
+                "HTTP_PROXY": "http://agent-vault-adapter:18080",
+                "http_proxy": "http://agent-vault-adapter:18080",
+                "MINDROOM_CONFIG_PATH": "/bad/config.yaml",
+                "MINDROOM_STORAGE_PATH": "/bad/storage",
+                SHARED_CREDENTIALS_PATH_ENV: "/bad/credentials",
+            },
+        ),
+        worker_runtime,
+        prepared_worker=prepared_worker,
+    )
+    subprocess_context = sandbox_runner_module._prepare_subprocess_context(prepared_request)
+
+    assert prepared_request.execution_env["HTTP_PROXY"] == "http://agent-vault-adapter:18080"
+    assert prepared_request.execution_env["http_proxy"] == "http://agent-vault-adapter:18080"
+    assert "MINDROOM_CONFIG_PATH" not in prepared_request.execution_env
+    assert "MINDROOM_STORAGE_PATH" not in prepared_request.execution_env
+    assert SHARED_CREDENTIALS_PATH_ENV not in prepared_request.execution_env
+    assert subprocess_context.subprocess_env is not None
+    assert subprocess_context.subprocess_env["HTTP_PROXY"] == "http://agent-vault-adapter:18080"
+    assert subprocess_context.subprocess_env["http_proxy"] == "http://agent-vault-adapter:18080"
+
+
 def test_filter_runtime_tool_init_overrides_keeps_only_safe_declared_fields() -> None:
     """Runner-side tool rebuilds should preserve only safe init overrides."""
     filtered = sandbox_runner_module._filter_runtime_tool_init_overrides(

--- a/tests/test_execution_preparation.py
+++ b/tests/test_execution_preparation.py
@@ -19,12 +19,7 @@ from mindroom.execution_preparation import (
     _prepare_execution_context_common,
     render_prepared_messages_text,
 )
-from mindroom.history import (
-    HistoryPolicy,
-    HistoryScope,
-    PreparedScopeHistory,
-    ResolvedHistorySettings,
-)
+from mindroom.history import HistoryPolicy, HistoryScope, PreparedScopeHistory, ResolvedHistorySettings
 from mindroom.history.policy import resolve_history_execution_plan
 from mindroom.history.runtime import _ResolvedPreparationInputs
 from mindroom.tool_system.events import ToolTraceEntry, build_tool_trace_content


### PR DESCRIPTION
## Summary

- Preserve explicit shell `execution_env` when a Docker/Kubernetes prepared worker is used.
- Keep worker-local protected paths filtered while allowing broker env like `HTTP_PROXY`/`http_proxy` to reach the subprocess.
- Add a regression test for the dedicated-worker shell preparation path.

## Validation

- `uv run pytest tests/api/test_sandbox_runner_api.py::test_prepared_dedicated_shell_request_preserves_explicit_execution_env tests/api/test_sandbox_runner_api.py::test_prepare_execute_request_preserves_dedicated_worker_runtime_contract tests/test_worker_egress.py`
- `uv run ruff check .`
- `uv run tach check`
- `uv run pytest`
- `docker build -t mindroom:live-egress-test -f local/instances/deploy/Dockerfile.mindroom .`
- Static-runner live Docker stack: primary container + sandbox-runner + Agent Vault adapter + fake vault + upstream; brokered hidden URL succeeded, direct unbrokered path failed.
- Docker-worker live test: host primary created real `mindroom:live-egress-test` worker containers; brokered hidden URL succeeded through `host.docker.internal:18080`, direct unbrokered path failed.
- Plugin checks: `ruff check .`, `pytest tests -q` via MindRoom venv, `./local/broker_smoke/smoke.sh`.
