### PR TITLE
Avoid refreshing ready semantic file memory reads

### DIFF
--- a/src/mindroom/knowledge/__init__.py
+++ b/src/mindroom/knowledge/__init__.py
@@ -2,6 +2,7 @@
 
 # ruff: noqa: RUF022
 
+from mindroom.knowledge.availability import KnowledgeAvailability
 from mindroom.knowledge.manager import list_knowledge_files
 from mindroom.knowledge.refresh_scheduler import KnowledgeRefreshScheduler
 from mindroom.knowledge.status import reconcile_knowledge_mode_transition_states
@@ -16,6 +17,7 @@ from mindroom.knowledge.utils import (
 
 __all__ = [
     "KnowledgeAccessSupport",
+    "KnowledgeAvailability",
     "KnowledgeBaseAccessResolution",
     "KnowledgeAvailabilityDetail",
     "format_knowledge_availability_notice",

--- a/src/mindroom/memory/_semantic_file_search.py
+++ b/src/mindroom/memory/_semantic_file_search.py
@@ -8,7 +8,12 @@ import time
 from typing import TYPE_CHECKING
 
 from mindroom.config.knowledge import KnowledgeBaseConfig
-from mindroom.knowledge import KnowledgeRefreshScheduler, list_knowledge_files, resolve_knowledge_base_access
+from mindroom.knowledge import (
+    KnowledgeAvailability,
+    KnowledgeRefreshScheduler,
+    list_knowledge_files,
+    resolve_knowledge_base_access,
+)
 from mindroom.logging_config import get_logger
 from mindroom.memory._shared import MemoryResult
 from mindroom.timing import emit_elapsed_timing
@@ -205,15 +210,17 @@ async def search_semantic_file_memories(
         timing_scope=timing_scope,
         availability=resolution.availability.value,
     )
+    refresh_scheduled = False
     schedule_start = time.monotonic()
-    refresh_scheduled = schedule_semantic_file_memory_refresh(
-        scope_user_id=scope_user_id,
-        root=root,
-        config=config,
-        runtime_paths=runtime_paths,
-        search_config=search_config,
-        execution_identity=execution_identity,
-    )
+    if resolution.availability is not KnowledgeAvailability.READY:
+        refresh_scheduled = schedule_semantic_file_memory_refresh(
+            scope_user_id=scope_user_id,
+            root=root,
+            config=config,
+            runtime_paths=runtime_paths,
+            search_config=search_config,
+            execution_identity=execution_identity,
+        )
     emit_elapsed_timing(
         f"{_SEMANTIC_TIMING_PREFIX}.published_index.schedule_refresh",
         schedule_start,

--- a/tests/test_memory_file_backend.py
+++ b/tests/test_memory_file_backend.py
@@ -256,7 +256,7 @@ def config(storage_path: Path) -> Config:
 
 
 @pytest.mark.asyncio
-async def test_semantic_memory_search_uses_knowledge_published_index(
+async def test_semantic_memory_search_uses_ready_published_index_without_refresh(
     storage_path: Path,
     config: Config,
     monkeypatch: pytest.MonkeyPatch,
@@ -322,7 +322,7 @@ async def test_semantic_memory_search_uses_knowledge_published_index(
 
     assert results[0]["memory"] == "Published semantic memory."
     assert access_base_ids
-    assert scheduled_base_ids == access_base_ids
+    assert scheduled_base_ids == []
 
 
 class _FakeSemanticTimingKnowledge:
@@ -336,11 +336,6 @@ class _FakeSemanticTimingKnowledge:
                 reranking_score=0.8,
             ),
         ]
-
-
-class _FakeSemanticTimingScheduler:
-    def schedule_refresh(self, *_args: object, **_kwargs: object) -> None:
-        return None
 
 
 @pytest.mark.asyncio
@@ -366,7 +361,6 @@ async def test_semantic_memory_search_emits_nested_query_timings(
 
     monkeypatch.setattr(semantic_file_search, "list_knowledge_files", lambda *_args, **_kwargs: [memory_file.resolve()])
     monkeypatch.setattr(semantic_file_search, "resolve_knowledge_base_access", resolve_access)
-    monkeypatch.setattr(semantic_file_search, "_memory_refresh_scheduler", _FakeSemanticTimingScheduler())
     monkeypatch.setattr(semantic_file_search, "emit_elapsed_timing", emit_timing)
 
     results = await semantic_file_search.search_semantic_file_memories(


### PR DESCRIPTION
## Summary
- stop semantic file-memory search from scheduling a refresh when the published index is already ready
- keep best-effort refresh scheduling for non-ready indexes
- update file-memory coverage so ready-index reads stay read-only

## Tests
- uv run ruff check src/mindroom/memory/_semantic_file_search.py tests/test_memory_file_backend.py
- uv run ruff format --check src/mindroom/memory/_semantic_file_search.py tests/test_memory_file_backend.py
- uv run ty check src/mindroom/memory/_semantic_file_search.py tests/test_memory_file_backend.py
- uv run pytest tests/test_memory_file_backend.py -q
- uv run tach check
- pre-commit hooks on commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized semantic file memory refresh scheduling to only trigger when the index is unavailable, improving performance by preventing unnecessary refresh attempts when the index is already ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->