### PR TITLE
Degrade gracefully when an optional MCP server is unavailable

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -100,6 +100,7 @@ Use the OAuth `auth` block for remote MCP servers that need a different bearer t
 | Option | Type | Default | Notes |
 |--------|------|---------|-------|
 | `enabled` | bool | `true` | Set to `false` to disable one server without removing its config |
+| `required` | bool | `false` | Block dependent agent startup while this server is unavailable instead of degrading |
 | `transport` | string | *required* | One of `stdio`, `sse`, or `streamable-http` |
 | `command` | string | `null` | Required for `stdio` |
 | `args` | list[string] | `[]` | Optional `stdio` arguments |
@@ -409,8 +410,9 @@ The palace enforces deduplication at a 0.9 similarity threshold.
 MindRoom connects to MCP servers during startup and whenever `config.yaml` changes.
 If a server fails to start, initialize, or publish a valid tool catalog, MindRoom marks that server as failed and logs a warning.
 
-Agents and teams that reference `mcp_<server_id>` are blocked from starting while that server is failed.
-MindRoom retries failed MCP discovery during later syncs and config reloads.
+By default a failed server degrades gracefully: agents and teams that reference `mcp_<server_id>` still start, with that server's tools omitted from their tool schema.
+MindRoom keeps retrying failed MCP discovery in the background with exponential backoff, and restarts the affected agents and teams once the server recovers so they pick up its tools.
+Set `required: true` on a server to restore hard-fail behavior, where dependent agents and teams stay blocked from starting until the server is available.
 
 During tool execution, explicit MCP tool failures are surfaced as tool errors.
 Those explicit server-side errors are not retried automatically.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -9494,6 +9494,7 @@ Use the OAuth `auth` block for remote MCP servers that need a different bearer t
 | Option | Type | Default | Notes |
 |--------|------|---------|-------|
 | `enabled` | bool | `true` | Set to `false` to disable one server without removing its config |
+| `required` | bool | `false` | Block dependent agent startup while this server is unavailable instead of degrading |
 | `transport` | string | *required* | One of `stdio`, `sse`, or `streamable-http` |
 | `command` | string | `null` | Required for `stdio` |
 | `args` | list[string] | `[]` | Optional `stdio` arguments |
@@ -9803,8 +9804,9 @@ The palace enforces deduplication at a 0.9 similarity threshold.
 MindRoom connects to MCP servers during startup and whenever `config.yaml` changes.
 If a server fails to start, initialize, or publish a valid tool catalog, MindRoom marks that server as failed and logs a warning.
 
-Agents and teams that reference `mcp_<server_id>` are blocked from starting while that server is failed.
-MindRoom retries failed MCP discovery during later syncs and config reloads.
+By default a failed server degrades gracefully: agents and teams that reference `mcp_<server_id>` still start, with that server's tools omitted from their tool schema.
+MindRoom keeps retrying failed MCP discovery in the background with exponential backoff, and restarts the affected agents and teams once the server recovers so they pick up its tools.
+Set `required: true` on a server to restore hard-fail behavior, where dependent agents and teams stay blocked from starting until the server is available.
 
 During tool execution, explicit MCP tool failures are surfaced as tool errors.
 Those explicit server-side errors are not retried automatically.

--- a/skills/mindroom-docs/references/page__mcp__index.md
+++ b/skills/mindroom-docs/references/page__mcp__index.md
@@ -96,6 +96,7 @@ Use the OAuth `auth` block for remote MCP servers that need a different bearer t
 | Option | Type | Default | Notes |
 |--------|------|---------|-------|
 | `enabled` | bool | `true` | Set to `false` to disable one server without removing its config |
+| `required` | bool | `false` | Block dependent agent startup while this server is unavailable instead of degrading |
 | `transport` | string | *required* | One of `stdio`, `sse`, or `streamable-http` |
 | `command` | string | `null` | Required for `stdio` |
 | `args` | list[string] | `[]` | Optional `stdio` arguments |
@@ -405,8 +406,9 @@ The palace enforces deduplication at a 0.9 similarity threshold.
 MindRoom connects to MCP servers during startup and whenever `config.yaml` changes.
 If a server fails to start, initialize, or publish a valid tool catalog, MindRoom marks that server as failed and logs a warning.
 
-Agents and teams that reference `mcp_<server_id>` are blocked from starting while that server is failed.
-MindRoom retries failed MCP discovery during later syncs and config reloads.
+By default a failed server degrades gracefully: agents and teams that reference `mcp_<server_id>` still start, with that server's tools omitted from their tool schema.
+MindRoom keeps retrying failed MCP discovery in the background with exponential backoff, and restarts the affected agents and teams once the server recovers so they pick up its tools.
+Set `required: true` on a server to restore hard-fail behavior, where dependent agents and teams stay blocked from starting until the server is available.
 
 During tool execution, explicit MCP tool failures are surfaced as tool errors.
 Those explicit server-side errors are not retried automatically.

