### PR TITLE
Add Agent Vault parent chaining for approved egress

### DIFF
--- a/cluster/k8s/runtime/README.md
+++ b/cluster/k8s/runtime/README.md
@@ -297,6 +297,37 @@ Set `approvedEgress.manageRuntimeConfig: false` to skip that flag when the autho
 The proxy pod reads `MINDROOM_APPROVED_EGRESS_TOKEN` from `approvedEgress.token.existingSecret` when set, otherwise it reuses `workers.sandbox.proxyToken`.
 Pin `approvedEgress.image.tag` or `approvedEgress.image.digest` before enabling the feature.
 
+When Agent Vault is also enabled, keep approved egress as the first network hop.
+The proxy resolves dynamic `request_network_access` grants from the worker pod's source IP; if worker traffic goes to Agent Vault first, every request reaches Squid from the vault pod IP and worker identity cannot be resolved.
+Enable `approvedEgress.parentProxy` to route only token-bearing Agent Vault tool traffic through the vault parent after the allowlist/grant check:
+
+```yaml
+workers:
+  backend: kubernetes
+  kubernetes:
+    agentVault:
+      enabled: true
+      cliImage: infisical/agent-vault:<pinned>
+      ownerEmail: owner@example.test
+      server:
+        enabled: true
+      # Leave proxyUrl at the default; parentProxy makes workers use approved
+      # egress first and Squid forwards Proxy-Authorization traffic to the vault.
+
+approvedEgress:
+  enabled: true
+  image:
+    tag: v0.1.0
+  parentProxy:
+    enabled: true
+    host: agent-vault
+    port: 14322
+```
+
+With this setup, workers mint Agent Vault tokens through the API port (`14321`), workers proxy tool egress to the approved egress Service, Squid enforces allowlists and dynamic grants using the real worker IP, and Squid forwards requests carrying `Proxy-Authorization` to Agent Vault (`login=PASSTHRU`) for credential injection.
+Tokenless traffic egresses directly from Squid after the normal policy check.
+The chart rejects the unsafe default combination of chart-managed approved egress plus Agent Vault without `approvedEgress.parentProxy`, because that would be vault-first and break dynamic grants.
+
 Use `egressProxy` when another chart or platform layer already manages the proxy:
 
 ```yaml

--- a/cluster/k8s/runtime/templates/_helpers.tpl
+++ b/cluster/k8s/runtime/templates/_helpers.tpl
@@ -215,6 +215,27 @@ app.kubernetes.io/component: runtime
 {{- end -}}
 {{- end -}}
 
+{{- define "mindroom-runtime.approvedEgressSquidConfigMapName" -}}
+{{- printf "%s-squid-config" (include "mindroom-runtime.approvedEgressName" .) -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.approvedEgressSquidConfigPath" -}}
+/etc/mindroom-egress-squid/squid.conf
+{{- end -}}
+
+{{- define "mindroom-runtime.approvedEgressSquidConfig" -}}
+include /etc/squid/squid.conf
+
+acl egress_has_token req_header Proxy-Authorization .
+dns_defnames on
+cache_peer {{ .Values.approvedEgress.parentProxy.host }} parent {{ .Values.approvedEgress.parentProxy.port }} 0 no-query no-digest login=PASSTHRU
+cache_peer_access {{ .Values.approvedEgress.parentProxy.host }} allow egress_has_token
+cache_peer_access {{ .Values.approvedEgress.parentProxy.host }} deny all
+nonhierarchical_direct off
+always_direct allow !egress_has_token
+never_direct allow egress_has_token
+{{- end -}}
+
 {{- define "mindroom-runtime.approvedEgressClaimName" -}}
 {{- if .Values.approvedEgress.persistence.existingClaim -}}
 {{- .Values.approvedEgress.persistence.existingClaim -}}
@@ -325,6 +346,14 @@ matchLabels:
 {{- $scheme = "http" -}}
 {{- end -}}
 {{- printf "%s://%s.%s.svc.cluster.local:%v" $scheme $serviceName $namespace $servicePort -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.agentVaultProxyUrl" -}}
+{{- if and .Values.approvedEgress.enabled .Values.approvedEgress.parentProxy.enabled -}}
+{{- include "mindroom-runtime.egressProxyUrl" . -}}
+{{- else -}}
+{{- .Values.workers.kubernetes.agentVault.proxyUrl -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "mindroom-runtime.workerExtraEnvJson" -}}

--- a/cluster/k8s/runtime/templates/_helpers.tpl
+++ b/cluster/k8s/runtime/templates/_helpers.tpl
@@ -220,7 +220,7 @@ app.kubernetes.io/component: runtime
 {{- end -}}
 
 {{- define "mindroom-runtime.approvedEgressSquidConfigPath" -}}
-/etc/mindroom-egress-squid/squid.conf
+/etc/squid/mindroom-egress-chain.conf
 {{- end -}}
 
 {{- define "mindroom-runtime.approvedEgressSquidConfig" -}}

--- a/cluster/k8s/runtime/templates/approved-egress.yaml
+++ b/cluster/k8s/runtime/templates/approved-egress.yaml
@@ -17,8 +17,20 @@ metadata:
 data:
   {{ .Values.approvedEgress.allowlist.key }}: {{ $allowlist | quote }}
 {{- end }}
+{{- if .Values.approvedEgress.parentProxy.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mindroom-runtime.approvedEgressSquidConfigMapName" . }}
+  labels:
+    {{- include "mindroom-runtime.approvedEgressLabels" . | nindent 4 }}
+data:
+  squid.conf: |
+{{ include "mindroom-runtime.approvedEgressSquidConfig" . | nindent 4 }}
+{{- end }}
 {{- if .Values.approvedEgress.serviceAccount.create }}
-{{- if not .Values.approvedEgress.allowlist.existingConfigMap }}
+{{- if or (not .Values.approvedEgress.allowlist.existingConfigMap) .Values.approvedEgress.parentProxy.enabled }}
 ---
 {{- end }}
 apiVersion: v1
@@ -112,9 +124,14 @@ spec:
         {{- with .Values.approvedEgress.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.approvedEgress.podAnnotations }}
+      {{- if or .Values.approvedEgress.podAnnotations .Values.approvedEgress.parentProxy.enabled }}
       annotations:
+        {{- with .Values.approvedEgress.podAnnotations }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if .Values.approvedEgress.parentProxy.enabled }}
+        checksum/squid-config: {{ include "mindroom-runtime.approvedEgressSquidConfig" . | sha256sum | quote }}
+        {{- end }}
       {{- end }}
     spec:
       serviceAccountName: {{ include "mindroom-runtime.approvedEgressServiceAccountName" . }}
@@ -146,6 +163,10 @@ spec:
             {{- if .Values.approvedEgress.logLevel }}
             - name: MINDROOM_APPROVED_EGRESS_LOG_LEVEL
               value: {{ .Values.approvedEgress.logLevel | quote }}
+            {{- end }}
+            {{- if .Values.approvedEgress.parentProxy.enabled }}
+            - name: MINDROOM_EGRESS_SQUID_CONFIG_PATH
+              value: {{ include "mindroom-runtime.approvedEgressSquidConfigPath" . | quote }}
             {{- end }}
             - name: MINDROOM_APPROVED_EGRESS_TOKEN
               valueFrom:
@@ -184,6 +205,12 @@ spec:
               readOnly: true
             - name: data
               mountPath: {{ .Values.approvedEgress.dataPath | quote }}
+            {{- if .Values.approvedEgress.parentProxy.enabled }}
+            - name: squid-config
+              mountPath: {{ include "mindroom-runtime.approvedEgressSquidConfigPath" . | quote }}
+              subPath: "squid.conf"
+              readOnly: true
+            {{- end }}
       volumes:
         - name: allowlist
           configMap:
@@ -195,6 +222,11 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- if .Values.approvedEgress.parentProxy.enabled }}
+        - name: squid-config
+          configMap:
+            name: {{ include "mindroom-runtime.approvedEgressSquidConfigMapName" . }}
+        {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/cluster/k8s/runtime/templates/deployment.yaml
+++ b/cluster/k8s/runtime/templates/deployment.yaml
@@ -316,7 +316,7 @@ spec:
             - name: MINDROOM_KUBERNETES_AGENT_VAULT_API_URL
               value: {{ .apiUrl | quote }}
             - name: MINDROOM_KUBERNETES_AGENT_VAULT_PROXY_URL
-              value: {{ .proxyUrl | quote }}
+              value: {{ include "mindroom-runtime.agentVaultProxyUrl" $ | quote }}
             - name: MINDROOM_KUBERNETES_AGENT_VAULT_BOOTSTRAP_SECRET_NAME
               value: {{ .bootstrapSecretName | quote }}
             {{- if .workerCaConfigMapName }}

--- a/cluster/k8s/runtime/templates/networkpolicy.yaml
+++ b/cluster/k8s/runtime/templates/networkpolicy.yaml
@@ -2,6 +2,7 @@
 {{- $egressPolicyEnabled := and (include "mindroom-runtime.egressProxyEnabled" .) .Values.egressProxy.networkPolicy.create -}}
 {{- $proxyNamespace := include "mindroom-runtime.egressProxyNamespace" . -}}
 {{- $proxyPort := include "mindroom-runtime.egressProxyServicePort" . -}}
+{{- $agentVault := .Values.workers.kubernetes.agentVault -}}
 {{- $dnsNamespaceSelector := .Values.egressProxy.networkPolicy.dns.namespaceSelector -}}
 {{- $dnsPodSelector := .Values.egressProxy.networkPolicy.dns.podSelector -}}
 {{- $hasDnsNamespaceSelector := kindIs "map" $dnsNamespaceSelector -}}
@@ -75,6 +76,18 @@ spec:
       ports:
         - protocol: TCP
           port: {{ $proxyPort }}
+    {{- if and $agentVault.enabled $agentVault.server.enabled }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
+          podSelector:
+            matchLabels:
+              {{- include "mindroom-runtime.agentVaultSelectorLabels" . | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: {{ $agentVault.server.apiPort }}
+    {{- end }}
     {{- with .Values.egressProxy.networkPolicy.extraEgress }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/cluster/k8s/runtime/templates/validate.yaml
+++ b/cluster/k8s/runtime/templates/validate.yaml
@@ -188,13 +188,14 @@
 {{- if not (trim (default "" .Values.approvedEgress.parentProxy.host)) -}}
 {{- fail "approvedEgress.parentProxy.host is required when approvedEgress.parentProxy.enabled=true" -}}
 {{- end -}}
-{{- if not .Values.approvedEgress.parentProxy.port -}}
-{{- fail "approvedEgress.parentProxy.port is required when approvedEgress.parentProxy.enabled=true" -}}
+{{- $parentProxyPort := int .Values.approvedEgress.parentProxy.port -}}
+{{- if or (lt $parentProxyPort 1) (gt $parentProxyPort 65535) -}}
+{{- fail "approvedEgress.parentProxy.port must be between 1 and 65535 when approvedEgress.parentProxy.enabled=true" -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
 {{- $agentVault := .Values.workers.kubernetes.agentVault -}}
-{{- $agentVaultProxyUrl := trimSuffix "/" (default "" $agentVault.proxyUrl) -}}
+{{- $agentVaultProxyUrl := lower (regexReplaceAll "/+$" (trim (default "" $agentVault.proxyUrl)) "") -}}
 {{- $agentVaultServiceName := include "mindroom-runtime.agentVaultServerName" . -}}
 {{- $agentVaultMitmPort := printf "%v" $agentVault.server.mitmPort -}}
 {{- $agentVaultServiceProxyUrls := list (printf "http://%s:%s" $agentVaultServiceName $agentVaultMitmPort) (printf "http://%s.%s:%s" $agentVaultServiceName .Release.Namespace $agentVaultMitmPort) (printf "http://%s.%s.svc:%s" $agentVaultServiceName .Release.Namespace $agentVaultMitmPort) (printf "http://%s.%s.svc.cluster.local:%s" $agentVaultServiceName .Release.Namespace $agentVaultMitmPort) -}}

--- a/cluster/k8s/runtime/templates/validate.yaml
+++ b/cluster/k8s/runtime/templates/validate.yaml
@@ -194,7 +194,7 @@
 {{- end -}}
 {{- end -}}
 {{- $agentVault := .Values.workers.kubernetes.agentVault -}}
-{{- $agentVaultProxyUrl := default "" $agentVault.proxyUrl -}}
+{{- $agentVaultProxyUrl := trimSuffix "/" (default "" $agentVault.proxyUrl) -}}
 {{- $agentVaultServiceName := include "mindroom-runtime.agentVaultServerName" . -}}
 {{- $agentVaultMitmPort := printf "%v" $agentVault.server.mitmPort -}}
 {{- $agentVaultServiceProxyUrls := list (printf "http://%s:%s" $agentVaultServiceName $agentVaultMitmPort) (printf "http://%s.%s:%s" $agentVaultServiceName .Release.Namespace $agentVaultMitmPort) (printf "http://%s.%s.svc:%s" $agentVaultServiceName .Release.Namespace $agentVaultMitmPort) (printf "http://%s.%s.svc.cluster.local:%s" $agentVaultServiceName .Release.Namespace $agentVaultMitmPort) -}}

--- a/cluster/k8s/runtime/templates/validate.yaml
+++ b/cluster/k8s/runtime/templates/validate.yaml
@@ -184,8 +184,19 @@
 {{- if and .Values.approvedEgress.persistence.enabled (not .Values.approvedEgress.persistence.existingClaim) (not .Values.approvedEgress.persistence.size) -}}
 {{- fail "approvedEgress.persistence.size is required when chart-managed approved egress persistence is enabled" -}}
 {{- end -}}
+{{- if .Values.approvedEgress.parentProxy.enabled -}}
+{{- if not (trim (default "" .Values.approvedEgress.parentProxy.host)) -}}
+{{- fail "approvedEgress.parentProxy.host is required when approvedEgress.parentProxy.enabled=true" -}}
+{{- end -}}
+{{- if not .Values.approvedEgress.parentProxy.port -}}
+{{- fail "approvedEgress.parentProxy.port is required when approvedEgress.parentProxy.enabled=true" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 {{- $agentVault := .Values.workers.kubernetes.agentVault -}}
+{{- if and .Values.approvedEgress.enabled $agentVault.enabled (not .Values.approvedEgress.parentProxy.enabled) (eq (default "" $agentVault.proxyUrl) "http://agent-vault:14322") -}}
+{{- fail "approvedEgress with Agent Vault must be squid-first: enable approvedEgress.parentProxy so Squid sees worker source IPs for dynamic grants, or set workers.kubernetes.agentVault.proxyUrl to a non-default proxy URL explicitly" -}}
+{{- end -}}
 {{- if $agentVault.accessTool.enabled -}}
 {{- if not $agentVault.enabled -}}
 {{- fail "workers.kubernetes.agentVault.accessTool.enabled requires workers.kubernetes.agentVault.enabled=true" -}}

--- a/cluster/k8s/runtime/templates/validate.yaml
+++ b/cluster/k8s/runtime/templates/validate.yaml
@@ -194,8 +194,12 @@
 {{- end -}}
 {{- end -}}
 {{- $agentVault := .Values.workers.kubernetes.agentVault -}}
-{{- if and .Values.approvedEgress.enabled $agentVault.enabled (not .Values.approvedEgress.parentProxy.enabled) (eq (default "" $agentVault.proxyUrl) "http://agent-vault:14322") -}}
-{{- fail "approvedEgress with Agent Vault must be squid-first: enable approvedEgress.parentProxy so Squid sees worker source IPs for dynamic grants, or set workers.kubernetes.agentVault.proxyUrl to a non-default proxy URL explicitly" -}}
+{{- $agentVaultProxyUrl := default "" $agentVault.proxyUrl -}}
+{{- $agentVaultServiceName := include "mindroom-runtime.agentVaultServerName" . -}}
+{{- $agentVaultMitmPort := printf "%v" $agentVault.server.mitmPort -}}
+{{- $agentVaultServiceProxyUrls := list (printf "http://%s:%s" $agentVaultServiceName $agentVaultMitmPort) (printf "http://%s.%s:%s" $agentVaultServiceName .Release.Namespace $agentVaultMitmPort) (printf "http://%s.%s.svc:%s" $agentVaultServiceName .Release.Namespace $agentVaultMitmPort) (printf "http://%s.%s.svc.cluster.local:%s" $agentVaultServiceName .Release.Namespace $agentVaultMitmPort) -}}
+{{- if and .Values.approvedEgress.enabled $agentVault.enabled (not .Values.approvedEgress.parentProxy.enabled) (has $agentVaultProxyUrl $agentVaultServiceProxyUrls) -}}
+{{- fail "approvedEgress with Agent Vault must be squid-first: enable approvedEgress.parentProxy so Squid sees worker source IPs for dynamic grants, or set workers.kubernetes.agentVault.proxyUrl to an external/custom proxy URL explicitly" -}}
 {{- end -}}
 {{- if $agentVault.accessTool.enabled -}}
 {{- if not $agentVault.enabled -}}

--- a/cluster/k8s/runtime/values.yaml
+++ b/cluster/k8s/runtime/values.yaml
@@ -359,11 +359,14 @@ workers:
     # http://<token>:@<proxyUrl host> for python/shell egress. No separate
     # bridge pod or Service is created.
     #
-    # NOTE: if egressProxy/approvedEgress NetworkPolicies are also enabled, they
-    # restrict worker egress and do NOT open the Agent Vault api/proxy ports.
-    # You must allow the worker pods (and their init container) to reach the
-    # agent-vault api (apiUrl) and proxy (proxyUrl) ports, e.g. via
-    # egressProxy.networkPolicy.extraEgress, or the init container will time out.
+    # NOTE: if egressProxy/approvedEgress NetworkPolicies are also enabled,
+    # workers still need Agent Vault API egress (apiUrl) so the init container
+    # can mint the per-worker token. For a chart-managed vault server, the chart
+    # opens that API egress automatically. For externally managed vaults, add
+    # an explicit API-only egress rule. Do not open direct worker egress to the
+    # Agent Vault proxy port when approvedEgress owns dynamic grants; enable
+    # approvedEgress.parentProxy so Squid remains the first hop and forwards
+    # token-bearing traffic to the vault parent.
     agentVault:
       enabled: false
       # Agent Vault CLI image used by the init container to mint per-worker
@@ -541,6 +544,16 @@ approvedEgress:
   maxTtlSeconds: 21600
   sandboxProxyTimeoutSeconds: ""
   logLevel: info
+  # Optional parent proxy for token-bearing worker traffic. This is primarily
+  # for Agent Vault: workers proxy to approved egress first, so dynamic grants
+  # resolve from the real worker source IP, then Squid forwards requests with a
+  # Proxy-Authorization header to the Agent Vault MITM proxy for credential
+  # injection. Tokenless traffic egresses direct from Squid after the normal
+  # allowlist/grant check.
+  parentProxy:
+    enabled: false
+    host: agent-vault
+    port: 14322
   resources:
     requests:
       cpu: 100m

--- a/docs/deployment/approved-egress.md
+++ b/docs/deployment/approved-egress.md
@@ -43,7 +43,9 @@ When approved egress and Agent Vault are used together, the correct chain is:
 worker -> approved egress (Squid) -> Agent Vault MITM parent -> internet
 ```
 
