### PR TITLE
Extract knowledge file listing and add extra_extensions opt-in

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,7 @@ Matrix sync callback
 | `agent_policy.py` | Canonical execution-policy derivation from authored agent config |
 | `memory/` | Mem0 memory: agent and team-scoped |
 | `knowledge/` | Knowledge base / RAG file indexing with watcher |
+| `knowledge/file_listing.py` | Which files belong to a knowledge base: include patterns, traversal, symlink-safe inclusion rules |
 | `tool_system/skills.py` | Skill integration system (OpenClaw-compatible) |
 | `tool_system/plugins.py` | Plugin loading and tool/skill extension |
 | `scheduling.py` | Cron and natural-language task scheduling |

--- a/docs/dev/exhaustive-live-test-checklist.md
+++ b/docs/dev/exhaustive-live-test-checklist.md
@@ -336,7 +336,7 @@ Expected outcome: Router echo is emitted at most once per voice event, reused ac
 
 ## 10. Memory, Knowledge, Workspaces, Private Roots, And Cultures
 
-Source anchors: `src/mindroom/agents.py`, `src/mindroom/memory/`, `src/mindroom/memory/auto_flush.py`, `src/mindroom/memory/config.py`, `src/mindroom/workspaces.py`, `src/mindroom/knowledge/manager.py`, `src/mindroom/knowledge/utils.py`, `src/mindroom/api/knowledge.py`.
+Source anchors: `src/mindroom/agents.py`, `src/mindroom/memory/`, `src/mindroom/memory/auto_flush.py`, `src/mindroom/memory/config.py`, `src/mindroom/workspaces.py`, `src/mindroom/knowledge/manager.py`, `src/mindroom/knowledge/file_listing.py`, `src/mindroom/knowledge/utils.py`, `src/mindroom/api/knowledge.py`.
 
 - [ ] `MEM-001` Use a runtime configured with `memory.backend: mem0`.
 Expected outcome: Agent memory persists across turns and later retrieval reflects the stored semantic memory state.

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -111,11 +111,37 @@ knowledge_bases:
 | `watch` | bool | `true` | When true, shared local folders watch filesystem changes and schedule background published-index refresh without blocking reads. When false, direct external edits require explicit reindex; dashboard/API upload and delete actions still schedule refresh |
 | `chunk_size` | int | `5000` | Maximum characters per chunk for text-like files (minimum: `128`) |
 | `chunk_overlap` | int | `0` | Overlap characters between adjacent chunks (must be `< chunk_size`) |
+| `include_patterns` | list | `[]` | Root-anchored glob patterns to include before extension filtering |
+| `exclude_patterns` | list | `[]` | Root-anchored glob patterns to exclude after include filtering |
+| `include_extensions` | list | `null` | Exact set of file extensions to index instead of the default text-like set (semantic mode only) |
+| `extra_extensions` | list | `[]` | File extensions to index in addition to the default text-like set (semantic mode only) |
+| `exclude_extensions` | list | `[]` | File extensions to exclude after include filtering (semantic mode only) |
 | `git` | object | `null` | Optional Git repository sync settings |
 
 Use smaller `chunk_size` values when your embedding server has lower token or batch limits.
 `chunk_size` and `chunk_overlap` only affect semantic mode.
 If chunking is too large, semantic indexing retries will fail with embedder 500 errors.
+
+### File Type Filtering
+
+In semantic mode, MindRoom indexes a default set of text-like extensions covering Markdown, plain text, source code, and structured text formats such as `.json`, `.yaml`, and `.csv`.
+
+```yaml
+knowledge_bases:
+  reports:
+    path: ./knowledge_docs/reports
+    extra_extensions: [".pdf", ".docx"]  # Default text-like set plus PDF and Word
+    exclude_extensions: [".csv"]         # Drop CSV files from the default set
+```
+
+- `extra_extensions` adds extensions on top of the default set.
+- `include_extensions` replaces the default set entirely, and `extra_extensions` still adds on top of it.
+- `exclude_extensions` removes extensions last and wins over both.
+
+The allowed set is always explicit configuration and never changes based on the configured embedder or the installed packages.
+Non-text formats such as `.pdf`, `.docx`, or `.pptx` require their reader package (for example `pypdf`, `python-docx`, or `python-pptx`) in the MindRoom environment.
+When a reader package is missing, the refresh indexes every other file, logs a warning naming the file and the missing package, and records a partial-index error instead of publishing an index without the opted-in content.
+Extension filtering does not apply in `files` mode, which exposes every managed file.
 
 ### Private Agent Knowledge
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -11679,11 +11679,37 @@ knowledge_bases:
 | `watch` | bool | `true` | When true, shared local folders watch filesystem changes and schedule background published-index refresh without blocking reads. When false, direct external edits require explicit reindex; dashboard/API upload and delete actions still schedule refresh |
 | `chunk_size` | int | `5000` | Maximum characters per chunk for text-like files (minimum: `128`) |
 | `chunk_overlap` | int | `0` | Overlap characters between adjacent chunks (must be `< chunk_size`) |
+| `include_patterns` | list | `[]` | Root-anchored glob patterns to include before extension filtering |
+| `exclude_patterns` | list | `[]` | Root-anchored glob patterns to exclude after include filtering |
+| `include_extensions` | list | `null` | Exact set of file extensions to index instead of the default text-like set (semantic mode only) |
+| `extra_extensions` | list | `[]` | File extensions to index in addition to the default text-like set (semantic mode only) |
+| `exclude_extensions` | list | `[]` | File extensions to exclude after include filtering (semantic mode only) |
 | `git` | object | `null` | Optional Git repository sync settings |
 
 Use smaller `chunk_size` values when your embedding server has lower token or batch limits.
 `chunk_size` and `chunk_overlap` only affect semantic mode.
 If chunking is too large, semantic indexing retries will fail with embedder 500 errors.
+
+### File Type Filtering
+
+In semantic mode, MindRoom indexes a default set of text-like extensions covering Markdown, plain text, source code, and structured text formats such as `.json`, `.yaml`, and `.csv`.
+
+```yaml
+knowledge_bases:
+  reports:
+    path: ./knowledge_docs/reports
+    extra_extensions: [".pdf", ".docx"]  # Default text-like set plus PDF and Word
+    exclude_extensions: [".csv"]         # Drop CSV files from the default set
+```
+
+- `extra_extensions` adds extensions on top of the default set.
+- `include_extensions` replaces the default set entirely, and `extra_extensions` still adds on top of it.
+- `exclude_extensions` removes extensions last and wins over both.
+
+The allowed set is always explicit configuration and never changes based on the configured embedder or the installed packages.
+Non-text formats such as `.pdf`, `.docx`, or `.pptx` require their reader package (for example `pypdf`, `python-docx`, or `python-pptx`) in the MindRoom environment.
+When a reader package is missing, the refresh indexes every other file, logs a warning naming the file and the missing package, and records a partial-index error instead of publishing an index without the opted-in content.
+Extension filtering does not apply in `files` mode, which exposes every managed file.
 
 ### Private Agent Knowledge
 

