### PR TITLE
Make the ingress→execution response seam one-way

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,7 @@ Matrix sync callback
 | `response_attempt.py` | Runs one visible response attempt with placeholder and stop tracking |
 | `response_lifecycle.py` | Shared response lifecycle helpers and queued-notice state |
 | `execution_preparation.py` | Request-scoped execution preparation for prompts and persisted replay |
+| `response_payload_preparation.py` | Execution-side, under-lock assembly of one response's payload from immutable ingress inputs |
 | `delivery_gateway.py` | Visible Matrix delivery for already-generated responses (send, edit, finalize) |
 | `post_response_effects.py` | Shared post-response effects after Matrix delivery |
 | `tool_approval.py` | Tool-call approval rule evaluation and public approval API |

--- a/docs/architecture/bot-runtime.md
+++ b/docs/architecture/bot-runtime.md
@@ -84,10 +84,16 @@ That path sends the acknowledgment, runs response generation, and records the ha
 It sends thinking placeholders, registers stop tracking, runs the cancellable response task, logs cancellation provenance, and clears stop tracking.
 `ResponseRunner` keeps the existing attempt entry point, but delegates attempt mechanics through this deeper module.
 
+The ingress-to-execution seam is now one-way.
+Ingress (`TurnController` and `text_ingress_dispatch`) builds an immutable `ResponsePayloadPreparation` value and hands it to the runner inside `ResponseRequest`.
+The runner acquires the lifecycle lock, refreshes thread history, then calls `ResponsePayloadPreparer.prepare` as a first-class execution step to assemble the final payload, run enrichment hooks, and log startup latency.
+The old `prepare_after_lock` callback that ran payload building back inside `TurnController` is deleted; data crosses the seam as values, not closures.
+
 ## Next Simplification Work
 
-Shrink `ResponseRunner`.
-It should keep locking, streaming, AI or team execution, and post-response effects, but it should stop accumulating unrelated side paths.
+Shrink `ResponseRunner` further.
+It keeps locking, streaming, AI or team execution, and post-response effects.
+The under-lock payload-assembly side path now lives in `ResponsePayloadPreparer`; the remaining follow-up is to fold `execution_preparation.py` into the execution side and move any other side paths that belong to ingress or delivery out of `ResponseRunner`.
 
 Revisit `IngressHookRunner`.
 It may stay as a helper, but it should not grow into another top-level orchestration object.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -71,6 +71,7 @@ MindRoom's architecture consists of several key components working together.
 | `response_runner.py` | Response lifecycle execution (locking, streaming vs non-streaming, cancellation) |
 | `response_lifecycle.py` | Shared response lifecycle helpers and queued-notice state |
 | `execution_preparation.py` | Request-scoped execution preparation for prompts and persisted replay |
+| `response_payload_preparation.py` | Execution-side, under-lock assembly of one response's payload from immutable ingress inputs |
 | `delivery_gateway.py` | Visible Matrix delivery for already-generated responses (send, edit, finalize) |
 | `post_response_effects.py` | Shared post-response effects after Matrix delivery |
 | `routing.py` | Intelligent agent or team selection when no entity is mentioned |

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -13870,6 +13870,7 @@ MindRoom's architecture consists of several key components working together.
 | `response_runner.py` | Response lifecycle execution (locking, streaming vs non-streaming, cancellation) |
 | `response_lifecycle.py` | Shared response lifecycle helpers and queued-notice state |
 | `execution_preparation.py` | Request-scoped execution preparation for prompts and persisted replay |
+| `response_payload_preparation.py` | Execution-side, under-lock assembly of one response's payload from immutable ingress inputs |
 | `delivery_gateway.py` | Visible Matrix delivery for already-generated responses (send, edit, finalize) |
 | `post_response_effects.py` | Shared post-response effects after Matrix delivery |
 | `routing.py` | Intelligent agent or team selection when no entity is mentioned |

--- a/skills/mindroom-docs/references/page__architecture__index.md
+++ b/skills/mindroom-docs/references/page__architecture__index.md
@@ -67,6 +67,7 @@ MindRoom's architecture consists of several key components working together.
 | `response_runner.py` | Response lifecycle execution (locking, streaming vs non-streaming, cancellation) |
 | `response_lifecycle.py` | Shared response lifecycle helpers and queued-notice state |
 | `execution_preparation.py` | Request-scoped execution preparation for prompts and persisted replay |
+| `response_payload_preparation.py` | Execution-side, under-lock assembly of one response's payload from immutable ingress inputs |
 | `delivery_gateway.py` | Visible Matrix delivery for already-generated responses (send, edit, finalize) |
 | `post_response_effects.py` | Shared post-response effects after Matrix delivery |
 | `routing.py` | Intelligent agent or team selection when no entity is mentioned |

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -98,6 +98,7 @@ from .matrix.room_member_joins import (
     room_member_joins_from_sync_timeline,
 )
 from .media_inputs import MediaInputs
+from .response_payload_preparation import ResponsePayloadPreparer
 from .response_runner import ResponseRequest, ResponseRunner, ResponseRunnerDeps, prepare_memory_and_model_context
 from .scheduling import (
     cancel_all_running_scheduled_tasks,
@@ -288,6 +289,7 @@ class AgentBot:
     _tool_runtime_support: ToolRuntimeSupport
     _post_response_effects_support: PostResponseEffectsSupport
     _ingress_hook_runner: IngressHookRunner
+    _request_payload_preparer: ResponsePayloadPreparer
     _hook_context_support: HookContextSupport
     _knowledge_access_support: KnowledgeAccessSupport
     _deferred_overdue_task_drain_task: asyncio.Task[None] | None
@@ -459,6 +461,15 @@ class AgentBot:
             delivery_gateway=self._delivery_gateway,
             conversation_cache=self._conversation_cache,
         )
