### PR TITLE
Disable !config chat command by default

### DIFF
--- a/cluster/k8s/instance/default-config.yaml
+++ b/cluster/k8s/instance/default-config.yaml
@@ -354,6 +354,7 @@ agents:
     tools: []
 authorization:
   default_room_access: false
+  config_command_enabled: false
   global_users:
   - '@test:m-test-4.mindroom.chat'
   room_permissions: {}

--- a/config.yaml
+++ b/config.yaml
@@ -410,6 +410,7 @@ agents:
     tools: []
 authorization:
   default_room_access: false
+  config_command_enabled: false
   global_users:
   - '@test:m-test-4.mindroom.chat'
   room_permissions: {}

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -32,6 +32,9 @@ authorization:
   # Default for rooms not in room_permissions
   default_room_access: false
 
+  # Optional: enable !config for global admin users
+  config_command_enabled: false
+
   # Optional: per-agent/team/router reply allowlists
   # Keys must match an agent name, team name, "router", or "*"
   # Values are canonical Matrix user IDs or glob patterns (aliases are resolved)
@@ -65,9 +68,14 @@ matrix_room_access:
 - `global_users: []`
 - `room_permissions: {}`
 - `default_room_access: false`
+- `config_command_enabled: false`
 - `agent_reply_permissions: {}`
 
 This means only MindRoom system users (agents, teams, router, and the configured internal user if present) can interact with agents by default.
+
+`!config` is disabled by default.
+Set `authorization.config_command_enabled: true` only for trusted single-user or admin-managed environments.
+Even when enabled, callers must be in `authorization.global_users`.
 
 `mindroom_user.username` is a one-time account-creation request used to create the internal Matrix account.
 After the account exists, keep the same configured username and only change `mindroom_user.display_name` for visible name changes.

--- a/docs/chat-commands.md
+++ b/docs/chat-commands.md
@@ -17,7 +17,7 @@ Commands start with `!` and are handled by the router agent.
 | `!list_schedules` | List pending scheduled tasks |
 | `!cancel_schedule <id>` | Cancel a scheduled task |
 | `!edit_schedule <id> <task>` | Edit an existing scheduled task |
-| `!config <operation>` | View and modify configuration |
+| `!config <operation>` | View and modify configuration (disabled by default, admin only when enabled) |
 | `!reload-plugins` | Force-reload all configured plugins (admin only) |
 
 ## Who Handles Commands
@@ -34,6 +34,9 @@ Commands are subject to the same authorization rules as normal messages.
 The sender must be authorized to interact with MindRoom entities in the room (via `global_users`, `room_permissions`, or `default_room_access`).
 See [Authorization](authorization.md) for details.
 
+`!config` is disabled by default.
+Set `authorization.config_command_enabled: true` to enable it.
+When enabled, callers must be in `authorization.global_users`.
 For `!config set`, only the user who requested the change can confirm or cancel it via reactions.
 Pending config changes expire after 24 hours.
 
@@ -145,6 +148,8 @@ Schedule type cannot be changed (one-time to recurring or vice versa) -- cancel 
 ### `!config`
 
 View and modify MindRoom configuration from chat.
+This command is disabled by default.
+Set `authorization.config_command_enabled: true` and use a user in `authorization.global_users` to enable it.
 Changes are validated against the Pydantic config schema before applying.
 
 **View configuration:**

--- a/docs/chat-commands.md
+++ b/docs/chat-commands.md
@@ -149,7 +149,8 @@ Schedule type cannot be changed (one-time to recurring or vice versa) -- cancel 
 
 View and modify MindRoom configuration from chat.
 This command is disabled by default.
-Set `authorization.config_command_enabled: true` and use a user in `authorization.global_users` to enable it.
+Set `authorization.config_command_enabled: true` to enable it.
+When enabled, only users in `authorization.global_users` can use it.
 Changes are validated against the Pydantic config schema before applying.
 
 **View configuration:**

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -448,6 +448,7 @@ authorization:
   global_users: []                 # Users with access to all rooms
   room_permissions: {}             # Keys: room ID (!id), full alias (#alias:domain), or managed room key (alias)
   default_room_access: false       # Default: false
+  config_command_enabled: false    # Enable !config for global admin users; default: false
   aliases: {}                      # Map canonical Matrix user IDs to bridge aliases (see authorization docs)
   agent_reply_permissions: {}      # Per-agent/team/router (or '*') reply allowlists; supports globs like '*:example.com'
 
@@ -647,6 +648,7 @@ Run `mindroom avatars sync --force` to replace existing Matrix room or root-spac
 - `memory.backend: none`, `memory: none`, or `agents.<name>.memory_backend: none` disables built-in durable memory for the effective agent without disabling Agno Learning
 - `defaults.max_preload_chars` caps preloaded file context (`context_files`)
 - When `authorization.default_room_access` is `false`, only users in `global_users` or room-specific `room_permissions` can interact with agents
+- `authorization.config_command_enabled` defaults to `false`; when set to `true`, `!config` still requires `global_users`
 - `authorization.agent_reply_permissions` can further restrict which users specific agents/teams/router will reply to
 - `authorization.aliases` maps bridge bot user IDs to canonical users so bridged messages inherit the same permissions (see [Authorization](../authorization.md))
 - `authorization.room_permissions` accepts room IDs, full room aliases, and managed room keys

--- a/docs/configuration/router.md
+++ b/docs/configuration/router.md
@@ -61,7 +61,7 @@ The router exclusively handles all commands:
 - `!list_schedules` - List scheduled tasks
 - `!cancel_schedule <id>` - Cancel a scheduled task
 - `!edit_schedule <id> <task>` - Edit an existing scheduled task
-- `!config <operation>` - Manage configuration
+- `!config <operation>` - Manage configuration when explicitly enabled for global admins
 
 Even in single-responder rooms, commands are always processed by the router.
 

