### PR TITLE
egress: one resolver for what a worker can reach

### DIFF
--- a/src/mindroom/egress/__init__.py
+++ b/src/mindroom/egress/__init__.py
@@ -1,1 +1,21 @@
-"""Egress broker helpers and sidecar entry points."""
+"""Worker egress policy: the local source of truth for "what can this worker reach"."""
+
+from mindroom.egress.policy import (
+    EgressGrantSubject,
+    WorkerEgressPolicy,
+    canonical_hostname,
+    is_hostname_allowed,
+    load_static_allowlist,
+    resolve_grant_subject,
+    resolve_worker_egress_policy,
+)
+
+__all__ = [
+    "EgressGrantSubject",
+    "WorkerEgressPolicy",
+    "canonical_hostname",
+    "is_hostname_allowed",
+    "load_static_allowlist",
+    "resolve_grant_subject",
+    "resolve_worker_egress_policy",
+]

--- a/src/mindroom/egress/policy.py
+++ b/src/mindroom/egress/policy.py
@@ -1,0 +1,227 @@
+"""Single owner of worker egress policy resolution: "what can this worker reach".
+
+Three layers cooperate on worker egress and this module is the local source of
+truth for the policy inputs the runtime can know about:
+
+- This module resolves the static allowlist (env or mounted file), canonical
+  hostname validation, and the grant subject derived from one agent's
+  execution scope.
+- ``mindroom.tools.approved_egress`` consumes this module to short-circuit
+  hostnames the static allowlist already covers and to address temporary
+  grant requests to the right subject.
+- The egress proxy (the external ``mindroom-egress-proxy`` image deployed by
+  the chart) enforces the combined policy — static allowlist plus approved
+  temporary grants — on actual worker traffic. Approved grants are stored in
+  the proxy's own database and are created via its policy API; they are not
+  readable from this process, so ``WorkerEgressPolicy`` intentionally carries
+  no grant list.
+
+Worker provisioning (``mindroom.workers.backends``) deliberately does not
+consume the allowlist: it only wires proxy credentials into worker pods, and
+the proxy enforces the policy centrally. The seam shared with provisioning is
+the grant subject — a ``worker_key`` grant minted here must use the same
+worker key the provisioning path uses for the same scope and identity, which
+is why both resolve it through ``mindroom.tool_system.worker_routing``.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from mindroom.tool_system.worker_routing import resolve_worker_key
+
+if TYPE_CHECKING:
+    from mindroom.tool_system.worker_routing import ToolExecutionIdentity, WorkerScope
+
+_DEFAULT_ALLOWLIST_PATH = "/etc/mindroom-egress/allowed-domains.txt"
+_MAX_DNS_NAME_LENGTH = 253
+_MAX_DNS_LABEL_LENGTH = 63
+_MIN_DNS_LABELS = 2
+_FORBIDDEN_HOSTNAMES = {
+    "localhost",
+    "metadata.google.internal",
+}
+_FORBIDDEN_HOST_SUFFIXES = (
+    ".localhost",
+    ".svc",
+    ".svc.cluster.local",
+    ".cluster.local",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class EgressGrantSubject:
+    """Address one approved-egress grant to an agent or a scoped worker."""
+
+    subject_type: str
+    subject: str
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerEgressPolicy:
+    """Locally-resolvable egress policy for one worker context.
+
+    Approved temporary grants are owned by the egress proxy's policy service
+    and cannot be enumerated here; this value carries the static allowlist and
+    the subject new grants must be addressed to.
+    """
+
+    static_allowlist: tuple[str, ...]
+    grant_subject: EgressGrantSubject | None = None
+
+
+def load_static_allowlist() -> tuple[str, ...]:
+    """Read the static egress allowlist from env or the mounted allowlist file."""
+    inline = os.environ.get("MINDROOM_APPROVED_EGRESS_ALLOWLIST", "").strip()
+    text = inline.replace(",", "\n") if inline else ""
+    if not text:
+        allowlist_path = (
+            os.environ.get("MINDROOM_APPROVED_EGRESS_ALLOWLIST_PATH")
+            or os.environ.get("MINDROOM_EGRESS_ALLOWLIST_PATH")
+            or _DEFAULT_ALLOWLIST_PATH
+        ).strip()
+        if allowlist_path:
+            try:
+                text = Path(allowlist_path).read_text(encoding="utf-8")
+            except OSError:
+                text = ""
+    entries = (line for raw in text.splitlines() if (line := raw.split("#", 1)[0].strip()))
+    return tuple(dict.fromkeys(entries))
+
+
+def _raw_hostname(value: str) -> str:
+    if not isinstance(value, str):
+        msg = "hostname must be a string"
+        raise TypeError(msg)
+    raw = value.strip().rstrip(".")
+    if not raw:
+        msg = "hostname must not be empty"
+        raise ValueError(msg)
+    if "://" in raw or any(part in raw for part in ("/", "?", "#", "@")):
+        msg = "hostname must not include a scheme, path, query, or credentials"
+        raise ValueError(msg)
+    if "*" in raw:
+        msg = "hostname wildcards are not supported"
+        raise ValueError(msg)
+    if ":" in raw:
+        msg = "hostname must not include a port"
+        raise ValueError(msg)
+    if len(raw) > _MAX_DNS_NAME_LENGTH:
+        msg = "hostname is too long"
+        raise ValueError(msg)
+    return raw
+
+
+def _reject_ip_literal(raw: str) -> None:
+    try:
+        ipaddress.ip_address(raw)
+    except ValueError:
+        return
+    msg = "IP literals are not valid egress hostnames"
+    raise ValueError(msg)
+
+
+def _idna_hostname(raw: str) -> str:
+    try:
+        return raw.encode("idna").decode("ascii").lower()
+    except UnicodeError as exc:
+        msg = "hostname is not valid IDNA"
+        raise ValueError(msg) from exc
+
+
+def _validate_dns_labels(normalized: str) -> None:
+    labels = normalized.split(".")
+    if len(labels) < _MIN_DNS_LABELS:
+        msg = "hostname must be a fully-qualified external DNS name"
+        raise ValueError(msg)
+    if len(normalized) > _MAX_DNS_NAME_LENGTH or any(not label for label in labels):
+        msg = "hostname is not a valid DNS name"
+        raise ValueError(msg)
+    for label in labels:
+        if len(label) > _MAX_DNS_LABEL_LENGTH or label.startswith("-") or label.endswith("-"):
+            msg = "hostname is not a valid DNS name"
+            raise ValueError(msg)
+        if not all(char.isalnum() or char == "-" for char in label):
+            msg = "hostname contains unsupported characters"
+            raise ValueError(msg)
+
+
+def _reject_internal_hostname(normalized: str) -> None:
+    if normalized in _FORBIDDEN_HOSTNAMES or normalized.endswith(_FORBIDDEN_HOST_SUFFIXES):
+        msg = "hostname points at an internal name"
+        raise ValueError(msg)
+
+
+def canonical_hostname(value: str) -> str:
+    """Canonicalize one egress hostname, rejecting malformed and internal names."""
+    raw = _raw_hostname(value)
+    _reject_ip_literal(raw)
+    normalized = _idna_hostname(raw)
+    _validate_dns_labels(normalized)
+    _reject_internal_hostname(normalized)
+    return normalized
+
+
+def is_hostname_allowed(hostname: str, policy: WorkerEgressPolicy) -> bool:
+    """Return whether one canonical hostname matches the policy's static allowlist."""
+    for entry in policy.static_allowlist:
+        try:
+            if entry.startswith("."):
+                base = canonical_hostname(entry[1:])
+                if hostname == base or hostname.endswith(f".{base}"):
+                    return True
+            elif hostname == canonical_hostname(entry):
+                return True
+        except ValueError:
+            continue
+    return False
+
+
+def resolve_grant_subject(
+    *,
+    agent_name: str,
+    worker_scope: WorkerScope | None,
+    execution_identity: ToolExecutionIdentity | None,
+) -> EgressGrantSubject:
+    """Resolve the grant subject one agent's execution scope maps to."""
+    if worker_scope == "user_agent":
+        worker_key = (
+            resolve_worker_key("user_agent", execution_identity, agent_name=agent_name)
+            if execution_identity is not None
+            else None
+        )
+        if worker_key is None:
+            msg = "could not resolve the user-agent worker key for this request"
+            raise RuntimeError(msg)
+        return EgressGrantSubject(subject_type="worker_key", subject=worker_key)
+    if worker_scope == "user":
+        msg = "approved egress is not supported for worker_scope=user"
+        raise RuntimeError(msg)
+    return EgressGrantSubject(subject_type="agent", subject=agent_name)
+
+
+def resolve_worker_egress_policy(
+    *,
+    agent_name: str | None = None,
+    worker_scope: WorkerScope | None = None,
+    execution_identity: ToolExecutionIdentity | None = None,
+) -> WorkerEgressPolicy:
+    """Collect the static allowlist and the scope-derived grant subject into one policy value.
+
+    Without ``agent_name`` this resolves the subject-less policy (static
+    allowlist only), which is all the allow-decision needs.
+    """
+    grant_subject = (
+        resolve_grant_subject(
+            agent_name=agent_name,
+            worker_scope=worker_scope,
+            execution_identity=execution_identity,
+        )
+        if agent_name is not None
+        else None
+    )
+    return WorkerEgressPolicy(static_allowlist=load_static_allowlist(), grant_subject=grant_subject)

