### PR TITLE
Add Agent Vault access grants

### DIFF
--- a/cluster/k8s/runtime/README.md
+++ b/cluster/k8s/runtime/README.md
@@ -379,7 +379,7 @@ If an email has not registered and verified in Agent Vault yet, the helper repor
 
 For `workerScope: shared`, `agent` is required and `requester` must be omitted.
 For `workerScope: user_agent`, both `requester` and `agent` are required.
-For `workerScope: user`, `requester` is required and `agent` is not used in the worker key.
+For `workerScope: user`, `requester` is required and `agent` must be omitted because the worker key is per-user, not per-agent.
 The initial supported role is `admin`.
 If your deployment sets `CUSTOMER_ID` or `ACCOUNT_ID` for tenant-specific worker keys, set `accessGrants.tenantId` or `accessGrants.accountId` to the same value.
 When `agentVault.bootstrap.enabled` is true, the bootstrap Job publishes the owner-role admin token Secret used by the access-grant Job.

--- a/cluster/k8s/runtime/README.md
+++ b/cluster/k8s/runtime/README.md
@@ -383,6 +383,7 @@ For `workerScope: user`, `requester` is required and `agent` must be omitted bec
 The initial supported role is `admin`.
 If your deployment sets `CUSTOMER_ID` or `ACCOUNT_ID` for tenant-specific worker keys, set `accessGrants.tenantId` or `accessGrants.accountId` to the same value.
 When `agentVault.bootstrap.enabled` is true, the bootstrap Job publishes the owner-role admin token Secret used by the access-grant Job.
+If `accessTool` and `accessGrants` use the same admin-token Secret name, configure the same key for both or use different Secret names.
 When bootstrap is disabled, provide `accessGrants.adminTokenSecret` yourself.
 
 Use `egressProxy` when another chart or platform layer already manages the proxy:

--- a/cluster/k8s/runtime/README.md
+++ b/cluster/k8s/runtime/README.md
@@ -329,6 +329,62 @@ Tokenless traffic egresses directly from Squid after the normal policy check.
 When `agentVault.accessTool.enabled` is set, self-service vault grants also keep `agentVault.ownerEmail` as an admin on each worker vault; the Kubernetes worker init container uses that owner account to mint and attach the proxy-role agent token.
 The chart rejects the unsafe default combination of chart-managed approved egress plus Agent Vault without `approvedEgress.parentProxy`, because that would be vault-first and break dynamic grants.
 
