### PR TITLE
Drop duplicate entity-name computation and dead defensive copy in config lifecycle

### DIFF
--- a/src/mindroom/orchestration/plugin_watch.py
+++ b/src/mindroom/orchestration/plugin_watch.py
@@ -56,7 +56,7 @@ class PluginWatchState:
         """Replace watcher baselines and clear any stale pending dirty state."""
         _drop_unconfigured_plugin_root_snapshots(configured_roots, self.last_snapshot_by_root)
         for root in configured_roots:
-            self.last_snapshot_by_root[root] = root_snapshots.get(root, {}).copy()
+            self.last_snapshot_by_root[root] = root_snapshots[root]
         self.revision += 1
 
     def refresh(self, config: Config | None) -> tuple[Path, ...]:

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -1078,13 +1078,14 @@ class _MultiAgentOrchestrator:
     async def _load_initial_config(self, new_config: Config) -> bool:
         """Handle config loading before the runtime has an active config."""
         hook_registry = self._build_hook_registry(new_config)
+        entity_names = configured_entity_names(new_config)
         self._preflight_account_provisioning(
             new_config,
-            entity_names=configured_entity_names(new_config),
+            entity_names=entity_names,
             include_internal_user=True,
         )
         await self._prepare_user_account(new_config, update_runtime_state=not self.running)
-        await self._prepare_entity_accounts(new_config, configured_entity_names(new_config))
+        await self._prepare_entity_accounts(new_config, entity_names)
         self.config = new_config
         self._activate_hook_registry(hook_registry)
         await self._sync_mcp_manager(new_config)


### PR DESCRIPTION
Post-merge review follow-up to #1218.

- `_load_initial_config` called `configured_entity_names(new_config)` twice; it now binds the result once, mirroring `initialize()`.
- `PluginWatchState.replace_snapshots` used `root_snapshots.get(root, {}).copy()`, but both call sites (`PluginWatchState.refresh` and `_apply_plugin_changes_for_config_update`) feed freshly built snapshots from `capture()` keyed by the identical `configured_roots` tuple — every root is guaranteed present and the dicts are never aliased, so the fallback-and-copy was dead defensive code. Now indexes directly.

`uv run pytest tests/test_config_reload.py tests/test_multi_agent_bot.py -n 0 --no-cov -q`: 324 passed, 5 skipped.