### PR TITLE
Offload plugin watcher tree snapshots

### DIFF
--- a/src/mindroom/orchestration/plugin_watch.py
+++ b/src/mindroom/orchestration/plugin_watch.py
@@ -109,7 +109,7 @@ async def watch_plugins_task(orchestrator: _PluginWatcherRuntime) -> None:
                 last_change_at = None
                 watch_state_revision = watch_state.revision
             pending_changes = _filter_pending_plugin_changes(pending_changes, configured_roots)
-            changed_paths = _collect_plugin_root_changes(configured_roots, watch_state.last_snapshot_by_root)
+            changed_paths = await _collect_plugin_root_changes(configured_roots, watch_state.last_snapshot_by_root)
 
             if changed_paths:
                 pending_changes.update(changed_paths)
@@ -140,20 +140,26 @@ def _filter_pending_plugin_changes(
     return {path for path in pending_changes if _path_is_under_any_root(path, configured_roots)}
 
 
-def _collect_plugin_root_changes(
+async def _collect_plugin_root_changes(
     configured_roots: tuple[Path, ...],
     last_snapshot_by_root: dict[Path, dict[Path, int]],
 ) -> set[Path]:
     """Collect edits across all currently configured plugin roots."""
+    current_snapshots = await asyncio.to_thread(_capture_plugin_root_snapshots, configured_roots)
     changed_paths = set()
     for root in configured_roots:
-        current_snapshot = file_watcher._tree_snapshot(root)
+        current_snapshot = current_snapshots[root]
         previous_snapshot = last_snapshot_by_root.get(root)
         last_snapshot_by_root[root] = current_snapshot
         if previous_snapshot is None:
             continue
         changed_paths.update(file_watcher._tree_changed_paths(previous_snapshot, current_snapshot))
     return changed_paths
+
+
+def _capture_plugin_root_snapshots(configured_roots: tuple[Path, ...]) -> dict[Path, dict[Path, int]]:
+    """Capture plugin root snapshots away from the event loop."""
+    return {root: file_watcher._tree_snapshot(root) for root in configured_roots}
 
 
 def _drop_unconfigured_plugin_root_snapshots(

--- a/src/mindroom/orchestration/plugin_watch.py
+++ b/src/mindroom/orchestration/plugin_watch.py
@@ -145,11 +145,14 @@ async def _collect_plugin_root_changes(
     last_snapshot_by_root: dict[Path, dict[Path, int]],
 ) -> set[Path]:
     """Collect edits across all currently configured plugin roots."""
+    previous_snapshot_by_root = {root: last_snapshot_by_root.get(root) for root in configured_roots}
     current_snapshots = await asyncio.to_thread(_capture_plugin_root_snapshots, configured_roots)
     changed_paths = set()
     for root in configured_roots:
         current_snapshot = current_snapshots[root]
-        previous_snapshot = last_snapshot_by_root.get(root)
+        previous_snapshot = previous_snapshot_by_root[root]
+        if last_snapshot_by_root.get(root) is not previous_snapshot:
+            continue
         last_snapshot_by_root[root] = current_snapshot
         if previous_snapshot is None:
             continue

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -16288,7 +16288,7 @@ class TestMultiAgentOrchestrator:
             loaded_hooks_module = plugin_module._MODULE_IMPORT_CACHE[hooks_path.resolve()].module
             assert loaded_hooks_module.VALUE == 1
 
-            changed_paths = _collect_plugin_root_changes(
+            changed_paths = await _collect_plugin_root_changes(
                 tuple(orchestrator.plugin_watch.last_snapshot_by_root),
                 orchestrator.plugin_watch.last_snapshot_by_root,
             )

--- a/tests/test_plugin_watch.py
+++ b/tests/test_plugin_watch.py
@@ -1,0 +1,32 @@
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from mindroom.orchestration import plugin_watch
+
+
+@pytest.mark.asyncio
+async def test_plugin_change_collection_offloads_tree_snapshots(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    root = tmp_path / "plugins"
+    plugin_file = root / "plugin.py"
+    last_snapshot_by_root: dict[Path, dict[Path, int]] = {root: {}}
+    to_thread_calls = 0
+
+    def fake_tree_snapshot(path: Path) -> dict[Path, int]:
+        assert path == root
+        return {plugin_file: 1}
+
+    async def fake_to_thread(function: Callable[..., object], *args: object, **kwargs: object) -> object:
+        nonlocal to_thread_calls
+        to_thread_calls += 1
+        return function(*args, **kwargs)
+
+    monkeypatch.setattr(plugin_watch.file_watcher, "_tree_snapshot", fake_tree_snapshot)
+    monkeypatch.setattr(plugin_watch.asyncio, "to_thread", fake_to_thread)
+
+    changed_paths = await plugin_watch._collect_plugin_root_changes((root,), last_snapshot_by_root)
+
+    assert changed_paths == {plugin_file}
+    assert last_snapshot_by_root[root] == {plugin_file: 1}
+    assert to_thread_calls == 1

--- a/tests/test_plugin_watch.py
+++ b/tests/test_plugin_watch.py
@@ -1,3 +1,5 @@
+"""Tests for plugin watcher snapshot collection."""
+
 from collections.abc import Callable
 from pathlib import Path
 
@@ -7,7 +9,11 @@ from mindroom.orchestration import plugin_watch
 
 
 @pytest.mark.asyncio
-async def test_plugin_change_collection_offloads_tree_snapshots(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+async def test_plugin_change_collection_offloads_tree_snapshots(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Plugin root scans should run through the thread offload boundary."""
     root = tmp_path / "plugins"
     plugin_file = root / "plugin.py"
     last_snapshot_by_root: dict[Path, dict[Path, int]] = {root: {}}
@@ -30,3 +36,34 @@ async def test_plugin_change_collection_offloads_tree_snapshots(monkeypatch: pyt
     assert changed_paths == {plugin_file}
     assert last_snapshot_by_root[root] == {plugin_file: 1}
     assert to_thread_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_plugin_change_collection_preserves_concurrently_replaced_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Stale thread snapshots should not overwrite a concurrently replaced baseline."""
+    root = tmp_path / "plugins"
+    plugin_file = root / "plugin.py"
+    original_snapshot = {plugin_file: 1}
+    replaced_snapshot = {plugin_file: 3}
+    stale_thread_snapshot = {plugin_file: 2}
+    last_snapshot_by_root: dict[Path, dict[Path, int]] = {root: original_snapshot}
+
+    def fake_tree_snapshot(path: Path) -> dict[Path, int]:
+        assert path == root
+        return stale_thread_snapshot
+
+    async def fake_to_thread(function: Callable[..., object], *args: object, **kwargs: object) -> object:
+        result = function(*args, **kwargs)
+        last_snapshot_by_root[root] = replaced_snapshot
+        return result
+
+    monkeypatch.setattr(plugin_watch.file_watcher, "_tree_snapshot", fake_tree_snapshot)
+    monkeypatch.setattr(plugin_watch.asyncio, "to_thread", fake_to_thread)
+
+    changed_paths = await plugin_watch._collect_plugin_root_changes((root,), last_snapshot_by_root)
+
+    assert changed_paths == set()
+    assert last_snapshot_by_root[root] is replaced_snapshot


### PR DESCRIPTION
## Summary
- move plugin root tree snapshotting out of the plugin watcher event loop with `asyncio.to_thread`
- keep snapshot comparison and watcher state mutation on the event loop
- add a regression test that verifies plugin root snapshots are offloaded

## Test Plan
- [x] `uv sync --all-extras`
- [x] `uv run pytest tests/test_plugin_watch.py tests/test_multi_agent_bot.py::TestMultiAgentOrchestrator::test_update_config_preserves_watcher_dirty_state_for_stale_prepared_plugin_snapshot -q --no-cov`
- [x] `uv run pytest -n auto --no-cov -q` — 8577 passed, 61 skipped
- [x] `uv run pre-commit run --all-files`