### PR TITLE
Make SaaS API type check portable

### DIFF
--- a/saas-platform/platform-frontend/package.json
+++ b/saas-platform/platform-frontend/package.json
@@ -10,6 +10,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
+    "test:api-check": "node --test scripts/check-api-types.test.mjs",
     "generate:api": "openapi-typescript ../platform-backend/openapi.json -o src/lib/api.generated.ts",
     "check:api": "bun scripts/check-api-types.mjs",
     "screenshot": "nix-shell --run 'node take_screenshot.js' 2>/dev/null || node take_screenshot.js"

--- a/saas-platform/platform-frontend/scripts/check-api-types.mjs
+++ b/saas-platform/platform-frontend/scripts/check-api-types.mjs
@@ -2,20 +2,34 @@
 // Run with `bun run check:api`; regenerate with `just saas-openapi` (or `bun run generate:api`).
 import { execFileSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
 const schemaPath = fileURLToPath(new URL('../../platform-backend/openapi.json', import.meta.url))
 const generatedPath = fileURLToPath(new URL('../src/lib/api.generated.ts', import.meta.url))
-const cliPath = fileURLToPath(new URL('../node_modules/.bin/openapi-typescript', import.meta.url))
+const cliPath = fileURLToPath(new URL('../node_modules/openapi-typescript/bin/cli.js', import.meta.url))
 
-const fresh = execFileSync(cliPath, [schemaPath], { encoding: 'utf8' })
-const committed = readFileSync(generatedPath, 'utf8')
-
-if (fresh !== committed) {
-  console.error(
-    'src/lib/api.generated.ts is stale relative to platform-backend/openapi.json.\n' +
-      'Run `just saas-openapi` from the repo root (or `bun run generate:api` here) and commit the result.',
-  )
-  process.exit(1)
+export function getOpenApiTypesCommand(schemaFilePath = schemaPath) {
+  return {
+    command: process.execPath,
+    args: [cliPath, schemaFilePath],
+  }
 }
-console.log('api.generated.ts is up to date.')
+
+export function checkApiTypes() {
+  const { command, args } = getOpenApiTypesCommand()
+  const fresh = execFileSync(command, args, { encoding: 'utf8' })
+  const committed = readFileSync(generatedPath, 'utf8')
+
+  if (fresh !== committed) {
+    console.error(
+      'src/lib/api.generated.ts is stale relative to platform-backend/openapi.json.\n' +
+        'Run `just saas-openapi` from the repo root (or `bun run generate:api` here) and commit the result.',
+    )
+    process.exit(1)
+  }
+  console.log('api.generated.ts is up to date.')
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  checkApiTypes()
+}

--- a/saas-platform/platform-frontend/scripts/check-api-types.mjs
+++ b/saas-platform/platform-frontend/scripts/check-api-types.mjs
@@ -6,7 +6,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 
 const schemaPath = fileURLToPath(new URL('../../platform-backend/openapi.json', import.meta.url))
 const generatedPath = fileURLToPath(new URL('../src/lib/api.generated.ts', import.meta.url))
-const cliPath = fileURLToPath(new URL('../node_modules/openapi-typescript/bin/cli.js', import.meta.url))
+const cliPath = fileURLToPath(new URL('bin/cli.js', import.meta.resolve('openapi-typescript/package.json')))
 
 export function getOpenApiTypesCommand(schemaFilePath = schemaPath) {
   return {

--- a/saas-platform/platform-frontend/scripts/check-api-types.test.mjs
+++ b/saas-platform/platform-frontend/scripts/check-api-types.test.mjs
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict'
+import path from 'node:path'
+import { test } from 'node:test'
+
+import { getOpenApiTypesCommand } from './check-api-types.mjs'
+
+test('runs openapi-typescript through the current JavaScript runtime', () => {
+  const { command, args } = getOpenApiTypesCommand('/tmp/openapi.json')
+
+  assert.equal(command, process.execPath)
+  assert.ok(args[0].endsWith(path.join('node_modules', 'openapi-typescript', 'bin', 'cli.js')))
+  assert.equal(args[1], '/tmp/openapi.json')
+})

--- a/saas-platform/platform-frontend/scripts/check-api-types.test.mjs
+++ b/saas-platform/platform-frontend/scripts/check-api-types.test.mjs
@@ -1,13 +1,14 @@
 import assert from 'node:assert/strict'
-import path from 'node:path'
 import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
 
 import { getOpenApiTypesCommand } from './check-api-types.mjs'
 
 test('runs openapi-typescript through the current JavaScript runtime', () => {
   const { command, args } = getOpenApiTypesCommand('/tmp/openapi.json')
+  const expectedCliPath = fileURLToPath(new URL('bin/cli.js', import.meta.resolve('openapi-typescript/package.json')))
 
   assert.equal(command, process.execPath)
-  assert.ok(args[0].endsWith(path.join('node_modules', 'openapi-typescript', 'bin', 'cli.js')))
+  assert.equal(args[0], expectedCliPath)
   assert.equal(args[1], '/tmp/openapi.json')
 })


### PR DESCRIPTION
## What

Follow-up to #1281.

Makes `platform-frontend/scripts/check-api-types.mjs` execute `openapi-typescript` through the current JavaScript runtime (`process.execPath`) and the package's real JS entrypoint instead of executing the `.bin` shim directly.

Adds a small Node test for the command construction.

## Review comment triage

- Gemini `.bin/openapi-typescript` portability comment: fixed here.
- Greptile schema freshness comment: stale; #1281 already added `platform-backend/tests/test_openapi_export.py`, and backend CI covered it.
- Gemini `toLocaleString()` hydration comment: not changed; this page renders instance data from client state/fetch, and broad date formatting cleanup would be separate if a real warning appears.

## Verification

- `bun run test:api-check` ✅
- `bun run check:api` ✅
- `node scripts/check-api-types.mjs` ✅
- `bun run build` ✅
- `uv run pre-commit run --all-files` ✅
- `uv run pytest -q` ✅ 8471 passed, 61 skipped
