### PR TITLE
Fix SaaS auth privilege leaks

### DIFF
--- a/saas-platform/API_ENDPOINT_MAPPING.md
+++ b/saas-platform/API_ENDPOINT_MAPPING.md
@@ -235,13 +235,13 @@ This document maps all backend API endpoints to their corresponding frontend usa
 - **Backend**: `backend/routes/sso.py`
 - **Frontend Usage**:
   - `platform-frontend/src/lib/api.ts` (setSsoCookie)
-- **Purpose**: Set SSO cookie for seamless instance access across subdomains
+- **Purpose**: Set API-host SSO cookie for platform API and Matrix OIDC
 
 ### DELETE `/my/sso-cookie`
 - **Backend**: `backend/routes/sso.py`
 - **Frontend Usage**:
   - `platform-frontend/src/lib/api.ts` (clearSsoCookie)
-- **Purpose**: Clear SSO cookie on logout
+- **Purpose**: Clear API-host SSO cookie on logout
 
 ## Analysis & Recommendations
 

--- a/saas-platform/docs/authentication.md
+++ b/saas-platform/docs/authentication.md
@@ -8,41 +8,43 @@ This repo deploys two types of frontends/backends with two related but different
 Components
 - Supabase: identity provider for both platform and instances.
 - Platform Frontend (Next.js): users log in here and obtain a Supabase session.
-- Platform Backend (FastAPI): sets a superdomain SSO cookie used by instances.
-- Instance Backend (FastAPI): serves the bundled UI, serves instance-specific APIs, and verifies JWTs.
+- Platform Backend (FastAPI): validates Supabase sessions and issues first-party Matrix OIDC codes for hosted Synapse login.
+- Instance Backend (FastAPI): serves the bundled UI, serves instance-specific APIs, and trusts only explicitly configured upstream identity or standalone credentials.
 
 How Auth Works (Platform Mode)
 1) User signs in at the Platform app (e.g., https://app.<superdomain>).
 2) Platform Frontend calls Platform Backend POST /my/sso-cookie with the Supabase access token.
-   - Platform Backend sets an HttpOnly cookie mindroom_jwt on the superdomain (e.g., .<superdomain>).
+   - Platform Backend sets an HttpOnly host-only cookie on the API host.
+   - The cookie is not scoped to the superdomain and is not sent to tenant instance subdomains.
 3) User navigates to an Instance domain (e.g., https://<id>.<superdomain>).
-   - The instance backend checks for mindroom_jwt on UI routes and redirects to platform login if missing.
-4) For /api calls on the Instance domain:
-   - The browser sends mindroom_jwt automatically as an HttpOnly cookie.
-   - Instance Backend reads the cookie directly, verifies the JWT against Supabase (using SUPABASE_URL + keys), and authorizes the request.
+   - The tenant instance must not rely on raw platform JWT cookies.
+   - Hosted Matrix login goes through the Platform Backend Matrix OIDC endpoints on the API host.
+4) For tenant instance browser and API calls:
+   - The instance accepts only the configured auth path for that deployment.
+   - For hosted deployments, prefer trusted upstream auth with deployment-owned identity headers and strict JWT verification.
+   - For standalone deployments, use the standalone dashboard API key flow.
 
-Why the instance no longer needs an auth sidecar
-- The instance backend now reads mindroom_jwt directly.
-- Ingress can route `/`, `/api`, and `/v1` to the same backend service.
-- This removes the extra instance frontend deployment and the header-injection proxy hop.
+Why raw platform JWT cookies are not shared with instances
+- Tenant subdomains must not receive the platform Supabase access token.
+- Instance auth fails closed unless an explicit trusted upstream or standalone auth path is configured.
+- Matrix SSO still works through the Platform Backend because the API-host cookie is available to the Matrix OIDC authorize endpoint.
 
 Key Settings
 - Platform Backend
-  - PLATFORM_DOMAIN must be the superdomain (e.g., <superdomain>) so the cookie covers all subdomains.
+  - PLATFORM_DOMAIN identifies the platform domain used for links and allowed origins.
   - SUPABASE_URL/ANON_KEY/SERVICE_KEY used to validate tokens and perform server actions.
 - Instance (Helm release instance-<id>)
-  - values.yaml: supabaseUrl, supabaseAnonKey, supabaseServiceKey must match the platform project.
-  - deployment-backend:
-    - UI: serves the bundled dashboard and redirects to the platform login if mindroom_jwt is missing.
-    - API: reads mindroom_jwt directly and validates it against Supabase.
+  - trustedUpstreamAuth.enabled should be set when an access layer injects authenticated identity.
+  - trustedUpstreamAuth.requireJwt should be true when the access layer can sign identity assertions.
+  - values.yaml Supabase fields are not a substitute for tenant auth.
 
 Notes and Gotchas
-- If the cookie exists but is invalid/expired, UI can still load but API calls return 401 (by design).
-- If instance Supabase vars don’t match platform’s project, backend will reject tokens (401).
-- WebSockets and SSE now terminate directly on the backend service instead of a proxy sidecar.
+- A missing or invalid API-host SSO cookie redirects Matrix OIDC authorization back to platform login.
+- A tenant instance request without the configured trusted upstream headers or standalone credential returns 401.
+- WebSockets and SSE should terminate only behind the same authenticated instance access layer as normal API traffic.
 
 Troubleshooting