--- a/src/mindroom/mcp/config.py
+++ b/src/mindroom/mcp/config.py
@@ -110,6 +110,10 @@ class MCPServerConfig(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     enabled: bool = Field(default=True, description="Whether the server is active")
+    required: bool = Field(
+        default=False,
+        description="Block dependent agent startup while this server is unavailable instead of degrading",
+    )
     transport: MCPTransport = Field(description="Transport type")
     command: str | None = Field(default=None, description="Executable name for stdio transport")
     args: list[str] = Field(default_factory=list, description="Arguments for stdio transport")

--- a/src/mindroom/mcp/manager.py
+++ b/src/mindroom/mcp/manager.py
@@ -54,8 +54,10 @@ _DISCOVERY_RETRY_MAX_DELAY_SECONDS = 60.0
 
 def _discovery_retry_delay_seconds(consecutive_failures: int) -> float:
     """Return the exponential-backoff delay before the next discovery retry."""
+    # Clamp the exponent so a long outage cannot overflow float conversion.
+    exponent = min(max(consecutive_failures - 1, 0), 10)
     return min(
-        _DISCOVERY_RETRY_INITIAL_DELAY_SECONDS * 2 ** max(consecutive_failures - 1, 0),
+        _DISCOVERY_RETRY_INITIAL_DELAY_SECONDS * 2**exponent,
         _DISCOVERY_RETRY_MAX_DELAY_SECONDS,
     )
 

--- a/src/mindroom/mcp/manager.py
+++ b/src/mindroom/mcp/manager.py
@@ -46,8 +46,10 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+# The cap matches STARTUP_RETRY_MAX_DELAY_SECONDS so a recovered required server
+# unblocks its dependent agents no slower than the bot-start retry loop did.
 _DISCOVERY_RETRY_INITIAL_DELAY_SECONDS = 5.0
-_DISCOVERY_RETRY_MAX_DELAY_SECONDS = 300.0
+_DISCOVERY_RETRY_MAX_DELAY_SECONDS = 60.0
 
 
 def _discovery_retry_delay_seconds(consecutive_failures: int) -> float:

--- a/src/mindroom/mcp/manager.py
+++ b/src/mindroom/mcp/manager.py
@@ -46,6 +46,17 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+_DISCOVERY_RETRY_INITIAL_DELAY_SECONDS = 5.0
+_DISCOVERY_RETRY_MAX_DELAY_SECONDS = 300.0
+
+
+def _discovery_retry_delay_seconds(consecutive_failures: int) -> float:
+    """Return the exponential-backoff delay before the next discovery retry."""
+    return min(
+        _DISCOVERY_RETRY_INITIAL_DELAY_SECONDS * 2 ** max(consecutive_failures - 1, 0),
+        _DISCOVERY_RETRY_MAX_DELAY_SECONDS,
+    )
+
 
 @dataclass(frozen=True)
 class _MCPSessionKey:
@@ -85,6 +96,10 @@ class MCPServerManager:
             if state.last_error is not None or (state.config.auth is None and state.catalog is None)
         }
 
+    def failed_required_server_ids(self) -> set[str]:
+        """Return failed servers configured to block dependent agent startup."""
+        return {server_id for server_id in self.failed_server_ids() if self._states[server_id].config.required}
+
     def get_catalog(self, server_id: str) -> MCPServerCatalog:
         """Return the cached catalog for one server."""
         state = self._require_state(server_id)
@@ -112,6 +127,7 @@ class MCPServerManager:
                 state = MCPServerState(server_id=server_id, config=server_config)
                 self._states[server_id] = state
             elif state.config != server_config:
+                await self._cancel_refresh_task(state)
                 async with state.lock:
                     await self._disconnect_state_when_idle(state)
                     await self._remove_scoped_server_states(server_id)
@@ -119,15 +135,19 @@ class MCPServerManager:
                     state.catalog = None
                     state.last_error = None
                     state.stale = True
+                    state.consecutive_failures = 0
                     state.semaphore = asyncio.Semaphore(server_config.max_concurrent_calls)
 
             if server_config.auth is not None:
                 state.stale = False
                 continue
 
+            retry_pending = state.refresh_task is not None and not state.refresh_task.done()
             if (
-                state.catalog is None or state.stale or state.last_error is not None or not state.connected
-            ) and await self._refresh_server_catalog(state, notify=False):
+                (state.catalog is None or state.stale or state.last_error is not None or not state.connected)
+                and not retry_pending
+                and await self._refresh_server_catalog(state, notify=False)
+            ):
                 changed_server_ids.add(server_id)
 
         invalid_server_ids = await self._validate_global_function_names()
@@ -140,18 +160,10 @@ class MCPServerManager:
         self._shutdown = True
         self._config = None
         for state in list(self._states.values()):
-            task = state.refresh_task
-            if task is not None:
-                task.cancel()
-                await asyncio.gather(task, return_exceptions=True)
-                state.refresh_task = None
+            await self._cancel_refresh_task(state)
             await self._disconnect_state_when_idle(state)
         for state in list(self._scoped_states.values()):
-            task = state.refresh_task
-            if task is not None:
-                task.cancel()
-                await asyncio.gather(task, return_exceptions=True)
-                state.refresh_task = None
+            await self._cancel_refresh_task(state)
             await self._disconnect_state_when_idle(state)
         self._states.clear()
         self._scoped_states.clear()
@@ -259,10 +271,7 @@ class MCPServerManager:
         state = self._scoped_states.pop(key, None)
         if state is None:
             return