-Squid must be first. Dynamic `request_network_access` grants are keyed to the worker that made the request, and the approved egress helper resolves that worker from the proxy client's source IP. If traffic goes `worker -> Agent Vault -> Squid`, Squid only sees the Agent Vault pod IP, so the grant lookup cannot match the worker and dynamic grants fail even though static allowlist entries can still work.
+Squid must be first.
+Dynamic `request_network_access` grants are keyed to the worker that made the request, and the approved egress helper resolves that worker from the proxy client's source IP.
+If traffic goes `worker -> Agent Vault -> Squid`, Squid only sees the Agent Vault pod IP, so the grant lookup cannot match the worker and dynamic grants fail even though static allowlist entries can still work.
 
 Use `approvedEgress.parentProxy` to make the chart render a layered Squid config and point Agent Vault tool traffic at approved egress first:
 
@@ -76,9 +78,14 @@ approvedEgress:
     port: 14322
 ```
 
-When `parentProxy.enabled` is true, workers use the approved egress Service for `MINDROOM_KUBERNETES_AGENT_VAULT_PROXY_URL`. Squid enforces the allowlist and dynamic grants, then forwards requests that carry `Proxy-Authorization` to the Agent Vault parent with `login=PASSTHRU` so the vault still validates the worker's proxy-role token and injects credentials. Tokenless traffic remains direct from Squid after the policy check.
+When `parentProxy.enabled` is true, workers use the approved egress Service for `MINDROOM_KUBERNETES_AGENT_VAULT_PROXY_URL`.
+Squid enforces the allowlist and dynamic grants, then forwards requests that carry `Proxy-Authorization` to the Agent Vault parent with `login=PASSTHRU` so the vault still validates the worker's proxy-role token and injects credentials.
+Tokenless traffic remains direct from Squid after the policy check.
 
-Do not leave Agent Vault tool traffic pointed directly at the chart-managed Agent Vault MITM Service when chart-managed approved egress is enabled. That path either bypasses Squid, or forces Squid behind the vault where worker identity is lost. The chart rejects direct URLs to the chart-managed Agent Vault proxy Service, including short and cluster-local DNS names, unless `approvedEgress.parentProxy` is enabled. Truly external/custom proxy URLs remain an explicit escape hatch.
+Do not leave Agent Vault tool traffic pointed directly at the chart-managed Agent Vault MITM Service when chart-managed approved egress is enabled.
+That path either bypasses Squid, or forces Squid behind the vault where worker identity is lost.
+The chart rejects direct URLs to the chart-managed Agent Vault proxy Service, including short and cluster-local DNS names, unless `approvedEgress.parentProxy` is enabled.
+Truly external/custom proxy URLs remain an explicit escape hatch.
 
 ## Custom Config
 

--- a/docs/deployment/approved-egress.md
+++ b/docs/deployment/approved-egress.md
@@ -78,7 +78,7 @@ approvedEgress:
 
 When `parentProxy.enabled` is true, workers use the approved egress Service for `MINDROOM_KUBERNETES_AGENT_VAULT_PROXY_URL`. Squid enforces the allowlist and dynamic grants, then forwards requests that carry `Proxy-Authorization` to the Agent Vault parent with `login=PASSTHRU` so the vault still validates the worker's proxy-role token and injects credentials. Tokenless traffic remains direct from Squid after the policy check.
 
-Do not leave Agent Vault tool traffic pointed directly at `http://agent-vault:14322` when chart-managed approved egress is enabled. That path either bypasses Squid, or forces Squid behind the vault where worker identity is lost. The chart rejects that default combination unless `approvedEgress.parentProxy` is enabled or `workers.kubernetes.agentVault.proxyUrl` is set to another explicit proxy URL.
+Do not leave Agent Vault tool traffic pointed directly at the chart-managed Agent Vault MITM Service when chart-managed approved egress is enabled. That path either bypasses Squid, or forces Squid behind the vault where worker identity is lost. The chart rejects direct URLs to the chart-managed Agent Vault proxy Service, including short and cluster-local DNS names, unless `approvedEgress.parentProxy` is enabled. Truly external/custom proxy URLs remain an explicit escape hatch.
 
 ## Custom Config
 

