### PR TITLE
Fix thread model metadata snapshot, stale override reporting, and thread_model docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Email: I'll compile and send every Friday
 
 ### 🔌 100+ Integrations
 Gmail, GitHub, Spotify, Home Assistant, Google Drive, Reddit, weather services, news APIs, financial data, and many more. Your agents can interact with all your tools.
-Native Matrix tools include `matrix_message`, `matrix_room`, `thread_tags`, and `matrix_api` for room, thread, event, state, and room-search operations.
+Native Matrix tools include `matrix_message`, `matrix_room`, `thread_tags`, `thread_model`, and `matrix_api` for room, thread, event, state, and room-search operations.
 
 ### 📅 Automation & Scheduling
 - Daily check-ins from your mindfulness agent

--- a/docs/dev/agent_configuration.md
+++ b/docs/dev/agent_configuration.md
@@ -478,6 +478,7 @@ Below is a representative selection:
 - **discord** - Discord messaging (requires bot token)
 - **matrix_message** - Send messages to other Matrix rooms
 - **thread_summary** - Write or update a one-line Matrix thread summary with `set_thread_summary`
+- **thread_model** - Show, switch, or reset the model override for the current Matrix thread (applies from the next message)
 
 ### AI & Generation Tools
 - **dalle** - Generate images with DALL-E

--- a/docs/tools/builtin.md
+++ b/docs/tools/builtin.md
@@ -19,7 +19,7 @@ icon: lucide/box
 | **Research Sources** | arxiv, wikipedia, pubmed, hackernews | [→ research-sources](research-sources.md) |
 | **AI & Generation** | openai, gemini, groq, replicate, fal, dalle, eleven_labs | [→ ai-and-generation](ai-and-generation.md) |
 | **Media & Content** | youtube, spotify, giphy, moviepy, unsplash, brandfetch | [→ media-and-content](media-and-content.md) |
-| **Matrix & Attachments** | matrix_message, thread_tags, thread_summary, matrix_api, attachments | [→ matrix-and-attachments](matrix-and-attachments.md) |
+| **Matrix & Attachments** | matrix_message, thread_tags, thread_summary, thread_model, matrix_api, attachments | [→ matrix-and-attachments](matrix-and-attachments.md) |
 | **Messaging & Social** | gmail, slack, discord, telegram, whatsapp, email, x, reddit | [→ messaging-and-social](messaging-and-social.md) |
 | **Project Management** | github, jira, linear, clickup, notion, trello, todoist | [→ project-management](project-management.md) |
 | **Calendar & Scheduling** | google_calendar, cal_com, scheduler | [→ calendar-and-scheduling](calendar-and-scheduling.md) |

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -49,7 +49,7 @@ See [MCP](../mcp.md) for the `mcp_servers` config and naming rules.
 - [Research Sources](research-sources.md) - ArXiv, Wikipedia, PubMed, and Hacker News.
 - [AI & Generation](ai-and-generation.md) - Image, video, speech, and transcription APIs.
 - [Media & Content](media-and-content.md) - Media processing, brand/media retrieval, and Spotify.
-- [Matrix & Attachments](matrix-and-attachments.md) - Matrix-native messaging, thread tags and summaries, low-level Matrix API access, and attachment-aware workflows.
+- [Matrix & Attachments](matrix-and-attachments.md) - Matrix-native messaging, thread tags, summaries, and model overrides, low-level Matrix API access, and attachment-aware workflows.
 - [Messaging & Social](messaging-and-social.md) - Email, chat, and social/community integrations.
 - [Project Management](project-management.md) - Git hosting, issue trackers, docs platforms, and task managers.
 - [Calendar & Scheduling](calendar-and-scheduling.md) - Calendar APIs and MindRoom scheduling tools.

--- a/docs/tools/matrix-and-attachments.md
+++ b/docs/tools/matrix-and-attachments.md
@@ -4,18 +4,19 @@ icon: lucide/wrench
 
 # Matrix & Attachments
 
-Use these tools to work inside the active Matrix room and thread, send follow-up messages, manage thread tags and summaries, and reuse files that belong to the current conversation.
+Use these tools to work inside the active Matrix room and thread, send follow-up messages, manage thread tags, summaries, and model overrides, and reuse files that belong to the current conversation.
 
 ## What This Page Covers
 
 This page documents the built-in tools in the `matrix-and-attachments` group.
-Use these tools when you need to send or inspect Matrix messages, manage thread tags or summaries, or handle attachment IDs that are scoped to the current room and thread.
+Use these tools when you need to send or inspect Matrix messages, manage thread tags, summaries, or model overrides, or handle attachment IDs that are scoped to the current room and thread.
 
 ## Tools On This Page
 
 - [`matrix_message`] - Send, reply, react, read, edit, or inspect Matrix conversation context.
 - [`thread_tags`] - Add, remove, and inspect shared tags on a Matrix thread.
 - [`thread_summary`] - Set or update a Matrix thread summary from the current room and thread context.
+- [`thread_model`] - Show, switch, or reset the model override for the current Matrix thread.
 - [`matrix_api`] - Use a low-level Matrix event and state API with explicit room and event IDs.
 - [`attachments`] - List, inspect, and register context-scoped attachment IDs for later tool calls.
 
@@ -24,7 +25,7 @@ Use these tools when you need to send or inspect Matrix messages, manage thread 
 These tools depend on the active `ToolRuntimeContext`, so they only work when an agent is running in a Matrix-connected conversation.
 `matrix_message` implies `attachments` through `Config.IMPLIED_TOOLS`, so enabling `matrix_message` makes the `attachments` toolkit available even when you do not list it separately.
 Attachment IDs are context-scoped `att_*` values, and the runtime only exposes IDs from the current conversation plus any IDs registered during the current tool run.
-Current source in this worktree exposes `matrix_message`, `thread_tags`, `thread_summary`, `matrix_api`, and `attachments` in this area.
+Current source in this worktree exposes `matrix_message`, `thread_tags`, `thread_summary`, `thread_model`, `matrix_api`, and `attachments` in this area.
 
 ## [`matrix_message`]
 
