### PR TITLE
Add approved egress proxy runtime chart support

### DIFF
--- a/cluster/k8s/runtime/README.md
+++ b/cluster/k8s/runtime/README.md
@@ -78,8 +78,37 @@ When using `config.existingConfigMap` or custom `config.data`, keep that config'
 
 ## Worker Egress Proxy
 
-For dedicated Kubernetes workers, the chart can point worker pods at an existing HTTP proxy Service and render a worker egress NetworkPolicy.
-This keeps the proxy deployment, domain allowlist, approval API token, and persistence in the platform layer while making the runtime chart own worker wiring.
+For dedicated Kubernetes workers, the chart can either deploy the approved egress proxy or point workers at an existing HTTP proxy Service.
+In both modes, the worker egress NetworkPolicy keeps worker internet access on the proxy path instead of allowing direct public egress.
+
+Use `approvedEgress` when you want the runtime chart to manage the proxy side too:
+
+```yaml
+workers:
+  backend: kubernetes
+  sandbox:
+    proxyToken:
+      existingSecret: mindroom-sandbox-proxy
+      key: MINDROOM_SANDBOX_PROXY_TOKEN
+
+approvedEgress:
+  enabled: true
+  image:
+    tag: v0.1.0
+  allowlist:
+    domains:
+      - example.com
+      - .docs.example.com
+```
+
+This renders the proxy Deployment, Service, ServiceAccount, RBAC, allowlist ConfigMap, persistence PVC, and proxy ingress NetworkPolicy.
+By default, chart-managed proxy resources use the release-derived `<fullname>-egress-proxy` name; set `approvedEgress.service.name` only when an explicit shared name is required.
+The control-plane pod receives `MINDROOM_APPROVED_EGRESS_API_URL`, `MINDROOM_APPROVED_EGRESS_ALLOWLIST_PATH`, `MINDROOM_APPROVED_EGRESS_TOKEN`, and `MINDROOM_APPROVED_EGRESS_MAX_TTL_SECONDS`.
+The control-plane pod also mounts the same allowlist file so the approved egress plugin can avoid asking for domains that are already static-allowed.
+The proxy pod reads `MINDROOM_APPROVED_EGRESS_TOKEN` from `approvedEgress.token.existingSecret` when set, otherwise it reuses `workers.sandbox.proxyToken`.
+Pin `approvedEgress.image.tag` or `approvedEgress.image.digest` before enabling the feature.
+
+Use `egressProxy` when another chart or platform layer already manages the proxy:
 
 ```yaml
 workers:
@@ -113,8 +142,9 @@ egressProxy:
 
 When `egressProxy.injectWorkerProxyEnv` is true, worker pods receive `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and lowercase variants through `MINDROOM_KUBERNETES_WORKER_ENV_JSON`.
 `workers.kubernetes.extraEnv` is still applied after those defaults, so platform values can override individual variables.
+When `approvedEgress.enabled` is true, the chart automatically points worker proxy settings and the worker egress policy at the chart-managed proxy.
 When `egressProxy.networkPolicy.create` is true, workers can egress only to DNS, the selected proxy pods, and `egressProxy.networkPolicy.extraEgress`.
-NetworkPolicy targets pods rather than Services, so `proxyPodSelector` must match the existing proxy Deployment labels.
+For externally managed proxies, NetworkPolicy targets pods rather than Services, so `proxyPodSelector` must match the existing proxy Deployment labels.
 
 ## Existing Platform Example
 

--- a/cluster/k8s/runtime/templates/_helpers.tpl
+++ b/cluster/k8s/runtime/templates/_helpers.tpl
@@ -133,18 +133,141 @@ app.kubernetes.io/component: runtime
 {{- default (printf "%s-workers" (include "mindroom-runtime.fullname" .)) .Values.workers.kubernetes.networkPolicy.name -}}
 {{- end -}}
 
