### PR TITLE
Release coalescing gate at response start instead of response completion

### DIFF
--- a/src/mindroom/coalescing.py
+++ b/src/mindroom/coalescing.py
@@ -207,6 +207,13 @@ class CoalescingGate:
     State machine per (room, thread, sender) key:
     IDLE (absent) -> DEBOUNCE -> GRACE (optional, wait for images) ->
     flush -> IN_FLIGHT, while all undispatched work remains in one FIFO queue.
+
+    The gate owns ingress ORDERING, not response EXECUTION: a dispatched batch
+    holds its gate only until the executor marks ``batch.response_start``
+    (target resolved, per-thread response lock held) or the dispatch callback
+    returns, whichever happens first. Started responses keep running on
+    gate-tracked background tasks so later batches for other targets dispatch
+    concurrently while drains can still settle or cancel them.
     """
 
     def __init__(
@@ -226,6 +233,7 @@ class CoalescingGate:
         self._gates: dict[CoalescingKey, _GateEntry] = {}
         self._order_book = CoalescingOrderBook()
         self._active_drain_context: _DrainContext | None = None
+        self._started_dispatch_tasks: set[asyncio.Task[None]] = set()
 
     def _remove_gate(self, key: CoalescingKey) -> None:
         self._gates.pop(key, None)
@@ -1172,6 +1180,37 @@ class CoalescingGate:
             error_message="Coalesced dispatch failed.",
         )
 
+    async def _dispatch_batch_until_response_started(self, batch: CoalescedBatch) -> asyncio.Task[None] | None:
+        """Run one dispatch until it completes or its response starts, whichever is first.
+
+        Returns the still-running dispatch task when the executor signalled
+        response start before completing, so the caller can release ordering
+        while execution continues.
+        """
+
+        async def _run_dispatch() -> None:
+            await self._dispatch_batch(batch)
+
+        dispatch_task = asyncio.create_task(
+            _run_dispatch(),
+            name=f"coalescing_dispatch:{batch.primary_event.event_id}",
+        )
+        response_started = asyncio.create_task(batch.response_start.wait_started())
+        try:
+            await asyncio.wait({dispatch_task, response_started}, return_when=asyncio.FIRST_COMPLETED)
+        except asyncio.CancelledError:
+            dispatch_task.cancel()
+            await asyncio.gather(dispatch_task, return_exceptions=True)
+            raise
+        finally:
+            # The waiter only observes an asyncio.Event, so a plain cancel is
+            # safe without awaiting its termination.
+            response_started.cancel()
+        if dispatch_task.done():
+            await dispatch_task
+            return None
+        return dispatch_task
+
     async def _dispatch_events(
         self,
         key: CoalescingKey,
@@ -1179,8 +1218,8 @@ class CoalescingGate:
         pending_events: list[PendingEvent],
         *,
         bypass_grace: bool,
-    ) -> str:
-        """Dispatch a claimed batch."""
+    ) -> asyncio.Task[None] | None:
+        """Dispatch a claimed batch, returning its task while the started response keeps running."""
         flush_start = time.monotonic()
         gate.phase = GatePhase.IN_FLIGHT
         gate.deadline = None
@@ -1197,7 +1236,7 @@ class CoalescingGate:
             "source_event_ids": self._source_event_ids(pending_events),
             "timing_scope": timing_scope,
         }
-        dispatched = False
+        outcome = "failed"
         try:
             diagnostics = self._flush_diagnostics(key, pending_events, bypass_grace=bypass_grace)
             pending_count = diagnostics.pending_count
@@ -1205,8 +1244,8 @@ class CoalescingGate:
             log_context = diagnostics.log_context
             logger.info("coalescing_gate_flush_started", **log_context)
             dispatch_batch_start = time.monotonic()
-            await self._dispatch_batch(diagnostics.batch)
-            dispatched = True
+            started_dispatch = await self._dispatch_batch_until_response_started(diagnostics.batch)
+            outcome = "dispatched" if started_dispatch is None else "response_started"
             emit_elapsed_timing(
                 "coalescing_gate.flush.dispatch_batch",
                 dispatch_batch_start,
@@ -1214,9 +1253,8 @@ class CoalescingGate:
                 bypass_grace=bypass_grace,
                 timing_scope=timing_scope,
             )
-            return "dispatched"
+            return started_dispatch
         finally:
-            outcome = "dispatched" if dispatched else "failed"
             emit_elapsed_timing(
                 "coalescing_gate.flush",
                 flush_start,
@@ -1235,6 +1273,43 @@ class CoalescingGate:
             gate.deadline = None
             self._wake_related_gates(key)
 
+    async def _settle_started_dispatch(
+        self,
+        key: CoalescingKey,
+        gate: _GateEntry,
+        segment_owner: ClaimedSegmentOwner,
+        dispatch_task: asyncio.Task[None],
+    ) -> None:
+        """Await one started dispatch after the gate released its ordering hold."""
+        try:
+            await dispatch_task
+        except asyncio.CancelledError:
+            if not dispatch_task.done():
+                dispatch_task.cancel()
+                await asyncio.gather(dispatch_task, return_exceptions=True)
+            segment_owner.close_metadata_once()
+            raise
+        except Exception as error:
+            segment_owner.close_metadata_once()
+            if (drain_context := self._current_drain_context(gate)) is not None:
+                drain_context.result.dispatch_failure_count += 1
+            self._log_dispatch_failure(key, gate, error)
+
+    def _adopt_started_dispatch(
+        self,
+        key: CoalescingKey,
+        gate: _GateEntry,
+        segment_owner: ClaimedSegmentOwner,
+        dispatch_task: asyncio.Task[None],
+    ) -> None:
+        """Track one started dispatch so drains can settle it after the gate releases."""
+        settle_task = asyncio.create_task(
+            self._settle_started_dispatch(key, gate, segment_owner, dispatch_task),
+            name=f"coalescing_started_dispatch:{key.room_id}:{key.thread_id or 'room'}:{key.requester_user_id}",
+        )
+        self._started_dispatch_tasks.add(settle_task)
+        settle_task.add_done_callback(self._started_dispatch_tasks.discard)
+
     async def _dispatch_claimed_events(
         self,
         key: CoalescingKey,
@@ -1244,7 +1319,12 @@ class CoalescingGate:
         bypass_grace: bool,
     ) -> None:
         try:
-            await self._dispatch_events(key, gate, segment_owner.pending_events, bypass_grace=bypass_grace)
+            started_dispatch = await self._dispatch_events(
+                key,
+                gate,
+                segment_owner.pending_events,
+                bypass_grace=bypass_grace,
+            )
         except asyncio.CancelledError:
             segment_owner.close_metadata_once()
             if (drain_context := self._current_drain_context(gate)) is not None:
@@ -1255,6 +1335,9 @@ class CoalescingGate:
             if (drain_context := self._current_drain_context(gate)) is not None:
                 drain_context.result.dispatch_failure_count += 1
             self._log_dispatch_failure(key, gate, error)
+        else:
+            if started_dispatch is not None:
+                self._adopt_started_dispatch(key, gate, segment_owner, started_dispatch)
 
     async def _dispatch_after_upload_grace(
         self,
@@ -1610,9 +1693,34 @@ class _CoalescingDrainCoordinator:
         result = await asyncio.gather(*done, return_exceptions=True)
         return close_ready_task_result_metadata(result[0])
 
+    async def _cancel_started_dispatch_tasks_for_bounded_shutdown(self) -> None:
+        """Cancel started responses a bounded drain can no longer wait for."""
+        pending_tasks = [task for task in self.gate._started_dispatch_tasks if not task.done()]
+        for task in pending_tasks:
+            task.cancel()
+            self.context.result.dispatch_cancelled_count += 1
+        if pending_tasks:
+            await asyncio.gather(*pending_tasks, return_exceptions=True)
+
+    async def _await_started_dispatch_tasks(self) -> None:
+        """Settle started dispatches that keep running after their gates released."""
+        pending_tasks = [task for task in self.gate._started_dispatch_tasks if not task.done()]
+        if not pending_tasks:
+            return
+        if not self.gate._is_bounded_drain(self.context):
+            await asyncio.gather(*pending_tasks, return_exceptions=True)
+            return
+        _, still_pending = await asyncio.wait(pending_tasks, timeout=self.context.ready_timeout_seconds)
+        for task in still_pending:
+            task.cancel()
+            self.context.result.dispatch_cancelled_count += 1
+        if still_pending:
+            await asyncio.gather(*still_pending, return_exceptions=True)
+
     async def _abandon_gate_work_for_bounded_shutdown(self) -> None:
         if not self.gate._is_bounded_drain(self.context):
             return
+        await self._cancel_started_dispatch_tasks_for_bounded_shutdown()
         dropped_ready_count = 0
         for gate in self.gate._gates.values():
             if gate.drain_task is not None and not gate.drain_task.done():
@@ -1668,6 +1776,7 @@ class _CoalescingDrainCoordinator:
             return True
         if active_pending:
             return False
+        await self._await_started_dispatch_tasks()
         return self.gate._order_book.all_settled()
 
     def _clear_context(self) -> None:

--- a/src/mindroom/coalescing_batch.py
+++ b/src/mindroom/coalescing_batch.py
@@ -13,6 +13,7 @@ from .dispatch_handoff import (
     DispatchEvent,
     MediaDispatchEvent,
     PendingDispatchMetadata,
+    ResponseStartSignal,
     dispatch_prompt_for_event,
     event_content_dict,
     is_media_dispatch_event,
@@ -90,6 +91,7 @@ class CoalescedBatch:
     original_sender: str | None = None
     raw_audio_fallback: bool = False
     dispatch_metadata: tuple[PendingDispatchMetadata, ...] = ()
+    response_start: ResponseStartSignal = field(default_factory=ResponseStartSignal, compare=False)
 
 
 def _pending_event_trusts_internal_payload(pending_event: PendingEvent) -> bool:

--- a/src/mindroom/dispatch_handoff.py
+++ b/src/mindroom/dispatch_handoff.py
@@ -135,7 +135,7 @@ class DispatchHandoff:
     source_event_prompts: Mapping[str, str] = field(default_factory=dict)
     media_events: tuple[MediaDispatchEvent, ...] = ()
     dispatch_metadata: tuple[PendingDispatchMetadata, ...] = ()
-    response_start: ResponseStartSignal | None = None
+    response_start: ResponseStartSignal = field(default_factory=ResponseStartSignal)
 
 
 def event_content_dict(event: DispatchEvent) -> dict[str, object] | None:

--- a/src/mindroom/dispatch_handoff.py
+++ b/src/mindroom/dispatch_handoff.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, Protocol, TypeGuard, cast
 
@@ -60,6 +61,32 @@ type TextDispatchEvent = nio.RoomMessageText | PreparedTextEvent
 type DispatchEvent = TextDispatchEvent | MediaDispatchEvent
 
 
+@dataclass(eq=False)
+class ResponseStartSignal:
+    """One-way signal set when the response runner takes ownership of a dispatched batch.
+
+    Ingress ordering (the coalescing gate) only needs to hold a batch until its
+    target is resolved and the per-thread response lock is held; response
+    execution can take minutes and must not extend that ordering hold. The
+    executor marks this signal at lock acquisition so the gate can release.
+    """
+
+    _started: asyncio.Event = field(default_factory=asyncio.Event, repr=False)
+
+    def mark_started(self) -> None:
+        """Record that the response runner owns this batch's response turn."""
+        self._started.set()
+
+    @property
+    def started(self) -> bool:
+        """Return whether the batch's response has started."""
+        return self._started.is_set()
+
+    async def wait_started(self) -> None:
+        """Wait until the batch's response has started."""
+        await self._started.wait()
+
+
 @dataclass
 class PendingDispatchMetadata:
     """Opaque metadata that must be closed if claimed work cannot dispatch."""
