### PR TITLE
Fix scheduled task state persistence fallback

### DIFF
--- a/src/mindroom/commands/handler.py
+++ b/src/mindroom/commands/handler.py
@@ -276,6 +276,7 @@ async def handle_command(  # noqa: C901, PLR0912, PLR0915
             response_text = await cancel_all_scheduled_tasks(
                 client=context.client,
                 room_id=room.room_id,
+                matrix_admin=context.matrix_admin,
             )
         else:
             # Cancel specific task
@@ -284,6 +285,7 @@ async def handle_command(  # noqa: C901, PLR0912, PLR0915
                 client=context.client,
                 room_id=room.room_id,
                 task_id=task_id,
+                matrix_admin=context.matrix_admin,
             )
 
     elif command.type == CommandType.EDIT_SCHEDULE:

--- a/src/mindroom/custom_tools/scheduler.py
+++ b/src/mindroom/custom_tools/scheduler.py
@@ -127,6 +127,7 @@ class SchedulerTools(Toolkit):
             client=context.client,
             room_id=context.room_id,
             task_id=task_id,
+            matrix_admin=context.matrix_admin,
         )
         _raise_for_scheduler_error(response_text)
         return response_text

--- a/src/mindroom/hooks/matrix_admin.py
+++ b/src/mindroom/hooks/matrix_admin.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import nio
 
@@ -62,6 +62,22 @@ class _BoundHookMatrixAdmin:
             runtime_paths=self.runtime_paths,
         )
         return await add_room_to_space(self.client, space_room_id, room_id, server_name)
