### PR TITLE
Remove dead _KnowledgeResolution.missing field

### DIFF
--- a/src/mindroom/knowledge/utils.py
+++ b/src/mindroom/knowledge/utils.py
@@ -55,7 +55,6 @@ class _KnowledgeResolution:
     """Resolved knowledge plus availability diagnostics for one agent."""
 
     knowledge: Knowledge | None
-    missing: tuple[str, ...] = ()
     unavailable: Mapping[str, KnowledgeAvailabilityDetail] = field(default_factory=dict)
 
 
@@ -447,7 +446,6 @@ def resolve_agent_knowledge_access(
         )
     return _KnowledgeResolution(
         knowledge=_merge_knowledge(agent_name, knowledges),
-        missing=tuple(missing_base_ids),
         unavailable=unavailable_bases,
     )
 

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -437,7 +437,6 @@ def test_file_mode_knowledge_skips_semantic_lookup_and_refresh(
     )
 
     assert resolution.knowledge is None
-    assert resolution.missing == ()
     assert resolution.unavailable == {}
     get_published_index.assert_not_called()
     scheduler.is_refreshing.assert_not_called()


### PR DESCRIPTION
Post-merge review follow-up to #1215.

#1215 deleted all three caller-side consumers of `resolution.missing` (`KnowledgeAccessSupport.resolve_for_agent`, `teams._build_member`, `api/openai_compat.chat_completions`) and moved the warning inside `resolve_agent_knowledge_access`, which logs from the local `missing_base_ids` list. The field was left write-only. This removes it and the one test assertion on it; the warning log is unchanged.

`uv run pytest tests/test_knowledge_manager.py -n 0 --no-cov -q`: 174 passed.