### PR TITLE
Refresh architecture maps to document the inbound turn pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,11 +53,49 @@ Gemini API docs call `gemini-3.1-flash-image-preview` Nano Banana 2, while Verte
 - **Agents**: Single-specialty actors defined under `agents:` in `config.yaml`
 - **Teams**: Collaborative bundles of agents that coordinate or parallelize work
 
+**Inbound turn pipeline** (the path from a Matrix message to a delivered response; see `docs/architecture/bot-runtime.md`):
+
+```text
+Matrix sync callback
+  -> bot.py (AgentBot/TeamBot runtime shell)
+  -> turn_controller.py (owns one turn: precheck -> normalize -> resolve -> coalesce -> decide -> execute -> record)
+       -> inbound_turn_normalizer.py + conversation_resolver.py  (canonical turn input, conversation identity)
+       -> coalescing.py                                          (debounced batching per room/thread)
+       -> text_ingress_dispatch.py + turn_policy.py              (commands; ignore / route / respond decision)
+       -> response_runner.py -> ai.py                            (lifecycle lock, Agno agent/team run)
+       -> streaming.py + streaming_delivery.py -> delivery_gateway.py  (progressive edits, Matrix send)
+       -> turn_store.py / handled_turns.py                       (durable dedup so restarts don't double-reply)
+```
+
 **Key modules**:
 | Module | Purpose |
 |--------|---------|
 | `orchestrator.py` | MultiAgentOrchestrator - boots agents, manages sync loops, hot-reload |
-| `bot.py` | AgentBot and TeamBot runtime for Matrix event handling, responses, and room behavior |
+| `orchestration/` | Extracted orchestrator helpers (config update plans, plugin watch, rooms, runtime) |
+| `runtime_state.py` | Shared runtime readiness state for health/ready endpoints |
+| `runtime_resolution.py` | Authoritative runtime resolution for one agent materialization |
+| `team_exact_members.py` | Runtime resolution for exact team member materialization |
+| `bot.py` | AgentBot and TeamBot runtime shells for Matrix lifecycle, sync callbacks, and room behavior |
+| `turn_controller.py` | TurnController - owns one inbound turn from ingress to recorded outcome |
+| `inbound_turn_normalizer.py` | Raw input shaping (text, voice, sidecars, media) into canonical turn inputs |
+| `conversation_resolver.py` | Conversation identity, thread history, and ingress envelope assembly |
+| `coalescing.py` | Live message coalescing gate (debounced batching per room/thread) |
+| `coalescing_batch.py` | Coalesced dispatch batch construction |
+| `text_ingress_dispatch.py` | Text ingress dispatch path used by TurnController |
+| `turn_policy.py` | Pure turn policy: decide ignore, route, or respond for inbound turns |
+| `dispatch_replay_guard.py` | Replay-guard checks for dispatch sequencing |
+| `turn_store.py` | Unified durable turn access (wraps the handled-turn ledger) |
+| `handled_turns.py` | Disk-backed handled-turn ledger preventing duplicate responses |
+| `response_runner.py` | Response lifecycle execution (locking, streaming vs non-streaming, cancellation) |
+| `response_attempt.py` | Runs one visible response attempt with placeholder and stop tracking |
+| `response_lifecycle.py` | Shared response lifecycle helpers and queued-notice state |
+| `execution_preparation.py` | Request-scoped execution preparation for prompts and persisted replay |
+| `delivery_gateway.py` | Visible Matrix delivery for already-generated responses (send, edit, finalize) |
+| `streaming_delivery.py` | Internal delivery and supervision helpers for streaming responses |
+| `post_response_effects.py` | Shared post-response effects after Matrix delivery |
+| `tool_approval.py` | Tool-call approval rule evaluation and public approval API |
+| `approval_manager.py` | Matrix-backed tool approval runtime state |
+| `workspaces.py` | Agent workspace scaffolding, template seeding, and context file resolution |
 | `agents.py` | Agent creation and configuration |
 | `config/` | Pydantic models for YAML config parsing (root model in `config/main.py`) |
 | `routing.py` | Intelligent responder selection when no agent or team is mentioned |
@@ -122,7 +160,6 @@ Gemini API docs call `gemini-3.1-flash-image-preview` Nano Banana 2, while Verte
 | `cli/local_stack.py` | Local stack setup command |
 | `credentials_sync.py` | Shared provider/bootstrap env to credentials sync |
 | `logging_config.py` | Structured logging setup |
