### PR TITLE
Unify raise paths in _handle_auxiliary_task_completion

### DIFF
--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -1592,8 +1592,8 @@ async def _handle_auxiliary_task_completion(
         if not isinstance(task_error, Exception):
             raise task_error
         if task is delivery_task:
-            raise _NonTerminalDeliveryError(task_error) from task_error
-        _raise_progress_delivery_error(task_error)
+            _raise_nonterminal_delivery_error(task_error)
+        raise task_error
 
     monitored_tasks.discard(task)
     return True


### PR DESCRIPTION
Post-merge review follow-up to #1216.

In `_handle_auxiliary_task_completion`:
- Delivery-task failures now use the existing `_raise_nonterminal_delivery_error` helper (identical semantics to the inline `raise _NonTerminalDeliveryError(task_error) from task_error`).
- The non-delivery branch raises `task_error` directly. `_raise_progress_delivery_error` exists only to satisfy TRY301 inside try blocks, and this call site has no enclosing try; the helper keeps its remaining use inside `send_streaming_response`.

`uv run pytest tests/test_streaming_behavior.py -n 0 --no-cov -q`: 94 passed, including the worker progress-delivery failure and late-delivery-failure tests.