### PR TITLE
Fix restored schedule admin fallback

### DIFF
--- a/src/mindroom/api/schedules.py
+++ b/src/mindroom/api/schedules.py
@@ -212,12 +212,14 @@ async def cancel_schedule(
         if not existing:
             raise HTTPException(status_code=404, detail=f"Task `{task_id}` not found")
 
-        await cancel_scheduled_task(
+        result = await cancel_scheduled_task(
             client=client,
             room_id=resolved_room_id,
             task_id=task_id,
             cancel_in_memory=False,
         )
+        if result.startswith("❌"):
+            raise HTTPException(status_code=400, detail=result)
     finally:
         await client.close()
 

--- a/src/mindroom/api/schedules.py
+++ b/src/mindroom/api/schedules.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     from mindroom.config.main import Config
 
 router = APIRouter(prefix="/api/schedules", tags=["schedules"])
+_SCHEDULER_ERROR_PREFIX = "❌ "
 
 
 class ScheduledTaskResponse(BaseModel):
@@ -104,6 +105,18 @@ def _to_response_task(task: ScheduledTaskReadModel, runtime_paths: RuntimePaths)
         room_alias=get_room_alias_from_id(task.room_id, runtime_paths=runtime_paths),
         **asdict(task),
     )
+
+
+def _scheduler_error_detail(result: str) -> str:
+    """Convert chat-formatted scheduler errors into API response details."""
+    return result.removeprefix(_SCHEDULER_ERROR_PREFIX).strip()
+
+
+def _cancel_error_status_code(detail: str) -> int:
+    """Return the HTTP status for one scheduler cancel failure detail."""
+    if detail.startswith("Task `") and detail.endswith("` not found."):
+        return 404
+    return 500
 
 
 async def _get_router_client(runtime_paths: RuntimePaths) -> AsyncClient:
@@ -219,7 +232,8 @@ async def cancel_schedule(
             cancel_in_memory=False,
         )
         if result.startswith("❌"):
-            raise HTTPException(status_code=400, detail=result)
+            detail = _scheduler_error_detail(result)
+            raise HTTPException(status_code=_cancel_error_status_code(detail), detail=detail)
     finally:
         await client.close()
 

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -22,6 +22,7 @@ from pydantic import BaseModel, Field
 from mindroom import model_loading, scheduling_executor
 from mindroom.authorization import responder_candidate_entities_for_room
 from mindroom.entity_resolution import entity_identity_registry
+from mindroom.hooks import build_hook_matrix_admin
 from mindroom.logging_config import bound_log_context, get_logger
 from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.mentions import parse_mentions_in_text
@@ -448,6 +449,7 @@ async def drain_deferred_overdue_tasks(
 ) -> int:
     """Start queued overdue one-time tasks after Matrix sync is ready."""
     drained_count = 0
+    matrix_admin = build_hook_matrix_admin(client, runtime_paths)
 
     while _deferred_overdue_tasks:
         queued_task = _deferred_overdue_tasks.popleft()
@@ -462,6 +464,7 @@ async def drain_deferred_overdue_tasks(
                 runtime_paths,
                 event_cache,
                 conversation_cache,
+                matrix_admin=matrix_admin,
             ):
                 drained_count += 1
         except Exception:
@@ -1565,6 +1568,7 @@ async def restore_scheduled_tasks(  # noqa: C901
         return 0
 
     restored_count = 0
+    matrix_admin = build_hook_matrix_admin(client, runtime_paths)
     for task in _parse_task_records_from_state(room_id, response, include_non_pending=False):
         task_id = task.task_id
         workflow = task.workflow
@@ -1591,6 +1595,7 @@ async def restore_scheduled_tasks(  # noqa: C901
                             workflow=workflow,
                             status="failed",
                             created_at=task.created_at,
+                            matrix_admin=matrix_admin,
                         )
                     except Exception:
                         logger.exception("Failed to mark ancient task as failed", task_id=task_id)
@@ -1616,6 +1621,7 @@ async def restore_scheduled_tasks(  # noqa: C901
             runtime_paths,
             event_cache,
             conversation_cache,
+            matrix_admin=matrix_admin,
         ):
             restored_count += 1
 

--- a/tests/api/test_schedules_api.py
+++ b/tests/api/test_schedules_api.py
@@ -300,6 +300,23 @@ def test_cancel_schedule_success(test_client: TestClient) -> None:
     assert cancel_mock.await_args.kwargs["room_id"] == "test_room"
 
 
+def test_cancel_schedule_returns_error_when_backend_cancel_fails(test_client: TestClient) -> None:
+    """Cancel endpoint should not report success when Matrix state persistence fails."""
+    mock_client = _mock_matrix_client()
+    existing_task = _task("abc12345", execute_at=datetime(2026, 2, 10, 9, 0, tzinfo=UTC))
+    cancel_mock = AsyncMock(return_value="❌ Failed to cancel task `abc12345`: Matrix rejected state write")
+    with (
+        patch("mindroom.api.schedules.create_agent_user", return_value=_mock_agent_user()),
+        patch("mindroom.api.schedules.login_agent_user", return_value=mock_client),
+        patch("mindroom.api.schedules.get_scheduled_task", return_value=existing_task),
+        patch("mindroom.api.schedules.cancel_scheduled_task", cancel_mock),
+    ):
+        response = test_client.delete("/api/schedules/abc12345?room_id=test_room")
+
+    assert response.status_code == 400
+    assert "Failed to cancel task" in response.json()["detail"]
+
+
 def test_cancel_schedule_not_found(test_client: TestClient) -> None:
     """Cancel endpoint should return 404 when task does not exist."""
     mock_client = _mock_matrix_client()

--- a/tests/api/test_schedules_api.py
+++ b/tests/api/test_schedules_api.py
@@ -300,8 +300,8 @@ def test_cancel_schedule_success(test_client: TestClient) -> None:
     assert cancel_mock.await_args.kwargs["room_id"] == "test_room"
 
 
-def test_cancel_schedule_returns_error_when_backend_cancel_fails(test_client: TestClient) -> None:
-    """Cancel endpoint should not report success when Matrix state persistence fails."""
+def test_cancel_schedule_returns_server_error_when_backend_cancel_fails(test_client: TestClient) -> None:
+    """Cancel endpoint should report persistence failures as server errors."""
     mock_client = _mock_matrix_client()
     existing_task = _task("abc12345", execute_at=datetime(2026, 2, 10, 9, 0, tzinfo=UTC))
     cancel_mock = AsyncMock(return_value="❌ Failed to cancel task `abc12345`: Matrix rejected state write")
@@ -313,8 +313,25 @@ def test_cancel_schedule_returns_error_when_backend_cancel_fails(test_client: Te
     ):
         response = test_client.delete("/api/schedules/abc12345?room_id=test_room")
 
-    assert response.status_code == 400
-    assert "Failed to cancel task" in response.json()["detail"]
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Failed to cancel task `abc12345`: Matrix rejected state write"
+
+
+def test_cancel_schedule_returns_not_found_when_backend_cancel_reports_missing(test_client: TestClient) -> None:
+    """Cancel endpoint should preserve 404 when the task disappears after the guard read."""
+    mock_client = _mock_matrix_client()
+    existing_task = _task("abc12345", execute_at=datetime(2026, 2, 10, 9, 0, tzinfo=UTC))
+    cancel_mock = AsyncMock(return_value="❌ Task `abc12345` not found.")
+    with (
+        patch("mindroom.api.schedules.create_agent_user", return_value=_mock_agent_user()),
+        patch("mindroom.api.schedules.login_agent_user", return_value=mock_client),
+        patch("mindroom.api.schedules.get_scheduled_task", return_value=existing_task),
+        patch("mindroom.api.schedules.cancel_scheduled_task", cancel_mock),
+    ):
+        response = test_client.delete("/api/schedules/abc12345?room_id=test_room")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Task `abc12345` not found."
 
 
 def test_cancel_schedule_not_found(test_client: TestClient) -> None:

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -401,6 +401,7 @@ async def test_drain_deferred_overdue_tasks_starts_queued_tasks_after_sync() -> 
 
     assert drained == 2
     assert [call.args[1] for call in mock_start.call_args_list] == ["task_overdue_1", "task_overdue_2"]
+    assert all(call.kwargs["matrix_admin"] is not None for call in mock_start.call_args_list)
     mock_sleep.assert_awaited_once_with(scheduling._DEFERRED_OVERDUE_TASK_START_DELAY_SECONDS)
     assert len(scheduling._deferred_overdue_tasks) == 0
 
@@ -532,6 +533,7 @@ async def test_restore_scheduled_tasks_keeps_cron_restoration_unchanged() -> Non
 
     assert restored == 1
     mock_start.assert_called_once()
+    assert mock_start.call_args.kwargs["matrix_admin"] is not None
     assert len(scheduling._deferred_overdue_tasks) == 0
 
 
@@ -578,6 +580,7 @@ async def test_restore_scheduled_tasks_does_not_queue_when_nothing_is_overdue() 
 
     assert restored == 1
     mock_start.assert_called_once()
+    assert mock_start.call_args.kwargs["matrix_admin"] is not None
     assert len(scheduling._deferred_overdue_tasks) == 0
 
 


### PR DESCRIPTION
## Summary
- Restore router-backed Matrix admin fallback for scheduled tasks started from restart restore and deferred overdue drains.
- Use the same fallback when marking ancient missed one-time schedules failed during restore.
- Return an API error when schedule cancellation fails to persist Matrix state instead of reporting success.

## Follow-up
- Fixes post-merge gaps from #1294.

## Test Plan
- `uv run pytest tests/test_scheduling.py::test_drain_deferred_overdue_tasks_starts_queued_tasks_after_sync tests/test_scheduling.py::test_restore_scheduled_tasks_keeps_cron_restoration_unchanged tests/test_scheduling.py::test_restore_scheduled_tasks_does_not_queue_when_nothing_is_overdue tests/api/test_schedules_api.py::test_cancel_schedule_returns_error_when_backend_cancel_fails -q -n 0 --no-cov`
- `uv run pytest tests/test_scheduling.py tests/api/test_schedules_api.py -q -n 0 --no-cov`
- `uv run ruff check src/mindroom/scheduling.py src/mindroom/api/schedules.py tests/test_scheduling.py tests/api/test_schedules_api.py`
- `git diff --check`
- `uv sync --all-extras`
- `uv run pre-commit run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Schedule cancellation now returns detailed error messages when operations fail, providing clear feedback instead of silent failures.

* **Tests**
  * Added test coverage for schedule cancellation error handling scenarios and scheduled task startup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->