--- a/docs/deployment/approved-egress.md
+++ b/docs/deployment/approved-egress.md
@@ -35,6 +35,51 @@ When `MINDROOM_APPROVED_EGRESS_ENABLED=true`, MindRoom adds `approved_egress` to
 These runtime-derived entries are not written back to `config.yaml` by dashboard or API saves.
 Set `approvedEgress.manageRuntimeConfig: false` to keep the proxy wiring but skip the runtime config overlay, for example when the authored config assigns `approved_egress` to specific agents instead of `defaults.tools`.
 
+## Agent Vault Chaining
+
+When approved egress and Agent Vault are used together, the correct chain is:
+
+```text
+worker -> approved egress (Squid) -> Agent Vault MITM parent -> internet
+```
+
+Squid must be first. Dynamic `request_network_access` grants are keyed to the worker that made the request, and the approved egress helper resolves that worker from the proxy client's source IP. If traffic goes `worker -> Agent Vault -> Squid`, Squid only sees the Agent Vault pod IP, so the grant lookup cannot match the worker and dynamic grants fail even though static allowlist entries can still work.
+
+Use `approvedEgress.parentProxy` to make the chart render a layered Squid config and point Agent Vault tool traffic at approved egress first:
+
+```yaml
+workers:
+  backend: kubernetes
+  sandbox:
+    proxyToken:
+      existingSecret: mindroom-sandbox-proxy
+      key: MINDROOM_SANDBOX_PROXY_TOKEN
+  kubernetes:
+    agentVault:
+      enabled: true
+      cliImage: infisical/agent-vault:<pinned>
+      ownerEmail: owner@example.test
+      server:
+        enabled: true
+      bootstrap:
+        enabled: true
+        kubectlImage: bitnami/kubectl:<pinned>
+      workerCaConfigMapName: agent-vault-ca
+
+approvedEgress:
+  enabled: true
+  image:
+    tag: v0.1.0
+  parentProxy:
+    enabled: true
+    host: agent-vault
+    port: 14322
+```
+
+When `parentProxy.enabled` is true, workers use the approved egress Service for `MINDROOM_KUBERNETES_AGENT_VAULT_PROXY_URL`. Squid enforces the allowlist and dynamic grants, then forwards requests that carry `Proxy-Authorization` to the Agent Vault parent with `login=PASSTHRU` so the vault still validates the worker's proxy-role token and injects credentials. Tokenless traffic remains direct from Squid after the policy check.
+
+Do not leave Agent Vault tool traffic pointed directly at `http://agent-vault:14322` when chart-managed approved egress is enabled. That path either bypasses Squid, or forces Squid behind the vault where worker identity is lost. The chart rejects that default combination unless `approvedEgress.parentProxy` is enabled or `workers.kubernetes.agentVault.proxyUrl` is set to another explicit proxy URL.
+
 ## Custom Config
 
 The runtime chart handles custom `config.data` and `config.existingConfigMap` through `MINDROOM_APPROVED_EGRESS_ENABLED=true`, so you do not need to duplicate this block there.

