### PR TITLE
Remove unreachable runtime-config hydration fallbacks

### DIFF
--- a/src/mindroom/api/config_lifecycle.py
+++ b/src/mindroom/api/config_lifecycle.py
@@ -12,7 +12,7 @@ from contextlib import ExitStack
 from copy import deepcopy
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, NoReturn, cast
 
 import yaml
 from fastapi import FastAPI, HTTPException, Request
@@ -189,7 +189,7 @@ def _raise_for_config_load_result(result: ConfigLoadResult | None) -> None:
     )
 
 
-def _raise_missing_loaded_config() -> None:
+def _raise_missing_loaded_config() -> NoReturn:
     """Raise the shared missing-config HTTP error used by cached API reads and writes."""
     raise HTTPException(status_code=500, detail="Failed to load configuration")
 
@@ -659,12 +659,9 @@ def read_app_committed_runtime_config(
     with initial_state.config_lock:
         snapshot = require_api_state(api_app).snapshot
         _raise_for_config_load_result(snapshot.config_load_result)
-        if not snapshot.config_data:
+        if not snapshot.config_data or snapshot.runtime_config is None:
             _raise_missing_loaded_config()
-        runtime_paths = snapshot.runtime_paths
-        if snapshot.runtime_config is not None:
-            return snapshot.runtime_config, runtime_paths
-        return Config.model_validate(snapshot.config_data, context={"runtime_paths": runtime_paths}), runtime_paths
+        return snapshot.runtime_config, snapshot.runtime_paths
 
 
 def read_committed_config[T](
@@ -697,12 +694,9 @@ def read_committed_runtime_config(
     """Read one validated runtime config and runtime from one coherent request snapshot."""
     snapshot = _request_or_current_snapshot(request)
     _raise_for_config_load_result(snapshot.config_load_result)
-    if not snapshot.config_data:
+    if not snapshot.config_data or snapshot.runtime_config is None:
         _raise_missing_loaded_config()
-    runtime_paths = snapshot.runtime_paths
-    if snapshot.runtime_config is not None:
-        return snapshot.runtime_config, runtime_paths
-    return Config.model_validate(snapshot.config_data, context={"runtime_paths": runtime_paths}), runtime_paths
+    return snapshot.runtime_config, snapshot.runtime_paths
 
 
 def write_committed_config[T](

--- a/src/mindroom/api/credentials.py
+++ b/src/mindroom/api/credentials.py
@@ -15,7 +15,6 @@ from mindroom.agent_policy import (
 )
 from mindroom.api import config_lifecycle
 from mindroom.authorization import is_sender_allowed_for_agent_credential_management
-from mindroom.config.main import Config
 from mindroom.credential_policy import (
     OAUTH_CREDENTIAL_FIELDS,
     credential_service_policy,
@@ -48,6 +47,7 @@ from mindroom.tool_system.worker_routing import (
 )
 
 if TYPE_CHECKING:
+    from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
     from mindroom.oauth.providers import OAuthProvider
     from mindroom.tool_system.worker_routing import ResolvedWorkerTarget
@@ -659,15 +659,9 @@ def _request_may_target_scoped_credentials(request: Request, agent_name: str | N
     return agent_name is not None or bool(request.query_params.get("execution_scope"))
 
 
-def _oauth_providers_for_request(request: Request) -> dict[str, OAuthProvider]:
-    snapshot = config_lifecycle.bind_current_request_snapshot(request)
-    if snapshot.runtime_config is None and not snapshot.config_data:
-        snapshot.runtime_config = Config.model_validate({})
-    return load_oauth_providers_for_snapshot(snapshot)
-
-
 def _oauth_services_for_request(request: Request) -> _OAuthCredentialServices:
-    return _OAuthCredentialServices(providers=_oauth_providers_for_request(request))
+    snapshot = config_lifecycle.bind_current_request_snapshot(request)
+    return _OAuthCredentialServices(providers=load_oauth_providers_for_snapshot(snapshot))
 
 
 def _oauth_service_match(request: Request, service: str) -> _OAuthCredentialServiceMatch | None:

--- a/src/mindroom/oauth/registry.py
+++ b/src/mindroom/oauth/registry.py
@@ -226,10 +226,10 @@ def load_oauth_providers_for_snapshot(
 ) -> dict[str, OAuthProvider]:
     """Return OAuth providers cached by one API config snapshot."""
     cache_key = ("snapshot", snapshot.generation, id(snapshot), snapshot.runtime_paths, skip_broken_plugins)
-    if snapshot.runtime_config is not None:
-        config = snapshot.runtime_config
-    else:
-        config = Config.model_validate(snapshot.config_data or {}, context={"runtime_paths": snapshot.runtime_paths})
+    config = snapshot.runtime_config
+    if config is None:
+        # Only pre-first-load snapshots lack a runtime config; they expose built-in providers only.
+        config = Config.model_validate({}, context={"runtime_paths": snapshot.runtime_paths})
     return _load_oauth_provider_registry(
         config,
         snapshot.runtime_paths,

--- a/tests/test_oauth_registry.py
+++ b/tests/test_oauth_registry.py
@@ -119,17 +119,18 @@ def test_load_oauth_providers_uses_config_cache_key(
     assert calls == [(config, runtime_paths, ("config", id(config), runtime_paths, False), False)]
 
 
-def test_load_oauth_providers_for_snapshot_hydrates_config_before_shared_load(
+def test_load_oauth_providers_for_snapshot_uses_runtime_config_and_cache_key(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Snapshot loading should preserve hydration and snapshot-specific cache key shape."""
+    """Snapshot loading should pass the snapshot's runtime config and cache key shape through."""
     runtime_paths = _runtime_paths(tmp_path)
+    runtime_config = Config.validate_with_runtime({"agents": {}}, runtime_paths)
     snapshot = ApiSnapshot(
         generation=7,
         runtime_paths=runtime_paths,
         config_data={"agents": {}},
-        runtime_config=None,
+        runtime_config=runtime_config,
     )
     expected_providers = {"provider": _provider("provider")}
     calls: list[tuple[Config, RuntimePaths, tuple[object, ...], bool]] = []
@@ -149,10 +150,39 @@ def test_load_oauth_providers_for_snapshot_hydrates_config_before_shared_load(
     providers = oauth_registry.load_oauth_providers_for_snapshot(snapshot, skip_broken_plugins=False)
 
     assert providers is expected_providers
+    assert calls == [(runtime_config, runtime_paths, ("snapshot", 7, id(snapshot), runtime_paths, False), False)]
+
+
+def test_load_oauth_providers_for_pre_load_snapshot_falls_back_to_empty_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Snapshots published before the first config load should use an empty config."""
+    runtime_paths = _runtime_paths(tmp_path)
+    snapshot = ApiSnapshot(
+        generation=0,
+        runtime_paths=runtime_paths,
+        config_data={},
+        runtime_config=None,
+    )
+    expected_providers = {"provider": _provider("provider")}
+    calls: list[Config] = []
+
+    def load_registry(
+        received_config: Config,
+        received_runtime_paths: RuntimePaths,
+        cache_key: tuple[object, ...],
+        *,
+        skip_broken_plugins: bool,
+    ) -> dict[str, OAuthProvider]:
+        del received_runtime_paths, cache_key, skip_broken_plugins
+        calls.append(received_config)
+        return expected_providers
+
+    monkeypatch.setattr(oauth_registry, "_load_oauth_provider_registry", load_registry)
+
+    providers = oauth_registry.load_oauth_providers_for_snapshot(snapshot)
+
+    assert providers is expected_providers
     assert len(calls) == 1
-    received_config, received_runtime_paths, cache_key, skip_broken_plugins = calls[0]
-    assert isinstance(received_config, Config)
-    assert received_config.authored_model_dump() == {"agents": {}}
-    assert received_runtime_paths == runtime_paths
-    assert cache_key == ("snapshot", 7, id(snapshot), runtime_paths, False)
-    assert skip_broken_plugins is False
+    assert calls[0].authored_model_dump() == {}


### PR DESCRIPTION
## Why

Follow-up from the #1197 review. The `Config.model_validate(snapshot.config_data, ...)` fallbacks in `read_committed_runtime_config`, `read_app_committed_runtime_config`, and `load_oauth_providers_for_snapshot` are unreachable in production: every snapshot publish path pairs non-empty `config_data` with a validated `runtime_config`.

- All `_published_snapshot` call sites set `runtime_config` together with `config_data`, sourced from `validate_with_runtime`.
- The only bare `ApiSnapshot` construction (initial app state) has empty `config_data`, and the readers already raise on that before reaching the fallback.
- On failed loads, `load_config_into_app` preserves the previous paired values.

The fallbacks were also dangerous if ever revived: they would silently return a config that diverges from `validate_with_runtime` (no plugin-load tolerance, no runtime overlays such as the approved-egress injection from #1197).

## Changes

- `read_committed_runtime_config` and `read_app_committed_runtime_config` now treat a missing `runtime_config` as a missing loaded config and raise the shared 500.
- `_raise_missing_loaded_config` is annotated `NoReturn` so the type checker narrows after it.
- `load_oauth_providers_for_snapshot` keeps only the legitimately reachable case: pre-first-load snapshots (empty `config_data`) fall back to an empty config so OAuth endpoints work before the first config load.
- That consolidation lets `api/credentials.py` drop its in-place snapshot mutation (`snapshot.runtime_config = Config.model_validate({})`), which mutated the shared published snapshot, and removes the now-pointless `_oauth_providers_for_request` wrapper.
- The OAuth registry test that constructed the impossible state (`config_data` set, `runtime_config=None`) now covers the real contract: runtime config passthrough plus the pre-first-load empty-config case.

## Verification

- Full suite: `uv run pytest -q --no-cov` — 8030 passed, 61 skipped.
- `uv run pre-commit run` on all changed files — clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Tightened runtime configuration requirements for configuration and OAuth credential loading to ensure proper initialization.
  * Improved type safety for configuration validation error handling.

* **Tests**
  * Enhanced test coverage for OAuth provider loading, including scenarios for early-stage configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->