+{{- define "mindroom-runtime.approvedEgressName" -}}
+{{- default (printf "%s-egress-proxy" (include "mindroom-runtime.fullname" .) | trunc 63 | trimSuffix "-") .Values.approvedEgress.service.name -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.approvedEgressServiceAccountName" -}}
+{{- if .Values.approvedEgress.serviceAccount.create -}}
+{{- default (include "mindroom-runtime.approvedEgressName" .) .Values.approvedEgress.serviceAccount.name -}}
+{{- else -}}
+{{- .Values.approvedEgress.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.approvedEgressConfigMapName" -}}
+{{- if .Values.approvedEgress.allowlist.existingConfigMap -}}
+{{- .Values.approvedEgress.allowlist.existingConfigMap -}}
+{{- else -}}
+{{- printf "%s-config" (include "mindroom-runtime.approvedEgressName" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.approvedEgressClaimName" -}}
+{{- if .Values.approvedEgress.persistence.existingClaim -}}
+{{- .Values.approvedEgress.persistence.existingClaim -}}
+{{- else -}}
+{{- printf "%s-data" (include "mindroom-runtime.approvedEgressName" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.approvedEgressTokenSecretName" -}}
+{{- if .Values.approvedEgress.token.existingSecret -}}
+{{- .Values.approvedEgress.token.existingSecret -}}
+{{- else -}}
+{{- include "mindroom-runtime.proxyTokenSecretName" . -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.approvedEgressTokenSecretKey" -}}
+{{- if .Values.approvedEgress.token.existingSecret -}}
+{{- .Values.approvedEgress.token.key -}}
+{{- else -}}
+{{- .Values.workers.sandbox.proxyToken.key -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.approvedEgressImage" -}}
+{{- $image := .Values.approvedEgress.image -}}
+{{- if and $image.tag $image.digest -}}
+{{- printf "%s:%s@%s" $image.repository $image.tag $image.digest -}}
+{{- else if $image.digest -}}
+{{- printf "%s@%s" $image.repository $image.digest -}}
+{{- else -}}
+{{- printf "%s:%s" $image.repository $image.tag -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.approvedEgressSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "mindroom-runtime.approvedEgressName" . | quote }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+app.kubernetes.io/component: approved-egress-proxy
+{{- end -}}
+
+{{- define "mindroom-runtime.approvedEgressLabels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | quote }}
+{{ include "mindroom-runtime.approvedEgressSelectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+{{- end -}}
+
+{{- define "mindroom-runtime.approvedEgressPodSelector" -}}
+matchLabels:
+  {{- include "mindroom-runtime.approvedEgressSelectorLabels" . | nindent 2 }}
+{{- end -}}
+
+{{- define "mindroom-runtime.approvedEgressNetworkPolicyName" -}}
+{{- default (printf "%s-ingress" (include "mindroom-runtime.approvedEgressName" .)) .Values.approvedEgress.networkPolicy.name -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.approvedEgressDbPath" -}}
+{{- printf "%s/%s" (.Values.approvedEgress.dataPath | trimSuffix "/") .Values.approvedEgress.dbFileName -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.approvedEgressApiUrl" -}}
+{{- printf "http://%s.%s.svc.cluster.local:%v" (include "mindroom-runtime.approvedEgressName" .) .Release.Namespace .Values.approvedEgress.service.apiPort -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.egressProxyEnabled" -}}
+{{- if or .Values.egressProxy.enabled .Values.approvedEgress.enabled -}}true{{- end -}}
+{{- end -}}
+
 {{- define "mindroom-runtime.egressProxyNamespace" -}}
+{{- if .Values.approvedEgress.enabled -}}
+{{- .Release.Namespace -}}
+{{- else -}}
 {{- default .Release.Namespace .Values.egressProxy.service.namespace -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.egressProxyServiceName" -}}
+{{- if .Values.approvedEgress.enabled -}}
+{{- include "mindroom-runtime.approvedEgressName" . -}}
+{{- else -}}
+{{- .Values.egressProxy.service.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.egressProxyServicePort" -}}
+{{- if .Values.approvedEgress.enabled -}}
+{{- .Values.approvedEgress.service.proxyPort -}}
+{{- else -}}
+{{- .Values.egressProxy.service.port -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.egressProxyPodSelector" -}}
+{{- if .Values.approvedEgress.enabled -}}
+{{- include "mindroom-runtime.approvedEgressPodSelector" . -}}
+{{- else -}}
+{{- toYaml .Values.egressProxy.networkPolicy.proxyPodSelector -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "mindroom-runtime.egressProxyUrl" -}}
 {{- $namespace := include "mindroom-runtime.egressProxyNamespace" . -}}
-{{- printf "%s://%s.%s.svc.cluster.local:%v" .Values.egressProxy.service.scheme .Values.egressProxy.service.name $namespace .Values.egressProxy.service.port -}}
+{{- $serviceName := include "mindroom-runtime.egressProxyServiceName" . -}}
+{{- $servicePort := include "mindroom-runtime.egressProxyServicePort" . -}}
+{{- $scheme := .Values.egressProxy.service.scheme -}}
+{{- if .Values.approvedEgress.enabled -}}
+{{- $scheme = "http" -}}
+{{- end -}}
+{{- printf "%s://%s.%s.svc.cluster.local:%v" $scheme $serviceName $namespace $servicePort -}}
 {{- end -}}
 
 {{- define "mindroom-runtime.workerExtraEnvJson" -}}
 {{- $extraEnv := dict -}}
-{{- if and .Values.egressProxy.enabled .Values.egressProxy.injectWorkerProxyEnv -}}
+{{- if and (include "mindroom-runtime.egressProxyEnabled" .) .Values.egressProxy.injectWorkerProxyEnv -}}
 {{- $proxyUrl := include "mindroom-runtime.egressProxyUrl" . -}}
 {{- $_ := set $extraEnv "HTTP_PROXY" $proxyUrl -}}
 {{- $_ := set $extraEnv "HTTPS_PROXY" $proxyUrl -}}

--- a/cluster/k8s/runtime/templates/approved-egress.yaml
+++ b/cluster/k8s/runtime/templates/approved-egress.yaml
@@ -1,0 +1,222 @@
+{{- if .Values.approvedEgress.enabled }}
+{{- $name := include "mindroom-runtime.approvedEgressName" . -}}
+{{- $tokenSecretName := include "mindroom-runtime.approvedEgressTokenSecretName" . -}}
+{{- $tokenSecretKey := include "mindroom-runtime.approvedEgressTokenSecretKey" . -}}
+{{- $workerNamespace := include "mindroom-runtime.workerNamespace" . -}}
+{{- $allowlist := "" -}}
+{{- if .Values.approvedEgress.allowlist.domains -}}
+{{- $allowlist = printf "%s\n" (join "\n" .Values.approvedEgress.allowlist.domains) -}}
+{{- end -}}
+{{- if not .Values.approvedEgress.allowlist.existingConfigMap }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mindroom-runtime.approvedEgressConfigMapName" . }}
+  labels:
+    {{- include "mindroom-runtime.approvedEgressLabels" . | nindent 4 }}
+data:
+  {{ .Values.approvedEgress.allowlist.key }}: {{ $allowlist | quote }}
+{{- end }}
+{{- if .Values.approvedEgress.serviceAccount.create }}
+{{- if not .Values.approvedEgress.allowlist.existingConfigMap }}
+---
+{{- end }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mindroom-runtime.approvedEgressServiceAccountName" . }}
+  labels:
+    {{- include "mindroom-runtime.approvedEgressLabels" . | nindent 4 }}
+  {{- with .Values.approvedEgress.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.approvedEgress.serviceAccount.automountServiceAccountToken }}
+{{- end }}
+{{- if .Values.approvedEgress.rbac.create }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $name }}
+  namespace: {{ $workerNamespace }}
+  labels:
+    {{- include "mindroom-runtime.approvedEgressLabels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $name }}
+  namespace: {{ $workerNamespace }}
+  labels:
+    {{- include "mindroom-runtime.approvedEgressLabels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "mindroom-runtime.approvedEgressServiceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $name }}
+{{- end }}
+{{- if and .Values.approvedEgress.persistence.enabled (not .Values.approvedEgress.persistence.existingClaim) }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "mindroom-runtime.approvedEgressClaimName" . }}
+  labels:
+    {{- include "mindroom-runtime.approvedEgressLabels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if .Values.approvedEgress.persistence.storageClassName }}
+  storageClassName: {{ .Values.approvedEgress.persistence.storageClassName | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.approvedEgress.persistence.size | quote }}
+{{- end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "mindroom-runtime.approvedEgressLabels" . | nindent 4 }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "mindroom-runtime.approvedEgressSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "mindroom-runtime.approvedEgressSelectorLabels" . | nindent 8 }}
+        {{- with .Values.approvedEgress.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.approvedEgress.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "mindroom-runtime.approvedEgressServiceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.approvedEgress.serviceAccount.automountServiceAccountToken }}
+      enableServiceLinks: false
+      {{- with .Values.approvedEgress.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: approved-egress-proxy
+          image: {{ include "mindroom-runtime.approvedEgressImage" . | quote }}
+          imagePullPolicy: {{ .Values.approvedEgress.image.pullPolicy }}
+          env:
+            - name: POD_NAMESPACE
+              value: {{ $workerNamespace | quote }}
+            - name: MINDROOM_EGRESS_PROXY_LISTEN_PORT
+              value: {{ .Values.approvedEgress.service.proxyPort | quote }}
+            - name: MINDROOM_APPROVED_EGRESS_API_PORT
+              value: {{ .Values.approvedEgress.service.apiPort | quote }}
+            - name: MINDROOM_EGRESS_ALLOWLIST_PATH
+              value: {{ .Values.approvedEgress.allowlist.mountPath | quote }}
+            - name: MINDROOM_EGRESS_DB_PATH
+              value: {{ include "mindroom-runtime.approvedEgressDbPath" . | quote }}
+            {{- if .Values.approvedEgress.maxTtlSeconds }}
+            - name: MINDROOM_APPROVED_EGRESS_MAX_TTL_SECONDS
+              value: {{ .Values.approvedEgress.maxTtlSeconds | quote }}
+            {{- end }}
+            {{- if .Values.approvedEgress.logLevel }}
+            - name: MINDROOM_APPROVED_EGRESS_LOG_LEVEL
+              value: {{ .Values.approvedEgress.logLevel | quote }}
+            {{- end }}
+            - name: MINDROOM_APPROVED_EGRESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $tokenSecretName }}
+                  key: {{ $tokenSecretKey }}
+          ports:
+            - name: proxy
+              containerPort: {{ .Values.approvedEgress.service.proxyPort }}
+              protocol: TCP
+            - name: policy-api
+              containerPort: {{ .Values.approvedEgress.service.apiPort }}
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: policy-api
+            periodSeconds: 10
+            timeoutSeconds: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: policy-api
+            periodSeconds: 30
+            timeoutSeconds: 5
+          resources:
+            {{- toYaml .Values.approvedEgress.resources | nindent 12 }}
+          {{- with .Values.approvedEgress.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: allowlist
+              mountPath: {{ .Values.approvedEgress.allowlist.mountPath | quote }}
+              subPath: {{ .Values.approvedEgress.allowlist.key | quote }}
+              readOnly: true
+            - name: data
+              mountPath: {{ .Values.approvedEgress.dataPath | quote }}
+      volumes:
+        - name: allowlist
+          configMap:
+            name: {{ include "mindroom-runtime.approvedEgressConfigMapName" . }}
+        - name: data
+          {{- if .Values.approvedEgress.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "mindroom-runtime.approvedEgressClaimName" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "mindroom-runtime.approvedEgressLabels" . | nindent 4 }}
+  {{- with .Values.approvedEgress.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "mindroom-runtime.approvedEgressSelectorLabels" . | nindent 4 }}
+  ports:
+    - name: proxy
+      port: {{ .Values.approvedEgress.service.proxyPort }}
+      targetPort: proxy
+      protocol: TCP
+    - name: policy-api
+      port: {{ .Values.approvedEgress.service.apiPort }}
+      targetPort: policy-api
+      protocol: TCP
+{{- end }}

--- a/cluster/k8s/runtime/templates/deployment.yaml
+++ b/cluster/k8s/runtime/templates/deployment.yaml
@@ -6,6 +6,8 @@
 {{- $eventCacheDatabaseUrlSecretName := include "mindroom-runtime.eventCacheDatabaseUrlSecretName" . -}}
 {{- $eventCacheDatabaseUrlSecretKey := include "mindroom-runtime.eventCacheDatabaseUrlSecretKey" . -}}
 {{- $workerExtraEnvJson := include "mindroom-runtime.workerExtraEnvJson" . -}}
+{{- $approvedEgressTokenSecretName := include "mindroom-runtime.approvedEgressTokenSecretName" . -}}
+{{- $approvedEgressTokenSecretKey := include "mindroom-runtime.approvedEgressTokenSecretKey" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -131,6 +133,25 @@ spec:
                 secretKeyRef:
                   name: {{ $proxyTokenSecretName }}
                   key: {{ .Values.workers.sandbox.proxyToken.key }}
+            {{- end }}
+            {{- if .Values.approvedEgress.enabled }}
+            - name: MINDROOM_APPROVED_EGRESS_API_URL
+              value: {{ include "mindroom-runtime.approvedEgressApiUrl" . | quote }}
+            - name: MINDROOM_APPROVED_EGRESS_ALLOWLIST_PATH
+              value: {{ .Values.approvedEgress.allowlist.mountPath | quote }}
+            - name: MINDROOM_APPROVED_EGRESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $approvedEgressTokenSecretName }}
+                  key: {{ $approvedEgressTokenSecretKey }}
+            {{- if .Values.approvedEgress.maxTtlSeconds }}
+            - name: MINDROOM_APPROVED_EGRESS_MAX_TTL_SECONDS
+              value: {{ .Values.approvedEgress.maxTtlSeconds | quote }}
+            {{- end }}
+            {{- if .Values.approvedEgress.sandboxProxyTimeoutSeconds }}
+            - name: MINDROOM_SANDBOX_PROXY_TIMEOUT_SECONDS
+              value: {{ .Values.approvedEgress.sandboxProxyTimeoutSeconds | quote }}
+            {{- end }}
             {{- end }}
             {{- if eq .Values.workers.backend "static_runner" }}
             - name: MINDROOM_SANDBOX_PROXY_URL
@@ -277,6 +298,12 @@ spec:
               readOnly: true
             - name: {{ include "mindroom-runtime.storageVolumeName" . }}
               mountPath: {{ .Values.storage.mountPath }}
+            {{- if .Values.approvedEgress.enabled }}
+            - name: approved-egress-allowlist
+              mountPath: {{ .Values.approvedEgress.allowlist.mountPath | quote }}
+              subPath: {{ .Values.approvedEgress.allowlist.key | quote }}
+              readOnly: true
+            {{- end }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -343,6 +370,11 @@ spec:
         - name: {{ include "mindroom-runtime.storageVolumeName" . }}
           persistentVolumeClaim:
             claimName: {{ include "mindroom-runtime.storageClaimName" . }}
+        {{- if .Values.approvedEgress.enabled }}
+        - name: approved-egress-allowlist
+          configMap:
+            name: {{ include "mindroom-runtime.approvedEgressConfigMapName" . }}
+        {{- end }}
         {{- if eq .Values.workers.backend "static_runner" }}
         - name: sandbox-workspace
           emptyDir: {}

--- a/cluster/k8s/runtime/templates/networkpolicy.yaml
+++ b/cluster/k8s/runtime/templates/networkpolicy.yaml
@@ -1,6 +1,7 @@
 {{- if and (eq .Values.workers.backend "kubernetes") .Values.workers.kubernetes.networkPolicy.create }}
-{{- $egressPolicyEnabled := and .Values.egressProxy.enabled .Values.egressProxy.networkPolicy.create -}}
+{{- $egressPolicyEnabled := and (include "mindroom-runtime.egressProxyEnabled" .) .Values.egressProxy.networkPolicy.create -}}
 {{- $proxyNamespace := include "mindroom-runtime.egressProxyNamespace" . -}}
+{{- $proxyPort := include "mindroom-runtime.egressProxyServicePort" . -}}
 {{- $dnsNamespaceSelector := .Values.egressProxy.networkPolicy.dns.namespaceSelector -}}
 {{- $dnsPodSelector := .Values.egressProxy.networkPolicy.dns.podSelector -}}
 {{- $hasDnsNamespaceSelector := kindIs "map" $dnsNamespaceSelector -}}
@@ -61,7 +62,7 @@ spec:
         - protocol: TCP
           port: 53
     - to:
-        - {{- if .Values.egressProxy.networkPolicy.proxyNamespaceSelector }}
+        - {{- if and (not .Values.approvedEgress.enabled) .Values.egressProxy.networkPolicy.proxyNamespaceSelector }}
           namespaceSelector:
             {{- toYaml .Values.egressProxy.networkPolicy.proxyNamespaceSelector | nindent 12 }}
           {{- else }}
@@ -70,12 +71,52 @@ spec:
               kubernetes.io/metadata.name: {{ $proxyNamespace | quote }}
           {{- end }}
           podSelector:
-            {{- toYaml .Values.egressProxy.networkPolicy.proxyPodSelector | nindent 12 }}
+            {{- include "mindroom-runtime.egressProxyPodSelector" . | nindent 12 }}
       ports:
         - protocol: TCP
-          port: {{ .Values.egressProxy.service.port }}
+          port: {{ $proxyPort }}
     {{- with .Values.egressProxy.networkPolicy.extraEgress }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- end }}
+{{- end }}
+{{- if and .Values.approvedEgress.enabled .Values.approvedEgress.networkPolicy.create }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "mindroom-runtime.approvedEgressNetworkPolicyName" . }}
+  labels:
+    {{- include "mindroom-runtime.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    {{- include "mindroom-runtime.approvedEgressPodSelector" . | nindent 4 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ include "mindroom-runtime.workerNamespace" . | quote }}
+          podSelector:
+            matchLabels:
+              mindroom.ai/component: worker
+              app.kubernetes.io/managed-by: mindroom
+              app.kubernetes.io/name: mindroom-worker
+              {{- with .Values.workers.kubernetes.extraLabels }}
+              {{- toYaml . | nindent 14 }}
+              {{- end }}
+      ports:
+        - port: {{ .Values.approvedEgress.service.proxyPort }}
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
+          podSelector:
+            matchLabels:
+              {{- include "mindroom-runtime.selectorLabels" . | nindent 14 }}
+      ports:
+        - port: {{ .Values.approvedEgress.service.apiPort }}
+          protocol: TCP
 {{- end }}

--- a/cluster/k8s/runtime/templates/validate.yaml
+++ b/cluster/k8s/runtime/templates/validate.yaml
@@ -13,18 +13,19 @@
 {{- if and (eq .Values.eventCache.backend "postgres") .Values.eventCache.postgres.create (not .Values.eventCache.postgres.auth.existingSecret) (not .Values.eventCache.databaseUrl.existingSecret) (eq .Values.eventCache.postgres.auth.passwordKey (include "mindroom-runtime.eventCacheDatabaseUrlSecretKey" .)) -}}
 {{- fail "eventCache.postgres.auth.passwordKey must differ from the event-cache database URL secret key" -}}
 {{- end -}}
-{{- $egressPolicyEnabled := and .Values.egressProxy.enabled .Values.egressProxy.networkPolicy.create -}}
-{{- if and .Values.egressProxy.enabled (ne .Values.workers.backend "kubernetes") -}}
-{{- fail "egressProxy.enabled requires workers.backend=kubernetes" -}}
+{{- $egressProxyEnabled := or .Values.egressProxy.enabled .Values.approvedEgress.enabled -}}
+{{- $egressPolicyEnabled := and $egressProxyEnabled .Values.egressProxy.networkPolicy.create -}}
+{{- if and $egressProxyEnabled (ne .Values.workers.backend "kubernetes") -}}
+{{- fail "egressProxy.enabled or approvedEgress.enabled requires workers.backend=kubernetes" -}}
 {{- end -}}
-{{- if and .Values.egressProxy.enabled (not .Values.egressProxy.service.name) -}}
-{{- fail "egressProxy.service.name is required when egressProxy.enabled=true" -}}
+{{- if and $egressProxyEnabled (not (include "mindroom-runtime.egressProxyServiceName" .)) -}}
+{{- fail "egress proxy service name is required when egressProxy.enabled=true or approvedEgress.enabled=true" -}}
 {{- end -}}
 {{- if and $egressPolicyEnabled (not .Values.workers.kubernetes.networkPolicy.create) -}}
 {{- fail "egressProxy.networkPolicy.create=true requires workers.kubernetes.networkPolicy.create=true" -}}
 {{- end -}}
 {{- $proxyPodSelector := .Values.egressProxy.networkPolicy.proxyPodSelector -}}
-{{- if and $egressPolicyEnabled (or (not (kindIs "map" $proxyPodSelector)) (not (or $proxyPodSelector.matchLabels $proxyPodSelector.matchExpressions))) -}}
+{{- if and $egressPolicyEnabled (not .Values.approvedEgress.enabled) (or (not (kindIs "map" $proxyPodSelector)) (not (or $proxyPodSelector.matchLabels $proxyPodSelector.matchExpressions))) -}}
 {{- fail "egressProxy.networkPolicy.proxyPodSelector with matchLabels or matchExpressions is required when egressProxy.networkPolicy.create=true" -}}
 {{- end -}}
 {{- $dnsNamespaceSelector := .Values.egressProxy.networkPolicy.dns.namespaceSelector -}}
@@ -32,4 +33,33 @@
 {{- $dnsIpBlocks := .Values.egressProxy.networkPolicy.dns.ipBlocks -}}
 {{- if and $egressPolicyEnabled (not (or (kindIs "map" $dnsNamespaceSelector) (kindIs "map" $dnsPodSelector) $dnsIpBlocks)) -}}
 {{- fail "egressProxy.networkPolicy.dns requires namespaceSelector, podSelector, or ipBlocks when egressProxy.networkPolicy.create=true" -}}
+{{- end -}}
+{{- if .Values.approvedEgress.enabled -}}
+{{- if not .Values.approvedEgress.image.repository -}}
+{{- fail "approvedEgress.image.repository is required when approvedEgress.enabled=true" -}}
+{{- end -}}
+{{- if not (or .Values.approvedEgress.image.tag .Values.approvedEgress.image.digest) -}}
+{{- fail "approvedEgress.image.tag or approvedEgress.image.digest is required when approvedEgress.enabled=true" -}}
+{{- end -}}
+{{- if and (not .Values.approvedEgress.serviceAccount.create) (not .Values.approvedEgress.serviceAccount.name) -}}
+{{- fail "approvedEgress.serviceAccount.name is required when approvedEgress.serviceAccount.create=false" -}}
+{{- end -}}
+{{- if not (include "mindroom-runtime.approvedEgressTokenSecretName" .) -}}
+{{- fail "approvedEgress.enabled requires approvedEgress.token.existingSecret or workers.sandbox.proxyToken" -}}
+{{- end -}}
+{{- if not (include "mindroom-runtime.approvedEgressTokenSecretKey" .) -}}
+{{- fail "approvedEgress token key is required when approvedEgress.enabled=true" -}}
+{{- end -}}
+{{- if not .Values.approvedEgress.allowlist.key -}}
+{{- fail "approvedEgress.allowlist.key is required when approvedEgress.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.approvedEgress.allowlist.existingConfigMap .Values.approvedEgress.allowlist.domains -}}
+{{- fail "approvedEgress.allowlist.domains cannot be set when approvedEgress.allowlist.existingConfigMap is set" -}}
+{{- end -}}
+{{- if not .Values.egressProxy.networkPolicy.create -}}
+{{- fail "approvedEgress.enabled requires egressProxy.networkPolicy.create=true so workers cannot bypass the proxy" -}}
+{{- end -}}
+{{- if and .Values.approvedEgress.persistence.enabled (not .Values.approvedEgress.persistence.existingClaim) (not .Values.approvedEgress.persistence.size) -}}
+{{- fail "approvedEgress.persistence.size is required when chart-managed approved egress persistence is enabled" -}}
+{{- end -}}
 {{- end -}}

--- a/cluster/k8s/runtime/values.yaml
+++ b/cluster/k8s/runtime/values.yaml
@@ -259,9 +259,9 @@ workers:
         memory: 1Gi
 
 # Optional external HTTP proxy for dedicated Kubernetes workers.
-# This chart does not deploy the proxy itself. It only points worker pods at an
-# existing proxy Service and, when requested, restricts worker egress so direct
-# internet access must go through that proxy.
+# This chart can point worker pods at an existing proxy Service and, when
+# requested, restrict worker egress so direct internet access must go through
+# that proxy.
 egressProxy:
   enabled: false
   injectWorkerProxyEnv: true
@@ -289,6 +289,74 @@ egressProxy:
       ipBlocks: []
     # Raw Kubernetes NetworkPolicyEgressRule entries appended after DNS and proxy rules.
     extraEgress: []
+
+# Optional chart-managed approved egress proxy for dedicated Kubernetes workers.
+# Enabling this deploys the proxy side and automatically points worker proxy
+# settings at it. Worker direct egress still depends on the worker NetworkPolicy.
+approvedEgress:
+  enabled: false
+  image:
+    repository: ghcr.io/mindroom-ai/mindroom-egress-proxy
+    # Pin a tag or digest before enabling this feature.
+    tag: ""
+    digest: ""
+    pullPolicy: IfNotPresent
+  serviceAccount:
+    create: true
+    name: ""
+    annotations: {}
+    automountServiceAccountToken: true
+  rbac:
+    create: true
+  service:
+    # Leave empty for <fullname>-egress-proxy.
+    name: ""
+    proxyPort: 3128
+    apiPort: 8080
+    annotations: {}
+  token:
+    # Leave empty to reuse workers.sandbox.proxyToken.
+    existingSecret: ""
+    key: MINDROOM_SANDBOX_PROXY_TOKEN
+  allowlist:
+    domains: []
+    existingConfigMap: ""
+    key: allowed-domains.txt
+    mountPath: /etc/mindroom-egress/allowed-domains.txt
+  persistence:
+    enabled: true
+    existingClaim: ""
+    size: 10Gi
+    storageClassName: ""
+  dataPath: /var/lib/mindroom-egress
+  dbFileName: grants.sqlite3
+  maxTtlSeconds: 21600
+  sandboxProxyTimeoutSeconds: ""
+  logLevel: info
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      memory: 1Gi
+  podAnnotations: {}
+  podLabels: {}
+  podSecurityContext:
+    fsGroup: 1000
+    fsGroupChangePolicy: OnRootMismatch
+    seccompProfile:
+      type: RuntimeDefault
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+  networkPolicy:
+    create: true
+    name: ""
 
 initContainers: []
 extraContainers: []

--- a/tests/test_helm_instance_worker_isolation.py
+++ b/tests/test_helm_instance_worker_isolation.py
@@ -17,6 +17,7 @@ def _render_chart(
     chart_dir: Path,
     *set_args: str,
     release_name: str = "mindroom-demo",
+    namespace: str | None = None,
     set_string_args: tuple[str, ...] = (),
     values_files: tuple[Path, ...] = (),
 ) -> list[dict[str, Any]]:
@@ -24,6 +25,7 @@ def _render_chart(
         chart_dir,
         *set_args,
         release_name=release_name,
+        namespace=namespace,
         set_string_args=set_string_args,
         values_files=values_files,
     )
@@ -35,6 +37,7 @@ def _run_helm_template(
     chart_dir: Path,
     *set_args: str,
     release_name: str = "mindroom-demo",
+    namespace: str | None = None,
     set_string_args: tuple[str, ...] = (),
     values_files: tuple[Path, ...] = (),
 ) -> subprocess.CompletedProcess[str]:
@@ -47,6 +50,7 @@ def _run_helm_template(
             "template",
             release_name,
             str(chart_dir),
+            *(("--namespace", namespace) if namespace else ()),
             *(arg for value in values_files for arg in ("--values", str(value))),
             *(arg for value in set_args for arg in ("--set", value)),
             *(arg for value in set_string_args for arg in ("--set-string", value)),
@@ -752,6 +756,346 @@ def test_runtime_chart_can_route_kubernetes_workers_through_existing_egress_prox
         "to": [{"podSelector": {"matchLabels": {"app": "internal-api"}}}],
         "ports": [{"protocol": "TCP", "port": 8080}],
     }
+
+
+def test_runtime_chart_can_deploy_chart_managed_approved_egress_proxy(tmp_path: Path) -> None:
+    """Approved egress should render the proxy side and wire workers through it."""
+    values_path = tmp_path / "values.yaml"
+    values_path.write_text(
+        yaml.safe_dump(
+            {
+                "approvedEgress": {
+                    "enabled": True,
+                    "image": {"tag": "v0.1.0"},
+                    "allowlist": {"domains": ["example.com", ".docs.example.com"]},
+                },
+                "eventCache": {"postgres": {"auth": {"password": "test-password"}}},
+                "workers": {
+                    "backend": "kubernetes",
+                    "sandbox": {"proxyToken": {"value": "test-token"}},
+                },
+            },
+        ),
+        encoding="utf-8",
+    )
+    docs = _render_chart(
+        Path("cluster/k8s/runtime"),
+        values_files=(values_path,),
+        release_name="mindroom-runtime",
+    )
+    proxy_name = "mindroom-runtime-egress-proxy"
+    proxy_config_name = f"{proxy_name}-config"
+    proxy_pvc_name = f"{proxy_name}-data"
+    runtime_deployment = _resource(docs, "Deployment", "mindroom-runtime")
+    proxy_deployment = _resource(docs, "Deployment", proxy_name)
+    proxy_service = _resource(docs, "Service", proxy_name)
+    proxy_config = _resource(docs, "ConfigMap", proxy_config_name)
+    proxy_pvc = _resource(docs, "PersistentVolumeClaim", proxy_pvc_name)
+    proxy_role = _resource(docs, "Role", proxy_name)
+    proxy_role_binding = _resource(docs, "RoleBinding", proxy_name)
+    proxy_service_account = _resource(docs, "ServiceAccount", proxy_name)
+    worker_policy = _resource(docs, "NetworkPolicy", "mindroom-runtime-workers")
+    proxy_policy = _resource(docs, "NetworkPolicy", f"{proxy_name}-ingress")
+    runtime_container = _container(runtime_deployment, "mindroom")
+    proxy_container = _container(proxy_deployment, "approved-egress-proxy")
+    runtime_env = _env_by_name(runtime_container)
+    proxy_env = _env_by_name(proxy_container)
+    worker_env = json.loads(runtime_env["MINDROOM_KUBERNETES_WORKER_ENV_JSON"]["value"])
+
+    assert proxy_config["data"]["allowed-domains.txt"] == "example.com\n.docs.example.com\n"
+    assert proxy_pvc["spec"]["resources"]["requests"]["storage"] == "10Gi"
+    assert proxy_service_account["automountServiceAccountToken"] is True
+    assert proxy_role["rules"] == [
+        {"apiGroups": [""], "resources": ["pods"], "verbs": ["get", "list"]},
+        {"apiGroups": ["apps"], "resources": ["deployments"], "verbs": ["get"]},
+    ]
+    assert proxy_role_binding["subjects"] == [
+        {"kind": "ServiceAccount", "name": proxy_name, "namespace": "default"},
+    ]
+
+    assert proxy_container["image"] == "ghcr.io/mindroom-ai/mindroom-egress-proxy:v0.1.0"
+    assert proxy_container["ports"] == [
+        {"name": "proxy", "containerPort": 3128, "protocol": "TCP"},
+        {"name": "policy-api", "containerPort": 8080, "protocol": "TCP"},
+    ]
+    assert proxy_env["POD_NAMESPACE"]["value"] == "default"
+    assert proxy_env["MINDROOM_EGRESS_PROXY_LISTEN_PORT"]["value"] == "3128"
+    assert proxy_env["MINDROOM_APPROVED_EGRESS_API_PORT"]["value"] == "8080"
+    assert proxy_env["MINDROOM_EGRESS_ALLOWLIST_PATH"]["value"] == "/etc/mindroom-egress/allowed-domains.txt"
+    assert proxy_env["MINDROOM_EGRESS_DB_PATH"]["value"] == "/var/lib/mindroom-egress/grants.sqlite3"
+    assert proxy_env["MINDROOM_APPROVED_EGRESS_MAX_TTL_SECONDS"]["value"] == "21600"
+    assert proxy_env["MINDROOM_APPROVED_EGRESS_TOKEN"]["valueFrom"]["secretKeyRef"] == {
+        "name": "mindroom-runtime-sandbox-proxy",
+        "key": "MINDROOM_SANDBOX_PROXY_TOKEN",
+    }
+    assert proxy_deployment["spec"]["template"]["spec"]["volumes"] == [
+        {"name": "allowlist", "configMap": {"name": proxy_config_name}},
+        {"name": "data", "persistentVolumeClaim": {"claimName": proxy_pvc_name}},
+    ]
+
+    assert proxy_service["spec"]["ports"] == [
+        {"name": "proxy", "port": 3128, "targetPort": "proxy", "protocol": "TCP"},
+        {"name": "policy-api", "port": 8080, "targetPort": "policy-api", "protocol": "TCP"},
+    ]
+    assert runtime_env["MINDROOM_APPROVED_EGRESS_API_URL"]["value"] == (
+        "http://mindroom-runtime-egress-proxy.default.svc.cluster.local:8080"
+    )
+    assert runtime_env["MINDROOM_APPROVED_EGRESS_ALLOWLIST_PATH"]["value"] == (
+        "/etc/mindroom-egress/allowed-domains.txt"
+    )
+    assert runtime_env["MINDROOM_APPROVED_EGRESS_TOKEN"]["valueFrom"]["secretKeyRef"] == {
+        "name": "mindroom-runtime-sandbox-proxy",
+        "key": "MINDROOM_SANDBOX_PROXY_TOKEN",
+    }
+    assert runtime_env["MINDROOM_APPROVED_EGRESS_MAX_TTL_SECONDS"]["value"] == "21600"
+    assert {
+        "name": "approved-egress-allowlist",
+        "mountPath": "/etc/mindroom-egress/allowed-domains.txt",
+        "subPath": "allowed-domains.txt",
+        "readOnly": True,
+    } in runtime_container["volumeMounts"]
+
+    assert worker_env["HTTP_PROXY"] == "http://mindroom-runtime-egress-proxy.default.svc.cluster.local:3128"
+    assert worker_policy["spec"]["egress"][1] == {
+        "to": [
+            {
+                "namespaceSelector": {"matchLabels": {"kubernetes.io/metadata.name": "default"}},
+                "podSelector": {
+                    "matchLabels": {
+                        "app.kubernetes.io/name": proxy_name,
+                        "app.kubernetes.io/instance": "mindroom-runtime",
+                        "app.kubernetes.io/component": "approved-egress-proxy",
+                    },
+                },
+            },
+        ],
+        "ports": [{"protocol": "TCP", "port": 3128}],
+    }
+    assert proxy_policy["spec"]["ingress"] == [
+        {
+            "from": [
+                {
+                    "namespaceSelector": {"matchLabels": {"kubernetes.io/metadata.name": "default"}},
+                    "podSelector": {
+                        "matchLabels": {
+                            "mindroom.ai/component": "worker",
+                            "app.kubernetes.io/managed-by": "mindroom",
+                            "app.kubernetes.io/name": "mindroom-worker",
+                        },
+                    },
+                },
+            ],
+            "ports": [{"port": 3128, "protocol": "TCP"}],
+        },
+        {
+            "from": [
+                {
+                    "namespaceSelector": {"matchLabels": {"kubernetes.io/metadata.name": "default"}},
+                    "podSelector": {
+                        "matchLabels": {
+                            "app.kubernetes.io/name": "mindroom-runtime",
+                            "app.kubernetes.io/instance": "mindroom-runtime",
+                            "app.kubernetes.io/component": "runtime",
+                        },
+                    },
+                },
+            ],
+            "ports": [{"port": 8080, "protocol": "TCP"}],
+        },
+    ]
+
+
+def test_runtime_chart_approved_egress_uses_worker_namespace_for_pod_lookup_and_rbac() -> None:
+    """The proxy runs in the release namespace but reads worker pods from the worker namespace."""
+    docs = _render_chart(
+        Path("cluster/k8s/runtime"),
+        "workers.backend=kubernetes",
+        "workers.kubernetes.namespace=mindroom-workers",
+        "workers.sandbox.proxyToken.value=test-token",
+        "eventCache.postgres.auth.password=test-password",
+        "approvedEgress.enabled=true",
+        "approvedEgress.image.tag=v0.1.0",
+        release_name="mindroom-runtime",
+        namespace="mindroom-runtime-system",
+    )
+    proxy_name = "mindroom-runtime-egress-proxy"
+    proxy_deployment = _resource(docs, "Deployment", proxy_name)
+    proxy_role = _resource(docs, "Role", proxy_name)
+    proxy_role_binding = _resource(docs, "RoleBinding", proxy_name)
+    proxy_service_account = _resource(docs, "ServiceAccount", proxy_name)
+    proxy_container = _container(proxy_deployment, "approved-egress-proxy")
+    proxy_env = _env_by_name(proxy_container)
+
+    assert proxy_deployment["metadata"].get("namespace", "mindroom-runtime-system") == "mindroom-runtime-system"
+    assert proxy_service_account["metadata"].get("namespace", "mindroom-runtime-system") == "mindroom-runtime-system"
+    assert proxy_env["POD_NAMESPACE"]["value"] == "mindroom-workers"
+    assert proxy_role["metadata"]["namespace"] == "mindroom-workers"
+    assert proxy_role_binding["metadata"]["namespace"] == "mindroom-workers"
+    assert proxy_role_binding["subjects"] == [
+        {"kind": "ServiceAccount", "name": proxy_name, "namespace": "mindroom-runtime-system"},
+    ]
+
+
+def test_runtime_chart_approved_egress_ignores_external_proxy_scheme_and_namespace_selector(
+    tmp_path: Path,
+) -> None:
+    """Chart-managed approved egress should not inherit external proxy routing values."""
+    values_path = tmp_path / "values.yaml"
+    values_path.write_text(
+        yaml.safe_dump(
+            {
+                "approvedEgress": {"enabled": True, "image": {"tag": "v0.1.0"}},
+                "egressProxy": {
+                    "service": {
+                        "name": "external-proxy",
+                        "namespace": "external-proxy",
+                        "port": 9443,
+                        "scheme": "https",
+                    },
+                    "networkPolicy": {
+                        "proxyNamespaceSelector": {"matchLabels": {"name": "external-proxy"}},
+                    },
+                },
+                "eventCache": {"postgres": {"auth": {"password": "test-password"}}},
+                "workers": {
+                    "backend": "kubernetes",
+                    "sandbox": {"proxyToken": {"value": "test-token"}},
+                },
+            },
+        ),
+        encoding="utf-8",
+    )
+    docs = _render_chart(
+        Path("cluster/k8s/runtime"),
+        values_files=(values_path,),
+        release_name="mindroom-runtime",
+    )
+    runtime_deployment = _resource(docs, "Deployment", "mindroom-runtime")
+    worker_policy = _resource(docs, "NetworkPolicy", "mindroom-runtime-workers")
+    runtime_container = _container(runtime_deployment, "mindroom")
+    runtime_env = _env_by_name(runtime_container)
+    worker_env = json.loads(runtime_env["MINDROOM_KUBERNETES_WORKER_ENV_JSON"]["value"])
+
+    assert worker_env["HTTP_PROXY"] == "http://mindroom-runtime-egress-proxy.default.svc.cluster.local:3128"
+    assert worker_policy["spec"]["egress"][1] == {
+        "to": [
+            {
+                "namespaceSelector": {"matchLabels": {"kubernetes.io/metadata.name": "default"}},
+                "podSelector": {
+                    "matchLabels": {
+                        "app.kubernetes.io/name": "mindroom-runtime-egress-proxy",
+                        "app.kubernetes.io/instance": "mindroom-runtime",
+                        "app.kubernetes.io/component": "approved-egress-proxy",
+                    },
+                },
+            },
+        ],
+        "ports": [{"protocol": "TCP", "port": 3128}],
+    }
+
+
+def test_runtime_chart_approved_egress_ignores_external_proxy_namespace_selector(
+    tmp_path: Path,
+) -> None:
+    """Chart-managed approved egress should always select its own namespace."""
+    values_path = tmp_path / "values.yaml"
+    values_path.write_text(
+        yaml.safe_dump(
+            {
+                "approvedEgress": {"enabled": True, "image": {"tag": "v0.1.0"}},
+                "egressProxy": {
+                    "networkPolicy": {
+                        "proxyNamespaceSelector": {"matchLabels": {"name": "external-proxy"}},
+                    },
+                },
+                "eventCache": {"postgres": {"auth": {"password": "test-password"}}},
+                "workers": {
+                    "backend": "kubernetes",
+                    "sandbox": {"proxyToken": {"value": "test-token"}},
+                },
+            },
+        ),
+        encoding="utf-8",
+    )
+    docs = _render_chart(
+        Path("cluster/k8s/runtime"),
+        values_files=(values_path,),
+        release_name="mindroom-runtime",
+    )
+    worker_policy = _resource(docs, "NetworkPolicy", "mindroom-runtime-workers")
+
+    assert worker_policy["spec"]["egress"][1]["to"][0]["namespaceSelector"] == {
+        "matchLabels": {"kubernetes.io/metadata.name": "default"},
+    }
+
+
+def test_runtime_chart_does_not_render_approved_egress_resources_by_default() -> None:
+    """Disabled approved egress must leave the runtime chart on the existing worker path."""
+    docs = _render_runtime_chart()
+    deployment = _resource(docs, "Deployment", "mindroom-runtime")
+    runtime_env_names = {env["name"] for env in _container(deployment, "mindroom")["env"]}
+    rendered_proxy_resources = [
+        doc
+        for doc in docs
+        if doc.get("metadata", {}).get("labels", {}).get("app.kubernetes.io/component") == "approved-egress-proxy"
+    ]
+
+    assert rendered_proxy_resources == []
+    assert "MINDROOM_APPROVED_EGRESS_API_URL" not in runtime_env_names
+    assert "MINDROOM_APPROVED_EGRESS_TOKEN" not in runtime_env_names
+
+
+def test_runtime_chart_rejects_approved_egress_without_pinned_proxy_image() -> None:
+    """Operators should pin the optional proxy image before enabling the firewall path."""
+    completed = _run_helm_template(
+        Path("cluster/k8s/runtime"),
+        "workers.backend=kubernetes",
+        "workers.sandbox.proxyToken.value=test-token",
+        "eventCache.postgres.auth.password=test-password",
+        "approvedEgress.enabled=true",
+        release_name="mindroom-runtime",
+    )
+
+    assert completed.returncode != 0
+    assert "approvedEgress.image.tag or approvedEgress.image.digest is required" in completed.stderr
+
+
+def test_runtime_chart_rejects_approved_egress_without_token_secret() -> None:
+    """The policy API and plugin should not render without a bearer-token Secret."""
+    completed = _run_helm_template(
+        Path("cluster/k8s/runtime"),
+        "workers.backend=kubernetes",
+        "eventCache.postgres.auth.password=test-password",
+        "approvedEgress.enabled=true",
+        "approvedEgress.image.tag=v0.1.0",
+        release_name="mindroom-runtime",
+    )
+
+    assert completed.returncode != 0
+    assert (
+        "approvedEgress.enabled requires approvedEgress.token.existingSecret "
+        "or workers.sandbox.proxyToken" in completed.stderr
+    )
+
+
+def test_runtime_chart_rejects_approved_egress_existing_service_account_without_name() -> None:
+    """Existing approved egress ServiceAccounts must be named explicitly."""
+    completed = _run_helm_template(
+        Path("cluster/k8s/runtime"),
+        "workers.backend=kubernetes",
+        "workers.sandbox.proxyToken.value=test-token",
+        "eventCache.postgres.auth.password=test-password",
+        "approvedEgress.enabled=true",
+        "approvedEgress.image.tag=v0.1.0",
+        "approvedEgress.serviceAccount.create=false",
+        release_name="mindroom-runtime",
+    )
+
+    assert completed.returncode != 0
+    assert (
+        "approvedEgress.serviceAccount.name is required when "
+        "approvedEgress.serviceAccount.create=false" in completed.stderr
+    )
 
 
 def test_runtime_chart_dns_policy_renders_empty_namespace_selector_with_pod_selector(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add optional chart-managed approved egress proxy resources for Kubernetes workers.
- Wire control-plane approved egress env, allowlist mount, token secret, worker proxy env, and NetworkPolicies.
- Add Helm validation, runtime chart tests, and generic README examples.
- Keep chart-managed approved egress isolated from stale external proxy scheme/namespace-selector values and release-name collisions.
- Require an explicit existing proxy ServiceAccount name when the chart does not create one.

## Validation
- PATH="$HOME/.bun/bin:$HOME/.local/bin:/opt/homebrew/bin:$PATH" uv run pre-commit run --all-files
- PATH="$HOME/.local/bin:/opt/homebrew/bin:$PATH" helm lint cluster/k8s/runtime
- PATH="$HOME/.local/bin:/opt/homebrew/bin:$PATH" uv run pytest tests/test_helm_instance_worker_isolation.py -q -n 0 --no-cov
- PATH="$HOME/.local/bin:/opt/homebrew/bin:$PATH" helm template approvedEgress.enabled=false: no approved egress resources or env rendered
- PATH="$HOME/.local/bin:/opt/homebrew/bin:$PATH" helm template approvedEgress.enabled=true: release-derived proxy resources, env, and NetworkPolicies rendered
- PATH="$HOME/.local/bin:/opt/homebrew/bin:$PATH" helm template approvedEgress.enabled=true with stale external proxy scheme/namespace selector: chart-managed proxy still uses http and release namespace
- git diff --check
- private leak scan over chart/tests
- PATH="$HOME/.bun/bin:$HOME/.local/bin:/opt/homebrew/bin:$PATH" uv run pytest -n auto --no-cov -> 7772 passed, 60 skipped
