### PR TITLE
Set GIT_SSL_CAINFO and NODE_EXTRA_CA_CERTS for the worker egress proxy CA

### DIFF
--- a/src/mindroom/constants.py
+++ b/src/mindroom/constants.py
@@ -706,6 +706,11 @@ def worker_proxy_execution_env(process_env: Mapping[str, str]) -> dict[str, str]
         env["REQUESTS_CA_BUNDLE"] = ca_file
         env["CURL_CA_BUNDLE"] = ca_file
         env["SSL_CERT_FILE"] = ca_file
+        # git and node do not honor the bundles above: git needs GIT_SSL_CAINFO
+        # (else `git clone` over HTTPS rejects the MITM proxy's certificate)
+        # and node only *adds* roots via NODE_EXTRA_CA_CERTS.
+        env["GIT_SSL_CAINFO"] = ca_file
+        env["NODE_EXTRA_CA_CERTS"] = ca_file
     return env
 
 

--- a/src/mindroom/runtime_env_policy.py
+++ b/src/mindroom/runtime_env_policy.py
@@ -302,6 +302,7 @@ _NON_SANDBOX_RUNTIME_CONTROL_ENV_NAMES = frozenset(
 _SANDBOX_SUBPROCESS_SYSTEM_ENV_NAMES = frozenset(
     {
         "CURL_CA_BUNDLE",
+        "GIT_SSL_CAINFO",
         "HOME",
         "HTTP_PROXY",
         "HTTPS_PROXY",
@@ -311,6 +312,7 @@ _SANDBOX_SUBPROCESS_SYSTEM_ENV_NAMES = frozenset(
         "LD_LIBRARY_PATH",
         "NIX_LD",
         "NIX_LD_LIBRARY_PATH",
+        "NODE_EXTRA_CA_CERTS",
         "NO_PROXY",
         "PATH",
         "PYTHONPATH",

--- a/src/mindroom/tools/shell.py
+++ b/src/mindroom/tools/shell.py
@@ -40,12 +40,14 @@ from mindroom.vendor_telemetry import vendor_telemetry_env_values
 _LOCAL_SHELL_PASSTHROUGH_ENV_KEYS = frozenset(
     {
         "CURL_CA_BUNDLE",
+        "GIT_SSL_CAINFO",
         "HOME",
         "HTTP_PROXY",
         "HTTPS_PROXY",
         "LANG",
         "LC_ALL",
         "LC_CTYPE",
+        "NODE_EXTRA_CA_CERTS",
         "NO_PROXY",
         "PATH",
         "PIP_CACHE_DIR",

--- a/tests/api/test_worker_egress_proxy_compose.py
+++ b/tests/api/test_worker_egress_proxy_compose.py
@@ -38,6 +38,9 @@ def test_request_execution_env_overlays_proxy_when_no_primary_env(tmp_path: Path
     assert env["HTTP_PROXY"] == expected_proxy
     assert env["HTTPS_PROXY"] == expected_proxy
     assert env["REQUESTS_CA_BUNDLE"] == "/etc/agent-vault/ca.pem"
+    # git and node ignore the curl/python bundles; they need their own keys.
+    assert env["GIT_SSL_CAINFO"] == "/etc/agent-vault/ca.pem"
+    assert env["NODE_EXTRA_CA_CERTS"] == "/etc/agent-vault/ca.pem"
 
 
 def test_request_execution_env_overlays_proxy_onto_shipped_env(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

When the worker egress proxy (Agent Vault MITM) is active, the composed execution env sets `REQUESTS_CA_BUNDLE`/`CURL_CA_BUNDLE`/`SSL_CERT_FILE`, so curl and python trust the proxy's interception certificate — but **git and node ignore all three**. In practice: `curl https://github.com` works while `git clone` of the same URL fails with *certificate signer not trusted*, and the agent has to hand-roll `git -c http.sslCAInfo=...` after spelunking the env.

## Fix

- `_worker_egress_proxy_execution_env` additionally sets `GIT_SSL_CAINFO` (git's CA bundle override) and `NODE_EXTRA_CA_CERTS` (node appends these roots to its defaults) to the same CA file.
- Both keys added to `_SANDBOX_SUBPROCESS_SYSTEM_ENV_NAMES` and `_LOCAL_SHELL_PASSTHROUGH_ENV_KEYS` so they survive the env allowlists.

## Tests

Extended `test_request_execution_env_overlays_proxy_when_no_primary_env` to pin both new keys. Egress-compose + runtime-env-policy (19) and shell/sandbox suites (316) pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSL/TLS certificate trust configuration for git and Node.js processes when using custom CA bundles. These tools now properly recognize and trust custom certificates configured in the proxy environment, resolving certificate verification issues in corporate proxy setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->