### PR TITLE
List unstructured file memories

### DIFF
--- a/src/mindroom/memory/_file_backend.py
+++ b/src/mindroom/memory/_file_backend.py
@@ -449,7 +449,8 @@ def _load_scope_path_memory_line(
     if target_path is None or not target_path.exists():
         return None
 
-    eligible_paths = {path.resolve() for path in _scope_markdown_files(scope_path)}
+    entrypoint_path = _scope_entrypoint_path(scope_path)
+    eligible_paths = {path.resolve() for path in _scope_markdown_files(scope_path) if path != entrypoint_path}
     if target_path not in eligible_paths:
         return None
 
@@ -554,15 +555,14 @@ def _replace_scope_path_memory_entry(
         return False
 
     lines = list(path_memory_line.lines)
-    line_no = path_memory_line.line_no
-    if line_no <= 0 or line_no > len(lines):
-        return False
 
     if content is None or not content.strip():
-        lines[line_no - 1] = ""
+        lines[path_memory_line.line_no - 1] = ""
     else:
         prefix_len = len(path_memory_line.raw_line) - len(path_memory_line.raw_line.lstrip(" "))
-        lines[line_no - 1] = f"{path_memory_line.raw_line[:prefix_len]}{' '.join(content.strip().split())}"
+        lines[path_memory_line.line_no - 1] = (
+            f"{path_memory_line.raw_line[:prefix_len]}{' '.join(content.strip().split())}"
+        )
     path_memory_line.target_path.write_text(f"{'\n'.join(lines)}\n" if lines else "", encoding="utf-8")
     return True
 

--- a/src/mindroom/memory/_file_backend.py
+++ b/src/mindroom/memory/_file_backend.py
@@ -59,6 +59,7 @@ class _PathMemoryLine:
     line_no: int
     raw_line: str
     memory: str
+    lines: tuple[str, ...]
 
 
 def _tag_keyword_mode(result: MemoryResult) -> None:
@@ -152,6 +153,10 @@ def _is_unstructured_memory_line(snippet: str) -> bool:
     return bool(snippet) and not snippet.startswith("#") and FILE_MEMORY_ENTRY_PATTERN.match(snippet) is None
 
 
+def _normalize_memory_text_for_dedup(text: str) -> str:
+    return " ".join(text.lower().split())
+
+
 def _load_scope_id_entries(
     scope_user_id: str,
     resolution: FileMemoryResolution,
@@ -203,13 +208,16 @@ def _load_scope_unstructured_entries(
 
     results: list[MemoryResult] = []
     seen_memory_text = set(existing_memory_text)
+    entrypoint_path = _scope_entrypoint_path(scope_path)
     for file_path in _scope_markdown_files(scope_path):
+        if file_path == entrypoint_path:
+            continue
         relative_path = file_path.relative_to(scope_path).as_posix()
         for line_no, raw_line in enumerate(file_path.read_text(encoding="utf-8").splitlines(), 1):
             snippet = raw_line.strip()
             if not _is_unstructured_memory_line(snippet):
                 continue
-            normalized_snippet = snippet.lower()
+            normalized_snippet = _normalize_memory_text_for_dedup(snippet)
             if normalized_snippet in seen_memory_text:
                 continue
             seen_memory_text.add(normalized_snippet)
@@ -349,7 +357,7 @@ def _search_scope_memory_entries(
     seen_scored_text: set[str] = set()
     for entry in id_entries:
         text = entry.get("memory", "")
-        normalized_text = text.strip().lower()
+        normalized_text = _normalize_memory_text_for_dedup(text)
         if normalized_text in seen_scored_text:
             continue
         score = _match_score(query_tokens, text)
@@ -372,7 +380,9 @@ def _search_scope_memory_entries(
     entrypoint_path = _scope_entrypoint_path(scope_path)
     snippet_results: list[MemoryResult] = []
     existing_memory_text = {
-        memory_text for entry in scored_entries if (memory_text := entry.get("memory", "").strip().lower())
+        memory_text
+        for entry in scored_entries
+        if (memory_text := _normalize_memory_text_for_dedup(entry.get("memory", "")))
     }
     snippet_results = _scan_scope_memory_snippets(
         scope_user_id,
@@ -403,7 +413,7 @@ def _scan_scope_memory_snippets(
             snippet = raw_line.strip()
             if not _is_unstructured_memory_line(snippet):
                 continue
-            normalized_snippet = snippet.lower()
+            normalized_snippet = _normalize_memory_text_for_dedup(snippet)
             if normalized_snippet in existing_memory_text:
                 continue
             score = _match_score(query_tokens, snippet)
@@ -457,6 +467,7 @@ def _load_scope_path_memory_line(
         line_no=line_no,
         raw_line=raw_line,
         memory=snippet,
+        lines=tuple(lines),
     )
 
 
@@ -542,12 +553,12 @@ def _replace_scope_path_memory_entry(
     if path_memory_line is None:
         return False
 
-    lines = path_memory_line.target_path.read_text(encoding="utf-8").splitlines()
+    lines = list(path_memory_line.lines)
     line_no = path_memory_line.line_no
     if line_no <= 0 or line_no > len(lines):
         return False
 
-    if content is None:
+    if content is None or not content.strip():
         lines[line_no - 1] = ""
     else:
         prefix_len = len(path_memory_line.raw_line) - len(path_memory_line.raw_line.lstrip(" "))
@@ -963,7 +974,7 @@ class FileMemoryBackend:
             return results[:limit]
 
         existing_memory_text = {
-            memory_text.strip().lower() for entry in results if (memory_text := entry.get("memory"))
+            _normalize_memory_text_for_dedup(memory_text) for entry in results if (memory_text := entry.get("memory"))
         }
         unstructured_results = await asyncio.to_thread(
             _load_scope_unstructured_entries,

--- a/src/mindroom/memory/_file_backend.py
+++ b/src/mindroom/memory/_file_backend.py
@@ -178,6 +178,39 @@ def _load_scope_id_entries(
     return results, id_to_file
 
 
+def _load_scope_unstructured_entries(
+    scope_user_id: str,
+    resolution: FileMemoryResolution,
+    config: Config,
+    existing_memory_text: set[str],
+) -> list[MemoryResult]:
+    scope_path = _scope_dir(scope_user_id, resolution, config, create=False)
+    if not scope_path.exists():
+        return []
+
+    results: list[MemoryResult] = []
+    seen_memory_text = set(existing_memory_text)
+    for file_path in _scope_markdown_files(scope_path):
+        relative_path = file_path.relative_to(scope_path).as_posix()
+        for line_no, raw_line in enumerate(file_path.read_text(encoding="utf-8").splitlines(), 1):
+            snippet = raw_line.strip()
+            if not snippet or snippet.startswith("#") or FILE_MEMORY_ENTRY_PATTERN.match(snippet):
+                continue
+            normalized_snippet = snippet.lower()
+            if normalized_snippet in seen_memory_text:
+                continue
+            seen_memory_text.add(normalized_snippet)
+            results.append(
+                {
+                    "id": f"file:{relative_path}:{line_no}",
+                    "memory": snippet,
+                    "user_id": scope_user_id,
+                    "metadata": {"source_file": relative_path, "line": line_no},
+                },
+            )
+    return results
+
+
 @timed("system_prompt_assembly.memory_search.file.id_entries_load")
 def _load_scope_entries_for_search(
     scope_user_id: str,
@@ -429,6 +462,9 @@ def _replace_scope_memory_entry(
     resolution: FileMemoryResolution,
     config: Config,
 ) -> bool:
+    if FILE_MEMORY_PATH_ID_PATTERN.match(memory_id):
+        return _replace_scope_path_memory_entry(scope_user_id, memory_id, content, resolution, config)
+
     _entries, id_to_file = _load_scope_id_entries(scope_user_id, resolution, config)
     if (file_path := id_to_file.get(memory_id)) is None:
         return False
@@ -455,6 +491,42 @@ def _replace_scope_memory_entry(
         return False
 
     file_path.write_text(f"{'\n'.join(new_lines)}\n" if new_lines else "", encoding="utf-8")
+    return True
+
+
+def _replace_scope_path_memory_entry(
+    scope_user_id: str,
+    memory_id: str,
+    content: str | None,
+    resolution: FileMemoryResolution,
+    config: Config,
+) -> bool:
+    match = FILE_MEMORY_PATH_ID_PATTERN.match(memory_id)
+    if match is None:
+        return False
+
+    line_no = int(match.group("line"))
+    relative_path = match.group("path")
+    scope_path = _scope_dir(scope_user_id, resolution, config, create=False)
+    target_path = _resolve_scope_markdown_path(scope_path, relative_path)
+    if target_path is None or not target_path.exists():
+        return False
+
+    lines = target_path.read_text(encoding="utf-8").splitlines()
+    if line_no <= 0 or line_no > len(lines):
+        return False
+
+    raw_line = lines[line_no - 1]
+    stripped = raw_line.strip()
+    if not stripped or stripped.startswith("#") or FILE_MEMORY_ENTRY_PATTERN.match(stripped):
+        return False
+
+    if content is None:
+        lines[line_no - 1] = ""
+    else:
+        prefix_len = len(raw_line) - len(raw_line.lstrip(" "))
+        lines[line_no - 1] = f"{raw_line[:prefix_len]}{' '.join(content.strip().split())}"
+    target_path.write_text(f"{'\n'.join(lines)}\n" if lines else "", encoding="utf-8")
     return True
 
 
@@ -861,7 +933,20 @@ class FileMemoryBackend:
             resolution,
             config,
         )
-        return results[:limit]
+        if len(results) >= limit:
+            return results[:limit]
+
+        existing_memory_text = {
+            memory_text.strip().lower() for entry in results if (memory_text := entry.get("memory"))
+        }
+        unstructured_results = await asyncio.to_thread(
+            _load_scope_unstructured_entries,
+            agent_scope_user_id(agent_name),
+            resolution,
+            config,
+            existing_memory_text,
+        )
+        return (results + unstructured_results)[:limit]
 
     async def get(
         self,

--- a/src/mindroom/memory/_file_backend.py
+++ b/src/mindroom/memory/_file_backend.py
@@ -52,6 +52,15 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+@dataclass(frozen=True)
+class _PathMemoryLine:
+    target_path: Path
+    relative_path: str
+    line_no: int
+    raw_line: str
+    memory: str
+
+
 def _tag_keyword_mode(result: MemoryResult) -> None:
     metadata = result.get("metadata")
     result["metadata"] = (
@@ -139,6 +148,10 @@ def _scope_markdown_files(scope_path: Path) -> list[Path]:
     return files
 
 
+def _is_unstructured_memory_line(snippet: str) -> bool:
+    return bool(snippet) and not snippet.startswith("#") and FILE_MEMORY_ENTRY_PATTERN.match(snippet) is None
+
+
 def _load_scope_id_entries(
     scope_user_id: str,
     resolution: FileMemoryResolution,
@@ -194,7 +207,7 @@ def _load_scope_unstructured_entries(
         relative_path = file_path.relative_to(scope_path).as_posix()
         for line_no, raw_line in enumerate(file_path.read_text(encoding="utf-8").splitlines(), 1):
             snippet = raw_line.strip()
-            if not snippet or snippet.startswith("#") or FILE_MEMORY_ENTRY_PATTERN.match(snippet):
+            if not _is_unstructured_memory_line(snippet):
                 continue
             normalized_snippet = snippet.lower()
             if normalized_snippet in seen_memory_text:
@@ -388,9 +401,7 @@ def _scan_scope_memory_snippets(
         relative_path = file_path.relative_to(scope_path).as_posix()
         for line_no, raw_line in enumerate(file_path.read_text(encoding="utf-8").splitlines(), 1):
             snippet = raw_line.strip()
-            if not snippet or snippet.startswith("#"):
-                continue
-            if FILE_MEMORY_ENTRY_PATTERN.match(snippet):
+            if not _is_unstructured_memory_line(snippet):
                 continue
             normalized_snippet = snippet.lower()
             if normalized_snippet in existing_memory_text:
@@ -411,32 +422,58 @@ def _scan_scope_memory_snippets(
     return snippet_results
 
 
-def _get_scope_memory_by_path_id(
+def _load_scope_path_memory_line(
     scope_user_id: str,
     memory_id: str,
     resolution: FileMemoryResolution,
     config: Config,
-) -> MemoryResult | None:
+) -> _PathMemoryLine | None:
     match = FILE_MEMORY_PATH_ID_PATTERN.match(memory_id)
     if match is None:
         return None
+
     line_no = int(match.group("line"))
     relative_path = match.group("path")
     scope_path = _scope_dir(scope_user_id, resolution, config, create=False)
     target_path = _resolve_scope_markdown_path(scope_path, relative_path)
     if target_path is None or not target_path.exists():
         return None
+
+    eligible_paths = {path.resolve() for path in _scope_markdown_files(scope_path)}
+    if target_path not in eligible_paths:
+        return None
+
     lines = target_path.read_text(encoding="utf-8").splitlines()
     if line_no <= 0 or line_no > len(lines):
         return None
-    snippet = lines[line_no - 1].strip()
-    if not snippet:
+
+    raw_line = lines[line_no - 1]
+    snippet = raw_line.strip()
+    if not _is_unstructured_memory_line(snippet):
+        return None
+    return _PathMemoryLine(
+        target_path=target_path,
+        relative_path=relative_path,
+        line_no=line_no,
+        raw_line=raw_line,
+        memory=snippet,
+    )
+
+
+def _get_scope_memory_by_path_id(
+    scope_user_id: str,
+    memory_id: str,
+    resolution: FileMemoryResolution,
+    config: Config,
+) -> MemoryResult | None:
+    path_memory_line = _load_scope_path_memory_line(scope_user_id, memory_id, resolution, config)
+    if path_memory_line is None:
         return None
     return {
         "id": memory_id,
-        "memory": snippet,
+        "memory": path_memory_line.memory,
         "user_id": scope_user_id,
-        "metadata": {"source_file": relative_path, "line": line_no},
+        "metadata": {"source_file": path_memory_line.relative_path, "line": path_memory_line.line_no},
     }
 
 
@@ -501,32 +538,21 @@ def _replace_scope_path_memory_entry(
     resolution: FileMemoryResolution,
     config: Config,
 ) -> bool:
-    match = FILE_MEMORY_PATH_ID_PATTERN.match(memory_id)
-    if match is None:
+    path_memory_line = _load_scope_path_memory_line(scope_user_id, memory_id, resolution, config)
+    if path_memory_line is None:
         return False
 
-    line_no = int(match.group("line"))
-    relative_path = match.group("path")
-    scope_path = _scope_dir(scope_user_id, resolution, config, create=False)
-    target_path = _resolve_scope_markdown_path(scope_path, relative_path)
-    if target_path is None or not target_path.exists():
-        return False
-
-    lines = target_path.read_text(encoding="utf-8").splitlines()
+    lines = path_memory_line.target_path.read_text(encoding="utf-8").splitlines()
+    line_no = path_memory_line.line_no
     if line_no <= 0 or line_no > len(lines):
-        return False
-
-    raw_line = lines[line_no - 1]
-    stripped = raw_line.strip()
-    if not stripped or stripped.startswith("#") or FILE_MEMORY_ENTRY_PATTERN.match(stripped):
         return False
 
     if content is None:
         lines[line_no - 1] = ""
     else:
-        prefix_len = len(raw_line) - len(raw_line.lstrip(" "))
-        lines[line_no - 1] = f"{raw_line[:prefix_len]}{' '.join(content.strip().split())}"
-    target_path.write_text(f"{'\n'.join(lines)}\n" if lines else "", encoding="utf-8")
+        prefix_len = len(path_memory_line.raw_line) - len(path_memory_line.raw_line.lstrip(" "))
+        lines[line_no - 1] = f"{path_memory_line.raw_line[:prefix_len]}{' '.join(content.strip().split())}"
+    path_memory_line.target_path.write_text(f"{'\n'.join(lines)}\n" if lines else "", encoding="utf-8")
     return True
 
 

--- a/tests/test_memory_auto_flush.py
+++ b/tests/test_memory_auto_flush.py
@@ -333,7 +333,9 @@ async def test_worker_flush_unscoped_uses_canonical_agent_workspace_memory_path(
     assert wrote_memory is True
     canonical_daily_files = list((agent_workspace_root_path(tmp_path, "general") / "memory").rglob("*.md"))
     assert len(canonical_daily_files) == 1
-    assert "important decision" in canonical_daily_files[0].read_text(encoding="utf-8")
+    daily_content = canonical_daily_files[0].read_text(encoding="utf-8")
+    assert daily_content.startswith("- [id=m_")
+    assert "] [auto_flush:session-general:100] important decision\n" in daily_content
     assert not list((tmp_path / "shared-memory").rglob("*.md"))
     assert not list((tmp_path / "memory_files").rglob("*.md"))
 

--- a/tests/test_memory_file_backend.py
+++ b/tests/test_memory_file_backend.py
@@ -1452,6 +1452,36 @@ async def test_file_backend_rejects_path_ids_outside_memory_files(
 
 
 @pytest.mark.asyncio
+async def test_file_backend_rejects_unstructured_entrypoint_path_ids(
+    storage_path: Path,
+    config: Config,
+) -> None:
+    config.memory.backend = "file"
+    config.agents["general"].memory_backend = "file"
+
+    workspace = agent_workspace_root_path(storage_path, "general")
+    memory_file = workspace / "MEMORY.md"
+    memory_file.parent.mkdir(parents=True, exist_ok=True)
+    memory_file.write_text(
+        "# Memory\n\nCurated raw entrypoint line.\n- [id=m_existing] Structured entrypoint note.\n",
+        encoding="utf-8",
+    )
+    original_content = memory_file.read_text(encoding="utf-8")
+
+    structured = await get_agent_memory("m_existing", "general", storage_path, config)
+    assert structured is not None
+    assert structured["memory"] == "Structured entrypoint note."
+    assert await get_agent_memory("file:MEMORY.md:3", "general", storage_path, config) is None
+
+    with pytest.raises(ValueError, match=r"No memory found with id=file:MEMORY\.md:3"):
+        await update_agent_memory("file:MEMORY.md:3", "Changed.", "general", storage_path, config)
+    with pytest.raises(ValueError, match=r"No memory found with id=file:MEMORY\.md:3"):
+        await delete_agent_memory("file:MEMORY.md:3", "general", storage_path, config)
+
+    assert memory_file.read_text(encoding="utf-8") == original_content
+
+
+@pytest.mark.asyncio
 async def test_file_backend_store_conversation_memory_uses_agent_scope_only(
     storage_path: Path,
     config: Config,

--- a/tests/test_memory_file_backend.py
+++ b/tests/test_memory_file_backend.py
@@ -441,6 +441,31 @@ async def test_file_backend_add_and_list_memories(storage_path: Path, config: Co
 
 
 @pytest.mark.asyncio
+async def test_file_backend_lists_unstructured_daily_memory_lines(storage_path: Path, config: Config) -> None:
+    config.memory.backend = "file"
+    config.agents["general"].memory_backend = "file"
+
+    workspace = agent_workspace_root_path(storage_path, "general")
+    daily_file = workspace / "memory" / "2026-06-13.md"
+    daily_file.parent.mkdir(parents=True, exist_ok=True)
+    daily_file.write_text(
+        "# Daily notes\n\nBas prefers repo-grounded answers.\n- [id=m_existing] Structured daily note.\n",
+        encoding="utf-8",
+    )
+
+    results = await list_all_agent_memories("general", storage_path, config)
+
+    assert [result["memory"] for result in results] == [
+        "Structured daily note.",
+        "Bas prefers repo-grounded answers.",
+    ]
+    assert [result["id"] for result in results] == [
+        "m_existing",
+        "file:memory/2026-06-13.md:3",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_file_backend_user_scoped_workers_share_agent_memory_across_requesters(
     storage_path: Path,
     config: Config,
@@ -1298,6 +1323,32 @@ async def test_file_backend_memory_crud_and_scope(storage_path: Path, config: Co
     assert await get_agent_memory(private_id, "other_agent", storage_path, config) is None
     with pytest.raises(ValueError, match=f"No memory found with id={private_id}"):
         await update_agent_memory(private_id, "Tampered", "other_agent", storage_path, config)
+
+
+@pytest.mark.asyncio
+async def test_file_backend_can_update_and_delete_unstructured_file_memory_line(
+    storage_path: Path,
+    config: Config,
+) -> None:
+    config.memory.backend = "file"
+    config.agents["general"].memory_backend = "file"
+
+    workspace = agent_workspace_root_path(storage_path, "general")
+    daily_file = workspace / "memory" / "2026-06-13.md"
+    daily_file.parent.mkdir(parents=True, exist_ok=True)
+    daily_file.write_text("Old raw note.\nKeep this line.\n", encoding="utf-8")
+
+    memory_id = "file:memory/2026-06-13.md:1"
+    await update_agent_memory(memory_id, "Updated raw note.", "general", storage_path, config)
+
+    assert daily_file.read_text(encoding="utf-8") == "Updated raw note.\nKeep this line.\n"
+    updated = await get_agent_memory(memory_id, "general", storage_path, config)
+    assert updated is not None
+    assert updated["memory"] == "Updated raw note."
+
+    await delete_agent_memory(memory_id, "general", storage_path, config)
+    assert daily_file.read_text(encoding="utf-8") == "\nKeep this line.\n"
+    assert await get_agent_memory(memory_id, "general", storage_path, config) is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_memory_file_backend.py
+++ b/tests/test_memory_file_backend.py
@@ -1352,6 +1352,33 @@ async def test_file_backend_can_update_and_delete_unstructured_file_memory_line(
 
 
 @pytest.mark.asyncio
+async def test_file_backend_rejects_path_ids_outside_memory_files(
+    storage_path: Path,
+    config: Config,
+) -> None:
+    config.memory.backend = "file"
+    config.agents["general"].memory_backend = "file"
+
+    workspace = agent_workspace_root_path(storage_path, "general")
+    docs_file = workspace / "docs" / "runbook.md"
+    docs_file.parent.mkdir(parents=True, exist_ok=True)
+    docs_file.write_text("Runbook instruction.\n", encoding="utf-8")
+    soul_file = workspace / "SOUL.md"
+    soul_file.write_text("Protected instruction.\n", encoding="utf-8")
+
+    assert await get_agent_memory("file:docs/runbook.md:1", "general", storage_path, config) is None
+    assert await get_agent_memory("file:SOUL.md:1", "general", storage_path, config) is None
+
+    with pytest.raises(ValueError, match=r"No memory found with id=file:docs/runbook\.md:1"):
+        await update_agent_memory("file:docs/runbook.md:1", "Changed.", "general", storage_path, config)
+    with pytest.raises(ValueError, match=r"No memory found with id=file:SOUL\.md:1"):
+        await delete_agent_memory("file:SOUL.md:1", "general", storage_path, config)
+
+    assert docs_file.read_text(encoding="utf-8") == "Runbook instruction.\n"
+    assert soul_file.read_text(encoding="utf-8") == "Protected instruction.\n"
+
+
+@pytest.mark.asyncio
 async def test_file_backend_store_conversation_memory_uses_agent_scope_only(
     storage_path: Path,
     config: Config,

--- a/tests/test_memory_file_backend.py
+++ b/tests/test_memory_file_backend.py
@@ -466,6 +466,59 @@ async def test_file_backend_lists_unstructured_daily_memory_lines(storage_path: 
 
 
 @pytest.mark.asyncio
+async def test_file_backend_deduplicates_unstructured_lines_with_internal_whitespace(
+    storage_path: Path,
+    config: Config,
+) -> None:
+    config.memory.backend = "file"
+    config.agents["general"].memory_backend = "file"
+
+    await add_agent_memory("Bas prefers repo-grounded answers.", "general", storage_path, config)
+
+    workspace = agent_workspace_root_path(storage_path, "general")
+    daily_file = workspace / "memory" / "2026-06-13.md"
+    daily_file.parent.mkdir(parents=True, exist_ok=True)
+    daily_file.write_text(
+        "Bas   prefers\trepo-grounded   answers.\nUnique raw note.\n",
+        encoding="utf-8",
+    )
+
+    results = await list_all_agent_memories("general", storage_path, config)
+
+    assert [result["memory"] for result in results] == [
+        "Bas prefers repo-grounded answers.",
+        "Unique raw note.",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_file_backend_list_all_skips_unstructured_entrypoint_lines(
+    storage_path: Path,
+    config: Config,
+) -> None:
+    config.memory.backend = "file"
+    config.agents["general"].memory_backend = "file"
+
+    workspace = agent_workspace_root_path(storage_path, "general")
+    memory_file = workspace / "MEMORY.md"
+    memory_file.parent.mkdir(parents=True, exist_ok=True)
+    memory_file.write_text(
+        "# Memory\n\nCurated raw entrypoint line.\n- [id=m_existing] Structured entrypoint note.\n",
+        encoding="utf-8",
+    )
+    daily_file = workspace / "memory" / "2026-06-13.md"
+    daily_file.parent.mkdir(parents=True, exist_ok=True)
+    daily_file.write_text("Daily raw note.\n", encoding="utf-8")
+
+    results = await list_all_agent_memories("general", storage_path, config)
+
+    assert [result["memory"] for result in results] == [
+        "Structured entrypoint note.",
+        "Daily raw note.",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_file_backend_user_scoped_workers_share_agent_memory_across_requesters(
     storage_path: Path,
     config: Config,
@@ -1347,6 +1400,26 @@ async def test_file_backend_can_update_and_delete_unstructured_file_memory_line(
     assert updated["memory"] == "Updated raw note."
 
     await delete_agent_memory(memory_id, "general", storage_path, config)
+    assert daily_file.read_text(encoding="utf-8") == "\nKeep this line.\n"
+    assert await get_agent_memory(memory_id, "general", storage_path, config) is None
+
+
+@pytest.mark.asyncio
+async def test_file_backend_whitespace_only_update_deletes_unstructured_file_memory_line(
+    storage_path: Path,
+    config: Config,
+) -> None:
+    config.memory.backend = "file"
+    config.agents["general"].memory_backend = "file"
+
+    workspace = agent_workspace_root_path(storage_path, "general")
+    daily_file = workspace / "memory" / "2026-06-13.md"
+    daily_file.parent.mkdir(parents=True, exist_ok=True)
+    daily_file.write_text("  Old raw note.\nKeep this line.\n", encoding="utf-8")
+
+    memory_id = "file:memory/2026-06-13.md:1"
+    await update_agent_memory(memory_id, "   \t", "general", storage_path, config)
+
     assert daily_file.read_text(encoding="utf-8") == "\nKeep this line.\n"
     assert await get_agent_memory(memory_id, "general", storage_path, config) is None
 


### PR DESCRIPTION
## Summary
- Include unstructured daily markdown memory lines in file-backed `list_memories` results after structured `m_...` entries.
- Add `file:<path>:<line>` IDs for raw daily memory lines, with update/delete support.
- Tighten auto-flush coverage to assert generated daily memories use pinned `m_...` IDs plus the `auto_flush` marker.

## Test Plan
- `/Users/bas.nijholt/.local/bin/uv sync --all-extras`
- `/Users/bas.nijholt/.local/bin/uv run pytest -q` (8473 passed, 61 skipped)
- `/Users/bas.nijholt/.local/bin/uv run pytest tests/test_memory_auto_flush.py tests/test_memory_file_backend.py tests/test_memory_tools.py -q` (81 passed)
- `/Users/bas.nijholt/.local/bin/uv run pre-commit run --all-files` (all non-Bun hooks passed; `typescript-check` and `check-bun-lock` could not run because local `bun` is not installed)
- `PATH="/Users/bas.nijholt/.local/bin:$PATH" git commit -m "List unstructured file memories"` (staged-file hooks passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Memory system now automatically captures and deduplicates unstructured snippets from markdown files across your workspace, reducing redundant entries.
  * Enhanced memory entry operations with improved validation for file path safety.

* **Tests**
  * Comprehensive test coverage added for unstructured memory handling, content-based deduplication, and file access security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->