--- a/docs/deployment/sandbox-proxy.md
+++ b/docs/deployment/sandbox-proxy.md
@@ -393,8 +393,14 @@ For HTTPS, Agent Vault terminates TLS at its proxy, so workers must trust the va
 Publish the CA (from `agent-vault ca fetch`) as a ConfigMap with key `ca.pem` and set `MINDROOM_KUBERNETES_AGENT_VAULT_WORKER_CA_CONFIGMAP_NAME` (chart: `workers.kubernetes.agentVault.workerCaConfigMapName`).
 Worker pods mount it at `/etc/agent-vault/ca.pem` and the runner exports `REQUESTS_CA_BUNDLE`/`CURL_CA_BUNDLE`/`SSL_CERT_FILE` for python/shell egress.
 
-If you also enable the worker egress-proxy / approved-egress NetworkPolicies, they restrict worker egress and do not open the Agent Vault ports.
-Allow the worker pods and their init container to reach the Agent Vault api (`apiUrl`) and proxy (`proxyUrl`) ports — e.g. via `egressProxy.networkPolicy.extraEgress` — or the init container's health-check loop times out and the pod never starts.
+If you also enable the worker egress-proxy / approved-egress NetworkPolicies, keep Squid as the first hop for tool egress.
+Dynamic `request_network_access` grants are resolved by the approved egress helper from the proxy client's source IP; a vault-first chain (`worker -> Agent Vault -> Squid`) collapses every worker to the Agent Vault pod IP, so dynamic grants cannot match the worker.
+With the runtime chart's managed approved egress, set `approvedEgress.parentProxy.enabled: true` and leave Agent Vault tool traffic pointed at the approved egress Service; Squid forwards requests carrying the worker's `Proxy-Authorization` token to the Agent Vault MITM parent with `login=PASSTHRU`.
+
+Workers still need Agent Vault API access (`apiUrl`, usually port `14321`) so the init container can mint the per-worker proxy token.
+When the chart also manages the Agent Vault server, the worker NetworkPolicy includes that API egress automatically.
+For an externally managed Agent Vault server, add an egress rule for the API endpoint only.
+Do not add worker egress directly to the Agent Vault MITM proxy port (`proxyUrl`, usually `14322`) when approved egress owns dynamic grants; that bypasses the Squid-first policy path.
 
 For non-Kubernetes deployments, point worker egress at a shared proxy you run yourself by setting the worker proxy env directly (see the shared egress proxy option above).
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -15985,7 +15985,7 @@ approvedEgress:
 
 When `parentProxy.enabled` is true, workers use the approved egress Service for `MINDROOM_KUBERNETES_AGENT_VAULT_PROXY_URL`. Squid enforces the allowlist and dynamic grants, then forwards requests that carry `Proxy-Authorization` to the Agent Vault parent with `login=PASSTHRU` so the vault still validates the worker's proxy-role token and injects credentials. Tokenless traffic remains direct from Squid after the policy check.
 
-Do not leave Agent Vault tool traffic pointed directly at `http://agent-vault:14322` when chart-managed approved egress is enabled. That path either bypasses Squid, or forces Squid behind the vault where worker identity is lost. The chart rejects that default combination unless `approvedEgress.parentProxy` is enabled or `workers.kubernetes.agentVault.proxyUrl` is set to another explicit proxy URL.
+Do not leave Agent Vault tool traffic pointed directly at the chart-managed Agent Vault MITM Service when chart-managed approved egress is enabled. That path either bypasses Squid, or forces Squid behind the vault where worker identity is lost. The chart rejects direct URLs to the chart-managed Agent Vault proxy Service, including short and cluster-local DNS names, unless `approvedEgress.parentProxy` is enabled. Truly external/custom proxy URLs remain an explicit escape hatch.
 
 ## Custom Config
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -15668,8 +15668,14 @@ For HTTPS, Agent Vault terminates TLS at its proxy, so workers must trust the va
 Publish the CA (from `agent-vault ca fetch`) as a ConfigMap with key `ca.pem` and set `MINDROOM_KUBERNETES_AGENT_VAULT_WORKER_CA_CONFIGMAP_NAME` (chart: `workers.kubernetes.agentVault.workerCaConfigMapName`).
 Worker pods mount it at `/etc/agent-vault/ca.pem` and the runner exports `REQUESTS_CA_BUNDLE`/`CURL_CA_BUNDLE`/`SSL_CERT_FILE` for python/shell egress.
 
