### PR TITLE
Finish Dynamic Workflows (Phase 1): restore design doc + remaining work

### DIFF
--- a/.claude/skills/live-test/references/core-mindroom.md
+++ b/.claude/skills/live-test/references/core-mindroom.md
@@ -1,5 +1,8 @@
-## IMPORTANT: Tuwunel Already Running
-On this machine, the Matrix homeserver (Tuwunel/Conduwuit) is ALREADY RUNNING on localhost:8008. Do NOT start a new one. Skip `just local-matrix-up`. Use `MATRIX_HOMESERVER=http://localhost:8008 MATRIX_SSL_VERIFY=false`.
+## IMPORTANT: Check for an Existing Homeserver First
+Some dev machines already run a Matrix homeserver (Tuwunel/Conduwuit) on localhost:8008; do not start a second one there.
+Probe first with `curl -s --max-time 5 http://localhost:8008/_matrix/client/versions`.
+If it responds, skip `just local-matrix-up`; if it does not, boot the Docker stack with `just local-matrix-up` (and `just local-matrix-down` when you are done).
+Either way, use `MATRIX_HOMESERVER=http://localhost:8008 MATRIX_SSL_VERIFY=false`.
 
 # Core MindRoom Live Run
 

--- a/docs/superpowers/specs/2026-06-07-dynamic-workflows-design.md
+++ b/docs/superpowers/specs/2026-06-07-dynamic-workflows-design.md
@@ -348,6 +348,7 @@ mindroom_data/
           artifacts/
 ```
 
+The tenant scope intentionally uses the literal owner key `tenant` because one storage root belongs to exactly one tenant; multi-tenant deployments isolate at the storage-root (instance) level, not inside it.
 `workflow.yaml` should be a small mutable pointer file.
 Revision files should be immutable.
 Run records should be append-only except for status updates.

--- a/docs/superpowers/specs/2026-06-07-dynamic-workflows-design.md
+++ b/docs/superpowers/specs/2026-06-07-dynamic-workflows-design.md
@@ -1,0 +1,578 @@
+# Dynamic Workflows Design
+
+## Summary
+
+MindRoom should add Dynamic Workflows.
+A Dynamic Workflow is a versioned, reusable workflow that agents can create, update, and run.
+The first concrete use case should be deep research with HTML report publishing, but the design should support many workflow types.
+Examples include due diligence, weekly briefings, PR review reports, incident reviews, migration plans, documentation audits, and recurring market reports.
+
+The core primitive is a MindRoom Dynamic Workflow.
+A Dynamic Workflow can use existing room agents and can create isolated ephemeral agents for one run.
+The first implementation executes a run inside the tool call and persists artifacts such as Markdown, JSON, files, or hosted HTML reports.
+Background jobs, progress events, and cancellation should be added after the runner lifecycle is managed by MindRoom.
+
+Agno factories should be used as the orchestration implementation where they fit.
+Agno `AgentFactory`, `TeamFactory`, and `WorkflowFactory` can build fresh components per request from caller identity and input.
+MindRoom should not expose raw AgentOS directly in the first release.
+MindRoom should own auth, tenant isolation, Matrix notifications, report URLs, storage, approval policy, and user-facing API.
+
+This design deliberately mirrors the useful parts of Claude Code dynamic workflows.
+The plan lives in a script or declarative spec, not inside the main agent context.
+Intermediate results stay in workflow state, not in the Matrix conversation context.
+The first implementation keeps workflow execution on the managed agent tool path.
+The user can inspect, approve, save, rerun, update, and roll back workflow definitions.
+
+## Goals
+
+- Let agents assemble repeatable workflows instead of manually coordinating every step in one chat turn.
+- Let workflows reuse durable room agents when their existing expertise, public role, model policy, or identity matter.
+- Let workflows create ephemeral agents for temporary roles such as planner, critic, source reader, analyst, or report writer.
+- Keep ephemeral agents isolated from durable agent memory, credentials, Matrix identity, and tools unless policy explicitly grants access.
+- Store Dynamic Workflows and revisions on disk so self-hosted users can inspect, back up, copy, and audit them.
+- Persist Dynamic Workflow runs with artifacts, report URLs, and final outputs.
+- Make permission expansion explicit and approval-gated.
+- Enable deep research workflows without hard-coding deep research as a one-off feature.
+
+## Non-Goals
+
+- Do not let agents create arbitrary executable Python or JavaScript workflow code in the first release.
+- Do not expose raw AgentOS HTTP endpoints to users or agents in the first release.
+- Do not create Matrix accounts for ephemeral workflow agents.
+- Do not mutate `config.yaml` when creating ephemeral agents.
+- Do not let a workflow coordinator call shell, filesystem, browser, or network tools directly.
+- Do not make database records the source of truth for workflow specs in the first release.
+
+## User Perspective
+
+### Creating a Dynamic Workflow From Chat
+
+A user can ask a MindRoom agent to create a workflow.
+For example, the user can say: "Create a recurring competitor research workflow that uses our research agent, adds a source critic, and publishes a report."
+
+The agent calls `create_workflow`.
+MindRoom validates the workflow spec and returns a draft with a summary of participants, tools, models, data access, cost limits, and output artifacts.
+If the workflow asks for new capabilities, MindRoom sends an approval card before it can become active.
+
+The user sees a clear summary instead of raw YAML.
+The user can approve once, approve always for that workflow in that scope, deny, or ask the agent to revise.
+
+### Running a Dynamic Workflow
+
+The user can ask: "Run the competitor research workflow for Anthropic, OpenAI, and Google."
+The agent calls `run_workflow`.
+MindRoom executes the active revision, stores a run record, and returns the final run payload with a private report URL when configured.
+The run is pinned to the active revision it started with.
+
+If the workflow produced an HTML report, the message includes a URL on the same hosted MindRoom domain.
+If the report is private, the URL requires normal MindRoom authentication.
+If the report is public, the URL uses an unguessable slug and records who published it.
+
+### Watching Progress
+
+The user can open a Dynamic Workflow run view in the dashboard.
+The run view shows phases, active agents, elapsed time, token and cost estimates when available, and recent step outputs.
+The first implementation stores completed or failed run state and artifacts.
+Cancellation and live progress should be added with the background runner.
+Future versions can pause and resume runs if the backing runner supports it.
+
+### Updating a Dynamic Workflow
+
+The user or agent can update a Dynamic Workflow after a bad run.
+For example, the agent can call `update_workflow` to add source confidence scoring or change the report outline.
+MindRoom creates a new revision instead of mutating the active revision in place.
+
+If the update does not expand permissions, MindRoom can auto-publish the new revision under policy.
+If the update adds a model, tool, data source, public visibility, larger budget, or new room agent, MindRoom requires approval.
+The user can inspect the diff and roll back to an older revision.
+
+### Dashboard Experience
+
+The dashboard should have a Dynamic Workflow library.
+The library lists agent-scoped, room-scoped, and tenant-scoped workflows.
+Each workflow page shows active revision, draft revisions, run history, artifacts, permissions, and rollback options.
+Admins can enable or disable Dynamic Workflow creation per agent, room, or tenant.
+
+## Core Concepts
+
+### Dynamic Workflow
+
+A Dynamic Workflow is a saved definition for building and running an agent, team, or workflow at request time.
+It has a stable ID, a scope, metadata, an active revision, and immutable revision files.
+It can be declarative or trusted-code-backed.
+
+### Workflow Revision
+
+A revision is an immutable workflow spec.
+Every run is pinned to one revision.
+Updating a Dynamic Workflow creates a new revision.
+Publishing a revision only changes the active revision pointer.
+
+### Workflow Run
+
+A run is one execution of one workflow revision with one input payload.
+It records status, participant outputs, artifacts, and final result.
+It may run in the primary runtime, a sandbox-runner sidecar, or a dedicated worker.
+
+### Room Agent Participant
+
+A room agent participant reuses an existing MindRoom agent that is available in the current room.
+The current implementation reuses the durable agent's public role, configured model policy, and Matrix-facing identity context.
+It does not inherit durable memory, tools, skills, credentials, or knowledge until an explicit approval policy grants those capabilities.
+It should run as an internal participant in the workflow instead of posting every intermediate step to Matrix.
+It should be constrained to the current room and thread context.
+
+Future memory or tool grants should be treated as permission expansion.
+Dynamic Workflows may request `read_only` or `normal` memory behavior only after that approval policy exists.
+
+### Ephemeral Agent Participant
+
+An ephemeral agent participant exists only for one workflow run.
+It has no Matrix account.
+It has no persistent memory by default.
+It does not inherit creator credentials, creator tools, or durable agent tools.
+It can use only allowlisted models in the current implementation.
+Future tool grants should be treated as permission expansion and require an explicit Dynamic Workflow approval policy.
+
+### Workflow Coordinator
+
+The coordinator is the workflow spec or script.
+The coordinator decides which steps run next and how intermediate outputs flow between steps.
+The coordinator should not directly use shell, filesystem, browser, Matrix, or network tools.
+Only agents inside the workflow should call tools after the workflow has explicit tool grants.
+
+This mirrors Claude Code dynamic workflows, where the workflow script coordinates agents and agents execute tools.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    A["Matrix user or dashboard"] --> B["MindRoom agent"]
+    B --> C["dynamic_workflow tool"]
+    C --> D["Dynamic Workflow service"]
+    D --> E["Dynamic Workflow store"]
+    D --> F["Approval policy"]
+    D --> G["Background runner"]
+    G --> H["Agno factory adapter"]
+    H --> I["Agno Workflow or Team"]
+    I --> J["Room agent participants"]
+    I --> K["Ephemeral agent participants"]
+    J --> L["Allowed tools and models"]
+    K --> L
+    I --> M["Artifacts"]
+    M --> N["Report publisher"]
+    N --> O["Tenant domain report URL"]
+    G --> P["Matrix completion notification"]
+```
+
+## MindRoom Tool Surface
+
+The first user-facing capability should be a tool named `dynamic_workflow`.
+This matches the product concept and hides Agno implementation details.
+
+```python
+create_workflow(spec: dict, scope: str = "agent", reason: str | None = None) -> dict
+validate_workflow(spec: dict) -> dict
+update_workflow(workflow_id: str, patch: dict, reason: str, scope: str = "agent") -> dict
+run_workflow(workflow_id: str, input: dict, scope: str = "agent") -> dict
+get_workflow_run(workflow_id: str, run_id: str, scope: str = "agent") -> dict
+list_workflows(scope: str = "agent") -> dict
+list_workflow_revisions(workflow_id: str, scope: str = "agent") -> dict
+```
+
+The first implementation configures the capability per agent by including the `dynamic_workflow` tool.
+When enabled, an agent can use the agent-scoped workflow actions listed above.
+Room-scoped and tenant-scoped mutations stay denied until an approval policy exists.
+Future admin policy can add per-action allowlists, for example allowing normal assistants to run workflows but not create or update them.
+
+## Declarative Workflow Spec
+
+The first release should use declarative YAML or JSON specs.
+Declarative specs are inspectable, diffable, policy-checkable, and safe for agents to write.
+The spec can compile to an Agno `WorkflowFactory` for factory-compatible surfaces.
+MindRoom's current tool path still executes through its own service runner so async Matrix-agent execution, report persistence, and policy checks stay in one place.
+
+Example:
+
+```yaml
+schema_version: 1
+id: competitor-research-report
+name: Competitor Research Report
+description: Create a cited HTML report about competitors.
+kind: workflow
+inputs:
+  type: object
+  required:
+    - topic
+  properties:
+    topic:
+      type: string
+    report_visibility:
+      type: string
+      enum:
+        - private
+        - public
+participants:
+  - id: existing_researcher
+    kind: room_agent
+    agent: researcher
+  - id: critic
+    kind: ephemeral_agent
+    name: Source Critic
+    model: claude-sonnet-4-6
+    tools: []
+  - id: writer
+    kind: ephemeral_agent
+    name: Report Writer
+    model: claude-sonnet-4-6
+    tools: []
+workflow:
+  - id: plan
+    type: agent_step
+    participant: existing_researcher
+    prompt: Create a research plan for {input.topic}.
+  - id: gather
+    type: transform_step
+    template: "Source notes for {input.topic}: use the research plan from {steps.plan}."
+  - id: check
+    type: agent_step
+    participant: critic
+    prompt: "Cross-check the plan and source notes. Plan: {steps.plan}\nNotes: {steps.gather}"
+  - id: write
+    type: agent_step
+    participant: writer
+    prompt: "Write a cited report in Markdown from these notes: {steps.gather}\nCritique: {steps.check}"
+outputs:
+  - id: report_markdown
+    type: markdown
+    from_step: write
+  - id: report_html
+    type: html_report
+    from_step: write
+permissions:
+  max_runtime_seconds: 1800
+  max_concurrent_agents: 1
+  max_total_agents: 3
+  models:
+    - claude-haiku-4-5
+    - claude-sonnet-4-6
+  tools: []
+  data:
+    matrix_history: none
+    attachments: none
+    knowledge_bases: []
+```
+
+## Trusted Code Workflows
+
+Trusted code workflows can come later.
+They can be installed through plugins or bundled modules.
+They should be admin-controlled and should not be authored directly by agents in the first release.
+
+A trusted code workflow may wrap an Agno `WorkflowFactory` module directly.
+This is useful for complex branching, loops, retries, and custom quality checks that are awkward in declarative YAML.
+Deep research can start declarative, but a mature version may become a trusted code workflow if the quality loop becomes complex.
+
+## Agent and Model Policy
+
+Dynamic Workflow execution must use a permission intersection.
+The creator does not grant power by asking for it.
+
+Effective permissions should be:
+
+```text
+requested workflow permissions
+intersect creator agent permissions
+intersect current room policy
+intersect authenticated user policy
+intersect tenant policy
+intersect global Dynamic Workflow allowlist
+```
+
+Models should be selected from explicit allowlists.
+The allowlist can come from `config.yaml`, tenant settings, and tool configuration.
+Ephemeral agents may request a model by ID, but the runner must reject or rewrite it if not allowed.
+
+The model allowlist should prefer the repository's current frontier model table when users do not specify a model.
+If model names conflict with the table or appear stale, provider docs should be checked before rejecting them.
+
+## Data Access Policy
+
+Dynamic Workflows should have explicit data access fields.
+A workflow can request current thread history, current room history, specific attachments, selected knowledge bases, web search, or private tools.
+The policy engine should validate every request.
+
+Data access defaults should be narrow.
+Default Matrix history should be current thread only.
+Default attachments should be current thread only.
+Default knowledge access should be none unless selected.
+Default report visibility should be private.
+
+Public report publishing should always be visible in the approval summary.
+
+## Storage Layout
+
+Dynamic Workflow specs should live under `MINDROOM_STORAGE_PATH`.
+This keeps self-hosted state portable and inspectable.
+
+```text
+mindroom_data/
+  dynamic_workflows/
+    agent/
+      <agent_name>/
+        <workflow_id>/
+          workflow.yaml
+          revisions/
+            000001.yaml
+            000002.yaml
+          runs/
+            run_<id>.json
+          artifacts/
+            run_<id>/
+              report.md
+              report.html
+              sources.json
+    room/
+      <room_id_hash>/
+        <workflow_id>/
+          workflow.yaml
+          revisions/
+          runs/
+          artifacts/
+    tenant/
+      tenant/
+        <workflow_id>/
+          workflow.yaml
+          revisions/
+          runs/
+          artifacts/
+```
+
+`workflow.yaml` should be a small mutable pointer file.
+Revision files should be immutable.
+Run records should be append-only except for status updates.
+Artifact files should be immutable after publication unless a new artifact revision is explicitly created.
+
+Example `workflow.yaml`:
+
+```yaml
+id: competitor-research-report
+scope: room
+active_revision: "000004"
+created_by: assistant
+created_at: "2026-06-07T12:00:00Z"
+updated_at: "2026-06-07T13:22:00Z"
+archived: false
+```
+
+Writes should be atomic.
+The implementation should write temporary files, validate them, then rename them into place.
+The implementation should use per-workflow locks to avoid concurrent update races.
+
+## Report Publishing
+
+The report publisher should be a MindRoom service, not an Agno or AgentOS public endpoint.
+It should serve private and public artifacts from the tenant's existing MindRoom domain.
+
+Example URLs:
+
+```text
+https://acme.mindroom.chat/reports/private/<scope>/<owner_key>/<workflow_id>/<run_id>
+https://acme.mindroom.chat/reports/public/<unguessable_slug>
+```
+
+Private reports should require normal dashboard authentication.
+Public reports should use unguessable slugs and should record publishing metadata.
+Public reports should be revocable.
+Report HTML should be sanitized.
+Report pages need a tailored Content Security Policy because HTML reports may use inline styles and images.
+
+## Run Lifecycle
+
+1. The agent calls `run_workflow`.
+2. MindRoom resolves the workflow and active revision.
+3. MindRoom validates input against the workflow input schema.
+4. MindRoom computes effective permissions.
+5. MindRoom creates a run record.
+6. MindRoom executes the run on the managed tool path.
+7. The runner builds Agno components from the workflow revision and request context.
+8. The workflow runs steps and records step outputs.
+9. The runner writes artifacts.
+10. The report publisher creates private or public URLs.
+11. MindRoom returns the final run payload to the caller.
+12. The dashboard and tool can read the run record.
+
+Running workflows should stay pinned to the revision they started with.
+Updating the active workflow should not change an in-flight run.
+
+## Approval Rules
+
+Dynamic Workflow creation can auto-approve only for low-risk agent-scoped workflows.
+Room-scoped and tenant-scoped workflows should require approval before activation unless admin policy says otherwise.
+
+Permission expansion should require approval.
+Examples include adding a tool, adding a model, adding a room agent, increasing runtime caps, increasing concurrency caps, requesting broader Matrix history, requesting attachments, requesting knowledge bases, or changing default visibility to public.
+
+Permission reduction can auto-publish under policy.
+Prompt-only edits can auto-publish under policy if they do not change data access or capabilities.
+
+Approval cards should show:
+
+- Workflow name and scope.
+- Participant list.
+- Existing room agents used.
+- Ephemeral agents created.
+- Models requested.
+- Tools requested.
+- Data sources requested.
+- Runtime and concurrency caps.
+- Output artifacts.
+- Visibility policy.
+- Diff from prior revision when updating.
+
+## Agno Integration
+
+MindRoom should upgrade Agno to at least the first version with factories.
+MindRoom currently uses Agno 2.6.12.
+The minimum feature version is Agno 2.6.0.
+
+The initial adapter path should keep MindRoom policy and storage outside Agno internals.
+The adapter should compile declarative workflow specs into Agno `Workflow`, `Team`, or `Agent` objects.
+When useful, it can wrap those builders with Agno `WorkflowFactory`, `TeamFactory`, or `AgentFactory`.
+The adapter should construct request context from MindRoom identity, not from untrusted model-provided input.
+
+If AgentOS is needed for run persistence or streaming, it should remain internal.
+MindRoom should call it through a service token or in-process adapter.
+Public routes should remain MindRoom routes.
+
+## Claude Dynamic Workflow Parallels
+
+Claude Code dynamic workflows provide a useful product model.
+Their documentation says workflows are scripts that orchestrate many subagents in the background.
+The script holds loops, branching, and intermediate results.
+The conversation receives the final answer instead of every intermediate result.
+The user can inspect, approve, save, rerun, and manage workflow runs.
+The runtime caps concurrency and total agents.
+The script coordinates agents, while agents may use tools after explicit grants.
+
+MindRoom should adopt those constraints.
+The workflow coordinator should coordinate, not execute arbitrary tools.
+Future managed runs should be inspectable and backgrounded.
+Saved workflows should become reusable commands or tool targets.
+Costs and limits should be visible before and during a run.
+
+## Deep Research as First Dynamic Workflow
+
+Deep research should be the first substantial bundled Dynamic Workflow after the basic runner is stable.
+It should produce Markdown and HTML report artifacts.
+It should default to private reports.
+It should use web search and website reading tools when allowed.
+It should support optional use of room agents.
+It should create ephemeral source readers, critics, and report writers.
+It should cross-check claims and filter unsupported claims before report writing.
+
+This gives users the desired hosted report workflow without building a separate Odysseus clone.
+The same Dynamic Workflow framework can then support other repeatable workflows.
+
+## Current Status
+
+Phase 1 shipped in #1194 (executable Dynamic Workflows) and #1202 (tool grants for participants).
+What works today: durable storage and revisions, spec validation, the seven `create/validate/update/run/get/list/list_revisions` tools, ephemeral and room-agent participants, the model allowlist, open tool grants for any registered tool with per-call approval (and `allowed_tools` pre-approval including `"*"`), caller-parity tool routing, run records, and private report serving.
+
+The remaining work to finish the feature is tracked in the "Finish Phase 1" section below; the original Phase 2-4 plan continues after it.
+
+### Finish Phase 1
+
+These items close the gap between "the grant plumbing works" and "the feature is trustworthy and usable end to end".
+
+- Stream ephemeral participant runs.
+  `_arun_agent` calls `agent.arun()` without `stream=True`, so Claude/Vertex participants fail their first model call with "Streaming is required for operations that may take longer than 10 minutes" before any tool runs.
+  The fix mirrors the main agent path, which streams and consumes events.
+  This blocks all Claude participant execution, with or without tool grants; Gemini participants are unaffected because that SDK has no equivalent guard.
+- Carry workflow provenance into the approval card.
+  `ToolApprovalCall` carries only `tool_name`, `arguments`, `agent_name`, and the Matrix scope, so a participant's approval card is indistinguishable from a normal agent tool call.
+  The card should name the workflow and participant so the approver gives informed consent.
+- Decide policy for high-power tools under tool grants.
+  `config_manager`, `subagents`, `scheduler`, and `claude_agent` are registered and grantable but absent from `_WORKFLOW_RESTRICTED_TOOLS`, so `allowed_tools: ["*"]` can pre-approve config rewrites, agent spawning, and cron creation with no per-call approval.
+  Either add them to the restricted set, forbid wildcard pre-approval for them, or consciously accept the risk.
+- Define blocking-approval behavior.
+  In the synchronous `run_workflow` path a participant tool call blocks on approval up to the workflow's `max_runtime_seconds`, which hangs the calling agent's turn.
+  Verify this behavior and decide on an acceptable cap or a clearer "waiting for approval" signal.
+- Live-test the full approval loop.
+  Drive the real path on a local Matrix stack: a participant calls a non-pre-approved tool, the card posts in the originating room, the requester reacts to approve, the tool runs, and the workflow completes; deny declines.
+
+### Phase 1: Storage, Validation, and Basic Runs
+
+- Upgrade Agno to a factory-capable version.
+- Add Dynamic Workflow storage under `MINDROOM_STORAGE_PATH`.
+- Add declarative workflow spec schema.
+- Add `create_workflow`, `validate_workflow`, `update_workflow`, `run_workflow`, `get_workflow_run`, `list_workflows`, and `list_workflow_revisions`.
+- Support ephemeral agents with a model allowlist.
+- Support room agent participants without durable memory, tools, skills, credentials, or knowledge.
+- Support ephemeral tool grants for any registered tool, declared in `permissions.tools` and per-participant `tools`, with per-call user approval unless the calling agent's `dynamic_workflow` `allowed_tools` config (including `"*"`) pre-approves the tool.
+- Run granted tools with the calling agent's tool routing: credentials, worker sandboxing, and egress proxying.
+- Reject Matrix context, attachment, and knowledge grants until they are wired into execution.
+- Store run records and artifacts.
+- Add private report serving.
+
+### Phase 2: Grants, Publishing, and Dashboard
+
+- Implement deep research as a bundled declarative Dynamic Workflow once web/data/tool grants exist.
+- Add publish, rollback, and archive actions.
+- Add approval cards for workflow activation and permission expansion.
+- Add full room-agent memory, tool, skill, and knowledge grants.
+- Add dashboard Dynamic Workflow library and run detail page.
+- Add public report links with revocation.
+- Add run cancellation.
+- Add token and cost summaries where provider metadata supports it.
+
+### Phase 3: Worker-Backed Execution and Advanced Control
+
+- Run long workflow jobs through sandbox-runner or dedicated Kubernetes workers.
+- Add pause and resume where practical.
+- Add run queues and per-tenant concurrency limits.
+- Add scheduled workflow runs.
+- Add trusted code-backed workflow modules through plugins.
+- Add richer progress UI with per-phase and per-agent detail.
+
+### Phase 4: Agent-Authored Workflow Evolution
+
+- Let agents propose workflow improvements from run results.
+- Add policy-based auto-publish for safe prompt-only edits.
+- Add quality scoring and self-review hooks.
+- Add template workflows for common domains.
+- Consider script-backed workflows for trusted users only.
+
+## Testing Strategy
+
+Unit tests should cover spec validation, permission intersection, storage paths, revision immutability, atomic writes, and patch classification.
+API tests should cover create, update, publish, run, list, and artifact serving.
+Future background execution tests should cover cancel.
+Security tests should cover cross-room access denial, unauthorized model denial, unauthorized tool denial, public report revocation, and invalid path traversal.
+Integration tests should run a tiny Dynamic Workflow with two ephemeral agents and one artifact.
+Live tests should run the deep research workflow with a small query and confirm the Matrix completion link works.
+
+Agno upgrade tests should cover existing MindRoom agent runs, teams, tools, skills, memory, and OpenAI-compatible API behavior.
+This is needed because the Agno upgrade touches a shared runtime dependency.
+
+## Expected User Experience
+
+After the deep research workflow is bundled, the user experience should feel like this:
+
+1. A user asks for a deep research report.
+2. The agent creates or reuses a Dynamic Workflow and calls the Dynamic Workflow tool.
+3. MindRoom creates a run, executes the active revision, and returns a private report URL when report artifacts exist.
+4. The final Matrix message links to the report.
+5. Future versions should move long runs to managed background jobs with progress and cancellation.
+6. The user can ask the agent to improve and save the workflow.
+7. The workflow revision history records what changed and why.
+
+This should make MindRoom feel like it can build and reuse its own workflow systems without turning every workflow into a permanent Matrix bot.
+
+## References
+
+- Agno Dynamic Agents: https://docs.agno.com/agent-os/factories/overview
+- Agno WorkflowFactory: https://docs.agno.com/agent-os/factories/workflow-factory
+- Agno Factories Reference: https://docs.agno.com/reference/agent-os/factories
+- Claude Code Dynamic Workflows: https://code.claude.com/docs/en/workflows
+- Odysseus Deep Research reference: https://github.com/pewdiepie-archdaemon/odysseus