@@ -169,6 +170,45 @@ set_thread_summary(
 - `summary` must be a non-empty string up to 300 characters after whitespace normalization.
 - The tool writes a normal Matrix notice event, so the updated summary remains visible in the thread timeline.
 - Automatic thread summaries still exist, but this tool gives an agent an explicit override path when a human asks for a manual summary refresh.
+
+## [`thread_model`]
+
+`thread_model` lets agents show, switch, or reset the model override for the current Matrix thread, mirroring the `!model` chat command.
+
+### What It Does
+
+`thread_model` exposes `get_thread_model()`, `switch_thread_model(model_name)`, and `reset_thread_model()`.
+All three functions require an active thread context and return an error outside a thread.
+`switch_thread_model` accepts a configured model name from the `models:` section of `config.yaml` and rejects unknown names with the available model list.
+The override applies to all agents and teams in the thread, persists across restarts, and takes effect from the next message; the current response keeps the model it started with.
+`get_thread_model` returns the active override and the available model names.
+When a stored override names a model that has been removed from `config.models`, runtime resolution ignores it, and `get_thread_model` reports `override: null` plus a `stale_override` field instead of an active override.
+`reset_thread_model` removes the override so agents use their configured models again.
+
+### Configuration
+
+This tool has no tool-specific inline configuration fields.
+
+### Example
+
+```yaml
+agents:
+  assistant:
+    tools:
+      - thread_model
+```
+
+```python
+get_thread_model()
+switch_thread_model("opus")
+reset_thread_model()
+```
+
+### Notes
+
+- The override is stored per thread root in `mindroom_data/tracking/thread_models.json`.
+- Users can manage the same override with the `!model` chat command; see [Chat Commands](../chat-commands.md).
+- An explicit `active_model_name` (for example a delegated child run) still beats the thread override, and the thread override beats `room_models` and the authored entity model.
 
 ## [`matrix_api`]
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -2788,7 +2788,7 @@ See [MCP](https://docs.mindroom.chat/mcp/) for the `mcp_servers` config and nami
 - [Research Sources](https://docs.mindroom.chat/tools/research-sources/) - ArXiv, Wikipedia, PubMed, and Hacker News.
 - [AI & Generation](https://docs.mindroom.chat/tools/ai-and-generation/) - Image, video, speech, and transcription APIs.
 - [Media & Content](https://docs.mindroom.chat/tools/media-and-content/) - Media processing, brand/media retrieval, and Spotify.
-- [Matrix & Attachments](https://docs.mindroom.chat/tools/matrix-and-attachments/) - Matrix-native messaging, thread tags and summaries, low-level Matrix API access, and attachment-aware workflows.
+- [Matrix & Attachments](https://docs.mindroom.chat/tools/matrix-and-attachments/) - Matrix-native messaging, thread tags, summaries, and model overrides, low-level Matrix API access, and attachment-aware workflows.
 - [Messaging & Social](https://docs.mindroom.chat/tools/messaging-and-social/) - Email, chat, and social/community integrations.
 - [Project Management](https://docs.mindroom.chat/tools/project-management/) - Git hosting, issue trackers, docs platforms, and task managers.
 - [Calendar & Scheduling](https://docs.mindroom.chat/tools/calendar-and-scheduling/) - Calendar APIs and MindRoom scheduling tools.
@@ -6414,18 +6414,19 @@ get_currently_playing()
 
 # Matrix & Attachments
 
-Use these tools to work inside the active Matrix room and thread, send follow-up messages, manage thread tags and summaries, and reuse files that belong to the current conversation.
+Use these tools to work inside the active Matrix room and thread, send follow-up messages, manage thread tags, summaries, and model overrides, and reuse files that belong to the current conversation.
 
 ## What This Page Covers
 
 This page documents the built-in tools in the `matrix-and-attachments` group.
-Use these tools when you need to send or inspect Matrix messages, manage thread tags or summaries, or handle attachment IDs that are scoped to the current room and thread.
+Use these tools when you need to send or inspect Matrix messages, manage thread tags, summaries, or model overrides, or handle attachment IDs that are scoped to the current room and thread.
 
 ## Tools On This Page
 
 - [`matrix_message`] - Send, reply, react, read, edit, or inspect Matrix conversation context.
 - [`thread_tags`] - Add, remove, and inspect shared tags on a Matrix thread.
 - [`thread_summary`] - Set or update a Matrix thread summary from the current room and thread context.
+- [`thread_model`] - Show, switch, or reset the model override for the current Matrix thread.
 - [`matrix_api`] - Use a low-level Matrix event and state API with explicit room and event IDs.
 - [`attachments`] - List, inspect, and register context-scoped attachment IDs for later tool calls.
 
@@ -6434,7 +6435,7 @@ Use these tools when you need to send or inspect Matrix messages, manage thread 
 These tools depend on the active `ToolRuntimeContext`, so they only work when an agent is running in a Matrix-connected conversation.
 `matrix_message` implies `attachments` through `Config.IMPLIED_TOOLS`, so enabling `matrix_message` makes the `attachments` toolkit available even when you do not list it separately.
 Attachment IDs are context-scoped `att_*` values, and the runtime only exposes IDs from the current conversation plus any IDs registered during the current tool run.
-Current source in this worktree exposes `matrix_message`, `thread_tags`, `thread_summary`, `matrix_api`, and `attachments` in this area.
+Current source in this worktree exposes `matrix_message`, `thread_tags`, `thread_summary`, `thread_model`, `matrix_api`, and `attachments` in this area.
 
 ## [`matrix_message`]
 
@@ -6579,6 +6580,45 @@ set_thread_summary(
 - `summary` must be a non-empty string up to 300 characters after whitespace normalization.
 - The tool writes a normal Matrix notice event, so the updated summary remains visible in the thread timeline.
 - Automatic thread summaries still exist, but this tool gives an agent an explicit override path when a human asks for a manual summary refresh.
+
+## [`thread_model`]
+
+`thread_model` lets agents show, switch, or reset the model override for the current Matrix thread, mirroring the `!model` chat command.
+
+### What It Does
+
+`thread_model` exposes `get_thread_model()`, `switch_thread_model(model_name)`, and `reset_thread_model()`.
+All three functions require an active thread context and return an error outside a thread.
+`switch_thread_model` accepts a configured model name from the `models:` section of `config.yaml` and rejects unknown names with the available model list.
+The override applies to all agents and teams in the thread, persists across restarts, and takes effect from the next message; the current response keeps the model it started with.
+`get_thread_model` returns the active override and the available model names.
+When a stored override names a model that has been removed from `config.models`, runtime resolution ignores it, and `get_thread_model` reports `override: null` plus a `stale_override` field instead of an active override.
+`reset_thread_model` removes the override so agents use their configured models again.
+
+### Configuration
+
+This tool has no tool-specific inline configuration fields.
+
+### Example
+
+```yaml
+agents:
+  assistant:
+    tools:
+      - thread_model
+```
+
+```python
+get_thread_model()
+switch_thread_model("opus")
+reset_thread_model()
+```
+
+### Notes
+
+- The override is stored per thread root in `mindroom_data/tracking/thread_models.json`.
+- Users can manage the same override with the `!model` chat command; see [Chat Commands](https://docs.mindroom.chat/chat-commands/).
+- An explicit `active_model_name` (for example a delegated child run) still beats the thread override, and the thread override beats `room_models` and the authored entity model.
 
 ## [`matrix_api`]
 
@@ -9345,7 +9385,7 @@ call_service("notify", "send_message", data='{"message": "Dinner is ready"}')
 | **Research Sources** | arxiv, wikipedia, pubmed, hackernews | [→ research-sources](https://docs.mindroom.chat/tools/research-sources/) |
 | **AI & Generation** | openai, gemini, groq, replicate, fal, dalle, eleven_labs | [→ ai-and-generation](https://docs.mindroom.chat/tools/ai-and-generation/) |
 | **Media & Content** | youtube, spotify, giphy, moviepy, unsplash, brandfetch | [→ media-and-content](https://docs.mindroom.chat/tools/media-and-content/) |
-| **Matrix & Attachments** | matrix_message, thread_tags, thread_summary, matrix_api, attachments | [→ matrix-and-attachments](https://docs.mindroom.chat/tools/matrix-and-attachments/) |
+| **Matrix & Attachments** | matrix_message, thread_tags, thread_summary, thread_model, matrix_api, attachments | [→ matrix-and-attachments](https://docs.mindroom.chat/tools/matrix-and-attachments/) |
 | **Messaging & Social** | gmail, slack, discord, telegram, whatsapp, email, x, reddit | [→ messaging-and-social](https://docs.mindroom.chat/tools/messaging-and-social/) |
 | **Project Management** | github, jira, linear, clickup, notion, trello, todoist | [→ project-management](https://docs.mindroom.chat/tools/project-management/) |
 | **Calendar & Scheduling** | google_calendar, cal_com, scheduler | [→ calendar-and-scheduling](https://docs.mindroom.chat/tools/calendar-and-scheduling/) |

--- a/skills/mindroom-docs/references/page__tools__builtin__index.md
+++ b/skills/mindroom-docs/references/page__tools__builtin__index.md
@@ -15,7 +15,7 @@
 | **Research Sources** | arxiv, wikipedia, pubmed, hackernews | [→ research-sources](https://docs.mindroom.chat/tools/research-sources/) |
 | **AI & Generation** | openai, gemini, groq, replicate, fal, dalle, eleven_labs | [→ ai-and-generation](https://docs.mindroom.chat/tools/ai-and-generation/) |
 | **Media & Content** | youtube, spotify, giphy, moviepy, unsplash, brandfetch | [→ media-and-content](https://docs.mindroom.chat/tools/media-and-content/) |
-| **Matrix & Attachments** | matrix_message, thread_tags, thread_summary, matrix_api, attachments | [→ matrix-and-attachments](https://docs.mindroom.chat/tools/matrix-and-attachments/) |
+| **Matrix & Attachments** | matrix_message, thread_tags, thread_summary, thread_model, matrix_api, attachments | [→ matrix-and-attachments](https://docs.mindroom.chat/tools/matrix-and-attachments/) |
 | **Messaging & Social** | gmail, slack, discord, telegram, whatsapp, email, x, reddit | [→ messaging-and-social](https://docs.mindroom.chat/tools/messaging-and-social/) |
 | **Project Management** | github, jira, linear, clickup, notion, trello, todoist | [→ project-management](https://docs.mindroom.chat/tools/project-management/) |
 | **Calendar & Scheduling** | google_calendar, cal_com, scheduler | [→ calendar-and-scheduling](https://docs.mindroom.chat/tools/calendar-and-scheduling/) |

--- a/skills/mindroom-docs/references/page__tools__index.md
+++ b/skills/mindroom-docs/references/page__tools__index.md
@@ -45,7 +45,7 @@ See [MCP](https://docs.mindroom.chat/mcp/) for the `mcp_servers` config and nami
 - [Research Sources](https://docs.mindroom.chat/tools/research-sources/) - ArXiv, Wikipedia, PubMed, and Hacker News.
 - [AI & Generation](https://docs.mindroom.chat/tools/ai-and-generation/) - Image, video, speech, and transcription APIs.
 - [Media & Content](https://docs.mindroom.chat/tools/media-and-content/) - Media processing, brand/media retrieval, and Spotify.
-- [Matrix & Attachments](https://docs.mindroom.chat/tools/matrix-and-attachments/) - Matrix-native messaging, thread tags and summaries, low-level Matrix API access, and attachment-aware workflows.
+- [Matrix & Attachments](https://docs.mindroom.chat/tools/matrix-and-attachments/) - Matrix-native messaging, thread tags, summaries, and model overrides, low-level Matrix API access, and attachment-aware workflows.
 - [Messaging & Social](https://docs.mindroom.chat/tools/messaging-and-social/) - Email, chat, and social/community integrations.
 - [Project Management](https://docs.mindroom.chat/tools/project-management/) - Git hosting, issue trackers, docs platforms, and task managers.
 - [Calendar & Scheduling](https://docs.mindroom.chat/tools/calendar-and-scheduling/) - Calendar APIs and MindRoom scheduling tools.

--- a/skills/mindroom-docs/references/page__tools__matrix-and-attachments__index.md
+++ b/skills/mindroom-docs/references/page__tools__matrix-and-attachments__index.md
@@ -1,17 +1,18 @@
 # Matrix & Attachments
 
-Use these tools to work inside the active Matrix room and thread, send follow-up messages, manage thread tags and summaries, and reuse files that belong to the current conversation.
+Use these tools to work inside the active Matrix room and thread, send follow-up messages, manage thread tags, summaries, and model overrides, and reuse files that belong to the current conversation.
 
 ## What This Page Covers
 
 This page documents the built-in tools in the `matrix-and-attachments` group.
-Use these tools when you need to send or inspect Matrix messages, manage thread tags or summaries, or handle attachment IDs that are scoped to the current room and thread.
+Use these tools when you need to send or inspect Matrix messages, manage thread tags, summaries, or model overrides, or handle attachment IDs that are scoped to the current room and thread.
 
 ## Tools On This Page
 
 - [`matrix_message`] - Send, reply, react, read, edit, or inspect Matrix conversation context.
 - [`thread_tags`] - Add, remove, and inspect shared tags on a Matrix thread.
 - [`thread_summary`] - Set or update a Matrix thread summary from the current room and thread context.
+- [`thread_model`] - Show, switch, or reset the model override for the current Matrix thread.
 - [`matrix_api`] - Use a low-level Matrix event and state API with explicit room and event IDs.
 - [`attachments`] - List, inspect, and register context-scoped attachment IDs for later tool calls.
 
@@ -20,7 +21,7 @@ Use these tools when you need to send or inspect Matrix messages, manage thread 
 These tools depend on the active `ToolRuntimeContext`, so they only work when an agent is running in a Matrix-connected conversation.
 `matrix_message` implies `attachments` through `Config.IMPLIED_TOOLS`, so enabling `matrix_message` makes the `attachments` toolkit available even when you do not list it separately.
 Attachment IDs are context-scoped `att_*` values, and the runtime only exposes IDs from the current conversation plus any IDs registered during the current tool run.
-Current source in this worktree exposes `matrix_message`, `thread_tags`, `thread_summary`, `matrix_api`, and `attachments` in this area.
+Current source in this worktree exposes `matrix_message`, `thread_tags`, `thread_summary`, `thread_model`, `matrix_api`, and `attachments` in this area.
 
 ## [`matrix_message`]
 
@@ -165,6 +166,45 @@ set_thread_summary(
 - `summary` must be a non-empty string up to 300 characters after whitespace normalization.
 - The tool writes a normal Matrix notice event, so the updated summary remains visible in the thread timeline.
 - Automatic thread summaries still exist, but this tool gives an agent an explicit override path when a human asks for a manual summary refresh.
+
+## [`thread_model`]
+
+`thread_model` lets agents show, switch, or reset the model override for the current Matrix thread, mirroring the `!model` chat command.
+
+### What It Does
+
+`thread_model` exposes `get_thread_model()`, `switch_thread_model(model_name)`, and `reset_thread_model()`.
+All three functions require an active thread context and return an error outside a thread.
+`switch_thread_model` accepts a configured model name from the `models:` section of `config.yaml` and rejects unknown names with the available model list.
+The override applies to all agents and teams in the thread, persists across restarts, and takes effect from the next message; the current response keeps the model it started with.
+`get_thread_model` returns the active override and the available model names.
+When a stored override names a model that has been removed from `config.models`, runtime resolution ignores it, and `get_thread_model` reports `override: null` plus a `stale_override` field instead of an active override.
+`reset_thread_model` removes the override so agents use their configured models again.
+
+### Configuration
+
+This tool has no tool-specific inline configuration fields.
+
+### Example
+
+```yaml
+agents:
+  assistant:
+    tools:
+      - thread_model
+```
+
+```python
+get_thread_model()
+switch_thread_model("opus")
+reset_thread_model()
+```
+
+### Notes
+
+- The override is stored per thread root in `mindroom_data/tracking/thread_models.json`.
+- Users can manage the same override with the `!model` chat command; see [Chat Commands](https://docs.mindroom.chat/chat-commands/).
+- An explicit `active_model_name` (for example a delegated child run) still beats the thread override, and the thread override beats `room_models` and the authored entity model.
 
 ## [`matrix_api`]
 

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -1170,8 +1170,7 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                     tool_count=len(response.tools) if response.tools is not None else 0,
                     prepared_history=prepared_run.prepared_history,
                 )
-                if run_metadata:
-                    run_metadata_collector.update(run_metadata)
+                run_metadata_collector.update(run_metadata)
 
             if response.status == RunStatus.cancelled:
                 partial_text = _extract_interrupted_partial_text(
@@ -1748,8 +1747,7 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                                 tool_count=state.observed_tool_calls,
                                 prepared_history=prepared_run.prepared_history,
                             )
-                            if cancelled_metadata:
-                                run_metadata_collector.update(cancelled_metadata)
+                            run_metadata_collector.update(cancelled_metadata)
                         if turn_recorder is None:
                             persist_interrupted_replay(
                                 scope_context=scope_context,
@@ -1806,8 +1804,7 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                         ),
                         prepared_history=prepared_run.prepared_history,
                     )
-                    if run_metadata:
-                        run_metadata_collector.update(run_metadata)
+                    run_metadata_collector.update(run_metadata)
                 if turn_recorder is not None:
                     final_visible_body = state.assistant_text or state.canonical_final_body_candidate or ""
                     turn_recorder.record_completed(

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -146,6 +146,10 @@ class _PreparedAgentRun:
     messages: tuple[Message, ...]
     unseen_event_ids: list[str]
     prepared_history: PreparedHistoryState
+    # Configured model name resolved at preparation time. Run metadata must use
+    # this snapshot instead of re-resolving, because the per-thread override
+    # store can change mid-run (for example via the thread_model tool).
+    runtime_model_name: str
 
     @property
     def prompt_text(self) -> str:
@@ -839,6 +843,7 @@ async def _prepare_agent_and_prompt(
         messages=run_messages,
         unseen_event_ids=unseen_event_ids,
         prepared_history=prepared_history,
+        runtime_model_name=runtime_model.model_name,
     )
 
 
@@ -1153,16 +1158,13 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                 tool_trace_collector.extend(_extract_tool_trace(response))
             if run_metadata_collector is not None:
                 run_metadata = build_ai_run_metadata_content(
-                    agent_name=agent_name,
                     config=config,
-                    runtime_paths=runtime_paths,
+                    model_name=prepared_run.runtime_model_name,
                     run_id=response.run_id,
                     session_id=response.session_id or session_id,
                     status=response.status,
                     model=response.model,
                     model_provider=response.model_provider,
-                    room_id=room_id,
-                    thread_id=thread_id,
                     metrics=response.metrics,
                     context_input_tokens=prepared_run.prepared_history.estimated_context_tokens,
                     tool_count=len(response.tools) if response.tools is not None else 0,
@@ -1731,16 +1733,13 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                                 state.observed_request_metric_fields,
                             )
                             cancelled_metadata = build_ai_run_metadata_content(
-                                agent_name=agent_name,
                                 config=config,
-                                runtime_paths=runtime_paths,
+                                model_name=prepared_run.runtime_model_name,
                                 run_id=state.cancelled_run_event.run_id,
                                 session_id=state.cancelled_run_event.session_id or session_id,
                                 status=RunStatus.cancelled,
                                 model=state.latest_model_id,
                                 model_provider=state.latest_model_provider,
-                                room_id=room_id,
-                                thread_id=thread_id,
                                 metrics=fallback_metrics,
                                 context_input_tokens=prepared_context_input_tokens,
                                 context_raw_input_tokens=state.latest_request_input_tokens,
@@ -1782,9 +1781,8 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                         fallback_metrics,
                     )
                     run_metadata = build_ai_run_metadata_content(
-                        agent_name=agent_name,
                         config=config,
-                        runtime_paths=runtime_paths,
+                        model_name=prepared_run.runtime_model_name,
                         run_id=state.completed_run_event.run_id if state.completed_run_event is not None else None,
                         session_id=(
                             state.completed_run_event.session_id
@@ -1795,8 +1793,6 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                         status=final_status,
                         model=state.latest_model_id,
                         model_provider=state.latest_model_provider,
-                        room_id=room_id,
-                        thread_id=thread_id,
                         metrics=usage_metrics,
                         metrics_fallback=usage_metrics_fallback,
                         context_input_tokens=prepared_context_input_tokens,

--- a/src/mindroom/ai_run_metadata.py
+++ b/src/mindroom/ai_run_metadata.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 from agno.models.metrics import Metrics
 from agno.run.base import RunStatus
 
-from mindroom.constants import AI_RUN_METADATA_KEY, ROUTER_AGENT_NAME, RuntimePaths
+from mindroom.constants import AI_RUN_METADATA_KEY
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -29,26 +29,6 @@ def empty_request_metric_totals() -> dict[str, int]:
         "cache_read_tokens": 0,
         "cache_write_tokens": 0,
     }
-
-
-def _get_model_config(
-    config: Config,
-    agent_name: str,
-    *,
-    runtime_paths: RuntimePaths,
-    room_id: str | None = None,
-    thread_id: str | None = None,
-) -> tuple[str | None, ModelConfig | None]:
-    """Return configured model name/config for an agent when available."""
-    if agent_name not in config.agents and agent_name not in config.teams and agent_name != ROUTER_AGENT_NAME:
-        return None, None
-    model_name = config.resolve_runtime_model(
-        entity_name=agent_name,
-        room_id=room_id,
-        thread_id=thread_id,
-        runtime_paths=runtime_paths,
-    ).model_name
-    return model_name, config.models.get(model_name)
 
 
 def _serialize_metrics(metrics: Metrics | dict[str, Any] | None) -> dict[str, Any] | None:
@@ -233,16 +213,13 @@ def ai_run_extra_content_from_metadata(run_metadata: Mapping[str, Any] | None) -
 
 def build_ai_run_metadata_content(  # noqa: C901, PLR0912, PLR0915
     *,
-    agent_name: str,
     config: Config,
-    runtime_paths: RuntimePaths,
+    model_name: str | None,
     run_id: str | None,
     session_id: str | None,
     status: RunStatus | str | None,
     model: str | None,
     model_provider: str | None,
-    room_id: str | None = None,
-    thread_id: str | None = None,
     metrics: Metrics | dict[str, Any] | None = None,
     metrics_fallback: dict[str, Any] | None = None,
     context_raw_input_tokens: int | None = None,
@@ -252,14 +229,14 @@ def build_ai_run_metadata_content(  # noqa: C901, PLR0912, PLR0915
     tool_count: int | None = None,
     prepared_history: PreparedHistoryState | None = None,
 ) -> dict[str, Any] | None:
-    """Build the Matrix event content fragment for one AI run."""
-    model_name, model_config = _get_model_config(
-        config,
-        agent_name,
-        runtime_paths=runtime_paths,
-        room_id=room_id,
-        thread_id=thread_id,
-    )
+    """Build the Matrix event content fragment for one AI run.
+
+    `model_name` is the configured model name resolved at run preparation time.
+    It must not be re-resolved here: the per-thread override store can change
+    mid-run (for example via `switch_thread_model`), and this metadata must
+    describe the model that actually produced the response.
+    """
+    model_config = config.models.get(model_name) if model_name is not None else None
     model_id = model or (model_config.id if model_config is not None else None)
     provider = model_provider or (model_config.provider if model_config is not None else None)
 

--- a/src/mindroom/ai_run_metadata.py
+++ b/src/mindroom/ai_run_metadata.py
@@ -211,10 +211,10 @@ def ai_run_extra_content_from_metadata(run_metadata: Mapping[str, Any] | None) -
     return {AI_RUN_METADATA_KEY: dict(ai_run_metadata)}
 
 
-def build_ai_run_metadata_content(  # noqa: C901, PLR0912, PLR0915
+def build_ai_run_metadata_content(  # noqa: C901, PLR0912
     *,
     config: Config,
-    model_name: str | None,
+    model_name: str,
     run_id: str | None,
     session_id: str | None,
     status: RunStatus | str | None,
@@ -228,7 +228,7 @@ def build_ai_run_metadata_content(  # noqa: C901, PLR0912, PLR0915
     context_cache_write_tokens: int | None = None,
     tool_count: int | None = None,
     prepared_history: PreparedHistoryState | None = None,
-) -> dict[str, Any] | None:
+) -> dict[str, Any]:
     """Build the Matrix event content fragment for one AI run.
 
     `model_name` is the configured model name resolved at run preparation time.
@@ -236,7 +236,7 @@ def build_ai_run_metadata_content(  # noqa: C901, PLR0912, PLR0915
     mid-run (for example via `switch_thread_model`), and this metadata must
     describe the model that actually produced the response.
     """
-    model_config = config.models.get(model_name) if model_name is not None else None
+    model_config = config.models.get(model_name)
     model_id = model or (model_config.id if model_config is not None else None)
     provider = model_provider or (model_config.provider if model_config is not None else None)
 
@@ -294,16 +294,12 @@ def build_ai_run_metadata_content(  # noqa: C901, PLR0912, PLR0915
     if status is not None:
         raw_status = status.value if isinstance(status, RunStatus) else str(status)
         payload["status"] = raw_status.lower()
-    if model_name is not None or model_id is not None or provider is not None:
-        model_payload: dict[str, Any] = {}
-        if model_name is not None:
-            model_payload["config"] = model_name
-        if model_id is not None:
-            model_payload["id"] = model_id
-        if provider is not None:
-            model_payload["provider"] = provider
-        if model_payload:
-            payload["model"] = model_payload
+    model_payload: dict[str, Any] = {"config": model_name}
+    if model_id is not None:
+        model_payload["id"] = model_id
+    if provider is not None:
+        model_payload["provider"] = provider
+    payload["model"] = model_payload
     if usage_payload:
         payload["usage"] = usage_payload
     context_payload = _build_context_payload(
@@ -324,6 +320,4 @@ def build_ai_run_metadata_content(  # noqa: C901, PLR0912, PLR0915
     if tool_count is not None:
         payload["tools"] = {"count": tool_count}
 
-    if len(payload) == 1:
-        return None
     return {AI_RUN_METADATA_KEY: payload}

--- a/src/mindroom/commands/model_commands.py
+++ b/src/mindroom/commands/model_commands.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from mindroom.thread_models import (
     clear_thread_model_override,
-    get_thread_model_override,
+    resolve_thread_model_override,
     set_thread_model_override,
 )
 
@@ -26,8 +26,8 @@ def _available_models_text(config: Config) -> str:
 
 
 def _show_thread_model(config: Config, runtime_paths: RuntimePaths, thread_id: str | None) -> str:
-    override = get_thread_model_override(runtime_paths, thread_id)
-    if override is not None and override in config.models:
+    override = resolve_thread_model_override(runtime_paths, thread_id, configured_models=config.models).active
+    if override is not None:
         model = config.models[override]
         current = f"This thread uses the `{override}` override ({model.provider} {model.id})."
     else:

--- a/src/mindroom/config/main.py
+++ b/src/mindroom/config/main.py
@@ -75,7 +75,7 @@ from mindroom.mcp.config import MCPServerConfig, normalize_mcp_server_id
 from mindroom.prompt_templates import render_prompt_template, validate_prompt_template_fields
 from mindroom.prompts import PROMPT_DEFAULT_NAMES, PROMPT_DEFAULTS
 from mindroom.runtime_env_policy import SANDBOX_RUNTIME_ENV_BY_KEY
-from mindroom.thread_models import get_thread_model_override
+from mindroom.thread_models import resolve_thread_model_override
 from mindroom.tool_system.plugin_imports import PluginValidationError
 from mindroom.tool_system.worker_routing import unsupported_shared_only_integration_names
 from mindroom.workspaces import validate_workspace_template_dir
@@ -1841,8 +1841,12 @@ class Config(BaseModel):
             if runtime_paths is None:
                 msg = "runtime_paths are required to resolve a thread-specific runtime model"
                 raise ValueError(msg)
-            thread_override = get_thread_model_override(runtime_paths, thread_id)
-            if thread_override is not None and thread_override in self.models:
+            thread_override = resolve_thread_model_override(
+                runtime_paths,
+                thread_id,
+                configured_models=self.models,
+            ).active
+            if thread_override is not None:
                 resolved_model_name = thread_override
         if resolved_model_name is None:
             if entity_name is None:

--- a/src/mindroom/custom_tools/thread_model.py
+++ b/src/mindroom/custom_tools/thread_model.py
@@ -7,7 +7,7 @@ from agno.tools import Toolkit
 from mindroom.custom_tools.tool_payloads import custom_tool_payload
 from mindroom.thread_models import (
     clear_thread_model_override,
-    get_thread_model_override,
+    resolve_thread_model_override,
     set_thread_model_override,
 )
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, get_tool_runtime_context
@@ -41,25 +41,24 @@ class ThreadModelTools(Toolkit):
         if isinstance(resolved, str):
             return resolved
         context, thread_id = resolved
-        override = get_thread_model_override(context.runtime_paths, thread_id)
-        # Runtime resolution ignores an override whose model name no longer
-        # exists in config.models, so report it as stale instead of active.
-        if override is not None and override not in context.config.models:
-            return self._payload(
-                "ok",
-                action="get",
-                thread_id=thread_id,
-                override=None,
-                stale_override=override,
-                note="The stored override names a model that is no longer configured, so agents use their configured models.",
-                available_models=sorted(context.config.models),
+        override = resolve_thread_model_override(
+            context.runtime_paths,
+            thread_id,
+            configured_models=context.config.models,
+        )
+        stale_fields: dict[str, object] = {}
+        if override.stale is not None:
+            stale_fields["stale_override"] = override.stale
+            stale_fields["note"] = (
+                "The stored override names a model that is no longer configured, so agents use their configured models."
             )
         return self._payload(
             "ok",
             action="get",
             thread_id=thread_id,
-            override=override,
+            override=override.active,
             available_models=sorted(context.config.models),
+            **stale_fields,
         )
 
     async def switch_thread_model(self, model_name: str) -> str:

--- a/src/mindroom/custom_tools/thread_model.py
+++ b/src/mindroom/custom_tools/thread_model.py
@@ -42,6 +42,18 @@ class ThreadModelTools(Toolkit):
             return resolved
         context, thread_id = resolved
         override = get_thread_model_override(context.runtime_paths, thread_id)
+        # Runtime resolution ignores an override whose model name no longer
+        # exists in config.models, so report it as stale instead of active.
+        if override is not None and override not in context.config.models:
+            return self._payload(
+                "ok",
+                action="get",
+                thread_id=thread_id,
+                override=None,
+                stale_override=override,
+                note="The stored override names a model that is no longer configured, so agents use their configured models.",
+                available_models=sorted(context.config.models),
+            )
         return self._payload(
             "ok",
             action="get",

--- a/src/mindroom/thread_models.py
+++ b/src/mindroom/thread_models.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import tempfile
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -11,6 +12,8 @@ from typing import TYPE_CHECKING
 from mindroom.constants import tracking_dir
 
 if TYPE_CHECKING:
+    from collections.abc import Container
+
     from mindroom.constants import RuntimePaths
 
 _THREAD_MODELS_FILENAME = "thread_models.json"
@@ -65,12 +68,40 @@ def _save_overrides(path: Path, overrides: dict[str, dict[str, str]]) -> None:
     _load_cache.pop(path, None)
 
 
-def get_thread_model_override(runtime_paths: RuntimePaths, thread_id: str | None) -> str | None:
+def _get_thread_model_override(runtime_paths: RuntimePaths, thread_id: str | None) -> str | None:
     """Return the model name stored for one thread root, if any."""
     if thread_id is None:
         return None
     record = _load_overrides(_store_path(runtime_paths)).get(thread_id)
     return record["model"] if record is not None else None
+
+
+@dataclass(frozen=True)
+class _ThreadModelOverrideState:
+    """One thread's stored override split into the runtime-active name and a stale leftover."""
+
+    active: str | None
+    stale: str | None
+
+
+def resolve_thread_model_override(
+    runtime_paths: RuntimePaths,
+    thread_id: str | None,
+    *,
+    configured_models: Container[str],
+) -> _ThreadModelOverrideState:
+    """Classify one thread's stored override against the configured model names.
+
+    An override naming a model that no longer exists in the config is stale:
+    runtime resolution, `!model`, and the `thread_model` tool must all ignore
+    it rather than apply or report it as active.
+    """
+    override = _get_thread_model_override(runtime_paths, thread_id)
+    if override is None:
+        return _ThreadModelOverrideState(active=None, stale=None)
+    if override in configured_models:
+        return _ThreadModelOverrideState(active=override, stale=None)
+    return _ThreadModelOverrideState(active=None, stale=override)
 
 
 def set_thread_model_override(

--- a/tests/test_ai_error_message_display.py
+++ b/tests/test_ai_error_message_display.py
@@ -147,6 +147,7 @@ def _prepared_run(agent: object, *, prompt: str = "Help me with something") -> S
         run_input=[Message(role="user", content=prompt)],
         unseen_event_ids=[],
         prepared_history=PreparedHistoryState(),
+        runtime_model_name="default",
     )
 
 

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -250,6 +250,7 @@ def _prepared_prompt_result(
     prompt: str = "test prompt",
     estimated_context_tokens: int | None = None,
     prepared_context_tokens: int | None = None,
+    runtime_model_name: str = "default",
 ) -> _PreparedAgentRun:
     return _PreparedAgentRun(
         agent=agent,
@@ -259,6 +260,7 @@ def _prepared_prompt_result(
             estimated_context_tokens=estimated_context_tokens,
             prepared_context_tokens=prepared_context_tokens,
         ),
+        runtime_model_name=runtime_model_name,
     )
 
 
@@ -2517,6 +2519,7 @@ async def test_generate_response_preserves_model_prompt_in_persisted_session(
             ),
             unseen_event_ids=[],
             prepared_history=PreparedHistoryState(),
+            runtime_model_name="default",
         )
 
     async def fake_cached_agent_run(
@@ -6631,7 +6634,7 @@ class TestUserIdPassthrough:
             patch("mindroom.ai_runtime.cached_agent_run", new_callable=AsyncMock, return_value=mock_run_output),
             patch("mindroom.matrix.state.get_room_alias_from_id", return_value="lobby"),
         ):
-            mock_prepare.return_value = _prepared_prompt_result(mock_agent)
+            mock_prepare.return_value = _prepared_prompt_result(mock_agent, runtime_model_name="large")
             run_metadata: dict[str, object] = {}
             await ai_response(
                 agent_name="general",
@@ -6697,7 +6700,7 @@ class TestUserIdPassthrough:
             patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare,
             patch("mindroom.matrix.state.get_room_alias_from_id", return_value="lobby"),
         ):
-            mock_prepare.return_value = _prepared_prompt_result(mock_agent)
+            mock_prepare.return_value = _prepared_prompt_result(mock_agent, runtime_model_name="large")
             run_metadata: dict[str, object] = {}
             async for _chunk in stream_agent_response(
                 agent_name="general",

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -360,7 +360,6 @@ def test_ai_run_metadata_separates_compaction_and_prepared_context_tokens(tmp_pa
         prepared_history=prepared_history,
     )
 
-    assert metadata is not None
     payload = metadata[AI_RUN_METADATA_KEY]
     assert payload["usage"]["input_tokens"] == 123
     assert payload["prepared_context"]["tokens"] == 20_000
@@ -400,7 +399,6 @@ def test_ai_run_metadata_fallback_usage_only_backfills_missing_fields(tmp_path: 
         },
     )
 
-    assert metadata is not None
     usage = metadata[AI_RUN_METADATA_KEY]["usage"]
     assert usage["input_tokens"] == 100
     assert usage["output_tokens"] == 25
@@ -440,7 +438,6 @@ def test_ai_run_metadata_bounds_context_cache_split_to_displayed_context(tmp_pat
         context_cache_write_tokens=500,
     )
 
-    assert metadata is not None
     context = metadata[AI_RUN_METADATA_KEY]["context"]
     assert context["input_tokens"] == 153_294
     assert context["window_tokens"] == 200_000

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -332,7 +332,7 @@ async def test_prepare_agent_and_prompt_omits_zero_breakdown_segments_in_notice(
 
 def test_ai_run_metadata_separates_compaction_and_prepared_context_tokens(tmp_path: Path) -> None:
     """Run metadata should expose prepared estimates without mixing them into provider usage."""
-    config, runtime_paths = _make_prepare_config(tmp_path)
+    config, _runtime_paths = _make_prepare_config(tmp_path)
     prepared_history = PreparedHistoryState(
         compaction_decision=classify_compaction_decision(
             plan=_make_execution_plan(),
@@ -349,9 +349,8 @@ def test_ai_run_metadata_separates_compaction_and_prepared_context_tokens(tmp_pa
     )
 
     metadata = build_ai_run_metadata_content(
-        agent_name="test_agent",
         config=config,
-        runtime_paths=runtime_paths,
+        model_name="default",
         run_id="run-1",
         session_id="session-1",
         status="completed",
@@ -382,12 +381,11 @@ def test_ai_run_metadata_separates_compaction_and_prepared_context_tokens(tmp_pa
 
 def test_ai_run_metadata_fallback_usage_only_backfills_missing_fields(tmp_path: Path) -> None:
     """Fallback request metrics should not replace provider-reported final usage."""
-    config, runtime_paths = _make_prepare_config(tmp_path)
+    config, _runtime_paths = _make_prepare_config(tmp_path)
 
     metadata = build_ai_run_metadata_content(
-        agent_name="test_agent",
         config=config,
-        runtime_paths=runtime_paths,
+        model_name="default",
         run_id="run-1",
         session_id="session-1",
         status="completed",
@@ -429,9 +427,8 @@ def test_ai_run_metadata_bounds_context_cache_split_to_displayed_context(tmp_pat
     )
 
     metadata = build_ai_run_metadata_content(
-        agent_name="test_agent",
         config=config,
-        runtime_paths=runtime_paths,
+        model_name="default",
         run_id="run-1",
         session_id="session-1",
         status="completed",

--- a/tests/test_issue_154_logging_integration.py
+++ b/tests/test_issue_154_logging_integration.py
@@ -217,6 +217,7 @@ def _prepared_prompt_result(agent: object, *, prompt: str = "expanded prompt") -
         messages=(Message(role="user", content=prompt),),
         unseen_event_ids=[],
         prepared_history=PreparedHistoryState(),
+        runtime_model_name="default",
     )
 
 

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -194,6 +194,7 @@ def _prepared_run(agent: object, *, prompt: str = "prompt") -> _PreparedAgentRun
         messages=(Message(role="user", content=prompt),),
         unseen_event_ids=[],
         prepared_history=MagicMock(),
+        runtime_model_name="default",
     )
 
 

--- a/tests/test_thread_models.py
+++ b/tests/test_thread_models.py
@@ -10,11 +10,13 @@ from unittest.mock import AsyncMock
 import pytest
 
 import mindroom.tools  # noqa: F401
+from mindroom.ai_run_metadata import build_ai_run_metadata_content
 from mindroom.commands.model_commands import handle_model_command
 from mindroom.commands.parsing import CommandType, command_parser
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
+from mindroom.constants import AI_RUN_METADATA_KEY
 from mindroom.custom_tools.thread_model import ThreadModelTools
 from mindroom.thread_models import (
     _store_path,
@@ -502,3 +504,63 @@ async def test_thread_model_tool_rejects_unknown_model() -> None:
     assert payload["status"] == "error"
     assert payload["available_models"] == ["default", "large"]
     assert get_thread_model_override(context.runtime_paths, THREAD_ID) is None
+
+
+@pytest.mark.asyncio
+async def test_thread_model_tool_reports_stale_override_as_inactive() -> None:
+    """An override naming a removed model must not be reported as active."""
+    context = _make_tool_context()
+    set_thread_model_override(
+        context.runtime_paths,
+        thread_id=THREAD_ID,
+        model_name="removed-model",
+        room_id=ROOM_ID,
+        set_by="@user:localhost",
+    )
+
+    with tool_runtime_context(context):
+        payload = json.loads(await ThreadModelTools().get_thread_model())
+
+    assert payload["status"] == "ok"
+    assert payload["override"] is None
+    assert payload["stale_override"] == "removed-model"
+    assert "no longer configured" in payload["note"]
+
+
+def test_ai_run_metadata_uses_preparation_time_model(tmp_path: Path) -> None:
+    """Run metadata must describe the model that produced the response, not the next override."""
+    config = _config_with_models(tmp_path)
+    runtime_paths = runtime_paths_for(config)
+    prepared_model_name = config.resolve_runtime_model(
+        entity_name="test_agent",
+        room_id=ROOM_ID,
+        thread_id=THREAD_ID,
+        runtime_paths=runtime_paths,
+    ).model_name
+
+    # A mid-run switch_thread_model call persists a new override before the
+    # metadata for the current response is built.
+    set_thread_model_override(
+        runtime_paths,
+        thread_id=THREAD_ID,
+        model_name="large",
+        room_id=ROOM_ID,
+        set_by="@user:localhost",
+    )
+
+    metadata = build_ai_run_metadata_content(
+        config=config,
+        model_name=prepared_model_name,
+        run_id="run-1",
+        session_id="session-1",
+        status="completed",
+        model="default-model",
+        model_provider="openai",
+    )
+
+    assert metadata is not None
+    assert metadata[AI_RUN_METADATA_KEY]["model"] == {
+        "config": "default",
+        "id": "default-model",
+        "provider": "openai",
+    }

--- a/tests/test_thread_models.py
+++ b/tests/test_thread_models.py
@@ -19,9 +19,9 @@ from mindroom.config.models import ModelConfig
 from mindroom.constants import AI_RUN_METADATA_KEY
 from mindroom.custom_tools.thread_model import ThreadModelTools
 from mindroom.thread_models import (
+    _get_thread_model_override,
     _store_path,
     clear_thread_model_override,
-    get_thread_model_override,
     set_thread_model_override,
 )
 from mindroom.tool_system.metadata import TOOL_METADATA, get_tool_by_name
@@ -49,8 +49,8 @@ def test_store_roundtrip(tmp_path: Path) -> None:
     """Set, get, and clear should persist one override per thread root."""
     runtime_paths = test_runtime_paths(tmp_path)
 
-    assert get_thread_model_override(runtime_paths, THREAD_ID) is None
-    assert get_thread_model_override(runtime_paths, None) is None
+    assert _get_thread_model_override(runtime_paths, THREAD_ID) is None
+    assert _get_thread_model_override(runtime_paths, None) is None
 
     set_thread_model_override(
         runtime_paths,
@@ -59,11 +59,11 @@ def test_store_roundtrip(tmp_path: Path) -> None:
         room_id=ROOM_ID,
         set_by="@user:localhost",
     )
-    assert get_thread_model_override(runtime_paths, THREAD_ID) == "large"
-    assert get_thread_model_override(runtime_paths, "$other:localhost") is None
+    assert _get_thread_model_override(runtime_paths, THREAD_ID) == "large"
+    assert _get_thread_model_override(runtime_paths, "$other:localhost") is None
 
     assert clear_thread_model_override(runtime_paths, THREAD_ID) is True
-    assert get_thread_model_override(runtime_paths, THREAD_ID) is None
+    assert _get_thread_model_override(runtime_paths, THREAD_ID) is None
     assert clear_thread_model_override(runtime_paths, THREAD_ID) is False
 
 
@@ -74,7 +74,7 @@ def test_store_ignores_corrupt_file(tmp_path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("not json", encoding="utf-8")
 
-    assert get_thread_model_override(runtime_paths, THREAD_ID) is None
+    assert _get_thread_model_override(runtime_paths, THREAD_ID) is None
 
     set_thread_model_override(
         runtime_paths,
@@ -83,7 +83,7 @@ def test_store_ignores_corrupt_file(tmp_path: Path) -> None:
         room_id=ROOM_ID,
         set_by="@user:localhost",
     )
-    assert get_thread_model_override(runtime_paths, THREAD_ID) == "large"
+    assert _get_thread_model_override(runtime_paths, THREAD_ID) == "large"
 
 
 def test_store_prunes_oldest_entries(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -102,7 +102,7 @@ def test_store_prunes_oldest_entries(tmp_path: Path, monkeypatch: pytest.MonkeyP
 
     stored = json.loads(_store_path(runtime_paths).read_text(encoding="utf-8"))
     assert len(stored) == 3
-    assert get_thread_model_override(runtime_paths, "$thread-4:localhost") == "large"
+    assert _get_thread_model_override(runtime_paths, "$thread-4:localhost") == "large"
 
 
 def test_resolve_runtime_model_prefers_thread_override(tmp_path: Path) -> None:
@@ -263,7 +263,7 @@ def test_model_command_set_and_reset(tmp_path: Path) -> None:
     )
     assert "✅" in response
     assert "`large`" in response
-    assert get_thread_model_override(runtime_paths, THREAD_ID) == "large"
+    assert _get_thread_model_override(runtime_paths, THREAD_ID) == "large"
 
     response = handle_model_command(
         "reset",
@@ -274,7 +274,7 @@ def test_model_command_set_and_reset(tmp_path: Path) -> None:
         requester_user_id="@user:localhost",
     )
     assert "✅" in response
-    assert get_thread_model_override(runtime_paths, THREAD_ID) is None
+    assert _get_thread_model_override(runtime_paths, THREAD_ID) is None
 
     response = handle_model_command(
         "reset",
@@ -355,7 +355,7 @@ def test_model_command_rejects_unknown_model(tmp_path: Path) -> None:
         requester_user_id="@user:localhost",
     )
     assert "Unknown model" in response
-    assert get_thread_model_override(runtime_paths, THREAD_ID) is None
+    assert _get_thread_model_override(runtime_paths, THREAD_ID) is None
 
 
 def test_model_command_requires_thread_for_set(tmp_path: Path) -> None:
@@ -372,7 +372,7 @@ def test_model_command_requires_thread_for_set(tmp_path: Path) -> None:
         requester_user_id="@user:localhost",
     )
     assert "only work inside a thread" in response
-    assert get_thread_model_override(runtime_paths, THREAD_ID) is None
+    assert _get_thread_model_override(runtime_paths, THREAD_ID) is None
 
 
 def test_model_command_default_sets_model_instead_of_resetting(tmp_path: Path) -> None:
@@ -390,7 +390,7 @@ def test_model_command_default_sets_model_instead_of_resetting(tmp_path: Path) -
     )
     assert "✅" in response
     assert "`default`" in response
-    assert get_thread_model_override(runtime_paths, THREAD_ID) == "default"
+    assert _get_thread_model_override(runtime_paths, THREAD_ID) == "default"
 
 
 def test_resolve_runtime_model_requires_runtime_paths_for_thread_id(tmp_path: Path) -> None:
@@ -411,7 +411,7 @@ def test_store_drops_records_with_corrupt_set_at(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    assert get_thread_model_override(runtime_paths, "$bad:localhost") is None
+    assert _get_thread_model_override(runtime_paths, "$bad:localhost") is None
 
     set_thread_model_override(
         runtime_paths,
@@ -420,7 +420,7 @@ def test_store_drops_records_with_corrupt_set_at(tmp_path: Path) -> None:
         room_id=ROOM_ID,
         set_by="@user:localhost",
     )
-    assert get_thread_model_override(runtime_paths, THREAD_ID) == "large"
+    assert _get_thread_model_override(runtime_paths, THREAD_ID) == "large"
 
 
 def _make_tool_context(*, thread_id: str | None = THREAD_ID) -> ToolRuntimeContext:
@@ -490,7 +490,7 @@ async def test_thread_model_tool_switch_get_and_reset() -> None:
     assert get_payload["override"] == "large"
     assert reset_payload["status"] == "ok"
     assert reset_payload["cleared"] is True
-    assert get_thread_model_override(context.runtime_paths, THREAD_ID) is None
+    assert _get_thread_model_override(context.runtime_paths, THREAD_ID) is None
 
 
 @pytest.mark.asyncio
@@ -503,7 +503,7 @@ async def test_thread_model_tool_rejects_unknown_model() -> None:
 
     assert payload["status"] == "error"
     assert payload["available_models"] == ["default", "large"]
-    assert get_thread_model_override(context.runtime_paths, THREAD_ID) is None
+    assert _get_thread_model_override(context.runtime_paths, THREAD_ID) is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_thread_models.py
+++ b/tests/test_thread_models.py
@@ -558,7 +558,6 @@ def test_ai_run_metadata_uses_preparation_time_model(tmp_path: Path) -> None:
         model_provider="openai",
     )
 
-    assert metadata is not None
     assert metadata[AI_RUN_METADATA_KEY]["model"] == {
         "config": "default",
         "id": "default-model",


### PR DESCRIPTION
Closes #1224. Follow-up to #1220.

## What Changed

### 1. Run metadata now reports the model that actually produced the response

`build_ai_run_metadata_content` used to re-resolve the runtime model through `config.resolve_runtime_model(..., thread_id=...)`, which reads the mutable thread override store. When `switch_thread_model` persisted a new override mid-run, the current response's metadata could report the next model's config name (`model.config=large`) alongside the actual provider request's `model.id=default-model`.

The resolved model name is now snapshotted in `_PreparedAgentRun` at run preparation time (where `resolve_runtime_model` already ran) and passed into the metadata builder. The builder no longer takes `agent_name`/`runtime_paths`/`room_id`/`thread_id` and never touches the override store; `_get_model_config` is removed.

### 2. `get_thread_model` no longer reports stale overrides as active

Runtime resolution and `!model` ignore an override whose model name no longer exists in `config.models`, but `ThreadModelTools.get_thread_model()` returned the raw stored value. It now mirrors runtime semantics: `override: null` plus a `stale_override` field and an explanatory note.

### 3. `thread_model` tool documentation

The tool from #1220 was missing from the tool docs. Added a full section to `docs/tools/matrix-and-attachments.md` (enablement, the three functions, thread-only behavior, next-message semantics, stale override behavior, precedence) and listed it in `docs/tools/builtin.md`, `docs/tools/index.md`, `docs/dev/agent_configuration.md`, the README native Matrix tool list, and the mirrored `skills/mindroom-docs/references` pages.

## Tests

- New regression test: metadata built from the prep-time snapshot ignores an override persisted mid-run (the exact repro from #1224).
- New regression test: `get_thread_model` reports a removed-model override as `stale_override` with no active override.
- Updated `_PreparedAgentRun` test fixtures and the two room-resolved-metadata tests for the new snapshot contract.

## Verification

- `uv run pytest -n 4 --no-cov` — 7994 passed, 61 skipped
- `uv run tach check --dependencies --interfaces` — passed
- `uv run pre-commit run --all-files` — passed (including the mindroom-docs reference regeneration hook)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `thread_model` tool enabling agents to display, switch, or reset model overrides for individual Matrix threads; override persists per-thread and takes effect on the next message.
  * Implemented stale override detection when configured models are removed; stored overrides display as inactive with explanatory notes.

* **Documentation**
  * Updated documentation across all relevant sections to describe the new `thread_model` tool and its capabilities in Matrix thread operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->