-If you also enable the worker egress-proxy / approved-egress NetworkPolicies, they restrict worker egress and do not open the Agent Vault ports.
-Allow the worker pods and their init container to reach the Agent Vault api (`apiUrl`) and proxy (`proxyUrl`) ports — e.g. via `egressProxy.networkPolicy.extraEgress` — or the init container's health-check loop times out and the pod never starts.
+If you also enable the worker egress-proxy / approved-egress NetworkPolicies, keep Squid as the first hop for tool egress.
+Dynamic `request_network_access` grants are resolved by the approved egress helper from the proxy client's source IP; a vault-first chain (`worker -> Agent Vault -> Squid`) collapses every worker to the Agent Vault pod IP, so dynamic grants cannot match the worker.
+With the runtime chart's managed approved egress, set `approvedEgress.parentProxy.enabled: true` and leave Agent Vault tool traffic pointed at the approved egress Service; Squid forwards requests carrying the worker's `Proxy-Authorization` token to the Agent Vault MITM parent with `login=PASSTHRU`.
+
+Workers still need Agent Vault API access (`apiUrl`, usually port `14321`) so the init container can mint the per-worker proxy token.
+When the chart also manages the Agent Vault server, the worker NetworkPolicy includes that API egress automatically.
+For an externally managed Agent Vault server, add an egress rule for the API endpoint only.
+Do not add worker egress directly to the Agent Vault MITM proxy port (`proxyUrl`, usually `14322`) when approved egress owns dynamic grants; that bypasses the Squid-first policy path.
 
 For non-Kubernetes deployments, point worker egress at a shared proxy you run yourself by setting the worker proxy env directly (see the shared egress proxy option above).
 
@@ -15935,6 +15941,51 @@ The chart also sets `MINDROOM_APPROVED_EGRESS_ENABLED`, `MINDROOM_APPROVED_EGRES
 When `MINDROOM_APPROVED_EGRESS_ENABLED=true`, MindRoom adds `approved_egress` to defaults and requires Matrix approval for `request_network_access` at runtime.
 These runtime-derived entries are not written back to `config.yaml` by dashboard or API saves.
 Set `approvedEgress.manageRuntimeConfig: false` to keep the proxy wiring but skip the runtime config overlay, for example when the authored config assigns `approved_egress` to specific agents instead of `defaults.tools`.
+
+## Agent Vault Chaining
+
+When approved egress and Agent Vault are used together, the correct chain is:
+
+```text
+worker -> approved egress (Squid) -> Agent Vault MITM parent -> internet
+```
+
+Squid must be first. Dynamic `request_network_access` grants are keyed to the worker that made the request, and the approved egress helper resolves that worker from the proxy client's source IP. If traffic goes `worker -> Agent Vault -> Squid`, Squid only sees the Agent Vault pod IP, so the grant lookup cannot match the worker and dynamic grants fail even though static allowlist entries can still work.
+
+Use `approvedEgress.parentProxy` to make the chart render a layered Squid config and point Agent Vault tool traffic at approved egress first:
+
+```yaml
+workers:
+  backend: kubernetes
+  sandbox:
+    proxyToken:
+      existingSecret: mindroom-sandbox-proxy
+      key: MINDROOM_SANDBOX_PROXY_TOKEN
+  kubernetes:
+    agentVault:
+      enabled: true
+      cliImage: infisical/agent-vault:<pinned>
+      ownerEmail: owner@example.test
+      server:
+        enabled: true
+      bootstrap:
+        enabled: true
+        kubectlImage: bitnami/kubectl:<pinned>
+      workerCaConfigMapName: agent-vault-ca
+
+approvedEgress:
+  enabled: true
+  image:
+    tag: v0.1.0
+  parentProxy:
+    enabled: true
+    host: agent-vault
+    port: 14322
+```
+
+When `parentProxy.enabled` is true, workers use the approved egress Service for `MINDROOM_KUBERNETES_AGENT_VAULT_PROXY_URL`. Squid enforces the allowlist and dynamic grants, then forwards requests that carry `Proxy-Authorization` to the Agent Vault parent with `login=PASSTHRU` so the vault still validates the worker's proxy-role token and injects credentials. Tokenless traffic remains direct from Squid after the policy check.
+
+Do not leave Agent Vault tool traffic pointed directly at `http://agent-vault:14322` when chart-managed approved egress is enabled. That path either bypasses Squid, or forces Squid behind the vault where worker identity is lost. The chart rejects that default combination unless `approvedEgress.parentProxy` is enabled or `workers.kubernetes.agentVault.proxyUrl` is set to another explicit proxy URL.
 
 ## Custom Config
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -15950,7 +15950,9 @@ When approved egress and Agent Vault are used together, the correct chain is:
 worker -> approved egress (Squid) -> Agent Vault MITM parent -> internet
 ```
 
-Squid must be first. Dynamic `request_network_access` grants are keyed to the worker that made the request, and the approved egress helper resolves that worker from the proxy client's source IP. If traffic goes `worker -> Agent Vault -> Squid`, Squid only sees the Agent Vault pod IP, so the grant lookup cannot match the worker and dynamic grants fail even though static allowlist entries can still work.
+Squid must be first.
+Dynamic `request_network_access` grants are keyed to the worker that made the request, and the approved egress helper resolves that worker from the proxy client's source IP.
+If traffic goes `worker -> Agent Vault -> Squid`, Squid only sees the Agent Vault pod IP, so the grant lookup cannot match the worker and dynamic grants fail even though static allowlist entries can still work.
 
 Use `approvedEgress.parentProxy` to make the chart render a layered Squid config and point Agent Vault tool traffic at approved egress first:
 
@@ -15983,9 +15985,14 @@ approvedEgress:
     port: 14322
 ```
 
-When `parentProxy.enabled` is true, workers use the approved egress Service for `MINDROOM_KUBERNETES_AGENT_VAULT_PROXY_URL`. Squid enforces the allowlist and dynamic grants, then forwards requests that carry `Proxy-Authorization` to the Agent Vault parent with `login=PASSTHRU` so the vault still validates the worker's proxy-role token and injects credentials. Tokenless traffic remains direct from Squid after the policy check.
+When `parentProxy.enabled` is true, workers use the approved egress Service for `MINDROOM_KUBERNETES_AGENT_VAULT_PROXY_URL`.
+Squid enforces the allowlist and dynamic grants, then forwards requests that carry `Proxy-Authorization` to the Agent Vault parent with `login=PASSTHRU` so the vault still validates the worker's proxy-role token and injects credentials.
+Tokenless traffic remains direct from Squid after the policy check.
 
-Do not leave Agent Vault tool traffic pointed directly at the chart-managed Agent Vault MITM Service when chart-managed approved egress is enabled. That path either bypasses Squid, or forces Squid behind the vault where worker identity is lost. The chart rejects direct URLs to the chart-managed Agent Vault proxy Service, including short and cluster-local DNS names, unless `approvedEgress.parentProxy` is enabled. Truly external/custom proxy URLs remain an explicit escape hatch.
+Do not leave Agent Vault tool traffic pointed directly at the chart-managed Agent Vault MITM Service when chart-managed approved egress is enabled.
+That path either bypasses Squid, or forces Squid behind the vault where worker identity is lost.
+The chart rejects direct URLs to the chart-managed Agent Vault proxy Service, including short and cluster-local DNS names, unless `approvedEgress.parentProxy` is enabled.
+Truly external/custom proxy URLs remain an explicit escape hatch.
 
 ## Custom Config
 

--- a/skills/mindroom-docs/references/page__deployment__approved-egress__index.md
+++ b/skills/mindroom-docs/references/page__deployment__approved-egress__index.md
@@ -74,7 +74,7 @@ approvedEgress:
 
 When `parentProxy.enabled` is true, workers use the approved egress Service for `MINDROOM_KUBERNETES_AGENT_VAULT_PROXY_URL`. Squid enforces the allowlist and dynamic grants, then forwards requests that carry `Proxy-Authorization` to the Agent Vault parent with `login=PASSTHRU` so the vault still validates the worker's proxy-role token and injects credentials. Tokenless traffic remains direct from Squid after the policy check.
 
