### PR TITLE
Centralize history-policy limits, require team execution_identity, fix team model log attribution

### DIFF
--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -833,7 +833,7 @@ def _build_dynamic_tooling_state_suffix(
     )
 
 
-def _enable_all_history_replay(entity: Agent | Team) -> None:
+def enable_all_history_replay(entity: Agent | Team) -> None:
     """Undo Agno's default three-run history fallback."""
     entity.num_history_runs = None
 
@@ -1447,8 +1447,6 @@ def create_agent(  # noqa: PLR0915, C901, PLR0912
     # Shared history-policy source of truth with the team replay path.
     history_settings = config.get_entity_history_settings(agent_name)
     history_policy = history_settings.policy
-    num_history_runs = history_policy.limit if history_policy.mode == "runs" else None
-    num_history_messages = history_policy.limit if history_policy.mode == "messages" else None
 
     compress_tool_results = (
         agent_config.compress_tool_results
@@ -1472,8 +1470,8 @@ def create_agent(  # noqa: PLR0915, C901, PLR0912
         search_knowledge=knowledge_enabled,
         add_history_to_context=persist_runtime_state,
         add_session_summary_to_context=persist_runtime_state,
-        num_history_runs=num_history_runs,
-        num_history_messages=num_history_messages,
+        num_history_runs=history_policy.num_history_runs,
+        num_history_messages=history_policy.num_history_messages,
         # Keep persisted runs raw even though Agno replays history natively.
         store_history_messages=False,
         culture_manager=culture_manager,
@@ -1485,7 +1483,7 @@ def create_agent(  # noqa: PLR0915, C901, PLR0912
         telemetry=False,
     )
     if history_policy.mode == "all":
-        _enable_all_history_replay(agent)
+        enable_all_history_replay(agent)
 
     logger.info(
         "Created agent",
@@ -1528,6 +1526,7 @@ __all__ = [
     "build_agent_toolkit",
     "create_agent",
     "describe_agent",
+    "enable_all_history_replay",
     "ensure_default_agent_workspaces",
     "get_agent_toolkit_names",
     "get_rooms_for_entity",

--- a/src/mindroom/history/types.py
+++ b/src/mindroom/history/types.py
@@ -71,6 +71,16 @@ class HistoryPolicy:
     mode: _HistoryMode
     limit: int | None = None
 
+    @property
+    def num_history_runs(self) -> int | None:
+        """Return the Agno run-replay limit for this policy."""
+        return self.limit if self.mode == "runs" else None
+
+    @property
+    def num_history_messages(self) -> int | None:
+        """Return the Agno message-replay limit for this policy."""
+        return self.limit if self.mode == "messages" else None
+
 
 @dataclass(frozen=True)
 class ResolvedHistorySettings:

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -29,7 +29,7 @@ from pydantic import BaseModel, Field
 from mindroom import ai_runtime, model_loading
 from mindroom.agent_run_context import append_knowledge_availability_enrichment
 from mindroom.agent_storage import get_team_session
-from mindroom.agents import create_agent
+from mindroom.agents import create_agent, enable_all_history_replay
 from mindroom.ai import build_matrix_run_metadata, resolve_run_correlation_id
 from mindroom.ai_run_metadata import build_prepared_history_metadata_content
 from mindroom.authorization import get_available_responders_in_room
@@ -62,7 +62,6 @@ from mindroom.llm_request_logging import (
     stream_with_llm_request_log_context,
 )
 from mindroom.logging_config import get_logger
-from mindroom.matrix.state import get_room_alias_from_id
 from mindroom.media_fallback import (
     append_inline_media_fallback_prompt,
     build_model_media_route,
@@ -1278,7 +1277,7 @@ def _create_team_instance(
     runtime_paths: RuntimePaths,
     team_display_name: str,
     fallback_team_id: str,
-    execution_identity: ToolExecutionIdentity | None = None,
+    execution_identity: ToolExecutionIdentity | None,
     model_name: str | None = None,
     configured_team_name: str | None = None,
     history_storage: BaseDb | None = None,
@@ -1342,8 +1341,8 @@ def _create_team_instance(
         delegate_to_all_members=mode == TeamMode.COLLABORATE,
         add_history_to_context=True,
         add_session_summary_to_context=True,
-        num_history_runs=history_settings.policy.limit if history_settings.policy.mode == "runs" else None,
-        num_history_messages=history_settings.policy.limit if history_settings.policy.mode == "messages" else None,
+        num_history_runs=history_settings.policy.num_history_runs,
+        num_history_messages=history_settings.policy.num_history_messages,
         max_tool_calls_from_history=history_settings.max_tool_calls_from_history,
         store_history_messages=False,
         show_members_responses=True,
@@ -1352,7 +1351,7 @@ def _create_team_instance(
         # Agno will automatically list members with their names, roles, and tools
     )
     if history_settings.policy.mode == "all":
-        team.num_history_runs = None
+        enable_all_history_replay(team)
     return team
 
 
@@ -1389,13 +1388,7 @@ def select_model_for_team(
         thread_id=thread_id,
         runtime_paths=runtime_paths,
     ).model_name
-    room_alias = get_room_alias_from_id(room_id, runtime_paths)
-    if room_alias and room_alias in config.room_models:
-        logger.info("using_room_specific_team_model", team_name=team_name, room_alias=room_alias, model_name=model_name)
-    elif team_name in config.teams and config.teams[team_name].model:
-        logger.info("using_team_specific_model", team_name=team_name, model_name=model_name)
-    else:
-        logger.info("using_default_team_model", team_name=team_name)
+    logger.info("selected_team_model", team_name=team_name, model_name=model_name)
     return model_name
 
 
@@ -1409,7 +1402,7 @@ def build_materialized_team_instance(
     scope_context: ScopeSessionContext | None,
     model_name: str | None,
     configured_team_name: str | None,
-    execution_identity: ToolExecutionIdentity | None = None,
+    execution_identity: ToolExecutionIdentity | None,
 ) -> Team:
     """Build one agno.Team instance for already-materialized members."""
     resolved_team_runtime_model = config.resolve_runtime_model(

--- a/tach.toml
+++ b/tach.toml
@@ -2441,6 +2441,7 @@ depends_on = [
 expose = [
     "create_agent",
     "describe_agent",
+    "enable_all_history_replay",
     "ensure_default_agent_workspaces",
     "get_rooms_for_entity",
     "show_tool_calls_for_agent",

--- a/tests/test_agno_history.py
+++ b/tests/test_agno_history.py
@@ -4225,6 +4225,7 @@ def test_create_team_instance_enables_native_team_history_and_disables_members(t
             runtime_paths=runtime_paths,
             team_display_name="Team-alpha-zeta",
             fallback_team_id="Team-alpha-zeta",
+            execution_identity=None,
             configured_team_name="pair",
         )
 
@@ -4272,6 +4273,7 @@ def test_create_team_instance_preserves_all_history_mode(tmp_path: Path) -> None
             runtime_paths=runtime_paths,
             team_display_name="Team-alpha-zeta",
             fallback_team_id="Team-alpha-zeta",
+            execution_identity=None,
             configured_team_name="pair",
         )
 

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -3049,6 +3049,7 @@ def test_create_team_instance_installs_notice_hook_on_team_model(tmp_path: Path)
             runtime_paths=runtime_paths,
             team_display_name="Queued Notice Team",
             fallback_team_id="queued-notice-team",
+            execution_identity=None,
         )
         messages = [Message(role="user", content="hello")]
         team.model.format_function_call_results(

--- a/tests/test_system_enrich.py
+++ b/tests/test_system_enrich.py
@@ -423,6 +423,7 @@ async def test_prepare_materialized_team_execution_applies_system_enrichment_to_
             scope_context=None,
             model_name=None,
             configured_team_name=None,
+            execution_identity=None,
         )
         await prepare_materialized_team_execution(
             scope_context=None,
@@ -502,6 +503,7 @@ async def test_prepare_materialized_team_execution_returns_prompt_helpers(tmp_pa
             scope_context=None,
             model_name=None,
             configured_team_name=None,
+            execution_identity=None,
         )
         prepared_execution = await prepare_materialized_team_execution(
             scope_context=None,


### PR DESCRIPTION
Post-merge review follow-up to #1215, #1220, and #1221. Three related team/history cleanups:

**One source of truth for history limits.** `HistoryPolicy` gains `num_history_runs` / `num_history_messages` properties; `agents.py` and `teams.py` previously each re-derived `policy.limit if policy.mode == ... else None` inline. The `mode == \"all\"` fixup in `_create_team_instance` now reuses `enable_all_history_replay` (made public, exported in `agents.__all__` and `tach.toml`) instead of a hand-rolled equivalent.

**`execution_identity` is now required** (keyword-only) on `_create_team_instance` and `build_materialized_team_instance`. #1215 wired the identity through to `get_model_instance`, but the `= None` default meant a silent revert of the pass-through would still pass the suite; now it's a `TypeError`. Test call sites pass `execution_identity=None` explicitly.

**Accurate team model-selection logging.** `select_model_for_team` logged its source by re-deriving from config (`using_room_specific_team_model` / `using_team_specific_model` / `using_default_team_model`), which misattributes the source whenever a thread override (#1220) wins — the default branch didn't even log the model name. Replaced with a single `selected_team_model` log line; the now-unused `get_room_alias_from_id` import is removed.

Validation: `uv run pytest tests/test_agno_history.py tests/test_agents.py tests/test_queued_message_notify.py tests/test_system_enrich.py tests/test_thread_models.py -n 0 --no-cov -q` → 406 passed; `uv run tach check --dependencies --interfaces` clean; pre-commit hooks pass.