@@ -108,6 +135,7 @@ class DispatchHandoff:
     source_event_prompts: Mapping[str, str] = field(default_factory=dict)
     media_events: tuple[MediaDispatchEvent, ...] = ()
     dispatch_metadata: tuple[PendingDispatchMetadata, ...] = ()
+    response_start: ResponseStartSignal | None = None
 
 
 def event_content_dict(event: DispatchEvent) -> dict[str, object] | None:
@@ -378,4 +406,5 @@ def build_dispatch_handoff(batch: CoalescedBatch) -> DispatchHandoff:
         source_event_prompts=dict(batch.source_event_prompts),
         media_events=tuple(batch.media_events),
         dispatch_metadata=batch.dispatch_metadata,
+        response_start=batch.response_start,
     )

--- a/src/mindroom/text_ingress_dispatch.py
+++ b/src/mindroom/text_ingress_dispatch.py
@@ -33,7 +33,7 @@ from mindroom.timing import (
 from mindroom.timing import timing_scope as timing_scope_context
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
 
     import nio
 
@@ -83,6 +83,7 @@ async def dispatch_text_message(
     ingress_metadata: DispatchIngressMetadata | None = None,
     payload_metadata: DispatchPayloadMetadata | None = None,
     trust_hydrated_internal_metadata: bool | None = None,
+    on_lifecycle_lock_acquired: Callable[[], None] | None = None,
 ) -> None:
     """Run the normal text or command dispatch pipeline for a prepared text event."""
     timing_scope_token = None
@@ -136,6 +137,7 @@ async def dispatch_text_message(
             trusted_attachment_ids=trusted_attachment_ids,
             media_events=media_events,
             queued_notice_reservation=queued_notice_reservation,
+            on_lifecycle_lock_acquired=on_lifecycle_lock_acquired,
         )
     finally:
         if queued_notice_reservation is not None:
@@ -337,6 +339,7 @@ async def _apply_turn_plan(
     trusted_attachment_ids: list[str],
     media_events: list[MediaDispatchEvent] | None,
     queued_notice_reservation: QueuedHumanNoticeReservation | None,
+    on_lifecycle_lock_acquired: Callable[[], None] | None,
 ) -> None:
     if plan.kind == "ignore":
         if plan.ignore_reason == "router":
@@ -377,6 +380,7 @@ async def _apply_turn_plan(
         handled_turn=handled_turn,
         matrix_run_metadata=controller.deps.turn_store.build_run_metadata(handled_turn),
         queued_notice_reservation=queued_notice_reservation,
+        on_lifecycle_lock_acquired=on_lifecycle_lock_acquired,
     )
 
 

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -1897,9 +1897,7 @@ class TurnController:
             ingress_metadata=handoff.ingress,
             payload_metadata=handoff.payload,
             trust_hydrated_internal_metadata=handoff.trust_hydrated_internal_metadata,
-            on_lifecycle_lock_acquired=(
-                None if handoff.response_start is None else handoff.response_start.mark_started
-            ),
+            on_lifecycle_lock_acquired=handoff.response_start.mark_started,
         )
 
     async def handle_text_event(

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -119,7 +119,7 @@ from mindroom.turn_origin import (
 from mindroom.turn_policy import IngressHookRunner, PreparedDispatch, ResponseAction, TurnPolicy
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
 
     import structlog
 
@@ -1716,6 +1716,7 @@ class TurnController:
         handled_turn: HandledTurnState,
         matrix_run_metadata: dict[str, Any] | None = None,
         queued_notice_reservation: QueuedHumanNoticeReservation | None = None,
+        on_lifecycle_lock_acquired: Callable[[], None] | None = None,
     ) -> None:
         """Execute one final response path for a prepared dispatch action."""
         if room.room_id != dispatch.target.room_id:
@@ -1800,6 +1801,7 @@ class TurnController:
                             matrix_run_metadata=matrix_run_metadata,
                             requires_model_history_refresh=dispatch.context.requires_model_history_refresh,
                             payload_preparation=payload_preparation,
+                            on_lifecycle_lock_acquired=on_lifecycle_lock_acquired,
                             pipeline_timing=dispatch_timing,
                             queued_notice_reservation=queued_notice_reservation,
                         ),