-Do not leave Agent Vault tool traffic pointed directly at `http://agent-vault:14322` when chart-managed approved egress is enabled. That path either bypasses Squid, or forces Squid behind the vault where worker identity is lost. The chart rejects that default combination unless `approvedEgress.parentProxy` is enabled or `workers.kubernetes.agentVault.proxyUrl` is set to another explicit proxy URL.
+Do not leave Agent Vault tool traffic pointed directly at the chart-managed Agent Vault MITM Service when chart-managed approved egress is enabled. That path either bypasses Squid, or forces Squid behind the vault where worker identity is lost. The chart rejects direct URLs to the chart-managed Agent Vault proxy Service, including short and cluster-local DNS names, unless `approvedEgress.parentProxy` is enabled. Truly external/custom proxy URLs remain an explicit escape hatch.
 
 ## Custom Config
 

--- a/skills/mindroom-docs/references/page__deployment__approved-egress__index.md
+++ b/skills/mindroom-docs/references/page__deployment__approved-egress__index.md
@@ -31,6 +31,51 @@ When `MINDROOM_APPROVED_EGRESS_ENABLED=true`, MindRoom adds `approved_egress` to
 These runtime-derived entries are not written back to `config.yaml` by dashboard or API saves.
 Set `approvedEgress.manageRuntimeConfig: false` to keep the proxy wiring but skip the runtime config overlay, for example when the authored config assigns `approved_egress` to specific agents instead of `defaults.tools`.
 
+## Agent Vault Chaining
+
+When approved egress and Agent Vault are used together, the correct chain is:
+
+```text
+worker -> approved egress (Squid) -> Agent Vault MITM parent -> internet
+```
+
+Squid must be first. Dynamic `request_network_access` grants are keyed to the worker that made the request, and the approved egress helper resolves that worker from the proxy client's source IP. If traffic goes `worker -> Agent Vault -> Squid`, Squid only sees the Agent Vault pod IP, so the grant lookup cannot match the worker and dynamic grants fail even though static allowlist entries can still work.
+
+Use `approvedEgress.parentProxy` to make the chart render a layered Squid config and point Agent Vault tool traffic at approved egress first:
+
+```yaml
+workers:
+  backend: kubernetes
+  sandbox:
+    proxyToken:
+      existingSecret: mindroom-sandbox-proxy
+      key: MINDROOM_SANDBOX_PROXY_TOKEN
+  kubernetes:
+    agentVault:
+      enabled: true
+      cliImage: infisical/agent-vault:<pinned>
+      ownerEmail: owner@example.test
+      server:
+        enabled: true
+      bootstrap:
+        enabled: true
+        kubectlImage: bitnami/kubectl:<pinned>
+      workerCaConfigMapName: agent-vault-ca
+
+approvedEgress:
+  enabled: true
+  image:
+    tag: v0.1.0
+  parentProxy:
+    enabled: true
+    host: agent-vault
+    port: 14322
+```
+
+When `parentProxy.enabled` is true, workers use the approved egress Service for `MINDROOM_KUBERNETES_AGENT_VAULT_PROXY_URL`. Squid enforces the allowlist and dynamic grants, then forwards requests that carry `Proxy-Authorization` to the Agent Vault parent with `login=PASSTHRU` so the vault still validates the worker's proxy-role token and injects credentials. Tokenless traffic remains direct from Squid after the policy check.
+
+Do not leave Agent Vault tool traffic pointed directly at `http://agent-vault:14322` when chart-managed approved egress is enabled. That path either bypasses Squid, or forces Squid behind the vault where worker identity is lost. The chart rejects that default combination unless `approvedEgress.parentProxy` is enabled or `workers.kubernetes.agentVault.proxyUrl` is set to another explicit proxy URL.
+
 ## Custom Config
 
 The runtime chart handles custom `config.data` and `config.existingConfigMap` through `MINDROOM_APPROVED_EGRESS_ENABLED=true`, so you do not need to duplicate this block there.

--- a/skills/mindroom-docs/references/page__deployment__approved-egress__index.md
+++ b/skills/mindroom-docs/references/page__deployment__approved-egress__index.md
@@ -39,7 +39,9 @@ When approved egress and Agent Vault are used together, the correct chain is:
 worker -> approved egress (Squid) -> Agent Vault MITM parent -> internet
 ```
 
-Squid must be first. Dynamic `request_network_access` grants are keyed to the worker that made the request, and the approved egress helper resolves that worker from the proxy client's source IP. If traffic goes `worker -> Agent Vault -> Squid`, Squid only sees the Agent Vault pod IP, so the grant lookup cannot match the worker and dynamic grants fail even though static allowlist entries can still work.
+Squid must be first.
+Dynamic `request_network_access` grants are keyed to the worker that made the request, and the approved egress helper resolves that worker from the proxy client's source IP.
+If traffic goes `worker -> Agent Vault -> Squid`, Squid only sees the Agent Vault pod IP, so the grant lookup cannot match the worker and dynamic grants fail even though static allowlist entries can still work.
 
 Use `approvedEgress.parentProxy` to make the chart render a layered Squid config and point Agent Vault tool traffic at approved egress first:
 
@@ -72,9 +74,14 @@ approvedEgress:
     port: 14322
 ```
 
-When `parentProxy.enabled` is true, workers use the approved egress Service for `MINDROOM_KUBERNETES_AGENT_VAULT_PROXY_URL`. Squid enforces the allowlist and dynamic grants, then forwards requests that carry `Proxy-Authorization` to the Agent Vault parent with `login=PASSTHRU` so the vault still validates the worker's proxy-role token and injects credentials. Tokenless traffic remains direct from Squid after the policy check.
+When `parentProxy.enabled` is true, workers use the approved egress Service for `MINDROOM_KUBERNETES_AGENT_VAULT_PROXY_URL`.
+Squid enforces the allowlist and dynamic grants, then forwards requests that carry `Proxy-Authorization` to the Agent Vault parent with `login=PASSTHRU` so the vault still validates the worker's proxy-role token and injects credentials.
+Tokenless traffic remains direct from Squid after the policy check.
 
-Do not leave Agent Vault tool traffic pointed directly at the chart-managed Agent Vault MITM Service when chart-managed approved egress is enabled. That path either bypasses Squid, or forces Squid behind the vault where worker identity is lost. The chart rejects direct URLs to the chart-managed Agent Vault proxy Service, including short and cluster-local DNS names, unless `approvedEgress.parentProxy` is enabled. Truly external/custom proxy URLs remain an explicit escape hatch.
+Do not leave Agent Vault tool traffic pointed directly at the chart-managed Agent Vault MITM Service when chart-managed approved egress is enabled.
+That path either bypasses Squid, or forces Squid behind the vault where worker identity is lost.
+The chart rejects direct URLs to the chart-managed Agent Vault proxy Service, including short and cluster-local DNS names, unless `approvedEgress.parentProxy` is enabled.
+Truly external/custom proxy URLs remain an explicit escape hatch.
 
 ## Custom Config
 

--- a/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
+++ b/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
@@ -389,8 +389,14 @@ For HTTPS, Agent Vault terminates TLS at its proxy, so workers must trust the va
 Publish the CA (from `agent-vault ca fetch`) as a ConfigMap with key `ca.pem` and set `MINDROOM_KUBERNETES_AGENT_VAULT_WORKER_CA_CONFIGMAP_NAME` (chart: `workers.kubernetes.agentVault.workerCaConfigMapName`).
 Worker pods mount it at `/etc/agent-vault/ca.pem` and the runner exports `REQUESTS_CA_BUNDLE`/`CURL_CA_BUNDLE`/`SSL_CERT_FILE` for python/shell egress.
 
