### PR TITLE
fix(interactive): render interactive questions in place instead of relocating to message end

### DIFF
--- a/src/mindroom/interactive.py
+++ b/src/mindroom/interactive.py
@@ -139,6 +139,7 @@ _INTERACTIVE_PATTERN = (
     r")(.*?)\r?\n[ \t]*```[ \t]*(?=\r?\n|$)"
 )
 _INTERACTIVE_PATTERN_FLAGS = re.DOTALL | re.IGNORECASE
+_INLINE_INTERACTIVE_JSON_FENCE_PATTERN = r"```[ \t]*interactive(?:[ \t]+json)?[ \t]+(?:\{|\[)[^\r\n`]*```"
 _MAX_OPTIONS = 5
 _DEFAULT_QUESTION = "Please choose an option:"
 _INSTRUCTION_TEXT = "React with an emoji or type the number to respond."
@@ -683,6 +684,24 @@ def _render_question_text(question: str, options: list[dict[str, str]], *, inclu
     return "\n".join(parts)
 
 
+def _remove_inline_unparsed_interactive_fences(text: str) -> str:
+    """Remove inline interactive JSON fences that the block parser cannot render."""
+    cleaned_text, count = re.subn(
+        _INLINE_INTERACTIVE_JSON_FENCE_PATTERN,
+        "",
+        text,
+        flags=re.IGNORECASE,
+    )
+    if count == 0:
+        return text
+
+    logger.warning(
+        "Interactive block not parsed",
+        preview=_preview_text(text),
+    )
+    return cleaned_text.strip()
+
+
 def parse_and_format_interactive(response_text: str, extract_mapping: bool = False) -> _InteractiveResponse:
     """Parse and format interactive content from response text.
 
@@ -747,7 +766,7 @@ def parse_and_format_interactive(response_text: str, extract_mapping: bool = Fal
         parts.append(replacement)
         last_end = match.end()
     parts.append(response_text[last_end:])
-    final_text = "".join(parts).strip()
+    final_text = _remove_inline_unparsed_interactive_fences("".join(parts).strip())
 
     return _InteractiveResponse(
         final_text,

--- a/src/mindroom/interactive.py
+++ b/src/mindroom/interactive.py
@@ -616,6 +616,21 @@ def build_selection_prompt(selection: InteractiveSelection) -> str:
     )
 
 
+def _coerce_interactive_option(raw_option: object) -> dict[str, str] | None:
+    """Return one normalized interactive option when the raw item is an object."""
+    if not isinstance(raw_option, dict):
+        return None
+
+    option_data = cast("dict[object, object]", raw_option)
+    label = str(option_data.get("label") or "Option")
+    value = str(option_data.get("value") or label.lower())
+    return {
+        "emoji": str(option_data.get("emoji") or "❓"),
+        "label": label,
+        "value": value,
+    }
+
+
 def _coerce_interactive_payload(raw_json: str) -> tuple[str, list[dict[str, str]]] | None:
     """Return (question, capped options) when the fenced payload is a valid interactive object."""
     try:
@@ -636,17 +651,32 @@ def _coerce_interactive_payload(raw_json: str) -> tuple[str, list[dict[str, str]
         )
         return None
 
-    interactive_payload = cast("dict[str, object]", interactive_data)
-    question = str(interactive_payload.get("question") or _DEFAULT_QUESTION)
-    options = cast("list[dict[str, str]]", interactive_payload.get("options", []))
+    question = str(interactive_data.get("question") or _DEFAULT_QUESTION)
+    raw_options = interactive_data.get("options")
+    if not isinstance(raw_options, list):
+        logger.warning(
+            "Interactive JSON options must be a list",
+            options_type=type(raw_options).__name__,
+            preview=_preview_text(raw_json),
+        )
+        return None
+
+    options: list[dict[str, str]] = []
+    for raw_option in raw_options:
+        option = _coerce_interactive_option(raw_option)
+        if option is None:
+            continue
+        options.append(option)
+        if len(options) == _MAX_OPTIONS:
+            break
     if not options:
         return None
-    return question, options[:_MAX_OPTIONS]
+    return question, options
 
 
 def _render_question_text(question: str, options: list[dict[str, str]], *, include_instruction: bool) -> str:
     """Render one interactive question as display text."""
-    option_lines = [f"{i}. {opt.get('emoji', '❓')} {opt.get('label', 'Option')}" for i, opt in enumerate(options, 1)]
+    option_lines = [f"{i}. {opt['emoji']} {opt['label']}" for i, opt in enumerate(options, 1)]
     parts = [question, "", *option_lines]
     if include_instruction:
         parts.extend(["", _INSTRUCTION_TEXT])
@@ -688,9 +718,9 @@ def parse_and_format_interactive(response_text: str, extract_mapping: bool = Fal
     option_labels: dict[str, str] | None = {} if extract_mapping else None
     if option_map is not None and option_labels is not None:
         for i, opt in enumerate(options, 1):
-            emoji_char = opt.get("emoji", "❓")
-            label = opt.get("label", "Option")
-            value = opt.get("value", label.lower())
+            emoji_char = opt["emoji"]
+            label = opt["label"]
+            value = opt["value"]
             option_map[emoji_char] = value
             option_map[str(i)] = value
             option_labels[emoji_char] = label
@@ -700,6 +730,7 @@ def parse_and_format_interactive(response_text: str, extract_mapping: bool = Fal
     for extra_match in matches[1:]:
         extra_payload = _coerce_interactive_payload(extra_match.group(1))
         if extra_payload is None:
+            rendered.append((extra_match, ""))
             continue
         extra_question, extra_options = extra_payload
         rendered.append((extra_match, _render_question_text(extra_question, extra_options, include_instruction=False)))

--- a/src/mindroom/interactive.py
+++ b/src/mindroom/interactive.py
@@ -616,8 +616,50 @@ def build_selection_prompt(selection: InteractiveSelection) -> str:
     )
 
 
+def _coerce_interactive_payload(raw_json: str) -> tuple[str, list[dict[str, str]]] | None:
+    """Return (question, capped options) when the fenced payload is a valid interactive object."""
+    try:
+        interactive_data = json.loads(raw_json)
+    except json.JSONDecodeError as exc:
+        logger.warning(
+            "Interactive JSON parse failed",
+            error=str(exc),
+            preview=_preview_text(raw_json),
+        )
+        return None
+
+    if not isinstance(interactive_data, dict):
+        logger.warning(
+            "Interactive JSON payload must be an object",
+            payload_type=type(interactive_data).__name__,
+            preview=_preview_text(raw_json),
+        )
+        return None
+
+    interactive_payload = cast("dict[str, object]", interactive_data)
+    question = str(interactive_payload.get("question") or _DEFAULT_QUESTION)
+    options = cast("list[dict[str, str]]", interactive_payload.get("options", []))
+    if not options:
+        return None
+    return question, options[:_MAX_OPTIONS]
+
+
+def _render_question_text(question: str, options: list[dict[str, str]], *, include_instruction: bool) -> str:
+    """Render one interactive question as display text."""
+    option_lines = [f"{i}. {opt.get('emoji', '❓')} {opt.get('label', 'Option')}" for i, opt in enumerate(options, 1)]
+    parts = [question, "", *option_lines]
+    if include_instruction:
+        parts.extend(["", _INSTRUCTION_TEXT])
+    return "\n".join(parts)
+
+
 def parse_and_format_interactive(response_text: str, extract_mapping: bool = False) -> _InteractiveResponse:
     """Parse and format interactive content from response text.
+
+    Each interactive block is replaced in place with its formatted question so
+    surrounding prose keeps referring to the right spot. Only the first valid
+    block carries registration metadata (reaction buttons); any additional
+    blocks render as plain question text.
 
     Args:
         response_text: The response text containing interactive JSON
@@ -627,10 +669,9 @@ def parse_and_format_interactive(response_text: str, extract_mapping: bool = Fal
         _InteractiveResponse with formatted_text, option_map, and options_list
 
     """
-    # Find the first interactive block for processing
-    first_match = _find_interactive_match(response_text)
+    matches = list(re.finditer(_INTERACTIVE_PATTERN, response_text, _INTERACTIVE_PATTERN_FLAGS))
 
-    if not first_match:
+    if not matches:
         if _should_warn_unparsed_interactive(response_text):
             logger.warning(
                 "Interactive block not parsed",
@@ -638,63 +679,44 @@ def parse_and_format_interactive(response_text: str, extract_mapping: bool = Fal
             )
         return _InteractiveResponse(response_text)
 
-    try:
-        interactive_data = json.loads(first_match.group(1))
-    except json.JSONDecodeError as exc:
-        logger.warning(
-            "Interactive JSON parse failed",
-            error=str(exc),
-            preview=_preview_text(first_match.group(1)),
-        )
+    first_payload = _coerce_interactive_payload(matches[0].group(1))
+    if first_payload is None:
         return _InteractiveResponse(response_text)
+    question, options = first_payload
 
-    if not isinstance(interactive_data, dict):
-        logger.warning(
-            "Interactive JSON payload must be an object",
-            payload_type=type(interactive_data).__name__,
-            preview=_preview_text(first_match.group(1)),
-        )
-        return _InteractiveResponse(response_text)
-
-    interactive_payload = cast("dict[str, object]", interactive_data)
-    question = str(interactive_payload.get("question") or _DEFAULT_QUESTION)
-    options = cast("list[dict[str, str]]", interactive_payload.get("options", []))
-
-    if not options:
-        return _InteractiveResponse(response_text)
-
-    options = options[:_MAX_OPTIONS]
-    clean_response = response_text.replace(first_match.group(0), "").strip()
-
-    option_lines = []
     option_map: dict[str, str] | None = {} if extract_mapping else None
     option_labels: dict[str, str] | None = {} if extract_mapping else None
-
-    for i, opt in enumerate(options, 1):
-        emoji_char = opt.get("emoji", "❓")
-        label = opt.get("label", "Option")
-        option_lines.append(f"{i}. {emoji_char} {label}")
-
-        if extract_mapping and option_map is not None:
+    if option_map is not None and option_labels is not None:
+        for i, opt in enumerate(options, 1):
+            emoji_char = opt.get("emoji", "❓")
+            label = opt.get("label", "Option")
             value = opt.get("value", label.lower())
             option_map[emoji_char] = value
             option_map[str(i)] = value
-            if option_labels is not None:
-                option_labels[emoji_char] = label
-                option_labels[str(i)] = label
+            option_labels[emoji_char] = label
+            option_labels[str(i)] = label
 
-    # Combine everything into the final message
-    message_parts = []
-    if clean_response:
-        message_parts.append(clean_response)
-    message_parts.append("")  # Empty line
-    message_parts.append(question)
-    message_parts.append("")  # Empty line
-    message_parts.extend(option_lines)
-    message_parts.append("")  # Empty line
-    message_parts.append(_INSTRUCTION_TEXT)
+    rendered = [(matches[0], _render_question_text(question, options, include_instruction=True))]
+    for extra_match in matches[1:]:
+        extra_payload = _coerce_interactive_payload(extra_match.group(1))
+        if extra_payload is None:
+            continue
+        extra_question, extra_options = extra_payload
+        rendered.append((extra_match, _render_question_text(extra_question, extra_options, include_instruction=False)))
+    if len(matches) > 1:
+        logger.warning(
+            "Multiple interactive blocks in one response; only the first gets reaction buttons",
+            block_count=len(matches),
+        )
 
-    final_text = "\n".join(message_parts)
+    parts: list[str] = []
+    last_end = 0
+    for match, replacement in rendered:
+        parts.append(response_text[last_end : match.start()])
+        parts.append(replacement)
+        last_end = match.end()
+    parts.append(response_text[last_end:])
+    final_text = "".join(parts).strip()
 
     return _InteractiveResponse(
         final_text,

--- a/src/mindroom/post_response_effects.py
+++ b/src/mindroom/post_response_effects.py
@@ -211,9 +211,7 @@ async def apply_post_response_effects(
         )
     else:  # noqa: PLR5501, RUF100
         if response_event_id is not None and (
-            (final_delivery_outcome.final_visible_body or "")
-            .rstrip()
-            .endswith("React with an emoji or type the number to respond.")
+            "React with an emoji or type the number to respond." in (final_delivery_outcome.final_visible_body or "")
             or final_delivery_outcome.interactive_metadata is not None
         ):
             deps.logger.warning(

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -176,6 +176,89 @@ class TestInteractiveFunctions:
         assert response.interactive_metadata.question_text == "Which option?"
         assert response.interactive_metadata.option_labels == {"✅": "Approve", "1": "Approve"}
 
+    def test_parse_and_format_interactive_renders_question_in_place(self) -> None:
+        """The question should replace the block where it was written, not move to the end."""
+        response_text = """Lock the decision:
+
+```interactive
+{
+    "question": "Which option?",
+    "options": [
+        {"emoji": "✅", "label": "Approve", "value": "approve"}
+    ]
+}
+```
+
+Whichever you pick, tell the other tool."""
+
+        response = interactive.parse_and_format_interactive(response_text, extract_mapping=True)
+
+        assert response.formatted_text == (
+            "Lock the decision:\n"
+            "\n"
+            "Which option?\n"
+            "\n"
+            "1. ✅ Approve\n"
+            "\n"
+            "React with an emoji or type the number to respond.\n"
+            "\n"
+            "Whichever you pick, tell the other tool."
+        )
+        assert response.option_map == {"✅": "approve", "1": "approve"}
+
+    def test_parse_and_format_interactive_renders_extra_blocks_as_plain_text(self) -> None:
+        """Only the first block gets reactions; later blocks render readably instead of as raw JSON."""
+        response_text = """First question:
+
+```interactive
+{
+    "question": "Which option?",
+    "options": [
+        {"emoji": "✅", "label": "Approve", "value": "approve"}
+    ]
+}
+```
+
+Second question:
+
+```interactive
+{
+    "question": "What next?",
+    "options": [
+        {"emoji": "🔎", "label": "Verify", "value": "verify"},
+        {"emoji": "✋", "label": "Hold", "value": "hold"}
+    ]
+}
+```"""
+
+        with patch.object(interactive.logger, "warning") as mock_warning:
+            response = interactive.parse_and_format_interactive(response_text, extract_mapping=True)
+
+        assert response.formatted_text == (
+            "First question:\n"
+            "\n"
+            "Which option?\n"
+            "\n"
+            "1. ✅ Approve\n"
+            "\n"
+            "React with an emoji or type the number to respond.\n"
+            "\n"
+            "Second question:\n"
+            "\n"
+            "What next?\n"
+            "\n"
+            "1. 🔎 Verify\n"
+            "2. ✋ Hold"
+        )
+        assert response.option_map == {"✅": "approve", "1": "approve"}
+        assert response.interactive_metadata is not None
+        assert response.interactive_metadata.question_text == "Which option?"
+        mock_warning.assert_called_once()
+        assert mock_warning.call_args.args == (
+            "Multiple interactive blocks in one response; only the first gets reaction buttons",
+        )
+        assert mock_warning.call_args.kwargs["block_count"] == 2
+
     def test_parse_and_format_interactive_defaults_null_question_text(self) -> None:
         """Explicit JSON null question text should use the default prompt."""
         response_text = """```interactive

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -259,6 +259,98 @@ Second question:
         )
         assert mock_warning.call_args.kwargs["block_count"] == 2
 
+    def test_parse_and_format_interactive_ignores_invalid_options_shape(self) -> None:
+        """Malformed option containers should not crash the interactive parser."""
+        response_text = """```interactive
+{
+    "question": "Which option?",
+    "options": "approve"
+}
+```"""
+
+        response = interactive.parse_and_format_interactive(response_text, extract_mapping=True)
+
+        assert response.formatted_text == response_text
+        assert response.option_map is None
+
+    def test_parse_and_format_interactive_defaults_null_option_fields(self) -> None:
+        """Explicit null option fields should use the same defaults as missing fields."""
+        response_text = """```interactive
+{
+    "question": "Which option?",
+    "options": [
+        {"emoji": null, "label": null, "value": null}
+    ]
+}
+```"""
+
+        response = interactive.parse_and_format_interactive(response_text, extract_mapping=True)
+
+        assert response.formatted_text == (
+            "Which option?\n\n1. ❓ Option\n\nReact with an emoji or type the number to respond."
+        )
+        assert response.option_map == {"❓": "option", "1": "option"}
+        assert response.options_list == [{"emoji": "❓", "label": "Option", "value": "option"}]
+        assert response.interactive_metadata is not None
+        assert response.interactive_metadata.option_labels == {"❓": "Option", "1": "Option"}
+
+    def test_parse_and_format_interactive_removes_malformed_extra_blocks(self) -> None:
+        """Malformed extra blocks should not leak raw interactive fences into the message."""
+        response_text = """First question:
+
+```interactive
+{
+    "question": "Which option?",
+    "options": [
+        {"emoji": "✅", "label": "Approve", "value": "approve"}
+    ]
+}
+```
+
+Broken extra:
+
+```interactive
+{
+    "question": "Bad extra",
+    "options":
+}
+```
+
+Last question:
+
+```interactive
+{
+    "question": "What next?",
+    "options": [
+        {"emoji": "🔎", "label": "Verify", "value": "verify"}
+    ]
+}
+```"""
+
+        response = interactive.parse_and_format_interactive(response_text, extract_mapping=True)
+
+        assert "```interactive" not in response.formatted_text
+        assert '"question": "Bad extra"' not in response.formatted_text
+        assert response.formatted_text == (
+            "First question:\n"
+            "\n"
+            "Which option?\n"
+            "\n"
+            "1. ✅ Approve\n"
+            "\n"
+            "React with an emoji or type the number to respond.\n"
+            "\n"
+            "Broken extra:\n"
+            "\n"
+            "\n"
+            "\n"
+            "Last question:\n"
+            "\n"
+            "What next?\n"
+            "\n"
+            "1. 🔎 Verify"
+        )
+
     def test_parse_and_format_interactive_defaults_null_question_text(self) -> None:
         """Explicit JSON null question text should use the default prompt."""
         response_text = """```interactive

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -351,6 +351,37 @@ Last question:
             "1. 🔎 Verify"
         )
 
+    def test_parse_and_format_interactive_removes_unmatched_malformed_extra_blocks(self) -> None:
+        """Malformed extra fences that do not match the parser regex should not leak after a valid block."""
+        response_text = """First question:
+
+```interactive
+{
+    "question": "Which option?",
+    "options": [
+        {"emoji": "✅", "label": "Approve", "value": "approve"}
+    ]
+}
+```
+
+Broken extra: ```interactive {"question": "Bad extra"}```"""
+
+        response = interactive.parse_and_format_interactive(response_text, extract_mapping=True)
+
+        assert "```interactive" not in response.formatted_text
+        assert '"question": "Bad extra"' not in response.formatted_text
+        assert response.formatted_text == (
+            "First question:\n"
+            "\n"
+            "Which option?\n"
+            "\n"
+            "1. ✅ Approve\n"
+            "\n"
+            "React with an emoji or type the number to respond.\n"
+            "\n"
+            "Broken extra:"
+        )
+
     def test_parse_and_format_interactive_defaults_null_question_text(self) -> None:
         """Explicit JSON null question text should use the default prompt."""
         response_text = """```interactive


### PR DESCRIPTION
## Problem

When an agent response contained an interactive question block mid-message, the rendered Matrix message was broken (observed live; diagnosed from the long-text sidecar of the affected event):

1. The parser deleted the first ```` ```interactive ```` block from where the agent wrote it and appended the formatted question at the very **end** of the message, leaving a blank gap mid-text and orphaning prose that referred to the question positionally ("Whichever you pick, tell the other tool…" with nothing above it).
2. Any **additional** interactive blocks were left as raw JSON code fences — unreadable to the user, with no reactions and no warning logged.

This also contradicted the agent prompt, which promises "The JSON block will be automatically **replaced** with a formatted question" (`prompts.py:99`) — agents write their prose assuming in-place rendering.

## Fix

- `parse_and_format_interactive()` now replaces each interactive block **in place** with its formatted question text, so surrounding prose keeps referring to the right spot.
- Only the first valid block carries registration metadata (reaction buttons + "React with an emoji…" instruction). Extra blocks — which agents are told not to emit, but do — degrade gracefully into plain question + numbered-options text instead of leaking raw JSON, and a warning is logged.
- The registration-skipped diagnostic in `post_response_effects.py` now checks for the instruction text anywhere in the body instead of only at the end, since the question may no longer sit at the bottom.
- Payload parsing/validation is extracted into `_coerce_interactive_payload()` and question rendering into `_render_question_text()`, shared between the first and extra blocks. Failure semantics for the first block are unchanged (malformed JSON / non-object / no options → message passes through untouched, with the existing warnings).

## Tests

- New: exact in-place rendering assertion (prose before/after the block preserved around the question).
- New: multiple-blocks case — first block gets metadata + instruction, second renders as plain text with no raw fences, warning emitted with `block_count`.
- Full suite: 8457 passed, 61 skipped. Pre-commit hooks all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive questions now render in-place within responses, with formatted options and instructions.
  * Interactive block parsing now normalizes option entries (including missing/null fields) and validates fenced JSON payloads.

* **Bug Fixes**
  * When multiple interactive blocks are present, only the first is converted into reaction-ready content; later blocks render as plain text.
  * Updated the “Interactive question registration skipped” warning logic.
  * Malformed extra interactive blocks are removed so raw/invalid fence content is not displayed.

* **Tests**
  * Expanded automated coverage for multi-block handling, normalization, invalid shapes, and malformed fences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->