### PR TITLE
Fix Agent Vault worker proxy scoping

### DIFF
--- a/cluster/k8s/runtime/values.yaml
+++ b/cluster/k8s/runtime/values.yaml
@@ -356,7 +356,7 @@ workers:
     # Per-worker Agent Vault egress. When enabled, each dedicated worker pod
     # gets an init container that mints a proxy-role Agent Vault token for that
     # worker's vault into an in-pod volume; the sandbox runner composes
-    # http://<token>:@<proxyUrl host> for python/shell egress. No separate
+    # http://<token>:<vault>@<proxyUrl host> for python/shell egress. No separate
     # bridge pod or Service is created.
     #
     # NOTE: if egressProxy/approvedEgress NetworkPolicies are also enabled,

--- a/src/mindroom/constants.py
+++ b/src/mindroom/constants.py
@@ -665,6 +665,7 @@ EXECUTION_ENV_TOOL_NAMES = frozenset({"python", "shell"})
 # primary; it is minted into the worker pod and read here at execution time.
 _WORKER_EGRESS_PROXY_URL_ENV = runtime_env_policy.WORKER_EGRESS_PROXY_ENV_BY_KEY["proxy_url"]
 _WORKER_EGRESS_PROXY_TOKEN_FILE_ENV = runtime_env_policy.WORKER_EGRESS_PROXY_ENV_BY_KEY["token_file"]
+_WORKER_EGRESS_PROXY_VAULT_ENV = runtime_env_policy.WORKER_EGRESS_PROXY_ENV_BY_KEY["vault"]
 _WORKER_EGRESS_PROXY_CA_FILE_ENV = runtime_env_policy.WORKER_EGRESS_PROXY_ENV_BY_KEY["ca_file"]
 _WORKER_EGRESS_NO_PROXY = "localhost,127.0.0.1,::1,.svc,.cluster.local"
 
@@ -701,10 +702,10 @@ def worker_proxy_execution_env(process_env: Mapping[str, str]) -> dict[str, str]
     """Return the per-worker egress proxy env overlay for python/shell, or ``{}``.
 
     General mechanism, provider-agnostic: reads a per-worker proxy endpoint plus
-    a token file written into the worker pod and composes ``http://<token>:@<host>``
-    (the token becomes the proxy basic-auth username, which credential-injecting
-    forward proxies such as Agent Vault accept). Returns empty when no per-worker
-    egress proxy is configured for this worker or the token is not yet present.
+    a token file written into the worker pod and composes proxy basic-auth
+    userinfo. The token becomes the username; when configured, the vault name
+    becomes the password. Returns empty when no per-worker egress proxy is
+    configured for this worker or the token is not yet present.
     """
     proxy_url = (process_env.get(_WORKER_EGRESS_PROXY_URL_ENV) or "").strip()
     token_file = (process_env.get(_WORKER_EGRESS_PROXY_TOKEN_FILE_ENV) or "").strip()
@@ -716,11 +717,11 @@ def worker_proxy_execution_env(process_env: Mapping[str, str]) -> dict[str, str]
         return {}
     if not token:
         return {}
+    vault = (process_env.get(_WORKER_EGRESS_PROXY_VAULT_ENV) or "").strip()
     scheme, _, rest = proxy_url.partition("://")
