### PR TITLE
Wire agent_vault_access end to end: bootstrap-minted admin token

### DIFF
--- a/cluster/k8s/runtime/templates/_helpers.tpl
+++ b/cluster/k8s/runtime/templates/_helpers.tpl
@@ -457,3 +457,13 @@ app.kubernetes.io/component: agent-vault-bootstrap
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 {{- end -}}
+
+{{- define "mindroom-runtime.agentVaultServerImage" -}}
+{{- $av := .Values.workers.kubernetes.agentVault -}}
+{{- required "workers.kubernetes.agentVault.server.image or cliImage is required when the Agent Vault server is enabled" (default $av.cliImage $av.server.image) -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.agentVaultBootstrapImage" -}}
+{{- $av := .Values.workers.kubernetes.agentVault -}}
+{{- required "workers.kubernetes.agentVault.bootstrap.image or cliImage is required when bootstrap is enabled" (default $av.cliImage $av.bootstrap.image) -}}
+{{- end -}}

--- a/cluster/k8s/runtime/templates/agent-vault-bootstrap.yaml
+++ b/cluster/k8s/runtime/templates/agent-vault-bootstrap.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.workers.kubernetes.agentVault.bootstrap.enabled }}
 {{- $av := .Values.workers.kubernetes.agentVault -}}
 {{- $bs := $av.bootstrap -}}
+{{- $accessTool := $av.accessTool -}}
 {{- $name := include "mindroom-runtime.agentVaultBootstrapName" . -}}
 {{- /* Target the same vault API the workers use, so bootstrap also works
      against an externally managed Agent Vault (server.enabled=false). */ -}}
@@ -32,6 +33,19 @@ rules:
       - create
       - update
       - patch
+  {{- if $accessTool.enabled }}
+  # Publishing the access-tool admin token. `create` cannot be name-scoped;
+  # the binding is namespace-local and only the bootstrap SA holds it.
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - create
+      - update
+      - patch
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -67,7 +81,7 @@ spec:
       serviceAccountName: {{ $name }}
       initContainers:
         - name: bootstrap-owner
-          image: {{ required "workers.kubernetes.agentVault.bootstrap.image is required when bootstrap is enabled" $bs.image | quote }}
+          image: {{ include "mindroom-runtime.agentVaultBootstrapImage" . | quote }}
           command:
             - sh
             - -ec
@@ -113,6 +127,18 @@ spec:
                 --allowed-domains "$AGENT_VAULT_ALLOWED_DOMAINS"
               agent-vault ca fetch --address "$addr" > /work/ca.pem
               test -s /work/ca.pem
+              {{- if $accessTool.enabled }}
+              # Owner-role agent for the agent_vault_access tool. Re-runs
+              # rotate the token; the control plane re-reads it from the
+              # mounted Secret per call, so rotation needs no restart.
+              if ! agent-vault agent create {{ $accessTool.adminAgentName | quote }} \
+                --token-only > /work/access-admin-token; then
+                agent-vault agent rotate {{ $accessTool.adminAgentName | quote }} \
+                  --token-only > /work/access-admin-token
+              fi
+              agent-vault agent set-role {{ $accessTool.adminAgentName | quote }} --role owner
+              test -s /work/access-admin-token
+              {{- end }}
           env:
             - name: AGENT_VAULT_OWNER_EMAIL
               value: {{ required "workers.kubernetes.agentVault.ownerEmail is required when bootstrap is enabled" $av.ownerEmail | quote }}
@@ -137,6 +163,11 @@ spec:
               kubectl -n "$POD_NAMESPACE" create configmap {{ $av.workerCaConfigMapName }} \
                 --from-file=ca.pem=/work/ca.pem \
                 --dry-run=client -o yaml | kubectl apply -f -
