### PR TITLE
Add runtime chart support for worker egress proxies

### DIFF
--- a/cluster/k8s/runtime/README.md
+++ b/cluster/k8s/runtime/README.md
@@ -76,6 +76,46 @@ eventCache:
 When `config.create` is enabled and `config.data` is empty, the chart renders a minimal config whose `cache` section follows `eventCache`.
 When using `config.existingConfigMap` or custom `config.data`, keep that config's cache settings aligned with the chart values.
 
+## Worker Egress Proxy
+
+For dedicated Kubernetes workers, the chart can point worker pods at an existing HTTP proxy Service and render a worker egress NetworkPolicy.
+This keeps the proxy deployment, domain allowlist, approval API token, and persistence in the platform layer while making the runtime chart own worker wiring.
+
+```yaml
+workers:
+  backend: kubernetes
+
+egressProxy:
+  enabled: true
+  service:
+    name: mindroom-egress-proxy
+    namespace: mindroom
+    port: 3128
+  noProxy:
+    - localhost
+    - 127.0.0.1
+    - ::1
+    - internal-api.mindroom.svc.cluster.local
+  networkPolicy:
+    create: true
+    proxyPodSelector:
+      matchLabels:
+        app.kubernetes.io/name: mindroom-egress-proxy
+    extraEgress:
+      - to:
+          - podSelector:
+              matchLabels:
+                app.kubernetes.io/name: internal-api
+        ports:
+          - protocol: TCP
+            port: 8080
+```
+
+When `egressProxy.injectWorkerProxyEnv` is true, worker pods receive `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and lowercase variants through `MINDROOM_KUBERNETES_WORKER_ENV_JSON`.
+`workers.kubernetes.extraEnv` is still applied after those defaults, so platform values can override individual variables.
+When `egressProxy.networkPolicy.create` is true, workers can egress only to DNS, the selected proxy pods, and `egressProxy.networkPolicy.extraEgress`.
+NetworkPolicy targets pods rather than Services, so `proxyPodSelector` must match the existing proxy Deployment labels.
+
 ## Existing Platform Example
 
 ```yaml

--- a/cluster/k8s/runtime/templates/_helpers.tpl
+++ b/cluster/k8s/runtime/templates/_helpers.tpl
@@ -133,6 +133,39 @@ app.kubernetes.io/component: runtime
 {{- default (printf "%s-workers" (include "mindroom-runtime.fullname" .)) .Values.workers.kubernetes.networkPolicy.name -}}
 {{- end -}}
 
