### PR TITLE
Extract scheduled-task firing into scheduling_executor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ Matrix sync callback
 | `tool_system/skills.py` | Skill integration system (OpenClaw-compatible) |
 | `tool_system/plugins.py` | Plugin loading and tool/skill extension |
 | `scheduling.py` | Cron and natural-language task scheduling |
+| `scheduling_executor.py` | Fire one scheduled task: hook emission, message build, Matrix delivery, failure notices |
 | `tools/` | 100+ tool integrations |
 | `tool_system/dependencies.py` | Auto-install per-tool optional dependencies at runtime |
 | `ai.py` | AI response generation, streaming, and Matrix run metadata |

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -61,7 +61,7 @@ from mindroom.mcp.registry import mcp_tool_name
 from mindroom.mcp.toolkit import bind_mcp_server_manager
 from mindroom.memory import MemoryAutoFlushWorker, auto_flush_enabled
 from mindroom.runtime_state import reset_runtime_state, set_runtime_failed, set_runtime_ready, set_runtime_starting
-from mindroom.scheduling import set_scheduling_hook_registry
+from mindroom.scheduling_executor import set_scheduling_hook_registry
 from mindroom.startup_errors import PermanentStartupError
 from mindroom.startup_maintenance import StartupMaintenanceController
 from mindroom.tool_approval import shutdown_approval_runtime

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -19,26 +19,13 @@ from cron_descriptor import Options, get_description
 from croniter import CroniterError, croniter
 from pydantic import BaseModel, Field
 
-from mindroom import model_loading
+from mindroom import model_loading, scheduling_executor
 from mindroom.authorization import responder_candidate_entities_for_room
-from mindroom.constants import ORIGINAL_SENDER_KEY, SOURCE_KIND_KEY
-from mindroom.dispatch_source import SCHEDULED_SOURCE_KIND
 from mindroom.entity_resolution import entity_identity_registry
-from mindroom.hooks import (
-    EVENT_SCHEDULE_FIRED,
-    HookRegistry,
-    ScheduleFiredContext,
-    build_hook_matrix_admin,
-    build_hook_message_sender,
-    build_hook_room_state_putter,
-    build_hook_room_state_querier,
-    emit,
-    send_and_track_message,
-)
+from mindroom.hooks import build_hook_matrix_admin
 from mindroom.logging_config import bound_log_context, get_logger
 from mindroom.matrix.identity import MatrixID
-from mindroom.matrix.mentions import format_message_with_mentions, parse_mentions_in_text
-from mindroom.matrix.message_builder import build_message_content
+from mindroom.matrix.mentions import parse_mentions_in_text
 from mindroom.message_target import MessageTarget
 from mindroom.thread_utils import filter_thread_agents_for_sender, get_agents_in_thread
 
@@ -73,7 +60,6 @@ _DEFERRED_OVERDUE_TASK_START_DELAY_SECONDS = 0.25
 _running_tasks: dict[str, asyncio.Task] = {}
 _deferred_overdue_tasks: deque[_DeferredOverdueTaskStart] = deque()
 _deferred_overdue_task_ids: set[str] = set()
-_ACTIVE_HOOK_REGISTRY: HookRegistry = HookRegistry.empty()
 
 
 class _AgentValidationResult(NamedTuple):
@@ -82,18 +68,6 @@ class _AgentValidationResult(NamedTuple):
     all_valid: bool
     valid_agents: list[MatrixID]
     invalid_agents: list[MatrixID]
-
-
-def _raise_scheduled_workflow_send_error() -> typing.NoReturn:
-    """Raise when a scheduled workflow message cannot be sent."""
-    msg = "Failed to send scheduled workflow message to Matrix"
-    raise RuntimeError(msg)
-
-
-def set_scheduling_hook_registry(hook_registry: HookRegistry) -> None:
-    """Update the immutable hook snapshot used by scheduled task runners."""
-    global _ACTIVE_HOOK_REGISTRY
-    _ACTIVE_HOOK_REGISTRY = hook_registry
 
 
 # ---- Workflow scheduling primitives ----
@@ -815,176 +789,6 @@ async def _parse_workflow_schedule(
         )
 
 
