### PR TITLE
Use mindroom-release-bot app tokens for release metadata and tap dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       # so a misconfigured app fails the job before the expensive notarized build.
       - name: Mint release bot token
         id: release-bot
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
@@ -219,7 +219,7 @@ jobs:
       # which the mindroom-release-bot app installation grants.
       - name: Mint release bot token
         id: release-bot
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,23 +42,14 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Verify release metadata token
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_METADATA_PAT || secrets.PAT }}
-        run: |
-          if [[ -z "$GH_TOKEN" ]]; then
-            echo "::error::RELEASE_METADATA_PAT or PAT secret is required to open the release metadata PR."
-            exit 1
-          fi
-          if ! CAN_PUSH=$(gh api "repos/${GITHUB_REPOSITORY}" --jq .permissions.push); then
-            echo "::error::The release metadata token (RELEASE_METADATA_PAT or PAT secret) was rejected by the GitHub API, most likely because it expired or was revoked. Rotate it in Settings -> Secrets and variables -> Actions, then re-run this workflow."
-            exit 1
-          fi
-          if [[ "$CAN_PUSH" != "true" ]]; then
-            echo "::error::The release metadata token cannot push to ${GITHUB_REPOSITORY}, so the release metadata PR steps would fail. Grant the token contents and pull-requests write access, then re-run this workflow."
-            exit 1
-          fi
-          echo "Release metadata token has push access to ${GITHUB_REPOSITORY}."
+      # Short-lived token from the mindroom-release-bot GitHub App; minted first
+      # so a misconfigured app fails the job before the expensive notarized build.
+      - name: Mint release bot token
+        id: release-bot
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.release_ref }}
@@ -148,7 +139,7 @@ jobs:
           cp "$APPCAST_DIR/appcast.xml" macos/appcast.xml
       - name: Update Sparkle appcast metadata
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_METADATA_PAT || secrets.PAT }}
+          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
           TAG_NAME: ${{ inputs.release_ref }}
         run: |
           python3 .github/scripts/normalize_appcast.py macos/appcast.xml
@@ -224,18 +215,21 @@ jobs:
     permissions:
       contents: read
     steps:
+      # repository_dispatch needs contents write on mindroom-ai/homebrew-tap,
+      # which the mindroom-release-bot app installation grants.
+      - name: Mint release bot token
+        id: release-bot
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: mindroom-ai
+          repositories: homebrew-tap
       - name: Dispatch tap workflow
         env:
-          # Token needs write access to mindroom-ai/homebrew-tap.
-          # Fine-grained tokens need Contents: write on that repo.
-          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_DISPATCH_TOKEN || secrets.PAT }}
+          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
           TAG_NAME: ${{ inputs.release_ref }}
         run: |
-          if [[ -z "$GH_TOKEN" ]]; then
-            echo "HOMEBREW_TAP_DISPATCH_TOKEN or PAT is required to update mindroom-ai/homebrew-tap." >&2
-            exit 1
-          fi
-
           gh api repos/mindroom-ai/homebrew-tap/dispatches \
             -f event_type=mindroom-release \
             -F "client_payload[tag_name]=$TAG_NAME" \


### PR DESCRIPTION
## Summary
- Replace `secrets.RELEASE_METADATA_PAT || secrets.PAT` with short-lived installation tokens minted per run from the new `mindroom-release-bot` GitHub App (`actions/create-github-app-token@v2`).
- `build_macos_app` mints its token as the first step, so a misconfigured app still fails before the ~25-minute notarized build; the manual push-permission probe from #1261 is no longer needed because the app installation guarantees contents + pull-requests write.
- `update_homebrew_tap` mints a token scoped to `mindroom-ai/homebrew-tap` instead of falling back to the PAT, and drops the now-redundant empty-token check (the mint step fails if the app vars/secrets are missing).

## Why
The v2026.6.122 release failures were caused by the `PAT` secret silently expiring (#1261 added the fail-fast diagnosis).
A PAT rotation just schedules the next incident; app installation tokens are minted fresh each run from a non-expiring private key, are org-owned rather than personal, trigger CI on the PRs they create (unlike `GITHUB_TOKEN`), and are auto-revoked after the job.

## Setup already done
- GitHub App `mindroom-release-bot` (App ID 4038650) created via the manifest flow with Contents: write and Pull requests: write, no webhook.
- Installed on exactly `mindroom-ai/mindroom` and `mindroom-ai/homebrew-tap` (verified via `GET /app/installations`).
- Repo variable `RELEASE_BOT_APP_ID` and secret `RELEASE_BOT_PRIVATE_KEY` set on this repo.

After merge the `PAT` repo secret has no remaining references in this repo and can be deleted.

## Verification
- `uv run python -c 'import yaml; yaml.safe_load(open(".github/workflows/release.yml"))'`
- `grep -n 'secrets.PAT\|RELEASE_METADATA_PAT\|HOMEBREW_TAP_DISPATCH_TOKEN' .github/workflows/release.yml` returns nothing.