### PR TITLE
Add runtime state storage support to runtime chart

### DIFF
--- a/cluster/k8s/runtime/README.md
+++ b/cluster/k8s/runtime/README.md
@@ -76,6 +76,49 @@ eventCache:
 When `config.create` is enabled and `config.data` is empty, the chart renders a minimal config whose `cache` section follows `eventCache`.
 When using `config.existingConfigMap` or custom `config.data`, keep that config's cache settings aligned with the chart values.
 
+## Runtime State Storage
+
+MindRoom stores Matrix encryption keys and sync-token checkpoints under `MINDROOM_STORAGE_PATH`.
+Hosted installs can keep those restart-critical directories on a dedicated PVC while normal workspace data stays on `storage`.
+The chart mounts the same state PVC at `stateStorage.mountPath` and overlays the configured subpaths where MindRoom already reads and writes those directories.
+The optional init container creates the state directories and applies the configured ownership before the runtime starts.
+`initPermissions.runAsUser` and `initPermissions.fsGroup` are the ownership targets used by the init container.
+
+Use an existing PVC when another platform layer owns durable storage:
+
+```yaml
+storage:
+  create: false
+  existingClaim: mindroom-workspace
+  mountPath: /app/agent_data
+
+stateStorage:
+  enabled: true
+  existingClaim: mindroom-state
+  mountPath: /app/mindroom_state
+  encryptionKeys:
+    enabled: true
+    mountPath: /app/agent_data/encryption_keys
+    subPath: encryption_keys
+  syncTokens:
+    enabled: true
+    mountPath: /app/agent_data/sync_tokens
+    subPath: sync_tokens
+  initPermissions:
+    enabled: true
+    runAsUser: 1000
+    fsGroup: 1000
+```
+
+Let the chart create the state PVC for simpler hosted installs:
+
+```yaml
+stateStorage:
+  enabled: true
+  create: true
+  size: 20Gi
+```
+
 ## Worker Egress Proxy
 
 For dedicated Kubernetes workers, the chart can either deploy the approved egress proxy or point workers at an existing HTTP proxy Service.
@@ -162,6 +205,10 @@ storage:
   create: false
   existingClaim: mindroom-data
   mountPath: /app/agent_data
+
+stateStorage:
+  enabled: true
+  existingClaim: mindroom-state
 
 matrix:
   homeserverUrl: http://matrix.example.svc.cluster.local:8008

--- a/cluster/k8s/runtime/README.md
+++ b/cluster/k8s/runtime/README.md
@@ -83,6 +83,7 @@ Hosted installs can keep those restart-critical directories on a dedicated PVC w
 The chart mounts the same state PVC at `stateStorage.mountPath` and overlays the configured subpaths where MindRoom already reads and writes those directories.
 The optional init container creates the state directories and applies the configured ownership before the runtime starts.
 `initPermissions.runAsUser` and `initPermissions.fsGroup` are the ownership targets used by the init container.
+By default, the init container runs as UID 0 because it performs `chown` and `chmod`, while the main runtime container keeps its own security context.
 
 Use an existing PVC when another platform layer owns durable storage:
 

--- a/cluster/k8s/runtime/templates/_helpers.tpl
+++ b/cluster/k8s/runtime/templates/_helpers.tpl
@@ -83,6 +83,18 @@ app.kubernetes.io/component: runtime
 {{- default "storage" .Values.storage.volumeName -}}
 {{- end -}}
 