-async def _build_workflow_message_content(
-    workflow: ScheduledWorkflow,
-    target: MessageTarget,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    message_text: str,
-    conversation_cache: ConversationCacheProtocol,
-) -> dict[str, typing.Any]:
-    """Build Matrix message content for a scheduled workflow."""
-    if workflow.new_thread:
-        return format_message_with_mentions(
-            config,
-            runtime_paths,
-            message_text,
-            thread_event_id=None,
-        )
-    automated_message = (
-        f"⏰ [Automated Task]\n{message_text}\n\n_Note: Automated task - follow-up expected when complete._"
-    )
-    assert workflow.room_id is not None  # Caller checks this
-    latest_thread_event_id = None
-    if target.resolved_thread_id is not None:
-        latest_thread_event_id = await conversation_cache.get_latest_thread_event_id_if_needed(
-            workflow.room_id,
-            target.resolved_thread_id,
-            caller_label="scheduled_workflow_message",
-        )
-    return format_message_with_mentions(
-        config,
-        runtime_paths,
-        automated_message,
-        thread_event_id=target.resolved_thread_id,
-        latest_thread_event_id=latest_thread_event_id,
-    )
-
-
-async def _build_scheduled_failure_content(
-    workflow: ScheduledWorkflow,
-    target: MessageTarget,
-    error_message: str,
-    conversation_cache: ConversationCacheProtocol,
-) -> dict[str, typing.Any]:
-    """Build a failure message that follows the scheduled workflow target."""
-    latest_thread_event_id = None
-    if target.resolved_thread_id is not None:
-        assert workflow.room_id is not None
-        latest_thread_event_id = await conversation_cache.get_latest_thread_event_id_if_needed(
-            workflow.room_id,
-            target.resolved_thread_id,
-            caller_label="scheduled_workflow_failure",
-        )
-    return build_message_content(
-        body=error_message,
-        thread_event_id=target.resolved_thread_id,
-        latest_thread_event_id=latest_thread_event_id,
-    )
-
-
-async def _notify_scheduled_workflow_failure(
-    client: nio.AsyncClient,
-    workflow: ScheduledWorkflow,
-    target: MessageTarget,
-    config: Config,
-    error: Exception,
-    conversation_cache: ConversationCacheProtocol,
-) -> None:
-    """Send the visible failure notice for one scheduled workflow when possible."""
-    if not workflow.room_id:
-        return
-    error_message = f"❌ Scheduled task failed: {workflow.description}\nError: {error!s}"
-    error_content = await _build_scheduled_failure_content(
-        workflow,
-        target,
-        error_message,
-        conversation_cache,
-    )
-    try:
-        await send_and_track_message(client, workflow.room_id, error_content, config, conversation_cache)
-    except Exception:
-        logger.exception("Failed to send scheduled workflow failure message")
-
-
-async def _execute_scheduled_workflow(
-    client: nio.AsyncClient,
-    workflow: ScheduledWorkflow,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    conversation_cache: ConversationCacheProtocol,
-    task_id: str = "scheduled-task",
-    matrix_admin: HookMatrixAdmin | None = None,
-) -> bool:
-    """Execute a scheduled workflow by posting its message to the thread."""
-    if not workflow.room_id:
-        logger.error("Cannot execute workflow without room_id")
-        return False
-
-    target = MessageTarget.for_scheduled_task(
-        workflow,
-    )
-
-    with bound_log_context(**target.log_context):
-        try:
-            message_text = workflow.message
-            if _ACTIVE_HOOK_REGISTRY.has_hooks(EVENT_SCHEDULE_FIRED):
-                context = ScheduleFiredContext(
-                    event_name=EVENT_SCHEDULE_FIRED,
-                    plugin_name="",
-                    settings={},
-                    config=config,
-                    runtime_paths=runtime_paths,
-                    logger=logger.bind(event_name=EVENT_SCHEDULE_FIRED),
-                    correlation_id=f"{EVENT_SCHEDULE_FIRED}:{task_id}",
-                    message_sender=build_hook_message_sender(
-                        client,
-                        config,
-                        runtime_paths,
-                        conversation_cache=conversation_cache,
-                    ),
-                    matrix_admin=matrix_admin,
-                    room_state_querier=build_hook_room_state_querier(client),
-                    room_state_putter=build_hook_room_state_putter(client),
-                    task_id=task_id,
-                    workflow=workflow,
-                    room_id=workflow.room_id,
-                    thread_id=target.resolved_thread_id,
-                    created_by=workflow.created_by,
-                    message_text=message_text,
-                )
-                await emit(_ACTIVE_HOOK_REGISTRY, EVENT_SCHEDULE_FIRED, context)
-                if context.suppress:
-                    logger.info("Scheduled workflow suppressed by hook", task_id=task_id, room_id=workflow.room_id)
-                    return False
-                message_text = context.message_text
-
-            content = await _build_workflow_message_content(
-                workflow,
-                target,
-                config,
-                runtime_paths,
-                message_text,
-                conversation_cache,
-            )
-            if workflow.created_by:
-                content[ORIGINAL_SENDER_KEY] = workflow.created_by
-            content[SOURCE_KIND_KEY] = SCHEDULED_SOURCE_KIND
-            delivered = await send_and_track_message(client, workflow.room_id, content, config, conversation_cache)
-            if delivered is None:
-                _raise_scheduled_workflow_send_error()
-            logger.info(
-                "Executed scheduled workflow",
-                description=workflow.description,
-                thread_id=target.resolved_thread_id,
-                new_thread=workflow.new_thread,
-                event_id=delivered.event_id,
-            )
-        except Exception as e:
-            logger.exception("Failed to execute scheduled workflow")
-            await _notify_scheduled_workflow_failure(
-                client,
-                workflow,
-                target,
-                config,
-                e,
-                conversation_cache,
-            )
-            return False
-        else:
-            return True
-
-
 async def _run_cron_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
     client: nio.AsyncClient,
     task_id: str,
@@ -1069,7 +873,7 @@ async def _run_cron_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
                     current_target = MessageTarget.for_scheduled_task(workflow)
                     continue
 