--- a/skills/mindroom-docs/references/page__knowledge__index.md
+++ b/skills/mindroom-docs/references/page__knowledge__index.md
@@ -107,11 +107,37 @@ knowledge_bases:
 | `watch` | bool | `true` | When true, shared local folders watch filesystem changes and schedule background published-index refresh without blocking reads. When false, direct external edits require explicit reindex; dashboard/API upload and delete actions still schedule refresh |
 | `chunk_size` | int | `5000` | Maximum characters per chunk for text-like files (minimum: `128`) |
 | `chunk_overlap` | int | `0` | Overlap characters between adjacent chunks (must be `< chunk_size`) |
+| `include_patterns` | list | `[]` | Root-anchored glob patterns to include before extension filtering |
+| `exclude_patterns` | list | `[]` | Root-anchored glob patterns to exclude after include filtering |
+| `include_extensions` | list | `null` | Exact set of file extensions to index instead of the default text-like set (semantic mode only) |
+| `extra_extensions` | list | `[]` | File extensions to index in addition to the default text-like set (semantic mode only) |
+| `exclude_extensions` | list | `[]` | File extensions to exclude after include filtering (semantic mode only) |
 | `git` | object | `null` | Optional Git repository sync settings |
 
 Use smaller `chunk_size` values when your embedding server has lower token or batch limits.
 `chunk_size` and `chunk_overlap` only affect semantic mode.
 If chunking is too large, semantic indexing retries will fail with embedder 500 errors.
+
+### File Type Filtering
+
+In semantic mode, MindRoom indexes a default set of text-like extensions covering Markdown, plain text, source code, and structured text formats such as `.json`, `.yaml`, and `.csv`.
+
+```yaml
+knowledge_bases:
+  reports:
+    path: ./knowledge_docs/reports
+    extra_extensions: [".pdf", ".docx"]  # Default text-like set plus PDF and Word
+    exclude_extensions: [".csv"]         # Drop CSV files from the default set
+```
+
+- `extra_extensions` adds extensions on top of the default set.
+- `include_extensions` replaces the default set entirely, and `extra_extensions` still adds on top of it.
+- `exclude_extensions` removes extensions last and wins over both.
+
+The allowed set is always explicit configuration and never changes based on the configured embedder or the installed packages.
+Non-text formats such as `.pdf`, `.docx`, or `.pptx` require their reader package (for example `pypdf`, `python-docx`, or `python-pptx`) in the MindRoom environment.
+When a reader package is missing, the refresh indexes every other file, logs a warning naming the file and the missing package, and records a partial-index error instead of publishing an index without the opted-in content.
+Extension filtering does not apply in `files` mode, which exposes every managed file.
 
 ### Private Agent Knowledge
 

--- a/src/mindroom/api/knowledge.py
+++ b/src/mindroom/api/knowledge.py
@@ -14,9 +14,9 @@ from fastapi import APIRouter, File, HTTPException, Request, UploadFile
 from mindroom.api import config_lifecycle
 from mindroom.constants import resolve_config_relative_path
 from mindroom.knowledge.availability import KnowledgeAvailability
