### PR TITLE
Add runtime content bundles

### DIFF
--- a/cluster/k8s/runtime/README.md
+++ b/cluster/k8s/runtime/README.md
@@ -120,6 +120,56 @@ stateStorage:
   size: 20Gi
 ```
 
+## Content Bundles
+
+Hosted deployments can copy immutable private content into MindRoom storage before the runtime starts.
+Use `contentBundles` for plugins, skills, agent templates, workspace templates, policy files, and small seed scripts that are packaged into an OCI image.
+The chart does not clone repositories or download release assets at pod startup.
+Private registry access should use normal Kubernetes image pull credentials through `imagePullSecrets`.
+
+Each bundle image must be pinned by digest and must contain a POSIX shell, `cp`, and `mkdir`, because the chart runs the bundle image as a copy init container.
+Because `overwrite` defaults to true, bundle images also need `rm` unless every bundle sets `overwrite: false`.
+Package content under `/bundle` by default:
+
+```dockerfile
+FROM busybox:1.36
+COPY . /bundle
+```
+
+Configure one or more bundles:
+
+```yaml
+imagePullSecrets:
+  - name: private-registry-pull
+
+contentBundles:
+  - name: team-config
+    image: ghcr.io/example/acme-mindroom-config@sha256:1111111111111111111111111111111111111111111111111111111111111111
+    sourcePath: /bundle
+    targetPath: /app/agent_data/content-bundles/team-config
+    seed:
+      enabled: true
+      command:
+        - /app/agent_data/content-bundles/team-config/scripts/seed-content.sh
+
+  - name: private-agent-content
+    image: ghcr.io/example/private-agent-content@sha256:2222222222222222222222222222222222222222222222222222222222222222
+```
+
+If `targetPath` is omitted, the chart copies to `/app/agent_data/content-bundles/<name>`.
+The init container removes the target path before copying unless `overwrite: false` is set.
+`seed.command` runs after the copy and should point at a short script or executable supplied by the bundle instead of embedding deployment-specific shell in Helm values.
+The script runs in the same bundle image, with MindRoom storage mounted at `storage.mountPath`.
+Raw `initContainers`, `extraVolumes`, and `extraVolumeMounts` still work for deployments that need lower-level Kubernetes wiring.
+
+Reference copied plugins from `config.yaml` with absolute paths:
+
+```yaml
+plugins:
+  - /app/agent_data/content-bundles/team-config/plugins/review-tools
+  - /app/agent_data/content-bundles/private-agent-content/plugins/team-tools
+```
+
 ## Worker Egress Proxy
 
 For dedicated Kubernetes workers, the chart can either deploy the approved egress proxy or point workers at an existing HTTP proxy Service.

--- a/cluster/k8s/runtime/templates/_helpers.tpl
+++ b/cluster/k8s/runtime/templates/_helpers.tpl
@@ -95,6 +95,26 @@ app.kubernetes.io/component: runtime
 {{- default "state-storage" .Values.stateStorage.volumeName -}}
 {{- end -}}
 
+{{- define "mindroom-runtime.contentBundleSourcePath" -}}
+{{- $bundle := index . 1 -}}
+{{- $sourcePath := default "/bundle" $bundle.sourcePath | clean -}}
+{{- if eq $sourcePath "/" -}}/{{- else -}}{{ $sourcePath | trimSuffix "/" }}{{- end -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.contentBundleTargetPath" -}}
+{{- $root := index . 0 -}}
+{{- $bundle := index . 1 -}}
+{{- $targetPath := default (printf "%s/content-bundles/%s" ($root.Values.storage.mountPath | trimSuffix "/") $bundle.name) $bundle.targetPath | clean -}}
+{{- if eq $targetPath "/" -}}/{{- else -}}{{ $targetPath | trimSuffix "/" }}{{- end -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.contentBundleSeedCommand" -}}
+{{- $bundle := index . 0 -}}
+{{- range $argIndex, $arg := $bundle.seed.command -}}
+{{- if $argIndex }} {{ end -}}{{ $arg | quote -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "mindroom-runtime.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
 {{- default (include "mindroom-runtime.fullname" .) .Values.serviceAccount.name -}}

--- a/cluster/k8s/runtime/templates/deployment.yaml
+++ b/cluster/k8s/runtime/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if or (and .Values.stateStorage.enabled .Values.stateStorage.initPermissions.enabled) .Values.initContainers }}
+      {{- if or (and .Values.stateStorage.enabled .Values.stateStorage.initPermissions.enabled) .Values.initContainers .Values.contentBundles }}
       initContainers:
 {{ if and .Values.stateStorage.enabled .Values.stateStorage.initPermissions.enabled }}
         - name: prepare-state-storage
@@ -89,7 +89,54 @@ spec:
 {{- end }}
         {{- with .Values.initContainers }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
+        {{ range $bundle := .Values.contentBundles }}
+        {{- $sourcePath := include "mindroom-runtime.contentBundleSourcePath" (list $ $bundle) -}}
+        {{- $targetPath := include "mindroom-runtime.contentBundleTargetPath" (list $ $bundle) -}}
+        {{- $overwrite := true -}}
+        {{- if hasKey $bundle "overwrite" -}}
+        {{- $overwrite = $bundle.overwrite -}}
+        {{- end -}}
+        - name: {{ printf "content-bundle-%s" $bundle.name | trunc 63 | trimSuffix "-" }}
+          image: {{ $bundle.image | quote }}
+          imagePullPolicy: {{ default "IfNotPresent" $bundle.imagePullPolicy }}
+          command:
+            - sh
+            - -ec
+          args:
+            - |-
+              set -eu
+              {{- if $overwrite }}
+              rm -rf {{ $targetPath | quote }}
+              {{- end }}
+              mkdir -p {{ $targetPath | quote }}
+              cp -a {{ printf "%s/." $sourcePath | quote }} {{ printf "%s/" $targetPath | quote }}
+              {{- if and $bundle.seed $bundle.seed.enabled }}
+              {{ include "mindroom-runtime.contentBundleSeedCommand" (list $bundle) }}
+              {{- end }}
+          volumeMounts:
+            - name: {{ include "mindroom-runtime.storageVolumeName" $ }}
+              mountPath: {{ $.Values.storage.mountPath }}
+            {{ with $bundle.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{ end }}
+          {{ with $bundle.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{ end }}
+          {{ with $bundle.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{ end }}
+          {{ with $bundle.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{ end }}
+          {{ with $bundle.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{ end }}
+        {{ end }}
       {{- end }}
       containers:
         - name: mindroom

--- a/cluster/k8s/runtime/templates/validate.yaml
+++ b/cluster/k8s/runtime/templates/validate.yaml
@@ -54,6 +54,49 @@
 {{- fail "stateStorage.syncTokens.subPath is required when stateStorage.syncTokens.enabled=true" -}}
 {{- end -}}
 {{- end -}}
+{{- $contentBundleNames := dict -}}
+{{- range $index, $bundle := .Values.contentBundles -}}
+{{- if not $bundle.name -}}
+{{- fail (printf "contentBundles[%d].name is required" $index) -}}
+{{- end -}}
+{{- if not (regexMatch "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$" $bundle.name) -}}
+{{- fail (printf "contentBundles[%d].name must contain only lowercase letters, numbers, and hyphens" $index) -}}
+{{- end -}}
+{{- if gt (len $bundle.name) 48 -}}
+{{- fail (printf "contentBundles[%d].name must be 48 characters or fewer" $index) -}}
+{{- end -}}
+{{- if hasKey $contentBundleNames $bundle.name -}}
+{{- fail (printf "contentBundles[%d].name %q is used more than once" $index $bundle.name) -}}
+{{- end -}}
+{{- $_ := set $contentBundleNames $bundle.name true -}}
+{{- if not $bundle.image -}}
+{{- fail (printf "contentBundles[%d].image is required" $index) -}}
+{{- end -}}
+{{- if not (regexMatch "@sha256:[a-f0-9]{64}$" $bundle.image) -}}
+{{- fail (printf "contentBundles[%d].image must be pinned by full sha256 digest" $index) -}}
+{{- end -}}
+{{- $sourcePath := default "/bundle" $bundle.sourcePath -}}
+{{- if not (hasPrefix "/" $sourcePath) -}}
+{{- fail (printf "contentBundles[%d].sourcePath must be absolute" $index) -}}
+{{- end -}}
+{{- if and $bundle.targetPath (not (hasPrefix "/" $bundle.targetPath)) -}}
+{{- fail (printf "contentBundles[%d].targetPath must be absolute" $index) -}}
+{{- end -}}
+{{- $targetPath := include "mindroom-runtime.contentBundleTargetPath" (list $ $bundle) -}}
+{{- $storageMountPath := $.Values.storage.mountPath | trimSuffix "/" -}}
+{{- if eq $storageMountPath "" -}}
+{{- $storageMountPath = "/" -}}
+{{- end -}}
+{{- if eq $targetPath $storageMountPath -}}
+{{- fail (printf "contentBundles[%d].targetPath cannot be equal to storage.mountPath %s" $index $.Values.storage.mountPath) -}}
+{{- end -}}
+{{- if and (ne $storageMountPath "/") (not (hasPrefix (printf "%s/" $storageMountPath) $targetPath)) -}}
+{{- fail (printf "contentBundles[%d].targetPath must be under storage.mountPath %s" $index $.Values.storage.mountPath) -}}
+{{- end -}}
+{{- if and $bundle.seed $bundle.seed.enabled (not $bundle.seed.command) -}}
+{{- fail (printf "contentBundles[%d].seed.command is required when seed.enabled=true" $index) -}}
+{{- end -}}
+{{- end -}}
 {{- $egressProxyEnabled := or .Values.egressProxy.enabled .Values.approvedEgress.enabled -}}
 {{- $egressPolicyEnabled := and $egressProxyEnabled .Values.egressProxy.networkPolicy.create -}}
 {{- if and $egressProxyEnabled (ne .Values.workers.backend "kubernetes") -}}

--- a/cluster/k8s/runtime/values.yaml
+++ b/cluster/k8s/runtime/values.yaml
@@ -177,6 +177,21 @@ stateStorage:
     fsGroup: 1000
     chmod: "2775"
 
+# Immutable content bundles copied into runtime storage before MindRoom starts.
+# Bundle images should be pinned by digest and contain files under sourcePath.
+# The default target path is <storage.mountPath>/content-bundles/<name>.
+contentBundles: []
+# Example:
+# contentBundles:
+#   - name: team-config
+#     image: ghcr.io/example/team-config@sha256:1111111111111111111111111111111111111111111111111111111111111111
+#     sourcePath: /bundle
+#     targetPath: /app/agent_data/content-bundles/team-config
+#     seed:
+#       enabled: true
+#       command:
+#         - /app/agent_data/content-bundles/team-config/scripts/seed-content.sh
+
 env:
   # Raw Kubernetes EnvVar entries appended to the MindRoom container.
   extra: []

--- a/tests/test_helm_instance_worker_isolation.py
+++ b/tests/test_helm_instance_worker_isolation.py
@@ -343,18 +343,25 @@ def test_runtime_chart_renders_content_bundle_init_containers_after_user_init_co
     ]
 
 
-def test_runtime_chart_rejects_content_bundle_images_without_digest() -> None:
+@pytest.mark.parametrize(
+    "image",
+    [
+        "ghcr.io/example/team-config:latest",
+        "ghcr.io/example/team-config@sha256:short",
+    ],
+)
+def test_runtime_chart_rejects_content_bundle_images_without_digest(image: str) -> None:
     """Hosted bundles should be pinned to immutable image digests."""
     completed = _run_helm_template(
         Path("cluster/k8s/runtime"),
         "eventCache.postgres.auth.password=test-password",
         "contentBundles[0].name=team-config",
-        "contentBundles[0].image=ghcr.io/example/team-config:latest",
+        f"contentBundles[0].image={image}",
         release_name="mindroom-runtime",
     )
 
     assert completed.returncode != 0
-    assert "contentBundles[0].image must include @sha256:" in completed.stderr
+    assert "contentBundles[0].image must be pinned by full sha256 digest" in completed.stderr
 
 
 def test_runtime_chart_rejects_duplicate_content_bundle_names() -> None:
@@ -395,6 +402,7 @@ def test_runtime_chart_rejects_content_bundle_names_that_would_be_truncated() ->
     [
         ("/app/agent_data", "contentBundles[0].targetPath cannot be equal to storage.mountPath /app/agent_data"),
         ("/app/content/team-config", "contentBundles[0].targetPath must be under storage.mountPath /app/agent_data"),
+        ("/app/agent_data/../outside", "contentBundles[0].targetPath must be under storage.mountPath /app/agent_data"),
     ],
 )
 def test_runtime_chart_rejects_content_bundle_target_paths_outside_storage(target_path: str, message: str) -> None:
@@ -411,6 +419,23 @@ def test_runtime_chart_rejects_content_bundle_target_paths_outside_storage(targe
 
     assert completed.returncode != 0
     assert message in completed.stderr
+
+
+def test_runtime_chart_rejects_content_bundle_target_path_equal_root_storage() -> None:
+    """The root path should not be accepted when storage itself is mounted at root."""
+    completed = _run_helm_template(
+        Path("cluster/k8s/runtime"),
+        "eventCache.postgres.auth.password=test-password",
+        "storage.mountPath=/",
+        "contentBundles[0].name=team-config",
+        "contentBundles[0].image=ghcr.io/example/team-config@sha256:"
+        "1111111111111111111111111111111111111111111111111111111111111111",
+        "contentBundles[0].targetPath=/",
+        release_name="mindroom-runtime",
+    )
+
+    assert completed.returncode != 0
+    assert "contentBundles[0].targetPath cannot be equal to storage.mountPath /" in completed.stderr
 
 
 def test_instance_chart_worker_manager_can_only_patch_own_worker_auth_secret() -> None:

--- a/tests/test_helm_instance_worker_isolation.py
+++ b/tests/test_helm_instance_worker_isolation.py
@@ -108,6 +108,15 @@ def _container(deployment: dict[str, Any], name: str) -> dict[str, Any]:
     raise AssertionError(msg)
 
 
+def _init_container(deployment: dict[str, Any], name: str) -> dict[str, Any]:
+    init_containers = deployment["spec"]["template"]["spec"].get("initContainers", [])
+    for container in init_containers:
+        if container["name"] == name:
+            return container
+    msg = f"init container {name} was not rendered"
+    raise AssertionError(msg)
+
+
 def _env_by_name(container: dict[str, Any]) -> dict[str, dict[str, Any]]:
     return {env["name"]: env for env in container["env"]}
 
@@ -252,6 +261,100 @@ def test_instance_chart_wires_image_pull_secrets_to_control_plane_pods() -> None
 
     assert deployment["spec"]["template"]["spec"]["imagePullSecrets"] == [{"name": "ghcr-pull"}]
     assert worker_manager_account["imagePullSecrets"] == [{"name": "ghcr-pull"}]
+
+
+def test_runtime_chart_renders_content_bundle_init_containers_after_user_init_containers(tmp_path: Path) -> None:
+    """Content bundles should copy immutable image contents into runtime storage without replacing user hooks."""
+    values_path = tmp_path / "content-bundles.yaml"
+    values_path.write_text(
+        yaml.safe_dump(
+            {
+                "eventCache": {"postgres": {"auth": {"password": "test-password"}}},
+                "initContainers": [
+                    {
+                        "name": "prepare-storage",
+                        "image": "busybox:1.36",
+                        "command": ["sh", "-ec", "mkdir -p /app/agent_data/bootstrap"],
+                    },
+                ],
+                "contentBundles": [
+                    {
+                        "name": "team-config",
+                        "image": "ghcr.io/example/team-config@sha256:"
+                        "1111111111111111111111111111111111111111111111111111111111111111",
+                        "sourcePath": "/bundle",
+                        "targetPath": "/app/agent_data/content-bundles/team-config",
+                        "seed": {
+                            "enabled": True,
+                            "command": [
+                                "/app/agent_data/content-bundles/team-config/scripts/seed-content.sh",
+                            ],
+                        },
+                    },
+                    {
+                        "name": "private-agent-content",
+                        "image": "ghcr.io/example/private-agent-content@sha256:"
+                        "2222222222222222222222222222222222222222222222222222222222222222",
+                        "overwrite": False,
+                    },
+                ],
+            },
+        ),
+        encoding="utf-8",
+    )
+
+    docs = _render_chart(
+        Path("cluster/k8s/runtime"),
+        values_files=(values_path,),
+        release_name="mindroom-runtime",
+    )
+    deployment = _resource(docs, "Deployment", "mindroom-runtime")
+    pod_spec = deployment["spec"]["template"]["spec"]
+    team_config = _init_container(deployment, "content-bundle-team-config")
+    agent_content = _init_container(deployment, "content-bundle-private-agent-content")
+
+    assert [container["name"] for container in pod_spec["initContainers"]][:3] == [
+        "prepare-storage",
+        "content-bundle-team-config",
+        "content-bundle-private-agent-content",
+    ]
+    assert team_config["image"] == (
+        "ghcr.io/example/team-config@sha256:1111111111111111111111111111111111111111111111111111111111111111"
+    )
+    assert team_config["imagePullPolicy"] == "IfNotPresent"
+    assert team_config["command"] == ["sh", "-ec"]
+    assert team_config["args"] == [
+        "set -eu\n"
+        'rm -rf "/app/agent_data/content-bundles/team-config"\n'
+        'mkdir -p "/app/agent_data/content-bundles/team-config"\n'
+        'cp -a "/bundle/." "/app/agent_data/content-bundles/team-config/"\n'
+        '"/app/agent_data/content-bundles/team-config/scripts/seed-content.sh"',
+    ]
+    assert team_config["volumeMounts"] == [
+        {
+            "name": "storage",
+            "mountPath": "/app/agent_data",
+        },
+    ]
+    assert agent_content["args"] == [
+        "set -eu\n"
+        'mkdir -p "/app/agent_data/content-bundles/private-agent-content"\n'
+        'cp -a "/bundle/." "/app/agent_data/content-bundles/private-agent-content/"',
+    ]
+
+
+def test_runtime_chart_rejects_content_bundle_images_without_digest() -> None:
+    """Hosted bundles should be pinned to immutable image digests."""
+    completed = _run_helm_template(
+        Path("cluster/k8s/runtime"),
+        "eventCache.postgres.auth.password=test-password",
+        "contentBundles[0].name=team-config",
+        "contentBundles[0].image=ghcr.io/example/team-config:latest",
+        release_name="mindroom-runtime",
+    )
+
+    assert completed.returncode != 0
+    assert "contentBundles[0].image must include @sha256:" in completed.stderr
 
 
 def test_instance_chart_worker_manager_can_only_patch_own_worker_auth_secret() -> None:

--- a/tests/test_helm_instance_worker_isolation.py
+++ b/tests/test_helm_instance_worker_isolation.py
@@ -357,6 +357,62 @@ def test_runtime_chart_rejects_content_bundle_images_without_digest() -> None:
     assert "contentBundles[0].image must include @sha256:" in completed.stderr
 
 
+def test_runtime_chart_rejects_duplicate_content_bundle_names() -> None:
+    """Generated init container names must stay unique."""
+    completed = _run_helm_template(
+        Path("cluster/k8s/runtime"),
+        "eventCache.postgres.auth.password=test-password",
+        "contentBundles[0].name=team-config",
+        "contentBundles[0].image=ghcr.io/example/team-config@sha256:"
+        "1111111111111111111111111111111111111111111111111111111111111111",
+        "contentBundles[1].name=team-config",
+        "contentBundles[1].image=ghcr.io/example/other-config@sha256:"
+        "2222222222222222222222222222222222222222222222222222222222222222",
+        release_name="mindroom-runtime",
+    )
+
+    assert completed.returncode != 0
+    assert 'contentBundles[1].name "team-config" is used more than once' in completed.stderr
+
+
+def test_runtime_chart_rejects_content_bundle_names_that_would_be_truncated() -> None:
+    """Bundle names must fit in generated Kubernetes init container names."""
+    completed = _run_helm_template(
+        Path("cluster/k8s/runtime"),
+        "eventCache.postgres.auth.password=test-password",
+        f"contentBundles[0].name={'a' * 49}",
+        "contentBundles[0].image=ghcr.io/example/team-config@sha256:"
+        "1111111111111111111111111111111111111111111111111111111111111111",
+        release_name="mindroom-runtime",
+    )
+
+    assert completed.returncode != 0
+    assert "contentBundles[0].name must be 48 characters or fewer" in completed.stderr
+
+
+@pytest.mark.parametrize(
+    ("target_path", "message"),
+    [
+        ("/app/agent_data", "contentBundles[0].targetPath cannot be equal to storage.mountPath /app/agent_data"),
+        ("/app/content/team-config", "contentBundles[0].targetPath must be under storage.mountPath /app/agent_data"),
+    ],
+)
+def test_runtime_chart_rejects_content_bundle_target_paths_outside_storage(target_path: str, message: str) -> None:
+    """Bundle copy targets must stay inside runtime storage."""
+    completed = _run_helm_template(
+        Path("cluster/k8s/runtime"),
+        "eventCache.postgres.auth.password=test-password",
+        "contentBundles[0].name=team-config",
+        "contentBundles[0].image=ghcr.io/example/team-config@sha256:"
+        "1111111111111111111111111111111111111111111111111111111111111111",
+        f"contentBundles[0].targetPath={target_path}",
+        release_name="mindroom-runtime",
+    )
+
+    assert completed.returncode != 0
+    assert message in completed.stderr
+
+
 def test_instance_chart_worker_manager_can_only_patch_own_worker_auth_secret() -> None:
     """Shared-namespace instances must not get cross-tenant Secret permissions."""
     docs = _render_instance_chart()


### PR DESCRIPTION
## Design Note

This adds a generic runtime chart API for digest-pinned content bundles.
Bundles are neutral OCI images copied into MindRoom storage before startup, so hosted deployments can provide plugins, skills, agent templates, workspace templates, policies, and seed scripts without cloning repositories or embedding download shell in Helm values.
The chart keeps existing raw `initContainers`, `extraVolumes`, and `extraVolumeMounts`, and app config can reference copied content through stable absolute paths under `/app/agent_data/content-bundles/<name>`.
This first step supports OCI image bundles only; tarball checksum support can be added later against the same target path and seed model.

## Changes

- Add `contentBundles` values, validation, and init-container rendering.
- Copy each bundle from `/bundle` by default into runtime storage, with optional overwrite and seed command control.
- Document neutral OCI bundle packaging and plugin path examples.
- Add Helm render tests for ordering, copy, seed, overwrite, and digest validation.

## Tests

- `uv sync --all-extras --frozen`
- `helm lint cluster/k8s/runtime`
- `uv run pre-commit run --files cluster/k8s/runtime/README.md cluster/k8s/runtime/templates/_helpers.tpl cluster/k8s/runtime/templates/deployment.yaml cluster/k8s/runtime/templates/validate.yaml cluster/k8s/runtime/values.yaml tests/test_helm_instance_worker_isolation.py`
- `uv run pytest tests/test_helm_instance_worker_isolation.py -q`
- `uv run pytest -q -o 'addopts=-p no:tach -vvv -n auto --asyncio-mode=strict --timeout 60 --durations 20'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for content bundles to package and install immutable private content via OCI image bundles into runtime storage before startup.
  * Optional seeding commands for bundles post-installation.
  * Full validation of bundle configuration.

* **Documentation**
  * Added comprehensive content bundles documentation with configuration examples and usage patterns.

* **Tests**
  * Added validation tests for content bundle rendering and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->