### PR TITLE
Clarify dynamic tool lazy-load timing

### DIFF
--- a/docs/tools/dynamic-tools.md
+++ b/docs/tools/dynamic-tools.md
@@ -35,7 +35,8 @@ No flags means the tool is eager and appears in every request.
 When an agent has at least one deferred tool and a stable session id, MindRoom injects the `dynamic_tools` manager.
 The manager exposes `list_tools()`, `tool_search(query)`, `load_tool(tool_name)`, and `unload_tool(tool_name)`.
 Search is plain keyword and exact-name lookup only.
-Loading or unloading takes effect on the next request in the same session.
+After `load_tool()` or `unload_tool()` succeeds, the agent should continue the same task in a later tool-call step in the same response.
+It should not wait for another user message, and it should not call a newly loaded tool in the same parallel tool-call batch as `load_tool()`.
 
 ## State Scope
 

--- a/docs/tools/dynamic-tools.md
+++ b/docs/tools/dynamic-tools.md
@@ -35,8 +35,9 @@ No flags means the tool is eager and appears in every request.
 When an agent has at least one deferred tool and a stable session id, MindRoom injects the `dynamic_tools` manager.
 The manager exposes `list_tools()`, `tool_search(query)`, `load_tool(tool_name)`, and `unload_tool(tool_name)`.
 Search is plain keyword and exact-name lookup only.
-After `load_tool()` or `unload_tool()` succeeds, the agent should continue the same task in a later tool-call step in the same response.
-It should not wait for another user message, and it should not call a newly loaded tool in the same parallel tool-call batch as `load_tool()`.
+A newly loaded tool becomes callable once it appears in the agent's available tools, never in the same parallel tool-call batch as `load_tool()`.
+A standalone agent continues the same task in a later tool-call step within the same response, because its run loop rebuilds the agent with the updated schema and resumes the turn without waiting for another user message.
+Team members and other embedded agents run without that continuation loop, so their loads and unloads take effect on the next request in the same session.
 
 ## State Scope
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -2890,8 +2890,9 @@ No flags means the tool is eager and appears in every request.
 When an agent has at least one deferred tool and a stable session id, MindRoom injects the `dynamic_tools` manager.
 The manager exposes `list_tools()`, `tool_search(query)`, `load_tool(tool_name)`, and `unload_tool(tool_name)`.
 Search is plain keyword and exact-name lookup only.
-After `load_tool()` or `unload_tool()` succeeds, the agent should continue the same task in a later tool-call step in the same response.
-It should not wait for another user message, and it should not call a newly loaded tool in the same parallel tool-call batch as `load_tool()`.
+A newly loaded tool becomes callable once it appears in the agent's available tools, never in the same parallel tool-call batch as `load_tool()`.
+A standalone agent continues the same task in a later tool-call step within the same response, because its run loop rebuilds the agent with the updated schema and resumes the turn without waiting for another user message.
+Team members and other embedded agents run without that continuation loop, so their loads and unloads take effect on the next request in the same session.
 
 ## State Scope
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -2890,7 +2890,8 @@ No flags means the tool is eager and appears in every request.
 When an agent has at least one deferred tool and a stable session id, MindRoom injects the `dynamic_tools` manager.
 The manager exposes `list_tools()`, `tool_search(query)`, `load_tool(tool_name)`, and `unload_tool(tool_name)`.
 Search is plain keyword and exact-name lookup only.
-Loading or unloading takes effect on the next request in the same session.
+After `load_tool()` or `unload_tool()` succeeds, the agent should continue the same task in a later tool-call step in the same response.
+It should not wait for another user message, and it should not call a newly loaded tool in the same parallel tool-call batch as `load_tool()`.
 
 ## State Scope
 

--- a/skills/mindroom-docs/references/page__tools__dynamic-tools__index.md
+++ b/skills/mindroom-docs/references/page__tools__dynamic-tools__index.md
@@ -35,7 +35,8 @@ No flags means the tool is eager and appears in every request.
 When an agent has at least one deferred tool and a stable session id, MindRoom injects the `dynamic_tools` manager.
 The manager exposes `list_tools()`, `tool_search(query)`, `load_tool(tool_name)`, and `unload_tool(tool_name)`.
 Search is plain keyword and exact-name lookup only.
-Loading or unloading takes effect on the next request in the same session.
+After `load_tool()` or `unload_tool()` succeeds, the agent should continue the same task in a later tool-call step in the same response.
+It should not wait for another user message, and it should not call a newly loaded tool in the same parallel tool-call batch as `load_tool()`.
 
 ## State Scope
 

--- a/skills/mindroom-docs/references/page__tools__dynamic-tools__index.md
+++ b/skills/mindroom-docs/references/page__tools__dynamic-tools__index.md
@@ -35,8 +35,9 @@ No flags means the tool is eager and appears in every request.
 When an agent has at least one deferred tool and a stable session id, MindRoom injects the `dynamic_tools` manager.
 The manager exposes `list_tools()`, `tool_search(query)`, `load_tool(tool_name)`, and `unload_tool(tool_name)`.
 Search is plain keyword and exact-name lookup only.
-After `load_tool()` or `unload_tool()` succeeds, the agent should continue the same task in a later tool-call step in the same response.
-It should not wait for another user message, and it should not call a newly loaded tool in the same parallel tool-call batch as `load_tool()`.
+A newly loaded tool becomes callable once it appears in the agent's available tools, never in the same parallel tool-call batch as `load_tool()`.
+A standalone agent continues the same task in a later tool-call step within the same response, because its run loop rebuilds the agent with the updated schema and resumes the turn without waiting for another user message.
+Team members and other embedded agents run without that continuation loop, so their loads and unloads take effect on the next request in the same session.
 
 ## State Scope
 

--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -557,12 +557,17 @@ def build_agent_toolkit(  # noqa: C901, PLR0911, PLR0912
     session_id: str | None = None,
     delegation_depth: int = 0,
     refresh_scheduler: KnowledgeRefreshScheduler | None = None,
+    dynamic_tool_continuation: bool = False,
 ) -> Toolkit | None:
     """Build one configured toolkit for an agent.
 
     Callers own runtime override resolution before invoking this builder.
     Returns ``None`` when the configured tool should be skipped, such as an
     explicit ``delegate`` entry without valid delegation targets.
+
+    ``dynamic_tool_continuation`` is only set by the standalone agent run loop
+    in ai.py, which resumes the turn after a load/unload. It stops the dynamic
+    tools manager's provider loop so the rebuilt agent sees the new schema.
     """
     agent_config = config.get_agent(agent_name)
     if agent_runtime is None:
@@ -696,6 +701,7 @@ def build_agent_toolkit(  # noqa: C901, PLR0911, PLR0912
                 agent_name=agent_name,
                 config=config,
                 session_id=session_id,
+                stop_after_tool_call=dynamic_tool_continuation,
             ),
             agent_runtime=agent_runtime,
             runtime_paths=runtime_paths,
