### PR TITLE
Consolidate media-kind helpers and attachment scoping after #1214 review

### DIFF
--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -67,14 +67,13 @@ from mindroom.llm_request_logging import (
 )
 from mindroom.logging_config import get_logger
 from mindroom.media_fallback import (
-    MediaKind,
     ModelMediaRoute,
     build_model_media_route,
     filter_media_inputs_for_route,
     retry_media_inputs_after_failure,
     unsupported_media_kinds_for_route,
 )
-from mindroom.media_inputs import MediaInputs
+from mindroom.media_inputs import MediaInputs, MediaKind
 from mindroom.memory import MemoryPromptParts, build_memory_prompt_parts, strip_user_turn_time_prefix
 from mindroom.metadata_merge import deep_merge_metadata
 from mindroom.timing import DispatchPipelineTiming, emit_timing_event, timed
@@ -447,7 +446,7 @@ def _request_stream_retry(
     retried_after_media_fallback: bool,
     media_route: ModelMediaRoute | None,
     media_inputs: MediaInputs,
-    context_media_kinds: frozenset[MediaKind] = frozenset(),
+    context_media_kinds: frozenset[MediaKind],
     error: Exception | str,
     log_message: str,
     agent_name: str,
@@ -1029,7 +1028,7 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                 turn_recorder.set_run_metadata(metadata)
 
             response: RunOutput | None = None
-            context_media_kinds = ai_runtime.run_input_media_kinds(run_input)
+            context_media_kinds = ai_runtime.media_inputs_from_run_input(run_input).kinds()
             media_route = (
                 build_model_media_route(agent.model) if media_inputs.has_any() or context_media_kinds else None
             )
@@ -1268,7 +1267,7 @@ async def _process_stream_events(  # noqa: C901, PLR0912, PLR0915
     retried_after_media_fallback: bool,
     timing_scope: str,
     media_route: ModelMediaRoute | None = None,
-    context_media_kinds: frozenset[MediaKind] = frozenset(),
+    context_media_kinds: frozenset[MediaKind],
     state_updated: Callable[[], None] | None = None,
     pipeline_timing: DispatchPipelineTiming | None = None,
 ) -> AsyncGenerator[AIStreamChunk, None]:
@@ -1566,7 +1565,7 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
             if turn_recorder is not None:
                 turn_recorder.set_run_metadata(metadata)
 
-            context_media_kinds = ai_runtime.run_input_media_kinds(run_input)
+            context_media_kinds = ai_runtime.media_inputs_from_run_input(run_input).kinds()
             media_route = (
                 build_model_media_route(agent.model) if media_inputs.has_any() or context_media_kinds else None
             )

--- a/src/mindroom/ai_runtime.py
+++ b/src/mindroom/ai_runtime.py
@@ -17,8 +17,8 @@ from agno.session.agent import AgentSession
 from agno.session.team import TeamSession
 
 from mindroom.logging_config import get_logger
-from mindroom.media_fallback import MediaKind, append_inline_media_fallback_prompt
-from mindroom.media_inputs import MediaInputs
+from mindroom.media_fallback import append_inline_media_fallback_prompt
+from mindroom.media_inputs import MediaInputs, MediaKind
 
 if TYPE_CHECKING:
     from agno.agent import Agent
@@ -40,7 +40,6 @@ __all__ = [
     "next_retry_run_id",
     "note_attempt_run_id",
     "queued_message_signal_context",
-    "run_input_media_kinds",
     "scrub_queued_notice_session_context",
 ]
 
@@ -78,26 +77,6 @@ def attach_media_to_run_input(
     return run_messages
 
 
-_ALL_MEDIA_KINDS: frozenset[MediaKind] = frozenset({"audio", "file", "image", "video"})
-
-
-def run_input_media_kinds(run_input: ModelRunInput) -> frozenset[MediaKind]:
-    """Return media kinds attached to canonical run-input messages."""
-    if isinstance(run_input, str):
-        return frozenset()
-    kinds: set[MediaKind] = set()
-    for message in run_input:
-        if message.audio:
-            kinds.add("audio")
-        if message.images:
-            kinds.add("image")
-        if message.files:
-            kinds.add("file")
-        if message.videos:
-            kinds.add("video")
-    return frozenset(kinds)
-
-
 def media_inputs_from_run_input(run_input: ModelRunInput) -> MediaInputs:
     """Collect media attached to canonical run-input messages.
 
@@ -122,19 +101,18 @@ def append_inline_media_fallback_to_run_input(
     run_input: ModelRunInput,
     *,
     fallback_prompt: str,
-    removed_kinds: frozenset[MediaKind] | None = None,
+    removed_kinds: frozenset[MediaKind],
 ) -> list[Message]:
     """Strip rejected media kinds from all run-input messages and append the fallback note."""
     run_messages = copy_run_input(run_input)
-    kinds = _ALL_MEDIA_KINDS if removed_kinds is None else removed_kinds
     for message in run_messages:
-        if "audio" in kinds:
+        if "audio" in removed_kinds:
             message.audio = None
-        if "image" in kinds:
+        if "image" in removed_kinds:
             message.images = None
-        if "file" in kinds:
+        if "file" in removed_kinds:
             message.files = None
-        if "video" in kinds:
+        if "video" in removed_kinds:
             message.videos = None
     current_message = run_messages[-1]
     current_text = current_message.content if isinstance(current_message.content, str) else ""

--- a/src/mindroom/ai_runtime.py
+++ b/src/mindroom/ai_runtime.py
@@ -80,8 +80,9 @@ def attach_media_to_run_input(
 def media_inputs_from_run_input(run_input: ModelRunInput) -> MediaInputs:
     """Collect media attached to canonical run-input messages.
 
-    Team runs flatten context messages to text, so media pinned to
-    thread-history messages must be re-collected into the current turn.
+    Agent paths read the collected ``kinds()`` to drive media-capability
+    routing; team runs also re-collect the media itself because Agno
+    flattens team context messages to text, dropping pinned history media.
     """
     if isinstance(run_input, str):
         return MediaInputs()

--- a/src/mindroom/attachments.py
+++ b/src/mindroom/attachments.py
@@ -139,7 +139,7 @@ def _thread_history_message_in_scope(message: ResolvedVisibleMessage, thread_id:
 _MEDIA_MSGTYPES = frozenset({"m.audio", "m.file", "m.image", "m.video"})
 
 
-def attachment_ids_for_visible_message(message: ResolvedVisibleMessage) -> list[str]:
+def _attachment_ids_for_visible_message(message: ResolvedVisibleMessage) -> list[str]:
     """Return attachment IDs carried by one visible message.
 
     MindRoom-sent messages reference attachments via content metadata; raw
@@ -152,6 +152,34 @@ def attachment_ids_for_visible_message(message: ResolvedVisibleMessage) -> list[
     if message.content.get("msgtype") in _MEDIA_MSGTYPES and message.event_id:
         return [_attachment_id_for_event(message.event_id)]
     return []
+
+
+def _attachment_record_in_message_scope(
+    record: AttachmentRecord,
+    message: ResolvedVisibleMessage,
+    *,
+    room_id: str | None,
+) -> bool:
+    if room_id is not None and record.room_id != room_id:
+        return False
+    # A record belongs to the thread of the message that references it:
+    # thread members match by thread ID, thread roots by their own event ID,
+    # and room-level messages only see room-level (thread-less) records.
+    return record.thread_id in (message.thread_id, message.event_id)
+
+
+def attachment_records_for_visible_message(
+    storage_path: Path,
+    message: ResolvedVisibleMessage,
+    *,
+    room_id: str | None,
+) -> list[AttachmentRecord]:
+    """Resolve attachment records carried by one visible message, scoped to its room and thread."""
+    attachment_ids = _attachment_ids_for_visible_message(message)
+    if not attachment_ids:
+        return []
+    records = resolve_attachments(storage_path, attachment_ids)
+    return [record for record in records if _attachment_record_in_message_scope(record, message, room_id=room_id)]
 
 
 def unique_attachment_ids(attachment_ids: Iterable[str]) -> list[str]:

--- a/src/mindroom/execution_preparation.py
+++ b/src/mindroom/execution_preparation.py
@@ -11,11 +11,7 @@ from agno.models.message import Message
 
 from mindroom import ai_runtime
 from mindroom.attachment_media import attachment_records_to_media
-from mindroom.attachments import (
-    attachment_ids_for_visible_message,
-    format_attachment_annotation,
-    resolve_attachments,
-)
+from mindroom.attachments import attachment_records_for_visible_message, format_attachment_annotation
 from mindroom.constants import (
     COMPACTION_NOTICE_CONTENT_KEY,
     ORIGINAL_SENDER_KEY,
@@ -128,25 +124,13 @@ class ThreadHistoryRenderLimits:
 
 @dataclass(frozen=True)
 class _ThreadAttachmentContext:
-    """Resolve per-message attachment records for thread-history rendering."""
+    """Bind attachment-record resolution to one room for thread-history rendering."""
 
     storage_path: Path
     room_id: str | None
 
     def records_for(self, message: ResolvedVisibleMessage) -> list[AttachmentRecord]:
-        attachment_ids = attachment_ids_for_visible_message(message)
-        if not attachment_ids:
-            return []
-        records = resolve_attachments(self.storage_path, attachment_ids)
-        return [record for record in records if self._record_in_scope(record, message)]
-
-    def _record_in_scope(self, record: AttachmentRecord, message: ResolvedVisibleMessage) -> bool:
-        if self.room_id is not None and record.room_id != self.room_id:
-            return False
-        # A record belongs to the thread of the message that references it:
-        # thread members match by thread ID, thread roots by their own event ID,
-        # and room-level messages only see room-level (thread-less) records.
-        return record.thread_id in (message.thread_id, message.event_id)
+        return attachment_records_for_visible_message(self.storage_path, message, room_id=self.room_id)
 
 
 def _wrap_msg_body(sender: str, body: str) -> str:

--- a/src/mindroom/media_fallback.py
+++ b/src/mindroom/media_fallback.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 from agno.models.anthropic import Claude
 from agno.models.azure.openai_chat import AzureOpenAI
@@ -17,7 +17,7 @@ from agno.models.openai import OpenAIChat, OpenAIResponses
 from agno.models.openrouter import OpenRouter
 from agno.models.vertexai.claude import Claude as VertexAIClaude
 
-from mindroom.media_inputs import MediaInputs
+from mindroom.media_inputs import MediaInputs, MediaKind
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -25,7 +25,6 @@ if TYPE_CHECKING:
     from agno.models.base import Model
 
 __all__ = [
-    "MediaKind",
     "ModelMediaRoute",
     "append_inline_media_fallback_prompt",
     "build_model_media_route",
@@ -49,8 +48,6 @@ _INLINE_MEDIA_UNSUPPORTED_PATTERNS = (
     re.compile(rf"support input (?P<kind>{_MEDIA_KIND_PATTERN})"),
     re.compile(rf"at most 0 (?P<kind>{_MEDIA_KIND_PATTERN})\(s\) may be provided"),
 )
-
-type MediaKind = Literal["audio", "image", "file", "video"]
 
 # Provider error vocabulary -> our MediaInputs kind (providers say "document" for files).
 _PROVIDER_MEDIA_KINDS: dict[str, MediaKind] = {
@@ -118,7 +115,7 @@ def filter_media_inputs_for_route(
     media_inputs: MediaInputs,
 ) -> _MediaFilterResult:
     """Omit learned-unsupported media kinds before a model request."""
-    removed_kinds = unsupported_media_kinds_for_route(route) & _media_kinds_present(media_inputs)
+    removed_kinds = unsupported_media_kinds_for_route(route) & media_inputs.kinds()
     if not removed_kinds:
         return _MediaFilterResult(media_inputs=media_inputs, removed_kinds=frozenset())
     return _MediaFilterResult(
@@ -142,7 +139,7 @@ def retry_media_inputs_after_failure(
     actually present in ``media_inputs`` or ``extra_present_kinds`` (media
     pinned to thread-history messages in the run input).
     """
-    present_kinds = _media_kinds_present(media_inputs) | extra_present_kinds
+    present_kinds = media_inputs.kinds() | extra_present_kinds
     if not present_kinds:
         return _no_media_retry_decision(media_inputs)
 
@@ -243,19 +240,6 @@ def _is_ambiguous_media_error(error_text: str) -> bool:
 
 def _canonical_media_kind(provider_kind: str) -> MediaKind | None:
     return _PROVIDER_MEDIA_KINDS.get(provider_kind)
-
-
-def _media_kinds_present(media_inputs: MediaInputs) -> frozenset[MediaKind]:
-    kinds: set[MediaKind] = set()
-    if media_inputs.audio:
-        kinds.add("audio")
-    if media_inputs.images:
-        kinds.add("image")
-    if media_inputs.files:
-        kinds.add("file")
-    if media_inputs.videos:
-        kinds.add("video")
-    return frozenset(kinds)
 
 
 def _without_media_kinds(media_inputs: MediaInputs, kinds: frozenset[MediaKind]) -> MediaInputs:

--- a/src/mindroom/media_inputs.py
+++ b/src/mindroom/media_inputs.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from agno.media import Audio, File, Image, Video
+
+type MediaKind = Literal["audio", "image", "file", "video"]
 
 
 @dataclass(frozen=True)
@@ -40,3 +42,29 @@ class MediaInputs:
     def has_any(self) -> bool:
         """Return whether any media collection contains items."""
         return bool(self.audio or self.images or self.files or self.videos)
+
+    def kinds(self) -> frozenset[MediaKind]:
+        """Return the media kinds with at least one item."""
+        kinds: set[MediaKind] = set()
+        if self.audio:
+            kinds.add("audio")
+        if self.images:
+            kinds.add("image")
+        if self.files:
+            kinds.add("file")
+        if self.videos:
+            kinds.add("video")
+        return frozenset(kinds)
+
+    def merge(self, other: MediaInputs) -> MediaInputs:
+        """Concatenate two media-input sets preserving order."""
+        if not self.has_any():
+            return other
+        if not other.has_any():
+            return self
+        return MediaInputs(
+            audio=(*self.audio, *other.audio),
+            images=(*self.images, *other.images),
+            files=(*self.files, *other.files),
+            videos=(*self.videos, *other.videos),
+        )

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -183,18 +183,6 @@ class _PreparedMaterializedTeamExecution:
         return self.messages[:-1]
 
 
-def _merge_media_inputs(first: MediaInputs, second: MediaInputs) -> MediaInputs:
-    """Concatenate two media-input sets preserving chronological order."""
-    if not first.has_any():
-        return second
-    return MediaInputs(
-        audio=(*first.audio, *second.audio),
-        images=(*first.images, *second.images),
-        files=(*first.files, *second.files),
-        videos=(*first.videos, *second.videos),
-    )
-
-
 class _TeamModeDecision(BaseModel):
     """AI decision for team collaboration mode."""
 
@@ -1641,7 +1629,7 @@ async def team_response(  # noqa: C901, PLR0912, PLR0915
             # Team runs flatten context messages to text, so media pinned to
             # thread-history messages is re-collected onto the current turn.
             context_media_inputs = ai_runtime.media_inputs_from_run_input(prepared_execution.messages)
-            media_inputs = _merge_media_inputs(context_media_inputs, media_inputs)
+            media_inputs = context_media_inputs.merge(media_inputs)
             logger.info("executing_team_response", agent_count=len(agents), mode=mode.value)
             logger.info("team_prompt_preview", agents=agent_list, prompt_preview=prompt[:500])
 
@@ -2069,7 +2057,7 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
             # Team runs flatten context messages to text, so media pinned to
             # thread-history messages is re-collected onto the current turn.
             context_media_inputs = ai_runtime.media_inputs_from_run_input(prepared_execution.messages)
-            media_inputs = _merge_media_inputs(context_media_inputs, media or MediaInputs())
+            media_inputs = context_media_inputs.merge(media or MediaInputs())
             inline_media_fallback_prompt = orchestrator.config.get_prompt("INLINE_MEDIA_FALLBACK_PROMPT")
             media_route = build_model_media_route(team.model) if media_inputs.has_any() else None
             media_filter = filter_media_inputs_for_route(media_route, media_inputs)

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -18,10 +18,10 @@ from mindroom.attachment_media import attachment_records_to_media, resolve_scope
 from mindroom.attachments import (
     AttachmentRecord,
     _attachment_id_for_event,
+    _attachment_ids_for_visible_message,
     _AttachmentKind,
     _register_image_attachment,
     _register_media_attachment,
-    attachment_ids_for_visible_message,
     filter_attachments_for_context,
     format_attachment_annotation,
     format_attachments_prompt,
@@ -443,16 +443,16 @@ def test_attachment_rendering_sanitizes_malicious_filenames() -> None:
     assert long_annotation == f'[attachments: att_2 (file, "{"a" * 79}…")]'
 
 
-def test_attachment_ids_for_visible_message_prefers_metadata() -> None:
+def test__attachment_ids_for_visible_message_prefers_metadata() -> None:
     """Metadata IDs win; raw media events map to the deterministic event ID."""
     metadata_message = make_visible_message(content={"com.mindroom.attachment_ids": ["att_meta"]})
-    assert attachment_ids_for_visible_message(metadata_message) == ["att_meta"]
+    assert _attachment_ids_for_visible_message(metadata_message) == ["att_meta"]
 
     media_message = make_visible_message(event_id="$img", content={"msgtype": "m.image", "body": "photo.jpg"})
-    assert attachment_ids_for_visible_message(media_message) == [_attachment_id_for_event("$img")]
+    assert _attachment_ids_for_visible_message(media_message) == [_attachment_id_for_event("$img")]
 
     text_message = make_visible_message(body="plain text", content={"msgtype": "m.text", "body": "plain text"})
-    assert attachment_ids_for_visible_message(text_message) == []
+    assert _attachment_ids_for_visible_message(text_message) == []
 
 
 def test_filter_attachments_for_context_enforces_room_and_thread(tmp_path: Path) -> None:

--- a/tests/test_dispatch_timing_instrumentation.py
+++ b/tests/test_dispatch_timing_instrumentation.py
@@ -62,6 +62,7 @@ async def test_stream_processing_marks_tool_call_started() -> None:
                 media_inputs=MediaInputs(),
                 retried_after_media_fallback=False,
                 timing_scope="test",
+                context_media_kinds=frozenset(),
             )
         ]
 

--- a/tests/test_media_fallback.py
+++ b/tests/test_media_fallback.py
@@ -190,10 +190,9 @@ def test_run_input_media_helpers_cover_pinned_history_media() -> None:
     current = Message(role="user", content="now")
     run_input = [history, current]
 
-    assert ai_runtime.run_input_media_kinds(run_input) == frozenset({"image", "audio"})
-    assert ai_runtime.run_input_media_kinds("plain prompt") == frozenset()
-
     collected = ai_runtime.media_inputs_from_run_input(run_input)
+    assert collected.kinds() == frozenset({"image", "audio"})
+    assert ai_runtime.media_inputs_from_run_input("plain prompt").kinds() == frozenset()
     assert list(collected.images) == [image]
     assert list(collected.audio) == [audio]
 
@@ -207,3 +206,18 @@ def test_run_input_media_helpers_cover_pinned_history_media() -> None:
     assert "[Inline media unavailable for this model]" in str(stripped[-1].content)
     # The original run input stays untouched for later retries.
     assert history.images == [image]
+
+
+def test_media_inputs_merge_concatenates_preserving_order() -> None:
+    """Merging media inputs keeps left-then-right (chronological) order per kind."""
+    history_image = Image(content=b"\x89PNG\r\n\x1a\nhistory")
+    current_image = Image(content=b"\x89PNG\r\n\x1a\ncurrent")
+    history = MediaInputs(images=(history_image,))
+    current = MediaInputs(images=(current_image,), audio=(Audio(content=b"audio-bytes", mime_type="audio/ogg"),))
+
+    merged = history.merge(current)
+
+    assert list(merged.images) == [history_image, current_image]
+    assert merged.kinds() == frozenset({"image", "audio"})
+    assert MediaInputs().merge(current) == current
+    assert history.merge(MediaInputs()) == history


### PR DESCRIPTION
## What

Follow-up to #1214 addressing the four findings from its retroactive review. 102 insertions, 98 deletions, all consolidation — no behavior changes.

**1. Dead strip-all default removed.** `append_inline_media_fallback_to_run_input` declared `removed_kinds: frozenset[MediaKind] | None = None` with a `None` → strip-all-kinds branch that no caller exercised (all six call sites in `ai.py` pass it explicitly). The parameter is now required and `_ALL_MEDIA_KINDS` is deleted.

**2. Never-used defaults dropped.** `_request_stream_retry` and `_process_stream_events` had `context_media_kinds: frozenset[MediaKind] = frozenset()` defaults that every caller overrode. Now required, so a future call site cannot silently skip context-media accounting.

**3. One source of truth for media-kind detection.** `MediaKind` moves to `media_inputs.py` alongside a new `MediaInputs.kinds()` and `MediaInputs.merge()`. This replaces three independent walks of the four media fields: `media_fallback._media_kinds_present`, `ai_runtime.run_input_media_kinds` (callers now use `media_inputs_from_run_input(run_input).kinds()`), and `teams._merge_media_inputs`.

**4. Attachment scoping policy lives in one module.** The per-message record-scope predicate (`_record_in_scope`) and resolution logic move from `execution_preparation._ThreadAttachmentContext` into `attachments.py` as `attachment_records_for_visible_message`, next to its sibling scope predicates (`filter_attachments_for_context`, `_thread_history_message_in_scope`). `_ThreadAttachmentContext` is now a thin room/storage binding for the render pipeline. `attachment_ids_for_visible_message` became module-private since its only external consumer was the moved code.

## Testing

- Full suite: 7922 passed, 61 skipped (one unrelated flake, `test_all_tools_can_be_imported`, hit the 60s import timeout under parallel load and passes in isolation).
- `pre-commit run --all-files` clean (ruff, ty, vulture, tach boundaries, module privacy).
- `tach check --dependencies --interfaces` clean — no boundary changes needed (`media_inputs`/`media_fallback` have no module entries; all importers already list `media_inputs`).
- New test: `MediaInputs.merge` order preservation and empty-side short-circuits; existing pinning/scoping tests cover the moved attachment logic unchanged.