@@ -1817,6 +1819,7 @@ class TurnController:
                             matrix_run_metadata=matrix_run_metadata,
                             requires_model_history_refresh=dispatch.context.requires_model_history_refresh,
                             payload_preparation=payload_preparation,
+                            on_lifecycle_lock_acquired=on_lifecycle_lock_acquired,
                             pipeline_timing=dispatch_timing,
                             queued_notice_reservation=queued_notice_reservation,
                         ),
@@ -1894,6 +1897,9 @@ class TurnController:
             ingress_metadata=handoff.ingress,
             payload_metadata=handoff.payload,
             trust_hydrated_internal_metadata=handoff.trust_hydrated_internal_metadata,
+            on_lifecycle_lock_acquired=(
+                None if handoff.response_start is None else handoff.response_start.mark_started
+            ),
         )
 
     async def handle_text_event(
@@ -2025,6 +2031,7 @@ class TurnController:
         ingress_metadata: DispatchIngressMetadata | None = None,
         payload_metadata: DispatchPayloadMetadata | None = None,
         trust_hydrated_internal_metadata: bool | None = None,
+        on_lifecycle_lock_acquired: Callable[[], None] | None = None,
     ) -> None:
         """Run the normal text or command dispatch pipeline for a prepared text event."""
         raw_event: TextDispatchEvent