@@ -1129,6 +1135,7 @@ def create_agent(  # noqa: PLR0915, C901, PLR0912
     delegation_depth: int = 0,
     refresh_scheduler: KnowledgeRefreshScheduler | None = None,
     timing_scope: str | None = None,
+    dynamic_tool_continuation: bool = False,
 ) -> Agent:
     """Create an agent instance from configuration.
 
@@ -1161,6 +1168,11 @@ def create_agent(  # noqa: PLR0915, C901, PLR0912
             passed through to delegated child agents.
         timing_scope: Optional correlated timing scope id for nested
             `system_prompt_assembly` sub-timers.
+        dynamic_tool_continuation: Whether this agent runs under the standalone
+            ai.py turn loop that resumes after a dynamic load/unload. Only that
+            loop stops the dynamic tools manager mid-turn; team members and other
+            embedded agents leave it False so a load/unload takes effect on the
+            next request instead of truncating the run.
 
     Returns:
         Configured Agent instance
@@ -1270,6 +1282,7 @@ def create_agent(  # noqa: PLR0915, C901, PLR0912
                     execution_identity=execution_identity,
                     delegation_depth=delegation_depth,
                     refresh_scheduler=refresh_scheduler,
+                    dynamic_tool_continuation=dynamic_tool_continuation,
                 )
             if toolkit:
                 toolkit = _prune_openai_approval_gated_tools(

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -1289,7 +1289,7 @@ async def _prepare_agent_run_context(
     )
 
 
-async def ai_response(  # noqa: C901, PLR0912, PLR0915
+async def ai_response(  # noqa: C901, PLR0915
     agent_name: str,
     prompt: str,
     session_id: str,
@@ -1403,6 +1403,169 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
             _assert_agent_target(agent_name, config)
         except ValueError as e:
             return get_user_friendly_error_message(e, agent_name)
+
+        async def _run_blocking_attempt(continuation_count: int) -> str | None:  # noqa: C901, PLR0912
+            """Run one agent attempt; return final text, or None to continue the turn."""
+            nonlocal agent, attempt, continuation_state, metadata, run_extra_content
+            nonlocal standalone_interrupted_replay_persisted, turn_state, unseen_event_ids
+            try:
+                run_context = await _prepare_agent_run_context(
+                    agent_name=agent_name,
+                    prompt=continuation_state.active_prompt,
+                    session_id=session_id,
+                    runtime_paths=runtime_paths,
+                    config=config,
+                    scope_context=scope_context,
+                    thread_history=thread_history,
+                    room_id=room_id,
+                    thread_id=thread_id,
+                    knowledge=knowledge,
+                    include_interactive_questions=include_interactive_questions,
+                    include_openai_compat_guidance=include_openai_compat_guidance,
+                    reply_to_event_id=reply_to_event_id,
+                    active_event_ids=active_event_ids,
+                    execution_identity=execution_identity,
+                    compaction_outcomes_collector=compaction_outcomes_collector,
+                    compaction_lifecycle=compaction_lifecycle,
+                    delegation_depth=delegation_depth,
+                    refresh_scheduler=refresh_scheduler,
+                    system_enrichment_items=system_enrichment_items,
+                    timing_scope=timing_scope,
+                    model_prompt=continuation_state.active_model_prompt,
+                    user_id=user_id,
+                    requester_id=resolved_requester_id,
+                    correlation_id=resolved_correlation_id,
+                    matrix_run_metadata=matrix_run_metadata,
+                    turn_recorder=turn_recorder,
+                    pipeline_timing=pipeline_timing,
+                )
+            except Exception as e:
+                logger.exception("Error preparing agent", agent=agent_name)
+                return get_user_friendly_error_message(e, agent_name)
+            prepared_run = run_context.prepared_run
+            agent = prepared_run.agent
+            run_input = run_context.run_input
+            unseen_event_ids = prepared_run.unseen_event_ids
+            metadata = run_context.metadata
+            run_extra_content = run_context.run_extra_content
+
+            attempt = _MediaAttempt.initial(
+                run_input,
+                media_inputs,
+                agent.model,
+                fallback_prompt=run_context.inline_media_fallback_prompt,
+                run_id=continuation_state.active_run_id,
+            )
+            attempt_result = await _run_non_streaming_agent_attempts(
+                run_context=run_context,
+                attempt=attempt,
+                user_id=user_id,
+                run_id=continuation_state.active_run_id,
+                run_id_callback=run_id_callback,
+                scope_context=scope_context,
+                pipeline_timing=pipeline_timing,
+            )
+            attempt = attempt_result.attempt
+            if attempt_result.user_error is not None:
+                return get_user_friendly_error_message(attempt_result.user_error, agent_name)
+            response = cast("RunOutput", attempt_result.response)
+
+            response_tool_trace = _extract_tool_trace(response)
+            if tool_trace_collector is not None:
+                tool_trace_collector.extend(response_tool_trace)
+            if run_metadata_collector is not None:
+                run_metadata = build_ai_run_metadata_content(
+                    config=config,
+                    model_name=prepared_run.runtime_model_name,
+                    run_id=response.run_id,
+                    session_id=response.session_id or session_id,
+                    status=response.status,
+                    model=response.model,
+                    model_provider=response.model_provider,
+                    metrics=response.metrics,
+                    context_input_tokens=prepared_run.prepared_history.estimated_context_tokens,
+                    tool_count=len(response.tools) if response.tools is not None else 0,
+                    prepared_history=prepared_run.prepared_history,
+                )
+                run_metadata_collector.update(run_metadata)
+
+            if response.status == RunStatus.cancelled:
+                partial_text = _extract_interrupted_partial_text(
+                    response.content,
+                    messages=response.messages,
+                )
+                completed_tools, interrupted_tools = _extract_cancelled_tool_trace(response)
+                if turn_recorder is not None:
+                    turn_state.record_interrupted(
+                        turn_recorder,
+                        run_metadata=metadata,
+                        assistant_text=partial_text,
+                        completed_tools=completed_tools,
+                        interrupted_tools=interrupted_tools,
+                    )
+                if turn_recorder is None:
+                    persist_interrupted_replay(
+                        scope_context=scope_context,
+                        session_id=response.session_id or session_id,
+                        run_id=response.run_id or attempt.attempt_run_id or str(uuid4()),
+                        user_message=prompt,
+                        partial_text=partial_text,
+                        completed_tools=turn_state.completed_tools_for(completed_tools),
+                        interrupted_tools=interrupted_tools,
+                        run_metadata=metadata,
+                        is_team=False,
+                    )
+                    standalone_interrupted_replay_persisted = True
+                _raise_agent_run_cancelled(response.content)
+            if response.status == RunStatus.error:
+                return get_user_friendly_error_message(
+                    Exception(str(response.content or "Unknown agent error")),
+                    agent_name,
+                )
+
+            continuation_decision = continuation_decision_from_tools(
+                response.tools,
+                original_prompt=continuation_state.original_prompt,
+                continuation_count=continuation_count,
+            )
+            completed_tools_for_turn = turn_state.completed_tools_for(response_tool_trace)
+            if continuation_decision.should_continue:
+                continuation_state, turn_state = _advance_dynamic_continuation(
+                    agent=agent,
+                    scope_context=scope_context,
+                    continuation_state=continuation_state,
+                    next_prompt=continuation_decision.next_prompt,
+                    previous_run_id=attempt.attempt_run_id,
+                    turn_recorder=turn_recorder,
+                    run_metadata=metadata,
+                    completed_tools_for_turn=completed_tools_for_turn,
+                )
+                agent = None
+                return None
+            if continuation_decision.limit_message is not None and continuation_decision.continuation is not None:
+                logger.warning(
+                    "Dynamic tool continuation limit reached",
+                    agent=agent_name,
+                    function_name=continuation_decision.continuation.function_name,
+                    tool_name=continuation_decision.continuation.tool_name,
+                    status=continuation_decision.continuation.status,
+                )
+
+            response_text = _extract_response_content(response, show_tool_calls=show_tool_calls)
+            if continuation_decision.limit_message is not None and not response.content:
+                response_text = continuation_decision.limit_message
+            if turn_recorder is not None:
+                replayable_response_text = _extract_replayable_response_text(response)
+                if continuation_decision.limit_message is not None and not response.content:
+                    replayable_response_text = continuation_decision.limit_message
+                turn_state.record_completed(
+                    turn_recorder,
+                    run_metadata=metadata,
+                    assistant_text=replayable_response_text,
+                    completed_tools=response_tool_trace,
+                )
+            return response_text
+
         with open_resolved_scope_session_context(
             agent_name=agent_name,
             scope=HistoryScope(kind="agent", scope_id=agent_name),
@@ -1422,163 +1585,9 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                 run_id=run_id,
             )
             for continuation_count in range(DYNAMIC_TOOL_CONTINUATION_LIMIT + 1):
-                try:
-                    run_context = await _prepare_agent_run_context(
-                        agent_name=agent_name,
-                        prompt=continuation_state.active_prompt,
-                        session_id=session_id,
-                        runtime_paths=runtime_paths,
-                        config=config,
-                        scope_context=scope_context,
-                        thread_history=thread_history,
-                        room_id=room_id,
-                        thread_id=thread_id,
-                        knowledge=knowledge,
-                        include_interactive_questions=include_interactive_questions,
-                        include_openai_compat_guidance=include_openai_compat_guidance,
-                        reply_to_event_id=reply_to_event_id,
-                        active_event_ids=active_event_ids,
-                        execution_identity=execution_identity,
-                        compaction_outcomes_collector=compaction_outcomes_collector,
-                        compaction_lifecycle=compaction_lifecycle,
-                        delegation_depth=delegation_depth,
-                        refresh_scheduler=refresh_scheduler,
-                        system_enrichment_items=system_enrichment_items,
-                        timing_scope=timing_scope,
-                        model_prompt=continuation_state.active_model_prompt,
-                        user_id=user_id,
-                        requester_id=resolved_requester_id,
-                        correlation_id=resolved_correlation_id,
-                        matrix_run_metadata=matrix_run_metadata,
-                        turn_recorder=turn_recorder,
-                        pipeline_timing=pipeline_timing,
-                    )
-                except Exception as e:
-                    logger.exception("Error preparing agent", agent=agent_name)
-                    return get_user_friendly_error_message(e, agent_name)
-                prepared_run = run_context.prepared_run
-                agent = prepared_run.agent
-                run_input = run_context.run_input
-                unseen_event_ids = prepared_run.unseen_event_ids
-                metadata = run_context.metadata
-                run_extra_content = run_context.run_extra_content
-
-                attempt = _MediaAttempt.initial(
-                    run_input,
-                    media_inputs,
-                    agent.model,
-                    fallback_prompt=run_context.inline_media_fallback_prompt,
-                    run_id=continuation_state.active_run_id,
-                )
-                attempt_result = await _run_non_streaming_agent_attempts(
-                    run_context=run_context,
-                    attempt=attempt,
-                    user_id=user_id,
-                    run_id=continuation_state.active_run_id,
-                    run_id_callback=run_id_callback,
-                    scope_context=scope_context,
-                    pipeline_timing=pipeline_timing,
-                )
-                attempt = attempt_result.attempt
-                if attempt_result.user_error is not None:
-                    return get_user_friendly_error_message(attempt_result.user_error, agent_name)
-                response = cast("RunOutput", attempt_result.response)
-
-                response_tool_trace = _extract_tool_trace(response)
-                if tool_trace_collector is not None:
-                    tool_trace_collector.extend(response_tool_trace)
-                if run_metadata_collector is not None:
-                    run_metadata = build_ai_run_metadata_content(
-                        config=config,
-                        model_name=prepared_run.runtime_model_name,
-                        run_id=response.run_id,
-                        session_id=response.session_id or session_id,
-                        status=response.status,
-                        model=response.model,
-                        model_provider=response.model_provider,
-                        metrics=response.metrics,
-                        context_input_tokens=prepared_run.prepared_history.estimated_context_tokens,
-                        tool_count=len(response.tools) if response.tools is not None else 0,
-                        prepared_history=prepared_run.prepared_history,
-                    )
-                    run_metadata_collector.update(run_metadata)
-
-                if response.status == RunStatus.cancelled:
-                    partial_text = _extract_interrupted_partial_text(
-                        response.content,
-                        messages=response.messages,
-                    )
-                    completed_tools, interrupted_tools = _extract_cancelled_tool_trace(response)
-                    if turn_recorder is not None:
-                        turn_state.record_interrupted(
-                            turn_recorder,
-                            run_metadata=metadata,
-                            assistant_text=partial_text,
-                            completed_tools=completed_tools,
-                            interrupted_tools=interrupted_tools,
-                        )
-                    if turn_recorder is None:
-                        persist_interrupted_replay(
-                            scope_context=scope_context,
-                            session_id=response.session_id or session_id,
-                            run_id=response.run_id or attempt.attempt_run_id or str(uuid4()),
-                            user_message=prompt,
-                            partial_text=partial_text,
-                            completed_tools=turn_state.completed_tools_for(completed_tools),
-                            interrupted_tools=interrupted_tools,
-                            run_metadata=metadata,
-                            is_team=False,
-                        )
-                        standalone_interrupted_replay_persisted = True
-                    _raise_agent_run_cancelled(response.content)
-                if response.status == RunStatus.error:
-                    return get_user_friendly_error_message(
-                        Exception(str(response.content or "Unknown agent error")),
-                        agent_name,
-                    )
-
-                continuation_decision = continuation_decision_from_tools(
-                    response.tools,
-                    original_prompt=continuation_state.original_prompt,
-                    continuation_count=continuation_count,
-                )
-                completed_tools_for_turn = turn_state.completed_tools_for(response_tool_trace)
-                if continuation_decision.should_continue:
-                    continuation_state, turn_state = _advance_dynamic_continuation(
-                        agent=agent,
-                        scope_context=scope_context,
-                        continuation_state=continuation_state,
-                        next_prompt=continuation_decision.next_prompt,
-                        previous_run_id=attempt.attempt_run_id,
-                        turn_recorder=turn_recorder,
-                        run_metadata=metadata,
-                        completed_tools_for_turn=completed_tools_for_turn,
-                    )
-                    agent = None
-                    continue
-                if continuation_decision.limit_message is not None and continuation_decision.continuation is not None:
-                    logger.warning(
-                        "Dynamic tool continuation limit reached",
-                        agent=agent_name,
-                        function_name=continuation_decision.continuation.function_name,
-                        tool_name=continuation_decision.continuation.tool_name,
-                        status=continuation_decision.continuation.status,
-                    )
-
-                response_text = _extract_response_content(response, show_tool_calls=show_tool_calls)
-                if continuation_decision.limit_message is not None and not response.content:
-                    response_text = continuation_decision.limit_message
-                if turn_recorder is not None:
-                    replayable_response_text = _extract_replayable_response_text(response)
-                    if continuation_decision.limit_message is not None and not response.content:
-                        replayable_response_text = continuation_decision.limit_message
-                    turn_state.record_completed(
-                        turn_recorder,
-                        run_metadata=metadata,
-                        assistant_text=replayable_response_text,
-                        completed_tools=response_tool_trace,
-                    )
-                return response_text
+                attempt_text = await _run_blocking_attempt(continuation_count)
+                if attempt_text is not None:
+                    return attempt_text
             # The continuation loop always returns on its final iteration: at
             # continuation_count == DYNAMIC_TOOL_CONTINUATION_LIMIT the decision
             # carries a limit_message and never asks to continue.
@@ -1830,7 +1839,7 @@ async def _stream_agent_attempt_chunks(
         state.user_error = e
 
 
-async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
+async def stream_agent_response(  # noqa: C901, PLR0915
     agent_name: str,
     prompt: str,
     session_id: str,
@@ -1936,7 +1945,6 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
     metadata: dict[str, Any] | None = None
     run_extra_content: dict[str, Any] | None = None
     attempt: _MediaAttempt | None = None
-    prepared_context_input_tokens: int | None = None
     state = _StreamingAttemptState()
 
     try:
@@ -1945,6 +1953,274 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
         except ValueError as e:
             yield get_user_friendly_error_message(e, agent_name)
             return
+
+        async def _run_streaming_attempt(  # noqa: C901, PLR0912, PLR0915
+            continuation_count: int,
+        ) -> AsyncGenerator[AIStreamChunk, None]:
+            """Stream one agent attempt; set keep_going when the turn should continue."""
+            nonlocal agent, attempt, continuation_state, keep_going, metadata, run_extra_content
+            nonlocal standalone_interrupted_replay_persisted, state, turn_state, unseen_event_ids
+            try:
+                run_context = await _prepare_agent_run_context(
+                    agent_name=agent_name,
+                    prompt=continuation_state.active_prompt,
+                    session_id=session_id,
+                    runtime_paths=runtime_paths,
+                    config=config,
+                    scope_context=scope_context,
+                    thread_history=thread_history,
+                    room_id=room_id,
+                    thread_id=thread_id,
+                    knowledge=knowledge,
+                    include_interactive_questions=include_interactive_questions,
+                    include_openai_compat_guidance=include_openai_compat_guidance,
+                    reply_to_event_id=reply_to_event_id,
+                    active_event_ids=active_event_ids,
+                    execution_identity=execution_identity,
+                    compaction_outcomes_collector=compaction_outcomes_collector,
+                    compaction_lifecycle=compaction_lifecycle,
+                    delegation_depth=delegation_depth,
+                    refresh_scheduler=refresh_scheduler,
+                    system_enrichment_items=system_enrichment_items,
+                    timing_scope=timing_scope,
+                    model_prompt=continuation_state.active_model_prompt,
+                    user_id=user_id,
+                    requester_id=resolved_requester_id,
+                    correlation_id=resolved_correlation_id,
+                    matrix_run_metadata=matrix_run_metadata,
+                    turn_recorder=turn_recorder,
+                    pipeline_timing=pipeline_timing,
+                )
+            except Exception as e:
+                logger.exception("Error preparing agent for streaming", agent=agent_name)
+                yield get_user_friendly_error_message(e, agent_name)
+                return
+            prepared_run = run_context.prepared_run
+            agent = prepared_run.agent
+            run_input = run_context.run_input
+            unseen_event_ids = prepared_run.unseen_event_ids
+            prepared_context_input_tokens = prepared_run.prepared_history.estimated_context_tokens
+            metadata = run_context.metadata
+            run_extra_content = run_context.run_extra_content
+
+            attempt = _MediaAttempt.initial(
+                run_input,
+                media_inputs,
+                agent.model,
+                fallback_prompt=run_context.inline_media_fallback_prompt,
+                run_id=continuation_state.active_run_id,
+            )
+            state = _StreamingAttemptState()
+
+            try:
+                for retried_after_media_fallback in (False, True):
+                    state = _StreamingAttemptState()
+
+                    def _sync_live_turn_recorder(
+                        *,
+                        state_ref: _StreamingAttemptState = state,
+                        turn_state_ref: AITurnState = turn_state,
+                        metadata_ref: dict[str, Any] | None = metadata,
+                    ) -> None:
+                        turn_state_ref.sync_partial(
+                            turn_recorder,
+                            run_metadata=metadata_ref,
+                            assistant_text=state_ref.assistant_text,
+                            completed_tools=state_ref.completed_tools,
+                            interrupted_tools=[pending.trace_entry for pending in state_ref.pending_tools],
+                        )
+
+                    async for stream_chunk in _stream_agent_attempt_chunks(
+                        run_context=run_context,
+                        attempt=attempt,
+                        state=state,
+                        show_tool_calls=show_tool_calls,
+                        user_id=user_id,
+                        run_id_callback=run_id_callback,
+                        retried_after_media_fallback=retried_after_media_fallback,
+                        state_updated=_sync_live_turn_recorder,
+                        pipeline_timing=pipeline_timing,
+                    ):
+                        yield stream_chunk
+
+                    if state.media_fallback_retry_requested:
+                        attempt.retry(
+                            run_input,
+                            fallback_prompt=run_context.inline_media_fallback_prompt,
+                            extra_removed_kinds=state.media_fallback_removed_kinds,
+                            retry_media_inputs=state.media_fallback_retry_inputs or MediaInputs(),
+                            run_id=continuation_state.active_run_id,
+                        )
+                        continue
+
+                    run_error = state.user_error or state.stream_exception
+                    if run_error is not None:
+                        if state.assistant_text or state.completed_tools or state.pending_tools:
+                            interrupted_tools = [pending.trace_entry for pending in state.pending_tools]
+                            if turn_recorder is not None:
+                                turn_state.record_interrupted(
+                                    turn_recorder,
+                                    run_metadata=metadata,
+                                    assistant_text=state.assistant_text,
+                                    completed_tools=state.completed_tools,
+                                    interrupted_tools=interrupted_tools,
+                                )
+                            elif not standalone_interrupted_replay_persisted:
+                                persist_interrupted_replay(
+                                    scope_context=scope_context,
+                                    session_id=session_id,
+                                    run_id=attempt.attempt_run_id or str(uuid4()),
+                                    user_message=prompt,
+                                    partial_text=state.assistant_text,
+                                    completed_tools=turn_state.completed_tools_for(state.completed_tools),
+                                    interrupted_tools=interrupted_tools,
+                                    run_metadata=metadata,
+                                    is_team=False,
+                                )
+                                standalone_interrupted_replay_persisted = True
+                        yield get_user_friendly_error_message(run_error, agent_name)
+                        return
+
+                    if state.cancelled_run_event is not None:
+                        interrupted_tools = [pending.trace_entry for pending in state.pending_tools]
+                        if turn_recorder is not None:
+                            turn_state.record_interrupted(
+                                turn_recorder,
+                                run_metadata=metadata,
+                                assistant_text=state.assistant_text,
+                                completed_tools=state.completed_tools,
+                                interrupted_tools=interrupted_tools,
+                            )
+                        if run_metadata_collector is not None:
+                            fallback_metrics = build_model_request_metrics_fallback(
+                                state.request_metric_totals,
+                                state.first_token_latency,
+                                state.observed_request_metric_fields,
+                            )
+                            cancelled_metadata = build_ai_run_metadata_content(
+                                config=config,
+                                model_name=prepared_run.runtime_model_name,
+                                run_id=state.cancelled_run_event.run_id,
+                                session_id=state.cancelled_run_event.session_id or session_id,
+                                status=RunStatus.cancelled,
+                                model=state.latest_model_id,
+                                model_provider=state.latest_model_provider,
+                                metrics=fallback_metrics,
+                                context_input_tokens=prepared_context_input_tokens,
+                                context_raw_input_tokens=state.latest_request_input_tokens,
+                                context_cache_read_tokens=state.latest_request_cache_read_tokens,
+                                context_cache_write_tokens=state.latest_request_cache_write_tokens,
+                                tool_count=state.observed_tool_calls,
+                                prepared_history=prepared_run.prepared_history,
+                            )
+                            run_metadata_collector.update(cancelled_metadata)
+                        if turn_recorder is None:
+                            persist_interrupted_replay(
+                                scope_context=scope_context,
+                                session_id=state.cancelled_run_event.session_id or session_id,
+                                run_id=state.cancelled_run_event.run_id or attempt.attempt_run_id or str(uuid4()),
+                                user_message=prompt,
+                                partial_text=state.assistant_text,
+                                completed_tools=turn_state.completed_tools_for(state.completed_tools),
+                                interrupted_tools=interrupted_tools,
+                                run_metadata=metadata,
+                                is_team=False,
+                            )
+                            standalone_interrupted_replay_persisted = True
+                        _raise_agent_run_cancelled(state.cancelled_run_event.reason)
+
+                    break
+
+                continuation_decision = continuation_decision_from_tools(
+                    state.completed_tool_executions,
+                    original_prompt=continuation_state.original_prompt,
+                    continuation_count=continuation_count,
+                )
+                completed_tools_for_turn = turn_state.completed_tools_for(state.completed_tools)
+                if continuation_decision.should_continue:
+                    continuation_state, turn_state = _advance_dynamic_continuation(
+                        agent=agent,
+                        scope_context=scope_context,
+                        continuation_state=continuation_state,
+                        next_prompt=continuation_decision.next_prompt,
+                        previous_run_id=attempt.attempt_run_id,
+                        turn_recorder=turn_recorder,
+                        run_metadata=metadata,
+                        completed_tools_for_turn=completed_tools_for_turn,
+                    )
+                    agent = None
+                    keep_going = True
+                    return
+                if continuation_decision.limit_message is not None and continuation_decision.continuation is not None:
+                    logger.warning(
+                        "Dynamic tool continuation limit reached during streaming",
+                        agent=agent_name,
+                        function_name=continuation_decision.continuation.function_name,
+                        tool_name=continuation_decision.continuation.tool_name,
+                        status=continuation_decision.continuation.status,
+                    )
+                    if not state.assistant_text and not state.canonical_final_body_candidate:
+                        state.assistant_text = continuation_decision.limit_message
+                        yield RunContentEvent(content=continuation_decision.limit_message)
+
+                if run_metadata_collector is not None:
+                    fallback_metrics = build_model_request_metrics_fallback(
+                        state.request_metric_totals,
+                        state.first_token_latency,
+                        state.observed_request_metric_fields,
+                    )
+                    final_status = (
+                        RunStatus.error if _stream_completed_without_visible_output(state) else RunStatus.completed
+                    )
+                    usage_metrics, usage_metrics_fallback = _select_streaming_usage_metrics(
+                        state.completed_run_event.metrics if state.completed_run_event is not None else None,
+                        fallback_metrics,
+                    )
+                    run_metadata = build_ai_run_metadata_content(
+                        config=config,
+                        model_name=prepared_run.runtime_model_name,
+                        run_id=state.completed_run_event.run_id if state.completed_run_event is not None else None,
+                        session_id=(
+                            state.completed_run_event.session_id
+                            if state.completed_run_event is not None
+                            and state.completed_run_event.session_id is not None
+                            else session_id
+                        ),
+                        status=final_status,
+                        model=state.latest_model_id,
+                        model_provider=state.latest_model_provider,
+                        metrics=usage_metrics,
+                        metrics_fallback=usage_metrics_fallback,
+                        context_input_tokens=prepared_context_input_tokens,
+                        context_raw_input_tokens=state.latest_request_input_tokens,
+                        context_cache_read_tokens=state.latest_request_cache_read_tokens,
+                        context_cache_write_tokens=state.latest_request_cache_write_tokens,
+                        tool_count=(
+                            len(state.completed_run_event.tools)
+                            if state.completed_run_event is not None and state.completed_run_event.tools is not None
+                            else state.observed_tool_calls
+                        ),
+                        prepared_history=prepared_run.prepared_history,
+                    )
+                    run_metadata_collector.update(run_metadata)
+                if turn_recorder is not None:
+                    final_visible_body = state.assistant_text or state.canonical_final_body_candidate or ""
+                    turn_state.record_completed(
+                        turn_recorder,
+                        run_metadata=metadata,
+                        assistant_text=final_visible_body,
+                        completed_tools=state.completed_tools,
+                    )
+                return
+            finally:
+                ai_runtime.cleanup_queued_notice_state(
+                    run_output=None,
+                    storage=scope_context.storage if scope_context is not None else None,
+                    session_id=session_id,
+                    session_type=SessionType.AGENT,
+                    entity_name=agent_name,
+                )
+
         with open_resolved_scope_session_context(
             agent_name=agent_name,
             scope=HistoryScope(kind="agent", scope_id=agent_name),
@@ -1964,268 +2240,16 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                 run_id=run_id,
             )
             for continuation_count in range(DYNAMIC_TOOL_CONTINUATION_LIMIT + 1):
-                try:
-                    run_context = await _prepare_agent_run_context(
-                        agent_name=agent_name,
-                        prompt=continuation_state.active_prompt,
-                        session_id=session_id,
-                        runtime_paths=runtime_paths,
-                        config=config,
-                        scope_context=scope_context,
-                        thread_history=thread_history,
-                        room_id=room_id,
-                        thread_id=thread_id,
-                        knowledge=knowledge,
-                        include_interactive_questions=include_interactive_questions,
-                        include_openai_compat_guidance=include_openai_compat_guidance,
-                        reply_to_event_id=reply_to_event_id,
-                        active_event_ids=active_event_ids,
-                        execution_identity=execution_identity,
-                        compaction_outcomes_collector=compaction_outcomes_collector,
-                        compaction_lifecycle=compaction_lifecycle,
-                        delegation_depth=delegation_depth,
-                        refresh_scheduler=refresh_scheduler,
-                        system_enrichment_items=system_enrichment_items,
-                        timing_scope=timing_scope,
-                        model_prompt=continuation_state.active_model_prompt,
-                        user_id=user_id,
-                        requester_id=resolved_requester_id,
-                        correlation_id=resolved_correlation_id,
-                        matrix_run_metadata=matrix_run_metadata,
-                        turn_recorder=turn_recorder,
-                        pipeline_timing=pipeline_timing,
-                    )
-                except Exception as e:
-                    logger.exception("Error preparing agent for streaming", agent=agent_name)
-                    yield get_user_friendly_error_message(e, agent_name)
+                keep_going = False
+                async for stream_chunk in _run_streaming_attempt(continuation_count):
+                    yield stream_chunk
+                if not keep_going:
                     return
-                prepared_run = run_context.prepared_run
-                agent = prepared_run.agent
-                run_input = run_context.run_input
-                unseen_event_ids = prepared_run.unseen_event_ids
-                prepared_context_input_tokens = prepared_run.prepared_history.estimated_context_tokens
-                metadata = run_context.metadata
-                run_extra_content = run_context.run_extra_content
-
-                attempt = _MediaAttempt.initial(
-                    run_input,
-                    media_inputs,
-                    agent.model,
-                    fallback_prompt=run_context.inline_media_fallback_prompt,
-                    run_id=continuation_state.active_run_id,
-                )
-                state = _StreamingAttemptState()
-
-                try:
-                    for retried_after_media_fallback in (False, True):
-                        state = _StreamingAttemptState()
-
-                        def _sync_live_turn_recorder(
-                            *,
-                            state_ref: _StreamingAttemptState = state,
-                            turn_state_ref: AITurnState = turn_state,
-                            metadata_ref: dict[str, Any] | None = metadata,
-                        ) -> None:
-                            turn_state_ref.sync_partial(
-                                turn_recorder,
-                                run_metadata=metadata_ref,
-                                assistant_text=state_ref.assistant_text,
-                                completed_tools=state_ref.completed_tools,
-                                interrupted_tools=[pending.trace_entry for pending in state_ref.pending_tools],
-                            )
-
-                        async for stream_chunk in _stream_agent_attempt_chunks(
-                            run_context=run_context,
-                            attempt=attempt,
-                            state=state,
-                            show_tool_calls=show_tool_calls,
-                            user_id=user_id,
-                            run_id_callback=run_id_callback,
-                            retried_after_media_fallback=retried_after_media_fallback,
-                            state_updated=_sync_live_turn_recorder,
-                            pipeline_timing=pipeline_timing,
-                        ):
-                            yield stream_chunk
-
-                        if state.media_fallback_retry_requested:
-                            attempt.retry(
-                                run_input,
-                                fallback_prompt=run_context.inline_media_fallback_prompt,
-                                extra_removed_kinds=state.media_fallback_removed_kinds,
-                                retry_media_inputs=state.media_fallback_retry_inputs or MediaInputs(),
-                                run_id=continuation_state.active_run_id,
-                            )
-                            continue
-
-                        run_error = state.user_error or state.stream_exception
-                        if run_error is not None:
-                            if state.assistant_text or state.completed_tools or state.pending_tools:
-                                interrupted_tools = [pending.trace_entry for pending in state.pending_tools]
-                                if turn_recorder is not None:
-                                    turn_state.record_interrupted(
-                                        turn_recorder,
-                                        run_metadata=metadata,
-                                        assistant_text=state.assistant_text,
-                                        completed_tools=state.completed_tools,
-                                        interrupted_tools=interrupted_tools,
-                                    )
-                                elif not standalone_interrupted_replay_persisted:
-                                    persist_interrupted_replay(
-                                        scope_context=scope_context,
-                                        session_id=session_id,
-                                        run_id=attempt.attempt_run_id or str(uuid4()),
-                                        user_message=prompt,
-                                        partial_text=state.assistant_text,
-                                        completed_tools=turn_state.completed_tools_for(state.completed_tools),
-                                        interrupted_tools=interrupted_tools,
-                                        run_metadata=metadata,
-                                        is_team=False,
-                                    )
-                                    standalone_interrupted_replay_persisted = True
-                            yield get_user_friendly_error_message(run_error, agent_name)
-                            return
-
-                        if state.cancelled_run_event is not None:
-                            interrupted_tools = [pending.trace_entry for pending in state.pending_tools]
-                            if turn_recorder is not None:
-                                turn_state.record_interrupted(
-                                    turn_recorder,
-                                    run_metadata=metadata,
-                                    assistant_text=state.assistant_text,
-                                    completed_tools=state.completed_tools,
-                                    interrupted_tools=interrupted_tools,
-                                )
-                            if run_metadata_collector is not None:
-                                fallback_metrics = build_model_request_metrics_fallback(
-                                    state.request_metric_totals,
-                                    state.first_token_latency,
-                                    state.observed_request_metric_fields,
-                                )
-                                cancelled_metadata = build_ai_run_metadata_content(
-                                    config=config,
-                                    model_name=prepared_run.runtime_model_name,
-                                    run_id=state.cancelled_run_event.run_id,
-                                    session_id=state.cancelled_run_event.session_id or session_id,
-                                    status=RunStatus.cancelled,
-                                    model=state.latest_model_id,
-                                    model_provider=state.latest_model_provider,
-                                    metrics=fallback_metrics,
-                                    context_input_tokens=prepared_context_input_tokens,
-                                    context_raw_input_tokens=state.latest_request_input_tokens,
-                                    context_cache_read_tokens=state.latest_request_cache_read_tokens,
-                                    context_cache_write_tokens=state.latest_request_cache_write_tokens,
-                                    tool_count=state.observed_tool_calls,
-                                    prepared_history=prepared_run.prepared_history,
-                                )
-                                run_metadata_collector.update(cancelled_metadata)
-                            if turn_recorder is None:
-                                persist_interrupted_replay(
-                                    scope_context=scope_context,
-                                    session_id=state.cancelled_run_event.session_id or session_id,
-                                    run_id=state.cancelled_run_event.run_id or attempt.attempt_run_id or str(uuid4()),
-                                    user_message=prompt,
-                                    partial_text=state.assistant_text,
-                                    completed_tools=turn_state.completed_tools_for(state.completed_tools),
-                                    interrupted_tools=interrupted_tools,
-                                    run_metadata=metadata,
-                                    is_team=False,
-                                )
-                                standalone_interrupted_replay_persisted = True
-                            _raise_agent_run_cancelled(state.cancelled_run_event.reason)
-
-                        break
-
-                    continuation_decision = continuation_decision_from_tools(
-                        state.completed_tool_executions,
-                        original_prompt=continuation_state.original_prompt,
-                        continuation_count=continuation_count,
-                    )
-                    completed_tools_for_turn = turn_state.completed_tools_for(state.completed_tools)
-                    if continuation_decision.should_continue:
-                        continuation_state, turn_state = _advance_dynamic_continuation(
-                            agent=agent,
-                            scope_context=scope_context,
-                            continuation_state=continuation_state,
-                            next_prompt=continuation_decision.next_prompt,
-                            previous_run_id=attempt.attempt_run_id,
-                            turn_recorder=turn_recorder,
-                            run_metadata=metadata,
-                            completed_tools_for_turn=completed_tools_for_turn,
-                        )
-                        agent = None
-                        continue
-                    if (
-                        continuation_decision.limit_message is not None
-                        and continuation_decision.continuation is not None
-                    ):
-                        logger.warning(
-                            "Dynamic tool continuation limit reached during streaming",
-                            agent=agent_name,
-                            function_name=continuation_decision.continuation.function_name,
-                            tool_name=continuation_decision.continuation.tool_name,
-                            status=continuation_decision.continuation.status,
-                        )
-                        if not state.assistant_text and not state.canonical_final_body_candidate:
-                            state.assistant_text = continuation_decision.limit_message
-                            yield RunContentEvent(content=continuation_decision.limit_message)
-
-                    if run_metadata_collector is not None:
-                        fallback_metrics = build_model_request_metrics_fallback(
-                            state.request_metric_totals,
-                            state.first_token_latency,
-                            state.observed_request_metric_fields,
-                        )
-                        final_status = (
-                            RunStatus.error if _stream_completed_without_visible_output(state) else RunStatus.completed
-                        )
-                        usage_metrics, usage_metrics_fallback = _select_streaming_usage_metrics(
-                            state.completed_run_event.metrics if state.completed_run_event is not None else None,
-                            fallback_metrics,
-                        )
-                        run_metadata = build_ai_run_metadata_content(
-                            config=config,
-                            model_name=prepared_run.runtime_model_name,
-                            run_id=state.completed_run_event.run_id if state.completed_run_event is not None else None,
-                            session_id=(
-                                state.completed_run_event.session_id
-                                if state.completed_run_event is not None
-                                and state.completed_run_event.session_id is not None
-                                else session_id
-                            ),
-                            status=final_status,
-                            model=state.latest_model_id,
-                            model_provider=state.latest_model_provider,
-                            metrics=usage_metrics,
-                            metrics_fallback=usage_metrics_fallback,
-                            context_input_tokens=prepared_context_input_tokens,
-                            context_raw_input_tokens=state.latest_request_input_tokens,
-                            context_cache_read_tokens=state.latest_request_cache_read_tokens,
-                            context_cache_write_tokens=state.latest_request_cache_write_tokens,
-                            tool_count=(
-                                len(state.completed_run_event.tools)
-                                if state.completed_run_event is not None and state.completed_run_event.tools is not None
-                                else state.observed_tool_calls
-                            ),
-                            prepared_history=prepared_run.prepared_history,
-                        )
-                        run_metadata_collector.update(run_metadata)
-                    if turn_recorder is not None:
-                        final_visible_body = state.assistant_text or state.canonical_final_body_candidate or ""
-                        turn_state.record_completed(
-                            turn_recorder,
-                            run_metadata=metadata,
-                            assistant_text=final_visible_body,
-                            completed_tools=state.completed_tools,
-                        )
-                    return
-                finally:
-                    ai_runtime.cleanup_queued_notice_state(
-                        run_output=None,
-                        storage=scope_context.storage if scope_context is not None else None,
-                        session_id=session_id,
-                        session_type=SessionType.AGENT,
-                        entity_name=agent_name,
-                    )
+            # The continuation loop always returns on its final iteration: at
+            # continuation_count == DYNAMIC_TOOL_CONTINUATION_LIMIT the decision
+            # carries a limit_message and never asks to continue.
+            msg = "dynamic tool continuation loop must return within its iteration budget"
+            raise AssertionError(msg)
     except asyncio.CancelledError:
         interrupted_tools = [pending.trace_entry for pending in state.pending_tools]
         if turn_recorder is not None:

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -40,6 +40,7 @@ from mindroom.constants import (
     MATRIX_SOURCE_EVENT_PROMPTS_METADATA_KEY,
     RuntimePaths,
 )
+from mindroom.dynamic_tool_continuation import DYNAMIC_TOOL_CONTINUATION_LIMIT, continuation_decision_from_tools
 from mindroom.error_handling import get_user_friendly_error_message
 from mindroom.execution_preparation import prepare_agent_execution_context, render_prepared_messages_text
 from mindroom.history import (
@@ -86,6 +87,7 @@ if TYPE_CHECKING:
     from agno.agent import Agent
     from agno.knowledge.knowledge import Knowledge
     from agno.models.base import Model
+    from agno.models.response import ToolExecution
 
     from mindroom.config.main import Config, ResolvedRuntimeModel
     from mindroom.history import CompactionLifecycle
@@ -127,17 +129,25 @@ def _compose_current_turn_prompt(
         prompt_chunks.append(raw_prompt)
     if prompt_parts.turn_context:
         prompt_chunks.append(prompt_parts.turn_context)
-    model_tail = raw_prompt if not model_prompt else strip_user_turn_time_prefix(model_prompt)
-    normalized_raw_prompt = raw_prompt.strip()
-    normalized_model_tail = model_tail.strip()
-    if raw_prompt and normalized_model_tail == normalized_raw_prompt:
-        model_tail = ""
-    elif raw_prompt and normalized_model_tail.startswith(f"{normalized_raw_prompt}\n\n"):
-        model_tail = normalized_model_tail[len(normalized_raw_prompt) + 2 :].lstrip()
-    if model_tail:
-        prompt_chunks.append(model_tail)
+    model_prompt_tail = _model_prompt_tail_after_raw_prompt(raw_prompt=raw_prompt, model_prompt=model_prompt)
+    if model_prompt_tail:
+        prompt_chunks.append(model_prompt_tail)
 
     return "\n\n".join(prompt_chunks)
+
+
+def _model_prompt_tail_after_raw_prompt(*, raw_prompt: str, model_prompt: str | None) -> str:
+    """Return model-only additions after the raw user prompt prefix."""
+    if not model_prompt:
+        return ""
+    model_prompt_tail = strip_user_turn_time_prefix(model_prompt)
+    normalized_raw_prompt = raw_prompt.strip()
+    normalized_model_prompt_tail = model_prompt_tail.strip()
+    if raw_prompt and normalized_model_prompt_tail == normalized_raw_prompt:
+        return ""
+    if raw_prompt and normalized_model_prompt_tail.startswith(f"{normalized_raw_prompt}\n\n"):
+        return normalized_model_prompt_tail[len(normalized_raw_prompt) + 2 :].lstrip()
+    return model_prompt_tail
 
 
 @dataclass(frozen=True)
@@ -293,6 +303,7 @@ class _StreamingAttemptState:
     cancelled_run_event: RunCancelledEvent | None = None
     completed_run_event: RunCompletedEvent | None = None
     canonical_final_body_candidate: str | None = None
+    completed_tool_executions: list[ToolExecution] = field(default_factory=list)
     request_metric_totals: dict[str, int] = field(default_factory=empty_request_metric_totals)
     first_token_latency: float | None = None
     first_token_logged: bool = False
@@ -608,6 +619,8 @@ def _track_stream_tool_completed(
     agent_name: str,
 ) -> None:
     """Track completed tool-call metadata for streaming output."""
+    if event.tool is not None:
+        state.completed_tool_executions.append(event.tool)
     completion = state.tool_tracker.complete(event.tool)
     if completion is None:
         return
@@ -1108,7 +1121,7 @@ async def _prepare_agent_run_context(
 ) -> _AgentRunContext:
     """Prepare one agent response lifecycle through metadata assembly."""
     if pipeline_timing is not None:
-        pipeline_timing.mark("ai_prepare_start")
+        pipeline_timing.mark("ai_prepare_start", overwrite=True)
     prepared_run = await _prepare_agent_and_prompt(
         agent_name,
         prompt,
@@ -1139,7 +1152,7 @@ async def _prepare_agent_run_context(
         pipeline_timing=pipeline_timing,
     )
     if pipeline_timing is not None:
-        pipeline_timing.mark("history_ready")
+        pipeline_timing.mark("history_ready", overwrite=True)
         note_prepared_history_timing(pipeline_timing, prepared_run.prepared_history)
 
     agent = prepared_run.agent
@@ -1310,130 +1323,181 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                 scope_context=scope_context,
                 entity_name=agent_name,
             )
-            try:
-                run_context = await _prepare_agent_run_context(
-                    agent_name=agent_name,
-                    prompt=prompt,
-                    session_id=session_id,
-                    runtime_paths=runtime_paths,
-                    config=config,
-                    scope_context=scope_context,
-                    thread_history=thread_history,
-                    room_id=room_id,
-                    thread_id=thread_id,
-                    knowledge=knowledge,
-                    include_interactive_questions=include_interactive_questions,
-                    include_openai_compat_guidance=include_openai_compat_guidance,
-                    reply_to_event_id=reply_to_event_id,
-                    active_event_ids=active_event_ids,
-                    execution_identity=execution_identity,
-                    compaction_outcomes_collector=compaction_outcomes_collector,
-                    compaction_lifecycle=compaction_lifecycle,
-                    delegation_depth=delegation_depth,
-                    refresh_scheduler=refresh_scheduler,
-                    system_enrichment_items=system_enrichment_items,
-                    timing_scope=timing_scope,
-                    model_prompt=model_prompt,
+            active_prompt = prompt
+            continuation_model_prompt_tail = _model_prompt_tail_after_raw_prompt(
+                raw_prompt=prompt,
+                model_prompt=model_prompt,
+            )
+            active_model_prompt = model_prompt
+            active_run_id = run_id
+            for continuation_count in range(DYNAMIC_TOOL_CONTINUATION_LIMIT + 1):
+                try:
+                    run_context = await _prepare_agent_run_context(
+                        agent_name=agent_name,
+                        prompt=active_prompt,
+                        session_id=session_id,
+                        runtime_paths=runtime_paths,
+                        config=config,
+                        scope_context=scope_context,
+                        thread_history=thread_history,
+                        room_id=room_id,
+                        thread_id=thread_id,
+                        knowledge=knowledge,
+                        include_interactive_questions=include_interactive_questions,
+                        include_openai_compat_guidance=include_openai_compat_guidance,
+                        reply_to_event_id=reply_to_event_id,
+                        active_event_ids=active_event_ids,
+                        execution_identity=execution_identity,
+                        compaction_outcomes_collector=compaction_outcomes_collector,
+                        compaction_lifecycle=compaction_lifecycle,
+                        delegation_depth=delegation_depth,
+                        refresh_scheduler=refresh_scheduler,
+                        system_enrichment_items=system_enrichment_items,
+                        timing_scope=timing_scope,
+                        model_prompt=active_model_prompt,
+                        user_id=user_id,
+                        requester_id=resolved_requester_id,
+                        correlation_id=resolved_correlation_id,
+                        matrix_run_metadata=matrix_run_metadata,
+                        turn_recorder=turn_recorder,
+                        pipeline_timing=pipeline_timing,
+                    )
+                except Exception as e:
+                    logger.exception("Error preparing agent", agent=agent_name)
+                    return get_user_friendly_error_message(e, agent_name)
+                prepared_run = run_context.prepared_run
+                agent = prepared_run.agent
+                run_input = run_context.run_input
+                unseen_event_ids = prepared_run.unseen_event_ids
+                metadata = run_context.metadata
+                run_extra_content = run_context.run_extra_content
+
+                attempt = _MediaAttempt.initial(
+                    run_input,
+                    media_inputs,
+                    agent.model,
+                    fallback_prompt=run_context.inline_media_fallback_prompt,
+                    run_id=active_run_id,
+                )
+                attempt_result = await _run_non_streaming_agent_attempts(
+                    run_context=run_context,
+                    attempt=attempt,
                     user_id=user_id,
-                    requester_id=resolved_requester_id,
-                    correlation_id=resolved_correlation_id,
-                    matrix_run_metadata=matrix_run_metadata,
-                    turn_recorder=turn_recorder,
+                    run_id=active_run_id,
+                    run_id_callback=run_id_callback,
+                    scope_context=scope_context,
                     pipeline_timing=pipeline_timing,
                 )
-            except Exception as e:
-                logger.exception("Error preparing agent", agent=agent_name)
-                return get_user_friendly_error_message(e, agent_name)
-            prepared_run = run_context.prepared_run
-            agent = prepared_run.agent
-            run_input = run_context.run_input
-            unseen_event_ids = prepared_run.unseen_event_ids
-            metadata = run_context.metadata
-            run_extra_content = run_context.run_extra_content
+                attempt = attempt_result.attempt
+                if attempt_result.user_error is not None:
+                    return get_user_friendly_error_message(attempt_result.user_error, agent_name)
+                response = cast("RunOutput", attempt_result.response)
 
-            attempt = _MediaAttempt.initial(
-                run_input,
-                media_inputs,
-                agent.model,
-                fallback_prompt=run_context.inline_media_fallback_prompt,
-                run_id=run_id,
-            )
-            attempt_result = await _run_non_streaming_agent_attempts(
-                run_context=run_context,
-                attempt=attempt,
-                user_id=user_id,
-                run_id=run_id,
-                run_id_callback=run_id_callback,
-                scope_context=scope_context,
-                pipeline_timing=pipeline_timing,
-            )
-            attempt = attempt_result.attempt
-            if attempt_result.user_error is not None:
-                return get_user_friendly_error_message(attempt_result.user_error, agent_name)
-            response = cast("RunOutput", attempt_result.response)
+                response_tool_trace = _extract_tool_trace(response)
+                if tool_trace_collector is not None:
+                    tool_trace_collector.extend(response_tool_trace)
+                if run_metadata_collector is not None:
+                    run_metadata = build_ai_run_metadata_content(
+                        config=config,
+                        model_name=prepared_run.runtime_model_name,
+                        run_id=response.run_id,
+                        session_id=response.session_id or session_id,
+                        status=response.status,
+                        model=response.model,
+                        model_provider=response.model_provider,
+                        metrics=response.metrics,
+                        context_input_tokens=prepared_run.prepared_history.estimated_context_tokens,
+                        tool_count=len(response.tools) if response.tools is not None else 0,
+                        prepared_history=prepared_run.prepared_history,
+                    )
+                    run_metadata_collector.update(run_metadata)
 
-            response_tool_trace = _extract_tool_trace(response)
-            if tool_trace_collector is not None:
-                tool_trace_collector.extend(response_tool_trace)
-            if run_metadata_collector is not None:
-                run_metadata = build_ai_run_metadata_content(
-                    config=config,
-                    model_name=prepared_run.runtime_model_name,
-                    run_id=response.run_id,
-                    session_id=response.session_id or session_id,
-                    status=response.status,
-                    model=response.model,
-                    model_provider=response.model_provider,
-                    metrics=response.metrics,
-                    context_input_tokens=prepared_run.prepared_history.estimated_context_tokens,
-                    tool_count=len(response.tools) if response.tools is not None else 0,
-                    prepared_history=prepared_run.prepared_history,
+                if response.status == RunStatus.cancelled:
+                    partial_text = _extract_interrupted_partial_text(
+                        response.content,
+                        messages=response.messages,
+                    )
+                    completed_tools, interrupted_tools = _extract_cancelled_tool_trace(response)
+                    if turn_recorder is not None:
+                        turn_state.record_interrupted(
+                            turn_recorder,
+                            run_metadata=metadata,
+                            assistant_text=partial_text,
+                            completed_tools=completed_tools,
+                            interrupted_tools=interrupted_tools,
+                        )
+                    if turn_recorder is None:
+                        persist_interrupted_replay(
+                            scope_context=scope_context,
+                            session_id=response.session_id or session_id,
+                            run_id=response.run_id or attempt.attempt_run_id or str(uuid4()),
+                            user_message=prompt,
+                            partial_text=partial_text,
+                            completed_tools=turn_state.completed_tools_for(completed_tools),
+                            interrupted_tools=interrupted_tools,
+                            run_metadata=metadata,
+                            is_team=False,
+                        )
+                        standalone_interrupted_replay_persisted = True
+                    _raise_agent_run_cancelled(response.content)
+                if response.status == RunStatus.error:
+                    return get_user_friendly_error_message(
+                        Exception(str(response.content or "Unknown agent error")),
+                        agent_name,
+                    )
+
+                continuation_decision = continuation_decision_from_tools(
+                    response.tools,
+                    original_prompt=prompt,
+                    continuation_count=continuation_count,
                 )
-                run_metadata_collector.update(run_metadata)
-
-            if response.status == RunStatus.cancelled:
-                partial_text = _extract_interrupted_partial_text(
-                    response.content,
-                    messages=response.messages,
-                )
-                completed_tools, interrupted_tools = _extract_cancelled_tool_trace(response)
-                if turn_recorder is not None:
-                    turn_state.record_interrupted(
+                completed_tools_for_turn = turn_state.completed_tools_for(response_tool_trace)
+                if continuation_decision.should_continue:
+                    close_agent_runtime_state_dbs(
+                        agent,
+                        shared_scope_storage=scope_context.storage if scope_context is not None else None,
+                    )
+                    agent = None
+                    active_prompt = continuation_decision.next_prompt or prompt
+                    active_model_prompt = continuation_model_prompt_tail or None
+                    active_run_id = ai_runtime.next_retry_run_id(attempt.attempt_run_id)
+                    turn_state = AITurnState(prior_completed_tools=completed_tools_for_turn)
+                    turn_state.sync_partial(
                         turn_recorder,
                         run_metadata=metadata,
-                        assistant_text=partial_text,
-                        completed_tools=completed_tools,
-                        interrupted_tools=interrupted_tools,
+                        assistant_text="",
+                        completed_tools=[],
+                        interrupted_tools=[],
                     )
-                if turn_recorder is None:
-                    persist_interrupted_replay(
-                        scope_context=scope_context,
-                        session_id=response.session_id or session_id,
-                        run_id=response.run_id or attempt.attempt_run_id or str(uuid4()),
-                        user_message=prompt,
-                        partial_text=partial_text,
-                        completed_tools=turn_state.completed_tools_for(completed_tools),
-                        interrupted_tools=interrupted_tools,
-                        run_metadata=metadata,
-                        is_team=False,
+                    continue
+                if continuation_decision.limit_message is not None and continuation_decision.continuation is not None:
+                    logger.warning(
+                        "Dynamic tool continuation limit reached",
+                        agent=agent_name,
+                        function_name=continuation_decision.continuation.function_name,
+                        tool_name=continuation_decision.continuation.tool_name,
+                        status=continuation_decision.continuation.status,
                     )
-                    standalone_interrupted_replay_persisted = True
-                _raise_agent_run_cancelled(response.content)
-            if response.status == RunStatus.error:
-                return get_user_friendly_error_message(
-                    Exception(str(response.content or "Unknown agent error")),
-                    agent_name,
-                )
 
-            response_text = _extract_response_content(response, show_tool_calls=show_tool_calls)
-            if turn_recorder is not None:
-                turn_state.record_completed(
-                    turn_recorder,
-                    run_metadata=metadata,
-                    assistant_text=_extract_replayable_response_text(response),
-                    completed_tools=response_tool_trace,
-                )
-            return response_text
+                response_text = _extract_response_content(response, show_tool_calls=show_tool_calls)
+                if continuation_decision.limit_message is not None and not response.content:
+                    response_text = continuation_decision.limit_message
+                if turn_recorder is not None:
+                    replayable_response_text = _extract_replayable_response_text(response)
+                    if continuation_decision.limit_message is not None and not response.content:
+                        replayable_response_text = continuation_decision.limit_message
+                    turn_state.record_completed(
+                        turn_recorder,
+                        run_metadata=metadata,
+                        assistant_text=replayable_response_text,
+                        completed_tools=response_tool_trace,
+                    )
+                return response_text
+            logger.warning("AI response exhausted dynamic tool continuation loop", agent=agent_name)
+            return get_user_friendly_error_message(
+                Exception("Dynamic tool continuation did not produce a final response"),
+                agent_name,
+            )
     except asyncio.CancelledError:
         if turn_recorder is not None:
             turn_state.record_interrupted_from_recorder(
@@ -1808,97 +1872,136 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                 scope_context=scope_context,
                 entity_name=agent_name,
             )
-            try:
-                run_context = await _prepare_agent_run_context(
-                    agent_name=agent_name,
-                    prompt=prompt,
-                    session_id=session_id,
-                    runtime_paths=runtime_paths,
-                    config=config,
-                    scope_context=scope_context,
-                    thread_history=thread_history,
-                    room_id=room_id,
-                    thread_id=thread_id,
-                    knowledge=knowledge,
-                    include_interactive_questions=include_interactive_questions,
-                    include_openai_compat_guidance=include_openai_compat_guidance,
-                    reply_to_event_id=reply_to_event_id,
-                    active_event_ids=active_event_ids,
-                    execution_identity=execution_identity,
-                    compaction_outcomes_collector=compaction_outcomes_collector,
-                    compaction_lifecycle=compaction_lifecycle,
-                    delegation_depth=delegation_depth,
-                    refresh_scheduler=refresh_scheduler,
-                    system_enrichment_items=system_enrichment_items,
-                    timing_scope=timing_scope,
-                    model_prompt=model_prompt,
-                    user_id=user_id,
-                    requester_id=resolved_requester_id,
-                    correlation_id=resolved_correlation_id,
-                    matrix_run_metadata=matrix_run_metadata,
-                    turn_recorder=turn_recorder,
-                    pipeline_timing=pipeline_timing,
-                )
-            except Exception as e:
-                logger.exception("Error preparing agent for streaming", agent=agent_name)
-                yield get_user_friendly_error_message(e, agent_name)
-                return
-            prepared_run = run_context.prepared_run
-            agent = prepared_run.agent
-            run_input = run_context.run_input
-            unseen_event_ids = prepared_run.unseen_event_ids
-            prepared_context_input_tokens = prepared_run.prepared_history.estimated_context_tokens
-            metadata = run_context.metadata
-            run_extra_content = run_context.run_extra_content
-
-            attempt = _MediaAttempt.initial(
-                run_input,
-                media_inputs,
-                agent.model,
-                fallback_prompt=run_context.inline_media_fallback_prompt,
-                run_id=run_id,
+            active_prompt = prompt
+            continuation_model_prompt_tail = _model_prompt_tail_after_raw_prompt(
+                raw_prompt=prompt,
+                model_prompt=model_prompt,
             )
-            state = _StreamingAttemptState()
-
-            def _sync_live_turn_recorder() -> None:
-                turn_state.sync_partial(
-                    turn_recorder,
-                    run_metadata=metadata,
-                    assistant_text=state.assistant_text,
-                    completed_tools=state.completed_tools,
-                    interrupted_tools=[pending.trace_entry for pending in state.pending_tools],
-                )
-
-            try:
-                for retried_after_media_fallback in (False, True):
-                    state = _StreamingAttemptState()
-
-                    async for stream_chunk in _stream_agent_attempt_chunks(
-                        run_context=run_context,
-                        attempt=attempt,
-                        state=state,
-                        show_tool_calls=show_tool_calls,
+            active_model_prompt = model_prompt
+            active_run_id = run_id
+            for continuation_count in range(DYNAMIC_TOOL_CONTINUATION_LIMIT + 1):
+                try:
+                    run_context = await _prepare_agent_run_context(
+                        agent_name=agent_name,
+                        prompt=active_prompt,
+                        session_id=session_id,
+                        runtime_paths=runtime_paths,
+                        config=config,
+                        scope_context=scope_context,
+                        thread_history=thread_history,
+                        room_id=room_id,
+                        thread_id=thread_id,
+                        knowledge=knowledge,
+                        include_interactive_questions=include_interactive_questions,
+                        include_openai_compat_guidance=include_openai_compat_guidance,
+                        reply_to_event_id=reply_to_event_id,
+                        active_event_ids=active_event_ids,
+                        execution_identity=execution_identity,
+                        compaction_outcomes_collector=compaction_outcomes_collector,
+                        compaction_lifecycle=compaction_lifecycle,
+                        delegation_depth=delegation_depth,
+                        refresh_scheduler=refresh_scheduler,
+                        system_enrichment_items=system_enrichment_items,
+                        timing_scope=timing_scope,
+                        model_prompt=active_model_prompt,
                         user_id=user_id,
-                        run_id_callback=run_id_callback,
-                        retried_after_media_fallback=retried_after_media_fallback,
-                        state_updated=_sync_live_turn_recorder,
+                        requester_id=resolved_requester_id,
+                        correlation_id=resolved_correlation_id,
+                        matrix_run_metadata=matrix_run_metadata,
+                        turn_recorder=turn_recorder,
                         pipeline_timing=pipeline_timing,
-                    ):
-                        yield stream_chunk
+                    )
+                except Exception as e:
+                    logger.exception("Error preparing agent for streaming", agent=agent_name)
+                    yield get_user_friendly_error_message(e, agent_name)
+                    return
+                prepared_run = run_context.prepared_run
+                agent = prepared_run.agent
+                run_input = run_context.run_input
+                unseen_event_ids = prepared_run.unseen_event_ids
+                prepared_context_input_tokens = prepared_run.prepared_history.estimated_context_tokens
+                metadata = run_context.metadata
+                run_extra_content = run_context.run_extra_content
 
-                    if state.media_fallback_retry_requested:
-                        attempt.retry(
-                            run_input,
-                            fallback_prompt=run_context.inline_media_fallback_prompt,
-                            extra_removed_kinds=state.media_fallback_removed_kinds,
-                            retry_media_inputs=state.media_fallback_retry_inputs or MediaInputs(),
-                            run_id=run_id,
-                        )
-                        continue
+                attempt = _MediaAttempt.initial(
+                    run_input,
+                    media_inputs,
+                    agent.model,
+                    fallback_prompt=run_context.inline_media_fallback_prompt,
+                    run_id=active_run_id,
+                )
+                state = _StreamingAttemptState()
 
-                    run_error = state.user_error or state.stream_exception
-                    if run_error is not None:
-                        if state.assistant_text or state.completed_tools or state.pending_tools:
+                try:
+                    for retried_after_media_fallback in (False, True):
+                        state = _StreamingAttemptState()
+
+                        def _sync_live_turn_recorder(
+                            *,
+                            state_ref: _StreamingAttemptState = state,
+                            turn_state_ref: AITurnState = turn_state,
+                            metadata_ref: dict[str, Any] | None = metadata,
+                        ) -> None:
+                            turn_state_ref.sync_partial(
+                                turn_recorder,
+                                run_metadata=metadata_ref,
+                                assistant_text=state_ref.assistant_text,
+                                completed_tools=state_ref.completed_tools,
+                                interrupted_tools=[pending.trace_entry for pending in state_ref.pending_tools],
+                            )
+
+                        async for stream_chunk in _stream_agent_attempt_chunks(
+                            run_context=run_context,
+                            attempt=attempt,
+                            state=state,
+                            show_tool_calls=show_tool_calls,
+                            user_id=user_id,
+                            run_id_callback=run_id_callback,
+                            retried_after_media_fallback=retried_after_media_fallback,
+                            state_updated=_sync_live_turn_recorder,
+                            pipeline_timing=pipeline_timing,
+                        ):
+                            yield stream_chunk
+
+                        if state.media_fallback_retry_requested:
+                            attempt.retry(
+                                run_input,
+                                fallback_prompt=run_context.inline_media_fallback_prompt,
+                                extra_removed_kinds=state.media_fallback_removed_kinds,
+                                retry_media_inputs=state.media_fallback_retry_inputs or MediaInputs(),
+                                run_id=active_run_id,
+                            )
+                            continue
+
+                        run_error = state.user_error or state.stream_exception
+                        if run_error is not None:
+                            if state.assistant_text or state.completed_tools or state.pending_tools:
+                                interrupted_tools = [pending.trace_entry for pending in state.pending_tools]
+                                if turn_recorder is not None:
+                                    turn_state.record_interrupted(
+                                        turn_recorder,
+                                        run_metadata=metadata,
+                                        assistant_text=state.assistant_text,
+                                        completed_tools=state.completed_tools,
+                                        interrupted_tools=interrupted_tools,
+                                    )
+                                elif not standalone_interrupted_replay_persisted:
+                                    persist_interrupted_replay(
+                                        scope_context=scope_context,
+                                        session_id=session_id,
+                                        run_id=attempt.attempt_run_id or str(uuid4()),
+                                        user_message=prompt,
+                                        partial_text=state.assistant_text,
+                                        completed_tools=turn_state.completed_tools_for(state.completed_tools),
+                                        interrupted_tools=interrupted_tools,
+                                        run_metadata=metadata,
+                                        is_team=False,
+                                    )
+                                    standalone_interrupted_replay_persisted = True
+                            yield get_user_friendly_error_message(run_error, agent_name)
+                            return
+
+                        if state.cancelled_run_event is not None:
                             interrupted_tools = [pending.trace_entry for pending in state.pending_tools]
                             if turn_recorder is not None:
                                 turn_state.record_interrupted(
@@ -1908,11 +2011,34 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                                     completed_tools=state.completed_tools,
                                     interrupted_tools=interrupted_tools,
                                 )
-                            elif not standalone_interrupted_replay_persisted:
+                            if run_metadata_collector is not None:
+                                fallback_metrics = build_model_request_metrics_fallback(
+                                    state.request_metric_totals,
+                                    state.first_token_latency,
+                                    state.observed_request_metric_fields,
+                                )
+                                cancelled_metadata = build_ai_run_metadata_content(
+                                    config=config,
+                                    model_name=prepared_run.runtime_model_name,
+                                    run_id=state.cancelled_run_event.run_id,
+                                    session_id=state.cancelled_run_event.session_id or session_id,
+                                    status=RunStatus.cancelled,
+                                    model=state.latest_model_id,
+                                    model_provider=state.latest_model_provider,
+                                    metrics=fallback_metrics,
+                                    context_input_tokens=prepared_context_input_tokens,
+                                    context_raw_input_tokens=state.latest_request_input_tokens,
+                                    context_cache_read_tokens=state.latest_request_cache_read_tokens,
+                                    context_cache_write_tokens=state.latest_request_cache_write_tokens,
+                                    tool_count=state.observed_tool_calls,
+                                    prepared_history=prepared_run.prepared_history,
+                                )
+                                run_metadata_collector.update(cancelled_metadata)
+                            if turn_recorder is None:
                                 persist_interrupted_replay(
                                     scope_context=scope_context,
-                                    session_id=session_id,
-                                    run_id=attempt.attempt_run_id or str(uuid4()),
+                                    session_id=state.cancelled_run_event.session_id or session_id,
+                                    run_id=state.cancelled_run_event.run_id or attempt.attempt_run_id or str(uuid4()),
                                     user_message=prompt,
                                     partial_text=state.assistant_text,
                                     completed_tools=turn_state.completed_tools_for(state.completed_tools),
@@ -1921,115 +2047,106 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                                     is_team=False,
                                 )
                                 standalone_interrupted_replay_persisted = True
-                        yield get_user_friendly_error_message(run_error, agent_name)
-                        return
+                            _raise_agent_run_cancelled(state.cancelled_run_event.reason)
 
-                    if state.cancelled_run_event is not None:
-                        interrupted_tools = [pending.trace_entry for pending in state.pending_tools]
-                        if turn_recorder is not None:
-                            turn_state.record_interrupted(
-                                turn_recorder,
-                                run_metadata=metadata,
-                                assistant_text=state.assistant_text,
-                                completed_tools=state.completed_tools,
-                                interrupted_tools=interrupted_tools,
-                            )
-                        if run_metadata_collector is not None:
-                            fallback_metrics = build_model_request_metrics_fallback(
-                                state.request_metric_totals,
-                                state.first_token_latency,
-                                state.observed_request_metric_fields,
-                            )
-                            cancelled_metadata = build_ai_run_metadata_content(
-                                config=config,
-                                model_name=prepared_run.runtime_model_name,
-                                run_id=state.cancelled_run_event.run_id,
-                                session_id=state.cancelled_run_event.session_id or session_id,
-                                status=RunStatus.cancelled,
-                                model=state.latest_model_id,
-                                model_provider=state.latest_model_provider,
-                                metrics=fallback_metrics,
-                                context_input_tokens=prepared_context_input_tokens,
-                                context_raw_input_tokens=state.latest_request_input_tokens,
-                                context_cache_read_tokens=state.latest_request_cache_read_tokens,
-                                context_cache_write_tokens=state.latest_request_cache_write_tokens,
-                                tool_count=state.observed_tool_calls,
-                                prepared_history=prepared_run.prepared_history,
-                            )
-                            run_metadata_collector.update(cancelled_metadata)
-                        if turn_recorder is None:
-                            persist_interrupted_replay(
-                                scope_context=scope_context,
-                                session_id=state.cancelled_run_event.session_id or session_id,
-                                run_id=state.cancelled_run_event.run_id or attempt.attempt_run_id or str(uuid4()),
-                                user_message=prompt,
-                                partial_text=state.assistant_text,
-                                completed_tools=turn_state.completed_tools_for(state.completed_tools),
-                                interrupted_tools=interrupted_tools,
-                                run_metadata=metadata,
-                                is_team=False,
-                            )
-                            standalone_interrupted_replay_persisted = True
-                        _raise_agent_run_cancelled(state.cancelled_run_event.reason)
+                        break
 
-                    break
+                    continuation_decision = continuation_decision_from_tools(
+                        state.completed_tool_executions,
+                        original_prompt=prompt,
+                        continuation_count=continuation_count,
+                    )
+                    completed_tools_for_turn = turn_state.completed_tools_for(state.completed_tools)
+                    if continuation_decision.should_continue:
+                        close_agent_runtime_state_dbs(
+                            agent,
+                            shared_scope_storage=scope_context.storage if scope_context is not None else None,
+                        )
+                        agent = None
+                        active_prompt = continuation_decision.next_prompt or prompt
+                        active_model_prompt = continuation_model_prompt_tail or None
+                        active_run_id = ai_runtime.next_retry_run_id(attempt.attempt_run_id)
+                        turn_state = AITurnState(prior_completed_tools=completed_tools_for_turn)
+                        turn_state.sync_partial(
+                            turn_recorder,
+                            run_metadata=metadata,
+                            assistant_text="",
+                            completed_tools=[],
+                            interrupted_tools=[],
+                        )
+                        continue
+                    if (
+                        continuation_decision.limit_message is not None
+                        and continuation_decision.continuation is not None
+                    ):
+                        logger.warning(
+                            "Dynamic tool continuation limit reached during streaming",
+                            agent=agent_name,
+                            function_name=continuation_decision.continuation.function_name,
+                            tool_name=continuation_decision.continuation.tool_name,
+                            status=continuation_decision.continuation.status,
+                        )
+                        if not state.assistant_text and not state.canonical_final_body_candidate:
+                            state.assistant_text = continuation_decision.limit_message
+                            yield RunContentEvent(content=continuation_decision.limit_message)
 
-                if run_metadata_collector is not None:
-                    fallback_metrics = build_model_request_metrics_fallback(
-                        state.request_metric_totals,
-                        state.first_token_latency,
-                        state.observed_request_metric_fields,
+                    if run_metadata_collector is not None:
+                        fallback_metrics = build_model_request_metrics_fallback(
+                            state.request_metric_totals,
+                            state.first_token_latency,
+                            state.observed_request_metric_fields,
+                        )
+                        final_status = (
+                            RunStatus.error if _stream_completed_without_visible_output(state) else RunStatus.completed
+                        )
+                        usage_metrics, usage_metrics_fallback = _select_streaming_usage_metrics(
+                            state.completed_run_event.metrics if state.completed_run_event is not None else None,
+                            fallback_metrics,
+                        )
+                        run_metadata = build_ai_run_metadata_content(
+                            config=config,
+                            model_name=prepared_run.runtime_model_name,
+                            run_id=state.completed_run_event.run_id if state.completed_run_event is not None else None,
+                            session_id=(
+                                state.completed_run_event.session_id
+                                if state.completed_run_event is not None
+                                and state.completed_run_event.session_id is not None
+                                else session_id
+                            ),
+                            status=final_status,
+                            model=state.latest_model_id,
+                            model_provider=state.latest_model_provider,
+                            metrics=usage_metrics,
+                            metrics_fallback=usage_metrics_fallback,
+                            context_input_tokens=prepared_context_input_tokens,
+                            context_raw_input_tokens=state.latest_request_input_tokens,
+                            context_cache_read_tokens=state.latest_request_cache_read_tokens,
+                            context_cache_write_tokens=state.latest_request_cache_write_tokens,
+                            tool_count=(
+                                len(state.completed_run_event.tools)
+                                if state.completed_run_event is not None and state.completed_run_event.tools is not None
+                                else state.observed_tool_calls
+                            ),
+                            prepared_history=prepared_run.prepared_history,
+                        )
+                        run_metadata_collector.update(run_metadata)
+                    if turn_recorder is not None:
+                        final_visible_body = state.assistant_text or state.canonical_final_body_candidate or ""
+                        turn_state.record_completed(
+                            turn_recorder,
+                            run_metadata=metadata,
+                            assistant_text=final_visible_body,
+                            completed_tools=state.completed_tools,
+                        )
+                    return
+                finally:
+                    ai_runtime.cleanup_queued_notice_state(
+                        run_output=None,
+                        storage=scope_context.storage if scope_context is not None else None,
+                        session_id=session_id,
+                        session_type=SessionType.AGENT,
+                        entity_name=agent_name,
                     )
-                    final_status = (
-                        RunStatus.error if _stream_completed_without_visible_output(state) else RunStatus.completed
-                    )
-                    usage_metrics, usage_metrics_fallback = _select_streaming_usage_metrics(
-                        state.completed_run_event.metrics if state.completed_run_event is not None else None,
-                        fallback_metrics,
-                    )
-                    run_metadata = build_ai_run_metadata_content(
-                        config=config,
-                        model_name=prepared_run.runtime_model_name,
-                        run_id=state.completed_run_event.run_id if state.completed_run_event is not None else None,
-                        session_id=(
-                            state.completed_run_event.session_id
-                            if state.completed_run_event is not None
-                            and state.completed_run_event.session_id is not None
-                            else session_id
-                        ),
-                        status=final_status,
-                        model=state.latest_model_id,
-                        model_provider=state.latest_model_provider,
-                        metrics=usage_metrics,
-                        metrics_fallback=usage_metrics_fallback,
-                        context_input_tokens=prepared_context_input_tokens,
-                        context_raw_input_tokens=state.latest_request_input_tokens,
-                        context_cache_read_tokens=state.latest_request_cache_read_tokens,
-                        context_cache_write_tokens=state.latest_request_cache_write_tokens,
-                        tool_count=(
-                            len(state.completed_run_event.tools)
-                            if state.completed_run_event is not None and state.completed_run_event.tools is not None
-                            else state.observed_tool_calls
-                        ),
-                        prepared_history=prepared_run.prepared_history,
-                    )
-                    run_metadata_collector.update(run_metadata)
-                if turn_recorder is not None:
-                    final_visible_body = state.assistant_text or state.canonical_final_body_candidate or ""
-                    turn_state.record_completed(
-                        turn_recorder,
-                        run_metadata=metadata,
-                        assistant_text=final_visible_body,
-                        completed_tools=state.completed_tools,
-                    )
-            finally:
-                ai_runtime.cleanup_queued_notice_state(
-                    run_output=None,
-                    storage=scope_context.storage if scope_context is not None else None,
-                    session_id=session_id,
-                    session_type=SessionType.AGENT,
-                    entity_name=agent_name,
-                )
     except asyncio.CancelledError:
         interrupted_tools = [pending.trace_entry for pending in state.pending_tools]
         if turn_recorder is not None:

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -326,6 +326,38 @@ def _reset_turn_state_for_dynamic_continuation(
     return turn_state
 
 
+def _advance_dynamic_continuation(
+    *,
+    agent: Agent | None,
+    scope_context: ScopeSessionContext | None,
+    continuation_state: _DynamicContinuationRunState,
+    next_prompt: str | None,
+    previous_run_id: str | None,
+    turn_recorder: TurnRecorder | None,
+    run_metadata: dict[str, Any] | None,
+    completed_tools_for_turn: Sequence[ToolTraceEntry],
+) -> tuple[_DynamicContinuationRunState, AITurnState]:
+    """Close the spent agent and prepare run state for one more continuation.
+
+    Shared by the blocking and streaming loops so the continuation handoff stays
+    identical across both paths.
+    """
+    close_agent_runtime_state_dbs(
+        agent,
+        shared_scope_storage=scope_context.storage if scope_context is not None else None,
+    )
+    advanced_state = continuation_state.advance(
+        continuation_prompt=next_prompt or continuation_state.original_prompt,
+        previous_run_id=previous_run_id,
+    )
+    turn_state = _reset_turn_state_for_dynamic_continuation(
+        turn_recorder=turn_recorder,
+        run_metadata=run_metadata,
+        completed_tools_for_turn=completed_tools_for_turn,
+    )
+    return advanced_state, turn_state
+
+
 @timed("system_prompt_assembly.system_enrichment_render")
 def _render_system_enrichment_context(
     system_enrichment_items: Sequence[EnrichmentItem],
@@ -1075,6 +1107,7 @@ async def _prepare_agent_and_prompt(
             delegation_depth=delegation_depth,
             refresh_scheduler=refresh_scheduler,
             timing_scope=timing_scope,
+            dynamic_tool_continuation=True,
         )
         return runtime_model, agent
 
@@ -1511,20 +1544,17 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                 )
                 completed_tools_for_turn = turn_state.completed_tools_for(response_tool_trace)
                 if continuation_decision.should_continue:
-                    close_agent_runtime_state_dbs(
-                        agent,
-                        shared_scope_storage=scope_context.storage if scope_context is not None else None,
-                    )
-                    agent = None
-                    continuation_state = continuation_state.advance(
-                        continuation_prompt=continuation_decision.next_prompt or continuation_state.original_prompt,
+                    continuation_state, turn_state = _advance_dynamic_continuation(
+                        agent=agent,
+                        scope_context=scope_context,
+                        continuation_state=continuation_state,
+                        next_prompt=continuation_decision.next_prompt,
                         previous_run_id=attempt.attempt_run_id,
-                    )
-                    turn_state = _reset_turn_state_for_dynamic_continuation(
                         turn_recorder=turn_recorder,
                         run_metadata=metadata,
                         completed_tools_for_turn=completed_tools_for_turn,
                     )
+                    agent = None
                     continue
                 if continuation_decision.limit_message is not None and continuation_decision.continuation is not None:
                     logger.warning(
@@ -1549,11 +1579,11 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                         completed_tools=response_tool_trace,
                     )
                 return response_text
-            logger.warning("AI response exhausted dynamic tool continuation loop", agent=agent_name)
-            return get_user_friendly_error_message(
-                Exception("Dynamic tool continuation did not produce a final response"),
-                agent_name,
-            )
+            # The continuation loop always returns on its final iteration: at
+            # continuation_count == DYNAMIC_TOOL_CONTINUATION_LIMIT the decision
+            # carries a limit_message and never asks to continue.
+            msg = "dynamic tool continuation loop must return within its iteration budget"
+            raise AssertionError(msg)
     except asyncio.CancelledError:
         if turn_recorder is not None:
             turn_state.record_interrupted_from_recorder(
@@ -2112,20 +2142,17 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                     )
                     completed_tools_for_turn = turn_state.completed_tools_for(state.completed_tools)
                     if continuation_decision.should_continue:
-                        close_agent_runtime_state_dbs(
-                            agent,
-                            shared_scope_storage=scope_context.storage if scope_context is not None else None,
-                        )
-                        agent = None
-                        continuation_state = continuation_state.advance(
-                            continuation_prompt=continuation_decision.next_prompt or continuation_state.original_prompt,
+                        continuation_state, turn_state = _advance_dynamic_continuation(
+                            agent=agent,
+                            scope_context=scope_context,
+                            continuation_state=continuation_state,
+                            next_prompt=continuation_decision.next_prompt,
                             previous_run_id=attempt.attempt_run_id,
-                        )
-                        turn_state = _reset_turn_state_for_dynamic_continuation(
                             turn_recorder=turn_recorder,
                             run_metadata=metadata,
                             completed_tools_for_turn=completed_tools_for_turn,
                         )
+                        agent = None
                         continue
                     if (
                         continuation_decision.limit_message is not None

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -151,6 +151,49 @@ def _model_prompt_tail_after_raw_prompt(*, raw_prompt: str, model_prompt: str | 
 
 
 @dataclass(frozen=True)
+class _DynamicContinuationRunState:
+    """Prompt and run identity for a dynamic-tool continuation sequence."""
+
+    original_prompt: str
+    active_prompt: str
+    active_model_prompt: str | None
+    active_run_id: str | None
+    continuation_model_prompt_tail: str
+
+    @classmethod
+    def initial(
+        cls,
+        *,
+        prompt: str,
+        model_prompt: str | None,
+        run_id: str | None,
+    ) -> _DynamicContinuationRunState:
+        return cls(
+            original_prompt=prompt,
+            active_prompt=prompt,
+            active_model_prompt=model_prompt,
+            active_run_id=run_id,
+            continuation_model_prompt_tail=_model_prompt_tail_after_raw_prompt(
+                raw_prompt=prompt,
+                model_prompt=model_prompt,
+            ),
+        )
+
+    def advance(
+        self,
+        *,
+        continuation_prompt: str,
+        previous_run_id: str | None,
+    ) -> _DynamicContinuationRunState:
+        return replace(
+            self,
+            active_prompt=continuation_prompt,
+            active_model_prompt=self.continuation_model_prompt_tail or None,
+            active_run_id=ai_runtime.next_retry_run_id(previous_run_id),
+        )
+
+
+@dataclass(frozen=True)
 class _PreparedAgentRun:
     """Prepared agent invocation state after history planning."""
 
@@ -264,6 +307,23 @@ def _build_timing_scope(
         if candidate:
             return candidate[:20]
     return "unknown"
+
+
+def _reset_turn_state_for_dynamic_continuation(
+    *,
+    turn_recorder: TurnRecorder | None,
+    run_metadata: dict[str, Any] | None,
+    completed_tools_for_turn: Sequence[ToolTraceEntry],
+) -> AITurnState:
+    turn_state = AITurnState(prior_completed_tools=completed_tools_for_turn)
+    turn_state.sync_partial(
+        turn_recorder,
+        run_metadata=run_metadata,
+        assistant_text="",
+        completed_tools=[],
+        interrupted_tools=[],
+    )
+    return turn_state
 
 
 @timed("system_prompt_assembly.system_enrichment_render")
@@ -1323,18 +1383,16 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                 scope_context=scope_context,
                 entity_name=agent_name,
             )
-            active_prompt = prompt
-            continuation_model_prompt_tail = _model_prompt_tail_after_raw_prompt(
-                raw_prompt=prompt,
+            continuation_state = _DynamicContinuationRunState.initial(
+                prompt=prompt,
                 model_prompt=model_prompt,
+                run_id=run_id,
             )
-            active_model_prompt = model_prompt
-            active_run_id = run_id
             for continuation_count in range(DYNAMIC_TOOL_CONTINUATION_LIMIT + 1):
                 try:
                     run_context = await _prepare_agent_run_context(
                         agent_name=agent_name,
-                        prompt=active_prompt,
+                        prompt=continuation_state.active_prompt,
                         session_id=session_id,
                         runtime_paths=runtime_paths,
                         config=config,
@@ -1354,7 +1412,7 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                         refresh_scheduler=refresh_scheduler,
                         system_enrichment_items=system_enrichment_items,
                         timing_scope=timing_scope,
-                        model_prompt=active_model_prompt,
+                        model_prompt=continuation_state.active_model_prompt,
                         user_id=user_id,
                         requester_id=resolved_requester_id,
                         correlation_id=resolved_correlation_id,
@@ -1377,13 +1435,13 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                     media_inputs,
                     agent.model,
                     fallback_prompt=run_context.inline_media_fallback_prompt,
-                    run_id=active_run_id,
+                    run_id=continuation_state.active_run_id,
                 )
                 attempt_result = await _run_non_streaming_agent_attempts(
                     run_context=run_context,
                     attempt=attempt,
                     user_id=user_id,
-                    run_id=active_run_id,
+                    run_id=continuation_state.active_run_id,
                     run_id_callback=run_id_callback,
                     scope_context=scope_context,
                     pipeline_timing=pipeline_timing,
@@ -1448,7 +1506,7 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
 
                 continuation_decision = continuation_decision_from_tools(
                     response.tools,
-                    original_prompt=prompt,
+                    original_prompt=continuation_state.original_prompt,
                     continuation_count=continuation_count,
                 )
                 completed_tools_for_turn = turn_state.completed_tools_for(response_tool_trace)
@@ -1458,16 +1516,14 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                         shared_scope_storage=scope_context.storage if scope_context is not None else None,
                     )
                     agent = None
-                    active_prompt = continuation_decision.next_prompt or prompt
-                    active_model_prompt = continuation_model_prompt_tail or None
-                    active_run_id = ai_runtime.next_retry_run_id(attempt.attempt_run_id)
-                    turn_state = AITurnState(prior_completed_tools=completed_tools_for_turn)
-                    turn_state.sync_partial(
-                        turn_recorder,
+                    continuation_state = continuation_state.advance(
+                        continuation_prompt=continuation_decision.next_prompt or continuation_state.original_prompt,
+                        previous_run_id=attempt.attempt_run_id,
+                    )
+                    turn_state = _reset_turn_state_for_dynamic_continuation(
+                        turn_recorder=turn_recorder,
                         run_metadata=metadata,
-                        assistant_text="",
-                        completed_tools=[],
-                        interrupted_tools=[],
+                        completed_tools_for_turn=completed_tools_for_turn,
                     )
                     continue
                 if continuation_decision.limit_message is not None and continuation_decision.continuation is not None:
@@ -1872,18 +1928,16 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                 scope_context=scope_context,
                 entity_name=agent_name,
             )
-            active_prompt = prompt
-            continuation_model_prompt_tail = _model_prompt_tail_after_raw_prompt(
-                raw_prompt=prompt,
+            continuation_state = _DynamicContinuationRunState.initial(
+                prompt=prompt,
                 model_prompt=model_prompt,
+                run_id=run_id,
             )
-            active_model_prompt = model_prompt
-            active_run_id = run_id
             for continuation_count in range(DYNAMIC_TOOL_CONTINUATION_LIMIT + 1):
                 try:
                     run_context = await _prepare_agent_run_context(
                         agent_name=agent_name,
-                        prompt=active_prompt,
+                        prompt=continuation_state.active_prompt,
                         session_id=session_id,
                         runtime_paths=runtime_paths,
                         config=config,
@@ -1903,7 +1957,7 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                         refresh_scheduler=refresh_scheduler,
                         system_enrichment_items=system_enrichment_items,
                         timing_scope=timing_scope,
-                        model_prompt=active_model_prompt,
+                        model_prompt=continuation_state.active_model_prompt,
                         user_id=user_id,
                         requester_id=resolved_requester_id,
                         correlation_id=resolved_correlation_id,
@@ -1928,7 +1982,7 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                     media_inputs,
                     agent.model,
                     fallback_prompt=run_context.inline_media_fallback_prompt,
-                    run_id=active_run_id,
+                    run_id=continuation_state.active_run_id,
                 )
                 state = _StreamingAttemptState()
 
@@ -1969,7 +2023,7 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                                 fallback_prompt=run_context.inline_media_fallback_prompt,
                                 extra_removed_kinds=state.media_fallback_removed_kinds,
                                 retry_media_inputs=state.media_fallback_retry_inputs or MediaInputs(),
-                                run_id=active_run_id,
+                                run_id=continuation_state.active_run_id,
                             )
                             continue
 
@@ -2053,7 +2107,7 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
 
                     continuation_decision = continuation_decision_from_tools(
                         state.completed_tool_executions,
-                        original_prompt=prompt,
+                        original_prompt=continuation_state.original_prompt,
                         continuation_count=continuation_count,
                     )
                     completed_tools_for_turn = turn_state.completed_tools_for(state.completed_tools)
@@ -2063,16 +2117,14 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                             shared_scope_storage=scope_context.storage if scope_context is not None else None,
                         )
                         agent = None
-                        active_prompt = continuation_decision.next_prompt or prompt
-                        active_model_prompt = continuation_model_prompt_tail or None
-                        active_run_id = ai_runtime.next_retry_run_id(attempt.attempt_run_id)
-                        turn_state = AITurnState(prior_completed_tools=completed_tools_for_turn)
-                        turn_state.sync_partial(
-                            turn_recorder,
+                        continuation_state = continuation_state.advance(
+                            continuation_prompt=continuation_decision.next_prompt or continuation_state.original_prompt,
+                            previous_run_id=attempt.attempt_run_id,
+                        )
+                        turn_state = _reset_turn_state_for_dynamic_continuation(
+                            turn_recorder=turn_recorder,
                             run_metadata=metadata,
-                            assistant_text="",
-                            completed_tools=[],
-                            interrupted_tools=[],
+                            completed_tools_for_turn=completed_tools_for_turn,
                         )
                         continue
                     if (

--- a/src/mindroom/custom_tools/dynamic_tools.py
+++ b/src/mindroom/custom_tools/dynamic_tools.py
@@ -39,6 +39,7 @@ class DynamicToolsToolkit(Toolkit):
         agent_name: str,
         config: Config,
         session_id: str | None,
+        stop_after_tool_call: bool = False,
     ) -> None:
         self._agent_name = agent_name
         self._config = config
@@ -48,8 +49,11 @@ class DynamicToolsToolkit(Toolkit):
             instructions=config.get_prompt("DYNAMIC_TOOLS_TOOLKIT_INSTRUCTIONS"),
             tools=[self.list_tools, self.load_tool, self.unload_tool, self.tool_search],
         )
+        # Same-turn continuation is only driven by the standalone agent run loop
+        # in ai.py. Team members and other embedded agents run without it, so
+        # only stop the provider loop when the caller will resume the turn.
         for tool_name in ("load_tool", "unload_tool"):
-            self.functions[tool_name].stop_after_tool_call = True
+            self.functions[tool_name].stop_after_tool_call = stop_after_tool_call
 
     @staticmethod
     def _payload(status: str, **kwargs: object) -> str:
@@ -150,12 +154,7 @@ class DynamicToolsToolkit(Toolkit):
                 "already_loaded",
                 tool_name=tool_name,
                 loaded_tools=loaded_tools,
-                takes_effect="later_tool_call_step",
-                message=(
-                    "After this tool result is processed, MindRoom continues the same task with the updated "
-                    f"tool schema. Call '{tool_name}' in a later tool-call step, not in the same parallel "
-                    "tool-call batch. Do not wait for another user message."
-                ),
+                message=f"Tool '{tool_name}' is already loaded for this session.",
             )
         elif result.status == "error":
             response = self._session_error(tool_name=tool_name, loaded_tools=loaded_tools)
@@ -183,11 +182,9 @@ class DynamicToolsToolkit(Toolkit):
                 "loaded",
                 tool_name=tool_name,
                 loaded_tools=loaded_tools,
-                takes_effect="later_tool_call_step",
                 message=(
-                    "After this tool result is processed, MindRoom continues the same task with the updated "
-                    f"tool schema. Call '{tool_name}' in a later tool-call step, not in the same parallel "
-                    "tool-call batch. Do not wait for another user message."
+                    f"Tool '{tool_name}' is now loaded for this session. It becomes callable once it appears "
+                    "in your available tools; do not call it in the same parallel tool-call batch as load_tool."
                 ),
             )
         return response
@@ -206,8 +203,8 @@ class DynamicToolsToolkit(Toolkit):
     def load_tool(self, tool_name: str) -> str:
         """Load one deferred tool for the current session.
 