+        self._ingress_hook_runner = IngressHookRunner(
+            hook_context=self._hook_context_support,
+        )
+        self._request_payload_preparer = ResponsePayloadPreparer(
+            normalizer=self._inbound_turn_normalizer,
+            ingress_hook_runner=self._ingress_hook_runner,
+            agent_name=self.agent_name,
+            logger=self.logger,
+        )
         self._response_runner = ResponseRunner(
             ResponseRunnerDeps(
                 runtime=self._runtime_view,
@@ -474,10 +485,8 @@ class AgentBot:
                 delivery_gateway=self._delivery_gateway,
                 post_response_effects=self._post_response_effects_support,
                 state_writer=self._conversation_state_writer,
+                request_preparer=self._request_payload_preparer,
             ),
-        )
-        self._ingress_hook_runner = IngressHookRunner(
-            hook_context=self._hook_context_support,
         )
         self._edit_regenerator = EditRegenerator(
             EditRegeneratorDeps(

--- a/src/mindroom/response_payload_preparation.py
+++ b/src/mindroom/response_payload_preparation.py
@@ -58,6 +58,7 @@ class ResponsePayloadPreparation:
 
     dispatch: PreparedDispatch
     prompt: str
+    action_kind: str
     message_attachment_ids: tuple[str, ...]
     trusted_attachment_ids: tuple[str, ...]
     media_events: tuple[MediaDispatchEvent, ...]
@@ -190,6 +191,7 @@ class ResponsePayloadPreparer:
         """Emit startup latency metrics for one dispatch that will respond."""
         latency_event_data: dict[str, str | float | int | bool] = {
             "event_id": preparation.dispatch.envelope.source_event_id,
+            "action_kind": preparation.action_kind,
             "context_hydration_ms": elapsed_ms_between(
                 preparation.dispatch_started_at,
                 preparation.context_ready_monotonic,

--- a/src/mindroom/response_payload_preparation.py
+++ b/src/mindroom/response_payload_preparation.py
@@ -59,9 +59,7 @@ class ResponsePayloadPreparation:
     dispatch: PreparedDispatch
     prompt: str
     action_kind: str
-    message_attachment_ids: tuple[str, ...]
-    trusted_attachment_ids: tuple[str, ...]
-    media_events: tuple[MediaDispatchEvent, ...]
+    payload_inputs: DispatchPayloadInputs
     target_member_names: tuple[str, ...] | None
     dispatch_started_at: float
     context_ready_monotonic: float
@@ -119,7 +117,6 @@ class ResponsePayloadPreparer:
         )
         return replace(
             request,
-            thread_history=request.thread_history,
             prompt=prepared_payload.payload.prompt,
             model_prompt=prepared_payload.payload.model_prompt,
             media=prepared_payload.payload.media,
@@ -138,6 +135,7 @@ class ResponsePayloadPreparer:
     ) -> DispatchPayload:
         """Register batch media and merge attachment context into one payload."""
         dispatch = preparation.dispatch
+        payload_inputs = preparation.payload_inputs
         room_id = dispatch.target.room_id
         media_thread_id = dispatch.target.resolved_thread_id
         payload_builder_started = time.monotonic()
@@ -145,12 +143,12 @@ class ResponsePayloadPreparer:
         try:
             media_attachment_ids: list[str] = []
             fallback_images = None
-            if preparation.media_events:
+            if payload_inputs.media_events:
                 media_result = await self.normalizer.register_batch_media_attachments(
                     BatchMediaAttachmentRequest(
                         room_id=room_id,
                         thread_id=media_thread_id,
-                        media_events=list(preparation.media_events),
+                        media_events=list(payload_inputs.media_events),
                     ),
                 )
                 media_attachment_ids = media_result.attachment_ids
@@ -160,10 +158,10 @@ class ResponsePayloadPreparer:
                     room_id=room_id,
                     prompt=preparation.prompt,
                     current_attachment_ids=merge_attachment_ids(
-                        list(preparation.message_attachment_ids),
+                        list(payload_inputs.message_attachment_ids),
                         media_attachment_ids,
                     ),
-                    trusted_current_attachment_ids=list(preparation.trusted_attachment_ids),
+                    trusted_current_attachment_ids=list(payload_inputs.trusted_attachment_ids),
                     thread_id=dispatch.context.thread_id,
                     media_thread_id=media_thread_id,
                     thread_history=thread_history,

--- a/src/mindroom/response_payload_preparation.py
+++ b/src/mindroom/response_payload_preparation.py
@@ -1,0 +1,208 @@
+"""Execution-side, under-lock assembly of one response request's payload.
+
+Ingress (``TurnController`` + ``text_ingress_dispatch``) builds a complete,
+immutable :class:`ResponsePayloadPreparation` value and hands it to the
+response runner inside the :class:`~mindroom.response_runner.ResponseRequest`.
+Once the runner owns the lifecycle lock and has refreshed thread history, it
+calls :meth:`ResponsePayloadPreparer.prepare` to finish assembling the request.
+
+This is the execution-side counterpart of what used to be a ``prepare_after_lock``
+callback into the caller: the data crosses the seam as values, and the work runs
+here as a first-class named step rather than as a closure back into ingress.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING
+
+from mindroom.attachments import merge_attachment_ids
+from mindroom.inbound_turn_normalizer import (
+    BatchMediaAttachmentRequest,
+    DispatchPayloadWithAttachmentsRequest,
+)
+from mindroom.matrix.cache import ThreadHistoryResult
+from mindroom.timing import elapsed_ms_between, emit_elapsed_timing
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    import structlog
+
+    from mindroom.dispatch_handoff import MediaDispatchEvent
+    from mindroom.inbound_turn_normalizer import DispatchPayload, InboundTurnNormalizer
+    from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
+    from mindroom.response_runner import ResponseRequest
+    from mindroom.turn_policy import IngressHookRunner, PreparedDispatch
+
+
+@dataclass(frozen=True)
+class DispatchPayloadInputs:
+    """Attachment and media inputs produced by ingress for one response payload."""
+
+    message_attachment_ids: tuple[str, ...]
+    trusted_attachment_ids: tuple[str, ...]
+    media_events: tuple[MediaDispatchEvent, ...]
+
+
+@dataclass(frozen=True)
+class ResponsePayloadPreparation:
+    """Immutable ingress inputs for the under-lock payload-assembly step.
+
+    Everything here is a value captured at dispatch time. The only input that
+    is *not* carried is the model-facing thread history, which the runner
+    refreshes after acquiring the lifecycle lock and supplies through
+    ``ResponseRequest.thread_history``.
+    """
+
+    dispatch: PreparedDispatch
+    prompt: str
+    message_attachment_ids: tuple[str, ...]
+    trusted_attachment_ids: tuple[str, ...]
+    media_events: tuple[MediaDispatchEvent, ...]
+    target_member_names: tuple[str, ...] | None
+    dispatch_started_at: float
+    context_ready_monotonic: float
+
+
+@dataclass
+class ResponsePayloadPreparer:
+    """Assemble the final payload for one response request under the lock."""
+
+    normalizer: InboundTurnNormalizer
+    ingress_hook_runner: IngressHookRunner
+    agent_name: str
+    logger: structlog.stdlib.BoundLogger
+
+    async def prepare(self, request: ResponseRequest) -> ResponseRequest:
+        """Return ``request`` with its payload built from refreshed history.
+
+        The runner has already refreshed ``request.thread_history`` and verified
+        that ``request.payload_preparation`` is set before calling this.
+        """
+        preparation = request.payload_preparation
+        assert preparation is not None
+        dispatch = preparation.dispatch
+        pipeline_timing = request.pipeline_timing
+        if pipeline_timing is not None:
+            pipeline_timing.mark("response_payload_start")
+
+        payload = await self._build_payload(preparation, thread_history=request.thread_history)
+
+        prepared_payload = await self.ingress_hook_runner.apply_message_enrichment(
+            dispatch,
+            payload,
+            target_entity_name=self.agent_name,
+            target_member_names=preparation.target_member_names,
+        )
+        system_enrichment_items = await self.ingress_hook_runner.apply_system_enrichment(
+            dispatch,
+            prepared_payload.envelope,
+            target_entity_name=self.agent_name,
+            target_member_names=preparation.target_member_names,
+        )
+        if system_enrichment_items:
+            prepared_payload = replace(
+                prepared_payload,
+                system_enrichment_items=tuple(system_enrichment_items),
+            )
+
+        payload_ready_monotonic = time.monotonic()
+        if pipeline_timing is not None:
+            pipeline_timing.mark("response_payload_ready")
+        self._log_dispatch_latency(
+            preparation,
+            payload_ready_monotonic=payload_ready_monotonic,
+            thread_history=request.thread_history,
+        )
+        return replace(
+            request,
+            thread_history=request.thread_history,
+            prompt=prepared_payload.payload.prompt,
+            model_prompt=prepared_payload.payload.model_prompt,
+            media=prepared_payload.payload.media,
+            attachment_ids=tuple(prepared_payload.payload.attachment_ids or ()),
+            response_envelope=prepared_payload.envelope,
+            system_enrichment_items=prepared_payload.system_enrichment_items,
+            requires_model_history_refresh=False,
+            payload_preparation=None,
+        )
+
+    async def _build_payload(
+        self,
+        preparation: ResponsePayloadPreparation,
+        *,
+        thread_history: Sequence[ResolvedVisibleMessage],
+    ) -> DispatchPayload:
+        """Register batch media and merge attachment context into one payload."""
+        dispatch = preparation.dispatch
+        room_id = dispatch.target.room_id
+        media_thread_id = dispatch.target.resolved_thread_id
+        payload_builder_started = time.monotonic()
+        payload_builder_outcome = "failed"
+        try:
+            media_attachment_ids: list[str] = []
+            fallback_images = None
+            if preparation.media_events:
+                media_result = await self.normalizer.register_batch_media_attachments(
+                    BatchMediaAttachmentRequest(
+                        room_id=room_id,
+                        thread_id=media_thread_id,
+                        media_events=list(preparation.media_events),
+                    ),
+                )
+                media_attachment_ids = media_result.attachment_ids
+                fallback_images = media_result.fallback_images
+            payload = await self.normalizer.build_dispatch_payload_with_attachments(
+                DispatchPayloadWithAttachmentsRequest(
+                    room_id=room_id,
+                    prompt=preparation.prompt,
+                    current_attachment_ids=merge_attachment_ids(
+                        list(preparation.message_attachment_ids),
+                        media_attachment_ids,
+                    ),
+                    trusted_current_attachment_ids=list(preparation.trusted_attachment_ids),
+                    thread_id=dispatch.context.thread_id,
+                    media_thread_id=media_thread_id,
+                    thread_history=thread_history,
+                    fallback_images=fallback_images,
+                ),
+            )
+            payload_builder_outcome = "success"
+            return payload
+        finally:
+            emit_elapsed_timing(
+                "response_payload.builder",
+                payload_builder_started,
+                room_id=room_id,
+                thread_id=media_thread_id,
+                outcome=payload_builder_outcome,
+            )
+
+    def _log_dispatch_latency(
+        self,
+        preparation: ResponsePayloadPreparation,
+        *,
+        payload_ready_monotonic: float,
+        thread_history: Sequence[ResolvedVisibleMessage],
+    ) -> None:
+        """Emit startup latency metrics for one dispatch that will respond."""
+        latency_event_data: dict[str, str | float | int | bool] = {
+            "event_id": preparation.dispatch.envelope.source_event_id,
+            "context_hydration_ms": elapsed_ms_between(
+                preparation.dispatch_started_at,
+                preparation.context_ready_monotonic,
+            ),
+            "payload_hydration_ms": elapsed_ms_between(
+                preparation.context_ready_monotonic,
+                payload_ready_monotonic,
+            ),
+            "startup_total_ms": elapsed_ms_between(
+                preparation.dispatch_started_at,
+                payload_ready_monotonic,
+            ),
+        }
+        if isinstance(thread_history, ThreadHistoryResult):
+            latency_event_data.update(thread_history.diagnostics)
+        self.logger.info("Response startup latency", **latency_event_data)

--- a/src/mindroom/response_payload_preparation.py
+++ b/src/mindroom/response_payload_preparation.py
@@ -6,9 +6,8 @@ response runner inside the :class:`~mindroom.response_runner.ResponseRequest`.
 Once the runner owns the lifecycle lock and has refreshed thread history, it
 calls :meth:`ResponsePayloadPreparer.prepare` to finish assembling the request.
 
-This is the execution-side counterpart of what used to be a ``prepare_after_lock``
-callback into the caller: the data crosses the seam as values, and the work runs
-here as a first-class named step rather than as a closure back into ingress.
+Data crosses the seam as values, and the work runs here as a first-class named
+step rather than as a closure back into ingress.
 """
 
 from __future__ import annotations

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -97,6 +97,7 @@ if TYPE_CHECKING:
     from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
     from mindroom.matrix.identity import MatrixID
     from mindroom.message_target import MessageTarget
+    from mindroom.response_payload_preparation import ResponsePayloadPreparation, ResponsePayloadPreparer
     from mindroom.stop import StopManager
     from mindroom.streaming import StreamInputChunk
     from mindroom.tool_system.events import ToolTraceEntry
@@ -274,7 +275,7 @@ class ResponseRequest:
     matrix_run_metadata: Mapping[str, Any] | None = None
     system_enrichment_items: tuple[EnrichmentItem, ...] = ()
     requires_model_history_refresh: bool = False
-    prepare_after_lock: Callable[[ResponseRequest], Awaitable[ResponseRequest]] | None = None
+    payload_preparation: ResponsePayloadPreparation | None = None
     on_lifecycle_lock_acquired: Callable[[], None] | None = None
     pipeline_timing: DispatchPipelineTiming | None = None
     queued_notice_reservation: QueuedHumanNoticeReservation | None = None
@@ -326,6 +327,7 @@ class ResponseRunnerDeps:
     delivery_gateway: DeliveryGateway
     post_response_effects: PostResponseEffectsSupport
     state_writer: ConversationStateWriter
+    request_preparer: ResponsePayloadPreparer
 
 
 @dataclass(frozen=True)
@@ -713,9 +715,9 @@ class ResponseRunner:
         """Refresh thread history and rebuild any history-derived payload once locked."""
         try:
             request = await self._refresh_model_history_after_lock(request)
-            if request.prepare_after_lock is None:
+            if request.payload_preparation is None:
                 return request
-            return await request.prepare_after_lock(request)
+            return await self.deps.request_preparer.prepare(request)
         except Exception as exc:
             raise PostLockRequestPreparationError from exc
 

--- a/src/mindroom/text_ingress_dispatch.py
+++ b/src/mindroom/text_ingress_dispatch.py
@@ -6,7 +6,7 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, Protocol
 
-from mindroom.attachments import merge_attachment_ids, parse_attachment_ids_from_event_source
+from mindroom.attachments import parse_attachment_ids_from_event_source
 from mindroom.commands.parsing import command_parser
 from mindroom.constants import ATTACHMENT_IDS_KEY, ORIGINAL_SENDER_KEY, ROUTER_AGENT_NAME, VOICE_RAW_AUDIO_FALLBACK_KEY
 from mindroom.dispatch_handoff import (
@@ -20,14 +20,10 @@ from mindroom.dispatch_handoff import (
 )
 from mindroom.dispatch_source import VOICE_SOURCE_KIND, is_voice_event
 from mindroom.handled_turns import HandledTurnState
-from mindroom.inbound_turn_normalizer import (
-    BatchMediaAttachmentRequest,
-    DispatchPayload,
-    DispatchPayloadWithAttachmentsRequest,
-    TextNormalizationRequest,
-)
+from mindroom.inbound_turn_normalizer import TextNormalizationRequest
 from mindroom.matrix.media import is_audio_message_event, is_matrix_media_dispatch_event
 from mindroom.matrix.rooms import is_dm_room
+from mindroom.response_payload_preparation import DispatchPayloadInputs
 from mindroom.timing import (
     DispatchPipelineTiming,
     attach_dispatch_pipeline_timing,
@@ -42,7 +38,6 @@ if TYPE_CHECKING:
     import nio
 
     from mindroom.commands.parsing import Command
-    from mindroom.conversation_resolver import MessageContext
     from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
     from mindroom.response_lifecycle import QueuedHumanNoticeReservation
     from mindroom.turn_controller import TurnController
@@ -365,42 +360,18 @@ async def _apply_turn_plan(
         conversation_target=prepared.dispatch.target,
     )
 
-    async def build_payload(context: MessageContext) -> DispatchPayload:
-        effective_thread_id = prepared.dispatch.target.resolved_thread_id
-        media_attachment_ids: list[str] = []
-        fallback_images = None
-        if media_events:
-            media_result = await controller.deps.normalizer.register_batch_media_attachments(
-                BatchMediaAttachmentRequest(
-                    room_id=room.room_id,
-                    thread_id=effective_thread_id,
-                    media_events=media_events,
-                ),
-            )
-            media_attachment_ids = media_result.attachment_ids
-            fallback_images = media_result.fallback_images
-        return await controller.deps.normalizer.build_dispatch_payload_with_attachments(
-            DispatchPayloadWithAttachmentsRequest(
-                room_id=room.room_id,
-                prompt=prepared.event.body,
-                current_attachment_ids=merge_attachment_ids(
-                    message_attachment_ids,
-                    media_attachment_ids,
-                ),
-                trusted_current_attachment_ids=trusted_attachment_ids,
-                thread_id=context.thread_id,
-                media_thread_id=effective_thread_id,
-                thread_history=context.thread_history,
-                fallback_images=fallback_images,
-            ),
-        )
+    payload_inputs = DispatchPayloadInputs(
+        message_attachment_ids=tuple(message_attachment_ids),
+        trusted_attachment_ids=tuple(trusted_attachment_ids),
+        media_events=tuple(media_events or ()),
+    )
 
     await controller._execute_response_action(
         room,
         prepared.event,
         prepared.dispatch,
         plan.response_action,
-        build_payload,
+        payload_inputs,
         processing_log="Processing",
         dispatch_started_at=prepared.dispatch_started_at,
         handled_turn=handled_turn,

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -1703,7 +1703,7 @@ class TurnController:
             ),
         )
 
-    async def _execute_response_action(  # noqa: C901, PLR0912, PLR0915
+    async def _execute_response_action(  # noqa: C901, PLR0912
         self,
         room: nio.MatrixRoom,
         event: DispatchEvent,
@@ -1763,20 +1763,7 @@ class TurnController:
                     for member in action.form_team.eligible_members
                 )
 
-            try:
-                context_ready_monotonic = time.monotonic()
-            except Exception as error:
-                response_event_id = await self._finalize_dispatch_failure(
-                    target=dispatch.target,
-                    error=error,
-                )
-                if response_event_id is not None:
-                    self._mark_source_events_responded(handled_turn.with_response_event_id(response_event_id))
-                    if dispatch_timing is not None:
-                        dispatch_timing.mark_first_visible_reply("final")
-                        dispatch_timing.mark("response_complete")
-                        dispatch_timing.emit_summary(self.deps.logger, outcome="dispatch_failure")
-                return
+            context_ready_monotonic = time.monotonic()
 
             if dispatch_timing is not None and isinstance(dispatch.context.thread_history, ThreadHistoryResult):
                 dispatch_timing.note(**dispatch.context.thread_history.diagnostics)
@@ -1786,9 +1773,7 @@ class TurnController:
                 dispatch=dispatch,
                 prompt=event.body,
                 action_kind=action.kind,
-                message_attachment_ids=payload_inputs.message_attachment_ids,
-                trusted_attachment_ids=payload_inputs.trusted_attachment_ids,
-                media_events=payload_inputs.media_events,
+                payload_inputs=payload_inputs,
                 target_member_names=target_member_names,
                 dispatch_started_at=dispatch_started_at,
                 context_ready_monotonic=context_ready_monotonic,

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -1785,6 +1785,7 @@ class TurnController:
             payload_preparation = ResponsePayloadPreparation(
                 dispatch=dispatch,
                 prompt=event.body,
+                action_kind=action.kind,
                 message_attachment_ids=payload_inputs.message_attachment_ids,
                 trusted_attachment_ids=payload_inputs.trusted_attachment_ids,
                 media_events=payload_inputs.media_events,

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -69,7 +69,6 @@ from mindroom.error_handling import get_user_friendly_error_message
 from mindroom.handled_turns import HandledTurnState
 from mindroom.hooks import MessageEnvelope, build_hook_matrix_admin, hook_ingress_policy
 from mindroom.inbound_turn_normalizer import (
-    DispatchPayload,
     InboundTurnNormalizer,
     TextNormalizationRequest,
     VoiceNormalizationRequest,
@@ -90,6 +89,10 @@ from mindroom.matrix.media import (
 )
 from mindroom.matrix.message_content import is_v2_sidecar_text_preview
 from mindroom.prompt_ingress_reservation import PromptIngressReservationOwner as _PromptIngressReservationOwner
+from mindroom.response_payload_preparation import (
+    DispatchPayloadInputs,
+    ResponsePayloadPreparation,
+)
 from mindroom.response_runner import PostLockRequestPreparationError, ResponseRequest
 from mindroom.routing import suggest_responder_for_message
 from mindroom.teams import TeamIntent, select_ad_hoc_team_mode
@@ -103,7 +106,6 @@ from mindroom.timing import (
     DispatchPipelineTiming,
     attach_dispatch_pipeline_timing,
     create_dispatch_pipeline_timing,
-    elapsed_ms_between,
     emit_elapsed_timing,
     event_timing_scope,
     get_dispatch_pipeline_timing,
@@ -117,13 +119,13 @@ from mindroom.turn_origin import (
 from mindroom.turn_policy import IngressHookRunner, PreparedDispatch, ResponseAction, TurnPolicy
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable, Sequence
+    from collections.abc import Sequence
 
     import structlog
 
     from mindroom.bot_runtime_view import BotRuntimeView
     from mindroom.commands.parsing import Command
-    from mindroom.conversation_resolver import ConversationResolver, MessageContext
+    from mindroom.conversation_resolver import ConversationResolver
     from mindroom.delivery_gateway import DeliveryGateway
     from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
     from mindroom.matrix.conversation_cache import MatrixConversationCache
@@ -134,7 +136,6 @@ if TYPE_CHECKING:
     from mindroom.tool_system.runtime_context import ToolRuntimeSupport
     from mindroom.turn_store import TurnStore
 
-type _DispatchPayloadBuilder = Callable[[MessageContext], Awaitable[DispatchPayload]]
 
 _QUEUED_NOTICE_METADATA_KIND = "queued_notice_reservation"
 
@@ -1702,38 +1703,13 @@ class TurnController:
             ),
         )
 
-    def _log_dispatch_latency(
-        self,
-        *,
-        event_id: str,
-        action_kind: str,
-        dispatch_started_at: float,
-        context_ready_monotonic: float,
-        payload_ready_monotonic: float,
-        thread_history: Sequence[ResolvedVisibleMessage],
-    ) -> None:
-        """Emit startup latency metrics for dispatch decisions that will respond."""
-        latency_event_data: dict[str, str | float | int | bool] = {
-            "event_id": event_id,
-            "action_kind": action_kind,
-            "context_hydration_ms": elapsed_ms_between(dispatch_started_at, context_ready_monotonic),
-            "payload_hydration_ms": elapsed_ms_between(context_ready_monotonic, payload_ready_monotonic),
-            "startup_total_ms": elapsed_ms_between(dispatch_started_at, payload_ready_monotonic),
-        }
-        if isinstance(thread_history, ThreadHistoryResult):
-            latency_event_data.update(thread_history.diagnostics)
-        self.deps.logger.info(
-            "Response startup latency",
-            **latency_event_data,
-        )
-
     async def _execute_response_action(  # noqa: C901, PLR0912, PLR0915
         self,
         room: nio.MatrixRoom,
         event: DispatchEvent,
         dispatch: PreparedDispatch,
         action: ResponseAction,
-        payload_builder: _DispatchPayloadBuilder,
+        payload_inputs: DispatchPayloadInputs,
         *,
         processing_log: str,
         dispatch_started_at: float,
@@ -1789,7 +1765,6 @@ class TurnController:
 
             try:
                 context_ready_monotonic = time.monotonic()
-                payload_ready_monotonic = context_ready_monotonic
             except Exception as error:
                 response_event_id = await self._finalize_dispatch_failure(
                     target=dispatch.target,
@@ -1807,82 +1782,17 @@ class TurnController:
                 dispatch_timing.note(**dispatch.context.thread_history.diagnostics)
 
             self.deps.logger.info(processing_log, event_id=event.event_id)
+            payload_preparation = ResponsePayloadPreparation(
+                dispatch=dispatch,
+                prompt=event.body,
+                message_attachment_ids=payload_inputs.message_attachment_ids,
+                trusted_attachment_ids=payload_inputs.trusted_attachment_ids,
+                media_events=payload_inputs.media_events,
+                target_member_names=target_member_names,
+                dispatch_started_at=dispatch_started_at,
+                context_ready_monotonic=context_ready_monotonic,
+            )
             try:
-
-                async def prepare_request_after_lock(request: ResponseRequest) -> ResponseRequest:
-                    nonlocal dispatch
-                    nonlocal payload_ready_monotonic
-                    if dispatch_timing is not None:
-                        dispatch_timing.mark("response_payload_start")
-                    dispatch = replace(
-                        dispatch,
-                        context=replace(
-                            dispatch.context,
-                            thread_history=request.thread_history,
-                            requires_model_history_refresh=request.requires_model_history_refresh,
-                        ),
-                    )
-                    payload_builder_started = time.monotonic()
-                    payload_builder_outcome = "failed"
-                    try:
-                        payload = await payload_builder(dispatch.context)
-                        payload_builder_outcome = "success"
-                    finally:
-                        emit_elapsed_timing(
-                            "response_payload.builder",
-                            payload_builder_started,
-                            room_id=request.room_id,
-                            thread_id=request.thread_id,
-                            outcome=payload_builder_outcome,
-                        )
-                    prepared_payload = await self.deps.ingress_hook_runner.apply_message_enrichment(
-                        dispatch,
-                        payload,
-                        target_entity_name=self.deps.agent_name,
-                        target_member_names=target_member_names,
-                    )
-                    system_enrichment_items = await self.deps.ingress_hook_runner.apply_system_enrichment(
-                        dispatch,
-                        prepared_payload.envelope,
-                        target_entity_name=self.deps.agent_name,
-                        target_member_names=target_member_names,
-                    )
-                    if system_enrichment_items:
-                        prepared_payload = type(prepared_payload)(
-                            payload=prepared_payload.payload,
-                            envelope=prepared_payload.envelope,
-                            system_enrichment_items=tuple(system_enrichment_items),
-                        )
-                    payload_ready_monotonic = time.monotonic()
-                    if dispatch_timing is not None:
-                        dispatch_timing.mark("response_payload_ready")
-                    self._log_dispatch_latency(
-                        event_id=event.event_id,
-                        action_kind=action.kind,
-                        dispatch_started_at=dispatch_started_at,
-                        context_ready_monotonic=context_ready_monotonic,
-                        payload_ready_monotonic=payload_ready_monotonic,
-                        thread_history=request.thread_history,
-                    )
-                    return ResponseRequest(
-                        thread_history=request.thread_history,
-                        prompt=prepared_payload.payload.prompt,
-                        model_prompt=prepared_payload.payload.model_prompt,
-                        existing_event_id=request.existing_event_id,
-                        existing_event_is_placeholder=request.existing_event_is_placeholder,
-                        user_id=request.user_id,
-                        media=prepared_payload.payload.media,
-                        attachment_ids=tuple(prepared_payload.payload.attachment_ids or ()),
-                        response_envelope=prepared_payload.envelope,
-                        correlation_id=request.correlation_id,
-                        matrix_run_metadata=matrix_run_metadata,
-                        system_enrichment_items=prepared_payload.system_enrichment_items,
-                        requires_model_history_refresh=False,
-                        on_lifecycle_lock_acquired=request.on_lifecycle_lock_acquired,
-                        pipeline_timing=request.pipeline_timing,
-                        queued_notice_reservation=request.queued_notice_reservation,
-                    )
-
                 if action.kind == "team":
                     assert action.form_team is not None
                     assert action.form_team.mode is not None
@@ -1903,7 +1813,7 @@ class TurnController:
                             correlation_id=dispatch.correlation_id,
                             matrix_run_metadata=matrix_run_metadata,
                             requires_model_history_refresh=dispatch.context.requires_model_history_refresh,
-                            prepare_after_lock=prepare_request_after_lock,
+                            payload_preparation=payload_preparation,
                             pipeline_timing=dispatch_timing,
                             queued_notice_reservation=queued_notice_reservation,
                         ),
@@ -1920,7 +1830,7 @@ class TurnController:
                             correlation_id=dispatch.correlation_id,
                             matrix_run_metadata=matrix_run_metadata,
                             requires_model_history_refresh=dispatch.context.requires_model_history_refresh,
-                            prepare_after_lock=prepare_request_after_lock,
+                            payload_preparation=payload_preparation,
                             pipeline_timing=dispatch_timing,
                             queued_notice_reservation=queued_notice_reservation,
                         ),

--- a/tach.toml
+++ b/tach.toml
@@ -1795,6 +1795,7 @@ depends_on = [
     "mindroom.matrix.users",
     "mindroom.matrix.visible_body",
     "mindroom.post_response_effects",
+    "mindroom.response_payload_preparation",
     "mindroom.response_runner",
     "mindroom.scheduling",
     "mindroom.teams",
@@ -2238,6 +2239,21 @@ depends_on = ["mindroom.coalescing"]
 visibility = ["mindroom.turn_controller"]
 
 [[modules]]
+path = "mindroom.response_payload_preparation"
+depends_on = [
+    "mindroom.attachments",
+    "mindroom.inbound_turn_normalizer",
+    "mindroom.matrix.cache",
+    "mindroom.timing",
+]
+visibility = [
+    "mindroom.bot",
+    "mindroom.response_runner",
+    "mindroom.text_ingress_dispatch",
+    "mindroom.turn_controller",
+]
+
+[[modules]]
 path = "mindroom.text_ingress_dispatch"
 depends_on = [
     "mindroom.attachments",
@@ -2250,6 +2266,7 @@ depends_on = [
     "mindroom.matrix.media",
     "mindroom.matrix.rooms",
     "mindroom.response_lifecycle",
+    "mindroom.response_payload_preparation",
     "mindroom.timing",
 ]
 visibility = ["mindroom.turn_controller"]
@@ -2275,6 +2292,7 @@ depends_on = [
     "mindroom.metadata_merge",
     "mindroom.prompt_ingress_reservation",
     "mindroom.response_lifecycle",
+    "mindroom.response_payload_preparation",
     "mindroom.response_runner",
     "mindroom.routing",
     "mindroom.teams",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,7 @@ from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.thread_diagnostics import is_thread_history_degraded
 from mindroom.media_fallback import reset_model_media_capability_cache
 from mindroom.message_target import MessageTarget
+from mindroom.response_payload_preparation import ResponsePayloadPreparer
 from mindroom.response_runner import PostLockRequestPreparationError, ResponseRequest, ResponseRunner
 from mindroom.runtime_support import StartupThreadPrewarmRegistry
 from mindroom.thread_utils import decide_agent_response
@@ -830,7 +831,27 @@ def wrap_extracted_collaborators(bot: RuntimeBot, *names: str) -> RuntimeBot:
         if isinstance(collaborator, MagicMock | _ExtractedCollaboratorProxy):
             continue
         setattr(bot, name, _ExtractedCollaboratorProxy(collaborator))
+    _sync_request_payload_preparer(bot)
     return bot
+
+
+def _sync_request_payload_preparer(bot: RuntimeBot) -> None:
+    """Repoint the response runner's payload preparer at the current collaborators.
+
+    The preparer captures the normalizer and ingress hook runner; tests swap
+    those for proxies after construction, so rebuild the preparer to track them.
+    """
+    if getattr(bot, "_request_payload_preparer", None) is None:
+        return
+    runner = unwrap_extracted_collaborator(bot._response_runner)
+    preparer = ResponsePayloadPreparer(
+        normalizer=bot._inbound_turn_normalizer,
+        ingress_hook_runner=bot._ingress_hook_runner,
+        agent_name=runner.deps.agent_name,
+        logger=runner.deps.logger,
+    )
+    bot._request_payload_preparer = preparer
+    runner.deps = replace(runner.deps, request_preparer=preparer)
 
 
 def sync_bot_runtime_state(bot: RuntimeBot) -> None:
@@ -1043,9 +1064,9 @@ def install_generate_response_mock(bot: RuntimeBot, generate_response: AsyncMock
         return result
 
     async def _generate(request: ResponseRequest) -> str | None:
-        if request.prepare_after_lock is not None:
+        if request.payload_preparation is not None:
             try:
-                request = await request.prepare_after_lock(request)
+                request = await bot._request_payload_preparer.prepare(request)
             except Exception as exc:
                 raise PostLockRequestPreparationError from exc
         attachment_ids = list(request.attachment_ids) if request.attachment_ids is not None else None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ from contextlib import ExitStack, contextmanager
 from dataclasses import replace
 from itertools import count
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import nio
@@ -42,7 +42,11 @@ from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.thread_diagnostics import is_thread_history_degraded
 from mindroom.media_fallback import reset_model_media_capability_cache
 from mindroom.message_target import MessageTarget
-from mindroom.response_payload_preparation import ResponsePayloadPreparer
+from mindroom.response_payload_preparation import (
+    DispatchPayloadInputs,
+    ResponsePayloadPreparation,
+    ResponsePayloadPreparer,
+)
 from mindroom.response_runner import PostLockRequestPreparationError, ResponseRequest, ResponseRunner
 from mindroom.runtime_support import StartupThreadPrewarmRegistry
 from mindroom.thread_utils import decide_agent_response
@@ -53,6 +57,7 @@ from mindroom.turn_store import TurnStore
 from tests.identity_helpers import persist_entity_accounts
 
 if TYPE_CHECKING:
+    from mindroom.dispatch_handoff import DispatchEvent
     from mindroom.matrix.cache import ConversationEventCache
 
 __all__ = [
@@ -88,6 +93,7 @@ __all__ = [
     "patch_response_runner_module",
     "postgres_event_cache_url",
     "prepare_history_for_run_for_test",
+    "prepare_payload_via_seam",
     "prepared_dispatch_result",
     "replace_delivery_gateway_deps",
     "replace_edit_regenerator_deps",
@@ -850,6 +856,29 @@ def _sync_request_payload_preparer(bot: RuntimeBot) -> None:
     )
     bot._request_payload_preparer = preparer
     runner.deps = replace(runner.deps, request_preparer=preparer)
+
+
+async def prepare_payload_via_seam(bot: RuntimeBot, execute_args: tuple[object, ...]) -> None:
+    """Drive the execution-side payload preparation from captured dispatch args."""
+    event = cast("DispatchEvent", execute_args[1])
+    dispatch = cast("PreparedDispatch", execute_args[2])
+    payload_inputs = cast("DispatchPayloadInputs", execute_args[4])
+    await bot._request_payload_preparer.prepare(
+        ResponseRequest(
+            thread_history=dispatch.context.thread_history,
+            prompt=event.body,
+            response_envelope=dispatch.envelope,
+            payload_preparation=ResponsePayloadPreparation(
+                dispatch=dispatch,
+                prompt=event.body,
+                action_kind="individual",
+                payload_inputs=payload_inputs,
+                target_member_names=None,
+                dispatch_started_at=0.0,
+                context_ready_monotonic=0.0,
+            ),
+        ),
+    )
 
 
 def sync_bot_runtime_state(bot: RuntimeBot) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -841,8 +841,6 @@ def _sync_request_payload_preparer(bot: RuntimeBot) -> None:
     The preparer captures the normalizer and ingress hook runner; tests swap
     those for proxies after construction, so rebuild the preparer to track them.
     """
-    if getattr(bot, "_request_payload_preparer", None) is None:
-        return
     runner = unwrap_extracted_collaborator(bot._response_runner)
     preparer = ResponsePayloadPreparer(
         normalizer=bot._inbound_turn_normalizer,

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -102,6 +102,7 @@ from mindroom.memory import MemoryPromptParts
 from mindroom.message_target import MessageTarget
 from mindroom.post_response_effects import PostResponseEffectsSupport
 from mindroom.prompts import INLINE_MEDIA_FALLBACK_PROMPT
+from mindroom.response_payload_preparation import ResponsePayloadPreparer
 from mindroom.response_runner import (
     ResponseRequest,
     ResponseRunner,
@@ -541,6 +542,12 @@ def _build_response_runner(
             delivery_gateway=delivery_gateway,
             post_response_effects=post_response_effects,
             state_writer=bot._conversation_state_writer,
+            request_preparer=ResponsePayloadPreparer(
+                normalizer=MagicMock(),
+                ingress_hook_runner=MagicMock(),
+                agent_name=bot.agent_name,
+                logger=bot.logger,
+            ),
         ),
     )
 

--- a/tests/test_hook_sender.py
+++ b/tests/test_hook_sender.py
@@ -1249,6 +1249,7 @@ async def test_dispatch_text_message_hydrates_sidecar_body_for_hooks_and_prompt(
             payload_preparation=ResponsePayloadPreparation(
                 dispatch=resolved_dispatch,
                 prompt=resolved_event.body,
+                action_kind="individual",
                 message_attachment_ids=payload_inputs.message_attachment_ids,
                 trusted_attachment_ids=payload_inputs.trusted_attachment_ids,
                 media_events=payload_inputs.media_events,

--- a/tests/test_hook_sender.py
+++ b/tests/test_hook_sender.py
@@ -49,8 +49,7 @@ from mindroom.logging_config import get_logger
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
 from mindroom.orchestrator import _MultiAgentOrchestrator
-from mindroom.response_payload_preparation import DispatchPayloadInputs, ResponsePayloadPreparation
-from mindroom.response_runner import ResponseRequest
+from mindroom.response_payload_preparation import DispatchPayloadInputs
 from mindroom.turn_controller import _IngressAdmissionOutcome, _PrecheckedEvent
 from mindroom.turn_origin import TurnIntent
 from mindroom.turn_policy import PreparedDispatch, ResponseAction, _DispatchPlan
@@ -62,6 +61,7 @@ from tests.conftest import (
     install_runtime_cache_support,
     message_origin,
     orchestrator_runtime_paths,
+    prepare_payload_via_seam,
     replace_turn_controller_deps,
     replace_turn_policy_deps,
     runtime_paths_for,
@@ -1239,26 +1239,8 @@ async def test_dispatch_text_message_hydrates_sidecar_body_for_hooks_and_prompt(
     assert captured_bodies == ["@mindroom_code:localhost what is 99+1?"]
     assert bot._turn_policy.plan_turn.await_args.args[1].body == "@mindroom_code:localhost what is 99+1?"
     execute_args = bot._turn_controller._execute_response_action.await_args.args
-    resolved_event, resolved_dispatch, payload_inputs = execute_args[1], execute_args[2], execute_args[4]
-    assert isinstance(payload_inputs, DispatchPayloadInputs)
-    await bot._request_payload_preparer.prepare(
-        ResponseRequest(
-            thread_history=[],
-            prompt=resolved_event.body,
-            response_envelope=resolved_dispatch.envelope,
-            payload_preparation=ResponsePayloadPreparation(
-                dispatch=resolved_dispatch,
-                prompt=resolved_event.body,
-                action_kind="individual",
-                message_attachment_ids=payload_inputs.message_attachment_ids,
-                trusted_attachment_ids=payload_inputs.trusted_attachment_ids,
-                media_events=payload_inputs.media_events,
-                target_member_names=None,
-                dispatch_started_at=0.0,
-                context_ready_monotonic=0.0,
-            ),
-        ),
-    )
+    assert isinstance(execute_args[4], DispatchPayloadInputs)
+    await prepare_payload_via_seam(bot, execute_args)
     payload_request = bot._inbound_turn_normalizer.build_dispatch_payload_with_attachments.await_args.args[0]
     assert payload_request.prompt == "@mindroom_code:localhost what is 99+1?"
 

--- a/tests/test_hook_sender.py
+++ b/tests/test_hook_sender.py
@@ -49,6 +49,8 @@ from mindroom.logging_config import get_logger
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
 from mindroom.orchestrator import _MultiAgentOrchestrator
+from mindroom.response_payload_preparation import DispatchPayloadInputs, ResponsePayloadPreparation
+from mindroom.response_runner import ResponseRequest
 from mindroom.turn_controller import _IngressAdmissionOutcome, _PrecheckedEvent
 from mindroom.turn_origin import TurnIntent
 from mindroom.turn_policy import PreparedDispatch, ResponseAction, _DispatchPlan
@@ -1236,8 +1238,26 @@ async def test_dispatch_text_message_hydrates_sidecar_body_for_hooks_and_prompt(
 
     assert captured_bodies == ["@mindroom_code:localhost what is 99+1?"]
     assert bot._turn_policy.plan_turn.await_args.args[1].body == "@mindroom_code:localhost what is 99+1?"
-    payload_builder = bot._turn_controller._execute_response_action.await_args.args[4]
-    await payload_builder(_dispatch_context(bot))
+    execute_args = bot._turn_controller._execute_response_action.await_args.args
+    resolved_event, resolved_dispatch, payload_inputs = execute_args[1], execute_args[2], execute_args[4]
+    assert isinstance(payload_inputs, DispatchPayloadInputs)
+    await bot._request_payload_preparer.prepare(
+        ResponseRequest(
+            thread_history=[],
+            prompt=resolved_event.body,
+            response_envelope=resolved_dispatch.envelope,
+            payload_preparation=ResponsePayloadPreparation(
+                dispatch=resolved_dispatch,
+                prompt=resolved_event.body,
+                message_attachment_ids=payload_inputs.message_attachment_ids,
+                trusted_attachment_ids=payload_inputs.trusted_attachment_ids,
+                media_events=payload_inputs.media_events,
+                target_member_names=None,
+                dispatch_started_at=0.0,
+                context_ready_monotonic=0.0,
+            ),
+        ),
+    )
     payload_request = bot._inbound_turn_normalizer.build_dispatch_payload_with_attachments.await_args.args[0]
     assert payload_request.prompt == "@mindroom_code:localhost what is 99+1?"
 

--- a/tests/test_issue_154_logging_integration.py
+++ b/tests/test_issue_154_logging_integration.py
@@ -31,6 +31,7 @@ from mindroom.llm_request_logging import install_llm_request_logging
 from mindroom.logging_config import get_logger, setup_logging
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
+from mindroom.response_payload_preparation import DispatchPayloadInputs
 from mindroom.tool_system.runtime_context import ToolDispatchContext
 from mindroom.tool_system.tool_hooks import build_tool_hook_bridge
 from mindroom.tool_system.worker_routing import build_tool_execution_identity
@@ -356,7 +357,7 @@ async def test_cross_sink_correlation_invariant_for_matrix_turn_processing_log( 
         event,
         dispatch,
         ResponseAction(kind="individual"),
-        AsyncMock(),
+        DispatchPayloadInputs((), (), ()),
         processing_log="Processing",
         dispatch_started_at=time.monotonic(),
         handled_turn=HandledTurnState.from_source_event_id(

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -73,12 +73,7 @@ from mindroom.matrix.thread_diagnostics import (
 )
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
-from mindroom.response_payload_preparation import (
-    DispatchPayloadInputs,
-    ResponsePayloadPreparation,
-    ResponsePayloadPreparer,
-)
-from mindroom.response_runner import ResponseRequest
+from mindroom.response_payload_preparation import ResponsePayloadPreparer
 from mindroom.turn_controller import _IngressAdmissionOutcome, _PrecheckedEvent
 from mindroom.turn_policy import PreparedDispatch, _DispatchPlan
 from tests.conftest import (
@@ -89,6 +84,7 @@ from tests.conftest import (
     install_send_response_mock,
     make_matrix_client_mock,
     message_origin,
+    prepare_payload_via_seam,
     prepared_dispatch_result,
     replace_turn_controller_deps,
     runtime_paths_for,
@@ -104,31 +100,6 @@ if TYPE_CHECKING:
 
 def _coalescing_gate_is_idle(gate: CoalescingGate) -> bool:
     return not gate._gates
-
-
-async def _prepare_payload_via_seam(bot: AgentBot, execute_args: tuple[object, ...]) -> None:
-    """Drive the execution-side payload preparation from captured dispatch args."""
-    event = cast("PreparedTextEvent", execute_args[1])
-    dispatch = cast("PreparedDispatch", execute_args[2])
-    payload_inputs = cast("DispatchPayloadInputs", execute_args[4])
-    await bot._request_payload_preparer.prepare(
-        ResponseRequest(
-            thread_history=dispatch.context.thread_history,
-            prompt=event.body,
-            response_envelope=dispatch.envelope,
-            payload_preparation=ResponsePayloadPreparation(
-                dispatch=dispatch,
-                prompt=event.body,
-                action_kind="individual",
-                message_attachment_ids=payload_inputs.message_attachment_ids,
-                trusted_attachment_ids=payload_inputs.trusted_attachment_ids,
-                media_events=payload_inputs.media_events,
-                target_member_names=None,
-                dispatch_started_at=0.0,
-                context_ready_monotonic=0.0,
-            ),
-        ),
-    )
 
 
 def _make_config(
@@ -6243,7 +6214,7 @@ async def _capture_gate_dispatches(
         return _respond_dispatch_plan()
 
     async def record_response(*args: object, **_kwargs: object) -> None:
-        await _prepare_payload_via_seam(bot, args)
+        await prepare_payload_via_seam(bot, args)
 
     async def record_payload_request(request: DispatchPayloadWithAttachmentsRequest) -> DispatchPayload:
         payload_requests.append(request)
@@ -6954,7 +6925,7 @@ async def test_untrusted_sidecar_payload_metadata_spoofing_does_not_reach_envelo
         return DispatchPayload(prompt=request.prompt, attachment_ids=list(request.current_attachment_ids))
 
     async def record_response(*args: object, **_kwargs: object) -> None:
-        await _prepare_payload_via_seam(bot, args)
+        await prepare_payload_via_seam(bot, args)
 
     async def extract_dispatch_context(
         _room: nio.MatrixRoom,
@@ -7045,7 +7016,7 @@ async def test_sidecar_hydration_preserves_trusted_attachment_metadata(tmp_path:
         return DispatchPayload(prompt=request.prompt, attachment_ids=list(request.current_attachment_ids))
 
     async def record_response(*args: object, **_kwargs: object) -> None:
-        await _prepare_payload_via_seam(bot, args)
+        await prepare_payload_via_seam(bot, args)
 
     with (
         patch.object(

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -73,6 +73,12 @@ from mindroom.matrix.thread_diagnostics import (
 )
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
+from mindroom.response_payload_preparation import (
+    DispatchPayloadInputs,
+    ResponsePayloadPreparation,
+    ResponsePayloadPreparer,
+)
+from mindroom.response_runner import ResponseRequest
 from mindroom.turn_controller import _IngressAdmissionOutcome, _PrecheckedEvent
 from mindroom.turn_policy import PreparedDispatch, _DispatchPlan
 from tests.conftest import (
@@ -92,12 +98,36 @@ from tests.conftest import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable, Sequence
+    from collections.abc import Callable, Sequence
     from pathlib import Path
 
 
 def _coalescing_gate_is_idle(gate: CoalescingGate) -> bool:
     return not gate._gates
+
+
+async def _prepare_payload_via_seam(bot: AgentBot, execute_args: tuple[object, ...]) -> None:
+    """Drive the execution-side payload preparation from captured dispatch args."""
+    event = cast("PreparedTextEvent", execute_args[1])
+    dispatch = cast("PreparedDispatch", execute_args[2])
+    payload_inputs = cast("DispatchPayloadInputs", execute_args[4])
+    await bot._request_payload_preparer.prepare(
+        ResponseRequest(
+            thread_history=dispatch.context.thread_history,
+            prompt=event.body,
+            response_envelope=dispatch.envelope,
+            payload_preparation=ResponsePayloadPreparation(
+                dispatch=dispatch,
+                prompt=event.body,
+                message_attachment_ids=payload_inputs.message_attachment_ids,
+                trusted_attachment_ids=payload_inputs.trusted_attachment_ids,
+                media_events=payload_inputs.media_events,
+                target_member_names=None,
+                dispatch_started_at=0.0,
+                context_ready_monotonic=0.0,
+            ),
+        ),
+    )
 
 
 def _make_config(
@@ -1730,7 +1760,7 @@ async def test_active_follow_up_owner_includes_later_media_payload(tmp_path: Pat
                 new=fake_build_payload,
             ),
             patch.object(bot._turn_controller, "_has_newer_unresponded_in_thread", return_value=False),
-            patch.object(bot._turn_controller, "_log_dispatch_latency"),
+            patch.object(ResponsePayloadPreparer, "_log_dispatch_latency"),
             patch(
                 "mindroom.response_runner.ResponseRunner.generate_response_locked",
                 new=fake_generate_response_locked,
@@ -4488,7 +4518,7 @@ async def test_turn_store_marks_all_batch_event_ids(tmp_path: Path) -> None:
             "build_dispatch_payload_with_attachments",
             new=AsyncMock(return_value=DispatchPayload(prompt="combined")),
         ),
-        patch.object(bot._turn_controller, "_log_dispatch_latency"),
+        patch.object(ResponsePayloadPreparer, "_log_dispatch_latency"),
     ):
         await _enqueue_for_dispatch(
             bot,
@@ -5315,7 +5345,7 @@ async def test_media_dispatch_uses_replay_snapshot_instead_of_mutated_planning_h
         ),
         patch.object(bot._turn_policy, "plan_turn", new=action_mock),
         patch.object(bot._turn_controller, "_has_newer_unresponded_in_thread", new=newer_mock),
-        patch.object(bot._turn_controller, "_log_dispatch_latency"),
+        patch.object(ResponsePayloadPreparer, "_log_dispatch_latency"),
     ):
         await bot._turn_controller._dispatch_text_message(
             room,
@@ -5361,7 +5391,7 @@ async def test_thread_history_guard_does_not_interfere_with_normal_dispatch(tmp_
             "build_dispatch_payload_with_attachments",
             new=AsyncMock(return_value=DispatchPayload(prompt="hello")),
         ),
-        patch.object(bot._turn_controller, "_log_dispatch_latency"),
+        patch.object(ResponsePayloadPreparer, "_log_dispatch_latency"),
     ):
         await bot._turn_controller._dispatch_text_message(room, event, "@user:localhost")
 
@@ -5668,7 +5698,7 @@ async def test_newer_command_does_not_suppress_older_message(tmp_path: Path) -> 
             "build_dispatch_payload_with_attachments",
             new=AsyncMock(return_value=DispatchPayload(prompt="What is the project structure?")),
         ),
-        patch.object(bot._turn_controller, "_log_dispatch_latency"),
+        patch.object(ResponsePayloadPreparer, "_log_dispatch_latency"),
     ):
         await bot._turn_controller._dispatch_text_message(room, older_event, "@user:localhost")
 
@@ -5718,7 +5748,7 @@ async def test_newer_command_with_whitespace_does_not_suppress(tmp_path: Path) -
             "build_dispatch_payload_with_attachments",
             new=AsyncMock(return_value=DispatchPayload(prompt="hello")),
         ),
-        patch.object(bot._turn_controller, "_log_dispatch_latency"),
+        patch.object(ResponsePayloadPreparer, "_log_dispatch_latency"),
     ):
         await bot._turn_controller._dispatch_text_message(room, older_event, "@user:localhost")
 
@@ -5776,7 +5806,7 @@ async def test_scheduled_event_not_suppressed(tmp_path: Path) -> None:
             "build_dispatch_payload_with_attachments",
             new=AsyncMock(return_value=DispatchPayload(prompt="scheduled task output")),
         ),
-        patch.object(bot._turn_controller, "_log_dispatch_latency"),
+        patch.object(ResponsePayloadPreparer, "_log_dispatch_latency"),
     ):
         await bot._turn_controller._dispatch_text_message(room, scheduled_event, "@mindroom_test_agent:localhost")
 
@@ -5826,7 +5856,7 @@ async def test_hook_event_not_suppressed(tmp_path: Path) -> None:
             "build_dispatch_payload_with_attachments",
             new=AsyncMock(return_value=DispatchPayload(prompt="hook result")),
         ),
-        patch.object(bot._turn_controller, "_log_dispatch_latency"),
+        patch.object(ResponsePayloadPreparer, "_log_dispatch_latency"),
     ):
         await bot._turn_controller._dispatch_text_message(room, hook_event, "@mindroom_test_agent:localhost")
 
@@ -5878,7 +5908,7 @@ async def test_multiple_scheduled_fires_not_suppressed(tmp_path: Path) -> None:
             "build_dispatch_payload_with_attachments",
             new=AsyncMock(return_value=DispatchPayload(prompt="scheduled fire 1")),
         ),
-        patch.object(bot._turn_controller, "_log_dispatch_latency"),
+        patch.object(ResponsePayloadPreparer, "_log_dispatch_latency"),
     ):
         await bot._turn_controller._dispatch_text_message(room, first_fire, "@mindroom_test_agent:localhost")
 
@@ -6212,9 +6242,7 @@ async def _capture_gate_dispatches(
         return _respond_dispatch_plan()
 
     async def record_response(*args: object, **_kwargs: object) -> None:
-        dispatch = cast("PreparedDispatch", args[2])
-        build_payload = cast("Callable[[MessageContext], Awaitable[DispatchPayload]]", args[4])
-        await build_payload(dispatch.context)
+        await _prepare_payload_via_seam(bot, args)
 
     async def record_payload_request(request: DispatchPayloadWithAttachmentsRequest) -> DispatchPayload:
         payload_requests.append(request)
@@ -6925,9 +6953,7 @@ async def test_untrusted_sidecar_payload_metadata_spoofing_does_not_reach_envelo
         return DispatchPayload(prompt=request.prompt, attachment_ids=list(request.current_attachment_ids))
 
     async def record_response(*args: object, **_kwargs: object) -> None:
-        dispatch = cast("PreparedDispatch", args[2])
-        build_payload = cast("Callable[[MessageContext], Awaitable[DispatchPayload]]", args[4])
-        await build_payload(dispatch.context)
+        await _prepare_payload_via_seam(bot, args)
 
     async def extract_dispatch_context(
         _room: nio.MatrixRoom,
@@ -7018,9 +7044,7 @@ async def test_sidecar_hydration_preserves_trusted_attachment_metadata(tmp_path:
         return DispatchPayload(prompt=request.prompt, attachment_ids=list(request.current_attachment_ids))
 
     async def record_response(*args: object, **_kwargs: object) -> None:
-        dispatch = cast("PreparedDispatch", args[2])
-        build_payload = cast("Callable[[MessageContext], Awaitable[DispatchPayload]]", args[4])
-        await build_payload(dispatch.context)
+        await _prepare_payload_via_seam(bot, args)
 
     with (
         patch.object(

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -119,6 +119,7 @@ async def _prepare_payload_via_seam(bot: AgentBot, execute_args: tuple[object, .
             payload_preparation=ResponsePayloadPreparation(
                 dispatch=dispatch,
                 prompt=event.body,
+                action_kind="individual",
                 message_attachment_ids=payload_inputs.message_attachment_ids,
                 trusted_attachment_ids=payload_inputs.trusted_attachment_ids,
                 media_events=payload_inputs.media_events,

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
-import itertools
 import os
 import signal
 import sys
@@ -122,6 +121,7 @@ from mindroom.orchestrator import (
     main,
 )
 from mindroom.response_lifecycle import _response_outcome_label
+from mindroom.response_payload_preparation import DispatchPayloadInputs, ResponsePayloadPreparer
 from mindroom.response_runner import (
     PostLockRequestPreparationError,
     ResponseRequest,
@@ -140,7 +140,7 @@ from mindroom.tool_system.events import ToolTraceEntry
 from mindroom.tool_system.metadata import TOOL_METADATA
 from mindroom.tool_system.skills import _get_plugin_skill_roots, set_plugin_skill_roots
 from mindroom.tool_system.worker_routing import agent_state_root_path
-from mindroom.turn_controller import TurnController, _IngressAdmissionOutcome, _PrecheckedEvent
+from mindroom.turn_controller import _IngressAdmissionOutcome, _PrecheckedEvent
 from mindroom.turn_policy import PreparedDispatch, ResponseAction, TurnPolicy, _DispatchPlan, _ResponderAvailability
 from tests.approval_test_support import resolve_pending_approval as _resolve_pending_approval
 from tests.conftest import (
@@ -4369,23 +4369,20 @@ class TestAgentBot:
             envelope=_hook_envelope(body="hello", source_event_id="$event", target=dispatch_target),
         )
 
-        async def payload_builder(_context: MessageContext) -> DispatchPayload:
-            return DispatchPayload(prompt="help me")
-
         with (
             patch.object(
                 bot._response_runner,
                 "generate_response",
                 new=AsyncMock(return_value="$cancelled"),
             ),
-            patch.object(bot._turn_controller, "_log_dispatch_latency", create=True),
+            patch.object(ResponsePayloadPreparer, "_log_dispatch_latency"),
         ):
             await bot._turn_controller._execute_response_action(
                 room,
                 event,
                 dispatch,
                 ResponseAction(kind="individual"),
-                payload_builder,
+                DispatchPayloadInputs((), (), ()),
                 processing_log="processing",
                 dispatch_started_at=0.0,
                 handled_turn=HandledTurnState.from_source_event_id(event.event_id),
@@ -11317,16 +11314,13 @@ class TestAgentBot:
 
         bot.client = AsyncMock(spec=nio.AsyncClient)
 
-        async def unused_payload_builder(_context: MessageContext) -> DispatchPayload:
-            return DispatchPayload(prompt="help me")
-
         with patch.object(DeliveryGateway, "send_text", new=AsyncMock(return_value="$reply")) as send_text:
             await bot._turn_controller._execute_response_action(
                 room,
                 event,
                 dispatch,
                 action,
-                unused_payload_builder,
+                DispatchPayloadInputs((), (), ()),
                 processing_log="processing",
                 dispatch_started_at=0.0,
                 handled_turn=HandledTurnState.from_source_event_id(event.event_id),
@@ -11391,16 +11385,13 @@ class TestAgentBot:
         )
         bot.client = AsyncMock(spec=nio.AsyncClient)
 
-        async def unused_payload_builder(_context: MessageContext) -> DispatchPayload:
-            return DispatchPayload(prompt="help me")
-
         with patch("mindroom.delivery_gateway.send_message_result", new=AsyncMock(return_value=None)):
             await bot._turn_controller._execute_response_action(
                 room,
                 event,
                 dispatch,
                 action,
-                unused_payload_builder,
+                DispatchPayloadInputs((), (), ()),
                 processing_log="processing",
                 dispatch_started_at=0.0,
                 handled_turn=HandledTurnState.from_source_event_id(event.event_id),
@@ -11683,7 +11674,7 @@ class TestAgentBot:
                 "run_cancellable_response",
                 new=AsyncMock(side_effect=run_cancellable_response),
             ),
-            patch.object(bot._turn_controller, "_log_dispatch_latency"),
+            patch.object(ResponsePayloadPreparer, "_log_dispatch_latency"),
             patch_response_runner_module(
                 should_use_streaming=AsyncMock(return_value=False),
                 prepare_memory_and_model_context=prepare_memory_and_model_context,
@@ -12732,22 +12723,18 @@ class TestAgentBot:
         )
 
         with (
-            patch.object(TurnController, "_log_dispatch_latency"),
+            patch.object(ResponsePayloadPreparer, "_log_dispatch_latency"),
             patch(
                 "mindroom.turn_controller.select_ad_hoc_team_mode",
                 new=AsyncMock(return_value=TeamMode.COORDINATE),
             ),
         ):
-
-            async def payload_builder(_context: MessageContext) -> DispatchPayload:
-                return DispatchPayload(prompt="help me")
-
             await bot._turn_controller._execute_response_action(
                 room,
                 event,
                 dispatch,
                 action,
-                payload_builder,
+                DispatchPayloadInputs((), (), ()),
                 processing_log="processing",
                 dispatch_started_at=0.0,
                 handled_turn=HandledTurnState.from_source_event_id(event.event_id),
@@ -12990,17 +12977,13 @@ class TestAgentBot:
             response_runner=bot._response_runner,
         )
 
-        with patch.object(TurnController, "_log_dispatch_latency"):
-
-            async def payload_builder(_context: MessageContext) -> DispatchPayload:
-                return DispatchPayload(prompt="help me")
-
+        with patch.object(ResponsePayloadPreparer, "_log_dispatch_latency"):
             await bot._turn_controller._execute_response_action(
                 room,
                 event,
                 dispatch,
                 ResponseAction(kind="individual"),
-                payload_builder,
+                DispatchPayloadInputs((), (), ()),
                 processing_log="processing",
                 dispatch_started_at=0.0,
                 handled_turn=HandledTurnState.from_source_event_id(event.event_id),
@@ -13074,7 +13057,7 @@ class TestAgentBot:
             ),
             patch("mindroom.turn_policy.decide_agent_response", return_value=AgentResponseDecision(True)),
             patch("mindroom.inbound_turn_normalizer.download_image", new_callable=AsyncMock, return_value=None),
-            patch.object(bot._turn_controller, "_log_dispatch_latency"),
+            patch.object(ResponsePayloadPreparer, "_log_dispatch_latency"),
         ):
             await bot._on_media_message(room, event)
             await drain_coalescing(bot)
@@ -13235,9 +13218,6 @@ class TestAgentBot:
 
         failure_message = "setup failed"
 
-        async def payload_builder(_context: MessageContext) -> DispatchPayload:
-            raise RuntimeError(failure_message)
-
         mock_edit = AsyncMock(return_value=False)
         install_edit_message_mock(bot, mock_edit)
         bot._delivery_gateway.send_text = AsyncMock(return_value="$error")
@@ -13246,13 +13226,17 @@ class TestAgentBot:
             delivery_gateway=bot._delivery_gateway,
         )
 
-        with patch.object(TurnController, "_log_dispatch_latency"):
+        with patch.object(
+            ResponsePayloadPreparer,
+            "prepare",
+            new=AsyncMock(side_effect=RuntimeError(failure_message)),
+        ):
             await bot._turn_controller._execute_response_action(
                 room,
                 event,
                 dispatch,
                 ResponseAction(kind="individual"),
-                payload_builder,
+                DispatchPayloadInputs((), (), ()),
                 processing_log="processing",
                 dispatch_started_at=0.0,
                 handled_turn=HandledTurnState.from_source_event_id(event.event_id),
@@ -13309,13 +13293,17 @@ class TestAgentBot:
 
         failure_message = "setup failed"
 
-        async def payload_builder(_context: MessageContext) -> DispatchPayload:
-            raise RuntimeError(failure_message)
-
-        with patch(
-            "mindroom.bot.TurnController._finalize_dispatch_failure",
-            new=AsyncMock(
-                return_value=None,
+        with (
+            patch.object(
+                ResponsePayloadPreparer,
+                "prepare",
+                new=AsyncMock(side_effect=RuntimeError(failure_message)),
+            ),
+            patch(
+                "mindroom.bot.TurnController._finalize_dispatch_failure",
+                new=AsyncMock(
+                    return_value=None,
+                ),
             ),
         ):
             await bot._turn_controller._execute_response_action(
@@ -13323,7 +13311,7 @@ class TestAgentBot:
                 event,
                 dispatch,
                 ResponseAction(kind="individual"),
-                payload_builder,
+                DispatchPayloadInputs((), (), ()),
                 processing_log="processing",
                 dispatch_started_at=0.0,
                 handled_turn=HandledTurnState.from_source_event_id(event.event_id),
@@ -13371,9 +13359,6 @@ class TestAgentBot:
             envelope=_hook_envelope(body="hello", source_event_id="$event", target=dispatch_target),
         )
 
-        async def payload_builder(_context: MessageContext) -> DispatchPayload:
-            return DispatchPayload(prompt="hello")
-
         async def fail_generate_response(*_args: object, **_kwargs: object) -> FinalDeliveryOutcome:
             message = "post-lock setup failed"
             error = RuntimeError(message)
@@ -13398,7 +13383,7 @@ class TestAgentBot:
                 event,
                 dispatch,
                 ResponseAction(kind="individual"),
-                payload_builder,
+                DispatchPayloadInputs((), (), ()),
                 processing_log="processing",
                 dispatch_started_at=0.0,
                 handled_turn=HandledTurnState.from_source_event_id(event.event_id),
@@ -13451,9 +13436,6 @@ class TestAgentBot:
             envelope=_hook_envelope(body="hello", source_event_id="$event", target=stable_target),
         )
 
-        async def payload_builder(_context: MessageContext) -> DispatchPayload:
-            return DispatchPayload(prompt="hello")
-
         async def fail_generate_response(*_args: object, **_kwargs: object) -> FinalDeliveryOutcome:
             message = "post-lock setup failed"
             error = RuntimeError(message)
@@ -13473,7 +13455,7 @@ class TestAgentBot:
             event,
             dispatch,
             ResponseAction(kind="individual"),
-            payload_builder,
+            DispatchPayloadInputs((), (), ()),
             processing_log="processing",
             dispatch_started_at=0.0,
             handled_turn=HandledTurnState.from_source_event_id(event.event_id),
@@ -13528,9 +13510,6 @@ class TestAgentBot:
             envelope=_hook_envelope(body="hello", source_event_id="$event", target=dispatch_target),
         )
 
-        async def payload_builder(_context: MessageContext) -> DispatchPayload:
-            return DispatchPayload(prompt="help me")
-
         with (
             patch.object(
                 bot._response_runner,
@@ -13539,14 +13518,14 @@ class TestAgentBot:
                     return_value="$thinking",
                 ),
             ),
-            patch.object(bot._turn_controller, "_log_dispatch_latency", create=True),
+            patch.object(ResponsePayloadPreparer, "_log_dispatch_latency"),
         ):
             await bot._turn_controller._execute_response_action(
                 room,
                 event,
                 dispatch,
                 ResponseAction(kind="individual"),
-                payload_builder,
+                DispatchPayloadInputs((), (), ()),
                 processing_log="processing",
                 dispatch_started_at=0.0,
                 handled_turn=HandledTurnState.from_source_event_id(event.event_id),
@@ -13783,9 +13762,6 @@ class TestAgentBot:
             envelope=_hook_envelope(body="hello", source_event_id="$event", target=dispatch_target),
         )
 
-        async def payload_builder(_context: MessageContext) -> DispatchPayload:
-            return DispatchPayload(prompt="help me")
-
         with (
             patch.object(
                 bot._response_runner,
@@ -13794,341 +13770,20 @@ class TestAgentBot:
                     return_value=None,
                 ),
             ),
-            patch.object(bot._turn_controller, "_log_dispatch_latency", create=True),
+            patch.object(ResponsePayloadPreparer, "_log_dispatch_latency"),
         ):
             await bot._turn_controller._execute_response_action(
                 room,
                 event,
                 dispatch,
                 ResponseAction(kind="individual"),
-                payload_builder,
+                DispatchPayloadInputs((), (), ()),
                 processing_log="processing",
                 dispatch_started_at=0.0,
                 handled_turn=HandledTurnState.from_source_event_id(event.event_id),
             )
 
         tracker.record_handled_turn.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_execute_dispatch_action_logs_startup_latency(
-        self,
-        mock_agent_user: AgentMatrixUser,
-        tmp_path: Path,
-    ) -> None:
-        """Dispatch execution should log setup timing fields before coordinator handoff."""
-        config = self._config_for_storage(tmp_path)
-        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
-        _set_turn_store_tracker(bot, MagicMock())
-        bot.logger = MagicMock()
-        _replace_turn_policy_deps(bot, logger=bot.logger)
-
-        room = MagicMock(spec=nio.MatrixRoom)
-        room.room_id = "!room:localhost"
-        event = MagicMock()
-        event.event_id = "$event"
-        dispatch = PreparedDispatch(
-            requester_user_id="@user:localhost",
-            context=MessageContext(
-                am_i_mentioned=False,
-                is_thread=False,
-                thread_id=None,
-                thread_history=ThreadHistoryResult(
-                    [],
-                    is_full_history=True,
-                    diagnostics={
-                        "cache_read_ms": 11.0,
-                        "incremental_refresh_ms": 22.0,
-                        "resolution_ms": 33.0,
-                        "sidecar_hydration_ms": 44.0,
-                    },
-                ),
-                mentioned_agents=[],
-                has_non_agent_mentions=False,
-                requires_model_history_refresh=False,
-            ),
-            target=(
-                dispatch_target := MessageTarget.resolve(
-                    room_id=room.room_id,
-                    thread_id=None,
-                    reply_to_event_id=event.event_id,
-                )
-            ),
-            correlation_id="corr-latency-log",
-            envelope=_hook_envelope(body="hello", source_event_id="$event", target=dispatch_target),
-        )
-
-        monotonic_values = itertools.count(start=10.0, step=0.1)
-        mock_generate_response = AsyncMock(return_value="$response")
-        install_generate_response_mock(bot, mock_generate_response)
-        _replace_turn_policy_deps(
-            bot,
-            logger=bot.logger,
-            response_runner=bot._response_runner,
-        )
-
-        with patch("mindroom.turn_controller.time.monotonic", side_effect=lambda: next(monotonic_values)):
-
-            async def payload_builder(_context: MessageContext) -> DispatchPayload:
-                return DispatchPayload(prompt="help me")
-
-            await bot._turn_controller._execute_response_action(
-                room,
-                event,
-                dispatch,
-                ResponseAction(kind="individual"),
-                payload_builder,
-                processing_log="processing",
-                dispatch_started_at=9.5,
-                handled_turn=HandledTurnState.from_source_event_id(event.event_id),
-            )
-
-        latency_logs = [
-            call for call in bot.logger.info.call_args_list if call.args and call.args[0] == "Response startup latency"
-        ]
-        assert latency_logs
-        latency_kwargs = latency_logs[-1].kwargs
-        assert "placeholder_event_id" not in latency_kwargs
-        assert "placeholder_visible_ms" not in latency_kwargs
-        assert latency_kwargs["context_hydration_ms"] == 500.0
-        assert latency_kwargs["cache_read_ms"] == 11.0
-        assert latency_kwargs["incremental_refresh_ms"] == 22.0
-        assert latency_kwargs["resolution_ms"] == 33.0
-        assert latency_kwargs["sidecar_hydration_ms"] == 44.0
-        assert latency_kwargs["payload_hydration_ms"] >= 0.0
-        assert latency_kwargs["startup_total_ms"] == (
-            latency_kwargs["context_hydration_ms"] + latency_kwargs["payload_hydration_ms"]
-        )
-
-    @pytest.mark.asyncio
-    async def test_execute_dispatch_action_logs_latency_after_locked_payload_preparation(
-        self,
-        mock_agent_user: AgentMatrixUser,
-        tmp_path: Path,
-    ) -> None:
-        """Latency logging should happen after the locked payload preparation path completes."""
-        config = self._config_for_storage(tmp_path)
-        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
-        _set_turn_store_tracker(bot, MagicMock())
-        bot.logger = MagicMock()
-        _replace_turn_policy_deps(bot, logger=bot.logger)
-
-        room = MagicMock(spec=nio.MatrixRoom)
-        room.room_id = "!room:localhost"
-        event = MagicMock()
-        event.event_id = "$event"
-        dispatch = PreparedDispatch(
-            requester_user_id="@user:localhost",
-            context=MessageContext(
-                am_i_mentioned=False,
-                is_thread=False,
-                thread_id=None,
-                thread_history=ThreadHistoryResult([], is_full_history=True),
-                mentioned_agents=[],
-                has_non_agent_mentions=False,
-                requires_model_history_refresh=False,
-            ),
-            target=(
-                dispatch_target := MessageTarget.resolve(
-                    room_id=room.room_id,
-                    thread_id=None,
-                    reply_to_event_id=event.event_id,
-                )
-            ),
-            correlation_id="corr-latency-order",
-            envelope=_hook_envelope(body="hello", source_event_id="$event", target=dispatch_target),
-        )
-
-        mock_generate_response = AsyncMock(return_value="$response")
-        install_generate_response_mock(bot, mock_generate_response)
-        _replace_turn_policy_deps(
-            bot,
-            logger=bot.logger,
-            response_runner=bot._response_runner,
-        )
-
-        payload_built = False
-
-        async def payload_builder(_context: MessageContext) -> DispatchPayload:
-            nonlocal payload_built
-            payload_built = True
-            return DispatchPayload(prompt="help me")
-
-        original_log_dispatch_latency = bot._turn_controller._log_dispatch_latency
-
-        def assert_payload_already_built(**kwargs: object) -> None:
-            assert payload_built is True
-            original_log_dispatch_latency(**kwargs)
-
-        with patch.object(
-            bot._turn_controller,
-            "_log_dispatch_latency",
-            side_effect=assert_payload_already_built,
-        ):
-            await bot._turn_controller._execute_response_action(
-                room,
-                event,
-                dispatch,
-                ResponseAction(kind="individual"),
-                payload_builder,
-                processing_log="processing",
-                dispatch_started_at=0.0,
-                handled_turn=HandledTurnState.from_source_event_id(event.event_id),
-            )
-
-        assert payload_built is True
-
-    @pytest.mark.asyncio
-    async def test_execute_dispatch_action_emits_payload_builder_timing(
-        self,
-        mock_agent_user: AgentMatrixUser,
-        tmp_path: Path,
-    ) -> None:
-        """Dispatch execution should time the payload builder inside the locked preparation path."""
-        config = self._config_for_storage(tmp_path)
-        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
-        _set_turn_store_tracker(bot, MagicMock())
-        bot.logger = MagicMock()
-        _replace_turn_policy_deps(bot, logger=bot.logger)
-
-        room = MagicMock(spec=nio.MatrixRoom)
-        room.room_id = "!room:localhost"
-        event = MagicMock()
-        event.event_id = "$event"
-        dispatch = PreparedDispatch(
-            requester_user_id="@user:localhost",
-            context=MessageContext(
-                am_i_mentioned=False,
-                is_thread=True,
-                thread_id="$thread",
-                thread_history=ThreadHistoryResult([], is_full_history=True),
-                mentioned_agents=[],
-                has_non_agent_mentions=False,
-                requires_model_history_refresh=False,
-            ),
-            target=(
-                dispatch_target := MessageTarget.resolve(
-                    room_id=room.room_id,
-                    thread_id="$thread",
-                    reply_to_event_id=event.event_id,
-                )
-            ),
-            correlation_id="corr-payload-builder-timing",
-            envelope=_hook_envelope(body="hello", source_event_id="$event", target=dispatch_target),
-        )
-
-        mock_generate_response = AsyncMock(return_value="$response")
-        install_generate_response_mock(bot, mock_generate_response)
-        _replace_turn_policy_deps(
-            bot,
-            logger=bot.logger,
-            response_runner=bot._response_runner,
-        )
-
-        async def payload_builder(_context: MessageContext) -> DispatchPayload:
-            return DispatchPayload(prompt="help me")
-
-        with patch("mindroom.turn_controller.emit_elapsed_timing") as mock_emit:
-            await bot._turn_controller._execute_response_action(
-                room,
-                event,
-                dispatch,
-                ResponseAction(kind="individual"),
-                payload_builder,
-                processing_log="processing",
-                dispatch_started_at=0.0,
-                handled_turn=HandledTurnState.from_source_event_id(event.event_id),
-            )
-
-        builder_calls = [
-            call for call in mock_emit.call_args_list if call.args and call.args[0] == "response_payload.builder"
-        ]
-        assert len(builder_calls) == 1
-        assert isinstance(builder_calls[0].args[1], float)
-        assert builder_calls[0].kwargs == {
-            "room_id": "!room:localhost",
-            "thread_id": "$thread",
-            "outcome": "success",
-        }
-
-    @pytest.mark.asyncio
-    async def test_execute_dispatch_action_emits_payload_builder_timing_on_failure(
-        self,
-        mock_agent_user: AgentMatrixUser,
-        tmp_path: Path,
-    ) -> None:
-        """Payload-builder timing should still emit when locked payload preparation fails."""
-        config = self._config_for_storage(tmp_path)
-        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
-        _set_turn_store_tracker(bot, MagicMock())
-        bot.logger = MagicMock()
-        _replace_turn_policy_deps(bot, logger=bot.logger)
-
-        room = MagicMock(spec=nio.MatrixRoom)
-        room.room_id = "!room:localhost"
-        event = MagicMock()
-        event.event_id = "$event"
-        dispatch = PreparedDispatch(
-            requester_user_id="@user:localhost",
-            context=MessageContext(
-                am_i_mentioned=False,
-                is_thread=True,
-                thread_id="$thread",
-                thread_history=ThreadHistoryResult([], is_full_history=True),
-                mentioned_agents=[],
-                has_non_agent_mentions=False,
-                requires_model_history_refresh=False,
-            ),
-            target=(
-                dispatch_target := MessageTarget.resolve(
-                    room_id=room.room_id,
-                    thread_id="$thread",
-                    reply_to_event_id=event.event_id,
-                )
-            ),
-            correlation_id="corr-payload-builder-failure-timing",
-            envelope=_hook_envelope(body="hello", source_event_id="$event", target=dispatch_target),
-        )
-
-        install_generate_response_mock(bot, AsyncMock(return_value="$response"))
-        _replace_turn_policy_deps(
-            bot,
-            logger=bot.logger,
-            response_runner=bot._response_runner,
-        )
-
-        async def payload_builder(_context: MessageContext) -> DispatchPayload:
-            msg = "payload failed"
-            raise RuntimeError(msg)
-
-        with (
-            patch.object(bot._turn_controller, "_finalize_dispatch_failure", new=AsyncMock(return_value="$error")),
-            patch("mindroom.turn_controller.emit_elapsed_timing") as mock_emit,
-        ):
-            await bot._turn_controller._execute_response_action(
-                room,
-                event,
-                dispatch,
-                ResponseAction(kind="individual"),
-                payload_builder,
-                processing_log="processing",
-                dispatch_started_at=0.0,
-                handled_turn=HandledTurnState.from_source_event_id(event.event_id),
-            )
-
-        builder_calls = [
-            call for call in mock_emit.call_args_list if call.args and call.args[0] == "response_payload.builder"
-        ]
-        assert len(builder_calls) == 1
-        assert isinstance(builder_calls[0].args[1], float)
-        assert builder_calls[0].kwargs == {
-            "room_id": "!room:localhost",
-            "thread_id": "$thread",
-            "outcome": "failed",
-        }
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("enable_streaming", [True, False])

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -12814,19 +12814,15 @@ class TestAgentBot:
 
         mock_select_team_mode = AsyncMock(return_value=TeamMode.COORDINATE)
         with (
-            patch.object(TurnController, "_log_dispatch_latency"),
+            patch.object(ResponsePayloadPreparer, "_log_dispatch_latency"),
             patch("mindroom.turn_controller.select_ad_hoc_team_mode", new=mock_select_team_mode),
         ):
-
-            async def payload_builder(_context: MessageContext) -> DispatchPayload:
-                return DispatchPayload(prompt="help me")
-
             await bot._turn_controller._execute_response_action(
                 room,
                 event,
                 dispatch,
                 action,
-                payload_builder,
+                DispatchPayloadInputs((), (), ()),
                 processing_log="processing",
                 dispatch_started_at=0.0,
                 handled_turn=HandledTurnState.from_source_event_id(event.event_id),
@@ -12905,19 +12901,15 @@ class TestAgentBot:
 
         mock_select_team_mode = AsyncMock(return_value=TeamMode.COLLABORATE)
         with (
-            patch.object(TurnController, "_log_dispatch_latency"),
+            patch.object(ResponsePayloadPreparer, "_log_dispatch_latency"),
             patch("mindroom.turn_controller.select_ad_hoc_team_mode", new=mock_select_team_mode),
         ):
-
-            async def payload_builder(_context: MessageContext) -> DispatchPayload:
-                return DispatchPayload(prompt="help me")
-
             await bot._turn_controller._execute_response_action(
                 room,
                 event,
                 dispatch,
                 action,
-                payload_builder,
+                DispatchPayloadInputs((), (), ()),
                 processing_log="processing",
                 dispatch_started_at=0.0,
                 handled_turn=HandledTurnState.from_source_event_id(event.event_id),

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -1217,7 +1217,7 @@ async def test_generate_response_uses_post_lock_reproof_target(tmp_path: Path) -
 
 
 @pytest.mark.asyncio
-async def test_generate_response_keeps_locked_target_when_prepare_after_lock_retargets(tmp_path: Path) -> None:
+async def test_generate_response_keeps_locked_target_when_payload_preparation_retargets(tmp_path: Path) -> None:
     """Post-lock request preparation may refresh context, but it must not retarget delivery."""
     bot = _bot(tmp_path)
     coordinator = unwrap_extracted_collaborator(bot._response_runner)
@@ -1369,7 +1369,7 @@ async def test_generate_team_response_uses_post_lock_reproof_target(tmp_path: Pa
 
 
 @pytest.mark.asyncio
-async def test_generate_team_response_keeps_locked_target_when_prepare_after_lock_retargets(tmp_path: Path) -> None:
+async def test_generate_team_response_keeps_locked_target_when_payload_preparation_retargets(tmp_path: Path) -> None:
     """Team response setup and delivery should keep the target selected before lock acquisition."""
     bot = _bot(tmp_path)
     bot.client = MagicMock()

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -221,6 +221,7 @@ def _payload_preparation(target: MessageTarget) -> ResponsePayloadPreparation:
             envelope=_envelope(source_event_id="$event", target=target),
         ),
         prompt="hello",
+        action_kind="individual",
         message_attachment_ids=(),
         trusted_attachment_ids=(),
         media_events=(),

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -67,7 +67,7 @@ from mindroom.post_response_effects import (
 )
 from mindroom.prompts import QUEUED_MESSAGE_NOTICE_TEXT
 from mindroom.response_lifecycle import _QueuedMessageState
-from mindroom.response_payload_preparation import ResponsePayloadPreparation
+from mindroom.response_payload_preparation import DispatchPayloadInputs, ResponsePayloadPreparation
 from mindroom.response_runner import PostLockRequestPreparationError, ResponseRequest, ResponseRunner
 from mindroom.teams import TeamMode, _create_team_instance
 from mindroom.turn_controller import _PrecheckedEvent
@@ -222,9 +222,7 @@ def _payload_preparation(target: MessageTarget) -> ResponsePayloadPreparation:
         ),
         prompt="hello",
         action_kind="individual",
-        message_attachment_ids=(),
-        trusted_attachment_ids=(),
-        media_events=(),
+        payload_inputs=DispatchPayloadInputs((), (), ()),
         target_member_names=None,
         dispatch_started_at=0.0,
         context_ready_monotonic=0.0,

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -67,6 +67,7 @@ from mindroom.post_response_effects import (
 )
 from mindroom.prompts import QUEUED_MESSAGE_NOTICE_TEXT
 from mindroom.response_lifecycle import _QueuedMessageState
+from mindroom.response_payload_preparation import ResponsePayloadPreparation
 from mindroom.response_runner import PostLockRequestPreparationError, ResponseRequest, ResponseRunner
 from mindroom.teams import TeamMode, _create_team_instance
 from mindroom.turn_controller import _PrecheckedEvent
@@ -206,6 +207,26 @@ def _message_context() -> MessageContext:
         thread_history=[],
         mentioned_agents=[],
         has_non_agent_mentions=False,
+    )
+
+
+def _payload_preparation(target: MessageTarget) -> ResponsePayloadPreparation:
+    """Build a minimal under-lock preparation carrier bound to ``target``."""
+    return ResponsePayloadPreparation(
+        dispatch=PreparedDispatch(
+            requester_user_id="@user:localhost",
+            context=_message_context(),
+            target=target,
+            correlation_id="$event",
+            envelope=_envelope(source_event_id="$event", target=target),
+        ),
+        prompt="hello",
+        message_attachment_ids=(),
+        trusted_attachment_ids=(),
+        media_events=(),
+        target_member_names=None,
+        dispatch_started_at=0.0,
+        context_ready_monotonic=0.0,
     )
 
 
@@ -1207,10 +1228,11 @@ async def test_generate_response_keeps_locked_target_when_prepare_after_lock_ret
     observed_delivery_targets: list[MessageTarget | None] = []
     observed_lifecycle_targets: list[MessageTarget] = []
 
-    async def prepare_after_lock(request: ResponseRequest) -> ResponseRequest:
+    async def fake_prepare(request: ResponseRequest) -> ResponseRequest:
         return replace(
             request,
             response_envelope=_envelope(source_event_id="$event", target=retarget),
+            payload_preparation=None,
         )
 
     async def fake_run_cancellable_response(**kwargs: object) -> str:
@@ -1246,6 +1268,11 @@ async def test_generate_response_keeps_locked_target_when_prepare_after_lock_ret
     with (
         patch.object(coordinator, "_build_lifecycle", MagicMock(side_effect=fake_build_lifecycle)),
         patch.object(
+            coordinator.deps.request_preparer,
+            "prepare",
+            new=AsyncMock(side_effect=fake_prepare),
+        ),
+        patch.object(
             coordinator,
             "run_cancellable_response",
             new=AsyncMock(side_effect=fake_run_cancellable_response),
@@ -1263,7 +1290,7 @@ async def test_generate_response_keeps_locked_target_when_prepare_after_lock_ret
                 prompt="hello",
                 user_id="@user:localhost",
                 response_envelope=_envelope(source_event_id="$event", target=stable_target),
-                prepare_after_lock=prepare_after_lock,
+                payload_preparation=_payload_preparation(stable_target),
             ),
         )
 
@@ -1357,10 +1384,11 @@ async def test_generate_team_response_keeps_locked_target_when_prepare_after_loc
     observed_run_targets: list[MessageTarget] = []
     observed_delivery_targets: list[MessageTarget] = []
 
-    async def prepare_after_lock(request: ResponseRequest) -> ResponseRequest:
+    async def fake_prepare(request: ResponseRequest) -> ResponseRequest:
         return replace(
             request,
             response_envelope=_envelope(source_event_id="$event", target=retarget),
+            payload_preparation=None,
         )
 
     async def fake_run_cancellable_response(**kwargs: object) -> str:
@@ -1387,6 +1415,11 @@ async def test_generate_team_response_keeps_locked_target_when_prepare_after_loc
     with (
         patch.object(coordinator, "_build_lifecycle", MagicMock(return_value=lifecycle)),
         patch.object(
+            coordinator.deps.request_preparer,
+            "prepare",
+            new=AsyncMock(side_effect=fake_prepare),
+        ),
+        patch.object(
             coordinator,
             "run_cancellable_response",
             new=AsyncMock(side_effect=fake_run_cancellable_response),
@@ -1401,7 +1434,7 @@ async def test_generate_team_response_keeps_locked_target_when_prepare_after_loc
                 prompt="hello",
                 user_id="@user:localhost",
                 response_envelope=_envelope(source_event_id="$event", target=stable_target),
-                prepare_after_lock=prepare_after_lock,
+                payload_preparation=_payload_preparation(stable_target),
             ),
             team_agents=[],
             team_mode="coordinate",

--- a/tests/test_response_payload_preparation.py
+++ b/tests/test_response_payload_preparation.py
@@ -1,0 +1,341 @@
+"""Direct tests for the one-way ingress -> execution payload seam.
+
+These exercise :class:`ResponsePayloadPreparer` (the execution-side, under-lock
+payload-assembly step) on its own, plus the response runner's guarantee that the
+step runs exactly once while the lifecycle lock is held.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import nio
+import pytest
+
+from mindroom.bot import AgentBot
+from mindroom.config.agent import AgentConfig
+from mindroom.config.auth import AuthorizationConfig
+from mindroom.config.main import Config
+from mindroom.config.models import ModelConfig
+from mindroom.conversation_resolver import MessageContext
+from mindroom.final_delivery import FinalDeliveryOutcome
+from mindroom.hooks import MessageEnvelope
+from mindroom.inbound_turn_normalizer import DispatchPayload
+from mindroom.matrix.cache import ThreadHistoryResult
+from mindroom.matrix.users import AgentMatrixUser
+from mindroom.message_target import MessageTarget
+from mindroom.response_payload_preparation import ResponsePayloadPreparation
+from mindroom.response_runner import ResponseRequest
+from mindroom.turn_policy import PreparedDispatch
+from tests.conftest import (
+    TEST_PASSWORD,
+    bind_runtime_paths,
+    install_runtime_cache_support,
+    message_origin,
+    runtime_paths_for,
+    test_runtime_paths,
+    unwrap_extracted_collaborator,
+    wrap_extracted_collaborators,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+    from pathlib import Path
+
+    from mindroom.message_target import MessageTarget as _MessageTarget
+
+
+def _config(tmp_path: Path) -> Config:
+    return bind_runtime_paths(
+        Config(
+            agents={"general": AgentConfig(display_name="General", rooms=["!room:localhost"])},
+            teams={},
+            models={"default": ModelConfig(provider="openai", id="test-model")},
+            authorization=AuthorizationConfig(default_room_access=True),
+        ),
+        test_runtime_paths(tmp_path),
+    )
+
+
+def _bot(tmp_path: Path) -> AgentBot:
+    config = _config(tmp_path)
+    agent_user = AgentMatrixUser(
+        agent_name="general",
+        password=TEST_PASSWORD,
+        display_name="General",
+        user_id="@mindroom_general:localhost",
+    )
+    bot = AgentBot(agent_user, tmp_path, config, runtime_paths_for(config), rooms=["!room:localhost"])
+    bot.client = AsyncMock(spec=nio.AsyncClient)
+    install_runtime_cache_support(bot)
+    wrap_extracted_collaborators(bot)
+    return bot
+
+
+def _target(thread_id: str | None = None) -> _MessageTarget:
+    return MessageTarget.resolve(
+        room_id="!room:localhost",
+        thread_id=thread_id,
+        reply_to_event_id="$event",
+        room_mode=thread_id is None,
+    )
+
+
+def _envelope(target: _MessageTarget) -> MessageEnvelope:
+    return MessageEnvelope(
+        source_event_id="$event",
+        room_id="!room:localhost",
+        target=target,
+        requester_id="@user:localhost",
+        sender_id="@user:localhost",
+        body="hello",
+        attachment_ids=(),
+        mentioned_agents=(),
+        agent_name="general",
+        source_kind="message",
+        origin=message_origin(sender_id="@user:localhost", requester_id="@user:localhost", source_kind="message"),
+    )
+
+
+def _preparation(
+    target: _MessageTarget,
+    *,
+    prompt: str = "raw prompt",
+    message_attachment_ids: tuple[str, ...] = (),
+    media_events: tuple[object, ...] = (),
+) -> ResponsePayloadPreparation:
+    return ResponsePayloadPreparation(
+        dispatch=PreparedDispatch(
+            requester_user_id="@user:localhost",
+            context=MessageContext(
+                am_i_mentioned=True,
+                is_thread=target.resolved_thread_id is not None,
+                thread_id=target.resolved_thread_id,
+                thread_history=[],
+                mentioned_agents=[],
+                has_non_agent_mentions=False,
+            ),
+            target=target,
+            correlation_id="$event",
+            envelope=_envelope(target),
+        ),
+        prompt=prompt,
+        message_attachment_ids=message_attachment_ids,
+        trusted_attachment_ids=(),
+        media_events=cast("tuple", media_events),
+        target_member_names=None,
+        dispatch_started_at=1.0,
+        context_ready_monotonic=2.0,
+    )
+
+
+def _request(
+    target: _MessageTarget,
+    preparation: ResponsePayloadPreparation,
+    *,
+    thread_history: object,
+) -> ResponseRequest:
+    return ResponseRequest(
+        thread_history=cast("list", thread_history),
+        prompt=preparation.prompt,
+        user_id="@user:localhost",
+        response_envelope=_envelope(target),
+        payload_preparation=preparation,
+    )
+
+
+@pytest.mark.asyncio
+async def test_prepare_builds_request_from_inputs_and_refreshed_history(tmp_path: Path) -> None:
+    """The preparer builds the final payload from the refreshed history and clears itself."""
+    bot = _bot(tmp_path)
+    preparer = bot._request_payload_preparer
+    target = _target()
+    refreshed_history = ThreadHistoryResult([], is_full_history=True)
+    seen: list[object] = []
+
+    async def fake_build(request: object) -> DispatchPayload:
+        seen.append(request)
+        return DispatchPayload(prompt="built prompt", model_prompt="model", attachment_ids=["att-1"])
+
+    with patch.object(
+        bot._inbound_turn_normalizer,
+        "build_dispatch_payload_with_attachments",
+        new=AsyncMock(side_effect=fake_build),
+    ):
+        result = await preparer.prepare(
+            _request(target, _preparation(target, message_attachment_ids=("att-1",)), thread_history=refreshed_history),
+        )
+
+    assert result.prompt == "built prompt"
+    assert result.model_prompt == "model"
+    assert result.attachment_ids == ("att-1",)
+    assert result.payload_preparation is None
+    assert result.requires_model_history_refresh is False
+    assert result.thread_history is refreshed_history
+    # The under-lock build consumes the refreshed history and the raw prompt.
+    build_request = seen[0]
+    assert build_request.thread_history is refreshed_history
+    assert build_request.prompt == "raw prompt"
+
+
+@pytest.mark.asyncio
+async def test_prepare_logs_startup_latency_fields(tmp_path: Path) -> None:
+    """The preparer emits one startup-latency log including thread diagnostics."""
+    bot = _bot(tmp_path)
+    preparer = bot._request_payload_preparer
+    preparer.logger = MagicMock()
+    target = _target()
+    refreshed_history = ThreadHistoryResult(
+        [],
+        is_full_history=True,
+        diagnostics={"cache_read_ms": 11.0, "resolution_ms": 33.0},
+    )
+
+    with patch.object(
+        bot._inbound_turn_normalizer,
+        "build_dispatch_payload_with_attachments",
+        new=AsyncMock(return_value=DispatchPayload(prompt="built")),
+    ):
+        await preparer.prepare(_request(target, _preparation(target), thread_history=refreshed_history))
+
+    latency_logs = [
+        call for call in preparer.logger.info.call_args_list if call.args and call.args[0] == "Response startup latency"
+    ]
+    assert len(latency_logs) == 1
+    kwargs = latency_logs[0].kwargs
+    assert kwargs["cache_read_ms"] == 11.0
+    assert kwargs["resolution_ms"] == 33.0
+    assert kwargs["context_hydration_ms"] == 1000.0  # (2.0 - 1.0) seconds in ms
+    assert kwargs["startup_total_ms"] == kwargs["context_hydration_ms"] + kwargs["payload_hydration_ms"]
+
+
+@pytest.mark.asyncio
+async def test_prepare_emits_payload_builder_timing_success(tmp_path: Path) -> None:
+    """A successful build emits one ``response_payload.builder`` timing with success outcome."""
+    bot = _bot(tmp_path)
+    target = _target(thread_id="$thread")
+
+    with (
+        patch.object(
+            bot._inbound_turn_normalizer,
+            "build_dispatch_payload_with_attachments",
+            new=AsyncMock(return_value=DispatchPayload(prompt="built")),
+        ),
+        patch("mindroom.response_payload_preparation.emit_elapsed_timing") as mock_emit,
+    ):
+        await bot._request_payload_preparer.prepare(
+            _request(target, _preparation(target), thread_history=ThreadHistoryResult([], is_full_history=True)),
+        )
+
+    builder_calls = [
+        call for call in mock_emit.call_args_list if call.args and call.args[0] == "response_payload.builder"
+    ]
+    assert len(builder_calls) == 1
+    assert builder_calls[0].kwargs == {
+        "room_id": "!room:localhost",
+        "thread_id": "$thread",
+        "outcome": "success",
+    }
+
+
+@pytest.mark.asyncio
+async def test_prepare_emits_payload_builder_timing_on_failure(tmp_path: Path) -> None:
+    """A failing build still emits one ``response_payload.builder`` timing with failed outcome."""
+    bot = _bot(tmp_path)
+    target = _target(thread_id="$thread")
+
+    with (
+        patch.object(
+            bot._inbound_turn_normalizer,
+            "build_dispatch_payload_with_attachments",
+            new=AsyncMock(side_effect=RuntimeError("boom")),
+        ),
+        patch("mindroom.response_payload_preparation.emit_elapsed_timing") as mock_emit,
+        pytest.raises(RuntimeError, match="boom"),
+    ):
+        await bot._request_payload_preparer.prepare(
+            _request(target, _preparation(target), thread_history=ThreadHistoryResult([], is_full_history=True)),
+        )
+
+    builder_calls = [
+        call for call in mock_emit.call_args_list if call.args and call.args[0] == "response_payload.builder"
+    ]
+    assert len(builder_calls) == 1
+    assert builder_calls[0].kwargs["outcome"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_prepare_registers_batch_media_when_media_events_present(tmp_path: Path) -> None:
+    """Media events trigger batch-media registration before the payload build."""
+    bot = _bot(tmp_path)
+    target = _target()
+    media_result = MagicMock(attachment_ids=["media-att"], fallback_images=None)
+    register_mock = AsyncMock(return_value=media_result)
+    build_mock = AsyncMock(return_value=DispatchPayload(prompt="built"))
+
+    with (
+        patch.object(bot._inbound_turn_normalizer, "register_batch_media_attachments", new=register_mock),
+        patch.object(bot._inbound_turn_normalizer, "build_dispatch_payload_with_attachments", new=build_mock),
+    ):
+        await bot._request_payload_preparer.prepare(
+            _request(
+                target,
+                _preparation(target, media_events=(object(),)),
+                thread_history=ThreadHistoryResult([], is_full_history=True),
+            ),
+        )
+
+    register_mock.assert_awaited_once()
+    build_request = build_mock.await_args.args[0]
+    assert "media-att" in build_request.current_attachment_ids
+
+
+@pytest.mark.asyncio
+async def test_generate_response_invokes_preparer_exactly_once_under_lock(tmp_path: Path) -> None:
+    """The runner calls the preparer once, after acquiring the lifecycle lock."""
+    bot = _bot(tmp_path)
+    coordinator = unwrap_extracted_collaborator(bot._response_runner)
+    target = _target()
+    prepare_calls: list[ResponseRequest] = []
+    lock_held_at_prepare: list[bool] = []
+
+    real_prepare = bot._request_payload_preparer.prepare
+
+    async def spy_prepare(request: ResponseRequest) -> ResponseRequest:
+        prepare_calls.append(request)
+        lock_held_at_prepare.append(coordinator.has_active_response_for_target(target))
+        return await real_prepare(request)
+
+    async def fake_run_cancellable_response(**kwargs: object) -> str:
+        response_function = cast("Callable[[object | None], Awaitable[object]]", kwargs["response_function"])
+        await response_function(None)
+        return "$response"
+
+    async def fake_process_and_respond(_request: ResponseRequest, **_kwargs: object) -> FinalDeliveryOutcome:
+        return FinalDeliveryOutcome(
+            terminal_status="completed",
+            event_id="$response",
+            is_visible_response=True,
+            final_visible_body="ok",
+            delivery_kind="sent",
+        )
+
+    with (
+        patch.object(bot._request_payload_preparer, "prepare", new=AsyncMock(side_effect=spy_prepare)),
+        patch.object(
+            bot._inbound_turn_normalizer,
+            "build_dispatch_payload_with_attachments",
+            new=AsyncMock(return_value=DispatchPayload(prompt="built")),
+        ),
+        patch.object(coordinator, "run_cancellable_response", new=AsyncMock(side_effect=fake_run_cancellable_response)),
+        patch.object(coordinator, "process_and_respond", new=AsyncMock(side_effect=fake_process_and_respond)),
+        patch("mindroom.response_runner.should_use_streaming", AsyncMock(return_value=False)),
+    ):
+        result = await coordinator.generate_response(
+            _request(target, _preparation(target), thread_history=[]),
+        )
+
+    assert result == "$response"
+    assert len(prepare_calls) == 1
+    assert lock_held_at_prepare == [True]

--- a/tests/test_response_payload_preparation.py
+++ b/tests/test_response_payload_preparation.py
@@ -25,7 +25,7 @@ from mindroom.inbound_turn_normalizer import DispatchPayload
 from mindroom.matrix.cache import ThreadHistoryResult
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
-from mindroom.response_payload_preparation import ResponsePayloadPreparation
+from mindroom.response_payload_preparation import DispatchPayloadInputs, ResponsePayloadPreparation
 from mindroom.response_runner import ResponseRequest
 from mindroom.turn_policy import PreparedDispatch
 from tests.conftest import (
@@ -123,9 +123,11 @@ def _preparation(
         ),
         prompt=prompt,
         action_kind=action_kind,
-        message_attachment_ids=message_attachment_ids,
-        trusted_attachment_ids=(),
-        media_events=cast("tuple", media_events),
+        payload_inputs=DispatchPayloadInputs(
+            message_attachment_ids=message_attachment_ids,
+            trusted_attachment_ids=(),
+            media_events=cast("tuple", media_events),
+        ),
         target_member_names=None,
         dispatch_started_at=1.0,
         context_ready_monotonic=2.0,

--- a/tests/test_response_payload_preparation.py
+++ b/tests/test_response_payload_preparation.py
@@ -102,6 +102,7 @@ def _preparation(
     target: _MessageTarget,
     *,
     prompt: str = "raw prompt",
+    action_kind: str = "individual",
     message_attachment_ids: tuple[str, ...] = (),
     media_events: tuple[object, ...] = (),
 ) -> ResponsePayloadPreparation:
@@ -121,6 +122,7 @@ def _preparation(
             envelope=_envelope(target),
         ),
         prompt=prompt,
+        action_kind=action_kind,
         message_attachment_ids=message_attachment_ids,
         trusted_attachment_ids=(),
         media_events=cast("tuple", media_events),
@@ -197,13 +199,16 @@ async def test_prepare_logs_startup_latency_fields(tmp_path: Path) -> None:
         "build_dispatch_payload_with_attachments",
         new=AsyncMock(return_value=DispatchPayload(prompt="built")),
     ):
-        await preparer.prepare(_request(target, _preparation(target), thread_history=refreshed_history))
+        await preparer.prepare(
+            _request(target, _preparation(target, action_kind="team"), thread_history=refreshed_history),
+        )
 
     latency_logs = [
         call for call in preparer.logger.info.call_args_list if call.args and call.args[0] == "Response startup latency"
     ]
     assert len(latency_logs) == 1
     kwargs = latency_logs[0].kwargs
+    assert kwargs["action_kind"] == "team"
     assert kwargs["cache_read_ms"] == 11.0
     assert kwargs["resolution_ms"] == 33.0
     assert kwargs["context_hydration_ms"] == 1000.0  # (2.0 - 1.0) seconds in ms

--- a/tests/test_response_payload_preparation.py
+++ b/tests/test_response_payload_preparation.py
@@ -40,10 +40,11 @@ from tests.conftest import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
+    from collections.abc import Awaitable, Callable, Sequence
     from pathlib import Path
 
-    from mindroom.message_target import MessageTarget as _MessageTarget
+    from mindroom.dispatch_handoff import MediaDispatchEvent
+    from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
 
 
 def _config(tmp_path: Path) -> Config:
@@ -73,7 +74,7 @@ def _bot(tmp_path: Path) -> AgentBot:
     return bot
 
 
-def _target(thread_id: str | None = None) -> _MessageTarget:
+def _target(thread_id: str | None = None) -> MessageTarget:
     return MessageTarget.resolve(
         room_id="!room:localhost",
         thread_id=thread_id,
@@ -82,7 +83,7 @@ def _target(thread_id: str | None = None) -> _MessageTarget:
     )
 
 
-def _envelope(target: _MessageTarget) -> MessageEnvelope:
+def _envelope(target: MessageTarget) -> MessageEnvelope:
     return MessageEnvelope(
         source_event_id="$event",
         room_id="!room:localhost",
@@ -99,12 +100,12 @@ def _envelope(target: _MessageTarget) -> MessageEnvelope:
 
 
 def _preparation(
-    target: _MessageTarget,
+    target: MessageTarget,
     *,
     prompt: str = "raw prompt",
     action_kind: str = "individual",
     message_attachment_ids: tuple[str, ...] = (),
-    media_events: tuple[object, ...] = (),
+    media_events: tuple[MediaDispatchEvent, ...] = (),
 ) -> ResponsePayloadPreparation:
     return ResponsePayloadPreparation(
         dispatch=PreparedDispatch(
@@ -126,7 +127,7 @@ def _preparation(
         payload_inputs=DispatchPayloadInputs(
             message_attachment_ids=message_attachment_ids,
             trusted_attachment_ids=(),
-            media_events=cast("tuple", media_events),
+            media_events=media_events,
         ),
         target_member_names=None,
         dispatch_started_at=1.0,
@@ -135,13 +136,13 @@ def _preparation(
 
 
 def _request(
-    target: _MessageTarget,
+    target: MessageTarget,
     preparation: ResponsePayloadPreparation,
     *,
-    thread_history: object,
+    thread_history: Sequence[ResolvedVisibleMessage],
 ) -> ResponseRequest:
     return ResponseRequest(
-        thread_history=cast("list", thread_history),
+        thread_history=thread_history,
         prompt=preparation.prompt,
         user_id="@user:localhost",
         response_envelope=_envelope(target),
@@ -288,7 +289,7 @@ async def test_prepare_registers_batch_media_when_media_events_present(tmp_path:
         await bot._request_payload_preparer.prepare(
             _request(
                 target,
-                _preparation(target, media_events=(object(),)),
+                _preparation(target, media_events=(MagicMock(),)),
                 thread_history=ThreadHistoryResult([], is_full_history=True),
             ),
         )


### PR DESCRIPTION
## What

The seam between turn planning (ingress) and response execution was circular: `turn_controller._execute_response_action` built a `ResponseRequest` carrying a `prepare_after_lock` callback; `response_runner` acquired the lifecycle lock and then invoked that callback, which called **back into** `turn_controller` to finish assembling the request. Neither side could be understood or tested alone.

This PR makes it an explicit **one-way** seam, implementing the "Shrink ResponseRunner" item in `docs/architecture/bot-runtime.md`.

## How

- **Ingress produces an immutable value.** `TurnController` + `text_ingress_dispatch` now build a `ResponsePayloadPreparation` (raw prompt, dispatch, a nested `DispatchPayloadInputs` carrier for attachment ids and media events, target member names, timing marks) and hand it to the runner inside `ResponseRequest.payload_preparation`. No closures cross the seam — data crosses as values.
- **Execution owns the under-lock step.** New module `response_payload_preparation.py` defines `ResponsePayloadPreparer`, a first-class, named execution-side step. After the runner takes the lifecycle lock and refreshes thread history, it calls `preparer.prepare(...)` to register batch media, merge attachments, run enrichment hooks, and log startup latency. Wired in via `ResponseRunnerDeps.request_preparer`.
- **Old owners deleted, not duplicated.** `ResponseRequest.prepare_after_lock` and `TurnController._log_dispatch_latency` are removed; the payload-building closures in `turn_controller`/`text_ingress_dispatch` are gone. The dead `try/except` around context-hydration timing in `_execute_response_action` (its body had shrunk to a bare `time.monotonic()` call, which cannot raise) is removed too, which also drops the `PLR0915` suppression on that method.

## Safety / behavior

This is a refactor, not a behavior change. Dedup (handled turns), lock semantics (no two concurrent responses per target), queued-notice behavior, and streaming output are preserved.

"What happens when a message arrives" is now two sequential stories with one data structure (`ResponsePayloadPreparation`) between them.

## Tests

- New `tests/test_response_payload_preparation.py` with direct seam tests: building the request from inputs + refreshed history, latency-log fields, payload-builder timing (success + failure), batch-media registration, and that the under-lock prep runs **exactly once** while the lock is held.
- Existing runtime tests updated to the new interface (no weakened assertions): `test_multi_agent_bot`, `test_live_message_coalescing`, `test_queued_message_notify`, `test_hook_sender`, `test_issue_154_logging_integration`, `test_ai_user_id`. A shared `prepare_payload_via_seam` helper in `tests/conftest.py` drives the execution-side preparation from captured dispatch args where tests need the payload built.
- All affected test files: **698 passed**, 4 skipped.
- `uv run tach check --dependencies --interfaces` ✅ (boundaries + new module entry updated).
- `pre-commit` (ruff, ruff format, ty, vulture, tach, module privacy) ✅ on all files in this change.

## Scope

This is **stage 1** (the load-bearing change) of the roadmap's "Shrink ResponseRunner" work. Follow-ups noted in `bot-runtime.md`: fold `execution_preparation.py` into the execution side, and move any remaining `ResponseRunner` side paths out.

## Docs

Updated `docs/architecture/bot-runtime.md` (Completed/Next sections) and the module tables in `CLAUDE.md` and `docs/architecture/index.md`.
