### PR TITLE
Limit managed room state-event power

### DIFF
--- a/src/mindroom/matrix/client_room_admin.py
+++ b/src/mindroom/matrix/client_room_admin.py
@@ -18,15 +18,10 @@ logger = get_logger(__name__)
 
 _POWER_LEVELS_EVENT_TYPE = "m.room.power_levels"
 _ROOM_ADMIN_POWER_LEVEL = 100
-_MINDROOM_STATE_EVENT_POWER_LEVEL = 0
+_THREAD_TAGS_POWER_LEVEL = 0
 _DEFAULT_STATE_EVENT_POWER_LEVEL = 50
 _DEFAULT_USER_POWER_LEVEL = 0
 _POWER_USER_POWER_LEVEL = 50
-_SCHEDULED_TASK_EVENT_TYPE = "com.mindroom.scheduled.task"
-_MANAGED_STATE_EVENT_POWER_LEVELS = {
-    THREAD_TAGS_EVENT_TYPE: _MINDROOM_STATE_EVENT_POWER_LEVEL,
-    _SCHEDULED_TASK_EVENT_TYPE: _MINDROOM_STATE_EVENT_POWER_LEVEL,
-}
 
 
 async def invite_to_room(
@@ -60,7 +55,9 @@ async def create_room(
     power_level_content: dict[str, Any] = {
         "users_default": _DEFAULT_USER_POWER_LEVEL,
         "state_default": _DEFAULT_STATE_EVENT_POWER_LEVEL,
-        "events": dict(_MANAGED_STATE_EVENT_POWER_LEVELS),
+        "events": {
+            THREAD_TAGS_EVENT_TYPE: _THREAD_TAGS_POWER_LEVEL,
+        },
     }
     users: dict[str, int] = {}
     if power_users:
@@ -84,12 +81,12 @@ async def create_room(
     return None
 
 
-def _with_managed_state_event_power_levels(power_levels_content: dict[str, Any]) -> dict[str, Any]:
-    """Return power-level content with MindRoom state-event overrides applied."""
+def _with_thread_tags_power_level(power_levels_content: dict[str, Any]) -> dict[str, Any]:
+    """Return power-level content with the thread-tags override applied."""
     next_content = dict(power_levels_content)
     existing_events = power_levels_content.get("events")
     next_events = dict(existing_events) if isinstance(existing_events, dict) else {}
-    next_events.update(_MANAGED_STATE_EVENT_POWER_LEVELS)
+    next_events[THREAD_TAGS_EVENT_TYPE] = _THREAD_TAGS_POWER_LEVEL
     next_content["events"] = next_events
     return next_content
 
@@ -98,11 +95,11 @@ async def ensure_thread_tags_power_level(
     client: nio.AsyncClient,
     room_id: str,
 ) -> bool:
-    """Ensure managed rooms allow PL0 users to send MindRoom state events."""
+    """Ensure managed rooms allow PL0 users to send the thread-tags state event."""
     current_response = await client.room_get_state_event(room_id, _POWER_LEVELS_EVENT_TYPE)
     if not isinstance(current_response, nio.RoomGetStateEventResponse):
         logger.error(
-            "Failed to read room power levels for managed state-event reconciliation",
+            "Failed to read room power levels for thread tags reconciliation",
             room_id=room_id,
             error=_describe_matrix_response_error(current_response),
         )
@@ -116,13 +113,13 @@ async def ensure_thread_tags_power_level(
         return False
     current_content = current_response.content
 
-    desired_content = _with_managed_state_event_power_levels(current_content)
+    desired_content = _with_thread_tags_power_level(current_content)
     if desired_content == current_content:
         logger.debug(
-            "Managed state-event power levels already configured",
+            "Thread tags power level already configured",
             room_id=room_id,
-            event_types=sorted(_MANAGED_STATE_EVENT_POWER_LEVELS),
-            power_level=_MINDROOM_STATE_EVENT_POWER_LEVEL,
+            event_type=THREAD_TAGS_EVENT_TYPE,
+            power_level=_THREAD_TAGS_POWER_LEVEL,
         )
         return True
 
@@ -133,15 +130,15 @@ async def ensure_thread_tags_power_level(
     )
     if isinstance(response, nio.RoomPutStateResponse):
         logger.info(
-            "Updated room power levels for managed state events",
+            "Updated room power levels for thread tags",
             room_id=room_id,
-            event_types=sorted(_MANAGED_STATE_EVENT_POWER_LEVELS),
-            power_level=_MINDROOM_STATE_EVENT_POWER_LEVEL,
+            event_type=THREAD_TAGS_EVENT_TYPE,
+            power_level=_THREAD_TAGS_POWER_LEVEL,
         )
         return True
 
     logger.error(
-        "Failed to update room power levels for managed state events",
+        "Failed to update room power levels for thread tags",
         room_id=room_id,
         error=_describe_matrix_response_error(response),
         hint="Ensure the service account is joined and can update m.room.power_levels.",

--- a/src/mindroom/matrix/client_room_admin.py
+++ b/src/mindroom/matrix/client_room_admin.py
@@ -18,8 +18,15 @@ logger = get_logger(__name__)
 
 _POWER_LEVELS_EVENT_TYPE = "m.room.power_levels"
 _ROOM_ADMIN_POWER_LEVEL = 100
-_THREAD_TAGS_POWER_LEVEL = 0
+_MINDROOM_STATE_EVENT_POWER_LEVEL = 0
 _DEFAULT_STATE_EVENT_POWER_LEVEL = 50
+_DEFAULT_USER_POWER_LEVEL = 0
+_POWER_USER_POWER_LEVEL = 50
+_SCHEDULED_TASK_EVENT_TYPE = "com.mindroom.scheduled.task"
+_MANAGED_STATE_EVENT_POWER_LEVELS = {
+    THREAD_TAGS_EVENT_TYPE: _MINDROOM_STATE_EVENT_POWER_LEVEL,
+    _SCHEDULED_TASK_EVENT_TYPE: _MINDROOM_STATE_EVENT_POWER_LEVEL,
+}
 
 
 async def invite_to_room(
@@ -51,16 +58,15 @@ async def create_room(
         room_config["topic"] = topic
 
     power_level_content: dict[str, Any] = {
+        "users_default": _DEFAULT_USER_POWER_LEVEL,
         "state_default": _DEFAULT_STATE_EVENT_POWER_LEVEL,
-        "events": {
-            THREAD_TAGS_EVENT_TYPE: _THREAD_TAGS_POWER_LEVEL,
-        },
+        "events": dict(_MANAGED_STATE_EVENT_POWER_LEVELS),
     }
     users: dict[str, int] = {}
     if power_users:
-        users.update(dict.fromkeys(power_users, 50))
+        users.update(dict.fromkeys(power_users, _POWER_USER_POWER_LEVEL))
     if client.user_id:
-        users[client.user_id] = 100
+        users[client.user_id] = _ROOM_ADMIN_POWER_LEVEL
     if users:
         power_level_content["users"] = users
     room_config["initial_state"] = [{"type": _POWER_LEVELS_EVENT_TYPE, "content": power_level_content}]
@@ -78,12 +84,12 @@ async def create_room(
     return None
 
 
-def _with_thread_tags_power_level(power_levels_content: dict[str, Any]) -> dict[str, Any]:
-    """Return power-level content with the thread-tags override applied."""
+def _with_managed_state_event_power_levels(power_levels_content: dict[str, Any]) -> dict[str, Any]:
+    """Return power-level content with MindRoom state-event overrides applied."""
     next_content = dict(power_levels_content)
     existing_events = power_levels_content.get("events")
     next_events = dict(existing_events) if isinstance(existing_events, dict) else {}
-    next_events[THREAD_TAGS_EVENT_TYPE] = _THREAD_TAGS_POWER_LEVEL
+    next_events.update(_MANAGED_STATE_EVENT_POWER_LEVELS)
     next_content["events"] = next_events
     return next_content
 
@@ -92,11 +98,11 @@ async def ensure_thread_tags_power_level(
     client: nio.AsyncClient,
     room_id: str,
 ) -> bool:
-    """Ensure managed rooms allow PL0 users to send the thread-tags state event."""
+    """Ensure managed rooms allow PL0 users to send MindRoom state events."""
     current_response = await client.room_get_state_event(room_id, _POWER_LEVELS_EVENT_TYPE)
     if not isinstance(current_response, nio.RoomGetStateEventResponse):
         logger.error(
-            "Failed to read room power levels for thread tags reconciliation",
+            "Failed to read room power levels for managed state-event reconciliation",
             room_id=room_id,
             error=_describe_matrix_response_error(current_response),
         )
@@ -110,13 +116,13 @@ async def ensure_thread_tags_power_level(
         return False
     current_content = current_response.content
 
-    desired_content = _with_thread_tags_power_level(current_content)
+    desired_content = _with_managed_state_event_power_levels(current_content)
     if desired_content == current_content:
         logger.debug(
-            "Thread tags power level already configured",
+            "Managed state-event power levels already configured",
             room_id=room_id,
-            event_type=THREAD_TAGS_EVENT_TYPE,
-            power_level=_THREAD_TAGS_POWER_LEVEL,
+            event_types=sorted(_MANAGED_STATE_EVENT_POWER_LEVELS),
+            power_level=_MINDROOM_STATE_EVENT_POWER_LEVEL,
         )
         return True
 
@@ -127,15 +133,15 @@ async def ensure_thread_tags_power_level(
     )
     if isinstance(response, nio.RoomPutStateResponse):
         logger.info(
-            "Updated room power levels for thread tags",
+            "Updated room power levels for managed state events",
             room_id=room_id,
-            event_type=THREAD_TAGS_EVENT_TYPE,
-            power_level=_THREAD_TAGS_POWER_LEVEL,
+            event_types=sorted(_MANAGED_STATE_EVENT_POWER_LEVELS),
+            power_level=_MINDROOM_STATE_EVENT_POWER_LEVEL,
         )
         return True
 
     logger.error(
-        "Failed to update room power levels for thread tags",
+        "Failed to update room power levels for managed state events",
         room_id=room_id,
         error=_describe_matrix_response_error(response),
         hint="Ensure the service account is joined and can update m.room.power_levels.",

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -619,7 +619,7 @@ async def _persist_scheduled_task_state(
     created_at: datetime | str | None = None,
 ) -> None:
     """Persist scheduled task state to Matrix."""
-    await client.room_put_state(
+    response = await client.room_put_state(
         room_id=room_id,
         event_type=_SCHEDULED_TASK_EVENT_TYPE,
         content={
@@ -631,6 +631,10 @@ async def _persist_scheduled_task_state(
         },
         state_key=task_id,
     )
+    if isinstance(response, nio.RoomPutStateResponse):
+        return
+    msg = f"Failed to persist scheduled task state: {response}"
+    raise ValueError(msg)
 
 
 async def _save_pending_scheduled_task(

--- a/tests/test_matrix_room_access.py
+++ b/tests/test_matrix_room_access.py
@@ -20,6 +20,8 @@ from mindroom.matrix.presence import is_user_online
 from mindroom.thread_tags import THREAD_TAGS_EVENT_TYPE
 from tests.conftest import TEST_ACCESS_TOKEN, bind_runtime_paths, load_config_yaml, runtime_paths_for
 
+_SCHEDULED_TASK_EVENT_TYPE = "com.mindroom.scheduled.task"
+
 
 class _FakeHttpResponse:
     """Simple fake aiohttp response for low-level Matrix API tests."""
@@ -316,7 +318,7 @@ async def test_new_room_creation_applies_access_policy_in_multi_user_mode(
 async def test_create_room_seeds_thread_tags_power_level(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Managed room creation should seed the custom state-event override."""
+    """Managed room creation should seed MindRoom state-event overrides."""
     mock_client = AsyncMock()
     mock_client.user_id = "@router:example.com"
     mock_client.room_create.return_value = nio.RoomCreateResponse(room_id="!lobby:example.com")
@@ -337,8 +339,10 @@ async def test_create_room_seeds_thread_tags_power_level(
     assert len(initial_state) == 1
     assert initial_state[0]["type"] == "m.room.power_levels"
     power_levels = initial_state[0]["content"]
+    assert power_levels["users_default"] == 0
     assert power_levels["state_default"] == 50
     assert power_levels["events"][THREAD_TAGS_EVENT_TYPE] == 0
+    assert power_levels["events"][_SCHEDULED_TASK_EVENT_TYPE] == 0
     assert power_levels["users"]["@agent:example.com"] == 50
     assert power_levels["users"]["@router:example.com"] == 100
     invite_to_room.assert_awaited_once_with(mock_client, "!lobby:example.com", "@agent:example.com")
@@ -374,6 +378,7 @@ async def test_ensure_thread_tags_power_level_preserves_existing_content() -> No
     assert kwargs["content"]["state_default"] == 50
     assert kwargs["content"]["events"]["m.room.name"] == 50
     assert kwargs["content"]["events"][THREAD_TAGS_EVENT_TYPE] == 0
+    assert kwargs["content"]["events"][_SCHEDULED_TASK_EVENT_TYPE] == 0
 
 
 @pytest.mark.asyncio
@@ -443,7 +448,10 @@ async def test_ensure_thread_tags_power_level_idempotent() -> None:
     mock_client = AsyncMock()
     mock_client.room_get_state_event.return_value = nio.RoomGetStateEventResponse(
         content={
-            "events": {THREAD_TAGS_EVENT_TYPE: 0},
+            "events": {
+                THREAD_TAGS_EVENT_TYPE: 0,
+                _SCHEDULED_TASK_EVENT_TYPE: 0,
+            },
             "state_default": 50,
             "users": {"@router:example.com": 100},
         },

--- a/tests/test_matrix_room_access.py
+++ b/tests/test_matrix_room_access.py
@@ -17,10 +17,9 @@ from mindroom.matrix import client_room_admin as matrix_room_admin
 from mindroom.matrix import rooms as matrix_rooms
 from mindroom.matrix import state as matrix_state
 from mindroom.matrix.presence import is_user_online
+from mindroom.scheduling import _SCHEDULED_TASK_EVENT_TYPE
 from mindroom.thread_tags import THREAD_TAGS_EVENT_TYPE
 from tests.conftest import TEST_ACCESS_TOKEN, bind_runtime_paths, load_config_yaml, runtime_paths_for
-
-_SCHEDULED_TASK_EVENT_TYPE = "com.mindroom.scheduled.task"
 
 
 class _FakeHttpResponse:
@@ -318,7 +317,7 @@ async def test_new_room_creation_applies_access_policy_in_multi_user_mode(
 async def test_create_room_seeds_thread_tags_power_level(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Managed room creation should seed MindRoom state-event overrides."""
+    """Managed room creation should seed only regular-user-safe state-event overrides."""
     mock_client = AsyncMock()
     mock_client.user_id = "@router:example.com"
     mock_client.room_create.return_value = nio.RoomCreateResponse(room_id="!lobby:example.com")
@@ -342,7 +341,7 @@ async def test_create_room_seeds_thread_tags_power_level(
     assert power_levels["users_default"] == 0
     assert power_levels["state_default"] == 50
     assert power_levels["events"][THREAD_TAGS_EVENT_TYPE] == 0
-    assert power_levels["events"][_SCHEDULED_TASK_EVENT_TYPE] == 0
+    assert _SCHEDULED_TASK_EVENT_TYPE not in power_levels["events"]
     assert power_levels["users"]["@agent:example.com"] == 50
     assert power_levels["users"]["@router:example.com"] == 100
     invite_to_room.assert_awaited_once_with(mock_client, "!lobby:example.com", "@agent:example.com")
@@ -378,7 +377,7 @@ async def test_ensure_thread_tags_power_level_preserves_existing_content() -> No
     assert kwargs["content"]["state_default"] == 50
     assert kwargs["content"]["events"]["m.room.name"] == 50
     assert kwargs["content"]["events"][THREAD_TAGS_EVENT_TYPE] == 0
-    assert kwargs["content"]["events"][_SCHEDULED_TASK_EVENT_TYPE] == 0
+    assert _SCHEDULED_TASK_EVENT_TYPE not in kwargs["content"]["events"]
 
 
 @pytest.mark.asyncio
@@ -450,7 +449,6 @@ async def test_ensure_thread_tags_power_level_idempotent() -> None:
         content={
             "events": {
                 THREAD_TAGS_EVENT_TYPE: 0,
-                _SCHEDULED_TASK_EVENT_TYPE: 0,
             },
             "state_default": 50,
             "users": {"@router:example.com": 100},

--- a/tests/test_schedule_agent_validation.py
+++ b/tests/test_schedule_agent_validation.py
@@ -50,6 +50,10 @@ def _event_cache() -> AsyncMock:
     return make_event_cache_mock()
 
 
+def _allow_schedule_state_persistence(client: AsyncMock, room_id: str) -> None:
+    client.room_put_state = AsyncMock(return_value=nio.RoomPutStateResponse("$scheduled-state", room_id))
+
+
 def _scheduling_runtime(
     *,
     client: AsyncMock,
@@ -210,7 +214,7 @@ async def test_schedule_allows_agents_in_room() -> None:
 
     # Mock client
     client = AsyncMock()
-    client.room_put_state = AsyncMock()
+    _allow_schedule_state_persistence(client, "test_room")
 
     # Create a mock room with both agents - use the actual domain from config
     room = create_mock_room(
@@ -346,7 +350,7 @@ async def test_schedule_with_no_agent_mentions() -> None:
     )
 
     client = AsyncMock()
-    client.room_put_state = AsyncMock()
+    _allow_schedule_state_persistence(client, "test_room")
 
     # Create a mock room - use the actual domain from config
     room = create_mock_room(
@@ -420,6 +424,7 @@ async def test_schedule_validation_respects_sender_reply_permissions() -> None:
     )
 
     client = AsyncMock()
+    _allow_schedule_state_persistence(client, "test_room")
     room = create_mock_room(
         "test_room",
         [
@@ -468,6 +473,7 @@ async def test_schedule_with_nonexistent_agent() -> None:
     )
 
     client = AsyncMock()
+    _allow_schedule_state_persistence(client, "test_room")
 
     # Create a mock room - use the actual domain from config
     room = create_mock_room(

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -21,6 +21,7 @@ from mindroom.scheduling import (
     ScheduledTaskRecord,
     ScheduledWorkflow,
     SchedulingRuntime,
+    _persist_scheduled_task_state,
     _run_cron_task,
     _run_once_task,
     build_edited_scheduled_workflow,
@@ -1508,6 +1509,10 @@ async def test_edit_scheduled_task_rejects_non_pending() -> None:
 async def test_save_edited_scheduled_task_preserves_created_at() -> None:
     """Editing should keep created_at metadata from the original task."""
     client = AsyncMock()
+    client.room_put_state.return_value = nio.RoomPutStateResponse.from_dict(
+        {"event_id": "$state"},
+        room_id="!test:server",
+    )
     created_at = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
     existing_workflow = ScheduledWorkflow(
         schedule_type="once",
@@ -1551,6 +1556,10 @@ async def test_save_edited_scheduled_task_preserves_created_at() -> None:
 async def test_save_edited_scheduled_task_is_state_only() -> None:
     """State-only edits should not require runtime-only scheduling collaborators."""
     client = AsyncMock()
+    client.room_put_state.return_value = nio.RoomPutStateResponse.from_dict(
+        {"event_id": "$state"},
+        room_id="!test:server",
+    )
     created_at = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
     existing_task = ScheduledTaskRecord(
         task_id="task123",
@@ -1684,6 +1693,28 @@ async def test_schedule_task_blocked_sender_new_thread_returns_error() -> None:
 
     assert task_id is None
     assert "No agents" in message
+
+
+@pytest.mark.asyncio
+async def test_persist_scheduled_task_state_raises_on_matrix_error() -> None:
+    """Schedule persistence must fail when Matrix rejects the state write."""
+    client = AsyncMock()
+    client.room_put_state.return_value = nio.RoomPutStateError("forbidden", "M_FORBIDDEN")
+    workflow = ScheduledWorkflow(
+        schedule_type="once",
+        execute_at=datetime.now(UTC) + timedelta(minutes=5),
+        message="check logs",
+        description="check logs",
+        room_id="!test:server",
+    )
+
+    with pytest.raises(ValueError, match="Failed to persist scheduled task state"):
+        await _persist_scheduled_task_state(
+            client=client,
+            room_id="!test:server",
+            task_id="task1234",
+            workflow=workflow,
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_workflow_scheduling.py
+++ b/tests/test_workflow_scheduling.py
@@ -783,6 +783,7 @@ class TestIntegrationWithScheduling:
     async def test_schedule_task_workflow_path(self, mock_parse_workflow: AsyncMock) -> None:
         """Test that schedule_task uses workflow parsing for complex requests."""
         client = AsyncMock()
+        client.room_put_state = AsyncMock(return_value=nio.RoomPutStateResponse("$scheduled-state", "!room:server"))
         mock_parse_workflow.return_value = ScheduledWorkflow(
             schedule_type="cron",
             cron_schedule=CronSchedule(minute="0", hour="9"),


### PR DESCRIPTION
## Summary
- keep `users_default` at the regular-user level while retaining separate PL50 grants for explicit power users and PL100 for the room admin
- seed and reconcile the PL0 override only for the regular-user-safe thread-tags state event
- keep scheduled-task state restricted to power/service users and fail schedule persistence when Matrix rejects the state write

## Why
Managed room creation seeds a full `m.room.power_levels` event.
Raising `users_default` would grant every joined member broad state-event power.
This keeps regular members at PL0 while allowing the specific thread-tag state event regular users need.
Scheduled-task state is executable state restored and run by the MindRoom runtime, so it stays behind the room's normal state-event power boundary instead of being writable by every joined user.
Matrix write failures for scheduled-task persistence are surfaced instead of returning a successful task id.

## Tests
- `uv run pytest tests/test_matrix_room_access.py::test_create_room_seeds_thread_tags_power_level tests/test_matrix_room_access.py::test_ensure_thread_tags_power_level_preserves_existing_content tests/test_scheduling.py::test_persist_scheduled_task_state_raises_on_matrix_error -q --no-cov -n 0`
- `uv run pytest tests/test_matrix_room_access.py tests/test_matrix_spaces.py tests/test_scheduling.py -q --no-cov -n 0`
- `uv run ruff check src/mindroom/matrix/client_room_admin.py src/mindroom/scheduling.py tests/test_matrix_room_access.py tests/test_scheduling.py`