-        The requested tool becomes available after this tool-call result is
-        processed, so continue in a later tool-call step in the same response.
+        The tool becomes callable once it appears in the agent's available
+        tools; it is never callable in the same parallel batch as this call.
         """
         result = load_tool_for_session(
             agent_name=self._agent_name,
@@ -219,11 +216,7 @@ class DynamicToolsToolkit(Toolkit):
         return self._load_tool_response(tool_name, result)
 
     def unload_tool(self, tool_name: str) -> str:
-        """Unload one deferred tool from the current session.
-
-        The tool stops being available after this tool-call result is processed,
-        so continue without it in later tool-call steps in the same response.
-        """
+        """Unload one deferred tool from the current session."""
         loaded_tools = self._loaded_tools()
         deferred_tools = self._deferred_tool_names()
         if tool_name not in deferred_tools:
@@ -248,11 +241,7 @@ class DynamicToolsToolkit(Toolkit):
                 "not_loaded",
                 tool_name=tool_name,
                 loaded_tools=loaded_tools,
-                takes_effect="later_tool_call_step",
-                message=(
-                    "After this tool result is processed, MindRoom continues the same task with the current "
-                    f"dynamic tool state. Tool '{tool_name}' is not currently loaded for this session."
-                ),
+                message=f"Tool '{tool_name}' is not currently loaded for this session.",
             )
 
         if self._session_id is None:
@@ -268,12 +257,7 @@ class DynamicToolsToolkit(Toolkit):
             "unloaded",
             tool_name=tool_name,
             loaded_tools=saved_loaded_tools,
-            takes_effect="later_tool_call_step",
-            message=(
-                "After this tool result is processed, MindRoom continues the same task with the current dynamic "
-                f"tool state. Tool '{tool_name}' is unloaded. Continue without calling it in later tool-call steps. "
-                "Do not wait for another user message."
-            ),
+            message=f"Tool '{tool_name}' is now unloaded for this session.",
         )
 
     @staticmethod

--- a/src/mindroom/custom_tools/dynamic_tools.py
+++ b/src/mindroom/custom_tools/dynamic_tools.py
@@ -48,6 +48,8 @@ class DynamicToolsToolkit(Toolkit):
             instructions=config.get_prompt("DYNAMIC_TOOLS_TOOLKIT_INSTRUCTIONS"),
             tools=[self.list_tools, self.load_tool, self.unload_tool, self.tool_search],
         )
+        for tool_name in ("load_tool", "unload_tool"):
+            self.functions[tool_name].stop_after_tool_call = True
 
     @staticmethod
     def _payload(status: str, **kwargs: object) -> str:
@@ -148,8 +150,12 @@ class DynamicToolsToolkit(Toolkit):
                 "already_loaded",
                 tool_name=tool_name,
                 loaded_tools=loaded_tools,
-                takes_effect="next_request",
-                message=f"Tool '{tool_name}' is already loaded for this session.",
+                takes_effect="later_tool_call_step",
+                message=(
+                    "After this tool result is processed, MindRoom continues the same task with the updated "
+                    f"tool schema. Call '{tool_name}' in a later tool-call step, not in the same parallel "
+                    "tool-call batch. Do not wait for another user message."
+                ),
             )
         elif result.status == "error":
             response = self._session_error(tool_name=tool_name, loaded_tools=loaded_tools)
@@ -177,8 +183,12 @@ class DynamicToolsToolkit(Toolkit):
                 "loaded",
                 tool_name=tool_name,
                 loaded_tools=loaded_tools,
-                takes_effect="next_request",
-                message=f"Tool '{tool_name}' will be available on the next request in this session.",
+                takes_effect="later_tool_call_step",
+                message=(
+                    "After this tool result is processed, MindRoom continues the same task with the updated "
+                    f"tool schema. Call '{tool_name}' in a later tool-call step, not in the same parallel "
+                    "tool-call batch. Do not wait for another user message."
+                ),
             )
         return response
 
@@ -196,8 +206,8 @@ class DynamicToolsToolkit(Toolkit):
     def load_tool(self, tool_name: str) -> str:
         """Load one deferred tool for the current session.
 
