### PR TITLE
Add optional control-plane NetworkPolicy to mindroom-runtime chart

### DIFF
--- a/.github/workflows/publish-helm-charts.yml
+++ b/.github/workflows/publish-helm-charts.yml
@@ -91,6 +91,11 @@ jobs:
             --set eventCache.databaseUrl.existingSecret=existing-event-cache-secrets \
             --set eventCache.databaseUrl.key=DATABASE_URL \
             > "$render_dir/adoption.yaml"
+          helm template mindroom-runtime "$RUNTIME_CHART_DIR" \
+            --namespace mindroom \
+            --set networkPolicy.create=true \
+            --set 'networkPolicy.apiIngressFrom[0].podSelector.matchLabels.app=my-ingress' \
+            > "$render_dir/network-policy.yaml"
 
       - name: Package runtime chart
         run: |

--- a/cluster/k8s/runtime/README.md
+++ b/cluster/k8s/runtime/README.md
@@ -218,7 +218,7 @@ networkPolicy:
 The API port follows `runtime.apiPort`, so the policy stays aligned with the Deployment without a separate port value.
 When `apiIngressFrom` is empty, the policy allows the API port from all sources while still denying other ingress to the pod.
 Use `networkPolicy.extraIngress` and `networkPolicy.extraEgress` for raw Kubernetes rules beyond the API rule.
-Setting any `extraEgress` entry adds `Egress` to `policyTypes`, so those rules must then cover every egress flow the runtime needs, such as DNS, the Matrix homeserver, model APIs, the event cache, and workers.
+Setting any `extraEgress` entry adds `Egress` to `policyTypes`, so those rules must then cover every egress flow the runtime needs, such as DNS, the Matrix homeserver, model APIs, the event cache, workers, and the Kubernetes API server when `workers.backend` is `kubernetes`.
 
 ## Worker Egress Proxy
 

--- a/cluster/k8s/runtime/README.md
+++ b/cluster/k8s/runtime/README.md
@@ -193,6 +193,29 @@ plugins:
   - /app/agent_data/content-bundles/policy-pack/plugins/policy-tools
 ```
 
+## Control-Plane NetworkPolicy
+
+The chart can create an optional NetworkPolicy for the control-plane pod, so operators can restrict runtime API ingress to an edge proxy and known clients.
+The policy targets the runtime pods through the chart selector labels and allows the API port only from the configured peers.
+NetworkPolicy targets pods rather than Services, so each `apiIngressFrom` entry must match the actual client pods.
+
+```yaml
+networkPolicy:
+  create: true
+  apiIngressFrom:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: my-ingress
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: my-api-client
+```
+
+The API port follows `runtime.apiPort`, so the policy stays aligned with the Deployment without a separate port value.
+When `apiIngressFrom` is empty, the policy allows the API port from all sources while still denying other ingress to the pod.
+Use `networkPolicy.extraIngress` and `networkPolicy.extraEgress` for raw Kubernetes rules beyond the API rule.
+Setting any `extraEgress` entry adds `Egress` to `policyTypes`, so those rules must then cover every egress flow the runtime needs, such as DNS, the Matrix homeserver, model APIs, the event cache, and workers.
+
 ## Worker Egress Proxy
 
 For dedicated Kubernetes workers, the chart can either deploy the approved egress proxy or point workers at an existing HTTP proxy Service.
@@ -327,6 +350,7 @@ workers:
 ## Notes
 
 - The chart does not create ingress or a Matrix homeserver.
+- Set `networkPolicy.create: true` to restrict control-plane API ingress to known client pods.
 - The chart can create PostgreSQL for MindRoom's event cache, or use an external PostgreSQL URL from an existing Secret.
 - Set `workers.sandbox.proxyToken.existingSecret` or `workers.sandbox.proxyToken.value` when sandbox proxying is enabled.
 - Set `workers.sandbox.credentialsEncryptionKey.existingSecret` when encrypted credential storage is enabled so the primary runtime and static runner sidecar receive the same Secret-backed key.

--- a/cluster/k8s/runtime/README.md
+++ b/cluster/k8s/runtime/README.md
@@ -198,12 +198,16 @@ plugins:
 The chart can create an optional NetworkPolicy for the control-plane pod, so operators can restrict runtime API ingress to an edge proxy and known clients.
 The policy targets the runtime pods through the chart selector labels and allows the API port only from the configured peers.
 NetworkPolicy targets pods rather than Services, so each `apiIngressFrom` entry must match the actual client pods.
+A bare `podSelector` entry only matches pods in the release namespace, so combine `namespaceSelector` and `podSelector` in one entry for cross-namespace clients such as an ingress controller.
 
 ```yaml
 networkPolicy:
   create: true
   apiIngressFrom:
-    - podSelector:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: my-ingress
+      podSelector:
         matchLabels:
           app.kubernetes.io/name: my-ingress
     - podSelector:

--- a/cluster/k8s/runtime/templates/_helpers.tpl
+++ b/cluster/k8s/runtime/templates/_helpers.tpl
@@ -187,6 +187,10 @@ app.kubernetes.io/component: runtime
 {{- end -}}
 {{- end -}}
 
