### PR TITLE
Cache corrupt thread-model store parses instead of re-reading every call

### DIFF
--- a/src/mindroom/thread_models.py
+++ b/src/mindroom/thread_models.py
@@ -37,9 +37,9 @@ def _load_overrides(path: Path) -> dict[str, dict[str, str]]:
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError, UnicodeDecodeError):
-        return {}
+        data = {}
     if not isinstance(data, dict):
-        return {}
+        data = {}
     # Records must keep the shape the store guarantees: a string model name
     # and a string set_at so prune sorting cannot fail on mixed types.
     overrides = {

--- a/tests/test_thread_models.py
+++ b/tests/test_thread_models.py
@@ -17,6 +17,7 @@ from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
 from mindroom.custom_tools.thread_model import ThreadModelTools
 from mindroom.thread_models import (
+    _load_cache,
     _store_path,
     clear_thread_model_override,
     get_thread_model_override,
@@ -73,6 +74,8 @@ def test_store_ignores_corrupt_file(tmp_path: Path) -> None:
     path.write_text("not json", encoding="utf-8")
 
     assert get_thread_model_override(runtime_paths, THREAD_ID) is None
+    # The corrupt parse result is cached so repeat reads skip re-parsing.
+    assert _load_cache[path] == (path.stat().st_mtime_ns, {})
 
     set_thread_model_override(
         runtime_paths,


### PR DESCRIPTION
Post-merge review follow-up to #1220.

The module comment promises the parsed store is keyed by path and invalidated by mtime so per-turn model resolution does not re-read the file on every call. But both early returns in `_load_overrides` — the `except (OSError, json.JSONDecodeError, UnicodeDecodeError)` branch and the `isinstance(data, dict)` guard — returned without populating `_load_cache`. Since a corrupt file's mtime doesn't change, every subsequent `resolve_runtime_model` call with a thread_id (4–6 per turn across response_runner, ai.py, execution_preparation, ai_run_metadata) re-read and re-parsed the bad file until the next write.

Both branches now set `data = {}` and fall through to the existing comprehension and cache assignment. `test_store_ignores_corrupt_file` additionally asserts the corrupt parse result is cached as `(mtime_ns, {})`.

`uv run pytest tests/test_thread_models.py -n 0 --no-cov -q`: 22 passed.