### PR TITLE
Reconcile worker Deployments that drift from the configured pod template

### DIFF
--- a/cluster/k8s/runtime/README.md
+++ b/cluster/k8s/runtime/README.md
@@ -335,6 +335,8 @@ workers:
   In the release namespace, the chart stores derived worker tokens and optional credential-encryption keys as entries in one chart-created worker-auth Secret and grants only `get` and `patch` on that Secret.
   When `workers.kubernetes.namespace` points at a separate worker namespace, the chart uses per-worker auth Secrets and grants Secret CRUD only in that namespace.
   The chart can create the worker-manager RBAC and a worker NetworkPolicy.
+- With `workers.kubernetes.reconcilePodTemplates` (default `true`), each cleanup pass recreates scaled-down worker Deployments whose pod template (image, env, resources) drifted from the configured spec, so existing workers do not need manual recycling after upgrades.
+  Running workers are recreated on their next provisioning after they scale down.
 - If workers run in a different namespace, provide storage, service accounts, and network policy behavior that are valid for that namespace.
   Kubernetes owner references are only set by default for same-namespace workers.
   The sandbox proxy token secret is only needed by the primary runtime; dedicated worker pods receive per-worker derived runner tokens.

--- a/cluster/k8s/runtime/templates/deployment.yaml
+++ b/cluster/k8s/runtime/templates/deployment.yaml
@@ -269,6 +269,8 @@ spec:
               value: {{ .Values.workers.kubernetes.idleTimeoutSeconds | quote }}
             - name: MINDROOM_KUBERNETES_WORKER_READY_TIMEOUT_SECONDS
               value: {{ .Values.workers.kubernetes.readyTimeoutSeconds | quote }}
+            - name: MINDROOM_KUBERNETES_WORKER_RECONCILE_POD_TEMPLATES
+              value: {{ .Values.workers.kubernetes.reconcilePodTemplates | quote }}
             - name: MINDROOM_KUBERNETES_WORKER_NAME_PREFIX
               value: {{ .Values.workers.kubernetes.namePrefix | quote }}
             - name: MINDROOM_KUBERNETES_WORKER_ENABLE_SERVICE_LINKS

--- a/cluster/k8s/runtime/values.yaml
+++ b/cluster/k8s/runtime/values.yaml
@@ -293,6 +293,10 @@ workers:
     port: 8766
     readyTimeoutSeconds: 60
     idleTimeoutSeconds: 1800
+    # Recreate scaled-down worker Deployments whose pod template (image, env,
+    # resources) drifted from current config during each cleanup interval.
+    # Running workers are recreated on their next provisioning after scale-down.
+    reconcilePodTemplates: true
     namePrefix: mindroom-worker
     storageSubpathPrefix: workers
     enableServiceLinks: false

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -201,6 +201,8 @@ Important behavior and constraints:
 
 - `kubernetesWorkerImage` and `kubernetesWorkerImagePullPolicy` default to the main MindRoom image settings when left empty.
 - `workerCleanupIntervalSeconds` controls how often the primary runtime runs idle-worker cleanup.
+- Worker pod-template drift (image, env, resources) is reconciled automatically: each cleanup pass recreates scaled-down worker Deployments whose pod template no longer matches the configured spec, and running workers are recreated on their next provisioning after they scale down.
+- Reconciliation is controlled by `workers.kubernetes.reconcilePodTemplates` in the runtime chart (`MINDROOM_KUBERNETES_WORKER_RECONCILE_POD_TEMPLATES`, default on), so worker Deployments do not need manual recycling after image or pod-template changes.
 - `kubernetesWorkerIdleTimeoutSeconds` controls when a worker is considered idle and eligible to scale down.
 - `kubernetesWorkerReadyTimeoutSeconds` controls how long the primary runtime waits for a worker Deployment to become ready.
 - `kubernetesWorkerPort` is the internal Service and container port used by dedicated workers.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -16144,6 +16144,8 @@ Important behavior and constraints:
 
 - `kubernetesWorkerImage` and `kubernetesWorkerImagePullPolicy` default to the main MindRoom image settings when left empty.
 - `workerCleanupIntervalSeconds` controls how often the primary runtime runs idle-worker cleanup.
+- Worker pod-template drift (image, env, resources) is reconciled automatically: each cleanup pass recreates scaled-down worker Deployments whose pod template no longer matches the configured spec, and running workers are recreated on their next provisioning after they scale down.
+- Reconciliation is controlled by `workers.kubernetes.reconcilePodTemplates` in the runtime chart (`MINDROOM_KUBERNETES_WORKER_RECONCILE_POD_TEMPLATES`, default on), so worker Deployments do not need manual recycling after image or pod-template changes.
 - `kubernetesWorkerIdleTimeoutSeconds` controls when a worker is considered idle and eligible to scale down.
 - `kubernetesWorkerReadyTimeoutSeconds` controls how long the primary runtime waits for a worker Deployment to become ready.
 - `kubernetesWorkerPort` is the internal Service and container port used by dedicated workers.

--- a/skills/mindroom-docs/references/page__deployment__kubernetes__index.md
+++ b/skills/mindroom-docs/references/page__deployment__kubernetes__index.md
@@ -197,6 +197,8 @@ Important behavior and constraints:
 
 - `kubernetesWorkerImage` and `kubernetesWorkerImagePullPolicy` default to the main MindRoom image settings when left empty.
 - `workerCleanupIntervalSeconds` controls how often the primary runtime runs idle-worker cleanup.