-        task = state.refresh_task
-        if task is not None:
-            task.cancel()
-            await asyncio.gather(task, return_exceptions=True)
+        await self._cancel_refresh_task(state)
         await self._disconnect_state_when_idle(state)
 
     def _oauth_connection_required(
@@ -454,20 +463,31 @@ class MCPServerManager:
                 try:
                     catalog = await self._connect_and_discover(state, auth_headers=auth_headers)
                 except MCPError as exc:
+                    repeated_error = state.last_error is not None and str(state.last_error) == str(exc)
                     state.last_error = exc
                     state.connected = False
                     state.catalog = None
-                    logger.warning(
+                    state.consecutive_failures += 1
+                    log = logger.debug if repeated_error else logger.warning
+                    log(
                         "MCP server discovery failed",
                         server_id=state.server_id,
                         transport=state.config.transport,
                         error=str(exc),
+                        required=state.config.required,
+                        affected_entities=sorted(self._entities_referencing_server(state.server_id)),
+                        consecutive_failures=state.consecutive_failures,
+                    )
+                    self._schedule_refresh_task(
+                        state,
+                        delay_seconds=_discovery_retry_delay_seconds(state.consecutive_failures),
                     )
                     return False
 
                 state.catalog = catalog
                 state.connected = True
                 state.last_error = None
+                state.consecutive_failures = 0
                 changed = previous_hash != catalog.catalog_hash
                 should_notify_catalog_change = notify and changed and self._on_catalog_change is not None
         invalid_server_ids = await self._validate_global_function_names()
@@ -614,15 +634,26 @@ class MCPServerManager:
 
         return cast("MessageHandlerFnT", handle_message)
 
-    def _schedule_refresh_task(self, state: MCPServerState) -> None:
-        existing_task = state.refresh_task
+    def _entities_referencing_server(self, server_id: str) -> set[str]:
+        """Return configured entities whose tools reference one MCP server."""
+        config = self._config
+        if config is None:
+            return set()
+        return config.get_entities_referencing_tools({mcp_tool_name(server_id)})
+
+    def _schedule_refresh_task(self, state: MCPServerState, *, delay_seconds: float = 0.0) -> None:
         if self._shutdown or state.config.auth is not None:
             return
-        if existing_task is not None and not existing_task.done():
+        existing_task = state.refresh_task
+        if existing_task is not None and not existing_task.done() and existing_task is not asyncio.current_task():
             return
 
         async def refresh() -> None:
+            current_task = asyncio.current_task()
+            cancelled = False
             try:
+                if delay_seconds > 0:
+                    await asyncio.sleep(delay_seconds)
                 changed = await self._refresh_server_catalog(state, notify=True)
                 if changed:
                     logger.info(
@@ -630,6 +661,9 @@ class MCPServerManager:
                         server_id=state.server_id,
                         transport=state.config.transport,
                     )
+            except asyncio.CancelledError:
+                cancelled = True
+                raise
             except Exception as exc:
                 logger.warning(
                     "MCP server catalog refresh failed",
@@ -638,9 +672,12 @@ class MCPServerManager:
                     error=str(exc),
                 )
             finally:
-                state.refresh_task = None
-                if state.stale:
-                    self._schedule_refresh_task(state)
+                # A failed refresh schedules its own backoff retry from within this
+                # task, so only clear or reschedule when no replacement exists.
+                if state.refresh_task is current_task:
+                    state.refresh_task = None
+                    if state.stale and not cancelled:
+                        self._schedule_refresh_task(state)
 
         state.refresh_task = asyncio.create_task(refresh(), name=f"mcp_catalog_refresh:{state.server_id}")
 
@@ -648,10 +685,7 @@ class MCPServerManager:
         state = self._states.pop(server_id, None)
         if state is None:
             return
-        task = state.refresh_task
-        if task is not None:
-            task.cancel()
-            await asyncio.gather(task, return_exceptions=True)
+        await self._cancel_refresh_task(state)
         await self._remove_scoped_server_states(server_id)
         await self._disconnect_state_when_idle(state)
 
@@ -659,11 +693,18 @@ class MCPServerManager:
         scoped_keys = [key for key in self._scoped_states if key.server_id == server_id]
         for key in scoped_keys:
             state = self._scoped_states.pop(key)
-            task = state.refresh_task
-            if task is not None:
-                task.cancel()
-                await asyncio.gather(task, return_exceptions=True)
+            await self._cancel_refresh_task(state)
             await self._disconnect_state_when_idle(state)
+
+    @staticmethod
+    async def _cancel_refresh_task(state: MCPServerState) -> None:
+        task = state.refresh_task
+        if task is None:
+            return
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+        if state.refresh_task is task:
+            state.refresh_task = None
 
     async def _disconnect_state_when_idle(self, state: MCPServerState) -> None:
         async with state.call_lock.write():

--- a/src/mindroom/mcp/registry.py
+++ b/src/mindroom/mcp/registry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
 
+from mindroom.logging_config import get_logger
 from mindroom.mcp.config import mcp_oauth_bridge_function_names, validate_mcp_tool_filter_overlap
 from mindroom.mcp.errors import MCPError
 from mindroom.mcp.oauth import mcp_oauth_provider_id
@@ -29,7 +30,11 @@ if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths
     from mindroom.credentials import CredentialsManager
     from mindroom.mcp.config import MCPServerConfig
+    from mindroom.mcp.manager import MCPServerManager
+    from mindroom.mcp.types import MCPServerCatalog
     from mindroom.tool_system.worker_routing import ResolvedWorkerTarget
+
+logger = get_logger(__name__)
 
 _MCP_TOOL_PREFIX = "mcp_"
 _MCP_TOOL_NAMES: set[str] = set()
@@ -156,6 +161,25 @@ def _tool_metadata(server_id: str, server_config: MCPServerConfig) -> ToolMetada
     )
 
 
+def _available_catalog(
+    server_id: str,
+    server_config: MCPServerConfig,
+    manager: MCPServerManager,
+) -> MCPServerCatalog | None:
+    """Return the cached catalog, degrading to None when an optional server is unavailable."""
+    try:
+        return manager.get_catalog(server_id)
+    except MCPError as exc:
+        if server_config.required:
+            raise
+        logger.debug(
+            "MCP server unavailable; building toolkit without its tools",
+            server_id=server_id,
+            error=str(exc),
+        )
+        return None
+
+
 def _tool_factory(server_id: str, server_config: MCPServerConfig) -> Callable[[], type[Toolkit]]:
     def factory() -> type[Toolkit]:
         class BoundMindRoomMCPToolkit(MindRoomMCPToolkit):
@@ -173,7 +197,11 @@ def _tool_factory(server_id: str, server_config: MCPServerConfig) -> Callable[[]
                 super().__init__(
                     server_id=server_id,
                     manager=manager,
-                    catalog=manager.get_catalog(server_id) if manager is not None and not is_oauth else None,
+                    catalog=(
+                        _available_catalog(server_id, server_config, manager)
+                        if manager is not None and not is_oauth
+                        else None
+                    ),
                     tool_name=mcp_tool_name(server_id),
                     server_config=server_config,
                     include_tools=include_tools,

--- a/src/mindroom/mcp/types.py
+++ b/src/mindroom/mcp/types.py
@@ -99,6 +99,7 @@ class MCPServerState:
     connected: bool = False
     stale: bool = False
     last_error: MCPError | None = None
+    consecutive_failures: int = 0
     refresh_task: asyncio.Task[None] | None = None
     refresh_revision: int = 0
     oauth_access_token_hash: str | None = None

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -581,17 +581,32 @@ class _MultiAgentOrchestrator:
         return await manager.sync_servers(config)
 
     def _entities_blocked_by_failed_mcp_servers(self, entity_names: set[str], config: Config) -> set[str]:
-        """Return entities whose required MCP servers are currently unavailable."""
+        """Return entities blocked because a required MCP server is currently unavailable."""
         manager = self._mcp_manager
         if manager is None:
             return set()
-        failed_server_ids = manager.failed_server_ids()
+        failed_server_ids = manager.failed_required_server_ids()
         if not failed_server_ids:
             return set()
         blocked_entities = config.get_entities_referencing_tools(
             {mcp_tool_name(server_id) for server_id in failed_server_ids},
         )
         return blocked_entities & entity_names
+
+    def _log_mcp_degraded_entities(self, config: Config) -> None:
+        """Warn once per unavailable optional MCP server about entities running without its tools."""
+        manager = self._mcp_manager
+        if manager is None:
+            return
+        for server_id in sorted(manager.failed_server_ids() - manager.failed_required_server_ids()):
+            degraded_entities = config.get_entities_referencing_tools({mcp_tool_name(server_id)})
+            if not degraded_entities:
+                continue
+            logger.warning(
+                "Entities running without tools from unavailable MCP server",
+                server_id=server_id,
+                degraded_entities=sorted(degraded_entities),
+            )
 
     async def _retry_blocked_mcp_entities(self, entity_names: set[str], config: Config) -> set[str]:
         """Retry failed MCP discovery once before deferring dependent entity startup."""
@@ -1048,6 +1063,7 @@ class _MultiAgentOrchestrator:
         )
 
         config = self._require_config()
+        self._log_mcp_degraded_entities(config)
         self._resolve_bot_room_aliases(started_bots, config)
         phase_started = log_startup_phase_started("bind_runtime_support")
         self._bind_started_runtime_support_services(started_bots)

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -609,7 +609,11 @@ class _MultiAgentOrchestrator:
             )
 
     async def _retry_blocked_mcp_entities(self, entity_names: set[str], config: Config) -> set[str]:
-        """Retry failed MCP discovery once before deferring dependent entity startup."""
+        """Re-sync the MCP manager before deferring dependent entity startup.
+
+        The sync retries failed discovery immediately unless the manager already
+        has a background backoff retry in flight for that server.
+        """
         blocked_entities = self._entities_blocked_by_failed_mcp_servers(entity_names, config)
         if not blocked_entities:
             return set()

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -483,7 +483,10 @@ class _MultiAgentOrchestrator:
                     return
 
                 config = self.config
-                if config is not None and entity_name in await self._retry_blocked_mcp_entities({entity_name}, config):
+                if config is not None and entity_name in self._entities_blocked_by_failed_mcp_servers(
+                    {entity_name},
+                    config,
+                ):
                     start_status = False
                 else:
                     start_status = await self._try_start_bot_once(entity_name, bot)
@@ -607,18 +610,6 @@ class _MultiAgentOrchestrator:
                 server_id=server_id,
                 degraded_entities=sorted(degraded_entities),
             )
