### PR TITLE
Constrain Agent Vault self-service admin access

### DIFF
--- a/docs/deployment/sandbox-proxy.md
+++ b/docs/deployment/sandbox-proxy.md
@@ -407,7 +407,8 @@ For non-Kubernetes deployments, point worker egress at a shared proxy you run yo
 ### Self-service vault access
 
 The `agent_vault_access` tool lets a user ask their own agent for a link to manage that agent's vault.
-It resolves the caller's worker target to that worker's vault (`worker_id_for_key(worker_key, prefix)`, matching `agentVault.vaultNamePrefix`), grants the caller's Agent Vault account membership of that vault through the API, and returns the gated UI link.
+It resolves the caller's worker target to that worker's vault (`worker_id_for_key(worker_key, prefix)`, matching `agentVault.vaultNamePrefix`), grants the caller's Agent Vault account admin access to that vault through the API, and returns the gated UI link.
+It only self-grants for requester-isolated worker scopes (`user` or `user_agent`); shared worker vaults require operator-managed credentials.
 Configure it per deployment:
 
 ```bash

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -15682,7 +15682,8 @@ For non-Kubernetes deployments, point worker egress at a shared proxy you run yo
 ### Self-service vault access
 
 The `agent_vault_access` tool lets a user ask their own agent for a link to manage that agent's vault.
-It resolves the caller's worker target to that worker's vault (`worker_id_for_key(worker_key, prefix)`, matching `agentVault.vaultNamePrefix`), grants the caller's Agent Vault account membership of that vault through the API, and returns the gated UI link.
+It resolves the caller's worker target to that worker's vault (`worker_id_for_key(worker_key, prefix)`, matching `agentVault.vaultNamePrefix`), grants the caller's Agent Vault account admin access to that vault through the API, and returns the gated UI link.
+It only self-grants for requester-isolated worker scopes (`user` or `user_agent`); shared worker vaults require operator-managed credentials.
 Configure it per deployment:
 
 ```bash

--- a/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
+++ b/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
@@ -403,7 +403,8 @@ For non-Kubernetes deployments, point worker egress at a shared proxy you run yo
 ### Self-service vault access
 
 The `agent_vault_access` tool lets a user ask their own agent for a link to manage that agent's vault.
