### PR TITLE
Fix MCP session lifecycle task ownership

### DIFF
--- a/src/mindroom/mcp/manager.py
+++ b/src/mindroom/mcp/manager.py
@@ -749,9 +749,14 @@ class MCPServerManager:
         state.session_close_event = None
         if owner_task is not None:
             try:
-                if close_event is not None:
+                if close_event is None:
+                    await self._cancel_session_owner_task(owner_task)
+                    close_error = RuntimeError(
+                        f"MCP server '{state.server_id}' session owner is missing close event",
+                    )
+                else:
                     close_event.set()
-                await owner_task
+                    await owner_task
             except BaseException as exc:
                 close_error = exc
         elif state.exit_stack is not None:

--- a/src/mindroom/mcp/manager.py
+++ b/src/mindroom/mcp/manager.py
@@ -510,39 +510,66 @@ class MCPServerManager:
         auth_headers: Mapping[str, str] | None = None,
     ) -> MCPServerCatalog:
         handle = build_transport_handle(state.server_id, state.config, self.runtime_paths, extra_headers=auth_headers)
-        exit_stack = AsyncExitStack()
+        ready: asyncio.Future[tuple[ClientSession, MCPServerCatalog]] = asyncio.get_running_loop().create_future()
+        close_event = asyncio.Event()
 
-        async def open_session_and_discover() -> tuple[ClientSession, MCPServerCatalog]:
-            read_stream, write_stream = await exit_stack.enter_async_context(handle.opener())
-            session = await exit_stack.enter_async_context(
-                ClientSession(
-                    read_stream,
-                    write_stream,
-                    read_timeout_seconds=timedelta(seconds=state.config.call_timeout_seconds),
-                    message_handler=self._build_message_handler(state),
-                ),
-            )
-            initialize_result = await session.initialize()
-            catalog = await self._discover_catalog(state.server_id, state.config, session, initialize_result)
-            return session, catalog
+        async def session_owner() -> None:
+            # MCP/AnyIO session contexts must exit in the same task that entered them.
+            exit_stack = AsyncExitStack()
+            try:
+                read_stream, write_stream = await exit_stack.enter_async_context(handle.opener())
+                session = await exit_stack.enter_async_context(
+                    ClientSession(
+                        read_stream,
+                        write_stream,
+                        read_timeout_seconds=timedelta(seconds=state.config.call_timeout_seconds),
+                        message_handler=self._build_message_handler(state),
+                    ),
+                )
+                initialize_result = await session.initialize()
+                catalog = await self._discover_catalog(state.server_id, state.config, session, initialize_result)
+                if not ready.done():
+                    ready.set_result((session, catalog))
+                await close_event.wait()
+            except asyncio.CancelledError:
+                if not ready.done():
+                    ready.cancel()
+                raise
+            except BaseException as exc:
+                if not ready.done():
+                    ready.set_exception(exc)
+                else:
+                    logger.warning(
+                        "MCP server session owner failed",
+                        server_id=state.server_id,
+                        transport=state.config.transport,
+                        error=self._runtime_exception_message(exc),
+                    )
+                raise
+            finally:
+                await exit_stack.aclose()
+
+        owner_task = asyncio.create_task(session_owner(), name=f"mcp_session:{state.server_id}")
 
         try:
             session, catalog = await asyncio.wait_for(
-                open_session_and_discover(),
+                asyncio.shield(ready),
                 timeout=state.config.startup_timeout_seconds,
             )
         except asyncio.CancelledError:
-            await exit_stack.aclose()
+            await self._cancel_session_owner_task(owner_task)
             raise
         except Exception as exc:
-            await exit_stack.aclose()
+            await self._cancel_session_owner_task(owner_task)
             if isinstance(exc, TimeoutError | asyncio.TimeoutError):
                 msg = f"MCP startup timed out after {state.config.startup_timeout_seconds} seconds"
                 raise MCPTimeoutError(state.server_id, msg) from exc
             raise self._wrap_runtime_exception(state.server_id, exc) from exc
 
-        state.exit_stack = exit_stack
+        state.exit_stack = None
         state.session = session