+              {{- if $accessTool.enabled }}
+              kubectl -n "$POD_NAMESPACE" create secret generic {{ $accessTool.adminTokenSecret.name }} \
+                --from-file={{ $accessTool.adminTokenSecret.key }}=/work/access-admin-token \
+                --dry-run=client -o yaml | kubectl apply -f -
+              {{- end }}
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/cluster/k8s/runtime/templates/agent-vault-bootstrap.yaml
+++ b/cluster/k8s/runtime/templates/agent-vault-bootstrap.yaml
@@ -23,26 +23,40 @@ metadata:
   name: {{ $name }}
   labels:
     {{- include "mindroom-runtime.agentVaultBootstrapLabels" . | nindent 4 }}
+# `create` cannot be name-scoped in RBAC; everything else is restricted to
+# the exact objects the Job publishes.
 rules:
   - apiGroups:
       - ""
     resources:
       - configmaps
     verbs:
-      - get
       - create
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - {{ $av.workerCaConfigMapName }}
+    verbs:
+      - get
       - update
       - patch
   {{- if $accessTool.enabled }}
-  # Publishing the access-tool admin token. `create` cannot be name-scoped;
-  # the binding is namespace-local and only the bootstrap SA holds it.
   - apiGroups:
       - ""
     resources:
       - secrets
     verbs:
-      - get
       - create
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    resourceNames:
+      - {{ $accessTool.adminTokenSecret.name }}
+    verbs:
+      - get
       - update
       - patch
   {{- end }}

--- a/cluster/k8s/runtime/templates/agent-vault-server.yaml
+++ b/cluster/k8s/runtime/templates/agent-vault-server.yaml
@@ -55,7 +55,7 @@ spec:
       {{- end }}
       containers:
         - name: agent-vault
-          image: {{ required "workers.kubernetes.agentVault.server.image is required when the Agent Vault server is enabled" $server.image | quote }}
+          image: {{ include "mindroom-runtime.agentVaultServerImage" . | quote }}
           imagePullPolicy: {{ $server.imagePullPolicy }}
           command:
             - agent-vault

--- a/cluster/k8s/runtime/templates/deployment.yaml
+++ b/cluster/k8s/runtime/templates/deployment.yaml
@@ -319,6 +319,22 @@ spec:
             {{- end }}
             {{- end }}
             {{- end }}
+            {{- with .Values.workers.kubernetes.agentVault }}
+            {{- if .accessTool.enabled }}
+            - name: MINDROOM_AGENT_VAULT_ACCESS_API_URL
+              value: {{ .apiUrl | quote }}
+            - name: MINDROOM_AGENT_VAULT_ACCESS_UI_BASE_URL
+              value: {{ required "workers.kubernetes.agentVault.accessTool.uiBaseUrl is required when the access tool is enabled" .accessTool.uiBaseUrl | quote }}
+            - name: MINDROOM_AGENT_VAULT_ACCESS_EMAIL_DOMAIN
+              value: {{ required "workers.kubernetes.agentVault.accessTool.emailDomain is required when the access tool is enabled" .accessTool.emailDomain | quote }}
+            - name: MINDROOM_AGENT_VAULT_ACCESS_VAULT_NAME_PREFIX
+              value: {{ .vaultNamePrefix | quote }}
+            # Mounted Secret file, not env: the kubelet refreshes the mount in
+            # place, so a bootstrap re-run (token rotation) needs no restart.
+            - name: MINDROOM_AGENT_VAULT_ACCESS_ADMIN_TOKEN_FILE
+              value: {{ printf "/etc/agent-vault-access/%s" .accessTool.adminTokenSecret.key | quote }}
+            {{- end }}
+            {{- end }}
             {{- end }}
             {{- if .Values.matrix.homeserverUrl }}
             - name: MATRIX_HOMESERVER
@@ -422,6 +438,11 @@ spec:
               subPath: {{ .Values.approvedEgress.allowlist.key | quote }}
               readOnly: true
             {{- end }}