-It resolves the caller's worker target to that worker's vault (`worker_id_for_key(worker_key, prefix)`, matching `agentVault.vaultNamePrefix`), grants the caller's Agent Vault account membership of that vault through the API, and returns the gated UI link.
+It resolves the caller's worker target to that worker's vault (`worker_id_for_key(worker_key, prefix)`, matching `agentVault.vaultNamePrefix`), grants the caller's Agent Vault account admin access to that vault through the API, and returns the gated UI link.
+It only self-grants for requester-isolated worker scopes (`user` or `user_agent`); shared worker vaults require operator-managed credentials.
 Configure it per deployment:
 
 ```bash

--- a/src/mindroom/custom_tools/agent_vault_access.py
+++ b/src/mindroom/custom_tools/agent_vault_access.py
@@ -3,12 +3,12 @@
 Lets a user ask their own agent for a link to manage that agent's Agent
 Vault secrets. MindRoom resolves the caller's worker target to the vault that
 backs that worker (the deterministic per-worker vault name), grants the
-caller's Agent Vault account membership of that vault, and returns the gated
+caller's Agent Vault account admin access to that vault, and returns the gated
 UI link.
 
 This grants *UI management access* only. The runtime secret boundary is still
 the per-worker vault scope plus the in-pod proxy-role token: that token can
-exercise a credential but cannot read it, and membership here never changes
+exercise a credential but cannot read it, and UI admin access here never changes
 which worker reaches which vault.
 """
 
@@ -76,15 +76,15 @@ class AgentVaultAccessTools(Toolkit):
         """Grant yourself access to manage this agent's Agent Vault secrets and return a link.
 
         Resolves the vault that backs your worker identity for this agent,
-        grants your Agent Vault account membership, and returns the UI link
+        grants your Agent Vault account admin access, and returns the UI link
         where you can add or update the secrets this agent's tools will use.
         """
         target = self._worker_target
-        if target is None or not target.worker_key:
-            return self._error(
-                "no worker identity is available for this agent, so it has no dedicated vault. "
-                "Agent Vault access requires a worker-scoped agent.",
-            )
+        if target_error := self._target_error(target):
+            return self._error(target_error)
+        assert target is not None  # Narrowed by _target_error.
+        worker_key = target.worker_key
+        assert worker_key is not None  # Narrowed by _target_error.
         identity = target.execution_identity
         requester_id = identity.requester_id if identity is not None else None
         if not requester_id:
@@ -97,14 +97,14 @@ class AgentVaultAccessTools(Toolkit):
                 "expected a Matrix ID whose localpart maps to the configured email domain.",
             )
 
-        vault = worker_id_for_key(target.worker_key, prefix=self._vault_name_prefix)
+        vault = worker_id_for_key(worker_key, prefix=self._vault_name_prefix)
         try:
             # One token read per request: both API calls must use the same
             # token, or a rotation between them could 401 the second call.
             token = self._resolve_admin_token()
             await self._ensure_vault(vault, token)
             await self._ensure_vault_admin(vault, token)
-            granted = await self._grant_member(vault, email, token)
+            granted = await self._grant_admin(vault, email, token)
         except _AgentVaultAccessError as exc:
             return self._error(str(exc))
         except httpx.HTTPError as exc:
@@ -127,6 +127,20 @@ class AgentVaultAccessTools(Toolkit):
             },
             sort_keys=True,
         )
+
+    def _target_error(self, target: ResolvedWorkerTarget | None) -> str | None:
+        if target is None or not target.worker_key:
+            return (
+                "no worker identity is available for this agent, so it has no dedicated vault. "
+                "Agent Vault access requires a worker-scoped agent."
+            )
+        if target.worker_scope not in {"user", "user_agent"}:
+            return (
+                "Agent Vault self-service admin access requires a requester-isolated worker vault "
+                "(worker_scope=user or worker_scope=user_agent). This agent uses a shared worker scope, "
+                "so ask an operator to configure shared credentials or give the agent a private worker scope."
+            )
+        return None
 
     def _requester_email(self, requester_id: str) -> str | None:
         # Matrix IDs look like @localpart:server; map localpart to the configured domain.
@@ -190,11 +204,11 @@ class AgentVaultAccessTools(Toolkit):
             raise _AgentVaultAccessError(msg)
         response.raise_for_status()
 
-    async def _grant_member(self, vault: str, email: str, token: str) -> bool:
+    async def _grant_admin(self, vault: str, email: str, token: str) -> bool:
         response = await self._post(
             f"v1/vaults/{quote(vault, safe='')}/users",
             token,
-            {"email": email, "role": "member"},
+            {"email": email, "role": "admin"},
         )
         if response.status_code in {200, 201}:
             return True

--- a/src/mindroom/custom_tools/agent_vault_access.py
+++ b/src/mindroom/custom_tools/agent_vault_access.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NoReturn
 from urllib.parse import quote, urljoin
 
 import httpx
@@ -213,7 +213,8 @@ class AgentVaultAccessTools(Toolkit):
         if response.status_code in {200, 201}:
             return True
         if response.status_code in {409, 422}:
-            # Already a member: idempotent success.
+            # Already has vault access: ensure it is the admin role this tool promises.
+            await self._set_admin_role(vault, email, token)
             return False
         if response.status_code == 404:
             msg = (
@@ -221,8 +222,24 @@ class AgentVaultAccessTools(Toolkit):
                 "Register and verify at the vault UI first, then ask again."
             )
             raise _AgentVaultAccessError(msg)
-        response.raise_for_status()
-        return False
+        return self._raise_api_error("granting vault admin access", response)
+
+    async def _set_admin_role(self, vault: str, email: str, token: str) -> None:
+        response = await self._post(
+            f"v1/vaults/{quote(vault, safe='')}/users/{quote(email, safe='')}/role",
+            token,
+            {"role": "admin"},
+        )
+        if response.status_code in {200, 201, 204}:
+            return
+        self._raise_api_error("updating vault user role to admin", response)
+
+    def _raise_api_error(self, action: str, response: httpx.Response) -> NoReturn:
+        detail = f"Agent Vault API returned {response.status_code} while {action}"
+        body = response.text.strip()
+        if body:
+            detail = f"{detail}: {body}"
+        raise _AgentVaultAccessError(detail)
 
     def _error(self, detail: str) -> str:
         return json.dumps(

--- a/src/mindroom/tools/__init__.py
+++ b/src/mindroom/tools/__init__.py
@@ -374,7 +374,7 @@ def _homeassistant_tools() -> type[Toolkit]:
             required=False,
             description=(
                 "Instance-owner session or agent token used to create vaults, join them as "
-                "vault-admin (the /join step is owner-only), and grant membership. "
+                "vault-admin (the /join step is owner-only), and grant vault admin access. "
                 "Provide this or the admin token file."
             ),
         ),

--- a/src/mindroom/tools_metadata.json
+++ b/src/mindroom/tools_metadata.json
@@ -6721,7 +6721,7 @@
         {
           "authored_override": true,
           "default": null,
-          "description": "Instance-owner session or agent token used to create vaults, join them as vault-admin (the /join step is owner-only), and grant membership. Provide this or the admin token file.",
+          "description": "Instance-owner session or agent token used to create vaults, join them as vault-admin (the /join step is owner-only), and grant vault admin access. Provide this or the admin token file.",
           "label": "Agent Vault Admin Token",
           "name": "MINDROOM_AGENT_VAULT_ACCESS_ADMIN_TOKEN",
           "options": null,

--- a/tests/test_agent_vault_access_tool.py
+++ b/tests/test_agent_vault_access_tool.py
@@ -38,7 +38,11 @@ def _runtime_paths(tmp_path: Path, *, env: dict[str, str] | None = None) -> Runt
     )
 
 
-def _worker_target(*, requester: str | None = "@bas.nijholt:example.test") -> object:
+def _worker_target(
+    *,
+    requester: str | None = "@bas.nijholt:example.test",
+    worker_scope: str = "user_agent",
+) -> object:
     identity = ToolExecutionIdentity(
         channel="matrix",
         agent_name="mind",
@@ -50,7 +54,7 @@ def _worker_target(*, requester: str | None = "@bas.nijholt:example.test") -> ob
         tenant_id=None,
     )
     return resolve_worker_target(
-        "user_agent",
+        worker_scope,
         "mind",
         execution_identity=identity,
         private_agent_names=frozenset({"mind"}),
@@ -113,7 +117,7 @@ async def test_request_vault_access_grants_and_returns_link(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A first request resolves the vault, grants membership, and returns the link."""
+    """A first request resolves the vault, grants admin access, and returns the link."""
     target = _worker_target()
     expected_vault = worker_id_for_key(target.worker_key, prefix="agent-vault")
     api = _FakeVaultAPI({"/v1/vaults": 201, "/join": 409, "/users": 201})
@@ -129,15 +133,35 @@ async def test_request_vault_access_grants_and_returns_link(
     assert payload["url"] == f"https://example.test/agent-vault/vaults/{expected_vault}"
     # The grant must target the resolved vault and the derived email.
     grant_calls = [body for path, body in api.calls if path.endswith("/users")]
-    assert grant_calls == [{"email": "bas.nijholt@example.test", "role": "member"}]
+    assert grant_calls == [{"email": "bas.nijholt@example.test", "role": "admin"}]
 
 
 @pytest.mark.asyncio
-async def test_request_vault_access_is_idempotent_when_already_member(
+async def test_request_vault_access_rejects_shared_scope_admin_grant(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Re-requesting when already a member reports success without error."""
+    """Shared worker vaults are not requester-owned, so the tool must not grant admin."""
+    api = _FakeVaultAPI({"/v1/vaults": 201, "/join": 409, "/users": 201})
+    _patch_client(monkeypatch, api)
+
+    tool = AgentVaultAccessTools(
+        runtime_paths=_runtime_paths(tmp_path),
+        worker_target=_worker_target(worker_scope="shared"),
+    )
+    payload = json.loads(await tool.request_vault_access())
+
+    assert payload["status"] == "error"
+    assert "requester-isolated" in payload["error"]
+    assert api.calls == []
+
+
+@pytest.mark.asyncio
+async def test_request_vault_access_is_idempotent_when_already_has_access(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Re-requesting when already granted reports success without error."""
     api = _FakeVaultAPI({"/v1/vaults": 409, "/join": 200, "/users": 409})
     _patch_client(monkeypatch, api)
 

--- a/tests/test_agent_vault_access_tool.py
+++ b/tests/test_agent_vault_access_tool.py
@@ -162,7 +162,7 @@ async def test_request_vault_access_is_idempotent_when_already_has_access(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Re-requesting when already granted reports success without error."""
-    api = _FakeVaultAPI({"/v1/vaults": 409, "/join": 200, "/users": 409})
+    api = _FakeVaultAPI({"/v1/vaults": 409, "/join": 200, "/users": 409, "/role": 200})
     _patch_client(monkeypatch, api)
 
     tool = AgentVaultAccessTools(runtime_paths=_runtime_paths(tmp_path), worker_target=_worker_target())
@@ -170,6 +170,23 @@ async def test_request_vault_access_is_idempotent_when_already_has_access(
 
     assert payload["status"] == "ok"
     assert payload["access"] == "already had access"
+
+
+@pytest.mark.asyncio
+async def test_request_vault_access_promotes_existing_member_to_admin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Existing vault members must be promoted so the tool always leaves admin access."""
+    api = _FakeVaultAPI({"/v1/vaults": 409, "/join": 200, "/users": 409, "/role": 200})
+    _patch_client(monkeypatch, api)
+
+    tool = AgentVaultAccessTools(runtime_paths=_runtime_paths(tmp_path), worker_target=_worker_target())
+    payload = json.loads(await tool.request_vault_access())
+
+    assert payload["status"] == "ok"
+    role_updates = [body for path, body in api.calls if path.endswith("/role")]
+    assert role_updates == [{"role": "admin"}]
 
 
 @pytest.mark.asyncio
@@ -233,6 +250,23 @@ async def test_request_vault_access_reports_unregistered_account(
 
     assert payload["status"] == "error"
     assert "does not have an Agent Vault account" in payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_request_vault_access_reports_grant_error_body(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unexpected grant API failures should include the upstream error body."""
+    api = _FakeVaultAPI({"/v1/vaults": 201, "/join": 409, "/users": 500})
+    _patch_client(monkeypatch, api)
+
+    tool = AgentVaultAccessTools(runtime_paths=_runtime_paths(tmp_path), worker_target=_worker_target())
+    payload = json.loads(await tool.request_vault_access())
+
+    assert payload["status"] == "error"
+    assert "500" in payload["error"]
+    assert "scripted" in payload["error"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- grant Agent Vault self-service users vault-scoped admin access so they can add/update credentials in the UI
- refuse self-service admin grants for shared worker scopes, where the requester does not own the vault
- update docs, tool metadata, and tests for the isolated-vault behavior

## Tests
- `uv run pytest tests/test_agent_vault_access_tool.py tests/test_tools_metadata.py::test_export_tools_metadata_json -q`
- `uv run ruff check src/mindroom/custom_tools/agent_vault_access.py src/mindroom/tools/__init__.py tests/test_agent_vault_access_tool.py`
- pre-commit hooks during commit: ruff, ty, vulture, docs reference regeneration