+{{- define "mindroom-runtime.egressProxyNamespace" -}}
+{{- default .Release.Namespace .Values.egressProxy.service.namespace -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.egressProxyUrl" -}}
+{{- $namespace := include "mindroom-runtime.egressProxyNamespace" . -}}
+{{- printf "%s://%s.%s.svc.cluster.local:%v" .Values.egressProxy.service.scheme .Values.egressProxy.service.name $namespace .Values.egressProxy.service.port -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.workerExtraEnvJson" -}}
+{{- $extraEnv := dict -}}
+{{- if and .Values.egressProxy.enabled .Values.egressProxy.injectWorkerProxyEnv -}}
+{{- $proxyUrl := include "mindroom-runtime.egressProxyUrl" . -}}
+{{- $_ := set $extraEnv "HTTP_PROXY" $proxyUrl -}}
+{{- $_ := set $extraEnv "HTTPS_PROXY" $proxyUrl -}}
+{{- $_ := set $extraEnv "ALL_PROXY" $proxyUrl -}}
+{{- $_ := set $extraEnv "http_proxy" $proxyUrl -}}
+{{- $_ := set $extraEnv "https_proxy" $proxyUrl -}}
+{{- $_ := set $extraEnv "all_proxy" $proxyUrl -}}
+{{- with .Values.egressProxy.noProxy -}}
+{{- $noProxy := join "," . -}}
+{{- $_ := set $extraEnv "NO_PROXY" $noProxy -}}
+{{- $_ := set $extraEnv "no_proxy" $noProxy -}}
+{{- end -}}
+{{- end -}}
+{{- range $key, $value := .Values.workers.kubernetes.extraEnv -}}
+{{- $_ := set $extraEnv $key $value -}}
+{{- end -}}
+{{- if $extraEnv -}}
+{{- toJson $extraEnv -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "mindroom-runtime.eventCacheNamespace" -}}
 {{- default .Release.Namespace .Values.eventCache.namespace -}}
 {{- end -}}

--- a/cluster/k8s/runtime/templates/deployment.yaml
+++ b/cluster/k8s/runtime/templates/deployment.yaml
@@ -5,6 +5,7 @@
 {{- $workerAuthSecretName := include "mindroom-runtime.workerAuthSecretName" . -}}
 {{- $eventCacheDatabaseUrlSecretName := include "mindroom-runtime.eventCacheDatabaseUrlSecretName" . -}}
 {{- $eventCacheDatabaseUrlSecretKey := include "mindroom-runtime.eventCacheDatabaseUrlSecretKey" . -}}
+{{- $workerExtraEnvJson := include "mindroom-runtime.workerExtraEnvJson" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -189,9 +190,9 @@ spec:
             - name: MINDROOM_KUBERNETES_WORKER_COLOCATE_WITH_CONTROL_PLANE_NODE
               value: "true"
             {{- end }}
-            {{- if .Values.workers.kubernetes.extraEnv }}
+            {{- if $workerExtraEnvJson }}
             - name: MINDROOM_KUBERNETES_WORKER_ENV_JSON
-              value: {{ toJson .Values.workers.kubernetes.extraEnv | quote }}
+              value: {{ $workerExtraEnvJson | quote }}
             {{- end }}
             {{- if or .Values.workers.kubernetes.ownerDeploymentName (eq $workerNamespace .Release.Namespace) }}
             - name: MINDROOM_KUBERNETES_WORKER_OWNER_DEPLOYMENT_NAME

--- a/cluster/k8s/runtime/templates/networkpolicy.yaml
+++ b/cluster/k8s/runtime/templates/networkpolicy.yaml
@@ -1,6 +1,10 @@
 {{- if and (eq .Values.workers.backend "kubernetes") .Values.workers.kubernetes.networkPolicy.create }}
 {{- $egressPolicyEnabled := and .Values.egressProxy.enabled .Values.egressProxy.networkPolicy.create -}}
 {{- $proxyNamespace := include "mindroom-runtime.egressProxyNamespace" . -}}
+{{- $dnsNamespaceSelector := .Values.egressProxy.networkPolicy.dns.namespaceSelector -}}
+{{- $dnsPodSelector := .Values.egressProxy.networkPolicy.dns.podSelector -}}
+{{- $hasDnsNamespaceSelector := kindIs "map" $dnsNamespaceSelector -}}
+{{- $hasDnsPodSelector := kindIs "map" $dnsPodSelector -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -36,12 +40,15 @@ spec:
   {{- if $egressPolicyEnabled }}
   egress:
     - to:
-        {{- with .Values.egressProxy.networkPolicy.dns.namespaceSelector }}
-        - namespaceSelector:
-            {{- toYaml . | nindent 12 }}
-          {{- with $.Values.egressProxy.networkPolicy.dns.podSelector }}
+        {{- if or $hasDnsNamespaceSelector $hasDnsPodSelector }}
+        -
+          {{- if $hasDnsNamespaceSelector }}
+          namespaceSelector:
+            {{- toYaml $dnsNamespaceSelector | nindent 12 }}
+          {{- end }}
+          {{- if $hasDnsPodSelector }}
           podSelector:
-            {{- toYaml . | nindent 12 }}
+            {{- toYaml $dnsPodSelector | nindent 12 }}
           {{- end }}
         {{- end }}
         {{- range .Values.egressProxy.networkPolicy.dns.ipBlocks }}

--- a/cluster/k8s/runtime/templates/networkpolicy.yaml
+++ b/cluster/k8s/runtime/templates/networkpolicy.yaml
@@ -1,4 +1,6 @@
 {{- if and (eq .Values.workers.backend "kubernetes") .Values.workers.kubernetes.networkPolicy.create }}
+{{- $egressPolicyEnabled := and .Values.egressProxy.enabled .Values.egressProxy.networkPolicy.create -}}
+{{- $proxyNamespace := include "mindroom-runtime.egressProxyNamespace" . -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -17,6 +19,9 @@ spec:
       {{- end }}
   policyTypes:
     - Ingress
+    {{- if $egressPolicyEnabled }}
+    - Egress
+    {{- end }}
   ingress:
     - from:
         - namespaceSelector:
@@ -28,4 +33,42 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.workers.kubernetes.port }}
+  {{- if $egressPolicyEnabled }}
+  egress:
+    - to:
+        {{- with .Values.egressProxy.networkPolicy.dns.namespaceSelector }}
+        - namespaceSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- with $.Values.egressProxy.networkPolicy.dns.podSelector }}
+          podSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
+        {{- range .Values.egressProxy.networkPolicy.dns.ipBlocks }}
+        - ipBlock:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - {{- if .Values.egressProxy.networkPolicy.proxyNamespaceSelector }}
+          namespaceSelector:
+            {{- toYaml .Values.egressProxy.networkPolicy.proxyNamespaceSelector | nindent 12 }}
+          {{- else }}
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $proxyNamespace | quote }}
+          {{- end }}
+          podSelector:
+            {{- toYaml .Values.egressProxy.networkPolicy.proxyPodSelector | nindent 12 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.egressProxy.service.port }}
+    {{- with .Values.egressProxy.networkPolicy.extraEgress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/cluster/k8s/runtime/templates/validate.yaml
+++ b/cluster/k8s/runtime/templates/validate.yaml
@@ -13,13 +13,23 @@
 {{- if and (eq .Values.eventCache.backend "postgres") .Values.eventCache.postgres.create (not .Values.eventCache.postgres.auth.existingSecret) (not .Values.eventCache.databaseUrl.existingSecret) (eq .Values.eventCache.postgres.auth.passwordKey (include "mindroom-runtime.eventCacheDatabaseUrlSecretKey" .)) -}}
 {{- fail "eventCache.postgres.auth.passwordKey must differ from the event-cache database URL secret key" -}}
 {{- end -}}
+{{- $egressPolicyEnabled := and .Values.egressProxy.enabled .Values.egressProxy.networkPolicy.create -}}
 {{- if and .Values.egressProxy.enabled (ne .Values.workers.backend "kubernetes") -}}
 {{- fail "egressProxy.enabled requires workers.backend=kubernetes" -}}
 {{- end -}}
 {{- if and .Values.egressProxy.enabled (not .Values.egressProxy.service.name) -}}
 {{- fail "egressProxy.service.name is required when egressProxy.enabled=true" -}}
 {{- end -}}
+{{- if and $egressPolicyEnabled (not .Values.workers.kubernetes.networkPolicy.create) -}}
+{{- fail "egressProxy.networkPolicy.create=true requires workers.kubernetes.networkPolicy.create=true" -}}
+{{- end -}}
 {{- $proxyPodSelector := .Values.egressProxy.networkPolicy.proxyPodSelector -}}
-{{- if and .Values.egressProxy.enabled .Values.egressProxy.networkPolicy.create (or (not $proxyPodSelector) (not (or $proxyPodSelector.matchLabels $proxyPodSelector.matchExpressions))) -}}
+{{- if and $egressPolicyEnabled (or (not (kindIs "map" $proxyPodSelector)) (not (or $proxyPodSelector.matchLabels $proxyPodSelector.matchExpressions))) -}}
 {{- fail "egressProxy.networkPolicy.proxyPodSelector with matchLabels or matchExpressions is required when egressProxy.networkPolicy.create=true" -}}
+{{- end -}}
+{{- $dnsNamespaceSelector := .Values.egressProxy.networkPolicy.dns.namespaceSelector -}}
+{{- $dnsPodSelector := .Values.egressProxy.networkPolicy.dns.podSelector -}}
+{{- $dnsIpBlocks := .Values.egressProxy.networkPolicy.dns.ipBlocks -}}
+{{- if and $egressPolicyEnabled (not (or (kindIs "map" $dnsNamespaceSelector) (kindIs "map" $dnsPodSelector) $dnsIpBlocks)) -}}
+{{- fail "egressProxy.networkPolicy.dns requires namespaceSelector, podSelector, or ipBlocks when egressProxy.networkPolicy.create=true" -}}
 {{- end -}}

--- a/cluster/k8s/runtime/templates/validate.yaml
+++ b/cluster/k8s/runtime/templates/validate.yaml
@@ -13,3 +13,13 @@
 {{- if and (eq .Values.eventCache.backend "postgres") .Values.eventCache.postgres.create (not .Values.eventCache.postgres.auth.existingSecret) (not .Values.eventCache.databaseUrl.existingSecret) (eq .Values.eventCache.postgres.auth.passwordKey (include "mindroom-runtime.eventCacheDatabaseUrlSecretKey" .)) -}}
 {{- fail "eventCache.postgres.auth.passwordKey must differ from the event-cache database URL secret key" -}}
 {{- end -}}
+{{- if and .Values.egressProxy.enabled (ne .Values.workers.backend "kubernetes") -}}
+{{- fail "egressProxy.enabled requires workers.backend=kubernetes" -}}
+{{- end -}}
+{{- if and .Values.egressProxy.enabled (not .Values.egressProxy.service.name) -}}
+{{- fail "egressProxy.service.name is required when egressProxy.enabled=true" -}}
+{{- end -}}
+{{- $proxyPodSelector := .Values.egressProxy.networkPolicy.proxyPodSelector -}}
+{{- if and .Values.egressProxy.enabled .Values.egressProxy.networkPolicy.create (or (not $proxyPodSelector) (not (or $proxyPodSelector.matchLabels $proxyPodSelector.matchExpressions))) -}}
+{{- fail "egressProxy.networkPolicy.proxyPodSelector with matchLabels or matchExpressions is required when egressProxy.networkPolicy.create=true" -}}
+{{- end -}}

--- a/cluster/k8s/runtime/values.yaml
+++ b/cluster/k8s/runtime/values.yaml
@@ -258,6 +258,38 @@ workers:
         cpu: 500m
         memory: 1Gi
 
+# Optional external HTTP proxy for dedicated Kubernetes workers.
+# This chart does not deploy the proxy itself. It only points worker pods at an
+# existing proxy Service and, when requested, restricts worker egress so direct
+# internet access must go through that proxy.
+egressProxy:
+  enabled: false
+  injectWorkerProxyEnv: true
+  service:
+    name: mindroom-egress-proxy
+    namespace: ""
+    port: 3128
+    scheme: http
+  noProxy:
+    - localhost
+    - 127.0.0.1
+    - ::1
+  networkPolicy:
+    create: true
+    # Labels selecting the existing proxy pods. NetworkPolicy cannot target a Service directly.
+    proxyPodSelector: {}
+    proxyNamespaceSelector: {}
+    dns:
+      namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+      ipBlocks: []
+    # Raw Kubernetes NetworkPolicyEgressRule entries appended after DNS and proxy rules.
+    extraEgress: []
+
 initContainers: []
 extraContainers: []
 extraVolumes: []

--- a/tests/test_helm_instance_worker_isolation.py
+++ b/tests/test_helm_instance_worker_isolation.py
@@ -690,7 +690,7 @@ def test_runtime_chart_can_route_kubernetes_workers_through_existing_egress_prox
                         "extraEnv": {
                             "FOO": "bar",
                             "NO_PROXY": "custom.local",
-                        }
+                        },
                     },
                 },
                 "egressProxy": {
@@ -707,12 +707,12 @@ def test_runtime_chart_can_route_kubernetes_workers_through_existing_egress_prox
                             {
                                 "to": [{"podSelector": {"matchLabels": {"app": "internal-api"}}}],
                                 "ports": [{"protocol": "TCP", "port": 8080}],
-                            }
+                            },
                         ],
                     },
                 },
