### PR TITLE
knowledge: extract indexing identity into indexing_config so registry stops reaching into manager privates

### DIFF
--- a/src/mindroom/knowledge/indexing_config.py
+++ b/src/mindroom/knowledge/indexing_config.py
@@ -1,0 +1,266 @@
+"""Indexing settings and storage-key identity for knowledge indexes.
+
+The values produced here are persisted in index metadata and embedded in
+on-disk storage paths and collection names, so they must stay byte-identical
+across refactors.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, cast
+
+from agno.knowledge.embedder.base import Embedder
+from agno.vectordb.chroma import ChromaDb
+
+from mindroom.embeddings import effective_knowledge_embedder_signature
+from mindroom.knowledge.redaction import credential_free_url_identity
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+    from pathlib import Path
+
+    from mindroom.config.knowledge import KnowledgeBaseMode
+    from mindroom.config.main import Config
+
+_INDEXING_MODES: set[str] = {"semantic", "files"}
+
+
+@dataclass(frozen=True)
+class IndexingSettings:
+    """Typed schema for settings that determine knowledge index compatibility."""
+
+    base_id: str
+    storage_root: str
+    knowledge_path: str
+    mode: KnowledgeBaseMode
+    embedder_provider: str
+    embedder_model: str
+    embedder_host: str
+    embedder_dimensions: str
+    chunk_size: str
+    chunk_overlap: str
+    repo_identity: str
+    git_branch: str
+    git_lfs: str
+    git_skip_hidden: str
+    git_include_patterns: str
+    git_exclude_patterns: str
+    include_patterns: str
+    exclude_patterns: str
+    include_extensions: str
+    exclude_extensions: str
+
+    @classmethod
+    def from_metadata(cls, settings: Mapping[str, str]) -> IndexingSettings | None:
+        """Build typed settings from the persisted JSON object."""
+        required_keys = {
+            "base_id",
+            "storage_root",
+            "knowledge_path",
+            "mode",
+            "embedder_provider",
+            "embedder_model",
+            "embedder_host",
+            "embedder_dimensions",
+            "chunk_size",
+            "chunk_overlap",
+            "repo_identity",
+            "git_branch",
+            "git_lfs",
+            "git_skip_hidden",
+            "git_include_patterns",
+            "git_exclude_patterns",
+            "include_extensions",
+            "exclude_extensions",
+        }
+        optional_keys = {"include_patterns", "exclude_patterns"}
+        if not required_keys.issubset(settings) or set(settings) - required_keys - optional_keys:
+            return None
+        mode = settings["mode"]
+        if mode not in _INDEXING_MODES:
+            return None
+        return cls(
+            base_id=settings["base_id"],
+            storage_root=settings["storage_root"],
+            knowledge_path=settings["knowledge_path"],
+            mode=cast("KnowledgeBaseMode", mode),
+            embedder_provider=settings["embedder_provider"],
+            embedder_model=settings["embedder_model"],
+            embedder_host=settings["embedder_host"],
+            embedder_dimensions=settings["embedder_dimensions"],
+            chunk_size=settings["chunk_size"],
+            chunk_overlap=settings["chunk_overlap"],
+            repo_identity=settings["repo_identity"],
+            git_branch=settings["git_branch"],
+            git_lfs=settings["git_lfs"],
+            git_skip_hidden=settings["git_skip_hidden"],
+            git_include_patterns=settings["git_include_patterns"],
+            git_exclude_patterns=settings["git_exclude_patterns"],
+            include_patterns=settings.get("include_patterns", ""),
+            exclude_patterns=settings.get("exclude_patterns", ""),
+            include_extensions=settings["include_extensions"],
+            exclude_extensions=settings["exclude_extensions"],
+        )
+
+    def to_metadata(self) -> dict[str, str]:
+        """Return the JSON object persisted in index metadata."""
+        return {
+            "base_id": self.base_id,
+            "storage_root": self.storage_root,
+            "knowledge_path": self.knowledge_path,
+            "mode": self.mode,
+            "embedder_provider": self.embedder_provider,
+            "embedder_model": self.embedder_model,
+            "embedder_host": self.embedder_host,
+            "embedder_dimensions": self.embedder_dimensions,
+            "chunk_size": self.chunk_size,
+            "chunk_overlap": self.chunk_overlap,
+            "repo_identity": self.repo_identity,
+            "git_branch": self.git_branch,
+            "git_lfs": self.git_lfs,
+            "git_skip_hidden": self.git_skip_hidden,
+            "git_include_patterns": self.git_include_patterns,
+            "git_exclude_patterns": self.git_exclude_patterns,
+            "include_patterns": self.include_patterns,
+            "exclude_patterns": self.exclude_patterns,
+            "include_extensions": self.include_extensions,
+            "exclude_extensions": self.exclude_extensions,
+        }
+
+    def query_compatibility_key(self) -> tuple[str, str, str, str, str, str, str, str]:
+        """Return fields that must match for safe vector queries."""
+        return (
+            self.base_id,
+            self.storage_root,
+            self.knowledge_path,
+            self.mode,
+            self.embedder_provider,
+            self.embedder_model,
+            self.embedder_host,
+            self.embedder_dimensions,
+        )
+
+    def corpus_compatibility_key(
+        self,
+    ) -> tuple[str, str, str, str, str, str, str, str, str, str, str, str, str, str]:
+        """Return fields that must match for safe source-corpus reuse."""
+        return (
+            self.base_id,
+            self.storage_root,
+            self.knowledge_path,
+            self.mode,
+            self.repo_identity,
+            self.git_branch,
+            self.git_lfs,
+            self.git_skip_hidden,
+            self.git_include_patterns,
+            self.git_exclude_patterns,
+            self.include_patterns,
+            self.exclude_patterns,
+            self.include_extensions,
+            self.exclude_extensions,
+        )
+
+
+class _CollectionExistenceEmbedder(Embedder):
+    """Minimal embedder for collection probes that must never embed content."""
+
+    def get_embedding(self, text: str) -> list[float]:
+        _ = text
+        msg = "Knowledge collection existence checks must not embed content"
+        raise NotImplementedError(msg)
+
+    def get_embedding_and_usage(self, text: str) -> tuple[list[float], dict[str, object] | None]:
+        _ = text
+        msg = "Knowledge collection existence checks must not embed content"
+        raise NotImplementedError(msg)
+
+    async def async_get_embedding(self, text: str) -> list[float]:
+        _ = text
+        msg = "Knowledge collection existence checks must not embed content"
+        raise NotImplementedError(msg)
+
+    async def async_get_embedding_and_usage(self, text: str) -> tuple[list[float], dict[str, object] | None]:
+        _ = text
+        msg = "Knowledge collection existence checks must not embed content"
+        raise NotImplementedError(msg)
+
+
+def chroma_collection_exists(storage_path: Path, collection_name: str) -> bool:
+    """Check collection existence without constructing Agno Knowledge."""
+    vector_db = ChromaDb(
+        collection=collection_name,
+        path=str(storage_path),
+        persistent_client=True,
+        embedder=_CollectionExistenceEmbedder(),
+    )
+    return vector_db.exists()
+
+
+def _safe_identifier(value: str) -> str:
+    sanitized = "".join(char if char.isalnum() or char in {"_", "-"} else "_" for char in value)
+    return sanitized or "default"
+
+
+def storage_key_for_base(base_id: str, knowledge_path: Path) -> str:
+    """Return the persisted storage-directory key for one knowledge base binding."""
+    digest_source = f"{base_id}:{knowledge_path.resolve()}"
+    digest = hashlib.sha256(digest_source.encode("utf-8")).hexdigest()[:8]
+    return f"{_safe_identifier(base_id)}_{digest}"
+
+
+def _filter_settings_key(values: Iterable[str]) -> str:
+    return str(tuple(sorted(values)))
+
+
+def indexing_settings_key(config: Config, storage_path: Path, base_id: str, knowledge_path: Path) -> IndexingSettings:
+    """Derive the indexing-compatibility settings for one knowledge base binding."""
+    base_config = config.get_knowledge_base_config(base_id)
+    git_config = base_config.git
+    if base_config.mode == "semantic":
+        embedder_config = config.memory.embedder.config
+        embedder_provider, embedder_model, embedder_host, embedder_dimensions = effective_knowledge_embedder_signature(
+            config.memory.embedder.provider,
+            embedder_config.model,
+            host=embedder_config.host,
+            dimensions=embedder_config.dimensions,
+        )
+        chunk_size = str(base_config.chunk_size)
+        chunk_overlap = str(base_config.chunk_overlap)
+        include_extensions = (
+            _filter_settings_key(base_config.include_extensions) if base_config.include_extensions is not None else ""
+        )
+        exclude_extensions = _filter_settings_key(base_config.exclude_extensions)
+    else:
+        embedder_provider = ""
+        embedder_model = ""
+        embedder_host = ""
+        embedder_dimensions = ""
+        chunk_size = ""
+        chunk_overlap = ""
+        include_extensions = ""
+        exclude_extensions = ""
+    return IndexingSettings(
+        base_id=base_id,
+        storage_root=str(storage_path.resolve()),
+        knowledge_path=str(knowledge_path.resolve()),
+        mode=base_config.mode,
+        embedder_provider=embedder_provider,
+        embedder_model=embedder_model,
+        embedder_host=embedder_host,
+        embedder_dimensions=embedder_dimensions,
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
+        repo_identity=credential_free_url_identity(git_config.repo_url) if git_config is not None else "",
+        git_branch=git_config.branch if git_config is not None else "",
+        git_lfs=str(git_config.lfs) if git_config is not None else "",
+        git_skip_hidden=str(git_config.skip_hidden) if git_config is not None else "",
+        git_include_patterns=_filter_settings_key(git_config.include_patterns) if git_config is not None else "",
+        git_exclude_patterns=_filter_settings_key(git_config.exclude_patterns) if git_config is not None else "",
+        include_patterns=_filter_settings_key(base_config.include_patterns),
+        exclude_patterns=_filter_settings_key(base_config.exclude_patterns),
+        include_extensions=include_extensions,
+        exclude_extensions=exclude_extensions,
+    )

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -17,7 +17,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, NoReturn, Protocol, cast, runtime_checkable
 from urllib.parse import quote, urlparse, urlunparse
 
-from agno.knowledge.embedder.base import Embedder
 from agno.knowledge.knowledge import Knowledge
 from agno.knowledge.reader import ReaderFactory
 from agno.knowledge.reader.markdown_reader import MarkdownReader
@@ -28,15 +27,19 @@ from mindroom.chunking import SafeFixedSizeChunking
 from mindroom.constants import RuntimePaths, resolve_config_relative_path
 from mindroom.credentials import get_runtime_shared_credentials_manager
 from mindroom.embedding_factory import create_configured_embedder
-from mindroom.embeddings import effective_knowledge_embedder_signature
 from mindroom.knowledge.index_metadata import (
     load_index_metadata_payload,
     parse_index_metadata_fields,
     write_index_metadata_payload,
 )
+from mindroom.knowledge.indexing_config import (
+    IndexingSettings,
+    chroma_collection_exists,
+    indexing_settings_key,
+    storage_key_for_base,
+)
 from mindroom.knowledge.redaction import (
     credential_free_repo_url,
-    credential_free_url_identity,
     embedded_http_userinfo,
     redact_credentials_in_text,
     redact_url_credentials,
@@ -49,7 +52,7 @@ if TYPE_CHECKING:
 
     from agno.knowledge.reader.base import Reader
 
-    from mindroom.config.knowledge import KnowledgeBaseMode, KnowledgeGitConfig
+    from mindroom.config.knowledge import KnowledgeGitConfig
     from mindroom.config.main import Config
 
 logger = get_logger(__name__)
@@ -70,7 +73,6 @@ _INDEXING_STATUSES = {
     _INDEXING_STATUS_INDEXING,
     _INDEXING_STATUS_COMPLETE,
 }
-_INDEXING_MODES: set[str] = {"semantic", "files"}
 _GLOB_CHARS = frozenset("*?[")
 _TEXT_LIKE_EXTENSIONS = {
     ".md",
@@ -129,143 +131,6 @@ _TEXT_LIKE_EXTENSIONS = {
 _FileSignature = tuple[int, int, str]
 
 
-@dataclass(frozen=True)
-class IndexingSettings:
-    """Typed schema for settings that determine knowledge index compatibility."""
-
-    base_id: str
-    storage_root: str
-    knowledge_path: str
-    mode: KnowledgeBaseMode
-    embedder_provider: str
-    embedder_model: str
-    embedder_host: str
-    embedder_dimensions: str
-    chunk_size: str
-    chunk_overlap: str
-    repo_identity: str
-    git_branch: str
-    git_lfs: str
-    git_skip_hidden: str
-    git_include_patterns: str
-    git_exclude_patterns: str
-    include_patterns: str
-    exclude_patterns: str
-    include_extensions: str
-    exclude_extensions: str
-
-    @classmethod
-    def from_metadata(cls, settings: Mapping[str, str]) -> IndexingSettings | None:
-        """Build typed settings from the persisted JSON object."""
-        required_keys = {
-            "base_id",
-            "storage_root",
-            "knowledge_path",
-            "mode",
-            "embedder_provider",
-            "embedder_model",
-            "embedder_host",
-            "embedder_dimensions",
-            "chunk_size",
-            "chunk_overlap",
-            "repo_identity",
-            "git_branch",
-            "git_lfs",
-            "git_skip_hidden",
-            "git_include_patterns",
-            "git_exclude_patterns",
-            "include_extensions",
-            "exclude_extensions",
-        }
-        optional_keys = {"include_patterns", "exclude_patterns"}
-        if not required_keys.issubset(settings) or set(settings) - required_keys - optional_keys:
-            return None
-        mode = settings["mode"]
-        if mode not in _INDEXING_MODES:
-            return None
-        return cls(
-            base_id=settings["base_id"],
-            storage_root=settings["storage_root"],
-            knowledge_path=settings["knowledge_path"],
-            mode=cast("KnowledgeBaseMode", mode),
-            embedder_provider=settings["embedder_provider"],
-            embedder_model=settings["embedder_model"],
-            embedder_host=settings["embedder_host"],
-            embedder_dimensions=settings["embedder_dimensions"],
-            chunk_size=settings["chunk_size"],
-            chunk_overlap=settings["chunk_overlap"],
-            repo_identity=settings["repo_identity"],
-            git_branch=settings["git_branch"],
-            git_lfs=settings["git_lfs"],
-            git_skip_hidden=settings["git_skip_hidden"],
-            git_include_patterns=settings["git_include_patterns"],
-            git_exclude_patterns=settings["git_exclude_patterns"],
-            include_patterns=settings.get("include_patterns", ""),
-            exclude_patterns=settings.get("exclude_patterns", ""),
-            include_extensions=settings["include_extensions"],
-            exclude_extensions=settings["exclude_extensions"],
-        )
-
-    def to_metadata(self) -> dict[str, str]:
-        """Return the JSON object persisted in index metadata."""
-        return {
-            "base_id": self.base_id,
-            "storage_root": self.storage_root,
-            "knowledge_path": self.knowledge_path,
-            "mode": self.mode,
-            "embedder_provider": self.embedder_provider,
-            "embedder_model": self.embedder_model,
-            "embedder_host": self.embedder_host,
-            "embedder_dimensions": self.embedder_dimensions,
-            "chunk_size": self.chunk_size,
-            "chunk_overlap": self.chunk_overlap,
-            "repo_identity": self.repo_identity,
-            "git_branch": self.git_branch,
-            "git_lfs": self.git_lfs,
-            "git_skip_hidden": self.git_skip_hidden,
-            "git_include_patterns": self.git_include_patterns,
-            "git_exclude_patterns": self.git_exclude_patterns,
-            "include_patterns": self.include_patterns,
-            "exclude_patterns": self.exclude_patterns,
-            "include_extensions": self.include_extensions,
-            "exclude_extensions": self.exclude_extensions,
-        }
-
-    def query_compatibility_key(self) -> tuple[str, str, str, str, str, str, str, str]:
-        """Return fields that must match for safe vector queries."""
-        return (
-            self.base_id,
-            self.storage_root,
-            self.knowledge_path,
-            self.mode,
-            self.embedder_provider,
-            self.embedder_model,
-            self.embedder_host,
-            self.embedder_dimensions,
-        )
-
-    def corpus_compatibility_key(
-        self,
-    ) -> tuple[str, str, str, str, str, str, str, str, str, str, str, str, str, str]:
-        """Return fields that must match for safe source-corpus reuse."""
-        return (
-            self.base_id,
-            self.storage_root,
-            self.knowledge_path,
-            self.mode,
-            self.repo_identity,
-            self.git_branch,
-            self.git_lfs,
-            self.git_skip_hidden,
-            self.git_include_patterns,
-            self.git_exclude_patterns,
-            self.include_patterns,
-            self.exclude_patterns,
-            self.include_extensions,
-            self.exclude_extensions,
-        )
-
-
 @runtime_checkable
 class _CollectionListingClient(Protocol):
     """Vector client surface needed for best-effort collection cleanup."""
@@ -280,30 +145,6 @@ class _NamedCollection(Protocol):
     """Collection object shape returned by Chroma clients."""
 
     name: str
-
-
-class _CollectionExistenceEmbedder(Embedder):
-    """Minimal embedder for collection probes that must never embed content."""
-
-    def get_embedding(self, text: str) -> list[float]:
-        _ = text
-        msg = "Knowledge collection existence checks must not embed content"
-        raise NotImplementedError(msg)
-
-    def get_embedding_and_usage(self, text: str) -> tuple[list[float], dict[str, object] | None]:
-        _ = text
-        msg = "Knowledge collection existence checks must not embed content"
-        raise NotImplementedError(msg)
-
-    async def async_get_embedding(self, text: str) -> list[float]:
-        _ = text
-        msg = "Knowledge collection existence checks must not embed content"
-        raise NotImplementedError(msg)
-
-    async def async_get_embedding_and_usage(self, text: str) -> tuple[list[float], dict[str, object] | None]:
-        _ = text
-        msg = "Knowledge collection existence checks must not embed content"
-        raise NotImplementedError(msg)
 
 
 @dataclass(frozen=True)
@@ -376,34 +217,8 @@ def git_checkout_present(root: Path, *, timeout_seconds: float | None = None) ->
         return False
 
 
-def chroma_collection_exists(storage_path: Path, collection_name: str) -> bool:
-    """Check collection existence without constructing Agno Knowledge."""
-    vector_db = ChromaDb(
-        collection=collection_name,
-        path=str(storage_path),
-        persistent_client=True,
-        embedder=_CollectionExistenceEmbedder(),
-    )
-    return vector_db.exists()
-
-
-def _safe_identifier(value: str) -> str:
-    sanitized = "".join(char if char.isalnum() or char in {"_", "-"} else "_" for char in value)
-    return sanitized or "default"
-
-
-def _base_storage_key(base_id: str, knowledge_path: Path) -> str:
-    digest_source = f"{base_id}:{knowledge_path.resolve()}"
-    digest = hashlib.sha256(digest_source.encode("utf-8")).hexdigest()[:8]
-    return f"{_safe_identifier(base_id)}_{digest}"
-
-
 def _collection_name(base_id: str, knowledge_path: Path) -> str:
-    return f"{_COLLECTION_PREFIX}_{_base_storage_key(base_id, knowledge_path)}"
-
-
-def _filter_settings_key(values: Iterable[str]) -> str:
-    return str(tuple(sorted(values)))
+    return f"{_COLLECTION_PREFIX}_{storage_key_for_base(base_id, knowledge_path)}"
 
 
 def _split_pattern_parts(pattern: str) -> tuple[str, ...]:
@@ -446,56 +261,6 @@ def _listing_targets(resolved_root: Path, patterns: list[str]) -> list[_ListingT
             seen.add(key)
             deduped.append(target)
     return deduped
-
-
-def _indexing_settings_key(config: Config, storage_path: Path, base_id: str, knowledge_path: Path) -> IndexingSettings:
-    base_config = config.get_knowledge_base_config(base_id)
-    git_config = base_config.git
-    if base_config.mode == "semantic":
-        embedder_config = config.memory.embedder.config
-        embedder_provider, embedder_model, embedder_host, embedder_dimensions = effective_knowledge_embedder_signature(
-            config.memory.embedder.provider,
-            embedder_config.model,
-            host=embedder_config.host,
-            dimensions=embedder_config.dimensions,
-        )
-        chunk_size = str(base_config.chunk_size)
-        chunk_overlap = str(base_config.chunk_overlap)
-        include_extensions = (
-            _filter_settings_key(base_config.include_extensions) if base_config.include_extensions is not None else ""
-        )
-        exclude_extensions = _filter_settings_key(base_config.exclude_extensions)
-    else:
-        embedder_provider = ""
-        embedder_model = ""
-        embedder_host = ""
-        embedder_dimensions = ""
-        chunk_size = ""
-        chunk_overlap = ""
-        include_extensions = ""
-        exclude_extensions = ""
-    return IndexingSettings(
-        base_id=base_id,
-        storage_root=str(storage_path.resolve()),
-        knowledge_path=str(knowledge_path.resolve()),
-        mode=base_config.mode,
-        embedder_provider=embedder_provider,
-        embedder_model=embedder_model,
-        embedder_host=embedder_host,
-        embedder_dimensions=embedder_dimensions,
-        chunk_size=chunk_size,
-        chunk_overlap=chunk_overlap,
-        repo_identity=credential_free_url_identity(git_config.repo_url) if git_config is not None else "",
-        git_branch=git_config.branch if git_config is not None else "",
-        git_lfs=str(git_config.lfs) if git_config is not None else "",
-        git_skip_hidden=str(git_config.skip_hidden) if git_config is not None else "",
-        git_include_patterns=_filter_settings_key(git_config.include_patterns) if git_config is not None else "",
-        git_exclude_patterns=_filter_settings_key(git_config.exclude_patterns) if git_config is not None else "",
-        include_patterns=_filter_settings_key(base_config.include_patterns),
-        exclude_patterns=_filter_settings_key(base_config.exclude_patterns),
-        include_extensions=include_extensions,
-        exclude_extensions=exclude_extensions,
-    )
 
 
 def _semantic_indexing_enabled(config: Config, base_id: str) -> bool:
@@ -948,7 +713,7 @@ class KnowledgeManager:
         _ensure_knowledge_directory_ready(self.knowledge_path)
         self._set_settings(self.config, self.runtime_paths, self.storage_path, self.knowledge_path)
         self._base_storage_path = (
-            self.storage_path / "knowledge_db" / _base_storage_key(self.base_id, self.knowledge_path)
+            self.storage_path / "knowledge_db" / storage_key_for_base(self.base_id, self.knowledge_path)
         ).resolve()
         self._base_storage_path.mkdir(parents=True, exist_ok=True)
         self._indexing_settings_path = self._base_storage_path / "indexing_settings.json"
@@ -981,7 +746,7 @@ class KnowledgeManager:
         self.runtime_paths = runtime_paths
         self.storage_path = storage_path
         self.knowledge_path = knowledge_path.resolve()
-        self._indexing_settings = _indexing_settings_key(
+        self._indexing_settings = indexing_settings_key(
             config,
             storage_path,
             self.base_id,

--- a/src/mindroom/knowledge/registry.py
+++ b/src/mindroom/knowledge/registry.py
@@ -13,7 +13,10 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, ParamSpec, Protocol, TypeVar, cast
 
-import mindroom.knowledge.manager as manager_module
+from agno.knowledge.knowledge import Knowledge
+from agno.vectordb.chroma import ChromaDb
+
+from mindroom.embedding_factory import create_configured_embedder
 from mindroom.knowledge.availability import KnowledgeAvailability
 from mindroom.knowledge.index_metadata import (
     load_index_metadata_payload,
@@ -21,13 +24,17 @@ from mindroom.knowledge.index_metadata import (
     parse_index_metadata_fields,
     write_index_metadata_payload,
 )
+from mindroom.knowledge.indexing_config import (
+    IndexingSettings,
+    chroma_collection_exists,
+    indexing_settings_key,
+    storage_key_for_base,
+)
 from mindroom.logging_config import get_logger
 from mindroom.runtime_resolution import resolve_knowledge_binding
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-
-    from agno.knowledge.knowledge import Knowledge
 
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
@@ -48,7 +55,7 @@ class PublishedIndexKey:
     base_id: str
     storage_root: str
     knowledge_path: str
-    indexing_settings: manager_module.IndexingSettings
+    indexing_settings: IndexingSettings
 
 
 @dataclass(frozen=True)
@@ -72,7 +79,7 @@ class KnowledgeSourceRoot:
 class PublishedIndexState:
     """Persisted state for the published knowledge index."""
 
-    settings: manager_module.IndexingSettings
+    settings: IndexingSettings
     status: Literal["resetting", "indexing", "complete", "failed"]
     collection: str | None = None
     last_published_at: str | None = None
@@ -153,7 +160,7 @@ def _published_index_key_from_binding(
         base_id=base_id,
         storage_root=str(storage_root),
         knowledge_path=str(knowledge_path),
-        indexing_settings=manager_module._indexing_settings_key(
+        indexing_settings=indexing_settings_key(
             config,
             storage_root,
             base_id,
@@ -242,9 +249,7 @@ def resolve_refresh_target(
 def _published_index_storage_path(key: PublishedIndexKey) -> Path:
     """Return the storage directory for one resolved knowledge base."""
     knowledge_path = Path(key.knowledge_path)
-    return (
-        Path(key.storage_root) / "knowledge_db" / manager_module._base_storage_key(key.base_id, knowledge_path)
-    ).resolve()
+    return (Path(key.storage_root) / "knowledge_db" / storage_key_for_base(key.base_id, knowledge_path)).resolve()
 
 
 def published_index_metadata_path(key: PublishedIndexKey) -> Path:
@@ -275,7 +280,7 @@ def load_published_index_state(metadata_path: Path) -> PublishedIndexState | Non
         indexed_count,
         source_signature,
     ) = fields
-    indexing_settings = manager_module.IndexingSettings.from_metadata(settings)
+    indexing_settings = IndexingSettings.from_metadata(settings)
     if indexing_settings is None:
         return None
 
@@ -442,11 +447,11 @@ def _build_published_index_vector_db(
 ) -> _PublishedIndexVectorDb:
     return cast(
         "_PublishedIndexVectorDb",
-        manager_module.ChromaDb(
+        ChromaDb(
             collection=_state_collection_name(state),
             path=str(_published_index_storage_path(key)),
             persistent_client=True,
-            embedder=manager_module.create_configured_embedder(config, runtime_paths),
+            embedder=create_configured_embedder(config, runtime_paths),
         ),
     )
 
@@ -458,7 +463,7 @@ def _build_published_index_knowledge(
     config: Config,
     runtime_paths: RuntimePaths,
 ) -> Knowledge:
-    return manager_module.Knowledge(
+    return Knowledge(
         vector_db=_build_published_index_vector_db(key, state, config=config, runtime_paths=runtime_paths),
     )
 
@@ -468,7 +473,7 @@ def published_index_collection_exists_for_state(key: PublishedIndexKey, state: P
     if state.status != "complete" or state.collection is None:
         return False
     try:
-        return manager_module.chroma_collection_exists(_published_index_storage_path(key), state.collection)
+        return chroma_collection_exists(_published_index_storage_path(key), state.collection)
     except Exception:
         logger.warning(
             "Published knowledge collection existence check failed",
@@ -480,32 +485,32 @@ def published_index_collection_exists_for_state(key: PublishedIndexKey, state: P
 
 
 def _indexing_settings_query_compatible(
-    published_settings: manager_module.IndexingSettings,
-    current_settings: manager_module.IndexingSettings,
+    published_settings: IndexingSettings,
+    current_settings: IndexingSettings,
 ) -> bool:
     """Return whether current queries can use a collection from published settings."""
     return published_settings.query_compatibility_key() == current_settings.query_compatibility_key()
 
 
 def _indexing_settings_corpus_compatible(
-    published_settings: manager_module.IndexingSettings,
-    current_settings: manager_module.IndexingSettings,
+    published_settings: IndexingSettings,
+    current_settings: IndexingSettings,
 ) -> bool:
     """Return whether published content is safe for the current corpus config."""
     return published_settings.corpus_compatibility_key() == current_settings.corpus_compatibility_key()
 
 
 def indexing_settings_metadata_equal(
-    published_settings: manager_module.IndexingSettings,
-    current_settings: manager_module.IndexingSettings,
+    published_settings: IndexingSettings,
+    current_settings: IndexingSettings,
 ) -> bool:
     """Return whether persisted metadata exactly matches current indexing settings."""
     return published_settings == current_settings
 
 
 def published_index_settings_compatible(
-    published_settings: manager_module.IndexingSettings,
-    current_settings: manager_module.IndexingSettings,
+    published_settings: IndexingSettings,
+    current_settings: IndexingSettings,
 ) -> bool:
     """Return whether a published index can be queried under the current config."""
     return _indexing_settings_query_compatible(

--- a/tach.toml
+++ b/tach.toml
@@ -2383,11 +2383,19 @@ visibility = [
 [[modules]]
 path = "mindroom.knowledge.registry"
 depends_on = [
+    "mindroom.embedding_factory",
     "mindroom.knowledge.availability",
     "mindroom.knowledge.index_metadata",
-    "mindroom.knowledge.manager",
+    "mindroom.knowledge.indexing_config",
     "mindroom.runtime_resolution",
     "mindroom.tool_system.worker_routing",
+]
+
+[[modules]]
+path = "mindroom.knowledge.indexing_config"
+depends_on = [
+    "mindroom.embeddings",
+    "mindroom.knowledge.redaction",
 ]
 
 [[modules]]
@@ -2397,6 +2405,7 @@ depends_on = [
     "mindroom.constants",
     "mindroom.embedding_factory",
     "mindroom.knowledge.index_metadata",
+    "mindroom.knowledge.indexing_config",
     "mindroom.knowledge.redaction",
     "mindroom.path_globs",
 ]

--- a/tests/api/test_knowledge_api.py
+++ b/tests/api/test_knowledge_api.py
@@ -268,6 +268,10 @@ def test_status_and_list_use_persisted_indexed_count_without_refresh(tmp_path: P
             "mindroom.knowledge.manager.create_configured_embedder",
             side_effect=AssertionError("embedder should not load"),
         ),
+        patch(
+            "mindroom.knowledge.registry.create_configured_embedder",
+            side_effect=AssertionError("embedder should not load"),
+        ),
         patch("mindroom.api.knowledge.refresh_knowledge_binding", new=AsyncMock()) as refresh,
     ):
         status_response = client.get("/api/knowledge/bases/research/status")
@@ -306,8 +310,14 @@ def test_status_reports_persisted_count_without_loading_collection(tmp_path: Pat
 
     with (
         patch("mindroom.knowledge.manager.ChromaDb", _BrokenVectorDb),
+        patch("mindroom.knowledge.registry.ChromaDb", _BrokenVectorDb),
+        patch("mindroom.knowledge.indexing_config.ChromaDb", _BrokenVectorDb),
         patch(
             "mindroom.knowledge.manager.create_configured_embedder",
+            side_effect=AssertionError("embedder should not load"),
+        ),
+        patch(
+            "mindroom.knowledge.registry.create_configured_embedder",
             side_effect=AssertionError("embedder should not load"),
         ),
     ):

--- a/tests/test_delegate_tools.py
+++ b/tests/test_delegate_tools.py
@@ -16,7 +16,7 @@ from mindroom.config.models import DefaultsConfig, ModelConfig
 from mindroom.constants import resolve_runtime_paths
 from mindroom.custom_tools.delegate import MAX_DELEGATION_DEPTH, DelegateTools
 from mindroom.knowledge.availability import KnowledgeAvailability
-from mindroom.knowledge.manager import IndexingSettings
+from mindroom.knowledge.indexing_config import IndexingSettings
 from mindroom.knowledge.utils import _KnowledgeResolution
 from mindroom.tool_system.metadata import TOOL_METADATA
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, get_tool_runtime_context, tool_runtime_context

--- a/tests/test_knowledge_indexing_config.py
+++ b/tests/test_knowledge_indexing_config.py
@@ -1,0 +1,94 @@
+"""Unit tests for knowledge indexing-config identity invariants.
+
+Storage keys and indexing-settings metadata are persisted cache/identity keys
+for vector collections, so their stability is the invariant pinned here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import TYPE_CHECKING
+
+from mindroom.knowledge.indexing_config import IndexingSettings, storage_key_for_base
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _settings(base_id: str = "docs") -> IndexingSettings:
+    return IndexingSettings(
+        base_id=base_id,
+        storage_root="storage",
+        knowledge_path=f"knowledge/{base_id}",
+        mode="semantic",
+        embedder_provider="openai",
+        embedder_model="text-embedding-3-small",
+        embedder_host="",
+        embedder_dimensions="",
+        chunk_size="5000",
+        chunk_overlap="0",
+        repo_identity="",
+        git_branch="",
+        git_lfs="",
+        git_skip_hidden="",
+        git_include_patterns="",
+        git_exclude_patterns="",
+        include_patterns="",
+        exclude_patterns="",
+        include_extensions="",
+        exclude_extensions="()",
+    )
+
+
+def test_storage_key_for_base_is_deterministic(tmp_path: Path) -> None:
+    """Same base ID and path must always produce the same persisted key."""
+    knowledge_path = tmp_path / "docs"
+    assert storage_key_for_base("docs", knowledge_path) == storage_key_for_base("docs", knowledge_path)
+
+
+def test_storage_key_for_base_pins_persisted_key_format(tmp_path: Path) -> None:
+    """The key format is persisted on disk and must stay byte-identical."""
+    knowledge_path = tmp_path / "docs"
+    digest = hashlib.sha256(f"docs:{knowledge_path.resolve()}".encode()).hexdigest()[:8]
+    assert storage_key_for_base("docs", knowledge_path) == f"docs_{digest}"
+
+
+def test_storage_key_for_base_differs_per_base_and_path(tmp_path: Path) -> None:
+    """Distinct base IDs or paths must map to distinct storage keys."""
+    docs_path = tmp_path / "docs"
+    other_path = tmp_path / "other"
+    assert storage_key_for_base("docs", docs_path) != storage_key_for_base("wiki", docs_path)
+    assert storage_key_for_base("docs", docs_path) != storage_key_for_base("docs", other_path)
+
+
+def test_storage_key_for_base_sanitizes_unsafe_identifiers(tmp_path: Path) -> None:
+    """Unsafe characters are sanitized while the digest keeps keys unique."""
+    knowledge_path = tmp_path / "docs"
+    key = storage_key_for_base("my docs/v1", knowledge_path)
+    assert key.startswith("my_docs_v1_")
+    assert key != storage_key_for_base("my docs.v1", knowledge_path)
+
+
+def test_indexing_settings_metadata_round_trip() -> None:
+    """to_metadata/from_metadata must round-trip without loss."""
+    settings = _settings()
+    assert IndexingSettings.from_metadata(settings.to_metadata()) == settings
+
+
+def test_indexing_settings_from_metadata_rejects_invalid_payloads() -> None:
+    """Unknown keys, missing keys, and unknown modes are rejected."""
+    metadata = _settings().to_metadata()
+    assert IndexingSettings.from_metadata({**metadata, "unexpected": "value"}) is None
+    assert IndexingSettings.from_metadata({key: value for key, value in metadata.items() if key != "base_id"}) is None
+    assert IndexingSettings.from_metadata({**metadata, "mode": "unknown"}) is None
+
+
+def test_indexing_settings_from_metadata_defaults_optional_filter_keys() -> None:
+    """Older payloads without include/exclude patterns still parse."""
+    metadata = _settings().to_metadata()
+    del metadata["include_patterns"]
+    del metadata["exclude_patterns"]
+    parsed = IndexingSettings.from_metadata(metadata)
+    assert parsed is not None
+    assert parsed.include_patterns == ""
+    assert parsed.exclude_patterns == ""

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -35,6 +35,7 @@ from mindroom.credentials import get_runtime_shared_credentials_manager
 from mindroom.knowledge import KnowledgeRefreshScheduler, resolve_agent_knowledge_access
 from mindroom.knowledge.availability import KnowledgeAvailability
 from mindroom.knowledge.index_metadata import write_index_metadata_payload
