### PR TITLE
Fix thread summary model overrides for ad-hoc rooms

### DIFF
--- a/src/mindroom/post_response_effects.py
+++ b/src/mindroom/post_response_effects.py
@@ -41,6 +41,7 @@ class ResponseOutcome:
     thread_summary_room_id: str | None = None
     thread_summary_thread_id: str | None = None
     thread_summary_message_count_hint: int | None = None
+    thread_summary_entity_name: str | None = None
     memory_prompt: str | None = None
     memory_thread_history: Sequence[ResolvedVisibleMessage] | None = None
 
@@ -60,7 +61,7 @@ class PostResponseEffectsDeps:
     queue_memory_persistence: Callable[[], None] | None = None
     persist_response_event_id: Callable[[str, str], None] | None = None
     should_queue_thread_summary: Callable[[str, str, int | None], bool] | None = None
-    queue_thread_summary: Callable[[str, str, int | None], None] | None = None
+    queue_thread_summary: Callable[[str, str, int | None, str | None], None] | None = None
 
 
 @dataclass(frozen=True)
@@ -136,6 +137,7 @@ class PostResponseEffectsSupport:
         room_id: str,
         thread_id: str,
         message_count_hint: int | None,
+        entity_name: str | None,
     ) -> None:
         """Queue background thread summarization with timing instrumentation."""
         summary_coro = maybe_generate_thread_summary(
@@ -146,6 +148,7 @@ class PostResponseEffectsSupport:
             runtime_paths=self.runtime_paths,
             conversation_cache=self.conversation_cache,
             message_count_hint=message_count_hint,
+            entity_name=entity_name,
         )
         create_background_task(
             self._timed_thread_summary(
@@ -275,4 +278,5 @@ async def apply_post_response_effects(
             outcome.thread_summary_room_id,
             outcome.thread_summary_thread_id,
             outcome.thread_summary_message_count_hint,
+            outcome.thread_summary_entity_name,
         )

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -1383,6 +1383,7 @@ class ResponseRunner:
                 thread_summary_room_id=(request.room_id if resolved_target.resolved_thread_id is not None else None),
                 thread_summary_thread_id=resolved_target.resolved_thread_id,
                 thread_summary_message_count_hint=thread_summary_message_count_hint(request.thread_history),
+                thread_summary_entity_name=self.deps.agent_name,
                 memory_prompt=_memory_prompt,
                 memory_thread_history=_memory_thread_history,
             ),
@@ -2348,6 +2349,7 @@ class ResponseRunner:
             thread_summary_room_id=(request.room_id if resolved_target.resolved_thread_id is not None else None),
             thread_summary_thread_id=resolved_target.resolved_thread_id,
             thread_summary_message_count_hint=thread_summary_message_count_hint(request.thread_history),
+            thread_summary_entity_name=self.deps.agent_name,
             memory_prompt=memory_prompt,
             memory_thread_history=memory_thread_history,
         )

