### PR TITLE
Fix release-workflow test broken by #1266's app-token switch

### DIFF
--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -51,9 +51,10 @@ def test_release_workflow_dispatches_homebrew_tap_update(release_workflow: str) 
     """The main release workflow should notify the dedicated Homebrew tap repo."""
     assert "update_homebrew_tap:" in release_workflow
     assert "needs: build_macos_app" in release_workflow
-    assert "HOMEBREW_TAP_DISPATCH_TOKEN" in release_workflow
-    assert "Token needs write access to mindroom-ai/homebrew-tap." in release_workflow
-    assert "Fine-grained tokens need Contents: write on that repo." in release_workflow
+    assert "actions/create-github-app-token@v3" in release_workflow
+    assert "owner: mindroom-ai" in release_workflow
+    assert "repositories: homebrew-tap" in release_workflow
+    assert "GH_TOKEN: ${{ steps.release-bot.outputs.token }}" in release_workflow
     assert "repos/mindroom-ai/homebrew-tap/dispatches" in release_workflow
     assert "-f event_type=mindroom-release" in release_workflow
     assert '-F "client_payload[tag_name]=$TAG_NAME"' in release_workflow


### PR DESCRIPTION
#1266 replaced `HOMEBREW_TAP_DISPATCH_TOKEN` in `release.yml` with a minted mindroom-release-bot app token, but only touched `.github/`, so the pytest workflow never ran on it and `test_release_workflow_dispatches_homebrew_tap_update` is now red on main.
Every open PR inherits the failure through its merge ref — #1264's `test (3.13)` job is currently failing on exactly this test and nothing else.
This updates the test to assert the new mechanism: `actions/create-github-app-token@v3` scoped to `owner: mindroom-ai` / `repositories: homebrew-tap`, the minted token as `GH_TOKEN`, and the unchanged repository-dispatch call.

Verified with `uv run pytest tests/test_release_workflow.py -n 0 --no-cov` — 6 passed (1 failed before on a clean main checkout).