### PR TITLE
Add semantic file memory search timing

### DIFF
--- a/src/mindroom/memory/_semantic_file_search.py
+++ b/src/mindroom/memory/_semantic_file_search.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from agno.knowledge.document.base import Document
+    from agno.knowledge.knowledge import Knowledge
 
     from mindroom.config.main import Config
     from mindroom.config.memory import MemorySearchConfig
@@ -28,6 +29,7 @@ _SOURCE_PATH_KEY = "source_path"
 _CHUNK_SIZE = 5000
 _CHUNK_OVERLAP = 0
 _MEMORY_KNOWLEDGE_PREFIX = "file_memory"
+_SEMANTIC_TIMING_PREFIX = "system_prompt_assembly.memory_search.semantic"
 _memory_refresh_scheduler = KnowledgeRefreshScheduler()
 
 
@@ -137,6 +139,24 @@ def _memory_results_from_documents(
     return results
 
 
+def _search_knowledge_with_timing(
+    knowledge: Knowledge,
+    *,
+    query: str,
+    limit: int,
+    timing_scope: str | None,
+) -> list[Document]:
+    search_start = time.monotonic()
+    documents = knowledge.search(query=query, max_results=limit)
+    emit_elapsed_timing(
+        f"{_SEMANTIC_TIMING_PREFIX}.knowledge_search",
+        search_start,
+        timing_scope=timing_scope,
+        result_count=len(documents),
+    )
+    return documents
+
+
 async def search_semantic_file_memories(
     query: str,
     *,
@@ -172,12 +192,20 @@ async def search_semantic_file_memories(
         return []
 
     access_start = time.monotonic()
+    resolve_start = time.monotonic()
     resolution = resolve_knowledge_base_access(
         base_id,
         knowledge_config,
         runtime_paths,
         execution_identity=execution_identity,
     )
+    emit_elapsed_timing(
+        f"{_SEMANTIC_TIMING_PREFIX}.published_index.resolve",
+        resolve_start,
+        timing_scope=timing_scope,
+        availability=resolution.availability.value,
+    )
+    schedule_start = time.monotonic()
     refresh_scheduled = schedule_semantic_file_memory_refresh(
         scope_user_id=scope_user_id,
         root=root,
@@ -185,6 +213,12 @@ async def search_semantic_file_memories(
         runtime_paths=runtime_paths,
         search_config=search_config,
         execution_identity=execution_identity,
+    )
+    emit_elapsed_timing(
+        f"{_SEMANTIC_TIMING_PREFIX}.published_index.schedule_refresh",
+        schedule_start,
+        timing_scope=timing_scope,
+        refresh_scheduled=refresh_scheduled,
     )
     emit_elapsed_timing(
         "system_prompt_assembly.memory_search.semantic.published_index_access",
@@ -198,11 +232,25 @@ async def search_semantic_file_memories(
         raise SemanticFileMemoryIndexUnavailableError(msg)
 
     query_start = time.monotonic()
-    documents: list[Document] = await asyncio.to_thread(resolution.knowledge.search, query=query, max_results=limit)
+    documents = await asyncio.to_thread(
+        _search_knowledge_with_timing,
+        resolution.knowledge,
+        query=query,
+        limit=limit,
+        timing_scope=timing_scope,
+    )
     emit_elapsed_timing(
         "system_prompt_assembly.memory_search.semantic.vector_query",
         query_start,
         timing_scope=timing_scope,
         availability=resolution.availability.value,
     )
-    return _memory_results_from_documents(documents, scope_user_id=scope_user_id)
+    results_start = time.monotonic()
+    results = _memory_results_from_documents(documents, scope_user_id=scope_user_id)
+    emit_elapsed_timing(
+        f"{_SEMANTIC_TIMING_PREFIX}.result_conversion",
+        results_start,
+        timing_scope=timing_scope,
+        result_count=len(results),
+    )
+    return results

--- a/tests/test_memory_file_backend.py
+++ b/tests/test_memory_file_backend.py
@@ -325,6 +325,69 @@ async def test_semantic_memory_search_uses_knowledge_published_index(
     assert scheduled_base_ids == access_base_ids
 
 
+class _FakeSemanticTimingKnowledge:
+    def search(self, *, query: str, max_results: int) -> list[object]:
+        assert query == "semantic memory"
+        assert max_results == 5
+        return [
+            SimpleNamespace(
+                content="Published semantic memory.",
+                meta_data={"source_path": "memory/2026-06-02.md"},
+                reranking_score=0.8,
+            ),
+        ]
+
+
+class _FakeSemanticTimingScheduler:
+    def schedule_refresh(self, *_args: object, **_kwargs: object) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_semantic_memory_search_emits_nested_query_timings(
+    storage_path: Path,
+    config: Config,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = storage_path / "memory-root"
+    memory_file = root / "memory" / "2026-06-02.md"
+    memory_file.parent.mkdir(parents=True)
+    memory_file.write_text("Published semantic memory.\n", encoding="utf-8")
+    runtime_paths = runtime_paths_for(config)
+    fake_knowledge = _FakeSemanticTimingKnowledge()
+
+    def resolve_access(*_args: object, **_kwargs: object) -> object:
+        return SimpleNamespace(knowledge=fake_knowledge, availability=KnowledgeAvailability.READY)
+
+    emitted: list[tuple[str, str | None]] = []
+
+    def emit_timing(label: str, _start: float, **event_data: object) -> None:
+        emitted.append((label, event_data.get("timing_scope")))
+
+    monkeypatch.setattr(semantic_file_search, "list_knowledge_files", lambda *_args, **_kwargs: [memory_file.resolve()])
+    monkeypatch.setattr(semantic_file_search, "resolve_knowledge_base_access", resolve_access)
+    monkeypatch.setattr(semantic_file_search, "_memory_refresh_scheduler", _FakeSemanticTimingScheduler())
+    monkeypatch.setattr(semantic_file_search, "emit_elapsed_timing", emit_timing)
+
+    results = await semantic_file_search.search_semantic_file_memories(
+        "semantic memory",
+        scope_user_id="agent_general",
+        root=root,
+        config=config,
+        runtime_paths=runtime_paths,
+        search_config=config.memory.search,
+        limit=5,
+        timing_scope="scope-123",
+    )
+
+    assert [result["memory"] for result in results] == ["Published semantic memory."]
+    assert ("system_prompt_assembly.memory_search.semantic.published_index.resolve", "scope-123") in emitted
+    assert ("system_prompt_assembly.memory_search.semantic.published_index.schedule_refresh", "scope-123") in emitted
+    assert ("system_prompt_assembly.memory_search.semantic.knowledge_search", "scope-123") in emitted
+    assert ("system_prompt_assembly.memory_search.semantic.vector_query", "scope-123") in emitted
+    assert ("system_prompt_assembly.memory_search.semantic.result_conversion", "scope-123") in emitted
+
+
 @pytest.mark.asyncio
 async def test_semantic_memory_missing_knowledge_index_schedules_refresh_and_raises_fallback(
     storage_path: Path,


### PR DESCRIPTION
## Summary
- add semantic file-memory timing labels at owned boundaries while preserving existing aggregate labels
- split published-index access into resolve and refresh-schedule timings
- add exact synchronous knowledge-search timing and result-conversion timing
- cover the timing labels with a focused file-memory test

## Tests
- uv run ruff check src/mindroom/memory/_semantic_file_search.py tests/test_memory_file_backend.py
- uv run ruff format --check src/mindroom/memory/_semantic_file_search.py tests/test_memory_file_backend.py
- uv run ty check src/mindroom/memory/_semantic_file_search.py tests/test_memory_file_backend.py
- uv run pytest tests/test_memory_file_backend.py -q
- uv run tach check
- pre-commit hooks on commit