### PR TITLE
Optionally deploy the Agent Vault server + bootstrap in the runtime chart

### DIFF
--- a/cluster/k8s/runtime/templates/_helpers.tpl
+++ b/cluster/k8s/runtime/templates/_helpers.tpl
@@ -419,3 +419,41 @@ cache:
   db_path: {{ .Values.eventCache.sqlite.dbPath | quote }}
 {{- end }}
 {{- end -}}
+
+{{- define "mindroom-runtime.agentVaultServerName" -}}
+{{- default "agent-vault" .Values.workers.kubernetes.agentVault.server.name -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.agentVaultSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "mindroom-runtime.agentVaultServerName" . | quote }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+app.kubernetes.io/component: agent-vault
+{{- end -}}
+
+{{- define "mindroom-runtime.agentVaultLabels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | quote }}
+{{ include "mindroom-runtime.agentVaultSelectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+{{- end -}}
+
+{{- define "mindroom-runtime.agentVaultServerClaimName" -}}
+{{- if .Values.workers.kubernetes.agentVault.server.persistence.existingClaim -}}
+{{- .Values.workers.kubernetes.agentVault.server.persistence.existingClaim -}}
+{{- else -}}
+{{- printf "%s-data" (include "mindroom-runtime.agentVaultServerName" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.agentVaultBootstrapName" -}}
+{{- printf "%s-bootstrap" (include "mindroom-runtime.agentVaultServerName" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.agentVaultBootstrapLabels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | quote }}
+app.kubernetes.io/name: {{ include "mindroom-runtime.agentVaultBootstrapName" . | quote }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+app.kubernetes.io/component: agent-vault-bootstrap
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+{{- end -}}

--- a/cluster/k8s/runtime/templates/agent-vault-bootstrap.yaml
+++ b/cluster/k8s/runtime/templates/agent-vault-bootstrap.yaml
@@ -1,0 +1,141 @@
+{{- if .Values.workers.kubernetes.agentVault.bootstrap.enabled }}
+{{- $av := .Values.workers.kubernetes.agentVault -}}
+{{- $bs := $av.bootstrap -}}
+{{- $name := include "mindroom-runtime.agentVaultBootstrapName" . -}}
+{{- $serverName := include "mindroom-runtime.agentVaultServerName" . -}}
+{{- $addr := printf "http://%s:%v" $serverName $av.server.apiPort -}}
+{{- if not $av.workerCaConfigMapName -}}
+{{- fail "workers.kubernetes.agentVault.workerCaConfigMapName is required when bootstrap is enabled (the Job publishes the root CA into it)" -}}
+{{- end -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "mindroom-runtime.agentVaultBootstrapLabels" . | nindent 4 }}
+automountServiceAccountToken: true
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "mindroom-runtime.agentVaultBootstrapLabels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - create
+      - update
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "mindroom-runtime.agentVaultBootstrapLabels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $name }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "mindroom-runtime.agentVaultBootstrapLabels" . | nindent 4 }}
+spec:
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        {{- include "mindroom-runtime.agentVaultBootstrapLabels" . | nindent 8 }}
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ $name }}
+      initContainers:
+        - name: bootstrap-owner
+          image: {{ required "workers.kubernetes.agentVault.bootstrap.image is required when bootstrap is enabled" $bs.image | quote }}
+          command:
+            - sh
+            - -ec
+          args:
+            - |
+              # Keep the CLI session in the init container's own filesystem so it
+              # is never exposed through the shared /work volume.
+              export HOME=/tmp/agent-vault-bootstrap-home
+              mkdir -p "$HOME"
+              addr="{{ $addr }}"
+              password="$(cat /bootstrap/{{ $bs.ownerPasswordSecretKey }})"
+              deadline=$(($(date +%s) + 180))
+              until wget -q -O /dev/null "$addr/health"; do
+                if [ "$(date +%s)" -ge "$deadline" ]; then
+                  echo "Agent Vault did not become ready" >&2
+                  exit 1
+                fi
+                sleep 2
+              done
+              if ! printf '%s\n' "$password" | agent-vault auth login \
+                --address "$addr" \
+                --email "$AGENT_VAULT_OWNER_EMAIL" \
+                --password-stdin >/tmp/login.log 2>&1; then
+                printf '%s\n' "$password" | agent-vault auth register \
+                  --address "$addr" \
+                  --email "$AGENT_VAULT_OWNER_EMAIL" \
+                  --password-stdin >/tmp/register.log 2>&1 || true
+                printf '%s\n' "$password" | agent-vault auth login \
+                  --address "$addr" \
+                  --email "$AGENT_VAULT_OWNER_EMAIL" \
+                  --password-stdin
+              fi
+              agent-vault owner config set \
+                --invite-only={{ $bs.inviteOnly }} \
+                --allowed-domains "$AGENT_VAULT_ALLOWED_DOMAINS"
+              agent-vault ca fetch --address "$addr" > /work/ca.pem
+              test -s /work/ca.pem
+          env:
+            - name: AGENT_VAULT_OWNER_EMAIL
+              value: {{ required "workers.kubernetes.agentVault.ownerEmail is required when bootstrap is enabled" $av.ownerEmail | quote }}
+            - name: AGENT_VAULT_ALLOWED_DOMAINS
+              value: {{ $bs.allowedDomains | quote }}
+          volumeMounts:
+            - name: work
+              mountPath: /work
+            - name: bootstrap
+              mountPath: /bootstrap
+              readOnly: true
+      containers:
+        - name: publish-ca
+          image: {{ required "workers.kubernetes.agentVault.bootstrap.kubectlImage is required when bootstrap is enabled" $bs.kubectlImage | quote }}
+          command:
+            - sh
+            - -ec
+          args:
+            - |
+              kubectl -n "$POD_NAMESPACE" create configmap {{ $av.workerCaConfigMapName }} \
+                --from-file=ca.pem=/work/ca.pem \
+                --dry-run=client -o yaml | kubectl apply -f -
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: work
+              mountPath: /work
+              readOnly: true
+      volumes:
+        - name: work
+          emptyDir: {}
+        - name: bootstrap
+          secret:
+            secretName: {{ required "workers.kubernetes.agentVault.bootstrapSecretName is required when bootstrap is enabled" $av.bootstrapSecretName }}
+{{- end }}

--- a/cluster/k8s/runtime/templates/agent-vault-bootstrap.yaml
+++ b/cluster/k8s/runtime/templates/agent-vault-bootstrap.yaml
@@ -2,8 +2,9 @@
 {{- $av := .Values.workers.kubernetes.agentVault -}}
 {{- $bs := $av.bootstrap -}}
 {{- $name := include "mindroom-runtime.agentVaultBootstrapName" . -}}
-{{- $serverName := include "mindroom-runtime.agentVaultServerName" . -}}
-{{- $addr := printf "http://%s:%v" $serverName $av.server.apiPort -}}
+{{- /* Target the same vault API the workers use, so bootstrap also works
+     against an externally managed Agent Vault (server.enabled=false). */ -}}
+{{- $addr := required "workers.kubernetes.agentVault.apiUrl is required when bootstrap is enabled" $av.apiUrl -}}
 {{- if not $av.workerCaConfigMapName -}}
 {{- fail "workers.kubernetes.agentVault.workerCaConfigMapName is required when bootstrap is enabled (the Job publishes the root CA into it)" -}}
 {{- end -}}

--- a/cluster/k8s/runtime/templates/agent-vault-bootstrap.yaml
+++ b/cluster/k8s/runtime/templates/agent-vault-bootstrap.yaml
@@ -53,6 +53,9 @@ metadata:
   labels:
     {{- include "mindroom-runtime.agentVaultBootstrapLabels" . | nindent 4 }}
 spec:
+  # The finished Job is garbage-collected after 24h; the RBAC objects above are
+  # Helm-managed and stay. To force a re-run (the script is idempotent), delete
+  # the Job and `helm upgrade`, which re-applies it.
   ttlSecondsAfterFinished: 86400
   template:
     metadata:
@@ -83,19 +86,27 @@ spec:
                 fi
                 sleep 2
               done
+              # The first login is expected to fail on a fresh instance (the
+              # owner does not exist yet), so capture it instead of spamming
+              # the log; if registration then fails too, surface both captures
+              # before the final unsuppressed login fails the Job with context.
               if ! printf '%s\n' "$password" | agent-vault auth login \
                 --address "$addr" \
                 --email "$AGENT_VAULT_OWNER_EMAIL" \
                 --password-stdin >/tmp/login.log 2>&1; then
-                printf '%s\n' "$password" | agent-vault auth register \
+                if ! printf '%s\n' "$password" | agent-vault auth register \
                   --address "$addr" \
                   --email "$AGENT_VAULT_OWNER_EMAIL" \
-                  --password-stdin >/tmp/register.log 2>&1 || true
+                  --password-stdin >/tmp/register.log 2>&1; then
+                  cat /tmp/login.log /tmp/register.log >&2 || true
+                fi
                 printf '%s\n' "$password" | agent-vault auth login \
                   --address "$addr" \
                   --email "$AGENT_VAULT_OWNER_EMAIL" \
                   --password-stdin
               fi
+              # owner config set has no --address flag; it uses the session
+              # (and server address) persisted in $HOME by auth login.
               agent-vault owner config set \
                 --invite-only={{ $bs.inviteOnly }} \
                 --allowed-domains "$AGENT_VAULT_ALLOWED_DOMAINS"
@@ -106,6 +117,8 @@ spec:
               value: {{ required "workers.kubernetes.agentVault.ownerEmail is required when bootstrap is enabled" $av.ownerEmail | quote }}
             - name: AGENT_VAULT_ALLOWED_DOMAINS
               value: {{ $bs.allowedDomains | quote }}
+          resources:
+            {{- toYaml $bs.resources | nindent 12 }}
           volumeMounts:
             - name: work
               mountPath: /work
@@ -128,6 +141,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          resources:
+            {{- toYaml $bs.resources | nindent 12 }}
           volumeMounts:
             - name: work
               mountPath: /work

--- a/cluster/k8s/runtime/templates/agent-vault-server.yaml
+++ b/cluster/k8s/runtime/templates/agent-vault-server.yaml
@@ -1,0 +1,157 @@
+{{- if .Values.workers.kubernetes.agentVault.server.enabled }}
+{{- $av := .Values.workers.kubernetes.agentVault -}}
+{{- $server := $av.server -}}
+{{- $name := include "mindroom-runtime.agentVaultServerName" . -}}
+{{- if and $server.persistence.enabled (not $server.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "mindroom-runtime.agentVaultServerClaimName" . }}
+  labels:
+    {{- include "mindroom-runtime.agentVaultLabels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if $server.persistence.storageClassName }}
+  storageClassName: {{ $server.persistence.storageClassName | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ $server.persistence.size | quote }}
+---
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "mindroom-runtime.agentVaultLabels" . | nindent 4 }}
+spec:
+  replicas: 1
+  # Single replica backed by an RWO PVC: never surge a second pod (it would
+  # deadlock waiting for the volume). Recreate stops the old pod first.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "mindroom-runtime.agentVaultSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "mindroom-runtime.agentVaultSelectorLabels" . | nindent 8 }}
+        {{- with $server.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with $server.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      {{- with $server.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: agent-vault
+          image: {{ required "workers.kubernetes.agentVault.server.image is required when the Agent Vault server is enabled" $server.image | quote }}
+          imagePullPolicy: {{ $server.imagePullPolicy }}
+          command:
+            - agent-vault
+          args:
+            - server
+            - --host
+            - 0.0.0.0
+            - --port
+            - {{ $server.apiPort | quote }}
+            - --mitm-port
+            - {{ $server.mitmPort | quote }}
+          env:
+            - name: AGENT_VAULT_MASTER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "workers.kubernetes.agentVault.bootstrapSecretName is required when the Agent Vault server is enabled" $av.bootstrapSecretName }}
+                  key: {{ $server.masterPasswordSecretKey }}
+            {{- if $server.smtp.enabled }}
+            - name: AGENT_VAULT_SMTP_HOST
+              value: {{ $server.smtp.host | quote }}
+            - name: AGENT_VAULT_SMTP_PORT
+              value: {{ $server.smtp.port | quote }}
+            - name: AGENT_VAULT_SMTP_TLS_MODE
+              value: {{ $server.smtp.tlsMode | quote }}
+            - name: AGENT_VAULT_SMTP_FROM_NAME
+              value: {{ $server.smtp.fromName | quote }}
+            - name: AGENT_VAULT_SMTP_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "workers.kubernetes.agentVault.server.smtp.existingSecret is required when smtp.enabled=true" $server.smtp.existingSecret }}
+                  key: AGENT_VAULT_SMTP_USERNAME
+            - name: AGENT_VAULT_SMTP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $server.smtp.existingSecret }}
+                  key: AGENT_VAULT_SMTP_PASSWORD
+            - name: AGENT_VAULT_SMTP_FROM
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $server.smtp.existingSecret }}
+                  key: AGENT_VAULT_SMTP_FROM
+            {{- end }}
+          ports:
+            - name: api
+              containerPort: {{ $server.apiPort }}
+              protocol: TCP
+            - name: proxy
+              containerPort: {{ $server.mitmPort }}
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: api
+            periodSeconds: 10
+            timeoutSeconds: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: api
+            periodSeconds: 30
+            timeoutSeconds: 5
+          resources:
+            {{- toYaml $server.resources | nindent 12 }}
+          {{- with $server.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          {{- if $server.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "mindroom-runtime.agentVaultServerClaimName" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "mindroom-runtime.agentVaultLabels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "mindroom-runtime.agentVaultSelectorLabels" . | nindent 4 }}
+  ports:
+    - name: api
+      port: {{ $server.apiPort }}
+      targetPort: api
+      protocol: TCP
+    - name: proxy
+      port: {{ $server.mitmPort }}
+      targetPort: proxy
+      protocol: TCP
+{{- end }}

--- a/cluster/k8s/runtime/values.yaml
+++ b/cluster/k8s/runtime/values.yaml
@@ -343,6 +343,63 @@ workers:
       # worker pods mount it at /etc/agent-vault/ca.pem so brokered HTTPS
       # traffic can trust the vault's TLS interception.
       workerCaConfigMapName: ""
+      # Optionally run the Agent Vault server in-cluster. Leave disabled to
+      # point apiUrl/proxyUrl at an externally managed Agent Vault instance.
+      server:
+        enabled: false
+        # Service/Deployment name. Must match the host in apiUrl/proxyUrl.
+        name: agent-vault
+        # Agent Vault server image, pinned by digest. Required when enabled.
+        image: ""
+        imagePullPolicy: IfNotPresent
+        apiPort: 14321
+        mitmPort: 14322
+        # Key in bootstrapSecretName holding the master password that protects
+        # the vault's encryption key.
+        masterPasswordSecretKey: AGENT_VAULT_MASTER_PASSWORD
+        persistence:
+          enabled: true
+          size: 1Gi
+          storageClassName: ""
+          existingClaim: ""
+        # Optional SMTP for signup verification emails. When disabled, the
+        # server logs verification codes for the owner to relay manually.
+        smtp:
+          enabled: false
+          host: ""
+          port: 587
+          # starttls | implicit | none
+          tlsMode: starttls
+          fromName: Agent Vault
+          # Secret with keys AGENT_VAULT_SMTP_USERNAME, AGENT_VAULT_SMTP_PASSWORD,
+          # and AGENT_VAULT_SMTP_FROM.
+          existingSecret: ""
+        podSecurityContext:
+          fsGroup: 101
+          fsGroupChangePolicy: OnRootMismatch
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - NET_RAW
+        resources: {}
+      # Optional one-shot bootstrap Job: create/log in the instance owner, set
+      # instance policy (invite-only, allowed signup domains), and publish the
+      # root CA into workerCaConfigMapName so worker pods trust the vault's TLS
+      # interception. Re-runs are idempotent.
+      bootstrap:
+        enabled: false
+        # Agent Vault image, pinned by digest. Required when enabled.
+        image: ""
+        # Image providing kubectl, used to publish the CA ConfigMap. Required
+        # when enabled.
+        kubectlImage: ""
+        # Key in bootstrapSecretName holding the owner account password.
+        ownerPasswordSecretKey: AGENT_VAULT_OWNER_PASSWORD
+        # Comma-separated signup domain allowlist; empty means no restriction.
+        allowedDomains: ""
+        inviteOnly: true
+        resources: {}
 
 # Optional external HTTP proxy for dedicated Kubernetes workers.
 # This chart can point worker pods at an existing proxy Service and, when

--- a/cluster/k8s/runtime/values.yaml
+++ b/cluster/k8s/runtime/values.yaml
@@ -381,7 +381,7 @@ workers:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-              - NET_RAW
+              - ALL
         resources: {}
       # Optional one-shot bootstrap Job: create/log in the instance owner, set
       # instance policy (invite-only, allowed signup domains), and publish the


### PR DESCRIPTION
## Why

The `mindroom-runtime` chart already wires the **worker side** of `agentVault` (the per-worker token mint init container + proxy env, from #1208) and references `apiUrl`, `proxyUrl`, `bootstrapSecretName`, and `workerCaConfigMapName` — but it **deploys none of them**. So enabling `agentVault` today requires hand-rolling the Agent Vault server and the CA-publishing bootstrap out of band. In particular, the chart consumes `workerCaConfigMapName` but nothing populates it.

## What

Two optional, **disabled-by-default** components under `workers.kubernetes.agentVault`:

- **`server`** — the Agent Vault `Deployment` + `Service` + `PVC` (`Recreate` strategy for the RWO volume), with optional **SMTP** for signup verification emails (from an existing Secret).
- **`bootstrap`** — a one-shot, idempotent `Job` (+ minimal `configmaps` RBAC) that logs in / registers the instance owner, sets `invite-only` and allowed signup domains, and **publishes the root CA into `workerCaConfigMapName`** so worker pods trust the vault's TLS interception. This closes the gap above.

## Compatibility & validation

- Both default to `enabled: false` — **no change to existing installs**.
- `helm lint` passes; renders cleanly with both enabled; `required` fires with clear messages when images/secrets are missing when enabled.
- Master/owner passwords and SMTP creds come from operator-provided Secrets (`bootstrapSecretName`, `server.smtp.existingSecret`); the server image is the public `infisical/agent-vault`.

## Out of scope

The UI SSO gate (oauth2-proxy/OIDC) and the SPA subpath nginx rewrite are deployment-specific / belong in the agent-vault project itself, so they're intentionally left out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deploy Agent Vault servers directly within Kubernetes clusters for centralized credential and authentication management.
  * Automated bootstrap system handles server initialization, CA certificate generation, and distribution to worker nodes.
  * Configurable options for data persistence, SMTP integration, pod security policies, and resource allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->