-        The requested tool becomes available on the next request in the same
-        session, not later in the current model run.
+        The requested tool becomes available after this tool-call result is
+        processed, so continue in a later tool-call step in the same response.
         """
         result = load_tool_for_session(
             agent_name=self._agent_name,
@@ -211,8 +221,8 @@ class DynamicToolsToolkit(Toolkit):
     def unload_tool(self, tool_name: str) -> str:
         """Unload one deferred tool from the current session.
 
-        The tool stops being available on the next request in the same session,
-        not later in the current model run.
+        The tool stops being available after this tool-call result is processed,
+        so continue without it in later tool-call steps in the same response.
         """
         loaded_tools = self._loaded_tools()
         deferred_tools = self._deferred_tool_names()
@@ -238,8 +248,11 @@ class DynamicToolsToolkit(Toolkit):
                 "not_loaded",
                 tool_name=tool_name,
                 loaded_tools=loaded_tools,
-                takes_effect="next_request",
-                message=f"Tool '{tool_name}' is not currently loaded for this session.",
+                takes_effect="later_tool_call_step",
+                message=(
+                    "After this tool result is processed, MindRoom continues the same task with the current "
+                    f"dynamic tool state. Tool '{tool_name}' is not currently loaded for this session."
+                ),
             )
 
         if self._session_id is None:
@@ -255,8 +268,12 @@ class DynamicToolsToolkit(Toolkit):
             "unloaded",
             tool_name=tool_name,
             loaded_tools=saved_loaded_tools,
-            takes_effect="next_request",
-            message=f"Tool '{tool_name}' will be removed on the next request in this session.",
+            takes_effect="later_tool_call_step",
+            message=(
+                "After this tool result is processed, MindRoom continues the same task with the current dynamic "
+                f"tool state. Tool '{tool_name}' is unloaded. Continue without calling it in later tool-call steps. "
+                "Do not wait for another user message."
+            ),
         )
 
     @staticmethod

--- a/src/mindroom/dynamic_tool_continuation.py
+++ b/src/mindroom/dynamic_tool_continuation.py
@@ -16,16 +16,7 @@ __all__ = ["DYNAMIC_TOOL_CONTINUATION_LIMIT", "continuation_decision_from_tools"
 DYNAMIC_TOOL_CONTINUATION_LIMIT = 4
 _DYNAMIC_TOOL_FUNCTION_NAMES = frozenset({"load_tool", "unload_tool"})
 _LOADED_STATUSES = frozenset({"loaded", "already_loaded"})
-
-
-def _string_key_dict(value: object) -> dict[str, object] | None:
-    """Return a string-keyed dict from one decoded structured payload."""
-    if not isinstance(value, dict):
-        return None
-    raw_payload = cast("dict[object, object]", value)
-    if not all(isinstance(key, str) for key in raw_payload):
-        return None
-    return cast("dict[str, object]", raw_payload)
+_UNLOADED_STATUS = "unloaded"
 
 
 @dataclass(frozen=True)
@@ -53,17 +44,15 @@ class _DynamicToolContinuationDecision:
 
 def _dynamic_tool_payload(result: object) -> dict[str, object] | None:
     """Return the structured dynamic-tools payload from one tool result."""
-    if isinstance(result, str):
-        try:
-            decoded = json.loads(result)
-        except json.JSONDecodeError:
-            return None
-        payload = _string_key_dict(decoded)
-    else:
-        payload = _string_key_dict(result)
-    if payload is None:
+    if not isinstance(result, str):
         return None
-
+    try:
+        decoded = json.loads(result)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(decoded, dict):
+        return None
+    payload = cast("dict[str, object]", decoded)
     if payload.get("tool") != "dynamic_tools":
         return None
     return payload
@@ -103,6 +92,12 @@ def _dynamic_tool_continuation_prompt(
         continuation_instruction = (
             "After this tool result is processed, MindRoom continues the same task with the updated tool schema. "
             "Continue the same task now and call the loaded tool in a later tool-call step. "
+            "Do not wait for another user message."
+        )
+    elif continuation.status == _UNLOADED_STATUS:
+        continuation_instruction = (
+            "After this tool result is processed, MindRoom continues the same task with the updated tool schema. "
+            "Continue the same task now without the unloaded tool. "
             "Do not wait for another user message."
         )
     else:

--- a/src/mindroom/dynamic_tool_continuation.py
+++ b/src/mindroom/dynamic_tool_continuation.py
@@ -1,0 +1,155 @@
+"""Same-turn continuation decisions for dynamically loaded tools."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from agno.models.response import ToolExecution
+
+__all__ = ["DYNAMIC_TOOL_CONTINUATION_LIMIT", "continuation_decision_from_tools"]
+
+DYNAMIC_TOOL_CONTINUATION_LIMIT = 4
+_DYNAMIC_TOOL_FUNCTION_NAMES = frozenset({"load_tool", "unload_tool"})
+_LOADED_STATUSES = frozenset({"loaded", "already_loaded"})
+
+
+def _string_key_dict(value: object) -> dict[str, object] | None:
+    """Return a string-keyed dict from one decoded structured payload."""
+    if not isinstance(value, dict):
+        return None
+    raw_payload = cast("dict[object, object]", value)
+    if not all(isinstance(key, str) for key in raw_payload):
+        return None
+    return cast("dict[str, object]", raw_payload)
+
+
+@dataclass(frozen=True)
+class _DynamicToolContinuation:
+    """One dynamic-tool manager call that stopped the provider loop."""
+
+    function_name: str
+    status: str | None
+    tool_name: str | None
+
+
+@dataclass(frozen=True)
+class _DynamicToolContinuationDecision:
+    """How one response path should handle a completed dynamic-tool call."""
+
+    continuation: _DynamicToolContinuation | None = None
+    next_prompt: str | None = None
+    limit_message: str | None = None
+
+    @property
+    def should_continue(self) -> bool:
+        """Return whether the caller should rebuild the agent and run again."""
+        return self.next_prompt is not None
+
+
+def _dynamic_tool_payload(result: object) -> dict[str, object] | None:
+    """Return the structured dynamic-tools payload from one tool result."""
+    if isinstance(result, str):
+        try:
+            decoded = json.loads(result)
+        except json.JSONDecodeError:
+            return None
+        payload = _string_key_dict(decoded)
+    else:
+        payload = _string_key_dict(result)
+    if payload is None:
+        return None
+
+    if payload.get("tool") != "dynamic_tools":
+        return None
+    return payload
+
+
+def _dynamic_tool_continuation_from_tools(
+    tools: Sequence[ToolExecution] | None,
+) -> _DynamicToolContinuation | None:
+    """Detect a dynamic-tool manager call that stopped before a fresh schema step."""
+    for tool in tools or ():
+        function_name = tool.tool_name
+        if function_name not in _DYNAMIC_TOOL_FUNCTION_NAMES:
+            continue
+
+        payload = _dynamic_tool_payload(tool.result)
+        if payload is None:
+            continue
+
+        status = payload.get("status")
+        tool_name = payload.get("tool_name")
+        return _DynamicToolContinuation(
+            function_name=function_name,
+            status=status if isinstance(status, str) else None,
+            tool_name=tool_name if isinstance(tool_name, str) else None,
+        )
+    return None
+
+
+def _dynamic_tool_continuation_prompt(
+    original_prompt: str,
+    continuation: _DynamicToolContinuation,
+) -> str:
+    """Append a hidden continuation notice after one dynamic-tool manager call."""
+    tool_part = f" for `{continuation.tool_name}`" if continuation.tool_name else ""
+    status_part = f" and returned status `{continuation.status}`" if continuation.status else ""
+    if continuation.status in _LOADED_STATUSES:
+        continuation_instruction = (
+            "After this tool result is processed, MindRoom continues the same task with the updated tool schema. "
+            "Continue the same task now and call the loaded tool in a later tool-call step. "
+            "Do not wait for another user message."
+        )
+    else:
+        continuation_instruction = (
+            "After this tool result is processed, MindRoom continues the same task with the current dynamic tool state. "
+            "Continue the same task now using only available tools. "
+            "If the requested tool is unavailable, explain that or choose another available deferred tool if useful. "
+            "Do not wait for another user message."
+        )
+    return (
+        f"{original_prompt}\n\n"
+        "[SYSTEM NOTICE - DYNAMIC TOOL CALL COMPLETED]\n"
+        f"The previous model step called `{continuation.function_name}` through dynamic_tools"
+        f"{tool_part}{status_part}. "
+        f"{continuation_instruction}"
+    )
+
+
+def _dynamic_tool_continuation_limit_message(continuation: _DynamicToolContinuation) -> str:
+    """Return visible fallback text when repeated dynamic-tool calls do not converge."""
+    tool_part = f" for `{continuation.tool_name}`" if continuation.tool_name else ""
+    status_part = f" returned status `{continuation.status}`" if continuation.status else "completed"
+    return (
+        "Dynamic tool calls did not produce a final answer after "
+        f"{DYNAMIC_TOOL_CONTINUATION_LIMIT} continuation attempts. "
+        f"The last dynamic tool call was `{continuation.function_name}`{tool_part}, which {status_part}."
+    )
+
+
+def continuation_decision_from_tools(
+    tools: Sequence[ToolExecution] | None,
+    *,
+    original_prompt: str,
+    continuation_count: int,
+) -> _DynamicToolContinuationDecision:
+    """Return the continuation decision for a completed model response."""
+    continuation = _dynamic_tool_continuation_from_tools(tools)
+    if continuation is None:
+        return _DynamicToolContinuationDecision()
+
+    if continuation_count >= DYNAMIC_TOOL_CONTINUATION_LIMIT:
+        return _DynamicToolContinuationDecision(
+            continuation=continuation,
+            limit_message=_dynamic_tool_continuation_limit_message(continuation),
+        )
+
+    return _DynamicToolContinuationDecision(
+        continuation=continuation,
+        next_prompt=_dynamic_tool_continuation_prompt(original_prompt, continuation),
+    )

