### PR TITLE
Keep Agent Vault owner admin on self-service vaults

### DIFF
--- a/cluster/k8s/runtime/README.md
+++ b/cluster/k8s/runtime/README.md
@@ -326,6 +326,7 @@ approvedEgress:
 
 With this setup, workers mint Agent Vault tokens through the API port (`14321`), workers proxy tool egress to the approved egress Service, Squid enforces allowlists and dynamic grants using the real worker IP, and Squid forwards requests carrying `Proxy-Authorization` to Agent Vault (`login=PASSTHRU`) for credential injection.
 Tokenless traffic egresses directly from Squid after the normal policy check.
+When `agentVault.accessTool.enabled` is set, self-service vault grants also keep `agentVault.ownerEmail` as an admin on each worker vault; the Kubernetes worker init container uses that owner account to mint and attach the proxy-role agent token.
 The chart rejects the unsafe default combination of chart-managed approved egress plus Agent Vault without `approvedEgress.parentProxy`, because that would be vault-first and break dynamic grants.
 
 Use `egressProxy` when another chart or platform layer already manages the proxy:

--- a/cluster/k8s/runtime/templates/deployment.yaml
+++ b/cluster/k8s/runtime/templates/deployment.yaml
@@ -335,6 +335,8 @@ spec:
               value: {{ required "workers.kubernetes.agentVault.accessTool.emailDomain is required when the access tool is enabled" .accessTool.emailDomain | quote }}
             - name: MINDROOM_AGENT_VAULT_ACCESS_VAULT_NAME_PREFIX
               value: {{ .vaultNamePrefix | quote }}
+            - name: MINDROOM_AGENT_VAULT_ACCESS_OWNER_EMAIL
+              value: {{ required "workers.kubernetes.agentVault.ownerEmail is required when the access tool is enabled" .ownerEmail | quote }}
             # Mounted Secret file, not env: the kubelet refreshes the mount in
             # place, so a bootstrap re-run (token rotation) needs no restart.
             - name: MINDROOM_AGENT_VAULT_ACCESS_ADMIN_TOKEN_FILE

--- a/cluster/k8s/runtime/values.yaml
+++ b/cluster/k8s/runtime/values.yaml
@@ -372,7 +372,10 @@ workers:
       # Agent Vault CLI image used by the init container to mint per-worker
       # proxy-role agent tokens. Required when enabled.
       cliImage: ""
-      # Agent Vault instance owner email used for provisioning. Required when enabled.
+      # Agent Vault instance owner email used for provisioning and worker token
+      # minting. Required when enabled. When accessTool is enabled, self-service
+      # grants also keep this owner admin on each worker vault so the init
+      # container can attach the proxy-role agent even for user-created vaults.
       ownerEmail: ""
       # Prefix for the per-worker vault name (worker_id_for_key); the
       # agent_vault_access tool must use the same prefix

--- a/src/mindroom/custom_tools/agent_vault_access.py
+++ b/src/mindroom/custom_tools/agent_vault_access.py
@@ -55,6 +55,7 @@ class AgentVaultAccessTools(Toolkit):
         self._vault_name_prefix = (
             runtime_paths.env_value(env["vault_name_prefix"]) or _DEFAULT_VAULT_NAME_PREFIX
         ).strip()
