### PR TITLE
Fix SaaS SSO cookie domain

### DIFF
--- a/saas-platform/platform-backend/openapi.json
+++ b/saas-platform/platform-backend/openapi.json
@@ -3716,7 +3716,7 @@
         "summary": "Clear Sso Cookie"
       },
       "post": {
-        "description": "Set an API-host SSO cookie with the current Supabase access token.\n\nTenant subdomains must not receive raw platform JWTs.",
+        "description": "Set an SSO cookie with the current Supabase access token.",
         "operationId": "set_sso_cookie_my_sso_cookie_post",
         "parameters": [
           {

--- a/saas-platform/platform-backend/openapi.json
+++ b/saas-platform/platform-backend/openapi.json
@@ -3740,6 +3740,9 @@
             },
             "description": "Successful Response"
           },
+          "401": {
+            "description": "Missing bearer token"
+          },
           "422": {
             "content": {
               "application/json": {

--- a/saas-platform/platform-backend/src/backend/routes/sso.py
+++ b/saas-platform/platform-backend/src/backend/routes/sso.py
@@ -1,6 +1,7 @@
 """SSO cookie management routes."""
 
 from datetime import timedelta
+from ipaddress import ip_address
 from typing import Annotated
 
 from backend.config import PLATFORM_DOMAIN
@@ -16,9 +17,14 @@ SSO_COOKIE_MAX_AGE_SECONDS = int(timedelta(hours=1).total_seconds())
 
 def _sso_cookie_domain() -> str | None:
     domain = PLATFORM_DOMAIN.strip()
-    if not domain:
+    host = domain.lstrip(".").lower()
+    if not host or host == "localhost" or ":" in host or "." not in host:
         return None
-    return domain if domain.startswith(".") else f".{domain}"
+    try:
+        ip_address(host)
+    except ValueError:
+        return domain if domain.startswith(".") else f".{domain}"
+    return None
 
 
 def _set_cookie(
@@ -48,10 +54,16 @@ def _expire_legacy_host_only_sso_cookie(response: Response) -> None:
 
 def _expire_sso_cookie(response: Response) -> None:
     _expire_legacy_host_only_sso_cookie(response)
-    _set_cookie(response, value="", max_age=0, domain=_sso_cookie_domain())
+    domain = _sso_cookie_domain()
+    if domain is not None:
+        _set_cookie(response, value="", max_age=0, domain=domain)
 
 
-@router.post("/my/sso-cookie", response_model=StatusResponse)
+@router.post(
+    "/my/sso-cookie",
+    response_model=StatusResponse,
+    responses={401: {"description": "Missing bearer token"}},
+)
 @limiter.limit("30/minute")
 async def set_sso_cookie(
     request: Request,

--- a/saas-platform/platform-backend/src/backend/routes/sso.py
+++ b/saas-platform/platform-backend/src/backend/routes/sso.py
@@ -3,23 +3,52 @@
 from datetime import timedelta
 from typing import Annotated
 
+from backend.config import PLATFORM_DOMAIN
 from backend.deps import _extract_bearer_token, limiter, verify_user
 from backend.models import StatusResponse
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response
 
 router = APIRouter()
 
+SSO_COOKIE_NAME = "mindroom_jwt"
+SSO_COOKIE_MAX_AGE_SECONDS = int(timedelta(hours=1).total_seconds())
+
+
+def _sso_cookie_domain() -> str | None:
+    domain = PLATFORM_DOMAIN.strip()
+    if not domain:
+        return None
+    return domain if domain.startswith(".") else f".{domain}"
+
+
+def _set_cookie(
+    response: Response,
+    *,
+    value: str,
+    max_age: int,
+    domain: str | None = None,
+) -> None:
+    kwargs = {
+        "key": SSO_COOKIE_NAME,
+        "value": value,
+        "path": "/",
+        "secure": True,
+        "httponly": True,
+        "samesite": "lax",
+        "max_age": max_age,
+    }
+    if domain:
+        kwargs["domain"] = domain
+    response.set_cookie(**kwargs)
+
+
+def _expire_legacy_host_only_sso_cookie(response: Response) -> None:
+    _set_cookie(response, value="", max_age=0)
+
 
 def _expire_sso_cookie(response: Response) -> None:
-    response.set_cookie(
-        key="mindroom_jwt",
-        value="",
-        path="/",
-        secure=True,
-        httponly=True,
-        samesite="lax",
-        max_age=0,
-    )
+    _expire_legacy_host_only_sso_cookie(response)
+    _set_cookie(response, value="", max_age=0, domain=_sso_cookie_domain())
 
 
 @router.post("/my/sso-cookie", response_model=StatusResponse)
@@ -30,24 +59,14 @@ async def set_sso_cookie(
     user: dict = Depends(verify_user),  # noqa: ARG001, FAST002, B008
     authorization: Annotated[str | None, Header()] = None,
 ) -> dict[str, str]:
-    """Set an API-host SSO cookie with the current Supabase access token.
-
-    Tenant subdomains must not receive raw platform JWTs.
-    """
+    """Set an SSO cookie with the current Supabase access token."""
     try:
         token = _extract_bearer_token(authorization or request.headers.get("authorization"))
     except HTTPException:
         raise HTTPException(status_code=401, detail="Missing bearer token") from None
 
-    response.set_cookie(
-        key="mindroom_jwt",
-        value=token,
-        path="/",
-        secure=True,
-        httponly=True,
-        samesite="lax",
-        max_age=int(timedelta(hours=1).total_seconds()),
-    )
+    _expire_legacy_host_only_sso_cookie(response)
+    _set_cookie(response, value=token, max_age=SSO_COOKIE_MAX_AGE_SECONDS, domain=_sso_cookie_domain())
     return {"status": "ok"}
 
 

--- a/saas-platform/platform-backend/tests/test_sso_cookie_attrs.py
+++ b/saas-platform/platform-backend/tests/test_sso_cookie_attrs.py
@@ -10,8 +10,8 @@ from tests.stripe_mock import create_stripe_mock
 sys.modules.setdefault("stripe", create_stripe_mock())
 
 import pytest  # noqa: E402
-from backend import config  # noqa: E402
 from backend.deps import Limiter, get_remote_address, limiter, verify_user  # noqa: E402
+from backend.routes import sso  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 from main import app  # noqa: E402
 
@@ -26,9 +26,59 @@ def _override_verify_user() -> dict[str, str]:
     return {"user_id": "test-user", "email": "test@example.com"}
 
 
-def _expected_cookie_domain() -> str:
-    domain = config.PLATFORM_DOMAIN.strip()
-    return domain if domain.startswith(".") else f".{domain}"
+def _expected_cookie_domain() -> str | None:
+    return sso._sso_cookie_domain()
+
+
+def _token_cookie(cookies: list[str]) -> str:
+    token_cookies = [cookie for cookie in cookies if cookie.startswith("mindroom_jwt=tok")]
+    assert len(token_cookies) == 1
+    return token_cookies[0]
+
+
+def _assert_host_only_expiry_cookie(cookies: list[str]) -> None:
+    assert any(
+        cookie.startswith("mindroom_jwt=") and "domain=" not in cookie.lower() and "max-age=0" in cookie.lower()
+        for cookie in cookies
+    )
+
+
+def _assert_cookie_domain(cookie: str, expected_domain: str | None) -> None:
+    cookie_lower = cookie.lower()
+    if expected_domain is None:
+        assert "domain=" not in cookie_lower
+        return
+    assert f"domain={expected_domain}".lower() in cookie_lower
+
+
+@pytest.mark.parametrize(
+    ("domain", "expected"),
+    [
+        ("mindroom.chat", ".mindroom.chat"),
+        (".mindroom.chat", ".mindroom.chat"),
+        ("api.mindroom.chat", ".api.mindroom.chat"),
+    ],
+)
+def test_sso_cookie_domain_uses_shared_domain_for_dns_hosts(
+    monkeypatch: pytest.MonkeyPatch,
+    domain: str,
+    expected: str,
+) -> None:
+    """Browser-valid DNS domains should produce shared-domain cookies."""
+    monkeypatch.setattr(sso, "PLATFORM_DOMAIN", domain)
+
+    assert sso._sso_cookie_domain() == expected
+
+
+@pytest.mark.parametrize(
+    "domain",
+    ["", " ", "localhost", ".localhost", "127.0.0.1", "192.168.1.10", "::1", "2001:db8::1", "internal"],
+)
+def test_sso_cookie_domain_omits_invalid_browser_domains(monkeypatch: pytest.MonkeyPatch, domain: str) -> None:
+    """Local, IP, and single-label hosts should fall back to host-only cookies."""
+    monkeypatch.setattr(sso, "PLATFORM_DOMAIN", domain)
+
+    assert sso._sso_cookie_domain() is None
 
 
 def test_sso_cookie_has_security_flags() -> None:
@@ -43,12 +93,25 @@ def test_sso_cookie_has_security_flags() -> None:
     # Use a unique client IP to avoid interference with rate-limit tests
     r = client.post("/my/sso-cookie", headers={"authorization": "Bearer tok", "X-Forwarded-For": "10.1.2.3"}, data="x")
     assert r.status_code == 200
-    set_cookie = r.headers.get("set-cookie") or ""
+    set_cookie = _token_cookie(r.headers.get_list("set-cookie")).lower()
     # Basic flags
-    assert "HttpOnly" in set_cookie
-    assert "Secure" in set_cookie
-    # Starlette normalizes to lowercase in some backends
-    assert "samesite=lax" in set_cookie.lower()
+    assert "httponly" in set_cookie
+    assert "secure" in set_cookie
+    assert "samesite=lax" in set_cookie
+
+
+def test_sso_cookie_returns_401_without_bearer_token() -> None:
+    """Missing bearer tokens should be reported by the SSO cookie route."""
+    app.dependency_overrides[verify_user] = _override_verify_user
+    app.state.limiter = Limiter(key_func=get_remote_address)
+    app.state.limiter.reset()
+    limiter.reset()
+    client = TestClient(app)
+
+    response = client.post("/my/sso-cookie", headers={"X-Forwarded-For": "10.1.2.6"}, data="x")
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Missing bearer token"}
 
 
 def test_sso_cookie_is_shared_with_tenant_subdomains() -> None:
@@ -65,12 +128,8 @@ def test_sso_cookie_is_shared_with_tenant_subdomains() -> None:
 
     assert response.status_code == 200
     cookies = response.headers.get_list("set-cookie")
-    token_cookies = [cookie for cookie in cookies if cookie.startswith("mindroom_jwt=tok")]
-    assert len(token_cookies) == 1
-    assert f"domain={_expected_cookie_domain()}".lower() in token_cookies[0].lower()
-    assert any(
-        cookie.startswith("mindroom_jwt=") and "Domain=" not in cookie and "Max-Age=0" in cookie for cookie in cookies
-    )
+    _assert_cookie_domain(_token_cookie(cookies), _expected_cookie_domain())
+    _assert_host_only_expiry_cookie(cookies)
 
 
 def test_clear_sso_cookie_clears_domain_and_legacy_host_only_cookie() -> None:
@@ -84,12 +143,28 @@ def test_clear_sso_cookie_clears_domain_and_legacy_host_only_cookie() -> None:
 
     assert response.status_code == 200
     cookies = response.headers.get_list("set-cookie")
-    assert any(
-        cookie.startswith("mindroom_jwt=") and "Domain=" not in cookie and "Max-Age=0" in cookie for cookie in cookies
-    )
+    _assert_host_only_expiry_cookie(cookies)
+    expected_domain = _expected_cookie_domain()
+    assert expected_domain is not None
     assert any(
         cookie.startswith("mindroom_jwt=")
-        and f"domain={_expected_cookie_domain()}".lower() in cookie.lower()
-        and "Max-Age=0" in cookie
+        and f"domain={expected_domain}".lower() in cookie.lower()
+        and "max-age=0" in cookie.lower()
         for cookie in cookies
     )
+
+
+def test_clear_sso_cookie_omits_domain_cookie_without_shared_domain(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Logout should not emit invalid domain cookies for local platform domains."""
+    monkeypatch.setattr(sso, "PLATFORM_DOMAIN", "localhost")
+    app.state.limiter = Limiter(key_func=get_remote_address)
+    app.state.limiter.reset()
+    limiter.reset()
+    client = TestClient(app)
+
+    response = client.delete("/my/sso-cookie", headers={"X-Forwarded-For": "10.1.2.7"})
+
+    assert response.status_code == 200
+    cookies = response.headers.get_list("set-cookie")
+    assert len(cookies) == 1
+    _assert_host_only_expiry_cookie(cookies)

--- a/saas-platform/platform-backend/tests/test_sso_cookie_attrs.py
+++ b/saas-platform/platform-backend/tests/test_sso_cookie_attrs.py
@@ -10,6 +10,7 @@ from tests.stripe_mock import create_stripe_mock
 sys.modules.setdefault("stripe", create_stripe_mock())
 
 import pytest  # noqa: E402
+from backend import config  # noqa: E402
 from backend.deps import Limiter, get_remote_address, limiter, verify_user  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 from main import app  # noqa: E402
@@ -23,6 +24,11 @@ def clear_dependency_overrides():
 
 def _override_verify_user() -> dict[str, str]:
     return {"user_id": "test-user", "email": "test@example.com"}
+
+
+def _expected_cookie_domain() -> str:
+    domain = config.PLATFORM_DOMAIN.strip()
+    return domain if domain.startswith(".") else f".{domain}"
 
 
 def test_sso_cookie_has_security_flags() -> None:
@@ -45,8 +51,8 @@ def test_sso_cookie_has_security_flags() -> None:
     assert "samesite=lax" in set_cookie.lower()
 
 
-def test_sso_cookie_is_host_only() -> None:
-    """SSO token cookie must stay on the API host, not every tenant subdomain."""
+def test_sso_cookie_is_shared_with_tenant_subdomains() -> None:
+    """SSO token cookie must be visible to hosted tenant subdomains."""
     app.dependency_overrides[verify_user] = _override_verify_user
     app.state.limiter = Limiter(key_func=get_remote_address)
     app.state.limiter.reset()
@@ -61,12 +67,14 @@ def test_sso_cookie_is_host_only() -> None:
     cookies = response.headers.get_list("set-cookie")
     token_cookies = [cookie for cookie in cookies if cookie.startswith("mindroom_jwt=tok")]
     assert len(token_cookies) == 1
-    assert "Domain=" not in token_cookies[0]
-    assert all("Domain=" not in cookie for cookie in cookies)
+    assert f"domain={_expected_cookie_domain()}".lower() in token_cookies[0].lower()
+    assert any(
+        cookie.startswith("mindroom_jwt=") and "Domain=" not in cookie and "Max-Age=0" in cookie for cookie in cookies
+    )
 
 
-def test_clear_sso_cookie_clears_host_only_cookie() -> None:
-    """Logout clears the current host-only cookie."""
+def test_clear_sso_cookie_clears_domain_and_legacy_host_only_cookie() -> None:
+    """Logout clears the shared-domain cookie and the legacy host-only cookie."""
     app.state.limiter = Limiter(key_func=get_remote_address)
     app.state.limiter.reset()
     limiter.reset()
@@ -79,4 +87,9 @@ def test_clear_sso_cookie_clears_host_only_cookie() -> None:
     assert any(
         cookie.startswith("mindroom_jwt=") and "Domain=" not in cookie and "Max-Age=0" in cookie for cookie in cookies
     )
-    assert all("Domain=" not in cookie for cookie in cookies)
+    assert any(
+        cookie.startswith("mindroom_jwt=")
+        and f"domain={_expected_cookie_domain()}".lower() in cookie.lower()
+        and "Max-Age=0" in cookie
+        for cookie in cookies
+    )

--- a/saas-platform/platform-frontend/src/lib/api.generated.ts
+++ b/saas-platform/platform-frontend/src/lib/api.generated.ts
@@ -690,9 +690,7 @@ export interface paths {
         put?: never;
         /**
          * Set Sso Cookie
-         * @description Set an API-host SSO cookie with the current Supabase access token.
-         *
-         *     Tenant subdomains must not receive raw platform JWTs.
+         * @description Set an SSO cookie with the current Supabase access token.
          */
         post: operations["set_sso_cookie_my_sso_cookie_post"];
         /**

--- a/saas-platform/platform-frontend/src/lib/api.generated.ts
+++ b/saas-platform/platform-frontend/src/lib/api.generated.ts
@@ -2965,6 +2965,13 @@ export interface operations {
                     "application/json": components["schemas"]["StatusResponse"];
                 };
             };
+            /** @description Missing bearer token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description Validation Error */
             422: {
                 headers: {


### PR DESCRIPTION
## Summary
- restore the SaaS SSO cookie to the shared `.mindroom.chat` domain so tenant subdomains receive it
- clear the legacy host-only cookie variant created by the bad release
- regenerate committed OpenAPI and frontend API artifacts

## Verification
- `uv run pytest -q` in `saas-platform/platform-backend`: 397 passed, 5 skipped
- `bun run check:api` in `saas-platform/platform-frontend`
- `bun run test -- --runInBand src/lib/__tests__/api.test.ts src/lib/__tests__/auth-redirect.test.ts src/components/auth/__tests__/auth-wrapper.test.tsx`: 72 passed
- deployed on `saas-hetzner` as `v2026.6.142-sso-cookie.2` and live endpoints/logs checked

## Production
Already deployed to `saas-hetzner` via Helm platform revision 61.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSO cookie handling with correct domain scoping for tenant subdomains, including safe behavior for local/IP/single-label domains.
  * Enhanced logout/clear-cookie to clear both current shared-domain cookies and the legacy host-only expiry cookie.
* **Documentation**
  * Updated the OpenAPI spec to clarify SSO cookie behavior and to document a `401` response when a bearer token is missing.
* **Tests**
  * Expanded coverage for SSO cookie domain behavior and logout/clear-cookie cleanup, plus added a test for `401` without a bearer token.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->