### PR TITLE
Unify memory backends behind one MemoryBackend protocol

### DIFF
--- a/src/mindroom/memory/_backend.py
+++ b/src/mindroom/memory/_backend.py
@@ -1,0 +1,150 @@
+"""Shared memory backend protocol and backend resolution."""
+
+from __future__ import annotations
+
+from functools import partial
+from typing import TYPE_CHECKING, Protocol
+
+from mindroom.memory.config import create_memory_instance
+
+from ._file_backend import FileMemoryBackend
+from ._mem0_backend import Mem0MemoryBackend
+from ._policy import caller_uses_disabled_memory_backend, caller_uses_file_memory_backend
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+    from mindroom.config.main import Config
+    from mindroom.constants import RuntimePaths
+    from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
+    from mindroom.tool_system.worker_routing import ToolExecutionIdentity
+
+    from ._shared import MemoryResult
+
+
+class MemoryBackend(Protocol):
+    """One storage backend behind the public memory facade.
+
+    Adapters implement every operation the facade dispatches, so call sites
+    resolve a backend once and never branch on backend type again.
+    """
+
+    context_label: str
+
+    async def add(
+        self,
+        content: str,
+        agent_name: str,
+        storage_path: Path,
+        config: Config,
+        *,
+        metadata: dict | None = None,
+        execution_identity: ToolExecutionIdentity | None = None,
+    ) -> None:
+        """Add one memory for an agent scope."""
+
+    async def search(
+        self,
+        query: str,
+        agent_name: str,
+        storage_path: Path,
+        config: Config,
+        *,
+        limit: int,
+        execution_identity: ToolExecutionIdentity | None = None,
+        timing_scope: str | None = None,
+    ) -> list[MemoryResult]:
+        """Search memories visible to an agent, including its team scopes."""
+
+    async def list_all(
+        self,
+        agent_name: str,
+        storage_path: Path,
+        config: Config,
+        *,
+        limit: int,
+        preserve_resolved_storage_path: bool = False,
+        execution_identity: ToolExecutionIdentity | None = None,
+    ) -> list[MemoryResult]:
+        """List memories stored for an agent scope."""
+
+    async def get(
+        self,
+        memory_id: str,
+        caller_context: str | list[str],
+        storage_path: Path,
+        config: Config,
+        *,
+        execution_identity: ToolExecutionIdentity | None = None,
+    ) -> MemoryResult | None:
+        """Return one memory visible to the caller, or None."""
+
+    async def update(
+        self,
+        memory_id: str,
+        content: str,
+        caller_context: str | list[str],
+        storage_path: Path,
+        config: Config,
+        *,
+        execution_identity: ToolExecutionIdentity | None = None,
+    ) -> None:
+        """Update one memory across its replica targets."""
+
+    async def delete(
+        self,
+        memory_id: str,
+        caller_context: str | list[str],
+        storage_path: Path,
+        config: Config,
+        *,
+        execution_identity: ToolExecutionIdentity | None = None,
+    ) -> None:
+        """Delete one memory across its replica targets."""
+
+    async def store_conversation(
+        self,
+        prompt: str,
+        agent_name: str | list[str],
+        storage_path: Path,
+        session_id: str,
+        config: Config,
+        *,
+        thread_history: Sequence[ResolvedVisibleMessage] | None = None,
+        user_id: str | None = None,
+        execution_identity: ToolExecutionIdentity | None = None,
+    ) -> None:
+        """Persist one conversation turn to the agent or team scope."""
+
+    def load_entrypoint_context(
+        self,
+        agent_name: str,
+        storage_path: Path,
+        config: Config,
+        *,
+        execution_identity: ToolExecutionIdentity | None = None,
+        timing_scope: str | None = None,
+    ) -> str:
+        """Return the stable session preamble context for an agent, if any."""
+
+
+def resolve_memory_backend(
+    caller_context: str | list[str],
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> MemoryBackend | None:
+    """Resolve the effective backend for one caller scope; None disables memory.
+
+    A team context (list of member names) resolves to the file backend only
+    when every member is file-backed, and to disabled only when every member
+    is disabled; otherwise it resolves to mem0.
+    """
+    if caller_uses_disabled_memory_backend(config, caller_context):
+        return None
+    if caller_uses_file_memory_backend(config, caller_context):
+        return FileMemoryBackend(runtime_paths=runtime_paths)
+    return Mem0MemoryBackend(
+        runtime_paths=runtime_paths,
+        create_memory=partial(create_memory_instance, runtime_paths=runtime_paths),
+    )

--- a/src/mindroom/memory/_backend.py
+++ b/src/mindroom/memory/_backend.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, ClassVar, Protocol
 
 from mindroom.memory.config import create_memory_instance
 
@@ -30,7 +30,7 @@ class MemoryBackend(Protocol):
     resolve a backend once and never branch on backend type again.
     """
 
-    context_label: str
+    context_label: ClassVar[str]
 
     async def add(
         self,

--- a/src/mindroom/memory/_file_backend.py
+++ b/src/mindroom/memory/_file_backend.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from datetime import datetime
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, ClassVar, cast
 from zoneinfo import ZoneInfo
 
 from mindroom.constants import resolve_config_relative_path
@@ -39,10 +40,12 @@ from ._shared import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from pathlib import Path
 
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
+    from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
     from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
 logger = get_logger(__name__)
@@ -455,7 +458,7 @@ def _replace_scope_memory_entry(
 
 
 @timed("system_prompt_assembly.memory_file_entrypoint_read")
-def load_scope_entrypoint_context(
+def _load_scope_entrypoint_context(
     scope_user_id: str,
     resolution: FileMemoryResolution,
     config: Config,
@@ -583,35 +586,6 @@ def _mutate_file_memory_targets(
     return scope_user_id, updated_targets, updated_resolutions
 
 
-def add_file_agent_memory(
-    content: str,
-    agent_name: str,
-    storage_path: Path,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    execution_identity: ToolExecutionIdentity | None = None,
-) -> None:
-    """Append one file-backed memory for an agent scope."""
-    resolution = resolve_file_memory_resolution(
-        storage_path,
-        config,
-        runtime_paths,
-        agent_name=agent_name,
-        execution_identity=execution_identity,
-    )
-    scope_user_id = agent_scope_user_id(agent_name)
-    _append_scope_memory_entry(scope_user_id, content, resolution, config)
-    _schedule_agent_semantic_refresh(
-        agent_name,
-        scope_user_id,
-        resolution,
-        config,
-        runtime_paths,
-        execution_identity=execution_identity,
-    )
-    logger.info("File memory added", agent=agent_name)
-
-
 def append_agent_daily_file_memory(
     content: str,
     agent_name: str,
@@ -691,286 +665,368 @@ def _search_team_file_scope_memories(
     )
 
 
-async def search_file_agent_memories(
-    query: str,
-    agent_name: str,
-    storage_path: Path,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    execution_identity: ToolExecutionIdentity | None = None,
-    *,
-    limit: int,
-    timing_scope: str | None = None,
-) -> list[MemoryResult]:
-    """Search file-backed memories visible to an agent."""
-    agent_resolution = resolve_file_memory_resolution(
-        storage_path,
-        config,
-        runtime_paths,
-        agent_name=agent_name,
-        execution_identity=execution_identity,
-    )
+@dataclass(frozen=True)
+class FileMemoryBackend:
+    """File-backed adapter implementing the shared memory backend surface."""
 
-    def keyword_results() -> list[MemoryResult]:
-        results = _search_agent_file_scope_memories(query, agent_name, agent_resolution, config, limit, timing_scope)
-        for result in results:
-            _tag_keyword_mode(result)
-        return results
+    runtime_paths: RuntimePaths
+    context_label: ClassVar[str] = "agent file"
 
-    search_config = config.get_agent_memory_search(agent_name)
-    if search_config.mode == "semantic":
-        scope_user_id = agent_scope_user_id(agent_name)
-        try:
-            results = await search_semantic_file_memories(
-                query,
-                scope_user_id=scope_user_id,
-                root=_scope_dir(scope_user_id, agent_resolution, config, create=False),
-                config=config,
-                runtime_paths=runtime_paths,
-                search_config=search_config,
-                limit=limit,
-                execution_identity=execution_identity,
-                timing_scope=timing_scope,
-            )
-        except SemanticFileMemoryIndexUnavailableError:
-            logger.debug("File-memory semantic index unavailable; falling back to keyword search", agent=agent_name)
-            results = keyword_results()
-        except Exception:
-            logger.exception("File-memory semantic search failed; falling back to keyword search", agent=agent_name)
-            results = keyword_results()
-    else:
-        results = keyword_results()
-
-    existing_memories = {result.get("memory", "") for result in results}
-    for team_id in get_team_ids_for_agent(agent_name, config):
-        for target_storage_path in storage_paths_for_scope_user_id(
-            team_id,
+    async def add(
+        self,
+        content: str,
+        agent_name: str,
+        storage_path: Path,
+        config: Config,
+        *,
+        metadata: dict | None = None,
+        execution_identity: ToolExecutionIdentity | None = None,
+    ) -> None:
+        """Append one file-backed memory for an agent scope."""
+        del metadata  # File memory entries persist plain text only.
+        resolution = resolve_file_memory_resolution(
             storage_path,
             config,
-            runtime_paths,
+            self.runtime_paths,
+            agent_name=agent_name,
             execution_identity=execution_identity,
-        ):
-            team_resolution = resolve_file_memory_resolution(
-                target_storage_path,
-                config,
-                runtime_paths,
-                original_storage_path=storage_path,
-                execution_identity=execution_identity,
-            )
-            for memory in _search_team_file_scope_memories(
-                team_id,
+        )
+        scope_user_id = agent_scope_user_id(agent_name)
+        _append_scope_memory_entry(scope_user_id, content, resolution, config)
+        _schedule_agent_semantic_refresh(
+            agent_name,
+            scope_user_id,
+            resolution,
+            config,
+            self.runtime_paths,
+            execution_identity=execution_identity,
+        )
+        logger.info("File memory added", agent=agent_name)
+
+    @timed("system_prompt_assembly.memory_search.file_backend")
+    async def search(
+        self,
+        query: str,
+        agent_name: str,
+        storage_path: Path,
+        config: Config,
+        *,
+        limit: int,
+        execution_identity: ToolExecutionIdentity | None = None,
+        timing_scope: str | None = None,
+    ) -> list[MemoryResult]:
+        """Search file-backed memories visible to an agent."""
+        agent_resolution = resolve_file_memory_resolution(
+            storage_path,
+            config,
+            self.runtime_paths,
+            agent_name=agent_name,
+            execution_identity=execution_identity,
+        )
+
+        def keyword_results() -> list[MemoryResult]:
+            results = _search_agent_file_scope_memories(
                 query,
-                team_resolution,
+                agent_name,
+                agent_resolution,
                 config,
                 limit,
                 timing_scope,
+            )
+            for result in results:
+                _tag_keyword_mode(result)
+            return results
+
+        search_config = config.get_agent_memory_search(agent_name)
+        if search_config.mode == "semantic":
+            scope_user_id = agent_scope_user_id(agent_name)
+            try:
+                results = await search_semantic_file_memories(
+                    query,
+                    scope_user_id=scope_user_id,
+                    root=_scope_dir(scope_user_id, agent_resolution, config, create=False),
+                    config=config,
+                    runtime_paths=self.runtime_paths,
+                    search_config=search_config,
+                    limit=limit,
+                    execution_identity=execution_identity,
+                    timing_scope=timing_scope,
+                )
+            except SemanticFileMemoryIndexUnavailableError:
+                logger.debug(
+                    "File-memory semantic index unavailable; falling back to keyword search",
+                    agent=agent_name,
+                )
+                results = keyword_results()
+            except Exception:
+                logger.exception(
+                    "File-memory semantic search failed; falling back to keyword search",
+                    agent=agent_name,
+                )
+                results = keyword_results()
+        else:
+            results = keyword_results()
+
+        existing_memories = {result.get("memory", "") for result in results}
+        for team_id in get_team_ids_for_agent(agent_name, config):
+            for target_storage_path in storage_paths_for_scope_user_id(
+                team_id,
+                storage_path,
+                config,
+                self.runtime_paths,
+                execution_identity=execution_identity,
             ):
-                memory_text = memory.get("memory", "")
-                if memory_text in existing_memories:
-                    continue
-                existing_memories.add(memory_text)
-                _tag_keyword_mode(memory)
-                results.append(memory)
-    results.sort(key=lambda item: cast("float", item.get("score", 0.0)), reverse=True)
-    return results[:limit]
+                team_resolution = resolve_file_memory_resolution(
+                    target_storage_path,
+                    config,
+                    self.runtime_paths,
+                    original_storage_path=storage_path,
+                    execution_identity=execution_identity,
+                )
+                for memory in _search_team_file_scope_memories(
+                    team_id,
+                    query,
+                    team_resolution,
+                    config,
+                    limit,
+                    timing_scope,
+                ):
+                    memory_text = memory.get("memory", "")
+                    if memory_text in existing_memories:
+                        continue
+                    existing_memories.add(memory_text)
+                    _tag_keyword_mode(memory)
+                    results.append(memory)
+        results.sort(key=lambda item: cast("float", item.get("score", 0.0)), reverse=True)
+        return results[:limit]
 
-
-def list_file_agent_memories(
-    agent_name: str,
-    storage_path: Path,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    execution_identity: ToolExecutionIdentity | None = None,
-    *,
-    limit: int,
-    preserve_resolved_storage_path: bool = False,
-) -> list[MemoryResult]:
-    """List file-backed memories stored for an agent."""
-    resolution = resolve_file_memory_resolution(
-        storage_path,
-        config,
-        runtime_paths,
-        agent_name=agent_name,
-        preserve_resolved_storage_path=preserve_resolved_storage_path,
-        execution_identity=execution_identity,
-    )
-    results, _ = _load_scope_id_entries(agent_scope_user_id(agent_name), resolution, config)
-    return results[:limit]
-
-
-def get_file_agent_memory(
-    memory_id: str,
-    caller_context: str | list[str],
-    storage_path: Path,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    execution_identity: ToolExecutionIdentity | None = None,
-) -> MemoryResult | None:
-    """Return one file-backed memory visible to the caller."""
-    return _find_file_anchor_memory_result(
-        memory_id,
-        caller_context,
-        storage_path,
-        config,
-        runtime_paths,
-        execution_identity=execution_identity,
-    )
-
-
-def update_file_agent_memory(
-    memory_id: str,
-    content: str,
-    caller_context: str | list[str],
-    storage_path: Path,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    execution_identity: ToolExecutionIdentity | None = None,
-) -> None:
-    """Update one file-backed memory across its replica targets."""
-    if (
-        anchor_result := _find_file_anchor_memory_result(
-            memory_id,
-            caller_context,
-            storage_path,
-            config,
-            runtime_paths,
-            execution_identity=execution_identity,
-        )
-    ) is None:
-        raise MemoryNotFoundError(memory_id)
-
-    scope_user_id, updated_targets, updated_resolutions = _mutate_file_memory_targets(
-        memory_id=memory_id,
-        content=content,
-        storage_path=storage_path,
-        config=config,
-        runtime_paths=runtime_paths,
-        anchor_result=anchor_result,
-        execution_identity=execution_identity,
-    )
-    if updated_targets > 0:
-        for resolution in updated_resolutions:
-            _schedule_scope_semantic_refresh(
-                scope_user_id,
-                resolution,
-                config,
-                runtime_paths,
-                execution_identity=execution_identity,
-            )
-        logger.info(
-            "File memory updated",
-            memory_id=memory_id,
-            scope=scope_user_id,
-            storage_targets=updated_targets,
-        )
-        return
-    raise MemoryNotFoundError(memory_id)
-
-
-def delete_file_agent_memory(
-    memory_id: str,
-    caller_context: str | list[str],
-    storage_path: Path,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    execution_identity: ToolExecutionIdentity | None = None,
-) -> None:
-    """Delete one file-backed memory across its replica targets."""
-    if (
-        anchor_result := _find_file_anchor_memory_result(
-            memory_id,
-            caller_context,
-            storage_path,
-            config,
-            runtime_paths,
-            execution_identity=execution_identity,
-        )
-    ) is None:
-        raise MemoryNotFoundError(memory_id)
-
-    scope_user_id, deleted_targets, deleted_resolutions = _mutate_file_memory_targets(
-        memory_id=memory_id,
-        content=None,
-        storage_path=storage_path,
-        config=config,
-        runtime_paths=runtime_paths,
-        anchor_result=anchor_result,
-        execution_identity=execution_identity,
-    )
-    if deleted_targets > 0:
-        for resolution in deleted_resolutions:
-            _schedule_scope_semantic_refresh(
-                scope_user_id,
-                resolution,
-                config,
-                runtime_paths,
-                execution_identity=execution_identity,
-            )
-        logger.info(
-            "File memory deleted",
-            memory_id=memory_id,
-            scope=scope_user_id,
-            storage_targets=deleted_targets,
-        )
-        return
-    raise MemoryNotFoundError(memory_id)
-
-
-def store_file_conversation_memory(
-    prompt: str,
-    agent_name: str | list[str],
-    storage_path: Path,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    execution_identity: ToolExecutionIdentity | None = None,
-) -> None:
-    """Persist condensed conversation text to file-backed memory scopes."""
-    condensed_prompt = " ".join(prompt.strip().split())
-    if not condensed_prompt:
-        return
-
-    target_storage_paths = effective_storage_paths_for_context(
-        agent_name,
-        storage_path,
-        config,
-        runtime_paths,
-        execution_identity=execution_identity,
-    )
-    scope_user_id = agent_scope_user_id(agent_name) if isinstance(agent_name, str) else build_team_user_id(agent_name)
-    team_memory_id = new_memory_id() if isinstance(agent_name, list) else None
-
-    for target_storage_path in target_storage_paths:
+    async def list_all(
+        self,
+        agent_name: str,
+        storage_path: Path,
+        config: Config,
+        *,
+        limit: int,
+        preserve_resolved_storage_path: bool = False,
+        execution_identity: ToolExecutionIdentity | None = None,
+    ) -> list[MemoryResult]:
+        """List file-backed memories stored for an agent."""
         resolution = resolve_file_memory_resolution(
-            target_storage_path,
+            storage_path,
             config,
-            runtime_paths,
-            agent_name=agent_name_from_scope_user_id(scope_user_id),
-            original_storage_path=storage_path,
+            self.runtime_paths,
+            agent_name=agent_name,
+            preserve_resolved_storage_path=preserve_resolved_storage_path,
             execution_identity=execution_identity,
         )
-        _append_scope_memory_entry(
-            scope_user_id,
-            condensed_prompt,
+        results, _ = _load_scope_id_entries(agent_scope_user_id(agent_name), resolution, config)
+        return results[:limit]
+
+    async def get(
+        self,
+        memory_id: str,
+        caller_context: str | list[str],
+        storage_path: Path,
+        config: Config,
+        *,
+        execution_identity: ToolExecutionIdentity | None = None,
+    ) -> MemoryResult | None:
+        """Return one file-backed memory visible to the caller."""
+        return _find_file_anchor_memory_result(
+            memory_id,
+            caller_context,
+            storage_path,
+            config,
+            self.runtime_paths,
+            execution_identity=execution_identity,
+        )
+
+    async def update(
+        self,
+        memory_id: str,
+        content: str,
+        caller_context: str | list[str],
+        storage_path: Path,
+        config: Config,
+        *,
+        execution_identity: ToolExecutionIdentity | None = None,
+    ) -> None:
+        """Update one file-backed memory across its replica targets."""
+        if (
+            anchor_result := _find_file_anchor_memory_result(
+                memory_id,
+                caller_context,
+                storage_path,
+                config,
+                self.runtime_paths,
+                execution_identity=execution_identity,
+            )
+        ) is None:
+            raise MemoryNotFoundError(memory_id)
+
+        scope_user_id, updated_targets, updated_resolutions = _mutate_file_memory_targets(
+            memory_id=memory_id,
+            content=content,
+            storage_path=storage_path,
+            config=config,
+            runtime_paths=self.runtime_paths,
+            anchor_result=anchor_result,
+            execution_identity=execution_identity,
+        )
+        if updated_targets > 0:
+            for resolution in updated_resolutions:
+                _schedule_scope_semantic_refresh(
+                    scope_user_id,
+                    resolution,
+                    config,
+                    self.runtime_paths,
+                    execution_identity=execution_identity,
+                )
+            logger.info(
+                "File memory updated",
+                memory_id=memory_id,
+                scope=scope_user_id,
+                storage_targets=updated_targets,
+            )
+            return
+        raise MemoryNotFoundError(memory_id)
+
+    async def delete(
+        self,
+        memory_id: str,
+        caller_context: str | list[str],
+        storage_path: Path,
+        config: Config,
+        *,
+        execution_identity: ToolExecutionIdentity | None = None,
+    ) -> None:
+        """Delete one file-backed memory across its replica targets."""
+        if (
+            anchor_result := _find_file_anchor_memory_result(
+                memory_id,
+                caller_context,
+                storage_path,
+                config,
+                self.runtime_paths,
+                execution_identity=execution_identity,
+            )
+        ) is None:
+            raise MemoryNotFoundError(memory_id)
+
+        scope_user_id, deleted_targets, deleted_resolutions = _mutate_file_memory_targets(
+            memory_id=memory_id,
+            content=None,
+            storage_path=storage_path,
+            config=config,
+            runtime_paths=self.runtime_paths,
+            anchor_result=anchor_result,
+            execution_identity=execution_identity,
+        )
+        if deleted_targets > 0:
+            for resolution in deleted_resolutions:
+                _schedule_scope_semantic_refresh(
+                    scope_user_id,
+                    resolution,
+                    config,
+                    self.runtime_paths,
+                    execution_identity=execution_identity,
+                )
+            logger.info(
+                "File memory deleted",
+                memory_id=memory_id,
+                scope=scope_user_id,
+                storage_targets=deleted_targets,
+            )
+            return
+        raise MemoryNotFoundError(memory_id)
+
+    async def store_conversation(
+        self,
+        prompt: str,
+        agent_name: str | list[str],
+        storage_path: Path,
+        session_id: str,
+        config: Config,
+        *,
+        thread_history: Sequence[ResolvedVisibleMessage] | None = None,
+        user_id: str | None = None,
+        execution_identity: ToolExecutionIdentity | None = None,
+    ) -> None:
+        """Persist condensed conversation text to file-backed memory scopes."""
+        del session_id, thread_history, user_id  # File conversation memory stores condensed text only.
+        condensed_prompt = " ".join(prompt.strip().split())
+        if not condensed_prompt:
+            return
+
+        target_storage_paths = effective_storage_paths_for_context(
+            agent_name,
+            storage_path,
+            config,
+            self.runtime_paths,
+            execution_identity=execution_identity,
+        )
+        scope_user_id = (
+            agent_scope_user_id(agent_name) if isinstance(agent_name, str) else build_team_user_id(agent_name)
+        )
+        team_memory_id = new_memory_id() if isinstance(agent_name, list) else None
+
+        for target_storage_path in target_storage_paths:
+            resolution = resolve_file_memory_resolution(
+                target_storage_path,
+                config,
+                self.runtime_paths,
+                agent_name=agent_name_from_scope_user_id(scope_user_id),
+                original_storage_path=storage_path,
+                execution_identity=execution_identity,
+            )
+            _append_scope_memory_entry(
+                scope_user_id,
+                condensed_prompt,
+                resolution,
+                config,
+                memory_id=team_memory_id,
+            )
+            if isinstance(agent_name, str):
+                _schedule_agent_semantic_refresh(
+                    agent_name,
+                    scope_user_id,
+                    resolution,
+                    config,
+                    self.runtime_paths,
+                    execution_identity=execution_identity,
+                )
+
+        if isinstance(agent_name, list):
+            logger.info(
+                "File team memory added",
+                team_id=scope_user_id,
+                members=agent_name,
+                storage_targets=len(target_storage_paths),
+            )
+        else:
+            logger.info("File memory added", agent=agent_name)
+
+    @timed("system_prompt_assembly.memory_file_entrypoint_load")
+    def load_entrypoint_context(
+        self,
+        agent_name: str,
+        storage_path: Path,
+        config: Config,
+        *,
+        execution_identity: ToolExecutionIdentity | None = None,
+        timing_scope: str | None = None,
+    ) -> str:
+        """Load the stable scoped `MEMORY.md` entrypoint text for one agent."""
+        resolution = resolve_file_memory_resolution(
+            storage_path,
+            config,
+            self.runtime_paths,
+            agent_name=agent_name,
+            execution_identity=execution_identity,
+        )
+        return _load_scope_entrypoint_context(
+            agent_scope_user_id(agent_name),
             resolution,
             config,
-            memory_id=team_memory_id,
+            timing_scope=timing_scope,
         )
-        if isinstance(agent_name, str):
-            _schedule_agent_semantic_refresh(
-                agent_name,
-                scope_user_id,
-                resolution,
-                config,
-                runtime_paths,
-                execution_identity=execution_identity,
-            )
-
-    if isinstance(agent_name, list):
-        logger.info(
-            "File team memory added",
-            team_id=scope_user_id,
-            members=agent_name,
-            storage_targets=len(target_storage_paths),
-        )
-    else:
-        logger.info("File memory added", agent=agent_name)

--- a/src/mindroom/memory/_mem0_backend.py
+++ b/src/mindroom/memory/_mem0_backend.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, cast
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, ClassVar, cast
 
 from mindroom.logging_config import get_logger
 from mindroom.timing import timed
@@ -17,13 +18,23 @@ from ._policy import (
     get_team_ids_for_agent,
     storage_paths_for_scope_user_id,
 )
-from ._shared import MEM0_REPLICA_KEY, MemoryNotFoundError, MemoryResult, ScopedMemoryCrud, ScopedMemoryWriter
+from ._prompting import build_memory_messages
+from ._shared import (
+    MEM0_REPLICA_KEY,
+    MemoryNotFoundError,
+    MemoryResult,
+    ScopedMemoryCrud,
+    ScopedMemoryWriter,
+    new_memory_id,
+)
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from pathlib import Path
 
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
+    from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
     from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
 _MemoryFactory = Callable[..., Awaitable[ScopedMemoryCrud]]
@@ -269,269 +280,286 @@ async def _add_mem0_scope_messages(
         logger.exception(failure_log, error=str(error), **failure_context)
 
 
-async def add_mem0_agent_memory(
-    content: str,
-    agent_name: str,
-    storage_path: Path,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    execution_identity: ToolExecutionIdentity | None = None,
-    *,
-    metadata: dict | None,
-    create_memory: _MemoryFactory,
-) -> None:
-    """Add one mem0 memory for an agent scope."""
-    resolved_storage_path = _primary_mem0_storage_path(
-        agent_name,
-        storage_path,
-        config,
-        runtime_paths,
-        execution_identity=execution_identity,
-    )
-    memory = await create_memory(resolved_storage_path, config)
-    metadata = dict(metadata or {})
-    metadata["agent"] = agent_name
-    messages = [{"role": "user", "content": content}]
-    try:
-        await memory.add(messages, user_id=agent_scope_user_id(agent_name), metadata=metadata)
-        logger.info("Memory added", agent=agent_name)
-    except Exception:
-        logger.exception("Failed to add memory", agent=agent_name)
-        raise
+@dataclass(frozen=True)
+class Mem0MemoryBackend:
+    """Mem0-backed adapter implementing the shared memory backend surface."""
 
+    runtime_paths: RuntimePaths
+    create_memory: _MemoryFactory
+    context_label: ClassVar[str] = "agent"
 
-async def search_mem0_agent_memories(
-    query: str,
-    agent_name: str,
-    storage_path: Path,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    execution_identity: ToolExecutionIdentity | None = None,
-    *,
-    limit: int,
-    create_memory: _MemoryFactory,
-    timing_scope: str | None = None,
-) -> list[MemoryResult]:
-    """Search mem0 memories visible to an agent."""
-    resolved_storage_path = _primary_mem0_storage_path(
-        agent_name,
-        storage_path,
-        config,
-        runtime_paths,
-        execution_identity=execution_identity,
-    )
-    memory = await _create_mem0_memory_instance(
-        resolved_storage_path,
-        config,
-        create_memory,
-        timing_scope,
-    )
-    results = await _search_mem0_agent_scope(memory, query, agent_name, limit)
-    existing_memories = {result.get("memory", "") for result in results}
+    async def add(
+        self,
+        content: str,
+        agent_name: str,
+        storage_path: Path,
+        config: Config,
+        *,
+        metadata: dict | None = None,
+        execution_identity: ToolExecutionIdentity | None = None,
+    ) -> None:
+        """Add one mem0 memory for an agent scope."""
+        resolved_storage_path = _primary_mem0_storage_path(
+            agent_name,
+            storage_path,
+            config,
+            self.runtime_paths,
+            execution_identity=execution_identity,
+        )
+        memory = await self.create_memory(resolved_storage_path, config)
+        metadata = dict(metadata or {})
+        metadata["agent"] = agent_name
+        messages = [{"role": "user", "content": content}]
+        try:
+            await memory.add(messages, user_id=agent_scope_user_id(agent_name), metadata=metadata)
+            logger.info("Memory added", agent=agent_name)
+        except Exception:
+            logger.exception("Failed to add memory", agent=agent_name)
+            raise
 
-    for team_id in get_team_ids_for_agent(agent_name, config):
-        team_memories = await _search_mem0_team_scope(memory, query, team_id, limit)
-        for memory_result in team_memories:
-            if memory_result.get("memory", "") not in existing_memories:
-                results.append(memory_result)
-                existing_memories.add(memory_result.get("memory", ""))
-        logger.debug("Team memories found", team_id=team_id, count=len(team_memories))
+    @timed("system_prompt_assembly.memory_search.mem0_backend")
+    async def search(
+        self,
+        query: str,
+        agent_name: str,
+        storage_path: Path,
+        config: Config,
+        *,
+        limit: int,
+        execution_identity: ToolExecutionIdentity | None = None,
+        timing_scope: str | None = None,
+    ) -> list[MemoryResult]:
+        """Search mem0 memories visible to an agent."""
+        resolved_storage_path = _primary_mem0_storage_path(
+            agent_name,
+            storage_path,
+            config,
+            self.runtime_paths,
+            execution_identity=execution_identity,
+        )
+        memory = await _create_mem0_memory_instance(
+            resolved_storage_path,
+            config,
+            self.create_memory,
+            timing_scope,
+        )
+        results = await _search_mem0_agent_scope(memory, query, agent_name, limit)
+        existing_memories = {result.get("memory", "") for result in results}
 
-    logger.debug("Total memories found", count=len(results), agent=agent_name)
-    return results[:limit]
+        for team_id in get_team_ids_for_agent(agent_name, config):
+            team_memories = await _search_mem0_team_scope(memory, query, team_id, limit)
+            for memory_result in team_memories:
+                if memory_result.get("memory", "") not in existing_memories:
+                    results.append(memory_result)
+                    existing_memories.add(memory_result.get("memory", ""))
+            logger.debug("Team memories found", team_id=team_id, count=len(team_memories))
 
+        logger.debug("Total memories found", count=len(results), agent=agent_name)
+        return results[:limit]
 
-async def list_mem0_agent_memories(
-    agent_name: str,
-    storage_path: Path,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    execution_identity: ToolExecutionIdentity | None = None,
-    *,
-    limit: int,
-    create_memory: _MemoryFactory,
-) -> list[MemoryResult]:
-    """List mem0 memories stored for an agent."""
-    resolved_storage_path = _primary_mem0_storage_path(
-        agent_name,
-        storage_path,
-        config,
-        runtime_paths,
-        execution_identity=execution_identity,
-    )
-    result = await create_memory(resolved_storage_path, config)
-    return _mem0_results(await result.get_all(filters=_scope_filter(agent_scope_user_id(agent_name)), top_k=limit))
+    async def list_all(
+        self,
+        agent_name: str,
+        storage_path: Path,
+        config: Config,
+        *,
+        limit: int,
+        preserve_resolved_storage_path: bool = False,
+        execution_identity: ToolExecutionIdentity | None = None,
+    ) -> list[MemoryResult]:
+        """List mem0 memories stored for an agent."""
+        del preserve_resolved_storage_path  # Only meaningful for file-backed storage roots.
+        resolved_storage_path = _primary_mem0_storage_path(
+            agent_name,
+            storage_path,
+            config,
+            self.runtime_paths,
+            execution_identity=execution_identity,
+        )
+        result = await self.create_memory(resolved_storage_path, config)
+        return _mem0_results(await result.get_all(filters=_scope_filter(agent_scope_user_id(agent_name)), top_k=limit))
 
-
-async def get_mem0_agent_memory(
-    memory_id: str,
-    caller_context: str | list[str],
-    storage_path: Path,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    execution_identity: ToolExecutionIdentity | None = None,
-    *,
-    create_memory: _MemoryFactory,
-) -> MemoryResult | None:
-    """Return one mem0 memory visible to the caller."""
-    return await _find_mem0_anchor_memory_result(
-        memory_id,
-        caller_context,
-        storage_path,
-        config,
-        runtime_paths,
-        create_memory=create_memory,
-        execution_identity=execution_identity,
-    )
-
-
-async def update_mem0_agent_memory(
-    memory_id: str,
-    content: str,
-    caller_context: str | list[str],
-    storage_path: Path,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    execution_identity: ToolExecutionIdentity | None = None,
-    *,
-    create_memory: _MemoryFactory,
-) -> None:
-    """Update one mem0 memory across its replica targets."""
-    if (
-        anchor_result := await _find_mem0_anchor_memory_result(
+    async def get(
+        self,
+        memory_id: str,
+        caller_context: str | list[str],
+        storage_path: Path,
+        config: Config,
+        *,
+        execution_identity: ToolExecutionIdentity | None = None,
+    ) -> MemoryResult | None:
+        """Return one mem0 memory visible to the caller."""
+        return await _find_mem0_anchor_memory_result(
             memory_id,
             caller_context,
             storage_path,
             config,
-            runtime_paths,
-            create_memory=create_memory,
+            self.runtime_paths,
+            create_memory=self.create_memory,
             execution_identity=execution_identity,
         )
-    ) is None:
+
+    async def update(
+        self,
+        memory_id: str,
+        content: str,
+        caller_context: str | list[str],
+        storage_path: Path,
+        config: Config,
+        *,
+        execution_identity: ToolExecutionIdentity | None = None,
+    ) -> None:
+        """Update one mem0 memory across its replica targets."""
+        if (
+            anchor_result := await _find_mem0_anchor_memory_result(
+                memory_id,
+                caller_context,
+                storage_path,
+                config,
+                self.runtime_paths,
+                create_memory=self.create_memory,
+                execution_identity=execution_identity,
+            )
+        ) is None:
+            raise MemoryNotFoundError(memory_id)
+
+        updated_targets = await _mutate_mem0_memory_targets(
+            memory_id=memory_id,
+            content=content,
+            operation="update",
+            caller_context=caller_context,
+            storage_path=storage_path,
+            config=config,
+            runtime_paths=self.runtime_paths,
+            anchor_result=anchor_result,
+            create_memory=self.create_memory,
+            execution_identity=execution_identity,
+        )
+        if updated_targets > 0:
+            logger.info("Memory updated", memory_id=memory_id, storage_targets=updated_targets)
+            return
         raise MemoryNotFoundError(memory_id)
 
-    updated_targets = await _mutate_mem0_memory_targets(
-        memory_id=memory_id,
-        content=content,
-        operation="update",
-        caller_context=caller_context,
-        storage_path=storage_path,
-        config=config,
-        runtime_paths=runtime_paths,
-        anchor_result=anchor_result,
-        create_memory=create_memory,
-        execution_identity=execution_identity,
-    )
-    if updated_targets > 0:
-        logger.info("Memory updated", memory_id=memory_id, storage_targets=updated_targets)
-        return
-    raise MemoryNotFoundError(memory_id)
+    async def delete(
+        self,
+        memory_id: str,
+        caller_context: str | list[str],
+        storage_path: Path,
+        config: Config,
+        *,
+        execution_identity: ToolExecutionIdentity | None = None,
+    ) -> None:
+        """Delete one mem0 memory across its replica targets."""
+        if (
+            anchor_result := await _find_mem0_anchor_memory_result(
+                memory_id,
+                caller_context,
+                storage_path,
+                config,
+                self.runtime_paths,
+                create_memory=self.create_memory,
+                execution_identity=execution_identity,
+            )
+        ) is None:
+            raise MemoryNotFoundError(memory_id)
 
+        deleted_targets = await _mutate_mem0_memory_targets(
+            memory_id=memory_id,
+            content=None,
+            operation="delete",
+            caller_context=caller_context,
+            storage_path=storage_path,
+            config=config,
+            runtime_paths=self.runtime_paths,
+            anchor_result=anchor_result,
+            create_memory=self.create_memory,
+            execution_identity=execution_identity,
+        )
+        if deleted_targets > 0:
+            logger.info("Memory deleted", memory_id=memory_id, storage_targets=deleted_targets)
+            return
+        raise MemoryNotFoundError(memory_id)
 
-async def delete_mem0_agent_memory(
-    memory_id: str,
-    caller_context: str | list[str],
-    storage_path: Path,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    execution_identity: ToolExecutionIdentity | None = None,
-    *,
-    create_memory: _MemoryFactory,
-) -> None:
-    """Delete one mem0 memory across its replica targets."""
-    if (
-        anchor_result := await _find_mem0_anchor_memory_result(
-            memory_id,
-            caller_context,
+    async def store_conversation(
+        self,
+        prompt: str,
+        agent_name: str | list[str],
+        storage_path: Path,
+        session_id: str,
+        config: Config,
+        *,
+        thread_history: Sequence[ResolvedVisibleMessage] | None = None,
+        user_id: str | None = None,
+        execution_identity: ToolExecutionIdentity | None = None,
+    ) -> None:
+        """Persist conversation messages to mem0-backed memory scopes."""
+        messages = build_memory_messages(prompt, thread_history, user_id)
+        if not messages:
+            return
+        replica_key = new_memory_id() if isinstance(agent_name, list) else None
+
+        target_storage_paths = effective_storage_paths_for_context(
+            agent_name,
             storage_path,
             config,
-            runtime_paths,
-            create_memory=create_memory,
+            self.runtime_paths,
             execution_identity=execution_identity,
         )
-    ) is None:
-        raise MemoryNotFoundError(memory_id)
 
-    deleted_targets = await _mutate_mem0_memory_targets(
-        memory_id=memory_id,
-        content=None,
-        operation="delete",
-        caller_context=caller_context,
-        storage_path=storage_path,
-        config=config,
-        runtime_paths=runtime_paths,
-        anchor_result=anchor_result,
-        create_memory=create_memory,
-        execution_identity=execution_identity,
-    )
-    if deleted_targets > 0:
-        logger.info("Memory deleted", memory_id=memory_id, storage_targets=deleted_targets)
-        return
-    raise MemoryNotFoundError(memory_id)
+        metadata: dict[str, object]
+        failure_context: dict[str, object]
+        if isinstance(agent_name, list):
+            scope_user_id = build_team_user_id(agent_name)
+            metadata = {
+                "type": "conversation",
+                "session_id": session_id,
+                "is_team": True,
+                "team_members": agent_name,
+            }
+            if replica_key is not None:
+                metadata[MEM0_REPLICA_KEY] = replica_key
+            failure_log = "Failed to add team memory"
+            failure_context = {"team_id": scope_user_id}
+        else:
+            scope_user_id = agent_scope_user_id(agent_name)
+            metadata = {
+                "type": "conversation",
+                "session_id": session_id,
+                "agent": agent_name,
+            }
+            failure_log = "Failed to add memory"
+            failure_context = {"agent": agent_name}
 
+        for target_storage_path in target_storage_paths:
+            memory = await self.create_memory(target_storage_path, config)
+            await _add_mem0_scope_messages(
+                memory=memory,
+                messages=messages,
+                user_id=scope_user_id,
+                metadata=metadata,
+                failure_log=failure_log,
+                failure_context=failure_context,
+            )
 
-async def store_mem0_conversation_memory(
-    messages: list[dict],
-    agent_name: str | list[str],
-    storage_path: Path,
-    session_id: str,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    execution_identity: ToolExecutionIdentity | None = None,
-    *,
-    replica_key: str | None,
-    create_memory: _MemoryFactory,
-) -> None:
-    """Persist conversation messages to mem0-backed memory scopes."""
-    target_storage_paths = effective_storage_paths_for_context(
-        agent_name,
-        storage_path,
-        config,
-        runtime_paths,
-        execution_identity=execution_identity,
-    )
+        if isinstance(agent_name, list):
+            logger.info(
+                "Team memory added",
+                team_id=scope_user_id,
+                members=agent_name,
+                storage_targets=len(target_storage_paths),
+            )
+        else:
+            logger.info("Memory added", agent=agent_name)
 
-    metadata: dict[str, object]
-    failure_context: dict[str, object]
-    if isinstance(agent_name, list):
-        scope_user_id = build_team_user_id(agent_name)
-        metadata = {
-            "type": "conversation",
-            "session_id": session_id,
-            "is_team": True,
-            "team_members": agent_name,
-        }
-        if replica_key is not None:
-            metadata[MEM0_REPLICA_KEY] = replica_key
-        failure_log = "Failed to add team memory"
-        failure_context = {"team_id": scope_user_id}
-    else:
-        scope_user_id = agent_scope_user_id(agent_name)
-        metadata = {
-            "type": "conversation",
-            "session_id": session_id,
-            "agent": agent_name,
-        }
-        failure_log = "Failed to add memory"
-        failure_context = {"agent": agent_name}
-
-    for target_storage_path in target_storage_paths:
-        memory = await create_memory(target_storage_path, config)
-        await _add_mem0_scope_messages(
-            memory=memory,
-            messages=messages,
-            user_id=scope_user_id,
-            metadata=metadata,
-            failure_log=failure_log,
-            failure_context=failure_context,
-        )
-
-    if isinstance(agent_name, list):
-        logger.info(
-            "Team memory added",
-            team_id=scope_user_id,
-            members=agent_name,
-            storage_targets=len(target_storage_paths),
-        )
-    else:
-        logger.info("Memory added", agent=agent_name)
+    def load_entrypoint_context(
+        self,
+        agent_name: str,
+        storage_path: Path,
+        config: Config,
+        *,
+        execution_identity: ToolExecutionIdentity | None = None,
+        timing_scope: str | None = None,
+    ) -> str:
+        """Return no stable entrypoint context; mem0 has no curated `MEMORY.md`."""
+        del agent_name, storage_path, config, execution_identity, timing_scope
+        return ""

--- a/src/mindroom/memory/_policy.py
+++ b/src/mindroom/memory/_policy.py
@@ -17,44 +17,38 @@ if TYPE_CHECKING:
     from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
 
-def use_file_memory_backend(config: Config, *, agent_name: str | None = None) -> bool:
-    """Return whether the resolved backend is file-backed."""
-    if agent_name is None:
-        return config.memory.backend == "file"
+def _agent_uses_file_memory_backend(config: Config, agent_name: str) -> bool:
     return config.get_agent_memory_backend(agent_name) == "file"
 
 
-def use_disabled_memory_backend(config: Config, *, agent_name: str | None = None) -> bool:
-    """Return whether the resolved backend disables memory."""
-    if agent_name is None:
-        return config.memory.backend == "none"
+def _agent_uses_disabled_memory_backend(config: Config, agent_name: str) -> bool:
     return config.get_agent_memory_backend(agent_name) == "none"
 
 
 def caller_uses_file_memory_backend(config: Config, caller_context: str | list[str]) -> bool:
     """Return whether the caller context resolves to file-backed memory."""
     if isinstance(caller_context, str):
-        return use_file_memory_backend(config, agent_name=caller_context)
-    return team_uses_file_memory_backend(config, caller_context)
+        return _agent_uses_file_memory_backend(config, caller_context)
+    return _team_uses_file_memory_backend(config, caller_context)
 
 
 def caller_uses_disabled_memory_backend(config: Config, caller_context: str | list[str]) -> bool:
     """Return whether the caller context resolves to disabled memory."""
     if isinstance(caller_context, str):
-        return use_disabled_memory_backend(config, agent_name=caller_context)
-    return team_uses_disabled_memory_backend(config, caller_context)
+        return _agent_uses_disabled_memory_backend(config, caller_context)
+    return _team_uses_disabled_memory_backend(config, caller_context)
 
 
-def team_uses_file_memory_backend(config: Config, agent_names: list[str]) -> bool:
+def _team_uses_file_memory_backend(config: Config, agent_names: list[str]) -> bool:
     """Return whether all team members resolve to file-backed memory."""
     config.assert_team_agents_supported(agent_names)
-    return all(use_file_memory_backend(config, agent_name=agent_name) for agent_name in agent_names)
+    return all(_agent_uses_file_memory_backend(config, agent_name) for agent_name in agent_names)
 
 
-def team_uses_disabled_memory_backend(config: Config, agent_names: list[str]) -> bool:
+def _team_uses_disabled_memory_backend(config: Config, agent_names: list[str]) -> bool:
     """Return whether all team members resolve to disabled memory."""
     config.assert_team_agents_supported(agent_names)
-    return all(use_disabled_memory_backend(config, agent_name=agent_name) for agent_name in agent_names)
+    return all(_agent_uses_disabled_memory_backend(config, agent_name) for agent_name in agent_names)
 
 
 def effective_storage_paths_for_context(

--- a/src/mindroom/memory/functions.py
+++ b/src/mindroom/memory/functions.py
@@ -3,48 +3,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from functools import partial
 from typing import TYPE_CHECKING
 
 from mindroom.logging_config import get_logger
-from mindroom.memory.config import create_memory_instance
 from mindroom.timing import timed
 
-from ._file_backend import (
-    add_file_agent_memory,
-    append_agent_daily_file_memory,
-    delete_file_agent_memory,
-    get_file_agent_memory,
-    list_file_agent_memories,
-    load_scope_entrypoint_context,
-    search_file_agent_memories,
-    store_file_conversation_memory,
-    update_file_agent_memory,
-)
-from ._mem0_backend import (
-    add_mem0_agent_memory,
-    delete_mem0_agent_memory,
-    get_mem0_agent_memory,
-    list_mem0_agent_memories,
-    search_mem0_agent_memories,
-    store_mem0_conversation_memory,
-    update_mem0_agent_memory,
-)
-from ._policy import (
-    agent_scope_user_id,
-    caller_uses_disabled_memory_backend,
-    caller_uses_file_memory_backend,
-    resolve_file_memory_resolution,
-    team_uses_disabled_memory_backend,
-    team_uses_file_memory_backend,
-    use_disabled_memory_backend,
-    use_file_memory_backend,
-)
-from ._prompting import build_memory_messages, format_memories_as_context
-from ._shared import MemoryResult, new_memory_id
+from ._backend import resolve_memory_backend
+from ._file_backend import append_agent_daily_file_memory
+from ._prompting import format_memories_as_context
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable, Sequence
+    from collections.abc import Sequence
     from pathlib import Path
 
     from mindroom.config.main import Config
@@ -52,7 +21,7 @@ if TYPE_CHECKING:
     from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
     from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
-    from ._shared import ScopedMemoryCrud
+    from ._shared import MemoryResult
 
 logger = get_logger(__name__)
 
@@ -65,83 +34,6 @@ class MemoryPromptParts:
     turn_context: str = ""
 
 
-def _create_memory_factory(
-    runtime_paths: RuntimePaths,
-) -> Callable[..., Awaitable[ScopedMemoryCrud]]:
-    return partial(create_memory_instance, runtime_paths=runtime_paths)
-
-
-@timed("system_prompt_assembly.memory_search.file_backend")
-async def _search_file_backend_memories(
-    query: str,
-    agent_name: str,
-    storage_path: Path,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    limit: int,
-    execution_identity: ToolExecutionIdentity | None,
-    timing_scope: str | None,
-) -> list[MemoryResult]:
-    return await search_file_agent_memories(
-        query,
-        agent_name,
-        storage_path,
-        config,
-        runtime_paths,
-        limit=limit,
-        execution_identity=execution_identity,
-        timing_scope=timing_scope,
-    )
-
-
-@timed("system_prompt_assembly.memory_search.mem0_backend")
-async def _search_mem0_backend_memories(
-    query: str,
-    agent_name: str,
-    storage_path: Path,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    limit: int,
-    execution_identity: ToolExecutionIdentity | None,
-    timing_scope: str | None,
-) -> list[MemoryResult]:
-    return await search_mem0_agent_memories(
-        query,
-        agent_name,
-        storage_path,
-        config,
-        runtime_paths,
-        limit=limit,
-        create_memory=_create_memory_factory(runtime_paths),
-        execution_identity=execution_identity,
-        timing_scope=timing_scope,
-    )
-
-
-@timed("system_prompt_assembly.memory_file_entrypoint_load")
-def _load_agent_file_entrypoint_context(
-    agent_name: str,
-    storage_path: Path,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    execution_identity: ToolExecutionIdentity | None,
-    timing_scope: str | None,
-) -> str:
-    resolution = resolve_file_memory_resolution(
-        storage_path,
-        config,
-        runtime_paths,
-        agent_name=agent_name,
-        execution_identity=execution_identity,
-    )
-    return load_scope_entrypoint_context(
-        agent_scope_user_id(agent_name),
-        resolution,
-        config,
-        timing_scope=timing_scope,
-    )
-
-
 async def add_agent_memory(
     content: str,
     agent_name: str,
@@ -152,26 +44,14 @@ async def add_agent_memory(
     execution_identity: ToolExecutionIdentity | None = None,
 ) -> None:
     """Add a memory for an agent."""
-    if use_disabled_memory_backend(config, agent_name=agent_name):
+    if (backend := resolve_memory_backend(agent_name, config, runtime_paths)) is None:
         return
-    if use_file_memory_backend(config, agent_name=agent_name):
-        add_file_agent_memory(
-            content,
-            agent_name,
-            storage_path,
-            config,
-            runtime_paths,
-            execution_identity=execution_identity,
-        )
-        return
-    await add_mem0_agent_memory(
+    await backend.add(
         content,
         agent_name,
         storage_path,
         config,
-        runtime_paths,
         metadata=metadata,
-        create_memory=_create_memory_factory(runtime_paths),
         execution_identity=execution_identity,
     )
 
@@ -210,25 +90,13 @@ async def search_agent_memories(
     timing_scope: str | None = None,
 ) -> list[MemoryResult]:
     """Search agent memories including team memories."""
-    if use_disabled_memory_backend(config, agent_name=agent_name):
+    if (backend := resolve_memory_backend(agent_name, config, runtime_paths)) is None:
         return []
-    if use_file_memory_backend(config, agent_name=agent_name):
-        return await _search_file_backend_memories(
-            query,
-            agent_name,
-            storage_path,
-            config,
-            runtime_paths,
-            limit=limit,
-            execution_identity=execution_identity,
-            timing_scope=timing_scope,
-        )
-    return await _search_mem0_backend_memories(
+    return await backend.search(
         query,
         agent_name,
         storage_path,
         config,
-        runtime_paths,
         limit=limit,
         execution_identity=execution_identity,
         timing_scope=timing_scope,
@@ -246,25 +114,14 @@ async def list_all_agent_memories(
     preserve_resolved_storage_path: bool = False,
 ) -> list[MemoryResult]:
     """List all memories for an agent."""
-    if use_disabled_memory_backend(config, agent_name=agent_name):
+    if (backend := resolve_memory_backend(agent_name, config, runtime_paths)) is None:
         return []
-    if use_file_memory_backend(config, agent_name=agent_name):
-        return list_file_agent_memories(
-            agent_name,
-            storage_path,
-            config,
-            runtime_paths,
-            limit=limit,
-            preserve_resolved_storage_path=preserve_resolved_storage_path,
-            execution_identity=execution_identity,
-        )
-    return await list_mem0_agent_memories(
+    return await backend.list_all(
         agent_name,
         storage_path,
         config,
-        runtime_paths,
         limit=limit,
-        create_memory=_create_memory_factory(runtime_paths),
+        preserve_resolved_storage_path=preserve_resolved_storage_path,
         execution_identity=execution_identity,
     )
 
@@ -278,24 +135,13 @@ async def get_agent_memory(
     execution_identity: ToolExecutionIdentity | None = None,
 ) -> MemoryResult | None:
     """Get a single memory by ID."""
-    if caller_uses_disabled_memory_backend(config, caller_context):
+    if (backend := resolve_memory_backend(caller_context, config, runtime_paths)) is None:
         return None
-    if caller_uses_file_memory_backend(config, caller_context):
-        return get_file_agent_memory(
-            memory_id,
-            caller_context,
-            storage_path,
-            config,
-            runtime_paths,
-            execution_identity=execution_identity,
-        )
-    return await get_mem0_agent_memory(
+    return await backend.get(
         memory_id,
         caller_context,
         storage_path,
         config,
-        runtime_paths,
-        create_memory=_create_memory_factory(runtime_paths),
         execution_identity=execution_identity,
     )
 
@@ -310,27 +156,14 @@ async def update_agent_memory(
     execution_identity: ToolExecutionIdentity | None = None,
 ) -> None:
     """Update a single memory by ID."""
-    if caller_uses_disabled_memory_backend(config, caller_context):
+    if (backend := resolve_memory_backend(caller_context, config, runtime_paths)) is None:
         return
-    if caller_uses_file_memory_backend(config, caller_context):
-        update_file_agent_memory(
-            memory_id,
-            content,
-            caller_context,
-            storage_path,
-            config,
-            runtime_paths,
-            execution_identity=execution_identity,
-        )
-        return
-    await update_mem0_agent_memory(
+    await backend.update(
         memory_id,
         content,
         caller_context,
         storage_path,
         config,
-        runtime_paths,
-        create_memory=_create_memory_factory(runtime_paths),
         execution_identity=execution_identity,
     )
 
@@ -344,25 +177,13 @@ async def delete_agent_memory(
     execution_identity: ToolExecutionIdentity | None = None,
 ) -> None:
     """Delete a single memory by ID."""
-    if caller_uses_disabled_memory_backend(config, caller_context):
+    if (backend := resolve_memory_backend(caller_context, config, runtime_paths)) is None:
         return
-    if caller_uses_file_memory_backend(config, caller_context):
-        delete_file_agent_memory(
-            memory_id,
-            caller_context,
-            storage_path,
-            config,
-            runtime_paths,
-            execution_identity=execution_identity,
-        )
-        return
-    await delete_mem0_agent_memory(
+    await backend.delete(
         memory_id,
         caller_context,
         storage_path,
         config,
-        runtime_paths,
-        create_memory=_create_memory_factory(runtime_paths),
         execution_identity=execution_identity,
     )
 
@@ -379,10 +200,9 @@ async def build_memory_prompt_parts(
 ) -> MemoryPromptParts:
     """Split stable entrypoint context from turn-local searched memories."""
     logger.debug("Building enhanced prompt", agent=agent_name)
-    if use_disabled_memory_backend(config, agent_name=agent_name):
+    if (backend := resolve_memory_backend(agent_name, config, runtime_paths)) is None:
         return MemoryPromptParts()
 
-    use_file_backend = use_file_memory_backend(config, agent_name=agent_name)
     agent_memories = await search_agent_memories(
         prompt,
         agent_name,
@@ -396,24 +216,20 @@ async def build_memory_prompt_parts(
         logger.debug("Agent memories added", count=len(agent_memories))
 
     session_preamble = ""
-    context_type = "agent"
-    if use_file_backend:
-        agent_entrypoint = _load_agent_file_entrypoint_context(
-            agent_name,
-            storage_path,
-            config,
-            runtime_paths,
-            execution_identity,
-            timing_scope,
-        )
-        if agent_entrypoint:
-            session_preamble = f"{config.get_prompt('FILE_MEMORY_ENTRYPOINT_HEADER')}\n{agent_entrypoint}"
-        context_type = "agent file"
+    agent_entrypoint = backend.load_entrypoint_context(
+        agent_name,
+        storage_path,
+        config,
+        execution_identity=execution_identity,
+        timing_scope=timing_scope,
+    )
+    if agent_entrypoint:
+        session_preamble = f"{config.get_prompt('FILE_MEMORY_ENTRYPOINT_HEADER')}\n{agent_entrypoint}"
 
     turn_context = (
         format_memories_as_context(
             agent_memories,
-            context_type,
+            backend.context_label,
             prompt_template=config.get_prompt("MEMORY_CONTEXT_PROMPT_TEMPLATE"),
         )
         if agent_memories
@@ -462,40 +278,15 @@ async def store_conversation_memory(
     """Store conversation in memory for future recall."""
     if not prompt:
         return
-
-    if isinstance(agent_name, str):
-        if use_disabled_memory_backend(config, agent_name=agent_name):
-            return
-    elif team_uses_disabled_memory_backend(config, agent_name):
+    if (backend := resolve_memory_backend(agent_name, config, runtime_paths)) is None:
         return
-
-    use_file_backend = (
-        use_file_memory_backend(config, agent_name=agent_name)
-        if isinstance(agent_name, str)
-        else team_uses_file_memory_backend(config, agent_name)
-    )
-    if use_file_backend:
-        store_file_conversation_memory(
-            prompt,
-            agent_name,
-            storage_path,
-            config,
-            runtime_paths,
-            execution_identity=execution_identity,
-        )
-        return
-
-    messages = build_memory_messages(prompt, thread_history, user_id)
-    if not messages:
-        return
-    await store_mem0_conversation_memory(
-        messages,
+    await backend.store_conversation(
+        prompt,
         agent_name,
         storage_path,
         session_id,
         config,
-        runtime_paths,
-        replica_key=new_memory_id() if isinstance(agent_name, list) else None,
-        create_memory=_create_memory_factory(runtime_paths),
+        thread_history=thread_history,
+        user_id=user_id,
         execution_identity=execution_identity,
     )

--- a/tach.toml
+++ b/tach.toml
@@ -1153,10 +1153,20 @@ depends_on = [
     "mindroom.runtime_resolution",
 ]
 visibility = [
+    "mindroom.memory._backend",
     "mindroom.memory._file_backend",
     "mindroom.memory._mem0_backend",
-    "mindroom.memory.functions",
 ]
+
+[[modules]]
+path = "mindroom.memory._backend"
+depends_on = [
+    "mindroom.memory._file_backend",
+    "mindroom.memory._mem0_backend",
+    "mindroom.memory._policy",
+    "mindroom.memory.config",
+]
+visibility = ["mindroom.memory.functions"]
 
 [[modules]]
 path = "mindroom.memory.auto_flush"
@@ -1173,12 +1183,9 @@ depends_on = [
 path = "mindroom.memory.functions"
 depends_on = [
     "mindroom.logging_config",
+    "mindroom.memory._backend",
     "mindroom.memory._file_backend",
-    "mindroom.memory._mem0_backend",
-    "mindroom.memory._policy",
     "mindroom.memory._prompting",
-    "mindroom.memory._shared",
-    "mindroom.memory.config",
     "mindroom.timing",
 ]
 visibility = ["mindroom.memory", "mindroom.memory.auto_flush"]
@@ -1206,7 +1213,7 @@ depends_on = [
     "mindroom.logging_config",
     "mindroom.timing",
 ]
-visibility = ["mindroom.memory.functions"]
+visibility = ["mindroom.memory._backend"]
 
 [[modules]]
 path = "mindroom.memory._file_backend"
@@ -1218,7 +1225,7 @@ depends_on = [
     "mindroom.memory._semantic_file_search",
     "mindroom.timing",
 ]
-visibility = ["mindroom.memory.functions"]
+visibility = ["mindroom.memory._backend", "mindroom.memory.functions"]
 
 [[modules]]
 path = "mindroom.memory._semantic_file_search"
@@ -1235,15 +1242,16 @@ path = "mindroom.memory._mem0_backend"
 depends_on = [
     "mindroom.logging_config",
     "mindroom.memory._policy",
+    "mindroom.memory._prompting",
     "mindroom.memory._shared",
     "mindroom.timing",
 ]
-visibility = ["mindroom.memory.functions"]
+visibility = ["mindroom.memory._backend"]
 
 [[modules]]
 path = "mindroom.memory._prompting"
 depends_on = ["mindroom.memory._shared", "mindroom.prompt_templates"]
-visibility = ["mindroom.memory", "mindroom.memory.functions"]
+visibility = ["mindroom.memory", "mindroom.memory._mem0_backend", "mindroom.memory.functions"]
 
 [[modules]]
 path = "mindroom.prompt_templates"
@@ -2455,6 +2463,13 @@ depends_on = [
     "mindroom.knowledge.registry",
     "mindroom.logging_config",
 ]
+
+[[interfaces]]
+expose = [
+    "MemoryBackend",
+    "resolve_memory_backend",
+]
+from = ["mindroom.memory._backend"]
 
 [[interfaces]]
 expose = [

--- a/tests/test_memory_backend_contract.py
+++ b/tests/test_memory_backend_contract.py
@@ -1,0 +1,175 @@
+"""Contract tests running the same behavior against both memory backend adapters."""
+# ruff: noqa: D103
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mindroom.config.agent import AgentConfig
+from mindroom.config.main import Config
+from mindroom.constants import resolve_runtime_paths
+from mindroom.memory._backend import resolve_memory_backend
+from mindroom.memory._file_backend import FileMemoryBackend
+from mindroom.memory._mem0_backend import Mem0MemoryBackend
+from mindroom.memory._shared import MemoryNotFoundError
+from tests.conftest import bind_runtime_paths, runtime_paths_for
+from tests.memory_test_support import FakeMem0ScopedMemory, MockTeamConfig
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from mindroom.memory._backend import MemoryBackend
+
+
+@dataclass
+class BackendEnv:
+    """One adapter under test plus the config and storage it operates on."""
+
+    backend: MemoryBackend
+    config: Config
+    storage_path: Path
+
+
+def _contract_config(tmp_path: Path, memory_backend: str) -> Config:
+    runtime_paths = resolve_runtime_paths(config_path=tmp_path / "config.yaml", storage_path=tmp_path)
+    config = bind_runtime_paths(
+        Config(
+            agents={
+                "alpha": AgentConfig(display_name="Alpha", role="First assistant"),
+                "beta": AgentConfig(display_name="Beta", role="Second assistant"),
+            },
+        ),
+        runtime_paths,
+    )
+    config.memory.backend = memory_backend
+    config.teams = {"pair": MockTeamConfig(agents=["alpha", "beta"])}
+    return config
+
+
+@pytest.fixture(params=["file", "mem0"])
+def backend_env(request: pytest.FixtureRequest, tmp_path: Path) -> BackendEnv:
+    config = _contract_config(tmp_path, request.param)
+    runtime_paths = runtime_paths_for(config)
+    backend: MemoryBackend
+    if request.param == "file":
+        backend = FileMemoryBackend(runtime_paths=runtime_paths)
+    else:
+        stores: dict[Path, FakeMem0ScopedMemory] = {}
+
+        async def create_fake_memory(
+            scope_storage_path: Path,
+            _config: Config,
+            *,
+            timing_scope: str | None = None,
+        ) -> FakeMem0ScopedMemory:
+            del timing_scope
+            return stores.setdefault(scope_storage_path, FakeMem0ScopedMemory())
+
+        backend = Mem0MemoryBackend(runtime_paths=runtime_paths, create_memory=create_fake_memory)
+    return BackendEnv(backend=backend, config=config, storage_path=tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_add_search_get_update_delete_roundtrip(backend_env: BackendEnv) -> None:
+    backend, config, storage_path = backend_env.backend, backend_env.config, backend_env.storage_path
+
+    await backend.add("Prefers green tea in the morning", "alpha", storage_path, config)
+    results = await backend.search("green tea", "alpha", storage_path, config, limit=5)
+    assert [result["memory"] for result in results] == ["Prefers green tea in the morning"]
+    memory_id = results[0]["id"]
+
+    loaded = await backend.get(memory_id, "alpha", storage_path, config)
+    assert loaded is not None
+    assert loaded["memory"] == "Prefers green tea in the morning"
+
+    await backend.update(memory_id, "Prefers black coffee instead", "alpha", storage_path, config)
+    updated = await backend.get(memory_id, "alpha", storage_path, config)
+    assert updated is not None
+    assert updated["memory"] == "Prefers black coffee instead"
+
+    await backend.delete(memory_id, "alpha", storage_path, config)
+    assert await backend.get(memory_id, "alpha", storage_path, config) is None
+    assert await backend.search("black coffee", "alpha", storage_path, config, limit=5) == []
+    with pytest.raises(MemoryNotFoundError):
+        await backend.delete(memory_id, "alpha", storage_path, config)
+
+
+@pytest.mark.asyncio
+async def test_list_all_returns_only_agent_scope(backend_env: BackendEnv) -> None:
+    backend, config, storage_path = backend_env.backend, backend_env.config, backend_env.storage_path
+
+    await backend.add("Alpha fact one", "alpha", storage_path, config)
+    await backend.add("Alpha fact two", "alpha", storage_path, config)
+    await backend.add("Beta fact", "beta", storage_path, config)
+
+    alpha_memories = await backend.list_all("alpha", storage_path, config, limit=10)
+    assert sorted(memory["memory"] for memory in alpha_memories) == ["Alpha fact one", "Alpha fact two"]
+    beta_memories = await backend.list_all("beta", storage_path, config, limit=10)
+    assert [memory["memory"] for memory in beta_memories] == ["Beta fact"]
+
+
+@pytest.mark.asyncio
+async def test_agent_scope_memories_invisible_to_other_agents(backend_env: BackendEnv) -> None:
+    backend, config, storage_path = backend_env.backend, backend_env.config, backend_env.storage_path
+
+    await backend.add("Alpha secret preference", "alpha", storage_path, config)
+    assert await backend.search("Alpha secret", "beta", storage_path, config, limit=5) == []
+
+    alpha_results = await backend.search("Alpha secret", "alpha", storage_path, config, limit=5)
+    assert len(alpha_results) == 1
+    memory_id = alpha_results[0]["id"]
+    assert await backend.get(memory_id, "beta", storage_path, config) is None
+    with pytest.raises(MemoryNotFoundError):
+        await backend.update(memory_id, "Hijacked by beta", "beta", storage_path, config)
+
+
+@pytest.mark.asyncio
+async def test_team_conversation_memory_visible_to_members_but_not_member_scoped(backend_env: BackendEnv) -> None:
+    backend, config, storage_path = backend_env.backend, backend_env.config, backend_env.storage_path
+
+    await backend.store_conversation(
+        "Quarterly metrics reviewed by the pair team",
+        ["alpha", "beta"],
+        storage_path,
+        "session-team",
+        config,
+    )
+
+    for member in ("alpha", "beta"):
+        results = await backend.search("Quarterly metrics", member, storage_path, config, limit=5)
+        assert [result["user_id"] for result in results] == ["team_alpha+beta"]
+        assert results[0]["memory"] == "Quarterly metrics reviewed by the pair team"
+
+    for member in ("alpha", "beta"):
+        assert await backend.list_all(member, storage_path, config, limit=10) == []
+
+
+@pytest.mark.asyncio
+async def test_single_agent_conversation_memory_stays_member_scoped(backend_env: BackendEnv) -> None:
+    backend, config, storage_path = backend_env.backend, backend_env.config, backend_env.storage_path
+
+    await backend.store_conversation("Alpha solo reflection", "alpha", storage_path, "session-solo", config)
+
+    alpha_results = await backend.search("Alpha solo", "alpha", storage_path, config, limit=5)
+    assert [result["user_id"] for result in alpha_results] == ["agent_alpha"]
+    assert await backend.search("Alpha solo", "beta", storage_path, config, limit=5) == []
+
+
+def test_resolve_memory_backend_maps_scopes_to_adapters(tmp_path: Path) -> None:
+    config = _contract_config(tmp_path, "file")
+    config.agents["beta"].memory_backend = "mem0"
+    runtime_paths = runtime_paths_for(config)
+
+    assert isinstance(resolve_memory_backend("alpha", config, runtime_paths), FileMemoryBackend)
+    assert isinstance(resolve_memory_backend("beta", config, runtime_paths), Mem0MemoryBackend)
+    assert isinstance(resolve_memory_backend(["alpha", "alpha"], config, runtime_paths), FileMemoryBackend)
+    # Mixed teams currently resolve to mem0; PR #798's partitioned-team fix
+    # slots in here as a new MemoryBackend implementation.
+    assert isinstance(resolve_memory_backend(["alpha", "beta"], config, runtime_paths), Mem0MemoryBackend)
+
+    config.agents["alpha"].memory_backend = "none"
+    assert resolve_memory_backend("alpha", config, runtime_paths) is None
+    assert resolve_memory_backend(["alpha", "alpha"], config, runtime_paths) is None

--- a/tests/test_memory_facade.py
+++ b/tests/test_memory_facade.py
@@ -208,7 +208,7 @@ class TestMemoryFacade:
 
     @pytest.mark.asyncio
     async def test_memory_instance_creation(self, mock_memory: AsyncMock, storage_path: Path, config: Config) -> None:
-        with patch("mindroom.memory.functions.create_memory_instance", return_value=mock_memory) as mock_create:
+        with patch("mindroom.memory._backend.create_memory_instance", return_value=mock_memory) as mock_create:
             await add_agent_memory("Test content", "test_agent", storage_path, config)
             assert mock_create.call_args[0][0] == agent_state_root_path(storage_path, "test_agent")
 
@@ -217,7 +217,7 @@ class TestMemoryFacade:
 
     @pytest.mark.asyncio
     async def test_add_agent_memory(self, mock_memory: AsyncMock, storage_path: Path, config: Config) -> None:
-        with patch("mindroom.memory.functions.create_memory_instance", return_value=mock_memory):
+        with patch("mindroom.memory._backend.create_memory_instance", return_value=mock_memory):
             await add_agent_memory(
                 "Test memory content",
                 "test_agent",
@@ -243,7 +243,7 @@ class TestMemoryFacade:
         mock_memory.add.side_effect = Exception("Memory error")
 
         with (
-            patch("mindroom.memory.functions.create_memory_instance", return_value=mock_memory),
+            patch("mindroom.memory._backend.create_memory_instance", return_value=mock_memory),
             pytest.raises(Exception, match="Memory error"),
         ):
             await add_agent_memory("Test content", "test_agent", storage_path, config)
@@ -255,7 +255,7 @@ class TestMemoryFacade:
         ]
         mock_memory.search.return_value = {"results": mock_results}
 
-        with patch("mindroom.memory.functions.create_memory_instance", return_value=mock_memory):
+        with patch("mindroom.memory._backend.create_memory_instance", return_value=mock_memory):
             results = await search_agent_memories("calculation", "calculator", storage_path, config, limit=5)
 
             mock_memory.search.assert_called_once_with(
@@ -274,7 +274,7 @@ class TestMemoryFacade:
     ) -> None:
         mock_memory.search.return_value = {"results": [{"memory": "test"}]}
 
-        with patch("mindroom.memory.functions.create_memory_instance", return_value=mock_memory):
+        with patch("mindroom.memory._backend.create_memory_instance", return_value=mock_memory):
             results = await search_agent_memories("query", "agent", storage_path, config)
             assert results == [{"memory": "test"}]
 
@@ -287,7 +287,7 @@ class TestMemoryFacade:
     ) -> None:
         mock_memory.search.return_value = [{"memory": "test"}]
 
-        with patch("mindroom.memory.functions.create_memory_instance", return_value=mock_memory):
+        with patch("mindroom.memory._backend.create_memory_instance", return_value=mock_memory):
             results = await search_agent_memories("query", "agent", storage_path, config)
             assert results == []
 
@@ -300,7 +300,7 @@ class TestMemoryFacade:
     ) -> None:
         mock_memory.get.return_value = {"id": "mem-1", "memory": "Own memory", "user_id": "agent_test_agent"}
 
-        with patch("mindroom.memory.functions.create_memory_instance", return_value=mock_memory):
+        with patch("mindroom.memory._backend.create_memory_instance", return_value=mock_memory):
             result = await get_agent_memory("mem-1", "test_agent", storage_path, config)
 
         assert result is not None
@@ -316,7 +316,7 @@ class TestMemoryFacade:
     ) -> None:
         mock_memory.get.return_value = {"id": "mem-1", "memory": "Other memory", "user_id": "agent_other_agent"}
 
-        with patch("mindroom.memory.functions.create_memory_instance", return_value=mock_memory):
+        with patch("mindroom.memory._backend.create_memory_instance", return_value=mock_memory):
             result = await get_agent_memory("mem-1", "test_agent", storage_path, config)
 
         assert result is None
@@ -332,7 +332,7 @@ class TestMemoryFacade:
         config.teams = {"test_team": MockTeamConfig(agents=["helper", "test_agent"])}
         mock_memory.get.return_value = {"id": "mem-team", "memory": "Team memory", "user_id": "team_helper+test_agent"}
 
-        with patch("mindroom.memory.functions.create_memory_instance", return_value=mock_memory):
+        with patch("mindroom.memory._backend.create_memory_instance", return_value=mock_memory):
             result = await get_agent_memory("mem-team", "test_agent", storage_path, config)
 
         assert result is not None
@@ -348,7 +348,7 @@ class TestMemoryFacade:
     ) -> None:
         mock_memory.get.return_value = {"id": "mem-member", "memory": "Member memory", "user_id": "agent_helper"}
 
-        with patch("mindroom.memory.functions.create_memory_instance", return_value=mock_memory):
+        with patch("mindroom.memory._backend.create_memory_instance", return_value=mock_memory):
             result = await get_agent_memory("mem-member", ["helper", "test_agent"], storage_path, config)
 
         assert result is None
@@ -365,7 +365,7 @@ class TestMemoryFacade:
         config.memory.team_reads_member_memory = True
         mock_memory.get.return_value = {"id": "mem-member", "memory": "Member memory", "user_id": "agent_helper"}
 
-        with patch("mindroom.memory.functions.create_memory_instance", return_value=mock_memory):
+        with patch("mindroom.memory._backend.create_memory_instance", return_value=mock_memory):
             result = await get_agent_memory("mem-member", ["helper", "test_agent"], storage_path, config)
 
         assert result is not None
@@ -382,7 +382,7 @@ class TestMemoryFacade:
         mock_memory.get.return_value = {"id": "mem-1", "memory": "Other memory", "user_id": "agent_other_agent"}
 
         with (
-            patch("mindroom.memory.functions.create_memory_instance", return_value=mock_memory),
+            patch("mindroom.memory._backend.create_memory_instance", return_value=mock_memory),
             pytest.raises(ValueError, match="No memory found with id=mem-1"),
         ):
             await update_agent_memory("mem-1", "Updated content", "test_agent", storage_path, config)
@@ -399,7 +399,7 @@ class TestMemoryFacade:
         mock_memory.get.return_value = {"id": "mem-1", "memory": "Other memory", "user_id": "agent_other_agent"}
 
         with (
-            patch("mindroom.memory.functions.create_memory_instance", return_value=mock_memory),
+            patch("mindroom.memory._backend.create_memory_instance", return_value=mock_memory),
             pytest.raises(ValueError, match="No memory found with id=mem-1"),
         ):
             await delete_agent_memory("mem-1", "test_agent", storage_path, config)
@@ -438,7 +438,7 @@ class TestMemoryFacade:
         agent_memories = [{"memory": "I previously calculated 2+2=4", "id": "1"}]
         mock_memory.search.return_value = {"results": agent_memories}
 
-        with patch("mindroom.memory.functions.create_memory_instance", return_value=mock_memory):
+        with patch("mindroom.memory._backend.create_memory_instance", return_value=mock_memory):
             prompt_parts = await build_memory_prompt_parts(
                 "What is 3+3?",
                 "calculator",
@@ -461,7 +461,7 @@ class TestMemoryFacade:
     ) -> None:
         mock_memory.search.return_value = {"results": []}
 
-        with patch("mindroom.memory.functions.create_memory_instance", return_value=mock_memory):
+        with patch("mindroom.memory._backend.create_memory_instance", return_value=mock_memory):
             prompt_parts = await build_memory_prompt_parts("Original prompt", "agent", storage_path, config)
 
         assert prompt_parts == MemoryPromptParts()
@@ -475,7 +475,7 @@ class TestMemoryFacade:
         config.memory.backend = "none"
 
         with patch(
-            "mindroom.memory.functions.create_memory_instance",
+            "mindroom.memory._backend.create_memory_instance",
             side_effect=AssertionError("disabled memory must not create Mem0"),
         ) as mock_create:
             prompt_parts = await build_memory_prompt_parts("Original prompt", "agent", storage_path, config)
@@ -485,7 +485,7 @@ class TestMemoryFacade:
 
     @pytest.mark.asyncio
     async def test_store_conversation_memory(self, mock_memory: AsyncMock, storage_path: Path, config: Config) -> None:
-        with patch("mindroom.memory.functions.create_memory_instance", return_value=mock_memory):
+        with patch("mindroom.memory._backend.create_memory_instance", return_value=mock_memory):
             await store_conversation_memory(
                 "What is 2+2?",
                 "calculator",
@@ -507,7 +507,7 @@ class TestMemoryFacade:
         storage_path: Path,
         config: Config,
     ) -> None:
-        with patch("mindroom.memory.functions.create_memory_instance", return_value=mock_memory):
+        with patch("mindroom.memory._backend.create_memory_instance", return_value=mock_memory):
             await store_conversation_memory("", "agent", storage_path, "session123", config)
 
         mock_memory.add.assert_not_called()
@@ -521,7 +521,7 @@ class TestMemoryFacade:
         config.memory.backend = "none"
 
         with patch(
-            "mindroom.memory.functions.create_memory_instance",
+            "mindroom.memory._backend.create_memory_instance",
             side_effect=AssertionError("disabled memory must not create Mem0"),
         ) as mock_create:
             await store_conversation_memory("Remember this", "calculator", storage_path, "session123", config)
@@ -543,7 +543,7 @@ class TestMemoryFacade:
         storage_path: Path,
         config: Config,
     ) -> None:
-        with patch("mindroom.memory.functions.create_memory_instance", return_value=mock_memory):
+        with patch("mindroom.memory._backend.create_memory_instance", return_value=mock_memory):
             await store_conversation_memory("What is 2+2?", "calculator", storage_path, "session123", config)
 
         assert mock_memory.add.call_count == 1
@@ -563,7 +563,7 @@ class TestMemoryFacade:
             make_visible_message(sender="@user:matrix.org", body="Yes please"),
         ]
 
-        with patch("mindroom.memory.functions.create_memory_instance", return_value=mock_memory):
+        with patch("mindroom.memory._backend.create_memory_instance", return_value=mock_memory):
             await store_conversation_memory(
                 "What is 2+2?",
                 "calculator",
@@ -591,7 +591,7 @@ class TestMemoryFacade:
     ) -> None:
         team_agents = ["calculator", "data_analyst", "finance"]
 
-        with patch("mindroom.memory.functions.create_memory_instance", return_value=mock_memory):
+        with patch("mindroom.memory._backend.create_memory_instance", return_value=mock_memory):
             await store_conversation_memory(
                 "Analyze our Q4 financial data",
                 team_agents,
@@ -618,7 +618,7 @@ class TestMemoryFacade:
         config.memory.backend = "file"
         config.agents["calculator"].memory_backend = "mem0"
 
-        with patch("mindroom.memory.functions.create_memory_instance", return_value=mock_memory) as mock_create:
+        with patch("mindroom.memory._backend.create_memory_instance", return_value=mock_memory) as mock_create:
             await store_conversation_memory("What is 2+2?", "calculator", storage_path, "session123", config)
 
         mock_create.assert_called_once_with(
@@ -639,7 +639,7 @@ class TestMemoryFacade:
         config.memory.file.path = str(storage_path / "memory-files")
         config.agents["calculator"].memory_backend = "mem0"
 
-        with patch("mindroom.memory.functions.create_memory_instance", return_value=mock_memory) as mock_create:
+        with patch("mindroom.memory._backend.create_memory_instance", return_value=mock_memory) as mock_create:
             await store_conversation_memory(
                 "Analyze our quarterly metrics",
                 ["calculator", "finance"],
@@ -673,7 +673,7 @@ class TestMemoryFacade:
         config.memory.backend = "none"
 
         with patch(
-            "mindroom.memory.functions.create_memory_instance",
+            "mindroom.memory._backend.create_memory_instance",
             side_effect=AssertionError("disabled memory must not create Mem0"),
         ) as mock_create:
             await add_agent_memory("Remember this", "general", storage_path, config)
@@ -709,7 +709,7 @@ class TestMemoryFacade:
 
         mock_memory.search = AsyncMock(side_effect=search_side_effect)
 
-        with patch("mindroom.memory.functions.create_memory_instance", return_value=mock_memory):
+        with patch("mindroom.memory._backend.create_memory_instance", return_value=mock_memory):
             results = await search_agent_memories("test query", "calculator", storage_path, config, limit=5)
 
         assert len(results) == 2
@@ -728,7 +728,7 @@ class TestMemoryFacade:
         config.memory.file.path = str(storage_path / "memory-files")
         config.agents["general"].memory_backend = "file"
 
-        with patch("mindroom.memory.functions.create_memory_instance", return_value=mock_memory) as mock_create:
+        with patch("mindroom.memory._backend.create_memory_instance", return_value=mock_memory) as mock_create:
             await add_agent_memory("Remember this", "general", storage_path, config)
 
         mock_create.assert_not_called()
@@ -746,7 +746,7 @@ class TestMemoryFacade:
         config.memory.backend = "file"
         config.agents["general"].memory_backend = "mem0"
 
-        with patch("mindroom.memory.functions.create_memory_instance", return_value=mock_memory) as mock_create:
+        with patch("mindroom.memory._backend.create_memory_instance", return_value=mock_memory) as mock_create:
             await add_agent_memory("Remember this", "general", storage_path, config)
 
         mock_create.assert_called_once_with(
@@ -773,7 +773,7 @@ class TestMemoryFacade:
         calculator_memory_id = calculator_memories[0]["id"]
 
         with patch(
-            "mindroom.memory.functions.create_memory_instance",
+            "mindroom.memory._backend.create_memory_instance",
             side_effect=AssertionError("Mem0 should not be used for file-backed team context"),
         ):
             allowed = await get_agent_memory(

--- a/tests/test_memory_integration.py
+++ b/tests/test_memory_integration.py
@@ -160,7 +160,7 @@ class TestMemoryIntegration:
 
         with (
             patch("mindroom.ai.create_agent", side_effect=Exception("Model error")),
-            patch("mindroom.memory.functions.create_memory_instance", return_value=mock_memory),
+            patch("mindroom.memory._backend.create_memory_instance", return_value=mock_memory),
         ):
             response = await ai_response(
                 agent_name="general",
@@ -183,7 +183,7 @@ class TestMemoryIntegration:
         mock_memory.search.return_value = {"results": []}
 
         with (
-            patch("mindroom.memory.functions.create_memory_instance", return_value=mock_memory),
+            patch("mindroom.memory._backend.create_memory_instance", return_value=mock_memory),
             patch("mindroom.ai_runtime.cached_agent_run", AsyncMock(return_value=MagicMock(content="First response"))),
             patch("mindroom.model_loading.get_model_instance", return_value=Ollama(id="test-model")),
             patch("mindroom.ai.create_agent", return_value=MagicMock()),

--- a/tests/test_memory_mem0_backend.py
+++ b/tests/test_memory_mem0_backend.py
@@ -104,7 +104,7 @@ async def test_store_conversation_memory_uses_explicit_execution_identity_for_de
         session_id="session-alice",
     )
 
-    with patch("mindroom.memory.functions.create_memory_instance", side_effect=create_fake_memory_instance):
+    with patch("mindroom.memory._backend.create_memory_instance", side_effect=create_fake_memory_instance):
         await store_conversation_memory(
             "Alice-authored shared memory",
             "general",
@@ -160,7 +160,7 @@ async def test_private_agent_explicit_mem0_uses_private_instance_storage(
     assert worker_key is not None
 
     with (
-        patch("mindroom.memory.functions.create_memory_instance", side_effect=create_fake_memory_instance),
+        patch("mindroom.memory._backend.create_memory_instance", side_effect=create_fake_memory_instance),
         tool_execution_identity(execution_identity),
     ):
         await add_agent_memory(
@@ -319,7 +319,7 @@ async def test_mem0_team_conversation_memory_is_shared_across_requesters_for_use
         del runtime_paths, timing_scope
         return FakeScopedMemory(scope_storage_path)
 
-    with patch("mindroom.memory.functions.create_memory_instance", side_effect=create_fake_memory_instance):
+    with patch("mindroom.memory._backend.create_memory_instance", side_effect=create_fake_memory_instance):
         with tool_execution_identity(alice_identity):
             await store_conversation_memory(
                 "Alice-authored shared team memory",
@@ -401,7 +401,7 @@ async def test_mixed_private_team_mem0_member_crud_is_rejected(
         id_prefix = scope_storage_path.name.replace("/", "_") or "mem"
         return memories_by_path.setdefault(scope_storage_path, FakeMem0ScopedMemory(id_prefix=id_prefix))
 
-    with patch("mindroom.memory.functions.create_memory_instance", side_effect=create_fake_memory_instance):
+    with patch("mindroom.memory._backend.create_memory_instance", side_effect=create_fake_memory_instance):
         await add_agent_memory("Shared calculator note", "calculator", storage_path, config, runtime_paths_for(config))
         calculator_memory_id = (
             await list_all_agent_memories("calculator", storage_path, config, runtime_paths_for(config), limit=10)
@@ -472,7 +472,7 @@ async def test_worker_scoped_team_mem0_memory_can_be_read_updated_and_deleted_ac
     )
 
     with (
-        patch("mindroom.memory.functions.create_memory_instance", side_effect=create_fake_memory_instance),
+        patch("mindroom.memory._backend.create_memory_instance", side_effect=create_fake_memory_instance),
         tool_execution_identity(execution_identity),
     ):
         await store_conversation_memory(


### PR DESCRIPTION
## Summary

`src/mindroom/memory/` had two backends that looked like adapters but had no shared interface: parallel-but-inconsistent function sets (sync vs async), and `functions.py` branching on backend type at every call site — the seam leak behind the mixed-backend team-memory bug class.

- New `src/mindroom/memory/_backend.py` with a single `MemoryBackend` protocol (`add`, `search`, `list_all`, `get`, `update`, `delete`, `store_conversation`, `load_entrypoint_context`, `context_label`) and `resolve_memory_backend(scope, config, runtime_paths) -> MemoryBackend | None`.
- The parallel module-level backend functions fold into `FileMemoryBackend` and `Mem0MemoryBackend` adapters (no importers outside `memory/` existed; the old entry functions are deleted). The file backend's sync internals are wrapped behind the async protocol so callers no longer care.
- All `use_file_backend`-style branching in `memory/functions.py` collapses into "resolve once, call protocol methods" (~500 → ~290 lines); **public facade signatures unchanged**, so no consumers are touched.
- Now-internal team backend predicates made private in `_policy.py`; dead `agent_name=None` branches dropped. (`build_team_user_id` was already deduplicated into `_policy.py`.) `auto_flush.py` has only file-only feature gates, not backend dispatch, so it needs no protocol migration.
- `tach.toml` updated for the new module graph; `MemoryBackend`/`resolve_memory_backend` declared as the module's symbol-level interface.
- Backend selection semantics, storage layout, scope IDs, timing labels, and logs are all unchanged — this is interface unification only. Resolution lives in `_backend.py` instead of `_policy.py` to avoid an import cycle (`_file_backend`/`_mem0_backend` → `_policy`).

## Relationship to PR #798 (open — NOT absorbed)

#798 fixes mixed-backend team memory writes by partitioning team members per effective backend. This refactor deliberately does **not** change mixed-team behavior (mixed team → mem0, exactly as on main, pinned by a contract test with a comment pointing at #798). It gives that fix an obvious home: a partitioned-team `MemoryBackend` implementation composed of the two adapters and returned by `resolve_memory_backend` for mixed teams — no facade changes required. Recommend rebasing #798 onto this seam; its ~400 lines of mixed-team branching in `functions.py` become one adapter.

## Tests

- New `tests/test_memory_backend_contract.py`: one parametrized test body run against both adapters (CRUD roundtrip incl. `MemoryNotFoundError`, `list_all` scoping, cross-agent scope isolation, team vs member conversation scope, backend resolution mapping) — 11 tests.
- `uv run pytest tests/test_memory_*.py -n auto --no-cov` → 144 passed (existing suites needed only mechanical patch-target moves, 36 sites).
- Full suite → **8066 passed, 61 skipped, 0 failed**.
- `uv run tach check --dependencies --interfaces`, `uv run privata .`, `uv run pre-commit run --all-files` → pass.

Part of the 2026-06-11 architecture-review refactor wave (`refactor-prompts/10`).