+        self._owner_email = (runtime_paths.env_value(env["owner_email"]) or "").strip()
         missing = [
             name
             for name, value in (
@@ -104,6 +105,19 @@ class AgentVaultAccessTools(Toolkit):
             token = self._resolve_admin_token()
             await self._ensure_vault(vault, token)
             await self._ensure_vault_admin(vault, token)
+            # Worker init logs in as the configured owner account to mint the
+            # proxy token, so keep that account admin on self-service vaults too.
+            if self._owner_email and self._owner_email.casefold() != email.casefold():
+                await self._grant_admin(
+                    vault,
+                    self._owner_email,
+                    token,
+                    missing_account_message=(
+                        "Agent Vault access is not ready: the configured worker token-mint owner account "
+                        "could not be kept as vault admin. Ask an operator to verify "
+                        f"{AGENT_VAULT_ACCESS_ENV_BY_KEY['owner_email']} is registered in Agent Vault."
+                    ),
+                )
             granted = await self._grant_admin(vault, email, token)
         except _AgentVaultAccessError as exc:
             return self._error(str(exc))
@@ -204,7 +218,14 @@ class AgentVaultAccessTools(Toolkit):
             raise _AgentVaultAccessError(msg)
         response.raise_for_status()
 
-    async def _grant_admin(self, vault: str, email: str, token: str) -> bool:
+    async def _grant_admin(
+        self,
+        vault: str,
+        email: str,
+        token: str,
+        *,
+        missing_account_message: str | None = None,
+    ) -> bool:
         response = await self._post(
             f"v1/vaults/{quote(vault, safe='')}/users",
             token,
@@ -218,7 +239,8 @@ class AgentVaultAccessTools(Toolkit):
             return False
         if response.status_code == 404:
             msg = (
-                f"{email} does not have an Agent Vault account yet. "
+                missing_account_message
+                or f"{email} does not have an Agent Vault account yet. "
                 "Register and verify at the vault UI first, then ask again."
             )
             raise _AgentVaultAccessError(msg)

--- a/src/mindroom/runtime_env_policy.py
+++ b/src/mindroom/runtime_env_policy.py
@@ -87,6 +87,7 @@ AGENT_VAULT_ACCESS_ENV_BY_KEY: Mapping[str, str] = MappingProxyType(
         "ui_base_url": "MINDROOM_AGENT_VAULT_ACCESS_UI_BASE_URL",
         "email_domain": "MINDROOM_AGENT_VAULT_ACCESS_EMAIL_DOMAIN",
         "vault_name_prefix": "MINDROOM_AGENT_VAULT_ACCESS_VAULT_NAME_PREFIX",
+        "owner_email": "MINDROOM_AGENT_VAULT_ACCESS_OWNER_EMAIL",
     },
 )
 

--- a/src/mindroom/tools/__init__.py
+++ b/src/mindroom/tools/__init__.py
@@ -413,6 +413,16 @@ def _homeassistant_tools() -> type[Toolkit]:
             default="agent-vault",
             description="Prefix used to derive the per-worker vault name; must match workers.kubernetes.agentVault.vaultNamePrefix.",
         ),
+        ConfigField(
+            name="MINDROOM_AGENT_VAULT_ACCESS_OWNER_EMAIL",
+            label="Agent Vault Owner Email",
+            type="text",
+            required=False,
+            description=(
+                "Agent Vault owner account used by Kubernetes worker init when minting proxy tokens. "
+                "When set, self-service grants keep this account admin on the worker vault too."
+            ),
+        ),
     ],
     function_names=("request_vault_access",),
 )

--- a/src/mindroom/tools_metadata.json
+++ b/src/mindroom/tools_metadata.json
@@ -6777,6 +6777,18 @@
           "required": false,
           "type": "text",
           "validation": null
+        },
+        {
+          "authored_override": true,
+          "default": null,
+          "description": "Agent Vault owner account used by Kubernetes worker init when minting proxy tokens. When set, self-service grants keep this account admin on the worker vault too.",
+          "label": "Agent Vault Owner Email",
+          "name": "MINDROOM_AGENT_VAULT_ACCESS_OWNER_EMAIL",
+          "options": null,
+          "placeholder": null,
+          "required": false,
+          "type": "text",
+          "validation": null
         }
       ],
       "consumes_workspace_paths": false,

--- a/src/mindroom/workers/backends/kubernetes_resources.py
+++ b/src/mindroom/workers/backends/kubernetes_resources.py
@@ -129,6 +129,7 @@ agent-vault auth login \\
   --email "$AGENT_VAULT_OWNER_EMAIL" \\
   --password-stdin < "{bootstrap_path}/{owner_password_key}" > /dev/null
 agent-vault vault create "$AGENT_VAULT_VAULT" > /dev/null 2>&1 || true
+agent-vault owner vault join "$AGENT_VAULT_VAULT" > /dev/null 2>&1 || true
 if ! agent-vault agent create "$AGENT_VAULT_VAULT" \\
   --vault "$AGENT_VAULT_VAULT:proxy" \\
   --token-only > "{token_path}"; then