--- a/src/mindroom/thread_summary.py
+++ b/src/mindroom/thread_summary.py
@@ -284,6 +284,8 @@ def _resolve_thread_summary_model_name(
     config: Config,
     runtime_paths: RuntimePaths,
     room_id: str | None,
+    *,
+    entity_name: str | None = None,
 ) -> str:
     """Return the model name for automatic thread summaries in one room."""
     if override := resolve_room_scoped_model_override(
@@ -293,6 +295,8 @@ def _resolve_thread_summary_model_name(
         allow_raw_room_id=True,
     ):
         return override
+    if entity_name and entity_name in config.room_thread_summary_models:
+        return config.room_thread_summary_models[entity_name]
     return config.defaults.thread_summary_model or "default"
 
 
@@ -489,6 +493,7 @@ async def maybe_generate_thread_summary(
     *,
     conversation_cache: ConversationCacheProtocol,
     message_count_hint: int | None = None,
+    entity_name: str | None = None,
 ) -> None:
     """Generate and send a thread summary if the message count crosses a threshold."""
     async with _thread_summary_lock(room_id, thread_id):
@@ -511,7 +516,12 @@ async def maybe_generate_thread_summary(
         if message_count < threshold:
             return
         try:
-            model_name = _resolve_thread_summary_model_name(config, runtime_paths, room_id)
+            model_name = _resolve_thread_summary_model_name(
+                config,
+                runtime_paths,
+                room_id,
+                entity_name=entity_name,
+            )
             summary = await _timed_generate_summary(thread_history, config, runtime_paths, model_name=model_name)
         except Exception:
             logger.exception("Thread summary generation failed", room_id=room_id, thread_id=thread_id)

--- a/src/mindroom/thread_summary.py
+++ b/src/mindroom/thread_summary.py
@@ -287,7 +287,12 @@ def _resolve_thread_summary_model_name(
     *,
     entity_name: str | None = None,
 ) -> str:
-    """Return the model name for automatic thread summaries in one room."""
+    """Return the model name for automatic thread summaries in one room.
+
+    Precedence: room-scoped override (alias or raw room ID) > responding
+    entity's name as a ``room_thread_summary_models`` key (covers ad-hoc
+    rooms with no managed alias) > ``defaults.thread_summary_model``.
+    """
     if override := resolve_room_scoped_model_override(
         config.room_thread_summary_models,
         room_id,

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -6173,6 +6173,7 @@ class TestAgentBot:
             runtime_paths=bot.runtime_paths,
             conversation_cache=bot._conversation_cache,
             message_count_hint=5,
+            entity_name=bot.agent_name,
         )
         assert "thread_summary_!test:localhost_$thread" in scheduled_names
 
@@ -6284,6 +6285,7 @@ class TestAgentBot:
             runtime_paths=bot.runtime_paths,
             conversation_cache=bot._conversation_cache,
             message_count_hint=1,
+            entity_name=bot.agent_name,
         )
         mock_send_compaction_lifecycle_start.assert_awaited_once()
         compaction_notice_kwargs = mock_send_compaction_lifecycle_start.await_args.kwargs

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -799,6 +799,89 @@ async def test_post_response_effects_queues_summary_with_stale_hint_inside_margi
 
 
 @pytest.mark.asyncio
+async def test_post_response_effects_queues_summary_with_entity_model_for_adhoc_room(tmp_path: Path) -> None:
+    """Ad-hoc invited rooms should inherit the responding entity's summary model override."""
+    config = _config(tmp_path)
+    config.room_thread_summary_models["general"] = "qwen"
+    config.models["qwen"] = ModelConfig(provider="openai", id="qwen-test-model")
+    runtime_paths = runtime_paths_for(config)
+    client = AsyncMock(spec=nio.AsyncClient)
+    runtime = BotRuntimeState(
+        client=client,
+        config=config,
+        runtime_paths=runtime_paths,
+        enable_streaming=False,
+        orchestrator=None,
+        event_cache=make_event_cache_mock(),
+        event_cache_write_coordinator=make_event_cache_write_coordinator_mock(),
+    )
+    conversation_cache = MagicMock()
+    support = PostResponseEffectsSupport(
+        runtime=runtime,
+        logger=MagicMock(),
+        runtime_paths=runtime_paths,
+        delivery_gateway=MagicMock(),
+        conversation_cache=conversation_cache,
+    )
+    deps = support.build_deps(
+        room_id="!adhoc:localhost",
+        interactive_agent_name="general",
+    )
+    thread_history = [
+        ResolvedVisibleMessage.synthetic(
+            sender=f"@user{i}:localhost",
+            body=f"Message {i}",
+            timestamp=i,
+            event_id=f"$message{i}",
+        )
+        for i in range(5)
+    ]
+    scheduled_tasks: list[asyncio.Task[None]] = []
+
+    def schedule_background_task(
+        coro: Coroutine[object, object, None],
+        *,
+        name: str,
+        error_handler: object | None = None,  # noqa: ARG001
+        owner: object | None = None,  # noqa: ARG001
+    ) -> asyncio.Task[None]:
+        task = asyncio.create_task(coro, name=name)
+        scheduled_tasks.append(task)
+        return task
+
+    with (
+        patch("mindroom.post_response_effects.create_background_task", side_effect=schedule_background_task),
+        patch("mindroom.thread_summary._load_thread_history", new=AsyncMock(return_value=thread_history)),
+        patch("mindroom.thread_summary._generate_summary", new=AsyncMock(return_value="Summary")) as mock_generate,
+        patch("mindroom.thread_summary.send_thread_summary_event", new=AsyncMock(return_value="$summary")),
+        patch("mindroom.thread_summary._recover_last_summary_count", new=AsyncMock(return_value=0)),
+        patch("mindroom.entity_resolution.matrix_state.get_room_alias_from_id", return_value=None),
+        patch("mindroom.entity_resolution.matrix_state.matrix_state_for_runtime", return_value=MagicMock(rooms={})),
+    ):
+        await apply_post_response_effects(
+            FinalDeliveryOutcome(
+                terminal_status="completed",
+                event_id="$response",
+                is_visible_response=True,
+                final_visible_body="response",
+                delivery_kind="sent",
+            ),
+            ResponseOutcome(
+                thread_summary_room_id="!adhoc:localhost",
+                thread_summary_thread_id="$thread",
+                thread_summary_message_count_hint=4,
+                thread_summary_entity_name="general",
+            ),
+            deps,
+        )
+
+        assert scheduled_tasks
+        await asyncio.gather(*scheduled_tasks)
+
+    mock_generate.assert_awaited_once_with(thread_history, config, runtime_paths, model_name="qwen")
+
+
+@pytest.mark.asyncio
 async def test_generate_response_sets_queued_signal_for_human_ingress(tmp_path: Path) -> None:
     """A waiting human-authored turn should notify the active turn before blocking on the lock."""
     bot = _bot(tmp_path)

--- a/tests/test_thread_summary.py
+++ b/tests/test_thread_summary.py
@@ -389,6 +389,37 @@ class TestResolveThreadSummaryModelName:
 
         assert result == "qwen"
 
+    def test_uses_entity_summary_model_for_unmanaged_room(self) -> None:
+        """Ad-hoc invited rooms can inherit the responding entity's summary model."""
+        config = _mock_config(model_name="haiku", room_thread_summary_models={"private": "qwen"})
+        rp = _mock_runtime_paths()
+
+        with (
+            patch("mindroom.entity_resolution.matrix_state.get_room_alias_from_id", return_value=None),
+            patch("mindroom.entity_resolution.matrix_state.matrix_state_for_runtime", return_value=MagicMock(rooms={})),
+        ):
+            result = _resolve_thread_summary_model_name(
+                config,
+                rp,
+                "!adhoc:example",
+                entity_name="private",
+            )
+
+        assert result == "qwen"
+
+    def test_room_specific_summary_model_precedes_entity_fallback(self) -> None:
+        """An explicit room match should win over the responding entity fallback."""
+        config = _mock_config(
+            model_name="haiku",
+            room_thread_summary_models={"dev": "sonnet", "private": "qwen"},
+        )
+        rp = _mock_runtime_paths()
+
+        with patch("mindroom.entity_resolution.matrix_state.get_room_alias_from_id", return_value="dev"):
+            result = _resolve_thread_summary_model_name(config, rp, "!dev:example", entity_name="private")
+
+        assert result == "sonnet"
+
     def test_uses_full_matrix_room_alias_override(self) -> None:
         """Full Matrix aliases persisted in room state should resolve to overrides."""
         config = _mock_config(model_name="haiku", room_thread_summary_models={"#private:example": "qwen"})


### PR DESCRIPTION
## Summary

Thread-summary model overrides in `room_thread_summary_models` only applied to managed rooms whose alias (or raw room ID) resolved through persisted Matrix state. In ad-hoc rooms (e.g. rooms the bot was invited to), resolution fell through to `defaults.thread_summary_model` even when the responding entity had an override configured under its own room name.

This adds an entity-name fallback to `_resolve_thread_summary_model_name`: when no room-scoped override matches, the responding agent/team name is looked up in `room_thread_summary_models` before falling back to the default.

Precedence: explicit room match > responding-entity fallback > `defaults.thread_summary_model` > `"default"`.

## Changes

- `thread_summary.py`: `_resolve_thread_summary_model_name` and `maybe_generate_thread_summary` accept an optional `entity_name` for the fallback lookup.
- `response_runner.py`: both summary-queuing outcome sites pass `deps.agent_name` (the team name for `TeamBot`), so the fallback works for agents and teams.
- `post_response_effects.py`: `ResponseOutcome.thread_summary_entity_name` threads the entity name through to the background summary task; `queue_thread_summary` callable signature updated accordingly.

## Tests

- Unit tests for the new fallback and for room-match precedence over the entity fallback (`tests/test_thread_summary.py`).
- End-to-end post-response-effects test verifying an ad-hoc room summary uses the entity's configured model (`tests/test_queued_message_notify.py`).
- `pytest tests/test_thread_summary.py tests/test_queued_message_notify.py`: 142 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Thread summary generation now supports entity/agent-specific model selection so summaries can be generated using agent-configured models where applicable.

* **Tests**
  * Added regression and unit tests to validate entity-specific model selection and the fallback/precedence behavior across room types and ad-hoc rooms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->