+{{- define "mindroom-runtime.networkPolicyName" -}}
+{{- default (include "mindroom-runtime.fullname" .) .Values.networkPolicy.name -}}
+{{- end -}}
+
 {{- define "mindroom-runtime.workerNetworkPolicyName" -}}
 {{- default (printf "%s-workers" (include "mindroom-runtime.fullname" .)) .Values.workers.kubernetes.networkPolicy.name -}}
 {{- end -}}

--- a/cluster/k8s/runtime/templates/networkpolicy.yaml
+++ b/cluster/k8s/runtime/templates/networkpolicy.yaml
@@ -138,13 +138,13 @@ spec:
     - Egress
     {{- end }}
   ingress:
-    - {{- with .Values.networkPolicy.apiIngressFrom }}
+    - ports:
+        - protocol: TCP
+          port: {{ .Values.runtime.apiPort }}
+      {{- with .Values.networkPolicy.apiIngressFrom }}
       from:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      ports:
-        - protocol: TCP
-          port: {{ .Values.runtime.apiPort }}
     {{- with .Values.networkPolicy.extraIngress }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/cluster/k8s/runtime/templates/networkpolicy.yaml
+++ b/cluster/k8s/runtime/templates/networkpolicy.yaml
@@ -120,3 +120,36 @@ spec:
         - port: {{ .Values.approvedEgress.service.apiPort }}
           protocol: TCP
 {{- end }}
+{{- if .Values.networkPolicy.create }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "mindroom-runtime.networkPolicyName" . }}
+  labels:
+    {{- include "mindroom-runtime.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "mindroom-runtime.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    {{- if .Values.networkPolicy.extraEgress }}
+    - Egress
+    {{- end }}
+  ingress:
+    - {{- with .Values.networkPolicy.apiIngressFrom }}
+      from:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.runtime.apiPort }}
+    {{- with .Values.networkPolicy.extraIngress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.networkPolicy.extraEgress }}
+  egress:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/cluster/k8s/runtime/values.yaml
+++ b/cluster/k8s/runtime/values.yaml
@@ -60,6 +60,7 @@ networkPolicy:
   name: ""
   # NetworkPolicyPeer entries allowed to reach the runtime API port, for example an edge proxy and known in-cluster clients.
   # NetworkPolicy targets pods rather than Services, so selectors must match the client pods.
+  # A bare podSelector only matches pods in the release namespace; combine namespaceSelector and podSelector for cross-namespace clients.
   # Leave empty to allow the API port from all sources while still denying other ingress.
   apiIngressFrom: []
   # Example:

--- a/cluster/k8s/runtime/values.yaml
+++ b/cluster/k8s/runtime/values.yaml
@@ -53,6 +53,26 @@ podDisruptionBudget:
   maxUnavailable: 1
   minAvailable: ""
 
+# Optional NetworkPolicy for the MindRoom control-plane pod.
+# When created, pod ingress is limited to the runtime API port from the configured peers.
+networkPolicy:
+  create: false
+  name: ""
+  # NetworkPolicyPeer entries allowed to reach the runtime API port, for example an edge proxy and known in-cluster clients.
+  # NetworkPolicy targets pods rather than Services, so selectors must match the client pods.
+  # Leave empty to allow the API port from all sources while still denying other ingress.
+  apiIngressFrom: []
+  # Example:
+  # apiIngressFrom:
+  #   - podSelector:
+  #       matchLabels:
+  #         app.kubernetes.io/name: my-ingress
+  # Raw Kubernetes NetworkPolicyIngressRule entries appended after the API rule.
+  extraIngress: []
+  # Raw Kubernetes NetworkPolicyEgressRule entries.
+  # Setting any entry adds Egress to policyTypes, so include every egress flow the runtime needs.
+  extraEgress: []
+
 runtime:
   apiHost: 0.0.0.0
   apiPort: 8765


### PR DESCRIPTION
## Summary

The runtime chart templates NetworkPolicies for dedicated Kubernetes workers, the approved-egress proxy, and the event-cache PostgreSQL, but none for the main runtime Deployment. Operators who lock down their namespaces currently have to hand-write a policy to restrict runtime API ingress to their edge proxy and known client pods.

This adds an opt-in `networkPolicy` values block (`create: false` by default) for the control-plane pod:

- Ingress to the runtime API port is limited to configurable `apiIngressFrom` NetworkPolicyPeer entries; leaving the list empty allows the API port from all sources while still denying other ingress.
- Raw `extraIngress` / `extraEgress` passthrough for rules beyond the API rule; setting any `extraEgress` entry adds `Egress` to `policyTypes`.
- The API port follows `runtime.apiPort`, so the policy stays aligned with the Deployment without a separate port value.
- `networkPolicy.name` overrides the release-derived default, matching the other NetworkPolicy naming helpers.

Documented in the chart README and values comments.

## Validation

- `helm lint cluster/k8s/runtime` passes.
- `helm template` passes for the four scenarios in `publish-helm-charts.yml` (default, sqlite, external-postgres, adoption); default output is unchanged since the policy is off by default.
- `helm template --set networkPolicy.create=true` renders the policy, including combined renders with the worker NetworkPolicy and with populated `apiIngressFrom` / `extraIngress` / `extraEgress`.
