### PR TITLE
Extract agent response attempt helpers

### DIFF
--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -311,6 +311,26 @@ class _StreamingAttemptState:
         return self.tool_tracker.completed_tools
 
 
+@dataclass(frozen=True)
+class _AgentRunContext:
+    """Prepared state shared by one top-level agent response lifecycle."""
+
+    prepared_run: _PreparedAgentRun
+    run_input: list[Message]
+    metadata: dict[str, Any] | None
+    run_extra_content: dict[str, Any] | None
+    inline_media_fallback_prompt: str
+
+
+@dataclass(frozen=True)
+class _NonStreamingAttemptResult:
+    """Result of running one non-streaming agent attempt sequence."""
+
+    response: RunOutput | None
+    attempt: _MediaAttempt
+    user_error: Exception | None = None
+
+
 def _extract_response_content(response: RunOutput, *, show_tool_calls: bool = True) -> str:
     response_parts = []
 
@@ -742,6 +762,129 @@ async def _run_cached_agent_attempt(
     )
 
 
+async def _run_non_streaming_agent_attempts(
+    *,
+    agent: Agent,
+    attempt: _MediaAttempt,
+    run_input: list[Message],
+    inline_media_fallback_prompt: str,
+    agent_name: str,
+    prompt: str,
+    model_prompt: str | None,
+    session_id: str,
+    room_id: str | None,
+    thread_id: str | None,
+    reply_to_event_id: str | None,
+    requester_id: str | None,
+    correlation_id: str,
+    metadata: dict[str, Any] | None,
+    user_id: str | None,
+    run_id: str | None,
+    run_id_callback: Callable[[str], None] | None,
+    timing_scope: str,
+    scope_context: ScopeSessionContext | None,
+    pipeline_timing: DispatchPipelineTiming | None,
+) -> _NonStreamingAttemptResult:
+    """Run one non-streaming agent response sequence, including media fallback."""
+    response: RunOutput | None = None
+    try:
+        for retried_after_media_fallback in (False, True):
+            response = None
+            try:
+                if pipeline_timing is not None:
+                    pipeline_timing.mark("model_request_sent", overwrite=True)
+                with bind_llm_request_log_context(
+                    **_attempt_request_log_context(
+                        agent_id=agent_name,
+                        session_id=session_id,
+                        room_id=room_id,
+                        thread_id=thread_id,
+                        reply_to_event_id=reply_to_event_id,
+                        requester_id=requester_id,
+                        correlation_id=correlation_id,
+                        prompt=prompt,
+                        model_prompt=model_prompt,
+                        attempt_prompt=attempt.attempt_prompt,
+                        metadata=metadata,
+                    ),
+                ):
+                    response = await _run_cached_agent_attempt(
+                        agent,
+                        attempt.attempt_prompt,
+                        session_id,
+                        user_id=user_id,
+                        run_id=attempt.attempt_run_id,
+                        run_id_callback=run_id_callback,
+                        media=attempt.attempt_media_inputs,
+                        metadata=metadata,
+                        timing_scope=timing_scope,
+                    )
+            except Exception as e:
+                retry_decision = retry_media_inputs_after_failure(
+                    attempt.media_route,
+                    e,
+                    attempt.attempt_media_inputs,
+                    extra_present_kinds=attempt.remaining_context_media_kinds,
+                )
+                if not retried_after_media_fallback and retry_decision.should_retry:
+                    logger.warning(
+                        "Retrying AI response after inline media validation error",
+                        agent=agent_name,
+                        error=str(e),
+                        removed_media_kinds=sorted(retry_decision.removed_kinds),
+                    )
+                    attempt.retry(
+                        run_input,
+                        fallback_prompt=inline_media_fallback_prompt,
+                        extra_removed_kinds=retry_decision.removed_kinds,
+                        retry_media_inputs=retry_decision.media_inputs,
+                        run_id=run_id,
+                    )
+                    continue
+
+                logger.exception("Error generating AI response", agent=agent_name)
+                return _NonStreamingAttemptResult(response=None, attempt=attempt, user_error=e)
+
+            if response.status == RunStatus.error:
+                error_text = str(response.content or "Unknown agent error")
+                retry_decision = retry_media_inputs_after_failure(
+                    attempt.media_route,
+                    error_text,
+                    attempt.attempt_media_inputs,
+                    extra_present_kinds=attempt.remaining_context_media_kinds,
+                )
+                if not retried_after_media_fallback and retry_decision.should_retry:
+                    logger.warning(
+                        "Retrying AI response after inline media errored run output",
+                        agent=agent_name,
+                        error=error_text,
+                        removed_media_kinds=sorted(retry_decision.removed_kinds),
+                    )
+                    attempt.retry(
+                        run_input,
+                        fallback_prompt=inline_media_fallback_prompt,
+                        extra_removed_kinds=retry_decision.removed_kinds,
+                        retry_media_inputs=retry_decision.media_inputs,
+                        run_id=run_id,
+                    )
+                    continue
+
+                logger.warning("AI response returned errored run output", agent=agent_name, error=error_text)
+
+            break
+
+        assert response is not None
+        return _NonStreamingAttemptResult(response=response, attempt=attempt)
+    finally:
+        ai_runtime.cleanup_queued_notice_state(
+            run_output=response,
+            storage=scope_context.storage if scope_context is not None else None,
+            session_id=session_id,
+            session_type=SessionType.AGENT,
+            entity_name=agent_name,
+        )
+
+
 def _assert_agent_target(agent_name: str, config: Config) -> None:
     """Reject configured team names in the agent-only AI helper path."""
     if agent_name in config.teams:
@@ -930,6 +1073,104 @@ async def _prepare_agent_and_prompt(
     )
 
 
+async def _prepare_agent_run_context(
+    *,
+    agent_name: str,
+    prompt: str,
+    session_id: str,
+    runtime_paths: RuntimePaths,
+    config: Config,
+    scope_context: ScopeSessionContext | None,
+    thread_history: Sequence[ResolvedVisibleMessage] | None,
+    room_id: str | None,
+    thread_id: str | None,
+    knowledge: Knowledge | None,
+    include_interactive_questions: bool,
+    include_openai_compat_guidance: bool,
+    reply_to_event_id: str | None,
+    active_event_ids: Collection[str],
+    execution_identity: ToolExecutionIdentity | None,
+    compaction_outcomes_collector: list[CompactionOutcome] | None,
+    compaction_lifecycle: CompactionLifecycle | None,
+    delegation_depth: int,
+    refresh_scheduler: KnowledgeRefreshScheduler | None,
+    system_enrichment_items: Sequence[EnrichmentItem],
+    timing_scope: str,
+    model_prompt: str | None,
+    user_id: str | None,
+    requester_id: str | None,
+    correlation_id: str,
+    matrix_run_metadata: dict[str, Any] | None,
+    turn_recorder: TurnRecorder | None,
+    pipeline_timing: DispatchPipelineTiming | None,
+) -> _AgentRunContext:
+    """Prepare one agent response lifecycle through metadata assembly."""
+    if pipeline_timing is not None:
+        pipeline_timing.mark("ai_prepare_start")
+    prepared_run = await _prepare_agent_and_prompt(
+        agent_name,
+        prompt,
+        runtime_paths,
+        config,
+        session_id,
+        scope_context,
+        thread_history,
+        room_id,
+        thread_id,
+        knowledge,
+        include_interactive_questions=include_interactive_questions,
+        reply_to_event_id=reply_to_event_id,
+        active_event_ids=active_event_ids,
+        execution_identity=execution_identity,
+        compaction_outcomes_collector=compaction_outcomes_collector,
+        compaction_lifecycle=compaction_lifecycle,
+        delegation_depth=delegation_depth,
+        refresh_scheduler=refresh_scheduler,
+        system_enrichment_items=system_enrichment_items,
+        include_openai_compat_guidance=include_openai_compat_guidance,
+        timing_scope=timing_scope,
+        model_prompt=model_prompt,
+        **_current_sender_id_kwargs(
+            user_id,
+            include_openai_compat_guidance=include_openai_compat_guidance,
+        ),
+        pipeline_timing=pipeline_timing,
+    )
+    if pipeline_timing is not None:
+        pipeline_timing.mark("history_ready")
+        note_prepared_history_timing(pipeline_timing, prepared_run.prepared_history)
+
+    agent = prepared_run.agent
+    if agent.model is not None:
+        ai_runtime.install_queued_message_notice_hook(
+            agent.model,
+            notice_text=config.get_prompt("QUEUED_MESSAGE_NOTICE_TEXT"),
+        )
+
+    run_extra_content = build_prepared_history_metadata_content(prepared_run.prepared_history)
+    metadata = build_matrix_run_metadata(
+        reply_to_event_id,
+        prepared_run.unseen_event_ids,
+        room_id=room_id,
+        thread_id=thread_id,
+        requester_id=requester_id,
+        correlation_id=correlation_id,
+        tools_schema=agent_tool_definition_payloads_for_logging(agent) if agent.model is not None else [],
+        model_params=model_params_payload(agent.model) if agent.model is not None else {},
+        extra_metadata=deep_merge_metadata(matrix_run_metadata, run_extra_content),
+    )
+    if turn_recorder is not None:
+        turn_recorder.set_run_metadata(metadata)
+
+    return _AgentRunContext(
+        prepared_run=prepared_run,
+        run_input=prepared_run.run_input,
+        metadata=metadata,
+        run_extra_content=run_extra_content,
+        inline_media_fallback_prompt=config.get_prompt("INLINE_MEDIA_FALLBACK_PROMPT"),
+    )
+
+
 async def ai_response(  # noqa: C901, PLR0912, PLR0915
     agent_name: str,
     prompt: str,
@@ -1058,20 +1299,19 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                 entity_name=agent_name,
             )
             try:
-                if pipeline_timing is not None:
-                    pipeline_timing.mark("ai_prepare_start")
-                prepared_run = await _prepare_agent_and_prompt(
-                    agent_name,
-                    prompt,
-                    runtime_paths,
-                    config,
-                    session_id,
-                    scope_context,
-                    thread_history,
-                    room_id,
-                    thread_id,
-                    knowledge,
+                run_context = await _prepare_agent_run_context(
+                    agent_name=agent_name,
+                    prompt=prompt,
+                    session_id=session_id,
+                    runtime_paths=runtime_paths,
+                    config=config,
+                    scope_context=scope_context,
+                    thread_history=thread_history,
+                    room_id=room_id,
+                    thread_id=thread_id,
+                    knowledge=knowledge,
                     include_interactive_questions=include_interactive_questions,
+                    include_openai_compat_guidance=include_openai_compat_guidance,
                     reply_to_event_id=reply_to_event_id,
                     active_event_ids=active_event_ids,
                     execution_identity=execution_identity,
@@ -1080,150 +1320,59 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                     delegation_depth=delegation_depth,
                     refresh_scheduler=refresh_scheduler,
                     system_enrichment_items=system_enrichment_items,
-                    include_openai_compat_guidance=include_openai_compat_guidance,
                     timing_scope=timing_scope,
                     model_prompt=model_prompt,
-                    **_current_sender_id_kwargs(
-                        user_id,
-                        include_openai_compat_guidance=include_openai_compat_guidance,
-                    ),
+                    user_id=user_id,
+                    requester_id=resolved_requester_id,
+                    correlation_id=resolved_correlation_id,
+                    matrix_run_metadata=matrix_run_metadata,
+                    turn_recorder=turn_recorder,
                     pipeline_timing=pipeline_timing,
                 )
-                if pipeline_timing is not None:
-                    pipeline_timing.mark("history_ready")
-                    note_prepared_history_timing(pipeline_timing, prepared_run.prepared_history)
             except Exception as e:
                 logger.exception("Error preparing agent", agent=agent_name)
                 return get_user_friendly_error_message(e, agent_name)
+            prepared_run = run_context.prepared_run
             agent = prepared_run.agent
-            run_input = prepared_run.run_input
+            run_input = run_context.run_input
             unseen_event_ids = prepared_run.unseen_event_ids
-            inline_media_fallback_prompt = config.get_prompt("INLINE_MEDIA_FALLBACK_PROMPT")
-            if agent.model is not None:
-                ai_runtime.install_queued_message_notice_hook(
-                    agent.model,
-                    notice_text=config.get_prompt("QUEUED_MESSAGE_NOTICE_TEXT"),
-                )
+            metadata = run_context.metadata
+            run_extra_content = run_context.run_extra_content
 
-            run_extra_content = build_prepared_history_metadata_content(prepared_run.prepared_history)
-            metadata = build_matrix_run_metadata(
-                reply_to_event_id,
-                unseen_event_ids,
-                room_id=room_id,
-                thread_id=thread_id,
-                requester_id=resolved_requester_id,
-                correlation_id=resolved_correlation_id,
-                tools_schema=agent_tool_definition_payloads_for_logging(agent) if agent.model is not None else [],
-                model_params=model_params_payload(agent.model) if agent.model is not None else {},
-                extra_metadata=deep_merge_metadata(matrix_run_metadata, run_extra_content),
-            )
-            if turn_recorder is not None:
-                turn_recorder.set_run_metadata(metadata)
-
-            response: RunOutput | None = None
             attempt = _MediaAttempt.initial(
                 run_input,
                 media_inputs,
                 agent.model,
-                fallback_prompt=inline_media_fallback_prompt,
+                fallback_prompt=run_context.inline_media_fallback_prompt,
                 run_id=run_id,
             )
-
-            try:
-                for retried_after_media_fallback in (False, True):
-                    response = None
-                    try:
-                        if pipeline_timing is not None:
-                            pipeline_timing.mark("model_request_sent", overwrite=True)
-                        with bind_llm_request_log_context(
-                            **_attempt_request_log_context(
-                                agent_id=agent_name,
-                                session_id=session_id,
-                                room_id=room_id,
-                                thread_id=thread_id,
-                                reply_to_event_id=reply_to_event_id,
-                                requester_id=resolved_requester_id,
-                                correlation_id=resolved_correlation_id,
-                                prompt=prompt,
-                                model_prompt=model_prompt,
-                                attempt_prompt=attempt.attempt_prompt,
-                                metadata=metadata,
-                            ),
-                        ):
-                            response = await _run_cached_agent_attempt(
-                                agent,
-                                attempt.attempt_prompt,
-                                session_id,
-                                user_id=user_id,
-                                run_id=attempt.attempt_run_id,
-                                run_id_callback=run_id_callback,
-                                media=attempt.attempt_media_inputs,
-                                metadata=metadata,
-                                timing_scope=timing_scope,
-                            )
-                    except Exception as e:
-                        retry_decision = retry_media_inputs_after_failure(
-                            attempt.media_route,
-                            e,
-                            attempt.attempt_media_inputs,
-                            extra_present_kinds=attempt.remaining_context_media_kinds,
-                        )
-                        if not retried_after_media_fallback and retry_decision.should_retry:
-                            logger.warning(
-                                "Retrying AI response after inline media validation error",
-                                agent=agent_name,
-                                error=str(e),
-                                removed_media_kinds=sorted(retry_decision.removed_kinds),
-                            )
-                            attempt.retry(
-                                run_input,
-                                fallback_prompt=inline_media_fallback_prompt,
-                                extra_removed_kinds=retry_decision.removed_kinds,
-                                retry_media_inputs=retry_decision.media_inputs,
-                                run_id=run_id,
-                            )
-                            continue
-
-                        logger.exception("Error generating AI response", agent=agent_name)
-                        return get_user_friendly_error_message(e, agent_name)
-
-                    if response.status == RunStatus.error:
-                        error_text = str(response.content or "Unknown agent error")
-                        retry_decision = retry_media_inputs_after_failure(
-                            attempt.media_route,
-                            error_text,
-                            attempt.attempt_media_inputs,
-                            extra_present_kinds=attempt.remaining_context_media_kinds,
-                        )
-                        if not retried_after_media_fallback and retry_decision.should_retry:
-                            logger.warning(
-                                "Retrying AI response after inline media errored run output",
-                                agent=agent_name,
-                                error=error_text,
-                                removed_media_kinds=sorted(retry_decision.removed_kinds),
-                            )
-                            attempt.retry(
-                                run_input,
-                                fallback_prompt=inline_media_fallback_prompt,
-                                extra_removed_kinds=retry_decision.removed_kinds,
-                                retry_media_inputs=retry_decision.media_inputs,
-                                run_id=run_id,
-                            )
-                            continue
-
-                        logger.warning("AI response returned errored run output", agent=agent_name, error=error_text)
-
-                    break
-
-                assert response is not None
-            finally:
-                ai_runtime.cleanup_queued_notice_state(
-                    run_output=response,
-                    storage=scope_context.storage if scope_context is not None else None,
-                    session_id=session_id,
-                    session_type=SessionType.AGENT,
-                    entity_name=agent_name,
-                )
+            attempt_result = await _run_non_streaming_agent_attempts(
+                agent=agent,
+                attempt=attempt,
+                run_input=run_input,
+                inline_media_fallback_prompt=run_context.inline_media_fallback_prompt,
+                agent_name=agent_name,
+                prompt=prompt,
+                model_prompt=model_prompt,
+                session_id=session_id,
+                room_id=room_id,
+                thread_id=thread_id,
+                reply_to_event_id=reply_to_event_id,
+                requester_id=resolved_requester_id,
+                correlation_id=resolved_correlation_id,
+                metadata=metadata,
+                user_id=user_id,
+                run_id=run_id,
+                run_id_callback=run_id_callback,
+                timing_scope=timing_scope,
+                scope_context=scope_context,
+                pipeline_timing=pipeline_timing,
+            )
+            attempt = attempt_result.attempt
+            if attempt_result.user_error is not None:
+                return get_user_friendly_error_message(attempt_result.user_error, agent_name)
+            response = attempt_result.response
+            assert response is not None
 
             response_tool_trace = _extract_tool_trace(response)
             if tool_trace_collector is not None:
@@ -1454,6 +1603,95 @@ async def _process_stream_events(  # noqa: C901, PLR0912, PLR0915
         state.stream_exception = e
 
 
+async def _stream_agent_attempt_chunks(
+    *,
+    agent: Agent,
+    attempt: _MediaAttempt,
+    state: _StreamingAttemptState,
+    show_tool_calls: bool,
+    agent_name: str,
+    session_id: str,
+    user_id: str | None,
+    run_id_callback: Callable[[str], None] | None,
+    prompt: str,
+    model_prompt: str | None,
+    room_id: str | None,
+    thread_id: str | None,
+    reply_to_event_id: str | None,
+    requester_id: str | None,
+    correlation_id: str,
+    metadata: dict[str, Any] | None,
+    retried_after_media_fallback: bool,
+    timing_scope: str,
+    state_updated: Callable[[], None] | None,
+    pipeline_timing: DispatchPipelineTiming | None,
+) -> AsyncGenerator[AIStreamChunk, None]:
+    """Start and consume one streaming agent attempt."""
+    try:
+        if pipeline_timing is not None:
+            pipeline_timing.mark("model_request_sent", overwrite=True)
+        ai_runtime.note_attempt_run_id(run_id_callback, attempt.attempt_run_id)
+        request_context = _attempt_request_log_context(
+            agent_id=agent_name,
+            session_id=session_id,
+            room_id=room_id,
+            thread_id=thread_id,
+            reply_to_event_id=reply_to_event_id,
+            requester_id=requester_id,
+            correlation_id=correlation_id,
+            prompt=prompt,
+            model_prompt=model_prompt,
+            attempt_prompt=attempt.attempt_prompt,
+            metadata=metadata,
+        )
+        with bind_llm_request_log_context(**request_context):
+            prepared_input = ai_runtime.attach_media_to_run_input(
+                attempt.attempt_prompt,
+                attempt.attempt_media_inputs,
+            )
+            stream_generator = agent.arun(
+                prepared_input,
+                session_id=session_id,
+                user_id=user_id,
+                run_id=attempt.attempt_run_id,
+                stream=True,
+                stream_events=True,
+                metadata=metadata,
+            )
+        stream_generator = stream_with_llm_request_log_context(
+            stream_generator,
+            request_context=request_context,
+        )
+        async for stream_chunk in _process_stream_events(
+            stream_generator,
+            state=state,
+            show_tool_calls=show_tool_calls,
+            agent_name=agent_name,
+            media_route=attempt.media_route,
+            media_inputs=attempt.attempt_media_inputs,
+            context_media_kinds=attempt.remaining_context_media_kinds,
+            retried_after_media_fallback=retried_after_media_fallback,
+            timing_scope=timing_scope,
+            state_updated=state_updated,
+            pipeline_timing=pipeline_timing,
+        ):
+            yield stream_chunk
+    except Exception as e:
+        if _request_stream_retry(
+            state,
+            retried_after_media_fallback=retried_after_media_fallback,
+            media_route=attempt.media_route,
+            media_inputs=attempt.attempt_media_inputs,
+            context_media_kinds=attempt.remaining_context_media_kinds,
+            error=e,
+            log_message="Retrying streaming AI response after inline media validation error",
+            agent_name=agent_name,
+        ):
+            return
+        logger.exception("Error starting streaming AI response")
+        state.user_error = e
+
+
 async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
     agent_name: str,
     prompt: str,
@@ -1583,20 +1821,19 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                 entity_name=agent_name,
             )
             try:
-                if pipeline_timing is not None:
-                    pipeline_timing.mark("ai_prepare_start")
-                prepared_run = await _prepare_agent_and_prompt(
-                    agent_name,
-                    prompt,
-                    runtime_paths,
-                    config,
-                    session_id,
-                    scope_context,
-                    thread_history,
-                    room_id,
-                    thread_id,
-                    knowledge,
+                run_context = await _prepare_agent_run_context(
+                    agent_name=agent_name,
+                    prompt=prompt,
+                    session_id=session_id,
+                    runtime_paths=runtime_paths,
+                    config=config,
+                    scope_context=scope_context,
+                    thread_history=thread_history,
+                    room_id=room_id,
+                    thread_id=thread_id,
+                    knowledge=knowledge,
                     include_interactive_questions=include_interactive_questions,
+                    include_openai_compat_guidance=include_openai_compat_guidance,
                     reply_to_event_id=reply_to_event_id,
                     active_event_ids=active_event_ids,
                     execution_identity=execution_identity,
@@ -1605,53 +1842,32 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                     delegation_depth=delegation_depth,
                     refresh_scheduler=refresh_scheduler,
                     system_enrichment_items=system_enrichment_items,
-                    include_openai_compat_guidance=include_openai_compat_guidance,
                     timing_scope=timing_scope,
                     model_prompt=model_prompt,
-                    **_current_sender_id_kwargs(
-                        user_id,
-                        include_openai_compat_guidance=include_openai_compat_guidance,
-                    ),
+                    user_id=user_id,
+                    requester_id=resolved_requester_id,
+                    correlation_id=resolved_correlation_id,
+                    matrix_run_metadata=matrix_run_metadata,
+                    turn_recorder=turn_recorder,
                     pipeline_timing=pipeline_timing,
                 )
-                if pipeline_timing is not None:
-                    pipeline_timing.mark("history_ready")
-                    note_prepared_history_timing(pipeline_timing, prepared_run.prepared_history)
             except Exception as e:
                 logger.exception("Error preparing agent for streaming", agent=agent_name)
                 yield get_user_friendly_error_message(e, agent_name)
                 return
+            prepared_run = run_context.prepared_run
             agent = prepared_run.agent
-            run_input = prepared_run.run_input
+            run_input = run_context.run_input
             unseen_event_ids = prepared_run.unseen_event_ids
             prepared_context_input_tokens = prepared_run.prepared_history.estimated_context_tokens
-            inline_media_fallback_prompt = config.get_prompt("INLINE_MEDIA_FALLBACK_PROMPT")
-            if agent.model is not None:
-                ai_runtime.install_queued_message_notice_hook(
-                    agent.model,
-                    notice_text=config.get_prompt("QUEUED_MESSAGE_NOTICE_TEXT"),
-                )
-
-            run_extra_content = build_prepared_history_metadata_content(prepared_run.prepared_history)
-            metadata = build_matrix_run_metadata(
-                reply_to_event_id,
-                unseen_event_ids,
-                room_id=room_id,
-                thread_id=thread_id,
-                requester_id=resolved_requester_id,
-                correlation_id=resolved_correlation_id,
-                tools_schema=agent_tool_definition_payloads_for_logging(agent) if agent.model is not None else [],
-                model_params=model_params_payload(agent.model) if agent.model is not None else {},
-                extra_metadata=deep_merge_metadata(matrix_run_metadata, run_extra_content),
-            )
-            if turn_recorder is not None:
-                turn_recorder.set_run_metadata(metadata)
+            metadata = run_context.metadata
+            run_extra_content = run_context.run_extra_content
 
             attempt = _MediaAttempt.initial(
                 run_input,
                 media_inputs,
                 agent.model,
-                fallback_prompt=inline_media_fallback_prompt,
+                fallback_prompt=run_context.inline_media_fallback_prompt,
                 run_id=run_id,
             )
             state = _StreamingAttemptState()
@@ -1669,82 +1885,34 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                 for retried_after_media_fallback in (False, True):
                     state = _StreamingAttemptState()
 
-                    try:
-                        if pipeline_timing is not None:
-                            pipeline_timing.mark("model_request_sent", overwrite=True)
-                        ai_runtime.note_attempt_run_id(run_id_callback, attempt.attempt_run_id)
-                        request_context = _attempt_request_log_context(
-                            agent_id=agent_name,
-                            session_id=session_id,
-                            room_id=room_id,
-                            thread_id=thread_id,
-                            reply_to_event_id=reply_to_event_id,
-                            requester_id=resolved_requester_id,
-                            correlation_id=resolved_correlation_id,
-                            prompt=prompt,
-                            model_prompt=model_prompt,
-                            attempt_prompt=attempt.attempt_prompt,
-                            metadata=metadata,
-                        )
-                        with bind_llm_request_log_context(**request_context):
-                            prepared_input = ai_runtime.attach_media_to_run_input(
-                                attempt.attempt_prompt,
-                                attempt.attempt_media_inputs,
-                            )
-                            stream_generator = agent.arun(
-                                prepared_input,
-                                session_id=session_id,
-                                user_id=user_id,
-                                run_id=attempt.attempt_run_id,
-                                stream=True,
-                                stream_events=True,
-                                metadata=metadata,
-                            )
-                        stream_generator = stream_with_llm_request_log_context(
-                            stream_generator,
-                            request_context=request_context,
-                        )
-                        async for stream_chunk in _process_stream_events(
-                            stream_generator,
-                            state=state,
-                            show_tool_calls=show_tool_calls,
-                            agent_name=agent_name,
-                            media_route=attempt.media_route,
-                            media_inputs=attempt.attempt_media_inputs,
-                            context_media_kinds=attempt.remaining_context_media_kinds,
-                            retried_after_media_fallback=retried_after_media_fallback,
-                            timing_scope=timing_scope,
-                            state_updated=_sync_live_turn_recorder,
-                            pipeline_timing=pipeline_timing,
-                        ):
-                            yield stream_chunk
-                    except Exception as e:
-                        if _request_stream_retry(
-                            state,
-                            retried_after_media_fallback=retried_after_media_fallback,
-                            media_route=attempt.media_route,
-                            media_inputs=attempt.attempt_media_inputs,
-                            context_media_kinds=attempt.remaining_context_media_kinds,
-                            error=e,
-                            log_message="Retrying streaming AI response after inline media validation error",
-                            agent_name=agent_name,
-                        ):
-                            attempt.retry(
-                                run_input,
-                                fallback_prompt=inline_media_fallback_prompt,
-                                extra_removed_kinds=state.media_fallback_removed_kinds,
-                                retry_media_inputs=state.media_fallback_retry_inputs or MediaInputs(),
-                                run_id=run_id,
-                            )
-                            continue
-                        logger.exception("Error starting streaming AI response")
-                        yield get_user_friendly_error_message(e, agent_name)
-                        return
+                    async for stream_chunk in _stream_agent_attempt_chunks(
+                        agent=agent,
+                        attempt=attempt,
+                        state=state,
+                        show_tool_calls=show_tool_calls,
+                        agent_name=agent_name,
+                        session_id=session_id,
+                        user_id=user_id,
+                        run_id_callback=run_id_callback,
+                        prompt=prompt,
+                        model_prompt=model_prompt,
+                        room_id=room_id,
+                        thread_id=thread_id,
+                        reply_to_event_id=reply_to_event_id,
+                        requester_id=resolved_requester_id,
+                        correlation_id=resolved_correlation_id,
+                        metadata=metadata,
+                        retried_after_media_fallback=retried_after_media_fallback,
+                        timing_scope=timing_scope,
+                        state_updated=_sync_live_turn_recorder,
+                        pipeline_timing=pipeline_timing,
+                    ):
+                        yield stream_chunk
 
                     if state.media_fallback_retry_requested:
                         attempt.retry(
                             run_input,
-                            fallback_prompt=inline_media_fallback_prompt,
+                            fallback_prompt=run_context.inline_media_fallback_prompt,
                             extra_removed_kinds=state.media_fallback_removed_kinds,
                             retry_media_inputs=state.media_fallback_retry_inputs or MediaInputs(),
                             run_id=run_id,

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -315,6 +315,16 @@ class _StreamingAttemptState:
 class _AgentRunContext:
     """Prepared state shared by one top-level agent response lifecycle."""
 
+    agent_name: str
+    prompt: str
+    session_id: str
+    model_prompt: str | None
+    room_id: str | None
+    thread_id: str | None
+    reply_to_event_id: str | None
+    requester_id: str | None
+    correlation_id: str
+    timing_scope: str
     prepared_run: _PreparedAgentRun
     run_input: list[Message]
     metadata: dict[str, Any] | None
@@ -764,28 +774,16 @@ async def _run_cached_agent_attempt(
 
 async def _run_non_streaming_agent_attempts(
     *,
-    agent: Agent,
+    run_context: _AgentRunContext,
     attempt: _MediaAttempt,
-    run_input: list[Message],
-    inline_media_fallback_prompt: str,
-    agent_name: str,
-    prompt: str,
-    model_prompt: str | None,
-    session_id: str,
-    room_id: str | None,
-    thread_id: str | None,
-    reply_to_event_id: str | None,
-    requester_id: str | None,
-    correlation_id: str,
-    metadata: dict[str, Any] | None,
     user_id: str | None,
     run_id: str | None,
     run_id_callback: Callable[[str], None] | None,
-    timing_scope: str,
     scope_context: ScopeSessionContext | None,
     pipeline_timing: DispatchPipelineTiming | None,
 ) -> _NonStreamingAttemptResult:
     """Run one non-streaming agent response sequence, including media fallback."""
+    agent = run_context.prepared_run.agent
     response: RunOutput | None = None
     try:
         for retried_after_media_fallback in (False, True):
@@ -795,29 +793,29 @@ async def _run_non_streaming_agent_attempts(
                     pipeline_timing.mark("model_request_sent", overwrite=True)
                 with bind_llm_request_log_context(
                     **_attempt_request_log_context(
-                        agent_id=agent_name,
-                        session_id=session_id,
-                        room_id=room_id,
-                        thread_id=thread_id,
-                        reply_to_event_id=reply_to_event_id,
-                        requester_id=requester_id,
-                        correlation_id=correlation_id,
-                        prompt=prompt,
-                        model_prompt=model_prompt,
+                        agent_id=run_context.agent_name,
+                        session_id=run_context.session_id,
+                        room_id=run_context.room_id,
+                        thread_id=run_context.thread_id,
+                        reply_to_event_id=run_context.reply_to_event_id,
+                        requester_id=run_context.requester_id,
+                        correlation_id=run_context.correlation_id,
+                        prompt=run_context.prompt,
+                        model_prompt=run_context.model_prompt,
                         attempt_prompt=attempt.attempt_prompt,
-                        metadata=metadata,
+                        metadata=run_context.metadata,
                     ),
                 ):
                     response = await _run_cached_agent_attempt(
                         agent,
                         attempt.attempt_prompt,
-                        session_id,
+                        run_context.session_id,
                         user_id=user_id,
                         run_id=attempt.attempt_run_id,
                         run_id_callback=run_id_callback,
                         media=attempt.attempt_media_inputs,
-                        metadata=metadata,
-                        timing_scope=timing_scope,
+                        metadata=run_context.metadata,
+                        timing_scope=run_context.timing_scope,
                     )
             except Exception as e:
                 retry_decision = retry_media_inputs_after_failure(
@@ -829,20 +827,20 @@ async def _run_non_streaming_agent_attempts(
                 if not retried_after_media_fallback and retry_decision.should_retry:
                     logger.warning(
                         "Retrying AI response after inline media validation error",
-                        agent=agent_name,
+                        agent=run_context.agent_name,
                         error=str(e),
                         removed_media_kinds=sorted(retry_decision.removed_kinds),
                     )
                     attempt.retry(
-                        run_input,
-                        fallback_prompt=inline_media_fallback_prompt,
+                        run_context.run_input,
+                        fallback_prompt=run_context.inline_media_fallback_prompt,
                         extra_removed_kinds=retry_decision.removed_kinds,
                         retry_media_inputs=retry_decision.media_inputs,
                         run_id=run_id,
                     )
                     continue
 
-                logger.exception("Error generating AI response", agent=agent_name)
+                logger.exception("Error generating AI response", agent=run_context.agent_name)
                 return _NonStreamingAttemptResult(response=None, attempt=attempt, user_error=e)
 
             if response.status == RunStatus.error:
@@ -856,20 +854,24 @@ async def _run_non_streaming_agent_attempts(
                 if not retried_after_media_fallback and retry_decision.should_retry:
                     logger.warning(
                         "Retrying AI response after inline media errored run output",
-                        agent=agent_name,
+                        agent=run_context.agent_name,
                         error=error_text,
                         removed_media_kinds=sorted(retry_decision.removed_kinds),
                     )
                     attempt.retry(
-                        run_input,
-                        fallback_prompt=inline_media_fallback_prompt,
+                        run_context.run_input,
+                        fallback_prompt=run_context.inline_media_fallback_prompt,
                         extra_removed_kinds=retry_decision.removed_kinds,
                         retry_media_inputs=retry_decision.media_inputs,
                         run_id=run_id,
                     )
                     continue
 
-                logger.warning("AI response returned errored run output", agent=agent_name, error=error_text)
+                logger.warning(
+                    "AI response returned errored run output",
+                    agent=run_context.agent_name,
+                    error=error_text,
+                )
 
             break
 
@@ -879,9 +881,9 @@ async def _run_non_streaming_agent_attempts(
         ai_runtime.cleanup_queued_notice_state(
             run_output=response,
             storage=scope_context.storage if scope_context is not None else None,
-            session_id=session_id,
+            session_id=run_context.session_id,
             session_type=SessionType.AGENT,
-            entity_name=agent_name,
+            entity_name=run_context.agent_name,
         )
 
 
@@ -1163,6 +1165,16 @@ async def _prepare_agent_run_context(
         turn_recorder.set_run_metadata(metadata)
 
     return _AgentRunContext(
+        agent_name=agent_name,
+        prompt=prompt,
+        session_id=session_id,
+        model_prompt=model_prompt,
+        room_id=room_id,
+        thread_id=thread_id,
+        reply_to_event_id=reply_to_event_id,
+        requester_id=requester_id,
+        correlation_id=correlation_id,
+        timing_scope=timing_scope,
         prepared_run=prepared_run,
         run_input=prepared_run.run_input,
         metadata=metadata,
@@ -1347,32 +1359,18 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                 run_id=run_id,
             )
             attempt_result = await _run_non_streaming_agent_attempts(
-                agent=agent,
+                run_context=run_context,
                 attempt=attempt,
-                run_input=run_input,
-                inline_media_fallback_prompt=run_context.inline_media_fallback_prompt,
-                agent_name=agent_name,
-                prompt=prompt,
-                model_prompt=model_prompt,
-                session_id=session_id,
-                room_id=room_id,
-                thread_id=thread_id,
-                reply_to_event_id=reply_to_event_id,
-                requester_id=resolved_requester_id,
-                correlation_id=resolved_correlation_id,
-                metadata=metadata,
                 user_id=user_id,
                 run_id=run_id,
                 run_id_callback=run_id_callback,
-                timing_scope=timing_scope,
                 scope_context=scope_context,
                 pipeline_timing=pipeline_timing,
             )
             attempt = attempt_result.attempt
             if attempt_result.user_error is not None:
                 return get_user_friendly_error_message(attempt_result.user_error, agent_name)
-            response = attempt_result.response
-            assert response is not None
+            response = cast("RunOutput", attempt_result.response)
 
             response_tool_trace = _extract_tool_trace(response)
             if tool_trace_collector is not None:
@@ -1605,44 +1603,34 @@ async def _process_stream_events(  # noqa: C901, PLR0912, PLR0915
 
 async def _stream_agent_attempt_chunks(
     *,
-    agent: Agent,
+    run_context: _AgentRunContext,
     attempt: _MediaAttempt,
     state: _StreamingAttemptState,
     show_tool_calls: bool,
-    agent_name: str,
-    session_id: str,
     user_id: str | None,
     run_id_callback: Callable[[str], None] | None,
-    prompt: str,
-    model_prompt: str | None,
-    room_id: str | None,
-    thread_id: str | None,
-    reply_to_event_id: str | None,
-    requester_id: str | None,
-    correlation_id: str,
-    metadata: dict[str, Any] | None,
     retried_after_media_fallback: bool,
-    timing_scope: str,
     state_updated: Callable[[], None] | None,
     pipeline_timing: DispatchPipelineTiming | None,
 ) -> AsyncGenerator[AIStreamChunk, None]:
     """Start and consume one streaming agent attempt."""
+    agent = run_context.prepared_run.agent
     try:
         if pipeline_timing is not None:
             pipeline_timing.mark("model_request_sent", overwrite=True)
         ai_runtime.note_attempt_run_id(run_id_callback, attempt.attempt_run_id)
         request_context = _attempt_request_log_context(
-            agent_id=agent_name,
-            session_id=session_id,
-            room_id=room_id,
-            thread_id=thread_id,
-            reply_to_event_id=reply_to_event_id,
-            requester_id=requester_id,
-            correlation_id=correlation_id,
-            prompt=prompt,
-            model_prompt=model_prompt,
+            agent_id=run_context.agent_name,
+            session_id=run_context.session_id,
+            room_id=run_context.room_id,
+            thread_id=run_context.thread_id,
+            reply_to_event_id=run_context.reply_to_event_id,
+            requester_id=run_context.requester_id,
+            correlation_id=run_context.correlation_id,
+            prompt=run_context.prompt,
+            model_prompt=run_context.model_prompt,
             attempt_prompt=attempt.attempt_prompt,
-            metadata=metadata,
+            metadata=run_context.metadata,
         )
         with bind_llm_request_log_context(**request_context):
             prepared_input = ai_runtime.attach_media_to_run_input(
@@ -1651,12 +1639,12 @@ async def _stream_agent_attempt_chunks(
             )
             stream_generator = agent.arun(
                 prepared_input,
-                session_id=session_id,
+                session_id=run_context.session_id,
                 user_id=user_id,
                 run_id=attempt.attempt_run_id,
                 stream=True,
                 stream_events=True,
-                metadata=metadata,
+                metadata=run_context.metadata,
             )
         stream_generator = stream_with_llm_request_log_context(
             stream_generator,
@@ -1666,12 +1654,12 @@ async def _stream_agent_attempt_chunks(
             stream_generator,
             state=state,
             show_tool_calls=show_tool_calls,
-            agent_name=agent_name,
+            agent_name=run_context.agent_name,
             media_route=attempt.media_route,
             media_inputs=attempt.attempt_media_inputs,
             context_media_kinds=attempt.remaining_context_media_kinds,
             retried_after_media_fallback=retried_after_media_fallback,
-            timing_scope=timing_scope,
+            timing_scope=run_context.timing_scope,
             state_updated=state_updated,
             pipeline_timing=pipeline_timing,
         ):
@@ -1685,7 +1673,7 @@ async def _stream_agent_attempt_chunks(
             context_media_kinds=attempt.remaining_context_media_kinds,
             error=e,
             log_message="Retrying streaming AI response after inline media validation error",
-            agent_name=agent_name,
+            agent_name=run_context.agent_name,
         ):
             return
         logger.exception("Error starting streaming AI response")
@@ -1886,24 +1874,13 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                     state = _StreamingAttemptState()
 
                     async for stream_chunk in _stream_agent_attempt_chunks(
-                        agent=agent,
+                        run_context=run_context,
                         attempt=attempt,
                         state=state,
                         show_tool_calls=show_tool_calls,
-                        agent_name=agent_name,
-                        session_id=session_id,
                         user_id=user_id,
                         run_id_callback=run_id_callback,
-                        prompt=prompt,
-                        model_prompt=model_prompt,
-                        room_id=room_id,
-                        thread_id=thread_id,
-                        reply_to_event_id=reply_to_event_id,
-                        requester_id=resolved_requester_id,
-                        correlation_id=resolved_correlation_id,
-                        metadata=metadata,
                         retried_after_media_fallback=retried_after_media_fallback,
-                        timing_scope=timing_scope,
                         state_updated=_sync_live_turn_recorder,
                         pipeline_timing=pipeline_timing,
                     ):


### PR DESCRIPTION
## Summary
- Behavior-preserving refactor of `src/mindroom/ai.py` around agent response attempts.
- Extracts shared agent run preparation/metadata setup used by both non-streaming and streaming paths.
- Extracts the non-streaming media-fallback attempt sequence and the streaming one-attempt start/consume boundary.
- Review follow-up narrows the attempt helper signatures by passing `_AgentRunContext` directly and removes the duplicate caller-side response assertion.

## Intent
This does not implement dynamic-tool continuation.
It prepares `ai.py` so future continuation or retry orchestration can wrap extracted attempt helpers later without copying or reindenting most of `ai_response` or `stream_agent_response`.
Public behavior, prompts, config, Matrix metadata, cancellation handling, media fallback, and turn recording are intended to remain unchanged.

## Verification
- `uv run pytest tests/test_ai_user_id.py -n 0 --no-cov -q` -> 145 passed
- `uv run pytest tests/test_ai_user_id.py tests/test_streaming_behavior.py tests/test_interrupted_replay.py -n 0 --no-cov -q` -> 248 passed
- `uv run pre-commit run --all-files` -> passed
- `uv run pytest -n auto --no-cov -q` -> 8529 passed, 30 skipped, 56 warnings

No Tach boundaries were changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal AI execution workflow for improved code maintainability and reliability. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->