-                await _execute_scheduled_workflow(
+                await scheduling_executor.execute_scheduled_workflow(
                     client,
                     workflow,
                     config,
@@ -1090,13 +894,14 @@ async def _run_cron_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
             logger.exception("cron_task_failed", task_id=task_id)
             if workflow.room_id:
                 error_message = f"❌ Recurring task failed: {workflow.description}\nTask ID: {task_id}\nError: {e!s}"
-                error_content = await _build_scheduled_failure_content(
+                await scheduling_executor.send_scheduled_failure_notice(
+                    client,
                     workflow,
                     current_target,
                     error_message,
+                    config,
                     conversation_cache,
                 )
-                await send_and_track_message(client, workflow.room_id, error_content, config, conversation_cache)
     finally:
         _cleanup_task_if_current(task_id, running_tasks)
 
@@ -1159,7 +964,7 @@ async def _run_once_task(  # noqa: C901, PLR0912, PLR0915
                 logger.error("No execution time provided for one-time task", task_id=task_id)
                 return
 
-            execution_succeeded = await _execute_scheduled_workflow(
+            outcome = await scheduling_executor.execute_scheduled_workflow(
                 client,
                 latest_workflow,
                 config,
@@ -1168,7 +973,7 @@ async def _run_once_task(  # noqa: C901, PLR0912, PLR0915
                 task_id,
                 matrix_admin,
             )
-            final_status = "completed" if execution_succeeded else "failed"
+            final_status = "completed" if outcome.delivered else "failed"
 
             try:
                 await _save_one_time_task_status(
@@ -1197,13 +1002,14 @@ async def _run_once_task(  # noqa: C901, PLR0912, PLR0915
             logger.exception("one_time_task_failed", task_id=task_id)
             if workflow.room_id:
                 error_message = f"❌ One-time task failed: {workflow.description}\nTask ID: {task_id}\nError: {e!s}"
-                error_content = await _build_scheduled_failure_content(
+                await scheduling_executor.send_scheduled_failure_notice(
+                    client,
                     workflow,
                     current_target,
                     error_message,
+                    config,
                     conversation_cache,
                 )
-                await send_and_track_message(client, workflow.room_id, error_content, config, conversation_cache)
             if latest_pending_task is not None:
                 try:
                     await _save_one_time_task_status(

--- a/src/mindroom/scheduling_executor.py
+++ b/src/mindroom/scheduling_executor.py
@@ -1,0 +1,246 @@
+"""Fire one scheduled task: hook emission, message construction, Matrix delivery, failure notices."""
+
+from __future__ import annotations
+
+import typing
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from mindroom.constants import ORIGINAL_SENDER_KEY, SOURCE_KIND_KEY
+from mindroom.dispatch_source import SCHEDULED_SOURCE_KIND
+from mindroom.hooks import (
+    EVENT_SCHEDULE_FIRED,
+    HookRegistry,
+    ScheduleFiredContext,
+    build_hook_message_sender,
+    build_hook_room_state_putter,
+    build_hook_room_state_querier,
+    emit,
+    send_and_track_message,
+)
+from mindroom.logging_config import bound_log_context, get_logger
+from mindroom.matrix.mentions import format_message_with_mentions
+from mindroom.matrix.message_builder import build_message_content
+from mindroom.message_target import MessageTarget
+
+if TYPE_CHECKING:
+    import nio
+
+    from mindroom.config.main import Config
+    from mindroom.constants import RuntimePaths
+    from mindroom.hooks import HookMatrixAdmin
+    from mindroom.matrix.conversation_cache import ConversationCacheProtocol
+    from mindroom.scheduling import ScheduledWorkflow
+
+logger = get_logger(__name__)
+
+_ACTIVE_HOOK_REGISTRY: HookRegistry = HookRegistry.empty()
+
+
+def set_scheduling_hook_registry(hook_registry: HookRegistry) -> None:
+    """Update the immutable hook snapshot used by scheduled task runners."""
+    global _ACTIVE_HOOK_REGISTRY
+    _ACTIVE_HOOK_REGISTRY = hook_registry
+
+
+@dataclass(frozen=True)
+class ScheduledWorkflowOutcome:
+    """Typed result of firing one scheduled workflow."""
+
+    delivered: bool
+    failure_reason: str | None = None
+
+
+def _raise_scheduled_workflow_send_error() -> typing.NoReturn:
+    """Raise when a scheduled workflow message cannot be sent."""
+    msg = "Failed to send scheduled workflow message to Matrix"
+    raise RuntimeError(msg)
+
+
+async def _build_workflow_message_content(
+    workflow: ScheduledWorkflow,
+    target: MessageTarget,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    message_text: str,
+    conversation_cache: ConversationCacheProtocol,
+) -> dict[str, typing.Any]:
+    """Build Matrix message content for a scheduled workflow."""
+    if workflow.new_thread:
+        return format_message_with_mentions(
+            config,
+            runtime_paths,
+            message_text,
+            thread_event_id=None,
+        )
+    automated_message = (
+        f"⏰ [Automated Task]\n{message_text}\n\n_Note: Automated task - follow-up expected when complete._"
+    )
+    assert workflow.room_id is not None  # Caller checks this
+    latest_thread_event_id = None
+    if target.resolved_thread_id is not None:
+        latest_thread_event_id = await conversation_cache.get_latest_thread_event_id_if_needed(
+            workflow.room_id,
+            target.resolved_thread_id,
+            caller_label="scheduled_workflow_message",
+        )
+    return format_message_with_mentions(
+        config,
+        runtime_paths,
+        automated_message,
+        thread_event_id=target.resolved_thread_id,
+        latest_thread_event_id=latest_thread_event_id,
+    )
+
+
+async def _build_scheduled_failure_content(
+    workflow: ScheduledWorkflow,
+    target: MessageTarget,
+    error_message: str,
+    conversation_cache: ConversationCacheProtocol,
+) -> dict[str, typing.Any]:
+    """Build a failure message that follows the scheduled workflow target."""
+    latest_thread_event_id = None
+    if target.resolved_thread_id is not None:
+        assert workflow.room_id is not None
+        latest_thread_event_id = await conversation_cache.get_latest_thread_event_id_if_needed(
+            workflow.room_id,
+            target.resolved_thread_id,
+            caller_label="scheduled_workflow_failure",
+        )
+    return build_message_content(
+        body=error_message,
+        thread_event_id=target.resolved_thread_id,
+        latest_thread_event_id=latest_thread_event_id,
+    )
+
+
+async def send_scheduled_failure_notice(
+    client: nio.AsyncClient,
+    workflow: ScheduledWorkflow,
+    target: MessageTarget,
+    error_message: str,
+    config: Config,
+    conversation_cache: ConversationCacheProtocol,
+) -> None:
+    """Send a visible failure notice that follows the scheduled workflow target."""
+    assert workflow.room_id is not None  # Callers guard on room_id before notifying
+    error_content = await _build_scheduled_failure_content(
+        workflow,
+        target,
+        error_message,
+        conversation_cache,
+    )
+    await send_and_track_message(client, workflow.room_id, error_content, config, conversation_cache)
+
+
+async def _notify_scheduled_workflow_failure(
+    client: nio.AsyncClient,
+    workflow: ScheduledWorkflow,
+    target: MessageTarget,
+    config: Config,
+    error: Exception,
+    conversation_cache: ConversationCacheProtocol,
+) -> None:
+    """Send the visible failure notice for one scheduled workflow when possible."""
+    if not workflow.room_id:
+        return
+    error_message = f"❌ Scheduled task failed: {workflow.description}\nError: {error!s}"
+    error_content = await _build_scheduled_failure_content(
+        workflow,
+        target,
+        error_message,
+        conversation_cache,
+    )
+    try:
+        await send_and_track_message(client, workflow.room_id, error_content, config, conversation_cache)
+    except Exception:
+        logger.exception("Failed to send scheduled workflow failure message")
+
+
+async def execute_scheduled_workflow(
+    client: nio.AsyncClient,
+    workflow: ScheduledWorkflow,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    conversation_cache: ConversationCacheProtocol,
+    task_id: str = "scheduled-task",
+    matrix_admin: HookMatrixAdmin | None = None,
+) -> ScheduledWorkflowOutcome:
+    """Execute a scheduled workflow by posting its message to the thread."""
+    if not workflow.room_id:
+        logger.error("Cannot execute workflow without room_id")
+        return ScheduledWorkflowOutcome(delivered=False, failure_reason="missing room_id")
+
+    target = MessageTarget.for_scheduled_task(
+        workflow,
+    )
+
+    with bound_log_context(**target.log_context):
+        try:
+            message_text = workflow.message
+            if _ACTIVE_HOOK_REGISTRY.has_hooks(EVENT_SCHEDULE_FIRED):
+                context = ScheduleFiredContext(
+                    event_name=EVENT_SCHEDULE_FIRED,
+                    plugin_name="",
+                    settings={},
+                    config=config,
+                    runtime_paths=runtime_paths,
+                    logger=logger.bind(event_name=EVENT_SCHEDULE_FIRED),
+                    correlation_id=f"{EVENT_SCHEDULE_FIRED}:{task_id}",
+                    message_sender=build_hook_message_sender(
+                        client,
+                        config,
+                        runtime_paths,
+                        conversation_cache=conversation_cache,
+                    ),
+                    matrix_admin=matrix_admin,
+                    room_state_querier=build_hook_room_state_querier(client),
+                    room_state_putter=build_hook_room_state_putter(client),
+                    task_id=task_id,
+                    workflow=workflow,
+                    room_id=workflow.room_id,
+                    thread_id=target.resolved_thread_id,
+                    created_by=workflow.created_by,
+                    message_text=message_text,
+                )
+                await emit(_ACTIVE_HOOK_REGISTRY, EVENT_SCHEDULE_FIRED, context)
+                if context.suppress:
+                    logger.info("Scheduled workflow suppressed by hook", task_id=task_id, room_id=workflow.room_id)
+                    return ScheduledWorkflowOutcome(delivered=False, failure_reason="suppressed by hook")
+                message_text = context.message_text
+
+            content = await _build_workflow_message_content(
+                workflow,
+                target,
+                config,
+                runtime_paths,
+                message_text,
+                conversation_cache,
+            )
+            if workflow.created_by:
+                content[ORIGINAL_SENDER_KEY] = workflow.created_by
+            content[SOURCE_KIND_KEY] = SCHEDULED_SOURCE_KIND
+            delivered = await send_and_track_message(client, workflow.room_id, content, config, conversation_cache)
+            if delivered is None:
+                _raise_scheduled_workflow_send_error()
+            logger.info(
+                "Executed scheduled workflow",
+                description=workflow.description,
+                thread_id=target.resolved_thread_id,
+                new_thread=workflow.new_thread,
+                event_id=delivered.event_id,
+            )
+        except Exception as e:
+            logger.exception("Failed to execute scheduled workflow")
+            await _notify_scheduled_workflow_failure(
+                client,
+                workflow,
+                target,
+                config,
+                e,
+                conversation_cache,
+            )
+            return ScheduledWorkflowOutcome(delivered=False, failure_reason=str(e))
+        else:
+            return ScheduledWorkflowOutcome(delivered=True)

--- a/tach.toml
+++ b/tach.toml
@@ -976,7 +976,7 @@ depends_on = [
     "mindroom.orchestration.config_lifecycle",
     "mindroom.orchestration.runtime",
     "mindroom.runtime_support",
-    "mindroom.scheduling",
+    "mindroom.scheduling_executor",
     "mindroom.tool_system.plugins",
     "mindroom.tool_system.skills",
     "mindroom.tool_approval",
@@ -2005,11 +2005,18 @@ depends_on = [
 [[modules]]
 path = "mindroom.scheduling"
 depends_on = [
-    "mindroom.constants",
     "mindroom.entity_resolution",
     "mindroom.hooks",
     "mindroom.matrix.client_delivery",
     "mindroom.model_loading",
+    "mindroom.scheduling_executor",
+]
+
+[[modules]]
+path = "mindroom.scheduling_executor"
+depends_on = [
+    "mindroom.constants",
+    "mindroom.hooks",
 ]
 
 [[modules]]
@@ -2554,6 +2561,15 @@ from = ["mindroom.ai"]
 [[interfaces]]
 expose = ["get_model_instance"]
 from = ["mindroom.model_loading"]
+
+[[interfaces]]
+expose = [
+    "ScheduledWorkflowOutcome",
+    "execute_scheduled_workflow",
+    "send_scheduled_failure_notice",
+    "set_scheduling_hook_registry",
+]
+from = ["mindroom.scheduling_executor"]
 
 [[interfaces]]
 expose = [

--- a/tests/test_hook_schedule.py
+++ b/tests/test_hook_schedule.py
@@ -20,11 +20,10 @@ from mindroom.logging_config import setup_logging
 from mindroom.scheduling import (
     CronSchedule,
     ScheduledWorkflow,
-    _execute_scheduled_workflow,
     _run_cron_task,
     _run_once_task,
-    set_scheduling_hook_registry,
 )
+from mindroom.scheduling_executor import execute_scheduled_workflow, set_scheduling_hook_registry
 from tests.conftest import (
     bind_runtime_paths,
     delivered_matrix_side_effect,
@@ -99,7 +98,7 @@ async def test_schedule_hook_rewrites_message_text(tmp_path: Path) -> None:
         "mindroom.hooks.sender._send_message_result",
         new=AsyncMock(side_effect=delivered_matrix_side_effect("$scheduled")),
     ) as mock_send:
-        await _execute_scheduled_workflow(
+        await execute_scheduled_workflow(
             AsyncMock(),
             _workflow("Prepare for meeting"),
             config,
@@ -126,7 +125,7 @@ async def test_schedule_hook_can_suppress_synthetic_message(tmp_path: Path) -> N
         "mindroom.hooks.sender._send_message_result",
         new=AsyncMock(side_effect=delivered_matrix_side_effect("$scheduled")),
     ) as mock_send:
-        await _execute_scheduled_workflow(
+        await execute_scheduled_workflow(
             AsyncMock(),
             _workflow("Do not send"),
             config,
@@ -159,7 +158,7 @@ async def test_schedule_hook_suppression_log_includes_workflow_thread_context(
         "mindroom.hooks.sender._send_message_result",
         new=AsyncMock(side_effect=delivered_matrix_side_effect("$scheduled")),
     ):
-        await _execute_scheduled_workflow(
+        await execute_scheduled_workflow(
             AsyncMock(),
             _workflow("Do not send"),
             config,
@@ -291,7 +290,7 @@ async def test_schedule_hook_send_message_inherits_context_thread_id(tmp_path: P
         "mindroom.hooks.sender._send_message_result",
         new=AsyncMock(side_effect=delivered_matrix_side_effect("$hook-event")),
     ) as mock_hook_send:
-        await _execute_scheduled_workflow(
+        await execute_scheduled_workflow(
             client,
             _workflow("Resume work"),
             config,
@@ -329,7 +328,7 @@ async def test_schedule_hook_send_message_allows_explicit_room_level_opt_out(tmp
         "mindroom.hooks.sender._send_message_result",
         new=AsyncMock(side_effect=delivered_matrix_side_effect("$hook-event")),
     ) as mock_hook_send:
-        await _execute_scheduled_workflow(
+        await execute_scheduled_workflow(
             client,
             _workflow("Resume work"),
             config,
@@ -370,7 +369,7 @@ async def test_schedule_hook_exposes_matrix_admin(tmp_path: Path) -> None:
         servers=["localhost"],
     )
 
-    await _execute_scheduled_workflow(
+    await execute_scheduled_workflow(
         client,
         _workflow("Resume work"),
         config,
@@ -399,7 +398,7 @@ async def test_schedule_hook_matrix_admin_is_unavailable_without_router_binding(
     client.user_id = "@mindroom_general:localhost"
     client.homeserver = "http://agent.local:8008"
 
-    await _execute_scheduled_workflow(
+    await execute_scheduled_workflow(
         client,
         _workflow("Resume work"),
         config,
@@ -429,7 +428,7 @@ async def test_schedule_hook_send_message_can_trigger_dispatch(tmp_path: Path) -
         "mindroom.hooks.sender._send_message_result",
         new=AsyncMock(side_effect=delivered_matrix_side_effect("$hook-event")),
     ) as mock_hook_send:
-        await _execute_scheduled_workflow(
+        await execute_scheduled_workflow(
             client,
             _workflow("Resume work"),
             config,
@@ -467,7 +466,7 @@ async def test_schedule_hook_room_state_helpers_use_live_client(tmp_path: Path) 
     client.room_get_state_event.return_value = SimpleNamespace(content={"name": "Lobby"})
     client.room_put_state.return_value = object()
 
-    await _execute_scheduled_workflow(
+    await execute_scheduled_workflow(
         client,
         _workflow("Resume work"),
         config,

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -36,6 +36,7 @@ from mindroom.scheduling import (
     schedule_task,
     scheduled_task_read_sort_key,
 )
+from mindroom.scheduling_executor import ScheduledWorkflowOutcome
 from tests.conftest import bind_runtime_paths, make_event_cache_mock
 from tests.identity_helpers import entity_ids, persist_entity_accounts
 
@@ -932,7 +933,10 @@ async def test_run_once_task_stops_when_cancelled_via_matrix_state() -> None:
 
     with (
         patch("mindroom.scheduling.get_scheduled_task", side_effect=_fetch_task),
-        patch("mindroom.scheduling._execute_scheduled_workflow", new=AsyncMock()) as execute_mock,
+        patch(
+            "mindroom.scheduling_executor.execute_scheduled_workflow",
+            new=AsyncMock(return_value=ScheduledWorkflowOutcome(delivered=True)),
+        ) as execute_mock,
         patch("mindroom.scheduling.asyncio.sleep", new=AsyncMock()),
     ):
         await _run_once_task(
@@ -975,7 +979,10 @@ async def test_run_once_task_executes_latest_state_workflow() -> None:
 
     with (
         patch("mindroom.scheduling.get_scheduled_task", side_effect=_fetch_task),
-        patch("mindroom.scheduling._execute_scheduled_workflow", new=AsyncMock()) as execute_mock,
+        patch(
+            "mindroom.scheduling_executor.execute_scheduled_workflow",
+            new=AsyncMock(return_value=ScheduledWorkflowOutcome(delivered=True)),
+        ) as execute_mock,
     ):
         await _run_once_task(
             client,
@@ -1014,7 +1021,10 @@ async def test_run_once_task_marks_completed_after_success() -> None:
             "mindroom.scheduling.get_scheduled_task",
             new=AsyncMock(side_effect=[pending_record, pending_record]),
         ),
-        patch("mindroom.scheduling._execute_scheduled_workflow", new=AsyncMock(return_value=True)) as execute_mock,
+        patch(
+            "mindroom.scheduling_executor.execute_scheduled_workflow",
+            new=AsyncMock(return_value=ScheduledWorkflowOutcome(delivered=True)),
+        ) as execute_mock,
     ):
         await _run_once_task(
             client,
@@ -1058,7 +1068,10 @@ async def test_run_once_task_marks_failed_after_execution_failure() -> None:
             "mindroom.scheduling.get_scheduled_task",
             new=AsyncMock(side_effect=[pending_record, pending_record]),
         ),
-        patch("mindroom.scheduling._execute_scheduled_workflow", new=AsyncMock(return_value=False)) as execute_mock,
+        patch(
+            "mindroom.scheduling_executor.execute_scheduled_workflow",
+            new=AsyncMock(return_value=ScheduledWorkflowOutcome(delivered=False, failure_reason="send failed")),
+        ) as execute_mock,
     ):
         await _run_once_task(
             client,
@@ -1110,7 +1123,10 @@ async def test_run_cron_task_executes_latest_state_workflow() -> None:
 
     with (
         patch("mindroom.scheduling.get_scheduled_task", side_effect=_fetch_task),
-        patch("mindroom.scheduling._execute_scheduled_workflow", new=AsyncMock()) as execute_mock,
+        patch(
+            "mindroom.scheduling_executor.execute_scheduled_workflow",
+            new=AsyncMock(return_value=ScheduledWorkflowOutcome(delivered=True)),
+        ) as execute_mock,
         patch("mindroom.scheduling.croniter", return_value=_ImmediateCron()),
     ):
         await _run_cron_task(
@@ -1154,7 +1170,10 @@ async def test_run_cron_task_keeps_pending_state_after_success() -> None:
             "mindroom.scheduling.get_scheduled_task",
             new=AsyncMock(side_effect=[pending_record, pending_record]),
         ),
-        patch("mindroom.scheduling._execute_scheduled_workflow", new=AsyncMock(return_value=True)) as execute_mock,
+        patch(
+            "mindroom.scheduling_executor.execute_scheduled_workflow",
+            new=AsyncMock(return_value=ScheduledWorkflowOutcome(delivered=True)),
+        ) as execute_mock,
         patch("mindroom.scheduling.croniter", return_value=_ImmediateCron()),
     ):
         await _run_cron_task(
@@ -1190,7 +1209,10 @@ async def test_run_cron_task_stops_when_cancelled_via_matrix_state() -> None:
 
     with (
         patch("mindroom.scheduling.get_scheduled_task", side_effect=_fetch_task),
-        patch("mindroom.scheduling._execute_scheduled_workflow", new=AsyncMock()) as execute_mock,
+        patch(
+            "mindroom.scheduling_executor.execute_scheduled_workflow",
+            new=AsyncMock(return_value=ScheduledWorkflowOutcome(delivered=True)),
+        ) as execute_mock,
     ):
         await _run_cron_task(
             client,

--- a/tests/test_scheduling_executor.py
+++ b/tests/test_scheduling_executor.py
@@ -1,0 +1,317 @@
+"""Tests for firing one scheduled task through the scheduling executor."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from mindroom.config.agent import AgentConfig
+from mindroom.config.main import Config
+from mindroom.config.models import ModelConfig
+from mindroom.constants import ORIGINAL_SENDER_KEY, SOURCE_KIND_KEY
+from mindroom.dispatch_source import SCHEDULED_SOURCE_KIND
+from mindroom.entity_resolution import entity_identity_registry
+from mindroom.hooks import EVENT_SCHEDULE_FIRED, HookRegistry, ScheduleFiredContext, hook
+from mindroom.message_target import MessageTarget
+from mindroom.scheduling import ScheduledWorkflow
+from mindroom.scheduling_executor import (
+    execute_scheduled_workflow,
+    send_scheduled_failure_notice,
+    set_scheduling_hook_registry,
+)
+from tests.conftest import (
+    bind_runtime_paths,
+    delivered_matrix_side_effect,
+    runtime_paths_for,
+    test_runtime_paths,
+)
+from tests.identity_helpers import persist_entity_accounts
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from pathlib import Path
+
+
+def _config(tmp_path: Path) -> Config:
+    return bind_runtime_paths(Config(), test_runtime_paths(tmp_path))
+
+
+def _agent_config(tmp_path: Path) -> Config:
+    config = bind_runtime_paths(
+        Config(
+            agents={"research": AgentConfig(display_name="Research")},
+            models={"default": ModelConfig(provider="test", id="test-model")},
+        ),
+        test_runtime_paths(tmp_path),
+    )
+    persist_entity_accounts(
+        config,
+        runtime_paths_for(config),
+        usernames={"router": "router", "research": "research"},
+    )
+    return config
+
+
+def _workflow(
+    message: str,
+    *,
+    room_id: str | None = "!room:localhost",
+    thread_id: str | None = "$thread",
+    new_thread: bool = False,
+) -> ScheduledWorkflow:
+    return ScheduledWorkflow(
+        schedule_type="once",
+        execute_at=datetime.now(UTC),
+        message=message,
+        description="executor test task",
+        room_id=room_id,
+        thread_id=thread_id,
+        new_thread=new_thread,
+        created_by="@user:localhost",
+    )
+
+
+def _conversation_cache(*, latest_thread_event_id: str | None = None) -> AsyncMock:
+    access = AsyncMock()
+    access.get_latest_thread_event_id_if_needed.return_value = latest_thread_event_id
+    access.notify_outbound_message = Mock()
+    return access
+
+
+def _plugin(name: str, callbacks: list[object]) -> object:
+    return type(
+        "PluginStub",
+        (),
+        {
+            "name": name,
+            "discovered_hooks": tuple(callbacks),
+            "entry_config": type("Entry", (), {"settings": {}, "hooks": {}})(),
+            "plugin_order": 0,
+        },
+    )()
+
+
+@pytest.fixture(autouse=True)
+def reset_schedule_registry() -> Generator[None, None, None]:
+    """Keep the module-global scheduling hook registry isolated per test."""
+    set_scheduling_hook_registry(HookRegistry.empty())
+    yield
+    set_scheduling_hook_registry(HookRegistry.empty())
+
+
+@pytest.mark.asyncio
+async def test_fire_task_with_valid_agent_delivers_in_thread(tmp_path: Path) -> None:
+    """Firing a task targeting a known agent delivers the automated message into the thread."""
+    config = _agent_config(tmp_path)
+    workflow = _workflow("@research Summarize today's AI news")
+    conversation_cache = _conversation_cache(latest_thread_event_id="$latest")
+
+    with patch(
+        "mindroom.hooks.sender._send_message_result",
+        new=AsyncMock(side_effect=delivered_matrix_side_effect("$delivered")),
+    ) as mock_send:
+        outcome = await execute_scheduled_workflow(
+            AsyncMock(),
+            workflow,
+            config,
+            runtime_paths_for(config),
+            conversation_cache,
+            task_id="task-1",
+        )
+
+    assert outcome.delivered is True
+    assert outcome.failure_reason is None
+    mock_send.assert_awaited_once()
+    assert mock_send.await_args.args[1] == "!room:localhost"
+    content = mock_send.await_args.args[2]
+    assert content["body"].startswith("⏰ [Automated Task]\n")
+    registry = entity_identity_registry(config, runtime_paths_for(config))
+    assert registry.current_id("research").full_id in content["body"]
+    assert content["m.relates_to"]["event_id"] == "$thread"
+    assert content[ORIGINAL_SENDER_KEY] == "@user:localhost"
+    assert content[SOURCE_KIND_KEY] == SCHEDULED_SOURCE_KIND
+
+
+@pytest.mark.asyncio
+async def test_fire_new_thread_task_posts_room_level_message(tmp_path: Path) -> None:
+    """new_thread tasks deliver the raw message at room level without the automated wrapper."""
+    config = _config(tmp_path)
+    workflow = _workflow("Kick off the weekly report", thread_id=None, new_thread=True)
+    conversation_cache = _conversation_cache()
+
+    with patch(
+        "mindroom.hooks.sender._send_message_result",
+        new=AsyncMock(side_effect=delivered_matrix_side_effect("$delivered")),
+    ) as mock_send:
+        outcome = await execute_scheduled_workflow(
+            AsyncMock(),
+            workflow,
+            config,
+            runtime_paths_for(config),
+            conversation_cache,
+        )
+
+    assert outcome.delivered is True
+    conversation_cache.get_latest_thread_event_id_if_needed.assert_not_awaited()
+    content = mock_send.await_args.args[2]
+    assert "⏰ [Automated Task]" not in content["body"]
+    assert "m.relates_to" not in content
+
+
+@pytest.mark.asyncio
+async def test_fire_task_without_room_id_is_typed_failure(tmp_path: Path) -> None:
+    """A workflow without a room is a typed failure and never touches Matrix."""
+    config = _config(tmp_path)
+    workflow = _workflow("Orphaned task", room_id=None, thread_id=None)
+
+    with patch("mindroom.hooks.sender._send_message_result", new=AsyncMock()) as mock_send:
+        outcome = await execute_scheduled_workflow(
+            AsyncMock(),
+            workflow,
+            config,
+            runtime_paths_for(config),
+            _conversation_cache(),
+        )
+
+    assert outcome.delivered is False
+    assert outcome.failure_reason == "missing room_id"
+    mock_send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delivery_returning_none_yields_failure_and_notice(tmp_path: Path) -> None:
+    """A send that returns no delivered event produces a failure outcome plus a visible notice."""
+    config = _config(tmp_path)
+    workflow = _workflow("Check the queue depth")
+    conversation_cache = _conversation_cache(latest_thread_event_id="$latest")
+
+    with patch(
+        "mindroom.hooks.sender._send_message_result",
+        new=AsyncMock(side_effect=[None, None]),
+    ) as mock_send:
+        outcome = await execute_scheduled_workflow(
+            AsyncMock(),
+            workflow,
+            config,
+            runtime_paths_for(config),
+            conversation_cache,
+        )
+
+    assert outcome.delivered is False
+    assert outcome.failure_reason == "Failed to send scheduled workflow message to Matrix"
+    assert mock_send.await_count == 2
+    notice_content = mock_send.await_args_list[1].args[2]
+    assert notice_content["body"] == (
+        "❌ Scheduled task failed: executor test task\nError: Failed to send scheduled workflow message to Matrix"
+    )
+    assert notice_content["m.relates_to"]["event_id"] == "$thread"
+
+
+@pytest.mark.asyncio
+async def test_delivery_exception_yields_failure_without_raising(tmp_path: Path) -> None:
+    """Send errors, including a failing notice send, never escape the executor."""
+    config = _config(tmp_path)
+    workflow = _workflow("Check the queue depth")
+
+    with patch(
+        "mindroom.hooks.sender._send_message_result",
+        new=AsyncMock(side_effect=RuntimeError("boom")),
+    ) as mock_send:
+        outcome = await execute_scheduled_workflow(
+            AsyncMock(),
+            workflow,
+            config,
+            runtime_paths_for(config),
+            _conversation_cache(latest_thread_event_id="$latest"),
+        )
+
+    assert outcome.delivered is False
+    assert outcome.failure_reason == "boom"
+    assert mock_send.await_count == 2  # original send plus the (also failing) notice
+
+
+@pytest.mark.asyncio
+async def test_hook_emission_fires_with_task_context(tmp_path: Path) -> None:
+    """schedule:fired hooks run for fired tasks and can rewrite the delivered message."""
+    seen: list[tuple[str, str | None]] = []
+
+    @hook(EVENT_SCHEDULE_FIRED)
+    async def rewrite(ctx: ScheduleFiredContext) -> None:
+        seen.append((ctx.task_id, ctx.thread_id))
+        ctx.message_text = f"{ctx.message_text} (hooked)"
+
+    config = _config(tmp_path)
+    set_scheduling_hook_registry(HookRegistry.from_plugins([_plugin("schedule-plugin", [rewrite])]))
+
+    with patch(
+        "mindroom.hooks.sender._send_message_result",
+        new=AsyncMock(side_effect=delivered_matrix_side_effect("$delivered")),
+    ) as mock_send:
+        outcome = await execute_scheduled_workflow(
+            AsyncMock(),
+            _workflow("Prepare the agenda"),
+            config,
+            runtime_paths_for(config),
+            _conversation_cache(latest_thread_event_id="$latest"),
+            task_id="task-hooked",
+        )
+
+    assert outcome.delivered is True
+    assert seen == [("task-hooked", "$thread")]
+    assert "Prepare the agenda (hooked)" in mock_send.await_args.args[2]["body"]
+
+
+@pytest.mark.asyncio
+async def test_hook_suppression_is_undelivered_outcome(tmp_path: Path) -> None:
+    """Hook suppression yields an undelivered outcome without sending anything."""
+
+    @hook(EVENT_SCHEDULE_FIRED)
+    async def suppress(ctx: ScheduleFiredContext) -> None:
+        ctx.suppress = True
+
+    config = _config(tmp_path)
+    set_scheduling_hook_registry(HookRegistry.from_plugins([_plugin("schedule-plugin", [suppress])]))
+
+    with patch("mindroom.hooks.sender._send_message_result", new=AsyncMock()) as mock_send:
+        outcome = await execute_scheduled_workflow(
+            AsyncMock(),
+            _workflow("Do not send"),
+            config,
+            runtime_paths_for(config),
+            _conversation_cache(),
+        )
+
+    assert outcome.delivered is False
+    assert outcome.failure_reason == "suppressed by hook"
+    mock_send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_scheduled_failure_notice_follows_workflow_target(tmp_path: Path) -> None:
+    """Runner failure notices follow the workflow thread and reply to its latest event."""
+    config = _config(tmp_path)
+    workflow = _workflow("Recurring job")
+    target = MessageTarget.for_scheduled_task(workflow)
+    conversation_cache = _conversation_cache(latest_thread_event_id="$latest")
+
+    with patch(
+        "mindroom.hooks.sender._send_message_result",
+        new=AsyncMock(side_effect=delivered_matrix_side_effect("$notice")),
+    ) as mock_send:
+        await send_scheduled_failure_notice(
+            AsyncMock(),
+            workflow,
+            target,
+            "❌ Recurring task failed: executor test task\nTask ID: task-9\nError: boom",
+            config,
+            conversation_cache,
+        )
+
+    mock_send.assert_awaited_once()
+    content = mock_send.await_args.args[2]
+    assert content["body"].startswith("❌ Recurring task failed: executor test task")
+    assert content["m.relates_to"]["event_id"] == "$thread"
+    assert content["m.relates_to"]["m.in_reply_to"]["event_id"] == "$latest"

--- a/tests/test_workflow_scheduling.py
+++ b/tests/test_workflow_scheduling.py
@@ -29,7 +29,7 @@ from mindroom.scheduling import (
     _WorkflowParseError,
     schedule_task,
 )
-from mindroom.scheduling_executor import _build_scheduled_failure_content, execute_scheduled_workflow
+from mindroom.scheduling_executor import execute_scheduled_workflow, send_scheduled_failure_notice
 from tests.conftest import bind_runtime_paths, make_event_cache_mock, runtime_paths_for, test_runtime_paths
 from tests.identity_helpers import persist_entity_accounts
 
@@ -543,8 +543,9 @@ class TestExecuteScheduledWorkflow:
         assert "m.relates_to" not in content
         assert content[ORIGINAL_SENDER_KEY] == "@user:server"
 
-    async def test_scheduled_failure_content_labels_latest_thread_lookup(self) -> None:
-        """Scheduled failure replies should attribute latest-thread lookups."""
+    async def test_scheduled_failure_notice_labels_latest_thread_lookup(self) -> None:
+        """Scheduled failure notices should attribute latest-thread lookups."""
+        config = _runtime_bound_config(Config())
         workflow = ScheduledWorkflow(
             schedule_type="once",
             execute_at=datetime.now(UTC),
@@ -557,13 +558,28 @@ class TestExecuteScheduledWorkflow:
         target = MessageTarget.resolve("!room:server", "$thread123", None)
         conversation_cache = _conversation_cache(latest_thread_event_id="$latest456")
 
-        content = await _build_scheduled_failure_content(
-            workflow,
-            target,
-            "Workflow failed",
-            conversation_cache,
-        )
+        with patch(
+            "mindroom.hooks.sender._send_message_result",
+            new=AsyncMock(
+                return_value=DeliveredMatrixEvent(
+                    event_id="$notice123",
+                    content_sent={"body": "sent"},
+                ),
+            ),
+        ) as mock_send:
+            await send_scheduled_failure_notice(
+                AsyncMock(),
+                workflow,
+                target,
+                "Workflow failed",
+                config,
+                conversation_cache,
+            )
 
+        mock_send.assert_awaited_once()
+        assert mock_send.await_args.args[1] == "!room:server"
+        content = mock_send.await_args.args[2]
+        assert content["body"] == "Workflow failed"
         assert content["m.relates_to"]["m.in_reply_to"]["event_id"] == "$latest456"
         conversation_cache.get_latest_thread_event_id_if_needed.assert_awaited_once_with(
             "!room:server",

--- a/tests/test_workflow_scheduling.py
+++ b/tests/test_workflow_scheduling.py
@@ -24,13 +24,12 @@ from mindroom.scheduling import (
     CronSchedule,
     ScheduledWorkflow,
     SchedulingRuntime,
-    _build_scheduled_failure_content,
-    _execute_scheduled_workflow,
     _parse_workflow_schedule,
     _validate_conditional_workflow,
     _WorkflowParseError,
     schedule_task,
 )
+from mindroom.scheduling_executor import _build_scheduled_failure_content, execute_scheduled_workflow
 from tests.conftest import bind_runtime_paths, make_event_cache_mock, runtime_paths_for, test_runtime_paths
 from tests.identity_helpers import persist_entity_accounts
 
@@ -463,7 +462,7 @@ class TestExecuteScheduledWorkflow:
                 ),
             ),
         ) as mock_send:
-            await _execute_scheduled_workflow(
+            await execute_scheduled_workflow(
                 client,
                 workflow,
                 config,
@@ -526,7 +525,7 @@ class TestExecuteScheduledWorkflow:
             ),
         ) as mock_send:
             conversation_cache = _conversation_cache()
-            await _execute_scheduled_workflow(
+            await execute_scheduled_workflow(
                 client,
                 workflow,
                 config,
@@ -593,7 +592,7 @@ class TestExecuteScheduledWorkflow:
                 ),
             ),
         ) as mock_send:
-            await _execute_scheduled_workflow(
+            await execute_scheduled_workflow(
                 client,
                 workflow,
                 config,
@@ -632,7 +631,7 @@ class TestExecuteScheduledWorkflow:
 
         with patch("mindroom.hooks.sender._send_message_result", new=mock_send):
             # Should not raise, but log error
-            await _execute_scheduled_workflow(
+            await execute_scheduled_workflow(
                 client,
                 workflow,
                 config,
@@ -674,10 +673,10 @@ class TestExecuteScheduledWorkflow:
                     ],
                 ),
             ) as mock_send,
-            patch("mindroom.scheduling.logger.info") as mock_info,
+            patch("mindroom.scheduling_executor.logger.info") as mock_info,
         ):
             conversation_cache = _conversation_cache(latest_thread_event_id="$latest123")
-            await _execute_scheduled_workflow(
+            await execute_scheduled_workflow(
                 client,
                 workflow,
                 config,
@@ -703,7 +702,7 @@ class TestExecuteScheduledWorkflow:
         )
 
         with patch("mindroom.hooks.sender._send_message_result", new=AsyncMock()) as mock_send:
-            await _execute_scheduled_workflow(
+            await execute_scheduled_workflow(
                 client,
                 workflow,
                 config,


### PR DESCRIPTION
## What

`scheduling.py` (~1760 lines) mixed schedule parsing, Matrix state persistence, task lifecycle, and the actual firing of scheduled tasks under one namespace. This PR extracts "fire one scheduled task" into a focused `scheduling_executor.py` module (246 lines): hook emission (`schedule:fired`), message construction, thread routing, Matrix delivery, and failure notices, returning a typed `ScheduledWorkflowOutcome` (frozen dataclass: `delivered`, `failure_reason`) instead of a bool. The hook registry moves with the firing path. `scheduling.py` (now 1566 lines) keeps parsing (CronSchedule/NL), persistence/state machine, lifecycle (defer/poll/cancel/restore, asyncio task tracking), and the public entrypoints; the cron/once runners shrink to compute-due → call executor → handle outcome → reschedule/cleanup.

## Why

Firing a scheduled task could not be tested without mocking Matrix transport through the whole scheduling module, and the firing machinery had no typed seam. The executor is now testable with a mocked Matrix client only (no orchestrator boot), covered by 8 new tests in `tests/test_scheduling_executor.py`.

## Zero behavior changes

Same message formats (`⏰ [Automated Task]` wrapper, new-thread plain body), same thread placement and reply-to-latest behavior, same failure notices, same rescheduling and completed/failed status semantics, same exception-propagation boundaries.

## Notes

- Prompt premise correction: the runners already shared `_execute_scheduled_workflow` on main; the extraction moves the firing path to its own module with a typed outcome rather than de-duplicating runner bodies. The runners' residual complexity is the poll/edit-refresh loops, which are rescheduling semantics and stay put.
- Agent-mention authorization helpers stay in `scheduling.py` — they validate at creation time (`schedule_task`), not at fire time.
- `tach.toml`: new module entry + symbol-level interface for `mindroom.scheduling_executor`; `mindroom.scheduling` and `mindroom.orchestrator` deps updated.
- Consumers (`custom_tools/scheduler.py`, `commands/handler.py`, `api/schedules.py`, `bot.py`) untouched; existing tests changed only in import/patch targets and outcome-typed mock returns. One module-table row added to `CLAUDE.md`.

## Testing

- Scheduling-area suites (10 files) → 172 passed; `tests/test_scheduling_executor.py` → 8 passed.
- Full suite → 8046 passed (17 timeout flakes from concurrent pre-commit run; 17/17 pass on rerun).
- `uv run tach check --dependencies --interfaces` and `uv run pre-commit run --all-files` pass.

Part of the 2026-06-11 architecture-review refactor wave (`refactor-prompts/13`).