-from mindroom.knowledge.manager import git_checkout_present, include_knowledge_relative_path
-from mindroom.knowledge.manager import list_git_tracked_knowledge_files as list_git_tracked_managed_knowledge_files
-from mindroom.knowledge.manager import list_knowledge_files as list_managed_knowledge_files
+from mindroom.knowledge.file_listing import git_checkout_present, include_knowledge_relative_path
+from mindroom.knowledge.file_listing import list_git_tracked_knowledge_files as list_git_tracked_managed_knowledge_files
+from mindroom.knowledge.file_listing import list_knowledge_files as list_managed_knowledge_files
 from mindroom.knowledge.redaction import redact_credentials_in_text, redact_url_credentials
 from mindroom.knowledge.refresh_runner import (
     is_refresh_active_for_binding,

--- a/src/mindroom/config/knowledge.py
+++ b/src/mindroom/config/knowledge.py
@@ -91,7 +91,14 @@ class KnowledgeBaseConfig(BaseModel):
     )
     include_extensions: list[str] | None = Field(
         default=None,
-        description="Optional file extensions to include for indexing, for example ['.md', '.py']",
+        description="Optional file extensions to index instead of the default text-like set, for example ['.md', '.py']",
+    )
+    extra_extensions: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Optional file extensions to index in addition to the default text-like set, "
+            "for example ['.pdf', '.docx']; the matching reader package must be installed"
+        ),
     )
     exclude_extensions: list[str] = Field(
         default_factory=list,
@@ -116,7 +123,7 @@ class KnowledgeBaseConfig(BaseModel):
         """Validate include and exclude patterns stay inside the knowledge root."""
         return _validate_relative_patterns(value, field_name=f"knowledge_bases.{info.field_name}")
 
-    @field_validator("include_extensions", "exclude_extensions")
+    @field_validator("include_extensions", "extra_extensions", "exclude_extensions")
     @classmethod
     def normalize_extensions(cls, value: list[str] | None) -> list[str] | None:
         """Normalize configured extensions to lowercase dotted suffixes."""

--- a/src/mindroom/knowledge/__init__.py
+++ b/src/mindroom/knowledge/__init__.py
@@ -3,7 +3,7 @@
 # ruff: noqa: RUF022
 
 from mindroom.knowledge.availability import KnowledgeAvailability
-from mindroom.knowledge.manager import list_knowledge_files
+from mindroom.knowledge.file_listing import list_knowledge_files
 from mindroom.knowledge.refresh_scheduler import KnowledgeRefreshScheduler
 from mindroom.knowledge.status import reconcile_knowledge_mode_transition_states
 from mindroom.knowledge.utils import (

--- a/src/mindroom/knowledge/file_listing.py
+++ b/src/mindroom/knowledge/file_listing.py
@@ -1,0 +1,375 @@
+"""File listing and inclusion rules for knowledge bases.
+
+This module decides which files belong to a knowledge base, in three composable layers:
+include patterns derive listing targets that bound where traversal looks, traversal
+yields only candidates whose directory chain is vetted, and per-file rules run cheap
+relative-path checks before filesystem safety checks.
+Every path returned by the listing functions is a regular file, not a symlink, with no
+symlinked ancestors, whose strictly resolved location stays inside the knowledge root.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+from mindroom.knowledge.redaction import redact_credentials_in_text
+from mindroom.path_globs import matches_root_glob
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
+
+    from mindroom.config.main import Config
+
+_GIT_CHECKOUT_DETECTION_TIMEOUT_SECONDS = 5.0
+_GLOB_CHARS = frozenset("*?[")
+_TEXT_LIKE_EXTENSIONS = {
+    ".md",
+    ".markdown",
+    ".txt",
+    ".text",
+    ".rst",
+    ".json",
+    ".yaml",
+    ".yml",
+    ".toml",
+    ".ini",
+    ".csv",
+    ".tsv",
+    ".html",
+    ".xml",
+    ".py",
+    ".pyi",
+    ".js",
+    ".jsx",
+    ".ts",
+    ".tsx",
+    ".mjs",
+    ".cjs",
+    ".c",
+    ".cc",
+    ".cpp",
+    ".cxx",
+    ".h",
+    ".hh",
+    ".hpp",
+    ".java",
+    ".kt",
+    ".kts",
+    ".go",
+    ".rs",
+    ".rb",
+    ".php",
+    ".swift",
+    ".scala",
+    ".sc",
+    ".sh",
+    ".bash",
+    ".zsh",
+    ".fish",
+    ".ps1",
+    ".sql",
+    ".css",
+    ".scss",
+    ".sass",
+    ".less",
+    ".vue",
+    ".svelte",
+    ".proto",
+}
+
+
+@dataclass(frozen=True)
+class _ListingTarget:
+    path: Path
+    mode: Literal["file", "dir", "walk"]
+
+
+def _split_pattern_parts(pattern: str) -> tuple[str, ...]:
+    normalized = pattern.replace("\\", "/").strip().removeprefix("./").strip("/")
+    if not normalized:
+        return ()
+    return tuple(part for part in normalized.split("/") if part and part != ".")
+
+
+def _part_has_glob(part: str) -> bool:
+    return any(char in part for char in _GLOB_CHARS)
+
+
+def _listing_targets_for_pattern(resolved_root: Path, pattern: str) -> list[_ListingTarget]:
+    parts = _split_pattern_parts(pattern)
+    if not parts:
+        return []
+    first_glob_index = next((index for index, part in enumerate(parts) if _part_has_glob(part)), len(parts))
+    if first_glob_index == len(parts):
+        return [_ListingTarget(resolved_root.joinpath(*parts), "file")]
+
+    base = resolved_root.joinpath(*parts[:first_glob_index]) if first_glob_index else resolved_root
+    remaining_parts = parts[first_glob_index:]
+    if len(remaining_parts) == 1 and remaining_parts[0] != "**":
+        return [_ListingTarget(base, "dir")]
+    return [_ListingTarget(base, "walk")]
+
+
+def _listing_targets(resolved_root: Path, patterns: list[str]) -> list[_ListingTarget]:
+    if not patterns:
+        return [_ListingTarget(resolved_root, "walk")]
+
+    deduped: list[_ListingTarget] = []
+    seen: set[tuple[Path, str]] = set()
+    for pattern in patterns:
+        for target in _listing_targets_for_pattern(resolved_root, pattern):
+            key = (target.path, target.mode)
+            if key in seen:
+                continue
+            seen.add(key)
+            deduped.append(target)
+    return deduped
+
+
+def _is_hidden_relative_path(relative_path: Path) -> bool:
+    return any(part.startswith(".") for part in relative_path.parts)
+
+
+def _include_knowledge_relative_path(config: Config, base_id: str, relative_path: str) -> bool:
+    """Return whether a relative path is managed by the base path filters."""
+    path_obj = Path(relative_path)
+    if path_obj.is_absolute() or ".." in path_obj.parts:
+        return False
+
+    base_config = config.get_knowledge_base_config(base_id)
+    if base_config.include_patterns and not any(
+        matches_root_glob(relative_path, pattern) for pattern in base_config.include_patterns
+    ):
+        return False
+    if any(matches_root_glob(relative_path, pattern) for pattern in base_config.exclude_patterns):
+        return False
+
+    git_config = base_config.git
+    if git_config is not None and git_config.skip_hidden and _is_hidden_relative_path(path_obj):
+        return False
+
+    if git_config is None:
+        return True
+
+    git_included = not git_config.include_patterns or any(
+        matches_root_glob(relative_path, pattern) for pattern in git_config.include_patterns
+    )
+    git_excluded = any(matches_root_glob(relative_path, pattern) for pattern in git_config.exclude_patterns)
+    return git_included and not git_excluded
+
+
+def include_semantic_knowledge_relative_path(config: Config, base_id: str, relative_path: str) -> bool:
+    """Return whether a relative path is semantically indexable for one base."""
+    if not _include_knowledge_relative_path(config, base_id, relative_path):
+        return False
+
+    base_config = config.get_knowledge_base_config(base_id)
+    include_extensions = set(base_config.include_extensions) if base_config.include_extensions is not None else None
+    exclude_extensions = set(base_config.exclude_extensions)
+    allowed_extensions = include_extensions if include_extensions is not None else _TEXT_LIKE_EXTENSIONS
+
+    suffix = Path(relative_path).suffix.lower()
+    if suffix not in allowed_extensions:
+        return False
+    return suffix not in exclude_extensions
+
+
+def include_knowledge_relative_path(config: Config, base_id: str, relative_path: str) -> bool:
+    """Return whether a relative path belongs to the active source set for one base."""
+    if config.get_knowledge_base_config(base_id).mode == "files":
+        return _include_knowledge_relative_path(config, base_id, relative_path)
+    return include_semantic_knowledge_relative_path(config, base_id, relative_path)
+
+
+@dataclass
+class _DirectoryGuard:
+    """Cached directory-chain vetting for one listing pass."""
+
+    root: Path
+    _symlink_cache: dict[Path, bool] = field(default_factory=dict)
+
+    def is_safe(self, directory: Path) -> bool:
+        """Return whether a directory is inside root and reached without symlinks."""
+        try:
+            relative_path = directory.relative_to(self.root)
+        except ValueError:
+            return False
+
+        current = self.root
+        for part in relative_path.parts:
+            current = current / part
+            cached = self._symlink_cache.get(current)
+            if cached is None:
+                cached = current.is_symlink()
+                self._symlink_cache[current] = cached
+            if cached:
+                return False
+        return True
+
+
+def _iter_target_files(target: _ListingTarget, guard: _DirectoryGuard) -> Iterator[Path]:
+    """Yield candidate files for one target, vetting their directory chain via the guard."""
+    if target.mode == "file":
+        if guard.is_safe(target.path.parent):
+            yield target.path
+        return
+    if not target.path.is_dir() or not guard.is_safe(target.path):
+        return
+    if target.mode == "dir":
+        yield from (path for path in target.path.iterdir() if path.is_file())
+        return
+    for dirpath, dirnames, filenames in os.walk(target.path, followlinks=False):
+        current_dir = Path(dirpath)
+        dirnames[:] = [dirname for dirname in dirnames if not (current_dir / dirname).is_symlink()]
+        for filename in filenames:
+            yield current_dir / filename
+
+
+def _resolve_safe_file(root: Path, candidate: Path) -> Path | None:
+    """Return the resolved path when a chain-vetted candidate is a regular file inside root."""
+    if candidate.is_symlink():
+        return None
+    try:
+        resolved = candidate.resolve(strict=True)
+        resolved.relative_to(root)
+    except (OSError, ValueError):
+        return None
+    if not candidate.is_file():
+        return None
+    return resolved
+
+
+def list_knowledge_files(config: Config, base_id: str, knowledge_root: Path) -> list[Path]:
+    """List managed files without constructing a knowledge manager."""
+    root = knowledge_root.resolve()
+    if not root.is_dir():
+        return []
+
+    guard = _DirectoryGuard(root=root)
+    include_patterns = config.get_knowledge_base_config(base_id).include_patterns
+    files: set[Path] = set()
+    for target in _listing_targets(root, include_patterns):
+        for candidate in _iter_target_files(target, guard):
+            if not include_knowledge_relative_path(config, base_id, candidate.relative_to(root).as_posix()):
+                continue
+            resolved = _resolve_safe_file(root, candidate)
+            if resolved is not None:
+                files.add(resolved)
+    return sorted(files)
+
+
+def knowledge_files_from_relative_paths(
+    config: Config,
+    base_id: str,
+    knowledge_root: Path,
+    relative_paths: Iterable[str],
+) -> list[Path]:
+    """Resolve claimed relative paths through the same inclusion rules and safety checks."""
+    root = knowledge_root.resolve()
+    guard = _DirectoryGuard(root=root)
+    files: list[Path] = []
+    for relative_path in sorted(set(relative_paths)):
+        if not include_knowledge_relative_path(config, base_id, relative_path):
+            continue
+        candidate = root / relative_path
+        if not guard.is_safe(candidate.parent):
+            continue
+        resolved = _resolve_safe_file(root, candidate)
+        if resolved is not None:
+            files.append(resolved)
+    return files
+
+
+def git_checkout_present(root: Path, *, timeout_seconds: float | None = None) -> bool:
+    """Return whether root itself is a Git worktree checkout."""
+    if not root.is_dir():
+        return False
+    effective_timeout_seconds = _GIT_CHECKOUT_DETECTION_TIMEOUT_SECONDS if timeout_seconds is None else timeout_seconds
+    if effective_timeout_seconds <= 0:
+        effective_timeout: float | None = None
+    else:
+        effective_timeout = effective_timeout_seconds
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "--is-inside-work-tree", "--show-toplevel"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=effective_timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    if result.returncode != 0:
+        return False
+    lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    if len(lines) < 2 or lines[0] != "true":
+        return False
+    try:
+        return Path(lines[1]).resolve() == root.resolve()
+    except OSError:
+        return False
+
+
+def git_tracked_relative_paths_from_checkout(
+    config: Config,
+    base_id: str,
+    knowledge_root: Path,
+    *,
+    timeout_seconds: float | None = None,
+) -> set[str]:
+    """Return the Git-tracked relative paths that pass the base inclusion rules."""
+    git_config = config.get_knowledge_base_config(base_id).git
+    if git_config is None:
+        return set()
+    effective_timeout_seconds = float(
+        git_config.sync_timeout_seconds if timeout_seconds is None else timeout_seconds,
+    )
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "-z"],
+            cwd=str(knowledge_root),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=effective_timeout_seconds,
+        )
+    except subprocess.TimeoutExpired as exc:
+        msg = f"Git command timed out after {effective_timeout_seconds:g}s: git ls-files -z"
+        raise RuntimeError(msg) from exc
+    except OSError as exc:
+        msg = f"Git command failed: git ls-files -z\n{exc}"
+        raise RuntimeError(msg) from exc
+
+    if result.returncode != 0:
+        details = redact_credentials_in_text((result.stderr or result.stdout).strip())
+        msg = f"Git command failed with exit code {result.returncode}: git ls-files -z"
+        if details:
+            msg = f"{msg}\n{details}"
+        raise RuntimeError(msg)
+
+    return {
+        path for path in result.stdout.split("\x00") if path and include_knowledge_relative_path(config, base_id, path)
+    }
+
+
+def list_git_tracked_knowledge_files(
+    config: Config,
+    base_id: str,
+    knowledge_root: Path,
+    *,
+    timeout_seconds: float | None = None,
+) -> list[Path]:
+    """List Git-tracked files using the active source set for one base."""
+    root = knowledge_root.resolve()
+    if not git_checkout_present(root, timeout_seconds=timeout_seconds):
+        return []
+    return knowledge_files_from_relative_paths(
+        config,
+        base_id,
+        root,
+        git_tracked_relative_paths_from_checkout(config, base_id, root, timeout_seconds=timeout_seconds),
+    )

--- a/src/mindroom/knowledge/file_listing.py
+++ b/src/mindroom/knowledge/file_listing.py
@@ -168,14 +168,15 @@ def include_semantic_knowledge_relative_path(config: Config, base_id: str, relat
         return False
 
     base_config = config.get_knowledge_base_config(base_id)
-    include_extensions = set(base_config.include_extensions) if base_config.include_extensions is not None else None
-    exclude_extensions = set(base_config.exclude_extensions)
-    allowed_extensions = include_extensions if include_extensions is not None else _TEXT_LIKE_EXTENSIONS
+    allowed_extensions = (
+        set(base_config.include_extensions) if base_config.include_extensions is not None else _TEXT_LIKE_EXTENSIONS
+    )
+    allowed_extensions = allowed_extensions | set(base_config.extra_extensions)
 
     suffix = Path(relative_path).suffix.lower()
     if suffix not in allowed_extensions:
         return False
-    return suffix not in exclude_extensions
+    return suffix not in base_config.exclude_extensions
 
 
 def include_knowledge_relative_path(config: Config, base_id: str, relative_path: str) -> bool:

--- a/src/mindroom/knowledge/indexing_config.py
+++ b/src/mindroom/knowledge/indexing_config.py
@@ -51,6 +51,7 @@ class IndexingSettings:
     exclude_patterns: str
     include_extensions: str
     exclude_extensions: str
+    extra_extensions: str = ""
 
     @classmethod
     def from_metadata(cls, settings: Mapping[str, str]) -> IndexingSettings | None:
@@ -75,7 +76,7 @@ class IndexingSettings:
             "include_extensions",
             "exclude_extensions",
         }
-        optional_keys = {"include_patterns", "exclude_patterns"}
+        optional_keys = {"include_patterns", "exclude_patterns", "extra_extensions"}
         if not required_keys.issubset(settings) or set(settings) - required_keys - optional_keys:
             return None
         mode = settings["mode"]
@@ -102,6 +103,7 @@ class IndexingSettings:
             exclude_patterns=settings.get("exclude_patterns", ""),
             include_extensions=settings["include_extensions"],
             exclude_extensions=settings["exclude_extensions"],
+            extra_extensions=settings.get("extra_extensions", ""),
         )
 
     def to_metadata(self) -> dict[str, str]:
@@ -127,6 +129,7 @@ class IndexingSettings:
             "exclude_patterns": self.exclude_patterns,
             "include_extensions": self.include_extensions,
             "exclude_extensions": self.exclude_extensions,
+            "extra_extensions": self.extra_extensions,
         }
 
     def query_compatibility_key(self) -> tuple[str, str, str, str, str, str, str, str]:
@@ -144,7 +147,7 @@ class IndexingSettings:
 
     def corpus_compatibility_key(
         self,
-    ) -> tuple[str, str, str, str, str, str, str, str, str, str, str, str, str, str]:
+    ) -> tuple[str, str, str, str, str, str, str, str, str, str, str, str, str, str, str]:
         """Return fields that must match for safe source-corpus reuse."""
         return (
             self.base_id,
@@ -161,6 +164,7 @@ class IndexingSettings:
             self.exclude_patterns,
             self.include_extensions,
             self.exclude_extensions,
+            self.extra_extensions,
         )
 
 
@@ -233,6 +237,7 @@ def indexing_settings_key(config: Config, storage_path: Path, base_id: str, know
             _filter_settings_key(base_config.include_extensions) if base_config.include_extensions is not None else ""
         )
         exclude_extensions = _filter_settings_key(base_config.exclude_extensions)
+        extra_extensions = _filter_settings_key(base_config.extra_extensions)
     else:
         embedder_provider = ""
         embedder_model = ""
@@ -242,6 +247,7 @@ def indexing_settings_key(config: Config, storage_path: Path, base_id: str, know
         chunk_overlap = ""
         include_extensions = ""
         exclude_extensions = ""
+        extra_extensions = ""
     return IndexingSettings(
         base_id=base_id,
         storage_root=str(storage_path.resolve()),
@@ -263,4 +269,5 @@ def indexing_settings_key(config: Config, storage_path: Path, base_id: str, know
         exclude_patterns=_filter_settings_key(base_config.exclude_patterns),
         include_extensions=include_extensions,
         exclude_extensions=exclude_extensions,
+        extra_extensions=extra_extensions,
     )

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -1007,7 +1007,17 @@ class KnowledgeManager:
             _SOURCE_SIZE_KEY: source_size,
             _SOURCE_DIGEST_KEY: source_digest,
         }
-        reader = self._build_reader(resolved_path)
+        try:
+            reader = self._build_reader(resolved_path)
+        except ImportError as exc:
+            logger.warning(
+                "Skipping knowledge file because its reader dependency is not installed",
+                base_id=self.base_id,
+                path=relative_path,
+                extension=resolved_path.suffix.lower(),
+                error=str(exc),
+            )
+            return False
         target_knowledge = knowledge or self._knowledge
 
         try:

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -6,14 +6,12 @@ import asyncio
 import base64
 import hashlib
 import os
-import subprocess
 import time
 import uuid
 from contextlib import suppress
 from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, NoReturn, Protocol, cast, runtime_checkable
 from urllib.parse import quote, urlparse, urlunparse
 
@@ -27,6 +25,13 @@ from mindroom.chunking import SafeFixedSizeChunking
 from mindroom.constants import RuntimePaths, resolve_config_relative_path
 from mindroom.credentials import get_runtime_shared_credentials_manager
 from mindroom.embedding_factory import create_configured_embedder
+from mindroom.knowledge.file_listing import (
+    git_checkout_present,
+    git_tracked_relative_paths_from_checkout,
+    include_knowledge_relative_path,
+    knowledge_files_from_relative_paths,
+    list_knowledge_files,
+)
 from mindroom.knowledge.index_metadata import (
     load_index_metadata_payload,
     parse_index_metadata_fields,
@@ -45,10 +50,10 @@ from mindroom.knowledge.redaction import (
     redact_url_credentials,
 )
 from mindroom.logging_config import get_logger
-from mindroom.path_globs import matches_root_glob
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
+    from pathlib import Path
 
     from agno.knowledge.reader.base import Reader
 
@@ -64,7 +69,6 @@ _SOURCE_SIZE_KEY = "source_size"
 _SOURCE_DIGEST_KEY = "source_digest"
 _MAX_CONCURRENT_KNOWLEDGE_FILE_INDEXES = 32
 _POST_INDEX_VECTOR_VISIBILITY_RETRY_DELAYS_SECONDS = (0.0, 0.01, 0.05)
-_GIT_CHECKOUT_DETECTION_TIMEOUT_SECONDS = 5.0
 _INDEXING_STATUS_RESETTING = "resetting"
 _INDEXING_STATUS_INDEXING = "indexing"
 _INDEXING_STATUS_COMPLETE = "complete"
@@ -72,61 +76,6 @@ _INDEXING_STATUSES = {
     _INDEXING_STATUS_RESETTING,
     _INDEXING_STATUS_INDEXING,
     _INDEXING_STATUS_COMPLETE,
-}
-_GLOB_CHARS = frozenset("*?[")
-_TEXT_LIKE_EXTENSIONS = {
-    ".md",
-    ".markdown",
-    ".txt",
-    ".text",
-    ".rst",
-    ".json",
-    ".yaml",
-    ".yml",
-    ".toml",
-    ".ini",
-    ".csv",
-    ".tsv",
-    ".html",
-    ".xml",
-    ".py",
-    ".pyi",
-    ".js",
-    ".jsx",
-    ".ts",
-    ".tsx",
-    ".mjs",
-    ".cjs",
-    ".c",
-    ".cc",
-    ".cpp",
-    ".cxx",
-    ".h",
-    ".hh",
-    ".hpp",
-    ".java",
-    ".kt",
-    ".kts",
-    ".go",
-    ".rs",
-    ".rb",
-    ".php",
-    ".swift",
-    ".scala",
-    ".sc",
-    ".sh",
-    ".bash",
-    ".zsh",
-    ".fish",
-    ".ps1",
-    ".sql",
-    ".css",
-    ".scss",
-    ".sass",
-    ".less",
-    ".vue",
-    ".svelte",
-    ".proto",
 }
 _FileSignature = tuple[int, int, str]
 
@@ -163,12 +112,6 @@ class _CandidatePublishState:
     index_published: bool = False
 
 
-@dataclass(frozen=True)
-class _ListingTarget:
-    path: Path
-    mode: Literal["file", "dir", "walk"]
-
-
 def _raise_cancelled() -> NoReturn:
     raise asyncio.CancelledError
 
@@ -187,80 +130,8 @@ def _ensure_knowledge_directory_ready(knowledge_path: Path) -> None:
     knowledge_path.mkdir(parents=True, exist_ok=True)
 
 
-def git_checkout_present(root: Path, *, timeout_seconds: float | None = None) -> bool:
-    """Return whether root itself is a Git worktree checkout."""
-    if not root.is_dir():
-        return False
-    effective_timeout_seconds = _GIT_CHECKOUT_DETECTION_TIMEOUT_SECONDS if timeout_seconds is None else timeout_seconds
-    if effective_timeout_seconds <= 0:
-        effective_timeout: float | None = None
-    else:
-        effective_timeout = effective_timeout_seconds
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(root), "rev-parse", "--is-inside-work-tree", "--show-toplevel"],
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=effective_timeout,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return False
-    if result.returncode != 0:
-        return False
-    lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
-    if len(lines) < 2 or lines[0] != "true":
-        return False
-    try:
-        return Path(lines[1]).resolve() == root.resolve()
-    except OSError:
-        return False
-
-
 def _collection_name(base_id: str, knowledge_path: Path) -> str:
     return f"{_COLLECTION_PREFIX}_{storage_key_for_base(base_id, knowledge_path)}"
-
-
-def _split_pattern_parts(pattern: str) -> tuple[str, ...]:
-    normalized = pattern.replace("\\", "/").strip().removeprefix("./").strip("/")
-    if not normalized:
-        return ()
-    return tuple(part for part in normalized.split("/") if part and part != ".")
-
-
-def _part_has_glob(part: str) -> bool:
-    return any(char in part for char in _GLOB_CHARS)
-
-
-def _listing_targets_for_pattern(resolved_root: Path, pattern: str) -> list[_ListingTarget]:
-    parts = _split_pattern_parts(pattern)
-    if not parts:
-        return []
-    first_glob_index = next((index for index, part in enumerate(parts) if _part_has_glob(part)), len(parts))
-    if first_glob_index == len(parts):
-        return [_ListingTarget(resolved_root.joinpath(*parts), "file")]
-
-    base = resolved_root.joinpath(*parts[:first_glob_index]) if first_glob_index else resolved_root
-    remaining_parts = parts[first_glob_index:]
-    if len(remaining_parts) == 1 and remaining_parts[0] != "**":
-        return [_ListingTarget(base, "dir")]
-    return [_ListingTarget(base, "walk")]
-
-
-def _listing_targets(resolved_root: Path, patterns: list[str]) -> list[_ListingTarget]:
-    if not patterns:
-        return [_ListingTarget(resolved_root, "walk")]
-
-    deduped: list[_ListingTarget] = []
-    seen: set[tuple[Path, str]] = set()
-    for pattern in patterns:
-        for target in _listing_targets_for_pattern(resolved_root, pattern):
-            key = (target.path, target.mode)
-            if key in seen:
-                continue
-            seen.add(key)
-            deduped.append(target)
-    return deduped
 
 
 def _semantic_indexing_enabled(config: Config, base_id: str) -> bool:
@@ -385,249 +256,6 @@ def _merge_git_env(*envs: dict[str, str] | None) -> dict[str, str] | None:
     return merged or None
 
 
-def _is_hidden_relative_path(relative_path: Path) -> bool:
-    return any(part.startswith(".") for part in relative_path.parts)
-
-
-def _include_knowledge_relative_path(config: Config, base_id: str, relative_path: str) -> bool:
-    """Return whether a relative path is managed by the base path filters."""
-    path_obj = Path(relative_path)
-    if path_obj.is_absolute() or ".." in path_obj.parts:
-        return False
-
-    base_config = config.get_knowledge_base_config(base_id)
-    if base_config.include_patterns and not any(
-        matches_root_glob(relative_path, pattern) for pattern in base_config.include_patterns
-    ):
-        return False
-    if any(matches_root_glob(relative_path, pattern) for pattern in base_config.exclude_patterns):
-        return False
-
-    git_config = base_config.git
-    if git_config is not None and git_config.skip_hidden and _is_hidden_relative_path(path_obj):
-        return False
-
-    if git_config is None:
-        return True
-
-    git_included = not git_config.include_patterns or any(
-        matches_root_glob(relative_path, pattern) for pattern in git_config.include_patterns
-    )
-    git_excluded = any(matches_root_glob(relative_path, pattern) for pattern in git_config.exclude_patterns)
-    return git_included and not git_excluded
-
-
-def include_semantic_knowledge_relative_path(config: Config, base_id: str, relative_path: str) -> bool:
-    """Return whether a relative path is semantically indexable for one base."""
-    if not _include_knowledge_relative_path(config, base_id, relative_path):
-        return False
-
-    base_config = config.get_knowledge_base_config(base_id)
-    include_extensions = set(base_config.include_extensions) if base_config.include_extensions is not None else None
-    exclude_extensions = set(base_config.exclude_extensions)
-    allowed_extensions = include_extensions if include_extensions is not None else _TEXT_LIKE_EXTENSIONS
-
-    suffix = Path(relative_path).suffix.lower()
-    if suffix not in allowed_extensions:
-        return False
-    return suffix not in exclude_extensions
-
-
-def include_knowledge_relative_path(config: Config, base_id: str, relative_path: str) -> bool:
-    """Return whether a relative path belongs to the active source set for one base."""
-    if config.get_knowledge_base_config(base_id).mode == "files":
-        return _include_knowledge_relative_path(config, base_id, relative_path)
-    return include_semantic_knowledge_relative_path(config, base_id, relative_path)
-
-
-@dataclass
-class _KnowledgePathFilter:
-    config: Config
-    base_id: str
-    root: Path
-    _directory_symlink_cache: dict[Path, bool] = field(default_factory=dict)
-
-    def include_file(self, file_path: Path, *, check_directory_symlinks: bool = True) -> bool:
-        """Return whether a file belongs to the active source set for one base."""
-        candidate = file_path if file_path.is_absolute() else self.root / file_path
-        try:
-            relative_path = candidate.relative_to(self.root)
-        except ValueError:
-            return False
-
-        if not include_knowledge_relative_path(self.config, self.base_id, relative_path.as_posix()):
-            return False
-        if check_directory_symlinks and self.directory_is_symlink_or_under_symlink(candidate.parent):
-            return False
-        if candidate.is_symlink():
-            return False
-        try:
-            resolved_candidate = candidate.resolve(strict=True)
-            resolved_candidate.relative_to(self.root)
-        except (OSError, ValueError):
-            return False
-        return candidate.is_file()
-
-    def directory_is_symlink_or_under_symlink(self, directory: Path) -> bool:
-        """Return whether a directory is outside root or reached through a symlink."""
-        try:
-            relative_path = directory.relative_to(self.root)
-        except ValueError:
-            return True
-
-        current = self.root
-        for part in relative_path.parts:
-            current = current / part
-            cached = self._directory_symlink_cache.get(current)
-            if cached is None:
-                cached = current.is_symlink()
-                self._directory_symlink_cache[current] = cached
-            if cached:
-                return True
-        return False
-
-
-def _add_listed_knowledge_file(
-    path_filter: _KnowledgePathFilter,
-    path: Path,
-    *,
-    check_directory_symlinks: bool,
-    files: list[Path],
-    seen_paths: set[Path],
-) -> None:
-    if not path_filter.include_file(path, check_directory_symlinks=check_directory_symlinks):
-        return
-    resolved_path = path.resolve()
-    if resolved_path in seen_paths:
-        return
-    seen_paths.add(resolved_path)
-    files.append(resolved_path)
-
-
-def _collect_listing_target_files(
-    path_filter: _KnowledgePathFilter,
-    target: _ListingTarget,
-    *,
-    files: list[Path],
-    seen_paths: set[Path],
-) -> None:
-    def add_file(path: Path, *, check_directory_symlinks: bool) -> None:
-        _add_listed_knowledge_file(
-            path_filter,
-            path,
-            check_directory_symlinks=check_directory_symlinks,
-            files=files,
-            seen_paths=seen_paths,
-        )
-
-    if target.mode == "file":
-        add_file(target.path, check_directory_symlinks=True)
-        return
-    if not target.path.is_dir() or path_filter.directory_is_symlink_or_under_symlink(target.path):
-        return
-    if target.mode == "dir":
-        for path in target.path.iterdir():
-            if path.is_file():
-                add_file(path, check_directory_symlinks=False)
-        return
-    for dirpath, dirnames, filenames in os.walk(target.path, followlinks=False):
-        current_dir = Path(dirpath)
-        dirnames[:] = [dirname for dirname in dirnames if not (current_dir / dirname).is_symlink()]
-        for filename in filenames:
-            add_file(current_dir / filename, check_directory_symlinks=False)
-
-
-def list_knowledge_files(config: Config, base_id: str, knowledge_root: Path) -> list[Path]:
-    """List managed files without constructing a knowledge manager."""
-    root = knowledge_root.resolve()
-    if not root.is_dir():
-        return []
-
-    path_filter = _KnowledgePathFilter(config=config, base_id=base_id, root=root)
-    files: list[Path] = []
-    seen_paths: set[Path] = set()
-    include_patterns = config.get_knowledge_base_config(base_id).include_patterns
-    for target in _listing_targets(root, include_patterns):
-        _collect_listing_target_files(path_filter, target, files=files, seen_paths=seen_paths)
-    return sorted(files)
-
-
-def _knowledge_file_paths_from_relative_paths(
-    config: Config,
-    base_id: str,
-    knowledge_root: Path,
-    relative_paths: Iterable[str],
-) -> list[Path]:
-    root = knowledge_root.resolve()
-    path_filter = _KnowledgePathFilter(config=config, base_id=base_id, root=root)
-    files: list[Path] = []
-    for relative_path in sorted(set(relative_paths)):
-        path = root / relative_path
-        if path_filter.include_file(path):
-            files.append(path)
-    return files
-
-
-def _git_tracked_relative_paths_from_checkout(
-    config: Config,
-    base_id: str,
-    knowledge_root: Path,
-    *,
-    timeout_seconds: float | None = None,
-) -> set[str]:
-    git_config = config.get_knowledge_base_config(base_id).git
-    if git_config is None:
-        return set()
-    effective_timeout_seconds = float(
-        git_config.sync_timeout_seconds if timeout_seconds is None else timeout_seconds,
-    )
-    try:
-        result = subprocess.run(
-            ["git", "ls-files", "-z"],
-            cwd=str(knowledge_root),
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=effective_timeout_seconds,
-        )
-    except subprocess.TimeoutExpired as exc:
-        msg = f"Git command timed out after {effective_timeout_seconds:g}s: git ls-files -z"
-        raise RuntimeError(msg) from exc
-    except OSError as exc:
-        msg = f"Git command failed: git ls-files -z\n{exc}"
-        raise RuntimeError(msg) from exc
-
-    if result.returncode != 0:
-        details = redact_credentials_in_text((result.stderr or result.stdout).strip())
-        msg = f"Git command failed with exit code {result.returncode}: git ls-files -z"
-        if details:
-            msg = f"{msg}\n{details}"
-        raise RuntimeError(msg)
-
-    return {
-        path for path in result.stdout.split("\x00") if path and include_knowledge_relative_path(config, base_id, path)
-    }
-
-
-def list_git_tracked_knowledge_files(
-    config: Config,
-    base_id: str,
-    knowledge_root: Path,
-    *,
-    timeout_seconds: float | None = None,
-) -> list[Path]:
-    """List Git-tracked files using the active source set for one base."""
-    root = knowledge_root.resolve()
-    if not git_checkout_present(root, timeout_seconds=timeout_seconds):
-        return []
-    return _knowledge_file_paths_from_relative_paths(
-        config,
-        base_id,
-        root,
-        _git_tracked_relative_paths_from_checkout(config, base_id, root, timeout_seconds=timeout_seconds),
-    )
-
-
 def _file_content_digest(file_path: Path) -> str:
     digest = hashlib.sha256()
     with file_path.open("rb") as handle:
@@ -653,9 +281,9 @@ def knowledge_source_signature(
         tracked_paths = (
             set(tracked_relative_paths)
             if tracked_relative_paths is not None
-            else _git_tracked_relative_paths_from_checkout(config, base_id, root)
+            else git_tracked_relative_paths_from_checkout(config, base_id, root)
         )
-        files = _knowledge_file_paths_from_relative_paths(config, base_id, root, tracked_paths)
+        files = knowledge_files_from_relative_paths(config, base_id, root, tracked_paths)
     for path in files:
         try:
             stat = path.stat()
@@ -1102,12 +730,12 @@ class KnowledgeManager:
             if self._git_tracked_relative_paths is None:
                 if not git_checkout_present(knowledge_root, timeout_seconds=self._git_sync_timeout_seconds()):
                     return []
-                self._git_tracked_relative_paths = _git_tracked_relative_paths_from_checkout(
+                self._git_tracked_relative_paths = git_tracked_relative_paths_from_checkout(
                     self.config,
                     self.base_id,
                     knowledge_root,
                 )
-            return _knowledge_file_paths_from_relative_paths(
+            return knowledge_files_from_relative_paths(
                 self.config,
                 self.base_id,
                 knowledge_root,

--- a/src/mindroom/knowledge/watch.py
+++ b/src/mindroom/knowledge/watch.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 from watchfiles import Change, awatch
 
-from mindroom.knowledge.manager import include_semantic_knowledge_relative_path
+from mindroom.knowledge.file_listing import include_semantic_knowledge_relative_path
 from mindroom.knowledge.registry import (
     KnowledgeRefreshTarget,
     KnowledgeSourceRoot,

--- a/tach.toml
+++ b/tach.toml
@@ -410,7 +410,7 @@ depends_on = [
     "mindroom.api.config_lifecycle",
     "mindroom.constants",
     "mindroom.knowledge.availability",
-    "mindroom.knowledge.manager",
+    "mindroom.knowledge.file_listing",
     "mindroom.knowledge.redaction",
     "mindroom.knowledge.refresh_runner",
     "mindroom.knowledge.status",
@@ -2447,7 +2447,7 @@ depends_on = [
 path = "mindroom.knowledge"
 depends_on = [
     "mindroom.knowledge.availability",
-    "mindroom.knowledge.manager",
+    "mindroom.knowledge.file_listing",
     "mindroom.knowledge.refresh_scheduler",
     "mindroom.knowledge.status",
     "mindroom.knowledge.utils",
@@ -2456,6 +2456,13 @@ depends_on = [
 [[modules]]
 path = "mindroom.knowledge.availability"
 depends_on = []
+
+[[modules]]
+path = "mindroom.knowledge.file_listing"
+depends_on = [
+    "mindroom.knowledge.redaction",
+    "mindroom.path_globs",
+]
 
 [[modules]]
 path = "mindroom.knowledge.index_metadata"
@@ -2489,10 +2496,10 @@ depends_on = [
     "mindroom.chunking",
     "mindroom.constants",
     "mindroom.embedding_factory",
+    "mindroom.knowledge.file_listing",
     "mindroom.knowledge.index_metadata",
     "mindroom.knowledge.indexing_config",
     "mindroom.knowledge.redaction",
-    "mindroom.path_globs",
 ]
 
 [[modules]]
@@ -2545,7 +2552,7 @@ depends_on = [
 [[modules]]
 path = "mindroom.knowledge.watch"
 depends_on = [
-    "mindroom.knowledge.manager",
+    "mindroom.knowledge.file_listing",
     "mindroom.knowledge.registry",
     "mindroom.logging_config",
 ]

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -20,6 +20,7 @@ from agno.knowledge.document.base import Document
 from fastapi.testclient import TestClient
 from watchfiles import Change
 
+import mindroom.knowledge.file_listing as knowledge_file_listing_module
 import mindroom.knowledge.manager as knowledge_manager_module
 import mindroom.knowledge.refresh_runner as knowledge_refresh_runner
 import mindroom.knowledge.refresh_scheduler as knowledge_refresh_scheduler
@@ -34,15 +35,14 @@ from mindroom.config.main import Config
 from mindroom.credentials import get_runtime_shared_credentials_manager
 from mindroom.knowledge import KnowledgeRefreshScheduler, resolve_agent_knowledge_access
 from mindroom.knowledge.availability import KnowledgeAvailability
-from mindroom.knowledge.index_metadata import write_index_metadata_payload
-from mindroom.knowledge.indexing_config import IndexingSettings
-from mindroom.knowledge.manager import (
-    KnowledgeManager,
+from mindroom.knowledge.file_listing import (
     git_checkout_present,
-    knowledge_source_signature,
     list_git_tracked_knowledge_files,
     list_knowledge_files,
 )
+from mindroom.knowledge.index_metadata import write_index_metadata_payload
+from mindroom.knowledge.indexing_config import IndexingSettings
+from mindroom.knowledge.manager import KnowledgeManager, knowledge_source_signature
 from mindroom.knowledge.redaction import credential_free_repo_url, credential_free_url_identity, redact_url_credentials
 from mindroom.knowledge.refresh_runner import knowledge_binding_mutation_lock, refresh_knowledge_binding
 from mindroom.knowledge.registry import (
@@ -1425,13 +1425,13 @@ def test_local_knowledge_file_listing_prunes_literal_include_prefixes(
     )
 
     walked_roots: list[Path] = []
-    original_walk = knowledge_manager_module.os.walk
+    original_walk = knowledge_file_listing_module.os.walk
 
     def recording_walk(top: object, *args: object, **kwargs: object) -> object:
         walked_roots.append(Path(top))
         return original_walk(top, *args, **kwargs)
 
-    monkeypatch.setattr(knowledge_manager_module.os, "walk", recording_walk)
+    monkeypatch.setattr(knowledge_file_listing_module.os, "walk", recording_walk)
 
     files = list_knowledge_files(config, "docs", docs_path)
 

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -1439,6 +1439,75 @@ def test_local_knowledge_file_listing_prunes_literal_include_prefixes(
     assert walked_roots == [memory_dir.resolve()]
 
 
+def test_extra_extensions_extend_default_semantic_set(tmp_path: Path) -> None:
+    """extra_extensions add to the default text-like set without replacing it."""
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    (docs_path / "notes.md").write_text("hello", encoding="utf-8")
+    (docs_path / "slides.pptx").write_bytes(b"fake deck")
+    (docs_path / "blob.bin").write_bytes(b"binary")
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+    config.knowledge_bases["docs"] = KnowledgeBaseConfig(
+        path=str(docs_path),
+        extra_extensions=[".pptx"],
+    )
+
+    files = list_knowledge_files(config, "docs", docs_path)
+
+    assert files == [(docs_path / "notes.md").resolve(), (docs_path / "slides.pptx").resolve()]
+
+
+def test_extra_extensions_compose_with_include_and_exclude_extensions(tmp_path: Path) -> None:
+    """include_extensions stay an exact set, extras add on top, excludes win last."""
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    (docs_path / "notes.md").write_text("hello", encoding="utf-8")
+    (docs_path / "readme.txt").write_text("hello", encoding="utf-8")
+    (docs_path / "slides.pptx").write_bytes(b"fake deck")
+    (docs_path / "report.pdf").write_bytes(b"fake report")
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+    config.knowledge_bases["docs"] = KnowledgeBaseConfig(
+        path=str(docs_path),
+        include_extensions=[".md"],
+        extra_extensions=[".pptx", ".pdf"],
+        exclude_extensions=[".pdf"],
+    )
+
+    files = list_knowledge_files(config, "docs", docs_path)
+
+    assert files == [(docs_path / "notes.md").resolve(), (docs_path / "slides.pptx").resolve()]
+
+
+@pytest.mark.asyncio
+async def test_reindex_skips_files_whose_reader_dependency_is_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing reader package skips the file loudly instead of failing the refresh."""
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    (docs_path / "notes.md").write_text("indexed text", encoding="utf-8")
+    (docs_path / "slides.pptx").write_text("fake deck", encoding="utf-8")
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+    config.knowledge_bases["docs"] = KnowledgeBaseConfig(
+        path=str(docs_path),
+        extra_extensions=[".pptx"],
+    )
+    original_get_reader = knowledge_manager_module.ReaderFactory.get_reader_for_extension
+
+    def failing_get_reader(extension: str) -> object:
+        if extension == ".pptx":
+            msg = "The `python-pptx` package is not installed."
+            raise ImportError(msg)
+        return original_get_reader(extension)
+
+    monkeypatch.setattr(knowledge_manager_module.ReaderFactory, "get_reader_for_extension", failing_get_reader)
+    manager = KnowledgeManager("docs", config=config, runtime_paths=runtime_paths_for(config))
+
+    assert await manager.reindex_all() == 1
+    assert manager._last_refresh_error == "Indexed 1 of 2 managed knowledge files"
+
+
 @pytest.mark.asyncio
 async def test_index_metadata_without_source_signature_is_unavailable_and_schedules_refresh(
     tmp_path: Path,


### PR DESCRIPTION
## Summary
Follow-up to #873, in two parts: extract the knowledge file listing subsystem into a focused module, then build the extension-configuration improvements on top of it.

### Part 1: extract `knowledge/file_listing.py`
Moves the file listing and inclusion subsystem out of `knowledge/manager.py` (1560 lines) into a focused module with one stated security contract: every returned path is a regular file, not a symlink, with no symlinked ancestors, whose strictly resolved location stays inside the knowledge root.

- **Directory vetting moved into traversal.** `_iter_target_files` yields only candidates whose directory chain is vetted by a cached `_DirectoryGuard`, so the `check_directory_symlinks` flag — whose correctness depended on a non-local invariant in the caller's head — is gone.
- **Per-file safety checks return the resolved path.** `_resolve_safe_file` returns `Path | None`, eliminating the duplicate `resolve()` per accepted file; dedup falls out of a plain set instead of out-parameters threaded through helper layers.
- **Cheap-to-expensive ordering preserved at each entry point** (the #873 optimization), and include-pattern-derived listing targets still bound traversal.
- `tach.toml` boundaries updated; manager no longer depends on `mindroom.path_globs` or `subprocess`.

### Part 2: explicit extension opt-in without surprises
- **New `extra_extensions` per-base config field** adds extensions on top of the default text-like set instead of replacing it, closing the trap where `include_extensions` silently drops every default when you only wanted "default plus `.pdf`". Composition: `include_extensions` = exact set, `extra_extensions` = additive, `exclude_extensions` = trims last.
- **The allowed set stays explicit config** — never derived from the configured embedder or installed packages, so swapping embedding models can never silently change which files get indexed.
- **Missing reader dependencies skip loudly instead of aborting the refresh.** `_build_reader` errors (e.g. `.pptx` opted in without `python-pptx`) previously escaped `_index_file_locked`'s try block and failed the entire reindex. Now the file is skipped with a warning naming the file, extension, and the install hint, every other file still indexes, and the refresh reports a partial-index error — the base never silently publishes an index missing opted-in content.
- `extra_extensions` joins `IndexingSettings` and the corpus compatibility key so changing it invalidates the published index like the other filters (optional metadata key, so existing persisted metadata still parses).

## Tests
- `uv run pytest` (8340 passed, 61 skipped)
- `uv run pre-commit run --all-files` (ruff, ty, vulture, tach, module privacy)
- `uv run tach check --dependencies --interfaces`
- New: `extra_extensions` extends defaults without replacing them, composes with `include_extensions`/`exclude_extensions`, and missing-reader-dependency files are skipped without failing the rest of the reindex.
- Existing regression tests pin the extraction contract unchanged: symlink escape rejection, no filesystem I/O for unsupported extensions, include-pattern walk pruning.