--- a/docs/superpowers/specs/2026-06-07-dynamic-workflows-design.md
+++ b/docs/superpowers/specs/2026-06-07-dynamic-workflows-design.md
@@ -485,19 +485,18 @@ The remaining work to finish the feature is tracked in the "Finish Phase 1" sect
 
 These items close the gap between "the grant plumbing works" and "the feature is trustworthy and usable end to end".
 
-- Stream ephemeral participant runs.
-  `_arun_agent` calls `agent.arun()` without `stream=True`, so Claude/Vertex participants fail their first model call with "Streaming is required for operations that may take longer than 10 minutes" before any tool runs.
-  The fix mirrors the main agent path, which streams and consumes events.
-  This blocks all Claude participant execution, with or without tool grants; Gemini participants are unaffected because that SDK has no equivalent guard.
-- Carry workflow provenance into the approval card.
-  `ToolApprovalCall` carries only `tool_name`, `arguments`, `agent_name`, and the Matrix scope, so a participant's approval card is indistinguishable from a normal agent tool call.
-  The card should name the workflow and participant so the approver gives informed consent.
-- Decide policy for high-power tools under tool grants.
-  `config_manager`, `subagents`, `scheduler`, and `claude_agent` are registered and grantable but absent from `_WORKFLOW_RESTRICTED_TOOLS`, so `allowed_tools: ["*"]` can pre-approve config rewrites, agent spawning, and cron creation with no per-call approval.
-  Either add them to the restricted set, forbid wildcard pre-approval for them, or consciously accept the risk.
-- Define blocking-approval behavior.
-  In the synchronous `run_workflow` path a participant tool call blocks on approval up to the workflow's `max_runtime_seconds`, which hangs the calling agent's turn.
-  Verify this behavior and decide on an acceptable cap or a clearer "waiting for approval" signal.
+- Done: stream ephemeral participant runs.
+  `_arun_agent` now streams with `stream=True` and `yield_run_output=True` and consumes the event stream, so Claude/Vertex participants no longer trip the SDK's "Streaming is required for operations that may take longer than 10 minutes" guard.
+  Verified live with a Vertex Claude participant that wrote and read a unique token through a granted shell tool.
+- Done: carry workflow provenance into the approval card.
+  `ToolApprovalCall` now carries a `ToolCallWorkflowOrigin` (workflow id plus participant id) injected through the participant's tool hook bridge.
+  Approval cards expose `workflow_id` and `participant_id` content fields, and the card body names the workflow and participant in both pending and resolved states.
+- Done: high-power tools are never pre-approved.
+  `claude_agent`, `config_manager`, `scheduler`, and `subagents` stay grantable, but `_WORKFLOW_NO_PREAPPROVAL_TOOLS` excludes them from `allowed_tools` pre-approval, wildcard or explicit, so every call posts an approval card.
+  This also closes the escalation where an agent with `self_config` edits its own `allowed_tools` config to silence approval for system-mutating tools.
+- Done: blocking-approval behavior is bounded by the runtime cap.
+  A participant tool call waiting on approval blocks the caller's turn, but `permissions.max_runtime_seconds` (hard-capped at 3600 seconds) fails the run at the deadline, and the cancelled approval wait edits the pending card to expired.
+  The approval card posted in the originating room is the "waiting for approval" signal; no additional cap was added.
 - Live-test the full approval loop.
   Drive the real path on a local Matrix stack: a participant calls a non-pre-approved tool, the card posts in the originating room, the requester reacts to approve, the tool runs, and the workflow completes; deny declines.
 

