### PR TITLE
Avoid repeated Agno tool determination in prompt prep

### DIFF
--- a/src/mindroom/execution_preparation.py
+++ b/src/mindroom/execution_preparation.py
@@ -26,14 +26,14 @@ from mindroom.constants import (
 )
 from mindroom.entity_resolution import entity_identity_registry
 from mindroom.history import (
+    AgentStaticTokenEstimator,
     PreparedHistoryState,
     PreparedScopeHistory,
     ResolvedReplayPlan,
     ScopeSessionContext,
+    TeamStaticTokenEstimator,
     apply_replay_plan,
     context_budget_after_reserve,
-    estimate_preparation_static_tokens,
-    estimate_preparation_static_tokens_for_team,
     finalize_history_preparation,
     prepare_bound_scope_history,
     prepare_scope_history,
@@ -769,6 +769,7 @@ async def prepare_agent_execution_context(
         thread_id=thread_id,
         runtime_paths=runtime_paths,
     )
+    static_token_estimator = AgentStaticTokenEstimator(agent)
 
     async def _prepare_agent_scope_history(
         prepared_prompt: str,
@@ -783,10 +784,7 @@ async def prepare_agent_execution_context(
             scope_context=scope_context,
             active_model_name=runtime_model.model_name,
             active_context_window=runtime_model.context_window,
-            static_prompt_tokens=estimate_preparation_static_tokens(
-                agent,
-                full_prompt=prepared_prompt,
-            ),
+            static_prompt_tokens=static_token_estimator.estimate(prepared_prompt),
             timing_scope=timing_scope,
             compaction_lifecycle=compaction_lifecycle,
             pipeline_timing=pipeline_timing,
@@ -795,10 +793,7 @@ async def prepare_agent_execution_context(
     def _estimate_agent_static_tokens(
         prepared_prompt: str,
     ) -> int:
-        return estimate_preparation_static_tokens(
-            agent,
-            full_prompt=prepared_prompt,
-        )
+        return static_token_estimator.estimate(prepared_prompt)
 
     return await _prepare_execution_context_common(
         scope_context=scope_context,
@@ -849,6 +844,7 @@ async def _prepare_bound_team_execution_context(
     pipeline_timing: DispatchPipelineTiming | None = None,
 ) -> _PreparedExecutionContext:
     """Prepare one bound team scope for the current call."""
+    static_token_estimator = TeamStaticTokenEstimator(team)
 
     async def _prepare_team_scope_history(
         prepared_prompt: str,
@@ -864,6 +860,7 @@ async def _prepare_bound_team_execution_context(
             team_name=team_name,
             active_model_name=active_model_name,
             active_context_window=active_context_window,
+            static_prompt_tokens=static_token_estimator.estimate(prepared_prompt),
             compaction_lifecycle=compaction_lifecycle,
             pipeline_timing=pipeline_timing,
         )
@@ -871,10 +868,7 @@ async def _prepare_bound_team_execution_context(
     def _estimate_team_static_tokens(
         prepared_prompt: str,
     ) -> int:
-        return estimate_preparation_static_tokens_for_team(
-            team,
-            full_prompt=prepared_prompt,
-        )
+        return static_token_estimator.estimate(prepared_prompt)
 
     return await _prepare_execution_context_common(
         scope_context=scope_context,

--- a/src/mindroom/history/__init__.py
+++ b/src/mindroom/history/__init__.py
@@ -2,6 +2,8 @@
 
 from mindroom.history import agno_team_patch
 from mindroom.history.compaction import (
+    AgentStaticTokenEstimator,
+    TeamStaticTokenEstimator,
     agent_tool_definition_payloads_for_logging,
     compute_prompt_token_breakdown,
     normalize_compaction_budget_tokens,
@@ -62,6 +64,7 @@ from mindroom.history.types import (
 agno_team_patch.apply_patch()
 
 __all__ = [
+    "AgentStaticTokenEstimator",
     "CompactionDecision",
     "CompactionLifecycle",
     "CompactionLifecycleFailure",
@@ -80,6 +83,7 @@ __all__ = [
     "ResolvedHistorySettings",
     "ResolvedReplayPlan",
     "ScopeSessionContext",
+    "TeamStaticTokenEstimator",
     "add_pending_force_compaction_scope",
     "agent_tool_definition_payloads_for_logging",
     "apply_replay_plan",

--- a/src/mindroom/history/compaction.py
+++ b/src/mindroom/history/compaction.py
@@ -74,6 +74,40 @@ _EXCERPT_METADATA_OMIT_KEYS = frozenset(
 type _ToolDefinition = dict[str, object]
 
 
+@dataclass(slots=True)
+class AgentStaticTokenEstimator:
+    """Request-local static-token estimator for one prepared agent response."""
+
+    agent: Agent
+    _non_prompt_tokens: int | None = None
+
+    def estimate(self, full_prompt: str) -> int:
+        """Estimate static prompt tokens while reusing Agno-prepared tools."""
+        return estimate_text_tokens(full_prompt) + self._resolved_non_prompt_tokens()
+
+    def _resolved_non_prompt_tokens(self) -> int:
+        if self._non_prompt_tokens is None:
+            self._non_prompt_tokens = _estimate_agent_non_prompt_static_tokens(self.agent)
+        return self._non_prompt_tokens
+
+
+@dataclass(slots=True)
+class TeamStaticTokenEstimator:
+    """Request-local static-token estimator for one prepared team response."""
+
+    team: Team
+    _non_prompt_tokens: int | None = None
+
+    def estimate(self, full_prompt: str) -> int:
+        """Estimate static prompt tokens while reusing Agno-prepared team tools."""
+        return estimate_text_tokens(full_prompt) + self._resolved_non_prompt_tokens()
+
+    def _resolved_non_prompt_tokens(self) -> int:
+        if self._non_prompt_tokens is None:
+            self._non_prompt_tokens = _estimate_team_non_prompt_static_tokens(self.team)
+        return self._non_prompt_tokens
+
+
 @dataclass(frozen=True)
 class _ExcerptBlock:
     open_tag: str
@@ -559,7 +593,12 @@ async def _emit_lifecycle_progress_after_persist(
 
 def estimate_agent_static_tokens(agent: Agent, full_prompt: str) -> int:
     """Estimate the non-history agent prompt using Agno's real system-message builder."""
-    static_tokens = estimate_text_tokens(full_prompt)
+    return AgentStaticTokenEstimator(agent).estimate(full_prompt)
+
+
+def _estimate_agent_non_prompt_static_tokens(agent: Agent) -> int:
+    """Estimate system-message and tool tokens that do not depend on the prompt text."""
+    static_tokens = 0
     previous_tool_instructions = agent._tool_instructions
     try:
         session, run_context, prepared_tools = _prepare_agent_prompt_inputs_for_estimation(agent)
@@ -587,7 +626,12 @@ def _estimate_tool_definition_tokens(agent: Agent) -> int:
 
 def estimate_team_static_tokens(team: Team, full_prompt: str) -> int:
     """Estimate the non-history team prompt using Agno's team system-message builder."""
-    static_tokens = estimate_text_tokens(full_prompt)
+    return TeamStaticTokenEstimator(team).estimate(full_prompt)
+
+
+def _estimate_team_non_prompt_static_tokens(team: Team) -> int:
+    """Estimate team system-message and tool tokens that do not depend on prompt text."""
+    static_tokens = 0
     previous_tool_instructions = team._tool_instructions
     try:
         session, prepared_tools = _prepare_team_prompt_inputs_for_estimation(team)
@@ -737,6 +781,7 @@ def _default_function_parameters() -> dict[str, object]:
     return {"type": "object", "properties": {}, "required": []}
 
 
+@timed("system_prompt_assembly.history_prepare.static_token_estimate.agno_determine_tools")
 def _prepare_team_prompt_inputs_for_estimation(
     team: Team,
 ) -> tuple[TeamSession, list[Function | _ToolDefinition]]:
@@ -776,6 +821,7 @@ def _prepare_team_prompt_inputs_for_estimation(
     return session, [tool for tool in prepared_tools if isinstance(tool, Function) or _is_tool_definition_dict(tool)]
 
 
+@timed("system_prompt_assembly.history_prepare.static_token_estimate.agno_determine_tools")
 def _prepare_agent_prompt_inputs_for_estimation(
     agent: Agent,
 ) -> tuple[AgentSession, RunContext, list[Function | _ToolDefinition]]:

--- a/src/mindroom/history/compaction.py
+++ b/src/mindroom/history/compaction.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Awaitable, Callable, Sequence
 from copy import deepcopy
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from html import escape
 from typing import TYPE_CHECKING, TypeGuard, cast
@@ -79,7 +79,7 @@ class AgentStaticTokenEstimator:
     """Request-local static-token estimator for one prepared agent response."""
 
     agent: Agent
-    _non_prompt_tokens: int | None = None
+    _non_prompt_tokens: int | None = field(default=None, init=False)
 
     def estimate(self, full_prompt: str) -> int:
         """Estimate static prompt tokens while reusing Agno-prepared tools."""
@@ -96,7 +96,7 @@ class TeamStaticTokenEstimator:
     """Request-local static-token estimator for one prepared team response."""
 
     team: Team
-    _non_prompt_tokens: int | None = None
+    _non_prompt_tokens: int | None = field(default=None, init=False)
 
     def estimate(self, full_prompt: str) -> int:
         """Estimate static prompt tokens while reusing Agno-prepared team tools."""

--- a/src/mindroom/history/runtime.py
+++ b/src/mindroom/history/runtime.py
@@ -886,6 +886,7 @@ async def prepare_bound_scope_history(
     team_name: str | None = None,
     active_model_name: str | None = None,
     active_context_window: int | None = None,
+    static_prompt_tokens: int | None = None,
     compaction_lifecycle: CompactionLifecycle | None = None,
     pipeline_timing: DispatchPipelineTiming | None = None,
 ) -> PreparedScopeHistory:
@@ -896,10 +897,10 @@ async def prepare_bound_scope_history(
         team_name=team_name,
     )
     if bound_scope is None:
-        resolved_inputs = _resolve_entity_preparation_inputs(
-            config=config,
-            entity_name=team_name if team_name in config.teams else None,
-            static_prompt_tokens=(
+        resolved_static_prompt_tokens = (
+            static_prompt_tokens
+            if static_prompt_tokens is not None
+            else (
                 estimate_preparation_static_tokens_for_team(
                     team,
                     full_prompt=full_prompt,
@@ -908,7 +909,12 @@ async def prepare_bound_scope_history(
                 else _estimate_preparation_prompt_tokens(
                     full_prompt=full_prompt,
                 )
-            ),
+            )
+        )
+        resolved_inputs = _resolve_entity_preparation_inputs(
+            config=config,
+            entity_name=team_name if team_name in config.teams else None,
+            static_prompt_tokens=resolved_static_prompt_tokens,
             active_model_name=active_model_name,
             active_context_window=active_context_window,
         )
@@ -918,20 +924,24 @@ async def prepare_bound_scope_history(
             resolved_inputs=resolved_inputs,
         )
 
-    static_prompt_tokens = (
-        estimate_preparation_static_tokens_for_team(
-            team,
-            full_prompt=full_prompt,
-        )
-        if team is not None
-        else _estimate_preparation_prompt_tokens(
-            full_prompt=full_prompt,
+    resolved_static_prompt_tokens = (
+        static_prompt_tokens
+        if static_prompt_tokens is not None
+        else (
+            estimate_preparation_static_tokens_for_team(
+                team,
+                full_prompt=full_prompt,
+            )
+            if team is not None
+            else _estimate_preparation_prompt_tokens(
+                full_prompt=full_prompt,
+            )
         )
     )
     resolved_inputs = _resolve_entity_preparation_inputs(
         config=config,
         entity_name=team_name if team_name in config.teams else None,
-        static_prompt_tokens=static_prompt_tokens,
+        static_prompt_tokens=resolved_static_prompt_tokens,
         active_model_name=active_model_name,
         active_context_window=active_context_window,
     )
@@ -948,7 +958,7 @@ async def prepare_bound_scope_history(
         has_authored_compaction_config=resolved_inputs.execution_plan.authored_compaction_config,
         active_model_name=resolved_inputs.active_model_name,
         active_context_window=resolved_inputs.active_context_window,
-        static_prompt_tokens=static_prompt_tokens,
+        static_prompt_tokens=resolved_static_prompt_tokens,
         scope=bound_scope.scope,
         execution_plan=resolved_inputs.execution_plan,
         compaction_lifecycle=compaction_lifecycle,

--- a/tach.toml
+++ b/tach.toml
@@ -3220,6 +3220,7 @@ from = ["mindroom.tool_system.worker_routing"]
 
 [[interfaces]]
 expose = [
+    "AgentStaticTokenEstimator",
     "CompactionOutcome",
     "HistoryPolicy",
     "HistoryScope",
@@ -3230,6 +3231,7 @@ expose = [
     "ResolvedHistorySettings",
     "ResolvedReplayPlan",
     "ScopeSessionContext",
+    "TeamStaticTokenEstimator",
     "add_pending_force_compaction_scope",
     "agent_tool_definition_payloads_for_logging",
     "apply_replay_plan",

--- a/tests/test_agno_history.py
+++ b/tests/test_agno_history.py
@@ -56,6 +56,8 @@ from mindroom.execution_preparation import (
 )
 from mindroom.history import PreparedHistoryState
 from mindroom.history.compaction import (
+    AgentStaticTokenEstimator,
+    TeamStaticTokenEstimator,
     _build_summary_input,
     _compaction_replay_messages,
     _emit_compaction_hook,
@@ -486,6 +488,11 @@ def test_estimate_static_tokens_includes_tool_definitions() -> None:
     )
     assert _estimate_tool_definition_tokens(baseline_agent) == 0
     assert tool_tokens > 0
+
+
+def test_static_token_estimator_cache_fields_are_not_constructor_inputs() -> None:
+    assert "_non_prompt_tokens" not in inspect.signature(AgentStaticTokenEstimator).parameters
+    assert "_non_prompt_tokens" not in inspect.signature(TeamStaticTokenEstimator).parameters
 
 
 def test_estimate_agent_static_tokens_uses_real_system_message_builder() -> None:

--- a/tests/test_agno_history.py
+++ b/tests/test_agno_history.py
@@ -5068,21 +5068,17 @@ async def test_prepare_agent_and_prompt_caps_thread_fallback_to_active_window(tm
         make_visible_message(sender="bob", body="Recent context"),
     ]
 
-    def fake_estimate_preparation_static_tokens(
-        agent: Agent,
-        *,
-        full_prompt: str,
-    ) -> int:
-        assert agent is live_agent
-        return estimate_text_tokens(full_prompt)
+    class FakeAgentStaticTokenEstimator:
+        def __init__(self, agent: Agent) -> None:
+            assert agent is live_agent
+
+        def estimate(self, full_prompt: str) -> int:
+            return estimate_text_tokens(full_prompt)
 
     with (
         patch("mindroom.ai.create_agent", return_value=live_agent),
         patch("mindroom.ai.build_memory_prompt_parts", new=AsyncMock(return_value=MemoryPromptParts())),
-        patch(
-            "mindroom.execution_preparation.estimate_preparation_static_tokens",
-            side_effect=fake_estimate_preparation_static_tokens,
-        ),
+        patch("mindroom.execution_preparation.AgentStaticTokenEstimator", FakeAgentStaticTokenEstimator),
         patch(
             "mindroom.execution_preparation.prepare_scope_history",
             new=AsyncMock(return_value=MagicMock()),

--- a/tests/test_execution_preparation.py
+++ b/tests/test_execution_preparation.py
@@ -3,31 +3,43 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from agno.agent import Agent
 from agno.models.message import Message
 from agno.run.agent import RunOutput
 from agno.run.base import RunStatus
 from agno.session.agent import AgentSession
+from agno.tools.function import Function
 
+import mindroom.history.compaction as compaction_module
 from mindroom import execution_preparation
 from mindroom.attachments import _attachment_id_for_event, register_local_attachment
 from mindroom.config.main import Config
 from mindroom.config.models import CompactionConfig
-from mindroom.constants import ATTACHMENT_IDS_KEY, ORIGINAL_SENDER_KEY
+from mindroom.constants import ATTACHMENT_IDS_KEY, ORIGINAL_SENDER_KEY, RuntimePaths, resolve_runtime_paths
 from mindroom.execution_preparation import (
     _build_thread_history_messages,
     _build_unseen_context_messages,
     _fallback_static_token_budget,
     _prepare_execution_context_common,
     _ThreadAttachmentContext,
+    prepare_agent_execution_context,
     render_prepared_messages_text,
 )
-from mindroom.history import HistoryPolicy, HistoryScope, PreparedScopeHistory, ResolvedHistorySettings
+from mindroom.history import (
+    HistoryPolicy,
+    HistoryScope,
+    PreparedHistoryState,
+    PreparedScopeHistory,
+    ResolvedHistorySettings,
+)
+from mindroom.history.compaction import estimate_agent_static_tokens
 from mindroom.history.policy import resolve_history_execution_plan
 from mindroom.history.runtime import _ResolvedPreparationInputs
 from mindroom.tool_system.events import ToolTraceEntry, build_tool_trace_content
-from tests.conftest import make_visible_message
+from tests.conftest import FakeModel, bind_runtime_paths, make_visible_message
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -35,6 +47,35 @@ if TYPE_CHECKING:
 
 def _config() -> Config:
     return Config.model_validate({})
+
+
+def _runtime_paths(tmp_path: Path) -> RuntimePaths:
+    return resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path / "mindroom_data",
+        process_env={
+            "MATRIX_HOMESERVER": "http://localhost:8008",
+            "MINDROOM_NAMESPACE": "",
+        },
+    )
+
+
+def _bound_agent_config(tmp_path: Path) -> tuple[Config, RuntimePaths]:
+    runtime_paths = _runtime_paths(tmp_path)
+    config = Config.model_validate(
+        {
+            "agents": {"test_agent": {"display_name": "Test Agent"}},
+            "defaults": {"tools": [], "compaction": {"enabled": False, "reserve_tokens": 0}},
+            "models": {
+                "default": {
+                    "provider": "openai",
+                    "id": "test-model",
+                    "context_window": 8_000,
+                },
+            },
+        },
+    )
+    return bind_runtime_paths(config, runtime_paths), runtime_paths
 
 
 def _tool_trace_content() -> dict[str, object]:
@@ -135,6 +176,71 @@ async def test_prepare_execution_context_skips_fallback_replay_when_persisted_hi
 
     assert prepared.replays_persisted_history is True
     assert prepared.context_messages[0].content == "@alice:localhost: older context"
+
+
+@pytest.mark.asyncio
+async def test_prepare_agent_execution_context_reuses_agno_tool_determination_for_static_estimates(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One prompt assembly should determine Agno tools once for repeated static estimates."""
+
+    def search_docs(query: str) -> str:
+        """Search indexed documentation."""
+        return query
+
+    agent = Agent(
+        id="test_agent",
+        name="Test Agent",
+        model=FakeModel(id="fake-model", provider="fake"),
+        tools=[Function(name="search_docs", entrypoint=search_docs)],
+    )
+    config, runtime_paths = _bound_agent_config(tmp_path)
+    prepare_scope_history = AsyncMock(return_value=MagicMock())
+    monkeypatch.setattr(execution_preparation, "prepare_scope_history", prepare_scope_history)
+    monkeypatch.setattr(
+        execution_preparation,
+        "finalize_history_preparation",
+        lambda **_kwargs: PreparedHistoryState(replays_persisted_history=False),
+    )
+
+    original_determine_tools = compaction_module.determine_tools_for_model
+    count_determine_tools = True
+    determine_tools_calls = 0
+
+    def counting_determine_tools(*args: object, **kwargs: object) -> list[object]:
+        nonlocal determine_tools_calls
+        if count_determine_tools:
+            determine_tools_calls += 1
+        return original_determine_tools(*args, **kwargs)
+
+    monkeypatch.setattr(compaction_module, "determine_tools_for_model", counting_determine_tools)
+
+    prepared = await prepare_agent_execution_context(
+        scope_context=None,
+        agent=agent,
+        agent_name="test_agent",
+        prompt="Current request",
+        thread_history=[
+            make_visible_message(sender="@alice:localhost", body="Earlier context", event_id="$older"),
+            make_visible_message(sender="@alice:localhost", body="Current request", event_id="$current"),
+        ],
+        runtime_paths=runtime_paths,
+        config=config,
+        room_id="!room:localhost",
+        thread_id="$thread",
+        reply_to_event_id="$current",
+        active_event_ids=(),
+        compaction_outcomes_collector=None,
+        current_sender_id="@alice:localhost",
+    )
+
+    preparation_determine_tools_calls = determine_tools_calls
+    count_determine_tools = False
+    assert prepared.prepared_context_tokens == estimate_agent_static_tokens(agent, prepared.final_prompt)
+    assert prepared.estimated_context_tokens == prepared.prepared_context_tokens
+    assert preparation_determine_tools_calls == 1
+    assert prepare_scope_history.await_count == 1
 
 
 def test_fallback_thread_history_caps_long_messages_without_dropping_them() -> None:

--- a/tests/test_team_media_fallback.py
+++ b/tests/test_team_media_fallback.py
@@ -1015,19 +1015,15 @@ async def test_prepare_bound_team_execution_context_uses_team_renderer_for_trimm
     mock_team = _make_test_team(name="General Team")
     captured_prompts: list[tuple[str, str | None]] = []
 
-    def fake_estimate_static_tokens(
-        team: AgnoTeam,
-        *,
-        full_prompt: str,
-    ) -> int:
-        assert team is mock_team
-        captured_prompts.append((full_prompt, None))
-        return 0
+    class FakeTeamStaticTokenEstimator:
+        def __init__(self, team: AgnoTeam) -> None:
+            assert team is mock_team
 
-    with patch(
-        "mindroom.execution_preparation.estimate_preparation_static_tokens_for_team",
-        side_effect=fake_estimate_static_tokens,
-    ):
+        def estimate(self, full_prompt: str) -> int:
+            captured_prompts.append((full_prompt, None))
+            return 0
+
+    with patch("mindroom.execution_preparation.TeamStaticTokenEstimator", FakeTeamStaticTokenEstimator):
         prepared = await _prepare_bound_team_execution_context(
             scope_context=None,
             agents=[fake_agent],
@@ -1059,6 +1055,7 @@ async def test_prepare_bound_team_execution_context_uses_team_renderer_for_trimm
         ("user", "Analyze this."),
     )
     assert captured_prompts == [
+        ("Analyze this.", None),
         ("Analyze this.", None),
         ("assistant: Previous team reply\n\nAnalyze this.", None),
     ]


### PR DESCRIPTION
## Summary
- Add request-local agent/team static-token estimators that cache the Agno-prepared non-prompt token portion for one response preparation.
- Reuse the estimator through agent/team execution preparation, including bound team history preparation, so repeated static estimates do not repeatedly call Agno tool determination for unchanged model/agent/tool state.
- Add regression coverage that drives repeated static estimates in one prompt assembly and asserts Agno determine-tools is called once while token estimates remain equivalent.

## Cause
Static token estimation was recomputing the full Agno static prompt cost every time it was asked for a prompt variant. During one response build, history preparation and fallback prompt trimming ask for static-token estimates multiple times, and each estimate called Agno's tool-preparation path again.

## Cache Scope
The cache is per `AgentStaticTokenEstimator` / `TeamStaticTokenEstimator` instance created inside one execution-preparation call. It stores only the prompt-independent system/tool token estimate for that exact in-memory Agno agent or team and still recomputes prompt text tokens for every prompt variant. Nothing is process-global or shared across concurrent responses.

## Test Plan
- `uv run ruff check src/mindroom/history/compaction.py src/mindroom/history/runtime.py src/mindroom/history/__init__.py src/mindroom/execution_preparation.py tests/test_execution_preparation.py tests/test_agno_history.py tests/test_team_media_fallback.py && uv run ruff format --check src/mindroom/history/compaction.py src/mindroom/history/runtime.py src/mindroom/history/__init__.py src/mindroom/execution_preparation.py tests/test_execution_preparation.py tests/test_agno_history.py tests/test_team_media_fallback.py`
- `uv run tach check --dependencies --interfaces`
- `uv run pytest tests/test_execution_preparation.py tests/test_agno_history.py tests/test_team_media_fallback.py -q -n 0 --no-cov` (`219 passed`)
- `uv run pytest -q --no-cov` (`8531 passed, 30 skipped`)
- Commit hook passed: ruff, ruff format, ty, vulture, Tach, module privacy, and related configured hooks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced public token estimator classes for direct token estimation capabilities.

* **Improvements**
  * Enhanced token estimation performance through improved caching mechanisms and streamlined computation logic, reducing redundant processing.

* **Tests**
  * Added test coverage for token estimator validation and execution context preparation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->