+            {{- if .Values.workers.kubernetes.agentVault.accessTool.enabled }}
+            - name: agent-vault-access-admin
+              mountPath: /etc/agent-vault-access
+              readOnly: true
+            {{- end }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -505,6 +526,14 @@ spec:
         {{- if eq .Values.workers.backend "static_runner" }}
         - name: sandbox-workspace
           emptyDir: {}
+        {{- end }}
+        {{- if .Values.workers.kubernetes.agentVault.accessTool.enabled }}
+        - name: agent-vault-access-admin
+          secret:
+            secretName: {{ .Values.workers.kubernetes.agentVault.accessTool.adminTokenSecret.name }}
+            # Optional: lets the control plane start before the first
+            # bootstrap publishes the token; the tool errors cleanly until then.
+            optional: true
         {{- end }}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/cluster/k8s/runtime/templates/validate.yaml
+++ b/cluster/k8s/runtime/templates/validate.yaml
@@ -160,6 +160,14 @@
 {{- end -}}
 {{- end -}}
 {{- $agentVault := .Values.workers.kubernetes.agentVault -}}
-{{- if and $agentVault.accessTool.enabled (not $agentVault.enabled) -}}
+{{- if $agentVault.accessTool.enabled -}}
+{{- if not $agentVault.enabled -}}
 {{- fail "workers.kubernetes.agentVault.accessTool.enabled requires workers.kubernetes.agentVault.enabled=true" -}}
+{{- end -}}
+{{- if not $agentVault.accessTool.adminAgentName -}}
+{{- fail "workers.kubernetes.agentVault.accessTool.adminAgentName must not be empty" -}}
+{{- end -}}
+{{- if not (and $agentVault.accessTool.adminTokenSecret.name $agentVault.accessTool.adminTokenSecret.key) -}}
+{{- fail "workers.kubernetes.agentVault.accessTool.adminTokenSecret.name and .key must not be empty" -}}
+{{- end -}}
 {{- end -}}

--- a/cluster/k8s/runtime/templates/validate.yaml
+++ b/cluster/k8s/runtime/templates/validate.yaml
@@ -159,3 +159,7 @@
 {{- fail "approvedEgress.persistence.size is required when chart-managed approved egress persistence is enabled" -}}
 {{- end -}}
 {{- end -}}
+{{- $agentVault := .Values.workers.kubernetes.agentVault -}}
+{{- if and $agentVault.accessTool.enabled (not $agentVault.enabled) -}}
+{{- fail "workers.kubernetes.agentVault.accessTool.enabled requires workers.kubernetes.agentVault.enabled=true" -}}
+{{- end -}}

--- a/cluster/k8s/runtime/templates/validate.yaml
+++ b/cluster/k8s/runtime/templates/validate.yaml
@@ -164,10 +164,10 @@
 {{- if not $agentVault.enabled -}}
 {{- fail "workers.kubernetes.agentVault.accessTool.enabled requires workers.kubernetes.agentVault.enabled=true" -}}
 {{- end -}}
-{{- if not $agentVault.accessTool.adminAgentName -}}
+{{- if not (trim (default "" $agentVault.accessTool.adminAgentName)) -}}
 {{- fail "workers.kubernetes.agentVault.accessTool.adminAgentName must not be empty" -}}
 {{- end -}}
-{{- if not (and $agentVault.accessTool.adminTokenSecret.name $agentVault.accessTool.adminTokenSecret.key) -}}
+{{- if not (and (trim (default "" $agentVault.accessTool.adminTokenSecret.name)) (trim (default "" $agentVault.accessTool.adminTokenSecret.key))) -}}
 {{- fail "workers.kubernetes.agentVault.accessTool.adminTokenSecret.name and .key must not be empty" -}}
 {{- end -}}
 {{- end -}}

--- a/cluster/k8s/runtime/values.yaml
+++ b/cluster/k8s/runtime/values.yaml
@@ -349,7 +349,7 @@ workers:
         enabled: false
         # Service/Deployment name. Must match the host in apiUrl/proxyUrl.
         name: agent-vault
-        # Agent Vault server image, pinned by digest. Required when enabled.
+        # Agent Vault server image, pinned by digest; defaults to cliImage.
         image: ""
         imagePullPolicy: IfNotPresent
         apiPort: 14321
@@ -389,7 +389,7 @@ workers:
       # interception. Re-runs are idempotent.
       bootstrap:
         enabled: false
-        # Agent Vault image, pinned by digest. Required when enabled.
+        # Agent Vault image, pinned by digest; defaults to cliImage.
         image: ""
         # Image providing kubectl, used to publish the CA ConfigMap. Required
         # when enabled.
@@ -400,6 +400,27 @@ workers:
         allowedDomains: ""
         inviteOnly: true
         resources: {}
+      # Optional wiring for the agent_vault_access tool: agents grant their
+      # requester UI access to the vault backing their own worker. When
+      # bootstrap.enabled, the bootstrap Job mints an owner-role agent and
+      # publishes its token into adminTokenSecret; the control plane reads it
+      # from a mounted file so a bootstrap re-run (token rotation) takes
+      # effect without a restart.
+      accessTool:
+        enabled: false
+        # Public base URL of the (deployer-gated) Agent Vault UI, e.g.
+        # https://example.com/agent-vault. Required when enabled.
+        uiBaseUrl: ""
+        # Domain that maps a requester's Matrix localpart to their vault
+        # account email. Required when enabled.
+        emailDomain: ""
+        # Owner-role agent the bootstrap Job creates/rotates for the tool.
+        adminAgentName: access-admin
+        # Secret the bootstrap Job publishes the token into (and the control
+        # plane mounts). Provide it yourself when bootstrap is disabled.
+        adminTokenSecret:
+          name: agent-vault-access-admin
+          key: token
 
 # Optional external HTTP proxy for dedicated Kubernetes workers.
 # This chart can point worker pods at an existing proxy Service and, when

--- a/src/mindroom/custom_tools/agent_vault_access.py
+++ b/src/mindroom/custom_tools/agent_vault_access.py
@@ -99,8 +99,11 @@ class AgentVaultAccessTools(Toolkit):
 
         vault = worker_id_for_key(target.worker_key, prefix=self._vault_name_prefix)
         try:
-            await self._ensure_vault(vault)
-            granted = await self._grant_member(vault, email)
+            # One token read per request: both API calls must use the same
+            # token, or a rotation between them could 401 the second call.
+            token = self._resolve_admin_token()
+            await self._ensure_vault(vault, token)
+            granted = await self._grant_member(vault, email, token)
         except _AgentVaultAccessError as exc:
             return self._error(str(exc))
         except httpx.HTTPError as exc:
@@ -150,14 +153,14 @@ class AgentVaultAccessTools(Toolkit):
             return token
         return self._admin_token
 
-    def _headers(self) -> dict[str, str]:
-        return {"Authorization": f"Bearer {self._resolve_admin_token()}", "Content-Type": "application/json"}
+    def _headers(self, token: str) -> dict[str, str]:
+        return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
 
-    async def _ensure_vault(self, vault: str) -> None:
+    async def _ensure_vault(self, vault: str, token: str) -> None:
         async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_SECONDS) as client:
             response = await client.post(
                 urljoin(self._api_url.rstrip("/") + "/", "v1/vaults"),
-                headers=self._headers(),
+                headers=self._headers(token),
                 json={"name": vault},
             )
         # 409/422 mean the vault already exists, which is fine for an idempotent grant.