@@ -2047,6 +2054,7 @@ class TurnController:
             ingress_metadata=ingress_metadata,
             payload_metadata=payload_metadata,
             trust_hydrated_internal_metadata=trust_hydrated_internal_metadata,
+            on_lifecycle_lock_acquired=on_lifecycle_lock_acquired,
         )
 
     async def handle_media_event(

--- a/tests/test_coalescing.py
+++ b/tests/test_coalescing.py
@@ -2066,6 +2066,196 @@ async def test_messages_in_different_threads_do_not_coalesce() -> None:
 
 
 @pytest.mark.asyncio
+async def test_second_root_batch_dispatches_once_first_response_starts() -> None:
+    """A later top-level batch must wait only for the previous response to start, not finish."""
+    dispatched: list[list[str]] = []
+    first_response_running = asyncio.Event()
+    release_first_response = asyncio.Event()
+
+    async def dispatch_batch(batch: CoalescedBatch) -> None:
+        dispatched.append(list(batch.source_event_ids))
+        if batch.source_event_ids == ["$first:localhost"]:
+            batch.response_start.mark_started()
+            first_response_running.set()
+            await release_first_response.wait()
+
+    gate = CoalescingGate(
+        dispatch_batch=dispatch_batch,
+        debounce_seconds=lambda: 0.0,
+        upload_grace_seconds=lambda: 0.0,
+        is_shutting_down=lambda: False,
+    )
+    key = CoalescingKey("!room:localhost", None, "@user:localhost")
+
+    await _admit_ready(gate, key, _pending(_text_event("$first:localhost", "first", 1_000_000)))
+    await asyncio.wait_for(first_response_running.wait(), timeout=1.0)
+    await _admit_ready(gate, key, _pending(_text_event("$second:localhost", "second", 1_000_600)))
+
+    await _wait_for(lambda: dispatched == [["$first:localhost"], ["$second:localhost"]])
+
+    assert not release_first_response.is_set()
+
+    release_first_response.set()
+    result = await gate.drain_all()
+
+    assert result.completed is True
+    assert dispatched == [["$first:localhost"], ["$second:localhost"]]
+
+
+@pytest.mark.asyncio
+async def test_thread_reply_dispatches_while_root_response_is_running() -> None:
+    """A reply in the thread rooted at an in-flight root turn waits only for response start."""
+    dispatched: list[list[str]] = []
+    root_response_running = asyncio.Event()
+    release_root_response = asyncio.Event()
+
+    async def dispatch_batch(batch: CoalescedBatch) -> None:
+        dispatched.append(list(batch.source_event_ids))
+        if batch.source_event_ids == ["$root:localhost"]:
+            batch.response_start.mark_started()
+            root_response_running.set()
+            await release_root_response.wait()
+
+    gate = CoalescingGate(
+        dispatch_batch=dispatch_batch,
+        debounce_seconds=lambda: 0.0,
+        upload_grace_seconds=lambda: 0.0,
+        is_shutting_down=lambda: False,
+    )
+    root_key = CoalescingKey("!room:localhost", None, "@user:localhost")
+    thread_key = CoalescingKey("!room:localhost", "$root:localhost", "@user:localhost")
+
+    await _admit_ready(gate, root_key, _pending(_text_event("$root:localhost", "root", 1_000_000)))
+    await asyncio.wait_for(root_response_running.wait(), timeout=1.0)
+    await _admit_ready(gate, thread_key, _pending(_text_event("$reply:localhost", "thread reply", 1_000_001)))
+
+    await _wait_for(lambda: dispatched == [["$root:localhost"], ["$reply:localhost"]])
+
+    assert not release_root_response.is_set()
+
+    release_root_response.set()
+    await gate.drain_all()
+
+    assert dispatched == [["$root:localhost"], ["$reply:localhost"]]
+
+
+@pytest.mark.asyncio
+async def test_drain_all_waits_for_started_dispatch_to_complete() -> None:
+    """An unbounded drain must still flush responses that already released the gate."""
+    response_running = asyncio.Event()
+    release_response = asyncio.Event()
+    finished: list[list[str]] = []
+
+    async def dispatch_batch(batch: CoalescedBatch) -> None:
+        batch.response_start.mark_started()
+        response_running.set()
+        await release_response.wait()
+        finished.append(list(batch.source_event_ids))
+
+    gate = CoalescingGate(
+        dispatch_batch=dispatch_batch,
+        debounce_seconds=lambda: 0.0,
+        upload_grace_seconds=lambda: 0.0,
+        is_shutting_down=lambda: False,
+    )
+    key = CoalescingKey("!room:localhost", None, "@user:localhost")
+
+    await _admit_ready(gate, key, _pending(_text_event("$text:localhost", "typed", 1_000_000)))
+    await asyncio.wait_for(response_running.wait(), timeout=1.0)
+
+    drain_task = asyncio.create_task(gate.drain_all())
+    await asyncio.sleep(0.01)
+    assert drain_task.done() is False
+
+    release_response.set()
+    result = await asyncio.wait_for(drain_task, timeout=1.0)
+
+    assert result.completed is True
+    assert finished == [["$text:localhost"]]
+
+
+@pytest.mark.asyncio
+async def test_bounded_drain_cancels_started_dispatch_and_reports_incomplete() -> None:
+    """A bounded drain must cancel a still-running started response instead of hanging."""
+    response_running = asyncio.Event()
+    release_response = asyncio.Event()
+
+    async def dispatch_batch(batch: CoalescedBatch) -> None:
+        batch.response_start.mark_started()
+        response_running.set()
+        await release_response.wait()
+
+    gate = CoalescingGate(
+        dispatch_batch=dispatch_batch,
+        debounce_seconds=lambda: 0.0,
+        upload_grace_seconds=lambda: 0.0,
+        is_shutting_down=lambda: True,
+    )
+    key = CoalescingKey("!room:localhost", "$thread:localhost", "@user:localhost")
+
+    await _admit_ready(gate, key, _pending(_text_event("$text:localhost", "typed", 1_000_000)))
+    await asyncio.wait_for(response_running.wait(), timeout=1.0)
+
+    drain_task = asyncio.create_task(gate.drain_all(ready_timeout_seconds=0.01))
+    try:
+        result = await asyncio.wait_for(asyncio.shield(drain_task), timeout=0.5)
+    except TimeoutError:  # pragma: no cover - documents the failure mode on regression
+        pytest.fail("bounded drain hung behind a started dispatch")
+    finally:
+        release_response.set()
+        if not drain_task.done():
+            drain_task.cancel()
+            await asyncio.gather(drain_task, return_exceptions=True)
+
+    assert result.completed is False
+    assert result.dispatch_cancelled_count == 1
+
+
+@pytest.mark.asyncio
+async def test_started_dispatch_failure_closes_segment_metadata() -> None:
+    """A response that fails after releasing the gate must still close gate-owned metadata."""
+    response_running = asyncio.Event()
+    release_response = asyncio.Event()
+    metadata_closed = asyncio.Event()
+    close_count = 0
+
+    def close() -> None:
+        nonlocal close_count
+        close_count += 1
+        metadata_closed.set()
+
+    async def dispatch_batch(batch: CoalescedBatch) -> None:
+        batch.response_start.mark_started()
+        response_running.set()
+        await release_response.wait()
+        msg = "response failed after start"
+        raise RuntimeError(msg)
+
+    gate = CoalescingGate(
+        dispatch_batch=dispatch_batch,
+        debounce_seconds=lambda: 0.0,
+        upload_grace_seconds=lambda: 0.0,
+        is_shutting_down=lambda: False,
+    )
+    key = CoalescingKey("!room:localhost", "$thread:localhost", "@user:localhost")
+    pending = _pending(_text_event("$text:localhost", "typed", 1_000_000))
+    pending.dispatch_metadata = (PendingDispatchMetadata(kind="test", payload=object(), close=close),)
+
+    await gate.admit(key, ready_result=ReadyPendingEvent(pending_event=pending))
+    await asyncio.wait_for(response_running.wait(), timeout=1.0)
+
+    release_response.set()
+    # Failure handling logs the exception with rendered locals, which can hold
+    # the loop well past a tight polling deadline; wait on the close signal.
+    await asyncio.wait_for(metadata_closed.wait(), timeout=5.0)
+
+    result = await gate.drain_all()
+
+    assert result.completed is True
+    assert close_count == 1
+
+
+@pytest.mark.asyncio
 async def test_drain_all_flushes_pending_debounced_work_and_idles_gate() -> None:
     """Shutdown drain dispatches queued work without waiting out the debounce window."""
     batches: list[CoalescedBatch] = []

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -676,7 +676,7 @@ async def test_text_first_image_during_debounce_dispatches_without_upload_grace_
         )
         await _wait_for(lambda: calls == [(["$m1", "$img1"], 1)], deadline_seconds=1.0)
 
