### PR TITLE
Set conservative llama.cpp tool defaults

### DIFF
--- a/src/mindroom/model_defaults.py
+++ b/src/mindroom/model_defaults.py
@@ -202,4 +202,7 @@ OPENAI_EMBEDDING_DIMENSIONS: Mapping[str, int] = MappingProxyType(
 
 def llama_cpp_server_command(model_id: str) -> str:
     """Return the llama.cpp OpenAI-compatible server command for a Hugging Face GGUF ref."""
-    return f"llama-server -hf {model_id} --host 127.0.0.1 --port 8080"
+    return (
+        f"llama-server -hf {model_id} --host 127.0.0.1 --port 8080 "
+        "--jinja --reasoning off --chat-template-kwargs '{\"enable_thinking\":false}'"
+    )

--- a/src/mindroom/model_loading.py
+++ b/src/mindroom/model_loading.py
@@ -52,6 +52,20 @@ def _canonical_provider(provider: str) -> str:
     return provider.strip().lower().replace("-", "_")
 
 
+def _populate_llama_cpp_tool_defaults(extra_kwargs: dict[str, Any]) -> None:
+    """Set conservative llama.cpp defaults for OpenAI-compatible tool calls."""
+    request_params = dict(cast("dict[str, Any]", extra_kwargs.get("request_params") or {}))
+    request_params.setdefault("parallel_tool_calls", False)
+    extra_kwargs["request_params"] = request_params
+
+    extra_body = dict(cast("dict[str, Any]", extra_kwargs.get("extra_body") or {}))
+    extra_body.setdefault("parse_tool_calls", True)
+    chat_template_kwargs = dict(cast("dict[str, Any]", extra_body.get("chat_template_kwargs") or {}))
+    chat_template_kwargs.setdefault("enable_thinking", False)
+    extra_body["chat_template_kwargs"] = chat_template_kwargs
+    extra_kwargs["extra_body"] = extra_body
+
+
 def _populate_azure_openai_runtime_kwargs(
     extra_kwargs: dict[str, Any],
     runtime_paths: RuntimePaths,
@@ -188,6 +202,9 @@ def _create_model_for_provider(  # noqa: C901, PLR0912, PLR0915
 
     if canonical_provider == "azure":
         _populate_azure_openai_runtime_kwargs(extra_kwargs, runtime_paths)
+
+    if canonical_provider == "llama_cpp":
+        _populate_llama_cpp_tool_defaults(extra_kwargs)
 
     if canonical_provider in {"anthropic", "vertexai_claude", _BEDROCK_CLAUDE_PROVIDER}:
         extra_kwargs.setdefault("cache_system_prompt", True)

--- a/tests/test_extra_kwargs.py
+++ b/tests/test_extra_kwargs.py
@@ -199,7 +199,51 @@ def test_get_model_instance_supports_llama_cpp_provider() -> None:
     assert model.api_key == "sk-no-key-required"
     assert model.base_url == "http://llama.local/v1"
     assert model.max_tokens == 32000
+    assert model.request_params == {"parallel_tool_calls": False}
+    assert model.extra_body == {
+        "parse_tool_calls": True,
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
     assert model.default_role_map["system"] == "system"
+
+
+def test_llama_cpp_provider_preserves_explicit_tool_request_overrides() -> None:
+    """Users should be able to opt out of MindRoom's llama.cpp request defaults."""
+    config_data = {
+        "models": {
+            "local_model": {
+                "provider": "llama_cpp",
+                "id": "gemma-4:31b-q4-uncensored",
+                "extra_kwargs": {
+                    "base_url": "http://llama.local/v1",
+                    "request_params": {
+                        "parallel_tool_calls": True,
+                    },
+                    "extra_body": {
+                        "parse_tool_calls": False,
+                        "chat_template_kwargs": {
+                            "enable_thinking": True,
+                        },
+                    },
+                },
+            },
+        },
+        "router": {
+            "model": "local_model",
+        },
+        "agents": {},
+    }
+
+    config, runtime_paths = _config_with_runtime_paths(config_data)
+
+    model = get_model_instance(config, runtime_paths, "local_model")
+
+    assert isinstance(model, LlamaCpp)
+    assert model.request_params == {"parallel_tool_calls": True}
+    assert model.extra_body == {
+        "parse_tool_calls": False,
+        "chat_template_kwargs": {"enable_thinking": True},
+    }
 
 
 def test_llama_cpp_provider_does_not_auto_fetch_api_key(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- set llama.cpp model requests to disable parallel tool calls by default
- pass llama.cpp tool parsing and `enable_thinking: false` through `extra_body`
- update generated llama-server startup hints to include `--jinja` and `--reasoning off`

## Context
This follows the llama.cpp/Qwen tool-loop investigation. The merged provider PR switched MindRoom to Agno's `LlamaCpp` provider; this PR adds the request/server defaults that address the fragile mixed content + tool-call path. These defaults remain overridable from `extra_kwargs`.

## Tests
- `uv run pytest tests/test_extra_kwargs.py tests/test_cli_config.py::TestConfigInit::test_init_mindroom_chat_llama_cpp_writes_hosted_openai_compatible_defaults -q -n 0 --no-cov`
- `uv run ruff check src/mindroom/model_loading.py src/mindroom/model_defaults.py tests/test_extra_kwargs.py && uv run ruff format --check src/mindroom/model_loading.py src/mindroom/model_defaults.py tests/test_extra_kwargs.py`
- `uv run pre-commit run --all-files`

## Summary by Sourcery

Set conservative default tool-calling behavior and server startup options for the llama.cpp provider while keeping explicit user overrides intact.

New Features:
- Add default llama.cpp request settings to disable parallel tool calls, enable tool parsing, and turn off thinking in chat templates.
- Extend the generated llama.cpp server startup command to include Jinja templates, reasoning disabled, and chat template kwargs for thinking control.

Enhancements:
- Populate llama.cpp-specific tool-related defaults during model creation without overriding user-specified extra_kwargs.

Tests:
- Expand tests to verify default llama.cpp tool request parameters and ensure explicit user overrides for tool behavior are preserved.