@@ -165,11 +168,11 @@ class AgentVaultAccessTools(Toolkit):
             return
         response.raise_for_status()
 
-    async def _grant_member(self, vault: str, email: str) -> bool:
+    async def _grant_member(self, vault: str, email: str, token: str) -> bool:
         async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_SECONDS) as client:
             response = await client.post(
                 urljoin(self._api_url.rstrip("/") + "/", f"v1/vaults/{quote(vault, safe='')}/users"),
-                headers=self._headers(),
+                headers=self._headers(token),
                 json={"email": email, "role": "member"},
             )
         if response.status_code in {200, 201}:

--- a/src/mindroom/custom_tools/agent_vault_access.py
+++ b/src/mindroom/custom_tools/agent_vault_access.py
@@ -15,6 +15,7 @@ which worker reaches which vault.
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import quote, urljoin
 
@@ -48,6 +49,7 @@ class AgentVaultAccessTools(Toolkit):
         env = AGENT_VAULT_ACCESS_ENV_BY_KEY
         self._api_url = (runtime_paths.env_value(env["api_url"]) or "").strip()
         self._admin_token = (runtime_paths.env_value(env["admin_token"]) or "").strip()
+        self._admin_token_file = (runtime_paths.env_value(env["admin_token_file"]) or "").strip()
         self._ui_base_url = (runtime_paths.env_value(env["ui_base_url"]) or "").strip()
         self._email_domain = (runtime_paths.env_value(env["email_domain"]) or "").strip().lstrip("@")
         self._vault_name_prefix = (
@@ -57,12 +59,13 @@ class AgentVaultAccessTools(Toolkit):
             name
             for name, value in (
                 (env["api_url"], self._api_url),
-                (env["admin_token"], self._admin_token),
                 (env["ui_base_url"], self._ui_base_url),
                 (env["email_domain"], self._email_domain),
             )
             if not value
         ]
