### PR TITLE
Add prompt assembly timing drilldowns

### DIFF
--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -32,7 +32,7 @@ from mindroom.runtime_resolution import (
     resolve_agent_runtime,
     resolve_private_requester_scope_root,
 )
-from mindroom.timing import timed
+from mindroom.timing import timed, timed_block
 from mindroom.tool_approval import tool_requires_approval_for_openai_compat
 from mindroom.tool_system.catalog import (
     TOOL_METADATA,
@@ -62,6 +62,7 @@ from mindroom.workspaces import ensure_workspace_template
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from contextlib import AbstractContextManager
 
     from agno.knowledge.protocol import KnowledgeProtocol
     from agno.models.base import Model
@@ -1168,16 +1169,20 @@ def create_agent(  # noqa: PLR0915, C901, PLR0912
         ValueError: If agent_name is not found in configuration
 
     """
-    del timing_scope
+
+    def agent_create_timing(label: str, **event_data: object) -> AbstractContextManager[None]:
+        return timed_block(f"system_prompt_assembly.agent_create.{label}", scope=timing_scope, **event_data)
+
     resolved_storage_path = runtime_paths.storage_root
     create_runtime_state = not disable_runtime_capabilities
-    agent_runtime = resolve_agent_runtime(
-        agent_name,
-        config,
-        runtime_paths,
-        execution_identity=execution_identity,
-        create=create_runtime_state,
-    )
+    with agent_create_timing("resolve_runtime"):
+        agent_runtime = resolve_agent_runtime(
+            agent_name,
+            config,
+            runtime_paths,
+            execution_identity=execution_identity,
+            create=create_runtime_state,
+        )
 
     agent_config = config.get_agent(agent_name)
     if create_runtime_state:
@@ -1197,20 +1202,21 @@ def create_agent(  # noqa: PLR0915, C901, PLR0912
         runtime_paths=runtime_paths,
     )
 
-    storage = (
-        None
-        if not persist_runtime_state
-        else (
-            history_storage
-            if history_storage is not None
-            else agent_storage.create_state_storage(
-                agent_name,
-                agent_runtime.state_root,
-                subdir="sessions",
-                session_table=f"{agent_name}_sessions",
+    with agent_create_timing("storage_open"):
+        storage = (
+            None
+            if not persist_runtime_state
+            else (
+                history_storage
+                if history_storage is not None
+                else agent_storage.create_state_storage(
+                    agent_name,
+                    agent_runtime.state_root,
+                    subdir="sessions",
+                    session_table=f"{agent_name}_sessions",
+                )
             )
         )
-    )
     # Dynamic tool state is keyed by agent and session scope, so team members
     # sharing one Matrix thread do not leak loaded tools across agents.
     dynamic_tool_selection = _resolve_agent_dynamic_tool_selection(
@@ -1237,32 +1243,34 @@ def create_agent(  # noqa: PLR0915, C901, PLR0912
             tool_name for tool_name in dynamic_tool_selection.loaded_tools if tool_name not in disabled_tool_names
         )
     )
-    worker_tools = resolve_runtime_worker_tools(
-        agent_name,
-        config,
-        runtime_paths,
-        list(resolved_tool_configs),
-        tool_registry_preloaded=True,
-    )
+    with agent_create_timing("resolve_worker_tools"):
+        worker_tools = resolve_runtime_worker_tools(
+            agent_name,
+            config,
+            runtime_paths,
+            list(resolved_tool_configs),
+            tool_registry_preloaded=True,
+        )
     workspace = agent_runtime.workspace
     tools: list[Toolkit] = []
     for tool_name in resolved_tool_configs:
         try:
             runtime_overrides = config.get_agent_tool_runtime_overrides(agent_name, tool_name)
-            toolkit = build_agent_toolkit(
-                tool_name,
-                agent_name=agent_name,
-                config=config,
-                runtime_paths=runtime_paths,
-                worker_tools=worker_tools,
-                runtime_overrides=runtime_overrides,
-                agent_runtime=agent_runtime,
-                tool_config_overrides=resolved_tool_configs.get(tool_name),
-                session_id=session_id,
-                execution_identity=execution_identity,
-                delegation_depth=delegation_depth,
-                refresh_scheduler=refresh_scheduler,
-            )
+            with agent_create_timing("toolkit_build.one", tool_name=tool_name):
+                toolkit = build_agent_toolkit(
+                    tool_name,
+                    agent_name=agent_name,
+                    config=config,
+                    runtime_paths=runtime_paths,
+                    worker_tools=worker_tools,
+                    runtime_overrides=runtime_overrides,
+                    agent_runtime=agent_runtime,
+                    tool_config_overrides=resolved_tool_configs.get(tool_name),
+                    session_id=session_id,
+                    execution_identity=execution_identity,
+                    delegation_depth=delegation_depth,
+                    refresh_scheduler=refresh_scheduler,
+                )
             if toolkit:
                 toolkit = _prune_openai_approval_gated_tools(
                     toolkit,
@@ -1300,15 +1308,16 @@ def create_agent(  # noqa: PLR0915, C901, PLR0912
         model_provider = "AI"
         model_id = model_name
 
-    identity_context = _render_agent_identity_context(
-        agent_name,
-        agent_config.display_name,
-        config,
-        runtime_paths,
-        model_provider=model_provider,
-        model_id=model_id,
-        include_openai_compat_guidance=include_openai_compat_guidance,
-    )
+    with agent_create_timing("identity_context"):
+        identity_context = _render_agent_identity_context(
+            agent_name,
+            agent_config.display_name,
+            config,
+            runtime_paths,
+            model_provider=model_provider,
+            model_id=model_id,
+            include_openai_compat_guidance=include_openai_compat_guidance,
+        )
 
     # Add current date context with the user's configured timezone
     datetime_context = _get_datetime_context(

--- a/src/mindroom/history/compaction.py
+++ b/src/mindroom/history/compaction.py
@@ -48,7 +48,7 @@ from mindroom.history.types import (
 )
 from mindroom.hooks import EVENT_COMPACTION_AFTER, EVENT_COMPACTION_BEFORE, CompactionHookContext, emit
 from mindroom.logging_config import get_logger
-from mindroom.timing import timed
+from mindroom.timing import timed, timed_block
 from mindroom.token_budget import estimate_text_tokens, stable_serialize
 from mindroom.tool_system.runtime_context import get_tool_runtime_context, resolve_tool_runtime_hook_bindings
 
@@ -810,21 +810,23 @@ def _prepare_agent_prompt_inputs_for_estimation(
     )
     model = agent.model
     assert model is not None
-    processed_tools = agent.get_tools(
-        run_response=run_response,
-        run_context=run_context,
-        session=session,
-        user_id=budget_user_id,
-    )
-    prepared_tools = determine_tools_for_model(
-        agent=agent,
-        model=model,
-        processed_tools=processed_tools,
-        run_response=run_response,
-        run_context=run_context,
-        session=session,
-        async_mode=False,
-    )
+    with timed_block("system_prompt_assembly.history_prepare.static_token_estimate.agno_get_tools"):
+        processed_tools = agent.get_tools(
+            run_response=run_response,
+            run_context=run_context,
+            session=session,
+            user_id=budget_user_id,
+        )
+    with timed_block("system_prompt_assembly.history_prepare.static_token_estimate.agno_determine_tools"):
+        prepared_tools = determine_tools_for_model(
+            agent=agent,
+            model=model,
+            processed_tools=processed_tools,
+            run_response=run_response,
+            run_context=run_context,
+            session=session,
+            async_mode=False,
+        )
     return (
         session,
         run_context,

--- a/src/mindroom/history/runtime.py
+++ b/src/mindroom/history/runtime.py
@@ -991,6 +991,7 @@ def resolve_bound_team_scope_context(
     )
 
 
+@timed("system_prompt_assembly.history_prepare.static_token_estimate")
 def estimate_preparation_static_tokens(
     agent: Agent,
     *,

--- a/src/mindroom/timing.py
+++ b/src/mindroom/timing.py
@@ -7,6 +7,7 @@ import functools
 import inspect
 import os
 import time
+from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, cast
@@ -14,7 +15,7 @@ from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, cast
 from mindroom.logging_config import get_logger
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
+    from collections.abc import AsyncIterator, Awaitable, Callable, Iterator, Mapping
 
     from structlog.stdlib import BoundLogger
 
@@ -218,6 +219,26 @@ def emit_elapsed_timing(label: str, start: float, **event_data: object) -> None:
         duration_ms=elapsed_ms_since(start),
         **event_data,
     )
+
+
+@contextmanager
+def timed_block(
+    label: str,
+    *,
+    scope: str | None = None,
+    **event_data: object,
+) -> Iterator[None]:
+    """Emit elapsed timing for a small inline block when timing diagnostics are enabled."""
+    if not _is_enabled():
+        yield
+        return
+    start = time.monotonic()
+    try:
+        yield
+    finally:
+        if scope is not None:
+            event_data["timing_scope"] = scope
+        emit_elapsed_timing(label, start, **event_data)
 
 
 def timed(label: str) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -22,6 +22,7 @@ from mindroom.timing import (
     emit_timing_event,
     milliseconds,
     timed,
+    timed_block,
     timing_enabled,
     timing_scope,
 )
@@ -77,6 +78,60 @@ def test_timed_sync_logs_on_exception(
         fail()
 
     _assert_timing_logged(logger, "sync_error_label")
+
+
+def test_timed_block_logs_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Inline timing blocks should emit the same timing event shape as timed()."""
+    monkeypatch.setenv("MINDROOM_TIMING", "1")
+    logger = _mock_timing_logger(monkeypatch)
+
+    with timed_block("block_label", scope="scope-123", phase="setup"):
+        pass
+
+    _assert_timing_logged(logger, "block_label", scope="scope-123")
+    assert logger.debug.call_args.kwargs["phase"] == "setup"
+
+
+def test_timed_block_logs_on_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Inline timing blocks should still emit a timing log when they raise."""
+    monkeypatch.setenv("MINDROOM_TIMING", "1")
+    logger = _mock_timing_logger(monkeypatch)
+
+    def fail() -> None:
+        with timed_block("block_error_label"):
+            msg = "boom"
+            raise RuntimeError(msg)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        fail()
+
+    _assert_timing_logged(logger, "block_error_label")
+
+
+def test_timed_block_does_not_log_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Inline timing blocks should stay quiet when timing is disabled."""
+    monkeypatch.delenv("MINDROOM_TIMING", raising=False)
+    logger = _mock_timing_logger(monkeypatch)
+
+    with timed_block("block_label"):
+        pass
+
+    logger.debug.assert_not_called()
+
+
+def test_timed_block_uses_context_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Inline timing blocks should inherit the active timing scope when omitted."""
+    monkeypatch.setenv("MINDROOM_TIMING", "1")
+    logger = _mock_timing_logger(monkeypatch)
+
+    token = timing_scope.set("scope-456")
+    try:
+        with timed_block("block_label"):
+            pass
+    finally:
+        timing_scope.reset(token)
+
+    _assert_timing_logged(logger, "block_label", scope="scope-456")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a tiny `timed_block()` helper for inline spans under the existing `MINDROOM_TIMING` flag
- split `agent_create` timing into focused phases such as runtime resolution, workspace setup, storage open, worker-tool resolution, per-tool toolkit build, identity prompt, and dynamic-tool prompt/state
- add static-token-estimation spans around Agno tool preparation in history prompt assembly

## Notes
This keeps the existing structured timing log path and avoids adding a metrics backend or persistent instrumentation surface. When `MINDROOM_TIMING` is off, `timed_block()` yields without clock/log work.

## Tests
- `uv run ruff check src/mindroom/timing.py src/mindroom/agents.py src/mindroom/history/compaction.py src/mindroom/history/runtime.py tests/test_timing.py`
- `uv run pytest tests/test_timing.py`
- `uv run pytest tests/test_agent_datetime_context.py tests/test_agents.py -k "create_agent or agent_datetime"`
- `uv run pre-commit run --files src/mindroom/agents.py src/mindroom/history/compaction.py src/mindroom/history/runtime.py src/mindroom/timing.py tests/test_timing.py`