### PR TITLE
Join worker-created vaults before granting UI membership in agent_vault_access

### DIFF
--- a/src/mindroom/custom_tools/agent_vault_access.py
+++ b/src/mindroom/custom_tools/agent_vault_access.py
@@ -182,6 +182,13 @@ class AgentVaultAccessTools(Toolkit):
         # 409 means this actor is already a vault member, fine for an idempotent grant.
         if response.status_code in {200, 201, 409}:
             return
+        if response.status_code == 403:
+            msg = (
+                "the configured Agent Vault admin token cannot join this vault: "
+                "/join is owner-only, so the token must belong to an instance-owner "
+                "agent or session, not a plain admin/member one."
+            )
+            raise _AgentVaultAccessError(msg)
         response.raise_for_status()
 
     async def _grant_member(self, vault: str, email: str, token: str) -> bool:

--- a/src/mindroom/custom_tools/agent_vault_access.py
+++ b/src/mindroom/custom_tools/agent_vault_access.py
@@ -103,6 +103,7 @@ class AgentVaultAccessTools(Toolkit):
             # token, or a rotation between them could 401 the second call.
             token = self._resolve_admin_token()
             await self._ensure_vault(vault, token)
+            await self._ensure_vault_admin(vault, token)
             granted = await self._grant_member(vault, email, token)
         except _AgentVaultAccessError as exc:
             return self._error(str(exc))
@@ -165,6 +166,21 @@ class AgentVaultAccessTools(Toolkit):
             )
         # 409/422 mean the vault already exists, which is fine for an idempotent grant.
         if response.status_code in {200, 201, 409, 422}:
+            return
+        response.raise_for_status()
+
+    async def _ensure_vault_admin(self, vault: str, token: str) -> None:
+        # Granting membership requires vault-admin on that specific vault, and
+        # instance owners are not vault admins implicitly. Vaults created by
+        # the worker token-mint flow do not include this admin actor, so join
+        # (owner-only, grants vault-admin) before granting.
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_SECONDS) as client:
+            response = await client.post(
+                urljoin(self._api_url.rstrip("/") + "/", f"v1/vaults/{quote(vault, safe='')}/join"),
+                headers=self._headers(token),
+            )
+        # 409 means this actor is already a vault member, fine for an idempotent grant.
+        if response.status_code in {200, 201, 409}:
             return
         response.raise_for_status()
 

--- a/src/mindroom/tools/__init__.py
+++ b/src/mindroom/tools/__init__.py
@@ -369,7 +369,8 @@ def _homeassistant_tools() -> type[Toolkit]:
             type="password",
             required=False,
             description=(
-                "Owner/admin session or agent token used to create vaults and grant membership. "
+                "Instance-owner session or agent token used to create vaults, join them as "
+                "vault-admin (the /join step is owner-only), and grant membership. "
                 "Provide this or the admin token file."
             ),
         ),

