### PR TITLE
Configure Git proxy auth for worker egress

### DIFF
--- a/src/mindroom/constants.py
+++ b/src/mindroom/constants.py
@@ -669,6 +669,29 @@ _WORKER_EGRESS_PROXY_CA_FILE_ENV = runtime_env_policy.WORKER_EGRESS_PROXY_ENV_BY
 _WORKER_EGRESS_NO_PROXY = "localhost,127.0.0.1,::1,.svc,.cluster.local"
 
 
+def _git_config_env(process_env: Mapping[str, str], entries: list[tuple[str, str]]) -> dict[str, str]:
+    existing_entries: list[tuple[str, str]] = []
+    try:
+        existing_count = int(process_env.get("GIT_CONFIG_COUNT", "0"))
+    except ValueError:
+        existing_count = 0
+    if existing_count > 0:
+        for index in range(existing_count):
+            key = process_env.get(f"GIT_CONFIG_KEY_{index}")
+            value = process_env.get(f"GIT_CONFIG_VALUE_{index}")
+            if key is None or value is None:
+                existing_entries = []
+                break
+            existing_entries.append((key, value))
+
+    merged_entries = [*existing_entries, *entries]
+    env = {"GIT_CONFIG_COUNT": str(len(merged_entries))}
+    for index, (key, value) in enumerate(merged_entries):
+        env[f"GIT_CONFIG_KEY_{index}"] = key
+        env[f"GIT_CONFIG_VALUE_{index}"] = value
+    return env
+
+
 def worker_proxy_execution_env(process_env: Mapping[str, str]) -> dict[str, str]:
     """Return the per-worker egress proxy env overlay for python/shell, or ``{}``.
 
@@ -698,9 +721,21 @@ def worker_proxy_execution_env(process_env: Mapping[str, str]) -> dict[str, str]
         "HTTPS_PROXY": authed,
         "http_proxy": authed,
         "https_proxy": authed,
+        # Git/libcurl does not always preemptively send proxy credentials from
+        # HTTPS_PROXY userinfo on CONNECT. Environment-backed Git config makes
+        # the same proxy explicit without writing user/global git config.
         "NO_PROXY": _WORKER_EGRESS_NO_PROXY,
         "no_proxy": _WORKER_EGRESS_NO_PROXY,
     }
+    env.update(
+        _git_config_env(
+            process_env,
+            [
+                ("http.proxy", authed),
+                ("http.proxyAuthMethod", "basic"),
+            ],
+        ),
+    )
     ca_file = (process_env.get(_WORKER_EGRESS_PROXY_CA_FILE_ENV) or "").strip()
     if ca_file:
         env["REQUESTS_CA_BUNDLE"] = ca_file

--- a/src/mindroom/constants.py
+++ b/src/mindroom/constants.py
@@ -670,6 +670,11 @@ _WORKER_EGRESS_NO_PROXY = "localhost,127.0.0.1,::1,.svc,.cluster.local"
 
 
 def _git_config_env(process_env: Mapping[str, str], entries: list[tuple[str, str]]) -> dict[str, str]:
+    """Append entries to any well-formed environment-backed Git config.
+
+    A malformed incoming block is discarded so Git never receives an
+    inconsistent count/key/value set.
+    """
     existing_entries: list[tuple[str, str]] = []
     try:
         existing_count = int(process_env.get("GIT_CONFIG_COUNT", "0"))

--- a/tests/api/test_worker_egress_proxy_compose.py
+++ b/tests/api/test_worker_egress_proxy_compose.py
@@ -47,7 +47,6 @@ def test_worker_proxy_execution_env_configures_git_proxy_auth(tmp_path: Path) ->
     """Git must receive proxy auth as config, not only env proxy userinfo."""
     _, expected_proxy = _runtime_paths_with_vault(tmp_path)
     token_path = tmp_path / "token"
-    token_path.write_text("av_sess_worker_token\n", encoding="utf-8")
 
     env = worker_proxy_execution_env(
         {
@@ -67,7 +66,6 @@ def test_worker_proxy_execution_env_appends_to_existing_git_config(tmp_path: Pat
     """Worker proxy Git config must not discard caller-supplied Git config."""
     _, expected_proxy = _runtime_paths_with_vault(tmp_path)
     token_path = tmp_path / "token"
-    token_path.write_text("av_sess_worker_token\n", encoding="utf-8")
 
     env = worker_proxy_execution_env(
         {

--- a/tests/api/test_worker_egress_proxy_compose.py
+++ b/tests/api/test_worker_egress_proxy_compose.py
@@ -43,6 +43,51 @@ def test_request_execution_env_overlays_proxy_when_no_primary_env(tmp_path: Path
     assert env["NODE_EXTRA_CA_CERTS"] == "/etc/agent-vault/ca.pem"
 
 
+def test_worker_proxy_execution_env_configures_git_proxy_auth(tmp_path: Path) -> None:
+    """Git must receive proxy auth as config, not only env proxy userinfo."""
+    _, expected_proxy = _runtime_paths_with_vault(tmp_path)
+    token_path = tmp_path / "token"
+    token_path.write_text("av_sess_worker_token\n", encoding="utf-8")
+
+    env = worker_proxy_execution_env(
+        {
+            "MINDROOM_WORKER_EGRESS_PROXY_URL": "http://agent-vault:14322",
+            "MINDROOM_WORKER_EGRESS_PROXY_TOKEN_FILE": str(token_path),
+        },
+    )
+
+    assert env["GIT_CONFIG_COUNT"] == "2"
+    assert env["GIT_CONFIG_KEY_0"] == "http.proxy"
+    assert env["GIT_CONFIG_VALUE_0"] == expected_proxy
+    assert env["GIT_CONFIG_KEY_1"] == "http.proxyAuthMethod"
+    assert env["GIT_CONFIG_VALUE_1"] == "basic"
+
+
+def test_worker_proxy_execution_env_appends_to_existing_git_config(tmp_path: Path) -> None:
+    """Worker proxy Git config must not discard caller-supplied Git config."""
+    _, expected_proxy = _runtime_paths_with_vault(tmp_path)
+    token_path = tmp_path / "token"
+    token_path.write_text("av_sess_worker_token\n", encoding="utf-8")
+
+    env = worker_proxy_execution_env(
+        {
+            "MINDROOM_WORKER_EGRESS_PROXY_URL": "http://agent-vault:14322",
+            "MINDROOM_WORKER_EGRESS_PROXY_TOKEN_FILE": str(token_path),
+            "GIT_CONFIG_COUNT": "1",
+            "GIT_CONFIG_KEY_0": "safe.directory",
+            "GIT_CONFIG_VALUE_0": "*",
+        },
+    )
+
+    assert env["GIT_CONFIG_COUNT"] == "3"
+    assert env["GIT_CONFIG_KEY_0"] == "safe.directory"
+    assert env["GIT_CONFIG_VALUE_0"] == "*"
+    assert env["GIT_CONFIG_KEY_1"] == "http.proxy"
+    assert env["GIT_CONFIG_VALUE_1"] == expected_proxy
+    assert env["GIT_CONFIG_KEY_2"] == "http.proxyAuthMethod"
+    assert env["GIT_CONFIG_VALUE_2"] == "basic"
+
+
 def test_request_execution_env_overlays_proxy_onto_shipped_env(tmp_path: Path) -> None:
     """A non-empty primary execution env still gets the worker-local proxy overlaid."""
     runtime_paths, expected_proxy = _runtime_paths_with_vault(tmp_path)


### PR DESCRIPTION
## Summary
- add Git environment-backed config for worker egress proxy auth
- keep the proxy token scoped to the subprocess environment, without writing user/global git config
- cover the worker proxy env composition with a regression test

## Why
Some Git/libcurl executions use the proxy host from `HTTPS_PROXY` but do not send proxy credentials from proxy URL userinfo on HTTPS `CONNECT`. The worker egress proxy depends on `Proxy-Authorization` to route credential-bearing traffic through the credential-injecting parent proxy. Supplying `http.proxy` and `http.proxyAuthMethod=basic` through `GIT_CONFIG_*` makes Git use the same authenticated proxy URL as other clients.

## Tests
- `uv run pytest tests/api/test_worker_egress_proxy_compose.py -q`
- `uv run ruff check src/mindroom/constants.py tests/api/test_worker_egress_proxy_compose.py`
- pre-commit hooks from `git commit`

## Summary by Sourcery

Configure worker egress proxy environments to pass authenticated proxy settings to Git via environment-backed config.

New Features:
- Provide environment-backed Git proxy and auth method configuration in worker egress proxy execution environments.

Tests:
- Add a regression test ensuring worker proxy execution environments correctly configure Git proxy authentication via GIT_CONFIG_* variables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Git now properly utilizes egress proxy settings for HTTPS connections when configured with the necessary authentication credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->