-    # Percent-encode the token: it becomes proxy basic-auth userinfo, so any
-    # URL-significant character (@ : / # ? % +, whitespace) would otherwise make
-    # HTTP clients mis-parse the proxy URL and silently break auth.
-    authed = f"{scheme}://{quote(token, safe='')}:@{rest}"
+    # Percent-encode proxy basic-auth userinfo so URL-significant characters
+    # (@ : / # ? % +, whitespace) cannot make HTTP clients mis-parse auth.
+    authed = f"{scheme}://{quote(token, safe='')}:{quote(vault, safe='')}@{rest}"
     env = {
         "HTTP_PROXY": authed,
         "HTTPS_PROXY": authed,

--- a/src/mindroom/runtime_env_policy.py
+++ b/src/mindroom/runtime_env_policy.py
@@ -98,6 +98,7 @@ WORKER_EGRESS_PROXY_ENV_BY_KEY: Mapping[str, str] = MappingProxyType(
     {
         "proxy_url": "MINDROOM_WORKER_EGRESS_PROXY_URL",
         "token_file": "MINDROOM_WORKER_EGRESS_PROXY_TOKEN_FILE",
+        "vault": "MINDROOM_WORKER_EGRESS_PROXY_VAULT",
         "ca_file": "MINDROOM_WORKER_EGRESS_PROXY_CA_FILE",
     },
 )

--- a/src/mindroom/workers/backends/kubernetes_config.py
+++ b/src/mindroom/workers/backends/kubernetes_config.py
@@ -104,8 +104,8 @@ class KubernetesAgentVaultConfig:
     When present, each dedicated worker pod gets an init container that mints
     (or rotates) a proxy-role Agent Vault agent token for that worker's vault
     and writes it to a shared in-pod volume. The sandbox runner composes
-    ``http://<token>:@<proxy host>`` for python/shell egress so Agent Vault
-    injects credentials in transit. The owner password is mounted only on the
+    ``http://<token>:<vault>@<proxy host>`` for python/shell egress so Agent
+    Vault injects credentials in transit. The owner password is mounted only on the
     init container, never on the agent-executing container.
     """
 

--- a/src/mindroom/workers/backends/kubernetes_resources.py
+++ b/src/mindroom/workers/backends/kubernetes_resources.py
@@ -90,7 +90,7 @@ _LABEL_NAME_VALUE = "mindroom-worker"
 _LABEL_WORKER_ID = "mindroom.ai/worker-id"
 # Agent Vault per-worker egress: an init container in the worker pod mints the
 # worker's proxy-role token into a shared in-pod volume; the sandbox runner
-# composes http://<token>:@<proxy host> for python/shell. No separate bridge pod.
+# composes http://<token>:<vault>@<proxy host> for python/shell. No separate bridge pod.
 _AGENT_VAULT_MINT_CONTAINER_NAME = "agent-vault-mint-token"
 _AGENT_VAULT_TOKEN_MOUNT_DIR = "/agent-vault"  # noqa: S105
 _AGENT_VAULT_TOKEN_FILE = "token"  # noqa: S105
@@ -106,6 +106,7 @@ _AGENT_VAULT_WORKER_CA_PATH = f"{_AGENT_VAULT_WORKER_CA_MOUNT_DIR}/{_AGENT_VAULT
 # Worker pod env consumed by the sandbox runner to compose python/shell proxy env.
 _WORKER_EGRESS_PROXY_URL_ENV = WORKER_EGRESS_PROXY_ENV_BY_KEY["proxy_url"]
 _WORKER_EGRESS_PROXY_TOKEN_FILE_ENV = WORKER_EGRESS_PROXY_ENV_BY_KEY["token_file"]
+_WORKER_EGRESS_PROXY_VAULT_ENV = WORKER_EGRESS_PROXY_ENV_BY_KEY["vault"]
 _WORKER_EGRESS_PROXY_CA_FILE_ENV = WORKER_EGRESS_PROXY_ENV_BY_KEY["ca_file"]
 # HOME is kept on the init container's own ephemeral filesystem (not the shared
 # token volume) so the owner CLI session never lands on a volume the
@@ -132,6 +133,13 @@ if ! agent-vault agent create "$AGENT_VAULT_VAULT" \\
   --vault "$AGENT_VAULT_VAULT:proxy" \\
   --token-only > "{token_path}"; then
   agent-vault agent rotate "$AGENT_VAULT_VAULT" --token-only > "{token_path}"
+fi
+if ! agent-vault vault agent add "$AGENT_VAULT_VAULT" \\
+  --vault "$AGENT_VAULT_VAULT" \\
+  --role proxy > /dev/null 2>&1; then
+  agent-vault vault agent set-role "$AGENT_VAULT_VAULT" \\
+    --vault "$AGENT_VAULT_VAULT" \\
+    --role proxy > /dev/null
 fi
 test -s "{token_path}"
 """
@@ -643,13 +651,18 @@ class KubernetesResourceManager:
             "securityContext": {"allowPrivilegeEscalation": False, "capabilities": {"drop": ["ALL"]}},
         }
 
