### PR TITLE
Add standalone mindroom-client Helm chart

### DIFF
--- a/.github/workflows/publish-helm-charts.yml
+++ b/.github/workflows/publish-helm-charts.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "cluster/k8s/runtime/**"
+      - "cluster/k8s/client/**"
       - ".github/workflows/publish-helm-charts.yml"
   workflow_dispatch:
     inputs:
@@ -17,6 +18,7 @@ env:
   REGISTRY: ghcr.io
   OWNER: ${{ github.repository_owner }}
   RUNTIME_CHART_DIR: cluster/k8s/runtime
+  CLIENT_CHART_DIR: cluster/k8s/client
 
 jobs:
   runtime-chart:
@@ -113,4 +115,90 @@ jobs:
         run: |
           helm push \
             "dist/mindroom-runtime-${{ steps.vars.outputs.chart_version }}.tgz" \
+            "oci://$REGISTRY/$OWNER/charts"
+
+  client-chart:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_ref || github.ref }}
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Set chart version
+        id: vars
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            release_ref="${{ inputs.release_ref }}"
+            if [[ "$release_ref" != v* ]]; then
+              echo "release_ref must be a tag starting with 'v', got '$release_ref'" >&2
+              exit 1
+            fi
+            chart_version="${release_ref#v}"
+            app_version="$release_ref"
+            publish="true"
+          else
+            chart_version="0.0.0-pr.${{ github.event.pull_request.number }}"
+            app_version="pr-${{ github.event.pull_request.number }}"
+            publish="false"
+          fi
+
+          {
+            echo "chart_version=$chart_version"
+            echo "app_version=$app_version"
+            echo "publish=$publish"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Lint client chart
+        run: helm lint "$CLIENT_CHART_DIR"
+
+      - name: Render client chart
+        run: |
+          render_dir="$(mktemp -d)"
+          helm template mindroom-client "$CLIENT_CHART_DIR" \
+            --namespace mindroom \
+            > "$render_dir/default.yaml"
+          helm template mindroom-client "$CLIENT_CHART_DIR" \
+            --namespace mindroom \
+            --set basePath=/mindroom \
+            --set rootServiceWorkerCleanup.enabled=true \
+            --set matrix.defaultServerName=matrix.example.com \
+            --set serviceWorker.enabled=false \
+            > "$render_dir/base-path.yaml"
+          helm template mindroom-client "$CLIENT_CHART_DIR" \
+            --namespace mindroom \
+            --set config.existingConfigMap=existing-client-config \
+            --set nginx.existingConfigMap=existing-client-nginx \
+            > "$render_dir/existing-configmaps.yaml"
+
+      - name: Package client chart
+        run: |
+          mkdir -p dist
+          helm package "$CLIENT_CHART_DIR" \
+            --version "${{ steps.vars.outputs.chart_version }}" \
+            --app-version "${{ steps.vars.outputs.app_version }}" \
+            --destination dist
+
+      - name: Login to GitHub Container Registry
+        if: steps.vars.outputs.publish == 'true'
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | helm registry login "$REGISTRY" \
+                --username "${{ github.actor }}" \
+                --password-stdin
+
+      - name: Push client chart
+        if: steps.vars.outputs.publish == 'true'
+        run: |
+          helm push \
+            "dist/mindroom-client-${{ steps.vars.outputs.chart_version }}.tgz" \
             "oci://$REGISTRY/$OWNER/charts"

--- a/cluster/k8s/client/Chart.yaml
+++ b/cluster/k8s/client/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: mindroom-client
+description: Standalone MindRoom web client chart that serves the published client image behind unprivileged nginx
+type: application
+version: 0.1.0
+appVersion: "0.0.0"

--- a/cluster/k8s/client/README.md
+++ b/cluster/k8s/client/README.md
@@ -76,6 +76,7 @@ nginx:
 ```
 
 The ConfigMap must provide the server config under `nginx.key`, listening on `nginx.port`.
+The server config must keep serving `config.json` under the base path, which the default readiness and liveness probes request, or you must override `probes.readiness.custom` and `probes.liveness.custom`.
 When `rootServiceWorkerCleanup.enabled` is true, the same ConfigMap must also provide the cleanup worker script under `nginx.cleanupWorkerKey`.
 
 ## Notes

--- a/cluster/k8s/client/README.md
+++ b/cluster/k8s/client/README.md
@@ -81,7 +81,8 @@ When `rootServiceWorkerCleanup.enabled` is true, the same ConfigMap must also pr
 ## Notes
 
 - The chart does not create ingress, TLS, or a Matrix homeserver.
-- The container runs as the unprivileged nginx user with a read-only root filesystem, so `nginx.port` must stay at 1024 or higher unless you grant extra privileges through `securityContext`.
+- The container runs as the unprivileged nginx user with a read-only root filesystem, so `nginx.port` must stay at 1024 or higher unless you grant extra privileges through `securityContext` or lower `net.ipv4.ip_unprivileged_port_start`.
+- Set `nginx.ipv6: false` on nodes without an IPv6 stack, where binding `[::]` makes nginx fail at startup.
 - Use `nodeSelector`, `affinity`, `tolerations`, and `topologySpreadConstraints` for cluster-specific scheduling policy.
 - Set `selectorLabels` when adopting an existing Deployment with an immutable selector.
 - Override `probes.*.custom` when a deployment needs custom Kubernetes readiness or liveness probes.

--- a/cluster/k8s/client/README.md
+++ b/cluster/k8s/client/README.md
@@ -1,0 +1,97 @@
+# MindRoom Client Chart
+
+This chart deploys only the MindRoom web client (`ghcr.io/mindroom-ai/mindroom-cinny`) behind unprivileged nginx.
+It is for clusters that already provide a Matrix homeserver, ingress, and TLS.
+
+Use the instance chart in `cluster/k8s/instance` when you want a complete MindRoom instance with its own Matrix homeserver.
+Use the runtime chart in `cluster/k8s/runtime` for the MindRoom agent runtime itself.
+Use this chart when you only need the web client in front of an existing homeserver.
+
+## Minimal Install
+
+```bash
+helm upgrade --install mindroom-client ./cluster/k8s/client \
+  --namespace mindroom \
+  --create-namespace \
+  --set matrix.homeserverUrl=https://matrix.example.com
+```
+
+The default values render a Deployment, Service, a client `config.json` ConfigMap, and an nginx ConfigMap.
+The Deployment carries checksum annotations for both chart-managed ConfigMaps, so config changes roll pods on upgrade.
+For production, pin `image.tag` or `image.digest` instead of the default `latest`.
+
+## Homeserver Configuration
+
+The chart renders a minimal `config.json` from the `matrix` values:
+
+```yaml
+matrix:
+  homeserverUrl: https://matrix.example.com
+  defaultServerName: ""
+  allowCustomHomeservers: false
+```
+
+When `defaultServerName` is set, the login form shows that server name instead of the URL, and the name must publish `/.well-known/matrix/client` pointing at `homeserverUrl`.
+Set `config.data` to a full JSON document when you need client options beyond the homeserver entry, or point `config.existingConfigMap` at a ConfigMap you manage yourself.
+
+## Base Path
+
+Set `basePath` to serve the client under a URL prefix instead of the origin root:
+
+```yaml
+basePath: /mindroom
+```
+
+The chart-managed nginx config serves the app shell, `config.json`, and the service worker under the base path, redirects `/` and the bare base path to `basePath/`, and resolves hashed build assets referenced from any route depth.
+The client always loads `/runtime-config.js` from the origin root, so route the full origin host to this Service even when `basePath` is not `/`.
+The chart serves `/runtime-config.js` directly from nginx because the image entrypoint would otherwise write it into the app directory, which the unprivileged read-only container forbids.
+
+## Service Worker Hygiene
+
+The client registers its service worker at `basePath/sw.js`, scoped to `basePath/`.
+Set `serviceWorker.enabled: false` to keep the client from registering it at all.
+
+A Matrix client that previously controlled the origin root is a known footgun: its root-scoped service worker keeps serving the old app for every path on the origin, including the new base path.
+Browsers replace a service worker by re-fetching its script URL, so the deterministic fix is to serve a worker at the old root `/sw.js` whose only job is to purge caches, release its clients into `basePath/`, and unregister itself.
+Enable that cleanup worker when migrating such an origin:
+
+```yaml
+basePath: /mindroom
+
+rootServiceWorkerCleanup:
+  enabled: true
+```
+
+The cleanup worker requires a `basePath` other than `/`, because at the origin root `/sw.js` is the client's own service worker.
+Once stale clients have cycled through the cleanup worker, the flag can be disabled again.
+
+## Custom nginx Config
+
+Point `nginx.existingConfigMap` at your own ConfigMap to take full control of the server config:
+
+```yaml
+nginx:
+  existingConfigMap: my-client-nginx
+  key: default.conf
+```
+
+The ConfigMap must provide the server config under `nginx.key`, listening on `nginx.port`.
+When `rootServiceWorkerCleanup.enabled` is true, the same ConfigMap must also provide the cleanup worker script under `nginx.cleanupWorkerKey`.
+
+## Notes
+
+- The chart does not create ingress, TLS, or a Matrix homeserver.
+- The container runs as the unprivileged nginx user with a read-only root filesystem, so `nginx.port` must stay at 1024 or higher unless you grant extra privileges through `securityContext`.
+- Use `nodeSelector`, `affinity`, `tolerations`, and `topologySpreadConstraints` for cluster-specific scheduling policy.
+- Set `selectorLabels` when adopting an existing Deployment with an immutable selector.
+- Override `probes.*.custom` when a deployment needs custom Kubernetes readiness or liveness probes.
+
+## Render Locally
+
+```bash
+helm template mindroom-client ./cluster/k8s/client \
+  --namespace mindroom \
+  --set matrix.homeserverUrl=https://matrix.example.com \
+  --set basePath=/mindroom \
+  --set rootServiceWorkerCleanup.enabled=true
+```

--- a/cluster/k8s/client/templates/NOTES.txt
+++ b/cluster/k8s/client/templates/NOTES.txt
@@ -1,0 +1,15 @@
+MindRoom client chart rendered.
+
+Service:
+  {{ include "mindroom-client.fullname" . }}:{{ .Values.service.port }}
+
+Client:
+  Base path: {{ include "mindroom-client.basePath" . }}
+  Config ConfigMap: {{ include "mindroom-client.configMapName" . }}
+  Nginx ConfigMap: {{ include "mindroom-client.nginxConfigMapName" . }}
+  Service worker: {{ ternary "enabled" "disabled" .Values.serviceWorker.enabled }}{{- if .Values.rootServiceWorkerCleanup.enabled }} (root cleanup worker at /sw.js){{- end }}
+
+Route the full origin host to this Service: the client loads /runtime-config.js
+from the origin root even when basePath is not /.
+For production, point matrix.homeserverUrl at your homeserver and pin image.tag
+or image.digest.

--- a/cluster/k8s/client/templates/_helpers.tpl
+++ b/cluster/k8s/client/templates/_helpers.tpl
@@ -109,7 +109,9 @@ runtime-config.js straight from nginx and the Deployment bypasses the entrypoint
 {{- $runtimeConfig := printf "window.__APP_BASE_PATH__ = \"%s\"; window.__ENABLE_SERVICE_WORKER__ = %t;" $base .Values.serviceWorker.enabled -}}
 server {
   listen {{ .Values.nginx.port }};
+{{- if .Values.nginx.ipv6 }}
   listen [::]:{{ .Values.nginx.port }};
+{{- end }}
   absolute_redirect off;
 {{- if ne $base "/" }}
 

--- a/cluster/k8s/client/templates/_helpers.tpl
+++ b/cluster/k8s/client/templates/_helpers.tpl
@@ -1,0 +1,226 @@
+{{/*
+Expand the chart name.
+*/}}
+{{- define "mindroom-client.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "mindroom-client.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mindroom-client.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | quote }}
+app.kubernetes.io/name: {{ include "mindroom-client.name" . | quote }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+{{- end -}}
+
+{{- define "mindroom-client.selectorLabels" -}}
+{{- if .Values.selectorLabels -}}
+{{- toYaml .Values.selectorLabels -}}
+{{- else -}}
+app.kubernetes.io/name: {{ include "mindroom-client.name" . | quote }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+app.kubernetes.io/component: client
+{{- end -}}
+{{- end -}}
+
+{{- define "mindroom-client.image" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s:%s@%s" .Values.image.repository $tag .Values.image.digest -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mindroom-client.configMapName" -}}
+{{- if .Values.config.existingConfigMap -}}
+{{- .Values.config.existingConfigMap -}}
+{{- else -}}
+{{- printf "%s-config" (include "mindroom-client.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mindroom-client.nginxConfigMapName" -}}
+{{- if .Values.nginx.existingConfigMap -}}
+{{- .Values.nginx.existingConfigMap -}}
+{{- else -}}
+{{- printf "%s-nginx" (include "mindroom-client.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Normalized base path: leading slash, no trailing slash, "/" for the origin root.
+*/}}
+{{- define "mindroom-client.basePath" -}}
+{{- $path := default "/" .Values.basePath | clean | trimSuffix "/" -}}
+{{- default "/" $path -}}
+{{- end -}}
+
+{{/*
+Path prefix prepended to client file locations; empty at the origin root.
+*/}}
+{{- define "mindroom-client.pathPrefix" -}}
+{{- $base := include "mindroom-client.basePath" . -}}
+{{- if ne $base "/" -}}{{- $base -}}{{- end -}}
+{{- end -}}
+
+{{- define "mindroom-client.probePath" -}}
+{{- printf "%s/config.json" (include "mindroom-client.pathPrefix" .) -}}
+{{- end -}}
+
+{{- define "mindroom-client.defaultClientConfig" -}}
+{{- $homeserver := default .Values.matrix.homeserverUrl .Values.matrix.defaultServerName -}}
+{
+  "defaultHomeserver": 0,
+  "homeserverList": [{{ $homeserver | quote }}],
+  "allowCustomHomeservers": {{ .Values.matrix.allowCustomHomeservers }},
+  "hashRouter": {
+    "enabled": false,
+    "basename": "/"
+  }
+}
+{{- end -}}
+
+{{/*
+The nginx server config serving the client under basePath.
+The image entrypoint normally writes runtime-config.js into the app directory,
+which an unprivileged read-only container forbids, so the chart serves
+runtime-config.js straight from nginx and the Deployment bypasses the entrypoint.
+*/}}
+{{- define "mindroom-client.defaultNginxConf" -}}
+{{- $base := include "mindroom-client.basePath" . -}}
+{{- $prefix := include "mindroom-client.pathPrefix" . -}}
+{{- $runtimeConfig := printf "window.__APP_BASE_PATH__ = \"%s\"; window.__ENABLE_SERVICE_WORKER__ = %t;" $base .Values.serviceWorker.enabled -}}
+server {
+  listen {{ .Values.nginx.port }};
+  listen [::]:{{ .Values.nginx.port }};
+  absolute_redirect off;
+{{- if ne $base "/" }}
+
+  location = / {
+    return 308 {{ $base }}/;
+  }
+
+  location = {{ $base }} {
+    return 308 {{ $base }}/;
+  }
+{{- end }}
+
+  # index.html loads /runtime-config.js from the origin root regardless of basePath.
+  location = /runtime-config.js {
+    default_type application/javascript;
+    add_header Cache-Control "no-store, max-age=0" always;
+    return 200 '{{ $runtimeConfig }}';
+  }
+
+  location = {{ $prefix }}/config.json {
+    alias /usr/share/nginx/html/config.json;
+    default_type application/json;
+    add_header Cache-Control "no-store, no-cache, must-revalidate, max-age=0" always;
+  }
+
+  # The client service worker, scoped to basePath.
+  location = {{ $prefix }}/sw.js {
+    alias /usr/share/nginx/html/sw.js;
+    default_type application/javascript;
+    add_header Cache-Control "no-store, max-age=0" always;
+  }
+{{- if .Values.rootServiceWorkerCleanup.enabled }}
+
+  # A Matrix client that previously controlled the origin root can leave a
+  # root-scoped service worker that keeps serving the old app for every path on
+  # this origin. Serving this cleanup worker at the old /sw.js URL makes the
+  # stale worker replace itself with one that purges caches and unregisters.
+  location = /sw.js {
+    alias /usr/share/nginx/html/root-cleanup-sw.js;
+    default_type application/javascript;
+    add_header Cache-Control "no-store, max-age=0" always;
+  }
+{{- end }}
+{{- if ne $base "/" }}
+
+  location = {{ $prefix }}/manifest.json {
+    alias /usr/share/nginx/html/manifest.json;
+    add_header Cache-Control "no-store, max-age=0" always;
+  }
+
+  location = {{ $prefix }}/pdf.worker.min.js {
+    alias /usr/share/nginx/html/pdf.worker.min.js;
+  }
+{{- end }}
+
+  # Hashed build assets are referenced relative to the current route, so strip
+  # any route prefix before the assets/ or public/ segment.
+  location ~ ^/(?:.+/)?(assets|public)/(.+)$ {
+    root /usr/share/nginx/html;
+    try_files /$1/$2 =404;
+    add_header Cache-Control "public, max-age=31536000, immutable" always;
+  }
+{{- if eq $base "/" }}
+
+  location / {
+    root /usr/share/nginx/html;
+    add_header Cache-Control "no-store, no-cache, must-revalidate, max-age=0" always;
+    try_files $uri $uri/ /index.html;
+  }
+{{- else }}
+
+  # Everything else under basePath is an app route served by index.html.
+  location {{ $base }}/ {
+    root /usr/share/nginx/html;
+    add_header Cache-Control "no-store, no-cache, must-revalidate, max-age=0" always;
+    try_files /index.html =404;
+  }
+{{- end }}
+}
+{{- end -}}
+
+{{/*
+Service worker served at the origin-root /sw.js to replace a stale root-scoped
+worker: it purges client caches, releases controlled pages into basePath, and
+unregisters itself.
+*/}}
+{{- define "mindroom-client.rootCleanupServiceWorker" -}}
+{{- $target := printf "%s/" (include "mindroom-client.pathPrefix" .) -}}
+self.addEventListener("install", () => {
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    (async () => {
+      if ("caches" in self) {
+        const names = await self.caches.keys();
+        await Promise.all(
+          names
+            .filter((name) => name.includes("mindroom") || name.includes("workbox"))
+            .map((name) => self.caches.delete(name))
+        );
+      }
+      await self.clients.claim();
+      const clients = await self.clients.matchAll({
+        includeUncontrolled: true,
+        type: "window",
+      });
+      await Promise.all(clients.map((client) => client.navigate("{{ $target }}")));
+      await self.registration.unregister();
+    })()
+  );
+});
+{{- end -}}

--- a/cluster/k8s/client/templates/configmap-config.yaml
+++ b/cluster/k8s/client/templates/configmap-config.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.config.create (not .Values.config.existingConfigMap) }}
+{{- $configData := default (include "mindroom-client.defaultClientConfig" .) .Values.config.data -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mindroom-client.configMapName" . }}
+  labels:
+    {{- include "mindroom-client.labels" . | nindent 4 }}
+data:
+  {{ .Values.config.key }}: |
+{{ $configData | indent 4 }}
+{{- end }}

--- a/cluster/k8s/client/templates/configmap-nginx.yaml
+++ b/cluster/k8s/client/templates/configmap-nginx.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.nginx.create (not .Values.nginx.existingConfigMap) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mindroom-client.nginxConfigMapName" . }}
+  labels:
+    {{- include "mindroom-client.labels" . | nindent 4 }}
+data:
+  {{ .Values.nginx.key }}: |
+{{ include "mindroom-client.defaultNginxConf" . | indent 4 }}
+  {{- if .Values.rootServiceWorkerCleanup.enabled }}
+  {{ .Values.nginx.cleanupWorkerKey }}: |
+{{ include "mindroom-client.rootCleanupServiceWorker" . | indent 4 }}
+  {{- end }}
+{{- end }}

--- a/cluster/k8s/client/templates/deployment.yaml
+++ b/cluster/k8s/client/templates/deployment.yaml
@@ -1,0 +1,144 @@
+{{- $configManaged := and .Values.config.create (not .Values.config.existingConfigMap) -}}
+{{- $nginxManaged := and .Values.nginx.create (not .Values.nginx.existingConfigMap) -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mindroom-client.fullname" . }}
+  labels:
+    {{- include "mindroom-client.labels" . | nindent 4 }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "mindroom-client.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "mindroom-client.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- if or $configManaged $nginxManaged .Values.podAnnotations }}
+      annotations:
+        {{- if $configManaged }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap-config.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if $nginxManaged }}
+        checksum/nginx-config: {{ include (print $.Template.BasePath "/configmap-nginx.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+    spec:
+      automountServiceAccountToken: false
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: client
+          image: {{ include "mindroom-client.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          # Run nginx directly: the image entrypoint writes runtime-config.js
+          # into the app directory, which the unprivileged read-only container
+          # forbids; the chart-managed nginx config serves runtime-config.js.
+          command:
+            - nginx
+            - -g
+            - daemon off;
+          ports:
+            - name: http
+              containerPort: {{ .Values.nginx.port }}
+              protocol: TCP
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            {{- if .Values.probes.readiness.custom }}
+            {{- toYaml .Values.probes.readiness.custom | nindent 12 }}
+            {{- else }}
+            httpGet:
+              path: {{ include "mindroom-client.probePath" . }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+            {{- if .Values.probes.liveness.custom }}
+            {{- toYaml .Values.probes.liveness.custom | nindent 12 }}
+            {{- else }}
+            httpGet:
+              path: {{ include "mindroom-client.probePath" . }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+            {{- end }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /app/config.json
+              subPath: {{ .Values.config.key }}
+              readOnly: true
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: {{ .Values.nginx.key }}
+              readOnly: true
+            {{- if .Values.rootServiceWorkerCleanup.enabled }}
+            - name: nginx-config
+              mountPath: /app/root-cleanup-sw.js
+              subPath: {{ .Values.nginx.cleanupWorkerKey }}
+              readOnly: true
+            {{- end }}
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: nginx-run
+              mountPath: /run
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "mindroom-client.configMapName" . }}
+        - name: nginx-config
+          configMap:
+            name: {{ include "mindroom-client.nginxConfigMapName" . }}
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}

--- a/cluster/k8s/client/templates/deployment.yaml
+++ b/cluster/k8s/client/templates/deployment.yaml
@@ -113,6 +113,8 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
+            # /usr/share/nginx/html is a symlink to /app in the client image,
+            # so the nginx aliases under html/ resolve to these mounts.
             - name: config
               mountPath: /app/config.json
               subPath: {{ .Values.config.key }}

--- a/cluster/k8s/client/templates/service.yaml
+++ b/cluster/k8s/client/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mindroom-client.fullname" . }}
+  labels:
+    {{- include "mindroom-client.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "mindroom-client.selectorLabels" . | nindent 4 }}

--- a/cluster/k8s/client/templates/validate.yaml
+++ b/cluster/k8s/client/templates/validate.yaml
@@ -1,0 +1,9 @@
+{{- if not (hasPrefix "/" .Values.basePath) -}}
+{{- fail "basePath must start with /" -}}
+{{- end -}}
+{{- if and .Values.rootServiceWorkerCleanup.enabled (eq (include "mindroom-client.basePath" .) "/") -}}
+{{- fail "rootServiceWorkerCleanup.enabled requires a basePath other than / because /sw.js is the client service worker at the origin root" -}}
+{{- end -}}
+{{- if and .Values.config.create (not .Values.config.existingConfigMap) (not .Values.config.data) (not .Values.matrix.homeserverUrl) (not .Values.matrix.defaultServerName) -}}
+{{- fail "matrix.homeserverUrl or matrix.defaultServerName is required when the chart renders the default client config" -}}
+{{- end -}}

--- a/cluster/k8s/client/templates/validate.yaml
+++ b/cluster/k8s/client/templates/validate.yaml
@@ -7,3 +7,9 @@
 {{- if and .Values.config.create (not .Values.config.existingConfigMap) (not .Values.config.data) (not .Values.matrix.homeserverUrl) (not .Values.matrix.defaultServerName) -}}
 {{- fail "matrix.homeserverUrl or matrix.defaultServerName is required when the chart renders the default client config" -}}
 {{- end -}}
+{{- if and (not .Values.config.create) (not .Values.config.existingConfigMap) -}}
+{{- fail "config.existingConfigMap is required when config.create=false" -}}
+{{- end -}}
+{{- if and (not .Values.nginx.create) (not .Values.nginx.existingConfigMap) -}}
+{{- fail "nginx.existingConfigMap is required when nginx.create=false" -}}
+{{- end -}}

--- a/cluster/k8s/client/values.yaml
+++ b/cluster/k8s/client/values.yaml
@@ -1,0 +1,123 @@
+# Standalone MindRoom web client chart.
+# It serves the published MindRoom client image through unprivileged nginx.
+# Matrix, ingress, and TLS come from your own cluster.
+
+nameOverride: ""
+fullnameOverride: ""
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/mindroom-ai/mindroom-cinny
+  tag: latest
+  digest: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+deploymentAnnotations: {}
+podAnnotations: {}
+podLabels: {}
+# Leave empty for the chart default.
+# Set this when adopting an existing Deployment whose selector is immutable.
+selectorLabels: {}
+priorityClassName: ""
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []
+
+# The client image runs nginx as the unprivileged nginx user.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 101
+  runAsGroup: 101
+  fsGroup: 101
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+service:
+  type: ClusterIP
+  port: 80
+  annotations: {}
+
+# URL path prefix the client is served under, for example /mindroom.
+# Use / when the client owns the origin root.
+# The client always loads /runtime-config.js from the origin root, so route the
+# full origin host to this Service even when basePath is not /.
+basePath: /
+
+matrix:
+  # Base URL of the Matrix homeserver the login flow connects to.
+  homeserverUrl: https://matrix.example.com
+  # Optional Matrix server name shown in the login form instead of the URL.
+  # The server name must publish /.well-known/matrix/client pointing at homeserverUrl.
+  # When set, this replaces homeserverUrl as the configured homeserver entry.
+  defaultServerName: ""
+  # Allow logging in to homeservers outside the configured entry.
+  allowCustomHomeservers: false
+
+serviceWorker:
+  # Register the client service worker, scoped to basePath.
+  enabled: true
+
+# Serve a cleanup service worker at the origin-root /sw.js.
+# A Matrix client that previously controlled the origin root can leave a
+# root-scoped service worker that keeps serving the old app for every path on
+# the origin, including basePath. Browsers replace a service worker by fetching
+# its script URL, so the deterministic fix is to serve a worker at the old URL
+# whose only job is to purge caches, release its clients, and unregister itself.
+# Enable this when moving such an origin to a basePath deployment.
+# Requires a basePath other than /.
+rootServiceWorkerCleanup:
+  enabled: false
+
+# Client config.json.
+config:
+  create: true
+  existingConfigMap: ""
+  key: config.json
+  # Leave empty to render the chart default client config from the matrix values.
+  # Set this when you want full control over config.json.
+  data: ""
+
+# Chart-managed nginx server configuration.
+nginx:
+  # Container port nginx listens on. Ports below 1024 require extra privileges.
+  port: 8080
+  create: true
+  existingConfigMap: ""
+  key: default.conf
+  # Key in the nginx ConfigMap holding the root cleanup service worker script.
+  # An existing ConfigMap must provide this key when rootServiceWorkerCleanup is enabled.
+  cleanupWorkerKey: root-cleanup-sw.js
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    memory: 256Mi
+
+probes:
+  readiness:
+    enabled: true
+    custom: {}
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+  liveness:
+    enabled: true
+    custom: {}
+    initialDelaySeconds: 20
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 6

--- a/cluster/k8s/client/values.yaml
+++ b/cluster/k8s/client/values.yaml
@@ -11,7 +11,7 @@ image:
   repository: ghcr.io/mindroom-ai/mindroom-cinny
   tag: latest
   digest: ""
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
 
 imagePullSecrets: []
 
@@ -92,6 +92,9 @@ config:
 nginx:
   # Container port nginx listens on. Ports below 1024 require extra privileges.
   port: 8080
+  # Also listen on IPv6. Disable on nodes without an IPv6 stack, for example
+  # kernels booted with ipv6.disable=1, where binding [::] fails at startup.
+  ipv6: true
   create: true
   existingConfigMap: ""
   key: default.conf


### PR DESCRIPTION
The project publishes a web client image (`ghcr.io/mindroom-ai/mindroom-cinny`) but ships no way to deploy it, so every self-hosted deployment hand-rolls an nginx Deployment, Service, client `config.json`, and service-worker handling. This adds `cluster/k8s/client`, a standalone `mindroom-client` chart following the structure and conventions of `cluster/k8s/runtime`.

**What the chart provides**
- Deployment serving the client behind unprivileged nginx (uid 101, read-only root filesystem, capabilities dropped) under a configurable `basePath` (e.g. `/mindroom`), plus a ClusterIP Service.
- Chart-managed ConfigMaps for `config.json` (homeserver URL, optional default server name, custom-homeserver toggle, full `config.data` override) and the nginx server config, each with an `existingConfigMap` escape hatch.
- The image entrypoint writes `runtime-config.js` into the app directory, which an unprivileged read-only container forbids, so the Deployment runs nginx directly and the chart-managed nginx config serves `runtime-config.js` itself.
- Service-worker hygiene: the client worker is served at `basePath/sw.js` scoped to the base path, and an opt-in `rootServiceWorkerCleanup` serves a root-level `/sw.js` that purges caches and unregisters a stale root-scoped service worker — a known footgun when a Matrix client previously controlled the origin root.
- Checksum annotations on the pod template so config changes roll pods, standard scheduling knobs (nodeSelector, tolerations, affinity, topologySpreadConstraints, priorityClassName, podAnnotations, security contexts), probe `custom` overrides, and `selectorLabels` for adopting existing Deployments.
- Chart README, and registration in `publish-helm-charts.yml` with lint, template scenarios (default, custom base path with cleanup worker, existing ConfigMaps), and package/push, mirroring the runtime chart job.

**Validation**
- `helm lint` and `helm template` pass for all CI scenarios; `helm package` succeeds.
- Smoke-tested the rendered configs against the published image running as uid 101 with the entrypoint bypassed: verified `runtime-config.js`, `config.json`, base-path redirects, app-shell and deep-route fallback, both service workers, prefix-stripped hashed assets with immutable caching, and probe paths.