### PR TITLE
Cache agent static prompt token estimates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -499,6 +499,7 @@ helm upgrade --install platform ./cluster/k8s/platform -f cluster/k8s/platform/v
 - **Check for Changes**: Before starting, review the latest changes from the main branch with `git diff origin/main | cat`. Make sure to use `--no-pager`, or pipe the output to `cat`.
 - **Commit Frequently**: Make small, frequent commits.
 - **Atomic Commits**: Ensure each commit corresponds to a tested, working state.
+- **Preserve Review History**: Do not amend commits or force-push PR branches unless the user explicitly asks for it. Prefer follow-up commits so PR history stays inspectable.
 - **Targeted Adds**: **NEVER** use `git add .`. Always add files individually (`git add <filename>`) to prevent committing unrelated changes.
 
 ### Step 4: Testing & Quality

--- a/src/mindroom/history/compaction.py
+++ b/src/mindroom/history/compaction.py
@@ -11,7 +11,6 @@ from html import escape
 from typing import TYPE_CHECKING, TypeGuard, cast
 from uuid import uuid4
 
-from agno.agent._tools import determine_tools_for_model
 from agno.run import RunContext
 from agno.run.agent import RunOutput
 from agno.run.base import RunStatus
@@ -50,6 +49,7 @@ from mindroom.hooks import EVENT_COMPACTION_AFTER, EVENT_COMPACTION_BEFORE, Comp
 from mindroom.logging_config import get_logger
 from mindroom.timing import timed, timed_block
 from mindroom.token_budget import estimate_text_tokens, stable_serialize
+from mindroom.tool_schema_cache import process_function_schema_for_prompt
 from mindroom.tool_system.runtime_context import get_tool_runtime_context, resolve_tool_runtime_hook_bindings
 
 if TYPE_CHECKING:
@@ -692,10 +692,14 @@ def _prepare_tools_for_estimation(tools: object) -> tuple[list[Function | _ToolD
                 continue
             seen_names.add(tool_name)
             prepared_tools.append(prepared_tool)
+            if (
+                isinstance(prepared_tool, Function)
+                and prepared_tool.add_instructions
+                and prepared_tool.instructions is not None
+            ):
+                tool_instructions.append(prepared_tool.instructions)
 
         if isinstance(tool, Toolkit) and tool.add_instructions and tool.instructions is not None:
-            tool_instructions.append(tool.instructions)
-        if isinstance(tool, Function) and tool.add_instructions and tool.instructions is not None:
             tool_instructions.append(tool.instructions)
     return prepared_tools, tool_instructions
 
@@ -727,7 +731,7 @@ def _prepare_function_for_estimation(function: Function) -> Function:
     prepared_function = function.model_copy(deep=True)
     if not prepared_function.skip_entrypoint_processing and prepared_function.entrypoint is not None:
         effective_strict = False if prepared_function.strict is None else prepared_function.strict
-        prepared_function.process_entrypoint(strict=effective_strict)
+        process_function_schema_for_prompt(prepared_function, strict=effective_strict)
     return prepared_function
 
 
@@ -794,19 +798,7 @@ def _prepare_team_prompt_inputs_for_estimation(
     MindRoom. This logic is verified against `agno==2.5.13`; if Agno changes those
     internals, update this estimator to match the new team prompt builder.
     """
-    budget_session_id = "history-budget"
-    session = TeamSession(session_id=budget_session_id, team_id=team.id)
-    run_response = TeamRunOutput(
-        run_id=budget_session_id,
-        team_id=team.id,
-        session_id=budget_session_id,
-        session_state={},
-    )
-    run_context = RunContext(
-        run_id=budget_session_id,
-        session_id=budget_session_id,
-        session_state={},
-    )
+    session, run_response, run_context = _team_prompt_estimation_inputs(team)
     model = team.model
     assert model is not None
     prepared_tools = _determine_tools_for_model(
@@ -821,18 +813,48 @@ def _prepare_team_prompt_inputs_for_estimation(
     return session, [tool for tool in prepared_tools if isinstance(tool, Function) or _is_tool_definition_dict(tool)]
 
 
-@timed("system_prompt_assembly.history_prepare.static_token_estimate.agno_determine_tools")
+@timed("system_prompt_assembly.history_prepare.static_token_estimate.tool_schema_prepare")
 def _prepare_agent_prompt_inputs_for_estimation(
     agent: Agent,
 ) -> tuple[AgentSession, RunContext, list[Function | _ToolDefinition]]:
     """Reuse Agno's agent tool-preparation path for prompt budgeting.
 
-    Agno exposes `Agent.get_system_message()` publicly, but the prepared tool
-    payload and `_tool_instructions` that feed that prompt are only finalized by
-    the shared `agno.agent._tools.determine_tools_for_model()` path. Using that
-    single internal entrypoint keeps MindRoom aligned with Agno without
-    re-implementing several private agent helpers.
+    The estimator only needs model-visible schemas and tool instructions, not
+    executable validate-call wrappers. Preparing those schemas here lets us reuse
+    cached Function schema metadata across fresh Agent instances.
     """
+    session, run_response, run_context = _agent_prompt_estimation_inputs(agent)
+    with timed_block("system_prompt_assembly.history_prepare.static_token_estimate.agno_get_tools"):
+        processed_tools = agent.get_tools(
+            run_response=run_response,
+            run_context=run_context,
+            session=session,
+            user_id=run_context.user_id,
+        )
+    with timed_block("system_prompt_assembly.history_prepare.static_token_estimate.tool_schema_prepare"):
+        prepared_tools, tool_instructions = _prepare_tools_for_estimation(processed_tools)
+    agent._tool_instructions = list(tool_instructions)
+    return session, run_context, prepared_tools
+
+
+def _team_prompt_estimation_inputs(team: Team) -> tuple[TeamSession, TeamRunOutput, RunContext]:
+    budget_session_id = "history-budget"
+    session = TeamSession(session_id=budget_session_id, team_id=team.id)
+    run_response = TeamRunOutput(
+        run_id=budget_session_id,
+        team_id=team.id,
+        session_id=budget_session_id,
+        session_state={},
+    )
+    run_context = RunContext(
+        run_id=budget_session_id,
+        session_id=budget_session_id,
+        session_state={},
+    )
+    return session, run_response, run_context
+
+
+def _agent_prompt_estimation_inputs(agent: Agent) -> tuple[AgentSession, RunOutput, RunContext]:
     budget_session_id = "history-budget"
     budget_user_id = "history-budget-user"
     session = AgentSession(
@@ -854,30 +876,7 @@ def _prepare_agent_prompt_inputs_for_estimation(
         user_id=budget_user_id,
         session_state={},
     )
-    model = agent.model
-    assert model is not None
-    with timed_block("system_prompt_assembly.history_prepare.static_token_estimate.agno_get_tools"):
-        processed_tools = agent.get_tools(
-            run_response=run_response,
-            run_context=run_context,
-            session=session,
-            user_id=budget_user_id,
-        )
-    with timed_block("system_prompt_assembly.history_prepare.static_token_estimate.agno_determine_tools"):
-        prepared_tools = determine_tools_for_model(
-            agent=agent,
-            model=model,
-            processed_tools=processed_tools,
-            run_response=run_response,
-            run_context=run_context,
-            session=session,
-            async_mode=False,
-        )
-    return (
-        session,
-        run_context,
-        [tool for tool in prepared_tools if isinstance(tool, Function) or _is_tool_definition_dict(tool)],
-    )
+    return session, run_response, run_context
 
 
 def resolve_effective_compaction_threshold(compaction_config: CompactionConfig, context_window: int) -> int:

--- a/src/mindroom/tool_schema_cache.py
+++ b/src/mindroom/tool_schema_cache.py
@@ -1,0 +1,102 @@
+"""Cached schema preparation for prompt-only tool descriptions."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from dataclasses import dataclass
+from functools import lru_cache
+from inspect import isfunction, ismethod
+from types import MethodType
+from typing import TYPE_CHECKING, Any
+
+from agno.tools.function import Function, UserInputField
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@dataclass(frozen=True, slots=True)
+class _ProcessedFunctionSchema:
+    parameters: dict[str, Any]
+    description: str | None
+    user_input_schema: tuple[UserInputField, ...] | None
+
+
+def process_function_schema_for_prompt(function: Function, *, strict: bool) -> None:
+    """Process one Function schema using a cache for stable entrypoints."""
+    if function.entrypoint is None:
+        function.process_entrypoint(strict=strict)
+        return
+
+    processor = function.process_entrypoint
+    if isinstance(processor, MethodType) and processor.__func__ is not Function.process_entrypoint:
+        function.process_entrypoint(strict=strict)
+        return
+
+    source_callable = getattr(function.entrypoint, "__wrapped__", function.entrypoint)
+    if isinstance(source_callable, MethodType) or ismethod(source_callable):
+        source_callable = source_callable.__func__
+    elif not isfunction(source_callable):
+        function.process_entrypoint(strict=strict)
+        return
+
+    try:
+        parameters_json = json.dumps(function.parameters, sort_keys=True, separators=(",", ":"))
+    except TypeError:
+        function.process_entrypoint(strict=strict)
+        return
+
+    snapshot = _cached_processed_function_schema(
+        source_callable,
+        function.name,
+        function.description,
+        parameters_json,
+        function.skip_entrypoint_processing,
+        function.requires_user_input,
+        tuple(function.user_input_fields) if function.user_input_fields is not None else None,
+        function.strict,
+        strict,
+    )
+    function.parameters = deepcopy(snapshot.parameters)
+    function.description = snapshot.description
+    function.user_input_schema = (
+        list(deepcopy(snapshot.user_input_schema)) if snapshot.user_input_schema is not None else None
+    )
+
+
+def clear_tool_schema_cache() -> None:
+    """Clear cached schemas after plugin or tool code changes."""
+    _cached_processed_function_schema.cache_clear()
+
+
+@lru_cache(maxsize=4096)
+def _cached_processed_function_schema(
+    source_callable: Callable[..., object],
+    name: str,
+    description: str | None,
+    parameters_json: str,
+    skip_entrypoint_processing: bool,
+    requires_user_input: bool | None,
+    user_input_fields: tuple[str, ...] | None,
+    function_strict: bool | None,
+    strict: bool,
+) -> _ProcessedFunctionSchema:
+    function = Function(
+        name=name,
+        description=description,
+        parameters=json.loads(parameters_json),
+        entrypoint=source_callable,
+        skip_entrypoint_processing=skip_entrypoint_processing,
+        requires_user_input=requires_user_input,
+        user_input_fields=list(user_input_fields) if user_input_fields is not None else None,
+        strict=function_strict,
+    )
+    function.process_entrypoint(strict=strict)
+    return _ProcessedFunctionSchema(
+        parameters=deepcopy(function.parameters),
+        description=function.description,
+        user_input_schema=tuple(deepcopy(function.user_input_schema))
+        if function.user_input_schema is not None
+        else None,
+    )

--- a/src/mindroom/tool_system/plugins.py
+++ b/src/mindroom/tool_system/plugins.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple, cast
 from mindroom.config.plugin import PluginEntryConfig  # noqa: TC001
 from mindroom.hooks import HookRegistry, iter_module_hooks
 from mindroom.logging_config import get_logger
+from mindroom.tool_schema_cache import clear_tool_schema_cache
 from mindroom.tool_system import plugin_imports
 from mindroom.tool_system.registry_state import (
     capture_tool_registry_snapshot,
@@ -327,6 +328,7 @@ def _iter_module_tasks(value: object) -> tuple[asyncio.Task[Any], ...]:
 
 def _clear_plugin_reload_caches() -> None:
     """Drop cached plugin manifests and imported plugin modules before one rebuild."""
+    clear_tool_schema_cache()
     _clear_configured_plugin_roots_cache()
     plugin_imports._PLUGIN_CACHE.clear()
     plugin_imports._MODULE_IMPORT_CACHE.clear()

--- a/tach.toml
+++ b/tach.toml
@@ -40,6 +40,14 @@ path = "mindroom.path_globs"
 depends_on = []
 
 [[modules]]
+path = "mindroom.tool_schema_cache"
+depends_on = []
+visibility = [
+    "mindroom.history.compaction",
+    "mindroom.tool_system.plugins",
+]
+
+[[modules]]
 path = "mindroom.dynamic_workflows"
 depends_on = []
 
@@ -836,6 +844,7 @@ depends_on = [
     "mindroom.hooks",
     "mindroom.logging_config",
     "mindroom.timing",
+    "mindroom.tool_schema_cache",
     "mindroom.token_budget",
     "mindroom.tool_system.runtime_context",
 ]
@@ -2275,6 +2284,7 @@ path = "mindroom.tool_system.plugins"
 depends_on = [
     "mindroom.constants",
     "mindroom.hooks",
+    "mindroom.tool_schema_cache",
     "mindroom.tool_system.plugin_imports",
     "mindroom.tool_system.registry_state",
     "mindroom.tool_system.skills",

--- a/tests/test_execution_preparation.py
+++ b/tests/test_execution_preparation.py
@@ -13,7 +13,6 @@ from agno.run.base import RunStatus
 from agno.session.agent import AgentSession
 from agno.tools.function import Function
 
-import mindroom.history.compaction as compaction_module
 from mindroom import execution_preparation
 from mindroom.attachments import _attachment_id_for_event, register_local_attachment
 from mindroom.config.main import Config
@@ -38,6 +37,7 @@ from mindroom.history import (
 from mindroom.history.compaction import estimate_agent_static_tokens
 from mindroom.history.policy import resolve_history_execution_plan
 from mindroom.history.runtime import _ResolvedPreparationInputs
+from mindroom.tool_schema_cache import clear_tool_schema_cache
 from mindroom.tool_system.events import ToolTraceEntry, build_tool_trace_content
 from tests.conftest import FakeModel, bind_runtime_paths, make_visible_message
 
@@ -179,22 +179,25 @@ async def test_prepare_execution_context_skips_fallback_replay_when_persisted_hi
 
 
 @pytest.mark.asyncio
-async def test_prepare_agent_execution_context_reuses_agno_tool_determination_for_static_estimates(
+async def test_prepare_agent_execution_context_reuses_function_schema_processing_for_static_estimates(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """One prompt assembly should determine Agno tools once for repeated static estimates."""
+    """One prompt assembly should process stable function schemas once for repeated static estimates."""
 
     def search_docs(query: str) -> str:
         """Search indexed documentation."""
         return query
 
-    agent = Agent(
-        id="test_agent",
-        name="Test Agent",
-        model=FakeModel(id="fake-model", provider="fake"),
-        tools=[Function(name="search_docs", entrypoint=search_docs)],
-    )
+    def make_agent() -> Agent:
+        return Agent(
+            id="test_agent",
+            name="Test Agent",
+            model=FakeModel(id="fake-model", provider="fake"),
+            tools=[Function(name="search_docs", entrypoint=search_docs)],
+        )
+
+    agent = make_agent()
     config, runtime_paths = _bound_agent_config(tmp_path)
     prepare_scope_history = AsyncMock(return_value=MagicMock())
     monkeypatch.setattr(execution_preparation, "prepare_scope_history", prepare_scope_history)
@@ -203,18 +206,19 @@ async def test_prepare_agent_execution_context_reuses_agno_tool_determination_fo
         "finalize_history_preparation",
         lambda **_kwargs: PreparedHistoryState(replays_persisted_history=False),
     )
+    clear_tool_schema_cache()
 
-    original_determine_tools = compaction_module.determine_tools_for_model
-    count_determine_tools = True
-    determine_tools_calls = 0
+    original_process_entrypoint = Function.process_entrypoint
+    count_schema_processing = True
+    process_entrypoint_calls = 0
 
-    def counting_determine_tools(*args: object, **kwargs: object) -> list[object]:
-        nonlocal determine_tools_calls
-        if count_determine_tools:
-            determine_tools_calls += 1
-        return original_determine_tools(*args, **kwargs)
+    def counting_process_entrypoint(self: Function, strict: bool = False) -> None:
+        nonlocal process_entrypoint_calls
+        if count_schema_processing:
+            process_entrypoint_calls += 1
+        original_process_entrypoint(self, strict=strict)
 
-    monkeypatch.setattr(compaction_module, "determine_tools_for_model", counting_determine_tools)
+    monkeypatch.setattr(Function, "process_entrypoint", counting_process_entrypoint)
 
     prepared = await prepare_agent_execution_context(
         scope_context=None,
@@ -235,12 +239,109 @@ async def test_prepare_agent_execution_context_reuses_agno_tool_determination_fo
         current_sender_id="@alice:localhost",
     )
 
-    preparation_determine_tools_calls = determine_tools_calls
-    count_determine_tools = False
+    preparation_process_entrypoint_calls = process_entrypoint_calls
+    count_schema_processing = False
     assert prepared.prepared_context_tokens == estimate_agent_static_tokens(agent, prepared.final_prompt)
     assert prepared.estimated_context_tokens == prepared.prepared_context_tokens
-    assert preparation_determine_tools_calls == 1
+    assert preparation_process_entrypoint_calls == 1
     assert prepare_scope_history.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_prepare_agent_execution_context_reuses_function_schema_processing_across_turns(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stable agent tool schema prep should be reused across prompt assemblies."""
+
+    def search_docs(query: str) -> str:
+        """Search indexed documentation."""
+        return query
+
+    def make_agent() -> Agent:
+        return Agent(
+            id="test_agent",
+            name="Test Agent",
+            model=FakeModel(id="fake-model", provider="fake"),
+            tools=[Function(name="search_docs", entrypoint=search_docs)],
+        )
+
+    config, runtime_paths = _bound_agent_config(tmp_path)
+    prepare_scope_history = AsyncMock(return_value=MagicMock())
+    monkeypatch.setattr(execution_preparation, "prepare_scope_history", prepare_scope_history)
+    monkeypatch.setattr(
+        execution_preparation,
+        "finalize_history_preparation",
+        lambda **_kwargs: PreparedHistoryState(replays_persisted_history=False),
+    )
+    clear_tool_schema_cache()
+
+    original_process_entrypoint = Function.process_entrypoint
+    process_entrypoint_calls = 0
+
+    def counting_process_entrypoint(self: Function, strict: bool = False) -> None:
+        nonlocal process_entrypoint_calls
+        process_entrypoint_calls += 1
+        original_process_entrypoint(self, strict=strict)
+
+    monkeypatch.setattr(Function, "process_entrypoint", counting_process_entrypoint)
+
+    for prompt in ("Current request", "Follow-up request"):
+        await prepare_agent_execution_context(
+            scope_context=None,
+            agent=make_agent(),
+            agent_name="test_agent",
+            prompt=prompt,
+            thread_history=[
+                make_visible_message(sender="@alice:localhost", body="Earlier context", event_id="$older"),
+                make_visible_message(sender="@alice:localhost", body=prompt, event_id="$current"),
+            ],
+            runtime_paths=runtime_paths,
+            config=config,
+            room_id="!room:localhost",
+            thread_id="$thread",
+            reply_to_event_id="$current",
+            active_event_ids=(),
+            compaction_outcomes_collector=None,
+            current_sender_id="@alice:localhost",
+        )
+
+    assert process_entrypoint_calls == 1
+    assert prepare_scope_history.await_count == 2
+
+
+def test_estimate_agent_static_tokens_reuses_function_schema_processing_across_fresh_agents(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stable function schema processing should be reused across fresh agent instances."""
+
+    def search_docs(query: str) -> str:
+        """Search indexed documentation."""
+        return query
+
+    def make_agent() -> Agent:
+        return Agent(
+            id="test_agent",
+            name="Test Agent",
+            model=FakeModel(id="fake-model", provider="fake"),
+            tools=[Function(name="search_docs", entrypoint=search_docs)],
+        )
+
+    original_process_entrypoint = Function.process_entrypoint
+    process_entrypoint_calls = 0
+
+    def counting_process_entrypoint(self: Function, strict: bool = False) -> None:
+        nonlocal process_entrypoint_calls
+        process_entrypoint_calls += 1
+        original_process_entrypoint(self, strict=strict)
+
+    monkeypatch.setattr(Function, "process_entrypoint", counting_process_entrypoint)
+    clear_tool_schema_cache()
+
+    for _ in range(2):
+        estimate_agent_static_tokens(make_agent(), "Current request")
+
+    assert process_entrypoint_calls == 1
 
 
 def test_fallback_thread_history_caps_long_messages_without_dropping_them() -> None:

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -368,10 +368,6 @@ class _FakeStorage:
 
 
 class _FakeModel:
-    id = "test-model"
-    provider = "openai"
-    supports_native_structured_outputs = False
-
     def format_function_call_results(
         self,
         messages: list[Message],

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -368,6 +368,10 @@ class _FakeStorage:
 
 
 class _FakeModel:
+    id = "test-model"
+    provider = "openai"
+    supports_native_structured_outputs = False
+
     def format_function_call_results(
         self,
         messages: list[Message],


### PR DESCRIPTION
## Summary
- replace the whole-agent static prompt cache with a small `@lru_cache` around prompt-only Function schema preparation
- avoid Agno validate-call/tool execution preparation in static token estimation; prepare only model-visible schemas and tool instructions
- clear cached tool schemas on plugin reload so changed plugin/tool code is not reused
- keep one readiness probe for positive startup wait timeouts so very short waits do not fail before probing

## Profiling
- synthetic uncached static-token profile, 12 fresh agents x 40 tools: 1.898s total; 1.804s in `Function.process_entrypoint()` across 480 calls
- same profile after schema cache: 0.216s total; `Function.process_entrypoint()` drops to 40 calls

## Test Plan
- [x] /Users/bas.nijholt/.local/bin/uv run pytest -n auto --no-cov -q
- [x] PATH="/Users/bas.nijholt/.local/bin:/Users/bas.nijholt/.bun/bin:/opt/homebrew/bin:$PATH" /Users/bas.nijholt/.local/bin/uv run pre-commit run --all-files