### PR TITLE
Use Agno LlamaCpp provider for llama.cpp configs

### DIFF
--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -795,7 +795,7 @@ def _additional_models_template_block(provider_preset: _ProviderPreset) -> str:
     if provider_preset == "llama_cpp":
         return (
             f"\n  {LOCAL_QWEN_PRESET_NAME}:\n"
-            "    provider: openai\n"
+            "    provider: llama_cpp\n"
             f"    id: {LLAMA_CPP_QWEN}\n"
             f"    context_window: {LOCAL_QWEN_CONTEXT_WINDOW}\n"
             "    extra_kwargs:\n"

--- a/src/mindroom/model_defaults.py
+++ b/src/mindroom/model_defaults.py
@@ -133,7 +133,7 @@ CONFIG_INIT_MODEL_PRESETS: Mapping[str, ModelPreset] = MappingProxyType(
         "bedrock_claude": ModelPreset("bedrock_claude", AWS_BEDROCK_CLAUDE_OPUS, 1_000_000),
         "azure": ModelPreset("azure", AZURE_OPENAI_DEFAULT_DEPLOYMENT),
         "codex": ModelPreset("codex", CODEX_GPT, 258_000),
-        "llama_cpp": ModelPreset("openai", LLAMA_CPP_GEMMA, 128_000),
+        "llama_cpp": ModelPreset("llama_cpp", LLAMA_CPP_GEMMA, 128_000),
         "ollama": ModelPreset("ollama", OLLAMA_GEMMA, 128_000),
         "openai": ModelPreset("openai", _OPENAI_GPT, 258_000),
         "openrouter": ModelPreset("openrouter", _OPENROUTER_CLAUDE_SONNET, 1_000_000),

--- a/src/mindroom/model_loading.py
+++ b/src/mindroom/model_loading.py
@@ -157,7 +157,8 @@ def _create_model_for_provider(  # noqa: C901, PLR0912, PLR0915
     canonical_provider = _canonical_provider(provider)
 
     if (
-        canonical_provider not in {"ollama", "vertexai_claude", "codex", "openai_codex", _BEDROCK_CLAUDE_PROVIDER}
+        canonical_provider
+        not in {"ollama", "llama_cpp", "vertexai_claude", "codex", "openai_codex", _BEDROCK_CLAUDE_PROVIDER}
         and "api_key" not in extra_kwargs
     ):
         api_key = get_api_key_for_provider(canonical_provider, runtime_paths=runtime_paths)

--- a/src/mindroom/model_loading.py
+++ b/src/mindroom/model_loading.py
@@ -11,6 +11,7 @@ from agno.models.cerebras import Cerebras
 from agno.models.deepseek import DeepSeek
 from agno.models.google import Gemini
 from agno.models.groq import Groq
+from agno.models.llama_cpp import LlamaCpp
 from agno.models.ollama import Ollama
 from agno.models.openai import OpenAIChat
 from agno.models.openrouter import OpenRouter
@@ -232,6 +233,7 @@ def _create_model_for_provider(  # noqa: C901, PLR0912, PLR0915
         "gemini": Gemini,
         "google": Gemini,
         "vertexai_claude": MindroomVertexAIClaude,
+        "llama_cpp": LlamaCpp,
         "cerebras": Cerebras,
         "groq": Groq,
         "deepseek": DeepSeek,

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -608,14 +608,14 @@ class TestConfigInit:
 
         config = yaml.safe_load(target.read_text())
         assert "mindroom_user" not in config
-        assert config["models"]["default"]["provider"] == "openai"
+        assert config["models"]["default"]["provider"] == "llama_cpp"
         assert config["models"]["default"]["id"] == LLAMA_CPP_GEMMA
         assert config["models"]["default"]["context_window"] == 128_000
         assert config["models"]["default"]["extra_kwargs"] == {
             "api_key": "sk-no-key-required",
             "base_url": "http://localhost:8080/v1",
         }
-        assert config["models"][LOCAL_QWEN_PRESET_NAME]["provider"] == "openai"
+        assert config["models"][LOCAL_QWEN_PRESET_NAME]["provider"] == "llama_cpp"
         assert config["models"][LOCAL_QWEN_PRESET_NAME]["id"] == LLAMA_CPP_QWEN
         assert config["models"][LOCAL_QWEN_PRESET_NAME]["context_window"] == LOCAL_QWEN_CONTEXT_WINDOW
         assert config["models"][LOCAL_QWEN_PRESET_NAME]["extra_kwargs"] == {

--- a/tests/test_extra_kwargs.py
+++ b/tests/test_extra_kwargs.py
@@ -178,6 +178,7 @@ def test_get_model_instance_supports_llama_cpp_provider() -> None:
                 "provider": "llama_cpp",
                 "id": "gemma-4:31b-q4-uncensored",
                 "extra_kwargs": {
+                    "api_key": "sk-no-key-required",
                     "base_url": "http://llama.local/v1",
                     "max_tokens": 32000,
                 },
@@ -195,9 +196,44 @@ def test_get_model_instance_supports_llama_cpp_provider() -> None:
 
     assert isinstance(model, LlamaCpp)
     assert model.id == "gemma-4:31b-q4-uncensored"
+    assert model.api_key == "sk-no-key-required"
     assert model.base_url == "http://llama.local/v1"
     assert model.max_tokens == 32000
     assert model.default_role_map["system"] == "system"
+
+
+def test_llama_cpp_provider_does_not_auto_fetch_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Custom llama.cpp configs without api_key should not consult shared credentials."""
+    config_data = {
+        "models": {
+            "local_model": {
+                "provider": "llama_cpp",
+                "id": "gemma-4:31b-q4-uncensored",
+                "extra_kwargs": {
+                    "base_url": "http://llama.local/v1",
+                },
+            },
+        },
+        "router": {
+            "model": "local_model",
+        },
+        "agents": {},
+    }
+    config, runtime_paths = _config_with_runtime_paths(config_data)
+    provider_lookups: list[str] = []
+
+    def get_api_key(provider: str, *, runtime_paths: RuntimePaths) -> str:
+        _ = runtime_paths
+        provider_lookups.append(provider)
+        return "unexpected-credential"
+
+    monkeypatch.setattr("mindroom.model_loading.get_api_key_for_provider", get_api_key)
+
+    model = get_model_instance(config, runtime_paths, "local_model")
+
+    assert isinstance(model, LlamaCpp)
+    assert provider_lookups == []
+    assert model.api_key == "not-provided"
 
 
 def test_different_providers_with_extra_kwargs() -> None:

--- a/tests/test_extra_kwargs.py
+++ b/tests/test_extra_kwargs.py
@@ -9,6 +9,7 @@ import pytest
 import yaml
 from agno.models.aws.claude import Claude as AwsBedrockClaude
 from agno.models.azure import AzureOpenAI
+from agno.models.llama_cpp import LlamaCpp
 from agno.models.message import Message
 from agno.models.response import ModelResponse
 from agno.models.vertexai.claude import Claude as VertexAIClaude
@@ -167,6 +168,36 @@ def test_get_model_instance_with_extra_kwargs() -> None:
 
     # Check that temperature was also passed
     assert model.temperature == 0.8
+
+
+def test_get_model_instance_supports_llama_cpp_provider() -> None:
+    """llama.cpp should use Agno's OpenAI-compatible local provider class."""
+    config_data = {
+        "models": {
+            "local_model": {
+                "provider": "llama_cpp",
+                "id": "gemma-4:31b-q4-uncensored",
+                "extra_kwargs": {
+                    "base_url": "http://llama.local/v1",
+                    "max_tokens": 32000,
+                },
+            },
+        },
+        "router": {
+            "model": "local_model",
+        },
+        "agents": {},
+    }
+
+    config, runtime_paths = _config_with_runtime_paths(config_data)
+
+    model = get_model_instance(config, runtime_paths, "local_model")
+
+    assert isinstance(model, LlamaCpp)
+    assert model.id == "gemma-4:31b-q4-uncensored"
+    assert model.base_url == "http://llama.local/v1"
+    assert model.max_tokens == 32000
+    assert model.default_role_map["system"] == "system"
 
 
 def test_different_providers_with_extra_kwargs() -> None:


### PR DESCRIPTION
## Summary
- Wire `provider: llama_cpp` to Agno's `LlamaCpp` model class instead of routing llama.cpp configs through generic OpenAIChat.
- Generate `llama_cpp` provider entries from the llama.cpp config-init preset, including the additional local Qwen model.
- Add model-loading coverage that verifies the Agno LlamaCpp class is used and preserves the OpenAI-compatible local settings.

## Tests
- `uv run pytest tests/test_extra_kwargs.py tests/test_cli_config.py::TestConfigInit::test_init_defaults_to_openai_for_mindroom_chat tests/test_cli_config.py::TestConfigInit::test_init_mindroom_chat_llama_cpp_writes_hosted_openai_compatible_defaults -q -n 0 --no-cov`
- `uv run pre-commit run --all-files`

## Summary by Sourcery

Wire the `llama_cpp` provider to use Agno’s dedicated LlamaCpp model and update defaults and templates accordingly.

Bug Fixes:
- Ensure `llama_cpp` presets use the correct `llama_cpp` provider instead of `openai` so llama.cpp configs are treated as local models.

Enhancements:
- Map the `llama_cpp` provider to the Agno LlamaCpp model class in the model loading registry.
- Update llama.cpp-related config templates and defaults so generated configs declare `llama_cpp` as the provider for both Gemma and local Qwen models.

Tests:
- Add model-loading tests to verify `llama_cpp` configs instantiate the LlamaCpp class and preserve OpenAI-compatible local settings.
- Adjust CLI config initialization tests to expect `llama_cpp` as the provider for llama.cpp presets.