--- a/src/mindroom/prompts.py
+++ b/src/mindroom/prompts.py
@@ -153,10 +153,7 @@ Deferred tools are available by exact name and can be loaded for this session.
 </available-deferred-tools>
 Use load_tool(tool_name) to load one by exact name.
 Use tool_search(query) for keyword lookup across deferred tools.
-After load_tool or unload_tool succeeds, continue the same task with the updated dynamic tool state in a later tool-call step.
-After load_tool succeeds, call the newly loaded tool only in that later tool-call step.
-Do not wait for another user message.
-Do not call a newly loaded tool in the same parallel tool-call batch as load_tool.
+A loaded tool becomes callable once it appears in your available tools; do not call it in the same parallel tool-call batch as load_tool.
 In team conversations, each member manages its own dynamic tool state."""
 
 PREVIOUS_CONVERSATION_THREAD_HEADER = "Previous conversation in this thread:"
@@ -426,9 +423,8 @@ CODEX_DEFAULT_INSTRUCTIONS = "You are a helpful assistant."
 DYNAMIC_TOOLS_TOOLKIT_INSTRUCTIONS = (
     "Manage deferred tools for this session. "
     "Use list_tools() or tool_search() when unsure. "
-    "After load_tool() or unload_tool() succeeds, continue the same task with the updated dynamic tool state "
-    "in a later tool-call step. After load_tool() succeeds, call the loaded tool only in that later step. "
-    "Do not wait for another user message or call a newly loaded tool in the same parallel tool-call batch."
+    "A tool loaded with load_tool() becomes callable once it appears in your available tools, and "
+    "unload_tool() removes one. Do not call a newly loaded tool in the same parallel tool-call batch as load_tool()."
 )
 DELEGATE_TOOLKIT_INSTRUCTIONS_TEMPLATE = """You can delegate tasks to the following agents:
 {agent_descriptions}

