### PR TITLE
Remove unused test-helper parameters in turn_policy and conversation_resolver tests

### DIFF
--- a/tests/test_conversation_resolver.py
+++ b/tests/test_conversation_resolver.py
@@ -88,9 +88,7 @@ def _event(content: dict[str, Any], *, event_id: str = _EVENT_ID) -> nio.RoomMes
         "room_id": _ROOM_ID,
         "type": "m.room.message",
     }
-    event = nio.RoomMessageText.from_dict(source)
-    event.source = source
-    return event
+    return nio.RoomMessageText.from_dict(source)
 
 
 def _threaded_event(body: str = "in thread") -> nio.RoomMessageText:

--- a/tests/test_turn_policy.py
+++ b/tests/test_turn_policy.py
@@ -113,19 +113,19 @@ def _context(
     )
 
 
-def _dispatch(context: MessageContext, *, agent_name: str, sender: str = _SENDER) -> PreparedDispatch:
+def _dispatch(context: MessageContext, *, agent_name: str) -> PreparedDispatch:
     target = MessageTarget.resolve(_ROOM_ID, context.thread_id, _EVENT_ID)
     envelope = request_envelope(
         room_id=_ROOM_ID,
         reply_to_event_id=_EVENT_ID,
         thread_id=context.thread_id,
         prompt="hello agents",
-        user_id=sender,
+        user_id=_SENDER,
         target=target,
         agent_name=agent_name,
     )
     return PreparedDispatch(
-        requester_user_id=sender,
+        requester_user_id=_SENDER,
         context=context,
         target=target,
         correlation_id="corr-test",


### PR DESCRIPTION
Post-merge review follow-up to #1217.

- `_dispatch` in `tests/test_turn_policy.py` took a `sender` parameter that no call site ever passed; it now uses `_SENDER` directly for `user_id` and `requester_user_id`.
- `_event` in `tests/test_conversation_resolver.py` re-assigned `event.source = source` after `nio.RoomMessageText.from_dict(source)` already set it; collapsed to a direct return.

`uv run pytest tests/test_turn_policy.py tests/test_conversation_resolver.py -n 0 --no-cov -q`: 36 passed.