-    def _agent_vault_main_env(self) -> list[dict[str, object]]:
+    def _agent_vault_main_env(self, *, worker_key: str) -> list[dict[str, object]]:
         cfg = self.config.agent_vault
         if cfg is None:
             return []
+        vault = self.agent_vault_vault_name(worker_key)
+        if vault is None:
+            msg = "Agent Vault main env requested without a worker vault name."
+            raise WorkerBackendError(msg)
         env: list[dict[str, object]] = [
             {"name": _WORKER_EGRESS_PROXY_URL_ENV, "value": cfg.proxy_url},
             {"name": _WORKER_EGRESS_PROXY_TOKEN_FILE_ENV, "value": _AGENT_VAULT_TOKEN_PATH},
+            {"name": _WORKER_EGRESS_PROXY_VAULT_ENV, "value": vault},
         ]
         if cfg.worker_ca_configmap_name is not None:
             env.append({"name": _WORKER_EGRESS_PROXY_CA_FILE_ENV, "value": _AGENT_VAULT_WORKER_CA_PATH})
@@ -1100,7 +1113,7 @@ class KubernetesResourceManager:
         if credentials_encryption_key_env is not None:
             env.append(credentials_encryption_key_env)
 
-        env.extend(self._agent_vault_main_env())
+        env.extend(self._agent_vault_main_env(worker_key=worker_key))
 
         for name, value in sorted(worker_extra_env(self.config.extra_env).items()):
             env.append({"name": name, "value": value})

--- a/src/mindroom/workers/backends/kubernetes_resources.py
+++ b/src/mindroom/workers/backends/kubernetes_resources.py
@@ -136,7 +136,7 @@ if ! agent-vault agent create "$AGENT_VAULT_VAULT" \\
 fi
 if ! agent-vault vault agent add "$AGENT_VAULT_VAULT" \\
   --vault "$AGENT_VAULT_VAULT" \\
-  --role proxy > /dev/null 2>&1; then
+  --role proxy > /dev/null; then
   agent-vault vault agent set-role "$AGENT_VAULT_VAULT" \\
     --vault "$AGENT_VAULT_VAULT" \\
     --role proxy > /dev/null
@@ -657,7 +657,7 @@ class KubernetesResourceManager:
             return []
         vault = self.agent_vault_vault_name(worker_key)
         if vault is None:
-            msg = "Agent Vault main env requested without a worker vault name."
+            msg = f"Agent Vault main env requested without a worker vault name for worker_key={worker_key!r}."
             raise WorkerBackendError(msg)
         env: list[dict[str, object]] = [
             {"name": _WORKER_EGRESS_PROXY_URL_ENV, "value": cfg.proxy_url},

--- a/tests/api/test_worker_egress_proxy_compose.py
+++ b/tests/api/test_worker_egress_proxy_compose.py
@@ -20,6 +20,7 @@ def _runtime_paths_with_vault(tmp_path: Path, *, with_ca: bool = True) -> tuple[
     env = {
         "MINDROOM_WORKER_EGRESS_PROXY_URL": "http://agent-vault:14322",
         "MINDROOM_WORKER_EGRESS_PROXY_TOKEN_FILE": str(token_path),
+        "MINDROOM_WORKER_EGRESS_PROXY_VAULT": "agent-vault-worker",
     }
     if with_ca:
         env["MINDROOM_WORKER_EGRESS_PROXY_CA_FILE"] = "/etc/agent-vault/ca.pem"
@@ -28,7 +29,7 @@ def _runtime_paths_with_vault(tmp_path: Path, *, with_ca: bool = True) -> tuple[
         storage_path=tmp_path,
         process_env=env,
     )
-    return runtime_paths, "http://av_sess_worker_token:@agent-vault:14322"
+    return runtime_paths, "http://av_sess_worker_token:agent-vault-worker@agent-vault:14322"
 
 
 def test_request_execution_env_overlays_proxy_when_no_primary_env(tmp_path: Path) -> None:
@@ -52,6 +53,7 @@ def test_worker_proxy_execution_env_configures_git_proxy_auth(tmp_path: Path) ->
         {
             "MINDROOM_WORKER_EGRESS_PROXY_URL": "http://agent-vault:14322",
             "MINDROOM_WORKER_EGRESS_PROXY_TOKEN_FILE": str(token_path),
+            "MINDROOM_WORKER_EGRESS_PROXY_VAULT": "agent-vault-worker",
         },
     )
 
@@ -71,6 +73,7 @@ def test_worker_proxy_execution_env_appends_to_existing_git_config(tmp_path: Pat
         {
             "MINDROOM_WORKER_EGRESS_PROXY_URL": "http://agent-vault:14322",
             "MINDROOM_WORKER_EGRESS_PROXY_TOKEN_FILE": str(token_path),
+            "MINDROOM_WORKER_EGRESS_PROXY_VAULT": "agent-vault-worker",
             "GIT_CONFIG_COUNT": "1",
             "GIT_CONFIG_KEY_0": "safe.directory",
             "GIT_CONFIG_VALUE_0": "*",
@@ -114,16 +117,17 @@ def test_request_execution_env_skips_non_execution_tools(tmp_path: Path) -> None
 
 
 def test_worker_proxy_execution_env_percent_encodes_token(tmp_path: Path) -> None:
-    """A token with URL-significant characters must be percent-encoded into the proxy URL."""
+    """Proxy userinfo with URL-significant characters must be percent-encoded."""
     token_path = tmp_path / "token"
     token_path.write_text("av/sess+a:b@c\n", encoding="utf-8")
     env = worker_proxy_execution_env(
         {
             "MINDROOM_WORKER_EGRESS_PROXY_URL": "http://agent-vault:14322",
             "MINDROOM_WORKER_EGRESS_PROXY_TOKEN_FILE": str(token_path),
+            "MINDROOM_WORKER_EGRESS_PROXY_VAULT": "vault/a:b@c",
         },
     )
-    assert env["HTTP_PROXY"] == "http://av%2Fsess%2Ba%3Ab%40c:@agent-vault:14322"
+    assert env["HTTP_PROXY"] == "http://av%2Fsess%2Ba%3Ab%40c:vault%2Fa%3Ab%40c@agent-vault:14322"
 
 
 def test_worker_proxy_execution_env_fail_closed_guards(tmp_path: Path) -> None:
@@ -133,6 +137,7 @@ def test_worker_proxy_execution_env_fail_closed_guards(tmp_path: Path) -> None:
     base = {
         "MINDROOM_WORKER_EGRESS_PROXY_URL": "http://agent-vault:14322",
         "MINDROOM_WORKER_EGRESS_PROXY_TOKEN_FILE": str(token_path),
+        "MINDROOM_WORKER_EGRESS_PROXY_VAULT": "agent-vault-worker",
     }
     # scheme-less proxy URL
     assert worker_proxy_execution_env({**base, "MINDROOM_WORKER_EGRESS_PROXY_URL": "agent-vault:14322"}) == {}
@@ -161,6 +166,11 @@ def test_worker_egress_proxy_env_names_have_single_source() -> None:
         resources._WORKER_EGRESS_PROXY_TOKEN_FILE_ENV
         == constants._WORKER_EGRESS_PROXY_TOKEN_FILE_ENV
         == WORKER_EGRESS_PROXY_ENV_BY_KEY["token_file"]
+    )
+    assert (
+        resources._WORKER_EGRESS_PROXY_VAULT_ENV
+        == constants._WORKER_EGRESS_PROXY_VAULT_ENV
+        == WORKER_EGRESS_PROXY_ENV_BY_KEY["vault"]
     )
     assert (
         resources._WORKER_EGRESS_PROXY_CA_FILE_ENV

--- a/tests/api/test_worker_egress_proxy_compose.py
+++ b/tests/api/test_worker_egress_proxy_compose.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
+
 from mindroom import constants
 from mindroom.api import sandbox_exec
 from mindroom.constants import resolve_runtime_paths, worker_proxy_execution_env
@@ -128,6 +130,35 @@ def test_worker_proxy_execution_env_percent_encodes_token(tmp_path: Path) -> Non
         },
     )
     assert env["HTTP_PROXY"] == "http://av%2Fsess%2Ba%3Ab%40c:vault%2Fa%3Ab%40c@agent-vault:14322"
+
+
+@pytest.mark.parametrize(
+    "vault_env",
+    [
+        pytest.param(None, id="absent"),
+        pytest.param(" \t\n", id="blank"),
+    ],
+)
+def test_worker_proxy_execution_env_allows_missing_vault_as_empty_proxy_password(
+    tmp_path: Path,
+    vault_env: str | None,
+) -> None:
+    """Missing/blank vault keeps the backwards-compatible token-only proxy URL."""
+    token_path = tmp_path / "token"
+    token_path.write_text("av/sess+a:b@c\n", encoding="utf-8")
+    process_env = {
+        "MINDROOM_WORKER_EGRESS_PROXY_URL": "http://agent-vault:14322",
+        "MINDROOM_WORKER_EGRESS_PROXY_TOKEN_FILE": str(token_path),
+    }
+    if vault_env is not None:
+        process_env["MINDROOM_WORKER_EGRESS_PROXY_VAULT"] = vault_env
+
+    env = worker_proxy_execution_env(process_env)
+
+    expected_proxy = "http://av%2Fsess%2Ba%3Ab%40c:@agent-vault:14322"
+    assert env["HTTP_PROXY"] == expected_proxy
+    assert env["HTTPS_PROXY"] == expected_proxy
+    assert env["GIT_CONFIG_VALUE_0"] == expected_proxy
 
 
 def test_worker_proxy_execution_env_fail_closed_guards(tmp_path: Path) -> None:

--- a/tests/manual/agent_vault_isolation_live_smoke.py
+++ b/tests/manual/agent_vault_isolation_live_smoke.py
@@ -4,7 +4,8 @@
 This proves the per-worker Agent Vault isolation model: one vault per worker
 identity plus one proxy-role agent per worker, against a single shared Agent
 Vault server. Each worker egresses by pointing HTTP(S)_PROXY straight at the
-vault MITM proxy with its proxy-role token as the basic-auth username (no
+vault MITM proxy with its proxy-role token as the basic-auth username and the
+vault name as the basic-auth password (no
 bridge pod or adapter).
 
 1. agent A's token injects only vault A's credential
@@ -290,6 +291,7 @@ def _agent_cli(
 def _run_worker(
     network: str,
     proxy_endpoint: str,
+    vault: str,
     token: str,
     target_host: str,
     *,
@@ -298,9 +300,10 @@ def _run_worker(
     """Run a worker that egresses through the vault with its token in the proxy URL.
 
     This is the no-bridge model: the worker points HTTP(S)_PROXY straight at the
-    Agent Vault MITM proxy with its proxy-role token as the basic-auth username.
+    Agent Vault MITM proxy with its proxy-role token as the basic-auth username
+    and the vault name as the basic-auth password.
     """
-    proxy_url = f"http://{token}:@{proxy_endpoint}"
+    proxy_url = f"http://{token}:{vault}@{proxy_endpoint}"
     worker_code = r"""
 import json
 import urllib.request
@@ -448,11 +451,11 @@ def main() -> int:  # noqa: PLR0915
 
         # 1 + 2: each token injects exactly its own vault's credential.
         shared_via_a = _parse_worker_headers(
-            _run_worker(network, proxy_endpoint, token_a, SHARED_ECHO_HOST).stdout,
+            _run_worker(network, proxy_endpoint, VAULT_A, token_a, SHARED_ECHO_HOST).stdout,
         )
-        only_b_via_a = _run_worker(network, proxy_endpoint, token_a, ONLY_B_ECHO_HOST, check=False)
+        only_b_via_a = _run_worker(network, proxy_endpoint, VAULT_A, token_a, ONLY_B_ECHO_HOST, check=False)
         shared_via_b = _parse_worker_headers(
-            _run_worker(network, proxy_endpoint, token_b, SHARED_ECHO_HOST).stdout,
+            _run_worker(network, proxy_endpoint, VAULT_B, token_b, SHARED_ECHO_HOST).stdout,
         )
 
         _assert(
@@ -482,6 +485,7 @@ def main() -> int:  # noqa: PLR0915
         garbage_result = _run_worker(
             network,
             proxy_endpoint,
+            VAULT_A,
             "garbage-token-that-should-never-work",
             SHARED_ECHO_HOST,
             check=False,

--- a/tests/test_kubernetes_worker_backend.py
+++ b/tests/test_kubernetes_worker_backend.py
@@ -3106,6 +3106,8 @@ def test_kubernetes_backend_adds_agent_vault_mint_init_container(tmp_path: Path)
     mint_script = mint["command"][2]
     assert "agent-vault agent create" in mint_script
     assert "agent-vault agent rotate" in mint_script
+    assert "agent-vault vault agent add" in mint_script
+    assert "agent-vault vault agent set-role" in mint_script
     assert ":proxy" in mint_script
     # The owner CLI session must not land on the shared token volume, or the
     # agent container (which mounts it) could read the owner credential.
@@ -3122,15 +3124,17 @@ def test_kubernetes_backend_adds_agent_vault_mint_init_container(tmp_path: Path)
     assert all(m["name"] != "agent-vault-bootstrap" for m in main["volumeMounts"])
     assert any(m["name"] == "agent-vault-token" and m.get("readOnly") for m in main["volumeMounts"])
     main_env = {e["name"]: e.get("value") for e in main["env"]}
+    expected_vault = worker_id_for_key(worker_key, prefix="agent-vault")
     assert main_env["MINDROOM_WORKER_EGRESS_PROXY_URL"] == "http://agent-vault:14322"
     assert main_env["MINDROOM_WORKER_EGRESS_PROXY_TOKEN_FILE"] == "/agent-vault/token"  # noqa: S105
+    assert main_env["MINDROOM_WORKER_EGRESS_PROXY_VAULT"] == expected_vault
     assert main_env["MINDROOM_WORKER_EGRESS_PROXY_CA_FILE"] == "/etc/agent-vault/ca.pem"
 
     volume_names = {v["name"] for v in template_spec["volumes"]}
     assert {"agent-vault-token", "agent-vault-bootstrap", "agent-vault-ca"} <= volume_names
 
     # No bridge/NetworkPolicy resources exist in this model.
-    assert backend._resources.agent_vault_vault_name(worker_key) == worker_id_for_key(worker_key, prefix="agent-vault")
+    assert backend._resources.agent_vault_vault_name(worker_key) == expected_vault
 
 
 def test_kubernetes_backend_omits_agent_vault_when_disabled(tmp_path: Path) -> None:

--- a/tests/test_kubernetes_worker_backend.py
+++ b/tests/test_kubernetes_worker_backend.py
@@ -3108,6 +3108,7 @@ def test_kubernetes_backend_adds_agent_vault_mint_init_container(tmp_path: Path)
     assert "agent-vault agent rotate" in mint_script
     assert "agent-vault vault agent add" in mint_script
     assert "agent-vault vault agent set-role" in mint_script
+    assert "--role proxy > /dev/null 2>&1" not in mint_script
     assert ":proxy" in mint_script
     # The owner CLI session must not land on the shared token volume, or the
     # agent container (which mounts it) could read the owner credential.
@@ -3135,6 +3136,29 @@ def test_kubernetes_backend_adds_agent_vault_mint_init_container(tmp_path: Path)
 
     # No bridge/NetworkPolicy resources exist in this model.
     assert backend._resources.agent_vault_vault_name(worker_key) == expected_vault
+
+
+def test_agent_vault_main_env_error_names_worker_key_when_vault_name_missing(tmp_path: Path) -> None:
+    """The defensive vault-name guard should include the worker key that failed."""
+    runtime_paths = resolve_primary_runtime_paths(
+        config_path=Path("config.yaml"),
+        storage_path=tmp_path / "mindroom-test-storage",
+    )
+    backend, _apps_api, _core_api = _backend(
+        runtime_paths=runtime_paths,
+        agent_vault=_test_agent_vault_config(),
+    )
+    worker_key = _TEST_SCOPED_WORKER_KEY_A
+
+    def _missing_vault_name(_self: object, requested_worker_key: str) -> None:
+        assert requested_worker_key == worker_key
+
+    backend._resources.agent_vault_vault_name = MethodType(_missing_vault_name, backend._resources)
+
+    with pytest.raises(WorkerBackendError) as exc_info:
+        backend._resources._agent_vault_main_env(worker_key=worker_key)
+
+    assert f"worker_key={worker_key!r}" in str(exc_info.value)
 
 
 def test_kubernetes_backend_omits_agent_vault_when_disabled(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fix Agent Vault worker proxy setup for Kubernetes workers:

- include the worker vault name in proxy Basic auth (`token:vault@proxy`) so Agent Vault can resolve the correct vault for MITM proxy requests
- expose the deterministic worker vault name to the sandbox runner via worker env
- make the worker init container idempotently repair the worker agent's vault role to `proxy` after create/rotate
- update tests and docs/comments for the token+vault proxy shape

This avoids two failure modes:

- proxy requests with only `token:@proxy` cannot resolve a vault and fail before target traffic is handled
- pre-existing worker agents without the expected vault grant can rotate a token successfully but still fail proxy auth against the vault

## Tests

- `uv run pytest tests/api/test_worker_egress_proxy_compose.py tests/test_kubernetes_worker_backend.py -q -n 0 --no-cov`
- `uv run ruff check src/mindroom/constants.py src/mindroom/runtime_env_policy.py src/mindroom/workers/backends/kubernetes_config.py src/mindroom/workers/backends/kubernetes_resources.py tests/api/test_worker_egress_proxy_compose.py tests/manual/agent_vault_isolation_live_smoke.py tests/test_kubernetes_worker_backend.py`
- `uv run ruff format --check src/mindroom/constants.py src/mindroom/runtime_env_policy.py src/mindroom/workers/backends/kubernetes_config.py src/mindroom/workers/backends/kubernetes_resources.py tests/api/test_worker_egress_proxy_compose.py tests/manual/agent_vault_isolation_live_smoke.py tests/test_kubernetes_worker_backend.py`
- `uv run tach check --dependencies --interfaces`
- `git diff --check`

## Summary by Sourcery

Ensure Kubernetes workers include a deterministic Agent Vault vault name in per-worker egress proxy configuration and repair worker agent roles to support scoped proxy authentication.

New Features:
- Expose the per-worker Agent Vault vault name to sandbox runtime via a dedicated worker environment variable and include it in proxy basic-auth composition.

Bug Fixes:
- Fix worker egress proxy authentication against Agent Vault by composing proxy credentials as token plus vault name instead of token-only and by keeping worker agent roles correctly set to proxy.

Enhancements:
- Make the Agent Vault mint init container idempotently enforce the worker agent's proxy role after token create or rotate.
- Align constants, runtime env policy, and Kubernetes resource wiring for the new vault env var used by the worker proxy.
- Clarify comments and manual smoke test scripts to document the token-plus-vault proxy shape and isolation guarantees.

Tests:
- Extend unit, API, and manual smoke tests to cover the new vault env wiring, proxy URL composition, and init container behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTTP proxy authentication now supports vault credentials embedded in proxy URLs alongside token credentials for secure worker egress traffic.
  * Enhanced worker egress proxy configuration to include per-worker vault identifiers, enabling vault-based credential authentication for outbound HTTP/HTTPS connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->