### PR TITLE
Support file-based runtime chart config

### DIFF
--- a/cluster/k8s/runtime/README.md
+++ b/cluster/k8s/runtime/README.md
@@ -84,7 +84,7 @@ Set `config.source: file` when another init container or content bundle places `
 In file mode, `config.path` must be an absolute container path.
 In file mode, the chart does not render or mount the runtime config ConfigMap.
 Dedicated Kubernetes workers receive the same config file path and do not receive worker ConfigMap settings.
-Dedicated Kubernetes workers also mount the shared runtime storage PVC at `storage.mountPath` so content-bundle files under that path are visible.
+Dedicated Kubernetes workers also mount the storage subtree containing the config file read-only so content-bundle files under that subtree are visible without broad worker state access.
 
 Use a content bundle as the source of truth for the runtime config:
 

--- a/cluster/k8s/runtime/README.md
+++ b/cluster/k8s/runtime/README.md
@@ -76,6 +76,29 @@ eventCache:
 When `config.create` is enabled and `config.data` is empty, the chart renders a minimal config whose `cache` section follows `eventCache`.
 When using `config.existingConfigMap` or custom `config.data`, keep that config's cache settings aligned with the chart values.
 
+## Config Sources
+
+By default the chart keeps the existing ConfigMap behavior.
+Omit `config.source` or set `config.source: configMap` to mount a chart-created or existing ConfigMap at `config.mountPath`.
+Set `config.source: file` when another init container or content bundle places `agent-config.yaml` on the runtime filesystem before MindRoom starts.
+In file mode, `config.path` must be an absolute container path.
+In file mode, the chart does not render or mount the runtime config ConfigMap.
+Dedicated Kubernetes workers receive the same config file path and do not receive worker ConfigMap settings.
+Dedicated Kubernetes workers also mount the shared runtime storage PVC at `storage.mountPath` so content-bundle files under that path are visible.
+
+Use a content bundle as the source of truth for the runtime config:
+
+```yaml
+contentBundles:
+  - name: team-config
+    image: registry.example.com/team/mindroom-config@sha256:1111111111111111111111111111111111111111111111111111111111111111
+    targetPath: /app/agent_data/content-bundles/team-config
+
+config:
+  source: file
+  path: /app/agent_data/content-bundles/team-config/content/environments/prod/agent-config.yaml
+```
+
 ## Runtime State Storage
 
 MindRoom stores Matrix encryption keys and sync-token checkpoints under `MINDROOM_STORAGE_PATH`.
@@ -144,7 +167,7 @@ imagePullSecrets:
 
 contentBundles:
   - name: team-config
-    image: ghcr.io/example/acme-mindroom-config@sha256:1111111111111111111111111111111111111111111111111111111111111111
+    image: registry.example.com/team/mindroom-config@sha256:1111111111111111111111111111111111111111111111111111111111111111
     sourcePath: /bundle
     targetPath: /app/agent_data/content-bundles/team-config
     seed:
@@ -152,8 +175,8 @@ contentBundles:
       command:
         - /app/agent_data/content-bundles/team-config/scripts/seed-content.sh
 
-  - name: private-agent-content
-    image: ghcr.io/example/private-agent-content@sha256:2222222222222222222222222222222222222222222222222222222222222222
+  - name: policy-pack
+    image: registry.example.com/team/policy-pack@sha256:2222222222222222222222222222222222222222222222222222222222222222
 ```
 
 If `targetPath` is omitted, the chart copies to `/app/agent_data/content-bundles/<name>`.
@@ -167,7 +190,7 @@ Reference copied plugins from `config.yaml` with absolute paths:
 ```yaml
 plugins:
   - /app/agent_data/content-bundles/team-config/plugins/review-tools
-  - /app/agent_data/content-bundles/private-agent-content/plugins/team-tools
+  - /app/agent_data/content-bundles/policy-pack/plugins/policy-tools
 ```
 
 ## Worker Egress Proxy