-| `response_tracker.py` | Duplicate response prevention |
 | `knowledge/utils.py` | Multi-knowledge-base vector DB utilities |
 
 **Persistent state** lives under `mindroom_data/` (next to `config.yaml`, overridable via `MINDROOM_STORAGE_PATH`):
@@ -130,7 +167,7 @@ Gemini API docs call `gemini-3.1-flash-image-preview` Nano Banana 2, while Verte
 - `learning/` – Per-agent Agno Learning preference data
 - `chroma/` – ChromaDB storage backing the memory system
 - `knowledge_db/` – Knowledge base vector stores for file-backed RAG
-- `tracking/` – Response tracking to avoid duplicate replies
+- `tracking/` – Durable handled-turn ledger to avoid duplicate replies
 - `credentials/` – JSON secrets synchronized from `.env`
 - `encryption_keys/` – Matrix E2E encryption keys
 - `culture/` – Shared culture state

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -41,6 +41,7 @@ MindRoom's architecture consists of several key components working together.
 
 - [Matrix Integration](matrix.md) - How MindRoom connects to Matrix
 - [Agent Orchestration](orchestration.md) - How agents are managed
+- [Bot Runtime](bot-runtime.md) - The inbound turn pipeline and its module boundaries
 
 ## Key Internal Modules
 
@@ -57,21 +58,38 @@ MindRoom's architecture consists of several key components working together.
 | `agent_descriptions.py` | Shared agent description rendering for routing and delegation |
 | `agent_policy.py` | Derives canonical execution policies from authored agent config |
 | `workspaces.py` | Agent workspace scaffolding, template seeding, context file resolution |
-| `bot.py` | AgentBot and TeamBot runtime for Matrix event handling |
+| `bot.py` | AgentBot and TeamBot runtime shells for Matrix lifecycle and sync callbacks |
+| `turn_controller.py` | TurnController — owns one inbound turn from ingress to recorded outcome |
+| `inbound_turn_normalizer.py` | Raw input shaping (text, voice, sidecars, media) into canonical turn inputs |
+| `conversation_resolver.py` | Conversation identity, thread history, and ingress envelope assembly |
+| `coalescing.py` | Live message coalescing gate (debounced batching per room/thread) |
+| `text_ingress_dispatch.py` | Text ingress dispatch path used by TurnController |
+| `turn_policy.py` | Pure turn policy: decide ignore, route, or respond for inbound turns |
+| `turn_store.py` | Unified durable turn access (wraps the handled-turn ledger) |
+| `handled_turns.py` | Disk-backed handled-turn ledger preventing duplicate responses |
+| `response_runner.py` | Response lifecycle execution (locking, streaming vs non-streaming, cancellation) |
+| `response_lifecycle.py` | Shared response lifecycle helpers and queued-notice state |
+| `execution_preparation.py` | Request-scoped execution preparation for prompts and persisted replay |
+| `delivery_gateway.py` | Visible Matrix delivery for already-generated responses (send, edit, finalize) |
+| `streaming_delivery.py` | Internal delivery and supervision helpers for streaming responses |
+| `post_response_effects.py` | Shared post-response effects after Matrix delivery |
 | `routing.py` | Intelligent agent or team selection when no entity is mentioned |
 | `streaming.py` | Response streaming via progressive message edits |
 | `media_inputs.py` | Shared media-input container passed across bot, teams, and AI layers |
 | `media_fallback.py` | Retries model requests without inline media when models reject media inputs |
 | `avatar_generation.py` | Generates and manages avatar assets for agents, rooms, and spaces |
-| `response_tracker.py` | Duplicate response prevention |
 | `topic_generator.py` | AI-generated room topics |
 | `background_tasks.py` | Non-blocking async task management with GC protection |
 
 ## Data Flow
 
-1. **Message arrives** from Matrix homeserver
-2. **Responder is resolved** directly when one eligible agent or team remains, otherwise the router selects among candidates
-3. **Selected entity processes** the message using the Agno runtime
-4. **Tools execute** as needed (file operations, API calls, etc.)
-5. **Response sent** back to Matrix room
-6. **Memory updates** asynchronously in background
+1. **Message arrives** from the Matrix homeserver and `bot.py` hands it to `turn_controller.py`, which owns the turn from ingress to recorded outcome
+2. **Input is normalized and resolved**: `inbound_turn_normalizer.py` shapes raw text, voice, and media into canonical turn inputs, and `conversation_resolver.py` resolves thread identity and history
+3. **Messages are coalesced**: `coalescing.py` debounces rapid messages per room/thread into one dispatch batch
+4. **The turn is planned**: `text_ingress_dispatch.py` parses commands and `turn_policy.py` decides to ignore, route, or respond; a direct responder is resolved when one eligible agent or team remains, otherwise the router selects among candidates
+5. **Selected entity processes** the message via `response_runner.py` and the Agno runtime, executing tools as needed
+6. **Response is delivered** through `streaming.py` (progressive edits) and `delivery_gateway.py` (Matrix send/edit)
+7. **The turn is recorded** in the durable handled-turn ledger (`turn_store.py` / `handled_turns.py`) so restarts do not double-reply
+8. **Memory updates** asynchronously in background
+
+See [Bot Runtime](bot-runtime.md) for the module boundaries and the ongoing simplification roadmap.

