### PR TITLE
Unify solo and team-member agent construction concerns

### DIFF
--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -1444,32 +1444,16 @@ def create_agent(  # noqa: PLR0915, C901, PLR0912
         update_cultural_knowledge = culture_settings.update_cultural_knowledge
         enable_agentic_culture = culture_settings.enable_agentic_culture
 
-    # Resolve history settings: per-agent override → defaults.
-    # When agent sets one knob, force the other to None to avoid Agno
-    # receiving both (it warns and drops num_history_messages).
-    if agent_config.num_history_messages is not None:
-        num_history_runs = None
-        num_history_messages = agent_config.num_history_messages
-    elif agent_config.num_history_runs is not None:
-        num_history_runs = agent_config.num_history_runs
-        num_history_messages = None
-    else:
-        num_history_runs = defaults.num_history_runs
-        num_history_messages = defaults.num_history_messages
-
-    # Track whether we want "all history" to bypass Agno's default after construction
-    include_all_history = num_history_runs is None and num_history_messages is None
+    # Shared history-policy source of truth with the team replay path.
+    history_settings = config.get_entity_history_settings(agent_name)
+    history_policy = history_settings.policy
+    num_history_runs = history_policy.limit if history_policy.mode == "runs" else None
+    num_history_messages = history_policy.limit if history_policy.mode == "messages" else None
 
     compress_tool_results = (
         agent_config.compress_tool_results
         if agent_config.compress_tool_results is not None
         else defaults.compress_tool_results
-    )
-
-    max_tool_calls_from_history = (
-        agent_config.max_tool_calls_from_history
-        if agent_config.max_tool_calls_from_history is not None
-        else defaults.max_tool_calls_from_history
     )
 
     agent = _initialize_agent_instance(
@@ -1497,10 +1481,10 @@ def create_agent(  # noqa: PLR0915, C901, PLR0912
         update_cultural_knowledge=update_cultural_knowledge,
         enable_agentic_culture=enable_agentic_culture,
         compress_tool_results=compress_tool_results,
-        max_tool_calls_from_history=max_tool_calls_from_history,
+        max_tool_calls_from_history=history_settings.max_tool_calls_from_history,
         telemetry=False,
     )
-    if include_all_history:
+    if history_policy.mode == "all":
         _enable_all_history_replay(agent)
 
     logger.info(

--- a/src/mindroom/api/openai_compat.py
+++ b/src/mindroom/api/openai_compat.py
@@ -799,15 +799,6 @@ def _request_knowledge_refresh_scheduler(request: Request) -> KnowledgeRefreshSc
     return config_lifecycle.app_state(request.app).knowledge_refresh_scheduler
 
 
-def _log_missing_knowledge_bases(agent_name: str) -> Callable[[list[str]], None]:
-    """Build a missing-knowledge callback for one agent name."""
-    return lambda missing_base_ids: logger.warning(
-        "Knowledge bases not available for agent",
-        agent=agent_name,
-        knowledge_bases=missing_base_ids,
-    )
-
-
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
@@ -978,8 +969,6 @@ async def chat_completions(  # noqa: C901, PLR0912
                 knowledge = None
                 unavailable_bases: dict[str, KnowledgeAvailabilityDetail] = {}
             else:
-                if knowledge_resolution.missing:
-                    _log_missing_knowledge_bases(agent_name)(list(knowledge_resolution.missing))
                 knowledge = knowledge_resolution.knowledge
                 unavailable_bases = dict(knowledge_resolution.unavailable)
             prompt = prepend_knowledge_availability_notice(prompt, unavailable_bases)
@@ -1381,6 +1370,7 @@ def _build_team(
             model_name=model_name,
             configured_team_name=team_name,
             scope_context=scope_context,
+            execution_identity=execution_identity,
         )
     except Exception:
         close_team_runtime_state_dbs(

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -388,7 +388,6 @@ class AgentBot:
         )
         self._knowledge_access_support = KnowledgeAccessSupport(
             runtime=self._runtime_view,
-            logger=self.logger,
             runtime_paths=self.runtime_paths,
         )
         self._conversation_cache = MatrixConversationCache(

--- a/src/mindroom/knowledge/utils.py
+++ b/src/mindroom/knowledge/utils.py
@@ -421,7 +421,7 @@ def resolve_agent_knowledge_access(
     missing_base_ids: list[str] = []
     unavailable_bases: dict[str, KnowledgeAvailabilityDetail] = {}
     knowledges: list[Knowledge] = []
-    for base_id in dict.fromkeys(base_ids):
+    for base_id in base_ids:
         knowledge, availability = _resolve_base_knowledge(
             base_id,
             config=config,

--- a/src/mindroom/knowledge/utils.py
+++ b/src/mindroom/knowledge/utils.py
@@ -29,7 +29,6 @@ if TYPE_CHECKING:
 
     from agno.knowledge.document import Document
     from agno.knowledge.knowledge import Knowledge
-    from structlog.stdlib import BoundLogger
 
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
@@ -373,6 +372,40 @@ def _semantic_agent_knowledge_base_ids(agent_name: str, config: Config) -> tuple
     )
 
 
+def _resolve_base_knowledge(
+    base_id: str,
+    *,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    refresh_scheduler: KnowledgeRefreshScheduler | None,
+    execution_identity: ToolExecutionIdentity | None,
+) -> tuple[Knowledge | None, KnowledgeAvailability]:
+    """Resolve one knowledge base handle with its effective availability."""
+    lookup = _lookup_knowledge_for_base(
+        base_id,
+        config=config,
+        runtime_paths=runtime_paths,
+        execution_identity=execution_identity,
+    )
+    availability = lookup.availability if lookup is not None else KnowledgeAvailability.INITIALIZING
+    if lookup is not None and availability is KnowledgeAvailability.READY:
+        availability = _ready_index_effective_availability(lookup, config)
+    knowledge = lookup.index.knowledge if lookup is not None and lookup.index is not None else None
+    if knowledge is not None:
+        _apply_knowledge_metadata(base_id, knowledge, config)
+    if refresh_scheduler is not None:
+        availability = _schedule_refresh_for_availability(
+            refresh_scheduler,
+            base_id,
+            config=config,
+            runtime_paths=runtime_paths,
+            execution_identity=execution_identity,
+            lookup=lookup,
+            availability=availability,
+        )
+    return knowledge, availability
+
+
 def resolve_agent_knowledge_access(
     agent_name: str,
     config: Config,
@@ -381,37 +414,6 @@ def resolve_agent_knowledge_access(
     execution_identity: ToolExecutionIdentity | None = None,
 ) -> _KnowledgeResolution:
     """Resolve configured knowledge base(s) with diagnostics for one agent."""
-    resolved_knowledge: dict[str, tuple[Knowledge | None, KnowledgeAvailability]] = {}
-
-    def _resolve(base_id: str) -> tuple[Knowledge | None, KnowledgeAvailability]:
-        if base_id in resolved_knowledge:
-            return resolved_knowledge[base_id]
-
-        lookup = _lookup_knowledge_for_base(
-            base_id,
-            config=config,
-            runtime_paths=runtime_paths,
-            execution_identity=execution_identity,
-        )
-        availability = lookup.availability if lookup is not None else KnowledgeAvailability.INITIALIZING
-        if lookup is not None and availability is KnowledgeAvailability.READY:
-            availability = _ready_index_effective_availability(lookup, config)
-        knowledge = lookup.index.knowledge if lookup is not None and lookup.index is not None else None
-        if knowledge is not None:
-            _apply_knowledge_metadata(base_id, knowledge, config)
-        if refresh_scheduler is not None:
-            availability = _schedule_refresh_for_availability(
-                refresh_scheduler,
-                base_id,
-                config=config,
-                runtime_paths=runtime_paths,
-                execution_identity=execution_identity,
-                lookup=lookup,
-                availability=availability,
-            )
-        resolved_knowledge[base_id] = (knowledge, availability)
-        return resolved_knowledge[base_id]
-
     base_ids = _semantic_agent_knowledge_base_ids(agent_name, config)
     if not base_ids:
         return _KnowledgeResolution(knowledge=None)
@@ -419,8 +421,14 @@ def resolve_agent_knowledge_access(
     missing_base_ids: list[str] = []
     unavailable_bases: dict[str, KnowledgeAvailabilityDetail] = {}
     knowledges: list[Knowledge] = []
-    for base_id in base_ids:
-        knowledge, availability = _resolve(base_id)
+    for base_id in dict.fromkeys(base_ids):
+        knowledge, availability = _resolve_base_knowledge(
+            base_id,
+            config=config,
+            runtime_paths=runtime_paths,
+            refresh_scheduler=refresh_scheduler,
+            execution_identity=execution_identity,
+        )
         if availability is not KnowledgeAvailability.READY:
             unavailable_bases[base_id] = KnowledgeAvailabilityDetail(
                 availability=availability,
@@ -431,6 +439,12 @@ def resolve_agent_knowledge_access(
             continue
         knowledges.append(knowledge)
 
+    if missing_base_ids:
+        logger.warning(
+            "Knowledge bases not available for agent",
+            agent_name=agent_name,
+            knowledge_bases=missing_base_ids,
+        )
     return _KnowledgeResolution(
         knowledge=_merge_knowledge(agent_name, knowledges),
         missing=tuple(missing_base_ids),
@@ -522,7 +536,6 @@ class KnowledgeAccessSupport:
     """Resolve live knowledge access for one runtime without routing through AgentBot."""
 
     runtime: SupportsConfigOrchestrator
-    logger: BoundLogger
     runtime_paths: RuntimePaths
 
     def for_agent(
@@ -544,20 +557,13 @@ class KnowledgeAccessSupport:
         orchestrator = self.runtime.orchestrator
         refresh_scheduler = orchestrator.knowledge_refresh_scheduler if orchestrator is not None else None
 
-        resolution = resolve_agent_knowledge_access(
+        return resolve_agent_knowledge_access(
             agent_name,
             self.runtime.config,
             self.runtime_paths,
             refresh_scheduler=refresh_scheduler,
             execution_identity=execution_identity,
         )
-        if resolution.missing:
-            self.logger.warning(
-                "Knowledge bases not available for agent",
-                agent_name=agent_name,
-                knowledge_bases=list(resolution.missing),
-            )
-        return resolution
 
 
 @dataclass

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -1204,12 +1204,6 @@ def materialize_exact_team_members(
             refresh_scheduler=refresh_scheduler,
             execution_identity=execution_identity,
         )
-        if knowledge_resolution.missing:
-            logger.warning(
-                "Knowledge bases not available for team agent",
-                agent_name=agent_name,
-                knowledge_bases=list(knowledge_resolution.missing),
-            )
         if unavailable_bases is not None:
             unavailable_bases.update(knowledge_resolution.unavailable)
         return create_agent(
@@ -1284,6 +1278,7 @@ def _create_team_instance(
     runtime_paths: RuntimePaths,
     team_display_name: str,
     fallback_team_id: str,
+    execution_identity: ToolExecutionIdentity | None = None,
     model_name: str | None = None,
     configured_team_name: str | None = None,
     history_storage: BaseDb | None = None,
@@ -1297,6 +1292,8 @@ def _create_team_instance(
         runtime_paths: Active runtime paths
         team_display_name: Human-readable Team name passed to Agno
         fallback_team_id: Stable fallback id when no team scope storage is available
+        execution_identity: Request execution identity used for provider-specific
+            model behavior such as codex prompt-cache keying
         model_name: Optional model name override
         configured_team_name: Optional configured team id for stable team-scope history
         history_storage: Optional already-open shared team history storage
@@ -1306,7 +1303,12 @@ def _create_team_instance(
         Configured Team instance
 
     """
-    model = model_loading.get_model_instance(config, runtime_paths, model_name or "default")
+    model = model_loading.get_model_instance(
+        config,
+        runtime_paths,
+        model_name or "default",
+        execution_identity=execution_identity,
+    )
     # Coordinate-mode tool calls run through the shared team model in v1.
     # Member-agent models are intentionally not wrapped here.
     ai_runtime.install_queued_message_notice_hook(
@@ -1402,6 +1404,7 @@ def build_materialized_team_instance(
     scope_context: ScopeSessionContext | None,
     model_name: str | None,
     configured_team_name: str | None,
+    execution_identity: ToolExecutionIdentity | None = None,
 ) -> Team:
     """Build one agno.Team instance for already-materialized members."""
     resolved_team_runtime_model = config.resolve_runtime_model(
@@ -1417,6 +1420,7 @@ def build_materialized_team_instance(
         runtime_paths=runtime_paths,
         team_display_name=team_label,
         fallback_team_id=team_label,
+        execution_identity=execution_identity,
         model_name=resolved_team_model_name,
         configured_team_name=configured_team_name,
         history_storage=scope_context.storage if scope_context is not None else None,
@@ -1590,6 +1594,7 @@ async def team_response(  # noqa: C901, PLR0912, PLR0915
                 scope_context=scope_context,
                 model_name=model_name,
                 configured_team_name=configured_team_name,
+                execution_identity=execution_identity,
             )
             prepared_execution = await prepare_materialized_team_execution(
                 scope_context=scope_context,
@@ -2012,6 +2017,7 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
                 scope_context=scope_context,
                 model_name=model_name,
                 configured_team_name=configured_team_name,
+                execution_identity=execution_identity,
             )
             prepared_execution = await prepare_materialized_team_execution(
                 scope_context=scope_context,

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -4420,6 +4420,10 @@ def test_team_member_matches_solo_agent_construction() -> None:
         assert member.max_tool_calls_from_history == solo.max_tool_calls_from_history
         assert member.knowledge == solo.knowledge
         assert member.culture_manager == solo.culture_manager
+        assert member.add_culture_to_context == solo.add_culture_to_context
+        assert member.update_cultural_knowledge == solo.update_cultural_knowledge
+        assert member.enable_agentic_culture == solo.enable_agentic_culture
+        assert member.compress_tool_results == solo.compress_tool_results
 
         # The only authored construction delta: members never get the Matrix
         # reaction-based interactive question prompt.

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -44,11 +44,13 @@ from mindroom.config.models import DefaultsConfig, ModelConfig
 from mindroom.constants import RuntimePaths, resolve_runtime_paths
 from mindroom.credentials import CredentialsManager, load_scoped_credentials
 from mindroom.entity_resolution import managed_entity_power_user_ids_for_room
+from mindroom.history import close_team_runtime_state_dbs
 from mindroom.knowledge import resolve_agent_knowledge_access
 from mindroom.knowledge.availability import KnowledgeAvailability
 from mindroom.matrix.state import MatrixState
 from mindroom.prompts import HIDDEN_TOOL_CALLS_PROMPT, OPENAI_COMPAT_HISTORY_GUIDANCE
 from mindroom.runtime_resolution import resolve_agent_runtime
+from mindroom.teams import materialize_exact_team_members
 from mindroom.tool_system.output_files import OUTPUT_PATH_ARGUMENT
 from mindroom.tool_system.worker_routing import (
     ToolExecutionIdentity,
@@ -4389,8 +4391,6 @@ def test_private_user_agent_agents_share_culture_manager_within_same_requester_s
 
 def test_team_member_matches_solo_agent_construction() -> None:
     """A team-materialized member must equal the same agent built solo, modulo explicit deltas."""
-    from mindroom.history import close_team_runtime_state_dbs  # noqa: PLC0415
-    from mindroom.teams import materialize_exact_team_members  # noqa: PLC0415
     from tests.conftest import runtime_paths_for  # noqa: PLC0415
 
     config = _test_config()

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -4385,3 +4385,48 @@ def test_private_user_agent_agents_share_culture_manager_within_same_requester_s
     second_kwargs = mock_agent_class.call_args_list[1].kwargs
     assert first_kwargs["culture_manager"] is created_culture_manager
     assert second_kwargs["culture_manager"] is created_culture_manager
+
+
+def test_team_member_matches_solo_agent_construction() -> None:
+    """A team-materialized member must equal the same agent built solo, modulo explicit deltas."""
+    from mindroom.history import close_team_runtime_state_dbs  # noqa: PLC0415
+    from mindroom.teams import materialize_exact_team_members  # noqa: PLC0415
+    from tests.conftest import runtime_paths_for  # noqa: PLC0415
+
+    config = _test_config()
+    runtime_paths = runtime_paths_for(config)
+
+    solo = create_agent("calculator", config, runtime_paths, execution_identity=None)
+    member = materialize_exact_team_members(
+        ["calculator"],
+        config=config,
+        runtime_paths=runtime_paths,
+        execution_identity=None,
+    ).agents[0]
+    try:
+        assert member.role == solo.role
+        assert member.name == solo.name
+        assert member.id == solo.id
+        assert type(member.model) is type(solo.model)
+        assert member.model is not None
+        assert solo.model is not None
+        assert member.model.id == solo.model.id
+        assert [tool.name for tool in member.tools or []] == [tool.name for tool in solo.tools or []]
+        assert member.markdown == solo.markdown
+        assert type(member.learning) is type(solo.learning)
+        assert member.add_history_to_context == solo.add_history_to_context
+        assert member.num_history_runs == solo.num_history_runs
+        assert member.num_history_messages == solo.num_history_messages
+        assert member.max_tool_calls_from_history == solo.max_tool_calls_from_history
+        assert member.knowledge == solo.knowledge
+        assert member.culture_manager == solo.culture_manager
+
+        # The only authored construction delta: members never get the Matrix
+        # reaction-based interactive question prompt.
+        interactive_prompt = config.get_prompt("INTERACTIVE_QUESTION_PROMPT")
+        assert interactive_prompt in solo.instructions
+        assert list(member.instructions or []) == [
+            instruction for instruction in solo.instructions or [] if instruction != interactive_prompt
+        ]
+    finally:
+        close_team_runtime_state_dbs(agents=[solo, member], team_db=None)


### PR DESCRIPTION
## Summary

This task asked for unifying solo-agent and team-member construction behind one materialization module, claiming the two were parallel reimplementations.
After reading both paths fully, the central premise turned out to be stale: team members are already built through `create_agent()` (`teams.py:materialize_exact_team_members` → `_build_member` → `create_agent`), and have been through that function's entire git history (at least since #686).
The remaining real asymmetries were narrower; this PR removes the ones that were drift and documents the ones that are intentional.

## Feature matrix and verdicts

| Construction concern | Solo path (`ai.py:_prepare_agent_and_prompt`) | Team member path (`teams.py:materialize_exact_team_members`) | Verdict |
|---|---|---|---|
| Agent construction | `create_agent()` | `create_agent()` | Already unified — claim in the task was stale |
| Model loading | `create_agent` → `_load_agent_model_instance` (with `execution_identity`) | Same via `create_agent` | Already unified |
| Identity / datetime / additional context / personality files | Built inside `create_agent` | Same | Already unified — task claim of members skipping these was incorrect |
| Learning, culture, show_tool_calls, markdown | Built inside `create_agent` | Same | Already unified — task claim incorrect |
| Toolkit build (incl. lazy `custom_tools` imports) | `create_agent` → `build_agent_toolkit` | Same | Already unified; lazy imports untouched |
| History knobs | Was inlined in `create_agent` | `config.get_entity_history_settings` (team scope) | **Duplication — fixed**: `create_agent` now also resolves through `config.get_entity_history_settings`, one source of truth (config validation makes the knobs mutually exclusive, so behavior is unchanged) |
| Knowledge resolution + missing-base warning | `KnowledgeAccessSupport.resolve_for_agent` (resolve + warn) | Inline resolve + warn in `_build_member`; third copy in `api/openai_compat.py` | **Duplication — fixed**: warning moved into `resolve_agent_knowledge_access` itself; all three caller-side copies deleted. Side effect: delegation (`custom_tools/delegate.py`) previously dropped missing knowledge silently and now logs the same warning |
| Team shared model (`_create_team_instance`) | n/a (solo models get `execution_identity` for codex prompt-cache keying) | Loaded without `execution_identity` | **Drift — fixed**: `execution_identity` is now threaded through `build_materialized_team_instance`/`_create_team_instance` from both Matrix team paths and the OpenAI-compatible team path |
| `include_interactive_questions=False` for members | True (Matrix solo) | False | **Intentional**: Matrix reaction-based Q&A flows are not usable inside aggregated team responses; already an explicit `create_agent` parameter |
| Members' `add_history_to_context`/`add_session_summary_to_context` flipped off after construction | True | Mutated to False in `_create_team_instance` | **Intentional**: the shared `TeamSession` owns replay; members must not independently replay their own sessions (commented in code) |
| No `active_model_name` (room model override) for members | Room-resolved via `config.resolve_runtime_model(entity_name, room_id)` | Not passed | **Intentional**: room/runtime model overrides target the room-facing entity — the team (`select_model_for_team`) — while members keep their authored specialist models |
| No per-member mem0 prompt preamble | `build_memory_prompt_parts` per run | Not per member | **Intentional team-mode difference**: this is run preparation, not materialization; the team run shares one prepared prompt |

## Behavior changes

- Delegated agents with missing knowledge bases now log a warning (previously silent).
- The team's shared model now receives the request execution identity, so codex prompt-cache keys are derived for team-level model calls.

## Tests

- New `test_team_member_matches_solo_agent_construction` asserts a member built via `materialize_exact_team_members` equals the same agent built solo via `create_agent` across role, model, tools, markdown, learning, history settings, knowledge, and culture — with the interactive-question prompt as the only authored delta.
- Full `pytest`, `pre-commit run --all-files`, and `tach check --dependencies --interfaces` pass (the TypeScript pre-commit hook fails environmentally with `tsc: command not found`; no frontend files are touched).
