### PR TITLE
dynamic_workflows: extract spec validation out of store.py

### DIFF
--- a/src/mindroom/api/dynamic_workflows.py
+++ b/src/mindroom/api/dynamic_workflows.py
@@ -10,7 +10,8 @@ from fastapi.responses import FileResponse
 from mindroom.api.config_lifecycle import api_runtime_paths
 from mindroom.api.report_headers import set_report_headers
 from mindroom.constants import OWNER_MATRIX_USER_ID_ENV
-from mindroom.dynamic_workflows.store import DynamicWorkflowError, DynamicWorkflowRun, DynamicWorkflowStore
+from mindroom.dynamic_workflows.store import DynamicWorkflowRun, DynamicWorkflowStore
+from mindroom.dynamic_workflows.validation import DynamicWorkflowError
 
 router = APIRouter(tags=["dynamic-workflows"])
 

--- a/src/mindroom/custom_tools/dynamic_workflow.py
+++ b/src/mindroom/custom_tools/dynamic_workflow.py
@@ -26,7 +26,7 @@ from mindroom.custom_tools.tool_payloads import custom_tool_payload
 from mindroom.custom_tools.toolkit_functions import JSON_OBJECT_SCHEMA, register_toolkit_functions
 from mindroom.dynamic_workflows.runner import DynamicWorkflowExecutionError
 from mindroom.dynamic_workflows.service import DynamicWorkflowService
-from mindroom.dynamic_workflows.store import DynamicWorkflowError
+from mindroom.dynamic_workflows.validation import DynamicWorkflowError
 from mindroom.entity_resolution import entity_identity_registry
 from mindroom.tool_approval import ToolCallWorkflowOrigin
 from mindroom.tool_system.catalog import TOOL_METADATA, ensure_tool_registry_loaded

--- a/src/mindroom/custom_tools/dynamic_workflow_context.py
+++ b/src/mindroom/custom_tools/dynamic_workflow_context.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import hashlib
 
-from mindroom.dynamic_workflows.store import DynamicWorkflowError, DynamicWorkflowRun, DynamicWorkflowStore
+from mindroom.dynamic_workflows.store import DynamicWorkflowRun, DynamicWorkflowStore
+from mindroom.dynamic_workflows.validation import DynamicWorkflowError
 from mindroom.runtime_resolution import resolve_agent_execution
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, build_execution_identity_from_runtime_context
 

--- a/src/mindroom/custom_tools/report_publishing.py
+++ b/src/mindroom/custom_tools/report_publishing.py
@@ -13,7 +13,7 @@ from mindroom.custom_tools.dynamic_workflow_context import (
 )
 from mindroom.custom_tools.tool_payloads import custom_tool_payload
 from mindroom.custom_tools.toolkit_functions import JSON_OBJECT_SCHEMA, register_toolkit_functions
-from mindroom.dynamic_workflows.store import DynamicWorkflowError
+from mindroom.dynamic_workflows.validation import DynamicWorkflowError
 from mindroom.report_publishing.store import (
     ARTIFACT_KIND_STATIC_SITE,
     PublishableReport,

--- a/src/mindroom/dynamic_workflows/agno_adapter.py
+++ b/src/mindroom/dynamic_workflows/agno_adapter.py
@@ -9,7 +9,7 @@ from agno.workflow import Step, Workflow, WorkflowFactory
 from agno.workflow.types import StepInput, StepOutput
 
 from mindroom.dynamic_workflows.runner import execute_workflow_step
-from mindroom.dynamic_workflows.store import validate_workflow_spec
+from mindroom.dynamic_workflows.validation import validate_workflow_spec
 
 if TYPE_CHECKING:
     from collections.abc import Mapping

--- a/src/mindroom/dynamic_workflows/service.py
+++ b/src/mindroom/dynamic_workflows/service.py
@@ -10,9 +10,8 @@ from contextlib import contextmanager, suppress
 from typing import TYPE_CHECKING
 
 from mindroom.dynamic_workflows.runner import async_execute_workflow_spec, execute_workflow_spec
-from mindroom.dynamic_workflows.store import (
+from mindroom.dynamic_workflows.validation import (
     DynamicWorkflowError,
-    DynamicWorkflowStore,
     validate_workflow_input,
     validate_workflow_spec,
     workflow_runtime_seconds,
@@ -22,7 +21,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
 
     from mindroom.dynamic_workflows.runner import AsyncParticipantExecutor, ParticipantExecutor
-    from mindroom.dynamic_workflows.store import DynamicWorkflowRun
+    from mindroom.dynamic_workflows.store import DynamicWorkflowRun, DynamicWorkflowStore
 
 
 class _SyncWorkflowTimeoutError(TimeoutError):

--- a/src/mindroom/dynamic_workflows/store.py
+++ b/src/mindroom/dynamic_workflows/store.py
@@ -17,60 +17,20 @@ from uuid import uuid4
 
 import yaml
 
+from mindroom.dynamic_workflows.validation import (
+    ID_RE,
+    DynamicWorkflowError,
+    object_mapping,
+    validate_id,
+    validate_workflow_spec,
+)
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator, Mapping
 
-_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,127}$")
 _REVISION_RE = re.compile(r"^[0-9]{6}$")
-_SUPPORTED_SCHEMA_VERSION = 1
-_STEP_TYPES = frozenset({"agent_step", "report_step", "transform_step"})
 _SCOPES = frozenset({"agent", "room", "tenant"})
-_PARTICIPANT_KINDS = frozenset({"ephemeral_agent", "room_agent"})
-_AGENT_STEP_TEMPLATE_FIELDS = ("prompt", "response_template", "output_template", "template")
-_TEMPLATE_REF_RE = re.compile(r"\{([a-zA-Z0-9_.-]+)\}")
-_MAX_WORKFLOW_PARTICIPANTS = 8
-_MAX_WORKFLOW_STEPS = 64
-_MAX_WORKFLOW_AGENT_STEPS = 16
-_MAX_WORKFLOW_RUNTIME_SECONDS = 3600
-_MAX_WORKFLOW_CONCURRENT_AGENTS = 8
-_PERMISSION_KEYS = frozenset(
-    {
-        "max_runtime_seconds",
-        "max_concurrent_agents",
-        "max_total_agents",
-        "models",
-        "tools",
-        "data",
-    },
-)
-_SPEC_KEYS = frozenset(
-    {
-        "schema_version",
-        "id",
-        "name",
-        "description",
-        "kind",
-        "inputs",
-        "participants",
-        "workflow",
-        "outputs",
-        "permissions",
-    },
-)
 _REVISION_METADATA_KEYS = frozenset({"revision", "revision_reason", "updated_by", "updated_at"})
-_ROOM_AGENT_PARTICIPANT_KEYS = frozenset({"id", "kind", "agent", "model", "tools"})
-_EPHEMERAL_PARTICIPANT_KEYS = frozenset({"id", "kind", "name", "role", "description", "model", "tools", "instructions"})
-_AGENT_STEP_KEYS = frozenset({"id", "type", "participant", *_AGENT_STEP_TEMPLATE_FIELDS})
-_TRANSFORM_STEP_KEYS = frozenset({"id", "type", "template", "text"})
-_REPORT_STEP_KEYS = frozenset({"id", "type", "body_template", "from_step", "title"})
-_OUTPUT_KEYS = frozenset({"id", "type", "from_step"})
-_OUTPUT_TYPES = frozenset({"text", "markdown", "json", "html_report"})
-_INPUT_SCHEMA_KEYS = frozenset({"type", "required", "properties"})
-_INPUT_PROPERTY_SCHEMA_KEYS = frozenset({"type", "description", "enum"})
-
-
-class DynamicWorkflowError(ValueError):
-    """Raised when a Dynamic Workflow operation is invalid."""
 
 
 @dataclass(frozen=True)
@@ -357,7 +317,7 @@ class DynamicWorkflowStore:
         run_id: str,
     ) -> DynamicWorkflowRun:
         """Load one workflow run."""
-        _validate_id(run_id, "run_id")
+        validate_id(run_id, "run_id")
         run_path = self._workflow_dir(scope, owner_id, workflow_id) / "runs" / f"{run_id}.json"
         return _run_from_json(_load_json_mapping(run_path))
 
@@ -371,9 +331,9 @@ class DynamicWorkflowStore:
     ) -> Path:
         """Return the private HTML report path for one scoped run."""
         _validate_scope(scope)
-        _validate_id(owner_key, "owner_key")
-        _validate_id(workflow_id, "workflow_id")
-        _validate_id(run_id, "run_id")
+        validate_id(owner_key, "owner_key")
+        validate_id(workflow_id, "workflow_id")
+        validate_id(run_id, "run_id")
         report_path = self._root / scope / owner_key / workflow_id / "artifacts" / run_id / "report.html"
         if not report_path.is_file():
             msg = f"Private report for run '{run_id}' was not found."
@@ -418,7 +378,7 @@ class DynamicWorkflowStore:
         return self._root / scope / owner_dir
 
     def _workflow_dir(self, scope: str, owner_id: str, workflow_id: str) -> Path:
-        _validate_id(workflow_id, "workflow_id")
+        validate_id(workflow_id, "workflow_id")
         return self._scope_dir(scope, owner_id) / workflow_id
 
     def _artifact_path_from_relative(self, artifact_path: str) -> Path:
@@ -452,596 +412,6 @@ class DynamicWorkflowStore:
             "report_html": _relative_artifact_path(report_path, self._storage_root),
             "step_outputs": _relative_artifact_path(step_outputs_path, self._storage_root),
         }