--- a/src/mindroom/egress/policy.py
+++ b/src/mindroom/egress/policy.py
@@ -41,6 +41,10 @@ _DEFAULT_ALLOWLIST_PATH = "/etc/mindroom-egress/allowed-domains.txt"
 _MAX_DNS_NAME_LENGTH = 253
 _MAX_DNS_LABEL_LENGTH = 63
 _MIN_DNS_LABELS = 2
+# Defense-in-depth deny entries. ``canonical_hostname`` rejects bare
+# "localhost" earlier via the minimum-label check, so that entry is currently
+# redundant on that path; it stays as a backstop so relaxing label validation
+# can never re-admit it.
 _FORBIDDEN_HOSTNAMES = {
     "localhost",
     "metadata.google.internal",
@@ -167,7 +171,12 @@ def canonical_hostname(value: str) -> str:
 
 
 def is_hostname_allowed(hostname: str, policy: WorkerEgressPolicy) -> bool:
-    """Return whether one canonical hostname matches the policy's static allowlist."""
+    """Return whether one canonical hostname matches the policy's static allowlist.
+
+    ``hostname`` must already be canonicalized via :func:`canonical_hostname`;
+    non-canonical input is not normalized here and fails closed (``False``),
+    which at worst routes an already-allowed host through the grant flow.
+    """
     for entry in policy.static_allowlist:
         try:
             if entry.startswith("."):

--- a/src/mindroom/tools/approved_egress.py
+++ b/src/mindroom/tools/approved_egress.py
@@ -1,4 +1,9 @@
-"""Approved worker egress tool."""
+"""Approved worker egress tool.
+
+Hostname validation, the static allowlist, and grant-subject resolution are
+owned by ``mindroom.egress.policy``; this module only drives the approval
+flow against the egress proxy's policy API.
+"""
 
 from __future__ import annotations
 
@@ -7,50 +12,35 @@ import ipaddress
 import json
 import os
 import unicodedata
-from dataclasses import dataclass
-from pathlib import Path
 from typing import TYPE_CHECKING, cast
 from urllib import error, parse, request
 
 from agno.tools import Toolkit
 
+from mindroom.egress.policy import (
+    canonical_hostname,
+    is_hostname_allowed,
+    load_static_allowlist,
+    resolve_grant_subject,
+    resolve_worker_egress_policy,
+)
 from mindroom.tool_system.metadata import SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
 from mindroom.tool_system.runtime_context import (
     build_execution_identity_from_runtime_context,
     get_tool_runtime_context,
 )
-from mindroom.tool_system.worker_routing import resolve_worker_key
 
 if TYPE_CHECKING:
     from http.client import HTTPMessage
     from typing import IO
 
+    from mindroom.egress.policy import EgressGrantSubject
     from mindroom.tool_system.runtime_context import ToolRuntimeContext
 
 _DEFAULT_MAX_TTL_SECONDS = 6 * 60 * 60
 _DEFAULT_POLICY_API_URL = "http://mindroom-egress-proxy:8080"
-_DEFAULT_ALLOWLIST_PATH = "/etc/mindroom-egress/allowed-domains.txt"
 _MAX_ALLOWLIST_ENTRIES_IN_TOOL_DESCRIPTION = 80
 _MAX_REASON_CHARS = 500
-_MAX_DNS_NAME_LENGTH = 253
-_MAX_DNS_LABEL_LENGTH = 63
-_MIN_DNS_LABELS = 2
-_FORBIDDEN_HOSTNAMES = {
-    "localhost",
-    "metadata.google.internal",
-}
-_FORBIDDEN_HOST_SUFFIXES = (
-    ".localhost",
-    ".svc",
-    ".svc.cluster.local",
-    ".cluster.local",
-)
-
-
-@dataclass(frozen=True, slots=True)
-class _GrantSubject:
-    subject_type: str
-    subject: str
 
 
 def _env_int(name: str, default: int) -> int:
@@ -64,26 +54,8 @@ def _env_int(name: str, default: int) -> int:
         raise RuntimeError(msg) from exc
 
 
-def _static_allowlist_entries() -> list[str]:
-    inline = os.environ.get("MINDROOM_APPROVED_EGRESS_ALLOWLIST", "").strip()
-    text = inline.replace(",", "\n") if inline else ""
-    if not text:
-        allowlist_path = (
-            os.environ.get("MINDROOM_APPROVED_EGRESS_ALLOWLIST_PATH")
-            or os.environ.get("MINDROOM_EGRESS_ALLOWLIST_PATH")
-            or _DEFAULT_ALLOWLIST_PATH
-        ).strip()
-        if allowlist_path:
-            try:
-                text = Path(allowlist_path).read_text(encoding="utf-8")
-            except OSError:
-                text = ""
-    entries = (line for raw in text.splitlines() if (line := raw.split("#", 1)[0].strip()))
-    return list(dict.fromkeys(entries))
-
-
 def _static_allowlist_description() -> str:
-    entries = _static_allowlist_entries()
+    entries = load_static_allowlist()
     if not entries:
         return (
             "Static egress allowlist: unavailable when this tool loaded. "
@@ -105,93 +77,6 @@ def _request_network_access_description() -> str:
         "Use this only when the worker needs a hostname that is not already allowed.\n\n"
         f"{_static_allowlist_description()}"
     )
-
-
-def _raw_hostname(value: str) -> str:
-    if not isinstance(value, str):
-        msg = "hostname must be a string"
-        raise TypeError(msg)
-    raw = value.strip().rstrip(".")
-    if not raw:
-        msg = "hostname must not be empty"
-        raise ValueError(msg)
-    if "://" in raw or any(part in raw for part in ("/", "?", "#", "@")):
-        msg = "hostname must not include a scheme, path, query, or credentials"
-        raise ValueError(msg)
-    if "*" in raw:
-        msg = "hostname wildcards are not supported"
-        raise ValueError(msg)
-    if ":" in raw:
-        msg = "hostname must not include a port"
-        raise ValueError(msg)
-    if len(raw) > _MAX_DNS_NAME_LENGTH:
-        msg = "hostname is too long"
-        raise ValueError(msg)
-    return raw
-
-
-def _reject_ip_literal(raw: str) -> None:
-    try:
-        ipaddress.ip_address(raw)
-    except ValueError:
-        return
-    msg = "IP literals are not valid egress hostnames"
-    raise ValueError(msg)
-
-
-def _idna_hostname(raw: str) -> str:
-    try:
-        return raw.encode("idna").decode("ascii").lower()
-    except UnicodeError as exc:
-        msg = "hostname is not valid IDNA"
-        raise ValueError(msg) from exc
-
-
-def _validate_dns_labels(normalized: str) -> None:
-    labels = normalized.split(".")
-    if len(labels) < _MIN_DNS_LABELS:
-        msg = "hostname must be a fully-qualified external DNS name"
-        raise ValueError(msg)
-    if len(normalized) > _MAX_DNS_NAME_LENGTH or any(not label for label in labels):
-        msg = "hostname is not a valid DNS name"
-        raise ValueError(msg)
-    for label in labels:
-        if len(label) > _MAX_DNS_LABEL_LENGTH or label.startswith("-") or label.endswith("-"):
-            msg = "hostname is not a valid DNS name"
-            raise ValueError(msg)
-        if not all(char.isalnum() or char == "-" for char in label):
-            msg = "hostname contains unsupported characters"
-            raise ValueError(msg)
-
-
-def _reject_internal_hostname(normalized: str) -> None:
-    if normalized in _FORBIDDEN_HOSTNAMES or normalized.endswith(_FORBIDDEN_HOST_SUFFIXES):
-        msg = "hostname points at an internal name"
-        raise ValueError(msg)
-
-
-def _canonical_hostname(value: str) -> str:
-    raw = _raw_hostname(value)
-    _reject_ip_literal(raw)
-    normalized = _idna_hostname(raw)
-    _validate_dns_labels(normalized)
-    _reject_internal_hostname(normalized)
-    return normalized
-
-
-def _static_allowlist_allows(host: str) -> bool:
-    """Return whether one canonical hostname matches the static allowlist."""
-    for entry in _static_allowlist_entries():
-        try:
-            if entry.startswith("."):
-                base = _canonical_hostname(entry[1:])
-                if host == base or host.endswith(f".{base}"):
-                    return True
-            elif host == _canonical_hostname(entry):
-                return True
-        except ValueError:
-            continue
-    return False
 
 
 def _is_plain_http_api_host_allowed(hostname: str) -> bool:
@@ -250,20 +135,15 @@ def _effective_ttl_seconds(requested_ttl_seconds: int) -> int:
     return max(1, min(requested_ttl_seconds, max_ttl))
 
 
-def _grant_subject(context: ToolRuntimeContext) -> _GrantSubject:
+def _grant_subject(context: ToolRuntimeContext) -> EgressGrantSubject:
     agent_name = context.agent_name
     scope = context.config.get_agent_execution_scope(agent_name)
-    if scope == "user_agent":
-        identity = build_execution_identity_from_runtime_context(context)
-        worker_key = resolve_worker_key("user_agent", identity, agent_name=agent_name)
-        if worker_key is None:
-            msg = "could not resolve the user-agent worker key for this request"
-            raise RuntimeError(msg)
-        return _GrantSubject(subject_type="worker_key", subject=worker_key)
-    if scope == "user":
-        msg = "approved egress is not supported for worker_scope=user"
-        raise RuntimeError(msg)
-    return _GrantSubject(subject_type="agent", subject=agent_name)
+    execution_identity = build_execution_identity_from_runtime_context(context) if scope == "user_agent" else None
+    return resolve_grant_subject(
+        agent_name=agent_name,
+        worker_scope=scope,
+        execution_identity=execution_identity,
+    )
 
 
 class _NoRedirectHandler(request.HTTPRedirectHandler):
@@ -361,8 +241,8 @@ class _ApprovedEgressTools(Toolkit):
         reason: str,
     ) -> str:
         """Request temporary worker egress to one exact external hostname."""