-
-    async def _retry_blocked_mcp_entities(self, entity_names: set[str], config: Config) -> set[str]:
-        """Re-sync the MCP manager before deferring dependent entity startup.
-
-        The sync retries failed discovery immediately unless the manager already
-        has a background backoff retry in flight for that server.
-        """
-        blocked_entities = self._entities_blocked_by_failed_mcp_servers(entity_names, config)
-        if not blocked_entities:
-            return set()
-        await self._sync_mcp_manager(config)
-        return self._entities_blocked_by_failed_mcp_servers(entity_names, config)
 
     @staticmethod
     def _entity_display_name(config: Config, entity_name: str) -> str:
@@ -821,7 +812,7 @@ class _MultiAgentOrchestrator:
 
         config = self.config
         blocked_entities = (
-            await self._retry_blocked_mcp_entities({entity_name for entity_name, _ in entity_bots}, config)
+            self._entities_blocked_by_failed_mcp_servers({entity_name for entity_name, _ in entity_bots}, config)
             if config is not None
             else set()
         )

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -601,8 +601,9 @@ class _MultiAgentOrchestrator:
         manager = self._mcp_manager
         if manager is None:
             return
+        running_entities = {entity_name for entity_name, bot in self.agent_bots.items() if bot.running}
         for server_id in sorted(manager.failed_server_ids() - manager.failed_required_server_ids()):
