### PR TITLE
Rename runtime memory protocol to ResolvedMemoryBackend

### DIFF
--- a/src/mindroom/memory/_backend.py
+++ b/src/mindroom/memory/_backend.py
@@ -23,11 +23,12 @@ if TYPE_CHECKING:
     from ._shared import MemoryResult
 
 
-class MemoryBackend(Protocol):
-    """One storage backend behind the public memory facade.
+class ResolvedMemoryBackend(Protocol):
+    """One resolved storage backend behind the public memory facade.
 
     Adapters implement every operation the facade dispatches, so call sites
-    resolve a backend once and never branch on backend type again.
+    resolve a backend once and never branch on backend type again. Distinct
+    from the ``MemoryBackend`` config literal, which names the authored choice.
     """
 
     context_label: ClassVar[str]
@@ -133,7 +134,7 @@ def resolve_memory_backend(
     caller_context: str | list[str],
     config: Config,
     runtime_paths: RuntimePaths,
-) -> MemoryBackend | None:
+) -> ResolvedMemoryBackend | None:
     """Resolve the effective backend for one caller scope; None disables memory.
 
     A team context (list of member names) resolves to the file backend only

--- a/tach.toml
+++ b/tach.toml
@@ -2547,7 +2547,7 @@ depends_on = [
 
 [[interfaces]]
 expose = [
-    "MemoryBackend",
+    "ResolvedMemoryBackend",
     "resolve_memory_backend",
 ]
 from = ["mindroom.memory._backend"]

--- a/tests/test_memory_backend_contract.py
+++ b/tests/test_memory_backend_contract.py
@@ -21,14 +21,14 @@ from tests.memory_test_support import FakeMem0ScopedMemory, MockTeamConfig
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from mindroom.memory._backend import MemoryBackend
+    from mindroom.memory._backend import ResolvedMemoryBackend
 
 
 @dataclass
 class BackendEnv:
     """One adapter under test plus the config and storage it operates on."""
 
-    backend: MemoryBackend
+    backend: ResolvedMemoryBackend
     config: Config
     storage_path: Path
 
@@ -53,7 +53,7 @@ def _contract_config(tmp_path: Path, memory_backend: str) -> Config:
 def backend_env(request: pytest.FixtureRequest, tmp_path: Path) -> BackendEnv:
     config = _contract_config(tmp_path, request.param)
     runtime_paths = runtime_paths_for(config)
-    backend: MemoryBackend
+    backend: ResolvedMemoryBackend
     if request.param == "file":
         backend = FileMemoryBackend(runtime_paths=runtime_paths)
     else:
@@ -167,7 +167,7 @@ def test_resolve_memory_backend_maps_scopes_to_adapters(tmp_path: Path) -> None:
     assert isinstance(resolve_memory_backend("beta", config, runtime_paths), Mem0MemoryBackend)
     assert isinstance(resolve_memory_backend(["alpha", "alpha"], config, runtime_paths), FileMemoryBackend)
     # Mixed teams currently resolve to mem0; PR #798's partitioned-team fix
-    # slots in here as a new MemoryBackend implementation.
+    # slots in here as a new ResolvedMemoryBackend implementation.
     assert isinstance(resolve_memory_backend(["alpha", "beta"], config, runtime_paths), Mem0MemoryBackend)
 
     config.agents["alpha"].memory_backend = "none"


### PR DESCRIPTION
## Why

Follow-up from the post-merge review of #1249 (memory backend seam).

#1249 introduced a runtime protocol in `src/mindroom/memory/_backend.py` named `MemoryBackend`, which collides with the pre-existing, user-facing config literal `MemoryBackend = Literal["mem0", "file", "none"]` exported from `mindroom.config.memory`. Two unrelated public types shared one name in the same conceptual domain — `Config.get_agent_memory_backend() -> MemoryBackend` (the literal) vs `resolve_memory_backend() -> MemoryBackend | None` (the protocol) — and both were exposed in `tach.toml` interface blocks.

## What

Rename the newer protocol to `ResolvedMemoryBackend`; the config literal is older and user-facing, so it keeps the name.

**Name rationale:** `ResolvedMemoryBackend` reads naturally at the call sites — `resolve_memory_backend(...) -> ResolvedMemoryBackend | None` — and keeps the "backend" vocabulary consistent with the implementations (`FileMemoryBackend`, `Mem0MemoryBackend`). The alternative `MemoryStore` would have split the domain terminology into backend-vs-store mid-seam. The new name also captures the actual distinction: the config literal names the user's *authored choice*, while the protocol names the *resolved runtime object*.

Changes:
- `src/mindroom/memory/_backend.py`: protocol class renamed, docstring now notes the distinction from the config literal, return annotation of `resolve_memory_backend` updated.
- `tach.toml`: `mindroom.memory._backend` interface exposes `ResolvedMemoryBackend`.
- `tests/test_memory_backend_contract.py`: import, annotations, and comment updated.

A repo-wide grep confirms the only remaining `MemoryBackend` references are the config literal and its users (`config/memory.py`, `config/main.py`, `config/agent.py`, the `config.memory` tach expose), which are intentionally untouched. No other modules referenced the protocol by name (`functions.py`, `_policy.py`, `auto_flush.py` only use `resolve_memory_backend`).

## Verification

- `uv run pytest tests/test_memory_*.py -x --no-cov` — 166 passed
- `uv run tach check --dependencies --interfaces` — all modules validated
- `uv run pre-commit run --all-files` — all hooks pass