### PR TITLE
Document, test, and minimally consolidate Matrix thread invariants

### DIFF
--- a/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
@@ -8,6 +8,8 @@ Durable trust-state invariants (mirrored by ``postgres_event_cache_threads``):
 2. Snapshot replacement is race-guarded: ``replace_thread_locked_if_not_newer`` refuses when
    ``validated_at``, ``invalidated_at``, or ``room_invalidated_at`` changed after the fetch began, so a
    slow fetch cannot bury an invalidation that landed mid-flight (PR #716).
+   The concrete caches additionally clamp the stored ``validated_at`` to the fetch start time, so an
+   invalidation that lands during the fetch still outranks the snapshot at read time.
 
 3. Incremental revalidation is allowlisted: ``revalidate_thread_after_incremental_update_locked`` clears
    an invalidation only when the thread was previously validated, the invalidation reason is one of the

--- a/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
@@ -1,4 +1,22 @@
-"""Thread snapshot and freshness storage helpers for the Matrix event cache."""
+"""Thread snapshot and freshness storage helpers for the Matrix event cache.
+
+Durable trust-state invariants (mirrored by ``postgres_event_cache_threads``):
+
+1. Stale markers are monotonic: ``mark_thread_stale_locked`` and ``mark_room_stale_locked`` never let an
+   older ``invalidated_at`` or its reason overwrite a newer one.
+
+2. Snapshot replacement is race-guarded: ``replace_thread_locked_if_not_newer`` refuses when
+   ``validated_at``, ``invalidated_at``, or ``room_invalidated_at`` changed after the fetch began, so a
+   slow fetch cannot bury an invalidation that landed mid-flight (PR #716).
+
+3. Incremental revalidation is allowlisted: ``revalidate_thread_after_incremental_update_locked`` clears
+   an invalidation only when the thread was previously validated, the invalidation reason is one of the
+   incremental mutation reasons, and the room was not invalidated at or after that validation.
+   Invalidations from any other reason can only be cleared by a full authoritative snapshot replacement.
+
+4. Thread snapshot rows and the lookup, edit, and thread index rows are written and deleted together so
+   point lookups can never resurrect rows the snapshot no longer contains.
+"""
 
 from __future__ import annotations
 

--- a/src/mindroom/matrix/cache/thread_cache_helpers.py
+++ b/src/mindroom/matrix/cache/thread_cache_helpers.py
@@ -1,4 +1,21 @@
-"""Shared pure helpers for Matrix thread cache policies."""
+"""Shared pure helpers for Matrix thread cache policies.
+
+``thread_cache_rejection_reason`` is the single trust gate for durable thread snapshots:
+
+1. Trust is durable-state-only: a snapshot is trusted when its state row exists, ``validated_at`` is
+   set, and neither ``invalidated_at`` nor ``room_invalidated_at`` is at or after ``validated_at``.
+   Timestamp ties reject: an invalidation written at the same instant as a validation wins.
+
+2. There is deliberately no age rule: a trusted snapshot stays trusted regardless of how long ago it was
+   validated (PR #731 removed ``cache_too_old``).
+
+3. There is deliberately no restart rule: trust survives process restarts without comparing against a
+   runtime start time (PR #734 removed ``validated_before_runtime_start``).
+   Cross-restart safety is owned by sync-token certification instead: a sync token is persisted only
+   after its sync response's timeline writes are durably complete, so a restored token proves the
+   durable cache kept up, and any uncertain outcome clears the token to force a cold sync (PR #714,
+   see ``mindroom.matrix.sync_certification``).
+"""
 
 from __future__ import annotations
 

--- a/src/mindroom/matrix/cache/thread_reads.py
+++ b/src/mindroom/matrix/cache/thread_reads.py
@@ -2,9 +2,11 @@
 
 Read-side invariants:
 
-1. Every thread read first waits for the room and same-thread write queue to drain
+1. Every thread read through this policy first waits for the room and same-thread write queue to drain
    (``wait_for_thread_idle``), so a read never observes cache state older than mutations already queued
    when the read began.
+   Startup prewarm deliberately bypasses this policy and relies on the write-time replacement guard
+   instead.
 
 2. Dispatch-safe modes (``DISPATCH_SNAPSHOT``, ``DISPATCH_FULL``) bound the whole wait-plus-fetch by one
    shared timeout and return an explicitly degraded empty result

--- a/src/mindroom/matrix/cache/thread_reads.py
+++ b/src/mindroom/matrix/cache/thread_reads.py
@@ -1,4 +1,23 @@
-"""Thread read policy for Matrix conversation cache."""
+"""Thread read policy for Matrix conversation cache.
+
+Read-side invariants:
+
+1. Every thread read first waits for the room and same-thread write queue to drain
+   (``wait_for_thread_idle``), so a read never observes cache state older than mutations already queued
+   when the read began.
+
+2. Dispatch-safe modes (``DISPATCH_SNAPSHOT``, ``DISPATCH_FULL``) bound the whole wait-plus-fetch by one
+   shared timeout and return an explicitly degraded empty result
+   (``THREAD_HISTORY_SOURCE_DEGRADED``) instead of blocking dispatch; consumers must treat that result
+   as unusable for caching, memoization, and root proofs.
+
+3. ``ADVISORY_FULL`` and ``STRICT_FULL`` have no dispatch timeout and run through the same-thread
+   barrier; ``STRICT_FULL`` is intentionally not dispatch-safe because it may block for authoritative
+   post-lock model context.
+
+4. A stale-cache thread tail is never used for MSC3440 latest-event fallback:
+   ``get_latest_thread_event_id_if_needed`` falls back to the thread root instead.
+"""
 
 from __future__ import annotations
 

--- a/src/mindroom/matrix/cache/thread_write_cache_ops.py
+++ b/src/mindroom/matrix/cache/thread_write_cache_ops.py
@@ -1,4 +1,21 @@
-"""Cache mutation operations for Matrix thread cache writes."""
+"""Cache mutation operations for Matrix thread cache writes.
+
+This is the application layer below the write policies in ``thread_writes``; it owns how mutations land:
+
+1. Invalidation is durable-marker-first and fails closed: ``mark_thread_stale`` and
+   ``mark_room_threads_stale`` write monotonic stale markers; when a marker cannot be written the rows
+   are deleted instead, and when even deletion fails (and the backend is not just temporarily
+   unavailable) the cache is disabled for the rest of the runtime.
+
+2. Appends are incremental-only: ``append_event`` refuses when the thread has no cached snapshot rows
+   (it then only records lookup-index rows), and a failed append re-invalidates the thread so a partial
+   snapshot is never trusted.
+
+3. After a successful append the thread is revalidated only under the conditions enforced by
+   ``revalidate_thread_after_incremental_update`` (see ``sqlite_event_cache_threads``): the prior
+   invalidation must come from an incremental mutation reason and the room must not have been
+   invalidated at or after the last validation.
+"""
 
 from __future__ import annotations
 

--- a/src/mindroom/matrix/cache/thread_writes.py
+++ b/src/mindroom/matrix/cache/thread_writes.py
@@ -18,8 +18,9 @@ These three policies are the only writers of durable thread-cache state:
    queue: concurrent per-thread writers cannot uphold the ``room_invalidated_at >= validated_at``
    ordering that read-time revalidation relies on.
 
-5. Within one sync batch, the room is invalidated at most once for UNKNOWN impacts; later UNKNOWN
-   mutations in the same batch reuse that invalidation instead of writing duplicate markers.
+5. Within one sync batch, UNKNOWN impacts invalidate the room at most once per pass (once across the
+   message pass and once across the redaction pass); later UNKNOWN mutations in the same pass reuse
+   that invalidation instead of writing duplicate markers.
 """
 
 from __future__ import annotations

--- a/src/mindroom/matrix/cache/thread_writes.py
+++ b/src/mindroom/matrix/cache/thread_writes.py
@@ -1,4 +1,26 @@
-"""Thread mutation grouping and advisory bookkeeping for Matrix conversation cache."""
+"""Thread mutation grouping and advisory bookkeeping for Matrix conversation cache.
+
+These three policies are the only writers of durable thread-cache state:
+
+1. ``ThreadOutboundWritePolicy`` records locally sent events after Matrix delivery succeeded, so it must
+   fail open: every cancellation or exception is swallowed and logged, never re-raised to the sender.
+
+2. ``ThreadLiveWritePolicy`` and ``ThreadSyncWritePolicy`` record homeserver timeline events; the sync
+   policy can additionally run in fail-closed mode (``raise_on_cache_write_failure``) so sync-token
+   certification only certifies responses whose writes durably landed.
+
+3. Barrier routing: mutations whose thread is known pre-queue run on the per-thread barrier; mutations
+   that need cache lookups to resolve their thread (plain edits and replies, outbound redactions) stay
+   on the room barrier, because earlier queued writes can create the lookup rows they depend on
+   (ISSUE-189 tracks finer routing).
+
+4. UNKNOWN-impact mutations invalidate the whole room's cached threads eagerly, outside the per-thread
+   queue: concurrent per-thread writers cannot uphold the ``room_invalidated_at >= validated_at``
+   ordering that read-time revalidation relies on.
+
+5. Within one sync batch, the room is invalidated at most once for UNKNOWN impacts; later UNKNOWN
+   mutations in the same batch reuse that invalidation instead of writing duplicate markers.
+"""
 
 from __future__ import annotations
 

--- a/src/mindroom/matrix/cache/write_coordinator.py
+++ b/src/mindroom/matrix/cache/write_coordinator.py
@@ -1,4 +1,20 @@
-"""Shared runtime coordinator for advisory Matrix event-cache writes."""
+"""Shared runtime coordinator for advisory Matrix event-cache writes.
+
+Barrier ordering invariants (PR #716 fixed regressions in each of these):
+
+1. Room-kind updates are exclusive within their room: one starts only when no room or thread update is
+   active, and everything queued after it waits for it.
+
+2. Thread-kind updates run in parallel across different threads but are serialized within one thread,
+   and never start while a room update queued ahead of them is pending or active.
+
+3. A room update cancelled before it started leaves a fence in the queue: later thread updates still
+   wait for the earlier queue segment to drain, so cancellation cannot reorder writes.
+   Read-style operations may opt in to ``ignore_cancelled_room_fences`` because they mutate nothing.
+
+4. Readers establish the write-read barrier with ``wait_for_thread_idle``: a thread read started after a
+   mutation was queued never observes cache state older than that mutation.
+"""
 
 from __future__ import annotations
 

--- a/src/mindroom/matrix/client_thread_history.py
+++ b/src/mindroom/matrix/client_thread_history.py
@@ -1,4 +1,35 @@
-"""Thread-history reads and reconstruction helpers."""
+"""Thread-history reads and reconstruction helpers.
+
+Cache-trust rules (each encodes a shipped regression fix; do not weaken them):
+
+1. A cached thread snapshot is served only when ``thread_cache_rejection_reason`` accepts its durable
+   state: the state row exists, ``validated_at`` is set, and neither ``invalidated_at`` nor
+   ``room_invalidated_at`` is at or after ``validated_at`` (see
+   ``mindroom.matrix.cache.thread_cache_helpers`` for the age and restart rules).
+
+2. Cached rows that do not include the thread-root event are never served: both the trusted-read path
+   and the stale-fallback path refuse such rows and invalidate the entry, and a fresh homeserver fetch
+   missing the root is never stored (PR #741).
+
+3. Cache repopulation is guarded against write races: every store passes the fetch start time to
+   ``replace_thread_if_not_newer``, so a fetch that raced with a thread or room invalidation cannot bury
+   the newer stale marker (PR #716).
+
+4. Stale fallback exists only on the advisory path: ``fetch_thread_history`` may serve stale cached rows
+   when a refetch fails, labelled ``stale_cache`` source with the degraded flag set.
+   The dispatch fetchers (``fetch_dispatch_thread_history``, ``fetch_dispatch_thread_snapshot``) never
+   serve stale rows; on refetch failure they raise.
+
+5. Reconstruction is canonical: membership of scanned events is decided by
+   ``resolve_thread_ids_for_event_infos`` over the page-local relation graph (same rules as live
+   resolution), edits collapse into their originals and never appear as standalone messages, and
+   ordering follows ``thread_projection`` (root first, then timestamp, with same-timestamp relation
+   ancestors before descendants).
+
+6. The room scan requests both ``m.room.message`` and ``m.room.encrypted`` timeline events so nio can
+   decrypt threads in encrypted rooms (PR #878), pages backwards until the root event is seen, and
+   raises ``ThreadRoomScanRootNotFoundError`` when the scan drains without finding it.
+"""
 
 from __future__ import annotations
 

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -1,4 +1,13 @@
-"""Facade for Matrix conversation reads and advisory cache notifications."""
+"""Facade for Matrix conversation reads and advisory cache notifications.
+
+``MatrixConversationCache`` is the only conversation-data surface bots and tools talk to; it composes
+the read policy (``cache.thread_reads``), the three write policies (``cache.thread_writes``), and the
+mutation resolver (``thread_bookkeeping``) over one shared write coordinator.
+
+Per-turn memoization invariant: ``turn_scope`` may replay an event lookup or thread read within one
+inbound turn, but degraded or stale thread reads are never memoized, so a failed read early in a turn
+cannot poison later reads in the same turn.
+"""
 
 from __future__ import annotations
 

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -42,12 +42,12 @@ from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.message_content import extract_edit_body
 from mindroom.matrix.thread_bookkeeping import ThreadMutationResolver
 from mindroom.matrix.thread_diagnostics import is_thread_history_degraded
-from mindroom.matrix.thread_membership import (
+from mindroom.matrix.thread_membership import resolve_event_thread_membership
+from mindroom.matrix.thread_room_scan import (
     fetch_event_info_for_client,
     lookup_thread_id_from_conversation_cache,
-    resolve_event_thread_membership,
+    room_scan_membership_access_for_client,
 )
-from mindroom.matrix.thread_room_scan import room_scan_membership_access_for_client
 from mindroom.timing import elapsed_ms_since
 
 if TYPE_CHECKING:

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -1,8 +1,10 @@
 """Facade for Matrix conversation reads and advisory cache notifications.
 
-``MatrixConversationCache`` is the only conversation-data surface bots and tools talk to; it composes
-the read policy (``cache.thread_reads``), the three write policies (``cache.thread_writes``), and the
-mutation resolver (``thread_bookkeeping``) over one shared write coordinator.
+``MatrixConversationCache`` is the facade for conversation reads and advisory thread bookkeeping; it
+composes the read policy (``cache.thread_reads``), the three write policies (``cache.thread_writes``),
+and the mutation resolver (``thread_bookkeeping``) over one shared write coordinator.
+Bots and tools still read the event cache directly for non-thread point lookups such as agent message
+snapshots and recent room events, but all thread reads and thread bookkeeping go through this facade.
 
 Per-turn memoization invariant: ``turn_scope`` may replay an event lookup or thread read within one
 inbound turn, but degraded or stale thread reads are never memoized, so a failed read early in a turn

--- a/src/mindroom/matrix/thread_bookkeeping.py
+++ b/src/mindroom/matrix/thread_bookkeeping.py
@@ -48,7 +48,6 @@ from mindroom.matrix.thread_membership import (
     ThreadResolution,
     ThreadResolutionState,
     ThreadRootProof,
-    fetch_event_info_for_client,
     page_event_info_counts_as_thread_child_proof,
     resolve_event_thread_membership,
     resolve_related_event_thread_membership,
@@ -56,6 +55,7 @@ from mindroom.matrix.thread_membership import (
 from mindroom.matrix.thread_projection import resolve_thread_ids_for_event_infos
 from mindroom.matrix.thread_room_scan import (
     RoomScanConversationCache,
+    fetch_event_info_for_client,
     fetch_event_info_from_conversation_cache,
     room_scan_membership_access_for_client,
 )

--- a/src/mindroom/matrix/thread_bookkeeping.py
+++ b/src/mindroom/matrix/thread_bookkeeping.py
@@ -10,13 +10,17 @@ Who may mutate thread state, and how:
 1. This module never writes thread state.
    It only classifies one mutation into ``MutationThreadImpact``: THREADED(thread_id), ROOM_LEVEL, or UNKNOWN.
 
-2. Durable thread-cache state is mutated through exactly one path:
+2. Mutation-driven thread-cache writes go through exactly one path:
    the three write policies in ``mindroom.matrix.cache.thread_writes``
    (``ThreadOutboundWritePolicy``, ``ThreadLiveWritePolicy``, ``ThreadSyncWritePolicy``),
    which all resolve impact through this module's ``ThreadMutationResolver``,
    apply it through ``mindroom.matrix.cache.thread_write_cache_ops.ThreadMutationCacheOps``,
    and order every write through the per-room ``EventCacheWriteCoordinator`` barrier.
-   No other code may call the event cache's thread-write methods.
+   The only other thread-cache writer is the read-refill in
+   ``mindroom.matrix.client_thread_history``: after an authoritative homeserver fetch it stores the
+   snapshot through the guarded ``replace_thread_if_not_newer``, and it invalidates entries it proves
+   corrupt (unresolvable payloads or rows missing the thread root).
+   No code outside those two sites may call the event cache's thread-write methods.
 
 3. Custom tools may not write thread state.
    A tool that sends or redacts Matrix events (see ``mindroom.custom_tools.matrix_api``) must resolve

--- a/src/mindroom/matrix/thread_bookkeeping.py
+++ b/src/mindroom/matrix/thread_bookkeeping.py
@@ -4,6 +4,35 @@ Ownership map:
 - canonical resolution: `mindroom.matrix.thread_membership`
 - mutation/bookkeeping impact: this module
 - tool-facing root normalization: `mindroom.custom_tools.attachment_helpers`
+
+Who may mutate thread state, and how:
+
+1. This module never writes thread state.
+   It only classifies one mutation into ``MutationThreadImpact``: THREADED(thread_id), ROOM_LEVEL, or UNKNOWN.
+
+2. Durable thread-cache state is mutated through exactly one path:
+   the three write policies in ``mindroom.matrix.cache.thread_writes``
+   (``ThreadOutboundWritePolicy``, ``ThreadLiveWritePolicy``, ``ThreadSyncWritePolicy``),
+   which all resolve impact through this module's ``ThreadMutationResolver``,
+   apply it through ``mindroom.matrix.cache.thread_write_cache_ops.ThreadMutationCacheOps``,
+   and order every write through the per-room ``EventCacheWriteCoordinator`` barrier.
+   No other code may call the event cache's thread-write methods.
+
+3. Custom tools may not write thread state.
+   A tool that sends or redacts Matrix events (see ``mindroom.custom_tools.matrix_api``) must resolve
+   impact pre-send via ``resolve_event_thread_impact_for_client`` or
+   ``resolve_redaction_thread_impact_for_client`` and refuse the Matrix operation when impact is UNKNOWN;
+   after a successful send it reports through ``ConversationCacheProtocol.notify_outbound_*``,
+   which routes into the same outbound write policy.
+
+4. The impact mapping is total and UNKNOWN fails closed:
+   THREADED means invalidate-then-append that one thread,
+   ROOM_LEVEL means no thread-cache change,
+   and UNKNOWN means the writer must invalidate the whole room's cached threads
+   (or, pre-send in tools, refuse the operation) because membership could not be proven.
+
+5. Redactions of reactions are always ROOM_LEVEL: removing an annotation cannot change any cached
+   thread's visible messages.
 """
 
 from __future__ import annotations

--- a/src/mindroom/matrix/thread_diagnostics.py
+++ b/src/mindroom/matrix/thread_diagnostics.py
@@ -1,4 +1,21 @@
-"""Shared Matrix thread-read diagnostic keys."""
+"""Shared Matrix thread-read diagnostic keys.
+
+This module is a deliberate dependency-cycle breaker between the cache package (which produces
+``ThreadHistoryResult`` diagnostics) and ``thread_membership`` (which consumes them for root proofs).
+
+Diagnostic semantics:
+
+1. ``thread_read_source`` distinguishes ``cache`` (trusted snapshot), ``homeserver`` (fresh fetch),
+   ``stale_cache`` (advisory fallback after a failed refetch), and ``degraded`` (empty fail-open result
+   from a dispatch timeout).
+
+2. ``is_thread_history_degraded`` is the planning-level check: both ``stale_cache`` and ``degraded``
+   reads count as degraded and must not be memoized or treated as authoritative context.
+
+3. ``is_thread_history_source_degraded`` is the stricter proof-level check: only the explicit
+   ``degraded`` source disqualifies a history from serving as thread-root proof, because a stale
+   snapshot still proves children existed while an empty degraded read proves nothing.
+"""
 
 from __future__ import annotations
 

--- a/src/mindroom/matrix/thread_membership.py
+++ b/src/mindroom/matrix/thread_membership.py
@@ -5,6 +5,43 @@ Ownership map:
 - scanned-event ordering and latest-thread-tail helpers: `mindroom.matrix.thread_projection`
 - mutation/bookkeeping impact: `mindroom.matrix.thread_bookkeeping`
 - tool-facing normalization: `mindroom.custom_tools.attachment_helpers`
+
+Invariants enforced here (every resolver in the repo must go through this module):
+
+1. An event is THREADED if and only if one of the following holds:
+   it carries a native ``m.thread`` relation (``EventInfo.thread_id``);
+   it is an edit whose ``m.new_content`` carries an ``m.thread`` relation (``thread_id_from_edit``);
+   a relation walk from it reaches an event satisfying either of the above;
+   or the walk terminates at a relation-free event that is proven to have at least one real threaded child,
+   in which case that terminal event is itself the thread root.
+   Per MSC3440 only relation-free events (``can_be_thread_root``) may become roots.
+
+2. The relation walk follows ``EventInfo.next_related_event_id``: edit original, then reaction target,
+   then ``m.reference`` target, then reply target.
+   An explicit thread relation always wins immediately; the walk never continues past one.
+   This is how implied membership works: plain replies, references, and reactions to threaded events
+   inherit the target's thread transitively.
+
+3. The walk always terminates: a visited set breaks relation cycles and ``_MAX_THREAD_MEMBERSHIP_HOPS``
+   caps pathological chains, resolving to the best answer found so far (initially ROOM_LEVEL).
+
+4. Root proof is three-valued (PROVEN, NOT_A_THREAD_ROOT, PROOF_UNAVAILABLE) and proof failure never
+   silently demotes to room level.
+   PROOF_UNAVAILABLE maps to ``ThreadResolution.indeterminate`` with the candidate root preserved so
+   callers can fail closed (mutation callers invalidate room-wide; dispatch callers coalesce on the
+   candidate root and retry).
+   Lookup failures and missing related events during the walk are likewise INDETERMINATE, never ROOM_LEVEL.
+
+5. Child proof excludes the candidate root itself and excludes edits of the root: an ``m.replace`` of a
+   relation-free event does not make that event a thread root.
+
+6. A root proof built from thread history whose read source is the explicit degraded fallback
+   (``THREAD_HISTORY_SOURCE_DEGRADED``, i.e. an empty fail-open read) is PROOF_UNAVAILABLE, never
+   NOT_A_THREAD_ROOT: an empty degraded read must not demote an existing thread to room level.
+   Stale-cache history (``stale_cache`` source) remains acceptable proof material.
+
+7. A room scan that completes without ever seeing the candidate root
+   (``ThreadRoomScanRootNotFoundError``) is definitive NOT_A_THREAD_ROOT, not a proof failure.
 """
 
 from __future__ import annotations

--- a/src/mindroom/matrix/thread_membership.py
+++ b/src/mindroom/matrix/thread_membership.py
@@ -1,7 +1,8 @@
 """Canonical Matrix thread resolution.
 
 Ownership map:
-- canonical thread identity: this module
+- canonical thread identity: this module (pure domain rules, no client or cache transport)
+- client- and cache-backed membership accessors: `mindroom.matrix.thread_room_scan`
 - scanned-event ordering and latest-thread-tail helpers: `mindroom.matrix.thread_projection`
 - mutation/bookkeeping impact: `mindroom.matrix.thread_bookkeeping`
 - tool-facing normalization: `mindroom.custom_tools.attachment_helpers`
@@ -49,15 +50,10 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import TYPE_CHECKING, Protocol
-
-import nio
+from typing import Protocol
 
 from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.thread_diagnostics import is_thread_history_source_degraded
-
-if TYPE_CHECKING:
-    from mindroom.matrix.conversation_cache import ConversationCacheProtocol
 
 type _ThreadIdLookup = Callable[[str, str], Awaitable[str | None]]
 type _EventInfoLookup = Callable[[str, str], Awaitable[EventInfo | None]]
@@ -464,49 +460,4 @@ def room_scan_thread_membership_access(
         lookup_thread_id=lookup_thread_id,
         fetch_event_info=fetch_event_info,
         prove_thread_root=prove_thread_root,
-    )
-
-
-async def lookup_thread_id_from_conversation_cache(
-    conversation_cache: ConversationCacheProtocol | None,
-    room_id: str,
-    event_id: str,
-) -> str | None:
-    """Return one cached thread root when a conversation cache is available."""
-    if conversation_cache is None:
-        return None
-    return await conversation_cache.get_thread_id_for_event(room_id, event_id)
-
-
-def _event_info_from_lookup_response(
-    response: object,
-    *,
-    event_id: str,
-    strict: bool,
-) -> EventInfo | None:
-    """Normalize one room-get-event style response into EventInfo when available."""
-    if isinstance(response, nio.RoomGetEventResponse):
-        return EventInfo.from_event(response.event.source)
-    if not strict:
-        return None
-    if isinstance(response, nio.RoomGetEventError) and response.status_code == "M_NOT_FOUND":
-        return None
-    detail = response.message if isinstance(response, nio.RoomGetEventError) else "unknown error"
-    msg = f"Failed to resolve Matrix event {event_id}: {detail}"
-    raise RuntimeError(msg)
-
-
-async def fetch_event_info_for_client(
-    client: nio.AsyncClient,
-    room_id: str,
-    event_id: str,
-    *,
-    strict: bool,
-) -> EventInfo | None:
-    """Fetch one event directly from Matrix and parse its relation metadata."""
-    response = await client.room_get_event(room_id, event_id)
-    return _event_info_from_lookup_response(
-        response,
-        event_id=event_id,
-        strict=strict,
     )

--- a/src/mindroom/matrix/thread_projection.py
+++ b/src/mindroom/matrix/thread_projection.py
@@ -1,4 +1,17 @@
-"""Matrix thread ordering and projection helpers."""
+"""Matrix thread ordering and projection helpers.
+
+Ordering and projection invariants:
+
+1. Thread order is root first, then ``(origin_server_ts, stable input order, event_id)``.
+
+2. Within one equal-timestamp group, relation ancestors precede their descendants (topological order
+   seeded by input order); events outside any relation chain keep their plain sort position.
+
+3. ``resolve_thread_ids_for_event_infos`` derives membership for a local event graph by iterating the
+   canonical resolver (``thread_membership``) to a fixpoint, so transitive implied membership (reply to
+   a reply to a threaded event) resolves regardless of input order.
+   It is the only sanctioned way to batch-resolve membership; it adds no rules of its own.
+"""
 
 from __future__ import annotations
 

--- a/src/mindroom/matrix/thread_room_scan.py
+++ b/src/mindroom/matrix/thread_room_scan.py
@@ -1,4 +1,13 @@
-"""Client-backed room-scan helpers for Matrix thread membership resolution."""
+"""Client-backed room-scan helpers for Matrix thread membership resolution.
+
+This module is the seam between pure resolution (``thread_membership``) and the homeserver transport
+(``client_thread_history``): it builds ``ThreadMembershipAccess`` adapters whose root proofs run real
+room scans.
+It exists as its own module because ``client_thread_history`` imports ``thread_membership`` (via
+``thread_projection`` and for ``ThreadRoomScanRootNotFoundError``), so ``thread_membership`` itself can
+never depend on the transport.
+Cache reads here are advisory accelerators only; the authoritative root proof is always the room scan.
+"""
 
 from __future__ import annotations
 

--- a/src/mindroom/matrix/thread_room_scan.py
+++ b/src/mindroom/matrix/thread_room_scan.py
@@ -64,7 +64,7 @@ def _event_info_from_lookup_response(
     raise RuntimeError(msg)
 
 
-async def _lookup_thread_id_from_conversation_cache(
+async def lookup_thread_id_from_conversation_cache(
     conversation_cache: RoomScanConversationCache | None,
     room_id: str,
     event_id: str,
@@ -73,6 +73,22 @@ async def _lookup_thread_id_from_conversation_cache(
     if conversation_cache is None:
         return None
     return await conversation_cache.get_thread_id_for_event(room_id, event_id)
+
+
+async def fetch_event_info_for_client(
+    client: nio.AsyncClient,
+    room_id: str,
+    event_id: str,
+    *,
+    strict: bool,
+) -> EventInfo | None:
+    """Fetch one event directly from Matrix and parse its relation metadata."""
+    response = await client.room_get_event(room_id, event_id)
+    return _event_info_from_lookup_response(
+        response,
+        event_id=event_id,
+        strict=strict,
+    )
 
 
 async def fetch_event_info_from_conversation_cache(
@@ -100,7 +116,7 @@ def room_scan_membership_access_for_client(
     """Build client-backed membership access without widening the cache protocol."""
 
     async def lookup_thread_id(lookup_room_id: str, lookup_event_id: str) -> str | None:
-        return await _lookup_thread_id_from_conversation_cache(
+        return await lookup_thread_id_from_conversation_cache(
             conversation_cache,
             lookup_room_id,
             lookup_event_id,
@@ -131,6 +147,8 @@ def room_scan_membership_access_for_client(
 
 __all__ = [
     "RoomScanConversationCache",
+    "fetch_event_info_for_client",
     "fetch_event_info_from_conversation_cache",
+    "lookup_thread_id_from_conversation_cache",
     "room_scan_membership_access_for_client",
 ]

--- a/tach.toml
+++ b/tach.toml
@@ -2827,7 +2827,9 @@ exclusive = true
 [[interfaces]]
 expose = [
     "RoomScanConversationCache",
+    "fetch_event_info_for_client",
     "fetch_event_info_from_conversation_cache",
+    "lookup_thread_id_from_conversation_cache",
     "room_scan_membership_access_for_client",
 ]
 from = ["mindroom.matrix.thread_room_scan"]

--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -23,6 +23,7 @@ from mindroom.config.models import ModelConfig
 from mindroom.conversation_resolver import ConversationResolver, ConversationResolverDeps, _ThreadIdLookup
 from mindroom.matrix.cache import (
     ConversationEventCache,
+    ThreadCacheState,
     event_normalization,
     sqlite_event_cache_events,
     sqlite_event_cache_threads,
@@ -920,6 +921,193 @@ async def test_sqlite_stale_markers_are_monotonic(tmp_path: Path) -> None:
     assert state.invalidation_reason == "newer_thread_marker"
     assert state.room_invalidated_at == 200.0
     assert state.room_invalidation_reason == "newer_room_marker"
+
+
+def _thread_cache_state(
+    *,
+    validated_at: float | None = None,
+    invalidated_at: float | None = None,
+    invalidation_reason: str | None = None,
+    room_invalidated_at: float | None = None,
+    room_invalidation_reason: str | None = None,
+) -> ThreadCacheState:
+    return ThreadCacheState(
+        validated_at=validated_at,
+        invalidated_at=invalidated_at,
+        invalidation_reason=invalidation_reason,
+        room_invalidated_at=room_invalidated_at,
+        room_invalidation_reason=room_invalidation_reason,
+    )
+
+
+@pytest.mark.parametrize(
+    ("cache_state", "expected_reason"),
+    [
+        pytest.param(None, "no_cache_state", id="missing_state_rejects"),
+        pytest.param(
+            _thread_cache_state(invalidated_at=100.0, invalidation_reason="live_thread_mutation"),
+            "cache_never_validated",
+            id="never_validated_rejects",
+        ),
+        pytest.param(
+            _thread_cache_state(validated_at=100.0, invalidated_at=100.0, invalidation_reason="tie"),
+            "thread_invalidated_after_validation",
+            id="thread_invalidation_tie_rejects",
+        ),
+        pytest.param(
+            _thread_cache_state(validated_at=100.0, room_invalidated_at=100.0, room_invalidation_reason="tie"),
+            "room_invalidated_after_validation",
+            id="room_invalidation_tie_rejects",
+        ),
+        pytest.param(
+            _thread_cache_state(validated_at=200.0, invalidated_at=100.0, invalidation_reason="superseded"),
+            None,
+            id="invalidation_before_validation_accepts",
+        ),
+        pytest.param(
+            _thread_cache_state(validated_at=200.0, room_invalidated_at=100.0, room_invalidation_reason="superseded"),
+            None,
+            id="room_invalidation_before_validation_accepts",
+        ),
+        # PR #731 removed the age rule and PR #734 removed the restart rule: an arbitrarily old
+        # validation stays trusted until an invalidation marker lands at or after it.
+        pytest.param(
+            _thread_cache_state(validated_at=1.0),
+            None,
+            id="ancient_validation_accepts",
+        ),
+    ],
+)
+def test_thread_cache_rejection_reason_rule_table(
+    cache_state: ThreadCacheState | None,
+    expected_reason: str | None,
+) -> None:
+    """The durable trust gate must reject exactly on missing/never-validated/invalidated-at-or-after state."""
+    assert thread_cache_rejection_reason(cache_state) == expected_reason
+
+
+@pytest.mark.asyncio
+async def test_replace_thread_if_not_newer_refuses_after_midflight_invalidation(tmp_path: Path) -> None:
+    """A fetch that raced with a thread or room invalidation must not bury the newer stale marker."""
+    cache = SqliteEventCache(tmp_path / "event_cache.db")
+    await cache.initialize()
+    root_source = {
+        "event_id": "$thread_root",
+        "sender": "@user:localhost",
+        "origin_server_ts": 1000,
+        "type": "m.room.message",
+        "content": {"body": "Root message", "msgtype": "m.text"},
+    }
+
+    try:
+        await _replace_thread(cache, "!room:localhost", "$thread_root", [root_source], validated_at=100.0)
+        with patch("mindroom.matrix.cache.sqlite_event_cache_threads.time.time", return_value=200.0):
+            await cache.mark_thread_stale("!room:localhost", "$thread_root", reason="live_thread_mutation")
+
+        replaced_behind_marker = await cache.replace_thread_if_not_newer(
+            "!room:localhost",
+            "$thread_root",
+            [root_source],
+            fetch_started_at=150.0,
+            validated_at=300.0,
+        )
+        state_after_refusal = await cache.get_thread_cache_state("!room:localhost", "$thread_root")
+
+        replaced_after_marker = await cache.replace_thread_if_not_newer(
+            "!room:localhost",
+            "$thread_root",
+            [root_source],
+            fetch_started_at=250.0,
+            validated_at=300.0,
+        )
+        state_after_replace = await cache.get_thread_cache_state("!room:localhost", "$thread_root")
+    finally:
+        await cache.close()
+
+    assert replaced_behind_marker is False
+    assert state_after_refusal is not None
+    assert state_after_refusal.invalidated_at == 200.0
+    assert thread_cache_rejection_reason(state_after_refusal) == "thread_invalidated_after_validation"
+
+    assert replaced_after_marker is True
+    assert state_after_replace is not None
+    # The stored validation time is clamped to fetch start, so an invalidation landing during the
+    # fetch still outranks this snapshot at read time even if it slipped past the replace guard.
+    assert state_after_replace.validated_at == 250.0
+    assert state_after_replace.invalidated_at is None
+    assert thread_cache_rejection_reason(state_after_replace) is None
+
+
+@pytest.mark.asyncio
+async def test_replace_thread_if_not_newer_refuses_after_midflight_room_invalidation(tmp_path: Path) -> None:
+    """A room-wide stale marker that landed after fetch start must also refuse snapshot replacement."""
+    cache = SqliteEventCache(tmp_path / "event_cache.db")
+    await cache.initialize()
+    root_source = {
+        "event_id": "$thread_root",
+        "sender": "@user:localhost",
+        "origin_server_ts": 1000,
+        "type": "m.room.message",
+        "content": {"body": "Root message", "msgtype": "m.text"},
+    }
+
+    try:
+        await _replace_thread(cache, "!room:localhost", "$thread_root", [root_source], validated_at=100.0)
+        with patch("mindroom.matrix.cache.sqlite_event_cache_threads.time.time", return_value=200.0):
+            await cache.mark_room_threads_stale("!room:localhost", reason="sync_thread_lookup_unavailable")
+
+        replaced = await cache.replace_thread_if_not_newer(
+            "!room:localhost",
+            "$thread_root",
+            [root_source],
+            fetch_started_at=150.0,
+            validated_at=300.0,
+        )
+        state = await cache.get_thread_cache_state("!room:localhost", "$thread_root")
+    finally:
+        await cache.close()
+
+    assert replaced is False
+    assert state is not None
+    assert state.room_invalidated_at == 200.0
+    assert thread_cache_rejection_reason(state) == "room_invalidated_after_validation"
+
+
+@pytest.mark.asyncio
+async def test_incremental_revalidation_requires_incremental_invalidation_reason(tmp_path: Path) -> None:
+    """Appends may only clear invalidations caused by incremental mutations, never other reasons."""
+    cache = SqliteEventCache(tmp_path / "event_cache.db")
+    await cache.initialize()
+    root_source = {
+        "event_id": "$thread_root",
+        "sender": "@user:localhost",
+        "origin_server_ts": 1000,
+        "type": "m.room.message",
+        "content": {"body": "Root message", "msgtype": "m.text"},
+    }
+
+    try:
+        await _replace_thread(cache, "!room:localhost", "$thread_root", [root_source], validated_at=100.0)
+
+        not_invalidated = await cache.revalidate_thread_after_incremental_update("!room:localhost", "$thread_root")
+
+        await cache.mark_thread_stale("!room:localhost", "$thread_root", reason="live_append_failed")
+        non_incremental = await cache.revalidate_thread_after_incremental_update("!room:localhost", "$thread_root")
+        state_after_non_incremental = await cache.get_thread_cache_state("!room:localhost", "$thread_root")
+
+        await cache.mark_thread_stale("!room:localhost", "$thread_root", reason="live_thread_mutation")
+        incremental = await cache.revalidate_thread_after_incremental_update("!room:localhost", "$thread_root")
+        state_after_incremental = await cache.get_thread_cache_state("!room:localhost", "$thread_root")
+    finally:
+        await cache.close()
+
+    assert not_invalidated is False
+    assert non_incremental is False
+    assert state_after_non_incremental is not None
+    assert thread_cache_rejection_reason(state_after_non_incremental) == "thread_invalidated_after_validation"
+    assert incremental is True
+    assert state_after_incremental is not None
+    assert thread_cache_rejection_reason(state_after_incremental) is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_matrix_thread_domain.py
+++ b/tests/test_matrix_thread_domain.py
@@ -13,6 +13,7 @@ from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.custom_tools.attachment_helpers import resolve_canonical_tool_thread_target
 from mindroom.matrix import thread_bookkeeping
+from mindroom.matrix.cache import ThreadHistoryResult
 from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.thread_bookkeeping import (
     MutationThreadImpact,
@@ -20,11 +21,21 @@ from mindroom.matrix.thread_bookkeeping import (
     resolve_event_thread_impact_for_client,
     resolve_redaction_thread_impact_for_client,
 )
+from mindroom.matrix.thread_diagnostics import (
+    THREAD_HISTORY_DEGRADED_DIAGNOSTIC,
+    THREAD_HISTORY_SOURCE_DEGRADED,
+    THREAD_HISTORY_SOURCE_DIAGNOSTIC,
+)
 from mindroom.matrix.thread_membership import (
+    ThreadMembershipAccess,
     ThreadResolution,
+    ThreadResolutionState,
+    ThreadRootProof,
     map_backed_thread_membership_access,
     page_event_info_counts_as_thread_child_proof,
     resolve_event_thread_membership,
+    resolve_related_event_thread_membership,
+    thread_messages_thread_membership_access,
 )
 from mindroom.tool_system.runtime_context import ToolRuntimeContext
 from tests.conftest import bind_runtime_paths, make_event_cache_mock, runtime_paths_for, test_runtime_paths
@@ -216,6 +227,89 @@ async def test_resolve_event_thread_membership_proves_current_root_when_allowed(
     )
 
     assert resolution == ThreadResolution.threaded("$thread-root:localhost")
+
+
+@pytest.mark.asyncio
+async def test_resolve_related_event_thread_membership_terminates_on_relation_cycle() -> None:
+    """A reply cycle must terminate as room-level instead of walking relations forever."""
+    event_infos = {
+        "$cycle-a:localhost": _message_event_info(
+            {
+                "body": "a",
+                "msgtype": "m.text",
+                "m.relates_to": {"m.in_reply_to": {"event_id": "$cycle-b:localhost"}},
+            },
+        ),
+        "$cycle-b:localhost": _message_event_info(
+            {
+                "body": "b",
+                "msgtype": "m.text",
+                "m.relates_to": {"m.in_reply_to": {"event_id": "$cycle-a:localhost"}},
+            },
+        ),
+    }
+    fetched_event_ids: list[str] = []
+
+    async def lookup_thread_id(_room_id: str, _event_id: str) -> str | None:
+        return None
+
+    async def fetch_event_info(_room_id: str, event_id: str) -> EventInfo | None:
+        fetched_event_ids.append(event_id)
+        return event_infos[event_id]
+
+    async def prove_thread_root(_room_id: str, _thread_root_id: str) -> ThreadRootProof:
+        msg = "events with relations can never become thread roots"
+        raise AssertionError(msg)
+
+    resolution = await resolve_related_event_thread_membership(
+        "!room:localhost",
+        "$cycle-a:localhost",
+        access=ThreadMembershipAccess(
+            lookup_thread_id=lookup_thread_id,
+            fetch_event_info=fetch_event_info,
+            prove_thread_root=prove_thread_root,
+        ),
+    )
+
+    assert resolution == ThreadResolution.room_level()
+    assert fetched_event_ids == ["$cycle-a:localhost", "$cycle-b:localhost"]
+
+
+@pytest.mark.asyncio
+async def test_thread_root_proof_from_degraded_history_is_indeterminate() -> None:
+    """An empty degraded thread read must yield an indeterminate result, never room-level demotion."""
+    thread_root_id = "$thread-root:localhost"
+    degraded_history = ThreadHistoryResult(
+        [],
+        is_full_history=False,
+        diagnostics={
+            THREAD_HISTORY_SOURCE_DIAGNOSTIC: THREAD_HISTORY_SOURCE_DEGRADED,
+            THREAD_HISTORY_DEGRADED_DIAGNOSTIC: True,
+        },
+    )
+
+    async def lookup_thread_id(_room_id: str, _event_id: str) -> str | None:
+        return None
+
+    async def fetch_event_info(_room_id: str, _event_id: str) -> EventInfo | None:
+        return _message_event_info({"body": "root", "msgtype": "m.text"})
+
+    async def fetch_thread_messages(_room_id: str, _thread_id: str) -> ThreadHistoryResult:
+        return degraded_history
+
+    resolution = await resolve_related_event_thread_membership(
+        "!room:localhost",
+        thread_root_id,
+        access=thread_messages_thread_membership_access(
+            lookup_thread_id=lookup_thread_id,
+            fetch_event_info=fetch_event_info,
+            fetch_thread_messages=fetch_thread_messages,
+        ),
+    )
+
+    assert resolution.state is ThreadResolutionState.INDETERMINATE
+    assert resolution.candidate_thread_root_id == thread_root_id
+    assert resolution.thread_id is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_thread_history.py
+++ b/tests/test_thread_history.py
@@ -2931,6 +2931,122 @@ class TestThreadHistoryCache:
         assert recovered_history.diagnostics[THREAD_HISTORY_SOURCE_DIAGNOSTIC] == THREAD_HISTORY_SOURCE_HOMESERVER
 
     @pytest.mark.asyncio
+    async def test_fetch_thread_history_refuses_stale_fallback_when_cached_rows_miss_root(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Stale fallback must never serve cached rows that lack the thread root (PR #741)."""
+        cache = SqliteEventCache(tmp_path / "event_cache.db")
+        await cache.initialize()
+
+        rootless_reply = self._make_text_event(
+            event_id="$reply",
+            sender="@agent:localhost",
+            body="Cached reply",
+            server_timestamp=2000,
+            source_content={
+                "body": "Cached reply",
+                "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread_root"},
+            },
+        )
+        client = MagicMock()
+        client.room_get_event = AsyncMock(side_effect=RuntimeError("root fetch failed"))
+        client.room_get_event_relations = MagicMock()
+        client.room_messages = AsyncMock(side_effect=RuntimeError("scan failed"))
+
+        try:
+            await _replace_thread(
+                cache,
+                "!room:localhost",
+                "$thread_root",
+                [self._cache_source(rootless_reply)],
+                validated_at=time.time(),
+            )
+            await cache.mark_thread_stale("!room:localhost", "$thread_root", reason="force_refetch")
+
+            with pytest.raises(RuntimeError, match="scan failed"):
+                await fetch_thread_history(
+                    client,
+                    "!room:localhost",
+                    "$thread_root",
+                    event_cache=cache,
+                )
+
+            remaining_rows = await cache.get_thread_events("!room:localhost", "$thread_root")
+        finally:
+            await cache.close()
+
+        assert remaining_rows is None
+
+    @pytest.mark.asyncio
+    async def test_fetch_dispatch_thread_history_never_falls_back_to_stale_cache(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Dispatch reads must raise on refetch failure instead of serving stale cached rows."""
+        cache = SqliteEventCache(tmp_path / "event_cache.db")
+        await cache.initialize()
+
+        root_event = self._make_text_event(
+            event_id="$thread_root",
+            sender="@user:localhost",
+            body="Root message",
+            server_timestamp=1000,
+            source_content={"body": "Root message"},
+        )
+        stale_reply = self._make_text_event(
+            event_id="$reply",
+            sender="@agent:localhost",
+            body="Cached reply",
+            server_timestamp=2000,
+            source_content={
+                "body": "Cached reply",
+                "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread_root"},
+            },
+        )
+        client = MagicMock()
+        client.room_get_event = AsyncMock(side_effect=RuntimeError("root fetch failed"))
+        client.room_get_event_relations = MagicMock()
+        client.room_messages = AsyncMock(side_effect=RuntimeError("scan failed"))
+
+        try:
+            await _replace_thread(
+                cache,
+                "!room:localhost",
+                "$thread_root",
+                [self._cache_source(root_event), self._cache_source(stale_reply)],
+                validated_at=time.time(),
+            )
+            await cache.mark_thread_stale("!room:localhost", "$thread_root", reason="force_refetch")
+
+            with pytest.raises(RuntimeError, match="scan failed"):
+                await matrix_client_module.fetch_dispatch_thread_history(
+                    client,
+                    "!room:localhost",
+                    "$thread_root",
+                    event_cache=cache,
+                )
+            with pytest.raises(RuntimeError, match="scan failed"):
+                await matrix_client_module.fetch_dispatch_thread_snapshot(
+                    client,
+                    "!room:localhost",
+                    "$thread_root",
+                    event_cache=cache,
+                )
+
+            advisory_history = await matrix_client_module.fetch_thread_history(
+                client,
+                "!room:localhost",
+                "$thread_root",
+                event_cache=cache,
+            )
+        finally:
+            await cache.close()
+
+        assert advisory_history.diagnostics[THREAD_HISTORY_SOURCE_DIAGNOSTIC] == THREAD_HISTORY_SOURCE_STALE_CACHE
+        assert [message.body for message in advisory_history] == ["Root message", "Cached reply"]
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         ("cache_state_side_effect", "cached_events_side_effect"),
         [


### PR DESCRIPTION
## Summary

The Matrix thread semantics in `src/mindroom/matrix/` were patched five separate times for one question — "when is cached thread state trustworthy?" (#714, #716, #731, #734, #741) — but the rules lived in nobody's head.
This PR extracts those rules into an invariant inventory, states them in the docstrings of the modules that own them, adds tests for every invariant that had none, and makes exactly one consolidation (deleting a duplicated lookup-response normalizer).
It is deliberately close to a null refactor: the area was recently stabilized (#659, #674, #621/#622, #910) and is not re-architected here.

## Invariant inventory

### A. Thread identity and roots (`thread_membership.py`)

- A1. An event is THREADED iff it carries a native `m.thread` relation, is an edit whose `m.new_content` carries one, a relation walk from it reaches such an event, or the walk terminates at a relation-free event proven to have at least one real threaded child (that event is then the root). Per MSC3440 only relation-free events may become roots.
- A2. The relation walk follows edit original → reaction target → `m.reference` target → reply target; an explicit thread relation wins immediately. This is how implied membership works: plain replies/references/reactions inherit the target's thread transitively.
- A3. The walk always terminates: a visited set breaks relation cycles, a 512-hop cap bounds pathological chains.
- A4. Root proof is three-valued (PROVEN / NOT_A_THREAD_ROOT / PROOF_UNAVAILABLE) and proof failure never silently demotes to room level — it maps to INDETERMINATE with the candidate root preserved so callers fail closed.
- A5. Child proof excludes the root itself and edits of the root: an `m.replace` of a relation-free event does not make it a thread root.
- A6. A root proof built from a source-degraded thread read (empty fail-open result) is PROOF_UNAVAILABLE, never NOT_A_THREAD_ROOT; stale-cache history remains acceptable proof material.
- A7. A room scan that drains without seeing the candidate root (`ThreadRoomScanRootNotFoundError`) is definitive NOT_A_THREAD_ROOT, not a proof failure.

### B. Mutation ownership (`thread_bookkeeping.py`, `cache/thread_writes.py`, `cache/thread_write_cache_ops.py`)

- B1. Mutation-driven thread-cache writes go through exactly one path: the three write policies in `cache/thread_writes.py` (outbound, live, sync), sharing one impact resolver (`thread_bookkeeping.ThreadMutationResolver`) and one cache-op layer (`ThreadMutationCacheOps`), all ordered through the `EventCacheWriteCoordinator`. I verified the cache thread-write modules do **not** constitute a second owner: `thread_bookkeeping` only classifies (THREADED / ROOM_LEVEL / UNKNOWN), `thread_writes` orchestrates, `thread_write_cache_ops` applies — three layers of one path, not two paths. The only other thread-cache writer is the read-refill in `client_thread_history` (guarded snapshot store after an authoritative fetch, plus corruption invalidation), which the docstrings name explicitly.
- B2. Custom tools may not write thread state: `matrix_api` resolves impact pre-send via the `*_for_client` resolvers (refusing the Matrix operation on UNKNOWN) and after a successful send reports through `notify_outbound_*`, which routes into the same outbound policy. `thread_bookkeeping.py`'s docstring now answers "may I write thread state from a custom tool?" directly.
- B3. UNKNOWN impact fails closed: room-wide thread-cache invalidation (eager, outside the per-thread queue, because concurrent per-thread writers cannot uphold `room_invalidated_at >= validated_at`).
- B4. Outbound bookkeeping is post-send advisory and fails open; sync writes can run fail-closed for certification.
- B5. Invalidation is durable-marker-first, then row deletion, then cache disable (fail closed); appends are incremental-only and refuse when no snapshot rows exist.

### C. Barrier ordering (`cache/write_coordinator.py`, #716)

- C1. Room updates are exclusive; thread updates parallelize across threads, serialize within one thread, and never pass a queued room barrier.
- C2. A cancelled not-yet-started room update leaves a fence so later thread updates still wait for the earlier segment; read-style callers may opt out (`ignore_cancelled_room_fences`) because they mutate nothing.
- C3. Mutations with a pre-known thread go on the thread barrier; lookup-dependent mutations stay on the room barrier (earlier writes can create the lookup rows they need, ISSUE-189).
- C4. Reads barrier-then-fetch via `wait_for_thread_idle`, so a read never observes cache state older than mutations queued before it began.

### D. Cache-trust rules (the five-patch question, now stated in `cache/thread_cache_helpers.py` and `client_thread_history.py`)

- D1. Trust is durable-state-only: state row exists, `validated_at` set, and neither `invalidated_at` nor `room_invalidated_at` at-or-after `validated_at`. Timestamp ties reject.
- D2. **No age rule** (#731): a trusted snapshot stays trusted regardless of age.
- D3. **No restart rule** (#734): trust survives restarts with no `runtime_started_at` comparison. Cross-restart safety is owned by sync-token certification (#714): a token is persisted only when its sync response's timeline writes durably completed (no errors, no limited rooms, nothing pending); any uncertain outcome (including `M_UNKNOWN_POS`) clears the token and forces a cold sync.
- D4. **Missing root never served** (#741): both the trusted-read path and the stale-fallback path refuse cached rows lacking the root and invalidate the entry; a fresh fetch missing the root is never stored.
- D5. **Write-race guard** (#716): every cache store routes through `replace_thread_if_not_newer` with the fetch start time; replacement is refused if any trust timestamp changed after fetch start, and the stored `validated_at` is additionally clamped to fetch start so a mid-flight invalidation outranks the snapshot even if it slipped past the guard.
- D6. Stale markers are monotonic; older markers never downgrade newer ones.
- D7. Stale fallback exists only on the advisory read path; dispatch/strict fetchers raise instead.
- D8. Incremental revalidation after an append is allowlisted to the three incremental mutation reasons and blocked when the room was invalidated at-or-after validation.
- D9. Degraded and stale reads are never memoized per-turn and never used for MSC3440 latest-event fallback.

### E. History reconstruction (`client_thread_history.py`) and its cache interaction

- E1. The authoritative source is a backwards room-history scan requesting `m.room.message` **and** `m.room.encrypted` (#878 — without the encrypted type, threads in encrypted rooms silently vanish), stopping at the page containing the root.
- E2. Membership of scanned events is decided by the canonical resolver over the page-local graph to a fixpoint — there is no second resolution implementation.
- E3. Edits collapse into their originals (latest edit wins, same-thread only, bundled `m.replace` counts) and never appear as standalone messages.
- E4. Ordering is root first, then `(timestamp, input order, event_id)`, with same-timestamp relation ancestors before descendants (`thread_projection`).
- E5. `conversation_cache` is the read/write facade: cache-hit reads resolve from cached rows (invalidating on corruption), misses repopulate through the guarded store, and per-turn memoization replays only non-degraded reads.

### F. Diagnostics (`thread_diagnostics.py`)

- F1. Every thread read carries source diagnostics (`cache` / `homeserver` / `stale_cache` / `degraded`); `is_thread_history_degraded` (planning: stale and degraded both count) is deliberately weaker than `is_thread_history_source_degraded` (proof: only the explicit degraded source disqualifies), because a stale snapshot still proves children existed while an empty degraded read proves nothing.

## New tests (invariants that previously had none)

- `test_thread_cache_rejection_reason_rule_table` — the full D1 rule table, including timestamp-tie rejection and the deliberate absence of the age (#731) and restart (#734) rules (pinned by accepting an ancient `validated_at`).
- `test_replace_thread_if_not_newer_refuses_after_midflight_invalidation` / `..._room_invalidation` — the D5 write-race guard on the SQLite backend (only Postgres pending-marker variants existed), including the `validated_at` clamp to fetch start, which the test work surfaced as an undocumented rule and is now also documented.
- `test_incremental_revalidation_requires_incremental_invalidation_reason` — D8: `live_append_failed` cannot be cleared by an append, `live_thread_mutation` can, and an uninvalidated thread reports nothing to revalidate.
- `test_fetch_thread_history_refuses_stale_fallback_when_cached_rows_miss_root` — the #741 stale-path hunk (D4); only the trusted-read hunk had a test.
- `test_fetch_dispatch_thread_history_never_falls_back_to_stale_cache` — D7 at the fetcher level: both dispatch fetchers raise while the advisory fetcher returns the stale result in the same scenario.
- `test_resolve_related_event_thread_membership_terminates_on_relation_cycle` — A3: a reply cycle resolves room-level after visiting each event once.
- `test_thread_root_proof_from_degraded_history_is_indeterminate` — A6 at the membership level (the stale-accepted half already had a direct test; the degraded-rejected half was only covered behaviorally at the bot level).

No existing assertions were weakened; all new tests use typed objects and existing fixture patterns.

## Consolidations

**Done — single owner for client-backed lookup normalization (deletes code).**
`thread_membership.py` and `thread_room_scan.py` each carried a verbatim copy of `_event_info_from_lookup_response` and an identical conversation-cache thread-id lookup.
`fetch_event_info_for_client` and `lookup_thread_id_from_conversation_cache` moved to `thread_room_scan` (which already owned the cache-backed variant) and the duplicates were deleted.
Net effect: −29 lines, one owner for the strict/lenient lookup-response rule, and `thread_membership` becomes pure domain logic with no `nio` import and no transport reads.
`conversation_resolver.py` was not touched; its `thread_membership` import surface is unchanged.
`tach.toml` updated in the same commit (`thread_room_scan` interface gains the two symbols); `tach check --dependencies --interfaces` passes.

**Declined — absorb `thread_diagnostics.py`.**
The module whose reads it diagnoses is `client_thread_history`, but moving the keys there creates an import cycle: `client_thread_history` imports `thread_membership` (directly and via `thread_projection`), and `thread_membership` consumes `is_thread_history_source_degraded`.
The module is a deliberate cycle breaker with nine importers spanning the cache package (producers) and the resolution layer (consumers); its docstring now says so explicitly.

**Declined — fold `thread_room_scan.py` into `thread_membership.py`.**
Same cycle: the room-scan proof needs `client_thread_history.fetch_thread_event_sources_via_room_messages`, and `client_thread_history` imports `thread_membership`.
The module is a real seam (pure resolution above, transport below), and after the consolidation above it is also the single owner of all client/cache-backed membership access.

**Declined — dedupe mutation logic between `thread_bookkeeping` and the cache thread-write modules.**
Reading both ends confirmed there is no duplicate owner — they are complementary layers of one path (classify → orchestrate → apply).
The three child-proof predicates (`page_event_info_counts_as_thread_child_proof`, the room-scan variant, the cached-rows variant) look similar but enforce deliberately different rules for different data shapes (page-local infos accept `thread_id_from_edit`; room-scan sources are pre-filtered so any non-root non-root-edit counts; cached rows require an explicit `thread_id` match); merging them would change behavior.

**Declined — remove resolution logic from `thread_utils.py`.**
It contains none: the module is agent participation/mention analysis and session-ID helpers, and duplicates nothing in `thread_membership`.

## Self-review pass

A zero-tolerance review of the diff against the code found three overstated invariants, corrected in the final commit:
the mutation-path claim now names the read-refill writer in `client_thread_history`;
the sync-batch room-invalidation claim is scoped to once per pass (messages and redactions track separately);
the conversation-cache facade claim acknowledges direct event-cache reads for non-thread point lookups, and the read-barrier rule is scoped to reads through `ThreadReadPolicy` since startup prewarm bypasses it.

## Verification

- `uv run pytest` (full suite) passes.
- `uv run pre-commit run --all-files` passes.
- `uv run tach check --dependencies --interfaces` passes.