-            degraded_entities = config.get_entities_referencing_tools({mcp_tool_name(server_id)})
+            degraded_entities = config.get_entities_referencing_tools({mcp_tool_name(server_id)}) & running_entities
             if not degraded_entities:
                 continue
             logger.warning(

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -54,6 +54,9 @@ class _ConfigStub:
     def get_agent_available_tools(self, _agent_name: str) -> list[str]:
         return []
 
+    def get_entities_referencing_tools(self, _tool_names: set[str]) -> set[str]:
+        return set()
+
 
 class _FakeClientSession:
     sessions: ClassVar[list[_FakeClientSession]] = []
@@ -625,6 +628,72 @@ async def test_mcp_manager_enforces_startup_timeout(
     state = manager._states["demo"]
     assert isinstance(state.last_error, MCPTimeoutError)
     assert "startup timed out" in str(state.last_error)
+    assert state.refresh_task is not None
+    await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_mcp_manager_retries_failed_discovery_and_notifies_on_recovery(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Failed discovery schedules a background retry that notifies catalog consumers on recovery."""
+    _patch_manager(monkeypatch)
+    monkeypatch.setattr("mindroom.mcp.manager._discovery_retry_delay_seconds", lambda _failures: 0.01)
+    _FakeClientSession.tool_list = [_tool("echo")]
+    _FakeClientSession.initialize_delay_seconds = 0.05
+    recovered: list[str] = []
+
+    async def on_catalog_change(server_id: str) -> None:
+        recovered.append(server_id)
+
+    manager = MCPServerManager(_runtime_paths(tmp_path), on_catalog_change=on_catalog_change)
+    config = _ConfigStub(
+        {"demo": MCPServerConfig(transport="stdio", command="npx", startup_timeout_seconds=0.01)},
+    )
+    changed = await manager.sync_servers(config)
+    assert changed == set()
+    state = manager._states["demo"]
+    assert isinstance(state.last_error, MCPTimeoutError)
+    assert state.consecutive_failures == 1
+    retry_task = state.refresh_task
+    assert retry_task is not None
+
+    _FakeClientSession.initialize_delay_seconds = 0.0
+    await asyncio.wait_for(retry_task, timeout=5)
+
+    assert state.last_error is None
+    assert state.catalog is not None
+    assert state.consecutive_failures == 0
+    assert manager.failed_server_ids() == set()
+    assert recovered == ["demo"]
+    await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_mcp_manager_failed_required_server_ids(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Only servers marked required should block dependent entity startup when failed."""
+    _patch_manager(monkeypatch)
+    _FakeClientSession.initialize_delay_seconds = 0.05
+    manager = MCPServerManager(_runtime_paths(tmp_path))
+    config = _ConfigStub(
+        {
+            "optional": MCPServerConfig(transport="stdio", command="npx", startup_timeout_seconds=0.01),
+            "mandatory": MCPServerConfig(
+                transport="stdio",
+                command="npx",
+                startup_timeout_seconds=0.01,
+                required=True,
+            ),
+        },
+    )
+    await manager.sync_servers(config)
+    assert manager.failed_server_ids() == {"optional", "mandatory"}
+    assert manager.failed_required_server_ids() == {"mandatory"}
+    await manager.shutdown()
 
 
 @pytest.mark.asyncio
@@ -1350,6 +1419,70 @@ async def test_dynamic_load_rejects_failed_deferred_non_oauth_mcp_server_before_
     tool_names = [tool.name for tool in agent.tools]
     assert "mcp_demo" not in tool_names
     assert "dynamic_tools" in tool_names
+
+
+@pytest.mark.asyncio
+async def test_agent_creation_omits_tools_of_failed_optional_mcp_server(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A timed-out optional MCP server must not break agent construction, only drop its tools."""
+    _patch_manager(monkeypatch)
+    _FakeClientSession.tool_list = [_tool("echo")]
+    _FakeClientSession.initialize_delay_seconds = 0.05
+    runtime_paths = _runtime_paths(tmp_path)
+    config = Config.validate_with_runtime(
+        {
+            "mcp_servers": {
+                "demo": {
+                    "transport": "stdio",
+                    "command": "npx",
+                    "startup_timeout_seconds": 0.01,
+                },
+            },
+            "models": {
+                "default": {
+                    "provider": "openai",
+                    "id": "gpt-4o-mini",
+                },
+            },
+            "agents": {
+                "code": {
+                    "display_name": "Code",
+                    "role": "Write code",
+                    "tools": ["mcp_demo"],
+                },
+            },
+        },
+        runtime_paths,
+    )
+    persist_entity_accounts(config, runtime_paths)
+    manager = MCPServerManager(runtime_paths)
+
+    changed = await manager.sync_servers(config)
+
+    assert changed == set()
+    assert manager.failed_server_ids() == {"demo"}
+    assert manager.failed_required_server_ids() == set()
+
+    bind_mcp_server_manager(manager)
+    try:
+        model = OpenAIChat(id="gpt-4o-mini", api_key="sk-test")
+        with patch("mindroom.model_loading.get_model_instance", return_value=model):
+            agent = create_agent(
+                "code",
+                config,
+                runtime_paths,
+                execution_identity=None,
+                include_interactive_questions=False,
+            )
+    finally:
+        await manager.shutdown()
+        bind_mcp_server_manager(None)
+
+    mcp_toolkit = next(tool for tool in agent.tools if tool.name == "mcp_demo")
+    assert mcp_toolkit.async_functions == {}
+    assert mcp_toolkit.functions == {}
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -21,7 +21,7 @@ from mindroom.credentials import get_runtime_credentials_manager, save_scoped_cr
 from mindroom.custom_tools.dynamic_tools import DynamicToolsToolkit
 from mindroom.mcp.config import MCPServerConfig
 from mindroom.mcp.errors import MCPProtocolError, MCPTimeoutError, MCPToolCallError
-from mindroom.mcp.manager import MCPServerManager
+from mindroom.mcp.manager import MCPServerManager, _discovery_retry_delay_seconds
 from mindroom.mcp.toolkit import bind_mcp_server_manager
 from mindroom.mcp.transports import _MCPTransportHandle
 from mindroom.tool_system import dynamic_toolkits as dynamic_toolkits_module
@@ -668,6 +668,13 @@ async def test_mcp_manager_retries_failed_discovery_and_notifies_on_recovery(
     assert manager.failed_server_ids() == set()
     assert recovered == ["demo"]
     await manager.shutdown()
+
+
+def test_discovery_retry_delay_saturates_for_long_outages() -> None:
+    """The backoff delay must stay at the cap for arbitrarily long outages instead of overflowing."""
+    delays = [_discovery_retry_delay_seconds(failures) for failures in (1, 2, 3, 4, 5)]
+    assert delays == [5.0, 10.0, 20.0, 40.0, 60.0]
+    assert _discovery_retry_delay_seconds(100_000) == 60.0
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_orchestrator.py
+++ b/tests/test_mcp_orchestrator.py
@@ -135,10 +135,15 @@ async def test_start_entities_marks_mcp_blocked_entities_retryable(tmp_path: Pat
 
 
 def test_log_mcp_degraded_entities_warns_per_failed_optional_server(tmp_path: Path) -> None:
-    """Report entities running without tools from an unavailable optional MCP server."""
+    """Report only running entities as degraded by an unavailable optional MCP server."""
     orchestrator = _MultiAgentOrchestrator(runtime_paths=_runtime_paths(tmp_path))
     config = _config(tmp_path)
     orchestrator._mcp_manager = _manager_with_failed_server(required=False)
+    running_bot = MagicMock(spec=AgentBot)
+    running_bot.running = True
+    stopped_bot = MagicMock(spec=AgentBot)
+    stopped_bot.running = False
+    orchestrator.agent_bots = {"code": running_bot, "dev_team": stopped_bot}
 
     with patch("mindroom.orchestrator.logger") as mock_logger:
         orchestrator._log_mcp_degraded_entities(config)
@@ -146,7 +151,7 @@ def test_log_mcp_degraded_entities_warns_per_failed_optional_server(tmp_path: Pa
     mock_logger.warning.assert_called_once()
     kwargs = mock_logger.warning.call_args.kwargs
     assert kwargs["server_id"] == "demo"
-    assert kwargs["degraded_entities"] == ["code", "dev_team"]
+    assert kwargs["degraded_entities"] == ["code"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_orchestrator.py
+++ b/tests/test_mcp_orchestrator.py
@@ -26,13 +26,14 @@ def _runtime_paths(tmp_path: Path) -> RuntimePaths:
     return resolve_runtime_paths(config_path=tmp_path / "config.yaml", storage_path=tmp_path, process_env={})
 
 
-def _config(tmp_path: Path, *, tool_name: str = "mcp_demo", command: str = "npx") -> Config:
+def _config(tmp_path: Path, *, tool_name: str = "mcp_demo", command: str = "npx", required: bool = False) -> Config:
     return Config.validate_with_runtime(
         {
             "mcp_servers": {
                 "demo": {
                     "transport": "stdio",
                     "command": command,
+                    "required": required,
                 },
             },
             "agents": {
@@ -75,11 +76,52 @@ def test_config_update_plan_restarts_only_entities_using_changed_mcp_server(tmp_
     assert "plain" not in plan.entities_to_restart
 
 
+def _manager_with_failed_server(*, required: bool) -> MagicMock:
+    manager = MagicMock()
+    manager.failed_server_ids.return_value = {"demo"}
+    manager.failed_required_server_ids.return_value = {"demo"} if required else set()
+    return manager
+
+
+def test_entities_blocked_only_by_failed_required_mcp_servers(tmp_path: Path) -> None:
+    """A failed optional MCP server must not block dependent entity startup."""
+    orchestrator = _MultiAgentOrchestrator(runtime_paths=_runtime_paths(tmp_path))
+    entity_names = {"code", "dev_team", "plain"}
+
+    config = _config(tmp_path)
+    orchestrator._mcp_manager = _manager_with_failed_server(required=False)
+    assert orchestrator._entities_blocked_by_failed_mcp_servers(entity_names, config) == set()
+
+    required_config = _config(tmp_path, required=True)
+    orchestrator._mcp_manager = _manager_with_failed_server(required=True)
+    assert orchestrator._entities_blocked_by_failed_mcp_servers(entity_names, required_config) == {
+        "code",
+        "dev_team",
+    }
+
+
 @pytest.mark.asyncio
-async def test_start_entities_marks_mcp_blocked_entities_retryable(tmp_path: Path) -> None:
-    """Treat MCP discovery outages as retryable startup failures, not permanent disablement."""
+async def test_start_entities_proceed_when_optional_mcp_server_failed(tmp_path: Path) -> None:
+    """Bots referencing a failed optional MCP server start normally in degraded mode."""
     orchestrator = _MultiAgentOrchestrator(runtime_paths=_runtime_paths(tmp_path))
     orchestrator.config = _config(tmp_path)
+    bot = MagicMock(spec=AgentBot)
+    orchestrator.agent_bots = {"code": bot}
+    orchestrator._mcp_manager = _manager_with_failed_server(required=False)
+
+    with patch.object(orchestrator, "_try_start_bot_once", new=AsyncMock(return_value=True)) as mock_try_start:
+        results = await orchestrator._start_entities_once(["code"], start_sync_tasks=False)
+
+    assert results.started_bots == [bot]
+    assert results.retryable_entities == []
+    mock_try_start.assert_awaited_once_with("code", bot)
+
+
+@pytest.mark.asyncio
+async def test_start_entities_marks_mcp_blocked_entities_retryable(tmp_path: Path) -> None:
+    """Treat required MCP discovery outages as retryable startup failures, not permanent disablement."""
+    orchestrator = _MultiAgentOrchestrator(runtime_paths=_runtime_paths(tmp_path))
+    orchestrator.config = _config(tmp_path, required=True)
     orchestrator.agent_bots = {"code": MagicMock(spec=AgentBot)}
 
     with (
@@ -93,6 +135,21 @@ async def test_start_entities_marks_mcp_blocked_entities_retryable(tmp_path: Pat
     assert results.permanently_failed_entities == []
     mock_sync.assert_awaited_once()
     mock_try_start.assert_not_awaited()
+
+
+def test_log_mcp_degraded_entities_warns_per_failed_optional_server(tmp_path: Path) -> None:
+    """Report entities running without tools from an unavailable optional MCP server."""
+    orchestrator = _MultiAgentOrchestrator(runtime_paths=_runtime_paths(tmp_path))
+    config = _config(tmp_path)
+    orchestrator._mcp_manager = _manager_with_failed_server(required=False)
+
+    with patch("mindroom.orchestrator.logger") as mock_logger:
+        orchestrator._log_mcp_degraded_entities(config)
+
+    mock_logger.warning.assert_called_once()
+    kwargs = mock_logger.warning.call_args.kwargs
+    assert kwargs["server_id"] == "demo"
+    assert kwargs["degraded_entities"] == ["code", "dev_team"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_orchestrator.py
+++ b/tests/test_mcp_orchestrator.py
@@ -11,6 +11,7 @@ import pytest
 from mindroom.bot import AgentBot
 from mindroom.config.main import Config
 from mindroom.constants import ROUTER_AGENT_NAME, resolve_runtime_paths
+from mindroom.mcp.manager import MCPServerManager
 from mindroom.orchestration.config_updates import build_config_update_plan
 from mindroom.orchestration.runtime import EntityStartResults
 from mindroom.orchestrator import _MultiAgentOrchestrator
@@ -77,7 +78,7 @@ def test_config_update_plan_restarts_only_entities_using_changed_mcp_server(tmp_
 
 
 def _manager_with_failed_server(*, required: bool) -> MagicMock:
-    manager = MagicMock()
+    manager = MagicMock(spec=MCPServerManager)
     manager.failed_server_ids.return_value = {"demo"}
     manager.failed_required_server_ids.return_value = {"demo"} if required else set()
     return manager

--- a/tests/test_mcp_orchestrator.py
+++ b/tests/test_mcp_orchestrator.py
@@ -124,17 +124,13 @@ async def test_start_entities_marks_mcp_blocked_entities_retryable(tmp_path: Pat
     orchestrator = _MultiAgentOrchestrator(runtime_paths=_runtime_paths(tmp_path))
     orchestrator.config = _config(tmp_path, required=True)
     orchestrator.agent_bots = {"code": MagicMock(spec=AgentBot)}
+    orchestrator._mcp_manager = _manager_with_failed_server(required=True)
 
-    with (
-        patch.object(orchestrator, "_entities_blocked_by_failed_mcp_servers", side_effect=[{"code"}, {"code"}]),
-        patch.object(orchestrator, "_sync_mcp_manager", new=AsyncMock(return_value=set())) as mock_sync,
-        patch.object(orchestrator, "_try_start_bot_once", new=AsyncMock()) as mock_try_start,
-    ):
+    with patch.object(orchestrator, "_try_start_bot_once", new=AsyncMock()) as mock_try_start:
         results = await orchestrator._start_entities_once(["code"], start_sync_tasks=False)
 
     assert results.retryable_entities == ["code"]
     assert results.permanently_failed_entities == []
-    mock_sync.assert_awaited_once()
     mock_try_start.assert_not_awaited()
 
 

--- a/tests/test_mcp_registry.py
+++ b/tests/test_mcp_registry.py
@@ -10,6 +10,8 @@ import pytest
 import mindroom.tools  # noqa: F401
 from mindroom.config.main import Config, ConfigRuntimeValidationError
 from mindroom.constants import resolve_runtime_paths
+from mindroom.mcp.errors import MCPTimeoutError
+from mindroom.mcp.manager import MCPServerManager
 from mindroom.mcp.registry import (
     _MCP_TOOL_NAMES,
     mcp_server_id_from_tool_name,
@@ -19,6 +21,7 @@ from mindroom.mcp.registry import (
     validate_mcp_agent_overrides,
 )
 from mindroom.mcp.toolkit import bind_mcp_server_manager
+from mindroom.mcp.types import MCPServerState
 from mindroom.tool_system.metadata import TOOL_METADATA, TOOL_REGISTRY, SetupType, ToolStatus, get_tool_by_name
 from mindroom.tool_system.worker_routing import supports_tool_name_for_worker_scope
 
@@ -27,6 +30,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from mindroom.constants import RuntimePaths
+    from mindroom.mcp.config import MCPServerConfig
 
 _BASE_TOOL_REGISTRY = {
     tool_name: factory for tool_name, factory in TOOL_REGISTRY.items() if not tool_name.startswith("mcp_")
@@ -336,6 +340,54 @@ def test_mcp_tool_registry_returns_empty_toolkit_without_bound_manager(tmp_path:
 
     assert toolkit.name == "mcp_demo"
     assert toolkit.async_functions == {}
+
+
+def _bind_failed_manager(tmp_path: Path, server_config: MCPServerConfig) -> None:
+    manager = MCPServerManager(_runtime_paths(tmp_path))
+    state = MCPServerState(server_id="demo", config=server_config)
+    state.last_error = MCPTimeoutError("demo", "MCP startup timed out after 60.0 seconds")
+    manager._states["demo"] = state
+    bind_mcp_server_manager(manager)
+
+
+def test_mcp_tool_registry_degrades_when_optional_server_unavailable(tmp_path: Path) -> None:
+    """A failed optional MCP server yields a toolkit without functions instead of an error."""
+    config = _config(tmp_path)
+    sync_mcp_tool_registry(config)
+    _bind_failed_manager(tmp_path, config.mcp_servers["demo"])
+
+    toolkit = get_tool_by_name("mcp_demo", _runtime_paths(tmp_path), worker_target=None)
+
+    assert toolkit.name == "mcp_demo"
+    assert toolkit.async_functions == {}
+
+
+def test_mcp_tool_registry_fails_when_required_server_unavailable(tmp_path: Path) -> None:
+    """A failed required MCP server keeps the old hard-fail toolkit behavior."""
+    config = Config.validate_with_runtime(
+        {
+            "mcp_servers": {
+                "demo": {
+                    "transport": "stdio",
+                    "command": "npx",
+                    "required": True,
+                },
+            },
+            "agents": {
+                "code": {
+                    "display_name": "Code",
+                    "role": "Write code",
+                    "tools": ["mcp_demo"],
+                },
+            },
+        },
+        _runtime_paths(tmp_path),
+    )
+    sync_mcp_tool_registry(config)
+    _bind_failed_manager(tmp_path, config.mcp_servers["demo"])
+
+    with pytest.raises(MCPTimeoutError, match="startup timed out"):
+        get_tool_by_name("mcp_demo", _runtime_paths(tmp_path), worker_target=None)
 
 
 def test_mcp_tool_names_are_shared_only(tmp_path: Path) -> None:

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -15276,7 +15276,7 @@ class TestMultiAgentOrchestrator:
         orchestrator.agent_bots = {"general": bot}
 
         with (
-            patch.object(orchestrator, "_retry_blocked_mcp_entities", new=AsyncMock(return_value=set())),
+            patch.object(orchestrator, "_entities_blocked_by_failed_mcp_servers", return_value=set()),
             patch.object(
                 orchestrator,
                 "_setup_rooms_and_memberships",


### PR DESCRIPTION
## Problem

When an MCP server fails discovery (connection refused, DNS, startup timeout), every agent whose config references that server is blocked from starting entirely. The bot-start retry loop then retries forever with backoff, logging "Bot startup failed; retrying in background" on every attempt — for days if the server stays down.

The blast radius is much larger than the lost tools: because the blocked agent's Matrix bot never syncs, every mention of it is silently dropped. The router intentionally skips shared ingress work for messages that mention another agent (assuming that agent's own bot will dispatch), so scheduled workflows that mention the blocked agent produce no response, no error, nothing visible to users. A single unreachable MCP sidecar takes the whole agent offline silently.

## Changes

- **`MCPServerConfig.required` (new, default `false`)**: only failed servers with `required: true` block dependent entity startup. `_entities_blocked_by_failed_mcp_servers` filters through a new `MCPServerManager.failed_required_server_ids()`, which covers both call sites (initial startup and the background bot-start retry path) plus the router special case.
- **Toolkit degrades instead of raising**: when the cached catalog is unavailable and the server is not required, the agent gets the toolkit with zero functions, so the server's tools are simply omitted from the model tool schema and agent construction succeeds. Required servers keep the hard-fail behavior.
- **Background discovery retry with backoff**: a failed discovery schedules its own retry task (5s doubling to a 60s cap, matching `STARTUP_RETRY_MAX_DELAY_SECONDS`). On recovery it fires the existing catalog-change notification, which already restarts dependent entities — tools reattach via a one-time bot restart using existing machinery, and the degraded state clears.
- **Log hygiene**: the discovery-failure warning now includes the affected entities and the `required` flag; repeated identical failures log at debug instead of warning; startup logs one warning per unavailable optional server listing the entities running without its tools (distinct from the not-running degraded summary). Config reloads no longer stall on a down server because `sync_servers` skips the synchronous refresh while a backoff retry is pending.
- **`PermanentStartupError` semantics unchanged**: genuinely fatal misconfiguration still fails hard with no retry loop.
- Docs: `docs/mcp.md` documents `required` and the new degrade/retry/recovery behavior.

## Tests

- Failed optional server: entity startup proceeds, `create_agent` succeeds, and the server's functions are absent from the agent tool schema.
- Failed `required: true` server: dependent entities still blocked (old behavior preserved).
- Failure schedules a background retry; recovery resets the failure counter, clears `failed_server_ids`, and fires the catalog-change notification that restarts dependent entities.
- Repeated-failure log demotion and per-server affected-entity reporting.
- Full suite passes (8054 passed, 61 skipped), pre-commit and `tach check` clean.

Also verified the lifecycle live in a simulation: first failure warns once with affected entities, reload-while-down returns instantly instead of stalling on the startup timeout, repeated failures log at debug, and recovery connects, notifies, and resets the backoff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `required` configuration option for MCP servers (defaults to `false`).
  * When optional, agents gracefully start without unavailable server's tools; background retries occur with exponential backoff.
  * When `required: true`, previous hard-fail behavior is restored.
  * Automatic recovery: affected agents restart once the server recovers.

* **Documentation**
  * Updated MCP configuration documentation to describe new failure-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->