### PR TITLE
Fix Smoke Stacks: replace broken engineerd/setup-kind with direct kind install

### DIFF
--- a/.github/workflows/smoke-stacks.yml
+++ b/.github/workflows/smoke-stacks.yml
@@ -62,6 +62,7 @@ jobs:
       - name: Set up kind
         run: |
           curl -fsSLo kind "https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-amd64"
+          echo "b89aada5a39d620da3fcd16435b7f28d858927dd53f92cbac77686b0588b600d  kind" | sha256sum --check
           chmod +x kind
           sudo mv kind /usr/local/bin/kind
           kind version

--- a/.github/workflows/smoke-stacks.yml
+++ b/.github/workflows/smoke-stacks.yml
@@ -60,11 +60,11 @@ jobs:
         uses: azure/setup-helm@v4
 
       - name: Set up kind
-        uses: engineerd/setup-kind@v0.6.2
-        with:
-          skipClusterCreation: true
-          skipClusterDeletion: true
-          skipClusterLogsExport: true
+        run: |
+          curl -fsSLo kind "https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-amd64"
+          chmod +x kind
+          sudo mv kind /usr/local/bin/kind
+          kind version
 
       - name: Free runner disk space
         run: |


### PR DESCRIPTION
## Problem

Every Smoke Stacks run fails at the **Set up kind** step since ~17:53 UTC today ([example run](https://github.com/mindroom-ai/mindroom/actions/runs/27433254497/job/81088663806)):

```
##[error]File not found: '/home/runner/work/_actions/engineerd/setup-kind/v0.6.2/dist/main/index.js'
```

Nothing in this repo changed — the previous run on `main` passed 22 minutes earlier with an identical workflow. The upstream breakage is verifiable: the tag archive that Actions runners download (`codeload.github.com/engineerd/setup-kind/tar.gz/refs/tags/v0.6.2`) contains `src/` but **no `dist/` directory at all**, so the action's `dist/main/index.js` entry point doesn't exist on the runner. All subsequent runs on all branches fail the same way.

## Fix

We only used the action to put the `kind` binary on PATH (`skipClusterCreation: true` — the cluster is created by `cluster/k8s/kind/up.sh`). Replace it with a direct binary install:

- Pin **kind v0.24.0**, the exact version the action was installing in passing runs, so this stays strictly a CI-unbreak with no cluster behavior change.
- Download URL verified to serve a valid Linux x86-64 ELF binary.
- Bonus: drops a third-party action that GitHub warns runs on deprecated Node 20 (actions are forced to Node 24 starting June 16, 2026 — four days from now).

The Smoke Stacks workflow triggers on changes to its own file, so this PR's checks validate the fix end to end.