### PR TITLE
Fix plugin OAuth credential scope storage

### DIFF
--- a/src/mindroom/credential_policy.py
+++ b/src/mindroom/credential_policy.py
@@ -30,8 +30,7 @@ OAUTH_CREDENTIAL_FIELDS = frozenset(
 )
 
 _OAUTH_CLIENT_CONFIG_SERVICE_SUFFIX = "_oauth_client"
-_MCP_OAUTH_TOKEN_SERVICE_PREFIX = "mcp_"  # noqa: S105
-_MCP_OAUTH_TOKEN_SERVICE_SUFFIX = "_oauth"  # noqa: S105
+_OAUTH_TOKEN_SERVICE_SUFFIX = "_oauth"  # noqa: S105
 
 _LOCAL_ONLY_SHARED_CREDENTIAL_SERVICES = frozenset(
     {
@@ -59,13 +58,9 @@ _UNSUPPORTED_WORKER_GRANTABLE_CREDENTIALS = frozenset(
 )
 
 
-def _is_mcp_oauth_token_service(service: str) -> bool:
-    """Return whether a service is a generated MCP OAuth token service."""
-    return (
-        service.startswith(_MCP_OAUTH_TOKEN_SERVICE_PREFIX)
-        and service.endswith(_MCP_OAUTH_TOKEN_SERVICE_SUFFIX)
-        and not is_oauth_client_config_service(service)
-    )
+def _is_oauth_token_service(service: str) -> bool:
+    """Return whether a service name follows the OAuth token naming contract."""
+    return service.endswith(_OAUTH_TOKEN_SERVICE_SUFFIX) and not is_oauth_client_config_service(service)
 
 
 @dataclass(frozen=True, slots=True)
@@ -82,7 +77,8 @@ class _CredentialServicePolicy:
 
 def credential_service_policy(service: str, worker_scope: _WorkerScope | None) -> _CredentialServicePolicy:
     """Return credential placement policy for one service in one worker scope."""
-    is_local_only = service in _LOCAL_ONLY_SHARED_CREDENTIAL_SERVICES or _is_mcp_oauth_token_service(service)
+    is_oauth_token_service = _is_oauth_token_service(service)
+    is_local_only = service in _LOCAL_ONLY_SHARED_CREDENTIAL_SERVICES or is_oauth_token_service
     is_primary_runtime_global = is_oauth_client_config_service(service)
     return _CredentialServicePolicy(
         service=service,
@@ -93,7 +89,7 @@ def credential_service_policy(service: str, worker_scope: _WorkerScope | None) -
             worker_scope in {"user", "user_agent"} and is_local_only and not is_primary_runtime_global
         ),
         worker_grantable_supported=not is_primary_runtime_global
-        and not _is_mcp_oauth_token_service(service)
+        and not is_oauth_token_service
         and service not in _UNSUPPORTED_WORKER_GRANTABLE_CREDENTIALS,
     )
 

--- a/src/mindroom/credential_policy.py
+++ b/src/mindroom/credential_policy.py
@@ -31,6 +31,8 @@ OAUTH_CREDENTIAL_FIELDS = frozenset(
 
 _OAUTH_CLIENT_CONFIG_SERVICE_SUFFIX = "_oauth_client"
 _OAUTH_TOKEN_SERVICE_SUFFIX = "_oauth"  # noqa: S105
+# OAuth provider token services use the *_oauth naming contract. The separate
+# *_oauth_client app-client config contract intentionally does not match it.
 
 _LOCAL_ONLY_SHARED_CREDENTIAL_SERVICES = frozenset(
     {
@@ -50,17 +52,13 @@ _LOCAL_ONLY_SHARED_CREDENTIAL_SERVICES = frozenset(
 _UNSUPPORTED_WORKER_GRANTABLE_CREDENTIALS = frozenset(
     {
         "google_vertex_adc",
-        "google_calendar_oauth",
-        "google_drive_oauth",
-        "google_gmail_oauth",
-        "google_sheets_oauth",
     },
 )
 
 
 def _is_oauth_token_service(service: str) -> bool:
     """Return whether a service name follows the OAuth token naming contract."""
-    return service.endswith(_OAUTH_TOKEN_SERVICE_SUFFIX) and not is_oauth_client_config_service(service)
+    return service.endswith(_OAUTH_TOKEN_SERVICE_SUFFIX)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/mindroom/credential_policy.py
+++ b/src/mindroom/credential_policy.py
@@ -37,13 +37,9 @@ _OAUTH_TOKEN_SERVICE_SUFFIX = "_oauth"  # noqa: S105
 _LOCAL_ONLY_SHARED_CREDENTIAL_SERVICES = frozenset(
     {
         "google_calendar",
-        "google_calendar_oauth",
         "google_drive",
-        "google_drive_oauth",
         "google_gmail",
-        "google_gmail_oauth",
         "google_sheets",
-        "google_sheets_oauth",
         "gmail",
         "homeassistant",
     },

--- a/tests/api/test_oauth_api.py
+++ b/tests/api/test_oauth_api.py
@@ -1917,6 +1917,102 @@ def test_shared_scope_oauth_token_uses_shared_store_not_worker_path(tmp_path: Pa
     assert manager.for_worker(worker_key).load_credentials(provider.credential_service) is None
 
 
+def test_shared_scope_plugin_oauth_token_uses_shared_store_not_worker_path(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(
+        tmp_path,
+        {"TEST_OAUTH_CLIENT_ID": "client-id", "TEST_OAUTH_CLIENT_SECRET": "client-secret"},
+    )
+    api_app = _make_test_app(runtime_paths, _config_payload(worker_scope="shared"))
+    provider = _fake_provider(
+        provider_id="acme",
+        credential_service="acme_oauth",
+        tool_config_service="acme",
+        client_config_services=("acme_oauth_client",),
+    )
+    manager = get_runtime_credentials_manager(runtime_paths)
+    manager.save_credentials(
+        "acme_oauth_client",
+        {
+            "client_id": "client-id",
+            "client_secret": "client-secret",
+            "_source": "ui",
+        },
+    )
+
+    with patch("mindroom.api.oauth.load_oauth_providers_for_snapshot", return_value={provider.id: provider}):
+        with TestClient(api_app) as client:
+            _login(client)
+            connect_response = client.post(f"/api/oauth/{provider.id}/connect?agent_name=general")
+            state = _state_from_auth_url(connect_response.json()["auth_url"])
+            callback_response = client.get(
+                f"/api/oauth/{provider.id}/callback?code=test-code&state={state}",
+                follow_redirects=False,
+            )
+
+    assert callback_response.status_code == 307
+    shared_credentials = manager.shared_manager().load_credentials(provider.credential_service)
+    identity = ToolExecutionIdentity(
+        channel="matrix",
+        agent_name="general",
+        requester_id=None,
+        room_id=None,
+        thread_id=None,
+        resolved_thread_id=None,
+        session_id=None,
+    )
+    worker_key = resolve_worker_key("shared", identity, agent_name="general")
+    assert worker_key is not None
+    assert shared_credentials is not None
+    assert shared_credentials["token"] == "acme-access-token"
+    assert manager.for_worker(worker_key).load_credentials(provider.credential_service) is None
+
+
+def test_user_agent_scope_plugin_oauth_token_uses_private_store_not_worker_path(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(
+        tmp_path,
+        {
+            "TEST_OAUTH_CLIENT_ID": "client-id",
+            "TEST_OAUTH_CLIENT_SECRET": "client-secret",
+            constants.OWNER_MATRIX_USER_ID_ENV: "@alice:example.org",
+        },
+    )
+    api_app = _make_test_app(runtime_paths, _config_payload(worker_scope="user_agent"))
+    provider = _fake_provider(
+        provider_id="acme",
+        credential_service="acme_oauth",
+        tool_config_service="acme",
+        client_config_services=("acme_oauth_client",),
+    )
+    manager = get_runtime_credentials_manager(runtime_paths)
+    manager.save_credentials(
+        "acme_oauth_client",
+        {
+            "client_id": "client-id",
+            "client_secret": "client-secret",
+            "_source": "ui",
+        },
+    )
+    owner_worker_key = _worker_key_for_matrix_user("@alice:example.org")
+
+    with patch("mindroom.api.oauth.load_oauth_providers_for_snapshot", return_value={provider.id: provider}):
+        with TestClient(api_app) as client:
+            _login(client)
+            connect_response = client.post(f"/api/oauth/{provider.id}/connect?agent_name=general")
+            state = _state_from_auth_url(connect_response.json()["auth_url"])
+            callback_response = client.get(
+                f"/api/oauth/{provider.id}/callback?code=test-code&state={state}",
+                follow_redirects=False,
+            )
+
+    assert callback_response.status_code == 307
+    stored_credentials = manager.for_primary_runtime_scope("@alice:example.org", "general").load_credentials(
+        provider.credential_service,
+    )
+    assert stored_credentials is not None
+    assert stored_credentials["token"] == "acme-access-token"
+    assert manager.for_worker(owner_worker_key).load_credentials(provider.credential_service) is None
+
+
 def test_dashboard_private_oauth_rejects_unbound_standalone_requester(tmp_path: Path) -> None:
     runtime_paths = _runtime_paths(
         tmp_path,

--- a/tests/test_credential_policy.py
+++ b/tests/test_credential_policy.py
@@ -20,6 +20,9 @@ from mindroom.credential_policy import (
         ("google_drive_oauth", "user", True),
         ("google_drive_oauth", "user_agent", True),
         ("google_drive_oauth", "shared", False),
+        ("acme_oauth", "user", True),
+        ("acme_oauth", "user_agent", True),
+        ("acme_oauth", "shared", False),
         ("openai", "user", False),
         ("homeassistant", "user_agent", True),
     ],
@@ -34,6 +37,7 @@ def test_primary_runtime_scoped_service_policy(service: str, worker_scope: str, 
     [
         ("google_drive", "shared", True),
         ("google_drive_oauth", "shared", True),
+        ("acme_oauth", "shared", True),
         ("gmail", "shared", True),
         ("openai", "shared", False),
         ("google_drive", "user", False),
@@ -68,6 +72,19 @@ def test_credential_service_policy_classifies_google_oauth_user_scope() -> None:
     assert policy.uses_primary_runtime_scoped_credentials is True
     assert policy.uses_local_shared_credentials is False
     assert policy.worker_grantable_supported is False
+
+
+def test_credential_service_policy_classifies_plugin_oauth_token_service() -> None:
+    """Plugin OAuth token services should use primary-runtime storage and reject worker grants."""
+    shared_policy = credential_service_policy("acme_oauth", "shared")
+    user_agent_policy = credential_service_policy("acme_oauth", "user_agent")
+
+    assert shared_policy.uses_local_shared_credentials is True
+    assert shared_policy.uses_primary_runtime_scoped_credentials is False
+    assert shared_policy.worker_grantable_supported is False
+    assert user_agent_policy.uses_local_shared_credentials is False
+    assert user_agent_policy.uses_primary_runtime_scoped_credentials is True
+    assert user_agent_policy.worker_grantable_supported is False
 
 
 def test_credential_service_policy_classifies_oauth_client_config_as_global_primary_runtime() -> None:

--- a/tests/test_credential_policy.py
+++ b/tests/test_credential_policy.py
@@ -55,12 +55,17 @@ def test_local_shared_service_policy(service: str, worker_scope: str, expected: 
         "google_drive_oauth",
         "google_gmail_oauth",
         "google_sheets_oauth",
-        "google_vertex_adc",
     ],
 )
-def test_worker_grantable_policy_rejects_sensitive_google_services(service: str) -> None:
-    """Sensitive Google credential services should stay unsupported for worker mirroring."""
-    assert service in _UNSUPPORTED_WORKER_GRANTABLE_CREDENTIALS
+def test_worker_grantable_policy_rejects_google_oauth_token_services(service: str) -> None:
+    """Google OAuth token services should stay unsupported for worker mirroring."""
+    assert credential_service_policy(service, "shared").worker_grantable_supported is False
+
+
+def test_worker_grantable_policy_rejects_sensitive_google_services() -> None:
+    """Sensitive non-OAuth Google credential services should stay unsupported for worker mirroring."""
+    assert frozenset({"google_vertex_adc"}) == _UNSUPPORTED_WORKER_GRANTABLE_CREDENTIALS
+    assert credential_service_policy("google_vertex_adc", "shared").worker_grantable_supported is False
 
 
 def test_credential_service_policy_classifies_google_oauth_user_scope() -> None:


### PR DESCRIPTION
## Summary
- Treat generic non-client `*_oauth` services as OAuth token credential state, not worker-grantable credentials.
- Keep OAuth client config services (`*_oauth_client`) in the global primary-runtime store.
- Add regression coverage for plugin OAuth callbacks in shared and user-agent scopes so tokens land in primary-runtime storage, not worker roots.

## Why
Plugin OAuth providers use the same naming contract as built-in OAuth providers, but only built-in services and generated MCP OAuth services were classified as local-only OAuth state. A plugin provider such as `acme_oauth` could be saved under a worker credential root, so a later run under a different worker key or execution scope would look disconnected even though a valid token existed elsewhere.

This makes plugin OAuth token placement match built-in OAuth token placement:
- shared scope: primary-runtime shared credential store
- user/user_agent scope: primary-runtime requester-scoped store
- no worker mirroring/grants for OAuth token material

## Tests
- `uv run pytest tests/test_credential_policy.py tests/api/test_oauth_api.py::test_shared_scope_plugin_oauth_token_uses_shared_store_not_worker_path tests/api/test_oauth_api.py::test_user_agent_scope_plugin_oauth_token_uses_private_store_not_worker_path`
- `uv run pytest tests/test_credentials.py tests/test_mcp_oauth.py tests/test_mcp_manager.py::test_mcp_manager_uses_requester_oauth_bearer_token tests/test_mcp_manager.py::test_mcp_manager_separates_oauth_sessions_by_requester`
- `uv run ruff check src/mindroom/credential_policy.py tests/test_credential_policy.py tests/api/test_oauth_api.py`
- `uv run ruff format --check src/mindroom/credential_policy.py tests/test_credential_policy.py tests/api/test_oauth_api.py`

## Summary by Sourcery

Classify all OAuth token credential services, including plugin providers, as local-only OAuth state and ensure plugin OAuth tokens are stored in the primary-runtime credential stores rather than worker roots.

Bug Fixes:
- Fix misclassification of plugin OAuth token services so their tokens follow the same primary-runtime storage rules as built-in OAuth providers and are never worker-grantable.

Enhancements:
- Broaden OAuth token service detection to use a generic naming contract, decoupled from MCP-specific prefixes.

Tests:
- Add regression tests verifying plugin OAuth callbacks store tokens in shared and user-agent primary-runtime stores and do not write to worker credential paths.
- Extend credential policy tests to cover plugin OAuth token services across shared and user-agent scopes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for OAuth API authentication with plugin-based providers, ensuring credentials are correctly stored in designated credential stores
  * Enhanced credential policy tests to validate OAuth token service classification and credential scoping across different worker scope configurations

* **Refactor**
  * Improved OAuth token service detection to use contract-based classification for better reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->