+{{- define "mindroom-runtime.stateStorageClaimName" -}}
+{{- if .Values.stateStorage.existingClaim -}}
+{{- .Values.stateStorage.existingClaim -}}
+{{- else -}}
+{{- printf "%s-state" (include "mindroom-runtime.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.stateStorageVolumeName" -}}
+{{- default "state-storage" .Values.stateStorage.volumeName -}}
+{{- end -}}
+
 {{- define "mindroom-runtime.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
 {{- default (include "mindroom-runtime.fullname" .) .Values.serviceAccount.name -}}

--- a/cluster/k8s/runtime/templates/deployment.yaml
+++ b/cluster/k8s/runtime/templates/deployment.yaml
@@ -65,9 +65,27 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.initContainers }}
+      {{- if or (and .Values.stateStorage.enabled .Values.stateStorage.initPermissions.enabled) .Values.initContainers }}
       initContainers:
+{{ if and .Values.stateStorage.enabled .Values.stateStorage.initPermissions.enabled }}
+        - name: prepare-state-storage
+          image: {{ .Values.stateStorage.initPermissions.image | quote }}
+          imagePullPolicy: {{ .Values.stateStorage.initPermissions.imagePullPolicy }}
+          command:
+            - sh
+            - -lc
+            - |
+              set -eu
+              mkdir -p /state{{ if .Values.stateStorage.encryptionKeys.enabled }} /state/{{ .Values.stateStorage.encryptionKeys.subPath }}{{ end }}{{ if .Values.stateStorage.syncTokens.enabled }} /state/{{ .Values.stateStorage.syncTokens.subPath }}{{ end }}
+              chown -R {{ .Values.stateStorage.initPermissions.runAsUser }}:{{ .Values.stateStorage.initPermissions.fsGroup }} /state{{ if .Values.stateStorage.encryptionKeys.enabled }} /state/{{ .Values.stateStorage.encryptionKeys.subPath }}{{ end }}{{ if .Values.stateStorage.syncTokens.enabled }} /state/{{ .Values.stateStorage.syncTokens.subPath }}{{ end }}
+              chmod {{ .Values.stateStorage.initPermissions.chmod }} /state{{ if .Values.stateStorage.encryptionKeys.enabled }} /state/{{ .Values.stateStorage.encryptionKeys.subPath }}{{ end }}{{ if .Values.stateStorage.syncTokens.enabled }} /state/{{ .Values.stateStorage.syncTokens.subPath }}{{ end }}
+          volumeMounts:
+            - name: {{ include "mindroom-runtime.stateStorageVolumeName" . }}
+              mountPath: /state
+{{- end }}
+        {{- with .Values.initContainers }}
         {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       containers:
         - name: mindroom
@@ -298,6 +316,22 @@ spec:
               readOnly: true
             - name: {{ include "mindroom-runtime.storageVolumeName" . }}
               mountPath: {{ .Values.storage.mountPath }}
+            {{- if .Values.stateStorage.enabled }}
+            {{- if .Values.stateStorage.mountPath }}
+            - name: {{ include "mindroom-runtime.stateStorageVolumeName" . }}
+              mountPath: {{ .Values.stateStorage.mountPath }}
+            {{- end }}
+            {{- if .Values.stateStorage.encryptionKeys.enabled }}
+            - name: {{ include "mindroom-runtime.stateStorageVolumeName" . }}
+              mountPath: {{ .Values.stateStorage.encryptionKeys.mountPath }}
+              subPath: {{ .Values.stateStorage.encryptionKeys.subPath }}
+            {{- end }}
+            {{- if .Values.stateStorage.syncTokens.enabled }}
+            - name: {{ include "mindroom-runtime.stateStorageVolumeName" . }}
+              mountPath: {{ .Values.stateStorage.syncTokens.mountPath }}
+              subPath: {{ .Values.stateStorage.syncTokens.subPath }}
+            {{- end }}
+            {{- end }}
             {{- if .Values.approvedEgress.enabled }}
             - name: approved-egress-allowlist
               mountPath: {{ .Values.approvedEgress.allowlist.mountPath | quote }}
@@ -370,6 +404,11 @@ spec:
         - name: {{ include "mindroom-runtime.storageVolumeName" . }}
           persistentVolumeClaim:
             claimName: {{ include "mindroom-runtime.storageClaimName" . }}
+        {{- if .Values.stateStorage.enabled }}
+        - name: {{ include "mindroom-runtime.stateStorageVolumeName" . }}
+          persistentVolumeClaim:
+            claimName: {{ include "mindroom-runtime.stateStorageClaimName" . }}
+        {{- end }}
         {{- if .Values.approvedEgress.enabled }}
         - name: approved-egress-allowlist
           configMap:

--- a/cluster/k8s/runtime/templates/deployment.yaml
+++ b/cluster/k8s/runtime/templates/deployment.yaml
@@ -71,14 +71,18 @@ spec:
         - name: prepare-state-storage
           image: {{ .Values.stateStorage.initPermissions.image | quote }}
           imagePullPolicy: {{ .Values.stateStorage.initPermissions.imagePullPolicy }}
+          {{- with .Values.stateStorage.initPermissions.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command:
             - sh
-            - -lc
+            - -c
             - |
               set -eu
-              mkdir -p /state{{ if .Values.stateStorage.encryptionKeys.enabled }} /state/{{ .Values.stateStorage.encryptionKeys.subPath }}{{ end }}{{ if .Values.stateStorage.syncTokens.enabled }} /state/{{ .Values.stateStorage.syncTokens.subPath }}{{ end }}
-              chown -R {{ .Values.stateStorage.initPermissions.runAsUser }}:{{ .Values.stateStorage.initPermissions.fsGroup }} /state{{ if .Values.stateStorage.encryptionKeys.enabled }} /state/{{ .Values.stateStorage.encryptionKeys.subPath }}{{ end }}{{ if .Values.stateStorage.syncTokens.enabled }} /state/{{ .Values.stateStorage.syncTokens.subPath }}{{ end }}
-              chmod {{ .Values.stateStorage.initPermissions.chmod }} /state{{ if .Values.stateStorage.encryptionKeys.enabled }} /state/{{ .Values.stateStorage.encryptionKeys.subPath }}{{ end }}{{ if .Values.stateStorage.syncTokens.enabled }} /state/{{ .Values.stateStorage.syncTokens.subPath }}{{ end }}
+              mkdir -p "/state"{{ if .Values.stateStorage.encryptionKeys.enabled }} "/state/{{ .Values.stateStorage.encryptionKeys.subPath }}"{{ end }}{{ if .Values.stateStorage.syncTokens.enabled }} "/state/{{ .Values.stateStorage.syncTokens.subPath }}"{{ end }}
+              chown -R {{ .Values.stateStorage.initPermissions.runAsUser }}:{{ .Values.stateStorage.initPermissions.fsGroup }} "/state"{{ if .Values.stateStorage.encryptionKeys.enabled }} "/state/{{ .Values.stateStorage.encryptionKeys.subPath }}"{{ end }}{{ if .Values.stateStorage.syncTokens.enabled }} "/state/{{ .Values.stateStorage.syncTokens.subPath }}"{{ end }}
+              chmod {{ .Values.stateStorage.initPermissions.chmod }} "/state"{{ if .Values.stateStorage.encryptionKeys.enabled }} "/state/{{ .Values.stateStorage.encryptionKeys.subPath }}"{{ end }}{{ if .Values.stateStorage.syncTokens.enabled }} "/state/{{ .Values.stateStorage.syncTokens.subPath }}"{{ end }}
           volumeMounts:
             - name: {{ include "mindroom-runtime.stateStorageVolumeName" . }}
               mountPath: /state

--- a/cluster/k8s/runtime/templates/pvc.yaml
+++ b/cluster/k8s/runtime/templates/pvc.yaml
@@ -15,3 +15,23 @@ spec:
     requests:
       storage: {{ .Values.storage.size | quote }}
 {{- end }}
+{{- if and .Values.stateStorage.enabled .Values.stateStorage.create (not .Values.stateStorage.existingClaim) }}
+{{- if and .Values.storage.create (not .Values.storage.existingClaim) }}
+---
+{{- end }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "mindroom-runtime.stateStorageClaimName" . }}
+  labels:
+    {{- include "mindroom-runtime.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.stateStorage.accessModes | nindent 4 }}
+  {{- if .Values.stateStorage.storageClassName }}
+  storageClassName: {{ .Values.stateStorage.storageClassName | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.stateStorage.size | quote }}
+{{- end }}

--- a/cluster/k8s/runtime/templates/validate.yaml
+++ b/cluster/k8s/runtime/templates/validate.yaml
@@ -13,6 +13,32 @@
 {{- if and (eq .Values.eventCache.backend "postgres") .Values.eventCache.postgres.create (not .Values.eventCache.postgres.auth.existingSecret) (not .Values.eventCache.databaseUrl.existingSecret) (eq .Values.eventCache.postgres.auth.passwordKey (include "mindroom-runtime.eventCacheDatabaseUrlSecretKey" .)) -}}
 {{- fail "eventCache.postgres.auth.passwordKey must differ from the event-cache database URL secret key" -}}
 {{- end -}}
+{{- if .Values.stateStorage.enabled -}}
+{{- if and (not .Values.stateStorage.create) (not .Values.stateStorage.existingClaim) -}}
+{{- fail "stateStorage.existingClaim or stateStorage.create=true is required when stateStorage.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.stateStorage.create (not .Values.stateStorage.existingClaim) (not .Values.stateStorage.size) -}}
+{{- fail "stateStorage.size is required when chart-managed state storage is enabled" -}}
+{{- end -}}
+{{- if eq (include "mindroom-runtime.storageVolumeName" .) (include "mindroom-runtime.stateStorageVolumeName" .) -}}
+{{- fail "stateStorage.volumeName must differ from storage.volumeName" -}}
+{{- end -}}
+{{- if and .Values.stateStorage.mountPath (eq .Values.stateStorage.mountPath .Values.storage.mountPath) -}}
+{{- fail "stateStorage.mountPath must differ from storage.mountPath" -}}
+{{- end -}}
+{{- if and .Values.stateStorage.encryptionKeys.enabled (not .Values.stateStorage.encryptionKeys.mountPath) -}}
+{{- fail "stateStorage.encryptionKeys.mountPath is required when stateStorage.encryptionKeys.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.stateStorage.encryptionKeys.enabled (not .Values.stateStorage.encryptionKeys.subPath) -}}
+{{- fail "stateStorage.encryptionKeys.subPath is required when stateStorage.encryptionKeys.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.stateStorage.syncTokens.enabled (not .Values.stateStorage.syncTokens.mountPath) -}}
+{{- fail "stateStorage.syncTokens.mountPath is required when stateStorage.syncTokens.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.stateStorage.syncTokens.enabled (not .Values.stateStorage.syncTokens.subPath) -}}
+{{- fail "stateStorage.syncTokens.subPath is required when stateStorage.syncTokens.enabled=true" -}}
+{{- end -}}
+{{- end -}}
 {{- $egressProxyEnabled := or .Values.egressProxy.enabled .Values.approvedEgress.enabled -}}
 {{- $egressPolicyEnabled := and $egressProxyEnabled .Values.egressProxy.networkPolicy.create -}}
 {{- if and $egressProxyEnabled (ne .Values.workers.backend "kubernetes") -}}

--- a/cluster/k8s/runtime/templates/validate.yaml
+++ b/cluster/k8s/runtime/templates/validate.yaml
@@ -26,6 +26,21 @@
 {{- if and .Values.stateStorage.mountPath (eq .Values.stateStorage.mountPath .Values.storage.mountPath) -}}
 {{- fail "stateStorage.mountPath must differ from storage.mountPath" -}}
 {{- end -}}
+{{- if and .Values.stateStorage.encryptionKeys.enabled .Values.stateStorage.encryptionKeys.mountPath (eq .Values.stateStorage.encryptionKeys.mountPath .Values.storage.mountPath) -}}
+{{- fail "stateStorage.encryptionKeys.mountPath must differ from storage.mountPath" -}}
+{{- end -}}
+{{- if and .Values.stateStorage.syncTokens.enabled .Values.stateStorage.syncTokens.mountPath (eq .Values.stateStorage.syncTokens.mountPath .Values.storage.mountPath) -}}
+{{- fail "stateStorage.syncTokens.mountPath must differ from storage.mountPath" -}}
+{{- end -}}
+{{- if and .Values.stateStorage.mountPath .Values.stateStorage.encryptionKeys.enabled .Values.stateStorage.encryptionKeys.mountPath (eq .Values.stateStorage.mountPath .Values.stateStorage.encryptionKeys.mountPath) -}}
+{{- fail "stateStorage.mountPath must differ from stateStorage.encryptionKeys.mountPath" -}}
+{{- end -}}
+{{- if and .Values.stateStorage.mountPath .Values.stateStorage.syncTokens.enabled .Values.stateStorage.syncTokens.mountPath (eq .Values.stateStorage.mountPath .Values.stateStorage.syncTokens.mountPath) -}}
+{{- fail "stateStorage.mountPath must differ from stateStorage.syncTokens.mountPath" -}}
+{{- end -}}
+{{- if and .Values.stateStorage.encryptionKeys.enabled .Values.stateStorage.encryptionKeys.mountPath .Values.stateStorage.syncTokens.enabled .Values.stateStorage.syncTokens.mountPath (eq .Values.stateStorage.encryptionKeys.mountPath .Values.stateStorage.syncTokens.mountPath) -}}
+{{- fail "stateStorage.encryptionKeys.mountPath must differ from stateStorage.syncTokens.mountPath" -}}
+{{- end -}}
 {{- if and .Values.stateStorage.encryptionKeys.enabled (not .Values.stateStorage.encryptionKeys.mountPath) -}}
 {{- fail "stateStorage.encryptionKeys.mountPath is required when stateStorage.encryptionKeys.enabled=true" -}}
 {{- end -}}

--- a/cluster/k8s/runtime/values.yaml
+++ b/cluster/k8s/runtime/values.yaml
@@ -145,6 +145,33 @@ storage:
   size: 10Gi
   mountPath: /app/agent_data
 
+stateStorage:
+  # Optional dedicated PVC for restart-critical Matrix client state.
+  enabled: false
+  create: false
+  existingClaim: ""
+  volumeName: state-storage
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ""
+  size: 10Gi
+  mountPath: /app/mindroom_state
+  encryptionKeys:
+    enabled: true
+    mountPath: /app/agent_data/encryption_keys
+    subPath: encryption_keys
+  syncTokens:
+    enabled: true
+    mountPath: /app/agent_data/sync_tokens
+    subPath: sync_tokens
+  initPermissions:
+    enabled: true
+    image: busybox:1.36
+    imagePullPolicy: IfNotPresent
+    runAsUser: 1000
+    fsGroup: 1000
+    chmod: "2775"
+
 env:
   # Raw Kubernetes EnvVar entries appended to the MindRoom container.
   extra: []

--- a/cluster/k8s/runtime/values.yaml
+++ b/cluster/k8s/runtime/values.yaml
@@ -168,6 +168,11 @@ stateStorage:
     enabled: true
     image: busybox:1.36
     imagePullPolicy: IfNotPresent
+    # The init container uses chown/chmod and therefore runs as root by default.
+    securityContext:
+      runAsUser: 0
+      runAsNonRoot: false
+      allowPrivilegeEscalation: false
     runAsUser: 1000
     fsGroup: 1000
     chmod: "2775"

--- a/tests/test_helm_instance_worker_isolation.py
+++ b/tests/test_helm_instance_worker_isolation.py
@@ -1283,6 +1283,110 @@ def test_runtime_chart_static_runner_uses_credentials_encryption_key_secret() ->
     assert _env_by_name(runner_container)["MINDROOM_CREDENTIALS_ENCRYPTION_KEY"] == expected_env
 
 
+def test_runtime_chart_state_storage_renders_existing_pvc_mounts_and_init_permissions(tmp_path: Path) -> None:
+    """Hosted runtimes should keep Matrix client state on a dedicated PVC."""
+    values_path = tmp_path / "values.yaml"
+    values_path.write_text(
+        yaml.safe_dump(
+            {
+                "eventCache": {"postgres": {"auth": {"password": "test-password"}}},
+                "stateStorage": {
+                    "enabled": True,
+                    "existingClaim": "mindroom-state",
+                    "mountPath": "/app/mindroom_state",
+                    "encryptionKeys": {
+                        "enabled": True,
+                        "mountPath": "/app/agent_data/encryption_keys",
+                        "subPath": "encryption_keys",
+                    },
+                    "syncTokens": {
+                        "enabled": True,
+                        "mountPath": "/app/agent_data/sync_tokens",
+                        "subPath": "sync_tokens",
+                    },
+                    "initPermissions": {
+                        "enabled": True,
+                        "runAsUser": 1000,
+                        "fsGroup": 1000,
+                    },
+                },
+                "initContainers": [
+                    {
+                        "name": "custom-init",
+                        "image": "busybox:1.36",
+                        "command": ["sh", "-c", "true"],
+                    },
+                ],
+                "extraVolumes": [{"name": "custom-config", "configMap": {"name": "custom-config"}}],
+                "extraVolumeMounts": [{"name": "custom-config", "mountPath": "/etc/custom"}],
+            },
+        ),
+        encoding="utf-8",
+    )
+    docs = _render_chart(
+        Path("cluster/k8s/runtime"),
+        values_files=(values_path,),
+        release_name="mindroom-runtime",
+    )
+    deployment = _resource(docs, "Deployment", "mindroom-runtime")
+    pod_spec = deployment["spec"]["template"]["spec"]
+    mindroom_container = _container(deployment, "mindroom")
+    volume_mounts = {mount["mountPath"]: mount for mount in mindroom_container["volumeMounts"]}
+    volumes = {volume["name"]: volume for volume in pod_spec["volumes"]}
+    init_containers = {container["name"]: container for container in pod_spec["initContainers"]}
+
+    assert volumes["state-storage"]["persistentVolumeClaim"]["claimName"] == "mindroom-state"
+    assert volumes["custom-config"]["configMap"]["name"] == "custom-config"
+    assert volume_mounts["/app/mindroom_state"] == {
+        "name": "state-storage",
+        "mountPath": "/app/mindroom_state",
+    }
+    assert volume_mounts["/app/agent_data/encryption_keys"] == {
+        "name": "state-storage",
+        "mountPath": "/app/agent_data/encryption_keys",
+        "subPath": "encryption_keys",
+    }
+    assert volume_mounts["/app/agent_data/sync_tokens"] == {
+        "name": "state-storage",
+        "mountPath": "/app/agent_data/sync_tokens",
+        "subPath": "sync_tokens",
+    }
+    assert volume_mounts["/etc/custom"] == {"name": "custom-config", "mountPath": "/etc/custom"}
+
+    assert "prepare-state-storage" in init_containers
+    assert "custom-init" in init_containers
+    assert init_containers["prepare-state-storage"]["volumeMounts"] == [
+        {"name": "state-storage", "mountPath": "/state"},
+    ]
+    assert init_containers["prepare-state-storage"]["command"] == [
+        "sh",
+        "-lc",
+        "set -eu\nmkdir -p /state /state/encryption_keys /state/sync_tokens\n"
+        "chown -R 1000:1000 /state /state/encryption_keys /state/sync_tokens\n"
+        "chmod 2775 /state /state/encryption_keys /state/sync_tokens\n",
+    ]
+
+
+def test_runtime_chart_state_storage_can_create_pvc() -> None:
+    """The runtime chart can manage the dedicated state PVC for simple hosted installs."""
+    docs = _render_chart(
+        Path("cluster/k8s/runtime"),
+        "eventCache.postgres.auth.password=test-password",
+        "stateStorage.enabled=true",
+        "stateStorage.create=true",
+        "stateStorage.size=20Gi",
+        "stateStorage.storageClassName=fast-rwo",
+        release_name="mindroom-runtime",
+    )
+    pvc = _resource(docs, "PersistentVolumeClaim", "mindroom-runtime-state")
+
+    assert pvc["spec"] == {
+        "accessModes": ["ReadWriteOnce"],
+        "storageClassName": "fast-rwo",
+        "resources": {"requests": {"storage": "20Gi"}},
+    }
+
+
 def test_runtime_chart_separate_worker_namespace_can_manage_per_worker_auth_secrets() -> None:
     """Explicit worker namespaces may use per-worker Secrets in that namespace."""
     docs = _render_runtime_chart_with_separate_worker_namespace()

--- a/tests/test_helm_instance_worker_isolation.py
+++ b/tests/test_helm_instance_worker_isolation.py
@@ -1358,13 +1358,16 @@ def test_runtime_chart_state_storage_renders_existing_pvc_mounts_and_init_permis
     assert init_containers["prepare-state-storage"]["volumeMounts"] == [
         {"name": "state-storage", "mountPath": "/state"},
     ]
-    assert init_containers["prepare-state-storage"]["command"] == [
-        "sh",
-        "-lc",
-        "set -eu\nmkdir -p /state /state/encryption_keys /state/sync_tokens\n"
-        "chown -R 1000:1000 /state /state/encryption_keys /state/sync_tokens\n"
-        "chmod 2775 /state /state/encryption_keys /state/sync_tokens\n",
-    ]
+    assert init_containers["prepare-state-storage"]["securityContext"] == {
+        "runAsUser": 0,
+        "runAsNonRoot": False,
+        "allowPrivilegeEscalation": False,
+    }
+    assert init_containers["prepare-state-storage"]["command"][:2] == ["sh", "-c"]
+    state_command = init_containers["prepare-state-storage"]["command"][2]
+    assert 'mkdir -p "/state" "/state/encryption_keys" "/state/sync_tokens"' in state_command
+    assert 'chown -R 1000:1000 "/state" "/state/encryption_keys" "/state/sync_tokens"' in state_command
+    assert 'chmod 2775 "/state" "/state/encryption_keys" "/state/sync_tokens"' in state_command
 
 
 def test_runtime_chart_state_storage_can_create_pvc() -> None:
@@ -1385,6 +1388,49 @@ def test_runtime_chart_state_storage_can_create_pvc() -> None:
         "storageClassName": "fast-rwo",
         "resources": {"requests": {"storage": "20Gi"}},
     }
+
+
+@pytest.mark.parametrize(
+    ("conflict_args", "expected_error"),
+    [
+        (
+            ("stateStorage.mountPath=/app/agent_data/encryption_keys",),
+            "stateStorage.mountPath must differ from stateStorage.encryptionKeys.mountPath",
+        ),
+        (
+            ("stateStorage.mountPath=/app/agent_data/sync_tokens",),
+            "stateStorage.mountPath must differ from stateStorage.syncTokens.mountPath",
+        ),
+        (
+            ("stateStorage.encryptionKeys.mountPath=/app/agent_data",),
+            "stateStorage.encryptionKeys.mountPath must differ from storage.mountPath",
+        ),
+        (
+            ("stateStorage.syncTokens.mountPath=/app/agent_data",),
+            "stateStorage.syncTokens.mountPath must differ from storage.mountPath",
+        ),
+        (
+            ("stateStorage.syncTokens.mountPath=/app/agent_data/encryption_keys",),
+            "stateStorage.encryptionKeys.mountPath must differ from stateStorage.syncTokens.mountPath",
+        ),
+    ],
+)
+def test_runtime_chart_state_storage_rejects_mount_path_conflicts(
+    conflict_args: tuple[str, ...],
+    expected_error: str,
+) -> None:
+    """Generated runtime volumeMount paths must stay unique."""
+    completed = _run_helm_template(
+        Path("cluster/k8s/runtime"),
+        "eventCache.postgres.auth.password=test-password",
+        "stateStorage.enabled=true",
+        "stateStorage.existingClaim=mindroom-state",
+        *conflict_args,
+        release_name="mindroom-runtime",
+    )
+
+    assert completed.returncode != 0
+    assert expected_error in completed.stderr
 
 
 def test_runtime_chart_separate_worker_namespace_can_manage_per_worker_auth_secrets() -> None:

--- a/tests/test_matrix_sync_tokens.py
+++ b/tests/test_matrix_sync_tokens.py
@@ -933,8 +933,6 @@ async def test_shutdown_timeout_reaches_already_running_same_window_reservation_
     """Bounded shutdown should interrupt same-window reservation waits already in progress."""
     shutting_down = False
     wait_entered = asyncio.Event()
-    target_reservation: IngressOrderReservation | None = None
-
     gate = CoalescingGate(
         dispatch_batch=AsyncMock(),
         debounce_seconds=lambda: 0.01,
@@ -942,6 +940,8 @@ async def test_shutdown_timeout_reaches_already_running_same_window_reservation_
         is_shutting_down=lambda: shutting_down,
     )
     key = CoalescingKey("!room:localhost", "$thread:localhost", "@user:localhost")
+    front_reservation = gate.reserve_order(room_id=key.room_id, requester_user_id=key.requester_user_id)
+    target_reservation = gate.reserve_order(room_id=key.room_id, requester_user_id=key.requester_user_id)
 
     original_wait_for_reservations = gate._wait_for_reservations
 
@@ -949,7 +949,7 @@ async def test_shutdown_timeout_reaches_already_running_same_window_reservation_
         wait_gate: _GateEntry,
         reservations: list[IngressOrderReservation],
     ) -> None:
-        if target_reservation is not None and target_reservation in reservations:
+        if target_reservation in reservations:
             wait_entered.set()
         await original_wait_for_reservations(wait_gate, reservations)
 
@@ -958,15 +958,14 @@ async def test_shutdown_timeout_reaches_already_running_same_window_reservation_
     await gate.admit(
         key,
         ready_result=ReadyPendingEvent(pending_event=_pending(_text_event("$text:localhost", "typed", 1000))),
+        order_reservation=front_reservation,
     )
-    reservation = gate.reserve_order(room_id=key.room_id, requester_user_id=key.requester_user_id)
-    target_reservation = reservation
     await asyncio.wait_for(wait_entered.wait(), timeout=5.0)
 
     shutting_down = True
     result = await gate.drain_all(ready_timeout_seconds=0.05)
 
-    assert reservation.released is True
+    assert target_reservation.released is True
     assert result.completed is False
     assert result.released_reservation_count == 1
 


### PR DESCRIPTION
## Summary
- Add runtime chart `stateStorage` values for dedicated persistent runtime state.
- Render optional state PVCs, existing PVC mounts, encryption-key and sync-token subPath overlays, and permission init container.
- Document a neutral hosted setup and add Helm render tests.

## Test Plan
- `helm lint cluster/k8s/runtime`
- `helm template mindroom-runtime cluster/k8s/runtime --set eventCache.postgres.auth.password=test-password`
- `helm template mindroom-runtime cluster/k8s/runtime --set eventCache.postgres.auth.password=test-password --set stateStorage.enabled=true --set stateStorage.create=true --set stateStorage.size=20Gi`
- `uv run pytest tests/test_helm_instance_worker_isolation.py -q`
- `uv run pytest tests/test_matrix_sync_tokens.py -q -n 0 --no-cov`
- `uv run pytest tests/test_matrix_sync_tokens.py -q -n 2 --no-cov`
- GitHub checks passed: `build`, `markdown-code-runner`, `runtime-chart`, `scan`, `smoke`, `test (3.13)`.