+
+    async def put_room_state(
+        self,
+        room_id: str,
+        event_type: str,
+        state_key: str,
+        content: dict[str, Any],
+    ) -> bool:
+        """Write one room state event using the bound admin-capable client."""
+        response = await self.client.room_put_state(
+            room_id=room_id,
+            event_type=event_type,
+            content=content,
+            state_key=state_key,
+        )
+        return isinstance(response, nio.RoomPutStateResponse)
 
 
 def build_hook_matrix_admin(

--- a/src/mindroom/hooks/types.py
+++ b/src/mindroom/hooks/types.py
@@ -136,6 +136,15 @@ class HookMatrixAdmin(Protocol):
     async def add_room_to_space(self, space_room_id: str, room_id: str) -> bool:
         """Link one room into one Space."""
 
+    async def put_room_state(
+        self,
+        room_id: str,
+        event_type: str,
+        state_key: str,
+        content: dict[str, Any],
+    ) -> bool:
+        """Write one room state event."""
+
 
 type HookRoomStateQuerier = Callable[
     [str, str, str | None],

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -610,6 +610,52 @@ def _serialize_scheduled_task_created_at(created_at: datetime | str | None) -> s
     return datetime.now(UTC).isoformat()
 
 
+async def _put_scheduled_task_state_content(
+    client: nio.AsyncClient,
+    room_id: str,
+    task_id: str,
+    content: dict[str, typing.Any],
+    matrix_admin: HookMatrixAdmin | None = None,
+) -> None:
+    """Write scheduled-task state, falling back to the admin-capable Matrix path on rejection."""
+    active_write_failure: str | None = None
+    try:
+        response = await client.room_put_state(
+            room_id=room_id,
+            event_type=_SCHEDULED_TASK_EVENT_TYPE,
+            content=content,
+            state_key=task_id,
+        )
+    except Exception as exc:
+        active_write_failure = f"{type(exc).__name__}: {exc!s}"
+    else:
+        if not isinstance(response, nio.RoomPutStateError):
+            return
+        active_write_failure = str(response)
+
+    if matrix_admin is not None:
+        try:
+            admin_wrote = await matrix_admin.put_room_state(
+                room_id,
+                _SCHEDULED_TASK_EVENT_TYPE,
+                task_id,
+                content,
+            )
+        except Exception as exc:
+            msg = (
+                f"Failed to persist scheduled task state for task `{task_id}`: "
+                f"active write failed ({active_write_failure}); privileged fallback raised {type(exc).__name__}: {exc!s}"
+            )
+            raise ValueError(msg) from exc
+        if admin_wrote:
+            logger.info("scheduled_task_state_persisted_via_admin", room_id=room_id, task_id=task_id)
+            return
+        active_write_failure = f"{active_write_failure}; privileged fallback failed"
+
+    msg = f"Failed to persist scheduled task state for task `{task_id}`: {active_write_failure}"
+    raise ValueError(msg)
+
+
 async def _persist_scheduled_task_state(
     client: nio.AsyncClient,
     room_id: str,
@@ -617,11 +663,13 @@ async def _persist_scheduled_task_state(
     workflow: ScheduledWorkflow,
     status: str = "pending",
     created_at: datetime | str | None = None,
+    matrix_admin: HookMatrixAdmin | None = None,
 ) -> None:
     """Persist scheduled task state to Matrix."""
-    response = await client.room_put_state(
+    await _put_scheduled_task_state_content(
+        client=client,
         room_id=room_id,
-        event_type=_SCHEDULED_TASK_EVENT_TYPE,
+        task_id=task_id,
         content={
             "task_id": task_id,
             "workflow": workflow.model_dump_json(),
@@ -629,12 +677,8 @@ async def _persist_scheduled_task_state(
             "created_at": _serialize_scheduled_task_created_at(created_at),
             "updated_at": datetime.now(UTC).isoformat(),
         },
-        state_key=task_id,
+        matrix_admin=matrix_admin,
     )
-    if isinstance(response, nio.RoomPutStateResponse):
-        return
-    msg = f"Failed to persist scheduled task state: {response}"
-    raise ValueError(msg)
 
 
 async def _save_pending_scheduled_task(
@@ -658,6 +702,7 @@ async def _save_pending_scheduled_task(
         workflow=workflow,
         status="pending",
         created_at=created_at,
+        matrix_admin=matrix_admin,
     )
     _start_scheduled_task(
         client,
@@ -675,6 +720,7 @@ async def _save_one_time_task_status(
     client: nio.AsyncClient,
     task: ScheduledTaskRecord,
     status: str,
+    matrix_admin: HookMatrixAdmin | None = None,
 ) -> None:
     """Persist the terminal status for a one-time task without restarting it."""
     await _persist_scheduled_task_state(
@@ -684,6 +730,7 @@ async def _save_one_time_task_status(
         workflow=task.workflow,
         status=status,
         created_at=task.created_at,
+        matrix_admin=matrix_admin,
     )
 
 
@@ -693,6 +740,7 @@ async def save_edited_scheduled_task(
     task_id: str,
     workflow: ScheduledWorkflow,
     existing_task: ScheduledTaskRecord,
+    matrix_admin: HookMatrixAdmin | None = None,
 ) -> ScheduledTaskRecord:
     """Persist edits to an existing task without touching runtime task runners."""
     if existing_task.status != "pending":
@@ -709,6 +757,7 @@ async def save_edited_scheduled_task(
         workflow=workflow,
         status="pending",
         created_at=existing_task.created_at,
+        matrix_admin=matrix_admin,
     )
 
     return ScheduledTaskRecord(
@@ -984,6 +1033,7 @@ async def _run_once_task(  # noqa: C901, PLR0912, PLR0915
                     client=client,
                     task=latest_pending_task,
                     status=final_status,
+                    matrix_admin=matrix_admin,
                 )
             except Exception:
                 logger.exception(
@@ -1020,6 +1070,7 @@ async def _run_once_task(  # noqa: C901, PLR0912, PLR0915
                         client=client,
                         task=latest_pending_task,
                         status="failed",
+                        matrix_admin=matrix_admin,
                     )
                 except Exception:
                     logger.exception("Failed to mark one-time task as failed", task_id=task_id)
@@ -1254,6 +1305,7 @@ async def schedule_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
                 task_id=task_id,
                 workflow=workflow_result,
                 existing_task=existing_task,
+                matrix_admin=runtime.matrix_admin,
             )
         else:
             await _save_pending_scheduled_task(
@@ -1413,12 +1465,9 @@ async def cancel_scheduled_task(
     room_id: str,
     task_id: str,
     cancel_in_memory: bool = True,
+    matrix_admin: HookMatrixAdmin | None = None,
 ) -> str:
     """Cancel a scheduled task."""
-    # Cancel the asyncio task if running
-    if cancel_in_memory:
-        _cancel_running_task(task_id)
-
     # First check if task exists
     response = await client.room_get_state_event(
         room_id=room_id,
@@ -1431,12 +1480,19 @@ async def cancel_scheduled_task(
 
     # Update to cancelled
     existing_content = response.content if isinstance(response.content, dict) else None
-    await client.room_put_state(
-        room_id=room_id,
-        event_type=_SCHEDULED_TASK_EVENT_TYPE,
-        content=_cancelled_task_content(task_id, existing_content),
-        state_key=task_id,
-    )
+    try:
+        await _put_scheduled_task_state_content(
+            client=client,
+            room_id=room_id,
+            task_id=task_id,
+            content=_cancelled_task_content(task_id, existing_content),
+            matrix_admin=matrix_admin,
+        )
+    except ValueError as e:
+        return f"❌ Failed to cancel task `{task_id}`: {e!s}"
+
+    if cancel_in_memory:
+        _cancel_running_task(task_id)
 
     return f"✅ Cancelled task `{task_id}`"
 
@@ -1444,6 +1500,7 @@ async def cancel_scheduled_task(
 async def cancel_all_scheduled_tasks(
     client: nio.AsyncClient,
     room_id: str,
+    matrix_admin: HookMatrixAdmin | None = None,
 ) -> str:
     """Cancel all scheduled tasks in a room."""
     # Get all scheduled tasks
@@ -1462,18 +1519,17 @@ async def cancel_all_scheduled_tasks(
             if content.get("status") == "pending":
                 task_id = event["state_key"]
 
-                # Cancel the asyncio task if running
-                _cancel_running_task(task_id)
-
                 # Update to cancelled in Matrix state
                 try:
                     existing_content = content if isinstance(content, dict) else None
-                    await client.room_put_state(
+                    await _put_scheduled_task_state_content(
+                        client=client,
                         room_id=room_id,
-                        event_type=_SCHEDULED_TASK_EVENT_TYPE,
+                        task_id=task_id,
                         content=_cancelled_task_content(task_id, existing_content),
-                        state_key=task_id,
+                        matrix_admin=matrix_admin,
                     )
+                    _cancel_running_task(task_id)
                     cancelled_count += 1
                     logger.info("scheduled_task_cancelled", task_id=task_id)
                 except Exception:
@@ -1481,6 +1537,8 @@ async def cancel_all_scheduled_tasks(
                     failed_count += 1
 
     if cancelled_count == 0:
+        if failed_count > 0:
+            return f"❌ Failed to cancel {failed_count} scheduled task(s)"
         return "No scheduled tasks to cancel."
 
     result = f"✅ Cancelled {cancelled_count} scheduled task(s)"
@@ -1535,6 +1593,7 @@ async def restore_scheduled_tasks(  # noqa: C901
                             workflow=workflow,
                             status="failed",
                             created_at=task.created_at,
+                            matrix_admin=build_hook_matrix_admin(client, runtime_paths),
                         )
                     except Exception:
                         logger.exception("Failed to mark ancient task as failed", task_id=task_id)

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -22,7 +22,6 @@ from pydantic import BaseModel, Field
 from mindroom import model_loading, scheduling_executor
 from mindroom.authorization import responder_candidate_entities_for_room
 from mindroom.entity_resolution import entity_identity_registry
-from mindroom.hooks import build_hook_matrix_admin
 from mindroom.logging_config import bound_log_context, get_logger
 from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.mentions import parse_mentions_in_text
@@ -463,7 +462,6 @@ async def drain_deferred_overdue_tasks(
                 runtime_paths,
                 event_cache,
                 conversation_cache,
-                matrix_admin=build_hook_matrix_admin(client, runtime_paths),
             ):
                 drained_count += 1
         except Exception:
@@ -629,7 +627,7 @@ async def _put_scheduled_task_state_content(
     except Exception as exc:
         active_write_failure = f"{type(exc).__name__}: {exc!s}"
     else:
-        if not isinstance(response, nio.RoomPutStateError):
+        if isinstance(response, nio.RoomPutStateResponse):
             return
         active_write_failure = str(response)
 
@@ -1593,7 +1591,6 @@ async def restore_scheduled_tasks(  # noqa: C901
                             workflow=workflow,
                             status="failed",
                             created_at=task.created_at,
-                            matrix_admin=build_hook_matrix_admin(client, runtime_paths),
                         )
                     except Exception:
                         logger.exception("Failed to mark ancient task as failed", task_id=task_id)
@@ -1619,7 +1616,6 @@ async def restore_scheduled_tasks(  # noqa: C901
             runtime_paths,
             event_cache,
             conversation_cache,
-            matrix_admin=build_hook_matrix_admin(client, runtime_paths),
         ):
             restored_count += 1
 

--- a/tests/test_bot_scheduling.py
+++ b/tests/test_bot_scheduling.py
@@ -293,7 +293,12 @@ class TestBotScheduleCommands:
 
             await _execute_command(mock_agent_bot, room, event, "@user:server", command)
 
-            mock_cancel.assert_called_once_with(client=mock_agent_bot.client, room_id="!test:server", task_id="task123")
+            mock_cancel.assert_called_once_with(
+                client=mock_agent_bot.client,
+                room_id="!test:server",
+                task_id="task123",
+                matrix_admin=None,
+            )
 
     @pytest.mark.asyncio
     async def test_handle_cancel_all_scheduled_tasks(self, mock_agent_bot: AgentBot) -> None:
@@ -318,7 +323,11 @@ class TestBotScheduleCommands:
 
             await _execute_command(mock_agent_bot, room, event, "@user:server", command)
 
-            mock_cancel_all.assert_called_once_with(client=mock_agent_bot.client, room_id="!test:server")
+            mock_cancel_all.assert_called_once_with(
+                client=mock_agent_bot.client,
+                room_id="!test:server",
+                matrix_admin=None,
+            )
 
         mock_agent_bot._send_response.assert_called_once()
         call_args = mock_agent_bot._send_response.call_args

--- a/tests/test_hook_matrix_admin.py
+++ b/tests/test_hook_matrix_admin.py
@@ -145,11 +145,22 @@ async def test_build_hook_matrix_admin_delegates_existing_room_helpers(tmp_path:
         invited = await admin.invite_user("!created:localhost", "@user:localhost")
         members = await admin.get_room_members("!created:localhost")
         added = await admin.add_room_to_space("!space:localhost", "!created:localhost")
+        client.room_put_state.return_value = nio.RoomPutStateResponse.from_dict(
+            {"event_id": "$state"},
+            room_id="!created:localhost",
+        )
+        wrote_state = await admin.put_room_state(
+            "!created:localhost",
+            "com.mindroom.scheduled.task",
+            "task123",
+            {"status": "pending"},
+        )
 
     assert room_id == "!created:localhost"
     assert invited is True
     assert members == {"@user:localhost", "@mindroom_router:localhost"}
     assert added is True
+    assert wrote_state is True
     mock_create.assert_awaited_once_with(
         client=client,
         name="Personal Room",
@@ -158,6 +169,12 @@ async def test_build_hook_matrix_admin_delegates_existing_room_helpers(tmp_path:
         power_users=None,
     )
     mock_invite.assert_awaited_once_with(client, "!created:localhost", "@user:localhost")
+    client.room_put_state.assert_awaited_once_with(
+        room_id="!created:localhost",
+        event_type="com.mindroom.scheduled.task",
+        content={"status": "pending"},
+        state_key="task123",
+    )
     mock_members.assert_awaited_once_with(client, "!created:localhost")
     mock_add.assert_awaited_once()
 

--- a/tests/test_restore_dedup.py
+++ b/tests/test_restore_dedup.py
@@ -110,6 +110,10 @@ async def test_restore_marks_ancient_missed_task_as_failed() -> None:
         room_id="!r:server",
     )
     client.room_get_state = AsyncMock(return_value=response)
+    client.room_put_state.return_value = nio.RoomPutStateResponse.from_dict(
+        {"event_id": "$failed"},
+        room_id="!r:server",
+    )
 
     restored = await restore_scheduled_tasks(
         client,

--- a/tests/test_scheduler_tool.py
+++ b/tests/test_scheduler_tool.py
@@ -258,7 +258,8 @@ async def test_cancel_schedule_tool_calls_backend() -> None:
     """Cancel tool should call cancel_scheduled_task with correct arguments."""
     tools = SchedulerTools()
     config = _bind_runtime_paths(Config(agents={"general": AgentConfig(display_name="General Agent")}))
-    context = _make_context(config)
+    matrix_admin = object()
+    context = _make_context(config, matrix_admin=matrix_admin)
 
     with (
         patch(
@@ -274,6 +275,7 @@ async def test_cancel_schedule_tool_calls_backend() -> None:
         client=context.client,
         room_id=context.room_id,
         task_id="task123",
+        matrix_admin=matrix_admin,
     )
 
 

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import nio
@@ -27,6 +27,7 @@ from mindroom.scheduling import (
     build_edited_scheduled_workflow,
     build_scheduled_task_read_model,
     cancel_all_scheduled_tasks,
+    cancel_scheduled_task,
     clear_deferred_overdue_tasks,
     drain_deferred_overdue_tasks,
     edit_scheduled_task,
@@ -94,6 +95,7 @@ def _scheduling_runtime(
     room: object | None = None,
     conversation_cache: AsyncMock | None = None,
     event_cache: AsyncMock | None = None,
+    matrix_admin: object | None = None,
 ) -> SchedulingRuntime:
     return SchedulingRuntime(
         client=client or AsyncMock(),
@@ -102,6 +104,7 @@ def _scheduling_runtime(
         room=room or MagicMock(),
         conversation_cache=conversation_cache or _conversation_cache(),
         event_cache=event_cache or _event_cache(),
+        matrix_admin=matrix_admin,
     )
 
 
@@ -119,6 +122,43 @@ def _record(
         created_at=datetime.now(UTC),
         workflow=workflow,
     )
+
+
+class _RecordingScheduleStateAdmin:
+    """Hook-admin test double that writes Matrix state into a shared room-state store."""
+
+    def __init__(self, room_state: dict[str, dict[str, Any]], *, should_succeed: bool = True) -> None:
+        self.room_state = room_state
+        self.should_succeed = should_succeed
+        self.put_room_state = AsyncMock(side_effect=self._put_room_state)
+
+    async def _put_room_state(
+        self,
+        room_id: str,
+        event_type: str,
+        state_key: str,
+        content: dict[str, Any],
+    ) -> bool:
+        if not self.should_succeed:
+            return False
+        self.room_state[state_key] = {
+            "type": event_type,
+            "state_key": state_key,
+            "content": dict(content),
+            "room_id": room_id,
+            "event_id": f"$admin_{state_key}",
+            "sender": "@mindroom_router:server",
+            "origin_server_ts": 1234567890,
+        }
+        return True
+
+
+def _room_state_response(room_id: str, room_state: dict[str, dict[str, Any]]) -> nio.RoomGetStateResponse:
+    return nio.RoomGetStateResponse.from_dict(list(room_state.values()), room_id=room_id)
+
+
+async def _forbidden_state_write(*_args: object, **_kwargs: object) -> nio.RoomPutStateError:
+    return nio.RoomPutStateError("forbidden", "M_FORBIDDEN")
 
 
 def test_scheduled_task_read_model_derives_display_fields_and_sort_order() -> None:
@@ -1229,6 +1269,83 @@ async def test_run_cron_task_stops_when_cancelled_via_matrix_state() -> None:
 
 
 @pytest.mark.asyncio
+async def test_cancel_scheduled_task_persists_via_admin_when_active_agent_lacks_state_power() -> None:
+    """Cancelling a task should fall back to admin state writes after active-client permission failure."""
+    client = AsyncMock()
+    client.room_put_state = AsyncMock(side_effect=_forbidden_state_write)
+    room_state: dict[str, dict[str, Any]] = {}
+    matrix_admin = _RecordingScheduleStateAdmin(room_state)
+    workflow = ScheduledWorkflow(
+        schedule_type="once",
+        execute_at=datetime.now(UTC) + timedelta(minutes=5),
+        message="cancel me",
+        description="cancel me",
+        room_id="!test:server",
+        thread_id="$thread",
+    )
+    client.room_get_state_event = AsyncMock(
+        return_value=nio.RoomGetStateEventResponse(
+            content={
+                "task_id": "taskcancel",
+                "workflow": workflow.model_dump_json(),
+                "status": "pending",
+                "created_at": datetime(2026, 1, 1, 12, 0, tzinfo=UTC).isoformat(),
+            },
+            event_type=_SCHEDULED_TASK_EVENT_TYPE,
+            state_key="taskcancel",
+            room_id="!test:server",
+        ),
+    )
+
+    result = await cancel_scheduled_task(
+        client=client,
+        room_id="!test:server",
+        task_id="taskcancel",
+        matrix_admin=matrix_admin,
+    )
+
+    assert result == "✅ Cancelled task `taskcancel`"
+    client.room_put_state.assert_awaited_once()
+    matrix_admin.put_room_state.assert_awaited_once()
+    assert room_state["taskcancel"]["content"]["status"] == "cancelled"
+    assert room_state["taskcancel"]["content"]["workflow"] == workflow.model_dump_json()
+
+
+@pytest.mark.asyncio
+async def test_cancel_scheduled_task_returns_error_when_state_write_fails() -> None:
+    """Failed Matrix state writes must not claim a task was cancelled."""
+    client = AsyncMock()
+    client.room_put_state = AsyncMock(side_effect=_forbidden_state_write)
+    workflow = ScheduledWorkflow(
+        schedule_type="once",
+        execute_at=datetime.now(UTC) + timedelta(minutes=5),
+        message="cancel me",
+        description="cancel me",
+        room_id="!test:server",
+        thread_id="$thread",
+    )
+    client.room_get_state_event = AsyncMock(
+        return_value=nio.RoomGetStateEventResponse(
+            content={
+                "task_id": "taskcancel",
+                "workflow": workflow.model_dump_json(),
+                "status": "pending",
+            },
+            event_type=_SCHEDULED_TASK_EVENT_TYPE,
+            state_key="taskcancel",
+            room_id="!test:server",
+        ),
+    )
+
+    result = await cancel_scheduled_task(
+        client=client,
+        room_id="!test:server",
+        task_id="taskcancel",
+    )
+
+    assert result.startswith("❌ Failed to cancel task `taskcancel`")
+
+
 @pytest.mark.asyncio
 async def test_cancel_all_scheduled_tasks() -> None:
     """Test cancel_all_scheduled_tasks functionality."""
@@ -1328,6 +1445,90 @@ async def test_cancel_all_scheduled_tasks() -> None:
         assert call[1]["content"]["task_id"] == state_key
         assert call[1]["content"]["workflow"] == expected_workflows[state_key]
         assert "created_at" in call[1]["content"]
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_scheduled_tasks_persists_via_admin_when_active_agent_lacks_state_power() -> None:
+    """Cancel-all should use the same privileged schedule-state persistence fallback."""
+    client = AsyncMock()
+    client.room_put_state = AsyncMock(side_effect=_forbidden_state_write)
+    room_state: dict[str, dict[str, Any]] = {}
+    matrix_admin = _RecordingScheduleStateAdmin(room_state)
+    workflow = ScheduledWorkflow(
+        schedule_type="once",
+        execute_at=datetime.now(UTC) + timedelta(minutes=5),
+        message="cancel all",
+        description="cancel all",
+        room_id="!test:server",
+        thread_id="$thread",
+    )
+    client.room_get_state = AsyncMock(
+        return_value=nio.RoomGetStateResponse.from_dict(
+            [
+                {
+                    "type": _SCHEDULED_TASK_EVENT_TYPE,
+                    "state_key": "task1",
+                    "content": {
+                        "task_id": "task1",
+                        "workflow": workflow.model_dump_json(),
+                        "status": "pending",
+                    },
+                    "event_id": "$state_task1",
+                    "sender": "@system:server",
+                    "origin_server_ts": 1234567890,
+                },
+            ],
+            room_id="!test:server",
+        ),
+    )
+
+    result = await cancel_all_scheduled_tasks(
+        client=client,
+        room_id="!test:server",
+        matrix_admin=matrix_admin,
+    )
+
+    assert result == "✅ Cancelled 1 scheduled task(s)"
+    matrix_admin.put_room_state.assert_awaited_once()
+    assert room_state["task1"]["content"]["status"] == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_scheduled_tasks_returns_error_when_state_write_fails() -> None:
+    """Cancel-all must not report success when pending task state cannot be written."""
+    client = AsyncMock()
+    client.room_put_state = AsyncMock(side_effect=_forbidden_state_write)
+    workflow = ScheduledWorkflow(
+        schedule_type="once",
+        execute_at=datetime.now(UTC) + timedelta(minutes=5),
+        message="cancel all",
+        description="cancel all",
+        room_id="!test:server",
+        thread_id="$thread",
+    )
+    client.room_get_state = AsyncMock(
+        return_value=nio.RoomGetStateResponse.from_dict(
+            [
+                {
+                    "type": _SCHEDULED_TASK_EVENT_TYPE,
+                    "state_key": "task1",
+                    "content": {
+                        "task_id": "task1",
+                        "workflow": workflow.model_dump_json(),
+                        "status": "pending",
+                    },
+                    "event_id": "$state_task1",
+                    "sender": "@system:server",
+                    "origin_server_ts": 1234567890,
+                },
+            ],
+            room_id="!test:server",
+        ),
+    )
+
+    result = await cancel_all_scheduled_tasks(client=client, room_id="!test:server")
+
+    assert result == "❌ Failed to cancel 1 scheduled task(s)"
 
 
 @pytest.mark.asyncio
@@ -1471,6 +1672,79 @@ async def test_edit_scheduled_task_preserves_new_thread_mode() -> None:
     call_kwargs = mock_schedule.await_args.kwargs
     assert call_kwargs["thread_id"] is None
     assert call_kwargs["new_thread"] is True
+
+
+@pytest.mark.asyncio
+async def test_edit_scheduled_task_persists_via_admin_when_active_agent_lacks_state_power(tmp_path: Path) -> None:
+    """Editing should use the same privileged schedule-state persistence fallback as creation."""
+    client = AsyncMock()
+    client.room_put_state = AsyncMock(side_effect=_forbidden_state_write)
+    room_state: dict[str, dict[str, Any]] = {}
+    client.room_get_state = AsyncMock(side_effect=lambda room_id: _room_state_response(room_id, room_state))
+    matrix_admin = _RecordingScheduleStateAdmin(room_state)
+    room = _matrix_room("!test:server")
+    runtime_paths = _test_runtime_paths(tmp_path)
+    config = bind_runtime_paths(
+        Config(
+            agents={"assistant": AgentConfig(display_name="Assistant", role="Test assistant")},
+            models={"default": ModelConfig(provider="test", id="test-model")},
+        ),
+        runtime_paths,
+    )
+    ids = entity_ids(config, runtime_paths)
+    existing_workflow = ScheduledWorkflow(
+        schedule_type="once",
+        execute_at=datetime.now(UTC) + timedelta(minutes=5),
+        message="old message",
+        description="old task",
+        created_by="@alice:server",
+        thread_id="$thread",
+        room_id="!test:server",
+    )
+    client.room_get_state_event = AsyncMock(
+        return_value=nio.RoomGetStateEventResponse(
+            content={
+                "task_id": "taskedit",
+                "workflow": existing_workflow.model_dump_json(),
+                "status": "pending",
+                "created_at": datetime(2026, 1, 1, 12, 0, tzinfo=UTC).isoformat(),
+            },
+            event_type=_SCHEDULED_TASK_EVENT_TYPE,
+            state_key="taskedit",
+            room_id="!test:server",
+        ),
+    )
+    updated_workflow = ScheduledWorkflow(
+        schedule_type="once",
+        execute_at=datetime.now(UTC) + timedelta(minutes=10),
+        message="updated message",
+        description="updated task",
+    )
+
+    with (
+        patch("mindroom.scheduling.responder_candidate_entities_for_room", return_value=[ids["assistant"]]),
+        patch("mindroom.scheduling._parse_workflow_schedule", new=AsyncMock(return_value=updated_workflow)),
+    ):
+        result = await edit_scheduled_task(
+            runtime=_scheduling_runtime(
+                client=client,
+                config=config,
+                runtime_paths=runtime_paths,
+                room=room,
+                matrix_admin=matrix_admin,
+            ),
+            room_id="!test:server",
+            task_id="taskedit",
+            full_text="in 10 minutes update logs",
+            scheduled_by="@alice:server",
+            thread_id="$thread",
+        )
+
+    assert "✅ Updated task `taskedit`." in result
+    matrix_admin.put_room_state.assert_awaited_once()
+    tasks = await get_scheduled_tasks_for_room(client=client, room_id="!test:server")
+    assert [task.task_id for task in tasks] == ["taskedit"]
+    assert tasks[0].workflow.message == "updated message"
 
 
 @pytest.mark.asyncio
@@ -1700,6 +1974,7 @@ async def test_persist_scheduled_task_state_raises_on_matrix_error() -> None:
     """Schedule persistence must fail when Matrix rejects the state write."""
     client = AsyncMock()
     client.room_put_state.return_value = nio.RoomPutStateError("forbidden", "M_FORBIDDEN")
+
     workflow = ScheduledWorkflow(
         schedule_type="once",
         execute_at=datetime.now(UTC) + timedelta(minutes=5),
@@ -1715,6 +1990,114 @@ async def test_persist_scheduled_task_state_raises_on_matrix_error() -> None:
             task_id="task1234",
             workflow=workflow,
         )
+
+
+@pytest.mark.asyncio
+async def test_schedule_task_persists_via_admin_when_active_agent_lacks_state_power(tmp_path: Path) -> None:
+    """A successful schedule must be visible in Matrix state even when the active agent cannot write state."""
+    client = AsyncMock()
+    client.room_put_state = AsyncMock(side_effect=_forbidden_state_write)
+    room_state: dict[str, dict[str, Any]] = {}
+    client.room_get_state = AsyncMock(side_effect=lambda room_id: _room_state_response(room_id, room_state))
+    matrix_admin = _RecordingScheduleStateAdmin(room_state)
+    room = _matrix_room("!test:server")
+    runtime_paths = _test_runtime_paths(tmp_path)
+    config = bind_runtime_paths(
+        Config(
+            agents={"assistant": AgentConfig(display_name="Assistant", role="Test assistant")},
+            models={"default": ModelConfig(provider="test", id="test-model")},
+        ),
+        runtime_paths,
+    )
+    ids = entity_ids(config, runtime_paths)
+    workflow = ScheduledWorkflow(
+        schedule_type="once",
+        execute_at=datetime.now(UTC) + timedelta(minutes=5),
+        message="check logs",
+        description="check logs",
+    )
+
+    with (
+        patch("mindroom.scheduling.responder_candidate_entities_for_room", return_value=[ids["assistant"]]),
+        patch("mindroom.scheduling._extract_mentioned_agents_from_text", return_value=[]),
+        patch("mindroom.scheduling._parse_workflow_schedule", new=AsyncMock(return_value=workflow)),
+        patch("mindroom.scheduling._start_scheduled_task", return_value=True),
+        patch("mindroom.scheduling.uuid.uuid4", return_value="task1234"),
+    ):
+        task_id, message = await schedule_task(
+            runtime=_scheduling_runtime(
+                client=client,
+                config=config,
+                runtime_paths=runtime_paths,
+                room=room,
+                matrix_admin=matrix_admin,
+            ),
+            room_id="!test:server",
+            thread_id="$thread",
+            scheduled_by="@alice:server",
+            full_text="in 5 minutes check logs",
+        )
+
+    assert task_id == "task1234"
+    assert "✅ Scheduled" in message
+    matrix_admin.put_room_state.assert_awaited_once()
+    tasks = await get_scheduled_tasks_for_room(client=client, room_id="!test:server")
+    assert [task.task_id for task in tasks] == ["task1234"]
+    persisted = tasks[0]
+    assert persisted.workflow.created_by == "@alice:server"
+    assert persisted.workflow.room_id == "!test:server"
+    assert persisted.workflow.thread_id == "$thread"
+    assert persisted.workflow.new_thread is False
+    listed = await list_scheduled_tasks(client=client, room_id="!test:server", thread_id="$thread", config=config)
+    assert "`task1234`" in listed
+
+
+@pytest.mark.asyncio
+async def test_schedule_task_returns_error_when_state_write_and_admin_fallback_fail(tmp_path: Path) -> None:
+    """Scheduling must not return a task ID when Matrix state persistence fails."""
+    client = AsyncMock()
+    client.room_put_state = AsyncMock(side_effect=_forbidden_state_write)
+    room = _matrix_room("!test:server")
+    runtime_paths = _test_runtime_paths(tmp_path)
+    config = bind_runtime_paths(
+        Config(
+            agents={"assistant": AgentConfig(display_name="Assistant", role="Test assistant")},
+            models={"default": ModelConfig(provider="test", id="test-model")},
+        ),
+        runtime_paths,
+    )
+    ids = entity_ids(config, runtime_paths)
+    workflow = ScheduledWorkflow(
+        schedule_type="once",
+        execute_at=datetime.now(UTC) + timedelta(minutes=5),
+        message="check logs",
+        description="check logs",
+    )
+
+    with (
+        patch("mindroom.scheduling.responder_candidate_entities_for_room", return_value=[ids["assistant"]]),
+        patch("mindroom.scheduling._extract_mentioned_agents_from_text", return_value=[]),
+        patch("mindroom.scheduling._parse_workflow_schedule", new=AsyncMock(return_value=workflow)),
+        patch("mindroom.scheduling._start_scheduled_task", return_value=True) as start_task,
+        patch("mindroom.scheduling.uuid.uuid4", return_value="taskfail"),
+    ):
+        task_id, message = await schedule_task(
+            runtime=_scheduling_runtime(
+                client=client,
+                config=config,
+                runtime_paths=runtime_paths,
+                room=room,
+            ),
+            room_id="!test:server",
+            thread_id="$thread",
+            scheduled_by="@alice:server",
+            full_text="in 5 minutes check logs",
+        )
+
+    assert task_id is None
+    assert "Failed to schedule" in message
+    assert "Failed to persist scheduled task state" in message
+    start_task.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -2101,6 +2101,54 @@ async def test_schedule_task_returns_error_when_state_write_and_admin_fallback_f
 
 
 @pytest.mark.asyncio
+async def test_schedule_task_returns_error_when_active_write_returns_unexpected_response(tmp_path: Path) -> None:
+    """Scheduling must require a positive Matrix state-write response before returning success."""
+    client = AsyncMock()
+    client.room_put_state = AsyncMock(return_value=None)
+    room = _matrix_room("!test:server")
+    runtime_paths = _test_runtime_paths(tmp_path)
+    config = bind_runtime_paths(
+        Config(
+            agents={"assistant": AgentConfig(display_name="Assistant", role="Test assistant")},
+            models={"default": ModelConfig(provider="test", id="test-model")},
+        ),
+        runtime_paths,
+    )
+    ids = entity_ids(config, runtime_paths)
+    workflow = ScheduledWorkflow(
+        schedule_type="once",
+        execute_at=datetime.now(UTC) + timedelta(minutes=5),
+        message="check logs",
+        description="check logs",
+    )
+
+    with (
+        patch("mindroom.scheduling.responder_candidate_entities_for_room", return_value=[ids["assistant"]]),
+        patch("mindroom.scheduling._extract_mentioned_agents_from_text", return_value=[]),
+        patch("mindroom.scheduling._parse_workflow_schedule", new=AsyncMock(return_value=workflow)),
+        patch("mindroom.scheduling._start_scheduled_task", return_value=True) as start_task,
+        patch("mindroom.scheduling.uuid.uuid4", return_value="taskweird"),
+    ):
+        task_id, message = await schedule_task(
+            runtime=_scheduling_runtime(
+                client=client,
+                config=config,
+                runtime_paths=runtime_paths,
+                room=room,
+            ),
+            room_id="!test:server",
+            thread_id="$thread",
+            scheduled_by="@alice:server",
+            full_text="in 5 minutes check logs",
+        )
+
+    assert task_id is None
+    assert "Failed to schedule" in message
+    assert "Failed to persist scheduled task state" in message
+    start_task.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_schedule_task_uses_configured_room_boundary_without_membership_refresh(tmp_path: Path) -> None:
     """Configured schedule rooms should use the static responder boundary without membership refresh."""
     client = AsyncMock()


### PR DESCRIPTION
## Summary
- Add a narrow scheduled-task state writer that tries the active Matrix client first, then falls back to the admin-capable Matrix helper for validated schedule actions.
- Route create, edit, cancel, cancel-all, and terminal status updates through that writer so success only returns after durable Matrix state persistence.
- Extend scheduler tests for admin fallback, no false success, edit/cancel behavior, and command/tool wiring.

## Test Plan
- `uv run pytest tests/test_scheduling.py tests/test_scheduler_tool.py tests/test_matrix_room_access.py tests/test_hook_matrix_admin.py tests/test_bot_scheduling.py::TestBotScheduleCommands::test_handle_cancel_schedule_command tests/test_bot_scheduling.py::TestBotScheduleCommands::test_handle_cancel_all_scheduled_tasks -q`
- `git ls-files 'tests/*.py' 'tests/**/*.py' | xargs uv run pytest`
- `uv sync --all-extras`
- `uv run pre-commit run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Scheduled task operations (scheduling, editing, and cancellation) now include a fallback mechanism that succeeds even when standard write permissions are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->