--- a/docs/superpowers/specs/2026-06-07-dynamic-workflows-design.md
+++ b/docs/superpowers/specs/2026-06-07-dynamic-workflows-design.md
@@ -497,8 +497,9 @@ These items close the gap between "the grant plumbing works" and "the feature is
 - Done: blocking-approval behavior is bounded by the runtime cap.
   A participant tool call waiting on approval blocks the caller's turn, but `permissions.max_runtime_seconds` (hard-capped at 3600 seconds) fails the run at the deadline, and the cancelled approval wait edits the pending card to expired.
   The approval card posted in the originating room is the "waiting for approval" signal; no additional cap was added.
-- Live-test the full approval loop.
-  Drive the real path on a local Matrix stack: a participant calls a non-pre-approved tool, the card posts in the originating room, the requester reacts to approve, the tool runs, and the workflow completes; deny declines.
+- Done: live-test the full approval loop.
+  Verified on a local Synapse stack with a Gemini-driven agent: the participant's `run_shell_command` posted a provenance-labeled card in the originating thread, a human ✅ reaction approved it, the command ran (token file on disk), and the workflow completed with the token in its outputs.
+  The deny path was verified by replying to the card: the card flipped to denied with the reply as `resolution_reason`, the command never ran, and a participant retry posted a fresh card that required its own decision.
 
 ### Phase 1: Storage, Validation, and Basic Runs
 