--- a/docs/dev/exhaustive-live-test-checklist.md
+++ b/docs/dev/exhaustive-live-test-checklist.md
@@ -260,10 +260,10 @@ Expected outcome: Mentions do not revive the removed command and the runtime sti
 - [ ] `CMD-009` Exercise reaction-based interactive prompts that are scoped to one conversation.
 Expected outcome: Reactions outside the intended room, message, or thread do not mutate the interactive workflow.
 
-- [ ] `CMD-010` Use `!config show`, `!config get <path>`, and `!config set <path> <value>` in chat.
+- [ ] `CMD-010` With `authorization.config_command_enabled: true` and a global admin user, use `!config show`, `!config get <path>`, and `!config set <path> <value>` in chat.
 Expected outcome: The router uses the active runtime config path, returns current values correctly, and `set` produces a preview plus confirmation flow before applying the change.
 
-- [ ] `CMD-011` Attempt malformed or invalid `!config set` inputs, including quote-parse failures and runtime-invalid changes.
+- [ ] `CMD-011` Attempt malformed or invalid `!config set` inputs while enabled, including quote-parse failures and runtime-invalid changes.
 Expected outcome: Parse or validation errors are explained clearly and no partial configuration change is applied.
 
 ## 8. Authorization And Room Access Policy

--- a/docs/index.md
+++ b/docs/index.md
@@ -125,7 +125,7 @@ mindroom run
 | **Authorization** | Fine-grained user and room access control |
 | **OpenAI-Compatible API** | Use agents from LibreChat, Open WebUI, or any OpenAI client |
 | **Streaming** | Progressive message edits with presence-based gating and tool-call markers |
-| **Chat Commands** | Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!help [topic]`, `!reload-plugins`, `!config <operation>`, and `!hi` commands handled by the router |
+| **Chat Commands** | Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!help [topic]`, admin `!reload-plugins`, opt-in admin `!config <operation>`, and `!hi` commands handled by the router |
 | **Hot Reload** | Config changes are detected and agents restart automatically |
 
 ## Architecture
@@ -164,7 +164,7 @@ mindroom run
 - [Image Messages](images.md) - Image analysis with vision models
 - [File & Video Attachments](attachments.md) - Context-scoped file and video handling
 - [Streaming Responses](streaming.md) - Progressive message edits with presence-based gating
-- [Chat Commands](chat-commands.md) - Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!help [topic]`, `!reload-plugins`, `!config <operation>`, and `!hi` commands
+- [Chat Commands](chat-commands.md) - Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!help [topic]`, admin `!reload-plugins`, opt-in admin `!config <operation>`, and `!hi` commands
 - [Interactive Q&A](interactive.md) - Clickable multiple-choice questions via Matrix reactions
 - [Authorization](authorization.md) - User and room access control
 - [Matrix Space](matrix-space.md) - Optional root Matrix Space for grouping managed rooms

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -127,7 +127,7 @@ mindroom run
 | **Authorization** | Fine-grained user and room access control |
 | **OpenAI-Compatible API** | Use agents from LibreChat, Open WebUI, or any OpenAI client |
 | **Streaming** | Progressive message edits with presence-based gating and tool-call markers |
-| **Chat Commands** | Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!help [topic]`, `!reload-plugins`, `!config <operation>`, and `!hi` commands handled by the router |
+| **Chat Commands** | Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!help [topic]`, admin `!reload-plugins`, opt-in admin `!config <operation>`, and `!hi` commands handled by the router |
 | **Hot Reload** | Config changes are detected and agents restart automatically |
 
 ## Architecture