-If you also enable the worker egress-proxy / approved-egress NetworkPolicies, they restrict worker egress and do not open the Agent Vault ports.
-Allow the worker pods and their init container to reach the Agent Vault api (`apiUrl`) and proxy (`proxyUrl`) ports — e.g. via `egressProxy.networkPolicy.extraEgress` — or the init container's health-check loop times out and the pod never starts.
+If you also enable the worker egress-proxy / approved-egress NetworkPolicies, keep Squid as the first hop for tool egress.
+Dynamic `request_network_access` grants are resolved by the approved egress helper from the proxy client's source IP; a vault-first chain (`worker -> Agent Vault -> Squid`) collapses every worker to the Agent Vault pod IP, so dynamic grants cannot match the worker.
+With the runtime chart's managed approved egress, set `approvedEgress.parentProxy.enabled: true` and leave Agent Vault tool traffic pointed at the approved egress Service; Squid forwards requests carrying the worker's `Proxy-Authorization` token to the Agent Vault MITM parent with `login=PASSTHRU`.
+
+Workers still need Agent Vault API access (`apiUrl`, usually port `14321`) so the init container can mint the per-worker proxy token.
+When the chart also manages the Agent Vault server, the worker NetworkPolicy includes that API egress automatically.
+For an externally managed Agent Vault server, add an egress rule for the API endpoint only.
+Do not add worker egress directly to the Agent Vault MITM proxy port (`proxyUrl`, usually `14322`) when approved egress owns dynamic grants; that bypasses the Squid-first policy path.
 
 For non-Kubernetes deployments, point worker egress at a shared proxy you run yourself by setting the worker proxy env directly (see the shared egress proxy option above).
 

--- a/tests/test_helm_instance_worker_isolation.py
+++ b/tests/test_helm_instance_worker_isolation.py
@@ -1368,6 +1368,14 @@ def test_runtime_chart_approved_egress_can_chain_agent_vault_parent(tmp_path: Pa
         ],
         "ports": [{"protocol": "TCP", "port": 14321}],
     }
+    assert not any(
+        any(port.get("port") == 14322 for port in rule.get("ports", []))
+        and any(
+            to.get("podSelector", {}).get("matchLabels", {}).get("app.kubernetes.io/name") == "agent-vault"
+            for to in rule.get("to", [])
+        )
+        for rule in worker_policy["spec"]["egress"]
+    )
 
     conf = squid_config["data"]["squid.conf"]
     assert "include /etc/squid/squid.conf" in conf
@@ -1401,10 +1409,34 @@ def test_runtime_chart_rejects_agent_vault_default_proxy_url_with_approved_egres
     assert "approvedEgress with Agent Vault must be squid-first" in completed.stderr
 
 