--- a/src/mindroom/approval_events.py
+++ b/src/mindroom/approval_events.py
@@ -29,6 +29,8 @@ class PendingApproval:
     created_at_ms: int
     thread_id: str | None = None
     agent_name: str | None = None
+    workflow_id: str | None = None
+    participant_id: str | None = None
     requested_at: str | None = None
     expires_at: str | None = None
 
@@ -66,6 +68,8 @@ class PendingApproval:
         requester_id = _content_str(content, "requester_id") or ""
         thread_id = _content_str(content, "thread_id")
         agent_name = _content_str(content, "agent_name")
+        workflow_id = _content_str(content, "workflow_id")
+        participant_id = _content_str(content, "participant_id")
 
         return cls(
             approval_id=approval_id,
@@ -81,6 +85,8 @@ class PendingApproval:
             created_at_ms=created_at_ms,
             thread_id=thread_id,
             agent_name=agent_name,
+            workflow_id=workflow_id,
+            participant_id=participant_id,
             requested_at=requested_at,
             expires_at=expires_at,
         )

--- a/src/mindroom/approval_manager.py
+++ b/src/mindroom/approval_manager.py
@@ -264,6 +264,8 @@ class _ApprovalManager:
         timeout_seconds: float,
         agent_name: str | None = None,
         thread_id: str | None = None,
+        workflow_id: str | None = None,
+        participant_id: str | None = None,
     ) -> ApprovalDecision:
         """Send one Matrix approval card and wait for the Matrix-backed resolution."""
         # Keep the send/bind/wait flow linear so cancellation cleanup remains visible.
@@ -287,6 +289,8 @@ class _ApprovalManager:
             arguments=event_arguments,
             arguments_truncated=arguments_truncated,
             agent_name=agent_name,
+            workflow_id=workflow_id,
+            participant_id=participant_id,
             thread_id=thread_id,
             requester_id=requester_id,
             approver_user_id=approver_user_id,
@@ -1076,10 +1080,17 @@ class _ApprovalManager:
         requested_at: datetime,
         expires_at: datetime,
         status: PendingApprovalStatus,
+        workflow_id: str | None = None,
+        participant_id: str | None = None,
     ) -> dict[str, Any]:
         content: dict[str, Any] = {
             "msgtype": "io.mindroom.tool_approval",
-            "body": _ApprovalManager._event_body(tool_name, status),
+            "body": _ApprovalManager._event_body(
+                tool_name,
+                status,
+                workflow_id=workflow_id,
+                participant_id=participant_id,
+            ),
             "tool_name": tool_name,
             "tool_call_id": approval_id,
             "arguments": arguments,
@@ -1092,6 +1103,10 @@ class _ApprovalManager:
         }
         if agent_name is not None:
             content["agent_name"] = agent_name
+        if workflow_id is not None:
+            content["workflow_id"] = workflow_id
+        if participant_id is not None:
+            content["participant_id"] = participant_id
         if arguments_truncated:
             content["arguments_truncated"] = True
         if requester_id is not None:
@@ -1116,7 +1131,12 @@ class _ApprovalManager:
         )
         content: dict[str, Any] = {
             "msgtype": "io.mindroom.tool_approval",
-            "body": _ApprovalManager._event_body(pending.tool_name, status),
+            "body": _ApprovalManager._event_body(
+                pending.tool_name,
+                status,
+                workflow_id=pending.workflow_id,
+                participant_id=pending.participant_id,
+            ),
             "tool_name": pending.tool_name,
             "tool_call_id": pending.approval_id,
             "arguments": pending.arguments_preview,
@@ -1131,6 +1151,10 @@ class _ApprovalManager:
         }
         if pending.agent_name is not None:
             content["agent_name"] = pending.agent_name
+        if pending.workflow_id is not None:
+            content["workflow_id"] = pending.workflow_id
+        if pending.participant_id is not None:
+            content["participant_id"] = pending.participant_id
         if pending.arguments_preview_truncated:
             content["arguments_truncated"] = True
         if pending.requester_id:
@@ -1140,14 +1164,23 @@ class _ApprovalManager:
         return content
 
     @staticmethod
-    def _event_body(tool_name: str, status: PendingApprovalStatus) -> str:
+    def _event_body(
+        tool_name: str,
+        status: PendingApprovalStatus,
+        *,
+        workflow_id: str | None = None,
+        participant_id: str | None = None,
+    ) -> str:
+        subject = tool_name
+        if workflow_id is not None and participant_id is not None:
+            subject = f"{tool_name} — Dynamic Workflow '{workflow_id}' participant '{participant_id}'"
         if status == "approved":
-            return f"Approved: {tool_name}"
+            return f"Approved: {subject}"
         if status == "denied":
-            return f"Denied: {tool_name}"
+            return f"Denied: {subject}"
         if status == "expired":