-    assert _coalescing_gate_is_idle(bot._coalescing_gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(bot._coalescing_gate))
 
 
 @pytest.mark.asyncio
@@ -1340,7 +1340,7 @@ async def test_already_queued_command_barrier_flushes_normal_without_debounce() 
 
     await _wait_for(lambda: calls == [["$m1"], ["$cmd"]], deadline_seconds=0.2)
 
-    assert _coalescing_gate_is_idle(gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(gate))
 
 
 @pytest.mark.asyncio
@@ -1825,7 +1825,7 @@ async def test_in_flight_command_barrier_flushes_buffered_normal_without_debounc
     release_first_dispatch.set()
     await _wait_for(lambda: calls == [["$m1"], ["$m2"], ["$cmd"]], deadline_seconds=0.2)
 
-    assert _coalescing_gate_is_idle(gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(gate))
 
 
 @pytest.mark.asyncio
@@ -1864,7 +1864,7 @@ async def test_command_during_active_dispatch_preserves_fifo_order() -> None:
     release_first_dispatch.set()
     await _wait_for(lambda: calls == [["$m1"], ["$m2"], ["$cmd"], ["$m3"]])
 
-    assert _coalescing_gate_is_idle(gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(gate))
 
 
 @pytest.mark.asyncio
@@ -1896,7 +1896,7 @@ async def test_room_scope_text_then_voice_live_debounce_coalesces_receive_time()
     await gate.drain_all()
 
     assert calls == [["$text", "$voice"]]
-    assert _coalescing_gate_is_idle(gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(gate))
 
 
 @pytest.mark.asyncio
@@ -1944,7 +1944,7 @@ async def test_room_scope_text_then_pending_voice_waits_for_voice_class_admissio
 
     release_voice.set()
     await _wait_for(lambda: calls == [["$text", "$voice"]], deadline_seconds=0.2)
-    assert _coalescing_gate_is_idle(gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(gate))
 
 
 @pytest.mark.asyncio
@@ -1995,7 +1995,7 @@ async def test_late_same_thread_text_does_not_join_expired_debounce_while_waitin
     release_voice.set()
     await gate.drain_all()
     assert calls == [["$typed1", "$voice"], ["$typed2"]]
