### PR TITLE
Fail fast on invalid release metadata token in macOS release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,19 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Verify release metadata token
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_METADATA_PAT || secrets.PAT }}
+        run: |
+          if [[ -z "$GH_TOKEN" ]]; then
+            echo "::error::RELEASE_METADATA_PAT or PAT secret is required to open the release metadata PR."
+            exit 1
+          fi
+          if ! TOKEN_LOGIN=$(gh api user --jq .login); then
+            echo "::error::The release metadata token (RELEASE_METADATA_PAT or PAT secret) was rejected by the GitHub API, most likely because it expired or was revoked. Rotate it in Settings -> Secrets and variables -> Actions, then re-run this workflow."
+            exit 1
+          fi
+          echo "Release metadata token authenticates as ${TOKEN_LOGIN}."
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.release_ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,11 +50,15 @@ jobs:
             echo "::error::RELEASE_METADATA_PAT or PAT secret is required to open the release metadata PR."
             exit 1
           fi
-          if ! TOKEN_LOGIN=$(gh api user --jq .login); then
+          if ! CAN_PUSH=$(gh api "repos/${GITHUB_REPOSITORY}" --jq .permissions.push); then
             echo "::error::The release metadata token (RELEASE_METADATA_PAT or PAT secret) was rejected by the GitHub API, most likely because it expired or was revoked. Rotate it in Settings -> Secrets and variables -> Actions, then re-run this workflow."
             exit 1
           fi
-          echo "Release metadata token authenticates as ${TOKEN_LOGIN}."
+          if [[ "$CAN_PUSH" != "true" ]]; then
+            echo "::error::The release metadata token cannot push to ${GITHUB_REPOSITORY}, so the release metadata PR steps would fail. Grant the token contents and pull-requests write access, then re-run this workflow."
+            exit 1
+          fi
+          echo "Release metadata token has push access to ${GITHUB_REPOSITORY}."
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.release_ref }}


### PR DESCRIPTION
## Summary
- Verify the release metadata token (`RELEASE_METADATA_PAT` falling back to `PAT`) with `gh api user` as the first step of `build_macos_app`, before the ~25-minute notarized build.

## Why
Every release run since June 5 (e.g. [27425299193](https://github.com/mindroom-ai/mindroom/actions/runs/27425299193)) fails at the final "Update Sparkle appcast metadata" step with `401 Bad credentials` from `gh pr list`.
The repo has no `RELEASE_METADATA_PAT` secret, so the step uses `PAT`, which was last updated 2026-04-09 and has since expired or been revoked.
The git fetch/pull in that step still "succeed" only because the repo is public, which made the failure look like a `gh`-specific problem.
The identical code worked in the last successful run on June 5, ruling out a workflow regression.

A workflow change cannot rotate the secret, but it can stop wasting a full signed/notarized macOS build (10 retries on June 12 alone) before surfacing a cryptic 401.
With this change an expired token fails the job in seconds with an actionable error naming the secret to rotate.

## Unblocking releases
Rotate the `PAT` repo secret (Settings -> Secrets and variables -> Actions) with a token that can push branches and open PRs on this repo; it is also the fallback for the Homebrew tap dispatch, so it needs access to `mindroom-ai/homebrew-tap` unless `HOMEBREW_TAP_DISPATCH_TOKEN` is set.

## Verification
- `uv run python -c 'import yaml; yaml.safe_load(open(".github/workflows/release.yml"))'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow robustness by improving authentication token validation in the build process. The system now performs comprehensive credential verification before proceeding and provides clear, descriptive error messages when credential issues are encountered, facilitating faster troubleshooting and ensuring more reliable release operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->