+        state.session_owner_task = owner_task
+        state.session_close_event = close_event
         logger.info(
             "MCP server connected",
             server_id=state.server_id,
@@ -716,7 +743,18 @@ class MCPServerManager:
 
     async def _disconnect_state(self, state: MCPServerState) -> None:
         close_error: BaseException | None = None
-        if state.exit_stack is not None:
+        owner_task = state.session_owner_task
+        close_event = state.session_close_event
+        state.session_owner_task = None
+        state.session_close_event = None
+        if owner_task is not None:
+            try:
+                if close_event is not None:
+                    close_event.set()
+                await owner_task
+            except BaseException as exc:
+                close_error = exc
+        elif state.exit_stack is not None:
             try:
                 await state.exit_stack.aclose()
             except BaseException as exc:
@@ -733,6 +771,11 @@ class MCPServerManager:
         state.connected = False
         if close_error is not None:
             raise close_error
+
+    @staticmethod
+    async def _cancel_session_owner_task(owner_task: asyncio.Task[None]) -> None:
+        owner_task.cancel()
+        await asyncio.gather(owner_task, return_exceptions=True)
 
     def _require_state(self, server_id: str) -> MCPServerState:
         state = self._states.get(server_id)
@@ -1102,9 +1145,19 @@ class MCPServerManager:
                 names.add(function_name)
         return names
 
+    @classmethod
+    def _runtime_exception_message(cls, exc: BaseException) -> str:
+        if isinstance(exc, BaseExceptionGroup):
+            nested_messages = [cls._runtime_exception_message(nested) for nested in exc.exceptions]
+            nested_text = "; ".join(message for message in nested_messages if message)
+            if nested_text:
+                return f"{exc.message}: {nested_text}"
+        return str(exc)
+
     def _wrap_runtime_exception(self, server_id: str, exc: Exception) -> MCPError:
         if isinstance(exc, MCPError):
             return exc
+        message = self._runtime_exception_message(exc)
         if isinstance(exc, TimeoutError | asyncio.TimeoutError):
-            return MCPTimeoutError(server_id, f"MCP operation timed out: {exc}")
-        return MCPConnectionError(server_id, f"MCP operation failed: {exc}")
+            return MCPTimeoutError(server_id, f"MCP operation timed out: {message}")
+        return MCPConnectionError(server_id, f"MCP operation failed: {message}")

--- a/src/mindroom/mcp/types.py
+++ b/src/mindroom/mcp/types.py
@@ -95,6 +95,8 @@ class MCPServerState:
     catalog: MCPServerCatalog | None = None
     session: ClientSession | None = None
     exit_stack: AsyncExitStack | None = None
+    session_owner_task: asyncio.Task[None] | None = None
+    session_close_event: asyncio.Event | None = None
     semaphore: asyncio.Semaphore = field(init=False)
     connected: bool = False
     stale: bool = False

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -73,6 +73,8 @@ class _FakeClientSession:
     call_started_event: ClassVar[asyncio.Event | None] = None
     call_continue_event: ClassVar[asyncio.Event | None] = None
     transport_extra_headers: ClassVar[list[dict[str, str]]] = []
+    enforce_same_task_exit: ClassVar[bool] = False
+    close_exception: ClassVar[BaseException | None] = None
 
     def __init__(
         self,
@@ -86,14 +88,21 @@ class _FakeClientSession:
         self.message_handler = message_handler
         self.read_timeout_seconds = read_timeout_seconds
         self.closed = False
+        self.entered_task: asyncio.Task[object] | None = None
         _FakeClientSession.sessions.append(self)
 
     async def __aenter__(self) -> Self:
         """Return the fake session as an async context manager."""
+        self.entered_task = asyncio.current_task()
         return self
 
     async def __aexit__(self, *_args: object) -> None:
         """Mark the fake session as closed when the context exits."""
+        if _FakeClientSession.enforce_same_task_exit and asyncio.current_task() is not self.entered_task:
+            msg = "Attempted to exit cancel scope in a different task than it was entered in"
+            raise RuntimeError(msg)
+        if _FakeClientSession.close_exception is not None:
+            raise _FakeClientSession.close_exception
         self.closed = True
 
     async def initialize(self) -> mcp_types.InitializeResult:
@@ -164,6 +173,8 @@ def _reset_fake_session_state() -> Generator[None, None, None]:
     _FakeClientSession.call_started_event = None
     _FakeClientSession.call_continue_event = None
     _FakeClientSession.transport_extra_headers = []
+    _FakeClientSession.enforce_same_task_exit = False
+    _FakeClientSession.close_exception = None
     yield
     dynamic_toolkits_module._loaded_tools.clear()
 
@@ -549,6 +560,41 @@ async def test_mcp_manager_reconnects_after_call_failure(
     result = await manager.call_tool("demo", "echo", {"value": "ping"})
     assert result.content == "pong"
     assert len(_FakeClientSession.sessions) == 2
+
+
+@pytest.mark.asyncio
+async def test_mcp_manager_closes_session_context_in_owner_task_during_reconnect(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """MCP session context managers must exit in the same task that entered them."""
+    _patch_manager(monkeypatch)
+    _FakeClientSession.enforce_same_task_exit = True
+    _FakeClientSession.tool_list = [_tool("echo")]
+    _FakeClientSession.planned_tool_results = [
+        BrokenPipeError("transport closed"),
+        CallToolResult(content=[mcp_types.TextContent(type="text", text="pong")]),
+    ]
+    manager = MCPServerManager(_runtime_paths(tmp_path))
+    config = _ConfigStub({"demo": MCPServerConfig(transport="stdio", command="npx")})
+
+    await asyncio.create_task(manager.sync_servers(config))
+    result = await manager.call_tool("demo", "echo", {"value": "ping"})
+
+    assert result.content == "pong"
+    assert _FakeClientSession.sessions[0].closed is True
+    assert len(_FakeClientSession.sessions) == 2
+
+
+def test_mcp_manager_wraps_exception_group_with_inner_message(tmp_path: Path) -> None:
+    """ExceptionGroup wrappers should expose the useful nested failure text."""
+    manager = MCPServerManager(_runtime_paths(tmp_path))
+    exc = ExceptionGroup("unhandled errors in a TaskGroup", [RuntimeError("transport handshake failed")])
+
+    wrapped = manager._wrap_runtime_exception("demo", exc)
+
+    assert "unhandled errors in a TaskGroup" in str(wrapped)
+    assert "transport handshake failed" in str(wrapped)
 
 
 @pytest.mark.asyncio
@@ -1655,7 +1701,7 @@ async def test_mcp_manager_disconnect_clears_state_even_when_close_fails(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """A close failure should not leave the state holding a poisoned exit stack."""
+    """A close failure should not leave the state holding a poisoned session owner."""
     _patch_manager(monkeypatch)
     _FakeClientSession.tool_list = [_tool("echo")]
     manager = MCPServerManager(_runtime_paths(tmp_path))
@@ -1663,16 +1709,13 @@ async def test_mcp_manager_disconnect_clears_state_even_when_close_fails(
     await manager.sync_servers(config)
     state = manager._states["demo"]
     close_failed_message = "close failed"
-
-    class _BrokenExitStack:
-        async def aclose(self) -> None:
-            raise RuntimeError(close_failed_message)
-
-    state.exit_stack = _BrokenExitStack()
+    _FakeClientSession.close_exception = RuntimeError(close_failed_message)
 
     with pytest.raises(RuntimeError, match=close_failed_message):
         await manager._disconnect_state(state)
 
+    assert state.session_owner_task is None
+    assert state.session_close_event is None
     assert state.exit_stack is None
     assert state.session is None
     assert state.connected is False

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -1719,3 +1719,29 @@ async def test_mcp_manager_disconnect_clears_state_even_when_close_fails(
     assert state.exit_stack is None
     assert state.session is None
     assert state.connected is False
+
+
+@pytest.mark.asyncio
+async def test_mcp_manager_disconnect_cancels_owner_task_when_close_event_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A corrupted owner handle should fail closed instead of hanging disconnect."""
+    _patch_manager(monkeypatch)
+    _FakeClientSession.tool_list = [_tool("echo")]
+    manager = MCPServerManager(_runtime_paths(tmp_path))
+    config = _ConfigStub({"demo": MCPServerConfig(transport="stdio", command="npx")})
+    await manager.sync_servers(config)
+    state = manager._states["demo"]
+    owner_task = state.session_owner_task
+    assert owner_task is not None
+    state.session_close_event = None
+
+    with pytest.raises(RuntimeError, match="missing close event"):
+        await asyncio.wait_for(manager._disconnect_state(state), timeout=1)
+
+    assert owner_task.cancelled()
+    assert state.session_owner_task is None
+    assert state.session_close_event is None
+    assert state.session is None
+    assert state.connected is False


### PR DESCRIPTION
## Summary
- keep each MCP `ClientSession` context owned by the same task for open and close
- close cached sessions by signaling the owner task instead of closing the async context from reconnect/shutdown callers
- include nested `ExceptionGroup` messages in MCP runtime errors so TaskGroup failures expose the real sub-error

## Test Plan
- `uv run pytest tests/test_mcp_manager.py tests/test_mcp_toolkit.py tests/test_mcp_transports.py tests/test_mcp_integration_fake_server.py tests/test_mcp_registry.py tests/test_mcp_results.py tests/test_mcp_config.py tests/test_mcp_oauth.py`
- `uv run ruff check src/mindroom/mcp tests/test_mcp_manager.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session lifecycle management for more reliable reconnections and session teardown.

* **Improvements**
  * Enhanced error messages now provide detailed failure information, including nested exception details for better debugging.
  * More robust coordination of session cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->