### PR TITLE
Ignore Claude Code machine-local files and drop duplicate gitignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -250,6 +250,7 @@ mindroom-test-storage/
 # Local AI-agent artifacts
 .claude/LIVE-TEST.md
 .claude/REPORT.md
-mindroom-test-storage/
+.claude/settings.local.json
+.claude/reports/
 REVIEW-*.md
 .codex-worktrees/


### PR DESCRIPTION
Follow-up to #1219 from a post-merge review sweep.

Un-ignoring `.claude/` (#1219) was intentional for tracking `agents/`, `commands/`, and `skills/`, but it dropped repo-level protection for Claude Code's machine-local files:

- `.claude/settings.local.json` (local permission allowlists) was only kept out of git by a personal global ignore that other contributors and CI don't have, so it could be committed by accident.
- Locally generated `.claude/reports/` showed as permanent untracked noise in `git status`.

Also removes the duplicate `mindroom-test-storage/` entry (keeping the one under `# Local artifacts`).

Verified `git check-ignore -v` matches both new patterns from the repo gitignore while tracked `.claude/agents`, `.claude/commands`, and `.claude/skills` files remain tracked.