-- Cookie missing: user is redirected to platform login.
-- 401 on /api: refresh SSO cookie via platform, verify instance Supabase vars match platform.
+- Matrix OIDC cookie missing: user is redirected to platform login.
+- 401 on tenant /api: verify trusted upstream auth headers, JWT settings, or standalone API key configuration.
 - 500 on UI: check backend logs and confirm the bundled frontend assets are present in the image.
 - Inspect logs: backend logs show both UI and API request handling.

--- a/saas-platform/platform-backend/src/backend/deps.py
+++ b/saas-platform/platform-backend/src/backend/deps.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import OrderedDict
+from copy import deepcopy
 from dataclasses import dataclass
 from hashlib import sha256
 import hmac
@@ -69,7 +70,7 @@ def _cached_user_data(token: str, now: datetime) -> dict[str, Any] | None:
         return None
 
     _auth_cache.move_to_end(cache_key)
-    return entry.user_data
+    return deepcopy(entry.user_data)
 
 
 def _store_auth_cache(token: str, user_data: dict[str, Any], now: datetime) -> None:
@@ -78,7 +79,7 @@ def _store_auth_cache(token: str, user_data: dict[str, Any], now: datetime) -> N
         return
 
     cache_key = _auth_cache_key(token)
-    _auth_cache[cache_key] = AuthCacheEntry(expires_at=expires_at, user_data=user_data)
+    _auth_cache[cache_key] = AuthCacheEntry(expires_at=expires_at, user_data=deepcopy(user_data))
     _auth_cache.move_to_end(cache_key)
     while len(_auth_cache) > AUTH_CACHE_MAX_ENTRIES:
         _auth_cache.popitem(last=False)

--- a/saas-platform/platform-backend/src/backend/deps.py
+++ b/saas-platform/platform-backend/src/backend/deps.py
@@ -2,15 +2,18 @@
 
 from __future__ import annotations
 
+from collections import OrderedDict
+from dataclasses import dataclass
+from hashlib import sha256
 import hmac
 import time
-from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any
 
+import jwt
 from backend import auth_monitor
 from backend.metrics import record_admin_verification, record_auth_event
 from backend.config import auth_client, logger, supabase
-from cachetools import TTLCache
 from fastapi import Header, HTTPException, Request
 from slowapi import Limiter
 from slowapi.util import get_remote_address
@@ -18,8 +21,67 @@ from slowapi.util import get_remote_address
 if TYPE_CHECKING:
     from supabase import Client
 
-# TTL cache for auth verification (5 minutes, max 100 entries)
-_auth_cache = TTLCache(maxsize=100, ttl=300)
+AUTH_CACHE_MAX_ENTRIES = 100
+AUTH_CACHE_MAX_TTL_SECONDS = 300
+
+
+@dataclass(frozen=True)
+class AuthCacheEntry:
+    """Cached auth result bounded by the JWT expiration."""
+
+    expires_at: datetime
+    user_data: dict[str, Any]
+
+
+_auth_cache: OrderedDict[str, AuthCacheEntry] = OrderedDict()
+
+
+def _auth_cache_key(token: str) -> str:
+    return sha256(token.encode()).hexdigest()
+
+
+def _token_cache_deadline(token: str, now: datetime) -> datetime | None:
+    try:
+        claims = jwt.decode(token, options={"verify_signature": False, "verify_exp": False})
+    except jwt.InvalidTokenError:
+        return None
+
+    exp = claims.get("exp")
+    if not isinstance(exp, int | float):
+        return None
+
+    token_expires_at = datetime.fromtimestamp(exp, UTC)
+    if token_expires_at <= now:
+        return None
+
+    max_cache_expires_at = now + timedelta(seconds=AUTH_CACHE_MAX_TTL_SECONDS)
+    return min(token_expires_at, max_cache_expires_at)
+
+
+def _cached_user_data(token: str, now: datetime) -> dict[str, Any] | None:
+    cache_key = _auth_cache_key(token)
+    entry = _auth_cache.get(cache_key)
+    if entry is None:
+        return None
+
+    if entry.expires_at <= now:
+        _auth_cache.pop(cache_key, None)
+        return None
+
+    _auth_cache.move_to_end(cache_key)
+    return entry.user_data
+
+
+def _store_auth_cache(token: str, user_data: dict[str, Any], now: datetime) -> None:
+    expires_at = _token_cache_deadline(token, now)
+    if expires_at is None:
+        return
+
+    cache_key = _auth_cache_key(token)
+    _auth_cache[cache_key] = AuthCacheEntry(expires_at=expires_at, user_data=user_data)
+    _auth_cache.move_to_end(cache_key)
+    while len(_auth_cache) > AUTH_CACHE_MAX_ENTRIES:
+        _auth_cache.popitem(last=False)
 
 
 def client_ip_from_request(request: Request) -> str:
@@ -102,10 +164,11 @@ async def verify_user(authorization: str = Header(None), request: Request = None
         auth_monitor.record_failure(client_ip)
         raise
 
-    # Check cache first
-    if token in _auth_cache:
+    now = datetime.now(UTC)
+    cached_user_data = _cached_user_data(token, now)
+    if cached_user_data is not None:
         logger.info("Auth cache hit (instant)")
-        return _auth_cache[token]
+        return cached_user_data
 
     # Start timing for database lookup
     start = time.perf_counter()
@@ -167,8 +230,7 @@ async def verify_user(authorization: str = Header(None), request: Request = None
             "account": result.data,
         }
 
-        # Cache the result (TTL handled by TTLCache)
-        _auth_cache[token] = user_data
+        _store_auth_cache(token, user_data, now)
 
         # Log the time taken for database auth
         db_time = time.perf_counter() - start

--- a/saas-platform/platform-backend/src/backend/deps.py
+++ b/saas-platform/platform-backend/src/backend/deps.py
@@ -197,7 +197,7 @@ async def verify_user(authorization: str = Header(None), request: Request = None
         except Exception:
             logger.info(f"Account not found for user {account_id}, creating...")
             try:
-                now = datetime.now(UTC).isoformat()
+                now_iso = now.isoformat()
                 create_result = (
                     sb.table("accounts")
                     .insert(
@@ -207,8 +207,8 @@ async def verify_user(authorization: str = Header(None), request: Request = None
                             "full_name": user.user.user_metadata.get("full_name", "")
                             if user.user.user_metadata
                             else "",
-                            "created_at": now,
-                            "updated_at": now,
+                            "created_at": now_iso,
+                            "updated_at": now_iso,
                         }
                     )
                     .execute()

--- a/saas-platform/platform-backend/src/backend/routes/sso.py
+++ b/saas-platform/platform-backend/src/backend/routes/sso.py
@@ -3,7 +3,6 @@
 from datetime import timedelta
 from typing import Annotated
 
-from backend.config import PLATFORM_DOMAIN
 from backend.deps import _extract_bearer_token, limiter, verify_user
 from backend.models import StatusResponse
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response
@@ -11,20 +10,10 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response
 router = APIRouter()
 
 
-def _legacy_wildcard_cookie_domain() -> str | None:
-    """Return the old superdomain cookie scope so it can be expired."""
-    if not PLATFORM_DOMAIN:
-        return None
-    if PLATFORM_DOMAIN.startswith("."):
-        return PLATFORM_DOMAIN
-    return f".{PLATFORM_DOMAIN}"
-
-
-def _expire_sso_cookie(response: Response, *, domain: str | None = None) -> None:
+def _expire_sso_cookie(response: Response) -> None:
     response.set_cookie(
         key="mindroom_jwt",
         value="",
-        domain=domain,
         path="/",
         secure=True,
         httponly=True,
@@ -50,10 +39,6 @@ async def set_sso_cookie(
     except HTTPException:
         raise HTTPException(status_code=401, detail="Missing bearer token") from None
 
-    legacy_domain = _legacy_wildcard_cookie_domain()
-    if legacy_domain:
-        _expire_sso_cookie(response, domain=legacy_domain)
-
     response.set_cookie(
         key="mindroom_jwt",
         value=token,
@@ -71,7 +56,4 @@ async def set_sso_cookie(
 async def clear_sso_cookie(request: Request, response: Response) -> dict[str, str]:  # noqa: ARG001
     """Clear the SSO cookie on logout."""
     _expire_sso_cookie(response)
-    legacy_domain = _legacy_wildcard_cookie_domain()
-    if legacy_domain:
-        _expire_sso_cookie(response, domain=legacy_domain)
     return {"status": "cleared"}

--- a/saas-platform/platform-backend/src/backend/routes/sso.py
+++ b/saas-platform/platform-backend/src/backend/routes/sso.py
@@ -11,6 +11,28 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response
 router = APIRouter()
 
 
+def _legacy_wildcard_cookie_domain() -> str | None:
+    """Return the old superdomain cookie scope so it can be expired."""
+    if not PLATFORM_DOMAIN:
+        return None
+    if PLATFORM_DOMAIN.startswith("."):
+        return PLATFORM_DOMAIN
+    return f".{PLATFORM_DOMAIN}"
+
+
+def _expire_sso_cookie(response: Response, *, domain: str | None = None) -> None:
+    response.set_cookie(
+        key="mindroom_jwt",
+        value="",
+        domain=domain,
+        path="/",
+        secure=True,
+        httponly=True,
+        samesite="lax",
+        max_age=0,
+    )
+
+
 @router.post("/my/sso-cookie", response_model=StatusResponse)
 @limiter.limit("30/minute")
 async def set_sso_cookie(
@@ -19,25 +41,22 @@ async def set_sso_cookie(
     user: dict = Depends(verify_user),  # noqa: ARG001, FAST002, B008
     authorization: Annotated[str | None, Header()] = None,
 ) -> dict[str, str]:
-    """Set a superdomain SSO cookie with the current Supabase access token.
+    """Set an API-host SSO cookie with the current Supabase access token.
 
-    The cookie is used by instance nginx to forward Authorization headers.
+    Tenant subdomains must not receive raw platform JWTs.
     """
     try:
         token = _extract_bearer_token(authorization or request.headers.get("authorization"))
     except HTTPException:
         raise HTTPException(status_code=401, detail="Missing bearer token") from None
 
-    # Normalize cookie domain: ensure it applies to all subdomains
-    domain = PLATFORM_DOMAIN
-    if domain and not domain.startswith("."):
-        domain = f".{domain}"
+    legacy_domain = _legacy_wildcard_cookie_domain()
+    if legacy_domain:
+        _expire_sso_cookie(response, domain=legacy_domain)
 
-    # Set HttpOnly cookie valid for all subdomains (platform + instances)
     response.set_cookie(
         key="mindroom_jwt",
         value=token,
-        domain=domain,  # e.g., .staging.mindroom.chat
         path="/",
         secure=True,
         httponly=True,
@@ -51,12 +70,8 @@ async def set_sso_cookie(
 @limiter.limit("10/minute")
 async def clear_sso_cookie(request: Request, response: Response) -> dict[str, str]:  # noqa: ARG001
     """Clear the SSO cookie on logout."""
-    # Normalize cookie domain: ensure it applies to all subdomains
-    domain = PLATFORM_DOMAIN
-    if domain and not domain.startswith("."):
-        domain = f".{domain}"
-
-    response.set_cookie(
-        key="mindroom_jwt", value="", domain=domain, path="/", secure=True, httponly=True, samesite="lax", max_age=0
-    )
+    _expire_sso_cookie(response)
+    legacy_domain = _legacy_wildcard_cookie_domain()
+    if legacy_domain:
+        _expire_sso_cookie(response, domain=legacy_domain)
     return {"status": "cleared"}

--- a/saas-platform/platform-backend/tests/test_accounts.py
+++ b/saas-platform/platform-backend/tests/test_accounts.py
@@ -1,6 +1,7 @@
 """Comprehensive HTTP API tests for accounts endpoints."""
 
 from datetime import UTC, datetime
+from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -8,6 +9,23 @@ from backend.deps import verify_user
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from main import app
+
+
+MIGRATION_SQL = Path(__file__).resolve().parents[2] / "supabase/migrations/000_consolidated_complete_schema.sql"
+
+
+def test_accounts_migration_restricts_authenticated_updates_to_profile_columns() -> None:
+    """Authenticated users may update profile fields, not admin/billing/status columns."""
+    sql = MIGRATION_SQL.read_text(encoding="utf-8")
+
+    assert "GRANT SELECT, INSERT, UPDATE ON TABLE accounts TO authenticated;" not in sql
+    assert "REVOKE INSERT, UPDATE ON TABLE accounts FROM authenticated;" in sql
+    assert (
+        "GRANT UPDATE (full_name, company_name, consent_marketing, consent_analytics, consent_updated_at) "
+        "ON TABLE accounts TO authenticated;"
+    ) in sql
+    for privileged_column in ("tier", "is_admin", "status", "stripe_customer_id", "deleted_at"):
+        assert f"GRANT UPDATE ({privileged_column}) ON TABLE accounts TO authenticated;" not in sql
 
 
 class TestAccountsEndpoints:

--- a/saas-platform/platform-backend/tests/test_accounts.py
+++ b/saas-platform/platform-backend/tests/test_accounts.py
@@ -11,13 +11,12 @@ from fastapi.testclient import TestClient
 from main import app
 
 
-MIGRATION_SQL = Path(__file__).resolve().parents[2] / "supabase/migrations/000_consolidated_complete_schema.sql"
+MIGRATIONS_DIR = Path(__file__).resolve().parents[2] / "supabase/migrations"
+BASELINE_MIGRATION_SQL = MIGRATIONS_DIR / "000_consolidated_complete_schema.sql"
+ACCOUNT_GRANTS_MIGRATION_SQL = MIGRATIONS_DIR / "002_restrict_account_grants.sql"
 
 
-def test_accounts_migration_restricts_authenticated_updates_to_profile_columns() -> None:
-    """Authenticated users may update profile fields, not admin/billing/status columns."""
-    sql = MIGRATION_SQL.read_text(encoding="utf-8")
-
+def assert_account_grants_restricted(sql: str) -> None:
     assert "GRANT SELECT, INSERT, UPDATE ON TABLE accounts TO authenticated;" not in sql
     assert "REVOKE INSERT, UPDATE ON TABLE accounts FROM authenticated;" in sql
     assert (
@@ -26,6 +25,16 @@ def test_accounts_migration_restricts_authenticated_updates_to_profile_columns()
     ) in sql
     for privileged_column in ("tier", "is_admin", "status", "stripe_customer_id", "deleted_at"):
         assert f"GRANT UPDATE ({privileged_column}) ON TABLE accounts TO authenticated;" not in sql
+
+
+def test_accounts_baseline_migration_restricts_authenticated_updates_to_profile_columns() -> None:
+    """Fresh databases restrict authenticated writes to profile fields."""
+    assert_account_grants_restricted(BASELINE_MIGRATION_SQL.read_text(encoding="utf-8"))
+
+
+def test_accounts_incremental_migration_restricts_existing_authenticated_grants() -> None:
+    """Existing databases receive the same account grant restriction."""
+    assert_account_grants_restricted(ACCOUNT_GRANTS_MIGRATION_SQL.read_text(encoding="utf-8"))
 
 
 class TestAccountsEndpoints:

--- a/saas-platform/platform-backend/tests/test_deps.py
+++ b/saas-platform/platform-backend/tests/test_deps.py
@@ -1,11 +1,18 @@
 """Test dependency injection utilities."""
 
+from datetime import UTC, datetime, timedelta
+from hashlib import sha256
 from unittest.mock import MagicMock, Mock, patch
 
+import jwt
 import pytest
 from fastapi import HTTPException
 
 from backend.metrics import get_admin_metric, reset_security_metrics
+
+
+def _jwt_with_exp(expires_at: datetime) -> str:
+    return jwt.encode({"sub": "user_123", "exp": int(expires_at.timestamp())}, "secret", algorithm="HS256")
 
 
 class TestDeps:
@@ -113,17 +120,21 @@ class TestDeps:
     @pytest.mark.asyncio
     async def test_verify_user_cache_hit(self, mock_supabase: MagicMock, mock_auth_client: MagicMock):
         """Test user verification uses cache."""
-        from backend.deps import _auth_cache, verify_user
+        from backend.deps import AuthCacheEntry, _auth_cache, verify_user
 
         # Pre-populate cache
-        _auth_cache["cached-token"] = {
-            "user_id": "cached_user",
-            "account_id": "cached_user",
-            "email": "cached@example.com",
-        }
+        token = _jwt_with_exp(datetime.now(UTC) + timedelta(minutes=5))
+        _auth_cache[sha256(token.encode()).hexdigest()] = AuthCacheEntry(
+            expires_at=datetime.now(UTC) + timedelta(minutes=5),
+            user_data={
+                "user_id": "cached_user",
+                "account_id": "cached_user",
+                "email": "cached@example.com",
+            },
+        )
 
         # Test
-        result = await verify_user("Bearer cached-token")
+        result = await verify_user(f"Bearer {token}")
 
         # Verify
         assert result["user_id"] == "cached_user"
@@ -132,6 +143,77 @@ class TestDeps:
         mock_auth_client.auth.get_user.assert_not_called()
 
         # Clean up cache
+        _auth_cache.clear()
+
+    @pytest.mark.asyncio
+    async def test_verify_user_cache_key_is_token_hash(self, mock_supabase: MagicMock, mock_auth_client: MagicMock):
+        """Auth cache must not store raw bearer tokens as keys."""
+        from backend.deps import _auth_cache, verify_user
+
+        _auth_cache.clear()
+        token = _jwt_with_exp(datetime.now(UTC) + timedelta(minutes=5))
+        mock_user = Mock()
+        mock_user.user.id = "user_123"
+        mock_user.user.email = "test@example.com"
+        mock_user.user.user_metadata = {"full_name": "Test User"}
+        mock_auth_client.auth.get_user.return_value = mock_user
+        mock_supabase.table().select().eq().single().execute.return_value = Mock(
+            data={"id": "user_123", "email": "test@example.com"}
+        )
+
+        await verify_user(f"Bearer {token}")
+
+        assert token not in _auth_cache
+        assert sha256(token.encode()).hexdigest() in _auth_cache
+        _auth_cache.clear()
+
+    @pytest.mark.asyncio
+    async def test_verify_user_cache_deadline_is_bounded_by_token_exp(
+        self, mock_supabase: MagicMock, mock_auth_client: MagicMock
+    ):
+        """Auth cache entries must expire no later than the JWT exp claim."""
+        from backend.deps import _auth_cache, verify_user
+
+        _auth_cache.clear()
+        expires_at = datetime.now(UTC) + timedelta(seconds=30)
+        token = _jwt_with_exp(expires_at)
+        mock_user = Mock()
+        mock_user.user.id = "user_123"
+        mock_user.user.email = "test@example.com"
+        mock_user.user.user_metadata = {"full_name": "Test User"}
+        mock_auth_client.auth.get_user.return_value = mock_user
+        mock_supabase.table().select().eq().single().execute.return_value = Mock(
+            data={"id": "user_123", "email": "test@example.com"}
+        )
+
+        await verify_user(f"Bearer {token}")
+
+        entry = _auth_cache[sha256(token.encode()).hexdigest()]
+        assert entry.expires_at <= expires_at
+        assert entry.expires_at > datetime.now(UTC)
+        _auth_cache.clear()
+
+    @pytest.mark.asyncio
+    async def test_verify_user_does_not_accept_expired_cached_token(self, mock_auth_client: MagicMock):
+        """Expired JWTs must not be accepted through a stale auth cache hit."""
+        from backend.deps import AuthCacheEntry, _auth_cache, verify_user
+
+        _auth_cache.clear()
+        token = _jwt_with_exp(datetime.now(UTC) - timedelta(seconds=1))
+        _auth_cache[token] = AuthCacheEntry(
+            expires_at=datetime.now(UTC) + timedelta(minutes=5),
+            user_data={
+                "user_id": "cached_user",
+                "account_id": "cached_user",
+                "email": "cached@example.com",
+            },
+        )
+        mock_auth_client.auth.get_user.return_value = None
+
+        with pytest.raises(HTTPException) as exc_info:
+            await verify_user(f"Bearer {token}")
+
+        assert exc_info.value.status_code == 401
         _auth_cache.clear()
 
     @pytest.mark.asyncio

--- a/saas-platform/platform-backend/tests/test_deps.py
+++ b/saas-platform/platform-backend/tests/test_deps.py
@@ -87,7 +87,10 @@ class TestDeps:
         self, mock_supabase: MagicMock, mock_auth_client: MagicMock, mock_time: Mock
     ):
         """Test user verification creates account if not exists."""
-        from backend.deps import verify_user
+        from backend.deps import _auth_cache, verify_user
+
+        _auth_cache.clear()
+        token = _jwt_with_exp(datetime.now(UTC) + timedelta(minutes=5))
 
         # Setup mock user
         mock_user = Mock()
@@ -106,7 +109,7 @@ class TestDeps:
         mock_supabase.table().insert().execute.return_value = Mock(data={"id": "new_user_123"})
 
         # Test
-        result = await verify_user("Bearer new-user-token")
+        result = await verify_user(f"Bearer {token}")
 
         # Verify
         assert result["user_id"] == "new_user_123"
@@ -116,6 +119,8 @@ class TestDeps:
         insert_call = mock_supabase.table().insert.call_args[0][0]
         assert insert_call["id"] == "new_user_123"
         assert insert_call["email"] == "new@example.com"
+        assert sha256(token.encode()).hexdigest() in _auth_cache
+        _auth_cache.clear()
 
     @pytest.mark.asyncio
     async def test_verify_user_cache_hit(self, mock_supabase: MagicMock, mock_auth_client: MagicMock):
@@ -200,8 +205,9 @@ class TestDeps:
 
         _auth_cache.clear()
         token = _jwt_with_exp(datetime.now(UTC) - timedelta(seconds=1))
-        _auth_cache[token] = AuthCacheEntry(
-            expires_at=datetime.now(UTC) + timedelta(minutes=5),
+        cache_key = sha256(token.encode()).hexdigest()
+        _auth_cache[cache_key] = AuthCacheEntry(
+            expires_at=datetime.now(UTC) - timedelta(seconds=1),
             user_data={
                 "user_id": "cached_user",
                 "account_id": "cached_user",
@@ -214,6 +220,7 @@ class TestDeps:
             await verify_user(f"Bearer {token}")
 
         assert exc_info.value.status_code == 401
+        assert cache_key not in _auth_cache
         _auth_cache.clear()
 
     @pytest.mark.asyncio

--- a/saas-platform/platform-backend/tests/test_deps.py
+++ b/saas-platform/platform-backend/tests/test_deps.py
@@ -199,6 +199,36 @@ class TestDeps:
         _auth_cache.clear()
 
     @pytest.mark.asyncio
+    async def test_verify_user_cache_does_not_share_mutable_user_data(
+        self, mock_supabase: MagicMock, mock_auth_client: MagicMock
+    ):
+        """Request handlers must not be able to mutate cached auth data."""
+        from backend.deps import _auth_cache, verify_user
+
+        _auth_cache.clear()
+        token = _jwt_with_exp(datetime.now(UTC) + timedelta(minutes=5))
+        mock_user = Mock()
+        mock_user.user.id = "user_123"
+        mock_user.user.email = "test@example.com"
+        mock_user.user.user_metadata = {"full_name": "Test User"}
+        mock_auth_client.auth.get_user.return_value = mock_user
+        mock_supabase.table().select().eq().single().execute.return_value = Mock(
+            data={"id": "user_123", "email": "test@example.com"}
+        )
+
+        result = await verify_user(f"Bearer {token}")
+        result["email"] = "mutated@example.com"
+        result["account"]["email"] = "mutated@example.com"
+        mock_auth_client.auth.get_user.reset_mock()
+
+        cached_result = await verify_user(f"Bearer {token}")
+
+        assert cached_result["email"] == "test@example.com"
+        assert cached_result["account"]["email"] == "test@example.com"
+        mock_auth_client.auth.get_user.assert_not_called()
+        _auth_cache.clear()
+
+    @pytest.mark.asyncio
     async def test_verify_user_does_not_accept_expired_cached_token(self, mock_auth_client: MagicMock):
         """Expired JWTs must not be accepted through a stale auth cache hit."""
         from backend.deps import AuthCacheEntry, _auth_cache, verify_user

--- a/saas-platform/platform-backend/tests/test_sso_cookie_attrs.py
+++ b/saas-platform/platform-backend/tests/test_sso_cookie_attrs.py
@@ -38,7 +38,7 @@ def test_sso_cookie_has_security_flags() -> None:
     assert "samesite=lax" in set_cookie.lower()
 
 
-def test_sso_cookie_is_host_only_and_clears_legacy_wildcard_cookie() -> None:
+def test_sso_cookie_is_host_only() -> None:
     """SSO token cookie must stay on the API host, not every tenant subdomain."""
     app.dependency_overrides[verify_user] = _override_verify_user
     app.state.limiter = Limiter(key_func=get_remote_address)
@@ -55,13 +55,11 @@ def test_sso_cookie_is_host_only_and_clears_legacy_wildcard_cookie() -> None:
     token_cookies = [cookie for cookie in cookies if cookie.startswith("mindroom_jwt=tok")]
     assert len(token_cookies) == 1
     assert "Domain=" not in token_cookies[0]
-    assert any(
-        "mindroom_jwt=" in cookie and "Domain=.mindroom.chat" in cookie and "Max-Age=0" in cookie for cookie in cookies
-    )
+    assert all("Domain=" not in cookie for cookie in cookies)
 
 
-def test_clear_sso_cookie_clears_host_only_and_legacy_wildcard_cookie() -> None:
-    """Logout clears both the current host-only cookie and the old wildcard cookie."""
+def test_clear_sso_cookie_clears_host_only_cookie() -> None:
+    """Logout clears the current host-only cookie."""
     app.state.limiter = Limiter(key_func=get_remote_address)
     app.state.limiter.reset()
     limiter.reset()
@@ -74,6 +72,4 @@ def test_clear_sso_cookie_clears_host_only_and_legacy_wildcard_cookie() -> None:
     assert any(
         cookie.startswith("mindroom_jwt=") and "Domain=" not in cookie and "Max-Age=0" in cookie for cookie in cookies
     )
-    assert any(
-        "mindroom_jwt=" in cookie and "Domain=.mindroom.chat" in cookie and "Max-Age=0" in cookie for cookie in cookies
-    )
+    assert all("Domain=" not in cookie for cookie in cookies)

--- a/saas-platform/platform-backend/tests/test_sso_cookie_attrs.py
+++ b/saas-platform/platform-backend/tests/test_sso_cookie_attrs.py
@@ -9,9 +9,16 @@ from tests.stripe_mock import create_stripe_mock
 
 sys.modules.setdefault("stripe", create_stripe_mock())
 
+import pytest  # noqa: E402
 from backend.deps import Limiter, get_remote_address, limiter, verify_user  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 from main import app  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def clear_dependency_overrides():
+    yield
+    app.dependency_overrides.pop(verify_user, None)
 
 
 def _override_verify_user() -> dict[str, str]:

--- a/saas-platform/platform-backend/tests/test_sso_cookie_attrs.py
+++ b/saas-platform/platform-backend/tests/test_sso_cookie_attrs.py
@@ -36,3 +36,44 @@ def test_sso_cookie_has_security_flags() -> None:
     assert "Secure" in set_cookie
     # Starlette normalizes to lowercase in some backends
     assert "samesite=lax" in set_cookie.lower()
+
+
+def test_sso_cookie_is_host_only_and_clears_legacy_wildcard_cookie() -> None:
+    """SSO token cookie must stay on the API host, not every tenant subdomain."""
+    app.dependency_overrides[verify_user] = _override_verify_user
+    app.state.limiter = Limiter(key_func=get_remote_address)
+    app.state.limiter.reset()
+    limiter.reset()
+    client = TestClient(app)
+
+    response = client.post(
+        "/my/sso-cookie", headers={"authorization": "Bearer tok", "X-Forwarded-For": "10.1.2.4"}, data="x"
+    )
+
+    assert response.status_code == 200
+    cookies = response.headers.get_list("set-cookie")
+    token_cookies = [cookie for cookie in cookies if cookie.startswith("mindroom_jwt=tok")]
+    assert len(token_cookies) == 1
+    assert "Domain=" not in token_cookies[0]
+    assert any(
+        "mindroom_jwt=" in cookie and "Domain=.mindroom.chat" in cookie and "Max-Age=0" in cookie for cookie in cookies
+    )
+
+
+def test_clear_sso_cookie_clears_host_only_and_legacy_wildcard_cookie() -> None:
+    """Logout clears both the current host-only cookie and the old wildcard cookie."""
+    app.state.limiter = Limiter(key_func=get_remote_address)
+    app.state.limiter.reset()
+    limiter.reset()
+    client = TestClient(app)
+
+    response = client.delete("/my/sso-cookie", headers={"X-Forwarded-For": "10.1.2.5"})
+
+    assert response.status_code == 200
+    cookies = response.headers.get_list("set-cookie")
+    assert any(
+        cookie.startswith("mindroom_jwt=") and "Domain=" not in cookie and "Max-Age=0" in cookie for cookie in cookies
+    )
+    assert any(
+        "mindroom_jwt=" in cookie and "Domain=.mindroom.chat" in cookie and "Max-Age=0" in cookie for cookie in cookies
+    )

--- a/saas-platform/platform-frontend/src/app/dashboard/page.tsx
+++ b/saas-platform/platform-frontend/src/app/dashboard/page.tsx
@@ -22,9 +22,9 @@ export default function DashboardPage() {
   const router = useRouter()
 
   useEffect(() => {
-    // Ensure SSO cookie for instance access (no-op if not logged in)
+    // Ensure API-host SSO cookie for Matrix OIDC (no-op if not logged in)
     setSsoCookie().catch((e) => logger.warn('Failed to set SSO cookie', e))
-    // Refresh cookie periodically for longer sessions
+    // Refresh cookie periodically for longer hosted Matrix login sessions
     const id = setInterval(() => { setSsoCookie().catch((e) => logger.warn('Failed to refresh SSO cookie', e)) }, 15 * 60 * 1000)
 
     return () => clearInterval(id)

--- a/saas-platform/platform-frontend/src/components/dashboard/InstanceCard.tsx
+++ b/saas-platform/platform-frontend/src/components/dashboard/InstanceCard.tsx
@@ -105,7 +105,7 @@ export function InstanceCard({
     }
   }
 
-  // Token passing handled by shared SSO cookie; open via plain link
+  // Tenant access is handled by the configured instance auth layer; open via plain link.
 
   // No instance yet - show provision card
   if (!instance) {

--- a/saas-platform/platform-frontend/src/lib/supabase/types.ts
+++ b/saas-platform/platform-frontend/src/lib/supabase/types.ts
@@ -31,38 +31,38 @@ export type Database = {
           email: string
           full_name?: string | null
           company_name?: string | null
-          stripe_customer_id?: string | null
-          tier?: PlanTier
-          is_admin?: boolean
-          status?: AccountStatus
-          deleted_at?: string | null
-          deletion_reason?: string | null
-          deletion_requested_by?: string | null
-          deletion_requested_at?: string | null
+          stripe_customer_id?: never
+          tier?: never
+          is_admin?: never
+          status?: never
+          deleted_at?: never
+          deletion_reason?: never
+          deletion_requested_by?: never
+          deletion_requested_at?: never
           consent_marketing?: boolean
           consent_analytics?: boolean
           consent_updated_at?: string | null
-          created_at?: string
-          updated_at?: string
+          created_at?: never
+          updated_at?: never
         }
         Update: {
-          id?: string
-          email?: string
+          id?: never
+          email?: never
           full_name?: string | null
           company_name?: string | null
-          stripe_customer_id?: string | null
-          tier?: PlanTier
-          is_admin?: boolean
-          status?: AccountStatus
-          deleted_at?: string | null
-          deletion_reason?: string | null
-          deletion_requested_by?: string | null
-          deletion_requested_at?: string | null
+          stripe_customer_id?: never
+          tier?: never
+          is_admin?: never
+          status?: never
+          deleted_at?: never
+          deletion_reason?: never
+          deletion_requested_by?: never
+          deletion_requested_at?: never
           consent_marketing?: boolean
           consent_analytics?: boolean
           consent_updated_at?: string | null
-          created_at?: string
-          updated_at?: string
+          created_at?: never
+          updated_at?: never
         }
       }
       subscriptions: {

--- a/saas-platform/supabase/migrations/000_consolidated_complete_schema.sql
+++ b/saas-platform/supabase/migrations/000_consolidated_complete_schema.sql
@@ -588,7 +588,9 @@ $$;
 REVOKE ALL ON FUNCTION exec_sql(TEXT) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION exec_sql(TEXT) TO service_role;
 
-GRANT SELECT, INSERT, UPDATE ON TABLE accounts TO authenticated;
+REVOKE INSERT, UPDATE ON TABLE accounts FROM authenticated;
+GRANT SELECT ON TABLE accounts TO authenticated;
+GRANT UPDATE (full_name, company_name, consent_marketing, consent_analytics, consent_updated_at) ON TABLE accounts TO authenticated;
 GRANT SELECT, INSERT, UPDATE ON TABLE subscriptions TO authenticated;
 GRANT SELECT, INSERT, UPDATE ON TABLE instances TO authenticated;
 

--- a/saas-platform/supabase/migrations/002_restrict_account_grants.sql
+++ b/saas-platform/supabase/migrations/002_restrict_account_grants.sql
@@ -1,0 +1,6 @@
+-- Apply account grant hardening to databases that already ran the baseline schema.
+-- Fresh installs get the same grants from 000_consolidated_complete_schema.sql.
+
+REVOKE INSERT, UPDATE ON TABLE accounts FROM authenticated;
+GRANT SELECT ON TABLE accounts TO authenticated;
+GRANT UPDATE (full_name, company_name, consent_marketing, consent_analytics, consent_updated_at) ON TABLE accounts TO authenticated;


### PR DESCRIPTION
## Summary
- restrict authenticated Supabase account writes to profile and consent fields only
- add incremental `002_restrict_account_grants.sql` so existing Supabase databases receive the same account grant hardening
- make the platform SSO cookie host-only, with no wildcard tenant-domain JWT emission or cleanup path
- hash auth cache keys and bound cached auth entries by JWT expiration
- deep-copy cached auth user data on store and read so handlers cannot mutate shared cache state
- fix the account-creation auth cache timestamp shadowing caught in review
- update SaaS auth docs and endpoint mapping to state tenant subdomains no longer receive the platform JWT cookie

## Test Plan
- /Users/bas.nijholt/.local/pipx/venvs/hatch/bin/uv run pytest tests/test_sso_cookie_attrs.py tests/test_rate_limit_sso.py tests/test_deps.py tests/test_accounts.py tests/test_matrix_oidc.py -q
- /Users/bas.nijholt/.local/pipx/venvs/hatch/bin/uvx ruff check src/backend/deps.py src/backend/routes/sso.py tests/test_deps.py tests/test_sso_cookie_attrs.py tests/test_accounts.py
- grep -RInE "GRANT SELECT, INSERT, UPDATE ON TABLE accounts TO authenticated|GRANT UPDATE \\((tier|is_admin|status|stripe_customer_id|deleted_at)\\) ON TABLE accounts TO authenticated" saas-platform/supabase/migrations 2>/dev/null
- grep -RInE "return entry\\.user_data|user_data=user_data|_auth_cache\\[token\\]|now = datetime\\.now\\(UTC\\)\\.isoformat\\(\\)|legacy_wildcard|wildcard cookie|superdomain SSO cookie|Instance Backend reads the cookie directly" saas-platform/platform-backend/src/backend/deps.py saas-platform/platform-backend/tests/test_deps.py saas-platform/platform-backend/src/backend/routes/sso.py saas-platform/platform-backend/tests/test_sso_cookie_attrs.py saas-platform/docs/authentication.md saas-platform/API_ENDPOINT_MAPPING.md 2>/dev/null

## Notes
- `.claude/REPORT.md` was removed at the user's request and is not included in this PR.