+from mindroom.knowledge.indexing_config import IndexingSettings
 from mindroom.knowledge.manager import (
     KnowledgeManager,
     git_checkout_present,
@@ -191,6 +192,10 @@ def patch_vector_store(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     monkeypatch.setattr("mindroom.knowledge.manager.ChromaDb", _VectorDb)
     monkeypatch.setattr("mindroom.knowledge.manager.Knowledge", _Knowledge)
     monkeypatch.setattr("mindroom.knowledge.manager.create_configured_embedder", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr("mindroom.knowledge.indexing_config.ChromaDb", _VectorDb)
+    monkeypatch.setattr("mindroom.knowledge.registry.ChromaDb", _VectorDb)
+    monkeypatch.setattr("mindroom.knowledge.registry.Knowledge", _Knowledge)
+    monkeypatch.setattr("mindroom.knowledge.registry.create_configured_embedder", lambda *_args, **_kwargs: object())
     knowledge_registry._published_indexes.clear()
     knowledge_utils._refresh_scheduled_at.clear()
     knowledge_refresh_runner._refresh_locks.clear()
@@ -220,8 +225,8 @@ def _create_idle_refresh_lock(key: knowledge_registry.KnowledgeSourceRoot) -> No
     knowledge_refresh_runner._release_refresh_lock_for_key(key, entry)
 
 
-def _test_indexing_settings(base_id: str = "docs") -> knowledge_manager_module.IndexingSettings:
-    return knowledge_manager_module.IndexingSettings(
+def _test_indexing_settings(base_id: str = "docs") -> IndexingSettings:
+    return IndexingSettings(
         base_id=base_id,
         storage_root="storage",
         knowledge_path=f"knowledge/{base_id}",
@@ -2310,9 +2315,7 @@ def test_indexing_settings_key_uses_named_settings(tmp_path: Path) -> None:
     assert key.indexing_settings.chunk_size == "5000"
     assert key.indexing_settings.chunk_overlap == "0"
     assert key.indexing_settings.repo_identity == credential_free_url_identity("https://example.com/org/repo.git")
-    assert knowledge_manager_module.IndexingSettings.from_metadata(key.indexing_settings.to_metadata()) == (
-        key.indexing_settings
-    )
+    assert IndexingSettings.from_metadata(key.indexing_settings.to_metadata()) == key.indexing_settings
     changed_repo_identity = replace(key.indexing_settings, repo_identity="https://example.com/other/repo.git")
     assert not knowledge_registry.published_index_settings_compatible(key.indexing_settings, changed_repo_identity)
 

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -93,7 +93,8 @@ from mindroom.hooks import (
 )
 from mindroom.inbound_turn_normalizer import DispatchPayload, DispatchPayloadWithAttachmentsRequest
 from mindroom.knowledge.availability import KnowledgeAvailability
-from mindroom.knowledge.manager import IndexingSettings, KnowledgeManager
+from mindroom.knowledge.indexing_config import IndexingSettings
+from mindroom.knowledge.manager import KnowledgeManager
 from mindroom.knowledge.utils import _KnowledgeResolution, _MultiKnowledgeVectorDb
 from mindroom.matrix.cache import ThreadHistoryResult
 from mindroom.matrix.cache.thread_history_result import thread_history_result

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -51,7 +51,7 @@ from mindroom.execution_preparation import _PreparedExecutionContext
 from mindroom.history.runtime import ScopeSessionContext, open_bound_scope_session_context
 from mindroom.history.types import CompactionDecision, HistoryScope, ResolvedReplayPlan
 from mindroom.knowledge.availability import KnowledgeAvailability
-from mindroom.knowledge.manager import IndexingSettings
+from mindroom.knowledge.indexing_config import IndexingSettings
 from mindroom.knowledge.utils import KnowledgeAvailabilityDetail, _KnowledgeResolution
 from mindroom.llm_request_logging import current_llm_request_log_context
 from mindroom.matrix.client import ResolvedVisibleMessage


### PR DESCRIPTION
## Problem

`knowledge/registry.py` imported `manager` as a module namespace and reached into its private internals (`manager_module._indexing_settings_key`, `manager_module._base_storage_key`) plus Agno pass-throughs (`manager_module.ChromaDb`, `.Knowledge`, `.create_configured_embedder`, `.chroma_collection_exists`). This private cross-module coupling meant any change to the 1.8k-line `manager.py` risked breaking the registry and the out-of-process refresh runner, and blocked any future decomposition of the manager.

## Change (phase 1 only — manager.py is not split here)

- New `src/mindroom/knowledge/indexing_config.py`: `IndexingSettings` (and its marshaling), the storage-key helpers renamed public (`storage_key_for_base`, `indexing_settings_key`), and the pure `chroma_collection_exists` probe, all moved **verbatim** from `manager.py` (−270 lines).
- `registry.py` imports these from `indexing_config`, and `ChromaDb` / `Knowledge` / `create_configured_embedder` from their real homes (`agno.vectordb.chroma`, `agno.knowledge.knowledge`, `mindroom.embedding_factory`). It no longer imports `manager` at all; zero `manager_module._<private>` accesses remain (the acceptance criterion).
- `manager.py` keeps its `ChromaDb`/`Knowledge`/`create_configured_embedder` imports because it uses them directly. `refresh_runner.py` is untouched (only uses public manager names; its `python -m` subprocess entry role is preserved and verified).
- Settings-marshaling home: typed `IndexingSettings` marshaling lives on the dataclass in `indexing_config.py`; `index_metadata.py` remains the generic JSON payload layer, unchanged.
- `tach.toml`: registry's dependency on `mindroom.knowledge.manager` replaced by `mindroom.knowledge.indexing_config` + `mindroom.embedding_factory`.

## No behavior change

Storage keys, collection names, and persisted `indexing_settings.json` metadata are byte-identical — function bodies moved without modification. New `tests/test_knowledge_indexing_config.py` (7 tests) pins the exact persisted key format (`{sanitized_id}_{sha256[:8]}`), per-base/per-path uniqueness, and the `IndexingSettings` metadata round-trip.

## Conflicts with open PRs

- #873 (open): touches untouched file-filter helpers in `manager.py`; only line-offset conflicts expected.
- #295 (open): edits the (pre-rename) settings-key function, which now lives in `indexing_config.py`; that hunk will need reapplying on rebase.

## Testing

- `uv run pytest tests/test_knowledge_indexing_config.py tests/test_knowledge_index_metadata.py -x --no-cov` → 12 passed.
- `uv run pytest tests/test_knowledge_manager.py tests/api/test_knowledge_api.py --no-cov` → 236 passed.
- Subprocess entry verified: `python -m mindroom.knowledge_refresh_runner` imports cleanly; in-suite subprocess tests pass.
- Full suite → 8061 passed, 61 skipped (1 flake, verified pre-existing on a clean baseline).
- `uv run tach check --dependencies --interfaces` and pre-commit pass.

Part of the 2026-06-11 architecture-review refactor wave (`refactor-prompts/11`).
