### PR TITLE
Fix CalVer release tag selection

### DIFF
--- a/.github/workflows/calver-auto-release.yml
+++ b/.github/workflows/calver-auto-release.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Create release
         id: create_release
-        uses: basnijholt/calver-auto-release@v1
+        uses: basnijholt/calver-auto-release@v1.0.8
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

- Pin the CalVer release workflow to `basnijholt/calver-auto-release@v1.0.8`.
- `v1.0.8` contains the exact CalVer tag-selection fix: only exact `vYYYY.M.PATCH` / `vYYYY.MM.PATCH` tags are treated as releases, while branch-specific tags like `v2026.6.142-sso-cookie.2` are ignored for release boundaries.

## Why

This fixes the release workflow failure without carrying a MindRoom-local release helper. The logic now lives upstream in `calver-auto-release`.

## CI Failure

Fixes https://github.com/mindroom-ai/mindroom/actions/runs/27526263249/job/81354081366, where the release workflow tried to create an existing tag.

## Verification

- Upstream fix released as https://github.com/basnijholt/calver-auto-release/releases/tag/v1.0.8
- MindRoom PR diff is now one workflow line: `@v1` -> `@v1.0.8`