+### Agent Vault Access Grants
+
+Agent Vault has two separate access questions.
+Runtime use is controlled by MindRoom worker scope and tool authorization.
+Raw secret visibility is controlled by Agent Vault vault membership.
+
+Use `worker_scope: user` or `worker_scope: user_agent` when each requester should manage and use their own credentials.
+Those requester-isolated workers can use the self-service `agent_vault_access` tool to grant the requester admin access to their own worker vault.
+
+Use `worker_scope: shared` when a shared agent should use a common service credential.
+In that model, all users who can invoke credential-capable tools on that shared agent may indirectly use the credentials through the worker proxy path.
+Only trusted maintainers should receive Agent Vault admin access, because admin access lets them view, edit, and manage the raw secret values in the vault.
+Access grants do not restrict who can cause a shared worker to use credentials at runtime.
+
+Set `workers.kubernetes.agentVault.accessGrants` to declaratively grant vault admin access without deployment-specific inline scripts:
+
+```yaml
+workers:
+  backend: kubernetes
+  kubernetes:
+    agentVault:
+      enabled: true
+      cliImage: infisical/agent-vault:<pinned>
+      ownerEmail: owner@example.test
+      accessGrants:
+        enabled: true
+        grants:
+          - email: maintainer@example.com
+            workerScope: shared
+            agent: example-agent
+            role: admin
+          - email: user@example.com
+            workerScope: user_agent
+            requester: "@user:example.com"
+            agent: example-agent
+            role: admin
+          - email: user@example.com
+            workerScope: user
+            requester: "@user:example.com"
+            role: admin
+```
+
+The chart renders no access-grant resources by default.
+When access grants are enabled and at least one grant is configured, the chart renders a ConfigMap plus a post-install/post-upgrade Job that runs `python -m mindroom.agent_vault_access_grants apply` from the MindRoom image.
+The helper resolves worker keys and vault names through MindRoom's worker-routing code, creates or joins the vault when needed, and grants the configured email the `admin` role.
+The Job is idempotent and safe to rerun on each deploy.
+If an email has not registered and verified in Agent Vault yet, the helper reports a warning and the grant can be applied again after registration.
+
+For `workerScope: shared`, `agent` is required and `requester` must be omitted.
+For `workerScope: user_agent`, both `requester` and `agent` are required.
+For `workerScope: user`, `requester` is required and `agent` is not used in the worker key.
+The initial supported role is `admin`.
+If your deployment sets `CUSTOMER_ID` or `ACCOUNT_ID` for tenant-specific worker keys, set `accessGrants.tenantId` or `accessGrants.accountId` to the same value.
+When `agentVault.bootstrap.enabled` is true, the bootstrap Job publishes the owner-role admin token Secret used by the access-grant Job.
+When bootstrap is disabled, provide `accessGrants.adminTokenSecret` yourself.
+
 Use `egressProxy` when another chart or platform layer already manages the proxy:
 
 ```yaml

--- a/cluster/k8s/runtime/templates/_helpers.tpl
+++ b/cluster/k8s/runtime/templates/_helpers.tpl
@@ -482,11 +482,32 @@ app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 {{- printf "%s-bootstrap" (include "mindroom-runtime.agentVaultServerName" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "mindroom-runtime.agentVaultAccessGrantsName" -}}
+{{- printf "%s-access-grants" (include "mindroom-runtime.agentVaultServerName" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.agentVaultAccessGrantsConfigPath" -}}
+/etc/mindroom-agent-vault-access-grants/access-grants.yaml
+{{- end -}}
+
+{{- define "mindroom-runtime.agentVaultAccessGrantsTokenPath" -}}
+{{- printf "/etc/agent-vault-access-grants/%s" .Values.workers.kubernetes.agentVault.accessGrants.adminTokenSecret.key -}}
+{{- end -}}
+
 {{- define "mindroom-runtime.agentVaultBootstrapLabels" -}}
 helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | quote }}
 app.kubernetes.io/name: {{ include "mindroom-runtime.agentVaultBootstrapName" . | quote }}
 app.kubernetes.io/instance: {{ .Release.Name | quote }}
 app.kubernetes.io/component: agent-vault-bootstrap
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+{{- end -}}
+
+{{- define "mindroom-runtime.agentVaultAccessGrantsLabels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | quote }}
+app.kubernetes.io/name: {{ include "mindroom-runtime.agentVaultAccessGrantsName" . | quote }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+app.kubernetes.io/component: agent-vault-access-grants
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 {{- end -}}

--- a/cluster/k8s/runtime/templates/agent-vault-access-grants.yaml
+++ b/cluster/k8s/runtime/templates/agent-vault-access-grants.yaml
@@ -1,0 +1,89 @@
+{{- $av := .Values.workers.kubernetes.agentVault -}}
+{{- $accessGrants := $av.accessGrants -}}
+{{- if and $accessGrants.enabled (gt (len $accessGrants.grants) 0) }}
+{{- $name := include "mindroom-runtime.agentVaultAccessGrantsName" . -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "mindroom-runtime.agentVaultAccessGrantsLabels" . | nindent 4 }}
+data:
+  access-grants.yaml: |
+    apiUrl: {{ $av.apiUrl | quote }}
+    vaultNamePrefix: {{ $av.vaultNamePrefix | quote }}
+    {{- if $accessGrants.tenantId }}
+    tenantId: {{ $accessGrants.tenantId | quote }}
+    {{- end }}
+    {{- if $accessGrants.accountId }}
+    accountId: {{ $accessGrants.accountId | quote }}
+    {{- end }}
+    grants:
+      {{- range $grant := $accessGrants.grants }}
+      - email: {{ $grant.email | quote }}
+        workerScope: {{ $grant.workerScope | quote }}
+        {{- if $grant.requester }}
+        requester: {{ $grant.requester | quote }}
+        {{- end }}
+        {{- if $grant.agent }}
+        agent: {{ $grant.agent | quote }}
+        {{- end }}
+        role: {{ default "admin" $grant.role | quote }}
+      {{- end }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "mindroom-runtime.agentVaultAccessGrantsLabels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        {{- include "mindroom-runtime.agentVaultAccessGrantsLabels" . | nindent 8 }}
+    spec:
+      restartPolicy: OnFailure
+      automountServiceAccountToken: false
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: access-grants
+          image: {{ include "mindroom-runtime.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          command:
+            - python
+            - -m
+            - mindroom.agent_vault_access_grants
+            - apply
+            - --config
+            - {{ include "mindroom-runtime.agentVaultAccessGrantsConfigPath" . | quote }}
+            - --admin-token-file
+            - {{ include "mindroom-runtime.agentVaultAccessGrantsTokenPath" . | quote }}
+            - --wait-ready-seconds
+            - {{ $accessGrants.waitReadySeconds | quote }}
+          resources:
+            {{- toYaml $accessGrants.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: access-grants-config
+              mountPath: /etc/mindroom-agent-vault-access-grants
+              readOnly: true
+            - name: access-grants-admin-token
+              mountPath: /etc/agent-vault-access-grants
+              readOnly: true
+      volumes:
+        - name: access-grants-config
+          configMap:
+            name: {{ $name }}
+        - name: access-grants-admin-token
+          secret:
+            secretName: {{ $accessGrants.adminTokenSecret.name }}
+{{- end }}

--- a/cluster/k8s/runtime/templates/agent-vault-bootstrap.yaml
+++ b/cluster/k8s/runtime/templates/agent-vault-bootstrap.yaml
@@ -2,6 +2,9 @@
 {{- $av := .Values.workers.kubernetes.agentVault -}}
 {{- $bs := $av.bootstrap -}}
 {{- $accessTool := $av.accessTool -}}
+{{- $accessGrants := $av.accessGrants -}}
+{{- $accessGrantsHasGrants := and $accessGrants.enabled (gt (len $accessGrants.grants) 0) -}}
+{{- $accessAdminTokenEnabled := or $accessTool.enabled $accessGrantsHasGrants -}}
 {{- $name := include "mindroom-runtime.agentVaultBootstrapName" . -}}
 {{- /* Target the same vault API the workers use, so bootstrap also works
      against an externally managed Agent Vault (server.enabled=false). */ -}}
@@ -42,7 +45,7 @@ rules:
       - get
       - update
       - patch
-  {{- if $accessTool.enabled }}
+  {{- if $accessAdminTokenEnabled }}
   - apiGroups:
       - ""
     resources:
@@ -54,7 +57,12 @@ rules:
     resources:
       - secrets
     resourceNames:
+      {{- if $accessTool.enabled }}
       - {{ $accessTool.adminTokenSecret.name }}
+      {{- end }}
+      {{- if $accessGrantsHasGrants }}
+      - {{ $accessGrants.adminTokenSecret.name }}
+      {{- end }}
     verbs:
       - get
       - update
@@ -141,10 +149,10 @@ spec:
                 --allowed-domains "$AGENT_VAULT_ALLOWED_DOMAINS"
               agent-vault ca fetch --address "$addr" > /work/ca.pem
               test -s /work/ca.pem
-              {{- if $accessTool.enabled }}
-              # Owner-role agent for the agent_vault_access tool. Re-runs
-              # rotate the token; the control plane re-reads it from the
-              # mounted Secret per call, so rotation needs no restart.
+              {{- if $accessAdminTokenEnabled }}
+              # Owner-role agent for Agent Vault UI/admin access helpers. Re-runs
+              # rotate the token; callers read it from the mounted Secret per
+              # call or per Job run, so rotation needs no runtime restart.
               if ! agent-vault agent create {{ $accessTool.adminAgentName | quote }} \
                 --token-only > /work/access-admin-token; then
                 agent-vault agent rotate {{ $accessTool.adminAgentName | quote }} \
@@ -180,6 +188,11 @@ spec:
               {{- if $accessTool.enabled }}
               kubectl -n "$POD_NAMESPACE" create secret generic {{ $accessTool.adminTokenSecret.name }} \
                 --from-file={{ $accessTool.adminTokenSecret.key }}=/work/access-admin-token \
+                --dry-run=client -o yaml | kubectl apply -f -
+              {{- end }}
+              {{- if $accessGrantsHasGrants }}
+              kubectl -n "$POD_NAMESPACE" create secret generic {{ $accessGrants.adminTokenSecret.name }} \
+                --from-file={{ $accessGrants.adminTokenSecret.key }}=/work/access-admin-token \
                 --dry-run=client -o yaml | kubectl apply -f -
               {{- end }}
           env:

--- a/cluster/k8s/runtime/templates/validate.yaml
+++ b/cluster/k8s/runtime/templates/validate.yaml
@@ -251,6 +251,9 @@
 {{- if not $requester -}}
 {{- fail (printf "%s.requester is required for workerScope=user" $path) -}}
 {{- end -}}
+{{- if $agent -}}
+{{- fail (printf "%s.agent must be empty for workerScope=user" $path) -}}
+{{- end -}}
 {{- else if eq $scope "user_agent" -}}
 {{- if not $requester -}}
 {{- fail (printf "%s.requester is required for workerScope=user_agent" $path) -}}

--- a/cluster/k8s/runtime/templates/validate.yaml
+++ b/cluster/k8s/runtime/templates/validate.yaml
@@ -213,3 +213,51 @@
 {{- fail "workers.kubernetes.agentVault.accessTool.adminTokenSecret.name and .key must not be empty" -}}
 {{- end -}}
 {{- end -}}
+{{- $accessGrants := $agentVault.accessGrants -}}
+{{- if and $accessGrants.enabled (gt (len $accessGrants.grants) 0) -}}
+{{- if not $agentVault.enabled -}}
+{{- fail "workers.kubernetes.agentVault.accessGrants.enabled requires workers.kubernetes.agentVault.enabled=true when grants are configured" -}}
+{{- end -}}
+{{- if not (and (trim (default "" $accessGrants.adminTokenSecret.name)) (trim (default "" $accessGrants.adminTokenSecret.key))) -}}
+{{- fail "workers.kubernetes.agentVault.accessGrants.adminTokenSecret.name and .key must not be empty" -}}
+{{- end -}}
+{{- if and $agentVault.bootstrap.enabled (not (trim (default "" $agentVault.accessTool.adminAgentName))) -}}
+{{- fail "workers.kubernetes.agentVault.accessTool.adminAgentName must not be empty when accessGrants and bootstrap are enabled" -}}
+{{- end -}}
+{{- range $index, $grant := $accessGrants.grants -}}
+{{- $path := printf "workers.kubernetes.agentVault.accessGrants.grants[%d]" $index -}}
+{{- $email := trim (default "" $grant.email) -}}
+{{- $scope := trim (default "" $grant.workerScope) -}}
+{{- $role := trim (default "admin" $grant.role) -}}
+{{- $requester := trim (default "" $grant.requester) -}}
+{{- $agent := trim (default "" $grant.agent) -}}
+{{- if not $email -}}
+{{- fail (printf "%s.email is required" $path) -}}
+{{- end -}}
+{{- if not (has $scope (list "shared" "user" "user_agent")) -}}
+{{- fail (printf "%s.workerScope must be one of: shared, user, user_agent" $path) -}}
+{{- end -}}
+{{- if ne $role "admin" -}}
+{{- fail (printf "%s.role must be admin" $path) -}}
+{{- end -}}
+{{- if eq $scope "shared" -}}
+{{- if $requester -}}
+{{- fail (printf "%s.requester must be empty for workerScope=shared" $path) -}}
+{{- end -}}
+{{- if not $agent -}}
+{{- fail (printf "%s.agent is required for workerScope=shared" $path) -}}
+{{- end -}}
+{{- else if eq $scope "user" -}}
+{{- if not $requester -}}
+{{- fail (printf "%s.requester is required for workerScope=user" $path) -}}
+{{- end -}}
+{{- else if eq $scope "user_agent" -}}
+{{- if not $requester -}}
+{{- fail (printf "%s.requester is required for workerScope=user_agent" $path) -}}
+{{- end -}}
+{{- if not $agent -}}
+{{- fail (printf "%s.agent is required for workerScope=user_agent" $path) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/cluster/k8s/runtime/templates/validate.yaml
+++ b/cluster/k8s/runtime/templates/validate.yaml
@@ -224,6 +224,9 @@
 {{- if and $agentVault.bootstrap.enabled (not (trim (default "" $agentVault.accessTool.adminAgentName))) -}}
 {{- fail "workers.kubernetes.agentVault.accessTool.adminAgentName must not be empty when accessGrants and bootstrap are enabled" -}}
 {{- end -}}
+{{- if and $agentVault.bootstrap.enabled $agentVault.accessTool.enabled (eq (trim (default "" $agentVault.accessTool.adminTokenSecret.name)) (trim (default "" $accessGrants.adminTokenSecret.name))) (ne (trim (default "" $agentVault.accessTool.adminTokenSecret.key)) (trim (default "" $accessGrants.adminTokenSecret.key))) -}}
+{{- fail "workers.kubernetes.agentVault.accessTool.adminTokenSecret.key must match workers.kubernetes.agentVault.accessGrants.adminTokenSecret.key when both use the same Secret name" -}}
+{{- end -}}
 {{- range $index, $grant := $accessGrants.grants -}}
 {{- $path := printf "workers.kubernetes.agentVault.accessGrants.grants[%d]" $index -}}
 {{- $email := trim (default "" $grant.email) -}}

--- a/cluster/k8s/runtime/values.yaml
+++ b/cluster/k8s/runtime/values.yaml
@@ -490,6 +490,8 @@ workers:
         resources: {}
         # Each grant gives an email raw UI/admin access to the resolved worker
         # vault. Supported workerScope values are shared, user, and user_agent.
+        # For workerScope=user, omit agent; use workerScope=user_agent when the
+        # vault should be both requester- and agent-specific.
         # Supported role is admin.
         grants: []
         # Example:

--- a/cluster/k8s/runtime/values.yaml
+++ b/cluster/k8s/runtime/values.yaml
@@ -483,6 +483,8 @@ workers:
         # Existing Secret holding an owner/admin token for Agent Vault. When
         # bootstrap.enabled is true, the bootstrap Job publishes the same
         # owner-role token it uses for accessTool into this Secret too.
+        # If accessTool uses the same Secret name, use the same key or a
+        # different Secret name so bootstrap never applies one Secret twice.
         adminTokenSecret:
           name: agent-vault-access-admin
           key: token

--- a/cluster/k8s/runtime/values.yaml
+++ b/cluster/k8s/runtime/values.yaml
@@ -468,6 +468,45 @@ workers:
         adminTokenSecret:
           name: agent-vault-access-admin
           key: token
+      # Optional declarative Agent Vault UI/admin grants for worker vaults.
+      # This controls raw secret visibility and management only. It does not
+      # restrict which users may cause a shared agent to use credentials at
+      # runtime.
+      accessGrants:
+        enabled: false
+        # Optional tenant/account identifiers used in MindRoom worker-key
+        # derivation. Set these to the same values the runtime receives through
+        # CUSTOMER_ID or ACCOUNT_ID when your deployment uses tenant-specific
+        # worker keys. Leave empty for the runtime default tenant.
+        tenantId: ""
+        accountId: ""
+        # Existing Secret holding an owner/admin token for Agent Vault. When
+        # bootstrap.enabled is true, the bootstrap Job publishes the same
+        # owner-role token it uses for accessTool into this Secret too.
+        adminTokenSecret:
+          name: agent-vault-access-admin
+          key: token
+        waitReadySeconds: 180
+        resources: {}
+        # Each grant gives an email raw UI/admin access to the resolved worker
+        # vault. Supported workerScope values are shared, user, and user_agent.
+        # Supported role is admin.
+        grants: []
+        # Example:
+        # grants:
+        #   - email: user@example.com
+        #     workerScope: shared
+        #     agent: example-agent
+        #     role: admin
+        #   - email: user@example.com
+        #     workerScope: user_agent
+        #     requester: "@user:example.com"
+        #     agent: example-agent
+        #     role: admin
+        #   - email: user@example.com
+        #     workerScope: user
+        #     requester: "@user:example.com"
+        #     role: admin
 
 # Optional external HTTP proxy for dedicated Kubernetes workers.
 # This chart can point worker pods at an existing proxy Service and, when

--- a/src/mindroom/agent_vault_access_grants.py
+++ b/src/mindroom/agent_vault_access_grants.py
@@ -1,0 +1,495 @@
+"""Declarative Agent Vault UI/admin access grants.
+
+This module is intentionally deployment-neutral.
+Kubernetes charts and other operators can feed it structured grant config,
+while worker identity and vault-name derivation stay delegated to the same
+worker-routing helpers used by runtime tool execution.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal, NoReturn, cast
+from urllib.parse import quote, urljoin
+
+import httpx
+import yaml
+
+from mindroom.tool_system.worker_routing import (
+    ToolExecutionIdentity,
+    WorkerScope,
+    resolve_worker_target,
+    worker_id_for_key,
+)
+
+_DEFAULT_VAULT_NAME_PREFIX = "agent-vault"
+_HTTP_TIMEOUT_SECONDS = 15.0
+_SUPPORTED_WORKER_SCOPES = frozenset({"shared", "user", "user_agent"})
+_SUPPORTED_ROLES = frozenset({"admin"})
+_CONFIG_PATH = "/etc/mindroom-agent-vault-access-grants/access-grants.yaml"
+
+__all__ = [
+    "AgentVaultAccessGrant",
+    "AgentVaultAccessGrantApplyResult",
+    "AgentVaultAccessGrantError",
+    "AgentVaultAccessGrantsConfig",
+    "ResolvedAgentVaultAccessGrantTarget",
+    "apply_agent_vault_access_grants",
+    "main",
+    "resolve_agent_vault_access_grant_targets",
+    "wait_for_agent_vault_ready",
+]
+
+_GrantRole = Literal["admin"]
+_GrantOutcome = Literal["granted", "already_admin", "missing_account"]
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+class AgentVaultAccessGrantError(RuntimeError):
+    """Raised when access-grant configuration or application fails."""
+
+
+@dataclass(frozen=True)
+class AgentVaultAccessGrant:
+    """One declarative Agent Vault access grant."""
+
+    email: str
+    worker_scope: WorkerScope
+    role: _GrantRole
+    requester: str | None = None
+    agent: str | None = None
+
+
+@dataclass(frozen=True)
+class AgentVaultAccessGrantsConfig:
+    """Validated Agent Vault access-grant config."""
+
+    api_url: str
+    grants: tuple[AgentVaultAccessGrant, ...]
+    admin_token: str | None = None
+    admin_token_file: str | None = None
+    vault_name_prefix: str = _DEFAULT_VAULT_NAME_PREFIX
+    tenant_id: str | None = None
+    account_id: str | None = None
+
+    @classmethod
+    def from_file(cls, path: Path) -> AgentVaultAccessGrantsConfig:
+        """Load and validate access grants from a YAML file."""
+        try:
+            raw_config = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            msg = f"could not read Agent Vault access grants config {str(path)!r}: {exc}"
+            raise AgentVaultAccessGrantError(msg) from exc
+        try:
+            payload = yaml.safe_load(raw_config)
+        except yaml.YAMLError as exc:
+            msg = f"could not parse Agent Vault access grants config {str(path)!r}: {exc}"
+            raise AgentVaultAccessGrantError(msg) from exc
+        return cls.from_payload(payload, source=str(path))
+
+    @classmethod
+    def from_payload(
+        cls,
+        payload: object,
+        *,
+        source: str = "Agent Vault access grants config",
+    ) -> AgentVaultAccessGrantsConfig:
+        """Validate one decoded access-grants payload."""
+        if not isinstance(payload, dict):
+            msg = f"{source} must be a YAML object"
+            raise AgentVaultAccessGrantError(msg)
+
+        raw_payload = cast("dict[str, object]", payload)
+        api_url = _required_string(raw_payload, "apiUrl", "api_url", label="apiUrl")
+        raw_grants = raw_payload.get("grants", [])
+        if raw_grants is None:
+            raw_grants = []
+        if not isinstance(raw_grants, list):
+            msg = "grants must be a list"
+            raise AgentVaultAccessGrantError(msg)
+
+        grants = tuple(_parse_grant(item, index) for index, item in enumerate(raw_grants))
+        vault_name_prefix = _optional_string(
+            raw_payload,
+            "vaultNamePrefix",
+            "vault_name_prefix",
+            label="vaultNamePrefix",
+        )
+        return cls(
+            api_url=api_url,
+            admin_token=_optional_string(raw_payload, "adminToken", "admin_token", label="adminToken"),
+            admin_token_file=_optional_string(
+                raw_payload,
+                "adminTokenFile",
+                "admin_token_file",
+                label="adminTokenFile",
+            ),
+            vault_name_prefix=vault_name_prefix or _DEFAULT_VAULT_NAME_PREFIX,
+            tenant_id=_optional_string(raw_payload, "tenantId", "tenant_id", label="tenantId"),
+            account_id=_optional_string(raw_payload, "accountId", "account_id", label="accountId"),
+            grants=grants,
+        )
+
+
+@dataclass(frozen=True)
+class ResolvedAgentVaultAccessGrantTarget:
+    """One grant resolved to the worker key and vault name Agent Vault uses."""
+
+    grant: AgentVaultAccessGrant
+    worker_key: str
+    vault: str
+
+
+@dataclass(frozen=True)
+class AgentVaultAccessGrantApplyResult:
+    """Summary of one access-grant application run."""
+
+    applied: int
+    already_admin: int
+    warnings: tuple[str, ...]
+
+
+def resolve_agent_vault_access_grant_targets(
+    config: AgentVaultAccessGrantsConfig,
+) -> tuple[ResolvedAgentVaultAccessGrantTarget, ...]:
+    """Resolve configured grants to worker keys and Agent Vault vault names."""
+    return tuple(_resolve_grant_target(config, grant) for grant in config.grants)
+
+
+async def apply_agent_vault_access_grants(
+    config: AgentVaultAccessGrantsConfig,
+    *,
+    admin_token: str | None = None,
+    admin_token_file: str | None = None,
+) -> AgentVaultAccessGrantApplyResult:
+    """Apply declarative Agent Vault access grants idempotently."""
+    resolved_token = _resolve_admin_token(config, admin_token=admin_token, admin_token_file=admin_token_file)
+    client = _AgentVaultClient(config.api_url, resolved_token)
+    applied = 0
+    already_admin = 0
+    warnings: list[str] = []
+
+    for target in resolve_agent_vault_access_grant_targets(config):
+        await client.ensure_vault(target.vault)
+        await client.ensure_vault_admin(target.vault)
+        outcome = await client.grant_admin(target.vault, target.grant.email)
+        if outcome == "granted":
+            applied += 1
+        elif outcome == "already_admin":
+            already_admin += 1
+        else:
+            warnings.append(
+                f"{target.grant.email} does not have an Agent Vault account yet; "
+                "ask them to register and verify before rerunning this grant.",
+            )
+
+    return AgentVaultAccessGrantApplyResult(
+        applied=applied,
+        already_admin=already_admin,
+        warnings=tuple(warnings),
+    )
+
+
+async def wait_for_agent_vault_ready(api_url: str, *, timeout_seconds: int) -> None:
+    """Wait until the Agent Vault health endpoint is ready."""
+    if timeout_seconds <= 0:
+        return
+
+    deadline = time.monotonic() + timeout_seconds
+    last_error: str | None = None
+    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_SECONDS) as client:
+        while time.monotonic() < deadline:
+            try:
+                response = await client.get(urljoin(api_url.rstrip("/") + "/", "health"))
+            except httpx.HTTPError as exc:
+                last_error = str(exc)
+            else:
+                if response.status_code < 500:
+                    return
+                last_error = f"HTTP {response.status_code}"
+            await asyncio.sleep(2)
+
+    detail = f": {last_error}" if last_error else ""
+    msg = f"Agent Vault did not become ready within {timeout_seconds}s{detail}"
+    raise AgentVaultAccessGrantError(msg)
+
+
+class _AgentVaultClient:
+    """Small Agent Vault admin API client for idempotent grants."""
+
+    def __init__(self, api_url: str, token: str) -> None:
+        self._api_url = api_url
+        self._token = token
+
+    async def ensure_vault(self, vault: str) -> None:
+        response = await self._post("v1/vaults", {"name": vault})
+        if response.status_code in {200, 201, 409, 422}:
+            return
+        response.raise_for_status()
+
+    async def ensure_vault_admin(self, vault: str) -> None:
+        response = await self._post(f"v1/vaults/{quote(vault, safe='')}/join")
+        if response.status_code in {200, 201, 409}:
+            return
+        if response.status_code == 403:
+            msg = (
+                "the Agent Vault admin token cannot join this vault: /join is owner-only, "
+                "so the token must belong to an instance-owner agent or session."
+            )
+            raise AgentVaultAccessGrantError(msg)
+        response.raise_for_status()
+
+    async def grant_admin(self, vault: str, email: str) -> _GrantOutcome:
+        response = await self._post(
+            f"v1/vaults/{quote(vault, safe='')}/users",
+            {"email": email, "role": "admin"},
+        )
+        if response.status_code in {200, 201}:
+            return "granted"
+        if response.status_code in {409, 422}:
+            await self._set_admin_role(vault, email)
+            return "already_admin"
+        if response.status_code == 404:
+            return "missing_account"
+        return self._raise_api_error("granting vault admin access", response)
+
+    async def _set_admin_role(self, vault: str, email: str) -> None:
+        response = await self._post(
+            f"v1/vaults/{quote(vault, safe='')}/users/{quote(email, safe='')}/role",
+            {"role": "admin"},
+        )
+        if response.status_code in {200, 201, 204}:
+            return
+        self._raise_api_error("updating vault user role to admin", response)
+
+    async def _post(self, path: str, payload: dict[str, object] | None = None) -> httpx.Response:
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_SECONDS) as client:
+            return await client.post(
+                urljoin(self._api_url.rstrip("/") + "/", path),
+                headers={"Authorization": f"Bearer {self._token}", "Content-Type": "application/json"},
+                json=payload,
+            )
+
+    def _raise_api_error(self, action: str, response: httpx.Response) -> NoReturn:
+        detail = f"Agent Vault API returned {response.status_code} while {action}"
+        body = response.text.strip()
+        if body:
+            detail = f"{detail}: {body}"
+        raise AgentVaultAccessGrantError(detail)
+
+
+def _resolve_grant_target(
+    config: AgentVaultAccessGrantsConfig,
+    grant: AgentVaultAccessGrant,
+) -> ResolvedAgentVaultAccessGrantTarget:
+    agent_name = grant.agent or "default"
+    identity = ToolExecutionIdentity(
+        channel="matrix",
+        agent_name=agent_name,
+        requester_id=grant.requester,
+        room_id=None,
+        thread_id=None,
+        resolved_thread_id=None,
+        session_id=None,
+        tenant_id=config.tenant_id,
+        account_id=config.account_id,
+    )
+    target = resolve_worker_target(
+        grant.worker_scope,
+        grant.agent,
+        execution_identity=identity,
+        tenant_id=config.tenant_id,
+        account_id=config.account_id,
+    )
+    if target.worker_key is None:
+        msg = f"could not resolve worker key for {grant.worker_scope} grant to {grant.email}"
+        raise AgentVaultAccessGrantError(msg)
+    return ResolvedAgentVaultAccessGrantTarget(
+        grant=grant,
+        worker_key=target.worker_key,
+        vault=worker_id_for_key(target.worker_key, prefix=config.vault_name_prefix),
+    )
+
+
+def _parse_grant(payload: object, index: int) -> AgentVaultAccessGrant:
+    label = f"grants[{index}]"
+    if not isinstance(payload, dict):
+        msg = f"{label} must be an object"
+        raise AgentVaultAccessGrantError(msg)
+    raw_payload = cast("dict[str, object]", payload)
+    email = _required_string(raw_payload, "email", label=f"{label}.email")
+    worker_scope = _parse_worker_scope(
+        _required_string(raw_payload, "workerScope", "worker_scope", label=f"{label}.workerScope"),
+        label=f"{label}.workerScope",
+    )
+    role = _parse_role(
+        _optional_string(raw_payload, "role", label=f"{label}.role") or "admin",
+        label=f"{label}.role",
+    )
+    requester = _optional_string(raw_payload, "requester", label=f"{label}.requester")
+    agent = _optional_string(raw_payload, "agent", label=f"{label}.agent")
+
+    if worker_scope == "shared":
+        if requester is not None:
+            msg = "shared grants must not set requester"
+            raise AgentVaultAccessGrantError(msg)
+        if agent is None:
+            msg = "shared grants require agent"
+            raise AgentVaultAccessGrantError(msg)
+    elif worker_scope == "user":
+        if requester is None:
+            msg = "user grants require requester"
+            raise AgentVaultAccessGrantError(msg)
+    elif worker_scope == "user_agent":
+        if requester is None:
+            msg = "user_agent grants require requester"
+            raise AgentVaultAccessGrantError(msg)
+        if agent is None:
+            msg = "user_agent grants require agent"
+            raise AgentVaultAccessGrantError(msg)
+
+    return AgentVaultAccessGrant(
+        email=email,
+        worker_scope=worker_scope,
+        role=role,
+        requester=requester,
+        agent=agent,
+    )
+
+
+def _parse_worker_scope(value: str, *, label: str) -> WorkerScope:
+    if value not in _SUPPORTED_WORKER_SCOPES:
+        msg = f"{label} must be one of: shared, user, user_agent"
+        raise AgentVaultAccessGrantError(msg)
+    return cast("WorkerScope", value)
+
+
+def _parse_role(value: str, *, label: str) -> _GrantRole:
+    if value not in _SUPPORTED_ROLES:
+        msg = f"{label} must be admin"
+        raise AgentVaultAccessGrantError(msg)
+    return cast("_GrantRole", value)
+
+
+def _required_string(payload: dict[str, object], *keys: str, label: str) -> str:
+    value = _optional_string(payload, *keys, label=label)
+    if value is None:
+        msg = f"{label} is required"
+        raise AgentVaultAccessGrantError(msg)
+    return value
+
+
+def _optional_string(payload: dict[str, object], *keys: str, label: str) -> str | None:
+    for key in keys:
+        if key not in payload:
+            continue
+        value = payload[key]
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            msg = f"{label} must be a string"
+            raise AgentVaultAccessGrantError(msg)
+        stripped = value.strip()
+        return stripped or None
+    return None
+
+
+def _resolve_admin_token(
+    config: AgentVaultAccessGrantsConfig,
+    *,
+    admin_token: str | None,
+    admin_token_file: str | None,
+) -> str:
+    token_file = admin_token_file or config.admin_token_file
+    if token_file:
+        try:
+            token = Path(token_file).read_text(encoding="utf-8").strip()
+        except OSError as exc:
+            msg = f"could not read the Agent Vault admin token file {token_file!r}: {exc}"
+            raise AgentVaultAccessGrantError(msg) from exc
+        if not token:
+            msg = f"the Agent Vault admin token file {token_file!r} is empty"
+            raise AgentVaultAccessGrantError(msg)
+        return token
+
+    token = (admin_token or config.admin_token or "").strip()
+    if not token:
+        msg = "Agent Vault access grants require adminToken or adminTokenFile"
+        raise AgentVaultAccessGrantError(msg)
+    return token
+
+
+async def _apply_from_args(args: argparse.Namespace) -> AgentVaultAccessGrantApplyResult:
+    config = AgentVaultAccessGrantsConfig.from_file(args.config)
+    await wait_for_agent_vault_ready(config.api_url, timeout_seconds=args.wait_ready_seconds)
+    return await apply_agent_vault_access_grants(
+        config,
+        admin_token=args.admin_token,
+        admin_token_file=args.admin_token_file,
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m mindroom.agent_vault_access_grants")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    apply_parser = subparsers.add_parser("apply", help="Apply Agent Vault access grants")
+    apply_parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path(_CONFIG_PATH),
+        help="YAML access-grants config path",
+    )
+    apply_parser.add_argument(
+        "--admin-token-file",
+        default=None,
+        help="File containing an Agent Vault owner/admin token",
+    )
+    apply_parser.add_argument(
+        "--admin-token",
+        default=None,
+        help="Agent Vault owner/admin token. Prefer --admin-token-file in deployments.",
+    )
+    apply_parser.add_argument(
+        "--wait-ready-seconds",
+        type=int,
+        default=0,
+        help="Wait for Agent Vault /health before applying grants",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entrypoint for Agent Vault access grants."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if args.command != "apply":
+        parser.error("unknown command")
+
+    try:
+        result = asyncio.run(_apply_from_args(args))
+    except AgentVaultAccessGrantError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    except httpx.HTTPError as exc:
+        print(f"error: Agent Vault API request failed: {exc}", file=sys.stderr)
+        return 1
+
+    for warning in result.warnings:
+        print(f"warning: {warning}", file=sys.stderr)
+    print(
+        "Agent Vault access grants applied: "
+        f"granted={result.applied} already_admin={result.already_admin} warnings={len(result.warnings)}",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/mindroom/agent_vault_access_grants.py
+++ b/src/mindroom/agent_vault_access_grants.py
@@ -171,24 +171,25 @@ async def apply_agent_vault_access_grants(
 ) -> AgentVaultAccessGrantApplyResult:
     """Apply declarative Agent Vault access grants idempotently."""
     resolved_token = _resolve_admin_token(config, admin_token=admin_token, admin_token_file=admin_token_file)
-    client = _AgentVaultClient(config.api_url, resolved_token)
     applied = 0
     already_admin = 0
     warnings: list[str] = []
 
-    for target in resolve_agent_vault_access_grant_targets(config):
-        await client.ensure_vault(target.vault)
-        await client.ensure_vault_admin(target.vault)
-        outcome = await client.grant_admin(target.vault, target.grant.email)
-        if outcome == "granted":
-            applied += 1
-        elif outcome == "already_admin":
-            already_admin += 1
-        else:
-            warnings.append(
-                f"{target.grant.email} does not have an Agent Vault account yet; "
-                "ask them to register and verify before rerunning this grant.",
-            )
+    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_SECONDS) as http_client:
+        client = _AgentVaultClient(config.api_url, resolved_token, http_client)
+        for target in resolve_agent_vault_access_grant_targets(config):
+            await client.ensure_vault(target.vault)
+            await client.ensure_vault_admin(target.vault)
+            outcome = await client.grant_admin(target.vault, target.grant.email)
+            if outcome == "granted":
+                applied += 1
+            elif outcome == "already_admin":
+                already_admin += 1
+            else:
+                warnings.append(
+                    f"{target.grant.email} does not have an Agent Vault account yet; "
+                    "ask them to register and verify before rerunning this grant.",
+                )
 
     return AgentVaultAccessGrantApplyResult(
         applied=applied,
@@ -197,7 +198,7 @@ async def apply_agent_vault_access_grants(
     )
 
 
-async def wait_for_agent_vault_ready(api_url: str, *, timeout_seconds: int) -> None:
+async def wait_for_agent_vault_ready(api_url: str, *, timeout_seconds: float) -> None:
     """Wait until the Agent Vault health endpoint is ready."""
     if timeout_seconds <= 0:
         return
@@ -211,7 +212,7 @@ async def wait_for_agent_vault_ready(api_url: str, *, timeout_seconds: int) -> N
             except httpx.HTTPError as exc:
                 last_error = str(exc)
             else:
-                if response.status_code < 500:
+                if 200 <= response.status_code < 300:
                     return
                 last_error = f"HTTP {response.status_code}"
             await asyncio.sleep(2)
@@ -224,9 +225,10 @@ async def wait_for_agent_vault_ready(api_url: str, *, timeout_seconds: int) -> N
 class _AgentVaultClient:
     """Small Agent Vault admin API client for idempotent grants."""
 
-    def __init__(self, api_url: str, token: str) -> None:
+    def __init__(self, api_url: str, token: str, client: httpx.AsyncClient) -> None:
         self._api_url = api_url
         self._token = token
+        self._client = client
 
     async def ensure_vault(self, vault: str) -> None:
         response = await self._post("v1/vaults", {"name": vault})
@@ -255,7 +257,7 @@ class _AgentVaultClient:
             return "granted"
         if response.status_code in {409, 422}:
             await self._set_admin_role(vault, email)
-            return "already_admin"
+            return "granted"
         if response.status_code == 404:
             return "missing_account"
         return self._raise_api_error("granting vault admin access", response)
@@ -270,12 +272,11 @@ class _AgentVaultClient:
         self._raise_api_error("updating vault user role to admin", response)
 
     async def _post(self, path: str, payload: dict[str, object] | None = None) -> httpx.Response:
-        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_SECONDS) as client:
-            return await client.post(
-                urljoin(self._api_url.rstrip("/") + "/", path),
-                headers={"Authorization": f"Bearer {self._token}", "Content-Type": "application/json"},
-                json=payload,
-            )
+        return await self._client.post(
+            urljoin(self._api_url.rstrip("/") + "/", path),
+            headers={"Authorization": f"Bearer {self._token}", "Content-Type": "application/json"},
+            json=payload,
+        )
 
     def _raise_api_error(self, action: str, response: httpx.Response) -> NoReturn:
         detail = f"Agent Vault API returned {response.status_code} while {action}"
@@ -412,10 +413,10 @@ def _resolve_admin_token(
         try:
             token = Path(token_file).read_text(encoding="utf-8").strip()
         except OSError as exc:
-            msg = f"could not read the Agent Vault admin token file {token_file!r}: {exc}"
+            msg = f"could not read adminTokenFile {token_file!r}: {exc}"
             raise AgentVaultAccessGrantError(msg) from exc
         if not token:
-            msg = f"the Agent Vault admin token file {token_file!r} is empty"
+            msg = f"adminTokenFile {token_file!r} is empty"
             raise AgentVaultAccessGrantError(msg)
         return token
 

--- a/src/mindroom/agent_vault_access_grants.py
+++ b/src/mindroom/agent_vault_access_grants.py
@@ -46,7 +46,7 @@ __all__ = [
 ]
 
 _GrantRole = Literal["admin"]
-_GrantOutcome = Literal["granted", "already_admin", "missing_account"]
+_GrantOutcome = Literal["granted", "missing_account"]
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -152,7 +152,6 @@ class AgentVaultAccessGrantApplyResult:
     """Summary of one access-grant application run."""
 
     applied: int
-    already_admin: int
     warnings: tuple[str, ...]
 
 
@@ -172,7 +171,6 @@ async def apply_agent_vault_access_grants(
     """Apply declarative Agent Vault access grants idempotently."""
     resolved_token = _resolve_admin_token(config, admin_token=admin_token, admin_token_file=admin_token_file)
     applied = 0
-    already_admin = 0
     warnings: list[str] = []
 
     async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_SECONDS) as http_client:
@@ -183,8 +181,6 @@ async def apply_agent_vault_access_grants(
             outcome = await client.grant_admin(target.vault, target.grant.email)
             if outcome == "granted":
                 applied += 1
-            elif outcome == "already_admin":
-                already_admin += 1
             else:
                 warnings.append(
                     f"{target.grant.email} does not have an Agent Vault account yet; "
@@ -193,7 +189,6 @@ async def apply_agent_vault_access_grants(
 
     return AgentVaultAccessGrantApplyResult(
         applied=applied,
-        already_admin=already_admin,
         warnings=tuple(warnings),
     )
 
@@ -272,11 +267,13 @@ class _AgentVaultClient:
         self._raise_api_error("updating vault user role to admin", response)
 
     async def _post(self, path: str, payload: dict[str, object] | None = None) -> httpx.Response:
-        return await self._client.post(
-            urljoin(self._api_url.rstrip("/") + "/", path),
-            headers={"Authorization": f"Bearer {self._token}", "Content-Type": "application/json"},
-            json=payload,
-        )
+        headers = {"Authorization": f"Bearer {self._token}"}
+        url = urljoin(self._api_url.rstrip("/") + "/", path)
+        if payload is None:
+            return await self._client.post(url, headers=headers)
+
+        headers["Content-Type"] = "application/json"
+        return await self._client.post(url, headers=headers, json=payload)
 
     def _raise_api_error(self, action: str, response: httpx.Response) -> NoReturn:
         detail = f"Agent Vault API returned {response.status_code} while {action}"
@@ -337,6 +334,18 @@ def _parse_grant(payload: object, index: int) -> AgentVaultAccessGrant:
     requester = _optional_string(raw_payload, "requester", label=f"{label}.requester")
     agent = _optional_string(raw_payload, "agent", label=f"{label}.agent")
 
+    _validate_grant_scope_fields(worker_scope, requester=requester, agent=agent)
+
+    return AgentVaultAccessGrant(
+        email=email,
+        worker_scope=worker_scope,
+        role=role,
+        requester=requester,
+        agent=agent,
+    )
+
+
+def _validate_grant_scope_fields(worker_scope: WorkerScope, *, requester: str | None, agent: str | None) -> None:
     if worker_scope == "shared":
         if requester is not None:
             msg = "shared grants must not set requester"
@@ -348,6 +357,9 @@ def _parse_grant(payload: object, index: int) -> AgentVaultAccessGrant:
         if requester is None:
             msg = "user grants require requester"
             raise AgentVaultAccessGrantError(msg)
+        if agent is not None:
+            msg = "user grants must not set agent"
+            raise AgentVaultAccessGrantError(msg)
     elif worker_scope == "user_agent":
         if requester is None:
             msg = "user_agent grants require requester"
@@ -355,14 +367,6 @@ def _parse_grant(payload: object, index: int) -> AgentVaultAccessGrant:
         if agent is None:
             msg = "user_agent grants require agent"
             raise AgentVaultAccessGrantError(msg)
-
-    return AgentVaultAccessGrant(
-        email=email,
-        worker_scope=worker_scope,
-        role=role,
-        requester=requester,
-        agent=agent,
-    )
 
 
 def _parse_worker_scope(value: str, *, label: str) -> WorkerScope:
@@ -486,8 +490,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     for warning in result.warnings:
         print(f"warning: {warning}", file=sys.stderr)
     print(
-        "Agent Vault access grants applied: "
-        f"granted={result.applied} already_admin={result.already_admin} warnings={len(result.warnings)}",
+        f"Agent Vault access grants applied: granted={result.applied} warnings={len(result.warnings)}",
     )
     return 0
 

--- a/tests/test_agent_vault_access_grants.py
+++ b/tests/test_agent_vault_access_grants.py
@@ -14,6 +14,7 @@ from mindroom.agent_vault_access_grants import (
     AgentVaultAccessGrantsConfig,
     apply_agent_vault_access_grants,
     resolve_agent_vault_access_grant_targets,
+    wait_for_agent_vault_ready,
 )
 from mindroom.tool_system.worker_routing import ToolExecutionIdentity, resolve_worker_target, worker_id_for_key
 
@@ -181,6 +182,44 @@ async def test_apply_grants_creates_joins_and_grants_admin(
 
 
 @pytest.mark.asyncio
+async def test_apply_grants_counts_existing_member_role_updates_as_applied(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Existing members are still counted as applied when their role is ensured as admin."""
+    path = _config_path(
+        tmp_path,
+        {
+            "apiUrl": "http://agent-vault:14321",
+            "adminToken": "owner-token",
+            "grants": [
+                {
+                    "email": "maintainer@example.test",
+                    "workerScope": "shared",
+                    "agent": "example-agent",
+                    "role": "admin",
+                },
+            ],
+        },
+    )
+    config = AgentVaultAccessGrantsConfig.from_file(path)
+    target = resolve_agent_vault_access_grant_targets(config)[0]
+    api = _FakeVaultAPI({"/v1/vaults": 409, "/join": 409, "/users": 409, "/role": 200})
+    _patch_client(monkeypatch, api)
+
+    result = await apply_agent_vault_access_grants(config)
+
+    assert result.applied == 1
+    assert result.already_admin == 0
+    assert [path for path, _ in api.calls] == [
+        "/v1/vaults",
+        f"/v1/vaults/{target.vault}/join",
+        f"/v1/vaults/{target.vault}/users",
+        f"/v1/vaults/{target.vault}/users/maintainer@example.test/role",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_apply_grants_warns_for_unregistered_account(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -209,6 +248,146 @@ async def test_apply_grants_warns_for_unregistered_account(
     assert result.applied == 0
     assert len(result.warnings) == 1
     assert "missing@example.test does not have an Agent Vault account" in result.warnings[0]
+
+
+@pytest.mark.asyncio
+async def test_apply_grants_uses_config_admin_token_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AdminTokenFile from config is preferred over inline config tokens."""
+    token_file = tmp_path / "admin-token"
+    token_file.write_text("file-token\n", encoding="utf-8")
+    path = _config_path(
+        tmp_path,
+        {
+            "apiUrl": "http://agent-vault:14321",
+            "adminToken": "ignored-token",
+            "adminTokenFile": str(token_file),
+            "grants": [
+                {
+                    "email": "maintainer@example.test",
+                    "workerScope": "shared",
+                    "agent": "example-agent",
+                    "role": "admin",
+                },
+            ],
+        },
+    )
+    api = _FakeVaultAPI({"/v1/vaults": 201, "/join": 200, "/users": 201})
+    _patch_client(monkeypatch, api)
+
+    await apply_agent_vault_access_grants(AgentVaultAccessGrantsConfig.from_file(path))
+
+    assert api.auth_headers == ["Bearer file-token", "Bearer file-token", "Bearer file-token"]
+
+
+@pytest.mark.asyncio
+async def test_apply_grants_explicit_admin_token_file_overrides_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CLI-provided admin token file wins over the config token file."""
+    config_token_file = tmp_path / "config-admin-token"
+    config_token_file.write_text("config-token\n", encoding="utf-8")
+    override_token_file = tmp_path / "override-admin-token"
+    override_token_file.write_text("override-token\n", encoding="utf-8")
+    path = _config_path(
+        tmp_path,
+        {
+            "apiUrl": "http://agent-vault:14321",
+            "adminTokenFile": str(config_token_file),
+            "grants": [
+                {
+                    "email": "maintainer@example.test",
+                    "workerScope": "shared",
+                    "agent": "example-agent",
+                    "role": "admin",
+                },
+            ],
+        },
+    )
+    api = _FakeVaultAPI({"/v1/vaults": 201, "/join": 200, "/users": 201})
+    _patch_client(monkeypatch, api)
+
+    await apply_agent_vault_access_grants(
+        AgentVaultAccessGrantsConfig.from_file(path),
+        admin_token_file=str(override_token_file),
+    )
+
+    assert api.auth_headers == ["Bearer override-token", "Bearer override-token", "Bearer override-token"]
+
+
+@pytest.mark.asyncio
+async def test_apply_grants_rejects_missing_admin_token_file(tmp_path: Path) -> None:
+    """Missing adminTokenFile fails before any Agent Vault API call."""
+    config = AgentVaultAccessGrantsConfig.from_payload(
+        {
+            "apiUrl": "http://agent-vault:14321",
+            "adminTokenFile": str(tmp_path / "missing-token"),
+            "grants": [],
+        },
+    )
+
+    with pytest.raises(AgentVaultAccessGrantError, match="could not read adminTokenFile"):
+        await apply_agent_vault_access_grants(config)
+
+
+@pytest.mark.asyncio
+async def test_apply_grants_rejects_empty_admin_token_file(tmp_path: Path) -> None:
+    """Empty adminTokenFile fails before any Agent Vault API call."""
+    token_file = tmp_path / "empty-token"
+    token_file.write_text("", encoding="utf-8")
+    config = AgentVaultAccessGrantsConfig.from_payload(
+        {
+            "apiUrl": "http://agent-vault:14321",
+            "adminTokenFile": str(token_file),
+            "grants": [],
+        },
+    )
+
+    with pytest.raises(AgentVaultAccessGrantError, match=r"adminTokenFile .* is empty"):
+        await apply_agent_vault_access_grants(config)
+
+
+@pytest.mark.asyncio
+async def test_apply_grants_requires_admin_token_or_file() -> None:
+    """Access grants require some owner/admin token source."""
+    config = AgentVaultAccessGrantsConfig.from_payload(
+        {
+            "apiUrl": "http://agent-vault:14321",
+            "grants": [],
+        },
+    )
+
+    with pytest.raises(AgentVaultAccessGrantError, match="adminToken or adminTokenFile"):
+        await apply_agent_vault_access_grants(config)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_agent_vault_ready_accepts_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 2xx health response marks Agent Vault as ready."""
+    api = _FakeVaultAPI({"/health": 204})
+    _patch_client(monkeypatch, api)
+
+    await wait_for_agent_vault_ready("http://agent-vault:14321", timeout_seconds=1)
+
+    assert [path for path, _ in api.calls] == ["/health"]
+
+
+@pytest.mark.asyncio
+async def test_wait_for_agent_vault_ready_rejects_client_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 4xx health response should not be treated as readiness."""
+    api = _FakeVaultAPI({"/health": 404})
+    _patch_client(monkeypatch, api)
+
+    async def sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr("mindroom.agent_vault_access_grants.asyncio.sleep", sleep)
+
+    with pytest.raises(AgentVaultAccessGrantError, match="HTTP 404"):
+        await wait_for_agent_vault_ready("http://agent-vault:14321", timeout_seconds=0.001)
 
 
 def test_config_rejects_shared_requester(tmp_path: Path) -> None:

--- a/tests/test_agent_vault_access_grants.py
+++ b/tests/test_agent_vault_access_grants.py
@@ -1,0 +1,278 @@
+"""Tests for declarative Agent Vault access grants."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+import yaml
+
+from mindroom.agent_vault_access_grants import (
+    AgentVaultAccessGrantError,
+    AgentVaultAccessGrantsConfig,
+    apply_agent_vault_access_grants,
+    resolve_agent_vault_access_grant_targets,
+)
+from mindroom.tool_system.worker_routing import ToolExecutionIdentity, resolve_worker_target, worker_id_for_key
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class _FakeVaultAPI:
+    """Records POSTs and returns scripted responses keyed by path suffix."""
+
+    def __init__(self, responses: dict[str, int]) -> None:
+        self.responses = responses
+        self.calls: list[tuple[str, dict[str, object]]] = []
+        self.auth_headers: list[str] = []
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        body = json.loads(request.content.decode()) if request.content else {}
+        self.calls.append((path, body))
+        self.auth_headers.append(request.headers.get("authorization", ""))
+        for suffix, status in self.responses.items():
+            if path.endswith(suffix):
+                payload = {"name": body.get("name", "")} if status < 300 else {"error": "scripted"}
+                return httpx.Response(status, json=payload)
+        return httpx.Response(500, json={"error": "unexpected path"})
+
+
+def _patch_client(monkeypatch: pytest.MonkeyPatch, api: _FakeVaultAPI) -> None:
+    transport = httpx.MockTransport(api.handler)
+    real_async_client = httpx.AsyncClient
+
+    def factory(**kwargs: object) -> httpx.AsyncClient:
+        kwargs.pop("timeout", None)
+        return real_async_client(transport=transport)
+
+    monkeypatch.setattr(httpx, "AsyncClient", factory)
+
+
+def _config_path(tmp_path: Path, data: dict[str, object]) -> Path:
+    path = tmp_path / "agent-vault-access-grants.yaml"
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+    return path
+
+
+def test_resolves_shared_grant_to_runtime_worker_vault(tmp_path: Path) -> None:
+    """Shared grants use the same worker key and vault-name derivation as runtime routing."""
+    path = _config_path(
+        tmp_path,
+        {
+            "apiUrl": "http://agent-vault:14321",
+            "adminToken": "owner-token",
+            "vaultNamePrefix": "agent-vault",
+            "tenantId": "tenant-42",
+            "grants": [
+                {
+                    "email": "maintainer@example.test",
+                    "workerScope": "shared",
+                    "agent": "example-agent",
+                    "role": "admin",
+                },
+            ],
+        },
+    )
+    config = AgentVaultAccessGrantsConfig.from_file(path)
+
+    target = resolve_agent_vault_access_grant_targets(config)[0]
+    expected_worker_target = resolve_worker_target(
+        "shared",
+        "example-agent",
+        execution_identity=ToolExecutionIdentity(
+            channel="matrix",
+            agent_name="example-agent",
+            requester_id=None,
+            room_id=None,
+            thread_id=None,
+            resolved_thread_id=None,
+            session_id=None,
+            tenant_id="tenant-42",
+        ),
+    )
+
+    assert target.worker_key == expected_worker_target.worker_key
+    assert target.vault == worker_id_for_key(expected_worker_target.worker_key, prefix="agent-vault")
+
+
+def test_resolves_user_agent_grant_to_runtime_worker_vault(tmp_path: Path) -> None:
+    """User-agent grants include both requester and agent in the worker identity."""
+    path = _config_path(
+        tmp_path,
+        {
+            "apiUrl": "http://agent-vault:14321",
+            "adminToken": "owner-token",
+            "vaultNamePrefix": "agent-vault",
+            "grants": [
+                {
+                    "email": "user@example.test",
+                    "workerScope": "user_agent",
+                    "requester": "@user:example.test",
+                    "agent": "example-agent",
+                    "role": "admin",
+                },
+            ],
+        },
+    )
+    config = AgentVaultAccessGrantsConfig.from_file(path)
+
+    target = resolve_agent_vault_access_grant_targets(config)[0]
+    expected_worker_target = resolve_worker_target(
+        "user_agent",
+        "example-agent",
+        execution_identity=ToolExecutionIdentity(
+            channel="matrix",
+            agent_name="example-agent",
+            requester_id="@user:example.test",
+            room_id=None,
+            thread_id=None,
+            resolved_thread_id=None,
+            session_id=None,
+            tenant_id=None,
+        ),
+    )
+
+    assert target.worker_key == expected_worker_target.worker_key
+    assert target.vault == worker_id_for_key(expected_worker_target.worker_key, prefix="agent-vault")
+
+
+@pytest.mark.asyncio
+async def test_apply_grants_creates_joins_and_grants_admin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Applying a grant creates/joins the vault and adds the configured admin."""
+    path = _config_path(
+        tmp_path,
+        {
+            "apiUrl": "http://agent-vault:14321",
+            "adminToken": "owner-token",
+            "vaultNamePrefix": "agent-vault",
+            "grants": [
+                {
+                    "email": "maintainer@example.test",
+                    "workerScope": "shared",
+                    "agent": "example-agent",
+                    "role": "admin",
+                },
+            ],
+        },
+    )
+    config = AgentVaultAccessGrantsConfig.from_file(path)
+    target = resolve_agent_vault_access_grant_targets(config)[0]
+    api = _FakeVaultAPI({"/v1/vaults": 201, "/join": 200, "/users": 201})
+    _patch_client(monkeypatch, api)
+
+    result = await apply_agent_vault_access_grants(config)
+
+    assert result.applied == 1
+    assert not result.warnings
+    assert [path for path, _ in api.calls] == [
+        "/v1/vaults",
+        f"/v1/vaults/{target.vault}/join",
+        f"/v1/vaults/{target.vault}/users",
+    ]
+    assert api.calls[-1][1] == {"email": "maintainer@example.test", "role": "admin"}
+    assert api.auth_headers == ["Bearer owner-token", "Bearer owner-token", "Bearer owner-token"]
+
+
+@pytest.mark.asyncio
+async def test_apply_grants_warns_for_unregistered_account(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unregistered Agent Vault users are reported as warnings, not deploy failures."""
+    path = _config_path(
+        tmp_path,
+        {
+            "apiUrl": "http://agent-vault:14321",
+            "adminToken": "owner-token",
+            "grants": [
+                {
+                    "email": "missing@example.test",
+                    "workerScope": "shared",
+                    "agent": "example-agent",
+                    "role": "admin",
+                },
+            ],
+        },
+    )
+    api = _FakeVaultAPI({"/v1/vaults": 409, "/join": 409, "/users": 404})
+    _patch_client(monkeypatch, api)
+
+    result = await apply_agent_vault_access_grants(AgentVaultAccessGrantsConfig.from_file(path))
+
+    assert result.applied == 0
+    assert len(result.warnings) == 1
+    assert "missing@example.test does not have an Agent Vault account" in result.warnings[0]
+
+
+def test_config_rejects_shared_requester(tmp_path: Path) -> None:
+    """Shared worker grants are not requester-specific."""
+    path = _config_path(
+        tmp_path,
+        {
+            "apiUrl": "http://agent-vault:14321",
+            "adminToken": "owner-token",
+            "grants": [
+                {
+                    "email": "maintainer@example.test",
+                    "workerScope": "shared",
+                    "requester": "@user:example.test",
+                    "agent": "example-agent",
+                    "role": "admin",
+                },
+            ],
+        },
+    )
+
+    with pytest.raises(AgentVaultAccessGrantError, match="shared grants must not set requester"):
+        AgentVaultAccessGrantsConfig.from_file(path)
+
+
+def test_config_rejects_user_agent_without_requester(tmp_path: Path) -> None:
+    """User-agent worker grants need the requester that contributes to the worker key."""
+    path = _config_path(
+        tmp_path,
+        {
+            "apiUrl": "http://agent-vault:14321",
+            "adminToken": "owner-token",
+            "grants": [
+                {
+                    "email": "user@example.test",
+                    "workerScope": "user_agent",
+                    "agent": "example-agent",
+                    "role": "admin",
+                },
+            ],
+        },
+    )
+
+    with pytest.raises(AgentVaultAccessGrantError, match="user_agent grants require requester"):
+        AgentVaultAccessGrantsConfig.from_file(path)
+
+
+def test_config_rejects_unsupported_role(tmp_path: Path) -> None:
+    """The first implementation only supports Agent Vault admin grants."""
+    path = _config_path(
+        tmp_path,
+        {
+            "apiUrl": "http://agent-vault:14321",
+            "adminToken": "owner-token",
+            "grants": [
+                {
+                    "email": "user@example.test",
+                    "workerScope": "user",
+                    "requester": "@user:example.test",
+                    "role": "viewer",
+                },
+            ],
+        },
+    )
+
+    with pytest.raises(AgentVaultAccessGrantError, match="role must be admin"):
+        AgentVaultAccessGrantsConfig.from_file(path)

--- a/tests/test_agent_vault_access_grants.py
+++ b/tests/test_agent_vault_access_grants.py
@@ -10,6 +10,7 @@ import pytest
 import yaml
 
 from mindroom.agent_vault_access_grants import (
+    AgentVaultAccessGrantApplyResult,
     AgentVaultAccessGrantError,
     AgentVaultAccessGrantsConfig,
     apply_agent_vault_access_grants,
@@ -29,12 +30,14 @@ class _FakeVaultAPI:
         self.responses = responses
         self.calls: list[tuple[str, dict[str, object]]] = []
         self.auth_headers: list[str] = []
+        self.content_type_headers: list[str | None] = []
 
     def handler(self, request: httpx.Request) -> httpx.Response:
         path = request.url.path
         body = json.loads(request.content.decode()) if request.content else {}
         self.calls.append((path, body))
         self.auth_headers.append(request.headers.get("authorization", ""))
+        self.content_type_headers.append(request.headers.get("content-type"))
         for suffix, status in self.responses.items():
             if path.endswith(suffix):
                 payload = {"name": body.get("name", "")} if status < 300 else {"error": "scripted"}
@@ -170,8 +173,7 @@ async def test_apply_grants_creates_joins_and_grants_admin(
 
     result = await apply_agent_vault_access_grants(config)
 
-    assert result.applied == 1
-    assert not result.warnings
+    assert result == AgentVaultAccessGrantApplyResult(applied=1, warnings=())
     assert [path for path, _ in api.calls] == [
         "/v1/vaults",
         f"/v1/vaults/{target.vault}/join",
@@ -179,6 +181,7 @@ async def test_apply_grants_creates_joins_and_grants_admin(
     ]
     assert api.calls[-1][1] == {"email": "maintainer@example.test", "role": "admin"}
     assert api.auth_headers == ["Bearer owner-token", "Bearer owner-token", "Bearer owner-token"]
+    assert api.content_type_headers == ["application/json", None, "application/json"]
 
 
 @pytest.mark.asyncio
@@ -210,7 +213,6 @@ async def test_apply_grants_counts_existing_member_role_updates_as_applied(
     result = await apply_agent_vault_access_grants(config)
 
     assert result.applied == 1
-    assert result.already_admin == 0
     assert [path for path, _ in api.calls] == [
         "/v1/vaults",
         f"/v1/vaults/{target.vault}/join",
@@ -432,6 +434,29 @@ def test_config_rejects_user_agent_without_requester(tmp_path: Path) -> None:
     )
 
     with pytest.raises(AgentVaultAccessGrantError, match="user_agent grants require requester"):
+        AgentVaultAccessGrantsConfig.from_file(path)
+
+
+def test_config_rejects_user_grant_with_agent(tmp_path: Path) -> None:
+    """User worker grants must not accept an agent that is ignored by worker-key resolution."""
+    path = _config_path(
+        tmp_path,
+        {
+            "apiUrl": "http://agent-vault:14321",
+            "adminToken": "owner-token",
+            "grants": [
+                {
+                    "email": "user@example.test",
+                    "workerScope": "user",
+                    "requester": "@user:example.test",
+                    "agent": "example-agent",
+                    "role": "admin",
+                },
+            ],
+        },
+    )
+
+    with pytest.raises(AgentVaultAccessGrantError, match="user grants must not set agent"):
         AgentVaultAccessGrantsConfig.from_file(path)
 
 

--- a/tests/test_helm_instance_worker_isolation.py
+++ b/tests/test_helm_instance_worker_isolation.py
@@ -1696,6 +1696,71 @@ def test_runtime_chart_agent_vault_bootstrap_publishes_access_grants_admin_token
     assert "agent-vault-grants-admin" in secret_rule["resourceNames"]
 
 
+def test_runtime_chart_rejects_agent_vault_access_token_same_secret_different_keys(tmp_path: Path) -> None:
+    """Bootstrap must not apply the same Secret twice with different admin-token keys."""
+    values_path = tmp_path / "values.yaml"
+    values_path.write_text(
+        yaml.safe_dump(
+            {
+                "workers": {
+                    "backend": "kubernetes",
+                    "sandbox": {"proxyToken": {"value": "test-token"}},
+                    "kubernetes": {
+                        "agentVault": {
+                            "enabled": True,
+                            "cliImage": "infisical/agent-vault:test",
+                            "ownerEmail": "owner@example.test",
+                            "workerCaConfigMapName": "agent-vault-ca",
+                            "bootstrap": {
+                                "enabled": True,
+                                "kubectlImage": "bitnami/kubectl:latest",
+                            },
+                            "accessTool": {
+                                "enabled": True,
+                                "uiBaseUrl": "https://example.test/agent-vault",
+                                "emailDomain": "example.test",
+                                "adminTokenSecret": {
+                                    "name": "agent-vault-access-admin",
+                                    "key": "tool-token",
+                                },
+                            },
+                            "accessGrants": {
+                                "enabled": True,
+                                "adminTokenSecret": {
+                                    "name": "agent-vault-access-admin",
+                                    "key": "grants-token",
+                                },
+                                "grants": [
+                                    {
+                                        "email": "maintainer@example.test",
+                                        "workerScope": "shared",
+                                        "agent": "example-agent",
+                                        "role": "admin",
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+                "eventCache": {"postgres": {"auth": {"password": "test-password"}}},
+            },
+        ),
+        encoding="utf-8",
+    )
+
+    completed = _run_helm_template(
+        Path("cluster/k8s/runtime"),
+        values_files=(values_path,),
+        release_name="mindroom-runtime",
+    )
+
+    assert completed.returncode != 0
+    assert (
+        "workers.kubernetes.agentVault.accessTool.adminTokenSecret.key must match "
+        "workers.kubernetes.agentVault.accessGrants.adminTokenSecret.key when both use the same Secret name"
+    ) in completed.stderr
+
+
 @pytest.mark.parametrize(
     ("grant", "message"),
     [

--- a/tests/test_helm_instance_worker_isolation.py
+++ b/tests/test_helm_instance_worker_isolation.py
@@ -1433,6 +1433,292 @@ def test_runtime_chart_rejects_agent_vault_default_proxy_url_with_approved_egres
     assert "approvedEgress with Agent Vault must be squid-first" in completed.stderr
 
 
+def test_runtime_chart_agent_vault_access_grants_are_noop_by_default() -> None:
+    """Access grants should not add grant resources unless explicitly enabled with grants."""
+    docs = _render_runtime_chart()
+
+    assert not any(
+        doc.get("kind") in {"ConfigMap", "Job"}
+        and isinstance(doc.get("metadata"), dict)
+        and doc["metadata"].get("name") == "agent-vault-access-grants"
+        for doc in docs
+    )
+
+
+def test_runtime_chart_agent_vault_access_grants_renders_shared_grant_job(tmp_path: Path) -> None:
+    """Shared worker vault admins can be declared without inline scripts."""
+    values_path = tmp_path / "values.yaml"
+    values_path.write_text(
+        yaml.safe_dump(
+            {
+                "workers": {
+                    "backend": "kubernetes",
+                    "sandbox": {"proxyToken": {"value": "test-token"}},
+                    "kubernetes": {
+                        "agentVault": {
+                            "enabled": True,
+                            "cliImage": "infisical/agent-vault:test",
+                            "ownerEmail": "owner@example.test",
+                            "accessGrants": {
+                                "enabled": True,
+                                "tenantId": "tenant-42",
+                                "grants": [
+                                    {
+                                        "email": "maintainer@example.test",
+                                        "workerScope": "shared",
+                                        "agent": "example-agent",
+                                        "role": "admin",
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+                "eventCache": {"postgres": {"auth": {"password": "test-password"}}},
+            },
+        ),
+        encoding="utf-8",
+    )
+
+    docs = _render_chart(
+        Path("cluster/k8s/runtime"),
+        values_files=(values_path,),
+        release_name="mindroom-runtime",
+    )
+    config_map = _resource(docs, "ConfigMap", "agent-vault-access-grants")
+    job = _resource(docs, "Job", "agent-vault-access-grants")
+    container = _container(job, "access-grants")
+    config = yaml.safe_load(config_map["data"]["access-grants.yaml"])
+
+    assert config == {
+        "apiUrl": "http://agent-vault:14321",
+        "vaultNamePrefix": "agent-vault",
+        "tenantId": "tenant-42",
+        "grants": [
+            {
+                "email": "maintainer@example.test",
+                "workerScope": "shared",
+                "agent": "example-agent",
+                "role": "admin",
+            },
+        ],
+    }
+    assert job["metadata"]["annotations"]["helm.sh/hook"] == "post-install,post-upgrade"
+    assert job["metadata"]["annotations"]["helm.sh/hook-delete-policy"] == "before-hook-creation,hook-succeeded"
+    assert container["image"] == "ghcr.io/mindroom-ai/mindroom:latest"
+    assert container["command"] == [
+        "python",
+        "-m",
+        "mindroom.agent_vault_access_grants",
+        "apply",
+        "--config",
+        "/etc/mindroom-agent-vault-access-grants/access-grants.yaml",
+        "--admin-token-file",
+        "/etc/agent-vault-access-grants/token",
+        "--wait-ready-seconds",
+        "180",
+    ]
+    assert {
+        "name": "access-grants-config",
+        "mountPath": "/etc/mindroom-agent-vault-access-grants",
+        "readOnly": True,
+    } in container["volumeMounts"]
+    assert {
+        "name": "access-grants-admin-token",
+        "mountPath": "/etc/agent-vault-access-grants",
+        "readOnly": True,
+    } in container["volumeMounts"]
+
+
+def test_runtime_chart_agent_vault_access_grants_renders_user_agent_grant(tmp_path: Path) -> None:
+    """The chart passes requester-scoped grant inputs through to the helper config."""
+    values_path = tmp_path / "values.yaml"
+    values_path.write_text(
+        yaml.safe_dump(
+            {
+                "workers": {
+                    "backend": "kubernetes",
+                    "sandbox": {"proxyToken": {"value": "test-token"}},
+                    "kubernetes": {
+                        "agentVault": {
+                            "enabled": True,
+                            "cliImage": "infisical/agent-vault:test",
+                            "ownerEmail": "owner@example.test",
+                            "accessGrants": {
+                                "enabled": True,
+                                "grants": [
+                                    {
+                                        "email": "user@example.test",
+                                        "workerScope": "user_agent",
+                                        "requester": "@user:example.test",
+                                        "agent": "example-agent",
+                                        "role": "admin",
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+                "eventCache": {"postgres": {"auth": {"password": "test-password"}}},
+            },
+        ),
+        encoding="utf-8",
+    )
+
+    docs = _render_chart(
+        Path("cluster/k8s/runtime"),
+        values_files=(values_path,),
+        release_name="mindroom-runtime",
+    )
+    config = yaml.safe_load(_resource(docs, "ConfigMap", "agent-vault-access-grants")["data"]["access-grants.yaml"])
+
+    assert config["grants"] == [
+        {
+            "email": "user@example.test",
+            "workerScope": "user_agent",
+            "requester": "@user:example.test",
+            "agent": "example-agent",
+            "role": "admin",
+        },
+    ]
+
+
+def test_runtime_chart_agent_vault_bootstrap_publishes_access_grants_admin_token(tmp_path: Path) -> None:
+    """The bootstrap Job should publish an owner-role token for access-grant jobs."""
+    values_path = tmp_path / "values.yaml"
+    values_path.write_text(
+        yaml.safe_dump(
+            {
+                "workers": {
+                    "backend": "kubernetes",
+                    "sandbox": {"proxyToken": {"value": "test-token"}},
+                    "kubernetes": {
+                        "agentVault": {
+                            "enabled": True,
+                            "cliImage": "infisical/agent-vault:test",
+                            "ownerEmail": "owner@example.test",
+                            "workerCaConfigMapName": "agent-vault-ca",
+                            "bootstrap": {
+                                "enabled": True,
+                                "kubectlImage": "bitnami/kubectl:latest",
+                            },
+                            "accessGrants": {
+                                "enabled": True,
+                                "adminTokenSecret": {
+                                    "name": "agent-vault-grants-admin",
+                                    "key": "token",
+                                },
+                                "grants": [
+                                    {
+                                        "email": "maintainer@example.test",
+                                        "workerScope": "shared",
+                                        "agent": "example-agent",
+                                        "role": "admin",
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+                "eventCache": {"postgres": {"auth": {"password": "test-password"}}},
+            },
+        ),
+        encoding="utf-8",
+    )
+
+    docs = _render_chart(
+        Path("cluster/k8s/runtime"),
+        values_files=(values_path,),
+        release_name="mindroom-runtime",
+    )
+    bootstrap_job = _resource(docs, "Job", "agent-vault-bootstrap")
+    bootstrap_init = _init_container(bootstrap_job, "bootstrap-owner")
+    publish_container = _container(bootstrap_job, "publish-ca")
+    bootstrap_role = _resource(docs, "Role", "agent-vault-bootstrap")
+
+    assert 'agent-vault agent create "access-admin"' in bootstrap_init["args"][0]
+    assert 'agent-vault agent set-role "access-admin" --role owner' in bootstrap_init["args"][0]
+    assert "create secret generic agent-vault-grants-admin" in publish_container["args"][0]
+    secret_rule = next(
+        rule for rule in bootstrap_role["rules"] if "secrets" in rule.get("resources", []) and "resourceNames" in rule
+    )
+    assert "agent-vault-grants-admin" in secret_rule["resourceNames"]
+
+
+@pytest.mark.parametrize(
+    ("grant", "message"),
+    [
+        (
+            {
+                "email": "maintainer@example.test",
+                "workerScope": "shared",
+                "requester": "@user:example.test",
+                "agent": "example-agent",
+                "role": "admin",
+            },
+            "workers.kubernetes.agentVault.accessGrants.grants[0].requester must be empty for workerScope=shared",
+        ),
+        (
+            {
+                "email": "user@example.test",
+                "workerScope": "user_agent",
+                "agent": "example-agent",
+                "role": "admin",
+            },
+            "workers.kubernetes.agentVault.accessGrants.grants[0].requester is required for workerScope=user_agent",
+        ),
+        (
+            {
+                "email": "user@example.test",
+                "workerScope": "user",
+                "requester": "@user:example.test",
+                "role": "viewer",
+            },
+            "workers.kubernetes.agentVault.accessGrants.grants[0].role must be admin",
+        ),
+    ],
+)
+def test_runtime_chart_rejects_invalid_agent_vault_access_grants(
+    tmp_path: Path,
+    grant: dict[str, str],
+    message: str,
+) -> None:
+    """Grant validation should fail during Helm rendering before the Job runs."""
+    values_path = tmp_path / "values.yaml"
+    values_path.write_text(
+        yaml.safe_dump(
+            {
+                "workers": {
+                    "backend": "kubernetes",
+                    "sandbox": {"proxyToken": {"value": "test-token"}},
+                    "kubernetes": {
+                        "agentVault": {
+                            "enabled": True,
+                            "cliImage": "infisical/agent-vault:test",
+                            "ownerEmail": "owner@example.test",
+                            "accessGrants": {
+                                "enabled": True,
+                                "grants": [grant],
+                            },
+                        },
+                    },
+                },
+                "eventCache": {"postgres": {"auth": {"password": "test-password"}}},
+            },
+        ),
+        encoding="utf-8",
+    )
+
+    completed = _run_helm_template(
+        Path("cluster/k8s/runtime"),
+        values_files=(values_path,),
+        release_name="mindroom-runtime",
+    )
+
+    assert completed.returncode != 0
+    assert message in completed.stderr
+
+
 def test_runtime_chart_rejects_invalid_approved_egress_parent_proxy_port() -> None:
     """Parent proxy ports must be valid TCP ports before rendering Squid config."""
     completed = _run_helm_template(

--- a/tests/test_helm_instance_worker_isolation.py
+++ b/tests/test_helm_instance_worker_isolation.py
@@ -1583,6 +1583,57 @@ def test_runtime_chart_agent_vault_access_grants_renders_user_agent_grant(tmp_pa
     ]
 
 
+def test_runtime_chart_agent_vault_access_grants_renders_user_grant(tmp_path: Path) -> None:
+    """The chart passes user-scoped grant inputs through without an agent."""
+    values_path = tmp_path / "values.yaml"
+    values_path.write_text(
+        yaml.safe_dump(
+            {
+                "workers": {
+                    "backend": "kubernetes",
+                    "sandbox": {"proxyToken": {"value": "test-token"}},
+                    "kubernetes": {
+                        "agentVault": {
+                            "enabled": True,
+                            "cliImage": "infisical/agent-vault:test",
+                            "ownerEmail": "owner@example.test",
+                            "accessGrants": {
+                                "enabled": True,
+                                "grants": [
+                                    {
+                                        "email": "user@example.test",
+                                        "workerScope": "user",
+                                        "requester": "@user:example.test",
+                                        "role": "admin",
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+                "eventCache": {"postgres": {"auth": {"password": "test-password"}}},
+            },
+        ),
+        encoding="utf-8",
+    )
+
+    docs = _render_chart(
+        Path("cluster/k8s/runtime"),
+        values_files=(values_path,),
+        release_name="mindroom-runtime",
+    )
+    config = yaml.safe_load(_resource(docs, "ConfigMap", "agent-vault-access-grants")["data"]["access-grants.yaml"])
+
+    assert config["grants"] == [
+        {
+            "email": "user@example.test",
+            "workerScope": "user",
+            "requester": "@user:example.test",
+            "role": "admin",
+        },
+    ]
+
+
 def test_runtime_chart_agent_vault_bootstrap_publishes_access_grants_admin_token(tmp_path: Path) -> None:
     """The bootstrap Job should publish an owner-role token for access-grant jobs."""
     values_path = tmp_path / "values.yaml"
@@ -1675,6 +1726,15 @@ def test_runtime_chart_agent_vault_bootstrap_publishes_access_grants_admin_token
                 "role": "viewer",
             },
             "workers.kubernetes.agentVault.accessGrants.grants[0].role must be admin",
+        ),
+        (
+            {
+                "email": "user@example.test",
+                "workerScope": "invalid",
+                "requester": "@user:example.test",
+                "role": "admin",
+            },
+            "workers.kubernetes.agentVault.accessGrants.grants[0].workerScope must be one of: shared, user, user_agent",
         ),
     ],
 )

--- a/tests/test_helm_instance_worker_isolation.py
+++ b/tests/test_helm_instance_worker_isolation.py
@@ -1736,6 +1736,16 @@ def test_runtime_chart_agent_vault_bootstrap_publishes_access_grants_admin_token
             },
             "workers.kubernetes.agentVault.accessGrants.grants[0].workerScope must be one of: shared, user, user_agent",
         ),
+        (
+            {
+                "email": "user@example.test",
+                "workerScope": "user",
+                "requester": "@user:example.test",
+                "agent": "example-agent",
+                "role": "admin",
+            },
+            "workers.kubernetes.agentVault.accessGrants.grants[0].agent must be empty for workerScope=user",
+        ),
     ],
 )
 def test_runtime_chart_rejects_invalid_agent_vault_access_grants(


### PR DESCRIPTION
## Summary
- Add `python -m mindroom.agent_vault_access_grants apply` for declarative Agent Vault UI/admin grants that reuse MindRoom worker routing to resolve worker keys and vault names.
- Add optional Helm `agentVault.accessGrants` values, validation, bootstrap token publishing, and a post-install/post-upgrade grant Job.
- Document self-service per-user vaults versus shared-agent service credentials, including the raw-secret admin versus runtime-use distinction.

## Test Plan
- [x] `uv run ruff check src/mindroom/agent_vault_access_grants.py tests/test_agent_vault_access_grants.py tests/test_helm_instance_worker_isolation.py`
- [x] `uv run ty check src/mindroom/agent_vault_access_grants.py tests/test_agent_vault_access_grants.py`
- [x] `uv run pytest tests/test_agent_vault_access_grants.py tests/test_agent_vault_access_tool.py tests/test_helm_instance_worker_isolation.py::test_runtime_chart_agent_vault_access_grants_are_noop_by_default tests/test_helm_instance_worker_isolation.py::test_runtime_chart_agent_vault_access_grants_renders_shared_grant_job tests/test_helm_instance_worker_isolation.py::test_runtime_chart_agent_vault_access_grants_renders_user_agent_grant tests/test_helm_instance_worker_isolation.py::test_runtime_chart_agent_vault_bootstrap_publishes_access_grants_admin_token tests/test_helm_instance_worker_isolation.py::test_runtime_chart_rejects_invalid_agent_vault_access_grants tests/test_kubernetes_worker_backend.py::test_kubernetes_backend_adds_agent_vault_mint_init_container -q -n 0`
- [ ] Full `uv run pytest -q` was attempted locally but is blocked by unrelated untracked workspace files outside this PR: `src/mindroom/team_execution_attempt.py` and `tests/test_team_execution_attempt.py`.

## Summary by Sourcery

Add declarative Agent Vault admin access grants driven by MindRoom worker routing and wire them into the Kubernetes runtime Helm chart.

New Features:
- Introduce a deployment-neutral agent_vault_access_grants module and CLI for applying declarative Agent Vault admin grants using MindRoom worker routing.
- Add Helm chart support for configuring Agent Vault accessGrants, including a post-install/upgrade Job that runs the grant helper with an admin token.
- Document how to configure Agent Vault access grants for shared and per-user workers, including workerScope semantics and tenant/account options.

Enhancements:
- Extend Agent Vault bootstrap Role and Job to mint and publish an owner-role admin token secret for both accessTool and accessGrants when configured.

Tests:
- Add unit tests for the Agent Vault access grants module and new Helm runtime behaviors, including validation rules and bootstrap token publishing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent Vault Access Grants: declarative YAML-based admin access management with `shared`, `user`, and `user_agent` scopes
  * Runtime chart now renders the necessary ConfigMap + apply Job (and integrates with bootstrap/admin token publishing)
  * Idempotent apply flow with readiness polling, plus warnings for unregistered accounts
* **Documentation**
  * Added chart and configuration guidance for Agent Vault Access Grants, including tenant scoping and examples
* **Tests**
  * Added unit tests for grant resolution/apply and Helm rendering/validation coverage
<!-- end of auto-generated comment: release notes by coderabbit.ai -->