### PR TITLE
Tests: align release workflow test with release-bot tap dispatch

### DIFF
--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -51,9 +51,13 @@ def test_release_workflow_dispatches_homebrew_tap_update(release_workflow: str) 
     """The main release workflow should notify the dedicated Homebrew tap repo."""
     assert "update_homebrew_tap:" in release_workflow
     assert "needs: build_macos_app" in release_workflow
-    assert "HOMEBREW_TAP_DISPATCH_TOKEN" in release_workflow
-    assert "Token needs write access to mindroom-ai/homebrew-tap." in release_workflow
-    assert "Fine-grained tokens need Contents: write on that repo." in release_workflow
+    assert "uses: actions/create-github-app-token@v3" in release_workflow
+    assert "app-id: ${{ vars.RELEASE_BOT_APP_ID }}" in release_workflow
+    assert "private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}" in release_workflow
+    assert "owner: mindroom-ai" in release_workflow
+    assert "repositories: homebrew-tap" in release_workflow
+    assert "GH_TOKEN: ${{ steps.release-bot.outputs.token }}" in release_workflow
+    assert "HOMEBREW_TAP_DISPATCH_TOKEN" not in release_workflow
     assert "repos/mindroom-ai/homebrew-tap/dispatches" in release_workflow
     assert "-f event_type=mindroom-release" in release_workflow
     assert '-F "client_payload[tag_name]=$TAG_NAME"' in release_workflow


### PR DESCRIPTION
## Summary
Pytest CI on main has been red since #1266.

#1266 replaced the `HOMEBREW_TAP_DISPATCH_TOKEN` PAT in `.github/workflows/release.yml` with a short-lived `mindroom-release-bot` GitHub App token, but `tests/test_release_workflow.py::test_release_workflow_dispatches_homebrew_tap_update` still asserted the old secret name and its PAT-scope comments, so the test fails on main.

This updates the test to assert the new app-token flow instead:
- `actions/create-github-app-token@v3` minting with `RELEASE_BOT_APP_ID` / `RELEASE_BOT_PRIVATE_KEY`, scoped to `mindroom-ai/homebrew-tap`
- dispatch step uses the minted token (`steps.release-bot.outputs.token`)
- `HOMEBREW_TAP_DISPATCH_TOKEN` is asserted to be fully gone

## Test plan
- `uv run pytest tests/test_release_workflow.py -n 0 --no-cov` — 6 passed