+def test_runtime_chart_rejects_invalid_approved_egress_parent_proxy_port() -> None:
+    """Parent proxy ports must be valid TCP ports before rendering Squid config."""
+    completed = _run_helm_template(
+        Path("cluster/k8s/runtime"),
+        "workers.backend=kubernetes",
+        "workers.sandbox.proxyToken.value=test-token",
+        "workers.kubernetes.agentVault.enabled=true",
+        "workers.kubernetes.agentVault.cliImage=infisical/agent-vault:test",
+        "workers.kubernetes.agentVault.ownerEmail=owner@example.test",
+        "workers.kubernetes.agentVault.server.enabled=true",
+        "eventCache.postgres.auth.password=test-password",
+        "approvedEgress.enabled=true",
+        "approvedEgress.image.tag=v0.1.0",
+        "approvedEgress.parentProxy.enabled=true",
+        "approvedEgress.parentProxy.port=70000",
+        release_name="mindroom-runtime",
+    )
+
+    assert completed.returncode != 0
+    assert "approvedEgress.parentProxy.port must be between 1 and 65535" in completed.stderr
+
+
 @pytest.mark.parametrize(
     "proxy_url",
     [
+        " http://agent-vault:14322 ",
         "http://agent-vault:14322/",
+        "HTTP://agent-vault:14322/",
         "http://agent-vault.default:14322",
         "http://agent-vault.default.svc:14322",
         "http://agent-vault.default.svc.cluster.local:14322",

--- a/tests/test_helm_instance_worker_isolation.py
+++ b/tests/test_helm_instance_worker_isolation.py
@@ -1401,6 +1401,34 @@ def test_runtime_chart_rejects_agent_vault_default_proxy_url_with_approved_egres
     assert "approvedEgress with Agent Vault must be squid-first" in completed.stderr
 
 
+@pytest.mark.parametrize(
+    "proxy_url",
+    [
+        "http://agent-vault.default:14322",
+        "http://agent-vault.default.svc:14322",
+        "http://agent-vault.default.svc.cluster.local:14322",
+    ],
+)
+def test_runtime_chart_rejects_agent_vault_service_proxy_url_aliases_with_approved_egress(proxy_url: str) -> None:
+    """Agent Vault service aliases must not avoid the Squid-first validation."""
+    completed = _run_helm_template(
+        Path("cluster/k8s/runtime"),
+        "workers.backend=kubernetes",
+        "workers.sandbox.proxyToken.value=test-token",
+        "workers.kubernetes.agentVault.enabled=true",
+        "workers.kubernetes.agentVault.cliImage=infisical/agent-vault:test",
+        "workers.kubernetes.agentVault.ownerEmail=owner@example.test",
+        f"workers.kubernetes.agentVault.proxyUrl={proxy_url}",
+        "eventCache.postgres.auth.password=test-password",
+        "approvedEgress.enabled=true",
+        "approvedEgress.image.tag=v0.1.0",
+        release_name="mindroom-runtime",
+    )
+
+    assert completed.returncode != 0
+    assert "approvedEgress with Agent Vault must be squid-first" in completed.stderr
+
+
 def test_runtime_chart_approved_egress_uses_worker_namespace_for_pod_lookup_and_rbac() -> None:
     """The proxy runs in the release namespace but reads worker pods from the worker namespace."""
     docs = _render_chart(

--- a/tests/test_helm_instance_worker_isolation.py
+++ b/tests/test_helm_instance_worker_isolation.py
@@ -1290,6 +1290,117 @@ def test_runtime_chart_approved_egress_can_opt_out_of_runtime_config_overlay(tmp
     assert "MINDROOM_APPROVED_EGRESS_TOKEN" in runtime_env
 
 
+def test_runtime_chart_approved_egress_can_chain_agent_vault_parent(tmp_path: Path) -> None:
+    """Tokened Agent Vault traffic should chain through Squid while grants keep worker IPs."""
+    values_path = tmp_path / "values.yaml"
+    values_path.write_text(
+        yaml.safe_dump(
+            {
+                "approvedEgress": {
+                    "enabled": True,
+                    "image": {"tag": "v0.1.0"},
+                    "parentProxy": {
+                        "enabled": True,
+                        "host": "agent-vault",
+                        "port": 14322,
+                    },
+                },
+                "eventCache": {"postgres": {"auth": {"password": "test-password"}}},
+                "workers": {
+                    "backend": "kubernetes",
+                    "sandbox": {"proxyToken": {"value": "test-token"}},
+                    "kubernetes": {
+                        "agentVault": {
+                            "enabled": True,
+                            "cliImage": "infisical/agent-vault:test",
+                            "ownerEmail": "owner@example.test",
+                            "server": {"enabled": True},
+                        },
+                    },
+                },
+            },
+        ),
+        encoding="utf-8",
+    )
+    docs = _render_chart(
+        Path("cluster/k8s/runtime"),
+        values_files=(values_path,),
+        release_name="mindroom-runtime",
+    )
+    proxy_name = "mindroom-runtime-egress-proxy"
+    proxy_deployment = _resource(docs, "Deployment", proxy_name)
+    proxy_container = _container(proxy_deployment, "approved-egress-proxy")
+    proxy_pod_template = proxy_deployment["spec"]["template"]
+    runtime_container = _container(_resource(docs, "Deployment", "mindroom-runtime"), "mindroom")
+    worker_policy = _resource(docs, "NetworkPolicy", "mindroom-runtime-workers")
+    proxy_env = _env_by_name(proxy_container)
+    runtime_env = _env_by_name(runtime_container)
+    squid_config = _resource(docs, "ConfigMap", f"{proxy_name}-squid-config")
+
+    assert runtime_env["MINDROOM_KUBERNETES_AGENT_VAULT_API_URL"]["value"] == "http://agent-vault:14321"
+    assert runtime_env["MINDROOM_KUBERNETES_AGENT_VAULT_PROXY_URL"]["value"] == (
+        "http://mindroom-runtime-egress-proxy.default.svc.cluster.local:3128"
+    )
+    assert "checksum/squid-config" in proxy_pod_template["metadata"]["annotations"]
+    assert proxy_env["MINDROOM_EGRESS_SQUID_CONFIG_PATH"]["value"] == "/etc/mindroom-egress-squid/squid.conf"
+    assert {
+        "name": "squid-config",
+        "mountPath": "/etc/mindroom-egress-squid/squid.conf",
+        "subPath": "squid.conf",
+        "readOnly": True,
+    } in proxy_container["volumeMounts"]
+    assert {
+        "name": "squid-config",
+        "configMap": {"name": f"{proxy_name}-squid-config"},
+    } in proxy_deployment["spec"]["template"]["spec"]["volumes"]
+    assert worker_policy["spec"]["egress"][2] == {
+        "to": [
+            {
+                "namespaceSelector": {"matchLabels": {"kubernetes.io/metadata.name": "default"}},
+                "podSelector": {
+                    "matchLabels": {
+                        "app.kubernetes.io/name": "agent-vault",
+                        "app.kubernetes.io/instance": "mindroom-runtime",
+                        "app.kubernetes.io/component": "agent-vault",
+                    },
+                },
+            },
+        ],
+        "ports": [{"protocol": "TCP", "port": 14321}],
+    }
+
+    conf = squid_config["data"]["squid.conf"]
+    assert "include /etc/squid/squid.conf" in conf
+    assert "acl egress_has_token req_header Proxy-Authorization ." in conf
+    assert "dns_defnames on" in conf
+    assert "cache_peer agent-vault parent 14322 0 no-query no-digest login=PASSTHRU" in conf
+    assert "cache_peer_access agent-vault allow egress_has_token" in conf
+    assert "cache_peer_access agent-vault deny all" in conf
+    assert "nonhierarchical_direct off" in conf
+    assert "always_direct allow !egress_has_token" in conf
+    assert "never_direct allow egress_has_token" in conf
+    assert "name=agentvault" not in conf
+
+
+def test_runtime_chart_rejects_agent_vault_default_proxy_url_with_approved_egress() -> None:
+    """Agent Vault must not stay vault-first when approved egress owns dynamic grants."""
+    completed = _run_helm_template(
+        Path("cluster/k8s/runtime"),
+        "workers.backend=kubernetes",
+        "workers.sandbox.proxyToken.value=test-token",
+        "workers.kubernetes.agentVault.enabled=true",
+        "workers.kubernetes.agentVault.cliImage=infisical/agent-vault:test",
+        "workers.kubernetes.agentVault.ownerEmail=owner@example.test",
+        "eventCache.postgres.auth.password=test-password",
+        "approvedEgress.enabled=true",
+        "approvedEgress.image.tag=v0.1.0",
+        release_name="mindroom-runtime",
+    )
+
+    assert completed.returncode != 0
+    assert "approvedEgress with Agent Vault must be squid-first" in completed.stderr
+
+
 def test_runtime_chart_approved_egress_uses_worker_namespace_for_pod_lookup_and_rbac() -> None:
     """The proxy runs in the release namespace but reads worker pods from the worker namespace."""
     docs = _render_chart(

--- a/tests/test_helm_instance_worker_isolation.py
+++ b/tests/test_helm_instance_worker_isolation.py
@@ -1342,10 +1342,10 @@ def test_runtime_chart_approved_egress_can_chain_agent_vault_parent(tmp_path: Pa
         "http://mindroom-runtime-egress-proxy.default.svc.cluster.local:3128"
     )
     assert "checksum/squid-config" in proxy_pod_template["metadata"]["annotations"]
-    assert proxy_env["MINDROOM_EGRESS_SQUID_CONFIG_PATH"]["value"] == "/etc/mindroom-egress-squid/squid.conf"
+    assert proxy_env["MINDROOM_EGRESS_SQUID_CONFIG_PATH"]["value"] == "/etc/squid/mindroom-egress-chain.conf"
     assert {
         "name": "squid-config",
-        "mountPath": "/etc/mindroom-egress-squid/squid.conf",
+        "mountPath": "/etc/squid/mindroom-egress-chain.conf",
         "subPath": "squid.conf",
         "readOnly": True,
     } in proxy_container["volumeMounts"]
@@ -1404,6 +1404,7 @@ def test_runtime_chart_rejects_agent_vault_default_proxy_url_with_approved_egres
 @pytest.mark.parametrize(
     "proxy_url",
     [
+        "http://agent-vault:14322/",
         "http://agent-vault.default:14322",
         "http://agent-vault.default.svc:14322",
         "http://agent-vault.default.svc.cluster.local:14322",


### PR DESCRIPTION
## Summary

This makes the runtime chart support the correct Agent Vault + approved egress chain:

```text
worker -> approved egress (Squid) -> Agent Vault MITM parent -> internet
```

The prior vault-first assumption breaks dynamic `request_network_access` grants because Squid resolves the worker from the proxy client's source IP. If traffic reaches Squid from Agent Vault, every worker looks like the vault pod and grants keyed by worker cannot match.

## Changes

- Add `approvedEgress.parentProxy` values that render a layered Squid config using `cache_peer ... login=PASSTHRU`.
- Mount the layered config into the approved egress Deployment, set `MINDROOM_EGRESS_SQUID_CONFIG_PATH`, and add a checksum annotation for rollout on config changes.
- Mount that file under existing `/etc/squid/mindroom-egress-chain.conf`, avoiding a `subPath` file mount under a missing parent directory.
- Point `MINDROOM_KUBERNETES_AGENT_VAULT_PROXY_URL` at chart-managed approved egress when parent chaining is enabled.
- Keep worker NetworkPolicy access to chart-managed Agent Vault API `14321` for token minting, without opening direct worker access to the Agent Vault MITM proxy port.
- Reject unsafe direct URLs to the chart-managed Agent Vault MITM Service, including short and cluster-local DNS aliases and trailing-slash variants, unless `approvedEgress.parentProxy` is enabled.
- Update runtime and deployment docs to make Squid-first the documented invariant and describe why vault-first breaks dynamic grants.

## Validation

- `uv run pytest tests/test_helm_instance_worker_isolation.py -q` (`76 passed`)
- `uv run ruff check tests/test_helm_instance_worker_isolation.py`
- `uv run ruff format --check tests/test_helm_instance_worker_isolation.py`
- `git diff --check`
- `helm lint cluster/k8s/runtime`
- `uv run python .github/scripts/generate_skill_references.py`
- Helm smoke with `approvedEgress.parentProxy.enabled=true`, then YAML parse confirmed 24 docs, config path `/etc/squid/mindroom-egress-chain.conf`, squid-config mount, and checksum annotation render.
- Helm trailing-slash rejection smoke for `workers.kubernetes.agentVault.proxyUrl=http://agent-vault:14322/` failed with the Squid-first validation error.
- Docker image dir check on `ghcr.io/mindroom-ai/mindroom-egress-proxy:v0.1.0` confirmed `/etc/squid` exists and `/etc/mindroom-egress-squid` is absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added proxy chaining configuration to layer approved egress with Agent Vault services, including built-in validation to prevent misconfiguration.

* **Documentation**
  * Updated deployment guides with detailed integration examples, network chaining requirements, and configuration best practices for both services.

* **Tests**
  * Added comprehensive tests verifying approved egress and Agent Vault integration scenarios and validation error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->