--- a/docs/dev/exhaustive-live-test-checklist.md
+++ b/docs/dev/exhaustive-live-test-checklist.md
@@ -132,7 +132,7 @@ Expected outcome: Root space creation, room grouping, and avatar propagation beh
 
 ## 4. Message Dispatch, DMs, Threads, And Plain-Reply Inheritance
 
-Source anchors: `src/mindroom/bot.py`, `src/mindroom/routing.py`, `src/mindroom/thread_utils.py`, `src/mindroom/conversation_resolver.py`, `src/mindroom/matrix/event_info.py`, `src/mindroom/matrix/thread_membership.py`, `src/mindroom/response_tracker.py`.
+Source anchors: `src/mindroom/bot.py`, `src/mindroom/routing.py`, `src/mindroom/thread_utils.py`, `src/mindroom/conversation_resolver.py`, `src/mindroom/matrix/event_info.py`, `src/mindroom/matrix/thread_membership.py`, `src/mindroom/handled_turns.py`.
 
 - [ ] `MSG-001` Send a non-command message in a single-agent room without any mention.
 Expected outcome: The sole configured agent responds directly without invoking AI router selection.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -13772,6 +13772,7 @@ MindRoom's architecture consists of several key components working together.
 
 - [Matrix Integration](https://docs.mindroom.chat/architecture/matrix/) - How MindRoom connects to Matrix
 - [Agent Orchestration](https://docs.mindroom.chat/architecture/orchestration/) - How agents are managed
+- [Bot Runtime](https://docs.mindroom.chat/architecture/bot-runtime/) - The inbound turn pipeline and its module boundaries
 
 ## Key Internal Modules
 
@@ -13788,24 +13789,41 @@ MindRoom's architecture consists of several key components working together.
 | `agent_descriptions.py` | Shared agent description rendering for routing and delegation |
 | `agent_policy.py` | Derives canonical execution policies from authored agent config |
 | `workspaces.py` | Agent workspace scaffolding, template seeding, context file resolution |
-| `bot.py` | AgentBot and TeamBot runtime for Matrix event handling |
+| `bot.py` | AgentBot and TeamBot runtime shells for Matrix lifecycle and sync callbacks |
+| `turn_controller.py` | TurnController — owns one inbound turn from ingress to recorded outcome |
+| `inbound_turn_normalizer.py` | Raw input shaping (text, voice, sidecars, media) into canonical turn inputs |
+| `conversation_resolver.py` | Conversation identity, thread history, and ingress envelope assembly |
+| `coalescing.py` | Live message coalescing gate (debounced batching per room/thread) |
+| `text_ingress_dispatch.py` | Text ingress dispatch path used by TurnController |
+| `turn_policy.py` | Pure turn policy: decide ignore, route, or respond for inbound turns |
+| `turn_store.py` | Unified durable turn access (wraps the handled-turn ledger) |
+| `handled_turns.py` | Disk-backed handled-turn ledger preventing duplicate responses |
+| `response_runner.py` | Response lifecycle execution (locking, streaming vs non-streaming, cancellation) |
+| `response_lifecycle.py` | Shared response lifecycle helpers and queued-notice state |
+| `execution_preparation.py` | Request-scoped execution preparation for prompts and persisted replay |
+| `delivery_gateway.py` | Visible Matrix delivery for already-generated responses (send, edit, finalize) |
+| `streaming_delivery.py` | Internal delivery and supervision helpers for streaming responses |
+| `post_response_effects.py` | Shared post-response effects after Matrix delivery |
 | `routing.py` | Intelligent agent or team selection when no entity is mentioned |
 | `streaming.py` | Response streaming via progressive message edits |
 | `media_inputs.py` | Shared media-input container passed across bot, teams, and AI layers |
 | `media_fallback.py` | Retries model requests without inline media when models reject media inputs |
 | `avatar_generation.py` | Generates and manages avatar assets for agents, rooms, and spaces |
-| `response_tracker.py` | Duplicate response prevention |
 | `topic_generator.py` | AI-generated room topics |
 | `background_tasks.py` | Non-blocking async task management with GC protection |
 
 ## Data Flow
 
-1. **Message arrives** from Matrix homeserver
-2. **Responder is resolved** directly when one eligible agent or team remains, otherwise the router selects among candidates
-3. **Selected entity processes** the message using the Agno runtime
-4. **Tools execute** as needed (file operations, API calls, etc.)
-5. **Response sent** back to Matrix room
-6. **Memory updates** asynchronously in background
+1. **Message arrives** from the Matrix homeserver and `bot.py` hands it to `turn_controller.py`, which owns the turn from ingress to recorded outcome
+2. **Input is normalized and resolved**: `inbound_turn_normalizer.py` shapes raw text, voice, and media into canonical turn inputs, and `conversation_resolver.py` resolves thread identity and history
+3. **Messages are coalesced**: `coalescing.py` debounces rapid messages per room/thread into one dispatch batch
+4. **The turn is planned**: `text_ingress_dispatch.py` parses commands and `turn_policy.py` decides to ignore, route, or respond; a direct responder is resolved when one eligible agent or team remains, otherwise the router selects among candidates
+5. **Selected entity processes** the message via `response_runner.py` and the Agno runtime, executing tools as needed
+6. **Response is delivered** through `streaming.py` (progressive edits) and `delivery_gateway.py` (Matrix send/edit)
+7. **The turn is recorded** in the durable handled-turn ledger (`turn_store.py` / `handled_turns.py`) so restarts do not double-reply
+8. **Memory updates** asynchronously in background
+
+See [Bot Runtime](https://docs.mindroom.chat/architecture/bot-runtime/) for the module boundaries and the ongoing simplification roadmap.
 
 # Matrix Integration
 

--- a/skills/mindroom-docs/references/page__architecture__index.md
+++ b/skills/mindroom-docs/references/page__architecture__index.md
@@ -37,6 +37,7 @@ MindRoom's architecture consists of several key components working together.
 
 - [Matrix Integration](https://docs.mindroom.chat/architecture/matrix/) - How MindRoom connects to Matrix
 - [Agent Orchestration](https://docs.mindroom.chat/architecture/orchestration/) - How agents are managed
+- [Bot Runtime](https://docs.mindroom.chat/architecture/bot-runtime/) - The inbound turn pipeline and its module boundaries
 
 ## Key Internal Modules
 
@@ -53,21 +54,38 @@ MindRoom's architecture consists of several key components working together.
 | `agent_descriptions.py` | Shared agent description rendering for routing and delegation |
 | `agent_policy.py` | Derives canonical execution policies from authored agent config |
 | `workspaces.py` | Agent workspace scaffolding, template seeding, context file resolution |
-| `bot.py` | AgentBot and TeamBot runtime for Matrix event handling |
+| `bot.py` | AgentBot and TeamBot runtime shells for Matrix lifecycle and sync callbacks |
+| `turn_controller.py` | TurnController — owns one inbound turn from ingress to recorded outcome |
+| `inbound_turn_normalizer.py` | Raw input shaping (text, voice, sidecars, media) into canonical turn inputs |
+| `conversation_resolver.py` | Conversation identity, thread history, and ingress envelope assembly |
+| `coalescing.py` | Live message coalescing gate (debounced batching per room/thread) |
+| `text_ingress_dispatch.py` | Text ingress dispatch path used by TurnController |
+| `turn_policy.py` | Pure turn policy: decide ignore, route, or respond for inbound turns |
+| `turn_store.py` | Unified durable turn access (wraps the handled-turn ledger) |
+| `handled_turns.py` | Disk-backed handled-turn ledger preventing duplicate responses |
+| `response_runner.py` | Response lifecycle execution (locking, streaming vs non-streaming, cancellation) |
+| `response_lifecycle.py` | Shared response lifecycle helpers and queued-notice state |
+| `execution_preparation.py` | Request-scoped execution preparation for prompts and persisted replay |
+| `delivery_gateway.py` | Visible Matrix delivery for already-generated responses (send, edit, finalize) |
+| `streaming_delivery.py` | Internal delivery and supervision helpers for streaming responses |
+| `post_response_effects.py` | Shared post-response effects after Matrix delivery |
 | `routing.py` | Intelligent agent or team selection when no entity is mentioned |
 | `streaming.py` | Response streaming via progressive message edits |
 | `media_inputs.py` | Shared media-input container passed across bot, teams, and AI layers |
 | `media_fallback.py` | Retries model requests without inline media when models reject media inputs |
 | `avatar_generation.py` | Generates and manages avatar assets for agents, rooms, and spaces |
-| `response_tracker.py` | Duplicate response prevention |
 | `topic_generator.py` | AI-generated room topics |
 | `background_tasks.py` | Non-blocking async task management with GC protection |
 
 ## Data Flow
 
-1. **Message arrives** from Matrix homeserver
-2. **Responder is resolved** directly when one eligible agent or team remains, otherwise the router selects among candidates
-3. **Selected entity processes** the message using the Agno runtime
-4. **Tools execute** as needed (file operations, API calls, etc.)
-5. **Response sent** back to Matrix room
-6. **Memory updates** asynchronously in background
+1. **Message arrives** from the Matrix homeserver and `bot.py` hands it to `turn_controller.py`, which owns the turn from ingress to recorded outcome
+2. **Input is normalized and resolved**: `inbound_turn_normalizer.py` shapes raw text, voice, and media into canonical turn inputs, and `conversation_resolver.py` resolves thread identity and history
+3. **Messages are coalesced**: `coalescing.py` debounces rapid messages per room/thread into one dispatch batch
+4. **The turn is planned**: `text_ingress_dispatch.py` parses commands and `turn_policy.py` decides to ignore, route, or respond; a direct responder is resolved when one eligible agent or team remains, otherwise the router selects among candidates
+5. **Selected entity processes** the message via `response_runner.py` and the Agno runtime, executing tools as needed
+6. **Response is delivered** through `streaming.py` (progressive edits) and `delivery_gateway.py` (Matrix send/edit)
+7. **The turn is recorded** in the durable handled-turn ledger (`turn_store.py` / `handled_turns.py`) so restarts do not double-reply
+8. **Memory updates** asynchronously in background
+
+See [Bot Runtime](https://docs.mindroom.chat/architecture/bot-runtime/) for the module boundaries and the ongoing simplification roadmap.


### PR DESCRIPTION
## Why

The repo's own architecture maps describe a runtime that no longer exists, which actively misleads both new contributors and AI agents that trust these files.
The message-handling path is no longer `bot.py → ai.py → Matrix`: a turn pipeline (~13k lines across `turn_controller.py`, `coalescing.py`, `turn_policy.py`, `response_runner.py`, `delivery_gateway.py`, `handled_turns.py`, …) now carries every message, and neither CLAUDE.md nor `docs/architecture/index.md` mentioned any of it.
Both still listed `response_tracker.py`, which was deleted.

## What changed

- **CLAUDE.md**: added an inbound turn pipeline sketch (sync callback → turn controller → normalize/resolve → coalesce → plan → execute → deliver → record) and added the missing pipeline, orchestration, and tool-approval modules to the module table; removed the stale `response_tracker.py` row; reworded the `tracking/` persistent-state entry to describe the handled-turn ledger.
- **docs/architecture/index.md**: updated the module table and rewrote the Data Flow section around the real pipeline; linked `bot-runtime.md` (which was already current — it is the simplification roadmap for this layer).
- **docs/dev/exhaustive-live-test-checklist.md**: replaced the `response_tracker.py` source anchor with `handled_turns.py`.
- Regenerated `skills/mindroom-docs/references` via the pre-commit hook.

All module descriptions were verified against the modules' docstrings, and the pipeline flow was verified against the code (`bot.py:_on_message` → `TurnController.handle_text_event` → `CoalescingGate` → `text_ingress_dispatch.dispatch_text_message` → `turn_policy.plan_turn` → `response_runner` → `delivery_gateway`).

## Dead-code candidates investigated and intentionally NOT deleted

An architecture review flagged three modules as possibly dead; all turned out to be alive, so this PR is docs-only:
- `knowledge_refresh_runner.py` — subprocess entry point spawned via `python -m mindroom.knowledge_refresh_runner` from `knowledge/refresh_runner.py:234`
- `tool_system/toolkit_aliases.py` — used by `custom_tools/google_drive.py`
- `tool_system/bootstrap.py` — used by `tool_system/catalog.py` and governed in `tach.toml`

Docs-only change; no runtime code touched. Pre-commit (including the tach boundary and docs-reference hooks) passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced architecture documentation to clarify the message processing pipeline and bot runtime components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->