-        host = _canonical_hostname(hostname)
-        if _static_allowlist_allows(host):
+        host = canonical_hostname(hostname)
+        if is_hostname_allowed(host, resolve_worker_egress_policy()):
             return f"{host} is already allowed by the static egress allowlist. No temporary grant was created."
         normalized_reason = _normalize_reason(reason)
         requested_ttl_seconds = ttl_minutes * 60

--- a/src/mindroom/workers/backends/kubernetes_resources.py
+++ b/src/mindroom/workers/backends/kubernetes_resources.py
@@ -1,4 +1,15 @@
-"""Resource and manifest helpers for the Kubernetes worker backend."""
+"""Resource and manifest helpers for the Kubernetes worker backend.
+
+Worker egress note: this provisioning path intentionally does not read the
+static egress allowlist owned by ``mindroom.egress.policy``. It only wires
+proxy credentials (URL, minted token, CA) into worker pods; the egress proxy
+deployed by the chart enforces the combined policy — static allowlist plus
+approved temporary grants — centrally on actual traffic. The seam shared with
+the policy layer is the worker key: grants minted by the approved-egress tool
+for ``subject_type=worker_key`` must address the same worker key this backend
+stamps on pods (``ANNOTATION_WORKER_KEY``), which both sides resolve through
+``mindroom.tool_system.worker_routing``.
+"""
 
 from __future__ import annotations
 