+- Worker pod-template drift (image, env, resources) is reconciled automatically: each cleanup pass recreates scaled-down worker Deployments whose pod template no longer matches the configured spec, and running workers are recreated on their next provisioning after they scale down.
+- Reconciliation is controlled by `workers.kubernetes.reconcilePodTemplates` in the runtime chart (`MINDROOM_KUBERNETES_WORKER_RECONCILE_POD_TEMPLATES`, default on), so worker Deployments do not need manual recycling after image or pod-template changes.
 - `kubernetesWorkerIdleTimeoutSeconds` controls when a worker is considered idle and eligible to scale down.
 - `kubernetesWorkerReadyTimeoutSeconds` controls how long the primary runtime waits for a worker Deployment to become ready.
 - `kubernetesWorkerPort` is the internal Service and container port used by dedicated workers.

--- a/src/mindroom/api/main.py
+++ b/src/mindroom/api/main.py
@@ -47,6 +47,7 @@ from mindroom.workers.runtime import (
     get_primary_worker_manager,
     primary_worker_backend_available,
     primary_worker_backend_name,
+    reconcile_drifted_worker_templates,
     serialized_kubernetes_worker_validation_snapshot,
 )
 
@@ -220,6 +221,13 @@ def _cleanup_workers_once(
         logger.info(
             "Cleaned idle workers",
             count=len(cleaned_workers),
+            backend=worker_manager.backend_name,
+        )
+    reconciled_workers = reconcile_drifted_worker_templates(worker_manager)
+    if reconciled_workers:
+        logger.info(
+            "Reconciled drifted worker pod templates",
+            count=len(reconciled_workers),
             backend=worker_manager.backend_name,
         )
     return len(cleaned_workers)

--- a/src/mindroom/runtime_env_policy.py
+++ b/src/mindroom/runtime_env_policy.py
@@ -143,6 +143,7 @@ KUBERNETES_WORKER_BACKEND_CONFIG_ENV_BY_KEY: Mapping[str, str] = MappingProxyTyp
         "name_prefix": "MINDROOM_KUBERNETES_WORKER_NAME_PREFIX",
         "node_name": "MINDROOM_KUBERNETES_WORKER_NODE_NAME",
         "colocate_with_control_plane_node": "MINDROOM_KUBERNETES_WORKER_COLOCATE_WITH_CONTROL_PLANE_NODE",
+        "reconcile_pod_templates": "MINDROOM_KUBERNETES_WORKER_RECONCILE_POD_TEMPLATES",
         "extra_env_json": "MINDROOM_KUBERNETES_WORKER_ENV_JSON",
         "extra_labels_json": "MINDROOM_KUBERNETES_WORKER_LABELS_JSON",
         "extra_annotations_json": "MINDROOM_KUBERNETES_WORKER_ANNOTATIONS_JSON",

--- a/src/mindroom/workers/backends/kubernetes.py
+++ b/src/mindroom/workers/backends/kubernetes.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import threading
 import time
 from dataclasses import dataclass
@@ -39,6 +40,8 @@ __all__ = [
 _COLD_START_GRACE_SECONDS = 1.5
 _WAITING_PROGRESS_INTERVAL_SECONDS = 5.0
 _PROGRESS_REPORTER_JOIN_TIMEOUT_SECONDS = 1.0
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -517,6 +520,67 @@ class KubernetesWorkerBackend:
             deployment.metadata.annotations = annotations
             cleaned.append(self._handle_from_deployment(deployment, now=timestamp))
         return cleaned
+
+    def reconcile_drifted_workers(self, *, now: float | None = None) -> list[WorkerHandle]:
+        """Recreate scaled-down worker Deployments whose pod template drifted from current config.
+
+        Running workers are left untouched; the ensure-time template-hash check
+        recreates them on their next provisioning after they scale down.
+        """
+        if not self.config.reconcile_pod_templates:
+            return []
+        timestamp = time.time() if now is None else now
+        reconciled: list[WorkerHandle] = []
+        for deployment in self._resources.list_deployments():
+            handle = self._handle_from_deployment(deployment, now=timestamp)
+            if handle.status != "idle" or int(deployment.spec.replicas or 0) != 0:
+                continue
+            worker_lock = self._worker_lock(handle.worker_key)
+            if not worker_lock.acquire(blocking=False):
+                continue
+            try:
+                refreshed = self._reconcile_worker_deployment(deployment, handle=handle, now=timestamp)
+            finally:
+                worker_lock.release()
+            if refreshed is not None:
+                reconciled.append(refreshed)
+        return reconciled
+
+    def _reconcile_worker_deployment(
+        self,
+        deployment: resources.KubernetesDeployment,
+        *,
+        handle: WorkerHandle,
+        now: float,
+    ) -> WorkerHandle | None:
+        annotations = dict(deployment.metadata.annotations or {})
+        private_agent_names = resources.parse_private_agent_names_annotation(annotations)
+        state_subpath = self._state_subpath(handle.worker_key)
+        try:
+            drifted = self._resources.deployment_template_drifted(
+                deployment,
+                worker_key=handle.worker_key,
+                worker_id=handle.worker_id,
+                state_subpath=state_subpath,
+                private_agent_names=private_agent_names,
+            )
+            if not drifted:
+                return None
+            self._resources.apply_deployment(
+                worker_key=handle.worker_key,
+                worker_id=handle.worker_id,
+                state_subpath=state_subpath,
+                annotations=annotations,
+                replicas=0,
+                private_agent_names=private_agent_names,
+            )
+        except WorkerBackendError:
+            logger.warning("Skipping pod-template reconciliation for worker %r", handle.worker_key, exc_info=True)
+            return None
+        refreshed = self._resources.read_deployment(handle.worker_id)
+        if refreshed is None:
+            return None
+        return self._handle_from_deployment(refreshed, now=now)
 
     def record_failure(
         self,

--- a/src/mindroom/workers/backends/kubernetes.py
+++ b/src/mindroom/workers/backends/kubernetes.py
@@ -539,7 +539,7 @@ class KubernetesWorkerBackend:
             if not worker_lock.acquire(blocking=False):
                 continue
             try:
-                refreshed = self._reconcile_worker_deployment(deployment, handle=handle, now=timestamp)
+                refreshed = self._reconcile_worker_deployment(deployment, handle=handle)
             finally:
                 worker_lock.release()
             if refreshed is not None:
@@ -551,7 +551,6 @@ class KubernetesWorkerBackend:
         deployment: resources.KubernetesDeployment,
         *,
         handle: WorkerHandle,
-        now: float,
     ) -> WorkerHandle | None:
         annotations = dict(deployment.metadata.annotations or {})
         private_agent_names = resources.parse_private_agent_names_annotation(annotations)
@@ -585,10 +584,9 @@ class KubernetesWorkerBackend:
         except WorkerBackendError:
             logger.warning("Skipping pod-template reconciliation for worker %r", handle.worker_key, exc_info=True)
             return None
-        refreshed = self._resources.read_deployment(handle.worker_id)
-        if refreshed is None:
-            return None
-        return self._handle_from_deployment(refreshed, now=now)
+        # The recreate keeps the lifecycle annotations and zero replicas, so the
+        # handle projected before the apply still describes the reconciled worker.
+        return handle
 
     def record_failure(
         self,

--- a/src/mindroom/workers/backends/kubernetes.py
+++ b/src/mindroom/workers/backends/kubernetes.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 from mindroom.credential_policy import credential_service_policy
 from mindroom.credentials import get_runtime_credentials_manager, sync_shared_credentials_to_worker
-from mindroom.tool_system.worker_routing import worker_dir_name, worker_id_for_key
+from mindroom.tool_system.worker_routing import resolved_worker_key_scope, worker_dir_name, worker_id_for_key
 from mindroom.workers.backend import WorkerBackendError, effective_idle_status, filter_and_sort_worker_handles
 from mindroom.workers.backends._lifecycle import mark_worker_failed, mark_worker_idle, touch_worker_lifecycle
 from mindroom.workers.models import (
@@ -555,6 +555,14 @@ class KubernetesWorkerBackend:
     ) -> WorkerHandle | None:
         annotations = dict(deployment.metadata.annotations or {})
         private_agent_names = resources.parse_private_agent_names_annotation(annotations)
+        if private_agent_names is None and resolved_worker_key_scope(handle.worker_key) == "user_agent":
+            # Deployments created before visibility persistence cannot be rebuilt
+            # deterministically; the ensure-time hash check recreates them on next use.
+            logger.debug(
+                "Deferring pod-template reconciliation for worker %r: no persisted private-agent visibility",
+                handle.worker_key,
+            )
+            return None
         state_subpath = self._state_subpath(handle.worker_key)
         try:
             drifted = self._resources.deployment_template_drifted(

--- a/src/mindroom/workers/backends/kubernetes_config.py
+++ b/src/mindroom/workers/backends/kubernetes_config.py
@@ -59,6 +59,7 @@ _READY_TIMEOUT_ENV = KUBERNETES_WORKER_BACKEND_CONFIG_ENV_BY_KEY["ready_timeout"
 _NAME_PREFIX_ENV = KUBERNETES_WORKER_BACKEND_CONFIG_ENV_BY_KEY["name_prefix"]
 _NODE_NAME_ENV = KUBERNETES_WORKER_BACKEND_CONFIG_ENV_BY_KEY["node_name"]
 _COLOCATE_WITH_CONTROL_PLANE_NODE_ENV = KUBERNETES_WORKER_BACKEND_CONFIG_ENV_BY_KEY["colocate_with_control_plane_node"]
+_RECONCILE_POD_TEMPLATES_ENV = KUBERNETES_WORKER_BACKEND_CONFIG_ENV_BY_KEY["reconcile_pod_templates"]
 _EXTRA_ENV_JSON_ENV = KUBERNETES_WORKER_BACKEND_CONFIG_ENV_BY_KEY["extra_env_json"]
 _EXTRA_LABELS_JSON_ENV = KUBERNETES_WORKER_BACKEND_CONFIG_ENV_BY_KEY["extra_labels_json"]
 _EXTRA_ANNOTATIONS_JSON_ENV = KUBERNETES_WORKER_BACKEND_CONFIG_ENV_BY_KEY["extra_annotations_json"]
@@ -235,6 +236,7 @@ class KubernetesWorkerBackendConfig:
     resource_limits: dict[str, str]
     enable_service_links: bool
     auth_secret_name: str | None
+    reconcile_pod_templates: bool = True
     agent_vault: KubernetesAgentVaultConfig | None = None
 
     @classmethod
@@ -290,6 +292,7 @@ class KubernetesWorkerBackendConfig:
             resource_limits=resource_limits,
             enable_service_links=_read_bool_env(env, _ENABLE_SERVICE_LINKS_ENV, default=False),
             auth_secret_name=_read_env(env, _AUTH_SECRET_NAME_ENV) or None,
+            reconcile_pod_templates=_read_bool_env(env, _RECONCILE_POD_TEMPLATES_ENV, default=True),
             agent_vault=KubernetesAgentVaultConfig.from_env(env),
         )
 
@@ -335,6 +338,7 @@ def kubernetes_backend_config_signature(
         resource_limits_json,
         str(config.enable_service_links),
         config.auth_secret_name or "",
+        str(config.reconcile_pod_templates),
         config.agent_vault.signature() if config.agent_vault is not None else "",
         credentials_encryption_key_marker,
         auth_token or "",

--- a/src/mindroom/workers/backends/kubernetes_resources.py
+++ b/src/mindroom/workers/backends/kubernetes_resources.py
@@ -79,6 +79,7 @@ _ANNOTATION_STARTUP_MANIFEST_HASH = "mindroom.ai/startup-manifest-hash"
 _ANNOTATION_RUNNER_TOKEN_HASH = "mindroom.ai/runner-token-hash"  # noqa: S105
 _ANNOTATION_CREDENTIALS_ENCRYPTION_KEY_HASH = "mindroom.ai/credentials-encryption-key-hash"
 _ANNOTATION_TEMPLATE_HASH = "mindroom.ai/template-hash"
+_ANNOTATION_PRIVATE_AGENT_NAMES = "mindroom.ai/private-agent-names"
 
 _LABEL_COMPONENT = "mindroom.ai/component"
 _LABEL_COMPONENT_VALUE = "worker"
@@ -371,6 +372,20 @@ def _template_hash(template: dict[str, object]) -> str:
     """Return a stable hash for one Deployment pod template."""
     payload = json.dumps(template, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def parse_private_agent_names_annotation(annotations: dict[str, str]) -> frozenset[str] | None:
+    """Parse the persisted private-agent visibility annotation, ``None`` when absent."""
+    raw = annotations.get(_ANNOTATION_PRIVATE_AGENT_NAMES)
+    if not raw:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(parsed, list):
+        return None
+    return frozenset(name for name in parsed if isinstance(name, str))
 
 
 def _labels(*, extra_labels: dict[str, str], worker_id: str) -> dict[str, str]:
@@ -885,22 +900,42 @@ class KubernetesResourceManager:
             secret_data[encryption_key_secret_key] = None
         return secret_data
 
-    def _deployment_manifest(
+    def deployment_template_drifted(
+        self,
+        deployment: KubernetesDeployment,
+        *,
+        worker_key: str,
+        worker_id: str,
+        state_subpath: str,
+        private_agent_names: frozenset[str] | None,
+    ) -> bool:
+        """Return whether one Deployment's recorded pod template differs from current config."""
+        startup_manifest_path, startup_manifest_hash = self._startup_manifest_path_and_hash(
+            worker_key=worker_key,
+            dedicated_root=Path(f"{self.config.storage_mount_path}/{state_subpath}".rstrip("/")),
+        )
+        template = self._pod_template(
+            worker_key=worker_key,
+            worker_id=worker_id,
+            state_subpath=state_subpath,
+            startup_manifest_path=startup_manifest_path,
+            startup_manifest_hash=startup_manifest_hash,
+            private_agent_names=private_agent_names,
+        )
+        recorded_hash = dict(deployment.metadata.annotations or {}).get(_ANNOTATION_TEMPLATE_HASH)
+        return recorded_hash != _template_hash(template)
+
+    def _pod_template(
         self,
         *,
         worker_key: str,
         worker_id: str,
         state_subpath: str,
-        annotations: dict[str, str],
-        replicas: int,
-        private_agent_names: frozenset[str] | None = None,
+        startup_manifest_path: str,
+        startup_manifest_hash: str,
+        private_agent_names: frozenset[str] | None,
     ) -> dict[str, object]:
         worker_labels = _labels(extra_labels=self.config.extra_labels, worker_id=worker_id)
-        startup_manifest_path, startup_manifest_hash = self._write_startup_manifest(
-            worker_key=worker_key,
-            dedicated_root=Path(f"{self.config.storage_mount_path}/{state_subpath}".rstrip("/")),
-            local_dedicated_root=(self.storage_root / state_subpath).resolve(),
-        )
         template_annotations = dict(self.config.extra_annotations)
         template_annotations[ANNOTATION_WORKER_KEY] = worker_key
         template_annotations[_ANNOTATION_STARTUP_MANIFEST_HASH] = startup_manifest_hash
@@ -912,10 +947,6 @@ class KubernetesResourceManager:
         credentials_key_hash = credentials_encryption_key_hash(self._credentials_encryption_key())
         if credentials_key_hash is not None:
             template_annotations[_ANNOTATION_CREDENTIALS_ENCRYPTION_KEY_HASH] = credentials_key_hash
-        template_metadata = {
-            "labels": worker_labels,
-            "annotations": template_annotations,
-        }
         template_spec: dict[str, object] = {
             "serviceAccountName": self.config.service_account_name,
             "automountServiceAccountToken": False,
@@ -971,10 +1002,41 @@ class KubernetesResourceManager:
         }
         if self.config.agent_vault is not None:
             template_spec["initContainers"] = [self._agent_vault_init_container(worker_key=worker_key)]
-        template: dict[str, object] = {
-            "metadata": template_metadata,
+        node_name = self._worker_node_name_or_none()
+        if node_name is not None:
+            template_spec["nodeName"] = node_name
+        return {
+            "metadata": {
+                "labels": worker_labels,
+                "annotations": template_annotations,
+            },
             "spec": template_spec,
         }
+
+    def _deployment_manifest(
+        self,
+        *,
+        worker_key: str,
+        worker_id: str,
+        state_subpath: str,
+        annotations: dict[str, str],
+        replicas: int,
+        private_agent_names: frozenset[str] | None = None,
+    ) -> dict[str, object]:
+        worker_labels = _labels(extra_labels=self.config.extra_labels, worker_id=worker_id)
+        startup_manifest_path, startup_manifest_hash = self._write_startup_manifest(
+            worker_key=worker_key,
+            dedicated_root=Path(f"{self.config.storage_mount_path}/{state_subpath}".rstrip("/")),
+            local_dedicated_root=(self.storage_root / state_subpath).resolve(),
+        )
+        template = self._pod_template(
+            worker_key=worker_key,
+            worker_id=worker_id,
+            state_subpath=state_subpath,
+            startup_manifest_path=startup_manifest_path,
+            startup_manifest_hash=startup_manifest_hash,
+            private_agent_names=private_agent_names,
+        )
         metadata: dict[str, object] = {
             "name": worker_id,
             "namespace": self.config.namespace,
@@ -983,11 +1045,13 @@ class KubernetesResourceManager:
         owner_reference = self._owner_reference_or_none()
         if owner_reference is not None:
             metadata["ownerReferences"] = [owner_reference]
-        node_name = self._worker_node_name_or_none()
-        if node_name is not None:
-            template_spec["nodeName"] = node_name
         desired_annotations = dict(annotations)
         desired_annotations[_ANNOTATION_TEMPLATE_HASH] = _template_hash(template)
+        if private_agent_names is not None:
+            desired_annotations[_ANNOTATION_PRIVATE_AGENT_NAMES] = json.dumps(
+                sorted(private_agent_names),
+                separators=(",", ":"),
+            )
         metadata["annotations"] = desired_annotations
 
         return {
@@ -1084,22 +1148,11 @@ class KubernetesResourceManager:
             raise WorkerBackendError(msg)
         return worker_token
 
-    def _write_startup_manifest(
-        self,
-        *,
-        worker_key: str,
-        dedicated_root: Path,
-        local_dedicated_root: Path,
-    ) -> tuple[str, str]:
+    def _startup_manifest_path_and_hash(self, *, worker_key: str, dedicated_root: Path) -> tuple[str, str]:
+        """Return the worker-visible startup manifest path and content hash without writing."""
         startup_runtime_paths = self._worker_runtime_paths(
             worker_key=worker_key,
             dedicated_root=dedicated_root,
-        )
-        constants.write_startup_manifest(
-            local_dedicated_root,
-            startup_runtime_paths,
-            tool_validation_snapshot=self.tool_validation_snapshot,
-            public_runtime=True,
         )
         return (
             str(constants.sandbox_startup_manifest_path(dedicated_root)),
@@ -1109,6 +1162,21 @@ class KubernetesResourceManager:
                 public_runtime=True,
             ),
         )
+
+    def _write_startup_manifest(
+        self,
+        *,
+        worker_key: str,
+        dedicated_root: Path,
+        local_dedicated_root: Path,
+    ) -> tuple[str, str]:
+        constants.write_startup_manifest(
+            local_dedicated_root,
+            self._worker_runtime_paths(worker_key=worker_key, dedicated_root=dedicated_root),
+            tool_validation_snapshot=self.tool_validation_snapshot,
+            public_runtime=True,
+        )
+        return self._startup_manifest_path_and_hash(worker_key=worker_key, dedicated_root=dedicated_root)
 
     def _worker_runtime_paths(
         self,

--- a/src/mindroom/workers/runtime.py
+++ b/src/mindroom/workers/runtime.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
     from mindroom.workers.backend import WorkerBackend
+    from mindroom.workers.models import WorkerHandle
 
 __all__ = [
     "PrimaryWorkerManagerLease",
@@ -33,6 +34,7 @@ __all__ = [
     "primary_worker_backend_available",
     "primary_worker_backend_is_dedicated",
     "primary_worker_backend_name",
+    "reconcile_drifted_worker_templates",
     "serialized_kubernetes_worker_validation_snapshot",
     "shutdown_primary_worker_manager",
 ]
@@ -171,6 +173,13 @@ def primary_worker_backend_name(runtime_paths: RuntimePaths) -> str:
 def primary_worker_backend_is_dedicated(runtime_paths: RuntimePaths) -> bool:
     """Return whether the configured backend provisions dedicated worker runtimes."""
     return primary_worker_backend_name(runtime_paths) in _DEDICATED_WORKER_BACKENDS
+
+
+def reconcile_drifted_worker_templates(worker_manager: WorkerBackend) -> list[WorkerHandle]:
+    """Reconcile drifted worker pod templates for backends that support reconciliation."""
+    if isinstance(worker_manager, KubernetesWorkerBackend):
+        return worker_manager.reconcile_drifted_workers()
+    return []
 
 
 def primary_worker_backend_available(

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -1124,6 +1124,41 @@ def test_worker_cleanup_once_cleans_workers(monkeypatch: pytest.MonkeyPatch) -> 
     assert captured_kwargs["worker_grantable_credentials"] == runtime_config.get_worker_grantable_credentials()
 
 
+def test_worker_cleanup_once_reconciles_drifted_worker_templates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Each background cleanup pass should also reconcile drifted worker pod templates."""
+
+    class _FakeWorkerManager:
+        backend_name = "kubernetes"
+
+        def cleanup_idle_workers(self) -> list[WorkerHandle]:
+            return []
+
+    worker_manager = _FakeWorkerManager()
+    monkeypatch.setenv("MINDROOM_WORKER_BACKEND", "kubernetes")
+    monkeypatch.setenv("MINDROOM_KUBERNETES_WORKER_IMAGE", "ghcr.io/mindroom-ai/mindroom:latest")
+    monkeypatch.setenv("MINDROOM_KUBERNETES_WORKER_STORAGE_PVC_NAME", "mindroom-storage")
+    monkeypatch.setattr(main, "primary_worker_backend_available", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(main, "primary_worker_backend_name", lambda *_args, **_kwargs: "kubernetes")
+    monkeypatch.setattr(main, "get_primary_worker_manager", lambda *_args, **_kwargs: worker_manager)
+    reconciled_managers: list[object] = []
+
+    def _fake_reconcile(manager: object) -> list[WorkerHandle]:
+        reconciled_managers.append(manager)
+        return []
+
+    monkeypatch.setattr(main, "reconcile_drifted_worker_templates", _fake_reconcile)
+
+    runtime_paths = main._app_runtime_paths(main.app)
+    runtime_config = Config.validate_with_runtime({}, runtime_paths)
+    main._cleanup_workers_once(
+        runtime_paths,
+        runtime_config=runtime_config,
+        worker_grantable_credentials=runtime_config.get_worker_grantable_credentials(),
+    )
+
+    assert reconciled_managers == [worker_manager]
+
+
 def test_list_workers_endpoint(test_client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
     """The dashboard should expose backend-neutral worker metadata."""
 

--- a/tests/test_kubernetes_worker_backend.py
+++ b/tests/test_kubernetes_worker_backend.py
@@ -2186,6 +2186,46 @@ def test_kubernetes_backend_reconcile_uses_persisted_private_visibility(tmp_path
     assert expected_private_root in mount_paths
 
 
+def test_kubernetes_backend_reconcile_defers_user_agent_workers_without_persisted_visibility(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """User-agent workers without persisted visibility defer to ensure-time recreation without warning each pass."""
+    runtime_paths = resolve_primary_runtime_paths(
+        config_path=Path("config.yaml"),
+        storage_path=tmp_path / "mindroom-test-storage",
+    )
+    backend, apps_api, core_api = _backend(runtime_paths=runtime_paths)
+    worker_key = resolve_worker_key(
+        "user_agent",
+        ToolExecutionIdentity(
+            channel="matrix",
+            agent_name="mind",
+            requester_id="@alice:example.org",
+            room_id="!room:example.org",
+            thread_id=None,
+            resolved_thread_id=None,
+            session_id=None,
+            tenant_id="tenant-123",
+        ),
+        agent_name="mind",
+    )
+    handle = backend.ensure_worker(WorkerSpec(worker_key, private_agent_names=frozenset({"mind"})), now=0.0)
+    backend.cleanup_idle_workers(now=80.0)
+    del apps_api.deployments[handle.worker_id].metadata.annotations[_ANNOTATION_PRIVATE_AGENT_NAMES]
+
+    updated_backend, _, _ = _backend(runtime_paths=runtime_paths, resource_limits={"memory": "2Gi", "cpu": "1"})
+    _wire_fake_apis(updated_backend, apps_api, core_api)
+
+    with caplog.at_level("WARNING", logger=kubernetes_backend_module.__name__):
+        reconciled = updated_backend.reconcile_drifted_workers(now=90.0)
+
+    assert reconciled == []
+    assert apps_api.deleted_names == []
+    assert len(apps_api.created_bodies) == 1
+    assert caplog.records == []
+
+
 def test_kubernetes_backend_config_reads_reconcile_pod_templates_from_env(tmp_path: Path) -> None:
     """Pod-template reconciliation defaults on and is disabled through runtime env."""
     config_dir = tmp_path / "cfg"

--- a/tests/test_kubernetes_worker_backend.py
+++ b/tests/test_kubernetes_worker_backend.py
@@ -43,6 +43,7 @@ from mindroom.workers.backends.kubernetes import (
 from mindroom.workers.backends.kubernetes_config import KubernetesAgentVaultConfig
 from mindroom.workers.backends.kubernetes_resources import (
     _ANNOTATION_CREDENTIALS_ENCRYPTION_KEY_HASH,
+    _ANNOTATION_PRIVATE_AGENT_NAMES,
     _ANNOTATION_RUNNER_TOKEN_HASH,
     _ANNOTATION_STARTUP_MANIFEST_HASH,
     _ANNOTATION_TEMPLATE_HASH,
@@ -384,6 +385,7 @@ def _backend(
     extra_annotations: dict[str, str] | None = None,
     enable_service_links: bool = False,
     auth_secret_name: str | None = None,
+    reconcile_pod_templates: bool = True,
     agent_vault: KubernetesAgentVaultConfig | None = None,
 ) -> tuple[KubernetesWorkerBackend, _FakeAppsApi, _FakeCoreApi]:
     config = KubernetesWorkerBackendConfig(
@@ -411,6 +413,7 @@ def _backend(
         resource_limits=resource_limits if resource_limits is not None else {"memory": "1Gi", "cpu": "500m"},
         enable_service_links=enable_service_links,
         auth_secret_name=auth_secret_name,
+        reconcile_pod_templates=reconcile_pod_templates,
         agent_vault=agent_vault,
     )
     resolved_runtime_paths = runtime_paths or resolve_primary_runtime_paths(
@@ -2035,6 +2038,184 @@ def test_kubernetes_backend_cleanup_idle_deletes_service_but_keeps_deployment() 
     assert apps_api.deployments[handle.worker_id].spec.replicas == 0
     assert handle.worker_id not in core_api.services
     assert handle.worker_id not in core_api.secrets
+
+
+def _wire_fake_apis(backend: KubernetesWorkerBackend, apps_api: _FakeAppsApi, core_api: _FakeCoreApi) -> None:
+    backend._resources.apps_api = apps_api
+    backend._resources.core_api = core_api
+    backend._resources.api_exception_cls = _FakeApiError
+
+
+def test_kubernetes_backend_reconciles_drifted_idle_worker_template(tmp_path: Path) -> None:
+    """Reconciliation should recreate scaled-down workers whose pod template drifted from current config."""
+    runtime_paths = resolve_primary_runtime_paths(
+        config_path=Path("config.yaml"),
+        storage_path=tmp_path / "mindroom-test-storage",
+    )
+    backend, apps_api, core_api = _backend(runtime_paths=runtime_paths)
+    handle = backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=0.0)
+    backend.cleanup_idle_workers(now=80.0)
+
+    updated_backend, _, _ = _backend(runtime_paths=runtime_paths, resource_limits={"memory": "2Gi", "cpu": "1"})
+    _wire_fake_apis(updated_backend, apps_api, core_api)
+
+    reconciled = updated_backend.reconcile_drifted_workers(now=90.0)
+
+    assert [worker.worker_key for worker in reconciled] == [_TEST_SCOPED_WORKER_KEY_A]
+    assert reconciled[0].status == "idle"
+    assert apps_api.deleted_names == [handle.worker_id]
+    assert len(apps_api.created_bodies) == 2
+    recreated = apps_api.created_bodies[1]
+    assert recreated["spec"]["replicas"] == 0
+    container = recreated["spec"]["template"]["spec"]["containers"][0]
+    assert container["resources"]["limits"] == {"memory": "2Gi", "cpu": "1"}
+    assert recreated["metadata"]["annotations"]["mindroom.ai/created-at"] == "0.0"
+
+
+def test_kubernetes_backend_reconcile_defers_running_workers(tmp_path: Path) -> None:
+    """Reconciliation should leave running workers to the ensure-time template-hash check."""
+    runtime_paths = resolve_primary_runtime_paths(
+        config_path=Path("config.yaml"),
+        storage_path=tmp_path / "mindroom-test-storage",
+    )
+    backend, apps_api, core_api = _backend(runtime_paths=runtime_paths)
+    backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=0.0)
+
+    updated_backend, _, _ = _backend(runtime_paths=runtime_paths, resource_limits={"memory": "2Gi", "cpu": "1"})
+    _wire_fake_apis(updated_backend, apps_api, core_api)
+
+    reconciled = updated_backend.reconcile_drifted_workers(now=10.0)
+
+    assert reconciled == []
+    assert apps_api.deleted_names == []
+    assert len(apps_api.created_bodies) == 1
+
+
+def test_kubernetes_backend_reconcile_leaves_unchanged_templates_alone(tmp_path: Path) -> None:
+    """Reconciliation should not touch scaled-down workers whose template still matches current config."""
+    runtime_paths = resolve_primary_runtime_paths(
+        config_path=Path("config.yaml"),
+        storage_path=tmp_path / "mindroom-test-storage",
+    )
+    backend, apps_api, core_api = _backend(runtime_paths=runtime_paths)
+    backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=0.0)
+    backend.cleanup_idle_workers(now=80.0)
+    patch_count_after_cleanup = len(apps_api.patched_bodies)
+
+    unchanged_backend, _, _ = _backend(runtime_paths=runtime_paths)
+    _wire_fake_apis(unchanged_backend, apps_api, core_api)
+
+    reconciled = unchanged_backend.reconcile_drifted_workers(now=90.0)
+
+    assert reconciled == []
+    assert apps_api.deleted_names == []
+    assert len(apps_api.created_bodies) == 1
+    assert len(apps_api.patched_bodies) == patch_count_after_cleanup
+
+
+def test_kubernetes_backend_reconcile_disabled_by_config(tmp_path: Path) -> None:
+    """Disabling pod-template reconciliation should keep drifted scaled-down workers untouched."""
+    runtime_paths = resolve_primary_runtime_paths(
+        config_path=Path("config.yaml"),
+        storage_path=tmp_path / "mindroom-test-storage",
+    )
+    backend, apps_api, core_api = _backend(runtime_paths=runtime_paths)
+    backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=0.0)
+    backend.cleanup_idle_workers(now=80.0)
+
+    updated_backend, _, _ = _backend(
+        runtime_paths=runtime_paths,
+        resource_limits={"memory": "2Gi", "cpu": "1"},
+        reconcile_pod_templates=False,
+    )
+    _wire_fake_apis(updated_backend, apps_api, core_api)
+
+    reconciled = updated_backend.reconcile_drifted_workers(now=90.0)
+
+    assert reconciled == []
+    assert apps_api.deleted_names == []
+    assert len(apps_api.created_bodies) == 1
+
+
+def test_kubernetes_backend_reconcile_uses_persisted_private_visibility(tmp_path: Path) -> None:
+    """Reconciliation should rebuild user-agent worker templates from persisted private visibility."""
+    runtime_paths = resolve_primary_runtime_paths(
+        config_path=Path("config.yaml"),
+        storage_path=tmp_path / "mindroom-test-storage",
+    )
+    backend, apps_api, core_api = _backend(runtime_paths=runtime_paths)
+    worker_key = resolve_worker_key(
+        "user_agent",
+        ToolExecutionIdentity(
+            channel="matrix",
+            agent_name="mind",
+            requester_id="@alice:example.org",
+            room_id="!room:example.org",
+            thread_id=None,
+            resolved_thread_id=None,
+            session_id=None,
+            tenant_id="tenant-123",
+        ),
+        agent_name="mind",
+    )
+    backend.ensure_worker(WorkerSpec(worker_key, private_agent_names=frozenset({"mind"})), now=0.0)
+    backend.cleanup_idle_workers(now=80.0)
+
+    unchanged_backend, _, _ = _backend(runtime_paths=runtime_paths)
+    _wire_fake_apis(unchanged_backend, apps_api, core_api)
+    assert unchanged_backend.reconcile_drifted_workers(now=90.0) == []
+
+    updated_backend, _, _ = _backend(runtime_paths=runtime_paths, resource_limits={"memory": "2Gi", "cpu": "1"})
+    _wire_fake_apis(updated_backend, apps_api, core_api)
+
+    reconciled = updated_backend.reconcile_drifted_workers(now=100.0)
+
+    assert [worker.worker_key for worker in reconciled] == [worker_key]
+    recreated = apps_api.created_bodies[-1]
+    assert recreated["metadata"]["annotations"][_ANNOTATION_PRIVATE_AGENT_NAMES] == '["mind"]'
+    mount_paths = {
+        mount["mountPath"] for mount in recreated["spec"]["template"]["spec"]["containers"][0]["volumeMounts"]
+    }
+    expected_private_root = str(
+        _private_instance_state_root_path(
+            Path("/app/worker"),
+            worker_key=worker_key,
+            agent_name="mind",
+        ),
+    )
+    assert expected_private_root in mount_paths
+
+
+def test_kubernetes_backend_config_reads_reconcile_pod_templates_from_env(tmp_path: Path) -> None:
+    """Pod-template reconciliation defaults on and is disabled through runtime env."""
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_path = config_dir / "config.yaml"
+    config_path.write_text(
+        "models:\n  default:\n    provider: openai\n    id: gpt-5.5\nagents: {}\nrouter:\n  model: default\n",
+        encoding="utf-8",
+    )
+    base_env = (
+        "MINDROOM_WORKER_BACKEND=kubernetes\n"
+        "MINDROOM_KUBERNETES_WORKER_IMAGE=test-image\n"
+        "MINDROOM_KUBERNETES_WORKER_STORAGE_PVC_NAME=test-pvc\n"
+    )
+    (config_dir / ".env").write_text(base_env, encoding="utf-8")
+
+    default_config = KubernetesWorkerBackendConfig.from_runtime(resolve_primary_runtime_paths(config_path=config_path))
+
+    assert default_config.reconcile_pod_templates is True
+
+    (config_dir / ".env").write_text(
+        base_env + "MINDROOM_KUBERNETES_WORKER_RECONCILE_POD_TEMPLATES=false\n",
+        encoding="utf-8",
+    )
+
+    disabled_config = KubernetesWorkerBackendConfig.from_runtime(
+        resolve_primary_runtime_paths(config_path=config_path),
+    )
+
+    assert disabled_config.reconcile_pod_templates is False
 
 
 def test_kubernetes_backend_list_workers_is_scoped_to_backend_labels() -> None:


### PR DESCRIPTION
**Problem.** With the Kubernetes worker backend, changing the worker pod template in the control plane's configuration (image, env, resources) does not update already-provisioned worker Deployments. The ensure-time template-hash check only fires when a worker is next requested, so idle and between-task workers keep running the old spec until manually recycled, and operators have to verify drift by hand through the workers API after every upgrade.

**Fix.** Reuse the existing deterministic `mindroom.ai/template-hash` annotation to reconcile proactively. Each idle-worker cleanup pass now compares every scaled-down worker Deployment's recorded hash against the pod template the current config would produce, and recreates drifted Deployments at zero replicas — the fleet converges shortly after an upgrade without traffic, and the next tool call doesn't pay the recreate latency. Running workers are left untouched and are recreated by the existing ensure-time check on their next provisioning after they scale down. The drift check is pure (no startup-manifest writes), and each worker is reconciled under its non-blocking per-worker lock so it never races an in-flight provisioning.

Explicit private-agent visibility is request-supplied, so it is now persisted as a `mindroom.ai/private-agent-names` annotation on the Deployment, letting user-agent worker templates be rebuilt deterministically outside a request.

**Config.** Default on; disable with `workers.kubernetes.reconcilePodTemplates: false` in the runtime chart (`MINDROOM_KUBERNETES_WORKER_RECONCILE_POD_TEMPLATES`).

**Tests.** Unit tests cover drifted-idle recreate (replicas stay 0, lifecycle annotations preserved), ready-worker deferral, unchanged-template no-op (hash stability across backend instances), the disable flag, persisted private-visibility round-trip, env parsing, and cleanup-pass wiring. Runtime chart renders and lints with the new value.

**Docs.** `docs/deployment/kubernetes.md` and the runtime chart README now document automatic reconciliation instead of implying workers need manual recycling after image changes.