### PR TITLE
Refactor AI turn state recording

### DIFF
--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -31,6 +31,7 @@ from mindroom.ai_run_metadata import (
     build_prepared_history_metadata_content,
     empty_request_metric_totals,
 )
+from mindroom.ai_turn_state import AITurnState
 from mindroom.cancellation import build_cancelled_error
 from mindroom.constants import (
     MATRIX_EVENT_ID_METADATA_KEY,
@@ -1033,6 +1034,7 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
     agent: Agent | None = None
     scope_context: ScopeSessionContext | None = None
     standalone_interrupted_replay_persisted = False
+    turn_state = AITurnState()
     unseen_event_ids: list[str] = []
     metadata: dict[str, Any] | None = None
     run_extra_content: dict[str, Any] | None = None
@@ -1223,8 +1225,9 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                     entity_name=agent_name,
                 )
 
+            response_tool_trace = _extract_tool_trace(response)
             if tool_trace_collector is not None:
-                tool_trace_collector.extend(_extract_tool_trace(response))
+                tool_trace_collector.extend(response_tool_trace)
             if run_metadata_collector is not None:
                 run_metadata = build_ai_run_metadata_content(
                     config=config,
@@ -1248,7 +1251,8 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                 )
                 completed_tools, interrupted_tools = _extract_cancelled_tool_trace(response)
                 if turn_recorder is not None:
-                    turn_recorder.record_interrupted(
+                    turn_state.record_interrupted(
+                        turn_recorder,
                         run_metadata=metadata,
                         assistant_text=partial_text,
                         completed_tools=completed_tools,
@@ -1261,7 +1265,7 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                         run_id=response.run_id or attempt.attempt_run_id or str(uuid4()),
                         user_message=prompt,
                         partial_text=partial_text,
-                        completed_tools=completed_tools,
+                        completed_tools=turn_state.completed_tools_for(completed_tools),
                         interrupted_tools=interrupted_tools,
                         run_metadata=metadata,
                         is_team=False,
@@ -1276,30 +1280,31 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
 
             response_text = _extract_response_content(response, show_tool_calls=show_tool_calls)
             if turn_recorder is not None:
-                turn_recorder.record_completed(
+                turn_state.record_completed(
+                    turn_recorder,
                     run_metadata=metadata,
                     assistant_text=_extract_replayable_response_text(response),
-                    completed_tools=_extract_tool_trace(response),
+                    completed_tools=response_tool_trace,
                 )
             return response_text
     except asyncio.CancelledError:
         if turn_recorder is not None:
-            turn_recorder.record_interrupted(
-                run_metadata=metadata
-                if metadata is not None
-                else turn_recorder.run_metadata
-                or build_matrix_run_metadata(
-                    reply_to_event_id,
-                    unseen_event_ids,
-                    room_id=room_id,
-                    thread_id=thread_id,
-                    requester_id=resolved_requester_id,
-                    correlation_id=resolved_correlation_id,
-                    extra_metadata=deep_merge_metadata(matrix_run_metadata, run_extra_content),
+            turn_state.record_interrupted_from_recorder(
+                turn_recorder,
+                run_metadata=(
+                    metadata
+                    if metadata is not None
+                    else turn_recorder.run_metadata
+                    or build_matrix_run_metadata(
+                        reply_to_event_id,
+                        unseen_event_ids,
+                        room_id=room_id,
+                        thread_id=thread_id,
+                        requester_id=resolved_requester_id,
+                        correlation_id=resolved_correlation_id,
+                        extra_metadata=deep_merge_metadata(matrix_run_metadata, run_extra_content),
+                    )
                 ),
-                assistant_text=turn_recorder.assistant_text,
-                completed_tools=turn_recorder.completed_tools,
-                interrupted_tools=turn_recorder.interrupted_tools,
             )
         elif not standalone_interrupted_replay_persisted:
             persist_interrupted_replay(
@@ -1308,7 +1313,7 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                 run_id=(attempt.attempt_run_id if attempt is not None else run_id) or str(uuid4()),
                 user_message=prompt,
                 partial_text="",
-                completed_tools=[],
+                completed_tools=turn_state.completed_tools_for([]),
                 interrupted_tools=[],
                 run_metadata=metadata
                 if metadata is not None
@@ -1550,6 +1555,7 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
     agent: Agent | None = None
     scope_context: ScopeSessionContext | None = None
     standalone_interrupted_replay_persisted = False
+    turn_state = AITurnState()
     unseen_event_ids: list[str] = []
     metadata: dict[str, Any] | None = None
     run_extra_content: dict[str, Any] | None = None
@@ -1651,9 +1657,8 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
             state = _StreamingAttemptState()
 
             def _sync_live_turn_recorder() -> None:
-                if turn_recorder is None:
-                    return
-                turn_recorder.sync_partial_state(
+                turn_state.sync_partial(
+                    turn_recorder,
                     run_metadata=metadata,
                     assistant_text=state.assistant_text,
                     completed_tools=state.completed_tools,
@@ -1751,7 +1756,8 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                         if state.assistant_text or state.completed_tools or state.pending_tools:
                             interrupted_tools = [pending.trace_entry for pending in state.pending_tools]
                             if turn_recorder is not None:
-                                turn_recorder.record_interrupted(
+                                turn_state.record_interrupted(
+                                    turn_recorder,
                                     run_metadata=metadata,
                                     assistant_text=state.assistant_text,
                                     completed_tools=state.completed_tools,
@@ -1764,7 +1770,7 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                                     run_id=attempt.attempt_run_id or str(uuid4()),
                                     user_message=prompt,
                                     partial_text=state.assistant_text,
-                                    completed_tools=state.completed_tools,
+                                    completed_tools=turn_state.completed_tools_for(state.completed_tools),
                                     interrupted_tools=interrupted_tools,
                                     run_metadata=metadata,
                                     is_team=False,
@@ -1774,12 +1780,14 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                         return
 
                     if state.cancelled_run_event is not None:
+                        interrupted_tools = [pending.trace_entry for pending in state.pending_tools]
                         if turn_recorder is not None:
-                            turn_recorder.record_interrupted(
+                            turn_state.record_interrupted(
+                                turn_recorder,
                                 run_metadata=metadata,
                                 assistant_text=state.assistant_text,
                                 completed_tools=state.completed_tools,
-                                interrupted_tools=[pending.trace_entry for pending in state.pending_tools],
+                                interrupted_tools=interrupted_tools,
                             )
                         if run_metadata_collector is not None:
                             fallback_metrics = build_model_request_metrics_fallback(
@@ -1811,8 +1819,8 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                                 run_id=state.cancelled_run_event.run_id or attempt.attempt_run_id or str(uuid4()),
                                 user_message=prompt,
                                 partial_text=state.assistant_text,
-                                completed_tools=state.completed_tools,
-                                interrupted_tools=[pending.trace_entry for pending in state.pending_tools],
+                                completed_tools=turn_state.completed_tools_for(state.completed_tools),
+                                interrupted_tools=interrupted_tools,
                                 run_metadata=metadata,
                                 is_team=False,
                             )
@@ -1863,7 +1871,8 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                     run_metadata_collector.update(run_metadata)
                 if turn_recorder is not None:
                     final_visible_body = state.assistant_text or state.canonical_final_body_candidate or ""
-                    turn_recorder.record_completed(
+                    turn_state.record_completed(
+                        turn_recorder,
                         run_metadata=metadata,
                         assistant_text=final_visible_body,
                         completed_tools=state.completed_tools,
@@ -1877,8 +1886,10 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                     entity_name=agent_name,
                 )
     except asyncio.CancelledError:
+        interrupted_tools = [pending.trace_entry for pending in state.pending_tools]
         if turn_recorder is not None:
-            turn_recorder.record_interrupted(
+            turn_state.record_interrupted(
+                turn_recorder,
                 run_metadata=metadata
                 if metadata is not None
                 else turn_recorder.run_metadata
@@ -1893,7 +1904,7 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                 ),
                 assistant_text=state.assistant_text,
                 completed_tools=state.completed_tools,
-                interrupted_tools=[pending.trace_entry for pending in state.pending_tools],
+                interrupted_tools=interrupted_tools,
             )
         elif not standalone_interrupted_replay_persisted:
             persist_interrupted_replay(
@@ -1902,8 +1913,8 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                 run_id=(attempt.attempt_run_id if attempt is not None else run_id) or str(uuid4()),
                 user_message=prompt,
                 partial_text=state.assistant_text,
-                completed_tools=state.completed_tools,
-                interrupted_tools=[pending.trace_entry for pending in state.pending_tools],
+                completed_tools=turn_state.completed_tools_for(state.completed_tools),
+                interrupted_tools=interrupted_tools,
                 run_metadata=metadata
                 if metadata is not None
                 else build_matrix_run_metadata(

--- a/src/mindroom/ai_turn_state.py
+++ b/src/mindroom/ai_turn_state.py
@@ -1,0 +1,107 @@
+"""AI response turn-state helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+    from mindroom.history.turn_recorder import TurnRecorder
+    from mindroom.tool_system.events import ToolTraceEntry
+
+
+@dataclass
+class AITurnState:
+    """Apply one AI response attempt's visible state to the top-level turn."""
+
+    prior_completed_tools: Sequence[ToolTraceEntry] = ()
+    assistant_text: str = ""
+    completed_tools: list[ToolTraceEntry] = field(default_factory=list, init=False)
+    interrupted_tools: list[ToolTraceEntry] = field(default_factory=list, init=False)
+
+    def completed_tools_for(self, attempt_completed_tools: Sequence[ToolTraceEntry]) -> list[ToolTraceEntry]:
+        """Return the top-level completed tool trace for one attempt."""
+        return [*self.prior_completed_tools, *attempt_completed_tools]
+
+    def sync_partial(
+        self,
+        recorder: TurnRecorder | None,
+        *,
+        run_metadata: Mapping[str, Any] | None,
+        assistant_text: str,
+        completed_tools: Sequence[ToolTraceEntry],
+        interrupted_tools: Sequence[ToolTraceEntry],
+    ) -> None:
+        """Refresh the live top-level turn state without deciding an outcome."""
+        self.assistant_text = assistant_text
+        self.completed_tools = self.completed_tools_for(completed_tools)
+        self.interrupted_tools = list(interrupted_tools)
+        if recorder is None:
+            return
+        recorder.sync_partial_state(
+            run_metadata=run_metadata,
+            assistant_text=self.assistant_text,
+            completed_tools=self.completed_tools,
+            interrupted_tools=self.interrupted_tools,
+        )
+
+    def record_completed(
+        self,
+        recorder: TurnRecorder | None,
+        *,
+        run_metadata: Mapping[str, Any] | None,
+        assistant_text: str,
+        completed_tools: Sequence[ToolTraceEntry],
+    ) -> None:
+        """Record a completed top-level turn when a recorder is present."""
+        self.assistant_text = assistant_text
+        self.completed_tools = self.completed_tools_for(completed_tools)
+        self.interrupted_tools = []
+        if recorder is None:
+            return
+        recorder.record_completed(
+            run_metadata=run_metadata,
+            assistant_text=self.assistant_text,
+            completed_tools=self.completed_tools,
+        )
+
+    def record_interrupted(
+        self,
+        recorder: TurnRecorder | None,
+        *,
+        run_metadata: Mapping[str, Any] | None,
+        assistant_text: str,
+        completed_tools: Sequence[ToolTraceEntry],
+        interrupted_tools: Sequence[ToolTraceEntry],
+    ) -> None:
+        """Record an interrupted top-level turn when a recorder is present."""
+        self.assistant_text = assistant_text
+        self.completed_tools = self.completed_tools_for(completed_tools)
+        self.interrupted_tools = list(interrupted_tools)
+        if recorder is None:
+            return
+        recorder.record_interrupted(
+            run_metadata=run_metadata,
+            assistant_text=self.assistant_text,
+            completed_tools=self.completed_tools,
+            interrupted_tools=self.interrupted_tools,
+        )
+
+    def record_interrupted_from_recorder(
+        self,
+        recorder: TurnRecorder,
+        *,
+        run_metadata: Mapping[str, Any] | None,
+    ) -> None:
+        """Mark the recorder interrupted using its already-canonical live state."""
+        self.assistant_text = recorder.assistant_text
+        self.completed_tools = list(recorder.completed_tools)
+        self.interrupted_tools = list(recorder.interrupted_tools)
+        recorder.record_interrupted(
+            run_metadata=run_metadata,
+            assistant_text=self.assistant_text,
+            completed_tools=self.completed_tools,
+            interrupted_tools=self.interrupted_tools,
+        )

--- a/tach.toml
+++ b/tach.toml
@@ -54,6 +54,7 @@ path = "mindroom.ai"
 depends_on = [
     "mindroom.agents",
     "mindroom.ai_run_metadata",
+    "mindroom.ai_turn_state",
     "mindroom.ai_runtime",
     "mindroom.cancellation",
     "mindroom.constants",
@@ -79,6 +80,11 @@ path = "mindroom.ai_run_metadata"
 depends_on = [
     "mindroom.constants",
 ]
+
+[[modules]]
+path = "mindroom.ai_turn_state"
+depends_on = []
+visibility = ["mindroom.ai"]
 
 [[modules]]
 path = "mindroom.agents"

--- a/tests/test_ai_turn_state.py
+++ b/tests/test_ai_turn_state.py
@@ -1,0 +1,51 @@
+"""Tests for AI turn-state recorder helpers."""
+
+from __future__ import annotations
+
+from mindroom.ai_turn_state import AITurnState
+from mindroom.history.turn_recorder import TurnRecorder
+from mindroom.tool_system.events import ToolTraceEntry
+
+
+def _tool(name: str) -> ToolTraceEntry:
+    return ToolTraceEntry(type="tool_call_completed", tool_name=name)
+
+
+def test_ai_turn_state_applies_prior_completed_tools_to_recorder_updates() -> None:
+    """Prior completed tools are prepended when recording attempt state."""
+    recorder = TurnRecorder(user_message="test")
+    load_tool = _tool("load_tool")
+    shell_tool = _tool("run_shell_command")
+    pending_tool = ToolTraceEntry(type="tool_call_started", tool_name="save_file")
+
+    state = AITurnState(prior_completed_tools=(load_tool,))
+    state.record_interrupted(
+        recorder,
+        run_metadata={"run": "1"},
+        assistant_text="partial",
+        completed_tools=[shell_tool],
+        interrupted_tools=[pending_tool],
+    )
+
+    assert recorder.assistant_text == "partial"
+    assert recorder.run_metadata == {"run": "1"}
+    assert [tool.tool_name for tool in recorder.completed_tools] == ["load_tool", "run_shell_command"]
+    assert [tool.tool_name for tool in recorder.interrupted_tools] == ["save_file"]
+
+
+def test_ai_turn_state_marks_existing_recorder_state_without_reprefixing() -> None:
+    """Already-canonical recorder state is not prefixed a second time."""
+    recorder = TurnRecorder(user_message="test")
+    recorder.sync_partial_state(
+        run_metadata={"run": "1"},
+        assistant_text="partial",
+        completed_tools=[_tool("load_tool"), _tool("run_shell_command")],
+        interrupted_tools=[ToolTraceEntry(type="tool_call_started", tool_name="save_file")],
+    )
+
+    state = AITurnState(prior_completed_tools=(_tool("load_tool"),))
+    state.record_interrupted_from_recorder(recorder, run_metadata={"run": "2"})
+
+    assert recorder.run_metadata == {"run": "2"}
+    assert [tool.tool_name for tool in recorder.completed_tools] == ["load_tool", "run_shell_command"]
+    assert [tool.tool_name for tool in recorder.interrupted_tools] == ["save_file"]


### PR DESCRIPTION
## Summary
- Extract AI turn-state recorder bookkeeping into `AITurnState`
- Route `ai.py` completion/interruption/partial recorder updates through the helper
- Add focused tests for carrying prior completed tool traces without re-prefixing existing recorder state

## Verification
- `uv run pytest tests/test_ai_turn_state.py -n 0 --no-cov -q`
- `uv run pytest tests/test_ai_user_id.py -n 0 --no-cov -q`
- `uv run pytest tests/test_ai_turn_state.py tests/test_ai_user_id.py -n 0 --no-cov -q`
- `uv run ruff check src/mindroom/ai.py src/mindroom/ai_turn_state.py tests/test_ai_turn_state.py`
- `uv run ruff format --check src/mindroom/ai.py src/mindroom/ai_turn_state.py tests/test_ai_turn_state.py`
- `uv run ty check src/mindroom/ai.py src/mindroom/ai_turn_state.py tests/test_ai_turn_state.py`
- `uv run tach check --dependencies --interfaces`
- `uv run pre-commit run --all-files`
- `uv run pytest -n 0 --no-cov -q`

This is intended as a behavior-preserving prep refactor before continuing the dynamic lazy-tool-loading PR.