-    assert _coalescing_gate_is_idle(gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(gate))
 
 
 @pytest.mark.asyncio
@@ -2043,7 +2043,7 @@ async def test_front_command_does_not_wait_for_later_unresolved_voice() -> None:
     release_voice.set()
     await gate.drain_all()
     assert calls == [["$cmd"], ["$voice"]]
-    assert _coalescing_gate_is_idle(gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(gate))
 
 
 @pytest.mark.asyncio
@@ -2086,7 +2086,7 @@ async def test_interrupted_claimed_admission_is_retried_on_next_drain() -> None:
     await gate.drain_all()
 
     assert calls == [["$first", "$second"]]
-    assert _coalescing_gate_is_idle(gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(gate))
 
 
 @pytest.mark.asyncio
@@ -2141,7 +2141,7 @@ async def test_voice_handoff_buffers_same_thread_followups_while_in_flight() -> 
 
     release_voice_dispatch.set()
     await _wait_for(lambda: calls == [["$voice"], ["$followup"]], deadline_seconds=0.2)
-    assert _coalescing_gate_is_idle(gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(gate))
 
 
 @pytest.mark.asyncio
@@ -2193,7 +2193,7 @@ async def test_voice_before_text_uses_stable_admission_key() -> None:
 
     release_voice.set()
     await _wait_for(lambda: calls == [(resolved_key, ["$voice", "$typed"])], deadline_seconds=0.2)
-    assert _coalescing_gate_is_idle(gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(gate))
 
 
 @pytest.mark.asyncio
@@ -2245,7 +2245,7 @@ async def test_text_before_voice_uses_stable_admission_key() -> None:
 
     release_voice.set()
     await _wait_for(lambda: calls == [(resolved_key, ["$typed", "$voice"])], deadline_seconds=0.2)
-    assert _coalescing_gate_is_idle(gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(gate))
 
 
 @pytest.mark.asyncio
@@ -2303,7 +2303,7 @@ async def test_same_thread_followup_after_voice_claim_stays_on_admitted_gate() -
         (admitted_key, ["$voice"]),
         (admitted_key, ["$typed"]),
     ]
-    assert _coalescing_gate_is_idle(gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(gate))
 
 
 @pytest.mark.asyncio
@@ -2354,7 +2354,7 @@ async def test_plain_reply_voice_resolution_batches_related_text() -> None:
 
     release_voice.set()
     await _wait_for(lambda: calls == [["$voice", "$typed"]], deadline_seconds=0.2)
-    assert _coalescing_gate_is_idle(gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(gate))
 
 
 @pytest.mark.asyncio
@@ -2407,7 +2407,7 @@ async def test_text_first_waits_for_plain_reply_voice_ready_during_debounce() ->
 
     release_voice.set()
     await _wait_for(lambda: calls == [["$typed", "$voice"]], deadline_seconds=0.2)
-    assert _coalescing_gate_is_idle(gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(gate))
 
 
 @pytest.mark.asyncio
@@ -2460,7 +2460,7 @@ async def test_later_different_thread_voice_does_not_hold_earlier_text() -> None
 
     release_voice.set()
     await _wait_for(lambda: calls == [["$typed"], ["$voice"]], deadline_seconds=0.2)
-    assert _coalescing_gate_is_idle(gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(gate))
 
 
 @pytest.mark.asyncio
@@ -2498,7 +2498,7 @@ async def test_failed_room_voice_does_not_coalesce_surviving_room_roots() -> Non
     await gate.drain_all()
 
     assert calls == [["$first"], ["$second"]]
-    assert _coalescing_gate_is_idle(gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(gate))
 
 
 @pytest.mark.asyncio
@@ -2549,7 +2549,7 @@ async def test_command_after_pending_voice_waits_for_same_resolved_thread() -> N
 
     release_voice.set()
     await _wait_for(lambda: calls == [["$voice"], ["$cmd"]], deadline_seconds=0.2)
-    assert _coalescing_gate_is_idle(gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(gate))
 
 
 @pytest.mark.asyncio
@@ -2608,7 +2608,7 @@ async def test_voice_admissions_resolving_to_different_threads_do_not_coalesce()
         (first_key, ["$voice1"]),
         (second_key, ["$voice2"]),
     ]
-    assert _coalescing_gate_is_idle(gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(gate))
 
 
 @pytest.mark.asyncio
@@ -2668,7 +2668,7 @@ async def test_pending_thread_voice_does_not_capture_unrelated_thread_text() -> 
         ),
         deadline_seconds=0.2,
     )
-    assert _coalescing_gate_is_idle(gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(gate))
 
 
 @pytest.mark.asyncio
@@ -2705,7 +2705,7 @@ async def test_room_scope_voice_burst_coalesces_under_null_thread_key() -> None:
     await gate.drain_all()
 
     assert calls == [["$voice1", "$voice2"]]
-    assert _coalescing_gate_is_idle(gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(gate))
 
 
 @pytest.mark.asyncio
@@ -2757,7 +2757,7 @@ async def test_deferred_room_scope_voice_burst_stays_one_turn_under_null_thread_
     await gate.drain_all()
 
     assert calls == [(key, ["$voice1", "$voice2"])]
-    assert _coalescing_gate_is_idle(gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(gate))
 
 
 @pytest.mark.asyncio
