### PR TITLE
tach: drop stale and TYPE_CHECKING-only depends_on entries left by #1252/#1253

### DIFF
--- a/tach.toml
+++ b/tach.toml
@@ -529,7 +529,6 @@ depends_on = [
     "mindroom.api.dashboard_credential_scope",
     "mindroom.oauth.providers",
     "mindroom.oauth.state",
-    "mindroom.tool_system.worker_routing",
 ]
 
 [[modules]]
@@ -2072,7 +2071,6 @@ path = "mindroom.scheduling"
 depends_on = [
     "mindroom.entity_resolution",
     "mindroom.hooks",
-    "mindroom.matrix.client_delivery",
     "mindroom.model_loading",
     "mindroom.scheduling_executor",
 ]


### PR DESCRIPTION
Follow-up from post-merge review of #1252 and #1253. Removes two `depends_on` entries that violate tach.toml's documented convention (TYPE_CHECKING-only / unused deps are noise and must not be listed):

- `mindroom.scheduling` no longer imports `mindroom.matrix.client_delivery` at runtime — the only delivery-related symbol moved to `scheduling_executor.py` in #1252. Verified: `grep -rn client_delivery src/mindroom/scheduling.py` has zero matches.
- `mindroom.api.credentials_oauth_flows` (added by #1253) imports `mindroom.tool_system.worker_routing` only under `if TYPE_CHECKING:` (line 19-20 of `src/mindroom/api/credentials_oauth_flows.py`).

No other tach.toml entries touched (smallest correct change; no general audit).

Verification:
- `uv run tach check --dependencies --interfaces` → ✅ All modules validated!
- `uv run pre-commit run --all-files` → all hooks pass (including "Enforce narrow Tach boundaries" and TypeScript type checking)