--- a/cluster/k8s/runtime/templates/_helpers.tpl
+++ b/cluster/k8s/runtime/templates/_helpers.tpl
@@ -71,6 +71,22 @@ app.kubernetes.io/component: runtime
 {{- end -}}
 {{- end -}}
 
+{{- define "mindroom-runtime.configSource" -}}
+{{- default "configMap" .Values.config.source -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.usesConfigMapConfig" -}}
+{{- if eq (include "mindroom-runtime.configSource" .) "configMap" -}}true{{- end -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.configPath" -}}
+{{- if eq (include "mindroom-runtime.configSource" .) "file" -}}
+{{- .Values.config.path -}}
+{{- else -}}
+{{- .Values.config.mountPath -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "mindroom-runtime.storageClaimName" -}}
 {{- if .Values.storage.existingClaim -}}
 {{- .Values.storage.existingClaim -}}
@@ -140,15 +156,25 @@ app.kubernetes.io/component: runtime
 {{- end -}}
 
 {{- define "mindroom-runtime.workerConfigMapName" -}}
+{{- if eq (include "mindroom-runtime.configSource" .) "file" -}}
+{{- else -}}
 {{- default (include "mindroom-runtime.configMapName" .) .Values.workers.kubernetes.configMapName -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "mindroom-runtime.workerConfigKey" -}}
+{{- if eq (include "mindroom-runtime.configSource" .) "file" -}}
+{{- else -}}
 {{- default .Values.config.key .Values.workers.kubernetes.configKey -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "mindroom-runtime.workerConfigPath" -}}
+{{- if eq (include "mindroom-runtime.configSource" .) "file" -}}
+{{- include "mindroom-runtime.configPath" . -}}
+{{- else -}}
 {{- default .Values.config.mountPath .Values.workers.kubernetes.configPath -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "mindroom-runtime.workerNamespace" -}}

--- a/cluster/k8s/runtime/templates/configmap.yaml
+++ b/cluster/k8s/runtime/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.config.create (not .Values.config.existingConfigMap) }}
+{{- if and (include "mindroom-runtime.usesConfigMapConfig" .) .Values.config.create (not .Values.config.existingConfigMap) }}
 {{- $configData := default (include "mindroom-runtime.defaultConfig" .) .Values.config.data -}}
 apiVersion: v1
 kind: ConfigMap

--- a/cluster/k8s/runtime/templates/deployment.yaml
+++ b/cluster/k8s/runtime/templates/deployment.yaml
@@ -8,6 +8,11 @@
 {{- $workerExtraEnvJson := include "mindroom-runtime.workerExtraEnvJson" . -}}
 {{- $approvedEgressTokenSecretName := include "mindroom-runtime.approvedEgressTokenSecretName" . -}}
 {{- $approvedEgressTokenSecretKey := include "mindroom-runtime.approvedEgressTokenSecretKey" . -}}
+{{- $usesConfigMapConfig := include "mindroom-runtime.usesConfigMapConfig" . -}}
+{{- $configPath := include "mindroom-runtime.configPath" . -}}
+{{- $workerConfigMapName := include "mindroom-runtime.workerConfigMapName" . -}}
+{{- $workerConfigKey := include "mindroom-runtime.workerConfigKey" . -}}
+{{- $workerConfigPath := include "mindroom-runtime.workerConfigPath" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -159,7 +164,7 @@ spec:
             - name: MINDROOM_STORAGE_PATH
               value: {{ .Values.storage.mountPath | quote }}
             - name: MINDROOM_CONFIG_PATH
-              value: {{ .Values.config.mountPath | quote }}
+              value: {{ $configPath | quote }}
             - name: HOME
               value: {{ .Values.storage.mountPath | quote }}
             {{- if .Values.runtime.logLevel }}
@@ -246,12 +251,16 @@ spec:
               value: {{ .Values.storage.mountPath | quote }}
             - name: MINDROOM_KUBERNETES_WORKER_STORAGE_SUBPATH_PREFIX
               value: {{ .Values.workers.kubernetes.storageSubpathPrefix | quote }}
+            {{- if $workerConfigMapName }}
             - name: MINDROOM_KUBERNETES_WORKER_CONFIG_MAP_NAME
-              value: {{ include "mindroom-runtime.workerConfigMapName" . | quote }}
+              value: {{ $workerConfigMapName | quote }}
+            {{- end }}
+            {{- if $workerConfigKey }}
             - name: MINDROOM_KUBERNETES_WORKER_CONFIG_KEY
-              value: {{ include "mindroom-runtime.workerConfigKey" . | quote }}
+              value: {{ $workerConfigKey | quote }}
+            {{- end }}
             - name: MINDROOM_KUBERNETES_WORKER_CONFIG_PATH
-              value: {{ include "mindroom-runtime.workerConfigPath" . | quote }}
+              value: {{ $workerConfigPath | quote }}
             - name: MINDROOM_KUBERNETES_WORKER_IDLE_TIMEOUT_SECONDS
               value: {{ .Values.workers.kubernetes.idleTimeoutSeconds | quote }}
             - name: MINDROOM_KUBERNETES_WORKER_READY_TIMEOUT_SECONDS
@@ -361,10 +370,12 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
+            {{- if $usesConfigMapConfig }}
             - name: config
               mountPath: {{ .Values.config.mountPath }}
               subPath: {{ .Values.config.key }}
               readOnly: true
+            {{- end }}
             - name: {{ include "mindroom-runtime.storageVolumeName" . }}
               mountPath: {{ .Values.storage.mountPath }}
             {{- if .Values.stateStorage.enabled }}
@@ -410,7 +421,7 @@ spec:
             - name: MINDROOM_SANDBOX_RUNNER_PORT
               value: {{ .Values.workers.staticRunner.port | quote }}
             - name: MINDROOM_CONFIG_PATH
-              value: {{ .Values.config.mountPath | quote }}
+              value: {{ $configPath | quote }}
             - name: MINDROOM_STORAGE_PATH
               value: {{ .Values.storage.mountPath | quote }}
             - name: HOME
@@ -436,10 +447,12 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
+            {{- if $usesConfigMapConfig }}
             - name: config
               mountPath: {{ .Values.config.mountPath }}
               subPath: {{ .Values.config.key }}
               readOnly: true
+            {{- end }}
             - name: {{ include "mindroom-runtime.storageVolumeName" . }}
               mountPath: {{ .Values.storage.mountPath }}
             - name: sandbox-workspace
@@ -447,11 +460,13 @@ spec:
         {{- end }}
         {{- with .Values.extraContainers }}
         {{- toYaml . | nindent 8 }}
-        {{- end }}
+          {{- end }}
       volumes:
+        {{- if $usesConfigMapConfig }}
         - name: config
           configMap:
             name: {{ include "mindroom-runtime.configMapName" . }}
+        {{- end }}
         - name: {{ include "mindroom-runtime.storageVolumeName" . }}
           persistentVolumeClaim:
             claimName: {{ include "mindroom-runtime.storageClaimName" . }}

--- a/cluster/k8s/runtime/templates/deployment.yaml
+++ b/cluster/k8s/runtime/templates/deployment.yaml
@@ -460,7 +460,7 @@ spec:
         {{- end }}
         {{- with .Values.extraContainers }}
         {{- toYaml . | nindent 8 }}
-          {{- end }}
+        {{- end }}
       volumes:
         {{- if $usesConfigMapConfig }}
         - name: config

--- a/cluster/k8s/runtime/templates/validate.yaml
+++ b/cluster/k8s/runtime/templates/validate.yaml
@@ -1,6 +1,18 @@
 {{- if not (or (eq .Values.eventCache.backend "postgres") (eq .Values.eventCache.backend "sqlite")) -}}
 {{- fail "eventCache.backend must be either postgres or sqlite" -}}
 {{- end -}}
+{{- $configSource := include "mindroom-runtime.configSource" . -}}
+{{- if not (or (eq $configSource "configMap") (eq $configSource "file")) -}}
+{{- fail "config.source must be either configMap or file" -}}
+{{- end -}}
+{{- if eq $configSource "file" -}}
+{{- if not .Values.config.path -}}
+{{- fail "config.path is required when config.source=file" -}}
+{{- end -}}
+{{- if not (hasPrefix "/" .Values.config.path) -}}
+{{- fail "config.path must be absolute when config.source=file" -}}
+{{- end -}}
+{{- end -}}
 {{- if and (eq .Values.eventCache.backend "postgres") (not .Values.eventCache.databaseUrlEnv) -}}
 {{- fail "eventCache.databaseUrlEnv is required when eventCache.backend=postgres" -}}
 {{- end -}}

--- a/cluster/k8s/runtime/values.yaml
+++ b/cluster/k8s/runtime/values.yaml
@@ -61,6 +61,10 @@ runtime:
   timing: false
 
 config:
+  # configMap keeps the existing chart-managed or externally managed ConfigMap behavior.
+  # file reads an absolute path that already exists in the runtime filesystem, commonly copied by contentBundles.
+  source: configMap
+  path: ""
   create: true
   existingConfigMap: ""
   key: config.yaml
@@ -184,13 +188,17 @@ contentBundles: []
 # Example:
 # contentBundles:
 #   - name: team-config
-#     image: ghcr.io/example/team-config@sha256:1111111111111111111111111111111111111111111111111111111111111111
+#     image: registry.example.com/team/mindroom-config@sha256:1111111111111111111111111111111111111111111111111111111111111111
 #     sourcePath: /bundle
 #     targetPath: /app/agent_data/content-bundles/team-config
 #     seed:
 #       enabled: true
 #       command:
 #         - /app/agent_data/content-bundles/team-config/scripts/seed-content.sh
+# Then point MindRoom at a config file copied by the bundle:
+# config:
+#   source: file
+#   path: /app/agent_data/content-bundles/team-config/content/environments/prod/agent-config.yaml
 
 env:
   # Raw Kubernetes EnvVar entries appended to the MindRoom container.

--- a/src/mindroom/workers/backends/kubernetes_resources.py
+++ b/src/mindroom/workers/backends/kubernetes_resources.py
@@ -1057,6 +1057,14 @@ class KubernetesResourceManager:
             state_subpath,
             private_agent_names=private_agent_names,
         )
+        if self.config.config_map_name is None:
+            mounts.insert(
+                0,
+                {
+                    "name": "worker-storage",
+                    "mountPath": self.config.storage_mount_path,
+                },
+            )
         if self.config.config_map_name is not None:
             mounts.append(
                 {

--- a/src/mindroom/workers/backends/kubernetes_resources.py
+++ b/src/mindroom/workers/backends/kubernetes_resources.py
@@ -8,9 +8,10 @@ import hmac
 import importlib
 import json
 import os
+import posixpath
 import time
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Protocol, cast
 
@@ -1058,13 +1059,7 @@ class KubernetesResourceManager:
             private_agent_names=private_agent_names,
         )
         if self.config.config_map_name is None:
-            mounts.insert(
-                0,
-                {
-                    "name": "worker-storage",
-                    "mountPath": self.config.storage_mount_path,
-                },
-            )
+            mounts.extend(self._file_config_storage_mounts())
         if self.config.config_map_name is not None:
             mounts.append(
                 {
@@ -1075,6 +1070,26 @@ class KubernetesResourceManager:
                 },
             )
         return mounts
+
+    def _file_config_storage_mounts(self) -> list[dict[str, object]]:
+        storage_root = PurePosixPath(posixpath.normpath(self.config.storage_mount_path))
+        config_path = PurePosixPath(posixpath.normpath(self.config.config_path))
+        try:
+            relative_config_path = config_path.relative_to(storage_root)
+        except ValueError:
+            return []
+        if not relative_config_path.parts:
+            return []
+
+        visible_subpath = PurePosixPath(relative_config_path.parts[0])
+        return [
+            {
+                "name": "worker-storage",
+                "mountPath": str(storage_root / visible_subpath),
+                "subPath": str(visible_subpath),
+                "readOnly": True,
+            },
+        ]
 
     def _volumes(self) -> list[dict[str, object]]:
         volumes: list[dict[str, object]] = [

--- a/tests/test_helm_instance_worker_isolation.py
+++ b/tests/test_helm_instance_worker_isolation.py
@@ -292,8 +292,8 @@ def test_runtime_chart_renders_content_bundle_init_containers_after_user_init_co
                         },
                     },
                     {
-                        "name": "private-agent-content",
-                        "image": "ghcr.io/example/private-agent-content@sha256:"
+                        "name": "policy-pack",
+                        "image": "registry.example.com/team/policy-pack@sha256:"
                         "2222222222222222222222222222222222222222222222222222222222222222",
                         "overwrite": False,
                     },
@@ -311,12 +311,12 @@ def test_runtime_chart_renders_content_bundle_init_containers_after_user_init_co
     deployment = _resource(docs, "Deployment", "mindroom-runtime")
     pod_spec = deployment["spec"]["template"]["spec"]
     team_config = _init_container(deployment, "content-bundle-team-config")
-    agent_content = _init_container(deployment, "content-bundle-private-agent-content")
+    policy_pack = _init_container(deployment, "content-bundle-policy-pack")
 
     assert [container["name"] for container in pod_spec["initContainers"]][:3] == [
         "prepare-storage",
         "content-bundle-team-config",
-        "content-bundle-private-agent-content",
+        "content-bundle-policy-pack",
     ]
     assert team_config["image"] == (
         "ghcr.io/example/team-config@sha256:1111111111111111111111111111111111111111111111111111111111111111"
@@ -336,10 +336,10 @@ def test_runtime_chart_renders_content_bundle_init_containers_after_user_init_co
             "mountPath": "/app/agent_data",
         },
     ]
-    assert agent_content["args"] == [
+    assert policy_pack["args"] == [
         "set -eu\n"
-        'mkdir -p "/app/agent_data/content-bundles/private-agent-content"\n'
-        'cp -a "/bundle/." "/app/agent_data/content-bundles/private-agent-content/"',
+        'mkdir -p "/app/agent_data/content-bundles/policy-pack"\n'
+        'cp -a "/bundle/." "/app/agent_data/content-bundles/policy-pack/"',
     ]
 
 
@@ -862,6 +862,103 @@ def test_runtime_chart_worker_network_policy_selects_dynamic_worker_labels() -> 
         "app.kubernetes.io/managed-by": "mindroom",
         "app.kubernetes.io/name": "mindroom-worker",
     }
+
+
+def test_runtime_chart_default_configmap_source_wires_runtime_and_worker_configmap() -> None:
+    """Default config mode should preserve the chart-managed ConfigMap mount and worker projection."""
+    docs = _render_runtime_chart()
+    config_map = _resource(docs, "ConfigMap", "mindroom-runtime-config")
+    deployment = _resource(docs, "Deployment", "mindroom-runtime")
+    pod_spec = deployment["spec"]["template"]["spec"]
+    mindroom_container = _container(deployment, "mindroom")
+    mindroom_env = _env_by_name(mindroom_container)
+
+    assert "config.yaml" in config_map["data"]
+    assert {"name": "config", "configMap": {"name": "mindroom-runtime-config"}} in pod_spec["volumes"]
+    assert {
+        "name": "config",
+        "mountPath": "/app/config.yaml",
+        "subPath": "config.yaml",
+        "readOnly": True,
+    } in mindroom_container["volumeMounts"]
+    assert mindroom_env["MINDROOM_CONFIG_PATH"]["value"] == "/app/config.yaml"
+    assert mindroom_env["MINDROOM_KUBERNETES_WORKER_CONFIG_MAP_NAME"]["value"] == "mindroom-runtime-config"
+    assert mindroom_env["MINDROOM_KUBERNETES_WORKER_CONFIG_KEY"]["value"] == "config.yaml"
+    assert mindroom_env["MINDROOM_KUBERNETES_WORKER_CONFIG_PATH"]["value"] == "/app/config.yaml"
+
+
+def test_runtime_chart_file_config_source_uses_bundle_path_without_configmap() -> None:
+    """File config mode should point runtime and workers at the bundle file without rendering a ConfigMap."""
+    config_path = "/app/agent_data/content-bundles/team-config/content/environments/prod/agent-config.yaml"
+    docs = _render_chart(
+        Path("cluster/k8s/runtime"),
+        "workers.backend=kubernetes",
+        "workers.sandbox.proxyToken.value=test-token",
+        "eventCache.postgres.auth.password=test-password",
+        "contentBundles[0].name=team-config",
+        "contentBundles[0].image=registry.example.com/team/mindroom-config@sha256:"
+        "1111111111111111111111111111111111111111111111111111111111111111",
+        "config.source=file",
+        f"config.path={config_path}",
+        release_name="mindroom-runtime",
+    )
+    deployment = _resource(docs, "Deployment", "mindroom-runtime")
+    pod_spec = deployment["spec"]["template"]["spec"]
+    mindroom_container = _container(deployment, "mindroom")
+    mindroom_env = _env_by_name(mindroom_container)
+
+    assert not any(
+        doc.get("kind") == "ConfigMap" and doc.get("metadata", {}).get("name") == "mindroom-runtime-config"
+        for doc in docs
+    )
+    assert not any(volume["name"] == "config" for volume in pod_spec["volumes"])
+    assert not any(mount["name"] == "config" for mount in mindroom_container["volumeMounts"])
+    assert mindroom_env["MINDROOM_CONFIG_PATH"]["value"] == config_path
+    assert "MINDROOM_KUBERNETES_WORKER_CONFIG_MAP_NAME" not in mindroom_env
+    assert "MINDROOM_KUBERNETES_WORKER_CONFIG_KEY" not in mindroom_env
+    assert mindroom_env["MINDROOM_KUBERNETES_WORKER_CONFIG_PATH"]["value"] == config_path
+    assert mindroom_env["MINDROOM_KUBERNETES_WORKER_STORAGE_MOUNT_PATH"]["value"] == "/app/agent_data"
+    assert mindroom_env["MINDROOM_KUBERNETES_WORKER_STORAGE_PVC_NAME"]["value"] == "mindroom-runtime-storage"
+
+
+def test_runtime_chart_file_config_source_rejects_missing_path() -> None:
+    """File config mode needs an explicit absolute file path."""
+    completed = _run_helm_template(
+        Path("cluster/k8s/runtime"),
+        "eventCache.postgres.auth.password=test-password",
+        "config.source=file",
+        release_name="mindroom-runtime",
+    )
+
+    assert completed.returncode != 0
+    assert "config.path is required when config.source=file" in completed.stderr
+
+
+def test_runtime_chart_file_config_source_rejects_relative_path() -> None:
+    """File config mode should fail early for paths that are not container-absolute."""
+    completed = _run_helm_template(
+        Path("cluster/k8s/runtime"),
+        "eventCache.postgres.auth.password=test-password",
+        "config.source=file",
+        "config.path=content/environments/prod/agent-config.yaml",
+        release_name="mindroom-runtime",
+    )
+
+    assert completed.returncode != 0
+    assert "config.path must be absolute when config.source=file" in completed.stderr
+
+
+def test_runtime_chart_rejects_unknown_config_source() -> None:
+    """Config source should be constrained to known chart modes."""
+    completed = _run_helm_template(
+        Path("cluster/k8s/runtime"),
+        "eventCache.postgres.auth.password=test-password",
+        "config.source=secret",
+        release_name="mindroom-runtime",
+    )
+
+    assert completed.returncode != 0
+    assert "config.source must be either configMap or file" in completed.stderr
 
 
 def test_runtime_chart_can_route_kubernetes_workers_through_existing_egress_proxy(tmp_path: Path) -> None:

--- a/tests/test_kubernetes_worker_backend.py
+++ b/tests/test_kubernetes_worker_backend.py
@@ -1231,16 +1231,38 @@ def test_kubernetes_backend_preserves_primary_config_path_without_configmap(tmp_
     assert committed_runtime.config_path == config_path.resolve()
 
 
-def test_kubernetes_backend_mounts_shared_storage_root_without_configmap(tmp_path: Path) -> None:
-    """File-backed configs need the worker pod to see the shared storage root that contains bundle files."""
-    config_path = tmp_path / "storage" / "content-bundles" / "team-config" / "agent-config.yaml"
+@pytest.mark.parametrize(
+    ("config_relative_path", "worker_config_path", "expected_mount_path", "expected_subpath"),
+    [
+        (
+            "content-bundles/team-config/agent-config.yaml",
+            "/app/agent_data/content-bundles/team-config/agent-config.yaml",
+            "/app/agent_data/content-bundles",
+            "content-bundles",
+        ),
+        (
+            "team-config/content/environments/prod/agent-config.yaml",
+            "/app/agent_data/team-config/content/environments/prod/agent-config.yaml",
+            "/app/agent_data/team-config",
+            "team-config",
+        ),
+    ],
+)
+def test_kubernetes_backend_mounts_config_storage_subtree_without_configmap(
+    tmp_path: Path,
+    config_relative_path: str,
+    worker_config_path: str,
+    expected_mount_path: str,
+    expected_subpath: str,
+) -> None:
+    """File-backed configs need bundle visibility without broadening worker state mounts."""
+    config_path = tmp_path / "storage" / config_relative_path
     config_path.parent.mkdir(parents=True)
     config_path.write_text(
         "models:\n  default:\n    provider: openai\n    id: gpt-5.4\nagents: {}\nrouter:\n  model: default\n",
         encoding="utf-8",
     )
     runtime_paths = resolve_primary_runtime_paths(config_path=config_path, storage_path=tmp_path / "storage")
-    worker_config_path = "/app/agent_data/content-bundles/team-config/agent-config.yaml"
     backend, apps_api, _core_api = _backend(
         runtime_paths=runtime_paths,
         storage_mount_path="/app/agent_data",
@@ -1253,8 +1275,18 @@ def test_kubernetes_backend_mounts_shared_storage_root_without_configmap(tmp_pat
     deployment = apps_api.created_bodies[0]
     container = deployment["spec"]["template"]["spec"]["containers"][0]
     env_by_name = {env["name"]: env for env in container["env"]}
+    mount_paths = {mount["mountPath"]: mount for mount in container["volumeMounts"]}
+    expected_worker_root = f"/app/agent_data/workers/{worker_dir_name(_TEST_SCOPED_WORKER_KEY_A)}"
 
-    assert {"name": "worker-storage", "mountPath": "/app/agent_data"} in container["volumeMounts"]
+    assert mount_paths[expected_mount_path] == {
+        "name": "worker-storage",
+        "mountPath": expected_mount_path,
+        "subPath": expected_subpath,
+        "readOnly": True,
+    }
+    assert "/app/agent_data" not in mount_paths
+    assert mount_paths["/app/agent_data/agents/code"]["subPath"] == "agents/code"
+    assert mount_paths[expected_worker_root]["subPath"] == f"workers/{worker_dir_name(_TEST_SCOPED_WORKER_KEY_A)}"
     assert not any(mount["name"] == "worker-config" for mount in container["volumeMounts"])
     assert deployment["spec"]["template"]["spec"]["volumes"] == [
         {"name": "worker-storage", "persistentVolumeClaim": {"claimName": "mindroom-storage"}},

--- a/tests/test_kubernetes_worker_backend.py
+++ b/tests/test_kubernetes_worker_backend.py
@@ -368,6 +368,7 @@ def _backend(
     storage_subpath_prefix: str = "workers",
     storage_mount_path: str = "/app/worker",
     config_map_name: str | None = "mindroom-config",
+    worker_config_path: str = "/app/config.yaml",
     node_name: str | None = None,
     colocate_with_control_plane_node: bool = False,
     name_prefix: str = "mindroom-worker",
@@ -393,7 +394,7 @@ def _backend(
         storage_subpath_prefix=storage_subpath_prefix,
         config_map_name=config_map_name,
         config_key="config.yaml",
-        config_path="/app/config.yaml",
+        config_path=worker_config_path,
         idle_timeout_seconds=idle_timeout_seconds,
         ready_timeout_seconds=5.0,
         name_prefix=name_prefix,
@@ -1228,6 +1229,37 @@ def test_kubernetes_backend_preserves_primary_config_path_without_configmap(tmp_
     )
 
     assert committed_runtime.config_path == config_path.resolve()
+
+
+def test_kubernetes_backend_mounts_shared_storage_root_without_configmap(tmp_path: Path) -> None:
+    """File-backed configs need the worker pod to see the shared storage root that contains bundle files."""
+    config_path = tmp_path / "storage" / "content-bundles" / "team-config" / "agent-config.yaml"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        "models:\n  default:\n    provider: openai\n    id: gpt-5.4\nagents: {}\nrouter:\n  model: default\n",
+        encoding="utf-8",
+    )
+    runtime_paths = resolve_primary_runtime_paths(config_path=config_path, storage_path=tmp_path / "storage")
+    worker_config_path = "/app/agent_data/content-bundles/team-config/agent-config.yaml"
+    backend, apps_api, _core_api = _backend(
+        runtime_paths=runtime_paths,
+        storage_mount_path="/app/agent_data",
+        config_map_name=None,
+        worker_config_path=worker_config_path,
+    )
+
+    backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=10.0)
+
+    deployment = apps_api.created_bodies[0]
+    container = deployment["spec"]["template"]["spec"]["containers"][0]
+    env_by_name = {env["name"]: env for env in container["env"]}
+
+    assert {"name": "worker-storage", "mountPath": "/app/agent_data"} in container["volumeMounts"]
+    assert not any(mount["name"] == "worker-config" for mount in container["volumeMounts"])
+    assert deployment["spec"]["template"]["spec"]["volumes"] == [
+        {"name": "worker-storage", "persistentVolumeClaim": {"claimName": "mindroom-storage"}},
+    ]
+    assert env_by_name["MINDROOM_CONFIG_PATH"]["value"] == worker_config_path
 
 
 def test_primary_worker_backend_available_uses_runtime_env_values(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add runtime Helm chart support for `config.source`, defaulting to current ConfigMap behavior.
- Support `config.source: file` with required absolute `config.path`, no generated config ConfigMap dependency, and runtime/worker config env pointed at the same file.
- Mount shared storage into Kubernetes workers when no worker ConfigMap is used, so bundle-hosted config files are visible.
- Document generic content-bundle usage and cover render/backend behavior with tests.

## Test Plan
- [x] `uv sync --all-extras`
- [x] `uv run pytest tests/test_helm_instance_worker_isolation.py tests/test_kubernetes_worker_backend.py -q`
- [x] `uv run ruff check tests/test_helm_instance_worker_isolation.py tests/test_kubernetes_worker_backend.py src/mindroom/workers/backends/kubernetes_resources.py`
- [x] `helm template` default ConfigMap mode
- [x] `helm template` file config mode
- [x] pre-commit hooks run by `git commit`
- [ ] `uv run pytest -q` local full suite: 1 failed, 7799 passed, 60 skipped. Failure is `tests/test_cli_config.py::TestRunErrorHandling::test_run_invalid_plugin_manifest_name`, caused by local frontend `rolldown-binding.darwin-arm64.node` code-signature/native-binding load failure during `bun run vite build`.