--- a/tests/test_agent_vault_access_tool.py
+++ b/tests/test_agent_vault_access_tool.py
@@ -219,6 +219,69 @@ async def test_request_vault_access_joins_worker_created_vault(
 
 
 @pytest.mark.asyncio
+async def test_request_vault_access_keeps_worker_token_owner_admin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Self-service grants must also keep the worker token-mint owner as vault admin."""
+    env = {**_ENV, "MINDROOM_AGENT_VAULT_ACCESS_OWNER_EMAIL": "owner@example.test"}
+    api = _FakeVaultAPI({"/v1/vaults": 409, "/join": 200, "/users": 201})
+    _patch_client(monkeypatch, api)
+
+    tool = AgentVaultAccessTools(runtime_paths=_runtime_paths(tmp_path, env=env), worker_target=_worker_target())
+    payload = json.loads(await tool.request_vault_access())
+
+    assert payload["status"] == "ok"
+    grant_calls = [body for path, body in api.calls if path.endswith("/users")]
+    assert grant_calls == [
+        {"email": "owner@example.test", "role": "admin"},
+        {"email": "bas.nijholt@example.test", "role": "admin"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_request_vault_access_skips_duplicate_owner_grant(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A requester who is also the configured owner should be granted once."""
+    env = {**_ENV, "MINDROOM_AGENT_VAULT_ACCESS_OWNER_EMAIL": "owner@example.test"}
+    api = _FakeVaultAPI({"/v1/vaults": 409, "/join": 200, "/users": 201})
+    _patch_client(monkeypatch, api)
+
+    tool = AgentVaultAccessTools(
+        runtime_paths=_runtime_paths(tmp_path, env=env),
+        worker_target=_worker_target(requester="@owner:example.test"),
+    )
+    payload = json.loads(await tool.request_vault_access())
+
+    assert payload["status"] == "ok"
+    grant_calls = [body for path, body in api.calls if path.endswith("/users")]
+    assert grant_calls == [{"email": "owner@example.test", "role": "admin"}]
+
+
+@pytest.mark.asyncio
+async def test_request_vault_access_reports_owner_account_setup_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Owner-account setup errors should not look like requester signup work."""
+    env = {**_ENV, "MINDROOM_AGENT_VAULT_ACCESS_OWNER_EMAIL": "owner@example.test"}
+    api = _FakeVaultAPI({"/v1/vaults": 409, "/join": 200, "/users": 404})
+    _patch_client(monkeypatch, api)
+
+    tool = AgentVaultAccessTools(runtime_paths=_runtime_paths(tmp_path, env=env), worker_target=_worker_target())
+    payload = json.loads(await tool.request_vault_access())
+
+    assert payload["status"] == "error"
+    assert "configured worker token-mint owner account" in payload["error"]
+    assert "operator" in payload["error"]
+    assert "Register and verify at the vault UI first, then ask again" not in payload["error"]
+    grant_calls = [body for path, body in api.calls if path.endswith("/users")]
+    assert grant_calls == [{"email": "owner@example.test", "role": "admin"}]
+
+
+@pytest.mark.asyncio
 async def test_request_vault_access_reports_non_owner_token_on_join(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_helm_instance_worker_isolation.py
+++ b/tests/test_helm_instance_worker_isolation.py
@@ -1390,6 +1390,30 @@ def test_runtime_chart_approved_egress_can_chain_agent_vault_parent(tmp_path: Pa
     assert "name=agentvault" not in conf
 
 
+def test_runtime_chart_agent_vault_access_tool_sets_owner_email() -> None:
+    """The self-service access tool must know the owner used by worker token minting."""
+    docs = _render_chart(
+        Path("cluster/k8s/runtime"),
+        "workers.backend=kubernetes",
+        "workers.sandbox.proxyToken.value=test-token",
+        "workers.kubernetes.agentVault.enabled=true",
+        "workers.kubernetes.agentVault.cliImage=infisical/agent-vault:test",
+        "workers.kubernetes.agentVault.ownerEmail=owner@example.test",
+        "workers.kubernetes.agentVault.accessTool.enabled=true",
+        "workers.kubernetes.agentVault.accessTool.uiBaseUrl=https://example.test/agent-vault",
+        "workers.kubernetes.agentVault.accessTool.emailDomain=example.test",
+        "eventCache.postgres.auth.password=test-password",
+        release_name="mindroom-runtime",
+    )
+
+    runtime_container = _container(_resource(docs, "Deployment", "mindroom-runtime"), "mindroom")
+    runtime_env = _env_by_name(runtime_container)
+
+    assert runtime_env["MINDROOM_AGENT_VAULT_ACCESS_OWNER_EMAIL"]["value"] == "owner@example.test"
+    assert runtime_env["MINDROOM_AGENT_VAULT_ACCESS_VAULT_NAME_PREFIX"]["value"] == "agent-vault"
+    assert runtime_env["MINDROOM_AGENT_VAULT_ACCESS_ADMIN_TOKEN_FILE"]["value"] == "/etc/agent-vault-access/token"
+
+
 def test_runtime_chart_rejects_agent_vault_default_proxy_url_with_approved_egress() -> None:
     """Agent Vault must not stay vault-first when approved egress owns dynamic grants."""
     completed = _run_helm_template(

--- a/tests/test_kubernetes_worker_backend.py
+++ b/tests/test_kubernetes_worker_backend.py
@@ -3104,10 +3104,12 @@ def test_kubernetes_backend_adds_agent_vault_mint_init_container(tmp_path: Path)
     assert mint["name"] == "agent-vault-mint-token"
     assert mint["image"] == "example.test/agent-vault:1"
     mint_script = mint["command"][2]
+    assert "agent-vault owner vault join" in mint_script
     assert "agent-vault agent create" in mint_script
     assert "agent-vault agent rotate" in mint_script
     assert "agent-vault vault agent add" in mint_script
     assert "agent-vault vault agent set-role" in mint_script
+    assert mint_script.index("agent-vault owner vault join") < mint_script.index("agent-vault agent create")
     assert "--role proxy > /dev/null 2>&1" not in mint_script
     assert ":proxy" in mint_script
     # The owner CLI session must not land on the shared token volume, or the


### PR DESCRIPTION
## Summary
- add an optional Agent Vault access-tool owner email env and wire the Helm chart from the existing `workers.kubernetes.agentVault.ownerEmail` value
- when `request_vault_access` grants a requester admin access, also keep that owner account admin on the same worker vault
- make Kubernetes worker init best-effort join the worker vault as the owner before minting/attaching the proxy-role agent token
- document the worker-init invariant and add tool, worker, Helm, and metadata regression coverage

## Why
Kubernetes worker init logs in as the configured Agent Vault owner account to mint and attach the proxy-role agent token. A self-service/user-created vault can otherwise exist without that owner account as a vault admin, which lets the UI grant path succeed but later leaves worker init unable to attach the proxy agent.

This keeps the user flow unchanged: users manage their own vault contents, while the configured runtime owner remains able to perform the internal token-mint/agent-attach step needed for the worker pod to start. Existing vaults can self-heal on the next worker init because the init script now runs `owner vault join` before token minting.

## Tests
- `uv run pytest tests/test_agent_vault_access_tool.py tests/test_helm_instance_worker_isolation.py::test_runtime_chart_agent_vault_access_tool_sets_owner_email tests/test_tools_metadata.py::test_export_tools_metadata_json -q`
- `uv run pytest tests/test_kubernetes_worker_backend.py::test_kubernetes_backend_adds_agent_vault_mint_init_container -q`
- `uv run ruff check src/mindroom/custom_tools/agent_vault_access.py src/mindroom/runtime_env_policy.py src/mindroom/tools/__init__.py tests/test_agent_vault_access_tool.py tests/test_helm_instance_worker_isolation.py`
- `uv run ruff check src/mindroom/workers/backends/kubernetes_resources.py tests/test_kubernetes_worker_backend.py`
- pre-commit on commit: ruff, ty, vulture, Tach boundaries, module privacy, tool extras sync

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agent Vault access tool now supports configurable owner email, maintaining the owner as an admin on worker vaults during self-service access grants.

* **Documentation**
  * Updated configuration guides and deployment documentation clarifying how owner email is used for vault provisioning and worker initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->