### PR TITLE
api: restore BOM/encoding tolerance in OpenAI completion body parsing

### DIFF
--- a/src/mindroom/api/openai_request_parsing.py
+++ b/src/mindroom/api/openai_request_parsing.py
@@ -9,6 +9,7 @@ team a requested model name maps to.
 from __future__ import annotations
 
 import hashlib
+import json
 from typing import TYPE_CHECKING, Literal
 from uuid import uuid4
 
@@ -74,13 +75,18 @@ class ChatCompletionRequest(BaseModel):
 def parse_chat_completion_body(body: bytes) -> ChatCompletionRequest | JSONResponse:
     """Parse one chat completion request body, or return an OpenAI-style error.
 
-    Validates the raw bytes directly so invalid JSON and valid-but-non-object
+    Validates the decoded text directly so invalid JSON and valid-but-non-object
     JSON bodies (``null``, ``[]``, scalars) both surface as ValidationError
     and map to the same 400 response.
+
+    Decodes via ``json.detect_encoding`` (the helper ``json.loads`` uses for
+    bytes) so BOM-prefixed UTF-8 and UTF-16/UTF-32 bodies keep parsing, since
+    pydantic's JSON parser only accepts strict BOM-less UTF-8.
     """
     try:
-        return ChatCompletionRequest.model_validate_json(body)
-    except ValidationError:
+        text = body.decode(json.detect_encoding(body))
+        return ChatCompletionRequest.model_validate_json(text)
+    except (UnicodeDecodeError, ValidationError):
         return error_response(400, "Invalid request body")
 
 

--- a/tests/test_openai_request_parsing.py
+++ b/tests/test_openai_request_parsing.py
@@ -101,7 +101,7 @@ class TestParseChatCompletionBody:
 
     def test_undecodable_body(self) -> None:
         """Bytes that cannot be decoded as detected encoding return 400."""
-        response = parse_chat_completion_body(b"\xff\xfe\xff{bad}")
+        response = parse_chat_completion_body(b"\xff\xff")
         assert isinstance(response, JSONResponse)
         assert response.status_code == 400
         assert _error_body(response)["message"] == "Invalid request body"

--- a/tests/test_openai_request_parsing.py
+++ b/tests/test_openai_request_parsing.py
@@ -76,6 +76,36 @@ class TestParseChatCompletionBody:
         )
         assert isinstance(parsed, ChatCompletionRequest)
 
+    def test_utf8_bom_body(self) -> None:
+        """A UTF-8 BOM-prefixed body parses (Windows/PowerShell and Java clients emit BOMs)."""
+        body = json.dumps({"model": "general", "messages": [{"role": "user", "content": "hi"}]})
+        parsed = parse_chat_completion_body(body.encode("utf-8-sig"))
+        assert isinstance(parsed, ChatCompletionRequest)
+        assert parsed.model == "general"
+
+    def test_utf16_and_utf32_bodies(self) -> None:
+        """UTF-16/UTF-32 bodies parse via json.detect_encoding, matching old json.loads behavior."""
+        body = json.dumps({"model": "general", "messages": [{"role": "user", "content": "hi"}]})
+        for encoding in ("utf-16", "utf-16-le", "utf-16-be", "utf-32"):
+            parsed = parse_chat_completion_body(body.encode(encoding))
+            assert isinstance(parsed, ChatCompletionRequest), encoding
+            assert parsed.model == "general"
+
+    def test_utf8_bom_invalid_and_non_object_bodies(self) -> None:
+        """BOM-prefixed invalid JSON and non-object JSON still return 400."""
+        for text in ("{not json", "null", "[]", "42"):
+            response = parse_chat_completion_body(text.encode("utf-8-sig"))
+            assert isinstance(response, JSONResponse), text
+            assert response.status_code == 400
+            assert _error_body(response)["message"] == "Invalid request body"
+
+    def test_undecodable_body(self) -> None:
+        """Bytes that cannot be decoded as detected encoding return 400."""
+        response = parse_chat_completion_body(b"\xff\xfe\xff{bad}")
+        assert isinstance(response, JSONResponse)
+        assert response.status_code == 400
+        assert _error_body(response)["message"] == "Invalid request body"
+
     def test_malformed_json(self) -> None:
         """Invalid JSON returns a 400 OpenAI-style error."""
         response = parse_chat_completion_body(b"{not json")


### PR DESCRIPTION
## Regression

PR #1243 extracted /v1 request parsing into `openai_request_parsing.py` and switched `parse_chat_completion_body` from `json.loads(body)` to `ChatCompletionRequest.model_validate_json(body)`.

`json.loads` on bytes auto-detects encoding via `json.detect_encoding`, which strips a UTF-8 BOM and handles UTF-16/UTF-32 bodies. Pydantic's JSON parser (jiter) requires strict BOM-less UTF-8. As a result, BOM-prefixed UTF-8 bodies (common from Windows/PowerShell and Java HTTP clients) and UTF-16/UTF-32 bodies that previously parsed fine started returning 400 "Invalid request body" — an unintended client-visible regression.

## Fix

Decode the raw bytes with `json.detect_encoding` (the exact stdlib helper `json.loads` uses for bytes input) before handing the text to `model_validate_json`:

- **Choice: full encoding auto-detection restored**, not just UTF-8 BOM stripping. Since `json.detect_encoding` is a single stdlib call that reproduces the old `json.loads` behavior exactly, this is simpler than special-casing only the UTF-8 BOM and avoids guessing which subset of the old tolerance clients relied on.
- Undecodable bytes raise `UnicodeDecodeError`, which maps to the same 400 as before.
- The intentional 400-on-non-object behavior from #1243 (`null`, `[]`, scalars) is unchanged.

## Tests

Added to `tests/test_openai_request_parsing.py`:
- UTF-8 BOM-prefixed valid body parses
- UTF-16 (BOM, LE, BE) and UTF-32 valid bodies parse
- BOM-prefixed invalid JSON and non-object JSON still return 400
- Undecodable bytes return 400

`uv run pytest tests/test_openai_request_parsing.py tests/test_openai_compat.py -x --no-cov`: 194 passed.
`uv run pre-commit run --all-files`: all hooks pass.