--- a/src/mindroom/tools_metadata.json
+++ b/src/mindroom/tools_metadata.json
@@ -6721,7 +6721,7 @@
         {
           "authored_override": true,
           "default": null,
-          "description": "Owner/admin session or agent token used to create vaults and grant membership. Provide this or the admin token file.",
+          "description": "Instance-owner session or agent token used to create vaults, join them as vault-admin (the /join step is owner-only), and grant membership. Provide this or the admin token file.",
           "label": "Agent Vault Admin Token",
           "name": "MINDROOM_AGENT_VAULT_ACCESS_ADMIN_TOKEN",
           "options": null,

--- a/tests/test_agent_vault_access_tool.py
+++ b/tests/test_agent_vault_access_tool.py
@@ -116,7 +116,7 @@ async def test_request_vault_access_grants_and_returns_link(
     """A first request resolves the vault, grants membership, and returns the link."""
     target = _worker_target()
     expected_vault = worker_id_for_key(target.worker_key, prefix="agent-vault")
-    api = _FakeVaultAPI({"/v1/vaults": 201, "/users": 201})
+    api = _FakeVaultAPI({"/v1/vaults": 201, "/join": 409, "/users": 201})
     _patch_client(monkeypatch, api)
 
     tool = AgentVaultAccessTools(runtime_paths=_runtime_paths(tmp_path), worker_target=target)
@@ -138,7 +138,7 @@ async def test_request_vault_access_is_idempotent_when_already_member(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Re-requesting when already a member reports success without error."""
-    api = _FakeVaultAPI({"/v1/vaults": 409, "/users": 409})
+    api = _FakeVaultAPI({"/v1/vaults": 409, "/join": 200, "/users": 409})
     _patch_client(monkeypatch, api)
 
     tool = AgentVaultAccessTools(runtime_paths=_runtime_paths(tmp_path), worker_target=_worker_target())
@@ -149,12 +149,41 @@ async def test_request_vault_access_is_idempotent_when_already_member(
 
 
 @pytest.mark.asyncio
+async def test_request_vault_access_joins_worker_created_vault(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Vaults created by the worker mint flow need an owner join before the grant.
+
+    Granting membership requires vault-admin on that vault and instance owners
+    are not vault admins implicitly, so the tool must POST /join (which grants
+    the owner actor vault-admin) before POSTing the member grant.
+    """
+    target = _worker_target()
+    expected_vault = worker_id_for_key(target.worker_key, prefix="agent-vault")
+    # Pre-existing vault (409 on create), not yet joined (200 on join).
+    api = _FakeVaultAPI({"/v1/vaults": 409, "/join": 200, "/users": 201})
+    _patch_client(monkeypatch, api)
+
+    tool = AgentVaultAccessTools(runtime_paths=_runtime_paths(tmp_path), worker_target=target)
+    payload = json.loads(await tool.request_vault_access())
+
+    assert payload["status"] == "ok"
+    assert payload["access"] == "granted"
+    paths = [path for path, _ in api.calls]
+    join_path = f"/v1/vaults/{expected_vault}/join"
+    grant_path = f"/v1/vaults/{expected_vault}/users"
+    assert join_path in paths
+    assert paths.index(join_path) < paths.index(grant_path)
+
+
+@pytest.mark.asyncio
 async def test_request_vault_access_reports_unregistered_account(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """An unregistered account yields a clean error, not a traceback."""
-    api = _FakeVaultAPI({"/v1/vaults": 201, "/users": 404})
+    api = _FakeVaultAPI({"/v1/vaults": 201, "/join": 409, "/users": 404})
     _patch_client(monkeypatch, api)
 
     tool = AgentVaultAccessTools(runtime_paths=_runtime_paths(tmp_path), worker_target=_worker_target())
@@ -194,7 +223,7 @@ async def test_admin_token_file_is_reread_per_call(
     token_file.write_text("first-token\n", encoding="utf-8")
     env = {k: v for k, v in _ENV.items() if k != "MINDROOM_AGENT_VAULT_ACCESS_ADMIN_TOKEN"}
     env["MINDROOM_AGENT_VAULT_ACCESS_ADMIN_TOKEN_FILE"] = str(token_file)
-    api = _FakeVaultAPI({"/v1/vaults": 201, "/users": 201})
+    api = _FakeVaultAPI({"/v1/vaults": 201, "/join": 409, "/users": 201})
     _patch_client(monkeypatch, api)
 
     tool = AgentVaultAccessTools(runtime_paths=_runtime_paths(tmp_path, env=env), worker_target=_worker_target())
@@ -214,7 +243,7 @@ async def test_admin_token_file_missing_is_reported(
     """An unreadable token file fails the call with a clear error, not a crash."""
     env = {k: v for k, v in _ENV.items() if k != "MINDROOM_AGENT_VAULT_ACCESS_ADMIN_TOKEN"}
     env["MINDROOM_AGENT_VAULT_ACCESS_ADMIN_TOKEN_FILE"] = str(tmp_path / "missing-token")
-    _patch_client(monkeypatch, _FakeVaultAPI({"/v1/vaults": 201, "/users": 201}))
+    _patch_client(monkeypatch, _FakeVaultAPI({"/v1/vaults": 201, "/join": 409, "/users": 201}))
 
     tool = AgentVaultAccessTools(runtime_paths=_runtime_paths(tmp_path, env=env), worker_target=_worker_target())
     payload = json.loads(await tool.request_vault_access())

--- a/tests/test_agent_vault_access_tool.py
+++ b/tests/test_agent_vault_access_tool.py
@@ -178,6 +178,24 @@ async def test_request_vault_access_joins_worker_created_vault(
 
 
 @pytest.mark.asyncio
+async def test_request_vault_access_reports_non_owner_token_on_join(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-owner token cannot use the owner-only /join; say so instead of a bare 403."""
+    api = _FakeVaultAPI({"/v1/vaults": 409, "/join": 403, "/users": 201})
+    _patch_client(monkeypatch, api)
+
+    tool = AgentVaultAccessTools(runtime_paths=_runtime_paths(tmp_path), worker_target=_worker_target())
+    payload = json.loads(await tool.request_vault_access())
+
+    assert payload["status"] == "error"
+    assert "owner-only" in payload["error"]
+    # The grant must not be attempted after the failed join.
+    assert not [path for path, _ in api.calls if path.endswith("/users")]
+
+
+@pytest.mark.asyncio
 async def test_request_vault_access_reports_unregistered_account(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Problem

The first live `request_vault_access` call against a vault created by the worker token-mint flow fails:

```
Client error '403 Forbidden' for url '.../v1/vaults/<vault>/users'
```

Agent Vault's `POST /v1/vaults/{name}/users` requires **vault-admin on that specific vault**, and instance owners are not vault admins implicitly (verified in `Infisical/agent-vault`: `handleVaultUserAdd` → `requireVaultAdmin`, which has no owner bypass). The tool's admin actor is only vault-admin on vaults it created itself via `_ensure_vault`; vaults minted by workers don't include it, so the grant 403s.

## Fix

Insert the owner-only `POST /v1/vaults/{name}/join` (grants the calling actor vault-admin; 409 when already a member) between vault creation and the member grant. 200/201/409 all proceed, so the flow stays idempotent.

## Tests

- New: `test_request_vault_access_joins_worker_created_vault` — pre-existing vault (409 on create), asserts the join call happens and precedes the grant.
- Existing fixtures gained a scripted `/join` response; 11/11 pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure admin credentials join the target vault as a vault-admin (idempotent) before granting user membership; surface clear error when the admin token lacks owner-capable join rights.

* **Tests**
  * Added tests to verify the join-then-grant sequence and error reporting when join is forbidden.

* **Documentation**
  * Clarified admin-token configuration/help text to describe the join-and-grant flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->