### PR TITLE
Add focused unit tests for turn_policy, conversation_resolver, and coalescing

### DIFF
--- a/tests/test_coalescing.py
+++ b/tests/test_coalescing.py
@@ -1971,3 +1971,120 @@ async def test_root_in_flight_child_followup_reservations_obey_debounce() -> Non
     await gate.drain_all()
 
     assert batches == [["$root:localhost"], ["$follow1:localhost"], ["$follow2:localhost"]]
+
+
+@pytest.mark.asyncio
+async def test_batch_order_follows_ingress_reservation_order_not_admission_order() -> None:
+    """One coalesced batch must keep receive order even when admissions resolve out of order."""
+    batches: list[CoalescedBatch] = []
+
+    async def dispatch_batch(batch: CoalescedBatch) -> None:
+        batches.append(batch)
+
+    gate = CoalescingGate(
+        dispatch_batch=dispatch_batch,
+        debounce_seconds=lambda: 0.5,
+        upload_grace_seconds=lambda: 0.0,
+        is_shutting_down=lambda: False,
+    )
+    key = CoalescingKey("!room:localhost", "$thread:localhost", "@user:localhost")
+    first_reservation = gate.reserve_order(
+        room_id=key.room_id,
+        requester_user_id=key.requester_user_id,
+        receipt_time=1.0,
+    )
+    second_reservation = gate.reserve_order(
+        room_id=key.room_id,
+        requester_user_id=key.requester_user_id,
+        receipt_time=1.2,
+    )
+
+    await gate.admit(
+        key,
+        ready_result=ReadyPendingEvent(pending_event=_pending(_text_event("$second:localhost", "second", 1_000_200))),
+        order_reservation=second_reservation,
+    )
+    await gate.admit(
+        key,
+        ready_result=ReadyPendingEvent(pending_event=_pending(_text_event("$first:localhost", "first", 1_000_000))),
+        order_reservation=first_reservation,
+    )
+
+    await gate.drain_all()
+
+    assert [batch.source_event_ids for batch in batches] == [["$first:localhost", "$second:localhost"]]
+
+
+@pytest.mark.asyncio
+async def test_messages_in_different_rooms_do_not_coalesce() -> None:
+    """Same-user messages in different rooms stay independent batches."""
+    batches: list[CoalescedBatch] = []
+
+    async def dispatch_batch(batch: CoalescedBatch) -> None:
+        batches.append(batch)
+
+    gate = CoalescingGate(
+        dispatch_batch=dispatch_batch,
+        debounce_seconds=lambda: 1.0,
+        upload_grace_seconds=lambda: 0.0,
+        is_shutting_down=lambda: False,
+    )
+    first_key = CoalescingKey("!room-a:localhost", "$thread:localhost", "@user:localhost")
+    second_key = CoalescingKey("!room-b:localhost", "$thread:localhost", "@user:localhost")
+
+    await _admit_ready(gate, first_key, _pending(_text_event("$a:localhost", "room a", 1_000_000)))
+    await _admit_ready(gate, second_key, _pending(_text_event("$b:localhost", "room b", 1_000_100)))
+
+    await gate.drain_all()
+
+    assert sorted(batch.source_event_ids for batch in batches) == [["$a:localhost"], ["$b:localhost"]]
+
+
+@pytest.mark.asyncio
+async def test_messages_in_different_threads_do_not_coalesce() -> None:
+    """Same-room messages in different threads stay independent batches."""
+    batches: list[CoalescedBatch] = []
+
+    async def dispatch_batch(batch: CoalescedBatch) -> None:
+        batches.append(batch)
+
+    gate = CoalescingGate(
+        dispatch_batch=dispatch_batch,
+        debounce_seconds=lambda: 1.0,
+        upload_grace_seconds=lambda: 0.0,
+        is_shutting_down=lambda: False,
+    )
+    first_key = CoalescingKey("!room:localhost", "$thread-a:localhost", "@user:localhost")
+    second_key = CoalescingKey("!room:localhost", "$thread-b:localhost", "@user:localhost")
+
+    await _admit_ready(gate, first_key, _pending(_text_event("$a:localhost", "thread a", 1_000_000)))
+    await _admit_ready(gate, second_key, _pending(_text_event("$b:localhost", "thread b", 1_000_100)))
+
+    await gate.drain_all()
+
+    assert sorted(batch.source_event_ids for batch in batches) == [["$a:localhost"], ["$b:localhost"]]
+
+
+@pytest.mark.asyncio
+async def test_drain_all_flushes_pending_debounced_work_and_idles_gate() -> None:
+    """Shutdown drain dispatches queued work without waiting out the debounce window."""
+    batches: list[CoalescedBatch] = []
+
+    async def dispatch_batch(batch: CoalescedBatch) -> None:
+        batches.append(batch)
+
+    gate = CoalescingGate(
+        dispatch_batch=dispatch_batch,
+        debounce_seconds=lambda: 60.0,
+        upload_grace_seconds=lambda: 0.0,
+        is_shutting_down=lambda: False,
+    )
+    key = CoalescingKey("!room:localhost", "$thread:localhost", "@user:localhost")
+    await _admit_ready(gate, key, _pending(_text_event("$pending:localhost", "pending", 1_000_000)))
+    assert batches == []
+
+    result = await gate.drain_all()
+
+    assert result.completed is True
+    assert [batch.source_event_ids for batch in batches] == [["$pending:localhost"]]
+    assert _coalescing_gate_is_idle(gate)

