### PR TITLE
Resolve Agent Vault broker per worker

### DIFF
--- a/docs/deployment/sandbox-proxy.md
+++ b/docs/deployment/sandbox-proxy.md
@@ -372,6 +372,7 @@ Example:
 ```yaml
 worker_egress_brokers:
   agent_vault:
+    kind: static
     proxy_url: http://agent-vault-bridge-adapter:18080
     ca_bundle: /etc/ssl/agent-vault-ca.pem
     no_proxy: localhost,127.0.0.1,.svc
@@ -400,6 +401,17 @@ Unknown broker names fail config validation when the config is loaded.
 Broker profiles are backend-neutral: the same config works for Docker/static runners and dedicated Kubernetes workers as long as the worker can reach `proxy_url` and read the configured CA path.
 The proxy should be an adapter or broker that owns the real credential or broker session.
 Do not put upstream API tokens in `extra_env_passthrough` or `.mindroom/worker-env.sh` unless you intentionally want the worker process to receive them.
+
+For Kubernetes deployments that run one proxy service per MindRoom worker identity, use a worker-scoped broker. MindRoom derives the service name from the resolved `worker_key`, using `service_name_prefix`, and injects `HTTP_PROXY`/`HTTPS_PROXY` for that worker only:
+
+```yaml
+worker_egress_brokers:
+  agent_vault:
+    kind: worker_scoped_proxy
+    service_name_prefix: agent-vault-bridge
+    port: 18080
+    no_proxy: localhost,127.0.0.1,::1,.svc,.cluster.local
+```
 
 ### Agent Vault bridge adapter
 

--- a/docs/deployment/sandbox-proxy.md
+++ b/docs/deployment/sandbox-proxy.md
@@ -403,6 +403,7 @@ The proxy should be an adapter or broker that owns the real credential or broker
 Do not put upstream API tokens in `extra_env_passthrough` or `.mindroom/worker-env.sh` unless you intentionally want the worker process to receive them.
 
 For Kubernetes deployments that run one proxy service per MindRoom worker identity, use a worker-scoped broker. MindRoom derives the service name from the resolved `worker_key`, using `service_name_prefix`, and injects `HTTP_PROXY`/`HTTPS_PROXY` for that worker only:
+Worker-scoped brokers only apply to agents with a worker execution scope; config validation fails if one is bound to an agent without `worker_scope`.
 
 ```yaml
 worker_egress_brokers:

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -15522,6 +15522,7 @@ Example:
 ```yaml
 worker_egress_brokers:
   agent_vault:
+    kind: static
     proxy_url: http://agent-vault-bridge-adapter:18080
     ca_bundle: /etc/ssl/agent-vault-ca.pem
     no_proxy: localhost,127.0.0.1,.svc
@@ -15550,6 +15551,17 @@ Unknown broker names fail config validation when the config is loaded.
 Broker profiles are backend-neutral: the same config works for Docker/static runners and dedicated Kubernetes workers as long as the worker can reach `proxy_url` and read the configured CA path.
 The proxy should be an adapter or broker that owns the real credential or broker session.
 Do not put upstream API tokens in `extra_env_passthrough` or `.mindroom/worker-env.sh` unless you intentionally want the worker process to receive them.
+
+For Kubernetes deployments that run one proxy service per MindRoom worker identity, use a worker-scoped broker. MindRoom derives the service name from the resolved `worker_key`, using `service_name_prefix`, and injects `HTTP_PROXY`/`HTTPS_PROXY` for that worker only:
+
+```yaml
+worker_egress_brokers:
+  agent_vault:
+    kind: worker_scoped_proxy
+    service_name_prefix: agent-vault-bridge
+    port: 18080
+    no_proxy: localhost,127.0.0.1,::1,.svc,.cluster.local
+```
 
 ### Agent Vault bridge adapter
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -15553,6 +15553,7 @@ The proxy should be an adapter or broker that owns the real credential or broker
 Do not put upstream API tokens in `extra_env_passthrough` or `.mindroom/worker-env.sh` unless you intentionally want the worker process to receive them.
 
 For Kubernetes deployments that run one proxy service per MindRoom worker identity, use a worker-scoped broker. MindRoom derives the service name from the resolved `worker_key`, using `service_name_prefix`, and injects `HTTP_PROXY`/`HTTPS_PROXY` for that worker only:
+Worker-scoped brokers only apply to agents with a worker execution scope; config validation fails if one is bound to an agent without `worker_scope`.
 
 ```yaml
 worker_egress_brokers:

--- a/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
+++ b/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
@@ -368,6 +368,7 @@ Example:
 ```yaml
 worker_egress_brokers:
   agent_vault:
+    kind: static
     proxy_url: http://agent-vault-bridge-adapter:18080
     ca_bundle: /etc/ssl/agent-vault-ca.pem
     no_proxy: localhost,127.0.0.1,.svc
@@ -396,6 +397,17 @@ Unknown broker names fail config validation when the config is loaded.
 Broker profiles are backend-neutral: the same config works for Docker/static runners and dedicated Kubernetes workers as long as the worker can reach `proxy_url` and read the configured CA path.
 The proxy should be an adapter or broker that owns the real credential or broker session.
 Do not put upstream API tokens in `extra_env_passthrough` or `.mindroom/worker-env.sh` unless you intentionally want the worker process to receive them.
+
+For Kubernetes deployments that run one proxy service per MindRoom worker identity, use a worker-scoped broker. MindRoom derives the service name from the resolved `worker_key`, using `service_name_prefix`, and injects `HTTP_PROXY`/`HTTPS_PROXY` for that worker only:
+
+```yaml
+worker_egress_brokers:
+  agent_vault:
+    kind: worker_scoped_proxy
+    service_name_prefix: agent-vault-bridge
+    port: 18080
+    no_proxy: localhost,127.0.0.1,::1,.svc,.cluster.local
+```
 
 ### Agent Vault bridge adapter
 

--- a/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
+++ b/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
@@ -399,6 +399,7 @@ The proxy should be an adapter or broker that owns the real credential or broker
 Do not put upstream API tokens in `extra_env_passthrough` or `.mindroom/worker-env.sh` unless you intentionally want the worker process to receive them.
 
 For Kubernetes deployments that run one proxy service per MindRoom worker identity, use a worker-scoped broker. MindRoom derives the service name from the resolved `worker_key`, using `service_name_prefix`, and injects `HTTP_PROXY`/`HTTPS_PROXY` for that worker only:
+Worker-scoped brokers only apply to agents with a worker execution scope; config validation fails if one is bound to an agent without `worker_scope`.
 
 ```yaml
 worker_egress_brokers:

--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -73,7 +73,7 @@ if TYPE_CHECKING:
     from mindroom.config.agent import AgentConfig, CultureConfig, CultureMode
     from mindroom.config.main import Config
     from mindroom.config.models import DefaultsConfig
-    from mindroom.config.worker_egress import ResolvedWorkerEgressBroker
+    from mindroom.config.worker_egress import WorkerEgressBrokerConfig
     from mindroom.credentials import CredentialsManager
     from mindroom.hooks import HookRegistryPlugin
     from mindroom.knowledge.refresh_scheduler import KnowledgeRefreshScheduler