--- a/src/mindroom/prompts.py
+++ b/src/mindroom/prompts.py
@@ -153,7 +153,10 @@ Deferred tools are available by exact name and can be loaded for this session.
 </available-deferred-tools>
 Use load_tool(tool_name) to load one by exact name.
 Use tool_search(query) for keyword lookup across deferred tools.
-Changes take effect on the next request in this session.
+After load_tool or unload_tool succeeds, continue the same task with the updated dynamic tool state in a later tool-call step.
+After load_tool succeeds, call the newly loaded tool only in that later tool-call step.
+Do not wait for another user message.
+Do not call a newly loaded tool in the same parallel tool-call batch as load_tool.
 In team conversations, each member manages its own dynamic tool state."""
 
 PREVIOUS_CONVERSATION_THREAD_HEADER = "Previous conversation in this thread:"
@@ -423,7 +426,9 @@ CODEX_DEFAULT_INSTRUCTIONS = "You are a helpful assistant."
 DYNAMIC_TOOLS_TOOLKIT_INSTRUCTIONS = (
     "Manage deferred tools for this session. "
     "Use list_tools() or tool_search() when unsure. "
-    "load_tool() and unload_tool() apply on the next request in the same session."
+    "After load_tool() or unload_tool() succeeds, continue the same task with the updated dynamic tool state "
+    "in a later tool-call step. After load_tool() succeeds, call the loaded tool only in that later step. "
+    "Do not wait for another user message or call a newly loaded tool in the same parallel tool-call batch."
 )
 DELEGATE_TOOLKIT_INSTRUCTIONS_TEMPLATE = """You can delegate tasks to the following agents:
 {agent_descriptions}