-
-
-def validate_workflow_spec(spec: dict[str, object]) -> dict[str, object]:
-    """Validate and normalize a declarative Dynamic Workflow spec."""
-    if not isinstance(spec, dict):
-        msg = "Workflow spec must be a mapping."
-        raise DynamicWorkflowError(msg)
-    normalized = copy.deepcopy(spec)
-    _reject_unsupported_fields(normalized, _SPEC_KEYS, "Workflow spec")
-    _validate_schema_version(normalized)
-    workflow_id = _required_text(normalized, "id")
-    _validate_id(workflow_id, "id")
-    normalized["id"] = workflow_id
-    normalized["name"] = _required_text(normalized, "name")
-    kind = _required_text(normalized, "kind")
-    if kind != "workflow":
-        msg = "Workflow spec kind must be 'workflow'."
-        raise DynamicWorkflowError(msg)
-    normalized["kind"] = kind
-
-    _validate_input_schema(normalized)
-    participants = _required_mapping_list(normalized, "participants", "Participant")
-    participant_ids = _validate_participants(participants)
-    workflow_steps = _required_mapping_list(normalized, "workflow", "Workflow step")
-    step_ids = _validate_workflow_steps(workflow_steps, participant_ids)
-    _validate_workflow_limits(normalized, participants, workflow_steps)
-    _validate_participant_tool_grants(normalized, participants)
-    _validate_outputs(normalized, step_ids)
-    return normalized
-
-
-def validate_workflow_input(spec: dict[str, object], input_data: dict[str, object]) -> None:
-    """Validate run input against the workflow's declared input schema."""
-    inputs = _input_schema(spec)
-    if inputs is None:
-        return
-    _validate_required_inputs(_input_required_fields(inputs), input_data)
-    _validate_input_property_types(_input_properties(inputs), input_data)
-
-
-def _validate_schema_version(spec: dict[str, object]) -> None:
-    value = spec.get("schema_version")
-    if not isinstance(value, int) or isinstance(value, bool) or value != _SUPPORTED_SCHEMA_VERSION:
-        msg = f"Workflow spec field 'schema_version' must be {_SUPPORTED_SCHEMA_VERSION}."
-        raise DynamicWorkflowError(msg)
-
-
-def workflow_runtime_seconds(spec: dict[str, object]) -> int:
-    """Return the validated runtime cap for one workflow spec."""
-    permissions = _permissions_mapping(spec)
-    value = permissions.get("max_runtime_seconds")
-    if value is None:
-        return _MAX_WORKFLOW_RUNTIME_SECONDS
-    return _positive_int_permission(value, "max_runtime_seconds", maximum=_MAX_WORKFLOW_RUNTIME_SECONDS)
-
-
-def _input_schema(spec: dict[str, object]) -> dict[str, object] | None:
-    raw_inputs = spec.get("inputs")
-    if raw_inputs is None:
-        return None
-    if not isinstance(raw_inputs, dict):
-        msg = "Workflow spec field 'inputs' must be a mapping."
-        raise DynamicWorkflowError(msg)
-    inputs = _object_mapping(cast("Mapping[object, object]", raw_inputs))
-    _reject_unsupported_fields(inputs, _INPUT_SCHEMA_KEYS, "Workflow input schema")
-    input_type = inputs.get("type", "object")
-    if input_type != "object":
-        msg = "Workflow input schema type must be 'object'."
-        raise DynamicWorkflowError(msg)
-    return inputs
-
-
-def _input_required_fields(inputs: dict[str, object]) -> list[str]:
-    raw_required = inputs.get("required", [])
-    if raw_required is None:
-        return []
-    if not isinstance(raw_required, list):
-        msg = "Workflow input schema field 'required' must be a list."
-        raise DynamicWorkflowError(msg)
-    required: list[str] = []
-    for field_name in raw_required:
-        if not isinstance(field_name, str) or not field_name.strip():
-            msg = "Workflow input schema required entries must be strings."
-            raise DynamicWorkflowError(msg)
-        required.append(field_name)
-    return required
-
-
-def _validate_required_inputs(required_fields: list[str], input_data: dict[str, object]) -> None:
-    for field_name in required_fields:
-        if field_name not in input_data:
-            msg = f"Input field '{field_name}' is required."
-            raise DynamicWorkflowError(msg)
-
-
-def _input_properties(inputs: dict[str, object]) -> dict[str, object]:
-    raw_properties = inputs.get("properties", {})
-    if raw_properties is None:
-        return {}
-    if not isinstance(raw_properties, dict):
-        msg = "Workflow input schema field 'properties' must be a mapping."
-        raise DynamicWorkflowError(msg)
-    return _object_mapping(cast("Mapping[object, object]", raw_properties))
-
-
-def _validate_input_schema(spec: dict[str, object]) -> None:
-    inputs = _input_schema(spec)
-    if inputs is None:
-        return
-    required_fields = _input_required_fields(inputs)
-    if len(required_fields) != len(set(required_fields)):
-        msg = "Workflow input schema required entries must be unique."
-        raise DynamicWorkflowError(msg)
-    for field_name, raw_field_schema in _input_properties(inputs).items():
-        if not isinstance(raw_field_schema, dict):
-            msg = f"Workflow input schema property '{field_name}' must be a mapping."
-            raise DynamicWorkflowError(msg)
-        field_schema = _object_mapping(cast("Mapping[object, object]", raw_field_schema))
-        _reject_unsupported_fields(
-            field_schema,
-            _INPUT_PROPERTY_SCHEMA_KEYS,
-            f"Workflow input schema property '{field_name}'",
-        )
-        allowed_types = _allowed_input_types(field_schema)
-        _validate_input_enum(field_name, field_schema, allowed_types)
-        for input_type in allowed_types:
-            if input_type not in _INPUT_TYPE_CHECKS:
-                msg = f"Unsupported workflow input schema type '{input_type}'."
-                raise DynamicWorkflowError(msg)
-
-
-def _validate_input_property_types(properties: dict[str, object], input_data: dict[str, object]) -> None:
-    for field_name, raw_field_schema in properties.items():
-        if field_name not in input_data or not isinstance(raw_field_schema, dict):
-            continue
-        field_schema = _object_mapping(cast("Mapping[object, object]", raw_field_schema))
-        allowed_types = _allowed_input_types(field_schema)
-        if not allowed_types:
-            _validate_input_enum_value(field_name, field_schema, input_data[field_name])
-            continue
-        if not any(_input_value_matches_type(input_data[field_name], allowed_type) for allowed_type in allowed_types):
-            msg = f"Input field '{field_name}' must be {_input_type_label(allowed_types)}."
-            raise DynamicWorkflowError(msg)
-        _validate_input_enum_value(field_name, field_schema, input_data[field_name])
-
-
-def _allowed_input_types(field_schema: dict[str, object]) -> list[str]:
-    expected_type = field_schema.get("type")
-    if expected_type is None:
-        return []
-    if isinstance(expected_type, list):
-        if not expected_type:
-            msg = "Workflow input schema type list must be non-empty."
-            raise DynamicWorkflowError(msg)
-        allowed_types = []
-        for item in expected_type:
-            if not isinstance(item, str) or not item.strip():
-                msg = "Workflow input schema type list entries must be non-empty strings."
-                raise DynamicWorkflowError(msg)
-            allowed_types.append(item.strip())
-        return allowed_types
-    if not isinstance(expected_type, str) or not expected_type.strip():
-        msg = "Workflow input schema type must be a non-empty string or list of strings."
-        raise DynamicWorkflowError(msg)
-    return [str(expected_type)]
-
-
-def _validate_input_enum(field_name: str, field_schema: dict[str, object], allowed_types: list[str]) -> None:
-    enum_values = field_schema.get("enum")
-    if enum_values is None:
-        return
-    if not isinstance(enum_values, list) or not enum_values:
-        msg = f"Workflow input schema property '{field_name}' enum must be a non-empty list."
-        raise DynamicWorkflowError(msg)
-    if not allowed_types:
-        return
-    for enum_value in enum_values:
-        if not any(_input_value_matches_type(enum_value, allowed_type) for allowed_type in allowed_types):
-            msg = f"Workflow input schema property '{field_name}' enum values must match its declared type."
-            raise DynamicWorkflowError(msg)
-
-
-def _validate_input_enum_value(field_name: str, field_schema: dict[str, object], value: object) -> None:
-    enum_values = field_schema.get("enum")
-    if enum_values is None:
-        return
-    if not isinstance(enum_values, list):
-        msg = f"Workflow input schema property '{field_name}' enum must be a list."
-        raise DynamicWorkflowError(msg)
-    if not any(_enum_value_matches(value, enum_value) for enum_value in enum_values):
-        msg = f"Input field '{field_name}' must be one of the declared enum values."
-        raise DynamicWorkflowError(msg)
-
-
-def _enum_value_matches(value: object, enum_value: object) -> bool:
-    if type(value) is not type(enum_value):
-        return False
-    return value == enum_value
-
-
-def _validate_participants(participants: list[dict[str, object]]) -> set[str]:
-    participant_ids: set[str] = set()
-    for index, participant in enumerate(participants):
-        context = f"Participant at index {index}"
-        participant_id = _required_text(participant, "id", context=context)
-        _validate_id(participant_id, f"{context} id")
-        if participant_id in participant_ids:
-            msg = f"Duplicate participant id '{participant_id}'."
-            raise DynamicWorkflowError(msg)
-        participant["id"] = participant_id
-        participant_ids.add(participant_id)
-        participant_kind = (
-            _required_text(participant, "kind", context=context) if "kind" in participant else "ephemeral_agent"
-        )
-        if participant_kind not in _PARTICIPANT_KINDS:
-            msg = f"{context} has unsupported kind '{participant_kind}'."
-            raise DynamicWorkflowError(msg)
-        participant["kind"] = participant_kind
-        if participant_kind == "room_agent":
-            _validate_room_agent_participant(participant, context)
-        else:
-            _validate_ephemeral_agent_participant(participant, context)
-    return participant_ids
-
-
-def _validate_room_agent_participant(participant: dict[str, object], context: str) -> None:
-    _reject_unsupported_fields(participant, _ROOM_AGENT_PARTICIPANT_KEYS, context)
-    agent_name = _required_text(participant, "agent", context=context)
-    participant["agent"] = agent_name
-    if "model" in participant and participant.get("model") not in (None, ""):
-        msg = f"{context} room_agent participants cannot override model."
-        raise DynamicWorkflowError(msg)
-    if participant.get("tools") not in (None, []):
-        msg = f"{context} room_agent participants cannot declare tools; tool grants are only available to ephemeral participants."
-        raise DynamicWorkflowError(msg)
-
-
-def _validate_ephemeral_agent_participant(participant: dict[str, object], context: str) -> None:
-    _reject_unsupported_fields(participant, _EPHEMERAL_PARTICIPANT_KEYS, context)
-    participant["tools"] = _normalized_tool_names(
-        participant.get("tools"),
-        f"{context} field 'tools'",
-    )
-    if "model" in participant and participant.get("model") is not None:
-        model = _required_text(participant, "model", context=context)
-        participant["model"] = model
-    if "instructions" in participant:
-        _validate_participant_instructions(participant["instructions"], context)
-
-
-def _validate_participant_instructions(value: object, context: str) -> None:
-    if value is None or isinstance(value, str):
-        return
-    if isinstance(value, list) and all(isinstance(instruction, str) for instruction in value):
-        return
-    msg = f"{context} field 'instructions' must be a string or list of strings."
-    raise DynamicWorkflowError(msg)
-
-
-def _validate_workflow_steps(workflow_steps: list[dict[str, object]], participant_ids: set[str]) -> set[str]:
-    step_ids: set[str] = set()
-    for index, step in enumerate(workflow_steps):
-        context = f"Workflow step at index {index}"
-        step_id = _required_text(step, "id", context=context)
-        _validate_id(step_id, f"{context} id")
-        if step_id in step_ids:
-            msg = f"Duplicate workflow step id '{step_id}'."
-            raise DynamicWorkflowError(msg)
-        step["id"] = step_id
-
-        step_type = _step_type(step, context)
-        step["type"] = step_type
-        if step_type == "agent_step":
-            _reject_unsupported_fields(step, _AGENT_STEP_KEYS, context)
-            _validate_agent_step(step, context, participant_ids, step_ids)
-        elif step_type == "transform_step":
-            _reject_unsupported_fields(step, _TRANSFORM_STEP_KEYS, context)
-            _validate_template_choice(step, context, ("template", "text"), step_ids)
-        elif step_type == "report_step":
-            _reject_unsupported_fields(step, _REPORT_STEP_KEYS, context)
-            _validate_report_step(step, context, step_ids)
-        step_ids.add(step_id)
-    return step_ids
-
-
-def _validate_workflow_limits(
-    spec: dict[str, object],
-    participants: list[dict[str, object]],
-    workflow_steps: list[dict[str, object]],
-) -> None:
-    if len(participants) > _MAX_WORKFLOW_PARTICIPANTS:
-        msg = f"Workflow participants cannot exceed {_MAX_WORKFLOW_PARTICIPANTS}."
-        raise DynamicWorkflowError(msg)
-    if len(workflow_steps) > _MAX_WORKFLOW_STEPS:
-        msg = f"Workflow steps cannot exceed {_MAX_WORKFLOW_STEPS}."
-        raise DynamicWorkflowError(msg)
-
-    permissions = _permissions_mapping(spec)
-    unknown_permissions = sorted(set(permissions) - _PERMISSION_KEYS)
-    if unknown_permissions:
-        msg = f"Workflow permissions contain unsupported keys: {', '.join(unknown_permissions)}."
-        raise DynamicWorkflowError(msg)
-
-    runtime_seconds = permissions.get("max_runtime_seconds")
-    if runtime_seconds is not None:
-        permissions["max_runtime_seconds"] = _positive_int_permission(
-            runtime_seconds,
-            "max_runtime_seconds",
-            maximum=_MAX_WORKFLOW_RUNTIME_SECONDS,
-        )
-
-    max_concurrent_agents = permissions.get("max_concurrent_agents")
-    if max_concurrent_agents is not None:
-        permissions["max_concurrent_agents"] = _positive_int_permission(
-            max_concurrent_agents,
-            "max_concurrent_agents",
-            maximum=_MAX_WORKFLOW_CONCURRENT_AGENTS,
-        )
-
-    agent_step_count = sum(1 for step in workflow_steps if step.get("type") == "agent_step")
-    max_total_agents = permissions.get("max_total_agents")
-    if max_total_agents is None:
-        max_total_agents = _MAX_WORKFLOW_AGENT_STEPS
-    max_total_agents = _positive_int_permission(
-        max_total_agents,
-        "max_total_agents",
-        maximum=_MAX_WORKFLOW_AGENT_STEPS,
-    )
-    permissions["max_total_agents"] = max_total_agents
-    if agent_step_count > max_total_agents:
-        msg = f"Workflow agent steps cannot exceed permissions.max_total_agents ({max_total_agents})."
-        raise DynamicWorkflowError(msg)
-
-    _validate_permission_models(permissions)
-    _validate_permission_tools(permissions)
-    _validate_permission_data(permissions)
-    spec["permissions"] = permissions
-
-
-def _permissions_mapping(spec: dict[str, object]) -> dict[str, object]:
-    raw_permissions = spec.get("permissions", {})
-    if raw_permissions is None:
-        return {}
-    if not isinstance(raw_permissions, dict):
-        msg = "Workflow spec field 'permissions' must be a mapping."
-        raise DynamicWorkflowError(msg)
-    permissions = _object_mapping(cast("Mapping[object, object]", raw_permissions))
-    spec["permissions"] = permissions
-    return permissions
-
-
-def _positive_int_permission(value: object, field_name: str, *, maximum: int) -> int:
-    if not isinstance(value, int) or isinstance(value, bool):
-        msg = f"Workflow permission '{field_name}' must be an integer."
-        raise DynamicWorkflowError(msg)
-    if value < 1 or value > maximum:
-        msg = f"Workflow permission '{field_name}' must be between 1 and {maximum}."
-        raise DynamicWorkflowError(msg)
-    return value
-
-
-def _validate_permission_models(permissions: dict[str, object]) -> None:
-    models = permissions.get("models")
-    if models is None:
-        return
-    if not isinstance(models, list) or not all(isinstance(model, str) and model.strip() for model in models):
-        msg = "Workflow permission 'models' must be a list of non-empty strings."
-        raise DynamicWorkflowError(msg)
-    permissions["models"] = [cast("str", model).strip() for model in models]
-
-
-def _validate_permission_tools(permissions: dict[str, object]) -> None:
-    permissions["tools"] = _normalized_tool_names(permissions.get("tools", []), "Workflow permission 'tools'")
-
-
-def _normalized_tool_names(raw_tools: object, context: str) -> list[str]:
-    if raw_tools is None:
-        return []
-    if not isinstance(raw_tools, list) or not all(isinstance(tool, str) and tool.strip() for tool in raw_tools):
-        msg = f"{context} must be a list of non-empty strings."
-        raise DynamicWorkflowError(msg)
-    tool_names: list[str] = []
-    for raw_tool in raw_tools:
-        tool_name = cast("str", raw_tool).strip()
-        if tool_name not in tool_names:
-            tool_names.append(tool_name)
-    return tool_names
-
-
-def _validate_participant_tool_grants(spec: dict[str, object], participants: list[dict[str, object]]) -> None:
-    granted_tools = _permissions_mapping(spec).get("tools", [])
-    granted = set(cast("list[str]", granted_tools))
-    for participant in participants:
-        for tool_name in cast("list[str]", participant.get("tools") or []):
-            if tool_name not in granted:
-                participant_id = participant["id"]
-                msg = f"Participant '{participant_id}' tool '{tool_name}' is not granted by permissions.tools."
-                raise DynamicWorkflowError(msg)
-
-
-def _validate_permission_data(permissions: dict[str, object]) -> None:
-    data = permissions.get("data", {})
-    if data is None:
-        permissions["data"] = {}
-        return
-    if not isinstance(data, dict):
-        msg = "Workflow permission 'data' must be a mapping."
-        raise DynamicWorkflowError(msg)
-    normalized = _object_mapping(cast("Mapping[object, object]", data))
-    supported_fields = {"matrix_history", "attachments", "knowledge_bases"}
-    unsupported_fields = sorted(set(normalized) - supported_fields)
-    if unsupported_fields:
-        msg = f"Workflow permission data.{unsupported_fields[0]} is not supported."
-        raise DynamicWorkflowError(msg)
-    for field_name in ("matrix_history", "attachments"):
-        value = normalized.get(field_name)
-        if value is not None and value != "none":
-            msg = f"Workflow permission data.{field_name} must be 'none' until workflow data grants are supported."
-            raise DynamicWorkflowError(msg)
-    knowledge_bases = normalized.get("knowledge_bases", [])
-    if not isinstance(knowledge_bases, list) or not all(isinstance(base, str) for base in knowledge_bases):
-        msg = "Workflow permission data.knowledge_bases must be a list of strings."
-        raise DynamicWorkflowError(msg)
-    if knowledge_bases:
-        msg = "Workflow permission data.knowledge_bases must be empty until workflow data grants are supported."
-        raise DynamicWorkflowError(msg)
-    permissions["data"] = normalized
-
-
-def _step_type(step: dict[str, object], context: str) -> str:
-    raw_step_type = step.get("type", "agent_step")
-    if not isinstance(raw_step_type, str) or not raw_step_type.strip():
-        msg = f"{context} field 'type' must be a non-empty string."
-        raise DynamicWorkflowError(msg)
-    step_type = raw_step_type.strip()
-    if step_type not in _STEP_TYPES:
-        msg = f"Unsupported workflow step type '{step_type}'."
-        raise DynamicWorkflowError(msg)
-    return step_type
-
-
-def _validate_agent_step(
-    step: dict[str, object],
-    context: str,
-    participant_ids: set[str],
-    available_step_ids: set[str],
-) -> None:
-    participant = _required_text(step, "participant", context=context)
-    if participant not in participant_ids:
-        msg = f"{context} references unknown participant '{participant}'."
-        raise DynamicWorkflowError(msg)
-    step["participant"] = participant
-    _validate_template_choice(
-        step,
-        context,
-        _AGENT_STEP_TEMPLATE_FIELDS,
-        available_step_ids,
-    )
-
-
-def _validate_report_step(step: dict[str, object], context: str, available_step_ids: set[str]) -> None:
-    if "body_template" in step and "from_step" in step:
-        msg = f"{context} must include only one report source field; found: body_template, from_step."
-        raise DynamicWorkflowError(msg)
-    if "body_template" in step:
-        body_template = _required_text(step, "body_template", context=context)
-        step["body_template"] = body_template
-        _validate_template_references(body_template, available_step_ids, f"{context} field 'body_template'")
-    else:
-        from_step = _required_text(step, "from_step", context=context)
-        if from_step not in available_step_ids:
-            msg = f"{context} references unknown prior step '{from_step}'."
-            raise DynamicWorkflowError(msg)
-        step["from_step"] = from_step
-
-    if "title" in step:
-        title = _required_text(step, "title", context=context)
-        step["title"] = title
-        _validate_template_references(title, available_step_ids, f"{context} field 'title'")
-
-
-def _validate_outputs(spec: dict[str, object], step_ids: set[str]) -> None:
-    raw_outputs = spec.get("outputs", [])
-    if raw_outputs is None:
-        spec["outputs"] = []
-        return
-    if not isinstance(raw_outputs, list):
-        msg = "Workflow spec field 'outputs' must be a list."
-        raise DynamicWorkflowError(msg)
-    outputs: list[dict[str, object]] = []
-    output_ids: set[str] = set()
-    for index, raw_output in enumerate(raw_outputs):
-        context = f"Workflow output at index {index}"
-        if not isinstance(raw_output, dict):
-            msg = f"{context} must be a mapping."
-            raise DynamicWorkflowError(msg)
-        output = _object_mapping(cast("Mapping[object, object]", raw_output))
-        output_id = _required_text(output, "id", context=context)
-        _validate_id(output_id, f"{context} id")
-        if output_id in output_ids:
-            msg = f"Duplicate workflow output id '{output_id}'."
-            raise DynamicWorkflowError(msg)
-        output["id"] = output_id
-        output_ids.add(output_id)
-        output_type = _required_text(output, "type", context=context)
-        if output_type not in _OUTPUT_TYPES:
-            msg = f"{context} has unsupported type '{output_type}'."
-            raise DynamicWorkflowError(msg)
-        output["type"] = output_type
-        from_step = _required_text(output, "from_step", context=context)
-        if from_step not in step_ids:
-            msg = f"{context} references unknown step '{from_step}'."
-            raise DynamicWorkflowError(msg)
-        output["from_step"] = from_step
-        _reject_unsupported_fields(output, _OUTPUT_KEYS, context)
-        outputs.append(output)
-    spec["outputs"] = outputs
-
-
-def _required_mapping_list(data: dict[str, object], key: str, item_label: str) -> list[dict[str, object]]:
-    value = data.get(key)
-    if value is None:
-        msg = f"Workflow spec field '{key}' is missing."
-        raise DynamicWorkflowError(msg)
-    if not isinstance(value, list):
-        msg = f"Workflow spec field '{key}' must be a list."
-        raise DynamicWorkflowError(msg)
-    if not value:
-        msg = f"Workflow spec field '{key}' cannot be empty."
-        raise DynamicWorkflowError(msg)
-    items: list[dict[str, object]] = []
-    for index, raw_item in enumerate(value):
-        if not isinstance(raw_item, dict):
-            msg = f"{item_label} at index {index} must be a mapping."
-            raise DynamicWorkflowError(msg)
-        items.append(_object_mapping(cast("Mapping[object, object]", raw_item)))
-    data[key] = items
-    return items
-
-
-def _reject_unsupported_fields(data: dict[str, object], allowed_fields: frozenset[str], context: str) -> None:
-    unsupported_fields = sorted(set(data) - allowed_fields)
-    if unsupported_fields:
-        msg = f"{context} contains unsupported field '{unsupported_fields[0]}'."
-        raise DynamicWorkflowError(msg)
-
-
-def _validate_template_choice(
-    step: dict[str, object],
-    context: str,
-    field_names: tuple[str, ...],
-    available_step_ids: set[str],
-) -> None:
-    present_fields = [field_name for field_name in field_names if field_name in step]
-    if len(present_fields) > 1:
-        fields = ", ".join(present_fields)
-        msg = f"{context} must include only one template field; found: {fields}."
-        raise DynamicWorkflowError(msg)
-    for field_name in present_fields:
-        template = _required_text(step, field_name, context=context)
-        step[field_name] = template
-        _validate_template_references(template, available_step_ids, f"{context} field '{field_name}'")
-        return
-    fields = ", ".join(field_names)
-    msg = f"{context} must include one of: {fields}."
-    raise DynamicWorkflowError(msg)
-
-
-def _validate_template_references(template: str, available_step_ids: set[str], context: str) -> None:
-    for match in _TEMPLATE_REF_RE.finditer(template):
-        reference = match.group(1)
-        if reference.startswith("input."):
-            parts = reference.split(".")
-            if len(parts) < 2 or any(not part for part in parts[1:]):
-                msg = f"{context} contains invalid template reference '{reference}'."
-                raise DynamicWorkflowError(msg)
-            continue
-        if reference.startswith("steps."):
-            parts = reference.split(".")
-            if len(parts) == 2 or (len(parts) == 3 and parts[2] == "content"):
-                step_id = parts[1]
-            else:
-                msg = f"{context} contains unsupported template reference '{reference}'."
-                raise DynamicWorkflowError(msg)
-            if step_id not in available_step_ids:
-                msg = f"{context} references unknown prior step '{step_id}'."
-                raise DynamicWorkflowError(msg)
-            continue
-        msg = f"{context} contains unknown template reference '{reference}'."
-        raise DynamicWorkflowError(msg)
 
 
 def _render_report_html(*, title: str, markdown: str) -> str:
@@ -1082,46 +452,6 @@ def _failed_input_report_markdown(title: str, input_data: dict[str, object], err
     )
 
 
-def _is_integer_input(value: object) -> bool:
-    return isinstance(value, int) and not isinstance(value, bool)
-
-
-def _is_number_input(value: object) -> bool:
-    return isinstance(value, (int, float)) and not isinstance(value, bool)
-
-
-_INPUT_TYPE_CHECKS = {
-    "string": lambda value: isinstance(value, str),
-    "integer": _is_integer_input,
-    "number": _is_number_input,
-    "boolean": lambda value: isinstance(value, bool),
-    "object": lambda value: isinstance(value, dict),
-    "array": lambda value: isinstance(value, list),
-    "null": lambda value: value is None,
-}
-
-
-def _input_value_matches_type(value: object, expected_type: str) -> bool:
-    checker = _INPUT_TYPE_CHECKS.get(expected_type)
-    if checker is not None:
-        return checker(value)
-    msg = f"Unsupported workflow input schema type '{expected_type}'."
-    raise DynamicWorkflowError(msg)
-
-
-def _input_type_label(allowed_types: list[str]) -> str:
-    labels = {
-        "string": "a string",
-        "integer": "an integer",
-        "number": "a number",
-        "boolean": "a boolean",
-        "object": "an object",
-        "array": "an array",
-        "null": "null",
-    }
-    return " or ".join(labels.get(input_type, input_type) for input_type in allowed_types)
-
-
 def _revision_spec(
     spec: dict[str, object],
     *,
@@ -1148,8 +478,8 @@ def _recursive_merge(base: dict[str, object], patch: dict[str, object]) -> dict[
         base_value = merged.get(key)
         if isinstance(value, dict) and isinstance(base_value, dict):
             merged[key] = _recursive_merge(
-                _object_mapping(cast("Mapping[object, object]", base_value)),
-                _object_mapping(cast("Mapping[object, object]", value)),
+                object_mapping(cast("Mapping[object, object]", base_value)),
+                object_mapping(cast("Mapping[object, object]", value)),
             )
         else:
             merged[key] = copy.deepcopy(value)
@@ -1218,11 +548,11 @@ def _run_from_json(data: dict[str, object]) -> DynamicWorkflowRun:
         owner_id=str(data["owner_id"]),
         revision=str(data["revision"]),
         status=str(data["status"]),
-        input_data=_object_mapping(cast("Mapping[object, object]", input_data)) if isinstance(input_data, dict) else {},
-        steps=[_object_mapping(cast("Mapping[object, object]", step)) for step in steps if isinstance(step, dict)]
+        input_data=object_mapping(cast("Mapping[object, object]", input_data)) if isinstance(input_data, dict) else {},
+        steps=[object_mapping(cast("Mapping[object, object]", step)) for step in steps if isinstance(step, dict)]
         if isinstance(steps, list)
         else [],
-        outputs=_object_mapping(cast("Mapping[object, object]", outputs)) if isinstance(outputs, dict) else {},
+        outputs=object_mapping(cast("Mapping[object, object]", outputs)) if isinstance(outputs, dict) else {},
         artifacts={str(key): str(value) for key, value in artifacts.items()} if isinstance(artifacts, dict) else {},
         report_url=str(data["report_url"]) if data.get("report_url") is not None else None,
         requested_by=str(data["requested_by"]),
@@ -1232,30 +562,9 @@ def _run_from_json(data: dict[str, object]) -> DynamicWorkflowRun:
     )
 
 
-def _required_text(data: dict[str, object], key: str, *, context: str = "Workflow spec") -> str:
-    if key not in data:
-        msg = f"{context} field '{key}' is missing."
-        raise DynamicWorkflowError(msg)
-    value = data[key]
-    if not isinstance(value, str):
-        msg = f"{context} field '{key}' must be a string."
-        raise DynamicWorkflowError(msg)
-    stripped = value.strip()
-    if not stripped:
-        msg = f"{context} field '{key}' cannot be empty."
-        raise DynamicWorkflowError(msg)
-    return stripped
-
-
 def _validate_scope(scope: str) -> None:
     if scope not in _SCOPES:
         msg = f"Unsupported Dynamic Workflow scope '{scope}'."
-        raise DynamicWorkflowError(msg)
-
-
-def _validate_id(value: str, field_name: str) -> None:
-    if not _ID_RE.fullmatch(value):
-        msg = f"{field_name} must match {_ID_RE.pattern}."
         raise DynamicWorkflowError(msg)
 
 
@@ -1268,7 +577,7 @@ def _validate_revision(value: str) -> None:
 def _owner_dir_name(scope: str, owner_id: str) -> str:
     if scope == "tenant":
         return "tenant"
-    if _ID_RE.fullmatch(owner_id):
+    if ID_RE.fullmatch(owner_id):
         return owner_id
     digest = hashlib.sha256(owner_id.encode("utf-8")).hexdigest()[:24]
     return f"hash_{digest}"
@@ -1289,10 +598,6 @@ def _private_report_url(
         return None
     owner_key = _owner_dir_name(scope, owner_id)
     return f"{base_url.rstrip('/')}/reports/private/{scope}/{owner_key}/{workflow_id}/{run_id}"
-
-
-def _object_mapping(data: Mapping[object, object]) -> dict[str, object]:
-    return {str(key): value for key, value in data.items()}
 
 
 def _relative_artifact_path(artifact_path: Path, storage_root: Path) -> str:

--- a/src/mindroom/dynamic_workflows/validation.py
+++ b/src/mindroom/dynamic_workflows/validation.py
@@ -1,0 +1,716 @@
+"""Declarative Dynamic Workflow spec and run-input validation."""
+
+from __future__ import annotations
+
+import copy
+import re
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,127}$")
+_SUPPORTED_SCHEMA_VERSION = 1
+_STEP_TYPES = frozenset({"agent_step", "report_step", "transform_step"})
+_PARTICIPANT_KINDS = frozenset({"ephemeral_agent", "room_agent"})
+_AGENT_STEP_TEMPLATE_FIELDS = ("prompt", "response_template", "output_template", "template")
+_TEMPLATE_REF_RE = re.compile(r"\{([a-zA-Z0-9_.-]+)\}")
+_MAX_WORKFLOW_PARTICIPANTS = 8
+_MAX_WORKFLOW_STEPS = 64
+_MAX_WORKFLOW_AGENT_STEPS = 16
+_MAX_WORKFLOW_RUNTIME_SECONDS = 3600
+_MAX_WORKFLOW_CONCURRENT_AGENTS = 8
+_PERMISSION_KEYS = frozenset(
+    {
+        "max_runtime_seconds",
+        "max_concurrent_agents",
+        "max_total_agents",
+        "models",
+        "tools",
+        "data",
+    },
+)
+_SPEC_KEYS = frozenset(
+    {
+        "schema_version",
+        "id",
+        "name",
+        "description",
+        "kind",
+        "inputs",
+        "participants",
+        "workflow",
+        "outputs",
+        "permissions",
+    },
+)
+_ROOM_AGENT_PARTICIPANT_KEYS = frozenset({"id", "kind", "agent", "model", "tools"})
+_EPHEMERAL_PARTICIPANT_KEYS = frozenset({"id", "kind", "name", "role", "description", "model", "tools", "instructions"})
+_AGENT_STEP_KEYS = frozenset({"id", "type", "participant", *_AGENT_STEP_TEMPLATE_FIELDS})
+_TRANSFORM_STEP_KEYS = frozenset({"id", "type", "template", "text"})
+_REPORT_STEP_KEYS = frozenset({"id", "type", "body_template", "from_step", "title"})
+_OUTPUT_KEYS = frozenset({"id", "type", "from_step"})
+_OUTPUT_TYPES = frozenset({"text", "markdown", "json", "html_report"})
+_INPUT_SCHEMA_KEYS = frozenset({"type", "required", "properties"})
+_INPUT_PROPERTY_SCHEMA_KEYS = frozenset({"type", "description", "enum"})
+
+
+class DynamicWorkflowError(ValueError):
+    """Raised when a Dynamic Workflow operation is invalid."""
+
+
+def validate_workflow_spec(spec: dict[str, object]) -> dict[str, object]:
+    """Validate and normalize a declarative Dynamic Workflow spec."""
+    if not isinstance(spec, dict):
+        msg = "Workflow spec must be a mapping."
+        raise DynamicWorkflowError(msg)
+    normalized = copy.deepcopy(spec)
+    _reject_unsupported_fields(normalized, _SPEC_KEYS, "Workflow spec")
+    _validate_schema_version(normalized)
+    workflow_id = _required_text(normalized, "id")
+    validate_id(workflow_id, "id")
+    normalized["id"] = workflow_id
+    normalized["name"] = _required_text(normalized, "name")
+    kind = _required_text(normalized, "kind")
+    if kind != "workflow":
+        msg = "Workflow spec kind must be 'workflow'."
+        raise DynamicWorkflowError(msg)
+    normalized["kind"] = kind
+
+    _validate_input_schema(normalized)
+    participants = _required_mapping_list(normalized, "participants", "Participant")
+    participant_ids = _validate_participants(participants)
+    workflow_steps = _required_mapping_list(normalized, "workflow", "Workflow step")
+    step_ids = _validate_workflow_steps(workflow_steps, participant_ids)
+    _validate_workflow_limits(normalized, participants, workflow_steps)
+    _validate_participant_tool_grants(normalized, participants)
+    _validate_outputs(normalized, step_ids)
+    return normalized
+
+
+def validate_workflow_input(spec: dict[str, object], input_data: dict[str, object]) -> None:
+    """Validate run input against the workflow's declared input schema."""
+    inputs = _input_schema(spec)
+    if inputs is None:
+        return
+    _validate_required_inputs(_input_required_fields(inputs), input_data)
+    _validate_input_property_types(_input_properties(inputs), input_data)
+
+
+def _validate_schema_version(spec: dict[str, object]) -> None:
+    value = spec.get("schema_version")
+    if not isinstance(value, int) or isinstance(value, bool) or value != _SUPPORTED_SCHEMA_VERSION:
+        msg = f"Workflow spec field 'schema_version' must be {_SUPPORTED_SCHEMA_VERSION}."
+        raise DynamicWorkflowError(msg)
+
+
+def workflow_runtime_seconds(spec: dict[str, object]) -> int:
+    """Return the validated runtime cap for one workflow spec."""
+    permissions = _permissions_mapping(spec)
+    value = permissions.get("max_runtime_seconds")
+    if value is None:
+        return _MAX_WORKFLOW_RUNTIME_SECONDS
+    return _positive_int_permission(value, "max_runtime_seconds", maximum=_MAX_WORKFLOW_RUNTIME_SECONDS)
+
+
+def _input_schema(spec: dict[str, object]) -> dict[str, object] | None:
+    raw_inputs = spec.get("inputs")
+    if raw_inputs is None:
+        return None
+    if not isinstance(raw_inputs, dict):
+        msg = "Workflow spec field 'inputs' must be a mapping."
+        raise DynamicWorkflowError(msg)
+    inputs = object_mapping(cast("Mapping[object, object]", raw_inputs))
+    _reject_unsupported_fields(inputs, _INPUT_SCHEMA_KEYS, "Workflow input schema")
+    input_type = inputs.get("type", "object")
+    if input_type != "object":
+        msg = "Workflow input schema type must be 'object'."
+        raise DynamicWorkflowError(msg)
+    return inputs
+
+
+def _input_required_fields(inputs: dict[str, object]) -> list[str]:
+    raw_required = inputs.get("required", [])
+    if raw_required is None:
+        return []
+    if not isinstance(raw_required, list):
+        msg = "Workflow input schema field 'required' must be a list."
+        raise DynamicWorkflowError(msg)
+    required: list[str] = []
+    for field_name in raw_required:
+        if not isinstance(field_name, str) or not field_name.strip():
+            msg = "Workflow input schema required entries must be strings."
+            raise DynamicWorkflowError(msg)
+        required.append(field_name)
+    return required
+
+
+def _validate_required_inputs(required_fields: list[str], input_data: dict[str, object]) -> None:
+    for field_name in required_fields:
+        if field_name not in input_data:
+            msg = f"Input field '{field_name}' is required."
+            raise DynamicWorkflowError(msg)
+
+
+def _input_properties(inputs: dict[str, object]) -> dict[str, object]:
+    raw_properties = inputs.get("properties", {})
+    if raw_properties is None:
+        return {}
+    if not isinstance(raw_properties, dict):
+        msg = "Workflow input schema field 'properties' must be a mapping."
+        raise DynamicWorkflowError(msg)
+    return object_mapping(cast("Mapping[object, object]", raw_properties))
+
+
+def _validate_input_schema(spec: dict[str, object]) -> None:
+    inputs = _input_schema(spec)
+    if inputs is None:
+        return
+    required_fields = _input_required_fields(inputs)
+    if len(required_fields) != len(set(required_fields)):
+        msg = "Workflow input schema required entries must be unique."
+        raise DynamicWorkflowError(msg)
+    for field_name, raw_field_schema in _input_properties(inputs).items():
+        if not isinstance(raw_field_schema, dict):
+            msg = f"Workflow input schema property '{field_name}' must be a mapping."
+            raise DynamicWorkflowError(msg)
+        field_schema = object_mapping(cast("Mapping[object, object]", raw_field_schema))
+        _reject_unsupported_fields(
+            field_schema,
+            _INPUT_PROPERTY_SCHEMA_KEYS,
+            f"Workflow input schema property '{field_name}'",
+        )
+        allowed_types = _allowed_input_types(field_schema)
+        _validate_input_enum(field_name, field_schema, allowed_types)
+        for input_type in allowed_types:
+            if input_type not in _INPUT_TYPE_CHECKS:
+                msg = f"Unsupported workflow input schema type '{input_type}'."
+                raise DynamicWorkflowError(msg)
+
+
+def _validate_input_property_types(properties: dict[str, object], input_data: dict[str, object]) -> None:
+    for field_name, raw_field_schema in properties.items():
+        if field_name not in input_data or not isinstance(raw_field_schema, dict):
+            continue
+        field_schema = object_mapping(cast("Mapping[object, object]", raw_field_schema))
+        allowed_types = _allowed_input_types(field_schema)
+        if not allowed_types:
+            _validate_input_enum_value(field_name, field_schema, input_data[field_name])
+            continue
+        if not any(_input_value_matches_type(input_data[field_name], allowed_type) for allowed_type in allowed_types):
+            msg = f"Input field '{field_name}' must be {_input_type_label(allowed_types)}."
+            raise DynamicWorkflowError(msg)
+        _validate_input_enum_value(field_name, field_schema, input_data[field_name])
+
+
+def _allowed_input_types(field_schema: dict[str, object]) -> list[str]:
+    expected_type = field_schema.get("type")
+    if expected_type is None:
+        return []
+    if isinstance(expected_type, list):
+        if not expected_type:
+            msg = "Workflow input schema type list must be non-empty."
+            raise DynamicWorkflowError(msg)
+        allowed_types = []
+        for item in expected_type:
+            if not isinstance(item, str) or not item.strip():
+                msg = "Workflow input schema type list entries must be non-empty strings."
+                raise DynamicWorkflowError(msg)
+            allowed_types.append(item.strip())
+        return allowed_types
+    if not isinstance(expected_type, str) or not expected_type.strip():
+        msg = "Workflow input schema type must be a non-empty string or list of strings."
+        raise DynamicWorkflowError(msg)
+    return [str(expected_type)]
+
+
+def _validate_input_enum(field_name: str, field_schema: dict[str, object], allowed_types: list[str]) -> None:
+    enum_values = field_schema.get("enum")
+    if enum_values is None:
+        return
+    if not isinstance(enum_values, list) or not enum_values:
+        msg = f"Workflow input schema property '{field_name}' enum must be a non-empty list."
+        raise DynamicWorkflowError(msg)
+    if not allowed_types:
+        return
+    for enum_value in enum_values:
+        if not any(_input_value_matches_type(enum_value, allowed_type) for allowed_type in allowed_types):
+            msg = f"Workflow input schema property '{field_name}' enum values must match its declared type."
+            raise DynamicWorkflowError(msg)
+
+
+def _validate_input_enum_value(field_name: str, field_schema: dict[str, object], value: object) -> None:
+    enum_values = field_schema.get("enum")
+    if enum_values is None:
+        return
+    if not isinstance(enum_values, list):
+        msg = f"Workflow input schema property '{field_name}' enum must be a list."
+        raise DynamicWorkflowError(msg)
+    if not any(_enum_value_matches(value, enum_value) for enum_value in enum_values):
+        msg = f"Input field '{field_name}' must be one of the declared enum values."
+        raise DynamicWorkflowError(msg)
+
+
+def _enum_value_matches(value: object, enum_value: object) -> bool:
+    if type(value) is not type(enum_value):
+        return False
+    return value == enum_value
+
+
+def _validate_participants(participants: list[dict[str, object]]) -> set[str]:
+    participant_ids: set[str] = set()
+    for index, participant in enumerate(participants):
+        context = f"Participant at index {index}"
+        participant_id = _required_text(participant, "id", context=context)
+        validate_id(participant_id, f"{context} id")
+        if participant_id in participant_ids:
+            msg = f"Duplicate participant id '{participant_id}'."
+            raise DynamicWorkflowError(msg)
+        participant["id"] = participant_id
+        participant_ids.add(participant_id)
+        participant_kind = (
+            _required_text(participant, "kind", context=context) if "kind" in participant else "ephemeral_agent"
+        )
+        if participant_kind not in _PARTICIPANT_KINDS:
+            msg = f"{context} has unsupported kind '{participant_kind}'."
+            raise DynamicWorkflowError(msg)
+        participant["kind"] = participant_kind
+        if participant_kind == "room_agent":
+            _validate_room_agent_participant(participant, context)
+        else:
+            _validate_ephemeral_agent_participant(participant, context)
+    return participant_ids
+
+
+def _validate_room_agent_participant(participant: dict[str, object], context: str) -> None:
+    _reject_unsupported_fields(participant, _ROOM_AGENT_PARTICIPANT_KEYS, context)
+    agent_name = _required_text(participant, "agent", context=context)
+    participant["agent"] = agent_name
+    if "model" in participant and participant.get("model") not in (None, ""):
+        msg = f"{context} room_agent participants cannot override model."
+        raise DynamicWorkflowError(msg)
+    if participant.get("tools") not in (None, []):
+        msg = f"{context} room_agent participants cannot declare tools; tool grants are only available to ephemeral participants."
+        raise DynamicWorkflowError(msg)
+
+
+def _validate_ephemeral_agent_participant(participant: dict[str, object], context: str) -> None:
+    _reject_unsupported_fields(participant, _EPHEMERAL_PARTICIPANT_KEYS, context)
+    participant["tools"] = _normalized_tool_names(
+        participant.get("tools"),
+        f"{context} field 'tools'",
+    )
+    if "model" in participant and participant.get("model") is not None:
+        model = _required_text(participant, "model", context=context)
+        participant["model"] = model
+    if "instructions" in participant:
+        _validate_participant_instructions(participant["instructions"], context)
+
+
+def _validate_participant_instructions(value: object, context: str) -> None:
+    if value is None or isinstance(value, str):
+        return
+    if isinstance(value, list) and all(isinstance(instruction, str) for instruction in value):
+        return
+    msg = f"{context} field 'instructions' must be a string or list of strings."
+    raise DynamicWorkflowError(msg)
+
+
+def _validate_workflow_steps(workflow_steps: list[dict[str, object]], participant_ids: set[str]) -> set[str]:
+    step_ids: set[str] = set()
+    for index, step in enumerate(workflow_steps):
+        context = f"Workflow step at index {index}"
+        step_id = _required_text(step, "id", context=context)
+        validate_id(step_id, f"{context} id")
+        if step_id in step_ids:
+            msg = f"Duplicate workflow step id '{step_id}'."
+            raise DynamicWorkflowError(msg)
+        step["id"] = step_id
+
+        step_type = _step_type(step, context)
+        step["type"] = step_type
+        if step_type == "agent_step":
+            _reject_unsupported_fields(step, _AGENT_STEP_KEYS, context)
+            _validate_agent_step(step, context, participant_ids, step_ids)
+        elif step_type == "transform_step":
+            _reject_unsupported_fields(step, _TRANSFORM_STEP_KEYS, context)
+            _validate_template_choice(step, context, ("template", "text"), step_ids)
+        elif step_type == "report_step":
+            _reject_unsupported_fields(step, _REPORT_STEP_KEYS, context)
+            _validate_report_step(step, context, step_ids)
+        step_ids.add(step_id)
+    return step_ids
+
+
+def _validate_workflow_limits(
+    spec: dict[str, object],
+    participants: list[dict[str, object]],
+    workflow_steps: list[dict[str, object]],
+) -> None:
+    if len(participants) > _MAX_WORKFLOW_PARTICIPANTS:
+        msg = f"Workflow participants cannot exceed {_MAX_WORKFLOW_PARTICIPANTS}."
+        raise DynamicWorkflowError(msg)
+    if len(workflow_steps) > _MAX_WORKFLOW_STEPS:
+        msg = f"Workflow steps cannot exceed {_MAX_WORKFLOW_STEPS}."
+        raise DynamicWorkflowError(msg)
+
+    permissions = _permissions_mapping(spec)
+    unknown_permissions = sorted(set(permissions) - _PERMISSION_KEYS)
+    if unknown_permissions:
+        msg = f"Workflow permissions contain unsupported keys: {', '.join(unknown_permissions)}."
+        raise DynamicWorkflowError(msg)
+
+    runtime_seconds = permissions.get("max_runtime_seconds")
+    if runtime_seconds is not None:
+        permissions["max_runtime_seconds"] = _positive_int_permission(
+            runtime_seconds,
+            "max_runtime_seconds",
+            maximum=_MAX_WORKFLOW_RUNTIME_SECONDS,
+        )
+
+    max_concurrent_agents = permissions.get("max_concurrent_agents")
+    if max_concurrent_agents is not None:
+        permissions["max_concurrent_agents"] = _positive_int_permission(
+            max_concurrent_agents,
+            "max_concurrent_agents",
+            maximum=_MAX_WORKFLOW_CONCURRENT_AGENTS,
+        )
+
+    agent_step_count = sum(1 for step in workflow_steps if step.get("type") == "agent_step")
+    max_total_agents = permissions.get("max_total_agents")
+    if max_total_agents is None:
+        max_total_agents = _MAX_WORKFLOW_AGENT_STEPS
+    max_total_agents = _positive_int_permission(
+        max_total_agents,
+        "max_total_agents",
+        maximum=_MAX_WORKFLOW_AGENT_STEPS,
+    )
+    permissions["max_total_agents"] = max_total_agents
+    if agent_step_count > max_total_agents:
+        msg = f"Workflow agent steps cannot exceed permissions.max_total_agents ({max_total_agents})."
+        raise DynamicWorkflowError(msg)
+
+    _validate_permission_models(permissions)
+    _validate_permission_tools(permissions)
+    _validate_permission_data(permissions)
+    spec["permissions"] = permissions
+
+
+def _permissions_mapping(spec: dict[str, object]) -> dict[str, object]:
+    raw_permissions = spec.get("permissions", {})
+    if raw_permissions is None:
+        return {}
+    if not isinstance(raw_permissions, dict):
+        msg = "Workflow spec field 'permissions' must be a mapping."
+        raise DynamicWorkflowError(msg)
+    permissions = object_mapping(cast("Mapping[object, object]", raw_permissions))
+    spec["permissions"] = permissions
+    return permissions
+
+
+def _positive_int_permission(value: object, field_name: str, *, maximum: int) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        msg = f"Workflow permission '{field_name}' must be an integer."
+        raise DynamicWorkflowError(msg)
+    if value < 1 or value > maximum:
+        msg = f"Workflow permission '{field_name}' must be between 1 and {maximum}."
+        raise DynamicWorkflowError(msg)
+    return value
+
+
+def _validate_permission_models(permissions: dict[str, object]) -> None:
+    models = permissions.get("models")
+    if models is None:
+        return
+    if not isinstance(models, list) or not all(isinstance(model, str) and model.strip() for model in models):
+        msg = "Workflow permission 'models' must be a list of non-empty strings."
+        raise DynamicWorkflowError(msg)
+    permissions["models"] = [cast("str", model).strip() for model in models]
+
+
+def _validate_permission_tools(permissions: dict[str, object]) -> None:
+    permissions["tools"] = _normalized_tool_names(permissions.get("tools", []), "Workflow permission 'tools'")
+
+
+def _normalized_tool_names(raw_tools: object, context: str) -> list[str]:
+    if raw_tools is None:
+        return []
+    if not isinstance(raw_tools, list) or not all(isinstance(tool, str) and tool.strip() for tool in raw_tools):
+        msg = f"{context} must be a list of non-empty strings."
+        raise DynamicWorkflowError(msg)
+    tool_names: list[str] = []
+    for raw_tool in raw_tools:
+        tool_name = cast("str", raw_tool).strip()
+        if tool_name not in tool_names:
+            tool_names.append(tool_name)
+    return tool_names
+
+
+def _validate_participant_tool_grants(spec: dict[str, object], participants: list[dict[str, object]]) -> None:
+    granted_tools = _permissions_mapping(spec).get("tools", [])
+    granted = set(cast("list[str]", granted_tools))
+    for participant in participants:
+        for tool_name in cast("list[str]", participant.get("tools") or []):
+            if tool_name not in granted:
+                participant_id = participant["id"]
+                msg = f"Participant '{participant_id}' tool '{tool_name}' is not granted by permissions.tools."
+                raise DynamicWorkflowError(msg)
+
+
+def _validate_permission_data(permissions: dict[str, object]) -> None:
+    data = permissions.get("data", {})
+    if data is None:
+        permissions["data"] = {}
+        return
+    if not isinstance(data, dict):
+        msg = "Workflow permission 'data' must be a mapping."
+        raise DynamicWorkflowError(msg)
+    normalized = object_mapping(cast("Mapping[object, object]", data))
+    supported_fields = {"matrix_history", "attachments", "knowledge_bases"}
+    unsupported_fields = sorted(set(normalized) - supported_fields)
+    if unsupported_fields:
+        msg = f"Workflow permission data.{unsupported_fields[0]} is not supported."
+        raise DynamicWorkflowError(msg)
+    for field_name in ("matrix_history", "attachments"):
+        value = normalized.get(field_name)
+        if value is not None and value != "none":
+            msg = f"Workflow permission data.{field_name} must be 'none' until workflow data grants are supported."
+            raise DynamicWorkflowError(msg)
+    knowledge_bases = normalized.get("knowledge_bases", [])
+    if not isinstance(knowledge_bases, list) or not all(isinstance(base, str) for base in knowledge_bases):
+        msg = "Workflow permission data.knowledge_bases must be a list of strings."
+        raise DynamicWorkflowError(msg)
+    if knowledge_bases:
+        msg = "Workflow permission data.knowledge_bases must be empty until workflow data grants are supported."
+        raise DynamicWorkflowError(msg)
+    permissions["data"] = normalized
+
+
+def _step_type(step: dict[str, object], context: str) -> str:
+    raw_step_type = step.get("type", "agent_step")
+    if not isinstance(raw_step_type, str) or not raw_step_type.strip():
+        msg = f"{context} field 'type' must be a non-empty string."
+        raise DynamicWorkflowError(msg)
+    step_type = raw_step_type.strip()
+    if step_type not in _STEP_TYPES:
+        msg = f"Unsupported workflow step type '{step_type}'."
+        raise DynamicWorkflowError(msg)
+    return step_type
+
+
+def _validate_agent_step(
+    step: dict[str, object],
+    context: str,
+    participant_ids: set[str],
+    available_step_ids: set[str],
+) -> None:
+    participant = _required_text(step, "participant", context=context)
+    if participant not in participant_ids:
+        msg = f"{context} references unknown participant '{participant}'."
+        raise DynamicWorkflowError(msg)
+    step["participant"] = participant
+    _validate_template_choice(
+        step,
+        context,
+        _AGENT_STEP_TEMPLATE_FIELDS,
+        available_step_ids,
+    )
+
+
+def _validate_report_step(step: dict[str, object], context: str, available_step_ids: set[str]) -> None:
+    if "body_template" in step and "from_step" in step:
+        msg = f"{context} must include only one report source field; found: body_template, from_step."
+        raise DynamicWorkflowError(msg)
+    if "body_template" in step:
+        body_template = _required_text(step, "body_template", context=context)
+        step["body_template"] = body_template
+        _validate_template_references(body_template, available_step_ids, f"{context} field 'body_template'")
+    else:
+        from_step = _required_text(step, "from_step", context=context)
+        if from_step not in available_step_ids:
+            msg = f"{context} references unknown prior step '{from_step}'."
+            raise DynamicWorkflowError(msg)
+        step["from_step"] = from_step
+
+    if "title" in step:
+        title = _required_text(step, "title", context=context)
+        step["title"] = title
+        _validate_template_references(title, available_step_ids, f"{context} field 'title'")
+
+
+def _validate_outputs(spec: dict[str, object], step_ids: set[str]) -> None:
+    raw_outputs = spec.get("outputs", [])
+    if raw_outputs is None:
+        spec["outputs"] = []
+        return
+    if not isinstance(raw_outputs, list):
+        msg = "Workflow spec field 'outputs' must be a list."
+        raise DynamicWorkflowError(msg)
+    outputs: list[dict[str, object]] = []
+    output_ids: set[str] = set()
+    for index, raw_output in enumerate(raw_outputs):
+        context = f"Workflow output at index {index}"
+        if not isinstance(raw_output, dict):
+            msg = f"{context} must be a mapping."
+            raise DynamicWorkflowError(msg)
+        output = object_mapping(cast("Mapping[object, object]", raw_output))
+        output_id = _required_text(output, "id", context=context)
+        validate_id(output_id, f"{context} id")
+        if output_id in output_ids:
+            msg = f"Duplicate workflow output id '{output_id}'."
+            raise DynamicWorkflowError(msg)
+        output["id"] = output_id
+        output_ids.add(output_id)
+        output_type = _required_text(output, "type", context=context)
+        if output_type not in _OUTPUT_TYPES:
+            msg = f"{context} has unsupported type '{output_type}'."
+            raise DynamicWorkflowError(msg)
+        output["type"] = output_type
+        from_step = _required_text(output, "from_step", context=context)
+        if from_step not in step_ids:
+            msg = f"{context} references unknown step '{from_step}'."
+            raise DynamicWorkflowError(msg)
+        output["from_step"] = from_step
+        _reject_unsupported_fields(output, _OUTPUT_KEYS, context)
+        outputs.append(output)
+    spec["outputs"] = outputs
+
+
+def _required_mapping_list(data: dict[str, object], key: str, item_label: str) -> list[dict[str, object]]:
+    value = data.get(key)
+    if value is None:
+        msg = f"Workflow spec field '{key}' is missing."
+        raise DynamicWorkflowError(msg)
+    if not isinstance(value, list):
+        msg = f"Workflow spec field '{key}' must be a list."
+        raise DynamicWorkflowError(msg)
+    if not value:
+        msg = f"Workflow spec field '{key}' cannot be empty."
+        raise DynamicWorkflowError(msg)
+    items: list[dict[str, object]] = []
+    for index, raw_item in enumerate(value):
+        if not isinstance(raw_item, dict):
+            msg = f"{item_label} at index {index} must be a mapping."
+            raise DynamicWorkflowError(msg)
+        items.append(object_mapping(cast("Mapping[object, object]", raw_item)))
+    data[key] = items
+    return items
+
+
+def _reject_unsupported_fields(data: dict[str, object], allowed_fields: frozenset[str], context: str) -> None:
+    unsupported_fields = sorted(set(data) - allowed_fields)
+    if unsupported_fields:
+        msg = f"{context} contains unsupported field '{unsupported_fields[0]}'."
+        raise DynamicWorkflowError(msg)
+
+
+def _validate_template_choice(
+    step: dict[str, object],
+    context: str,
+    field_names: tuple[str, ...],
+    available_step_ids: set[str],
+) -> None:
+    present_fields = [field_name for field_name in field_names if field_name in step]
+    if len(present_fields) > 1:
+        fields = ", ".join(present_fields)
+        msg = f"{context} must include only one template field; found: {fields}."
+        raise DynamicWorkflowError(msg)
+    for field_name in present_fields:
+        template = _required_text(step, field_name, context=context)
+        step[field_name] = template
+        _validate_template_references(template, available_step_ids, f"{context} field '{field_name}'")
+        return
+    fields = ", ".join(field_names)
+    msg = f"{context} must include one of: {fields}."
+    raise DynamicWorkflowError(msg)
+
+
+def _validate_template_references(template: str, available_step_ids: set[str], context: str) -> None:
+    for match in _TEMPLATE_REF_RE.finditer(template):
+        reference = match.group(1)
+        if reference.startswith("input."):
+            parts = reference.split(".")
+            if len(parts) < 2 or any(not part for part in parts[1:]):
+                msg = f"{context} contains invalid template reference '{reference}'."
+                raise DynamicWorkflowError(msg)
+            continue
+        if reference.startswith("steps."):
+            parts = reference.split(".")
+            if len(parts) == 2 or (len(parts) == 3 and parts[2] == "content"):
+                step_id = parts[1]
+            else:
+                msg = f"{context} contains unsupported template reference '{reference}'."
+                raise DynamicWorkflowError(msg)
+            if step_id not in available_step_ids:
+                msg = f"{context} references unknown prior step '{step_id}'."
+                raise DynamicWorkflowError(msg)
+            continue
+        msg = f"{context} contains unknown template reference '{reference}'."
+        raise DynamicWorkflowError(msg)
+
+
+def _is_integer_input(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _is_number_input(value: object) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+_INPUT_TYPE_CHECKS = {
+    "string": lambda value: isinstance(value, str),
+    "integer": _is_integer_input,
+    "number": _is_number_input,
+    "boolean": lambda value: isinstance(value, bool),
+    "object": lambda value: isinstance(value, dict),
+    "array": lambda value: isinstance(value, list),
+    "null": lambda value: value is None,
+}
+
+
+def _input_value_matches_type(value: object, expected_type: str) -> bool:
+    checker = _INPUT_TYPE_CHECKS.get(expected_type)
+    if checker is not None:
+        return checker(value)
+    msg = f"Unsupported workflow input schema type '{expected_type}'."
+    raise DynamicWorkflowError(msg)
+
+
+def _input_type_label(allowed_types: list[str]) -> str:
+    labels = {
+        "string": "a string",
+        "integer": "an integer",
+        "number": "a number",
+        "boolean": "a boolean",
+        "object": "an object",
+        "array": "an array",
+        "null": "null",
+    }
+    return " or ".join(labels.get(input_type, input_type) for input_type in allowed_types)
+
+
+def _required_text(data: dict[str, object], key: str, *, context: str = "Workflow spec") -> str:
+    if key not in data:
+        msg = f"{context} field '{key}' is missing."
+        raise DynamicWorkflowError(msg)
+    value = data[key]
+    if not isinstance(value, str):
+        msg = f"{context} field '{key}' must be a string."
+        raise DynamicWorkflowError(msg)
+    stripped = value.strip()
+    if not stripped:
+        msg = f"{context} field '{key}' cannot be empty."
+        raise DynamicWorkflowError(msg)
+    return stripped
+
+
+def validate_id(value: str, field_name: str) -> None:
+    """Validate one Dynamic Workflow identifier against the shared ID pattern."""
+    if not ID_RE.fullmatch(value):
+        msg = f"{field_name} must match {ID_RE.pattern}."
+        raise DynamicWorkflowError(msg)
+
+
+def object_mapping(data: Mapping[object, object]) -> dict[str, object]:
+    """Normalize one mapping to string keys."""
+    return {str(key): value for key, value in data.items()}

--- a/tests/test_dynamic_workflow_validation.py
+++ b/tests/test_dynamic_workflow_validation.py
@@ -1,0 +1,539 @@
+"""Direct unit tests for Dynamic Workflow spec and run-input validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from mindroom.dynamic_workflows.validation import (
+    DynamicWorkflowError,
+    validate_workflow_input,
+    validate_workflow_spec,
+    workflow_runtime_seconds,
+)
+
+
+def _spec(**overrides: object) -> dict[str, object]:
+    spec: dict[str, object] = {
+        "schema_version": 1,
+        "id": "demo-workflow",
+        "name": "Demo Workflow",
+        "kind": "workflow",
+        "participants": [{"id": "writer", "kind": "ephemeral_agent", "name": "Writer"}],
+        "workflow": [{"id": "write", "type": "agent_step", "participant": "writer", "prompt": "Write."}],
+    }
+    spec.update(overrides)
+    return spec
+
+
+def test_minimal_spec_validates_and_normalizes_defaults() -> None:
+    """A minimal spec validates and gains normalized defaults."""
+    validated = validate_workflow_spec(_spec())
+    assert validated["id"] == "demo-workflow"
+    assert validated["outputs"] == []
+    permissions = validated["permissions"]
+    assert permissions == {"tools": [], "data": {}, "max_total_agents": 16}
+    participant = validated["participants"][0]
+    assert participant["kind"] == "ephemeral_agent"
+    assert participant["tools"] == []
+
+
+def test_validate_does_not_mutate_the_input_spec() -> None:
+    """Validation normalizes a deep copy, leaving the input spec untouched."""
+    spec = _spec()
+    validate_workflow_spec(spec)
+    assert "permissions" not in spec
+    assert "tools" not in spec["participants"][0]
+
+
+def test_spec_must_be_a_mapping() -> None:
+    """Non-mapping specs are rejected."""
+    with pytest.raises(DynamicWorkflowError, match="must be a mapping"):
+        validate_workflow_spec(["not", "a", "mapping"])  # type: ignore[arg-type]
+
+
+def test_spec_rejects_unsupported_top_level_field() -> None:
+    """Unknown top-level spec fields are rejected."""
+    with pytest.raises(DynamicWorkflowError, match="unsupported field 'surprise'"):
+        validate_workflow_spec(_spec(surprise=True))
+
+
+@pytest.mark.parametrize("schema_version", [0, 2, True, 1.0, "1", None])
+def test_spec_rejects_unsupported_schema_version(schema_version: object) -> None:
+    """Only schema_version 1 as a true integer is accepted."""
+    with pytest.raises(DynamicWorkflowError, match="'schema_version' must be 1"):
+        validate_workflow_spec(_spec(schema_version=schema_version))
+
+
+def test_spec_rejects_missing_schema_version() -> None:
+    """A spec without schema_version is rejected."""
+    spec = _spec()
+    del spec["schema_version"]
+    with pytest.raises(DynamicWorkflowError, match="'schema_version' must be 1"):
+        validate_workflow_spec(spec)
+
+
+@pytest.mark.parametrize("workflow_id", ["", "Has Spaces", "UPPER", "-leading-dash"])
+def test_spec_rejects_invalid_workflow_id(workflow_id: str) -> None:
+    """Workflow IDs must match the lowercase id pattern."""
+    with pytest.raises(DynamicWorkflowError):
+        validate_workflow_spec(_spec(id=workflow_id))
+
+
+def test_spec_rejects_non_workflow_kind() -> None:
+    """Only kind 'workflow' is supported."""
+    with pytest.raises(DynamicWorkflowError, match="kind must be 'workflow'"):
+        validate_workflow_spec(_spec(kind="pipeline"))
+
+
+def test_spec_strips_text_fields() -> None:
+    """Required text fields are stripped during normalization."""
+    validated = validate_workflow_spec(_spec(id="  demo-workflow  ", name="  Demo  "))
+    assert validated["id"] == "demo-workflow"
+    assert validated["name"] == "Demo"
+
+
+# --- participants ---
+
+
+def test_participants_cannot_be_empty() -> None:
+    """At least one participant is required."""
+    with pytest.raises(DynamicWorkflowError, match="'participants' cannot be empty"):
+        validate_workflow_spec(_spec(participants=[]))
+
+
+def test_participants_must_be_mappings() -> None:
+    """Participant entries must be mappings."""
+    with pytest.raises(DynamicWorkflowError, match="Participant at index 0 must be a mapping"):
+        validate_workflow_spec(_spec(participants=["writer"]))
+
+
+def test_participant_requires_id() -> None:
+    """Each participant must declare an id."""
+    with pytest.raises(DynamicWorkflowError, match="Participant at index 0 field 'id' is missing"):
+        validate_workflow_spec(_spec(participants=[{"kind": "ephemeral_agent"}]))
+
+
+def test_participant_ids_must_be_unique() -> None:
+    """Duplicate participant ids are rejected."""
+    participants = [{"id": "writer"}, {"id": "writer"}]
+    with pytest.raises(DynamicWorkflowError, match="Duplicate participant id 'writer'"):
+        validate_workflow_spec(_spec(participants=participants))
+
+
+def test_participant_kind_defaults_to_ephemeral_agent() -> None:
+    """Participants without a kind default to ephemeral_agent."""
+    validated = validate_workflow_spec(_spec(participants=[{"id": "writer"}]))
+    assert validated["participants"][0]["kind"] == "ephemeral_agent"
+
+
+def test_participant_rejects_unsupported_kind() -> None:
+    """Unknown participant kinds are rejected."""
+    with pytest.raises(DynamicWorkflowError, match="unsupported kind 'robot'"):
+        validate_workflow_spec(_spec(participants=[{"id": "writer", "kind": "robot"}]))
+
+
+def test_participant_rejects_unsupported_field() -> None:
+    """Unknown participant fields are rejected."""
+    with pytest.raises(DynamicWorkflowError, match="unsupported field 'voice'"):
+        validate_workflow_spec(_spec(participants=[{"id": "writer", "voice": "baritone"}]))
+
+
+def test_room_agent_participant_requires_agent_name() -> None:
+    """room_agent participants must name a room agent."""
+    with pytest.raises(DynamicWorkflowError, match="field 'agent' is missing"):
+        validate_workflow_spec(_spec(participants=[{"id": "writer", "kind": "room_agent"}]))
+
+
+def test_room_agent_participant_cannot_override_model() -> None:
+    """room_agent participants cannot override the agent model."""
+    participants = [{"id": "writer", "kind": "room_agent", "agent": "code", "model": "gpt-5.5"}]
+    with pytest.raises(DynamicWorkflowError, match="cannot override model"):
+        validate_workflow_spec(_spec(participants=participants))
+
+
+def test_room_agent_participant_cannot_declare_tools() -> None:
+    """room_agent participants cannot declare tool grants."""
+    participants = [{"id": "writer", "kind": "room_agent", "agent": "code", "tools": ["shell"]}]
+    with pytest.raises(DynamicWorkflowError, match="cannot declare tools"):
+        validate_workflow_spec(_spec(participants=participants))
+
+
+def test_ephemeral_participant_instructions_must_be_strings() -> None:
+    """Participant instructions must be a string or list of strings."""
+    participants = [{"id": "writer", "instructions": [1, 2]}]
+    with pytest.raises(DynamicWorkflowError, match="must be a string or list of strings"):
+        validate_workflow_spec(_spec(participants=participants))
+
+
+def test_participant_tools_must_be_granted_by_permissions() -> None:
+    """Participant tools must appear in permissions.tools."""
+    participants = [{"id": "writer", "tools": ["shell"]}]
+    with pytest.raises(DynamicWorkflowError, match=r"not granted by permissions\.tools"):
+        validate_workflow_spec(_spec(participants=participants))
+
+
+def test_granted_participant_tools_validate_and_deduplicate() -> None:
+    """Granted participant tools are stripped and deduplicated."""
+    participants = [{"id": "writer", "tools": ["shell", " shell "]}]
+    validated = validate_workflow_spec(_spec(participants=participants, permissions={"tools": ["shell"]}))
+    assert validated["participants"][0]["tools"] == ["shell"]
+
+
+# --- workflow steps ---
+
+
+def test_workflow_steps_cannot_be_empty() -> None:
+    """At least one workflow step is required."""
+    with pytest.raises(DynamicWorkflowError, match="'workflow' cannot be empty"):
+        validate_workflow_spec(_spec(workflow=[]))
+
+
+def test_step_requires_id() -> None:
+    """Each workflow step must declare an id."""
+    with pytest.raises(DynamicWorkflowError, match="Workflow step at index 0 field 'id' is missing"):
+        validate_workflow_spec(_spec(workflow=[{"type": "agent_step", "participant": "writer", "prompt": "x"}]))
+
+
+def test_step_ids_must_be_unique() -> None:
+    """Duplicate step ids are rejected."""
+    workflow = [
+        {"id": "write", "type": "agent_step", "participant": "writer", "prompt": "x"},
+        {"id": "write", "type": "transform_step", "text": "y"},
+    ]
+    with pytest.raises(DynamicWorkflowError, match="Duplicate workflow step id 'write'"):
+        validate_workflow_spec(_spec(workflow=workflow))
+
+
+def test_step_rejects_unsupported_type() -> None:
+    """Unknown step types are rejected."""
+    with pytest.raises(DynamicWorkflowError, match="Unsupported workflow step type 'loop_step'"):
+        validate_workflow_spec(_spec(workflow=[{"id": "write", "type": "loop_step"}]))
+
+
+def test_agent_step_rejects_unknown_participant() -> None:
+    """Agent steps must reference a declared participant."""
+    workflow = [{"id": "write", "type": "agent_step", "participant": "ghost", "prompt": "x"}]
+    with pytest.raises(DynamicWorkflowError, match="references unknown participant 'ghost'"):
+        validate_workflow_spec(_spec(workflow=workflow))
+
+
+def test_agent_step_requires_exactly_one_template_field() -> None:
+    """Agent steps must include one template field."""
+    workflow = [{"id": "write", "type": "agent_step", "participant": "writer"}]
+    with pytest.raises(DynamicWorkflowError, match="must include one of"):
+        validate_workflow_spec(_spec(workflow=workflow))
+
+
+def test_agent_step_rejects_multiple_template_fields() -> None:
+    """Agent steps cannot mix multiple template fields."""
+    workflow = [{"id": "write", "type": "agent_step", "participant": "writer", "prompt": "x", "template": "y"}]
+    with pytest.raises(DynamicWorkflowError, match="only one template field"):
+        validate_workflow_spec(_spec(workflow=workflow))
+
+
+def test_transform_step_rejects_template_and_text_together() -> None:
+    """Transform steps cannot declare both template and text."""
+    workflow = [
+        {"id": "write", "type": "agent_step", "participant": "writer", "prompt": "x"},
+        {"id": "shape", "type": "transform_step", "template": "a", "text": "b"},
+    ]
+    with pytest.raises(DynamicWorkflowError, match="only one template field"):
+        validate_workflow_spec(_spec(workflow=workflow))
+
+
+def test_report_step_rejects_both_body_template_and_from_step() -> None:
+    """Report steps must use one source field."""
+    workflow = [
+        {"id": "write", "type": "agent_step", "participant": "writer", "prompt": "x"},
+        {"id": "report", "type": "report_step", "body_template": "a", "from_step": "write"},
+    ]
+    with pytest.raises(DynamicWorkflowError, match="only one report source field"):
+        validate_workflow_spec(_spec(workflow=workflow))
+
+
+def test_report_step_rejects_unknown_from_step() -> None:
+    """Report steps must reference a prior step."""
+    workflow = [
+        {"id": "write", "type": "agent_step", "participant": "writer", "prompt": "x"},
+        {"id": "report", "type": "report_step", "from_step": "missing"},
+    ]
+    with pytest.raises(DynamicWorkflowError, match="references unknown prior step 'missing'"):
+        validate_workflow_spec(_spec(workflow=workflow))
+
+
+def test_template_rejects_unknown_reference_namespace() -> None:
+    """Template references must use input. or steps. namespaces."""
+    workflow = [{"id": "write", "type": "agent_step", "participant": "writer", "prompt": "{secrets.key}"}]
+    with pytest.raises(DynamicWorkflowError, match=r"unknown template reference 'secrets\.key'"):
+        validate_workflow_spec(_spec(workflow=workflow))
+
+
+def test_template_rejects_reference_to_later_step() -> None:
+    """Template references may only target prior steps."""
+    workflow = [{"id": "write", "type": "agent_step", "participant": "writer", "prompt": "{steps.write}"}]
+    with pytest.raises(DynamicWorkflowError, match="references unknown prior step 'write'"):
+        validate_workflow_spec(_spec(workflow=workflow))
+
+
+def test_template_rejects_unsupported_step_attribute() -> None:
+    """Only step content references are supported."""
+    workflow = [
+        {"id": "write", "type": "agent_step", "participant": "writer", "prompt": "x"},
+        {"id": "shape", "type": "transform_step", "template": "{steps.write.tokens}"},
+    ]
+    with pytest.raises(DynamicWorkflowError, match="unsupported template reference"):
+        validate_workflow_spec(_spec(workflow=workflow))
+
+
+def test_template_accepts_input_and_prior_step_references() -> None:
+    """Valid input and prior-step references pass validation."""
+    workflow = [
+        {"id": "write", "type": "agent_step", "participant": "writer", "prompt": "Topic: {input.topic}"},
+        {"id": "shape", "type": "transform_step", "template": "{steps.write.content}"},
+    ]
+    validated = validate_workflow_spec(_spec(workflow=workflow))
+    assert [step["id"] for step in validated["workflow"]] == ["write", "shape"]
+
+
+# --- limits and permissions ---
+
+
+def test_rejects_too_many_participants() -> None:
+    """Participant count is capped at 8."""
+    participants = [{"id": "writer"}, *({"id": f"agent-{index}"} for index in range(8))]
+    with pytest.raises(DynamicWorkflowError, match="participants cannot exceed 8"):
+        validate_workflow_spec(_spec(participants=participants))
+
+
+def test_rejects_too_many_steps() -> None:
+    """Step count is capped at 64."""
+    workflow = [{"id": f"step-{index}", "type": "transform_step", "text": "x"} for index in range(65)]
+    with pytest.raises(DynamicWorkflowError, match="steps cannot exceed 64"):
+        validate_workflow_spec(_spec(workflow=workflow))
+
+
+def test_rejects_agent_steps_above_max_total_agents() -> None:
+    """Agent step count cannot exceed permissions.max_total_agents."""
+    workflow = [
+        {"id": f"step-{index}", "type": "agent_step", "participant": "writer", "prompt": "x"} for index in range(3)
+    ]
+    with pytest.raises(DynamicWorkflowError, match=r"cannot exceed permissions.max_total_agents \(2\)"):
+        validate_workflow_spec(_spec(workflow=workflow, permissions={"max_total_agents": 2}))
+
+
+def test_rejects_unknown_permission_keys() -> None:
+    """Unknown permission keys are rejected."""
+    with pytest.raises(DynamicWorkflowError, match="unsupported keys: budget"):
+        validate_workflow_spec(_spec(permissions={"budget": 10}))
+
+
+@pytest.mark.parametrize("runtime_seconds", [0, 3601, True, "60"])
+def test_rejects_invalid_max_runtime_seconds(runtime_seconds: object) -> None:
+    """max_runtime_seconds must be an int between 1 and 3600."""
+    with pytest.raises(DynamicWorkflowError, match="max_runtime_seconds"):
+        validate_workflow_spec(_spec(permissions={"max_runtime_seconds": runtime_seconds}))
+
+
+def test_rejects_max_concurrent_agents_above_cap() -> None:
+    """max_concurrent_agents is capped at 8."""
+    with pytest.raises(DynamicWorkflowError, match="'max_concurrent_agents' must be between 1 and 8"):
+        validate_workflow_spec(_spec(permissions={"max_concurrent_agents": 9}))
+
+
+def test_rejects_non_string_permission_models() -> None:
+    """permissions.models must be non-empty strings."""
+    with pytest.raises(DynamicWorkflowError, match="'models' must be a list of non-empty strings"):
+        validate_workflow_spec(_spec(permissions={"models": ["claude-sonnet-4-6", 7]}))
+
+
+def test_rejects_unknown_data_permission() -> None:
+    """Unknown data permission fields are rejected."""
+    with pytest.raises(DynamicWorkflowError, match=r"data\.secrets is not supported"):
+        validate_workflow_spec(_spec(permissions={"data": {"secrets": "all"}}))
+
+
+@pytest.mark.parametrize("field_name", ["matrix_history", "attachments"])
+def test_rejects_non_none_data_grants(field_name: str) -> None:
+    """Data grants other than 'none' are not yet supported."""
+    with pytest.raises(DynamicWorkflowError, match=f"data.{field_name} must be 'none'"):
+        validate_workflow_spec(_spec(permissions={"data": {field_name: "thread"}}))
+
+
+def test_rejects_non_empty_knowledge_bases_grant() -> None:
+    """Knowledge base grants are not yet supported."""
+    with pytest.raises(DynamicWorkflowError, match="knowledge_bases must be empty"):
+        validate_workflow_spec(_spec(permissions={"data": {"knowledge_bases": ["docs"]}}))
+
+
+def test_workflow_runtime_seconds_defaults_to_cap() -> None:
+    """The runtime cap defaults to 3600 seconds."""
+    assert workflow_runtime_seconds(validate_workflow_spec(_spec())) == 3600
+
+
+def test_workflow_runtime_seconds_returns_declared_value() -> None:
+    """A declared max_runtime_seconds is returned as-is."""
+    validated = validate_workflow_spec(_spec(permissions={"max_runtime_seconds": 120}))
+    assert workflow_runtime_seconds(validated) == 120
+
+
+# --- outputs ---
+
+
+def test_outputs_must_be_a_list() -> None:
+    """Outputs must be declared as a list."""
+    with pytest.raises(DynamicWorkflowError, match="'outputs' must be a list"):
+        validate_workflow_spec(_spec(outputs={"id": "report"}))
+
+
+def test_output_requires_supported_type() -> None:
+    """Output types are restricted to the supported set."""
+    outputs = [{"id": "report", "type": "pdf", "from_step": "write"}]
+    with pytest.raises(DynamicWorkflowError, match="unsupported type 'pdf'"):
+        validate_workflow_spec(_spec(outputs=outputs))
+
+
+def test_output_requires_known_from_step() -> None:
+    """Outputs must reference a declared step."""
+    outputs = [{"id": "report", "type": "markdown", "from_step": "missing"}]
+    with pytest.raises(DynamicWorkflowError, match="references unknown step 'missing'"):
+        validate_workflow_spec(_spec(outputs=outputs))
+
+
+def test_output_requires_type_field() -> None:
+    """Outputs must declare a type."""
+    outputs = [{"id": "report", "from_step": "write"}]
+    with pytest.raises(DynamicWorkflowError, match="field 'type' is missing"):
+        validate_workflow_spec(_spec(outputs=outputs))
+
+
+def test_output_ids_must_be_unique() -> None:
+    """Duplicate output ids are rejected."""
+    outputs = [
+        {"id": "report", "type": "markdown", "from_step": "write"},
+        {"id": "report", "type": "text", "from_step": "write"},
+    ]
+    with pytest.raises(DynamicWorkflowError, match="Duplicate workflow output id 'report'"):
+        validate_workflow_spec(_spec(outputs=outputs))
+
+
+def test_output_rejects_unsupported_field() -> None:
+    """Unknown output fields are rejected."""
+    outputs = [{"id": "report", "type": "markdown", "from_step": "write", "filename": "report.md"}]
+    with pytest.raises(DynamicWorkflowError, match="unsupported field 'filename'"):
+        validate_workflow_spec(_spec(outputs=outputs))
+
+
+# --- input schema declaration ---
+
+
+def test_input_schema_type_must_be_object() -> None:
+    """The input schema root type must be 'object'."""
+    with pytest.raises(DynamicWorkflowError, match="input schema type must be 'object'"):
+        validate_workflow_spec(_spec(inputs={"type": "array"}))
+
+
+def test_input_schema_rejects_unsupported_keywords() -> None:
+    """Unsupported JSON Schema keywords are rejected."""
+    inputs = {"type": "object", "additionalProperties": False}
+    with pytest.raises(DynamicWorkflowError, match="unsupported field 'additionalProperties'"):
+        validate_workflow_spec(_spec(inputs=inputs))
+
+
+def test_input_schema_rejects_duplicate_required_entries() -> None:
+    """Required entries must be unique."""
+    inputs = {"type": "object", "required": ["topic", "topic"]}
+    with pytest.raises(DynamicWorkflowError, match="required entries must be unique"):
+        validate_workflow_spec(_spec(inputs=inputs))
+
+
+def test_input_schema_rejects_unknown_property_type() -> None:
+    """Property types are restricted to the supported set."""
+    inputs = {"type": "object", "properties": {"topic": {"type": "uuid"}}}
+    with pytest.raises(DynamicWorkflowError, match="Unsupported workflow input schema type 'uuid'"):
+        validate_workflow_spec(_spec(inputs=inputs))
+
+
+def test_input_schema_rejects_empty_type_list() -> None:
+    """An empty property type list is rejected."""
+    inputs = {"type": "object", "properties": {"topic": {"type": []}}}
+    with pytest.raises(DynamicWorkflowError, match="type list must be non-empty"):
+        validate_workflow_spec(_spec(inputs=inputs))
+
+
+def test_input_schema_rejects_enum_values_outside_declared_type() -> None:
+    """Enum values must match the declared property type."""
+    inputs = {"type": "object", "properties": {"depth": {"type": "string", "enum": ["low", 2]}}}
+    with pytest.raises(DynamicWorkflowError, match="enum values must match its declared type"):
+        validate_workflow_spec(_spec(inputs=inputs))
+
+
+# --- validate_workflow_input ---
+
+
+def _inputs_spec(properties: dict[str, object], required: list[str] | None = None) -> dict[str, object]:
+    return {"inputs": {"type": "object", "required": required or [], "properties": properties}}
+
+
+def test_input_accepts_when_spec_declares_no_schema() -> None:
+    """Specs without an input schema accept any input."""
+    validate_workflow_input({}, {"anything": "goes"})
+
+
+def test_input_requires_declared_required_fields() -> None:
+    """Missing required input fields are rejected."""
+    spec = _inputs_spec({"topic": {"type": "string"}}, required=["topic"])
+    with pytest.raises(DynamicWorkflowError, match="Input field 'topic' is required"):
+        validate_workflow_input(spec, {})
+
+
+def test_input_accepts_valid_required_value() -> None:
+    """Valid required input passes validation."""
+    spec = _inputs_spec({"topic": {"type": "string"}}, required=["topic"])
+    validate_workflow_input(spec, {"topic": "competitors"})
+
+
+def test_input_rejects_wrong_type() -> None:
+    """Input values must match the declared property type."""
+    spec = _inputs_spec({"topic": {"type": "string"}})
+    with pytest.raises(DynamicWorkflowError, match="Input field 'topic' must be a string"):
+        validate_workflow_input(spec, {"topic": 7})
+
+
+def test_input_rejects_boolean_for_integer_field() -> None:
+    """Booleans are not accepted for integer fields."""
+    spec = _inputs_spec({"count": {"type": "integer"}})
+    with pytest.raises(DynamicWorkflowError, match="Input field 'count' must be an integer"):
+        validate_workflow_input(spec, {"count": True})
+
+
+def test_input_accepts_any_type_from_type_list() -> None:
+    """Any type from a declared type list is accepted."""
+    spec = _inputs_spec({"limit": {"type": ["integer", "null"]}})
+    validate_workflow_input(spec, {"limit": 3})
+    validate_workflow_input(spec, {"limit": None})
+
+
+def test_input_rejects_value_outside_enum() -> None:
+    """Input values outside the declared enum are rejected."""
+    spec = _inputs_spec({"depth": {"type": "string", "enum": ["low", "high"]}})
+    with pytest.raises(DynamicWorkflowError, match="must be one of the declared enum values"):
+        validate_workflow_input(spec, {"depth": "medium"})
+
+
+def test_input_accepts_enum_value() -> None:
+    """Declared enum values are accepted."""
+    spec = _inputs_spec({"depth": {"type": "string", "enum": ["low", "high"]}})
+    validate_workflow_input(spec, {"depth": "high"})
+
+
+def test_input_enum_without_type_still_enforced() -> None:
+    """Enums are enforced even without a declared type."""
+    spec = _inputs_spec({"depth": {"enum": [1, 2]}})
+    with pytest.raises(DynamicWorkflowError, match="must be one of the declared enum values"):
+        validate_workflow_input(spec, {"depth": True})
+
+
+def test_input_ignores_undeclared_fields() -> None:
+    """Undeclared input fields are ignored."""
+    spec = _inputs_spec({"topic": {"type": "string"}})
+    validate_workflow_input(spec, {"topic": "ok", "extra": object()})

--- a/tests/test_dynamic_workflows.py
+++ b/tests/test_dynamic_workflows.py
@@ -30,7 +30,8 @@ from mindroom.custom_tools.dynamic_workflow import DynamicWorkflowTools
 from mindroom.dynamic_workflows.agno_adapter import build_agno_workflow_factory
 from mindroom.dynamic_workflows.runner import DynamicWorkflowExecutionError, execute_workflow_spec
 from mindroom.dynamic_workflows.service import DynamicWorkflowService
-from mindroom.dynamic_workflows.store import DynamicWorkflowError, DynamicWorkflowStore
+from mindroom.dynamic_workflows.store import DynamicWorkflowStore
+from mindroom.dynamic_workflows.validation import DynamicWorkflowError
 from mindroom.entity_resolution import entity_identity_registry
 from mindroom.tool_approval import ToolCallWorkflowOrigin, _matching_tool_approval_rule, _shutdown_approval_store
 from mindroom.tool_system.metadata import TOOL_METADATA


### PR DESCRIPTION
## Summary

`src/mindroom/dynamic_workflows/store.py` (1356 lines) mixed persistence, the declarative workflow-DSL validation, and report rendering. The validation is pure domain logic and the part most likely to keep changing, but it was only exercised indirectly through workflow-execution tests.

- New `src/mindroom/dynamic_workflows/validation.py` (716 lines): mechanical move of `validate_workflow_spec`, `validate_workflow_input`, `workflow_runtime_seconds`, `DynamicWorkflowError`, and all private `_validate_*` helpers plus the constants they need. **No validation rules, error messages, or store persistence behavior changed.**
- `store.py` (now 633 lines) keeps persistence and report rendering and imports the validation entry points it still uses. No re-export aliases; all importers (`service.py`, `agno_adapter.py`, `api/dynamic_workflows.py`, `custom_tools/dynamic_workflow.py`, `custom_tools/dynamic_workflow_context.py`, `custom_tools/report_publishing.py`) now import the validation surface from `validation.py` directly.
- The `privata` pre-commit hook forbids cross-module private-symbol imports, so the three helpers shared between validation and the store were renamed public: `ID_RE`, `validate_id`, `object_mapping`. Names only; this is the only non-mechanical part of the move.
- `service.py`'s `spec_validator` remains an optional policy callback; its baseline spec/input validation now imports from the new module.
- `tach.toml` unchanged: `mindroom.dynamic_workflows` is governed as a single module and the new file is inside it.

## Tests

New `tests/test_dynamic_workflow_validation.py`: **82 direct unit tests** for the validation surface (no disk, no fixtures) covering spec normalization and non-mutation, schema-version rejection, participant rules, step rules (types, template choice, template-reference grammar incl. forward-reference rejection), limits/permissions, output-spec errors, input-schema declarations, and `validate_workflow_input` accept/reject cases.

## Verification

- `uv run pytest tests/test_dynamic_workflow_validation.py tests/test_dynamic_toolkits.py -x --no-cov` → 117 passed.
- `uv run pytest tests/test_dynamic_workflows.py tests/api/test_dynamic_workflows_api.py tests/test_report_publishing.py --no-cov` → 116 passed.
- Full suite → 8130 passed, 61 skipped (8 parallel-load flakes pass on serial rerun).
- `uv run tach check --dependencies --interfaces` → all modules validated.
- `uv run pre-commit run --all-files` → all hooks pass (TypeScript hook needs `bun install` in a fresh worktree; environmental).

Part of the 2026-06-11 architecture-review refactor wave (`refactor-prompts/09`).