--- a/tests/test_conversation_resolver.py
+++ b/tests/test_conversation_resolver.py
@@ -1,0 +1,386 @@
+"""Unit tests for conversation identity and ingress envelope assembly.
+
+These are characterization tests for ConversationResolver: they pin down
+thread root resolution, reply-chain fallback, candidate demotion, target
+building, and the per-turn cache scope so the planned refactor of this layer
+has a direct safety net.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock
+
+import nio
+import pytest
+
+from mindroom.config.agent import AgentConfig
+from mindroom.config.main import Config
+from mindroom.constants import SKIP_MENTIONS_KEY
+from mindroom.conversation_resolver import ConversationResolver, ConversationResolverDeps
+from mindroom.entity_resolution import entity_identity_registry
+from mindroom.logging_config import get_logger
+from mindroom.matrix.cache.thread_history_result import thread_history_result
+from tests.conftest import (
+    bind_runtime_paths,
+    make_conversation_cache_mock,
+    make_matrix_client_mock,
+    make_visible_message,
+    runtime_paths_for,
+    test_runtime_paths,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+_ROOM_ID = "!test:localhost"
+_SENDER = "@user:localhost"
+_EVENT_ID = "$event:localhost"
+_THREAD_ROOT = "$root:localhost"
+_PARENT = "$parent:localhost"
+
+
+@dataclass(frozen=True)
+class _RuntimeStub:
+    """Minimal SupportsClientConfig stand-in for resolver tests."""
+
+    client: nio.AsyncClient | None
+    config: Config
+
+
+@pytest.fixture
+def config(tmp_path: Path) -> Config:
+    """Single-agent config bound to isolated runtime paths."""
+    return bind_runtime_paths(
+        Config(agents={"general": AgentConfig(display_name="General")}),
+        test_runtime_paths(tmp_path),
+    )
+
+
+def _resolver(
+    config: Config,
+    *,
+    conversation_cache: AsyncMock | None = None,
+) -> ConversationResolver:
+    runtime_paths = runtime_paths_for(config)
+    registry = entity_identity_registry(config, runtime_paths)
+    return ConversationResolver(
+        ConversationResolverDeps(
+            runtime=_RuntimeStub(client=make_matrix_client_mock(), config=config),
+            logger=get_logger("test_conversation_resolver"),
+            runtime_paths=runtime_paths,
+            agent_name="general",
+            matrix_id=registry.current_id("general"),
+            conversation_cache=conversation_cache or make_conversation_cache_mock(),
+        ),
+    )
+
+
+def _event(content: dict[str, Any], *, event_id: str = _EVENT_ID) -> nio.RoomMessageText:
+    source = {
+        "content": {"msgtype": "m.text", **content},
+        "event_id": event_id,
+        "sender": _SENDER,
+        "origin_server_ts": 1_000_000,
+        "room_id": _ROOM_ID,
+        "type": "m.room.message",
+    }
+    event = nio.RoomMessageText.from_dict(source)
+    event.source = source
+    return event
+
+
+def _threaded_event(body: str = "in thread") -> nio.RoomMessageText:
+    return _event(
+        {
+            "body": body,
+            "m.relates_to": {"rel_type": "m.thread", "event_id": _THREAD_ROOT},
+        },
+    )
+
+
+def _reply_event(body: str = "a reply") -> nio.RoomMessageText:
+    return _event(
+        {
+            "body": body,
+            "m.relates_to": {"m.in_reply_to": {"event_id": _PARENT}},
+        },
+    )
+
+
+def _room() -> nio.MatrixRoom:
+    return nio.MatrixRoom(_ROOM_ID, "@mindroom_general:localhost")
+
+
+@pytest.mark.asyncio
+async def test_threaded_event_resolves_explicit_thread_root(config: Config) -> None:
+    """An m.thread relation is authoritative for thread identity and the delivery target."""
+    cache = make_conversation_cache_mock()
+    resolver = _resolver(config, conversation_cache=cache)
+
+    result = await resolver.extract_dispatch_context(_room(), _threaded_event())
+
+    assert result.context.is_thread is True
+    assert result.context.thread_id == _THREAD_ROOT
+    assert result.context.requires_model_history_refresh is False
+    assert result.thread_context is not None
+    assert result.thread_context.stable_target.resolved_thread_id == _THREAD_ROOT
+    cache.get_dispatch_thread_history.assert_awaited_once_with(_ROOM_ID, _THREAD_ROOT, caller_label="dispatch_context")
+
+
+@pytest.mark.asyncio
+async def test_reply_chain_falls_back_to_cached_thread_membership(config: Config) -> None:
+    """A plain reply inherits the thread of its parent through the cached thread index."""
+    cache = make_conversation_cache_mock()
+    cache.get_thread_id_for_event = AsyncMock(
+        side_effect=lambda _room_id, event_id: _THREAD_ROOT if event_id == _PARENT else None,
+    )
+    resolver = _resolver(config, conversation_cache=cache)
+
+    result = await resolver.extract_dispatch_context(_room(), _reply_event())
+
+    assert result.context.is_thread is True
+    assert result.context.thread_id == _THREAD_ROOT
+    assert result.thread_context is not None
+    assert result.thread_context.stable_target.resolved_thread_id == _THREAD_ROOT
+
+
+@pytest.mark.asyncio
+async def test_reply_to_proven_thread_root_joins_that_thread(config: Config) -> None:
+    """Replying to an event that provably has thread children resolves to that thread."""
+    cache = make_conversation_cache_mock()
+    cache.get_dispatch_thread_history = AsyncMock(
+        return_value=thread_history_result(
+            [make_visible_message(sender=_SENDER, body="child", event_id="$child:localhost")],
+            is_full_history=True,
+        ),
+    )
+    resolver = _resolver(config, conversation_cache=cache)
+
+    result = await resolver.extract_dispatch_context(_room(), _reply_event())
+
+    assert result.context.is_thread is True
+    assert result.context.thread_id == _PARENT
+    assert [message.event_id for message in result.context.thread_history] == ["$child:localhost"]
+
+
+@pytest.mark.asyncio
+async def test_reply_to_plain_message_demotes_to_room_level(config: Config) -> None:
+    """Replying to a childless event stays room-level with a room-level delivery target."""
+    resolver = _resolver(config)
+
+    result = await resolver.extract_dispatch_context(_room(), _reply_event())
+
+    assert result.context.is_thread is False
+    assert result.context.thread_id is None
+    assert result.thread_context is not None
+    assert result.thread_context.candidate_thread_root_id is None
+    # A reply event carries a relation, so per MSC3440 it cannot become a thread root itself.
+    assert result.thread_context.stable_target.source_thread_id is None
+    assert result.thread_context.stable_target.resolved_thread_id is None
+    assert result.thread_context.stable_target.reply_to_event_id == _EVENT_ID
+
+
+@pytest.mark.asyncio
+async def test_reply_to_missing_parent_keeps_unproven_candidate(config: Config) -> None:
+    """An unresolvable parent demotes to room level but keeps the candidate for replay safety."""
+    cache = make_conversation_cache_mock()
+    cache.get_event = AsyncMock(return_value=nio.RoomGetEventError("not found", "M_NOT_FOUND"))
+    resolver = _resolver(config, conversation_cache=cache)
+
+    result = await resolver.extract_dispatch_context(_room(), _reply_event())
+
+    assert result.context.is_thread is False
+    assert result.context.thread_id is None
+    assert result.thread_context is not None
+    assert result.thread_context.candidate_thread_root_id == _PARENT
+    assert result.thread_context.replay_guard_degraded is True
+    # Unproven candidates must not adopt a thread target.
+    assert result.thread_context.stable_target.resolved_thread_id is None
+
+
+@pytest.mark.asyncio
+async def test_room_thread_mode_skips_thread_resolution(tmp_path: Path) -> None:
+    """Agents in room thread mode treat every message as room-level."""
+    config = bind_runtime_paths(
+        Config(agents={"general": AgentConfig(display_name="General", thread_mode="room")}),
+        test_runtime_paths(tmp_path),
+    )
+    cache = make_conversation_cache_mock()
+    resolver = _resolver(config, conversation_cache=cache)
+
+    result = await resolver.extract_dispatch_context(_room(), _threaded_event())
+
+    assert result.context.is_thread is False
+    assert result.context.thread_id is None
+    assert result.thread_context is None
+    cache.get_dispatch_thread_history.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_coalescing_thread_id_for_threaded_and_room_level_events(config: Config) -> None:
+    """Coalescing scope follows canonical thread membership."""
+    resolver = _resolver(config)
+
+    assert await resolver.coalescing_thread_id(_room(), _threaded_event()) == _THREAD_ROOT
+    assert await resolver.coalescing_thread_id(_room(), _event({"body": "plain"})) is None
+
+
+@pytest.mark.asyncio
+async def test_coalescing_thread_id_is_room_scoped_in_room_thread_mode(tmp_path: Path) -> None:
+    """Room thread mode collapses coalescing scope to the room even for threaded events."""
+    config = bind_runtime_paths(
+        Config(agents={"general": AgentConfig(display_name="General", thread_mode="room")}),
+        test_runtime_paths(tmp_path),
+    )
+    resolver = _resolver(config)
+
+    assert await resolver.coalescing_thread_id(_room(), _threaded_event()) is None
+
+
+def test_build_message_target_for_thread_message(config: Config) -> None:
+    """A known thread id resolves to thread-level delivery."""
+    resolver = _resolver(config)
+
+    target = resolver.build_message_target(
+        room_id=_ROOM_ID,
+        thread_id=_THREAD_ROOT,
+        reply_to_event_id=_EVENT_ID,
+    )
+
+    assert target.resolved_thread_id == _THREAD_ROOT
+    assert target.session_id == f"{_ROOM_ID}:{_THREAD_ROOT}"
+
+
+def test_build_message_target_starts_thread_at_rootable_room_message(config: Config) -> None:
+    """A room-level message that can be a thread root becomes the new thread root."""
+    resolver = _resolver(config)
+    event = _event({"body": "plain"})
+
+    target = resolver.build_message_target(
+        room_id=_ROOM_ID,
+        thread_id=None,
+        reply_to_event_id=_EVENT_ID,
+        event_source=event.source,
+    )
+
+    assert target.source_thread_id is None
+    assert target.resolved_thread_id == _EVENT_ID
+
+
+def test_build_message_target_room_mode_override_stays_room_level(config: Config) -> None:
+    """A room thread-mode override discards thread identity from the target."""
+    resolver = _resolver(config)
+
+    target = resolver.build_message_target(
+        room_id=_ROOM_ID,
+        thread_id=_THREAD_ROOT,
+        reply_to_event_id=_EVENT_ID,
+        thread_mode_override="room",
+    )
+
+    assert target.resolved_thread_id is None
+    assert target.session_id == _ROOM_ID
+
+
+@dataclass
+class _ScopeTracker:
+    entered: int = 0
+    exited: int = 0
+
+
+@pytest.mark.asyncio
+async def test_turn_thread_cache_scope_wraps_conversation_cache_scope(config: Config) -> None:
+    """The per-turn cache scope opens and closes the conversation cache turn scope."""
+    cache = make_conversation_cache_mock()
+    tracker = _ScopeTracker()
+
+    @asynccontextmanager
+    async def turn_scope() -> AsyncIterator[None]:
+        tracker.entered += 1
+        try:
+            yield
+        finally:
+            tracker.exited += 1
+
+    cache.turn_scope = turn_scope
+    resolver = _resolver(config, conversation_cache=cache)
+
+    async with resolver.turn_thread_cache_scope():
+        assert tracker.entered == 1
+        assert tracker.exited == 0
+
+    assert tracker.exited == 1
+
+
+@pytest.mark.asyncio
+async def test_dispatch_context_extracts_agent_mentions(config: Config) -> None:
+    """m.mentions on the inbound event resolve to configured agent identities."""
+    registry = entity_identity_registry(config, runtime_paths_for(config))
+    general_id = registry.current_id("general")
+    resolver = _resolver(config)
+    event = _event(
+        {
+            "body": "hello @general",
+            "m.mentions": {"user_ids": [general_id.full_id, "@human:localhost"]},
+        },
+    )
+
+    result = await resolver.extract_dispatch_context(_room(), event)
+
+    assert result.context.am_i_mentioned is True
+    assert [agent.full_id for agent in result.context.mentioned_agents] == [general_id.full_id]
+    assert result.context.has_non_agent_mentions is True
+
+
+@pytest.mark.asyncio
+async def test_skip_mentions_metadata_suppresses_mention_extraction(config: Config) -> None:
+    """The skip-mentions content flag disables mention handling for one event."""
+    registry = entity_identity_registry(config, runtime_paths_for(config))
+    general_id = registry.current_id("general")
+    resolver = _resolver(config)
+    event = _event(
+        {
+            "body": "hello @general",
+            "m.mentions": {"user_ids": [general_id.full_id]},
+            SKIP_MENTIONS_KEY: True,
+        },
+    )
+
+    result = await resolver.extract_dispatch_context(_room(), event)
+
+    assert result.context.am_i_mentioned is False
+    assert result.context.mentioned_agents == []
+    assert result.context.has_non_agent_mentions is False
+
+
+@pytest.mark.asyncio
+async def test_build_ingress_envelope_carries_event_identity(config: Config) -> None:
+    """The lightweight ingress envelope mirrors the inbound event without thread extraction."""
+    resolver = _resolver(config)
+    event = _event({"body": "hello"})
+    target = resolver.build_message_target(
+        room_id=_ROOM_ID,
+        thread_id=_THREAD_ROOT,
+        reply_to_event_id=_EVENT_ID,
+    )
+
+    envelope = resolver.build_ingress_envelope(
+        room_id=_ROOM_ID,
+        event=event,
+        requester_user_id=_SENDER,
+        target=target,
+    )
+
+    assert envelope.source_event_id == _EVENT_ID
+    assert envelope.room_id == _ROOM_ID
+    assert envelope.target == target
+    assert envelope.requester_id == _SENDER
+    assert envelope.sender_id == _SENDER
+    assert envelope.body == "hello"
+    assert envelope.mentioned_agents == ()
+    assert envelope.agent_name == "general"
+    assert envelope.source_kind == "message"

--- a/tests/test_turn_policy.py
+++ b/tests/test_turn_policy.py
@@ -1,0 +1,519 @@
+"""Unit tests for the pure turn policy decisions in turn_policy.py.
+
+These are characterization tests for TurnPolicy.plan_turn: they pin down the
+current ignore/route/respond behavior so the planned refactor of this layer
+has a direct safety net that does not go through bot-level integration tests.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
+
+import nio
+import pytest
+
+from mindroom.config.agent import AgentConfig
+from mindroom.config.auth import AuthorizationConfig
+from mindroom.config.main import Config
+from mindroom.constants import ROUTER_AGENT_NAME
+from mindroom.conversation_resolver import MessageContext
+from mindroom.entity_resolution import entity_identity_registry
+from mindroom.logging_config import get_logger
+from mindroom.matrix.cache.thread_history_result import thread_history_result
+from mindroom.message_target import MessageTarget
+from mindroom.teams import TeamIntent, TeamMode, TeamOutcome
+from mindroom.turn_policy import PreparedDispatch, TurnPolicy, TurnPolicyDeps
+from tests.conftest import (
+    bind_runtime_paths,
+    make_visible_message,
+    request_envelope,
+    runtime_paths_for,
+    test_runtime_paths,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from mindroom.matrix.client import ResolvedVisibleMessage
+    from mindroom.matrix.identity import MatrixID
+
+_ROOM_ID = "!test:localhost"
+_SENDER = "@user:localhost"
+_EVENT_ID = "$event:localhost"
+
+
+@dataclass(frozen=True)
+class _RuntimeStub:
+    """Minimal SupportsClientConfigOrchestrator stand-in for pure policy tests."""
+
+    client: nio.AsyncClient | None
+    config: Config
+    orchestrator: None = None
+    runtime_started_at: float = 0.0
+
+
+@pytest.fixture
+def config(tmp_path: Path) -> Config:
+    """Two-agent config bound to isolated runtime paths."""
+    return bind_runtime_paths(
+        Config(
+            agents={
+                "general": AgentConfig(display_name="General"),
+                "research": AgentConfig(display_name="Research"),
+            },
+        ),
+        test_runtime_paths(tmp_path),
+    )
+
+
+def _policy_for(config: Config, agent_name: str) -> TurnPolicy:
+    runtime_paths = runtime_paths_for(config)
+    registry = entity_identity_registry(config, runtime_paths)
+    return TurnPolicy(
+        TurnPolicyDeps(
+            runtime=_RuntimeStub(client=None, config=config),
+            logger=get_logger("test_turn_policy"),
+            runtime_paths=runtime_paths,
+            agent_name=agent_name,
+            matrix_id=registry.current_id(agent_name),
+        ),
+    )
+
+
+def _entity_id(config: Config, entity_name: str) -> MatrixID:
+    return entity_identity_registry(config, runtime_paths_for(config)).current_id(entity_name)
+
+
+def _room_with_members(*user_ids: str) -> nio.MatrixRoom:
+    room = nio.MatrixRoom(_ROOM_ID, "@mindroom_general:localhost")
+    for user_id in user_ids:
+        room.add_member(user_id, user_id, None)
+    return room
+
+
+def _context(
+    *,
+    mentioned: list[MatrixID] | None = None,
+    am_i_mentioned: bool = False,
+    thread_id: str | None = None,
+    thread_history: list[ResolvedVisibleMessage] | None = None,
+    full_history: bool = True,
+) -> MessageContext:
+    history: object = thread_history or []
+    if full_history:
+        history = thread_history_result(thread_history or [], is_full_history=True)
+    return MessageContext(
+        am_i_mentioned=am_i_mentioned,
+        is_thread=thread_id is not None,
+        thread_id=thread_id,
+        thread_history=history,
+        mentioned_agents=mentioned or [],
+        has_non_agent_mentions=False,
+    )
+
+
+def _dispatch(context: MessageContext, *, agent_name: str, sender: str = _SENDER) -> PreparedDispatch:
+    target = MessageTarget.resolve(_ROOM_ID, context.thread_id, _EVENT_ID)
+    envelope = request_envelope(
+        room_id=_ROOM_ID,
+        reply_to_event_id=_EVENT_ID,
+        thread_id=context.thread_id,
+        prompt="hello agents",
+        user_id=sender,
+        target=target,
+        agent_name=agent_name,
+    )
+    return PreparedDispatch(
+        requester_user_id=sender,
+        context=context,
+        target=target,
+        correlation_id="corr-test",
+        envelope=envelope,
+    )
+
+
+def _text_event(body: str) -> nio.RoomMessageText:
+    return nio.RoomMessageText.from_dict(
+        {
+            "content": {"body": body, "msgtype": "m.text"},
+            "event_id": _EVENT_ID,
+            "sender": _SENDER,
+            "origin_server_ts": 1_000_000,
+            "room_id": _ROOM_ID,
+            "type": "m.room.message",
+        },
+    )
+
+
+async def _plan(
+    policy: TurnPolicy,
+    room: nio.MatrixRoom,
+    dispatch: PreparedDispatch,
+    *,
+    is_dm: bool = False,
+    has_active_response: bool = False,
+) -> object:
+    return await policy.plan_turn(
+        room,
+        _text_event("hello agents"),
+        dispatch,
+        is_dm=is_dm,
+        has_active_response_for_target=lambda _target: has_active_response,
+    )
+
+
+@pytest.mark.asyncio
+async def test_mentioned_agent_responds_individually(config: Config) -> None:
+    """A direct mention of one agent yields an individual respond plan."""
+    policy = _policy_for(config, "general")
+    room = _room_with_members(_SENDER, _entity_id(config, "general").full_id, _entity_id(config, "research").full_id)
+    context = _context(mentioned=[_entity_id(config, "general")], am_i_mentioned=True)
+
+    plan = await _plan(policy, room, _dispatch(context, agent_name="general"))
+
+    assert plan.kind == "respond"
+    assert plan.response_action is not None
+    assert plan.response_action.kind == "individual"
+
+
+@pytest.mark.asyncio
+async def test_mention_of_other_agent_is_ignored(config: Config) -> None:
+    """An agent must stay silent when only another agent is mentioned."""
+    policy = _policy_for(config, "general")
+    room = _room_with_members(_SENDER, _entity_id(config, "general").full_id, _entity_id(config, "research").full_id)
+    context = _context(mentioned=[_entity_id(config, "research")])
+
+    plan = await _plan(policy, room, _dispatch(context, agent_name="general"))
+
+    assert plan.kind == "ignore"
+
+
+@pytest.mark.asyncio
+async def test_unmentioned_room_message_with_multiple_responders_is_ignored(config: Config) -> None:
+    """With several visible responders, no agent self-selects for an untagged room message."""
+    policy = _policy_for(config, "general")
+    room = _room_with_members(_SENDER, _entity_id(config, "general").full_id, _entity_id(config, "research").full_id)
+
+    plan = await _plan(policy, room, _dispatch(_context(), agent_name="general"))
+
+    assert plan.kind == "ignore"
+
+
+@pytest.mark.asyncio
+async def test_unmentioned_room_message_with_single_responder_responds(config: Config) -> None:
+    """The only visible responder answers untagged room messages."""
+    policy = _policy_for(config, "general")
+    room = _room_with_members(_SENDER, _entity_id(config, "general").full_id)
+
+    plan = await _plan(policy, room, _dispatch(_context(), agent_name="general"))
+
+    assert plan.kind == "respond"
+    assert plan.response_action.kind == "individual"
+
+
+@pytest.mark.asyncio
+async def test_thread_continuation_by_sole_thread_agent_responds(config: Config) -> None:
+    """An agent keeps answering an untagged thread it already owns."""
+    policy = _policy_for(config, "general")
+    room = _room_with_members(_SENDER, _entity_id(config, "general").full_id, _entity_id(config, "research").full_id)
+    history = [
+        make_visible_message(sender=_SENDER, body="please help"),
+        make_visible_message(sender=_entity_id(config, "general").full_id, body="sure thing"),
+    ]
+    context = _context(thread_id="$thread:localhost", thread_history=history)
+
+    plan = await _plan(policy, room, _dispatch(context, agent_name="general"))
+
+    assert plan.kind == "respond"
+    assert plan.response_action.kind == "individual"
+
+
+@pytest.mark.asyncio
+async def test_thread_owned_by_other_agent_is_ignored(config: Config) -> None:
+    """An agent must not hijack an untagged thread owned by a different agent."""
+    policy = _policy_for(config, "general")
+    room = _room_with_members(_SENDER, _entity_id(config, "general").full_id, _entity_id(config, "research").full_id)
+    history = [
+        make_visible_message(sender=_SENDER, body="please help"),
+        make_visible_message(sender=_entity_id(config, "research").full_id, body="on it"),
+    ]
+    context = _context(thread_id="$thread:localhost", thread_history=history)
+
+    plan = await _plan(policy, room, _dispatch(context, agent_name="general"))
+
+    assert plan.kind == "ignore"
+
+
+@pytest.mark.asyncio
+async def test_thread_with_two_participating_agents_forms_implicit_team_for_owner(config: Config) -> None:
+    """Two agents already in one thread re-form an implicit team owned by the lowest agent ID."""
+    room = _room_with_members(_SENDER, _entity_id(config, "general").full_id, _entity_id(config, "research").full_id)
+    history = [
+        make_visible_message(sender=_SENDER, body="please help"),
+        make_visible_message(sender=_entity_id(config, "general").full_id, body="general here"),
+        make_visible_message(sender=_entity_id(config, "research").full_id, body="research here"),
+    ]
+    context = _context(thread_id="$thread:localhost", thread_history=history)
+
+    with patch("mindroom.teams._select_team_mode", new=AsyncMock(return_value=TeamMode.COLLABORATE)):
+        owner_plan = await _plan(
+            _policy_for(config, "general"),
+            room,
+            _dispatch(context, agent_name="general"),
+        )
+        other_plan = await _plan(
+            _policy_for(config, "research"),
+            room,
+            _dispatch(context, agent_name="research"),
+        )
+
+    assert owner_plan.kind == "respond"
+    assert owner_plan.response_action.kind == "team"
+    assert owner_plan.response_action.form_team.outcome is TeamOutcome.TEAM
+    assert owner_plan.response_action.form_team.intent is TeamIntent.IMPLICIT_THREAD_TEAM
+    assert other_plan.kind == "ignore"
+
+
+@pytest.mark.asyncio
+async def test_mentioning_two_agents_forms_explicit_team_for_owner_only(config: Config) -> None:
+    """Tagging multiple agents forms one team surfaced by the lowest agent ID."""
+    room = _room_with_members(_SENDER, _entity_id(config, "general").full_id, _entity_id(config, "research").full_id)
+    mentioned = [_entity_id(config, "general"), _entity_id(config, "research")]
+
+    with patch("mindroom.teams._select_team_mode", new=AsyncMock(return_value=TeamMode.COORDINATE)):
+        owner_plan = await _plan(
+            _policy_for(config, "general"),
+            room,
+            _dispatch(_context(mentioned=mentioned, am_i_mentioned=True), agent_name="general"),
+        )
+        other_plan = await _plan(
+            _policy_for(config, "research"),
+            room,
+            _dispatch(_context(mentioned=mentioned, am_i_mentioned=True), agent_name="research"),
+        )
+
+    assert owner_plan.kind == "respond"
+    assert owner_plan.response_action.kind == "team"
+    assert owner_plan.response_action.form_team.intent is TeamIntent.EXPLICIT_MEMBERS
+    assert other_plan.kind == "ignore"
+
+
+@pytest.mark.asyncio
+async def test_dm_room_with_multiple_agents_forms_auto_team(config: Config) -> None:
+    """Untagged DM-room messages auto-team all visible agents."""
+    room = _room_with_members(_SENDER, _entity_id(config, "general").full_id, _entity_id(config, "research").full_id)
+
+    with patch("mindroom.teams._select_team_mode", new=AsyncMock(return_value=TeamMode.COLLABORATE)):
+        plan = await _plan(
+            _policy_for(config, "general"),
+            room,
+            _dispatch(_context(), agent_name="general"),
+            is_dm=True,
+        )
+
+    assert plan.kind == "respond"
+    assert plan.response_action.kind == "team"
+    assert plan.response_action.form_team.intent is TeamIntent.DM_AUTO_TEAM
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_sender_is_ignored_even_when_mentioned(tmp_path: Path) -> None:
+    """A sender outside the per-agent reply allowlist never gets a response."""
+    config = bind_runtime_paths(
+        Config(
+            agents={"general": AgentConfig(display_name="General")},
+            authorization=AuthorizationConfig(agent_reply_permissions={"general": ["@owner:localhost"]}),
+        ),
+        test_runtime_paths(tmp_path),
+    )
+    policy = _policy_for(config, "general")
+    room = _room_with_members(_SENDER, _entity_id(config, "general").full_id)
+    context = _context(mentioned=[_entity_id(config, "general")], am_i_mentioned=True)
+
+    plan = await _plan(policy, room, _dispatch(context, agent_name="general"))
+
+    assert plan.kind == "ignore"
+    assert policy.can_reply_to_sender(_SENDER) is False
+
+
+@pytest.mark.asyncio
+async def test_internal_agent_sender_bypasses_reply_allowlist(tmp_path: Path) -> None:
+    """Bot-to-bot senders are system participants and bypass per-agent reply allowlists."""
+    config = bind_runtime_paths(
+        Config(
+            agents={
+                "general": AgentConfig(display_name="General"),
+                "research": AgentConfig(display_name="Research"),
+            },
+            authorization=AuthorizationConfig(agent_reply_permissions={"general": ["@owner:localhost"]}),
+        ),
+        test_runtime_paths(tmp_path),
+    )
+    policy = _policy_for(config, "general")
+
+    assert policy.can_reply_to_sender(_entity_id(config, "research").full_id) is True
+
+
+@pytest.mark.asyncio
+async def test_unavailable_thread_history_skips_with_multiple_responders(config: Config) -> None:
+    """Degraded thread policy history must not be treated as an empty thread."""
+    policy = _policy_for(config, "general")
+    room = _room_with_members(_SENDER, _entity_id(config, "general").full_id, _entity_id(config, "research").full_id)
+    # A plain non-empty sequence carries no completeness signal, so planning history is unavailable.
+    context = _context(
+        thread_id="$thread:localhost",
+        thread_history=[make_visible_message(sender=_SENDER, body="earlier")],
+        full_history=False,
+    )
+    assert context.planning_thread_history_unavailable
+
+    plan = await _plan(policy, room, _dispatch(context, agent_name="general"))
+
+    assert plan.kind == "ignore"
+
+
+@pytest.mark.asyncio
+async def test_unavailable_thread_history_still_responds_as_single_visible_responder(config: Config) -> None:
+    """The only visible responder continues a thread even when policy history degraded."""
+    policy = _policy_for(config, "general")
+    room = _room_with_members(_SENDER, _entity_id(config, "general").full_id)
+    context = _context(
+        thread_id="$thread:localhost",
+        thread_history=[make_visible_message(sender=_SENDER, body="earlier")],
+        full_history=False,
+    )
+
+    plan = await _plan(policy, room, _dispatch(context, agent_name="general"))
+
+    assert plan.kind == "respond"
+    assert plan.response_action.kind == "individual"
+
+
+@pytest.mark.asyncio
+async def test_active_response_queues_untagged_thread_follow_up(config: Config) -> None:
+    """A human follow-up in a thread with an in-flight response enters the queued path."""
+    policy = _policy_for(config, "general")
+    room = _room_with_members(_SENDER, _entity_id(config, "general").full_id, _entity_id(config, "research").full_id)
+    history = [
+        make_visible_message(sender=_SENDER, body="please help"),
+        make_visible_message(sender=_entity_id(config, "research").full_id, body="on it"),
+    ]
+    context = _context(thread_id="$thread:localhost", thread_history=history)
+
+    plan = await _plan(
+        policy,
+        room,
+        _dispatch(context, agent_name="general"),
+        has_active_response=True,
+    )
+
+    assert plan.kind == "respond"
+    assert plan.response_action.kind == "individual"
+
+
+@pytest.mark.asyncio
+async def test_router_routes_untagged_message_with_multiple_candidates(config: Config) -> None:
+    """The router produces a route plan when several responders could answer."""
+    policy = _policy_for(config, ROUTER_AGENT_NAME)
+    room = _room_with_members(_SENDER, _entity_id(config, "general").full_id, _entity_id(config, "research").full_id)
+
+    plan = await _plan(policy, room, _dispatch(_context(), agent_name=ROUTER_AGENT_NAME))
+
+    assert plan.kind == "route"
+    assert plan.router_event is not None
+
+
+@pytest.mark.asyncio
+async def test_router_ignores_untagged_message_with_single_candidate(config: Config) -> None:
+    """The router stays out of the way when only one responder candidate exists."""
+    policy = _policy_for(config, ROUTER_AGENT_NAME)
+    room = _room_with_members(_SENDER, _entity_id(config, "general").full_id)
+
+    plan = await _plan(policy, room, _dispatch(_context(), agent_name=ROUTER_AGENT_NAME))
+
+    assert plan.kind == "ignore"
+    assert plan.ignore_reason == "router"
+
+
+@pytest.mark.asyncio
+async def test_router_ignores_message_with_explicit_agent_mention(config: Config) -> None:
+    """Explicitly tagged messages bypass routing entirely."""
+    policy = _policy_for(config, ROUTER_AGENT_NAME)
+    room = _room_with_members(_SENDER, _entity_id(config, "general").full_id, _entity_id(config, "research").full_id)
+    context = _context(mentioned=[_entity_id(config, "general")])
+
+    plan = await _plan(policy, room, _dispatch(context, agent_name=ROUTER_AGENT_NAME))
+
+    assert plan.kind == "ignore"
+    assert plan.ignore_reason == "router"
+
+
+@pytest.mark.asyncio
+async def test_router_only_mention_returns_rules_of_engagement_rejection(config: Config) -> None:
+    """Tagging only the router yields the guidance rejection instead of routing."""
+    policy = _policy_for(config, ROUTER_AGENT_NAME)
+    room = _room_with_members(_SENDER, _entity_id(config, "general").full_id, _entity_id(config, "research").full_id)
+    context = _context(mentioned=[_entity_id(config, ROUTER_AGENT_NAME)])
+
+    plan = await _plan(policy, room, _dispatch(context, agent_name=ROUTER_AGENT_NAME))
+
+    assert plan.kind == "respond"
+    assert plan.response_action.kind == "reject"
+    assert "Rules of engagement" in plan.response_action.rejection_message
+
+
+@pytest.mark.asyncio
+async def test_router_ignores_thread_already_owned_by_an_agent(config: Config) -> None:
+    """The router never re-routes a thread that already has a visible agent owner."""
+    policy = _policy_for(config, ROUTER_AGENT_NAME)
+    room = _room_with_members(_SENDER, _entity_id(config, "general").full_id, _entity_id(config, "research").full_id)
+    history = [
+        make_visible_message(sender=_SENDER, body="please help"),
+        make_visible_message(sender=_entity_id(config, "general").full_id, body="answering"),
+    ]
+    context = _context(thread_id="$thread:localhost", thread_history=history)
+
+    plan = await _plan(policy, room, _dispatch(context, agent_name=ROUTER_AGENT_NAME))
+
+    assert plan.kind == "ignore"
+    assert plan.ignore_reason == "router"
+
+
+@pytest.mark.asyncio
+async def test_router_ignores_thread_with_unavailable_policy_history(config: Config) -> None:
+    """Routing is skipped rather than guessed when thread policy history degraded."""
+    policy = _policy_for(config, ROUTER_AGENT_NAME)
+    room = _room_with_members(_SENDER, _entity_id(config, "general").full_id, _entity_id(config, "research").full_id)
+    context = _context(
+        thread_id="$thread:localhost",
+        thread_history=[make_visible_message(sender=_SENDER, body="earlier")],
+        full_history=False,
+    )
+
+    plan = await _plan(policy, room, _dispatch(context, agent_name=ROUTER_AGENT_NAME))
+
+    assert plan.kind == "ignore"
+    assert plan.ignore_reason == "router"
+
+
+def test_prepared_dispatch_rejects_mismatched_envelope_target() -> None:
+    """PreparedDispatch enforces that envelope and dispatch describe the same delivery."""
+    target = MessageTarget.resolve(_ROOM_ID, None, _EVENT_ID)
+    other_target = MessageTarget.resolve(_ROOM_ID, "$thread:localhost", _EVENT_ID)
+    envelope = request_envelope(
+        room_id=_ROOM_ID,
+        reply_to_event_id=_EVENT_ID,
+        target=other_target,
+        agent_name="general",
+    )
+
+    with pytest.raises(ValueError, match="must match the resolved dispatch target"):
+        PreparedDispatch(
+            requester_user_id=_SENDER,
+            context=_context(),
+            target=target,
+            correlation_id="corr-test",
+            envelope=envelope,
+        )

--- a/tests/test_turn_policy.py
+++ b/tests/test_turn_policy.py
@@ -338,8 +338,7 @@ async def test_unauthorized_sender_is_ignored_even_when_mentioned(tmp_path: Path
     assert policy.can_reply_to_sender(_SENDER) is False
 
 
-@pytest.mark.asyncio
-async def test_internal_agent_sender_bypasses_reply_allowlist(tmp_path: Path) -> None:
+def test_internal_agent_sender_bypasses_reply_allowlist(tmp_path: Path) -> None:
     """Bot-to-bot senders are system participants and bypass per-agent reply allowlists."""
     config = bind_runtime_paths(
         Config(


### PR DESCRIPTION
## Summary

Characterization tests for three load-bearing inbound-turn-pipeline modules that were previously exercised mostly through bot-level integration tests. These pin down current behavior as a safety net for the planned refactor of this layer. **No production code changes.**

### `tests/test_turn_policy.py` (new, 21 tests)

Direct unit tests for `TurnPolicy.plan_turn` using a minimal `SupportsClientConfigOrchestrator` stub (`client=None`, `orchestrator=None`), so the whole decision path runs synchronously against real config/identity machinery:

- Mentioned agent responds individually; mention of another agent is ignored.
- Untagged room message: ignored with multiple visible responders, answered by a sole visible responder.
- Thread continuation: sole thread owner keeps answering; threads owned by a different agent are ignored.
- Team formation: implicit thread team (two agents in history), explicit two-agent mention, and DM auto-team — each surfaced only by the lowest-ID owner bot, skipped by the other (`mindroom.teams._select_team_mode` is mocked so no AI call runs).
- Per-agent reply allowlists block outside senders even when mentioned; internal agent (bot-to-bot) senders bypass the allowlist.
- Degraded/unavailable thread policy history skips unless the agent is the sole visible responder; in-flight responses queue untagged thread follow-ups.
- Router branches: route with multiple candidates, ignore with a single candidate, ignore on explicit mentions, "Rules of engagement" rejection for router-only mentions, ignore for agent-owned threads and unavailable policy history.
- `PreparedDispatch` envelope/target coherence validation.

### `tests/test_conversation_resolver.py` (new, 15 tests)

Direct unit tests for `ConversationResolver` using the existing `make_conversation_cache_mock` / `make_matrix_client_mock` conftest fixtures:

- Explicit `m.thread` relation resolves thread identity and delivery target.
- Reply-chain fallback through the cached thread index; reply to a proven thread root joins that thread and reuses the proof history.
- Reply to a childless event demotes to room level; reply to an unresolvable parent keeps the unproven candidate for replay safety with `replay_guard_degraded=True`.
- `coalescing_thread_id` for threaded/room-level events, and room-thread-mode collapsing scope to the room.
- `build_message_target`: thread targets, new-thread rooting at a thread-rootable room message, and the `room` mode override.
- `turn_thread_cache_scope` wraps the conversation cache turn scope; mention extraction, skip-mentions metadata, and `build_ingress_envelope` field mapping.

### `tests/test_coalescing.py` (extended, +4 tests)

`tests/test_coalescing.py` already existed with ~51 direct `CoalescingGate` tests covering most of the originally requested scenarios (in-window coalescing, debounce timeout firing, shutdown drain), so this PR gap-fills rather than duplicating:

- Batch ordering follows ingress reservation (receive) order even when admissions resolve out of order.
- Messages in different rooms / different threads never share a batch.
- `drain_all` flushes pending debounced work immediately and leaves the gate idle.

## Notes for reviewers

- These are characterization tests: they assert what the code does today, not what it ideally should do. One behavior worth knowing (not obviously a bug, but pinned with a comment): a reply event cannot become a thread root per MSC3440, so a reply demoted to room level gets a room-level delivery target (`resolved_thread_id=None`), unlike a plain room message which roots a new thread at itself.
- Command handling was requested as a `plan_turn` axis but lives in `text_ingress_dispatch.py` (commands are intercepted before turn policy), so it is out of scope for these files.
- Bot-to-bot filtering at the precheck level lives in `turn_controller.py`; at the policy level the testable surface is the reply-allowlist bypass for internal senders, which is covered.

## Testing

- `uv run pytest tests/test_turn_policy.py tests/test_conversation_resolver.py tests/test_coalescing.py -n 0 --no-cov` — 91 passed.
- Full suite: 7948 passed, 61 skipped; 2 unrelated 60s-timeout flakes under parallel load (`test_all_tools_can_be_imported`, `test_sandbox_runner_user_scope_allows_broad_agents_tree_base_dir`) pass in isolation.
- `uv run pre-commit run --all-files` — all Python hooks pass (the TypeScript hook fails locally only because `tsc` is not installed in this environment).