--- a/tach.toml
+++ b/tach.toml
@@ -2091,6 +2091,14 @@ depends_on = [
     "mindroom.tool_system.context_bound_streams",
 ]
 
+# Local worker egress policy resolution (static allowlist + grant subjects).
+# The egress proxy enforces grants server-side; this module stays a thin,
+# routing-aware leaf so the tool layer and worker provisioning share one
+# source of truth for the grant subject.
+[[modules]]
+path = "mindroom.egress"
+depends_on = ["mindroom.tool_system.worker_routing"]
+
 [[modules]]
 path = "mindroom.tool_system.events"
 depends_on = []

--- a/tests/test_approved_egress_tool.py
+++ b/tests/test_approved_egress_tool.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from mindroom.egress import policy as egress_policy_module
 from mindroom.tools import approved_egress as approved_egress_module
 
 if TYPE_CHECKING:
@@ -34,46 +35,6 @@ def _approved_egress_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "MINDROOM_APPROVED_EGRESS_MAX_TTL_SECONDS",
     ):
         monkeypatch.delenv(name, raising=False)
-
-
-@pytest.mark.parametrize(
-    ("hostname", "expected"),
-    [
-        ("Docs.Example.COM.", "docs.example.com"),
-        ("münchen.example", "xn--mnchen-3ya.example"),
-    ],
-)
-def test_canonical_hostname_normalizes_case_trailing_dot_and_idna(hostname: str, expected: str) -> None:
-    """Hostnames should canonicalize to lowercase ASCII DNS names."""
-    assert approved_egress_module._canonical_hostname(hostname) == expected
-
-
-@pytest.mark.parametrize(
-    ("hostname", "match"),
-    [
-        ("", "must not be empty"),
-        ("https://docs.example.com", "scheme, path, query, or credentials"),
-        ("docs.example.com/path", "scheme, path, query, or credentials"),
-        ("user@docs.example.com", "scheme, path, query, or credentials"),
-        ("docs.example.com:443", "must not include a port"),
-        ("*.example.com", "wildcards are not supported"),
-        ("203.0.113.7", "IP literals are not valid"),
-        ("example", "fully-qualified external DNS name"),
-        ("localhost", "fully-qualified external DNS name"),
-        ("metadata.google.internal", "points at an internal name"),
-        ("foo.svc.cluster.local", "points at an internal name"),
-        ("api.svc", "points at an internal name"),
-        ("foo.localhost", "points at an internal name"),
-        ("bad..example.com", "not valid IDNA"),
-        (f"{'a' * 64}.example.com", "not valid IDNA"),
-        ("-bad.example.com", "not a valid DNS name"),
-        ("foo_bar.example.com", "contains unsupported characters"),
-    ],
-)
-def test_canonical_hostname_rejects_invalid_and_internal_names(hostname: str, match: str) -> None:
-    """The hostname gate should reject malformed, internal, and non-DNS inputs."""
-    with pytest.raises(ValueError, match=match):
-        approved_egress_module._canonical_hostname(hostname)
 
 
 def test_request_network_access_rejects_internal_hostname_before_grant(
@@ -181,7 +142,7 @@ def test_request_network_access_posts_worker_key_grant(
         lambda _context: object(),
     )
     monkeypatch.setattr(
-        approved_egress_module,
+        egress_policy_module,
         "resolve_worker_key",
         lambda *_args, **_kwargs: "v1:default:user_agent:@user:server:assistant",
     )

--- a/tests/test_egress_policy.py
+++ b/tests/test_egress_policy.py
@@ -1,0 +1,308 @@
+"""Tests for the worker egress policy resolver."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mindroom.egress.policy import (
+    EgressGrantSubject,
+    WorkerEgressPolicy,
+    canonical_hostname,
+    is_hostname_allowed,
+    load_static_allowlist,
+    resolve_grant_subject,
+    resolve_worker_egress_policy,
+)
+from mindroom.tool_system.worker_routing import (
+    ToolExecutionIdentity,
+    resolve_worker_key,
+    resolve_worker_target,
+)
+from mindroom.tools import approved_egress as approved_egress_module
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from mindroom.tool_system.worker_routing import WorkerScope
+
+
+@pytest.fixture(autouse=True)
+def _egress_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    for name in (
+        "MINDROOM_APPROVED_EGRESS_ALLOWLIST",
+        "MINDROOM_EGRESS_ALLOWLIST_PATH",
+        "MINDROOM_APPROVED_EGRESS_API_URL",
+        "MINDROOM_APPROVED_EGRESS_TOKEN",
+        "MINDROOM_APPROVED_EGRESS_MAX_TTL_SECONDS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    # Keep tests hermetic on hosts that mount a real allowlist at the default path.
+    monkeypatch.setenv("MINDROOM_APPROVED_EGRESS_ALLOWLIST_PATH", str(tmp_path / "missing-allowlist.txt"))
+
+
+def _identity(requester_id: str | None = "@user:server") -> ToolExecutionIdentity:
+    return ToolExecutionIdentity(
+        channel="matrix",
+        agent_name="assistant",
+        requester_id=requester_id,
+        room_id="!room:server",
+        thread_id="$thread",
+        resolved_thread_id=None,
+        session_id=None,
+        tenant_id="tenant-a",
+        account_id=None,
+    )
+
+
+def test_load_static_allowlist_from_inline_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Inline env entries split on commas, drop comments, and deduplicate in order."""
+    monkeypatch.setenv(
+        "MINDROOM_APPROVED_EGRESS_ALLOWLIST",
+        "docs.example.com, .api.example.com,docs.example.com,# comment",
+    )
+
+    assert load_static_allowlist() == ("docs.example.com", ".api.example.com")
+
+
+def test_load_static_allowlist_from_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """File entries drop comments and blank lines."""
+    allowlist_path = tmp_path / "allowed-domains.txt"
+    allowlist_path.write_text("docs.example.com\n# comment\n\n.api.example.com  # trailing\n", encoding="utf-8")
+    monkeypatch.setenv("MINDROOM_APPROVED_EGRESS_ALLOWLIST_PATH", str(allowlist_path))
+
+    assert load_static_allowlist() == ("docs.example.com", ".api.example.com")
+
+
+def test_load_static_allowlist_falls_back_to_legacy_path_env(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """MINDROOM_EGRESS_ALLOWLIST_PATH backs the proxy-shared mount when the tool env is unset."""
+    allowlist_path = tmp_path / "allowed-domains.txt"
+    allowlist_path.write_text("docs.example.com\n", encoding="utf-8")
+    monkeypatch.delenv("MINDROOM_APPROVED_EGRESS_ALLOWLIST_PATH", raising=False)
+    monkeypatch.setenv("MINDROOM_EGRESS_ALLOWLIST_PATH", str(allowlist_path))
+
+    assert load_static_allowlist() == ("docs.example.com",)
+
+
+def test_load_static_allowlist_empty_when_file_missing() -> None:
+    """A missing allowlist file resolves to the empty allowlist."""
+    assert load_static_allowlist() == ()
+
+
+@pytest.mark.parametrize(
+    ("hostname", "expected"),
+    [
+        ("Docs.Example.COM.", "docs.example.com"),
+        ("münchen.example", "xn--mnchen-3ya.example"),
+    ],
+)
+def test_canonical_hostname_normalizes_case_trailing_dot_and_idna(hostname: str, expected: str) -> None:
+    """Hostnames should canonicalize to lowercase ASCII DNS names."""
+    assert canonical_hostname(hostname) == expected
+
+
+@pytest.mark.parametrize(
+    ("hostname", "match"),
+    [
+        ("", "must not be empty"),
+        ("https://docs.example.com", "scheme, path, query, or credentials"),
+        ("docs.example.com/path", "scheme, path, query, or credentials"),
+        ("user@docs.example.com", "scheme, path, query, or credentials"),
+        ("docs.example.com:443", "must not include a port"),
+        ("*.example.com", "wildcards are not supported"),
+        ("203.0.113.7", "IP literals are not valid"),
+        ("example", "fully-qualified external DNS name"),
+        ("localhost", "fully-qualified external DNS name"),
+        ("metadata.google.internal", "points at an internal name"),
+        ("foo.svc.cluster.local", "points at an internal name"),
+        ("api.svc", "points at an internal name"),
+        ("foo.localhost", "points at an internal name"),
+        ("bad..example.com", "not valid IDNA"),
+        (f"{'a' * 64}.example.com", "not valid IDNA"),
+        ("-bad.example.com", "not a valid DNS name"),
+        ("foo_bar.example.com", "contains unsupported characters"),
+    ],
+)
+def test_canonical_hostname_rejects_invalid_and_internal_names(hostname: str, match: str) -> None:
+    """The hostname gate should reject malformed, internal, and non-DNS inputs."""
+    with pytest.raises(ValueError, match=match):
+        canonical_hostname(hostname)
+
+
+@pytest.mark.parametrize(
+    ("entries", "hostname", "expected"),
+    [
+        (("docs.example.com",), "docs.example.com", True),
+        (("docs.example.com",), "sub.docs.example.com", False),
+        ((".example.com",), "example.com", True),
+        ((".example.com",), "deep.sub.example.com", True),
+        ((".example.com",), "badexample.com", False),
+        (("*.example.com", "docs.example.com"), "docs.example.com", True),
+        (("*.example.com",), "anything.example.com", False),
+        (("Docs.Example.COM.",), "docs.example.com", True),
+        ((".MüNCHEN.example",), "sub.xn--mnchen-3ya.example", True),
+        ((), "docs.example.com", False),
+    ],
+)
+def test_is_hostname_allowed_static_matching(entries: tuple[str, ...], hostname: str, expected: bool) -> None:
+    """Static matching supports exact entries, leading-dot suffix entries, and skips invalid entries."""
+    policy = WorkerEgressPolicy(static_allowlist=entries)
+
+    assert is_hostname_allowed(hostname, policy) is expected
+
+
+def test_resolve_policy_static_only_without_subject(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resolving without an agent yields the allowlist and no grant subject."""
+    monkeypatch.setenv("MINDROOM_APPROVED_EGRESS_ALLOWLIST", ".example.com")
+
+    policy = resolve_worker_egress_policy()
+
+    assert policy == WorkerEgressPolicy(static_allowlist=(".example.com",), grant_subject=None)
+
+
+def test_resolve_policy_empty_inputs() -> None:
+    """No allowlist sources and no agent resolve to the empty policy."""
+    assert resolve_worker_egress_policy() == WorkerEgressPolicy(static_allowlist=(), grant_subject=None)
+
+
+@pytest.mark.parametrize("worker_scope", [None, "shared"])
+def test_resolve_policy_agent_subject_for_non_isolating_scopes(worker_scope: WorkerScope | None) -> None:
+    """Shared and unscoped agents receive agent-addressed grants."""
+    policy = resolve_worker_egress_policy(
+        agent_name="assistant",
+        worker_scope=worker_scope,
+        execution_identity=None,
+    )
+
+    assert policy.grant_subject == EgressGrantSubject(subject_type="agent", subject="assistant")
+
+
+def test_resolve_policy_worker_key_subject_for_user_agent_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    """user_agent scope addresses grants to the resolved worker key."""
+    monkeypatch.setenv("MINDROOM_APPROVED_EGRESS_ALLOWLIST", "docs.example.com")
+    identity = _identity()
+
+    policy = resolve_worker_egress_policy(
+        agent_name="assistant",
+        worker_scope="user_agent",
+        execution_identity=identity,
+    )
+
+    expected_key = resolve_worker_key("user_agent", identity, agent_name="assistant")
+    assert expected_key is not None
+    assert policy.static_allowlist == ("docs.example.com",)
+    assert policy.grant_subject == EgressGrantSubject(subject_type="worker_key", subject=expected_key)
+
+
+def test_resolve_grant_subject_rejects_user_scope() -> None:
+    """worker_scope=user has no per-worker grant subject."""
+    with pytest.raises(RuntimeError, match="not supported for worker_scope=user"):
+        resolve_grant_subject(agent_name="assistant", worker_scope="user", execution_identity=_identity())
+
+
+@pytest.mark.parametrize("execution_identity", [None, _identity(requester_id=None)])
+def test_resolve_grant_subject_requires_resolvable_user_agent_key(
+    execution_identity: ToolExecutionIdentity | None,
+) -> None:
+    """user_agent scope fails closed when the worker key cannot be resolved."""
+    with pytest.raises(RuntimeError, match="could not resolve the user-agent worker key"):
+        resolve_grant_subject(
+            agent_name="assistant",
+            worker_scope="user_agent",
+            execution_identity=execution_identity,
+        )
+
+
+def test_tool_and_worker_provisioning_resolve_the_same_policy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The grant subject the tool POSTs equals the worker key the provisioning path uses.
+
+    This is the cross-layer egress boundary: a worker_key grant created via the
+    approved-egress tool only takes effect if it addresses the same worker key
+    that worker provisioning (sandbox routing -> WorkerSpec -> the Kubernetes
+    worker-key pod annotation) resolves for the same scope and identity.
+    """
+    identity = _identity()
+
+    # Worker-provisioning path: sandbox routing resolves the worker target whose
+    # worker_key reaches the backend and is stamped on the worker pod.
+    provisioning_key = resolve_worker_target("user_agent", "assistant", identity).worker_key
+    assert provisioning_key is not None
+
+    # Policy-resolver path.
+    policy = resolve_worker_egress_policy(
+        agent_name="assistant",
+        worker_scope="user_agent",
+        execution_identity=identity,
+    )
+    assert policy.grant_subject == EgressGrantSubject(subject_type="worker_key", subject=provisioning_key)
+
+    # Tool path: run the real request flow (real resolve_worker_key, no routing mocks)
+    # and capture the grant payload it would POST to the policy service.
+    captured: dict[str, object] = {}
+
+    def post_grant(payload: dict[str, object]) -> dict[str, object]:
+        captured.update(payload)
+        return {"expires_at": 123}
+
+    class Config:
+        def get_agent_execution_scope(self, agent_name: str) -> str:
+            del agent_name
+            return "user_agent"
+
+    class Context:
+        agent_name = "assistant"
+        room_id = "!room:server"
+        resolved_thread_id = None
+        thread_id = "$thread"
+        requester_id = "@user:server"
+        config = Config()
+
+    monkeypatch.setattr(approved_egress_module, "_post_grant", post_grant)
+    monkeypatch.setattr(approved_egress_module, "get_tool_runtime_context", lambda: Context())
+    monkeypatch.setattr(
+        approved_egress_module,
+        "build_execution_identity_from_runtime_context",
+        lambda _context: identity,
+    )
+
+    result = asyncio.run(
+        approved_egress_module.approved_egress_tools()().request_network_access(
+            "docs.example.com",
+            5,
+            "Need docs",
+        ),
+    )
+
+    assert result.startswith("Approved temporary network access to docs.example.com")
+    assert captured["subject_type"] == "worker_key"
+    assert captured["subject"] == provisioning_key
+
+
+def test_tool_static_allow_short_circuit_agrees_with_policy_decision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The tool's static-allow early return is exactly the policy allow-decision."""
+    monkeypatch.setenv("MINDROOM_APPROVED_EGRESS_ALLOWLIST", ".example.com")
+
+    assert is_hostname_allowed("docs.example.com", resolve_worker_egress_policy())
+
+    def post_grant(_payload: dict[str, object]) -> dict[str, object]:
+        msg = "static allowlist match should not create a grant"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(approved_egress_module, "_post_grant", post_grant)
+
+    result = asyncio.run(
+        approved_egress_module.approved_egress_tools()().request_network_access(
+            "docs.example.com",
+            5,
+            "Need docs",
+        ),
+    )
+
+    assert "docs.example.com is already allowed" in result


### PR DESCRIPTION
## Summary

PR #1197 left worker egress policy assembled across layers with no single owner: the approved-egress tool inlined hostname validation and the static allowlist read, worker provisioning wired proxy credentials with no stated relationship to the policy, and `mindroom/egress/` was an empty stub.

This PR makes `mindroom.egress.policy` the single owner of locally-resolvable egress policy:

- `WorkerEgressPolicy` dataclass (`static_allowlist`, `grant_subject`) and `EgressGrantSubject`.
- `resolve_worker_egress_policy(...)` — assembles static allowlist + scope-derived grant subject.
- `is_hostname_allowed(hostname, policy)` — the single allow-decision function (moved verbatim).
- `canonical_hostname(...)` and `load_static_allowlist(...)` — hostname validation chain and file/env allowlist read, moved verbatim from the tool.
- `resolve_grant_subject(...)` — the scope→subject mapping, preserving exact error messages.

`tools/approved_egress.py` becomes a consumer with **zero semantic change**: same messages, same check ordering (canonicalize → static check → context check → subject resolution), same TTL/reason handling and approval POST flow. Worker provisioning is documented rather than coupled: `kubernetes_resources.py` gets a module-docstring note that provisioning intentionally does not read the allowlist (the chart-deployed egress proxy enforces the combined policy centrally) and that the shared seam is the worker key (`ANNOTATION_WORKER_KEY`). New `mindroom.egress` tach module entry.

## Design notes

- `WorkerEgressPolicy` intentionally has no "approved grants" field — grants live server-side in the egress proxy's database and are only created via its API; inventing a local grants input would misrepresent the trust boundary.
- The tool's policy-API URL guard (`_is_plain_http_api_host_allowed`) uses looser normalization by design — it validates the policy service endpoint, not worker egress targets — and deliberately stays in the tool.
- No in-repo behavior discrepancies found: only the tool ever contained decision logic, so this was a move, not a merge. Whether the external egress-proxy image's hostname normalization matches `canonical_hostname` cannot be verified from this repo; the in-repo static check remains advisory with the same fail-safe direction as before.

## Tests

- New `tests/test_egress_policy.py` (44 tests): policy assembly from each input combination (inline env, file, legacy path fallback, empty), hostname allow/deny incl. leading-dot suffix entries and IDNA/case canonicalization, scope→subject cases, and the previously-missing **cross-layer test**: the grant subject the tool POSTs for `user_agent` scope equals the worker key the provisioning path resolves for the same identity (the key Kubernetes stamps via `ANNOTATION_WORKER_KEY`), through the real `worker_routing` resolver.
- `uv run pytest tests/test_egress_policy.py tests/test_approved_egress_tool.py -x -n 0 --no-cov` → 50 passed.
- `uv run pytest tests/test_kubernetes_worker_backend.py tests/test_docker_worker_backend.py -n 0 --no-cov` → 170 passed.
- Full suite → 8053 passed (26 parallel-load flakes, all pass on `--lf` rerun; none touch egress).
- `uv run tach check --dependencies --interfaces` and pre-commit pass.

Part of the 2026-06-11 architecture-review refactor wave (`refactor-prompts/12`).