--- a/tach.toml
+++ b/tach.toml
@@ -60,6 +60,7 @@ depends_on = [
     "mindroom.constants",
     "mindroom.credentials",
     "mindroom.credentials_sync",
+    "mindroom.dynamic_tool_continuation",
     "mindroom.error_handling",
     "mindroom.execution_preparation",
     "mindroom.history",
@@ -83,6 +84,11 @@ depends_on = [
 
 [[modules]]
 path = "mindroom.ai_turn_state"
+depends_on = []
+visibility = ["mindroom.ai"]
+
+[[modules]]
+path = "mindroom.dynamic_tool_continuation"
 depends_on = []
 visibility = ["mindroom.ai"]
 

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -66,6 +66,7 @@ from mindroom.constants import (
 )
 from mindroom.delivery_gateway import DeliveryGateway, DeliveryGatewayDeps, ResponseHookService
 from mindroom.dispatch_source import MESSAGE_SOURCE_KIND
+from mindroom.dynamic_tool_continuation import DYNAMIC_TOOL_CONTINUATION_LIMIT
 from mindroom.entity_resolution import entity_identity_registry
 from mindroom.execution_preparation import _PreparedExecutionContext
 from mindroom.final_delivery import FinalDeliveryOutcome, StreamTransportOutcome
@@ -6219,6 +6220,425 @@ class TestUserIdPassthrough:
         assert response == "Done."
         assert "<tool>" not in response
         assert len(tool_trace) == 1
+
+    @pytest.mark.asyncio
+    async def test_ai_response_continues_after_dynamic_tool_load(self, tmp_path: Path) -> None:
+        """Dynamic tool loads should rebuild the agent and continue the same task."""
+        first_agent = MagicMock()
+        first_agent.model = MagicMock()
+        first_agent.model.__class__.__name__ = "OpenAIChat"
+        first_agent.model.id = "test-model"
+        first_agent.name = "GeneralAgent"
+        first_agent.add_history_to_context = False
+
+        second_agent = MagicMock()
+        second_agent.model = MagicMock()
+        second_agent.model.__class__.__name__ = "OpenAIChat"
+        second_agent.model.id = "test-model"
+        second_agent.name = "GeneralAgent"
+        second_agent.add_history_to_context = False
+
+        load_tool_execution = ToolExecution(
+            tool_call_id="call-load",
+            tool_name="load_tool",
+            tool_args={"tool_name": "sleep"},
+            result=json.dumps(
+                {
+                    "status": "loaded",
+                    "takes_effect": "later_tool_call_step",
+                    "tool": "dynamic_tools",
+                    "tool_name": "sleep",
+                },
+            ),
+            stop_after_tool_call=True,
+        )
+
+        first_run_output = MagicMock()
+        first_run_output.content = ""
+        first_run_output.tools = [load_tool_execution]
+        first_run_output.status = RunStatus.completed
+        first_agent.arun = AsyncMock(return_value=first_run_output)
+
+        second_run_output = MagicMock()
+        second_run_output.content = "Used the loaded tool."
+        second_run_output.tools = []
+        second_run_output.status = RunStatus.completed
+        second_agent.arun = AsyncMock(return_value=second_run_output)
+
+        with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
+            mock_prepare.side_effect = [
+                _prepared_prompt_result(first_agent),
+                _prepared_prompt_result(second_agent, prompt="continuation prompt"),
+            ]
+            tool_trace: list[object] = []
+            run_ids: list[str] = []
+            response = await ai_response(
+                agent_name="general",
+                prompt="test",
+                session_id="session1",
+                runtime_paths=_runtime_paths(tmp_path),
+                config=_config(),
+                run_id="run-1",
+                model_prompt="test\n\nUse attachment att_1.",
+                run_id_callback=run_ids.append,
+                show_tool_calls=False,
+                tool_trace_collector=tool_trace,
+            )
+
+        assert response == "Used the loaded tool."
+        assert mock_prepare.await_count == 2
+        assert mock_prepare.await_args_list[0].kwargs["model_prompt"] == "test\n\nUse attachment att_1."
+        assert mock_prepare.await_args_list[1].kwargs["model_prompt"] == "Use attachment att_1."
+        assert "Continue the same task" in mock_prepare.await_args_list[1].args[1]
+        first_agent.arun.assert_awaited_once()
+        second_agent.arun.assert_awaited_once()
+        assert run_ids[0] == "run-1"
+        assert len(run_ids) == 2
+        assert run_ids[1] != "run-1"
+        assert first_agent.arun.await_args.kwargs["run_id"] == "run-1"
+        assert second_agent.arun.await_args.kwargs["run_id"] == run_ids[1]
+        assert len(tool_trace) == 1
+
+    @pytest.mark.asyncio
+    async def test_ai_response_continuation_cancelled_run_preserves_dynamic_tool_trace(self, tmp_path: Path) -> None:
+        """Cancelled continuation runs should keep dynamic-tool calls in interrupted history."""
+        first_agent = MagicMock()
+        first_agent.model = MagicMock()
+        first_agent.model.__class__.__name__ = "OpenAIChat"
+        first_agent.model.id = "test-model"
+        first_agent.name = "GeneralAgent"
+        first_agent.add_history_to_context = False
+
+        second_agent = MagicMock()
+        second_agent.model = MagicMock()
+        second_agent.model.__class__.__name__ = "OpenAIChat"
+        second_agent.model.id = "test-model"
+        second_agent.name = "GeneralAgent"
+        second_agent.add_history_to_context = False
+
+        load_tool_execution = ToolExecution(
+            tool_call_id="call-load",
+            tool_name="load_tool",
+            tool_args={"tool_name": "sleep"},
+            result=json.dumps(
+                {
+                    "status": "loaded",
+                    "takes_effect": "later_tool_call_step",
+                    "tool": "dynamic_tools",
+                    "tool_name": "sleep",
+                },
+            ),
+            stop_after_tool_call=True,
+        )
+        first_run_output = MagicMock()
+        first_run_output.content = ""
+        first_run_output.tools = [load_tool_execution]
+        first_run_output.status = RunStatus.completed
+        first_agent.arun = AsyncMock(return_value=first_run_output)
+
+        second_run_output = RunOutput(
+            run_id="run-2",
+            agent_id="general",
+            session_id="session1",
+            content="Half done",
+            messages=[Message(role="assistant", content="Half done")],
+            tools=[
+                ToolExecution(
+                    tool_name="run_shell_command",
+                    tool_args={"cmd": "pwd"},
+                    result="/app",
+                ),
+            ],
+            status=RunStatus.cancelled,
+        )
+        second_agent.arun = AsyncMock(return_value=second_run_output)
+        recorder = TurnRecorder(user_message="test")
+
+        with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
+            mock_prepare.side_effect = [
+                _prepared_prompt_result(first_agent),
+                _prepared_prompt_result(second_agent, prompt="continuation prompt"),
+            ]
+
+            with pytest.raises(asyncio.CancelledError):
+                await ai_response(
+                    agent_name="general",
+                    prompt="test",
+                    session_id="session1",
+                    runtime_paths=_runtime_paths(tmp_path),
+                    config=_config(),
+                    run_id="run-1",
+                    show_tool_calls=False,
+                    turn_recorder=recorder,
+                )
+
+        snapshot = recorder.interrupted_snapshot()
+        assert snapshot.user_message == "test"
+        assert snapshot.partial_text == "Half done"
+        assert [tool.tool_name for tool in snapshot.completed_tools] == ["load_tool", "run_shell_command"]
+
+    @pytest.mark.asyncio
+    async def test_stream_agent_response_continues_after_dynamic_tool_load(self, tmp_path: Path) -> None:
+        """Streaming dynamic tool loads should rebuild the agent before continuing."""
+        first_agent = MagicMock()
+        first_agent.model = MagicMock()
+        first_agent.model.__class__.__name__ = "OpenAIChat"
+        first_agent.model.id = "test-model"
+        first_agent.name = "GeneralAgent"
+        first_agent.add_history_to_context = False
+
+        second_agent = MagicMock()
+        second_agent.model = MagicMock()
+        second_agent.model.__class__.__name__ = "OpenAIChat"
+        second_agent.model.id = "test-model"
+        second_agent.name = "GeneralAgent"
+        second_agent.add_history_to_context = False
+
+        load_tool_execution = ToolExecution(
+            tool_call_id="call-load",
+            tool_name="load_tool",
+            tool_args={"tool_name": "sleep"},
+            result=json.dumps(
+                {
+                    "status": "loaded",
+                    "takes_effect": "later_tool_call_step",
+                    "tool": "dynamic_tools",
+                    "tool_name": "sleep",
+                },
+            ),
+            stop_after_tool_call=True,
+        )
+
+        async def first_stream() -> AsyncIterator[object]:
+            yield ToolCallCompletedEvent(tool=load_tool_execution)
+            yield RunCompletedEvent(content=None)
+
+        async def second_stream() -> AsyncIterator[object]:
+            yield RunContentEvent(content="Used the loaded tool.")
+            yield RunCompletedEvent(content="Used the loaded tool.")
+
+        first_agent.arun = MagicMock(return_value=first_stream())
+        second_agent.arun = MagicMock(return_value=second_stream())
+
+        with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
+            mock_prepare.side_effect = [
+                _prepared_prompt_result(first_agent),
+                _prepared_prompt_result(second_agent, prompt="continuation prompt"),
+            ]
+            run_ids: list[str] = []
+            chunks = [
+                chunk
+                async for chunk in stream_agent_response(
+                    agent_name="general",
+                    prompt="test",
+                    session_id="session1",
+                    runtime_paths=_runtime_paths(tmp_path),
+                    config=_config(),
+                    run_id="run-1",
+                    model_prompt="test\n\nUse attachment att_1.",
+                    run_id_callback=run_ids.append,
+                    show_tool_calls=False,
+                )
+            ]
+
+        assert [chunk.content for chunk in chunks if isinstance(chunk, RunContentEvent)] == ["Used the loaded tool."]
+        assert mock_prepare.await_count == 2
+        assert mock_prepare.await_args_list[0].kwargs["model_prompt"] == "test\n\nUse attachment att_1."
+        assert mock_prepare.await_args_list[1].kwargs["model_prompt"] == "Use attachment att_1."
+        assert "Continue the same task" in mock_prepare.await_args_list[1].args[1]
+        first_agent.arun.assert_called_once()
+        second_agent.arun.assert_called_once()
+        assert run_ids[0] == "run-1"
+        assert len(run_ids) == 2
+        assert run_ids[1] != "run-1"
+        assert first_agent.arun.call_args.kwargs["run_id"] == "run-1"
+        assert second_agent.arun.call_args.kwargs["run_id"] == run_ids[1]
+
+    @pytest.mark.asyncio
+    async def test_stream_agent_response_continuation_task_cancel_preserves_second_run_tools(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Task cancellation during a continuation run should not let the outer run overwrite recorder state."""
+        first_agent = MagicMock()
+        first_agent.model = MagicMock()
+        first_agent.model.__class__.__name__ = "OpenAIChat"
+        first_agent.model.id = "test-model"
+        first_agent.name = "GeneralAgent"
+        first_agent.add_history_to_context = False
+
+        second_agent = MagicMock()
+        second_agent.model = MagicMock()
+        second_agent.model.__class__.__name__ = "OpenAIChat"
+        second_agent.model.id = "test-model"
+        second_agent.name = "GeneralAgent"
+        second_agent.add_history_to_context = False
+
+        load_tool_execution = ToolExecution(
+            tool_call_id="call-load",
+            tool_name="load_tool",
+            tool_args={"tool_name": "sleep"},
+            result=json.dumps(
+                {
+                    "status": "loaded",
+                    "takes_effect": "later_tool_call_step",
+                    "tool": "dynamic_tools",
+                    "tool_name": "sleep",
+                },
+            ),
+            stop_after_tool_call=True,
+        )
+
+        async def first_stream() -> AsyncIterator[object]:
+            yield ToolCallCompletedEvent(tool=load_tool_execution)
+            yield RunCompletedEvent(content=None)
+
+        async def second_stream() -> AsyncIterator[object]:
+            yield RunContentEvent(content="Half done")
+            yield ToolCallCompletedEvent(
+                tool=ToolExecution(
+                    tool_name="run_shell_command",
+                    tool_args={"cmd": "pwd"},
+                    result="/app",
+                ),
+            )
+            cancellation_reason = "cancelled during continuation"
+            raise asyncio.CancelledError(cancellation_reason)
+
+        first_agent.arun = MagicMock(return_value=first_stream())
+        second_agent.arun = MagicMock(return_value=second_stream())
+        recorder = TurnRecorder(user_message="test")
+
+        with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
+            mock_prepare.side_effect = [
+                _prepared_prompt_result(first_agent),
+                _prepared_prompt_result(second_agent, prompt="continuation prompt"),
+            ]
+
+            with pytest.raises(asyncio.CancelledError):
+                async for _chunk in stream_agent_response(
+                    agent_name="general",
+                    prompt="test",
+                    session_id="session1",
+                    runtime_paths=_runtime_paths(tmp_path),
+                    config=_config(),
+                    run_id="run-1",
+                    show_tool_calls=False,
+                    turn_recorder=recorder,
+                ):
+                    pass
+
+        snapshot = recorder.interrupted_snapshot()
+        assert snapshot.partial_text == "Half done"
+        assert [tool.tool_name for tool in snapshot.completed_tools] == ["load_tool", "run_shell_command"]
+
+    @pytest.mark.asyncio
+    async def test_ai_response_returns_message_after_dynamic_tool_limit(self, tmp_path: Path) -> None:
+        """Repeated dynamic tool manager calls should return fallback text in the default visible mode."""
+        agents = []
+        prepared_runs = []
+        for index in range(DYNAMIC_TOOL_CONTINUATION_LIMIT + 1):
+            agent = MagicMock()
+            agent.model = MagicMock()
+            agent.model.__class__.__name__ = "OpenAIChat"
+            agent.model.id = "test-model"
+            agent.name = "GeneralAgent"
+            agent.add_history_to_context = False
+
+            load_tool_execution = ToolExecution(
+                tool_call_id=f"call-load-{index}",
+                tool_name="load_tool",
+                tool_args={"tool_name": "missing_tool"},
+                result=json.dumps(
+                    {
+                        "status": "unknown",
+                        "tool": "dynamic_tools",
+                        "tool_name": "missing_tool",
+                    },
+                ),
+                stop_after_tool_call=True,
+            )
+            run_output = MagicMock()
+            run_output.content = ""
+            run_output.tools = [load_tool_execution]
+            run_output.status = RunStatus.completed
+            agent.arun = AsyncMock(return_value=run_output)
+
+            agents.append(agent)
+            prepared_runs.append(_prepared_prompt_result(agent, prompt=f"continuation prompt {index}"))
+
+        with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
+            mock_prepare.side_effect = prepared_runs
+            response = await ai_response(
+                agent_name="general",
+                prompt="test",
+                session_id="session1",
+                runtime_paths=_runtime_paths(tmp_path),
+                config=_config(),
+            )
+
+        assert "Dynamic tool calls did not produce a final answer" in response
+        assert "`load_tool` for `missing_tool`" in response
+        assert "`unknown`" in response
+        assert mock_prepare.await_count == DYNAMIC_TOOL_CONTINUATION_LIMIT + 1
+        assert all(agent.arun.await_count == 1 for agent in agents)
+
+    @pytest.mark.asyncio
+    async def test_stream_agent_response_returns_message_after_dynamic_tool_limit(self, tmp_path: Path) -> None:
+        """Streaming repeated dynamic tool manager calls should yield visible fallback text."""
+        agents = []
+        prepared_runs = []
+        for index in range(DYNAMIC_TOOL_CONTINUATION_LIMIT + 1):
+            agent = MagicMock()
+            agent.model = MagicMock()
+            agent.model.__class__.__name__ = "OpenAIChat"
+            agent.model.id = "test-model"
+            agent.name = "GeneralAgent"
+            agent.add_history_to_context = False
+
+            load_tool_execution = ToolExecution(
+                tool_call_id=f"call-load-{index}",
+                tool_name="load_tool",
+                tool_args={"tool_name": "missing_tool"},
+                result=json.dumps(
+                    {
+                        "status": "unknown",
+                        "tool": "dynamic_tools",
+                        "tool_name": "missing_tool",
+                    },
+                ),
+                stop_after_tool_call=True,
+            )
+
+            async def stream(execution: ToolExecution = load_tool_execution) -> AsyncIterator[object]:
+                yield ToolCallCompletedEvent(tool=execution)
+                yield RunCompletedEvent(content=None)
+
+            agent.arun = MagicMock(return_value=stream())
+            agents.append(agent)
+            prepared_runs.append(_prepared_prompt_result(agent, prompt=f"continuation prompt {index}"))
+
+        with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
+            mock_prepare.side_effect = prepared_runs
+            chunks = [
+                chunk
+                async for chunk in stream_agent_response(
+                    agent_name="general",
+                    prompt="test",
+                    session_id="session1",
+                    runtime_paths=_runtime_paths(tmp_path),
+                    config=_config(),
+                    show_tool_calls=False,
+                )
+            ]
+
+        content_chunks = [chunk.content for chunk in chunks if isinstance(chunk, RunContentEvent)]
+        assert len(content_chunks) == 1
+        assert "Dynamic tool calls did not produce a final answer" in content_chunks[0]
+        assert "`load_tool` for `missing_tool`" in content_chunks[0]
+        assert "`unknown`" in content_chunks[0]
+        assert mock_prepare.await_count == DYNAMIC_TOOL_CONTINUATION_LIMIT + 1
+        assert all(agent.arun.call_count == 1 for agent in agents)
 
     @pytest.mark.asyncio
     async def test_ai_response_collects_run_metadata(self, tmp_path: Path) -> None:

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -6245,7 +6245,6 @@ class TestUserIdPassthrough:
             result=json.dumps(
                 {
                     "status": "loaded",
-                    "takes_effect": "later_tool_call_step",
                     "tool": "dynamic_tools",
                     "tool_name": "sleep",
                 },
@@ -6323,7 +6322,6 @@ class TestUserIdPassthrough:
             result=json.dumps(
                 {
                     "status": "loaded",
-                    "takes_effect": "later_tool_call_step",
                     "tool": "dynamic_tools",
                     "tool_name": "sleep",
                 },
@@ -6401,7 +6399,6 @@ class TestUserIdPassthrough:
             result=json.dumps(
                 {
                     "status": "loaded",
-                    "takes_effect": "later_tool_call_step",
                     "tool": "dynamic_tools",
                     "tool_name": "sleep",
                 },
@@ -6481,7 +6478,6 @@ class TestUserIdPassthrough:
             result=json.dumps(
                 {
                     "status": "loaded",
-                    "takes_effect": "later_tool_call_step",
                     "tool": "dynamic_tools",
                     "tool_name": "sleep",
                 },

--- a/tests/test_dynamic_tool_continuation.py
+++ b/tests/test_dynamic_tool_continuation.py
@@ -1,0 +1,99 @@
+"""Tests for dynamic-tool same-turn continuation decisions."""
+
+from __future__ import annotations
+
+import json
+
+from agno.models.response import ToolExecution
+
+from mindroom.dynamic_tool_continuation import (
+    DYNAMIC_TOOL_CONTINUATION_LIMIT,
+    continuation_decision_from_tools,
+)
+
+
+def _dynamic_tool_execution(status: str = "loaded") -> ToolExecution:
+    return ToolExecution(
+        tool_call_id="call-load",
+        tool_name="load_tool",
+        tool_args={"tool_name": "sleep"},
+        result=json.dumps(
+            {
+                "status": status,
+                "takes_effect": "later_tool_call_step",
+                "tool": "dynamic_tools",
+                "tool_name": "sleep",
+            },
+        ),
+        stop_after_tool_call=True,
+    )
+
+
+def test_continuation_decision_detects_dynamic_tool_call() -> None:
+    """A dynamic manager call produces a continuation prompt."""
+    decision = continuation_decision_from_tools(
+        [_dynamic_tool_execution()],
+        original_prompt="Book the campsite",
+        continuation_count=0,
+    )
+
+    assert decision.should_continue is True
+    assert decision.limit_message is None
+    assert decision.next_prompt is not None
+    assert "Book the campsite" in decision.next_prompt
+    assert "After this tool result is processed" in decision.next_prompt
+    assert "updated tool schema" in decision.next_prompt
+    assert "Continue the same task" in decision.next_prompt
+    assert "loaded" in decision.next_prompt
+
+
+def test_continuation_decision_handles_failed_dynamic_tool_call_without_assuming_availability() -> None:
+    """A failed dynamic manager call should continue without implying the requested tool is usable."""
+    decision = continuation_decision_from_tools(
+        [_dynamic_tool_execution(status="unknown")],
+        original_prompt="Book the campsite",
+        continuation_count=0,
+    )
+
+    assert decision.should_continue is True
+    assert decision.next_prompt is not None
+    assert "current dynamic tool state" in decision.next_prompt
+    assert "If the requested tool is unavailable" in decision.next_prompt
+    assert "explain that or choose another available deferred tool" in decision.next_prompt
+    assert "updated tool schema" not in decision.next_prompt
+
+
+def test_continuation_decision_ignores_non_dynamic_tool_payload() -> None:
+    """A load_tool-shaped call from another toolkit should not trigger continuation."""
+    execution = ToolExecution(
+        tool_call_id="call-load",
+        tool_name="load_tool",
+        tool_args={"tool_name": "sleep"},
+        result=json.dumps({"status": "loaded", "tool": "other"}),
+    )
+
+    decision = continuation_decision_from_tools(
+        [execution],
+        original_prompt="Book the campsite",
+        continuation_count=0,
+    )
+
+    assert decision.should_continue is False
+    assert decision.next_prompt is None
+    assert decision.limit_message is None
+
+
+def test_continuation_decision_returns_limit_message_at_limit() -> None:
+    """Repeated dynamic manager calls produce visible fallback text at the limit."""
+    decision = continuation_decision_from_tools(
+        [_dynamic_tool_execution(status="unknown")],
+        original_prompt="Book the campsite",
+        continuation_count=DYNAMIC_TOOL_CONTINUATION_LIMIT,
+    )
+
+    assert decision.should_continue is False
+    assert decision.next_prompt is None
+    assert decision.limit_message is not None
+    assert "Dynamic tool calls did not produce a final answer" in decision.limit_message
+    assert "`load_tool` for `sleep`" in decision.limit_message
+    assert "`unknown`" in decision.limit_message

--- a/tests/test_dynamic_tool_continuation.py
+++ b/tests/test_dynamic_tool_continuation.py
@@ -12,17 +12,21 @@ from mindroom.dynamic_tool_continuation import (
 )
 
 
-def _dynamic_tool_execution(status: str = "loaded") -> ToolExecution:
+def _dynamic_tool_execution(
+    status: str = "loaded",
+    *,
+    function_name: str = "load_tool",
+    tool_name: str = "sleep",
+) -> ToolExecution:
     return ToolExecution(
-        tool_call_id="call-load",
-        tool_name="load_tool",
-        tool_args={"tool_name": "sleep"},
+        tool_call_id=f"call-{function_name}",
+        tool_name=function_name,
+        tool_args={"tool_name": tool_name},
         result=json.dumps(
             {
                 "status": status,
-                "takes_effect": "later_tool_call_step",
                 "tool": "dynamic_tools",
-                "tool_name": "sleep",
+                "tool_name": tool_name,
             },
         ),
         stop_after_tool_call=True,
@@ -45,6 +49,34 @@ def test_continuation_decision_detects_dynamic_tool_call() -> None:
     assert "updated tool schema" in decision.next_prompt
     assert "Continue the same task" in decision.next_prompt
     assert "loaded" in decision.next_prompt
+
+
+def test_continuation_decision_detects_unload_tool_call() -> None:
+    """An unload_tool manager call continues the same task without the tool."""
+    decision = continuation_decision_from_tools(
+        [_dynamic_tool_execution(status="unloaded", function_name="unload_tool")],
+        original_prompt="Tidy up the tools",
+        continuation_count=0,
+    )
+
+    assert decision.should_continue is True
+    assert decision.next_prompt is not None
+    assert "unload_tool" in decision.next_prompt
+    assert "without the unloaded tool" in decision.next_prompt
+    assert "If the requested tool is unavailable" not in decision.next_prompt
+
+
+def test_continuation_decision_limit_message_names_unload_tool() -> None:
+    """The limit fallback names the unload_tool call that did not converge."""
+    decision = continuation_decision_from_tools(
+        [_dynamic_tool_execution(status="unloaded", function_name="unload_tool")],
+        original_prompt="Tidy up the tools",
+        continuation_count=DYNAMIC_TOOL_CONTINUATION_LIMIT,
+    )
+
+    assert decision.should_continue is False
+    assert decision.limit_message is not None
+    assert "`unload_tool` for `sleep`" in decision.limit_message
 
 
 def test_continuation_decision_handles_failed_dynamic_tool_call_without_assuming_availability() -> None:

--- a/tests/test_dynamic_toolkits.py
+++ b/tests/test_dynamic_toolkits.py
@@ -12,6 +12,7 @@ import pytest
 from mindroom.agents import (
     _build_dynamic_tooling_instruction_block,
     _build_dynamic_tooling_state_suffix,
+    build_agent_toolkit,
     get_agent_toolkit_names,
 )
 from mindroom.config.main import Config
@@ -559,46 +560,83 @@ def test_dynamic_tools_manager_loads_unloads_searches_and_respects_sticky_initia
 
     loaded_payload = _tool_payload(manager.load_tool("sleep"))
     assert loaded_payload["status"] == "loaded"
-    assert loaded_payload["takes_effect"] == "later_tool_call_step"
-    assert "After this tool result is processed" in loaded_payload["message"]
-    assert "updated tool schema" in loaded_payload["message"]
-    assert "later tool-call step" in loaded_payload["message"]
+    assert "takes_effect" not in loaded_payload
+    assert "is now loaded" in loaded_payload["message"]
+    assert "becomes callable once it appears" in loaded_payload["message"]
     assert "same parallel tool-call batch" in loaded_payload["message"]
     assert "next request" not in loaded_payload["message"]
 
     already_loaded_payload = _tool_payload(manager.load_tool("sleep"))
     assert already_loaded_payload["status"] == "already_loaded"
-    assert already_loaded_payload["takes_effect"] == "later_tool_call_step"
-    assert "After this tool result is processed" in already_loaded_payload["message"]
-    assert "updated tool schema" in already_loaded_payload["message"]
-    assert "next request" not in already_loaded_payload["message"]
+    assert "takes_effect" not in already_loaded_payload
+    assert already_loaded_payload["message"] == "Tool 'sleep' is already loaded for this session."
 
     assert _tool_payload(manager.unload_tool("shell"))["status"] == "sticky"
 
     unloaded_payload = _tool_payload(manager.unload_tool("sleep"))
     assert unloaded_payload["status"] == "unloaded"
-    assert unloaded_payload["takes_effect"] == "later_tool_call_step"
-    assert "current dynamic tool state" in unloaded_payload["message"]
-    assert "next request" not in unloaded_payload["message"]
+    assert "takes_effect" not in unloaded_payload
+    assert unloaded_payload["message"] == "Tool 'sleep' is now unloaded for this session."
 
     assert ("code", "thread-a") not in dynamic_toolkits_module._loaded_tools
     assert _tool_payload(manager.unload_tool("sleep"))["status"] == "not_loaded"
 
 
-def test_dynamic_tools_load_and_unload_stop_stale_agno_loop(tmp_path: Path) -> None:
-    """Dynamic surface changes should end the current Agno loop before the next provider call."""
+def test_dynamic_tools_stop_after_tool_call_only_when_continuation_enabled(tmp_path: Path) -> None:
+    """The manager stops the Agno loop only for the standalone continuation path."""
     raw = _base_config_data()
     raw["agents"]["code"]["tools"] = [  # type: ignore[index]
         {"shell": {"defer": True}},
     ]
     config = _validated_config(tmp_path, raw)
 
-    manager = DynamicToolsToolkit(agent_name="code", config=config, session_id="thread-a")
+    continuation_manager = DynamicToolsToolkit(
+        agent_name="code",
+        config=config,
+        session_id="thread-a",
+        stop_after_tool_call=True,
+    )
+    assert continuation_manager.functions["load_tool"].stop_after_tool_call is True
+    assert continuation_manager.functions["unload_tool"].stop_after_tool_call is True
+    assert continuation_manager.functions["list_tools"].stop_after_tool_call is False
+    assert continuation_manager.functions["tool_search"].stop_after_tool_call is False
 
-    assert manager.functions["load_tool"].stop_after_tool_call is True
-    assert manager.functions["unload_tool"].stop_after_tool_call is True
-    assert manager.functions["list_tools"].stop_after_tool_call is False
-    assert manager.functions["tool_search"].stop_after_tool_call is False
+    # Team members and other embedded agents run without the continuation loop,
+    # so the manager must not truncate their run after a load/unload.
+    member_manager = DynamicToolsToolkit(agent_name="code", config=config, session_id="thread-a")
+    assert member_manager.functions["load_tool"].stop_after_tool_call is False
+    assert member_manager.functions["unload_tool"].stop_after_tool_call is False
+
+
+def test_build_agent_toolkit_gates_dynamic_tool_continuation(tmp_path: Path) -> None:
+    """The continuation stop flag survives the build pipeline into the live toolkit."""
+    raw = _base_config_data()
+    raw["agents"]["code"]["tools"] = [{"shell": {"defer": True}}]  # type: ignore[index]
+    config = _validated_config(tmp_path, raw)
+    runtime_paths = _runtime_paths(tmp_path)
+
+    def _build(*, dynamic_tool_continuation: bool) -> object:
+        return build_agent_toolkit(
+            "dynamic_tools",
+            agent_name="code",
+            config=config,
+            runtime_paths=runtime_paths,
+            worker_tools=[],
+            runtime_overrides=None,
+            execution_identity=None,
+            session_id="thread-a",
+            dynamic_tool_continuation=dynamic_tool_continuation,
+        )
+
+    standalone = _build(dynamic_tool_continuation=True)
+    assert standalone is not None
+    assert standalone.functions["load_tool"].stop_after_tool_call is True
+    assert standalone.functions["unload_tool"].stop_after_tool_call is True
+
+    member = _build(dynamic_tool_continuation=False)
+    assert member is not None
+    assert member.functions["load_tool"].stop_after_tool_call is False
+    assert member.functions["unload_tool"].stop_after_tool_call is False
 
 
 def test_dynamic_tools_manager_catalog_responses_use_one_loaded_state_snapshot(
@@ -798,11 +836,11 @@ def test_dynamic_prompt_splits_static_catalog_from_volatile_loaded_state(tmp_pat
 
     assert static_before == static_after
     assert "shell - Execute shell commands" in static_before
-    assert "After load_tool or unload_tool succeeds" in static_before
-    assert "updated dynamic tool state" in static_before
-    assert "Do not wait for another user message" in static_before
+    assert "becomes callable once it appears in your available tools" in static_before
     assert "same parallel tool-call batch" in static_before
+    assert "each member manages its own dynamic tool state" in static_before
     assert "next request" not in static_before
+    assert "Do not wait for another user message" not in static_before
     assert suffix_before != suffix_after
     assert (
         suffix_after == "Dynamic tools currently loaded for this session: shell, sleep\n"

--- a/tests/test_dynamic_toolkits.py
+++ b/tests/test_dynamic_toolkits.py
@@ -557,12 +557,48 @@ def test_dynamic_tools_manager_loads_unloads_searches_and_respects_sticky_initia
     search_payload = _tool_payload(manager.tool_search("sleep"))
     assert [match["name"] for match in search_payload["matches"]] == ["sleep"]
 
-    assert _tool_payload(manager.load_tool("sleep"))["status"] == "loaded"
-    assert _tool_payload(manager.load_tool("sleep"))["status"] == "already_loaded"
+    loaded_payload = _tool_payload(manager.load_tool("sleep"))
+    assert loaded_payload["status"] == "loaded"
+    assert loaded_payload["takes_effect"] == "later_tool_call_step"
+    assert "After this tool result is processed" in loaded_payload["message"]
+    assert "updated tool schema" in loaded_payload["message"]
+    assert "later tool-call step" in loaded_payload["message"]
+    assert "same parallel tool-call batch" in loaded_payload["message"]
+    assert "next request" not in loaded_payload["message"]
+
+    already_loaded_payload = _tool_payload(manager.load_tool("sleep"))
+    assert already_loaded_payload["status"] == "already_loaded"
+    assert already_loaded_payload["takes_effect"] == "later_tool_call_step"
+    assert "After this tool result is processed" in already_loaded_payload["message"]
+    assert "updated tool schema" in already_loaded_payload["message"]
+    assert "next request" not in already_loaded_payload["message"]
+
     assert _tool_payload(manager.unload_tool("shell"))["status"] == "sticky"
-    assert _tool_payload(manager.unload_tool("sleep"))["status"] == "unloaded"
+
+    unloaded_payload = _tool_payload(manager.unload_tool("sleep"))
+    assert unloaded_payload["status"] == "unloaded"
+    assert unloaded_payload["takes_effect"] == "later_tool_call_step"
+    assert "current dynamic tool state" in unloaded_payload["message"]
+    assert "next request" not in unloaded_payload["message"]
+
     assert ("code", "thread-a") not in dynamic_toolkits_module._loaded_tools
     assert _tool_payload(manager.unload_tool("sleep"))["status"] == "not_loaded"
+
+
+def test_dynamic_tools_load_and_unload_stop_stale_agno_loop(tmp_path: Path) -> None:
+    """Dynamic surface changes should end the current Agno loop before the next provider call."""
+    raw = _base_config_data()
+    raw["agents"]["code"]["tools"] = [  # type: ignore[index]
+        {"shell": {"defer": True}},
+    ]
+    config = _validated_config(tmp_path, raw)
+
+    manager = DynamicToolsToolkit(agent_name="code", config=config, session_id="thread-a")
+
+    assert manager.functions["load_tool"].stop_after_tool_call is True
+    assert manager.functions["unload_tool"].stop_after_tool_call is True
+    assert manager.functions["list_tools"].stop_after_tool_call is False
+    assert manager.functions["tool_search"].stop_after_tool_call is False
 
 
 def test_dynamic_tools_manager_catalog_responses_use_one_loaded_state_snapshot(
@@ -762,6 +798,11 @@ def test_dynamic_prompt_splits_static_catalog_from_volatile_loaded_state(tmp_pat
 
     assert static_before == static_after
     assert "shell - Execute shell commands" in static_before
+    assert "After load_tool or unload_tool succeeds" in static_before
+    assert "updated dynamic tool state" in static_before
+    assert "Do not wait for another user message" in static_before
+    assert "same parallel tool-call batch" in static_before
+    assert "next request" not in static_before
     assert suffix_before != suffix_after
     assert (
         suffix_after == "Dynamic tools currently loaded for this session: shell, sleep\n"


### PR DESCRIPTION
## Summary

- Replace dynamic-tool lazy-loading wording that told agents to wait for the next request.
- Continue the same AI response after `load_tool()` / `unload_tool()` manager calls so updated tool state is available in a later tool-call step.
- Keep the continuation limit visible even when the final empty model response contains a visible tool trace.
- Preserve model-prompt metadata on continuation attempts without re-appending the original user request.
- Update docs, generated skill references, and regression coverage.

## Testing

- `uv sync --all-extras`
- `uv run pre-commit run --all-files`
- `uv run pytest tests/test_dynamic_tool_continuation.py tests/test_dynamic_toolkits.py tests/test_ai_user_id.py::TestUserIdPassthrough::test_ai_response_continues_after_dynamic_tool_load tests/test_ai_user_id.py::TestUserIdPassthrough::test_stream_agent_response_continues_after_dynamic_tool_load tests/test_ai_user_id.py::TestUserIdPassthrough::test_ai_response_returns_message_after_dynamic_tool_limit -n 0 --no-cov -q` (`43 passed`)
- `uv run pytest -n auto --no-cov -q` (`8541 passed, 30 skipped, 56 warnings`)