+        if not self._admin_token and not self._admin_token_file:
+            missing.append(f"{env['admin_token']} or {env['admin_token_file']}")
         if missing:
             msg = f"AgentVaultAccessTools requires these environment values: {', '.join(sorted(missing))}"
             raise _AgentVaultAccessError(msg)
@@ -132,8 +135,23 @@ class AgentVaultAccessTools(Toolkit):
             return localpart
         return f"{localpart}@{self._email_domain}"
 
+    def _resolve_admin_token(self) -> str:
+        # Re-read the token file on every call so a rotated Secret (refreshed
+        # in place by the kubelet) takes effect without a process restart.
+        if self._admin_token_file:
+            try:
+                token = Path(self._admin_token_file).read_text(encoding="utf-8").strip()
+            except OSError as exc:
+                msg = f"could not read the Agent Vault admin token file {self._admin_token_file!r}: {exc}"
+                raise _AgentVaultAccessError(msg) from exc
+            if not token:
+                msg = f"the Agent Vault admin token file {self._admin_token_file!r} is empty."
+                raise _AgentVaultAccessError(msg)
+            return token
+        return self._admin_token
+
     def _headers(self) -> dict[str, str]:
-        return {"Authorization": f"Bearer {self._admin_token}", "Content-Type": "application/json"}
+        return {"Authorization": f"Bearer {self._resolve_admin_token()}", "Content-Type": "application/json"}
 
     async def _ensure_vault(self, vault: str) -> None:
         async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_SECONDS) as client:

--- a/src/mindroom/runtime_env_policy.py
+++ b/src/mindroom/runtime_env_policy.py
@@ -79,6 +79,11 @@ AGENT_VAULT_ACCESS_ENV_BY_KEY: Mapping[str, str] = MappingProxyType(
     {
         "api_url": "MINDROOM_AGENT_VAULT_ACCESS_API_URL",
         "admin_token": "MINDROOM_AGENT_VAULT_ACCESS_ADMIN_TOKEN",
+        # File alternative to admin_token, read per call: a Secret mounted as a
+        # volume refreshes in place, so token rotation by a re-run of the vault
+        # bootstrap takes effect without a process restart (env values would
+        # need one).
+        "admin_token_file": "MINDROOM_AGENT_VAULT_ACCESS_ADMIN_TOKEN_FILE",
         "ui_base_url": "MINDROOM_AGENT_VAULT_ACCESS_UI_BASE_URL",
         "email_domain": "MINDROOM_AGENT_VAULT_ACCESS_EMAIL_DOMAIN",
         "vault_name_prefix": "MINDROOM_AGENT_VAULT_ACCESS_VAULT_NAME_PREFIX",

--- a/src/mindroom/tools/__init__.py
+++ b/src/mindroom/tools/__init__.py
@@ -367,8 +367,22 @@ def _homeassistant_tools() -> type[Toolkit]:
             name="MINDROOM_AGENT_VAULT_ACCESS_ADMIN_TOKEN",
             label="Agent Vault Admin Token",
             type="password",
-            required=True,
-            description="Owner/admin session or agent token used to create vaults and grant membership.",
+            required=False,
+            description=(
+                "Owner/admin session or agent token used to create vaults and grant membership. "
+                "Provide this or the admin token file."
+            ),
+        ),
+        ConfigField(
+            name="MINDROOM_AGENT_VAULT_ACCESS_ADMIN_TOKEN_FILE",
+            label="Agent Vault Admin Token File",
+            type="text",
+            required=False,
+            placeholder="/etc/agent-vault-access/token",
+            description=(
+                "Path to a file holding the admin token, re-read on every call so an in-place "
+                "Secret rotation takes effect without a restart. Takes precedence over the inline token."
+            ),
         ),
         ConfigField(
             name="MINDROOM_AGENT_VAULT_ACCESS_UI_BASE_URL",

--- a/src/mindroom/tools_metadata.json
+++ b/src/mindroom/tools_metadata.json
@@ -6721,13 +6721,25 @@
         {
           "authored_override": true,
           "default": null,
-          "description": "Owner/admin session or agent token used to create vaults and grant membership.",
+          "description": "Owner/admin session or agent token used to create vaults and grant membership. Provide this or the admin token file.",
           "label": "Agent Vault Admin Token",
           "name": "MINDROOM_AGENT_VAULT_ACCESS_ADMIN_TOKEN",
           "options": null,
           "placeholder": null,
-          "required": true,
+          "required": false,
           "type": "password",
+          "validation": null
+        },
+        {
+          "authored_override": true,
+          "default": null,
+          "description": "Path to a file holding the admin token, re-read on every call so an in-place Secret rotation takes effect without a restart. Takes precedence over the inline token.",
+          "label": "Agent Vault Admin Token File",
+          "name": "MINDROOM_AGENT_VAULT_ACCESS_ADMIN_TOKEN_FILE",
+          "options": null,
+          "placeholder": "/etc/agent-vault-access/token",
+          "required": false,
+          "type": "text",
           "validation": null
         },
         {

--- a/tests/test_agent_vault_access_tool.py
+++ b/tests/test_agent_vault_access_tool.py
@@ -63,11 +63,13 @@ class _FakeVaultAPI:
     def __init__(self, responses: dict[str, int]) -> None:
         self.responses = responses
         self.calls: list[tuple[str, dict]] = []
+        self.auth_headers: list[str] = []
 
     def handler(self, request: httpx.Request) -> httpx.Response:
         path = request.url.path
         body = json.loads(request.content.decode()) if request.content else {}
         self.calls.append((path, body))
+        self.auth_headers.append(request.headers.get("authorization", ""))
         for suffix, status in self.responses.items():
             if path.endswith(suffix):
                 payload = {"name": body.get("name", "")} if status < 300 else {"error": "scripted"}
@@ -180,3 +182,49 @@ async def test_request_vault_access_without_requester(tmp_path: Path) -> None:
     )
     payload = json.loads(await tool.request_vault_access())
     assert payload["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_admin_token_file_is_reread_per_call(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A rotated token file takes effect on the next call without a restart."""
+    token_file = tmp_path / "token"
+    token_file.write_text("first-token\n", encoding="utf-8")
+    env = {k: v for k, v in _ENV.items() if k != "MINDROOM_AGENT_VAULT_ACCESS_ADMIN_TOKEN"}
+    env["MINDROOM_AGENT_VAULT_ACCESS_ADMIN_TOKEN_FILE"] = str(token_file)
+    api = _FakeVaultAPI({"/v1/vaults": 201, "/users": 201})
+    _patch_client(monkeypatch, api)
+
+    tool = AgentVaultAccessTools(runtime_paths=_runtime_paths(tmp_path, env=env), worker_target=_worker_target())
+    assert json.loads(await tool.request_vault_access())["status"] == "ok"
+    token_file.write_text("second-token\n", encoding="utf-8")
+    assert json.loads(await tool.request_vault_access())["status"] == "ok"
+
+    assert "Bearer first-token" in api.auth_headers
+    assert "Bearer second-token" in api.auth_headers
+
+
+@pytest.mark.asyncio
+async def test_admin_token_file_missing_is_reported(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unreadable token file fails the call with a clear error, not a crash."""
+    env = {k: v for k, v in _ENV.items() if k != "MINDROOM_AGENT_VAULT_ACCESS_ADMIN_TOKEN"}
+    env["MINDROOM_AGENT_VAULT_ACCESS_ADMIN_TOKEN_FILE"] = str(tmp_path / "missing-token")
+    _patch_client(monkeypatch, _FakeVaultAPI({"/v1/vaults": 201, "/users": 201}))
+
+    tool = AgentVaultAccessTools(runtime_paths=_runtime_paths(tmp_path, env=env), worker_target=_worker_target())
+    payload = json.loads(await tool.request_vault_access())
+
+    assert payload["status"] == "error"
+    assert "admin token file" in payload["error"]
+
+
+def test_tool_requires_some_admin_token(tmp_path: Path) -> None:
+    """Construction fails when neither the inline token nor the token file is set."""
+    env = {k: v for k, v in _ENV.items() if k != "MINDROOM_AGENT_VAULT_ACCESS_ADMIN_TOKEN"}
+    with pytest.raises(_AgentVaultAccessError, match="ADMIN_TOKEN"):
+        AgentVaultAccessTools(runtime_paths=_runtime_paths(tmp_path, env=env), worker_target=_worker_target())


### PR DESCRIPTION
## Why

The `agent_vault_access` tool (from #1208) lets a user ask their agent for a UI link to manage that agent's vault — but nothing provisioned the **admin credential** it needs, so deployers could not enable it without hand-minting an owner token and managing its lifecycle out of band. This closes the loop, retiring static grants-file workflows: users self-serve vault access by asking their agent.

## What

**Chart** (all gated on new `workers.kubernetes.agentVault.accessTool.enabled`, default off):
- The bootstrap Job create-or-rotates an **owner-role agent** (`agent set-role --role owner`) and publishes its token into a Secret (`adminTokenSecret`, default `agent-vault-access-admin`). Namespace-local `secrets` RBAC is added to the bootstrap Role only when enabled.
- The control plane gets the `MINDROOM_AGENT_VAULT_ACCESS_*` env wired from existing `agentVault` values (`apiUrl`/`vaultNamePrefix` reused; `uiBaseUrl` and `emailDomain` are new required inputs).
- `agentVault.server.image` / `bootstrap.image` now default to `cliImage` (review follow-up from #1209).

**Runtime** (small):
- New `MINDROOM_AGENT_VAULT_ACCESS_ADMIN_TOKEN_FILE`: the token Secret is mounted as a **volume** (kubelet refreshes it in place) and the tool re-reads the file per call — so a bootstrap re-run that rotates the token takes effect **without a control-plane restart**. The inline env token still works; one of the two is required. The Secret volume is `optional` so the control plane can start before the first bootstrap completes (the tool errors cleanly until then).

## Verified
- Owner-role **agent** tokens verified live against the exact endpoints the tool calls (`POST /v1/vaults`, `POST /v1/vaults/{name}/users`) — create + grant succeed.
- `helm lint` clean; default render byte-identical (everything off by default); `required`/`fail` validations fire with clear messages.
- Tool, metadata, and config-sync suites: 147 passed. New tests cover per-call token-file re-read (rotation), missing-file error path, and the one-of token requirement.

## Out of scope (follow-ups)
- Chart-rendered NetworkPolicies for the vault server/bootstrap/control-plane API path.
- A stable CLI for worker-key → vault-name resolution (downstream grants Jobs currently import private APIs inline).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support loading Agent Vault admin tokens from a file (re-read on every request) to enable token rotation without restarts.
  * New optional Agent Vault access-tool configuration for Kubernetes: bootstrap flow, admin agent rotation/publishing, admin token secret mount, and access-related env vars.
  * Image sourcing now uses chart helpers with sensible defaults.

* **Tests**
  * Added tests for token-file re-read behavior and missing/unreadable token error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->