@@ -166,7 +166,7 @@ mindroom run
 - [Image Messages](https://docs.mindroom.chat/images/) - Image analysis with vision models
 - [File & Video Attachments](https://docs.mindroom.chat/attachments/) - Context-scoped file and video handling
 - [Streaming Responses](https://docs.mindroom.chat/streaming/) - Progressive message edits with presence-based gating
-- [Chat Commands](https://docs.mindroom.chat/chat-commands/) - Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!help [topic]`, `!reload-plugins`, `!config <operation>`, and `!hi` commands
+- [Chat Commands](https://docs.mindroom.chat/chat-commands/) - Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!help [topic]`, admin `!reload-plugins`, opt-in admin `!config <operation>`, and `!hi` commands
 - [Interactive Q&A](https://docs.mindroom.chat/interactive/) - Clickable multiple-choice questions via Matrix reactions
 - [Authorization](https://docs.mindroom.chat/authorization/) - User and room access control
 - [Matrix Space](https://docs.mindroom.chat/matrix-space/) - Optional root Matrix Space for grouping managed rooms
@@ -1239,6 +1239,7 @@ authorization:
   global_users: []                 # Users with access to all rooms
   room_permissions: {}             # Keys: room ID (!id), full alias (#alias:domain), or managed room key (alias)
   default_room_access: false       # Default: false
+  config_command_enabled: false    # Enable !config for global admin users; default: false
   aliases: {}                      # Map canonical Matrix user IDs to bridge aliases (see authorization docs)
   agent_reply_permissions: {}      # Per-agent/team/router (or '*') reply allowlists; supports globs like '*:example.com'
 
@@ -1438,6 +1439,7 @@ Run `mindroom avatars sync --force` to replace existing Matrix room or root-spac
 - `memory.backend: none`, `memory: none`, or `agents.<name>.memory_backend: none` disables built-in durable memory for the effective agent without disabling Agno Learning
 - `defaults.max_preload_chars` caps preloaded file context (`context_files`)
 - When `authorization.default_room_access` is `false`, only users in `global_users` or room-specific `room_permissions` can interact with agents
+- `authorization.config_command_enabled` defaults to `false`; when set to `true`, `!config` still requires `global_users`
 - `authorization.agent_reply_permissions` can further restrict which users specific agents/teams/router will reply to
 - `authorization.aliases` maps bridge bot user IDs to canonical users so bridged messages inherit the same permissions (see [Authorization](https://docs.mindroom.chat/authorization/))
 - `authorization.room_permissions` accepts room IDs, full room aliases, and managed room keys
@@ -2626,7 +2628,7 @@ The router exclusively handles all commands:
 - `!list_schedules` - List scheduled tasks
 - `!cancel_schedule <id>` - Cancel a scheduled task
 - `!edit_schedule <id> <task>` - Edit an existing scheduled task
-- `!config <operation>` - Manage configuration
+- `!config <operation>` - Manage configuration when explicitly enabled for global admins
 
 Even in single-responder rooms, commands are always processed by the router.
 
@@ -12478,7 +12480,7 @@ Commands start with `!` and are handled by the router agent.
 | `!list_schedules` | List pending scheduled tasks |
 | `!cancel_schedule <id>` | Cancel a scheduled task |
 | `!edit_schedule <id> <task>` | Edit an existing scheduled task |
-| `!config <operation>` | View and modify configuration |
+| `!config <operation>` | View and modify configuration (disabled by default, admin only when enabled) |
 | `!reload-plugins` | Force-reload all configured plugins (admin only) |
 
 ## Who Handles Commands
@@ -12495,6 +12497,9 @@ Commands are subject to the same authorization rules as normal messages.
 The sender must be authorized to interact with MindRoom entities in the room (via `global_users`, `room_permissions`, or `default_room_access`).
 See [Authorization](https://docs.mindroom.chat/authorization/) for details.
 
+`!config` is disabled by default.
+Set `authorization.config_command_enabled: true` to enable it.
+When enabled, callers must be in `authorization.global_users`.
 For `!config set`, only the user who requested the change can confirm or cancel it via reactions.
 Pending config changes expire after 24 hours.
 
@@ -12606,6 +12611,8 @@ Schedule type cannot be changed (one-time to recurring or vice versa) -- cancel 
 ### `!config`
 
 View and modify MindRoom configuration from chat.
+This command is disabled by default.
+Set `authorization.config_command_enabled: true` and use a user in `authorization.global_users` to enable it.
 Changes are validated against the Pydantic config schema before applying.
 
 **View configuration:**
@@ -13092,6 +13099,9 @@ authorization:
   # Default for rooms not in room_permissions
   default_room_access: false
 
+  # Optional: enable !config for global admin users
+  config_command_enabled: false
+
   # Optional: per-agent/team/router reply allowlists
   # Keys must match an agent name, team name, "router", or "*"
   # Values are canonical Matrix user IDs or glob patterns (aliases are resolved)
@@ -13125,9 +13135,14 @@ matrix_room_access:
 - `global_users: []`
 - `room_permissions: {}`
 - `default_room_access: false`
+- `config_command_enabled: false`
 - `agent_reply_permissions: {}`
 
 This means only MindRoom system users (agents, teams, router, and the configured internal user if present) can interact with agents by default.
+
+`!config` is disabled by default.
+Set `authorization.config_command_enabled: true` only for trusted single-user or admin-managed environments.
+Even when enabled, callers must be in `authorization.global_users`.
 
 `mindroom_user.username` is a one-time account-creation request used to create the internal Matrix account.
 After the account exists, keep the same configured username and only change `mindroom_user.display_name` for visible name changes.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -12612,7 +12612,8 @@ Schedule type cannot be changed (one-time to recurring or vice versa) -- cancel 
 
 View and modify MindRoom configuration from chat.
 This command is disabled by default.
-Set `authorization.config_command_enabled: true` and use a user in `authorization.global_users` to enable it.
+Set `authorization.config_command_enabled: true` to enable it.
+When enabled, only users in `authorization.global_users` can use it.
 Changes are validated against the Pydantic config schema before applying.
 
 **View configuration:**

--- a/skills/mindroom-docs/references/page__authorization__index.md
+++ b/skills/mindroom-docs/references/page__authorization__index.md
@@ -28,6 +28,9 @@ authorization:
   # Default for rooms not in room_permissions
   default_room_access: false
 
+  # Optional: enable !config for global admin users
+  config_command_enabled: false
+
   # Optional: per-agent/team/router reply allowlists
   # Keys must match an agent name, team name, "router", or "*"
   # Values are canonical Matrix user IDs or glob patterns (aliases are resolved)
@@ -61,9 +64,14 @@ matrix_room_access:
 - `global_users: []`
 - `room_permissions: {}`
 - `default_room_access: false`
+- `config_command_enabled: false`
 - `agent_reply_permissions: {}`
 
 This means only MindRoom system users (agents, teams, router, and the configured internal user if present) can interact with agents by default.
+
+`!config` is disabled by default.
+Set `authorization.config_command_enabled: true` only for trusted single-user or admin-managed environments.
+Even when enabled, callers must be in `authorization.global_users`.
 
 `mindroom_user.username` is a one-time account-creation request used to create the internal Matrix account.
 After the account exists, keep the same configured username and only change `mindroom_user.display_name` for visible name changes.

--- a/skills/mindroom-docs/references/page__chat-commands__index.md
+++ b/skills/mindroom-docs/references/page__chat-commands__index.md
@@ -13,7 +13,7 @@ Commands start with `!` and are handled by the router agent.
 | `!list_schedules` | List pending scheduled tasks |
 | `!cancel_schedule <id>` | Cancel a scheduled task |
 | `!edit_schedule <id> <task>` | Edit an existing scheduled task |
-| `!config <operation>` | View and modify configuration |
+| `!config <operation>` | View and modify configuration (disabled by default, admin only when enabled) |
 | `!reload-plugins` | Force-reload all configured plugins (admin only) |
 
 ## Who Handles Commands
@@ -30,6 +30,9 @@ Commands are subject to the same authorization rules as normal messages.
 The sender must be authorized to interact with MindRoom entities in the room (via `global_users`, `room_permissions`, or `default_room_access`).
 See [Authorization](https://docs.mindroom.chat/authorization/) for details.
 
+`!config` is disabled by default.
+Set `authorization.config_command_enabled: true` to enable it.
+When enabled, callers must be in `authorization.global_users`.
 For `!config set`, only the user who requested the change can confirm or cancel it via reactions.
 Pending config changes expire after 24 hours.
 
@@ -141,6 +144,8 @@ Schedule type cannot be changed (one-time to recurring or vice versa) -- cancel 
 ### `!config`
 
 View and modify MindRoom configuration from chat.
+This command is disabled by default.
+Set `authorization.config_command_enabled: true` and use a user in `authorization.global_users` to enable it.
 Changes are validated against the Pydantic config schema before applying.
 
 **View configuration:**

--- a/skills/mindroom-docs/references/page__chat-commands__index.md
+++ b/skills/mindroom-docs/references/page__chat-commands__index.md
@@ -145,7 +145,8 @@ Schedule type cannot be changed (one-time to recurring or vice versa) -- cancel 
 
 View and modify MindRoom configuration from chat.
 This command is disabled by default.
-Set `authorization.config_command_enabled: true` and use a user in `authorization.global_users` to enable it.
+Set `authorization.config_command_enabled: true` to enable it.
+When enabled, only users in `authorization.global_users` can use it.
 Changes are validated against the Pydantic config schema before applying.
 
 **View configuration:**

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -444,6 +444,7 @@ authorization:
   global_users: []                 # Users with access to all rooms
   room_permissions: {}             # Keys: room ID (!id), full alias (#alias:domain), or managed room key (alias)
   default_room_access: false       # Default: false
+  config_command_enabled: false    # Enable !config for global admin users; default: false
   aliases: {}                      # Map canonical Matrix user IDs to bridge aliases (see authorization docs)
   agent_reply_permissions: {}      # Per-agent/team/router (or '*') reply allowlists; supports globs like '*:example.com'
 
@@ -643,6 +644,7 @@ Run `mindroom avatars sync --force` to replace existing Matrix room or root-spac
 - `memory.backend: none`, `memory: none`, or `agents.<name>.memory_backend: none` disables built-in durable memory for the effective agent without disabling Agno Learning
 - `defaults.max_preload_chars` caps preloaded file context (`context_files`)
 - When `authorization.default_room_access` is `false`, only users in `global_users` or room-specific `room_permissions` can interact with agents
+- `authorization.config_command_enabled` defaults to `false`; when set to `true`, `!config` still requires `global_users`
 - `authorization.agent_reply_permissions` can further restrict which users specific agents/teams/router will reply to
 - `authorization.aliases` maps bridge bot user IDs to canonical users so bridged messages inherit the same permissions (see [Authorization](https://docs.mindroom.chat/authorization/))
 - `authorization.room_permissions` accepts room IDs, full room aliases, and managed room keys

--- a/skills/mindroom-docs/references/page__configuration__router__index.md
+++ b/skills/mindroom-docs/references/page__configuration__router__index.md
@@ -57,7 +57,7 @@ The router exclusively handles all commands:
 - `!list_schedules` - List scheduled tasks
 - `!cancel_schedule <id>` - Cancel a scheduled task
 - `!edit_schedule <id> <task>` - Edit an existing scheduled task
-- `!config <operation>` - Manage configuration
+- `!config <operation>` - Manage configuration when explicitly enabled for global admins
 
 Even in single-responder rooms, commands are always processed by the router.
 

--- a/skills/mindroom-docs/references/page__index.md
+++ b/skills/mindroom-docs/references/page__index.md
@@ -121,7 +121,7 @@ mindroom run
 | **Authorization** | Fine-grained user and room access control |
 | **OpenAI-Compatible API** | Use agents from LibreChat, Open WebUI, or any OpenAI client |
 | **Streaming** | Progressive message edits with presence-based gating and tool-call markers |
-| **Chat Commands** | Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!help [topic]`, `!reload-plugins`, `!config <operation>`, and `!hi` commands handled by the router |
+| **Chat Commands** | Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!help [topic]`, admin `!reload-plugins`, opt-in admin `!config <operation>`, and `!hi` commands handled by the router |
 | **Hot Reload** | Config changes are detected and agents restart automatically |
 
 ## Architecture
@@ -160,7 +160,7 @@ mindroom run
 - [Image Messages](https://docs.mindroom.chat/images/) - Image analysis with vision models
 - [File & Video Attachments](https://docs.mindroom.chat/attachments/) - Context-scoped file and video handling
 - [Streaming Responses](https://docs.mindroom.chat/streaming/) - Progressive message edits with presence-based gating
-- [Chat Commands](https://docs.mindroom.chat/chat-commands/) - Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!help [topic]`, `!reload-plugins`, `!config <operation>`, and `!hi` commands
+- [Chat Commands](https://docs.mindroom.chat/chat-commands/) - Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!help [topic]`, admin `!reload-plugins`, opt-in admin `!config <operation>`, and `!hi` commands
 - [Interactive Q&A](https://docs.mindroom.chat/interactive/) - Clickable multiple-choice questions via Matrix reactions
 - [Authorization](https://docs.mindroom.chat/authorization/) - User and room access control
 - [Matrix Space](https://docs.mindroom.chat/matrix-space/) - Optional root Matrix Space for grouping managed rooms

--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -947,6 +947,7 @@ memory:
 
 authorization:
   default_room_access: false
+  config_command_enabled: false
   global_users:
     # Replace with your Matrix user ID (example: @alice:mindroom.chat).
     - {constants.OWNER_MATRIX_USER_ID_PLACEHOLDER}

--- a/src/mindroom/commands/config_confirmation.py
+++ b/src/mindroom/commands/config_confirmation.py
@@ -370,20 +370,37 @@ async def handle_confirmation_reaction(
     )
 
     if reaction_key == "✅":
-        # User confirmed - apply the change
-        from mindroom.commands.config_commands import apply_config_change  # noqa: PLC0415
+        authorization = bot.config.authorization
+        resolved_requester = authorization.resolve_alias(event.sender)
+        if not authorization.config_command_enabled:
+            response_text = "❌ Config command disabled."
+            logger.info(
+                "Config change rejected because command is disabled",
+                path=pending_change.config_path,
+                requester=event.sender,
+            )
+        elif resolved_requester not in authorization.global_users:
+            response_text = "❌ Admin only."
+            logger.info(
+                "Config change rejected because requester is not admin",
+                path=pending_change.config_path,
+                requester=event.sender,
+            )
+        else:
+            # User confirmed - apply the change
+            from mindroom.commands.config_commands import apply_config_change  # noqa: PLC0415
 
-        response_text = await apply_config_change(
-            pending_change.config_path,
-            pending_change.new_value,
-            runtime_paths=bot.runtime_paths,
-        )
+            response_text = await apply_config_change(
+                pending_change.config_path,
+                pending_change.new_value,
+                runtime_paths=bot.runtime_paths,
+            )
 
-        logger.info(
-            "Config change confirmed",
-            path=pending_change.config_path,
-            requester=event.sender,
-        )
+            logger.info(
+                "Config change confirmed",
+                path=pending_change.config_path,
+                requester=event.sender,
+            )
     else:
         # User cancelled
         response_text = "❌ Configuration change cancelled."

--- a/src/mindroom/commands/config_confirmation.py
+++ b/src/mindroom/commands/config_confirmation.py
@@ -341,12 +341,16 @@ async def handle_confirmation_reaction(
         pending_change: The pending configuration change
 
     """
+    authorization = bot.config.authorization
+    resolved_sender = authorization.resolve_alias(event.sender)
+
     # Only process reactions from the requester
-    if event.sender != pending_change.requester:
+    if resolved_sender != pending_change.requester:
         logger.debug(
             "Ignoring config reaction from non-requester",
             sender=event.sender,
             requester=pending_change.requester,
+            resolved_sender=resolved_sender,
         )
         return
 
@@ -370,8 +374,6 @@ async def handle_confirmation_reaction(
     )
 
     if reaction_key == "✅":
-        authorization = bot.config.authorization
-        resolved_requester = authorization.resolve_alias(event.sender)
         if not authorization.config_command_enabled:
             response_text = "❌ Config command disabled."
             logger.info(
@@ -379,7 +381,7 @@ async def handle_confirmation_reaction(
                 path=pending_change.config_path,
                 requester=event.sender,
             )
-        elif resolved_requester not in authorization.global_users:
+        elif resolved_sender not in authorization.global_users:
             response_text = "❌ Admin only."
             logger.info(
                 "Config change rejected because requester is not admin",

--- a/src/mindroom/commands/handler.py
+++ b/src/mindroom/commands/handler.py
@@ -335,7 +335,7 @@ async def handle_command(  # noqa: C901, PLR0912, PLR0915
                         config_path=change_info["config_path"],
                         old_value=change_info["old_value"],
                         new_value=change_info["new_value"],
-                        requester=requester_user_id,
+                        requester=resolved_requester_user_id,
                     )
 
                     # Get the pending change we just registered

--- a/src/mindroom/commands/handler.py
+++ b/src/mindroom/commands/handler.py
@@ -298,61 +298,68 @@ async def handle_command(  # noqa: C901, PLR0912, PLR0915
         )
 
     elif command.type == CommandType.CONFIG:
-        # Handle config command
-        args_text = command.args.get("args_text", "")
-        response_text, change_info = await handle_config_command(
-            args_text,
-            runtime_paths=context.runtime_paths,
-        )
-
-        # If we have change_info, this is a config set that needs confirmation
-        if change_info:
-            # Send the preview message
-            raw_response_event_id = await context.send_response(
-                response_text,
-                skip_mentions=True,
-            )
-            response_event_id = _normalized_response_event_id(raw_response_event_id)
-            handled_turn = HandledTurnState.from_source_event_id(
-                event.event_id,
-                response_event_id=response_event_id,
+        authorization = context.config.authorization
+        resolved_requester_user_id = authorization.resolve_alias(requester_user_id)
+        if not authorization.config_command_enabled:
+            response_text = "❌ Config command disabled."
+        elif resolved_requester_user_id not in authorization.global_users:
+            response_text = "❌ Admin only."
+        else:
+            # Handle config command
+            args_text = command.args.get("args_text", "")
+            response_text, change_info = await handle_config_command(
+                args_text,
+                runtime_paths=context.runtime_paths,
             )
 
-            if response_event_id:
-                context.record_handled_turn(handled_turn)
-                # Register the pending change
-                config_confirmation.register_pending_change(
-                    event_id=response_event_id,
-                    room_id=room.room_id,
-                    thread_id=effective_thread_id,
-                    config_path=change_info["config_path"],
-                    old_value=change_info["old_value"],
-                    new_value=change_info["new_value"],
-                    requester=requester_user_id,
+            # If we have change_info, this is a config set that needs confirmation
+            if change_info:
+                # Send the preview message
+                raw_response_event_id = await context.send_response(
+                    response_text,
+                    skip_mentions=True,
+                )
+                response_event_id = _normalized_response_event_id(raw_response_event_id)
+                handled_turn = HandledTurnState.from_source_event_id(
+                    event.event_id,
+                    response_event_id=response_event_id,
                 )
 
-                # Get the pending change we just registered
-                pending_change = config_confirmation.get_pending_change(response_event_id)
-
-                # Store in Matrix state for persistence
-                if pending_change:
-                    await config_confirmation.store_pending_change_in_matrix(
-                        context.client,
-                        response_event_id,
-                        pending_change,
+                if response_event_id:
+                    context.record_handled_turn(handled_turn)
+                    # Register the pending change
+                    config_confirmation.register_pending_change(
+                        event_id=response_event_id,
+                        room_id=room.room_id,
+                        thread_id=effective_thread_id,
+                        config_path=change_info["config_path"],
+                        old_value=change_info["old_value"],
+                        new_value=change_info["new_value"],
+                        requester=requester_user_id,
                     )
 
-                # Add reaction buttons
-                await config_confirmation.add_confirmation_reactions(
-                    context.client,
-                    room.room_id,
-                    response_event_id,
-                    config=context.config,
-                )
+                    # Get the pending change we just registered
+                    pending_change = config_confirmation.get_pending_change(response_event_id)
 
-            if response_event_id is None:
-                context.record_handled_turn(handled_turn)
-            return  # Exit early since we've handled the response
+                    # Store in Matrix state for persistence
+                    if pending_change:
+                        await config_confirmation.store_pending_change_in_matrix(
+                            context.client,
+                            response_event_id,
+                            pending_change,
+                        )
+
+                    # Add reaction buttons
+                    await config_confirmation.add_confirmation_reactions(
+                        context.client,
+                        room.room_id,
+                        response_event_id,
+                        config=context.config,
+                    )
+
+                if response_event_id is None:
+                    context.record_handled_turn(handled_turn)
+                return  # Exit early since we've handled the response
 
     elif command.type == CommandType.UNKNOWN:
         # Handle unknown commands

--- a/src/mindroom/commands/parsing.py
+++ b/src/mindroom/commands/parsing.py
@@ -311,6 +311,9 @@ Usage: `!config <operation>` - View and modify MindRoom configuration
 - Arrays use indexes (e.g., `agents.analyst.tools.0` for first tool)
 - String values with spaces must be quoted
 
+**Permission:** Disabled by default.
+Set `authorization.config_command_enabled: true`; caller must also be in `authorization.global_users`.
+
 **Note:** Configuration changes are immediately saved to config.yaml and affect all new agent interactions."""
 
     # General help - dynamically generated from COMMAND_DOCS

--- a/src/mindroom/config/auth.py
+++ b/src/mindroom/config/auth.py
@@ -25,6 +25,10 @@ class AuthorizationConfig(BaseModel):
         default=False,
         description="Default permission for rooms not explicitly configured",
     )
+    config_command_enabled: bool = Field(
+        default=False,
+        description="Enable the chat !config command for global admin users.",
+    )
     aliases: dict[str, list[str]] = Field(
         default_factory=dict,
         description=(

--- a/tests/test_config_commands.py
+++ b/tests/test_config_commands.py
@@ -846,6 +846,51 @@ async def test_handle_confirmation_reaction_respects_disabled_config_command(tmp
 
 
 @pytest.mark.asyncio
+async def test_handle_confirmation_reaction_requires_current_admin(tmp_path: Path) -> None:
+    """Confirmation should fail if hot reload removed the requester from global admins."""
+    target = MessageTarget.resolve("!room:example.org", None, "$preview")
+    bot = SimpleNamespace(
+        client=SimpleNamespace(user_id="@router:example.org"),
+        config=SimpleNamespace(
+            authorization=_handler_authorization(
+                config_command_enabled=True,
+                global_users=["@other-admin:example.org"],
+            ),
+        ),
+        runtime_paths=resolve_runtime_paths(config_path=tmp_path / "config.yaml", storage_path=tmp_path),
+        _conversation_resolver=SimpleNamespace(
+            build_message_target=MagicMock(return_value=target),
+        ),
+        _send_response=AsyncMock(),
+    )
+    room = SimpleNamespace(room_id="!room:example.org")
+    event = SimpleNamespace(sender="@admin:example.org", key="✅", reacts_to="$preview")
+    pending_change = SimpleNamespace(
+        room_id="!room:example.org",
+        thread_id=None,
+        config_path="defaults.markdown",
+        new_value=False,
+        requester="@admin:example.org",
+    )
+
+    with (
+        patch(
+            "mindroom.commands.config_confirmation._remove_pending_change_from_matrix",
+            new_callable=AsyncMock,
+        ),
+        patch("mindroom.commands.config_commands.apply_config_change", new_callable=AsyncMock) as mock_apply,
+    ):
+        await handle_confirmation_reaction(bot, room, event, pending_change)
+
+    mock_apply.assert_not_awaited()
+    bot._send_response.assert_awaited_once_with(
+        target=target,
+        response_text="❌ Admin only.",
+        skip_mentions=True,
+    )
+
+
+@pytest.mark.asyncio
 async def test_handle_config_command_uses_explicit_runtime_paths(tmp_path: Path) -> None:
     """Direct config commands should use the provided runtime context."""
     config_path = tmp_path / "runtime-config.yaml"

--- a/tests/test_config_commands.py
+++ b/tests/test_config_commands.py
@@ -46,20 +46,11 @@ def _handler_authorization(
     config_command_enabled: bool,
     global_users: list[str] | None = None,
     aliases: dict[str, list[str]] | None = None,
-) -> SimpleNamespace:
-    auth_aliases = aliases or {}
-
-    def resolve_alias(sender_id: str) -> str:
-        for canonical, alias_list in auth_aliases.items():
-            if sender_id in alias_list:
-                return canonical
-        return sender_id
-
-    return SimpleNamespace(
+) -> AuthorizationConfig:
+    return AuthorizationConfig(
         config_command_enabled=config_command_enabled,
         global_users=global_users or [],
-        aliases=auth_aliases,
-        resolve_alias=resolve_alias,
+        aliases=aliases or {},
     )
 
 
@@ -647,6 +638,7 @@ async def test_handle_command_config_set_confirmation_records_preview_event_id(t
             authorization=_handler_authorization(
                 config_command_enabled=True,
                 global_users=["@alice:example.org"],
+                aliases={"@alice:example.org": ["@telegram_alice:example.org"]},
             ),
         ),
         runtime_paths=resolve_runtime_paths(config_path=tmp_path / "config.yaml", storage_path=tmp_path),
@@ -659,7 +651,7 @@ async def test_handle_command_config_set_confirmation_records_preview_event_id(t
     )
     room = SimpleNamespace(room_id="!room:example.org")
     event = SimpleNamespace(
-        sender="@alice:example.org",
+        sender="@telegram_alice:example.org",
         event_id="$event",
         source={"content": {"body": "!config set defaults.markdown false"}},
     )
@@ -699,7 +691,7 @@ async def test_handle_command_config_set_confirmation_records_preview_event_id(t
             room=room,
             event=event,
             command=command,
-            requester_user_id="@alice:example.org",
+            requester_user_id="@telegram_alice:example.org",
         )
 
     mock_register.assert_called_once_with(
@@ -886,6 +878,60 @@ async def test_handle_confirmation_reaction_requires_current_admin(tmp_path: Pat
     bot._send_response.assert_awaited_once_with(
         target=target,
         response_text="❌ Admin only.",
+        skip_mentions=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_confirmation_reaction_accepts_alias_backed_requester(tmp_path: Path) -> None:
+    """Alias-backed admins should be able to confirm their own pending config changes."""
+    target = MessageTarget.resolve("!room:example.org", None, "$preview")
+    bot = SimpleNamespace(
+        client=SimpleNamespace(user_id="@router:example.org"),
+        config=SimpleNamespace(
+            authorization=_handler_authorization(
+                config_command_enabled=True,
+                global_users=["@admin:example.org"],
+                aliases={"@admin:example.org": ["@telegram_admin:example.org"]},
+            ),
+        ),
+        runtime_paths=resolve_runtime_paths(config_path=tmp_path / "config.yaml", storage_path=tmp_path),
+        _conversation_resolver=SimpleNamespace(
+            build_message_target=MagicMock(return_value=target),
+        ),
+        _send_response=AsyncMock(),
+    )
+    room = SimpleNamespace(room_id="!room:example.org")
+    event = SimpleNamespace(sender="@telegram_admin:example.org", key="✅", reacts_to="$preview")
+    pending_change = SimpleNamespace(
+        room_id="!room:example.org",
+        thread_id=None,
+        config_path="defaults.markdown",
+        new_value=False,
+        requester="@admin:example.org",
+    )
+
+    with (
+        patch(
+            "mindroom.commands.config_confirmation._remove_pending_change_from_matrix",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "mindroom.commands.config_commands.apply_config_change",
+            new_callable=AsyncMock,
+            return_value="✅ Configuration updated successfully.",
+        ) as mock_apply,
+    ):
+        await handle_confirmation_reaction(bot, room, event, pending_change)
+
+    mock_apply.assert_awaited_once_with(
+        "defaults.markdown",
+        False,
+        runtime_paths=bot.runtime_paths,
+    )
+    bot._send_response.assert_awaited_once_with(
+        target=target,
+        response_text="✅ Configuration updated successfully.",
         skip_mentions=True,
     )
 

--- a/tests/test_config_commands.py
+++ b/tests/test_config_commands.py
@@ -23,7 +23,7 @@ from mindroom.commands.config_commands import (
     apply_config_change,
     handle_config_command,
 )
-from mindroom.commands.config_confirmation import add_confirmation_reactions
+from mindroom.commands.config_confirmation import add_confirmation_reactions, handle_confirmation_reaction
 from mindroom.commands.handler import CommandHandlerContext, handle_command
 from mindroom.commands.parsing import Command, CommandType, _CommandParser
 from mindroom.config.auth import AuthorizationConfig
@@ -39,6 +39,33 @@ from tests.conftest import make_event_cache_mock, write_config_yaml
 
 def _runtime_paths_for_config(config_path: Path) -> constants_mod.RuntimePaths:
     return resolve_runtime_paths(config_path=config_path)
+
+
+def _handler_authorization(
+    *,
+    config_command_enabled: bool,
+    global_users: list[str] | None = None,
+    aliases: dict[str, list[str]] | None = None,
+) -> SimpleNamespace:
+    auth_aliases = aliases or {}
+
+    def resolve_alias(sender_id: str) -> str:
+        for canonical, alias_list in auth_aliases.items():
+            if sender_id in alias_list:
+                return canonical
+        return sender_id
+
+    return SimpleNamespace(
+        config_command_enabled=config_command_enabled,
+        global_users=global_users or [],
+        aliases=auth_aliases,
+        resolve_alias=resolve_alias,
+    )
+
+
+def test_authorization_config_disables_config_command_by_default() -> None:
+    """Chat config commands should be disabled unless explicitly enabled."""
+    assert AuthorizationConfig().config_command_enabled is False
 
 
 def test_validate_and_persist_config_payload_validates_and_writes_authored_payload(tmp_path: Path) -> None:
@@ -317,7 +344,12 @@ async def test_handle_command_threads_config_path_to_config_commands(tmp_path: P
     config_path = tmp_path / "custom-config.yaml"
     context = CommandHandlerContext(
         client=AsyncMock(),
-        config=MagicMock(),
+        config=SimpleNamespace(
+            authorization=_handler_authorization(
+                config_command_enabled=True,
+                global_users=["@alice:example.org"],
+            ),
+        ),
         runtime_paths=resolve_runtime_paths(config_path=config_path, storage_path=tmp_path),
         logger=MagicMock(),
         conversation_cache=MagicMock(),
@@ -347,6 +379,92 @@ async def test_handle_command_threads_config_path_to_config_commands(tmp_path: P
         )
 
     mock_handle_config_command.assert_awaited_once_with("show", runtime_paths=context.runtime_paths)
+
+
+@pytest.mark.asyncio
+async def test_handle_command_config_disabled_by_default(tmp_path: Path) -> None:
+    """Disabled config commands should reject before loading or previewing config."""
+    context = CommandHandlerContext(
+        client=AsyncMock(),
+        config=SimpleNamespace(
+            authorization=_handler_authorization(
+                config_command_enabled=False,
+                global_users=["@admin:example.org"],
+            ),
+        ),
+        runtime_paths=resolve_runtime_paths(config_path=tmp_path / "config.yaml", storage_path=tmp_path),
+        logger=MagicMock(),
+        conversation_cache=MagicMock(),
+        event_cache=make_event_cache_mock(),
+        stable_target=MessageTarget.resolve("!room:example.org", None, "$event"),
+        record_handled_turn=MagicMock(),
+        send_response=AsyncMock(return_value="$reply"),
+    )
+    room = SimpleNamespace(room_id="!room:example.org")
+    event = SimpleNamespace(
+        sender="@admin:example.org",
+        event_id="$event",
+        source={"content": {"body": "!config show"}},
+    )
+    command = Command(type=CommandType.CONFIG, args={"args_text": "show"}, raw_text="!config show")
+
+    with patch(
+        "mindroom.commands.handler.handle_config_command",
+        AsyncMock(return_value=("ok", None)),
+    ) as mock_handle_config_command:
+        await handle_command(
+            context=context,
+            room=room,
+            event=event,
+            command=command,
+            requester_user_id="@admin:example.org",
+        )
+
+    mock_handle_config_command.assert_not_awaited()
+    assert context.send_response.await_args.args[0] == "❌ Config command disabled."
+
+
+@pytest.mark.asyncio
+async def test_handle_command_config_enabled_requires_admin(tmp_path: Path) -> None:
+    """Enabled config commands should still require a global admin."""
+    context = CommandHandlerContext(
+        client=AsyncMock(),
+        config=SimpleNamespace(
+            authorization=_handler_authorization(
+                config_command_enabled=True,
+                global_users=["@admin:example.org"],
+            ),
+        ),
+        runtime_paths=resolve_runtime_paths(config_path=tmp_path / "config.yaml", storage_path=tmp_path),
+        logger=MagicMock(),
+        conversation_cache=MagicMock(),
+        event_cache=make_event_cache_mock(),
+        stable_target=MessageTarget.resolve("!room:example.org", None, "$event"),
+        record_handled_turn=MagicMock(),
+        send_response=AsyncMock(return_value="$reply"),
+    )
+    room = SimpleNamespace(room_id="!room:example.org")
+    event = SimpleNamespace(
+        sender="@alice:example.org",
+        event_id="$event",
+        source={"content": {"body": "!config show"}},
+    )
+    command = Command(type=CommandType.CONFIG, args={"args_text": "show"}, raw_text="!config show")
+
+    with patch(
+        "mindroom.commands.handler.handle_config_command",
+        AsyncMock(return_value=("ok", None)),
+    ) as mock_handle_config_command:
+        await handle_command(
+            context=context,
+            room=room,
+            event=event,
+            command=command,
+            requester_user_id="@alice:example.org",
+        )
+
+    mock_handle_config_command.assert_not_awaited()
+    assert context.send_response.await_args.args[0] == "❌ Admin only."
 
 
 @pytest.mark.asyncio
@@ -525,7 +643,12 @@ async def test_handle_command_config_set_confirmation_records_preview_event_id(t
     """Config preview replies should persist confirmation state and record the preview event ID."""
     context = CommandHandlerContext(
         client=AsyncMock(),
-        config=MagicMock(),
+        config=SimpleNamespace(
+            authorization=_handler_authorization(
+                config_command_enabled=True,
+                global_users=["@alice:example.org"],
+            ),
+        ),
         runtime_paths=resolve_runtime_paths(config_path=tmp_path / "config.yaml", storage_path=tmp_path),
         logger=MagicMock(),
         conversation_cache=MagicMock(),
@@ -609,7 +732,12 @@ async def test_handle_command_config_set_records_preview_before_post_send_failur
     """Preview sends should still be recorded if later confirmation setup fails."""
     context = CommandHandlerContext(
         client=AsyncMock(),
-        config=MagicMock(),
+        config=SimpleNamespace(
+            authorization=_handler_authorization(
+                config_command_enabled=True,
+                global_users=["@alice:example.org"],
+            ),
+        ),
         runtime_paths=resolve_runtime_paths(config_path=tmp_path / "config.yaml", storage_path=tmp_path),
         logger=MagicMock(),
         conversation_cache=MagicMock(),
@@ -669,6 +797,51 @@ async def test_handle_command_config_set_records_preview_before_post_send_failur
             "$event",
             response_event_id="$preview",
         ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_confirmation_reaction_respects_disabled_config_command(tmp_path: Path) -> None:
+    """Disabling !config should also block already-pending confirmation reactions."""
+    target = MessageTarget.resolve("!room:example.org", None, "$preview")
+    bot = SimpleNamespace(
+        client=SimpleNamespace(user_id="@router:example.org"),
+        config=SimpleNamespace(
+            authorization=_handler_authorization(
+                config_command_enabled=False,
+                global_users=["@admin:example.org"],
+            ),
+        ),
+        runtime_paths=resolve_runtime_paths(config_path=tmp_path / "config.yaml", storage_path=tmp_path),
+        _conversation_resolver=SimpleNamespace(
+            build_message_target=MagicMock(return_value=target),
+        ),
+        _send_response=AsyncMock(),
+    )
+    room = SimpleNamespace(room_id="!room:example.org")
+    event = SimpleNamespace(sender="@admin:example.org", key="✅", reacts_to="$preview")
+    pending_change = SimpleNamespace(
+        room_id="!room:example.org",
+        thread_id=None,
+        config_path="defaults.markdown",
+        new_value=False,
+        requester="@admin:example.org",
+    )
+
+    with (
+        patch(
+            "mindroom.commands.config_confirmation._remove_pending_change_from_matrix",
+            new_callable=AsyncMock,
+        ),
+        patch("mindroom.commands.config_commands.apply_config_change", new_callable=AsyncMock) as mock_apply,
+    ):
+        await handle_confirmation_reaction(bot, room, event, pending_change)
+
+    mock_apply.assert_not_awaited()
+    bot._send_response.assert_awaited_once_with(
+        target=target,
+        response_text="❌ Config command disabled.",
+        skip_mentions=True,
     )
 
 


### PR DESCRIPTION
## Summary
- add authorization.config_command_enabled, default false
- require global_users admin status before !config dispatch and again before confirmation apply
- update generated/default configs and docs, including mindroom-docs references

## Tests
- uv sync --all-extras
- PATH="$PWD/.venv/bin:/Users/bas.nijholt/.bun/bin:/opt/homebrew/bin:/usr/local/bin:$PATH" .venv/bin/pre-commit run --all-files
- PYTHONPATH=/Users/bas.nijholt/Work/dev/mindroom-worktrees/security-config-command-toggle/src .venv/bin/python -m pytest tests/test_config_commands.py tests/test_cli_config.py tests/test_config_validation_helpers.py -q -n 0 --no-cov

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Documentation**
- Updated to clarify that the `!config` command is disabled by default and requires explicit enablement for global administrators

**New Features**
- Added authorization gating for the `!config` command with new `authorization.config_command_enabled` configuration option

**Tests**
- Added tests for config command authorization requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->