-            }
-        )
+            },
+        ),
     )
     docs = _render_chart(
         Path("cluster/k8s/runtime"),
@@ -744,7 +744,7 @@ def test_runtime_chart_can_route_kubernetes_workers_through_existing_egress_prox
             {
                 "namespaceSelector": {"matchLabels": {"kubernetes.io/metadata.name": "proxy-system"}},
                 "podSelector": {"matchLabels": {"app": "egress-proxy"}},
-            }
+            },
         ],
         "ports": [{"protocol": "TCP", "port": 3128}],
     }
@@ -752,6 +752,107 @@ def test_runtime_chart_can_route_kubernetes_workers_through_existing_egress_prox
         "to": [{"podSelector": {"matchLabels": {"app": "internal-api"}}}],
         "ports": [{"protocol": "TCP", "port": 8080}],
     }
+
+
+def test_runtime_chart_dns_policy_renders_empty_namespace_selector_with_pod_selector(tmp_path: Path) -> None:
+    """An explicit empty DNS namespaceSelector should still render with the podSelector."""
+    values_path = tmp_path / "values.yaml"
+    values_path.write_text(
+        yaml.safe_dump(
+            {
+                "eventCache": {"postgres": {"auth": {"password": "test-password"}}},
+                "workers": {
+                    "backend": "kubernetes",
+                    "sandbox": {"proxyToken": {"value": "test-token"}},
+                },
+                "egressProxy": {
+                    "enabled": True,
+                    "networkPolicy": {
+                        "proxyPodSelector": {"matchLabels": {"app": "egress-proxy"}},
+                        "dns": {
+                            # Helm deep-merges maps, so null deletes default labels and leaves {}.
+                            "namespaceSelector": {"matchLabels": None},
+                            "podSelector": {"matchLabels": {"k8s-app": "node-local-dns"}},
+                            "ipBlocks": [],
+                        },
+                    },
+                },
+            },
+        ),
+        encoding="utf-8",
+    )
+    docs = _render_chart(
+        Path("cluster/k8s/runtime"),
+        values_files=(values_path,),
+        release_name="mindroom-runtime",
+    )
+    policy = _resource(docs, "NetworkPolicy", "mindroom-runtime-workers")
+
+    assert policy["spec"]["egress"][0]["to"] == [
+        {
+            "namespaceSelector": {},
+            "podSelector": {"matchLabels": {"k8s-app": "node-local-dns"}},
+        },
+    ]
+
+
+def test_runtime_chart_rejects_egress_proxy_policy_without_dns_destinations(tmp_path: Path) -> None:
+    """Worker egress policy should not render a DNS rule with no destination peers."""
+    values_path = tmp_path / "values.yaml"
+    values_path.write_text(
+        yaml.safe_dump(
+            {
+                "eventCache": {"postgres": {"auth": {"password": "test-password"}}},
+                "workers": {
+                    "backend": "kubernetes",
+                    "sandbox": {"proxyToken": {"value": "test-token"}},
+                },
+                "egressProxy": {
+                    "enabled": True,
+                    "networkPolicy": {
+                        "proxyPodSelector": {"matchLabels": {"app": "egress-proxy"}},
+                        "dns": {
+                            "namespaceSelector": None,
+                            "podSelector": None,
+                            "ipBlocks": [],
+                        },
+                    },
+                },
+            },
+        ),
+        encoding="utf-8",
+    )
+    completed = _run_helm_template(
+        Path("cluster/k8s/runtime"),
+        values_files=(values_path,),
+        release_name="mindroom-runtime",
+    )
+
+    assert completed.returncode != 0
+    assert (
+        "egressProxy.networkPolicy.dns requires namespaceSelector, podSelector, or ipBlocks "
+        "when egressProxy.networkPolicy.create=true" in completed.stderr
+    )
+
+
+def test_runtime_chart_rejects_egress_proxy_policy_without_worker_network_policy() -> None:
+    """Proxy egress rules only apply when the worker NetworkPolicy is rendered."""
+    completed = _run_helm_template(
+        Path("cluster/k8s/runtime"),
+        "workers.backend=kubernetes",
+        "workers.kubernetes.networkPolicy.create=false",
+        "workers.sandbox.proxyToken.value=test-token",
+        "eventCache.postgres.auth.password=test-password",
+        "egressProxy.enabled=true",
+        "egressProxy.networkPolicy.proxyPodSelector.matchLabels.app=egress-proxy",
+        release_name="mindroom-runtime",
+    )
+
+    assert completed.returncode != 0
+    assert (
+        "egressProxy.networkPolicy.create=true requires workers.kubernetes.networkPolicy.create=true"
+        in completed.stderr
+    )
 
 
 def test_runtime_chart_rejects_egress_proxy_policy_without_proxy_pod_selector() -> None:
@@ -768,8 +869,7 @@ def test_runtime_chart_rejects_egress_proxy_policy_without_proxy_pod_selector() 
     assert completed.returncode != 0
     assert (
         "egressProxy.networkPolicy.proxyPodSelector with matchLabels or matchExpressions is required "
-        "when egressProxy.networkPolicy.create=true"
-        in completed.stderr
+        "when egressProxy.networkPolicy.create=true" in completed.stderr
     )
 
 

--- a/tests/test_helm_instance_worker_isolation.py
+++ b/tests/test_helm_instance_worker_isolation.py
@@ -676,6 +676,103 @@ def test_runtime_chart_worker_network_policy_selects_dynamic_worker_labels() -> 
     }
 
 
+def test_runtime_chart_can_route_kubernetes_workers_through_existing_egress_proxy(tmp_path: Path) -> None:
+    """The runtime chart can inject proxy env and egress policy for dedicated workers."""
+    values_path = tmp_path / "values.yaml"
+    values_path.write_text(
+        yaml.safe_dump(
+            {
+                "eventCache": {"postgres": {"auth": {"password": "test-password"}}},
+                "workers": {
+                    "backend": "kubernetes",
+                    "sandbox": {"proxyToken": {"value": "test-token"}},
+                    "kubernetes": {
+                        "extraEnv": {
+                            "FOO": "bar",
+                            "NO_PROXY": "custom.local",
+                        }
+                    },
+                },
+                "egressProxy": {
+                    "enabled": True,
+                    "service": {
+                        "name": "egress-proxy",
+                        "namespace": "proxy-system",
+                        "port": 3128,
+                    },
+                    "noProxy": ["localhost", "127.0.0.1"],
+                    "networkPolicy": {
+                        "proxyPodSelector": {"matchLabels": {"app": "egress-proxy"}},
+                        "extraEgress": [
+                            {
+                                "to": [{"podSelector": {"matchLabels": {"app": "internal-api"}}}],
+                                "ports": [{"protocol": "TCP", "port": 8080}],
+                            }
+                        ],
+                    },
+                },
+            }
+        )
+    )
+    docs = _render_chart(
+        Path("cluster/k8s/runtime"),
+        values_files=(values_path,),
+        release_name="mindroom-runtime",
+    )
+    deployment = _resource(docs, "Deployment", "mindroom-runtime")
+    policy = _resource(docs, "NetworkPolicy", "mindroom-runtime-workers")
+    mindroom_container = _container(deployment, "mindroom")
+    worker_env = json.loads(_env_by_name(mindroom_container)["MINDROOM_KUBERNETES_WORKER_ENV_JSON"]["value"])
+
+    assert worker_env["HTTP_PROXY"] == "http://egress-proxy.proxy-system.svc.cluster.local:3128"
+    assert worker_env["HTTPS_PROXY"] == "http://egress-proxy.proxy-system.svc.cluster.local:3128"
+    assert worker_env["ALL_PROXY"] == "http://egress-proxy.proxy-system.svc.cluster.local:3128"
+    assert worker_env["http_proxy"] == "http://egress-proxy.proxy-system.svc.cluster.local:3128"
+    assert worker_env["https_proxy"] == "http://egress-proxy.proxy-system.svc.cluster.local:3128"
+    assert worker_env["all_proxy"] == "http://egress-proxy.proxy-system.svc.cluster.local:3128"
+    assert worker_env["NO_PROXY"] == "custom.local"
+    assert worker_env["no_proxy"] == "localhost,127.0.0.1"
+    assert worker_env["FOO"] == "bar"
+
+    assert policy["spec"]["policyTypes"] == ["Ingress", "Egress"]
+    assert policy["spec"]["egress"][0]["to"][0] == {
+        "namespaceSelector": {"matchLabels": {"kubernetes.io/metadata.name": "kube-system"}},
+        "podSelector": {"matchLabels": {"k8s-app": "kube-dns"}},
+    }
+    assert policy["spec"]["egress"][1] == {
+        "to": [
+            {
+                "namespaceSelector": {"matchLabels": {"kubernetes.io/metadata.name": "proxy-system"}},
+                "podSelector": {"matchLabels": {"app": "egress-proxy"}},
+            }
+        ],
+        "ports": [{"protocol": "TCP", "port": 3128}],
+    }
+    assert policy["spec"]["egress"][2] == {
+        "to": [{"podSelector": {"matchLabels": {"app": "internal-api"}}}],
+        "ports": [{"protocol": "TCP", "port": 8080}],
+    }
+
+
+def test_runtime_chart_rejects_egress_proxy_policy_without_proxy_pod_selector() -> None:
+    """Worker egress policy needs proxy pod labels because NetworkPolicy cannot target Services."""
+    completed = _run_helm_template(
+        Path("cluster/k8s/runtime"),
+        "workers.backend=kubernetes",
+        "workers.sandbox.proxyToken.value=test-token",
+        "eventCache.postgres.auth.password=test-password",
+        "egressProxy.enabled=true",
+        release_name="mindroom-runtime",
+    )
+
+    assert completed.returncode != 0
+    assert (
+        "egressProxy.networkPolicy.proxyPodSelector with matchLabels or matchExpressions is required "
+        "when egressProxy.networkPolicy.create=true"
+        in completed.stderr
+    )
+
+
 def test_runtime_chart_disables_service_links_for_dynamic_worker_pods_by_default() -> None:
     """The runtime chart should pass the default service-link setting to generated workers."""
     docs = _render_runtime_chart()


### PR DESCRIPTION
## Summary
- add runtime chart values for routing Kubernetes workers through an existing HTTP egress proxy
- render proxy env through MINDROOM_KUBERNETES_WORKER_ENV_JSON while preserving workers.kubernetes.extraEnv overrides
- extend worker NetworkPolicy to optionally restrict egress to DNS, selected proxy pods, and explicit extra egress rules

## Validation
- uv run pytest tests/test_helm_instance_worker_isolation.py -q
- helm lint cluster/k8s/runtime
- git diff --check -- cluster/k8s/runtime tests/test_helm_instance_worker_isolation.py