### PR TITLE
Re-validate live worker state before reconcile recreation

### DIFF
--- a/src/mindroom/workers/backends/kubernetes.py
+++ b/src/mindroom/workers/backends/kubernetes.py
@@ -525,7 +525,9 @@ class KubernetesWorkerBackend:
         """Recreate scaled-down worker Deployments whose pod template drifted from current config.
 
         Running workers are left untouched; the ensure-time template-hash check
-        recreates them on their next provisioning after they scale down.
+        recreates them on their next provisioning after they scale down. The
+        listed snapshot only nominates candidates; each worker is re-validated
+        against a fresh read under its provisioning lock before recreation.
         """
         if not self.config.reconcile_pod_templates:
             return []
@@ -533,25 +535,23 @@ class KubernetesWorkerBackend:
         reconciled: list[WorkerHandle] = []
         for deployment in self._resources.list_deployments():
             handle = self._handle_from_deployment(deployment, now=timestamp)
-            if handle.status != "idle" or int(deployment.spec.replicas or 0) != 0:
+            if not self._is_reconcile_candidate(deployment, handle=handle):
                 continue
             worker_lock = self._worker_lock(handle.worker_key)
             if not worker_lock.acquire(blocking=False):
                 continue
             try:
-                refreshed = self._reconcile_worker_deployment(deployment, handle=handle)
+                refreshed = self._reconcile_worker_deployment(handle, now=timestamp)
             finally:
                 worker_lock.release()
             if refreshed is not None:
                 reconciled.append(refreshed)
         return reconciled
 
-    def _reconcile_worker_deployment(
-        self,
-        deployment: resources.KubernetesDeployment,
-        *,
-        handle: WorkerHandle,
-    ) -> WorkerHandle | None:
+    def _is_reconcile_candidate(self, deployment: resources.KubernetesDeployment, *, handle: WorkerHandle) -> bool:
+        """Return whether one Deployment is a scaled-down worker with a drifted pod template."""
+        if handle.status != "idle" or int(deployment.spec.replicas or 0) != 0:
+            return False
         annotations = dict(deployment.metadata.annotations or {})
         private_agent_names = resources.parse_private_agent_names_annotation(annotations)
         if private_agent_names is None and resolved_worker_key_scope(handle.worker_key) == "user_agent":
@@ -561,32 +561,47 @@ class KubernetesWorkerBackend:
                 "Deferring pod-template reconciliation for worker %r: no persisted private-agent visibility",
                 handle.worker_key,
             )
-            return None
-        state_subpath = self._state_subpath(handle.worker_key)
+            return False
         try:
-            drifted = self._resources.deployment_template_drifted(
+            return self._resources.deployment_template_drifted(
                 deployment,
                 worker_key=handle.worker_key,
                 worker_id=handle.worker_id,
-                state_subpath=state_subpath,
-                private_agent_names=private_agent_names,
-            )
-            if not drifted:
-                return None
-            self._resources.apply_deployment(
-                worker_key=handle.worker_key,
-                worker_id=handle.worker_id,
-                state_subpath=state_subpath,
-                annotations=annotations,
-                replicas=0,
+                state_subpath=self._state_subpath(handle.worker_key),
                 private_agent_names=private_agent_names,
             )
         except WorkerBackendError:
             logger.warning("Skipping pod-template reconciliation for worker %r", handle.worker_key, exc_info=True)
+            return False
+
+    def _reconcile_worker_deployment(self, handle: WorkerHandle, *, now: float) -> WorkerHandle | None:
+        """Recreate one nominated worker after re-validating a fresh read under its lock.
+
+        The list snapshot can be stale: a worker provisioned between the snapshot
+        and the lock acquisition must not be scaled back down.
+        """
+        live = self._resources.read_deployment(handle.worker_id)
+        if live is None:
+            return None
+        live_handle = self._handle_from_deployment(live, now=now)
+        if not self._is_reconcile_candidate(live, handle=live_handle):
+            return None
+        annotations = dict(live.metadata.annotations or {})
+        try:
+            self._resources.apply_deployment(
+                worker_key=live_handle.worker_key,
+                worker_id=live_handle.worker_id,
+                state_subpath=self._state_subpath(live_handle.worker_key),
+                annotations=annotations,
+                replicas=0,
+                private_agent_names=resources.parse_private_agent_names_annotation(annotations),
+            )
+        except WorkerBackendError:
+            logger.warning("Skipping pod-template reconciliation for worker %r", live_handle.worker_key, exc_info=True)
             return None
         # The recreate keeps the lifecycle annotations and zero replicas, so the
-        # handle projected before the apply still describes the reconciled worker.
-        return handle
+        # handle projected from the live read still describes the reconciled worker.
+        return live_handle
 
     def record_failure(
         self,

--- a/tests/test_kubernetes_worker_backend.py
+++ b/tests/test_kubernetes_worker_backend.py
@@ -2186,6 +2186,38 @@ def test_kubernetes_backend_reconcile_uses_persisted_private_visibility(tmp_path
     assert expected_private_root in mount_paths
 
 
+def test_kubernetes_backend_reconcile_revalidates_live_state_before_recreating(tmp_path: Path) -> None:
+    """A worker provisioned between the list snapshot and the lock must not be scaled back down."""
+    runtime_paths = resolve_primary_runtime_paths(
+        config_path=Path("config.yaml"),
+        storage_path=tmp_path / "mindroom-test-storage",
+    )
+    backend, apps_api, core_api = _backend(runtime_paths=runtime_paths)
+    handle = backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=0.0)
+    backend.cleanup_idle_workers(now=80.0)
+    stale_deployment = apps_api.deployments[handle.worker_id]
+
+    updated_backend, _, _ = _backend(runtime_paths=runtime_paths, resource_limits={"memory": "2Gi", "cpu": "1"})
+    _wire_fake_apis(updated_backend, apps_api, core_api)
+    updated_backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=85.0)
+
+    def _stale_snapshot() -> list[object]:
+        return [stale_deployment]
+
+    updated_backend._resources.list_deployments = _stale_snapshot
+
+    reconciled = updated_backend.reconcile_drifted_workers(now=90.0)
+
+    assert reconciled == []
+    live_deployment = apps_api.deployments[handle.worker_id]
+    assert int(live_deployment.spec.replicas) == 1
+    assert live_deployment.metadata.annotations[ANNOTATION_WORKER_KEY] == _TEST_SCOPED_WORKER_KEY_A
+    assert (
+        live_deployment.metadata.annotations[_ANNOTATION_TEMPLATE_HASH]
+        != stale_deployment.metadata.annotations[_ANNOTATION_TEMPLATE_HASH]
+    )
+
+
 def test_kubernetes_backend_reconcile_defers_user_agent_workers_without_persisted_visibility(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,

--- a/tests/test_kubernetes_worker_backend.py
+++ b/tests/test_kubernetes_worker_backend.py
@@ -2195,7 +2195,7 @@ def test_kubernetes_backend_reconcile_revalidates_live_state_before_recreating(t
     backend, apps_api, core_api = _backend(runtime_paths=runtime_paths)
     handle = backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=0.0)
     backend.cleanup_idle_workers(now=80.0)
-    stale_deployment = apps_api.deployments[handle.worker_id]
+    stale_deployment = deepcopy(apps_api.deployments[handle.worker_id])
 
     updated_backend, _, _ = _backend(runtime_paths=runtime_paths, resource_limits={"memory": "2Gi", "cpu": "1"})
     _wire_fake_apis(updated_backend, apps_api, core_api)


### PR DESCRIPTION
Follow-up to #1273, fixing the stale-snapshot race flagged in the post-merge review there.

**Problem.** `reconcile_drifted_workers` decided both the scaled-down gate and the drift check from the `list_deployments` snapshot. A worker provisioned between that snapshot and the reconciler's non-blocking lock acquisition (realistic mid-pass after an upgrade, when several drifted workers are recreated sequentially ahead of it) would be judged drifted by its stale hash; `apply_deployment` then read the live Deployment, saw matching hashes, skipped the recreate branch, and fell through to a merge-patch whose manifest carried `replicas: 0` — scaling down a just-provisioned, actively running worker.

**Fix.** The list snapshot now only nominates candidates (the pure drift pre-filter keeps the steady-state pass free of extra API calls). After acquiring the per-worker provisioning lock, the worker is re-read and the scaled-down and drift checks are repeated against the live Deployment. Since `ensure_worker` mutates workers only under the same lock, the live read cannot go stale, so a worker provisioned in the window is observed as running and skipped.

**Tests.** New regression test replays the interleaving (stale snapshot listing a worker that was re-provisioned at replicas=1 with the new template) and asserts the running Deployment is left untouched; it fails on the previous code. Full Kubernetes worker backend suite: 84 passed.