### PR TITLE
Fix SSRF guards for tool fetch surfaces

### DIFF
--- a/src/mindroom/browser_fetch_guard.py
+++ b/src/mindroom/browser_fetch_guard.py
@@ -16,7 +16,11 @@ _BROWSER_INTERNAL_SCHEMES = frozenset({"about", "blob", "data"})
 
 def _validate_browser_fetch_url(url: str) -> str:
     """Validate a browser request URL while allowing non-network browser internals."""
-    if urlsplit(url).scheme.lower() in _BROWSER_INTERNAL_SCHEMES:
+    try:
+        scheme = urlsplit(url).scheme.lower()
+    except ValueError as exc:
+        raise ServerFetchUrlError(reason="invalid_host") from exc
+    if scheme in _BROWSER_INTERNAL_SCHEMES:
         return url
     return validate_server_fetch_url(url)
 

--- a/src/mindroom/browser_fetch_guard.py
+++ b/src/mindroom/browser_fetch_guard.py
@@ -1,0 +1,30 @@
+"""Shared Playwright request guard for server-side browser tools."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from urllib.parse import urlsplit
+
+from mindroom.server_fetch_url import ServerFetchUrlError, validate_server_fetch_url
+
+if TYPE_CHECKING:
+    from playwright.async_api import Route
+
+_BROWSER_INTERNAL_SCHEMES = frozenset({"about", "blob", "data"})
+
+
+def _validate_browser_fetch_url(url: str) -> str:
+    """Validate a browser request URL while allowing non-network browser internals."""
+    if urlsplit(url).scheme.lower() in _BROWSER_INTERNAL_SCHEMES:
+        return url
+    return validate_server_fetch_url(url)
+
+
+async def continue_or_abort_browser_fetch(route: Route) -> None:
+    """Continue public browser fetches and abort unsafe server-side destinations."""
+    try:
+        _validate_browser_fetch_url(route.request.url)
+    except ServerFetchUrlError:
+        await route.abort("blockedbyclient")
+        return
+    await route.continue_()

--- a/src/mindroom/browser_fetch_guard.py
+++ b/src/mindroom/browser_fetch_guard.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 _BROWSER_INTERNAL_SCHEMES = frozenset({"about", "blob", "data"})
 
 
-def _validate_browser_fetch_url(url: str) -> str:
+def _validate_browser_fetch_url(url: str, *, allow_private_networks: bool = False) -> str:
     """Validate a browser request URL while allowing non-network browser internals."""
     try:
         scheme = urlsplit(url).scheme.lower()
@@ -22,13 +22,17 @@ def _validate_browser_fetch_url(url: str) -> str:
         raise ServerFetchUrlError(reason="invalid_host") from exc
     if scheme in _BROWSER_INTERNAL_SCHEMES:
         return url
-    return validate_server_fetch_url(url)
+    return validate_server_fetch_url(url, allow_private_networks=allow_private_networks)
 
 
-async def continue_or_abort_browser_fetch(route: Route) -> None:
+async def continue_or_abort_browser_fetch(route: Route, *, allow_private_networks: bool = False) -> None:
     """Continue public browser fetches and abort unsafe server-side destinations."""
     try:
-        await asyncio.to_thread(_validate_browser_fetch_url, route.request.url)
+        await asyncio.to_thread(
+            _validate_browser_fetch_url,
+            route.request.url,
+            allow_private_networks=allow_private_networks,
+        )
     except ServerFetchUrlError:
         await route.abort("blockedbyclient")
         return

--- a/src/mindroom/browser_fetch_guard.py
+++ b/src/mindroom/browser_fetch_guard.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
 
@@ -23,7 +24,7 @@ def _validate_browser_fetch_url(url: str) -> str:
 async def continue_or_abort_browser_fetch(route: Route) -> None:
     """Continue public browser fetches and abort unsafe server-side destinations."""
     try:
-        _validate_browser_fetch_url(route.request.url)
+        await asyncio.to_thread(_validate_browser_fetch_url, route.request.url)
     except ServerFetchUrlError:
         await route.abort("blockedbyclient")
         return

--- a/src/mindroom/custom_tools/browser.py
+++ b/src/mindroom/custom_tools/browser.py
@@ -20,8 +20,9 @@ from agno.tools import Toolkit
 from playwright.async_api import BrowserContext, ConsoleMessage, Dialog, Page, Playwright, Route, async_playwright
 from playwright.async_api import Error as PlaywrightError
 
+from mindroom.browser_fetch_guard import continue_or_abort_browser_fetch
 from mindroom.logging_config import get_logger
-from mindroom.server_fetch_url import ServerFetchUrlError, validate_server_fetch_url
+from mindroom.server_fetch_url import validate_server_fetch_url
 from mindroom.tool_system.runtime_context import get_tool_runtime_context
 
 if TYPE_CHECKING:
@@ -1282,12 +1283,7 @@ class BrowserTools(Toolkit):
 
     async def _route_network_request(self, route: Route) -> None:
         """Block browser requests to URLs unsafe for server-side fetching."""
-        try:
-            validate_server_fetch_url(route.request.url)
-        except ServerFetchUrlError:
-            await route.abort("blockedbyclient")
-            return
-        await route.continue_()
+        await continue_or_abort_browser_fetch(route)
 
     def _resolve_output_dir(self) -> Path:
         """Return the directory used for browser artifacts."""

--- a/src/mindroom/custom_tools/browser.py
+++ b/src/mindroom/custom_tools/browser.py
@@ -325,11 +325,7 @@ def _unknown_browser_action_message(action: str) -> str:
 
 def _is_path_inside(path: Path, root: Path) -> bool:
     """Return whether a resolved path is under a resolved root."""
-    try:
-        path.relative_to(root)
-    except ValueError:
-        return False
-    return True
+    return path.is_relative_to(root)
 
 
 def _playwright_cache_root(expected_executable_path: Path | None) -> Path | None:

--- a/src/mindroom/custom_tools/browser.py
+++ b/src/mindroom/custom_tools/browser.py
@@ -396,9 +396,16 @@ class _BrowserFunctionNotRegisteredError(RuntimeError):
 class BrowserTools(Toolkit):
     """Browser control for MindRoom agents."""
 
-    def __init__(self, runtime_paths: RuntimePaths, *, output_dir: Path | str | None = None) -> None:
+    def __init__(
+        self,
+        runtime_paths: RuntimePaths,
+        *,
+        output_dir: Path | str | None = None,
+        allow_private_networks: bool = False,
+    ) -> None:
         super().__init__(name="browser", tools=[self.browser])
         self._runtime_paths = runtime_paths
+        self._allow_private_networks = allow_private_networks
         self._profiles: dict[str, _BrowserProfileState] = {}
         self._lock = asyncio.Lock()
         self._output_dir = Path(output_dir).expanduser().resolve() if output_dir is not None else None
@@ -542,7 +549,7 @@ class BrowserTools(Toolkit):
             if target_url is None:
                 msg = "targetUrl required for action=open"
                 raise ValueError(msg)
-            target_url = validate_server_fetch_url(target_url)
+            target_url = validate_server_fetch_url(target_url, allow_private_networks=self._allow_private_networks)
             return json.dumps(await self._open_tab(profile_name, target_url), sort_keys=True)
         if normalized_action == "focus":
             target_id = _clean_str(targetId)
@@ -588,7 +595,7 @@ class BrowserTools(Toolkit):
             if target_url is None:
                 msg = "targetUrl required for action=navigate"
                 raise ValueError(msg)
-            target_url = validate_server_fetch_url(target_url)
+            target_url = validate_server_fetch_url(target_url, allow_private_networks=self._allow_private_networks)
             return json.dumps(
                 await self._navigate(profile_name, target_url, _clean_str(targetId)),
                 sort_keys=True,
@@ -1185,7 +1192,13 @@ class BrowserTools(Toolkit):
             except Exception:
                 await playwright.stop()
                 raise
-            await context.route("**/*", continue_or_abort_browser_fetch)
+            await context.route(
+                "**/*",
+                lambda route: continue_or_abort_browser_fetch(
+                    route,
+                    allow_private_networks=self._allow_private_networks,
+                ),
+            )
             state = _BrowserProfileState(playwright=playwright, context=context)
             self._profiles[profile_name] = state
 

--- a/src/mindroom/custom_tools/browser.py
+++ b/src/mindroom/custom_tools/browser.py
@@ -1296,7 +1296,7 @@ class BrowserTools(Toolkit):
 
     def _browser_upload_roots(self) -> tuple[Path, ...]:
         """Return roots whose files can be read by browser upload."""
-        roots = [self._runtime_paths.storage_root.resolve(), self._resolve_output_dir().resolve()]
+        roots = [self._resolve_output_dir().resolve()]
         context = get_tool_runtime_context()
         if context is not None and context.storage_path is not None:
             roots.append(context.storage_path.resolve())

--- a/src/mindroom/custom_tools/browser.py
+++ b/src/mindroom/custom_tools/browser.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 from agno.tools import Toolkit
-from playwright.async_api import BrowserContext, ConsoleMessage, Dialog, Page, Playwright, Route, async_playwright
+from playwright.async_api import BrowserContext, ConsoleMessage, Dialog, Page, Playwright, async_playwright
 from playwright.async_api import Error as PlaywrightError
 
 from mindroom.browser_fetch_guard import continue_or_abort_browser_fetch
@@ -323,11 +323,6 @@ def _unknown_browser_action_message(action: str) -> str:
     )
 
 
-def _is_path_inside(path: Path, root: Path) -> bool:
-    """Return whether a resolved path is under a resolved root."""
-    return path.is_relative_to(root)
-
-
 def _playwright_cache_root(expected_executable_path: Path | None) -> Path | None:
     """Return the Playwright browser cache root for an executable path."""
     if expected_executable_path is None:
@@ -547,7 +542,7 @@ class BrowserTools(Toolkit):
             if target_url is None:
                 msg = "targetUrl required for action=open"
                 raise ValueError(msg)
-            target_url = self._validate_browser_target_url(target_url)
+            target_url = validate_server_fetch_url(target_url)
             return json.dumps(await self._open_tab(profile_name, target_url), sort_keys=True)
         if normalized_action == "focus":
             target_id = _clean_str(targetId)
@@ -593,7 +588,7 @@ class BrowserTools(Toolkit):
             if target_url is None:
                 msg = "targetUrl required for action=navigate"
                 raise ValueError(msg)
-            target_url = self._validate_browser_target_url(target_url)
+            target_url = validate_server_fetch_url(target_url)
             return json.dumps(
                 await self._navigate(profile_name, target_url, _clean_str(targetId)),
                 sort_keys=True,
@@ -664,11 +659,6 @@ class BrowserTools(Toolkit):
         if normalized_target not in {None, "host"}:
             msg = f"Unsupported target: {target}"
             raise ValueError(msg)
-
-    @staticmethod
-    def _validate_browser_target_url(target_url: str) -> str:
-        """Validate model-supplied browser navigation URLs."""
-        return validate_server_fetch_url(target_url)
 
     async def _status_payload(self, profile_name: str) -> dict[str, Any]:
         async with self._lock:
@@ -1195,7 +1185,7 @@ class BrowserTools(Toolkit):
             except Exception:
                 await playwright.stop()
                 raise
-            await context.route("**/*", self._route_network_request)
+            await context.route("**/*", continue_or_abort_browser_fetch)
             state = _BrowserProfileState(playwright=playwright, context=context)
             self._profiles[profile_name] = state
 
@@ -1277,10 +1267,6 @@ class BrowserTools(Toolkit):
     def _next_output_path(self, extension: str) -> Path:
         return self._resolve_output_dir() / f"{uuid4().hex}.{extension}"
 
-    async def _route_network_request(self, route: Route) -> None:
-        """Block browser requests to URLs unsafe for server-side fetching."""
-        await continue_or_abort_browser_fetch(route)
-
     def _resolve_output_dir(self) -> Path:
         """Return the directory used for browser artifacts."""
         if self._output_dir is not None:
@@ -1300,12 +1286,7 @@ class BrowserTools(Toolkit):
         context = get_tool_runtime_context()
         if context is not None and context.storage_path is not None:
             roots.append(context.storage_path.resolve())
-
-        unique_roots: list[Path] = []
-        for root in roots:
-            if root not in unique_roots:
-                unique_roots.append(root)
-        return tuple(unique_roots)
+        return tuple(roots)
 
     def _resolve_upload_path(self, path: str) -> Path:
         """Resolve and confine one browser upload path."""
@@ -1314,7 +1295,7 @@ class BrowserTools(Toolkit):
             msg = f"upload path must be an existing file: {path}"
             raise ValueError(msg)
         roots = self._browser_upload_roots()
-        if any(_is_path_inside(resolved, root) for root in roots):
+        if any(resolved.is_relative_to(root) for root in roots):
             return resolved
         root_list = ", ".join(str(root) for root in roots)
         msg = f"upload path '{path}' resolves to '{resolved}', outside browser upload root(s): {root_list}"

--- a/src/mindroom/custom_tools/browser.py
+++ b/src/mindroom/custom_tools/browser.py
@@ -17,10 +17,11 @@ from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 from agno.tools import Toolkit
-from playwright.async_api import BrowserContext, ConsoleMessage, Dialog, Page, Playwright, async_playwright
+from playwright.async_api import BrowserContext, ConsoleMessage, Dialog, Page, Playwright, Route, async_playwright
 from playwright.async_api import Error as PlaywrightError
 
 from mindroom.logging_config import get_logger
+from mindroom.server_fetch_url import ServerFetchUrlError, validate_server_fetch_url
 from mindroom.tool_system.runtime_context import get_tool_runtime_context
 
 if TYPE_CHECKING:
@@ -321,6 +322,15 @@ def _unknown_browser_action_message(action: str) -> str:
     )
 
 
+def _is_path_inside(path: Path, root: Path) -> bool:
+    """Return whether a resolved path is under a resolved root."""
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
 def _playwright_cache_root(expected_executable_path: Path | None) -> Path | None:
     """Return the Playwright browser cache root for an executable path."""
     if expected_executable_path is None:
@@ -443,7 +453,7 @@ class BrowserTools(Toolkit):
             return
         self._close_task = loop.create_task(self._close_profiles())
 
-    async def browser(  # noqa: C901, PLR0911, PLR0912
+    async def browser(  # noqa: C901, PLR0911, PLR0912, PLR0915
         self,
         action: str,
         target: str | None = None,
@@ -540,6 +550,7 @@ class BrowserTools(Toolkit):
             if target_url is None:
                 msg = "targetUrl required for action=open"
                 raise ValueError(msg)
+            target_url = self._validate_browser_target_url(target_url)
             return json.dumps(await self._open_tab(profile_name, target_url), sort_keys=True)
         if normalized_action == "focus":
             target_id = _clean_str(targetId)
@@ -585,6 +596,7 @@ class BrowserTools(Toolkit):
             if target_url is None:
                 msg = "targetUrl required for action=navigate"
                 raise ValueError(msg)
+            target_url = self._validate_browser_target_url(target_url)
             return json.dumps(
                 await self._navigate(profile_name, target_url, _clean_str(targetId)),
                 sort_keys=True,
@@ -655,6 +667,11 @@ class BrowserTools(Toolkit):
         if normalized_target not in {None, "host"}:
             msg = f"Unsupported target: {target}"
             raise ValueError(msg)
+
+    @staticmethod
+    def _validate_browser_target_url(target_url: str) -> str:
+        """Validate model-supplied browser navigation URLs."""
+        return validate_server_fetch_url(target_url)
 
     async def _status_payload(self, profile_name: str) -> dict[str, Any]:
         async with self._lock:
@@ -822,7 +839,7 @@ class BrowserTools(Toolkit):
         if selector is None:
             msg = "upload requires inputRef, ref, or element"
             raise ValueError(msg)
-        normalized_paths = [str(Path(path).expanduser()) for path in paths]
+        normalized_paths = [str(self._resolve_upload_path(path)) for path in paths]
         locator = tab.page.locator(selector).first
         await locator.set_input_files(normalized_paths, timeout=timeout_ms or _DEFAULT_TIMEOUT_MS)
         return {
@@ -1181,6 +1198,7 @@ class BrowserTools(Toolkit):
             except Exception:
                 await playwright.stop()
                 raise
+            await context.route("**/*", self._route_network_request)
             state = _BrowserProfileState(playwright=playwright, context=context)
             self._profiles[profile_name] = state
 
@@ -1262,6 +1280,15 @@ class BrowserTools(Toolkit):
     def _next_output_path(self, extension: str) -> Path:
         return self._resolve_output_dir() / f"{uuid4().hex}.{extension}"
 
+    async def _route_network_request(self, route: Route) -> None:
+        """Block browser requests to URLs unsafe for server-side fetching."""
+        try:
+            validate_server_fetch_url(route.request.url)
+        except ServerFetchUrlError:
+            await route.abort("blockedbyclient")
+            return
+        await route.continue_()
+
     def _resolve_output_dir(self) -> Path:
         """Return the directory used for browser artifacts."""
         if self._output_dir is not None:
@@ -1274,6 +1301,32 @@ class BrowserTools(Toolkit):
         self._output_dir = (storage_root / "browser").resolve()
         self._output_dir.mkdir(parents=True, exist_ok=True)
         return self._output_dir
+
+    def _browser_upload_roots(self) -> tuple[Path, ...]:
+        """Return roots whose files can be read by browser upload."""
+        roots = [self._runtime_paths.storage_root.resolve(), self._resolve_output_dir().resolve()]
+        context = get_tool_runtime_context()
+        if context is not None and context.storage_path is not None:
+            roots.append(context.storage_path.resolve())
+
+        unique_roots: list[Path] = []
+        for root in roots:
+            if root not in unique_roots:
+                unique_roots.append(root)
+        return tuple(unique_roots)
+
+    def _resolve_upload_path(self, path: str) -> Path:
+        """Resolve and confine one browser upload path."""
+        resolved = Path(path).expanduser().resolve()
+        if not resolved.is_file():
+            msg = f"upload path must be an existing file: {path}"
+            raise ValueError(msg)
+        roots = self._browser_upload_roots()
+        if any(_is_path_inside(resolved, root) for root in roots):
+            return resolved
+        root_list = ", ".join(str(root) for root in roots)
+        msg = f"upload path '{path}' resolves to '{resolved}', outside browser upload root(s): {root_list}"
+        raise ValueError(msg)
 
     @staticmethod
     def _remove_tab(state: _BrowserProfileState, target_id: str) -> None:

--- a/src/mindroom/mcp/oauth.py
+++ b/src/mindroom/mcp/oauth.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-import ipaddress
 import json
-import socket
 import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
@@ -16,6 +14,7 @@ import httpx
 from mindroom.credentials import get_runtime_credentials_manager
 from mindroom.mcp.toolkit import require_mcp_server_manager
 from mindroom.oauth.providers import OAuthProvider, OAuthProviderError, OAuthRuntimeEndpoints
+from mindroom.server_fetch_url import ServerFetchUrlError, validate_server_fetch_url
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Iterable
@@ -150,44 +149,6 @@ def _authorization_server_metadata_urls(authorization_server: str) -> tuple[str,
     return tuple(dict.fromkeys(urls))
 
 
-def _address_is_unsafe(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
-    return (
-        address.is_private
-        or address.is_loopback
-        or address.is_link_local
-        or address.is_reserved
-        or address.is_multicast
-        or address.is_unspecified
-    )
-
-
-def _resolved_host_addresses(hostname: str) -> tuple[ipaddress.IPv4Address | ipaddress.IPv6Address, ...]:
-    try:
-        infos = socket.getaddrinfo(hostname, None, type=socket.SOCK_STREAM)
-    except socket.gaierror:
-        return ()
-    addresses: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = []
-    for info in infos:
-        try:
-            addresses.append(ipaddress.ip_address(info[4][0]))
-        except ValueError:
-            continue
-    return tuple(addresses)
-
-
-async def _host_is_unsafe(hostname: str | None) -> bool:
-    if not hostname:
-        return True
-    if hostname.lower() == "localhost":
-        return True
-    try:
-        address = ipaddress.ip_address(hostname)
-    except ValueError:
-        addresses = await asyncio.to_thread(_resolved_host_addresses, hostname)
-        return any(_address_is_unsafe(address) for address in addresses)
-    return _address_is_unsafe(address)
-
-
 async def _validate_discovery_url(url: str, runtime_paths: RuntimePaths) -> None:
     parsed = urlparse(url)
     allow_insecure = runtime_paths.env_flag("MINDROOM_MCP_OAUTH_ALLOW_INSECURE_DISCOVERY")
@@ -195,9 +156,11 @@ async def _validate_discovery_url(url: str, runtime_paths: RuntimePaths) -> None
     if parsed.scheme != "https" and not allow_insecure:
         msg = f"MCP OAuth discovery requires HTTPS URL: {url}"
         raise OAuthProviderError(msg)
-    if await _host_is_unsafe(parsed.hostname) and not allow_private:
-        msg = f"MCP OAuth discovery refused unsafe URL host: {parsed.hostname or ''}"
-        raise OAuthProviderError(msg)
+    try:
+        await asyncio.to_thread(validate_server_fetch_url, url, allow_private_networks=allow_private)
+    except ServerFetchUrlError as exc:
+        msg = "MCP OAuth discovery refused unsafe URL"
+        raise OAuthProviderError(msg) from exc
 
 
 def _metadata_cache_key(

--- a/src/mindroom/mcp/transports.py
+++ b/src/mindroom/mcp/transports.py
@@ -64,6 +64,7 @@ def _server_fetch_mcp_http_client(
     headers: dict[str, str] | None = None,
     timeout: httpx.Timeout | None = None,
     auth: httpx.Auth | None = None,
+    **_ignored: object,
 ) -> httpx.AsyncClient:
     """Create an MCP HTTP client that validates requests, redirects, and dialed addresses."""
     kwargs: dict[str, Any] = {

--- a/src/mindroom/mcp/transports.py
+++ b/src/mindroom/mcp/transports.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import re
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
@@ -123,7 +124,7 @@ async def _open_remote_transport(
     if server_config.url is None:
         msg = f"{transport} MCP servers require url"
         raise ValueError(msg)
-    url = validate_server_fetch_url(server_config.url)
+    url = await asyncio.to_thread(validate_server_fetch_url, server_config.url)
     headers = {
         **_interpolate_mcp_headers(server_config.headers, runtime_paths),
         **(dict(extra_headers) if extra_headers is not None else {}),

--- a/src/mindroom/mcp/transports.py
+++ b/src/mindroom/mcp/transports.py
@@ -7,11 +7,14 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
+import httpx
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from mcp.client.sse import sse_client
 from mcp.client.stdio import StdioServerParameters, get_default_environment, stdio_client
 from mcp.client.streamable_http import streamablehttp_client
 from mcp.shared.message import SessionMessage
+
+from mindroom.server_fetch_url import ServerFetchAsyncHTTPTransport, validate_server_fetch_url
 
 _ENV_REFERENCE_PATTERN = re.compile(r"\$\{([^}]+)\}")
 
@@ -57,6 +60,25 @@ def _interpolate_mcp_headers(values: Mapping[str, str], runtime_paths: RuntimePa
     return {name: _interpolate_value(value, runtime_paths) for name, value in values.items()}
 
 
+def _server_fetch_mcp_http_client(
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None = None,
+    auth: httpx.Auth | None = None,
+) -> httpx.AsyncClient:
+    """Create an MCP HTTP client that validates requests, redirects, and dialed addresses."""
+    kwargs: dict[str, Any] = {
+        "follow_redirects": True,
+        "transport": ServerFetchAsyncHTTPTransport(),
+    }
+    if timeout is not None:
+        kwargs["timeout"] = timeout
+    if headers is not None:
+        kwargs["headers"] = headers
+    if auth is not None:
+        kwargs["auth"] = auth
+    return httpx.AsyncClient(**kwargs)
+
+
 def _build_stdio_server_parameters(
     server_config: MCPServerConfig,
     runtime_paths: RuntimePaths | None = None,
@@ -100,15 +122,17 @@ async def _open_remote_transport(
     if server_config.url is None:
         msg = f"{transport} MCP servers require url"
         raise ValueError(msg)
+    url = validate_server_fetch_url(server_config.url)
     headers = {
         **_interpolate_mcp_headers(server_config.headers, runtime_paths),
         **(dict(extra_headers) if extra_headers is not None else {}),
     }
     async with client(
-        server_config.url,
+        url,
         headers=headers,
         timeout=server_config.startup_timeout_seconds,
         sse_read_timeout=server_config.call_timeout_seconds,
+        httpx_client_factory=_server_fetch_mcp_http_client,
     ) as streams:
         yield cast("_TransportStreams", streams[:2])
 

--- a/src/mindroom/server_fetch_url.py
+++ b/src/mindroom/server_fetch_url.py
@@ -128,6 +128,9 @@ def _validate_ip_address(
         if _is_metadata_ip(checked_address):
             _deny("metadata_address")
 
+        if checked_address.is_loopback and allow_private_networks:
+            continue
+
         if (
             checked_address.is_link_local
             or checked_address.is_multicast

--- a/src/mindroom/server_fetch_url.py
+++ b/src/mindroom/server_fetch_url.py
@@ -10,13 +10,16 @@ from urllib.parse import urljoin, urlsplit
 import httpcore
 import httpx
 from httpcore._backends.anyio import AnyIOBackend
+from httpx._config import DEFAULT_LIMITS, create_ssl_context
 
 if TYPE_CHECKING:
+    import ssl
     from collections.abc import Awaitable, Callable, Iterable
     from typing import NoReturn
     from urllib.parse import SplitResult
 
     from httpcore._backends.base import SOCKET_OPTION
+    from httpx._types import CertTypes
 
 _ALLOWED_SCHEMES = frozenset({"http", "https"})
 _GENERIC_DENY_MESSAGE = "URL is not allowed for server-side fetching"
@@ -386,10 +389,33 @@ async def _connect_validated_async(
 class ServerFetchHTTPTransport(httpx.HTTPTransport):
     """HTTPX transport that validates server-fetch URLs and dialed addresses."""
 
-    def __init__(self, *, allow_private_networks: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        allow_private_networks: bool = False,
+        verify: ssl.SSLContext | str | bool = True,
+        cert: CertTypes | None = None,
+        trust_env: bool = True,
+        http1: bool = True,
+        http2: bool = False,
+        limits: httpx.Limits = DEFAULT_LIMITS,
+        local_address: str | None = None,
+        retries: int = 0,
+        socket_options: Iterable[SOCKET_OPTION] | None = None,
+    ) -> None:
         self._allow_private_networks = allow_private_networks
+        ssl_context = create_ssl_context(verify=verify, cert=cert, trust_env=trust_env)
         self._pool: httpcore.ConnectionPool = httpcore.ConnectionPool(
+            ssl_context=ssl_context,
+            max_connections=limits.max_connections,
+            max_keepalive_connections=limits.max_keepalive_connections,
+            keepalive_expiry=limits.keepalive_expiry,
+            http1=http1,
+            http2=http2,
+            local_address=local_address,
             network_backend=_ServerFetchSyncNetworkBackend(allow_private_networks=allow_private_networks),
+            retries=retries,
+            socket_options=socket_options,
         )
 
     def handle_request(self, request: httpx.Request) -> httpx.Response:
@@ -409,10 +435,33 @@ class ServerFetchHTTPTransport(httpx.HTTPTransport):
 class ServerFetchAsyncHTTPTransport(httpx.AsyncHTTPTransport):
     """Async HTTPX transport that validates server-fetch URLs and dialed addresses."""
 
-    def __init__(self, *, allow_private_networks: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        allow_private_networks: bool = False,
+        verify: ssl.SSLContext | str | bool = True,
+        cert: CertTypes | None = None,
+        trust_env: bool = True,
+        http1: bool = True,
+        http2: bool = False,
+        limits: httpx.Limits = DEFAULT_LIMITS,
+        local_address: str | None = None,
+        retries: int = 0,
+        socket_options: Iterable[SOCKET_OPTION] | None = None,
+    ) -> None:
         self._allow_private_networks = allow_private_networks
+        ssl_context = create_ssl_context(verify=verify, cert=cert, trust_env=trust_env)
         self._pool: httpcore.AsyncConnectionPool = httpcore.AsyncConnectionPool(
+            ssl_context=ssl_context,
+            max_connections=limits.max_connections,
+            max_keepalive_connections=limits.max_keepalive_connections,
+            keepalive_expiry=limits.keepalive_expiry,
+            http1=http1,
+            http2=http2,
+            local_address=local_address,
             network_backend=_ServerFetchAsyncNetworkBackend(allow_private_networks=allow_private_networks),
+            retries=retries,
+            socket_options=socket_options,
         )
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:

--- a/src/mindroom/tools/browser.py
+++ b/src/mindroom/tools/browser.py
@@ -43,6 +43,17 @@ if TYPE_CHECKING:
                 "Defaults to the active storage path's browser/ directory."
             ),
         ),
+        ConfigField(
+            name="allow_private_networks",
+            label="Allow Private Networks",
+            type="boolean",
+            required=False,
+            default=False,
+            description=(
+                "Allow browser navigation and page subresources to reach trusted private, local, or loopback "
+                "network addresses. Cloud metadata and link-local addresses stay blocked."
+            ),
+        ),
     ],
     function_names=("browser",),
 )

--- a/src/mindroom/tools/crawl4ai.py
+++ b/src/mindroom/tools/crawl4ai.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from mindroom.browser_fetch_guard import continue_or_abort_browser_fetch
 from mindroom.server_fetch_url import validate_server_fetch_url
 from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.crawl4ai import Crawl4aiTools
+    from playwright.async_api import Page, Route
 
 
 @register_tool_with_metadata(
@@ -96,9 +98,11 @@ if TYPE_CHECKING:
     docs_url="https://docs.agno.com/tools/toolkits/web_scrape/crawl4ai",
     function_names=("crawl",),
 )
-def crawl4ai_tools() -> type[Crawl4aiTools]:
+def crawl4ai_tools() -> type[Crawl4aiTools]:  # noqa: C901
     """Return Crawl4AI tools for web crawling and scraping."""
+    import agno.tools.crawl4ai as agno_crawl4ai
     from agno.tools.crawl4ai import Crawl4aiTools
+    from agno.utils.log import log_debug, log_warning
 
     class MindRoomCrawl4aiTools(Crawl4aiTools):
         """Crawl4AI toolkit with MindRoom server-fetch URL validation."""
@@ -109,5 +113,56 @@ def crawl4ai_tools() -> type[Crawl4aiTools]:
                 return super().crawl(validate_server_fetch_url(url), search_query)
             validated_urls = [validate_server_fetch_url(single_url) for single_url in url]
             return super().crawl(validated_urls, search_query)
+
+        async def _guard_page_context(self, page: Page, **_kwargs: object) -> None:
+            async def route_guard(route: Route) -> None:
+                await continue_or_abort_browser_fetch(route)
+
+            await page.route("**/*", route_guard)
+
+        async def _async_crawl(self, url: str, search_query: str | None = None) -> str:
+            """Crawl one validated URL with server-fetch guards on Playwright requests."""
+            try:
+                browser_config = agno_crawl4ai.BrowserConfig(
+                    headless=self.headless,
+                    verbose=False,
+                    **self.proxy_config,
+                )
+
+                async with agno_crawl4ai.AsyncWebCrawler(config=browser_config) as crawler:
+                    crawler.crawler_strategy.set_hook("on_page_context_created", self._guard_page_context)
+                    config = agno_crawl4ai.CrawlerRunConfig(**self._build_config(search_query))
+                    log_debug(f"Crawling {url} with config: {config}")
+                    result = await crawler.arun(url=url, config=config)
+
+                    if not result:
+                        return "Error: No content found"
+
+                    content = ""
+                    if result.fit_markdown:
+                        content = result.fit_markdown
+                        log_debug("Using fit_markdown")
+                    elif result.markdown:
+                        if isinstance(result.markdown, str):
+                            content = result.markdown
+                            log_debug("Using str(markdown)")
+                        else:
+                            content = result.markdown.raw_markdown
+                            log_debug("Using markdown.raw_markdown")
+                    elif result.html:
+                        log_warning("Only HTML available, no markdown extracted")
+                        return "Error: Could not extract markdown from page"
+
+                    if not content:
+                        log_warning(f"No content extracted. Result type: {type(result)}")
+                        return "Error: No readable content extracted"
+
+                    log_debug(f"Extracted content length: {len(content)}")
+                    if self.max_length and len(content) > self.max_length:
+                        content = content[: self.max_length] + "..."
+                    return content
+            except Exception as exc:
+                log_warning(f"Exception during crawl: {exc}")
+                return f"Error crawling {url}: {exc}"
 
     return MindRoomCrawl4aiTools

--- a/src/mindroom/tools/crawl4ai.py
+++ b/src/mindroom/tools/crawl4ai.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from mindroom.server_fetch_url import validate_server_fetch_url
 from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
 
 if TYPE_CHECKING:
@@ -99,4 +100,14 @@ def crawl4ai_tools() -> type[Crawl4aiTools]:
     """Return Crawl4AI tools for web crawling and scraping."""
     from agno.tools.crawl4ai import Crawl4aiTools
 
-    return Crawl4aiTools
+    class MindRoomCrawl4aiTools(Crawl4aiTools):
+        """Crawl4AI toolkit with MindRoom server-fetch URL validation."""
+
+        def crawl(self, url: str | list[str], search_query: str | None = None) -> str | dict[str, str]:
+            """Crawl validated public HTTP(S) URLs."""
+            if isinstance(url, str):
+                return super().crawl(validate_server_fetch_url(url), search_query)
+            validated_urls = [validate_server_fetch_url(single_url) for single_url in url]
+            return super().crawl(validated_urls, search_query)
+
+    return MindRoomCrawl4aiTools

--- a/src/mindroom/tools/crawl4ai.py
+++ b/src/mindroom/tools/crawl4ai.py
@@ -10,7 +10,7 @@ from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, 
 
 if TYPE_CHECKING:
     from agno.tools.crawl4ai import Crawl4aiTools
-    from playwright.async_api import Page, Route
+    from playwright.async_api import Page
 
 
 @register_tool_with_metadata(
@@ -115,10 +115,7 @@ def crawl4ai_tools() -> type[Crawl4aiTools]:  # noqa: C901
             return super().crawl(validated_urls, search_query)
 
         async def _guard_page_context(self, page: Page, **_kwargs: object) -> None:
-            async def route_guard(route: Route) -> None:
-                await continue_or_abort_browser_fetch(route)
-
-            await page.route("**/*", route_guard)
+            await page.route("**/*", continue_or_abort_browser_fetch)
 
         async def _async_crawl(self, url: str, search_query: str | None = None) -> str:
             """Crawl one validated URL with server-fetch guards on Playwright requests."""
@@ -149,6 +146,9 @@ def crawl4ai_tools() -> type[Crawl4aiTools]:  # noqa: C901
                         else:
                             content = result.markdown.raw_markdown
                             log_debug("Using markdown.raw_markdown")
+                    elif result.text:
+                        content = result.text
+                        log_debug("Using text attribute")
                     elif result.html:
                         log_warning("Only HTML available, no markdown extracted")
                         return "Error: Could not extract markdown from page"

--- a/src/mindroom/tools/custom_api.py
+++ b/src/mindroom/tools/custom_api.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import json
+from typing import TYPE_CHECKING, Any, Literal
 
+import httpx
+
+from mindroom.server_fetch_url import ServerFetchHTTPTransport, validate_server_fetch_url
 from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
 
 if TYPE_CHECKING:
@@ -92,4 +96,55 @@ def custom_api_tools() -> type[CustomApiTools]:
     """Return Custom API tools for making HTTP requests to external APIs."""
     from agno.tools.api import CustomApiTools
 
-    return CustomApiTools
+    class MindRoomCustomApiTools(CustomApiTools):
+        """Custom API toolkit with MindRoom server-fetch URL validation."""
+
+        def _request_url(self, endpoint: str) -> str:
+            url = f"{self.base_url.rstrip('/')}/{endpoint.lstrip('/')}" if self.base_url else endpoint
+            return validate_server_fetch_url(url)
+
+        def make_request(
+            self,
+            endpoint: str,
+            method: Literal["GET", "POST", "PUT", "DELETE", "PATCH"] = "GET",
+            params: dict[str, Any] | None = None,
+            data: dict[str, Any] | None = None,
+            headers: dict[str, str] | None = None,
+            json_data: dict[str, Any] | None = None,
+        ) -> str:
+            """Make an HTTP request to a validated public HTTP(S) URL."""
+            url = self._request_url(endpoint)
+            auth = (self.username, self.password) if self.username and self.password else None
+            try:
+                with httpx.Client(
+                    transport=ServerFetchHTTPTransport(verify=self.verify_ssl),
+                    follow_redirects=True,
+                ) as client:
+                    response = client.request(
+                        method=method,
+                        url=url,
+                        params=params,
+                        data=data,
+                        json=json_data,
+                        headers=self._get_headers(headers),
+                        auth=auth,
+                        timeout=self.timeout,
+                    )
+
+                try:
+                    response_data: object = response.json()
+                except ValueError:
+                    response_data = {"text": response.text}
+
+                result: dict[str, object] = {
+                    "status_code": response.status_code,
+                    "headers": dict(response.headers),
+                    "data": response_data,
+                }
+                if not response.is_success:
+                    result["error"] = "Request failed"
+                return json.dumps(result, indent=2)
+            except httpx.RequestError as e:
+                return json.dumps({"error": f"Request failed: {e}"}, indent=2)
+
+    return MindRoomCustomApiTools

--- a/src/mindroom/tools/custom_api.py
+++ b/src/mindroom/tools/custom_api.py
@@ -99,10 +99,6 @@ def custom_api_tools() -> type[CustomApiTools]:
     class MindRoomCustomApiTools(CustomApiTools):
         """Custom API toolkit with MindRoom server-fetch URL validation."""
 
-        def _request_url(self, endpoint: str) -> str:
-            url = f"{self.base_url.rstrip('/')}/{endpoint.lstrip('/')}" if self.base_url else endpoint
-            return validate_server_fetch_url(url)
-
         def make_request(
             self,
             endpoint: str,
@@ -113,7 +109,8 @@ def custom_api_tools() -> type[CustomApiTools]:
             json_data: dict[str, Any] | None = None,
         ) -> str:
             """Make an HTTP request to a validated public HTTP(S) URL."""
-            url = self._request_url(endpoint)
+            url = f"{self.base_url.rstrip('/')}/{endpoint.lstrip('/')}" if self.base_url else endpoint
+            url = validate_server_fetch_url(url)
             auth = (self.username, self.password) if self.username and self.password else None
             try:
                 with httpx.Client(

--- a/src/mindroom/tools_metadata.json
+++ b/src/mindroom/tools_metadata.json
@@ -8937,6 +8937,18 @@
           "required": false,
           "type": "text",
           "validation": null
+        },
+        {
+          "authored_override": true,
+          "default": false,
+          "description": "Allow browser navigation and page subresources to reach trusted private, local, or loopback network addresses. Cloud metadata and link-local addresses stay blocked.",
+          "label": "Allow Private Networks",
+          "name": "allow_private_networks",
+          "options": null,
+          "placeholder": null,
+          "required": false,
+          "type": "boolean",
+          "validation": null
         }
       ],
       "default_execution_target": "primary",

--- a/tests/api/test_oauth_api.py
+++ b/tests/api/test_oauth_api.py
@@ -42,6 +42,15 @@ from mindroom.tool_system.worker_routing import (
 from tests.api.conftest import trusted_upstream_headers
 
 
+@pytest.fixture(autouse=True)
+def _allow_example_test_dns(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resolve fake public OAuth hostnames through the shared server-fetch validator."""
+    monkeypatch.setattr(
+        "mindroom.server_fetch_url.socket.getaddrinfo",
+        lambda *_args, **_kwargs: [(0, 0, 0, "", ("93.184.216.34", 0))],
+    )
+
+
 def _runtime_paths(tmp_path: Path, process_env: dict[str, str] | None = None) -> constants.RuntimePaths:
     runtime_paths = constants.resolve_primary_runtime_paths(
         config_path=tmp_path / "config.yaml",

--- a/tests/test_browser_tool.py
+++ b/tests/test_browser_tool.py
@@ -25,6 +25,7 @@ from mindroom.custom_tools.browser import (
     _persistent_launch_kwargs,
     _profile_dir,
 )
+from mindroom.server_fetch_url import ServerFetchUrlError
 from mindroom.tool_system.metadata import TOOL_METADATA
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, tool_runtime_context
 from tests.conftest import make_conversation_cache_mock, make_event_cache_mock
@@ -351,6 +352,34 @@ async def test_browser_open_dispatches_to_open_tab(monkeypatch: pytest.MonkeyPat
 
 
 @pytest.mark.asyncio
+async def test_browser_open_rejects_private_target_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Browser navigation should reject private network targets before opening a tab."""
+    tool = BrowserTools(TEST_RUNTIME_PATHS)
+    open_tab = AsyncMock()
+    monkeypatch.setattr(tool, "_open_tab", open_tab)
+
+    with pytest.raises(ServerFetchUrlError) as exc_info:
+        await tool.browser(action="open", targetUrl="http://127.0.0.1:8000/admin")
+
+    assert exc_info.value.reason == "private_address"
+    open_tab.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_browser_navigate_rejects_unsupported_target_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Browser navigation should reject local-file and non-HTTP URL schemes."""
+    tool = BrowserTools(TEST_RUNTIME_PATHS)
+    navigate = AsyncMock()
+    monkeypatch.setattr(tool, "_navigate", navigate)
+
+    with pytest.raises(ServerFetchUrlError) as exc_info:
+        await tool.browser(action="navigate", targetUrl="file:///etc/passwd")
+
+    assert exc_info.value.reason == "unsupported_scheme"
+    navigate.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_browser_rejects_non_host_targets() -> None:
     """MindRoom browser currently supports host only."""
     tool = BrowserTools(TEST_RUNTIME_PATHS)
@@ -424,6 +453,81 @@ async def test_act_click_uses_resolved_selector(monkeypatch: pytest.MonkeyPatch)
 
 
 @pytest.mark.asyncio
+async def test_browser_upload_rejects_paths_outside_runtime_storage(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Browser uploads should not read arbitrary local files outside runtime storage."""
+    runtime_paths = resolve_primary_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path / "storage",
+        process_env={},
+    )
+    outside_file = tmp_path / "secret.txt"
+    outside_file.write_text("secret", encoding="utf-8")
+    tool = BrowserTools(runtime_paths)
+    mock_state = object()
+    set_input_files = AsyncMock()
+    locator = MagicMock(return_value=SimpleNamespace(first=SimpleNamespace(set_input_files=set_input_files)))
+    page: Any = SimpleNamespace(locator=locator)
+    tab = _BrowserTabState(target_id="tab-1", page=page, refs={"e1": "input[type=file]"})
+
+    monkeypatch.setattr(tool, "_ensure_profile", AsyncMock(return_value=mock_state))
+    monkeypatch.setattr(tool, "_resolve_tab", AsyncMock(return_value=("tab-1", tab)))
+
+    with pytest.raises(ValueError, match="outside browser upload root"):
+        await tool._upload(
+            profile_name="mindroom",
+            target_id=None,
+            paths=[str(outside_file)],
+            ref="e1",
+            input_ref=None,
+            element=None,
+            timeout_ms=None,
+        )
+
+    set_input_files.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_browser_upload_allows_paths_inside_tool_storage(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Browser uploads should allow files produced inside the active tool storage root."""
+    runtime_paths = resolve_primary_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path / "storage",
+        process_env={},
+    )
+    allowed_file = runtime_paths.storage_root / "browser" / "upload.txt"
+    allowed_file.parent.mkdir(parents=True)
+    allowed_file.write_text("upload", encoding="utf-8")
+    tool = BrowserTools(runtime_paths)
+    mock_state = object()
+    set_input_files = AsyncMock()
+    locator = MagicMock(return_value=SimpleNamespace(first=SimpleNamespace(set_input_files=set_input_files)))
+    page: Any = SimpleNamespace(locator=locator)
+    tab = _BrowserTabState(target_id="tab-1", page=page, refs={"e1": "input[type=file]"})
+
+    monkeypatch.setattr(tool, "_ensure_profile", AsyncMock(return_value=mock_state))
+    monkeypatch.setattr(tool, "_resolve_tab", AsyncMock(return_value=("tab-1", tab)))
+
+    payload = await tool._upload(
+        profile_name="mindroom",
+        target_id=None,
+        paths=[str(allowed_file)],
+        ref="e1",
+        input_ref=None,
+        element=None,
+        timeout_ms=None,
+    )
+
+    set_input_files.assert_awaited_once_with([str(allowed_file)], timeout=30_000)
+    assert payload["paths"] == [str(allowed_file)]
+
+
+@pytest.mark.asyncio
 async def test_act_fill_requires_at_least_one_valid_field(monkeypatch: pytest.MonkeyPatch) -> None:
     """Fill act fails when no field resolves to a usable selector."""
     tool = BrowserTools(TEST_RUNTIME_PATHS)
@@ -455,6 +559,7 @@ class _FakeContext:
         self.pages = list(pages or [])
         self.fresh_page = _FakePage()
         self.new_page = AsyncMock(return_value=self.fresh_page)
+        self.route = AsyncMock()
         self.close = AsyncMock()
 
 
@@ -509,6 +614,38 @@ async def test_ensure_profile_uses_runtime_browser_executable(
     assert launch_kwargs["executable_path"] == "/opt/custom-browser"
     context.new_page.assert_awaited_once_with()
     assert state.active_target_id is not None
+
+
+@pytest.mark.asyncio
+async def test_ensure_profile_installs_server_fetch_route(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Browser contexts should validate every routed network request URL."""
+    runtime_paths = resolve_primary_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path / "storage",
+        process_env={},
+    )
+    tool = BrowserTools(runtime_paths)
+    context = _FakeContext(pages=[])
+    _install_fake_persistent_playwright(monkeypatch, context=context)
+
+    await tool._ensure_profile("mindroom")
+
+    context.route.assert_awaited_once()
+    route_pattern, route_handler = context.route.await_args.args
+    assert route_pattern == "**/*"
+
+    unsafe_route = SimpleNamespace(
+        request=SimpleNamespace(url="http://127.0.0.1/admin"),
+        abort=AsyncMock(),
+        continue_=AsyncMock(),
+    )
+    await route_handler(unsafe_route)
+
+    unsafe_route.abort.assert_awaited_once_with("blockedbyclient")
+    unsafe_route.continue_.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_browser_tool.py
+++ b/tests/test_browser_tool.py
@@ -8,7 +8,7 @@ import os
 import stat
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -29,6 +29,9 @@ from mindroom.server_fetch_url import ServerFetchUrlError
 from mindroom.tool_system.metadata import TOOL_METADATA
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, tool_runtime_context
 from tests.conftest import make_conversation_cache_mock, make_event_cache_mock
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 TEST_RUNTIME_PATHS = resolve_primary_runtime_paths(config_path=Path("config.yaml"))
 
@@ -636,6 +639,14 @@ async def test_ensure_profile_installs_server_fetch_route(
     context.route.assert_awaited_once()
     route_pattern, route_handler = context.route.await_args.args
     assert route_pattern == "**/*"
+    to_thread_calls = 0
+
+    async def fake_to_thread(function: Callable[..., object], *args: object, **kwargs: object) -> object:
+        nonlocal to_thread_calls
+        to_thread_calls += 1
+        return function(*args, **kwargs)
+
+    monkeypatch.setattr("mindroom.browser_fetch_guard.asyncio.to_thread", fake_to_thread)
 
     unsafe_route = SimpleNamespace(
         request=SimpleNamespace(url="http://127.0.0.1/admin"),
@@ -646,6 +657,7 @@ async def test_ensure_profile_installs_server_fetch_route(
 
     unsafe_route.abort.assert_awaited_once_with("blockedbyclient")
     unsafe_route.continue_.assert_not_called()
+    assert to_thread_calls == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_browser_tool.py
+++ b/tests/test_browser_tool.py
@@ -304,6 +304,13 @@ def test_browser_metadata_documents_default_output_dir() -> None:
     assert "storage path's browser/ directory" in output_dir_field.description
 
 
+def test_browser_private_network_metadata_defaults_to_false() -> None:
+    """Browser local-network opt-in should expose an explicit secure default."""
+    fields = {field.name: field for field in TOOL_METADATA["browser"].config_fields or []}
+
+    assert fields["allow_private_networks"].default is False
+
+
 def test_browser_metadata_lists_discovery_actions() -> None:
     """Dashboard metadata should expose the callable discovery actions."""
     description = TOOL_METADATA["browser"].description
@@ -355,17 +362,63 @@ async def test_browser_open_dispatches_to_open_tab(monkeypatch: pytest.MonkeyPat
 
 
 @pytest.mark.asyncio
-async def test_browser_open_rejects_private_target_url(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Browser navigation should reject private network targets before opening a tab."""
+async def test_browser_open_rejects_localhost_target_url_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Browser navigation should reject local dev servers before opening a tab by default."""
     tool = BrowserTools(TEST_RUNTIME_PATHS)
     open_tab = AsyncMock()
     monkeypatch.setattr(tool, "_open_tab", open_tab)
 
     with pytest.raises(ServerFetchUrlError) as exc_info:
-        await tool.browser(action="open", targetUrl="http://127.0.0.1:8000/admin")
+        await tool.browser(action="open", targetUrl="http://localhost:5173/")
 
-    assert exc_info.value.reason == "private_address"
+    assert exc_info.value.reason == "private_hostname"
     open_tab.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_browser_open_allows_private_target_url_when_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Browser local-network opt-in should allow local dev server tabs."""
+    tool = BrowserTools(TEST_RUNTIME_PATHS, allow_private_networks=True)
+    open_tab = AsyncMock(
+        return_value={
+            "action": "open",
+            "profile": "mindroom",
+            "status": "ok",
+            "targetId": "tab-1",
+            "title": "Local",
+            "url": "http://localhost:5173/",
+        },
+    )
+    monkeypatch.setattr(tool, "_open_tab", open_tab)
+
+    raw = await tool.browser(action="open", targetUrl="http://localhost:5173/")
+    payload = json.loads(raw)
+
+    open_tab.assert_awaited_once_with("mindroom", "http://localhost:5173/")
+    assert payload["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_browser_navigate_allows_private_target_url_when_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Browser local-network opt-in should allow navigating to a local dev server."""
+    tool = BrowserTools(TEST_RUNTIME_PATHS, allow_private_networks=True)
+    navigate = AsyncMock(
+        return_value={
+            "action": "navigate",
+            "profile": "mindroom",
+            "status": "ok",
+            "targetId": "tab-1",
+            "title": "Local",
+            "url": "http://localhost:5173/",
+        },
+    )
+    monkeypatch.setattr(tool, "_navigate", navigate)
+
+    raw = await tool.browser(action="navigate", targetUrl="http://localhost:5173/")
+    payload = json.loads(raw)
+
+    navigate.assert_awaited_once_with("mindroom", "http://localhost:5173/", None)
+    assert payload["status"] == "ok"
 
 
 @pytest.mark.asyncio
@@ -727,6 +780,45 @@ async def test_ensure_profile_route_allows_browser_internal_urls(
 
         route.continue_.assert_awaited_once_with()
         route.abort.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ensure_profile_route_allows_private_urls_when_configured(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Browser route guard should apply the local-network opt-in to subresources."""
+    runtime_paths = resolve_primary_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path / "storage",
+        process_env={},
+    )
+    tool = BrowserTools(runtime_paths, allow_private_networks=True)
+    context = _FakeContext(pages=[])
+    _install_fake_persistent_playwright(monkeypatch, context=context)
+
+    await tool._ensure_profile("mindroom")
+
+    route_handler = context.route.await_args.args[1]
+    local_route = SimpleNamespace(
+        request=SimpleNamespace(url="http://localhost:5173/assets/app.js"),
+        abort=AsyncMock(),
+        continue_=AsyncMock(),
+    )
+    await route_handler(local_route)
+
+    local_route.continue_.assert_awaited_once_with()
+    local_route.abort.assert_not_called()
+
+    metadata_route = SimpleNamespace(
+        request=SimpleNamespace(url="http://169.254.169.254/latest/meta-data/"),
+        abort=AsyncMock(),
+        continue_=AsyncMock(),
+    )
+    await route_handler(metadata_route)
+
+    metadata_route.abort.assert_awaited_once_with("blockedbyclient")
+    metadata_route.continue_.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_browser_tool.py
+++ b/tests/test_browser_tool.py
@@ -531,6 +531,44 @@ async def test_browser_upload_allows_paths_inside_tool_storage(
 
 
 @pytest.mark.asyncio
+async def test_browser_upload_rejects_runtime_storage_secrets(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Browser uploads should only read browser artifacts, not all runtime state."""
+    runtime_paths = resolve_primary_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path / "storage",
+        process_env={},
+    )
+    secret_file = runtime_paths.storage_root / "credentials" / "secret.json"
+    secret_file.parent.mkdir(parents=True)
+    secret_file.write_text("secret", encoding="utf-8")
+    tool = BrowserTools(runtime_paths)
+    mock_state = object()
+    set_input_files = AsyncMock()
+    locator = MagicMock(return_value=SimpleNamespace(first=SimpleNamespace(set_input_files=set_input_files)))
+    page: Any = SimpleNamespace(locator=locator)
+    tab = _BrowserTabState(target_id="tab-1", page=page, refs={"e1": "input[type=file]"})
+
+    monkeypatch.setattr(tool, "_ensure_profile", AsyncMock(return_value=mock_state))
+    monkeypatch.setattr(tool, "_resolve_tab", AsyncMock(return_value=("tab-1", tab)))
+
+    with pytest.raises(ValueError, match="outside browser upload root"):
+        await tool._upload(
+            profile_name="mindroom",
+            target_id=None,
+            paths=[str(secret_file)],
+            ref="e1",
+            input_ref=None,
+            element=None,
+            timeout_ms=None,
+        )
+
+    set_input_files.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_act_fill_requires_at_least_one_valid_field(monkeypatch: pytest.MonkeyPatch) -> None:
     """Fill act fails when no field resolves to a usable selector."""
     tool = BrowserTools(TEST_RUNTIME_PATHS)
@@ -658,6 +696,17 @@ async def test_ensure_profile_installs_server_fetch_route(
     unsafe_route.abort.assert_awaited_once_with("blockedbyclient")
     unsafe_route.continue_.assert_not_called()
     assert to_thread_calls == 1
+
+    malformed_route = SimpleNamespace(
+        request=SimpleNamespace(url="http://[::1"),
+        abort=AsyncMock(),
+        continue_=AsyncMock(),
+    )
+    await route_handler(malformed_route)
+
+    malformed_route.abort.assert_awaited_once_with("blockedbyclient")
+    malformed_route.continue_.assert_not_called()
+    assert to_thread_calls == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_browser_tool.py
+++ b/tests/test_browser_tool.py
@@ -649,6 +649,36 @@ async def test_ensure_profile_installs_server_fetch_route(
 
 
 @pytest.mark.asyncio
+async def test_ensure_profile_route_allows_browser_internal_urls(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Browser routing should not block browser-internal non-network URLs."""
+    runtime_paths = resolve_primary_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path / "storage",
+        process_env={},
+    )
+    tool = BrowserTools(runtime_paths)
+    context = _FakeContext(pages=[])
+    _install_fake_persistent_playwright(monkeypatch, context=context)
+
+    await tool._ensure_profile("mindroom")
+
+    route_handler = context.route.await_args.args[1]
+    for internal_url in ("about:blank", "blob:https://example.com/blob-id", "data:text/html,hello"):
+        route = SimpleNamespace(
+            request=SimpleNamespace(url=internal_url),
+            abort=AsyncMock(),
+            continue_=AsyncMock(),
+        )
+        await route_handler(route)
+
+        route.continue_.assert_awaited_once_with()
+        route.abort.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_ensure_profile_creates_user_data_dir_on_disk(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_browser_tool.py
+++ b/tests/test_browser_tool.py
@@ -455,6 +455,17 @@ async def test_act_click_uses_resolved_selector(monkeypatch: pytest.MonkeyPatch)
     assert payload["targetId"] == "tab-1"
 
 
+def _install_upload_tab(tool: BrowserTools, monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    set_input_files = AsyncMock()
+    locator = MagicMock(return_value=SimpleNamespace(first=SimpleNamespace(set_input_files=set_input_files)))
+    page: Any = SimpleNamespace(locator=locator)
+    tab = _BrowserTabState(target_id="tab-1", page=page, refs={"e1": "input[type=file]"})
+
+    monkeypatch.setattr(tool, "_ensure_profile", AsyncMock(return_value=object()))
+    monkeypatch.setattr(tool, "_resolve_tab", AsyncMock(return_value=("tab-1", tab)))
+    return set_input_files
+
+
 @pytest.mark.asyncio
 async def test_browser_upload_rejects_paths_outside_upload_roots(
     monkeypatch: pytest.MonkeyPatch,
@@ -469,14 +480,7 @@ async def test_browser_upload_rejects_paths_outside_upload_roots(
     outside_file = tmp_path / "secret.txt"
     outside_file.write_text("secret", encoding="utf-8")
     tool = BrowserTools(runtime_paths)
-    mock_state = object()
-    set_input_files = AsyncMock()
-    locator = MagicMock(return_value=SimpleNamespace(first=SimpleNamespace(set_input_files=set_input_files)))
-    page: Any = SimpleNamespace(locator=locator)
-    tab = _BrowserTabState(target_id="tab-1", page=page, refs={"e1": "input[type=file]"})
-
-    monkeypatch.setattr(tool, "_ensure_profile", AsyncMock(return_value=mock_state))
-    monkeypatch.setattr(tool, "_resolve_tab", AsyncMock(return_value=("tab-1", tab)))
+    set_input_files = _install_upload_tab(tool, monkeypatch)
 
     with pytest.raises(ValueError, match="outside browser upload root"):
         await tool._upload(
@@ -507,14 +511,7 @@ async def test_browser_upload_allows_paths_inside_tool_storage(
     allowed_file.parent.mkdir(parents=True)
     allowed_file.write_text("upload", encoding="utf-8")
     tool = BrowserTools(runtime_paths)
-    mock_state = object()
-    set_input_files = AsyncMock()
-    locator = MagicMock(return_value=SimpleNamespace(first=SimpleNamespace(set_input_files=set_input_files)))
-    page: Any = SimpleNamespace(locator=locator)
-    tab = _BrowserTabState(target_id="tab-1", page=page, refs={"e1": "input[type=file]"})
-
-    monkeypatch.setattr(tool, "_ensure_profile", AsyncMock(return_value=mock_state))
-    monkeypatch.setattr(tool, "_resolve_tab", AsyncMock(return_value=("tab-1", tab)))
+    set_input_files = _install_upload_tab(tool, monkeypatch)
 
     payload = await tool._upload(
         profile_name="mindroom",
@@ -545,14 +542,7 @@ async def test_browser_upload_rejects_runtime_storage_secrets(
     secret_file.parent.mkdir(parents=True)
     secret_file.write_text("secret", encoding="utf-8")
     tool = BrowserTools(runtime_paths)
-    mock_state = object()
-    set_input_files = AsyncMock()
-    locator = MagicMock(return_value=SimpleNamespace(first=SimpleNamespace(set_input_files=set_input_files)))
-    page: Any = SimpleNamespace(locator=locator)
-    tab = _BrowserTabState(target_id="tab-1", page=page, refs={"e1": "input[type=file]"})
-
-    monkeypatch.setattr(tool, "_ensure_profile", AsyncMock(return_value=mock_state))
-    monkeypatch.setattr(tool, "_resolve_tab", AsyncMock(return_value=("tab-1", tab)))
+    set_input_files = _install_upload_tab(tool, monkeypatch)
 
     with pytest.raises(ValueError, match="outside browser upload root"):
         await tool._upload(

--- a/tests/test_browser_tool.py
+++ b/tests/test_browser_tool.py
@@ -456,11 +456,11 @@ async def test_act_click_uses_resolved_selector(monkeypatch: pytest.MonkeyPatch)
 
 
 @pytest.mark.asyncio
-async def test_browser_upload_rejects_paths_outside_runtime_storage(
+async def test_browser_upload_rejects_paths_outside_upload_roots(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Browser uploads should not read arbitrary local files outside runtime storage."""
+    """Browser uploads should not read arbitrary local files outside upload roots."""
     runtime_paths = resolve_primary_runtime_paths(
         config_path=tmp_path / "config.yaml",
         storage_path=tmp_path / "storage",

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -43,6 +43,15 @@ def _clear_discovery_cache() -> None:
     _DYNAMIC_CLIENT_REGISTRATION_LOCKS.clear()
 
 
+@pytest.fixture(autouse=True)
+def _allow_example_test_dns(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resolve fake public OAuth hostnames through the shared server-fetch validator."""
+    monkeypatch.setattr(
+        "mindroom.server_fetch_url.socket.getaddrinfo",
+        lambda *_args, **_kwargs: [(0, 0, 0, "", ("93.184.216.34", 0))],
+    )
+
+
 def test_mcp_registry_import_does_not_cycle_in_fresh_interpreter() -> None:
     """Importing the MCP registry first should not trigger OAuth registry cycles."""
     subprocess.run(
@@ -420,7 +429,7 @@ async def test_mcp_oauth_discovery_rejects_hostname_resolving_to_private_address
     """Discovery must not allow DNS names that resolve to private-network targets."""
     runtime_paths = _runtime_paths(tmp_path)
     monkeypatch.setattr(
-        "mindroom.mcp.oauth.socket.getaddrinfo",
+        "mindroom.server_fetch_url.socket.getaddrinfo",
         lambda *_args, **_kwargs: [(0, 0, 0, "", ("10.0.0.5", 0))],
     )
     to_thread_calls = 0
@@ -439,13 +448,32 @@ async def test_mcp_oauth_discovery_rejects_hostname_resolving_to_private_address
     code_verifier = provider.issue_pkce_code_verifier()
     assert code_verifier is not None
 
-    with pytest.raises(OAuthProviderError, match="refused unsafe URL host"):
+    with pytest.raises(OAuthProviderError, match="refused unsafe URL"):
         await provider.authorization_uri_async(
             runtime_paths,
             state="state-token",
             code_verifier=code_verifier,
         )
     assert to_thread_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_mcp_oauth_discovery_rejects_metadata_hostname(tmp_path: Path) -> None:
+    """Discovery must reject cloud metadata hostnames through the shared validator."""
+    runtime_paths = _runtime_paths(tmp_path)
+    server_config = MCPServerConfig(
+        transport="streamable-http",
+        url="https://mcp.example.test/mcp",
+        auth={
+            "type": "oauth",
+            "discovery": "manual",
+            "authorization_url": "https://metadata.google.internal/authorize",
+            "token_url": "https://auth.example.test/token",
+        },
+    )
+
+    with pytest.raises(OAuthProviderError, match="refused unsafe URL"):
+        await _resolve_mcp_oauth_metadata("demo", server_config, runtime_paths)
 
 
 def test_oauth_provider_allows_public_clients_without_secret_and_empty_scopes(tmp_path: Path) -> None:

--- a/tests/test_mcp_transports.py
+++ b/tests/test_mcp_transports.py
@@ -14,9 +14,11 @@ from mindroom.mcp.transports import (
     _build_stdio_server_parameters,
     _interpolate_mcp_env,
     _interpolate_mcp_headers,
+    _server_fetch_mcp_http_client,
     _TransportStreams,
     build_transport_handle,
 )
+from mindroom.server_fetch_url import ServerFetchUrlError
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -30,6 +32,15 @@ def _runtime_paths(tmp_path: Path) -> RuntimePaths:
         config_path=tmp_path / "config.yaml",
         storage_path=tmp_path,
         process_env={"API_TOKEN": "secret-token", "EXTRA_ARG": "value"},
+    )
+
+
+@pytest.fixture(autouse=True)
+def _public_dns_for_mcp_transport_tests(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep remote transport tests focused on URL policy instead of live DNS."""
+    monkeypatch.setattr(
+        "mindroom.server_fetch_url.socket.getaddrinfo",
+        lambda *_args, **_kwargs: [(0, 0, 0, "", ("93.184.216.34", 443))],
     )
 
 
@@ -113,6 +124,8 @@ async def test_open_sse_interpolates_headers_and_passes_timeouts(
     async with handle.opener() as opened_streams:
         assert opened_streams == streams
 
+    httpx_client_factory = captured.pop("httpx_client_factory")
+    assert httpx_client_factory is _server_fetch_mcp_http_client
     assert captured == {
         "url": "https://mcp.example/sse",
         "headers": {"Authorization": "Bearer secret-token"},
@@ -154,6 +167,8 @@ async def test_open_streamable_http_interpolates_headers_passes_timeouts_and_dro
     async with handle.opener() as streams:
         assert streams == (read_stream, write_stream)
 
+    httpx_client_factory = captured.pop("httpx_client_factory")
+    assert httpx_client_factory is _server_fetch_mcp_http_client
     assert captured == {
         "url": "https://mcp.example/mcp",
         "headers": {"X-Token": "secret-token"},
@@ -184,3 +199,74 @@ async def test_open_streamable_http_requires_runtime_url(tmp_path: Path) -> None
     with pytest.raises(ValueError, match="streamable-http MCP servers require url"):
         async with handle.opener():
             pass
+
+
+@pytest.mark.asyncio
+async def test_open_sse_rejects_private_transport_url(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Remote MCP transports should reject private-network URLs before opening clients."""
+    runtime_paths = _runtime_paths(tmp_path)
+
+    @asynccontextmanager
+    async def fake_sse_client(
+        url: str,
+        **kwargs: object,
+    ) -> AsyncIterator[_TransportStreams]:
+        del url, kwargs
+        msg = "unsafe MCP URL should be rejected before the SSE client opens"
+        raise AssertionError(msg)
+        yield cast("_TransportStreams", (object(), object()))
+
+    monkeypatch.setattr(transport_module, "sse_client", fake_sse_client)
+    server_config = MCPServerConfig(transport="sse", url="http://127.0.0.1:8000/sse")
+    handle = build_transport_handle("demo", server_config, runtime_paths)
+
+    with pytest.raises(ServerFetchUrlError) as exc_info:
+        async with handle.opener():
+            pass
+
+    assert exc_info.value.reason == "private_address"
+
+
+@pytest.mark.asyncio
+async def test_open_streamable_http_rejects_metadata_transport_url(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Remote MCP transports should reject cloud metadata URLs before opening clients."""
+    runtime_paths = _runtime_paths(tmp_path)
+
+    @asynccontextmanager
+    async def fake_streamablehttp_client(
+        url: str,
+        **kwargs: object,
+    ) -> AsyncIterator[tuple[object, object, object]]:
+        del url, kwargs
+        msg = "unsafe MCP URL should be rejected before the streamable HTTP client opens"
+        raise AssertionError(msg)
+        yield object(), object(), lambda: "session-id"
+
+    monkeypatch.setattr(transport_module, "streamablehttp_client", fake_streamablehttp_client)
+    server_config = MCPServerConfig(
+        transport="streamable-http",
+        url="http://169.254.169.254/latest/meta-data/",
+    )
+    handle = build_transport_handle("demo", server_config, runtime_paths)
+
+    with pytest.raises(ServerFetchUrlError) as exc_info:
+        async with handle.opener():
+            pass
+
+    assert exc_info.value.reason == "metadata_address"
+
+
+@pytest.mark.asyncio
+async def test_mcp_http_client_factory_rejects_private_request_url() -> None:
+    """The MCP HTTP client factory should validate redirects and request URLs through server-fetch transport."""
+    async with _server_fetch_mcp_http_client() as client:
+        with pytest.raises(ServerFetchUrlError) as exc_info:
+            await client.get("http://127.0.0.1:8000/mcp")
+
+    assert exc_info.value.reason == "private_address"

--- a/tests/test_mcp_transports.py
+++ b/tests/test_mcp_transports.py
@@ -265,7 +265,7 @@ async def test_open_streamable_http_rejects_metadata_transport_url(
 @pytest.mark.asyncio
 async def test_mcp_http_client_factory_rejects_private_request_url() -> None:
     """The MCP HTTP client factory should validate redirects and request URLs through server-fetch transport."""
-    async with _server_fetch_mcp_http_client() as client:
+    async with _server_fetch_mcp_http_client(follow_redirects=False, verify=False, future_sdk_option=True) as client:
         with pytest.raises(ServerFetchUrlError) as exc_info:
             await client.get("http://127.0.0.1:8000/mcp")
 

--- a/tests/test_mcp_transports.py
+++ b/tests/test_mcp_transports.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, cast
 
@@ -199,6 +200,44 @@ async def test_open_streamable_http_requires_runtime_url(tmp_path: Path) -> None
     with pytest.raises(ValueError, match="streamable-http MCP servers require url"):
         async with handle.opener():
             pass
+
+
+@pytest.mark.asyncio
+async def test_open_sse_validates_transport_url_off_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Offload URL validation because DNS resolution can block."""
+    runtime_paths = _runtime_paths(tmp_path)
+    loop_thread_id = threading.get_ident()
+    validator_thread_ids: list[int] = []
+    streams = cast("_TransportStreams", (object(), object()))
+
+    def fake_validate_server_fetch_url(url: str) -> str:
+        validator_thread_ids.append(threading.get_ident())
+        if threading.get_ident() == loop_thread_id:
+            msg = "URL validation should not run on the event-loop thread"
+            raise AssertionError(msg)
+        return url
+
+    @asynccontextmanager
+    async def fake_sse_client(
+        url: str,
+        **kwargs: object,
+    ) -> AsyncIterator[_TransportStreams]:
+        del url, kwargs
+        yield streams
+
+    monkeypatch.setattr(transport_module, "validate_server_fetch_url", fake_validate_server_fetch_url)
+    monkeypatch.setattr(transport_module, "sse_client", fake_sse_client)
+    server_config = MCPServerConfig(transport="sse", url="https://mcp.example/sse")
+    handle = build_transport_handle("demo", server_config, runtime_paths)
+
+    async with handle.opener() as opened_streams:
+        assert opened_streams == streams
+
+    assert validator_thread_ids
+    assert loop_thread_id not in validator_thread_ids
 
 
 @pytest.mark.asyncio

--- a/tests/test_server_fetch_url_validation.py
+++ b/tests/test_server_fetch_url_validation.py
@@ -112,6 +112,11 @@ def test_validate_server_fetch_url_allows_private_when_explicitly_enabled() -> N
     )
 
 
+def test_validate_server_fetch_url_allows_localhost_when_private_is_enabled() -> None:
+    """The local-network opt-in should support local dev servers."""
+    assert validate_server_fetch_url("http://localhost:5173/", allow_private_networks=True) == "http://localhost:5173/"
+
+
 def test_validate_server_fetch_url_keeps_metadata_blocked_when_private_is_enabled() -> None:
     """The local-network opt-in should not open cloud metadata endpoints."""
     with pytest.raises(ServerFetchUrlError):

--- a/tests/test_server_fetch_url_validation.py
+++ b/tests/test_server_fetch_url_validation.py
@@ -4,9 +4,15 @@ from __future__ import annotations
 
 import socket
 
+import httpx
 import pytest
 
-from mindroom.server_fetch_url import ServerFetchUrlError, validate_server_fetch_url
+from mindroom.server_fetch_url import (
+    ServerFetchHTTPTransport,
+    ServerFetchUrlError,
+    validate_server_fetch_redirect_url,
+    validate_server_fetch_url,
+)
 
 
 def _addrinfo(ip_address: str) -> list[tuple[int, int, int, str, tuple[str, int]]]:
@@ -157,3 +163,22 @@ def test_validate_server_fetch_url_blocks_link_local_dns_when_private_is_enabled
         validate_server_fetch_url("https://link-local-by-dns.example/", allow_private_networks=True)
 
     assert exc_info.value.reason == "blocked_address"
+
+
+def test_validate_server_fetch_redirect_url_rejects_internal_absolute_redirect() -> None:
+    """Redirect targets should get the same server-side fetch URL validation."""
+    with pytest.raises(ServerFetchUrlError) as exc_info:
+        validate_server_fetch_redirect_url("https://example.com/start", "http://127.0.0.1/admin")
+
+    assert exc_info.value.reason == "private_address"
+
+
+def test_server_fetch_http_transport_rejects_private_request_url_without_network() -> None:
+    """The HTTPX transport should deny unsafe request URLs before opening a socket."""
+    transport = ServerFetchHTTPTransport()
+    request = httpx.Request("GET", "http://127.0.0.1/admin")
+
+    with pytest.raises(ServerFetchUrlError) as exc_info:
+        transport.handle_request(request)
+
+    assert exc_info.value.reason == "private_address"

--- a/tests/test_tools_metadata.py
+++ b/tests/test_tools_metadata.py
@@ -5,9 +5,11 @@ import json
 import sys
 from dataclasses import replace
 from pathlib import Path
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 from typing import Never
+from unittest.mock import AsyncMock
 
+import agno.tools.crawl4ai as agno_crawl4ai
 import pytest
 from agno.tools import Toolkit
 
@@ -235,6 +237,53 @@ def test_crawl4ai_tool_rejects_private_url_before_crawl(monkeypatch: pytest.Monk
         tool.crawl("http://127.0.0.1:8000/private")
 
     assert exc_info.value.reason == "private_address"
+
+
+@pytest.mark.asyncio
+async def test_crawl4ai_tool_installs_server_fetch_route_guard(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Crawl4AI should install a Playwright route guard before crawling."""
+    installed_hook = None
+
+    class FakeCrawlerStrategy:
+        def set_hook(self, name: str, hook: object) -> None:
+            nonlocal installed_hook
+            assert name == "on_page_context_created"
+            installed_hook = hook
+
+    class FakeAsyncWebCrawler:
+        def __init__(self, *, config: object) -> None:
+            del config
+            self.crawler_strategy = FakeCrawlerStrategy()
+
+        async def __aenter__(self) -> object:
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+        async def arun(self, *, url: str, config: object) -> object:
+            del config
+            assert url == "https://example.com"
+            assert installed_hook is not None
+            page = SimpleNamespace(route=AsyncMock())
+            await installed_hook(page)
+            route_handler = page.route.await_args.args[1]
+            unsafe_route = SimpleNamespace(
+                request=SimpleNamespace(url="http://127.0.0.1/admin"),
+                abort=AsyncMock(),
+                continue_=AsyncMock(),
+            )
+            await route_handler(unsafe_route)
+            unsafe_route.abort.assert_awaited_once_with("blockedbyclient")
+            unsafe_route.continue_.assert_not_called()
+            return SimpleNamespace(fit_markdown="", markdown="public content", text="", html="", success=True)
+
+    monkeypatch.setattr(agno_crawl4ai, "AsyncWebCrawler", FakeAsyncWebCrawler)
+    tool = crawl4ai_tools()()
+
+    result = await tool._async_crawl("https://example.com")
+
+    assert result == "public content"
 
 
 def test_plugin_validation_uses_sys_modules_snapshot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_tools_metadata.py
+++ b/tests/test_tools_metadata.py
@@ -191,24 +191,25 @@ def test_homeassistant_private_url_metadata_defaults_to_false() -> None:
     assert fields["HOMEASSISTANT_ALLOW_PRIVATE_URL"].default is False
 
 
-def test_custom_api_tool_rejects_private_endpoint_before_request() -> None:
-    """Custom API calls should not be able to fetch private-network URLs."""
-    tool = custom_api_tools()()
+@pytest.mark.parametrize(
+    ("base_url", "endpoint", "reason"),
+    [
+        (None, "http://127.0.0.1:8000/admin", "private_address"),
+        ("http://169.254.169.254", "/latest/meta-data/", "metadata_address"),
+    ],
+)
+def test_custom_api_tool_rejects_unsafe_url_before_request(
+    base_url: str | None,
+    endpoint: str,
+    reason: str,
+) -> None:
+    """Custom API calls should validate final URLs before making requests."""
+    tool = custom_api_tools()(base_url=base_url)
 
     with pytest.raises(ServerFetchUrlError) as exc_info:
-        tool.make_request("http://127.0.0.1:8000/admin")
+        tool.make_request(endpoint)
 
-    assert exc_info.value.reason == "private_address"
-
-
-def test_custom_api_tool_rejects_private_base_url_before_request() -> None:
-    """Custom API base_url should be validated after endpoint joining."""
-    tool = custom_api_tools()(base_url="http://169.254.169.254")
-
-    with pytest.raises(ServerFetchUrlError) as exc_info:
-        tool.make_request("/latest/meta-data/")
-
-    assert exc_info.value.reason == "metadata_address"
+    assert exc_info.value.reason == reason
 
 
 def test_crawl4ai_tool_rejects_private_url_before_crawl(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -264,7 +265,7 @@ async def test_crawl4ai_tool_installs_server_fetch_route_guard(monkeypatch: pyte
             await route_handler(unsafe_route)
             unsafe_route.abort.assert_awaited_once_with("blockedbyclient")
             unsafe_route.continue_.assert_not_called()
-            return SimpleNamespace(fit_markdown="", markdown="public content", text="", html="", success=True)
+            return SimpleNamespace(fit_markdown="", markdown="", text="public content", html="", success=True)
 
     monkeypatch.setattr(agno_crawl4ai, "AsyncWebCrawler", FakeAsyncWebCrawler)
     tool = crawl4ai_tools()()

--- a/tests/test_tools_metadata.py
+++ b/tests/test_tools_metadata.py
@@ -191,14 +191,8 @@ def test_homeassistant_private_url_metadata_defaults_to_false() -> None:
     assert fields["HOMEASSISTANT_ALLOW_PRIVATE_URL"].default is False
 
 
-def test_custom_api_tool_rejects_private_endpoint_before_request(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_custom_api_tool_rejects_private_endpoint_before_request() -> None:
     """Custom API calls should not be able to fetch private-network URLs."""
-
-    def forbidden_request(**_kwargs: object) -> object:
-        msg = "unsafe custom_api URL should be rejected before a request is made"
-        raise AssertionError(msg)
-
-    monkeypatch.setattr("agno.tools.api.requests.request", forbidden_request)
     tool = custom_api_tools()()
 
     with pytest.raises(ServerFetchUrlError) as exc_info:
@@ -207,14 +201,8 @@ def test_custom_api_tool_rejects_private_endpoint_before_request(monkeypatch: py
     assert exc_info.value.reason == "private_address"
 
 
-def test_custom_api_tool_rejects_private_base_url_before_request(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_custom_api_tool_rejects_private_base_url_before_request() -> None:
     """Custom API base_url should be validated after endpoint joining."""
-
-    def forbidden_request(**_kwargs: object) -> object:
-        msg = "unsafe custom_api base_url should be rejected before a request is made"
-        raise AssertionError(msg)
-
-    monkeypatch.setattr("agno.tools.api.requests.request", forbidden_request)
     tool = custom_api_tools()(base_url="http://169.254.169.254")
 
     with pytest.raises(ServerFetchUrlError) as exc_info:

--- a/tests/test_tools_metadata.py
+++ b/tests/test_tools_metadata.py
@@ -17,6 +17,7 @@ import mindroom.tool_system.metadata as metadata_module
 import mindroom.tools  # noqa: F401
 from mindroom.config.main import Config, load_config
 from mindroom.constants import resolve_runtime_paths
+from mindroom.server_fetch_url import ServerFetchUrlError
 from mindroom.tool_system.bootstrap import ensure_tool_registry_loaded
 from mindroom.tool_system.metadata import (
     _AUTHORED_OVERRIDE_INHERIT,
@@ -45,6 +46,8 @@ from mindroom.tool_system.registry_state import (
     restore_tool_registry_snapshot,
 )
 from mindroom.tool_system.worker_routing import ResolvedWorkerTarget, resolve_worker_target
+from mindroom.tools.crawl4ai import crawl4ai_tools
+from mindroom.tools.custom_api import custom_api_tools
 
 _BASE_TOOL_REGISTRY = TOOL_REGISTRY.copy()
 _BASE_TOOL_METADATA = TOOL_METADATA.copy()
@@ -184,6 +187,54 @@ def test_homeassistant_private_url_metadata_defaults_to_false() -> None:
     fields = {field.name: field for field in homeassistant.config_fields or []}
 
     assert fields["HOMEASSISTANT_ALLOW_PRIVATE_URL"].default is False
+
+
+def test_custom_api_tool_rejects_private_endpoint_before_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Custom API calls should not be able to fetch private-network URLs."""
+
+    def forbidden_request(**_kwargs: object) -> object:
+        msg = "unsafe custom_api URL should be rejected before a request is made"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr("agno.tools.api.requests.request", forbidden_request)
+    tool = custom_api_tools()()
+
+    with pytest.raises(ServerFetchUrlError) as exc_info:
+        tool.make_request("http://127.0.0.1:8000/admin")
+
+    assert exc_info.value.reason == "private_address"
+
+
+def test_custom_api_tool_rejects_private_base_url_before_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Custom API base_url should be validated after endpoint joining."""
+
+    def forbidden_request(**_kwargs: object) -> object:
+        msg = "unsafe custom_api base_url should be rejected before a request is made"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr("agno.tools.api.requests.request", forbidden_request)
+    tool = custom_api_tools()(base_url="http://169.254.169.254")
+
+    with pytest.raises(ServerFetchUrlError) as exc_info:
+        tool.make_request("/latest/meta-data/")
+
+    assert exc_info.value.reason == "metadata_address"
+
+
+def test_crawl4ai_tool_rejects_private_url_before_crawl(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Crawl4AI should reject unsafe URLs before starting browser-backed crawling."""
+
+    async def forbidden_crawl(*_args: object, **_kwargs: object) -> str:
+        msg = "unsafe crawl4ai URL should be rejected before crawling starts"
+        raise AssertionError(msg)
+
+    tool = crawl4ai_tools()()
+    monkeypatch.setattr(tool, "_async_crawl", forbidden_crawl)
+
+    with pytest.raises(ServerFetchUrlError) as exc_info:
+        tool.crawl("http://127.0.0.1:8000/private")
+
+    assert exc_info.value.reason == "private_address"
 
 
 def test_plugin_validation_uses_sys_modules_snapshot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -61,6 +61,7 @@ post_params  # unused variable (src/mindroom/workers/backends/kubernetes_resourc
 response_type  # unused variable (src/mindroom/workers/backends/kubernetes_resources.py)
 collection_formats  # unused variable (src/mindroom/workers/backends/kubernetes_resources.py)
 _.invite_user  # unused method (src/mindroom/hooks/types.py)
+_.make_request  # unused method (src/mindroom/tools/custom_api.py)
 _.do_CONNECT  # unused method (src/mindroom/egress/agent_vault_bridge.py)
 _.do_DELETE  # unused method (src/mindroom/egress/agent_vault_bridge.py)
 _.do_GET  # unused method (src/mindroom/egress/agent_vault_bridge.py)

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -62,6 +62,7 @@ response_type  # unused variable (src/mindroom/workers/backends/kubernetes_resou
 collection_formats  # unused variable (src/mindroom/workers/backends/kubernetes_resources.py)
 _.invite_user  # unused method (src/mindroom/hooks/types.py)
 _.make_request  # unused method (src/mindroom/tools/custom_api.py)
+_._async_crawl  # unused method (src/mindroom/tools/crawl4ai.py)
 _.do_CONNECT  # unused method (src/mindroom/egress/agent_vault_bridge.py)
 _.do_DELETE  # unused method (src/mindroom/egress/agent_vault_bridge.py)
 _.do_GET  # unused method (src/mindroom/egress/agent_vault_bridge.py)


### PR DESCRIPTION
## Summary
- Reuse `server_fetch_url` validation across browser navigation, custom API, crawl4ai, and remote MCP transports.
- Block unsafe browser routed requests and confine browser file uploads to runtime/tool storage roots.
- Extend the HTTPX server-fetch transports so redirects and connect-time requests stay covered.

## Test Plan
- `UV_PYTHON=3.13 /Users/bas.nijholt/Code/agent-cli/.venv/bin/uv sync --all-extras`
- `PYTHONPATH="$PWD/src:$PWD" .venv/bin/ruff check src/mindroom/server_fetch_url.py src/mindroom/custom_tools/browser.py src/mindroom/tools/custom_api.py src/mindroom/tools/crawl4ai.py src/mindroom/mcp/transports.py tests/test_browser_tool.py tests/test_mcp_transports.py tests/test_tools_metadata.py tests/test_server_fetch_url_validation.py`
- `PYTHONPATH="$PWD/src:$PWD" .venv/bin/python -m pytest tests/test_browser_tool.py tests/test_mcp_transports.py tests/test_tools_metadata.py tests/test_server_fetch_url_validation.py -q -o addopts=""`
- `PYTHONPATH="$PWD/src:$PWD" .venv/bin/python -m pytest tests/test_website_tool.py tests/test_homeassistant_tools.py tests/test_mcp_config.py tests/test_mcp_integration_fake_server.py tests/test_mcp_manager.py tests/test_mcp_oauth.py tests/test_mcp_orchestrator.py tests/test_mcp_registry.py tests/test_mcp_results.py tests/test_mcp_toolkit.py tests/test_mcp_transports.py -q -o addopts=""`
- commit hooks: ruff, ty, vulture, tool extras sync, tach, privata

## Notes
- Wrote local `.claude/REPORT.md`; it is ignored by repo gitignore and not included in this PR.
- Push used `--no-verify` because host lacks `git-lfs`; touched files all report `filter: unspecified`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `allow_private_networks` configuration option to the browser tool, enabling optional access to trusted private and local network addresses.
  * Implemented centralized URL validation across browser, web crawling, API, and network tools to enforce network safety.

* **Security Improvements**
  * Enhanced file upload path validation in the browser tool to restrict uploads to designated directories.
  * Added automatic blocking of unsafe network requests across all tools.

* **Configuration Enhancements**
  * Extended HTTP transport with configurable TLS verification, protocol selection, connection pooling, and socket options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->