@@ -451,7 +451,7 @@ def _build_registered_agent_tool(
     routing_agent_is_private: bool,
     execution_identity: ToolExecutionIdentity | None,
     runtime_overrides: dict[str, object] | None,
-    worker_egress_broker: ResolvedWorkerEgressBroker | None,
+    worker_egress_broker: WorkerEgressBrokerConfig | None,
 ) -> Toolkit:
     """Build one registered toolkit using the resolved routing inputs for this agent."""
     worker_target = build_worker_target_from_runtime_env(

--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -61,7 +61,7 @@ from mindroom.tool_system.worker_routing import (
 from mindroom.workspaces import ensure_workspace_template
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
+    from collections.abc import Callable
 
     from agno.knowledge.protocol import KnowledgeProtocol
     from agno.models.base import Model
@@ -73,6 +73,7 @@ if TYPE_CHECKING:
     from mindroom.config.agent import AgentConfig, CultureConfig, CultureMode
     from mindroom.config.main import Config
     from mindroom.config.models import DefaultsConfig
+    from mindroom.config.worker_egress import ResolvedWorkerEgressBroker
     from mindroom.credentials import CredentialsManager
     from mindroom.hooks import HookRegistryPlugin
     from mindroom.knowledge.refresh_scheduler import KnowledgeRefreshScheduler
@@ -450,7 +451,7 @@ def _build_registered_agent_tool(
     routing_agent_is_private: bool,
     execution_identity: ToolExecutionIdentity | None,
     runtime_overrides: dict[str, object] | None,
-    worker_egress_env: Mapping[str, str] | None,
+    worker_egress_broker: ResolvedWorkerEgressBroker | None,
 ) -> Toolkit:
     """Build one registered toolkit using the resolved routing inputs for this agent."""
     worker_target = build_worker_target_from_runtime_env(
@@ -463,6 +464,11 @@ def _build_registered_agent_tool(
             if worker_scope == "user_agent" and routing_agent_is_private
             else (frozenset() if worker_scope == "user_agent" else None)
         ),
+    )
+    worker_egress_env = (
+        worker_egress_broker.execution_env_for_worker_target(worker_target)
+        if worker_egress_broker is not None
+        else None
     )
 
     return get_tool_by_name(
@@ -719,7 +725,7 @@ def build_agent_toolkit(  # noqa: C901, PLR0911, PLR0912
         agent_runtime.is_private,
         execution_identity,
         runtime_overrides,
-        worker_egress_broker.execution_env if worker_egress_broker is not None else None,
+        worker_egress_broker,
     )
 
 

--- a/src/mindroom/config/main.py
+++ b/src/mindroom/config/main.py
@@ -1273,7 +1273,8 @@ class Config(BaseModel):
             available = ", ".join(sorted(self.worker_egress_brokers)) or "(none)"
             msg = f"Unknown worker_egress_broker '{broker_reference}'. Available worker_egress_brokers: {available}"
             raise ConfigRuntimeValidationError(msg)
-        return ResolvedWorkerEgressBroker(name=broker_reference, execution_env=broker.execution_env())
+        execution_env = broker.execution_env() if broker.kind == "static" else {}
+        return ResolvedWorkerEgressBroker(name=broker_reference, execution_env=execution_env, config=broker)
 
     def get_agent_execution_scope(self, agent_name: str) -> WorkerScope | None:
         """Return the internal derived execution scope for one agent.

--- a/src/mindroom/config/main.py
+++ b/src/mindroom/config/main.py
@@ -52,7 +52,7 @@ from mindroom.config.models import (
 )
 from mindroom.config.plugin import PluginEntryConfig  # noqa: TC001
 from mindroom.config.voice import VoiceConfig
-from mindroom.config.worker_egress import ResolvedWorkerEgressBroker, WorkerEgressBrokerConfig
+from mindroom.config.worker_egress import WorkerEgressBrokerConfig  # noqa: TC001
 from mindroom.constants import (
     DEFAULT_WORKER_GRANTABLE_CREDENTIALS,
     ROUTER_AGENT_NAME,
@@ -604,6 +604,18 @@ class Config(BaseModel):
                 agent_config.worker_egress_broker,
                 config_path=f"agents.{agent_name}.worker_egress_broker",
             )
+        for agent_name in self.agents:
+            broker_reference = self._agent_worker_egress_broker_reference(agent_name)
+            if broker_reference is None:
+                continue
+            broker = self.worker_egress_brokers[broker_reference]
+            if broker.kind == "worker_scoped_proxy" and self.get_agent_execution_scope(agent_name) is None:
+                msg = (
+                    f"Agent '{agent_name}' uses worker-scoped egress broker '{broker_reference}' but has no "
+                    "worker execution scope. Set worker_scope on the agent or defaults, use a static broker, "
+                    f"or disable the broker with agents.{agent_name}.worker_egress_broker: false"
+                )
+                raise ValueError(msg)
         return self
 
     def _validate_worker_egress_broker_reference(
@@ -1259,13 +1271,10 @@ class Config(BaseModel):
             return DEFAULT_WORKER_GRANTABLE_CREDENTIALS
         return frozenset(configured)
 
-    def get_agent_worker_egress_broker(self, agent_name: str) -> ResolvedWorkerEgressBroker | None:
-        """Return resolved worker egress broker env for one agent, if configured."""
-        agent_config = self.get_agent(agent_name)
-        broker_reference = agent_config.worker_egress_broker
+    def get_agent_worker_egress_broker(self, agent_name: str) -> WorkerEgressBrokerConfig | None:
+        """Return the effective worker egress broker for one agent, if configured."""
+        broker_reference = self._agent_worker_egress_broker_reference(agent_name)
         if broker_reference is None:
-            broker_reference = self.defaults.worker_egress_broker
-        if broker_reference is False or broker_reference is None:
             return None
 
         broker = self.worker_egress_brokers.get(broker_reference)
@@ -1273,8 +1282,17 @@ class Config(BaseModel):
             available = ", ".join(sorted(self.worker_egress_brokers)) or "(none)"
             msg = f"Unknown worker_egress_broker '{broker_reference}'. Available worker_egress_brokers: {available}"
             raise ConfigRuntimeValidationError(msg)
-        execution_env = broker.execution_env() if broker.kind == "static" else {}
-        return ResolvedWorkerEgressBroker(name=broker_reference, execution_env=execution_env, config=broker)
+        return broker
+
+    def _agent_worker_egress_broker_reference(self, agent_name: str) -> str | None:
+        """Return the effective worker egress broker name for one agent."""
+        agent_config = self.get_agent(agent_name)
+        broker_reference = agent_config.worker_egress_broker
+        if broker_reference is None:
+            broker_reference = self.defaults.worker_egress_broker
+        if broker_reference is False:
+            return None
+        return broker_reference
 
     def get_agent_execution_scope(self, agent_name: str) -> WorkerScope | None:
         """Return the internal derived execution scope for one agent.

--- a/src/mindroom/config/worker_egress.py
+++ b/src/mindroom/config/worker_egress.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
 from urllib.parse import urlsplit
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+if TYPE_CHECKING:
+    from mindroom.tool_system.worker_routing import ResolvedWorkerTarget
 
 
 @dataclass(frozen=True)
@@ -14,6 +18,14 @@ class ResolvedWorkerEgressBroker:
 
     name: str
     execution_env: dict[str, str]
+    config: WorkerEgressBrokerConfig
+
+    def execution_env_for_worker_target(
+        self,
+        worker_target: ResolvedWorkerTarget | None,
+    ) -> dict[str, str]:
+        """Return broker env for one resolved worker target."""
+        return self.config.execution_env_for_worker_target(worker_target)
 
 
 class WorkerEgressBrokerConfig(BaseModel):
@@ -21,8 +33,22 @@ class WorkerEgressBrokerConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    proxy_url: str = Field(
+    kind: Literal["static", "worker_scoped_proxy"] = Field(
+        description="Broker resolver kind: static proxy URL or worker-scoped service proxy",
+    )
+    proxy_url: str | None = Field(
+        default=None,
         description="HTTP proxy URL reachable from worker containers or pods",
+    )
+    service_name_prefix: str = Field(
+        default="agent-vault-bridge",
+        description="Service-name prefix used for worker-scoped proxy services",
+    )
+    port: int = Field(
+        default=18080,
+        ge=1,
+        le=65535,
+        description="Worker-scoped proxy service port",
     )
     ca_bundle: str | None = Field(
         default=None,
@@ -33,7 +59,7 @@ class WorkerEgressBrokerConfig(BaseModel):
         description="Optional NO_PROXY value for local or cluster-local addresses",
     )
 
-    @field_validator("proxy_url", "ca_bundle", "no_proxy")
+    @field_validator("proxy_url", "service_name_prefix", "ca_bundle", "no_proxy")
     @classmethod
     def validate_non_empty_string(cls, value: str | None) -> str | None:
         """Reject empty strings for authored env values."""
@@ -47,21 +73,62 @@ class WorkerEgressBrokerConfig(BaseModel):
 
     @field_validator("proxy_url")
     @classmethod
-    def validate_proxy_url_scheme(cls, value: str) -> str:
+    def validate_proxy_url_scheme(cls, value: str | None) -> str | None:
         """Reject proxy URLs that common HTTP clients cannot parse."""
+        if value is None:
+            return None
         parsed = urlsplit(value)
         if parsed.scheme not in {"http", "https"} or not parsed.netloc:
             msg = "proxy_url must include an http:// or https:// scheme"
             raise ValueError(msg)
         return value
 
+    @model_validator(mode="after")
+    def validate_kind_fields(self) -> WorkerEgressBrokerConfig:
+        """Ensure required fields exist for the selected broker kind."""
+        if self.kind == "static" and self.proxy_url is None:
+            msg = "proxy_url is required for static worker egress brokers"
+            raise ValueError(msg)
+        return self
+
     def execution_env(self) -> dict[str, str]:
         """Return process env overlay for worker execution tools."""
+        if self.kind == "worker_scoped_proxy":
+            msg = "Worker-scoped proxy broker requires a resolved worker key"
+            raise ValueError(msg)
+        return self._proxy_execution_env(self._required_proxy_url())
+
+    def execution_env_for_worker_target(
+        self,
+        worker_target: ResolvedWorkerTarget | None,
+    ) -> dict[str, str]:
+        """Return process env overlay for one worker target."""
+        if self.kind == "static":
+            return self.execution_env()
+
+        worker_key = worker_target.worker_key if worker_target is not None else None
+        if not worker_key:
+            msg = "Worker-scoped proxy broker requires a resolved worker key"
+            raise ValueError(msg)
+
+        from mindroom.workers.backends.kubernetes_resources import worker_id_for_key  # noqa: PLC0415
+
+        service_name = worker_id_for_key(worker_key, prefix=self.service_name_prefix)
+        proxy_url = f"http://{service_name}:{self.port}"
+        return self._proxy_execution_env(proxy_url)
+
+    def _required_proxy_url(self) -> str:
+        if self.proxy_url is None:
+            msg = "proxy_url is required for static worker egress brokers"
+            raise ValueError(msg)
+        return self.proxy_url
+
+    def _proxy_execution_env(self, proxy_url: str) -> dict[str, str]:
         env = {
-            "HTTP_PROXY": self.proxy_url,
-            "HTTPS_PROXY": self.proxy_url,
-            "http_proxy": self.proxy_url,
-            "https_proxy": self.proxy_url,
+            "HTTP_PROXY": proxy_url,
+            "HTTPS_PROXY": proxy_url,
+            "http_proxy": proxy_url,
+            "https_proxy": proxy_url,
         }
         if self.ca_bundle:
             env.update(

--- a/src/mindroom/config/worker_egress.py
+++ b/src/mindroom/config/worker_egress.py
@@ -2,30 +2,15 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 from urllib.parse import urlsplit
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from mindroom.tool_system.worker_routing import worker_id_for_key
+
 if TYPE_CHECKING:
     from mindroom.tool_system.worker_routing import ResolvedWorkerTarget
-
-
-@dataclass(frozen=True)
-class ResolvedWorkerEgressBroker:
-    """Resolved worker egress broker env for one agent."""
-
-    name: str
-    execution_env: dict[str, str]
-    config: WorkerEgressBrokerConfig
-
-    def execution_env_for_worker_target(
-        self,
-        worker_target: ResolvedWorkerTarget | None,
-    ) -> dict[str, str]:
-        """Return broker env for one resolved worker target."""
-        return self.config.execution_env_for_worker_target(worker_target)
 
 
 class WorkerEgressBrokerConfig(BaseModel):
@@ -85,43 +70,35 @@ class WorkerEgressBrokerConfig(BaseModel):
 
     @model_validator(mode="after")
     def validate_kind_fields(self) -> WorkerEgressBrokerConfig:
-        """Ensure required fields exist for the selected broker kind."""
-        if self.kind == "static" and self.proxy_url is None:
-            msg = "proxy_url is required for static worker egress brokers"
+        """Ensure authored fields match the selected broker kind."""
+        if self.kind == "static":
+            if self.proxy_url is None:
+                msg = "proxy_url is required for static worker egress brokers"
+                raise ValueError(msg)
+            mismatched = {"service_name_prefix", "port"} & self.model_fields_set
+            if mismatched:
+                msg = f"{', '.join(sorted(mismatched))} only applies to worker_scoped_proxy brokers"
+                raise ValueError(msg)
+        elif self.proxy_url is not None:
+            msg = "proxy_url does not apply to worker_scoped_proxy brokers; the URL is derived from the worker key"
             raise ValueError(msg)
         return self
-
-    def execution_env(self) -> dict[str, str]:
-        """Return process env overlay for worker execution tools."""
-        if self.kind == "worker_scoped_proxy":
-            msg = "Worker-scoped proxy broker requires a resolved worker key"
-            raise ValueError(msg)
-        return self._proxy_execution_env(self._required_proxy_url())
 
     def execution_env_for_worker_target(
         self,
         worker_target: ResolvedWorkerTarget | None,
     ) -> dict[str, str]:
         """Return process env overlay for one worker target."""
-        if self.kind == "static":
-            return self.execution_env()
+        # validate_kind_fields guarantees proxy_url is set exactly for static brokers.
+        if self.proxy_url is not None:
+            return self._proxy_execution_env(self.proxy_url)
 
         worker_key = worker_target.worker_key if worker_target is not None else None
         if not worker_key:
             msg = "Worker-scoped proxy broker requires a resolved worker key"
             raise ValueError(msg)
-
-        from mindroom.workers.backends.kubernetes_resources import worker_id_for_key  # noqa: PLC0415
-
         service_name = worker_id_for_key(worker_key, prefix=self.service_name_prefix)
-        proxy_url = f"http://{service_name}:{self.port}"
-        return self._proxy_execution_env(proxy_url)
-
-    def _required_proxy_url(self) -> str:
-        if self.proxy_url is None:
-            msg = "proxy_url is required for static worker egress brokers"
-            raise ValueError(msg)
-        return self.proxy_url
+        return self._proxy_execution_env(f"http://{service_name}:{self.port}")
 
     def _proxy_execution_env(self, proxy_url: str) -> dict[str, str]:
         env = {

--- a/src/mindroom/tool_system/worker_routing.py
+++ b/src/mindroom/tool_system/worker_routing.py
@@ -22,6 +22,7 @@ ResolvedWorkerKeyScope = Literal["shared", "user", "user_agent", "unscoped"]
 _ExecutionChannel = Literal["matrix", "openai_compat"]
 
 _WORKER_DIRNAME_MAX_PREFIX_LENGTH = 80
+_DEFAULT_WORKER_NAME_PREFIX = "mindroom-worker"
 _AGENT_WORKSPACE_DIRNAME = "workspace"
 _PRIVATE_INSTANCE_ROOT_DIRNAME = "private_instances"
 _SHARED_ONLY_INTEGRATION_NAMES = frozenset(
@@ -222,6 +223,17 @@ def normalize_worker_key_part(value: str) -> str:
     """Return one normalized worker-key component."""
     normalized = re.sub(r"[^a-zA-Z0-9._@+-]+", "_", value.strip()).strip("_")
     return normalized or "default"
+
+
+def worker_id_for_key(worker_key: str, *, prefix: str) -> str:
+    """Return a DNS-safe resource name for one worker key (63-char label limit)."""
+    digest = hashlib.sha256(worker_key.encode("utf-8")).hexdigest()[:24]
+    normalized_prefix = prefix.strip().lower().strip("-") or _DEFAULT_WORKER_NAME_PREFIX
+    max_prefix_length = 63 - len(digest) - 1
+    safe_prefix = normalized_prefix[:max_prefix_length].rstrip("-")
+    if not safe_prefix:
+        safe_prefix = _DEFAULT_WORKER_NAME_PREFIX[:max_prefix_length].rstrip("-") or "worker"
+    return f"{safe_prefix}-{digest}"
 
 
 def _normalize_worker_requester_part(value: str) -> str:

--- a/src/mindroom/tools_metadata.json
+++ b/src/mindroom/tools_metadata.json
@@ -7390,7 +7390,7 @@
         {
           "authored_override": true,
           "default": null,
-          "description": "Tool names workflow participants may call without per-call user approval. Use \"*\" to pre-approve every granted tool.",
+          "description": "Tool names workflow participants may call without per-call user approval. Use \"*\" to pre-approve every granted tool. System-mutating tools (claude_agent, config_manager, scheduler, subagents) always require per-call approval and cannot be pre-approved.",
           "label": "Pre-approved participant tools",
           "name": "allowed_tools",
           "options": null,

--- a/src/mindroom/workers/backends/kubernetes.py
+++ b/src/mindroom/workers/backends/kubernetes.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 
 from mindroom.credential_policy import credential_service_policy
 from mindroom.credentials import get_runtime_credentials_manager, sync_shared_credentials_to_worker
-from mindroom.tool_system.worker_routing import worker_dir_name
+from mindroom.tool_system.worker_routing import worker_dir_name, worker_id_for_key
 from mindroom.workers.backend import WorkerBackendError, effective_idle_status, filter_and_sort_worker_handles
 from mindroom.workers.backends._lifecycle import mark_worker_failed, mark_worker_idle, touch_worker_lifecycle
 from mindroom.workers.models import (
@@ -584,7 +584,7 @@ class KubernetesWorkerBackend:
         return worker_lock
 
     def _worker_id(self, worker_key: str) -> str:
-        return resources.worker_id_for_key(worker_key, prefix=self.config.name_prefix)
+        return worker_id_for_key(worker_key, prefix=self.config.name_prefix)
 
     def _state_subpath(self, worker_key: str) -> str:
         prefix = self.config.storage_subpath_prefix.strip().strip("/")

--- a/src/mindroom/workers/backends/kubernetes_resources.py
+++ b/src/mindroom/workers/backends/kubernetes_resources.py
@@ -49,7 +49,6 @@ if TYPE_CHECKING:
 
     from .kubernetes_config import KubernetesWorkerBackendConfig
 
-_DEFAULT_NAME_PREFIX = "mindroom-worker"
 _READY_POLL_INTERVAL_SECONDS = 1.0
 _DELETE_POLL_INTERVAL_SECONDS = 0.2
 _HOSTNAME_ENV = "HOSTNAME"
@@ -189,17 +188,6 @@ class _CoreApiProtocol(Protocol):
     def delete_namespaced_secret(self, name: str, namespace: str) -> None: ...
 
     def read_namespaced_pod(self, name: str, namespace: str) -> _KubernetesPod: ...
-
-
-def worker_id_for_key(worker_key: str, *, prefix: str) -> str:
-    """Return a DNS-safe Kubernetes resource name for one worker key."""
-    digest = hashlib.sha256(worker_key.encode("utf-8")).hexdigest()[:24]
-    normalized_prefix = prefix.strip().lower().strip("-") or _DEFAULT_NAME_PREFIX
-    max_prefix_length = 63 - len(digest) - 1
-    safe_prefix = normalized_prefix[:max_prefix_length].rstrip("-")
-    if not safe_prefix:
-        safe_prefix = _DEFAULT_NAME_PREFIX[:max_prefix_length].rstrip("-") or "worker"
-    return f"{safe_prefix}-{digest}"
 
 
 def service_host(service_name: str, namespace: str, port: int) -> str:

--- a/tests/test_worker_egress.py
+++ b/tests/test_worker_egress.py
@@ -11,8 +11,7 @@ import mindroom.agents as agents_module
 import mindroom.tool_system.sandbox_proxy as sandbox_proxy_module
 from mindroom.config.main import Config
 from mindroom.constants import resolve_runtime_paths
-from mindroom.tool_system.worker_routing import ToolExecutionIdentity, resolve_worker_target
-from mindroom.workers.backends.kubernetes_resources import worker_id_for_key
+from mindroom.tool_system.worker_routing import ToolExecutionIdentity, resolve_worker_target, worker_id_for_key
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -122,11 +121,9 @@ def test_worker_egress_broker_resolves_proxy_env_from_default_and_agent_override
     override_broker = config.get_agent_worker_egress_broker("local_code")
 
     assert default_broker is not None
-    assert default_broker.name == "agent_vault"
-    assert default_broker.execution_env == _agent_vault_env()
+    assert default_broker.execution_env_for_worker_target(None) == _agent_vault_env()
     assert override_broker is not None
-    assert override_broker.name == "local"
-    assert override_broker.execution_env["HTTP_PROXY"] == "http://127.0.0.1:19090"
+    assert override_broker.execution_env_for_worker_target(None)["HTTP_PROXY"] == "http://127.0.0.1:19090"
 
 
 def test_worker_egress_broker_requires_explicit_kind() -> None:
@@ -167,6 +164,48 @@ def test_worker_scoped_proxy_broker_requires_worker_key() -> None:
     assert broker is not None
     with pytest.raises(ValueError, match="Worker-scoped proxy broker requires a resolved worker key"):
         broker.execution_env_for_worker_target(None)
+
+
+def test_worker_scoped_proxy_broker_requires_worker_scoped_agent() -> None:
+    """Worker-scoped proxy broker bound to an agent without worker scope should fail at config load."""
+    payload = _worker_scoped_proxy_payload()
+    agents = payload["agents"]
+    assert isinstance(agents, dict)
+    code_agent = agents["code"]
+    assert isinstance(code_agent, dict)
+    del code_agent["worker_scope"]
+
+    with pytest.raises(
+        ValueError,
+        match=r"Agent 'code' uses worker-scoped egress broker 'agent_vault' but has no worker execution scope",
+    ):
+        Config.model_validate(payload)
+
+
+def test_static_broker_rejects_worker_scoped_fields() -> None:
+    """Static brokers should reject worker-scoped-only fields instead of ignoring them."""
+    payload = _broker_config_payload()
+    brokers = payload["worker_egress_brokers"]
+    assert isinstance(brokers, dict)
+    local_broker = brokers["local"]
+    assert isinstance(local_broker, dict)
+    local_broker["port"] = 18080
+
+    with pytest.raises(ValueError, match="port only applies to worker_scoped_proxy brokers"):
+        Config.model_validate(payload)
+
+
+def test_worker_scoped_proxy_broker_rejects_proxy_url() -> None:
+    """Worker-scoped proxy brokers should reject a static proxy_url instead of ignoring it."""
+    payload = _worker_scoped_proxy_payload()
+    brokers = payload["worker_egress_brokers"]
+    assert isinstance(brokers, dict)
+    broker = brokers["agent_vault"]
+    assert isinstance(broker, dict)
+    broker["proxy_url"] = "http://agent-vault-adapter:18080"
+
+    with pytest.raises(ValueError, match="proxy_url does not apply to worker_scoped_proxy brokers"):
+        Config.model_validate(payload)
 
 
 def test_agent_can_disable_default_worker_egress_broker() -> None:
@@ -240,7 +279,7 @@ def test_sandbox_execution_env_payload_includes_worker_egress_env(tmp_path: Path
     execution_env = sandbox_proxy_module._execution_env_payload(
         "shell",
         runtime_paths=runtime_paths,
-        worker_egress_env=broker.execution_env,
+        worker_egress_env=broker.execution_env_for_worker_target(None),
     )
 
     assert execution_env is not None

--- a/tests/test_worker_egress.py
+++ b/tests/test_worker_egress.py
@@ -11,6 +11,8 @@ import mindroom.agents as agents_module
 import mindroom.tool_system.sandbox_proxy as sandbox_proxy_module
 from mindroom.config.main import Config
 from mindroom.constants import resolve_runtime_paths
+from mindroom.tool_system.worker_routing import ToolExecutionIdentity, resolve_worker_target
+from mindroom.workers.backends.kubernetes_resources import worker_id_for_key
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -20,11 +22,13 @@ def _broker_config_payload() -> dict[str, object]:
     return {
         "worker_egress_brokers": {
             "agent_vault": {
+                "kind": "static",
                 "proxy_url": "http://agent-vault-adapter:18080",
                 "ca_bundle": "/etc/agent-vault/ca.pem",
                 "no_proxy": "localhost,127.0.0.1,.svc",
             },
             "local": {
+                "kind": "static",
                 "proxy_url": "http://127.0.0.1:19090",
             },
         },
@@ -61,6 +65,55 @@ def _agent_vault_env() -> dict[str, str]:
     }
 
 
+def _worker_scoped_proxy_payload() -> dict[str, object]:
+    return {
+        "worker_egress_brokers": {
+            "agent_vault": {
+                "kind": "worker_scoped_proxy",
+                "service_name_prefix": "agent-vault-bridge",
+                "port": 18080,
+                "no_proxy": "localhost,127.0.0.1,::1,.svc,.cluster.local",
+            },
+        },
+        "defaults": {
+            "worker_egress_broker": "agent_vault",
+        },
+        "agents": {
+            "code": {
+                "display_name": "Code",
+                "tools": ["shell"],
+                "worker_scope": "user_agent",
+            },
+        },
+    }
+
+
+def _execution_identity() -> ToolExecutionIdentity:
+    return ToolExecutionIdentity(
+        channel="matrix",
+        agent_name="code",
+        requester_id="@alice:example.test",
+        room_id="!room:example.test",
+        thread_id=None,
+        resolved_thread_id=None,
+        session_id="session-1",
+        tenant_id="ionq",
+    )
+
+
+def _expected_worker_scoped_proxy_env(worker_key: str, *, service_name_prefix: str) -> dict[str, str]:
+    bridge_service_name = worker_id_for_key(worker_key, prefix=service_name_prefix)
+    proxy_url = f"http://{bridge_service_name}:18080"
+    return {
+        "HTTP_PROXY": proxy_url,
+        "HTTPS_PROXY": proxy_url,
+        "http_proxy": proxy_url,
+        "https_proxy": proxy_url,
+        "NO_PROXY": "localhost,127.0.0.1,::1,.svc,.cluster.local",
+        "no_proxy": "localhost,127.0.0.1,::1,.svc,.cluster.local",
+    }
+
+
 def test_worker_egress_broker_resolves_proxy_env_from_default_and_agent_override() -> None:
     """Worker egress broker should resolve default and per-agent broker env."""
     config = Config.model_validate(_broker_config_payload())
@@ -74,6 +127,46 @@ def test_worker_egress_broker_resolves_proxy_env_from_default_and_agent_override
     assert override_broker is not None
     assert override_broker.name == "local"
     assert override_broker.execution_env["HTTP_PROXY"] == "http://127.0.0.1:19090"
+
+
+def test_worker_egress_broker_requires_explicit_kind() -> None:
+    """Worker egress brokers should not accept legacy implicit static config."""
+    payload = _broker_config_payload()
+    brokers = payload["worker_egress_brokers"]
+    assert isinstance(brokers, dict)
+    local_broker = brokers["local"]
+    assert isinstance(local_broker, dict)
+    del local_broker["kind"]
+
+    with pytest.raises(ValueError, match=r"worker_egress_brokers\.local\.kind"):
+        Config.model_validate(payload)
+
+
+def test_worker_scoped_proxy_broker_resolves_proxy_env_from_worker_key() -> None:
+    """Worker-scoped proxy broker should derive a bridge URL from the worker key."""
+    config = Config.model_validate(_worker_scoped_proxy_payload())
+    broker = config.get_agent_worker_egress_broker("code")
+    identity = _execution_identity()
+    worker_target = resolve_worker_target("user_agent", "code", execution_identity=identity)
+    assert worker_target.worker_key is not None
+
+    assert broker is not None
+    assert broker.execution_env_for_worker_target(worker_target) == (
+        _expected_worker_scoped_proxy_env(
+            worker_target.worker_key,
+            service_name_prefix="agent-vault-bridge",
+        )
+    )
+
+
+def test_worker_scoped_proxy_broker_requires_worker_key() -> None:
+    """Worker-scoped proxy broker should fail closed when no worker key is available."""
+    config = Config.model_validate(_worker_scoped_proxy_payload())
+    broker = config.get_agent_worker_egress_broker("code")
+
+    assert broker is not None
+    with pytest.raises(ValueError, match="Worker-scoped proxy broker requires a resolved worker key"):
+        broker.execution_env_for_worker_target(None)
 
 
 def test_agent_can_disable_default_worker_egress_broker() -> None:
@@ -204,3 +297,56 @@ def test_build_agent_toolkit_passes_worker_egress_env_to_registered_tools(
     assert isinstance(worker_egress_env, dict)
     for key, value in _agent_vault_env().items():
         assert worker_egress_env[key] == value
+
+
+def test_build_agent_toolkit_passes_worker_scoped_proxy_egress_env(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Agent tool construction should pass worker-key-derived proxy env to registered tools."""
+    runtime_paths = resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path / "storage",
+        process_env={
+            "MINDROOM_KUBERNETES_WORKER_NAME_PREFIX": "mindroom-worker-staging",
+        },
+    )
+    config = Config.model_validate(_worker_scoped_proxy_payload())
+    captured: dict[str, object] = {}
+
+    def fake_resolve_agent_runtime(*_args: object, **_kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            execution_scope="user_agent",
+            is_private=False,
+            tool_base_dir=tmp_path / "workspace",
+            workspace=tmp_path / "workspace",
+        )
+
+    def fake_get_tool_by_name(*args: object, **kwargs: object) -> SimpleNamespace:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(name="shell", functions={}, async_functions={})
+
+    monkeypatch.setattr(agents_module, "resolve_agent_runtime", fake_resolve_agent_runtime)
+    monkeypatch.setattr(agents_module, "get_tool_by_name", fake_get_tool_by_name)
+    monkeypatch.setattr(agents_module, "get_runtime_credentials_manager", lambda *_args: object())
+
+    toolkit = agents_module.build_agent_toolkit(
+        "shell",
+        agent_name="code",
+        config=config,
+        runtime_paths=runtime_paths,
+        worker_tools=["shell"],
+        runtime_overrides=config.get_agent_tool_runtime_overrides("code", "shell", runtime_paths=runtime_paths),
+        execution_identity=_execution_identity(),
+    )
+
+    worker_target = resolve_worker_target("user_agent", "code", execution_identity=_execution_identity())
+    assert worker_target.worker_key is not None
+    assert toolkit is not None
+    kwargs = captured["kwargs"]
+    assert isinstance(kwargs, dict)
+    assert kwargs["worker_egress_env"] == _expected_worker_scoped_proxy_env(
+        worker_target.worker_key,
+        service_name_prefix="agent-vault-bridge",
+    )

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -211,6 +211,7 @@ _.validate_worker_egress_broker_references  # unused method (src/mindroom/config
 get_credential_status  # unused function (src/mindroom/api/credentials.py)
 connect_spotify  # unused function (src/mindroom/api/integrations.py)
 _.validate_worker_grantable_credentials  # unused method (src/mindroom/config/models.py)
+_.validate_kind_fields  # unused method (src/mindroom/config/worker_egress.py)
 _.validate_non_empty_string  # unused method (src/mindroom/config/worker_egress.py)
 _.validate_proxy_url_scheme  # unused method (src/mindroom/config/worker_egress.py)
 set_api_key  # unused function (src/mindroom/api/credentials.py)


### PR DESCRIPTION
## Summary
- Add `kind: worker_scoped_proxy` worker egress broker config that derives a per-worker bridge proxy URL from the resolved MindRoom worker key.
- Resolve worker egress env after `worker_target` construction so user/user-agent/shared scopes can route to distinct worker-scoped proxy services.
- Keep static broker behavior explicit via `kind: static`.

## Review fixes
- `get_agent_worker_egress_broker` returns the broker config directly; the `ResolvedWorkerEgressBroker` dataclass and its write-only precomputed `execution_env` are gone.
- `worker_id_for_key` moved to `tool_system.worker_routing` (pure hashing helper) so config no longer imports the Kubernetes backend through a function-level import.
- Broker kind dispatch collapsed into a single `execution_env_for_worker_target`; defensive duplicates of the model validator removed.
- Config-load validation: worker-scoped brokers must bind to agents with a worker execution scope (error names the agent), and kind-mismatched fields are rejected (`proxy_url` on `worker_scoped_proxy`; `service_name_prefix`/`port` on `static`).
- Regenerated `tools_metadata.json` (stale on main after the Dynamic Workflow grant description change; fixes the failing `test_export_tools_metadata_json` CI job).

## Test Plan
- `uv run pytest tests/test_worker_egress.py tests/test_kubernetes_worker_backend.py tests/test_worker_runtime.py tests/test_sandbox_proxy.py` (233 passed)
- Full suite: 7944 passed, 60 skipped
- `uv run pre-commit run --all-files` (all hooks pass, including tach, vulture, ty, docs reference generation)

## Notes
- App-side prerequisite only. Staging config should switch to `kind: worker_scoped_proxy` after this lands and staging runs an image containing it.
- Infra still needs matching per-worker Agent Vault bridge resources/services derived with the same `worker_id_for_key(..., prefix="agent-vault-bridge")`.