### PR TITLE
Collapse attachment_records_to_media wrapper indirection

### DIFF
--- a/src/mindroom/attachment_media.py
+++ b/src/mindroom/attachment_media.py
@@ -42,10 +42,13 @@ def _inline_media_content_key(record: AttachmentRecord) -> tuple[str, ...]:
     return (record.kind, mime_type, "filepath", str(record.local_path))
 
 
-def _attachment_records_to_media(
+def attachment_records_to_media(
     attachment_records: list[AttachmentRecord],
 ) -> tuple[list[Audio], list[Image], list[File], list[Video]]:
-    """Convert persisted attachments into Agno media objects."""
+    """Convert attachment records into Agno media objects and remember them for dedupe."""
+    for record in attachment_records:
+        _remember_attachment_record(record)
+
     audio: list[Audio] = []
     images: list[Image] = []
     files: list[File] = []
@@ -97,15 +100,6 @@ def _attachment_records_to_media(
             )
 
     return audio, images, files, videos
-
-
-def attachment_records_to_media(
-    attachment_records: list[AttachmentRecord],
-) -> tuple[list[Audio], list[Image], list[File], list[Video]]:
-    """Convert attachment records into Agno media objects and remember them for dedupe."""
-    for record in attachment_records:
-        _remember_attachment_record(record)
-    return _attachment_records_to_media(attachment_records)
 
 
 def resolve_scoped_attachments(


### PR DESCRIPTION
Post-merge review follow-up to #1214.

#1214 deleted `_partition_inline_media_by_content`, leaving `_attachment_records_to_media` with exactly one caller: the public `attachment_records_to_media` wrapper, whose entire body was the `_remember_attachment_record` loop plus a delegation. The split existed only for the deleted partitioning path, so this merges them: the dedupe-remember loop now sits at the top of the single public function. No caller or import changes; `_remember_attachment_record` and the inline-media registries (still used by `history/agno_team_patch.py`) are untouched.

`uv run pytest tests/test_attachments.py tests/test_attachment_media.py -n 0 --no-cov -q`: 29 passed.