-            return f"Expired: {tool_name}"
-        return f"🔒 Approval required: {tool_name}"
+            return f"Expired: {subject}"
+        return f"🔒 Approval required: {subject}"
 
     @classmethod
     def _normalized_resolution_request(

--- a/src/mindroom/custom_tools/dynamic_workflow.py
+++ b/src/mindroom/custom_tools/dynamic_workflow.py
@@ -28,6 +28,7 @@ from mindroom.dynamic_workflows.runner import DynamicWorkflowExecutionError
 from mindroom.dynamic_workflows.service import DynamicWorkflowService
 from mindroom.dynamic_workflows.store import DynamicWorkflowError
 from mindroom.entity_resolution import entity_identity_registry
+from mindroom.tool_approval import ToolCallWorkflowOrigin
 from mindroom.tool_system.catalog import TOOL_METADATA, ensure_tool_registry_loaded
 from mindroom.tool_system.runtime_context import (
     ToolRuntimeContext,
@@ -46,6 +47,11 @@ if TYPE_CHECKING:
 _WORKFLOW_RESTRICTED_TOOLS = frozenset(
     {"compact_context", "delegate", "dynamic_tools", "dynamic_workflow", "memory", "self_config"},
 )
+
+# Tools that mutate the MindRoom system itself (rewrite config.yaml, spawn agents, create
+# cron jobs, run an autonomous coding agent). Participants may be granted these, but every
+# call needs a human decision: allowed_tools (including "*") never pre-approves them.
+_WORKFLOW_NO_PREAPPROVAL_TOOLS = frozenset({"claude_agent", "config_manager", "scheduler", "subagents"})
 
 _TOOL_DESCRIPTIONS = {
     "create_workflow": (
@@ -445,7 +451,7 @@ def _participant_executor(context: ToolRuntimeContext, workflow_id: str) -> Part
         step_outputs: dict[str, object],
     ) -> object:
         del input_data, step_outputs
-        return _execute_participant(context, participant, prompt, run_scope=run_scope)
+        return _execute_participant(context, participant, prompt, run_scope=run_scope, workflow_id=workflow_id)
 
     return execute
 
@@ -461,7 +467,7 @@ def _aparticipant_executor(context: ToolRuntimeContext, workflow_id: str) -> Asy
         step_outputs: dict[str, object],
     ) -> object:
         del input_data, step_outputs
-        return await _aexecute_participant(context, participant, prompt, run_scope=run_scope)
+        return await _aexecute_participant(context, participant, prompt, run_scope=run_scope, workflow_id=workflow_id)
 
     return execute
 
@@ -472,12 +478,19 @@ def _execute_participant(
     prompt: str,
     *,
     run_scope: str,
+    workflow_id: str,
 ) -> object:
     participant_kind = str(participant.get("kind", "ephemeral_agent")).strip() or "ephemeral_agent"
     if participant_kind == "room_agent":
         return _execute_room_agent_participant(context, participant, prompt, run_scope=run_scope)
     if participant_kind == "ephemeral_agent":
-        return _execute_ephemeral_agent_participant(context, participant, prompt, run_scope=run_scope)
+        return _execute_ephemeral_agent_participant(
+            context,
+            participant,
+            prompt,
+            run_scope=run_scope,
+            workflow_id=workflow_id,
+        )
     msg = f"Unsupported Dynamic Workflow participant kind '{participant_kind}'."
     raise DynamicWorkflowError(msg)
 
@@ -488,12 +501,19 @@ async def _aexecute_participant(
     prompt: str,
     *,
     run_scope: str,
+    workflow_id: str,
 ) -> object:
     participant_kind = str(participant.get("kind", "ephemeral_agent")).strip() or "ephemeral_agent"
     if participant_kind == "room_agent":
         return await _aexecute_room_agent_participant(context, participant, prompt, run_scope=run_scope)
     if participant_kind == "ephemeral_agent":
-        return await _aexecute_ephemeral_agent_participant(context, participant, prompt, run_scope=run_scope)
+        return await _aexecute_ephemeral_agent_participant(
+            context,
+            participant,
+            prompt,
+            run_scope=run_scope,
+            workflow_id=workflow_id,
+        )
     msg = f"Unsupported Dynamic Workflow participant kind '{participant_kind}'."
     raise DynamicWorkflowError(msg)
 
@@ -605,8 +625,17 @@ def _execute_ephemeral_agent_participant(
     prompt: str,
     *,
     run_scope: str,
+    workflow_id: str,
 ) -> object:
-    return asyncio.run(_aexecute_ephemeral_agent_participant(context, participant, prompt, run_scope=run_scope))
+    return asyncio.run(
+        _aexecute_ephemeral_agent_participant(
+            context,
+            participant,
+            prompt,
+            run_scope=run_scope,
+            workflow_id=workflow_id,
+        ),
+    )
 
 
 async def _aexecute_ephemeral_agent_participant(
@@ -615,6 +644,7 @@ async def _aexecute_ephemeral_agent_participant(
     prompt: str,
     *,
     run_scope: str,
+    workflow_id: str,
 ) -> object:
     toolkits_by_name = _resolve_participant_toolkits(context, participant)
     participant_id = _required_participant_text(participant, "id")
@@ -631,6 +661,7 @@ async def _aexecute_ephemeral_agent_participant(
         agent_name=context.agent_name,
         config=run_config,
         runtime_paths=context.runtime_paths,
+        workflow_origin=ToolCallWorkflowOrigin(workflow_id=workflow_id, participant_id=participant_id),
     )
     agent = Agent(
         id=f"dynamic_workflow_{participant_id}",
@@ -731,7 +762,11 @@ def _participant_run_config(context: ToolRuntimeContext, toolkits_by_name: dict[
     for tool_name, toolkit in toolkits_by_name.items():
         for function_name in (*toolkit.functions, *toolkit.async_functions):
             owning_tools.setdefault(function_name, set()).add(tool_name)
-    pre_approved_tools = {tool_name for tool_name in toolkits_by_name if allow_all or tool_name in allowed_tools}
+    pre_approved_tools = {
+        tool_name
+        for tool_name in toolkits_by_name
+        if tool_name not in _WORKFLOW_NO_PREAPPROVAL_TOOLS and (allow_all or tool_name in allowed_tools)
+    }
     pre_approved_functions = sorted(
         function_name for function_name, tools in owning_tools.items() if tools <= pre_approved_tools
     )

--- a/src/mindroom/custom_tools/dynamic_workflow.py
+++ b/src/mindroom/custom_tools/dynamic_workflow.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 
 import nio
 from agno.agent import Agent
-from agno.run.agent import RunStatus
+from agno.run.agent import RunOutput, RunStatus
 from agno.tools import Toolkit
 
 from mindroom import model_loading
@@ -771,15 +771,29 @@ def _workflow_allowed_tools(context: ToolRuntimeContext) -> frozenset[str]:
 
 
 async def _arun_agent(context: ToolRuntimeContext, agent: Agent, prompt: str) -> object:
+    # Stream the run: the participant inherits the caller's model and the workflow's runtime
+    # budget, and the Anthropic/Vertex SDK refuses a non-streaming request whose budget could
+    # exceed 10 minutes. Consuming the event stream drives tool calls and their approval gating;
+    # yield_run_output makes the final RunOutput the last streamed item, which works without a db.
+    final_output: RunOutput | None = None
     with tool_runtime_context(context):
-        response = await agent.arun(
+        event_stream = agent.arun(
             prompt,
             user_id=context.requester_id,
             session_id=context.session_id,
+            stream=True,
+            stream_events=True,
+            yield_run_output=True,
         )
-    content = response.content if response.content is not None else ""
-    if response.status != RunStatus.completed:
-        message = str(content) if content else f"Agent run ended with status {response.status.value}."
+        async for event in event_stream:
+            if isinstance(event, RunOutput):
+                final_output = event
+    if final_output is None:
+        msg = "Dynamic Workflow participant run produced no output."
+        raise DynamicWorkflowExecutionError(msg)
+    content = final_output.content if final_output.content is not None else ""
+    if final_output.status != RunStatus.completed:
+        message = str(content) if content else f"Agent run ended with status {final_output.status.value}."
         raise DynamicWorkflowExecutionError(message)
     return content
 

--- a/src/mindroom/custom_tools/dynamic_workflow.py
+++ b/src/mindroom/custom_tools/dynamic_workflow.py
@@ -58,7 +58,9 @@ _TOOL_DESCRIPTIONS = {
         "Create a Dynamic Workflow from a declarative workflow spec. "
         "Ephemeral participants may declare any registered tool when it is also granted in "
         "permissions.tools; participant tool calls require per-call user approval unless the "
-        "tool is pre-approved by the dynamic_workflow allowed_tools config."
+        "tool is pre-approved by the dynamic_workflow allowed_tools config. System-mutating "
+        "tools (claude_agent, config_manager, scheduler, subagents) always require per-call "
+        "approval and can never be pre-approved."
     ),
     "validate_workflow": "Validate a declarative Dynamic Workflow spec without saving it.",
     "update_workflow": "Create and publish a new Dynamic Workflow revision from a patch.",

--- a/src/mindroom/tool_approval.py
+++ b/src/mindroom/tool_approval.py
@@ -47,6 +47,7 @@ __all__ = [
     "ToolApprovalCall",
     "ToolApprovalScriptError",
     "ToolApprovalTransportError",
+    "ToolCallWorkflowOrigin",
     "evaluate_tool_approval",
     "expire_orphaned_approval_cards_on_startup",
     "handle_matrix_approval_action",
@@ -69,6 +70,14 @@ class ToolApprovalScriptError(RuntimeError):
 
 
 @dataclass(frozen=True, slots=True)
+class ToolCallWorkflowOrigin:
+    """Dynamic Workflow provenance for one participant tool call."""
+
+    workflow_id: str
+    participant_id: str
+
+
+@dataclass(frozen=True, slots=True)
 class ToolApprovalCall:
     """One tool call that may require a Matrix approval card."""
 
@@ -80,6 +89,7 @@ class ToolApprovalCall:
     room_id: str | None
     thread_id: str | None
     requester_id: str | None
+    workflow_origin: ToolCallWorkflowOrigin | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -254,6 +264,7 @@ async def request_tool_approval_for_call(call: ToolApprovalCall) -> ApprovalDeci
             "Tool approval is required but the approval store is not initialized.",
         )
 
+    origin = call.workflow_origin
     return await manager.request_approval(
         tool_name=call.tool_name,
         arguments=deepcopy(call.arguments),
@@ -261,6 +272,8 @@ async def request_tool_approval_for_call(call: ToolApprovalCall) -> ApprovalDeci
         room_id=call.room_id,
         thread_id=call.thread_id,
         requester_id=call.requester_id,
+        workflow_id=origin.workflow_id if origin is not None else None,
+        participant_id=origin.participant_id if origin is not None else None,
         approver_user_id=resolve_tool_approval_approver(
             call.config,
             call.runtime_paths,

--- a/src/mindroom/tool_system/tool_hooks.py
+++ b/src/mindroom/tool_system/tool_hooks.py
@@ -29,7 +29,12 @@ from mindroom.logging_config import get_logger
 from mindroom.oauth.providers import OAuthConnectionRequired, oauth_connection_required_payload
 from mindroom.sync_bridge_state import sync_tool_bridge_blocked_loop
 from mindroom.timing import elapsed_ms_since, emit_timing_event
-from mindroom.tool_approval import ToolApprovalCall, ToolApprovalScriptError, request_tool_approval_for_call
+from mindroom.tool_approval import (
+    ToolApprovalCall,
+    ToolApprovalScriptError,
+    ToolCallWorkflowOrigin,
+    request_tool_approval_for_call,
+)
 from mindroom.tool_system.runtime_context import (
     LiveToolDispatchContext,
     ToolDispatchContext,
@@ -474,6 +479,7 @@ async def _maybe_block_for_tool_approval(
     tool_name: str,
     has_after_hooks: bool,
     started_at: float,
+    workflow_origin: ToolCallWorkflowOrigin | None,
 ) -> str | None:
     if resolved_context.config is None or resolved_context.runtime_paths is None:
         return None
@@ -489,6 +495,7 @@ async def _maybe_block_for_tool_approval(
                 room_id=resolved_context.room_id,
                 thread_id=resolved_context.thread_id,
                 requester_id=resolved_context.requester_id,
+                workflow_origin=workflow_origin,
             ),
         )
     except ToolApprovalScriptError:
@@ -580,6 +587,7 @@ async def _execute_bridge(
     runtime_paths: RuntimePaths | None,
     has_before_hooks: bool,
     has_after_hooks: bool,
+    workflow_origin: ToolCallWorkflowOrigin | None,
 ) -> _ToolHookResult:
     started_at = time.perf_counter()
     effective_dispatch_context = _explicit_bridge_dispatch_context(dispatch_context) or _ambient_tool_dispatch_context()
@@ -622,6 +630,7 @@ async def _execute_bridge(
         tool_name=tool_name,
         has_after_hooks=has_after_hooks,
         started_at=started_at,
+        workflow_origin=workflow_origin,
     )
     if blocked_result is not None:
         return blocked_result
@@ -741,6 +750,7 @@ def build_tool_hook_bridge(
     dispatch_context: ToolDispatchContext | None = None,
     config: Config | None = None,
     runtime_paths: RuntimePaths | None = None,
+    workflow_origin: ToolCallWorkflowOrigin | None = None,
 ) -> Callable[..., Any]:
     """Return one Agno-compatible tool hook bridge."""
     has_before_hooks = hook_registry.has_hooks(EVENT_TOOL_BEFORE_CALL)
@@ -758,6 +768,7 @@ def build_tool_hook_bridge(
             runtime_paths=runtime_paths,
             has_before_hooks=has_before_hooks,
             has_after_hooks=has_after_hooks,
+            workflow_origin=workflow_origin,
         )
 
     def sync_bridge(name: str, func: Callable[..., Any], args: dict[str, Any]) -> _ToolHookResult:
@@ -774,6 +785,7 @@ def build_tool_hook_bridge(
                     runtime_paths=runtime_paths,
                     has_before_hooks=has_before_hooks,
                     has_after_hooks=has_after_hooks,
+                    workflow_origin=workflow_origin,
                 ),
             )
         return _run_coroutine_from_sync(
@@ -788,6 +800,7 @@ def build_tool_hook_bridge(
                 runtime_paths=runtime_paths,
                 has_before_hooks=has_before_hooks,
                 has_after_hooks=has_after_hooks,
+                workflow_origin=workflow_origin,
             ),
         )
 

--- a/src/mindroom/tools/dynamic_workflow.py
+++ b/src/mindroom/tools/dynamic_workflow.py
@@ -28,7 +28,9 @@ register_builtin_tool_metadata(
                 default=None,
                 description=(
                     "Tool names workflow participants may call without per-call user approval. "
-                    'Use "*" to pre-approve every granted tool.'
+                    'Use "*" to pre-approve every granted tool. '
+                    "System-mutating tools (claude_agent, config_manager, scheduler, subagents) "
+                    "always require per-call approval and cannot be pre-approved."
                 ),
             ),
         ],

--- a/tach.toml
+++ b/tach.toml
@@ -3203,6 +3203,7 @@ expose = [
     "ToolApprovalCall",
     "ToolApprovalScriptError",
     "ToolApprovalTransportError",
+    "ToolCallWorkflowOrigin",
     "evaluate_tool_approval",
     "expire_orphaned_approval_cards_on_startup",
     "handle_matrix_approval_action",

--- a/tests/test_dynamic_workflows.py
+++ b/tests/test_dynamic_workflows.py
@@ -21,6 +21,7 @@ from agno.workflow import Workflow, WorkflowFactory
 from agno.workflow.types import StepInput, StepOutput
 
 import mindroom.tools  # noqa: F401
+from mindroom.approval_manager import SentApprovalEvent, initialize_approval_store
 from mindroom.config.agent import AgentConfig, AgentPrivateConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
@@ -31,7 +32,7 @@ from mindroom.dynamic_workflows.runner import DynamicWorkflowExecutionError, exe
 from mindroom.dynamic_workflows.service import DynamicWorkflowService
 from mindroom.dynamic_workflows.store import DynamicWorkflowError, DynamicWorkflowStore
 from mindroom.entity_resolution import entity_identity_registry
-from mindroom.tool_approval import _matching_tool_approval_rule
+from mindroom.tool_approval import ToolCallWorkflowOrigin, _matching_tool_approval_rule, _shutdown_approval_store
 from mindroom.tool_system.metadata import TOOL_METADATA
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, get_tool_runtime_context, tool_runtime_context
 from tests.conftest import bind_runtime_paths, make_event_cache_mock, runtime_paths_for, test_runtime_paths
@@ -1181,6 +1182,72 @@ async def test_service_async_run_fails_at_deadline_when_cancellation_is_suppress
 
 
 @pytest.mark.asyncio
+async def test_async_run_timeout_expires_pending_approval_card(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A participant blocked on approval must fail at the runtime cap and expire its card."""
+    store = DynamicWorkflowStore(tmp_path / "mindroom_data")
+    runtime_paths = test_runtime_paths(tmp_path)
+    sender = AsyncMock(return_value=SentApprovalEvent("$approval"))
+    editor = AsyncMock(return_value=True)
+    approval_store = initialize_approval_store(
+        runtime_paths,
+        sender=sender,
+        editor=editor,
+        transport_sender=lambda: "@mindroom_router:localhost",
+    )
+
+    async def blocked_executor(**_kwargs: object) -> object:
+        return await approval_store.request_approval(
+            tool_name="run_shell_command",
+            arguments={"command": "ls"},
+            agent_name="general",
+            room_id="!room:localhost",
+            requester_id="@user:localhost",
+            approver_user_id="@user:localhost",
+            timeout_seconds=600,
+            workflow_id="competitor-research-report",
+            participant_id="writer",
+        )
+
+    service = DynamicWorkflowService(store, async_participant_executor=blocked_executor)
+    monkeypatch.setattr("mindroom.dynamic_workflows.service.workflow_runtime_seconds", lambda _spec: 0.1)
+    store.create_workflow(
+        spec=_workflow_spec(),
+        scope="agent",
+        owner_id="general",
+        created_by="general",
+        reason="initial design",
+    )
+
+    try:
+        run = await service.arun_workflow(
+            workflow_id="competitor-research-report",
+            scope="agent",
+            owner_id="general",
+            input_data={"topic": "Agno factories"},
+            requested_by="general",
+            base_url="https://acme.mindroom.chat",
+        )
+
+        assert run.status == "failed"
+        assert "max_runtime_seconds" in str(run.error)
+        # The cancelled approval wait finishes its cleanup in the background.
+        async with asyncio.timeout(5):
+            while True:
+                if editor.await_count:
+                    break
+                await asyncio.sleep(0)
+        assert editor.await_args.args[:2] == ("!room:localhost", "$approval")
+        assert editor.await_args.args[2]["status"] == "expired"
+        assert editor.await_args.args[2]["workflow_id"] == "competitor-research-report"
+        assert editor.await_args.args[2]["participant_id"] == "writer"
+    finally:
+        await _shutdown_approval_store()
+
+
+@pytest.mark.asyncio
 async def test_service_async_run_persists_cancelled_status(tmp_path: Path) -> None:
     """Cancelling an async workflow run should not leave the run stuck as running."""
     store = DynamicWorkflowStore(tmp_path / "mindroom_data")
@@ -2121,6 +2188,33 @@ def test_participant_run_config_does_not_pre_approve_colliding_function_names(tm
     assert "read_file" not in rules
 
 
+def test_participant_run_config_never_pre_approves_system_mutating_tools(tmp_path: Path) -> None:
+    """allowed_tools (wildcard or explicit) must not pre-approve system-mutating tools."""
+    context = _make_context(tmp_path)
+    config = bind_runtime_paths(
+        Config(
+            agents={
+                "general": AgentConfig(
+                    display_name="General Agent",
+                    tools=[{"dynamic_workflow": {"allowed_tools": ["*", "scheduler"]}}],
+                ),
+            },
+            models={"default": ModelConfig(provider="anthropic", id="claude-sonnet-4-6")},
+        ),
+        context.runtime_paths,
+    )
+    context = replace(context, config=config, runtime_paths=runtime_paths_for(config))
+    scheduler = Toolkit(name="fake_scheduler")
+    scheduler.functions["schedule_task"] = SimpleNamespace(name="schedule_task")
+    website = Toolkit(name="fake_website")
+    website.functions["read_url"] = SimpleNamespace(name="read_url")
+
+    run_config = dynamic_workflow_module._participant_run_config(context, {"scheduler": scheduler, "website": website})
+
+    assert run_config.tool_approval.default == "require_approval"
+    assert [(rule.match, rule.action) for rule in run_config.tool_approval.rules] == [("read_url", "auto_approve")]
+
+
 def test_participant_run_config_preserves_operator_rule_precedence(tmp_path: Path) -> None:
     """An operator require_approval rule must win over workflow pre-approval (first-match)."""
     context = _make_context(tmp_path)
@@ -2217,6 +2311,54 @@ def test_ephemeral_participant_runs_with_granted_toolkits(tmp_path: Path) -> Non
     assert build_calls["website"]["worker_tools"] == ["shell"]
     assert build_calls["website"]["session_id"] == context.session_id
     assert build_calls["shell"]["worker_tools"] == ["shell"]
+
+
+def test_ephemeral_participant_tool_bridge_carries_workflow_origin(tmp_path: Path) -> None:
+    """The participant's tool hook bridge must carry workflow + participant provenance for approval cards."""
+    context = _make_context(tmp_path)
+    config = bind_runtime_paths(
+        Config(
+            agents={
+                "general": AgentConfig(display_name="General Agent", tools=["dynamic_workflow", "website"]),
+            },
+            models={"default": ModelConfig(provider="anthropic", id="claude-sonnet-4-6")},
+        ),
+        context.runtime_paths,
+    )
+    context = replace(context, config=config, runtime_paths=runtime_paths_for(config))
+    tool = DynamicWorkflowTools()
+    spec = _workflow_spec(
+        participants=[
+            {
+                "id": "writer",
+                "kind": "ephemeral_agent",
+                "model": "claude-sonnet-4-6",
+                "tools": ["website"],
+            },
+        ],
+        permissions={"models": ["claude-sonnet-4-6"], "tools": ["website"]},
+    )
+    bridge_mock = Mock(return_value=None)
+    agent_mock = Mock(return_value=_fake_stream_agent(content="done"))
+    with (
+        tool_runtime_context(context),
+        patch(
+            "mindroom.agents.build_agent_toolkit",
+            side_effect=lambda name, **_kwargs: Toolkit(name=f"fake_{name}"),
+        ),
+        patch.object(dynamic_workflow_module, "build_tool_hook_bridge", bridge_mock),
+        patch.object(dynamic_workflow_module.model_loading, "get_model_instance", return_value=SimpleNamespace()),
+        patch.object(dynamic_workflow_module, "Agent", agent_mock),
+    ):
+        create_payload = _tool_payload(tool.create_workflow(spec))
+        run_payload = _tool_payload(tool.run_workflow("competitor-research-report", {"topic": "Agno"}))
+
+    assert create_payload["status"] == "ok"
+    assert run_payload["status"] == "completed"
+    assert bridge_mock.call_args.kwargs["workflow_origin"] == ToolCallWorkflowOrigin(
+        workflow_id="competitor-research-report",
+        participant_id="writer",
+    )
 
 
 def test_ephemeral_participant_without_grants_runs_with_empty_tools(tmp_path: Path) -> None:

--- a/tests/test_dynamic_workflows.py
+++ b/tests/test_dynamic_workflows.py
@@ -15,7 +15,7 @@ import nio
 import pytest
 import yaml
 from agno.factory import RequestContext
-from agno.run.agent import RunStatus
+from agno.run.agent import RunOutput, RunStatus
 from agno.tools import Toolkit
 from agno.workflow import Workflow, WorkflowFactory
 from agno.workflow.types import StepInput, StepOutput
@@ -38,7 +38,32 @@ from tests.conftest import bind_runtime_paths, make_event_cache_mock, runtime_pa
 from tests.identity_helpers import persist_entity_accounts
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Callable
     from pathlib import Path
+
+
+def _fake_stream_agent(
+    *,
+    content: str,
+    status: RunStatus = RunStatus.completed,
+    on_run: Callable[..., None] | None = None,
+) -> SimpleNamespace:
+    """Build a fake Agent matching the streaming participant run contract.
+
+    ``_arun_agent`` calls ``agent.arun(..., stream=True, yield_run_output=True)`` (not awaited)
+    and consumes the event iterator, treating the final ``RunOutput`` as the result.
+    """
+
+    def arun(prompt: str, *, user_id: str, session_id: str, **_kwargs: object) -> AsyncIterator[RunOutput]:
+        if on_run is not None:
+            on_run(prompt, user_id=user_id, session_id=session_id)
+
+        async def _events() -> AsyncIterator[RunOutput]:
+            yield RunOutput(content=content, status=status)
+
+        return _events()
+
+    return SimpleNamespace(arun=arun)
 
 
 def _workflow_spec(**overrides: object) -> dict[str, object]:
@@ -1924,7 +1949,7 @@ def test_room_agent_participant_rebinds_context_and_uses_isolated_state(tmp_path
     context = replace(context, config=config, runtime_paths=runtime_paths)
     parent_loop = asyncio.new_event_loop()
 
-    async def fake_arun(prompt: str, *, user_id: str, session_id: str) -> SimpleNamespace:
+    def assert_run(prompt: str, *, user_id: str, session_id: str) -> None:
         runtime_context = get_tool_runtime_context()
         assert runtime_context is not None
         assert asyncio.get_running_loop() is parent_loop
@@ -1934,9 +1959,8 @@ def test_room_agent_participant_rebinds_context_and_uses_isolated_state(tmp_path
         assert "competitor-research-report:run_1:writer_a" in session_id
         assert prompt == "Write a report."
         assert user_id == "@user:localhost"
-        return SimpleNamespace(content="done", status=RunStatus.completed)
 
-    fake_agent = SimpleNamespace(arun=fake_arun)
+    fake_agent = _fake_stream_agent(content="done", on_run=assert_run)
     with patch("mindroom.agents.create_agent", return_value=fake_agent) as create_agent_mock:
         asyncio.set_event_loop(parent_loop)
         try:
@@ -2159,16 +2183,15 @@ def test_ephemeral_participant_runs_with_granted_toolkits(tmp_path: Path) -> Non
     )
     sentinel_toolkits = {name: Toolkit(name=f"fake_{name}") for name in ("website", "shell")}
 
-    async def fake_arun(prompt: str, *, user_id: str, session_id: str) -> SimpleNamespace:
+    def assert_run(prompt: str, *, user_id: str, session_id: str) -> None:
         assert "Write a cited report" in prompt
         assert user_id == "@user:localhost"
         assert session_id
         runtime_context = get_tool_runtime_context()
         assert runtime_context is not None
         assert runtime_context.config.tool_approval.default == "require_approval"
-        return SimpleNamespace(content="researched", status=RunStatus.completed)
 
-    agent_mock = Mock(return_value=SimpleNamespace(arun=fake_arun))
+    agent_mock = Mock(return_value=_fake_stream_agent(content="researched", on_run=assert_run))
     with (
         tool_runtime_context(context),
         patch(
@@ -2212,12 +2235,11 @@ def test_ephemeral_participant_without_grants_runs_with_empty_tools(tmp_path: Pa
         outputs=[{"id": "report_html", "type": "html_report", "from_step": "edit"}],
     )
 
-    async def fake_arun(_prompt: str, *, user_id: str, session_id: str) -> SimpleNamespace:
+    def assert_run(_prompt: str, *, user_id: str, session_id: str) -> None:
         assert user_id == "@user:localhost"
         assert session_id
-        return SimpleNamespace(content="done", status=RunStatus.completed)
 
-    agent_mock = Mock(return_value=SimpleNamespace(arun=fake_arun))
+    agent_mock = Mock(return_value=_fake_stream_agent(content="done", on_run=assert_run))
     with (
         tool_runtime_context(context),
         patch("mindroom.agents.build_agent_toolkit") as build_toolkit_mock,
@@ -2238,10 +2260,11 @@ def test_run_agent_raises_on_failed_agno_status(tmp_path: Path) -> None:
     """Participant failures from Agno should become failed workflow steps, not normal content."""
     context = _make_context(tmp_path)
 
-    async def fake_arun(_prompt: str, *, user_id: str, session_id: str) -> SimpleNamespace:
+    def assert_run(_prompt: str, *, user_id: str, session_id: str) -> None:
         assert user_id == "@user:localhost"
         assert session_id == context.session_id
-        return SimpleNamespace(content="provider auth failed", status=RunStatus.error)
+
+    fake_agent = _fake_stream_agent(content="provider auth failed", status=RunStatus.error, on_run=assert_run)
 
     with pytest.raises(dynamic_workflow_module.DynamicWorkflowExecutionError, match="provider auth failed"):
-        asyncio.run(dynamic_workflow_module._arun_agent(context, SimpleNamespace(arun=fake_arun), "Write."))
+        asyncio.run(dynamic_workflow_module._arun_agent(context, fake_agent, "Write."))

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -302,6 +302,63 @@ async def test_request_approval_approves_and_edits_matrix_event(tmp_path: Path) 
 
 
 @pytest.mark.asyncio
+async def test_request_approval_carries_workflow_provenance_through_resolution(tmp_path: Path) -> None:
+    """Dynamic Workflow participant cards must name the workflow and participant, pending and resolved."""
+    runtime_paths = test_runtime_paths(tmp_path)
+    sender = AsyncMock(return_value=SentApprovalEvent("$approval"))
+    editor = AsyncMock(return_value=True)
+    store = initialize_approval_store(
+        runtime_paths,
+        sender=sender,
+        editor=editor,
+        transport_sender=lambda: "@mindroom_router:localhost",
+    )
+
+    task = asyncio.create_task(
+        store.request_approval(
+            tool_name="run_shell_command",
+            arguments={"command": "ls"},
+            agent_name="general",
+            room_id="!room:localhost",
+            thread_id="$thread",
+            requester_id="@user:localhost",
+            approver_user_id="@user:localhost",
+            timeout_seconds=30,
+            workflow_id="competitor-research-report",
+            participant_id="writer",
+        ),
+    )
+    pending = await _wait_for_pending(store, sender=sender)
+
+    card_content = sender.await_args.args[2]
+    assert card_content["workflow_id"] == "competitor-research-report"
+    assert card_content["participant_id"] == "writer"
+    assert card_content["body"] == (
+        "🔒 Approval required: run_shell_command — Dynamic Workflow 'competitor-research-report' participant 'writer'"
+    )
+    assert pending.workflow_id == "competitor-research-report"
+    assert pending.participant_id == "writer"
+
+    result = await store.handle_card_response(
+        room_id="!room:localhost",
+        sender_id="@user:localhost",
+        card_event_id=pending.card_event_id,
+        status="approved",
+        reason=None,
+    )
+    decision = await task
+
+    assert result.resolved is True
+    assert decision.status == "approved"
+    edited_content = editor.await_args.args[2]
+    assert edited_content["workflow_id"] == "competitor-research-report"
+    assert edited_content["participant_id"] == "writer"
+    assert edited_content["body"] == (
+        "Approved: run_shell_command — Dynamic Workflow 'competitor-research-report' participant 'writer'"
+    )
+
+
+@pytest.mark.asyncio
 async def test_live_card_response_ignores_cached_terminal_edit_from_different_sender(tmp_path: Path) -> None:
     cache = FakeEventCache()
     runtime_paths = test_runtime_paths(tmp_path)

--- a/tests/test_tool_hooks.py
+++ b/tests/test_tool_hooks.py
@@ -50,7 +50,7 @@ from mindroom.message_target import MessageTarget
 from mindroom.oauth.providers import OAuthConnectionRequired
 from mindroom.orchestrator import _MultiAgentOrchestrator
 from mindroom.sync_bridge_state import is_loop_blocked_by_sync_tool_bridge
-from mindroom.tool_approval import _shutdown_approval_store
+from mindroom.tool_approval import ToolCallWorkflowOrigin, _shutdown_approval_store
 from mindroom.tool_system import tool_hooks
 from mindroom.tool_system.metadata import TOOL_METADATA, TOOL_REGISTRY, ToolCategory, register_tool_with_metadata
 from mindroom.tool_system.runtime_context import (
@@ -2389,6 +2389,53 @@ async def test_tool_before_call_hooks_run_before_tool_approval_gate(tmp_path: Pa
 
     assert result == "ok"
     assert seen == ["before", "tool"]
+
+
+@pytest.mark.asyncio
+async def test_bridge_workflow_origin_reaches_approval_card(tmp_path: Path) -> None:
+    """A bridge built with workflow provenance must surface it on the approval card."""
+    runtime_paths = test_runtime_paths(tmp_path)
+    config = bind_runtime_paths(
+        Config(
+            agents={"code": AgentConfig(display_name="Code", role="Help with coding.", rooms=[])},
+            models={"default": ModelConfig(provider="openai", id="test-model")},
+            tool_approval={"rules": [{"match": "read_file", "action": "require_approval"}]},
+        ),
+        runtime_paths,
+    )
+    sender, _ = _initialize_test_approval_store(runtime_paths)
+    bridge = build_tool_hook_bridge(
+        HookRegistry.empty(),
+        agent_name="code",
+        dispatch_context=_dispatch_context(_execution_identity()),
+        config=config,
+        runtime_paths=runtime_paths,
+        workflow_origin=ToolCallWorkflowOrigin(workflow_id="research-report", participant_id="writer"),
+    )
+    assert bridge is not None
+
+    async def next_func(**kwargs: object) -> str:
+        del kwargs
+        return "ok"
+
+    with tool_execution_identity(_execution_identity()):
+        task = asyncio.create_task(bridge("read_file", next_func, {"path": "notes.txt"}))
+        await asyncio.sleep(0)
+        store = get_approval_store()
+        assert store is not None
+        pending = await _wait_for_sent_pending(store, sender)
+
+        card_content = sender.await_args.args[2]
+        assert card_content["workflow_id"] == "research-report"
+        assert card_content["participant_id"] == "writer"
+        assert card_content["body"] == (
+            "🔒 Approval required: read_file — Dynamic Workflow 'research-report' participant 'writer'"
+        )
+
+        await _resolve_pending_approval(store, pending, status="approved")
+        result = await task
+
+    assert result == "ok"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

Dynamic Workflow tool grants shipped in #1202, but a live PoC found the feature wasn't usable end to end: Claude/Vertex participants couldn't run at all, approval cards gave the approver no workflow context, `allowed_tools: ["*"]` could silently pre-approve system-mutating tools, and the human-approval loop had never been exercised live. The design doc was also accidentally removed in that PR's squash merge. This PR restores the doc and finishes Phase 1.

## What this PR does

**1. Restores the design doc** (`docs/superpowers/specs/2026-06-07-dynamic-workflows-design.md`) with a new **Current Status** + **Finish Phase 1** section recording each decision below, plus a clarification (from review) that the tenant scope's literal `tenant` owner key is one-tenant-per-storage-root by design.

**2. Streams ephemeral participant runs** (was the Claude blocker). `_arun_agent` now calls `agent.arun(..., stream=True, stream_events=True, yield_run_output=True)` and consumes the event stream, taking the final `RunOutput`. Claude/Vertex participants no longer trip the SDK's "Streaming is required for operations that may take longer than 10 minutes" guard. Live-verified with a Vertex Claude participant writing and reading a unique token via a granted `shell` tool.

**3. Adds workflow provenance to approval cards.** `ToolApprovalCall` carries a new `ToolCallWorkflowOrigin` (workflow id + participant id) injected through the participant's tool hook bridge. Cards expose `workflow_id` / `participant_id` content fields and the body names both in pending and resolved states, e.g. `🔒 Approval required: run_shell_command — Dynamic Workflow 'approval-live-test' participant 'writer'`. Room-agent participants are tool-less (`disable_runtime_capabilities=True`), so no card can exist without provenance.

**4. Locks down high-power tool pre-approval.** `claude_agent`, `config_manager`, `scheduler`, and `subagents` stay grantable, but `_WORKFLOW_NO_PREAPPROVAL_TOOLS` excludes them from `allowed_tools` pre-approval — wildcard or explicit — so every call posts an approval card. This also closes the escalation where an agent with `self_config` edits its own `allowed_tools` to silence approval. Both the agent-facing `create_workflow` tool description and the dashboard ConfigField document the exception.

**5. Verifies blocking-approval behavior.** A participant blocked on approval is bounded by `permissions.max_runtime_seconds` (hard cap 3600s): the run fails at the deadline and the cancelled approval wait edits the pending card to expired (new regression test). The card in the originating room is the "waiting" signal; no extra cap added.

**6. Live-tests the full approval loop** on a local Synapse stack (the end-to-end proof #1202 never had):
- participant `run_shell_command` → provenance-labeled card posted in the originating thread
- human ✅ reaction approved → command ran (unique token confirmed on disk) → workflow completed with the token in outputs
- reply-denial → card flipped to denied with the reply as `resolution_reason`, command never ran
- a participant retry after denial posted a fresh card requiring its own decision (no bypass)

## Tests

New coverage at every seam: approval-manager provenance through resolution, bridge-level provenance end to end, executor-level origin injection, never-pre-approved system-mutating tools, and runtime-cap expiry of a blocked approval card. Existing participant tests updated to the streaming run contract via a shared `_fake_stream_agent` helper. Full suite: 7910 passed (2 pre-existing parallelism flakes pass in isolation).

## Known limits (accepted)

- The sync `run_workflow` path (main-thread-only; the Matrix runtime always uses the async path) is not covered by the card-expiry-at-timeout test.
- A denied participant may retry and post additional cards; each requires its own human decision and the run stays bounded by `max_runtime_seconds`.

## Out of scope (later phases)

Dashboard workflow library, public report revocation, run cancellation, Matrix-history/attachment/knowledge data grants, worker-backed background execution, agent-authored workflow evolution.