@@ -2819,7 +2819,7 @@ async def test_enqueue_for_dispatch_returns_while_drain_dispatch_blocks(tmp_path
         release_first_dispatch.set()
         await _wait_for(lambda: calls == [["$m1"], ["$m2"]])
 
-    assert _coalescing_gate_is_idle(bot._coalescing_gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(bot._coalescing_gate))
 
 
 def test_automation_source_kinds_are_coalescing_exempt() -> None:
@@ -2987,7 +2987,7 @@ async def test_bypass_preserves_fifo_order_behind_existing_normal_work() -> None
 
     await _wait_for(lambda: calls == [["$m1"], ["$hook"], ["$m2"]])
 
-    assert _coalescing_gate_is_idle(gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(gate))
 
 
 @pytest.mark.asyncio
@@ -3036,7 +3036,7 @@ async def test_room_mode_voice_queued_notice_is_solo_barrier_before_nearby_norma
 
     assert calls == [["$voice-room"], ["$normal"]]
     reservation.cancel.assert_not_called()
-    assert _coalescing_gate_is_idle(gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(gate))
 
 
 @pytest.mark.asyncio
@@ -3153,7 +3153,7 @@ async def test_prepare_for_sync_shutdown_waits_for_active_flush_task(tmp_path: P
         await shutdown_task
 
     assert calls == [["$m1"]]
-    assert _coalescing_gate_is_idle(bot._coalescing_gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(bot._coalescing_gate))
 
 
 @pytest.mark.asyncio
@@ -3187,7 +3187,7 @@ async def test_prepare_for_sync_shutdown_drains_pending_debounced_messages(tmp_p
         await bot.prepare_for_sync_shutdown()
 
     assert calls == [("hello", ["$m1"])]
-    assert _coalescing_gate_is_idle(bot._coalescing_gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(bot._coalescing_gate))
 
 
 @pytest.mark.asyncio
@@ -3225,7 +3225,7 @@ async def test_prepare_for_sync_shutdown_drains_pending_upload_grace(tmp_path: P
         await bot.prepare_for_sync_shutdown()
 
     assert calls == [("hello", ["$m1"])]
-    assert _coalescing_gate_is_idle(bot._coalescing_gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(bot._coalescing_gate))
 
 
 @pytest.mark.asyncio
@@ -3283,7 +3283,7 @@ async def test_shutdown_during_in_flight_dispatch_does_not_start_grace(tmp_path:
         await shutdown_task
 
     assert calls == [("first", ["$m1"]), ("second", ["$m2"])]
-    assert _coalescing_gate_is_idle(bot._coalescing_gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(bot._coalescing_gate))
 
 
 @pytest.mark.asyncio
@@ -3344,7 +3344,7 @@ async def test_thread_followups_wait_behind_first_turn_root_in_flight(tmp_path: 
         await _wait_for(lambda: calls == [["$m1"], ["$m2", "$m3"]])
 
     assert calls == [["$m1"], ["$m2", "$m3"]]
-    assert _coalescing_gate_is_idle(bot._coalescing_gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(bot._coalescing_gate))
 
 
 @pytest.mark.asyncio
@@ -3796,6 +3796,41 @@ async def test_coalesced_room_plain_reply_target_uses_prompt_thread_not_reply_th
     assert dispatches[0].context.thread_id is None
 
 
+@pytest.mark.asyncio
+async def test_handle_coalesced_batch_threads_response_start_signal_to_executor(tmp_path: Path) -> None:
+    """The batch's response-start signal must reach the response executor as the lock callback."""
+    bot = _make_bot(tmp_path, debounce_ms=0, upload_grace_ms=0)
+    room = _make_room()
+    batch = build_coalesced_batch(
+        CoalescingKey(room.room_id, None, "@user:localhost"),
+        [
+            PendingEvent(
+                event=_text_event(event_id="$m1", body="hello"),
+                room=room,
+                source_kind="message",
+            ),
+        ],
+    )
+    captured: list[Callable[[], None] | None] = []
+
+    async def record_response(*_args: object, **kwargs: object) -> None:
+        captured.append(cast("Callable[[], None] | None", kwargs.get("on_lifecycle_lock_acquired")))
+
+    with (
+        patch.object(bot._turn_policy, "plan_turn", new=AsyncMock(return_value=_respond_dispatch_plan())),
+        patch.object(bot._turn_controller, "_execute_response_action", new=AsyncMock(side_effect=record_response)),
+    ):
+        await bot._turn_controller.handle_coalesced_batch(batch)
+
+    assert len(captured) == 1
+    assert captured[0] is not None
+    assert batch.response_start.started is False
+
+    captured[0]()
+
+    assert batch.response_start.started is True
+
+
 def test_single_mentioned_followup_batch_uses_coalescing_thread_relation() -> None:
     """Mentions must not preserve an explicit stale thread relation."""
     room = _make_room()
@@ -4018,7 +4053,7 @@ async def test_flush_logs_failed_outcome_when_dispatch_batch_raises() -> None:
             ),
         )
         await gate.drain_all()
-        assert _coalescing_gate_is_idle(gate)
+        await _wait_for(lambda: _coalescing_gate_is_idle(gate))
 
     flush_calls = [call for call in mock_emit.call_args_list if call.args and call.args[0] == "coalescing_gate.flush"]
     assert len(flush_calls) == 1
@@ -4134,7 +4169,7 @@ async def test_timer_flush_logs_dispatch_failure_without_unhandled_task() -> Non
     assert mock_exception.call_args.kwargs["error_message"] == "Coalesced dispatch failed."
     assert "pending_count" in mock_exception.call_args.kwargs
     assert "oldest_pending_age_ms" in mock_exception.call_args.kwargs
-    assert _coalescing_gate_is_idle(gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(gate))
 
 
 @pytest.mark.asyncio
@@ -4169,7 +4204,7 @@ async def test_failed_drain_does_not_poison_future_ingress() -> None:
         )
         await _wait_for(lambda: mock_exception.called)
 
-    assert _coalescing_gate_is_idle(gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(gate))
 
     await _admit_ready(
         gate,
@@ -4182,7 +4217,7 @@ async def test_failed_drain_does_not_poison_future_ingress() -> None:
     )
     await _wait_for(lambda: dispatched_source_event_ids == [["$m2"]])
 
-    assert _coalescing_gate_is_idle(gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(gate))
 
 
 @pytest.mark.asyncio
@@ -4234,7 +4269,7 @@ async def test_failed_drain_dispatches_buffered_ingress_without_waiting_for_anot
         await _wait_for(lambda: mock_exception.called)
         await _wait_for(lambda: dispatched_source_event_ids == [["$m2"]])
 
-    assert _coalescing_gate_is_idle(gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(gate))
 
 
 @pytest.mark.asyncio
@@ -4275,7 +4310,7 @@ async def test_cancelled_drain_cleans_state_for_later_message() -> None:
     drain_task.cancel()
     await asyncio.gather(drain_task, return_exceptions=True)
 
-    assert _coalescing_gate_is_idle(gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(gate))
 
     await _admit_ready(
         gate,
@@ -4288,7 +4323,7 @@ async def test_cancelled_drain_cleans_state_for_later_message() -> None:
     )
     await _wait_for(lambda: dispatched_source_event_ids == [["$m1"], ["$m2"]])
 
-    assert _coalescing_gate_is_idle(gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(gate))
 
 
 @pytest.mark.asyncio
@@ -4339,7 +4374,7 @@ async def test_cancelled_drain_dispatches_buffered_ingress_without_waiting_for_a
     await asyncio.gather(drain_task, return_exceptions=True)
     await _wait_for(lambda: dispatched_source_event_ids == [["$m1"], ["$m2"]])
 
-    assert _coalescing_gate_is_idle(gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(gate))
 
 
 @pytest.mark.asyncio
@@ -4405,7 +4440,7 @@ async def test_cleanup_drains_pending_debounce_tasks(tmp_path: Path) -> None:
         await bot.cleanup()
 
     mock_dispatch.assert_awaited_once()
-    assert _coalescing_gate_is_idle(bot._coalescing_gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(bot._coalescing_gate))
 
 
 @pytest.mark.asyncio
@@ -4548,7 +4583,7 @@ async def test_zero_debounce_dispatches_immediately(tmp_path: Path) -> None:
         await _wait_for(lambda: len(calls) == 1)
 
     assert calls == [("immediate", ["$m1"])]
-    assert _coalescing_gate_is_idle(bot._coalescing_gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(bot._coalescing_gate))
 
 
 @pytest.mark.asyncio
@@ -4603,7 +4638,7 @@ async def test_gate_entry_removed_after_dispatch_with_no_pending(tmp_path: Path)
     event = _text_event(event_id="$m1", body="hello")
 
     with patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock()):
-        assert _coalescing_gate_is_idle(bot._coalescing_gate)
+        await _wait_for(lambda: _coalescing_gate_is_idle(bot._coalescing_gate))
         await _enqueue_for_dispatch(
             bot,
             event,
@@ -4613,7 +4648,7 @@ async def test_gate_entry_removed_after_dispatch_with_no_pending(tmp_path: Path)
         )
         await _wait_for(lambda: _coalescing_gate_is_idle(bot._coalescing_gate))
 
-    assert _coalescing_gate_is_idle(bot._coalescing_gate)
+    await _wait_for(lambda: _coalescing_gate_is_idle(bot._coalescing_gate))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

A coalescing gate's drain awaits the entire response generation for a dispatched batch (`handle_batch` spans placeholder, streaming, tool calls, completion). Agent turns can legitimately run for minutes, and the gate holds ingress ordering the whole time:

- All of one user's top-level messages in a room share the coalescing key `(room, thread=None, requester)`, so the next top-level message queues behind the in-flight batch for the **full duration of the previous turn**. We measured a gate wait of 6.5 minutes (`coalescing_gate_flush_slow` with `oldest_pending_age_ms: 389262`) for a message whose pipeline took ~2 s once the gate released.
- Thread replies wait on the requester's root gate via `_older_owner_root_gates` while it has older queued work, so an agent writing in one thread blocks the user's messages in **other threads** of the same room.

The root cause is that the gate conflates ingress **ordering** (which must be held only briefly so messages are observed in order) with response **execution** (which can take minutes).

## Fix

A dispatched batch now carries a `ResponseStartSignal`. The response runner marks it through the existing `on_lifecycle_lock_acquired` hook at the moment it takes the per-thread response lock — i.e. once the response's target is resolved and same-thread coherence is owned by the response lock. The gate waits only until the dispatch completes **or** the response starts, whichever is first.

Started responses keep running on tracked tasks with explicit lifecycle semantics:

- unbounded drains (`drain_all`) await them before reporting completion,
- bounded drains cancel them and count the cancellation,
- a response that fails after the gate released still closes gate-owned dispatch metadata exactly once.

## Tests

New coverage in `tests/test_coalescing.py` / `tests/test_live_message_coalescing.py`:

- a second root batch dispatches once the first response has *started* (not completed),
- a thread reply dispatches while a root response is still running,
- `drain_all` awaits started dispatches,
- a bounded drain cancels started dispatches and reports incomplete,
- the failure path closes segment metadata,
- the response-start signal reaches the executor as the lifecycle-lock callback.

Full suite: 8051 passed, 48 skipped. Lint (`ruff`), `ty`, and pre-commit hooks pass.

One pre-existing test-env observation worth noting separately: rendering a large exception via `logger.exception` (structlog + rich in tests) can hold the event loop past tight polling deadlines; one new test waits on an explicit close signal instead of polling for this reason.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved dispatch execution lifecycle management with finer-grained control over response start signaling.
  * Enhanced shutdown drain coordination to better handle concurrent dispatch task completion and cancellation.

* **Tests**
  * Added comprehensive test coverage for dispatch coalescing and drain behavior scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->