### PR TITLE
Preserve Agent Vault proxy auth in dedicated workers

### DIFF
--- a/src/mindroom/api/sandbox_exec.py
+++ b/src/mindroom/api/sandbox_exec.py
@@ -157,7 +157,8 @@ def request_execution_env(
     # Agent Vault egress is composed from the worker pod's own token + endpoint,
     # so it is always overlaid here at the worker (never shipped from the
     # primary, which has neither the token nor the endpoint env).
-    agent_vault_env = constants.worker_proxy_execution_env({**os.environ, **runtime_paths.process_env})
+    worker_local_env = {**runtime_paths.process_env, **os.environ}
+    agent_vault_env = constants.worker_proxy_execution_env(worker_local_env)
     if execution_env:
         protected_env_names = _protected_dedicated_worker_execution_env_names(runtime_paths)
         env = {key: value for key, value in execution_env.items() if key not in protected_env_names}
@@ -168,11 +169,14 @@ def request_execution_env(
         if runner_uses_dedicated_worker(runtime_paths)
         else {**os.environ, **runtime_paths.process_env}
     )
-    return constants.build_execution_tool_env(
-        tool_name,
-        runtime_paths,
-        extra_env_passthrough=extra_env_passthrough,
-        shell_process_env=shell_process_env,
+    return (
+        constants.build_execution_tool_env(
+            tool_name,
+            runtime_paths,
+            extra_env_passthrough=extra_env_passthrough,
+            shell_process_env=shell_process_env,
+        )
+        | agent_vault_env
     )
 
 

--- a/tests/api/test_worker_egress_proxy_compose.py
+++ b/tests/api/test_worker_egress_proxy_compose.py
@@ -38,7 +38,10 @@ def _git_config_value(env: dict[str, str], key: str) -> str:
     count = int(env.get("GIT_CONFIG_COUNT", "0"))
     for index in range(count):
         if env.get(f"GIT_CONFIG_KEY_{index}") == key:
-            return env[f"GIT_CONFIG_VALUE_{index}"]
+            value = env.get(f"GIT_CONFIG_VALUE_{index}")
+            if value is None:
+                pytest.fail(f"missing env-backed Git config value for key {key!r}")
+            return value
     pytest.fail(f"missing env-backed Git config key {key!r}")
 
 
@@ -65,6 +68,9 @@ def test_request_execution_env_overlays_proxy_in_dedicated_worker_from_pod_env(
     monkeypatch.setenv("MINDROOM_WORKER_EGRESS_PROXY_TOKEN_FILE", str(token_path))
     monkeypatch.setenv("MINDROOM_WORKER_EGRESS_PROXY_VAULT", "agent-vault-worker")
     monkeypatch.setenv("MINDROOM_WORKER_EGRESS_PROXY_CA_FILE", "/etc/agent-vault/ca.pem")
+    monkeypatch.setenv("GIT_CONFIG_COUNT", "1")
+    monkeypatch.setenv("GIT_CONFIG_KEY_0", "safe.directory")
+    monkeypatch.setenv("GIT_CONFIG_VALUE_0", "*")
 
     runtime_paths = resolve_runtime_paths(
         config_path=tmp_path / "config.yaml",
@@ -85,6 +91,10 @@ def test_request_execution_env_overlays_proxy_in_dedicated_worker_from_pod_env(
     assert env["HTTPS_PROXY"] == expected_proxy
     assert env["http_proxy"] == expected_proxy
     assert env["https_proxy"] == expected_proxy
+    assert env["REQUESTS_CA_BUNDLE"] == "/etc/agent-vault/ca.pem"
+    assert env["GIT_SSL_CAINFO"] == "/etc/agent-vault/ca.pem"
+    assert env["NODE_EXTRA_CA_CERTS"] == "/etc/agent-vault/ca.pem"
+    assert _git_config_value(env, "safe.directory") == "*"
     assert _git_config_value(env, "http.proxy") == expected_proxy
 
 

--- a/tests/api/test_worker_egress_proxy_compose.py
+++ b/tests/api/test_worker_egress_proxy_compose.py
@@ -34,6 +34,14 @@ def _runtime_paths_with_vault(tmp_path: Path, *, with_ca: bool = True) -> tuple[
     return runtime_paths, "http://av_sess_worker_token:agent-vault-worker@agent-vault:14322"
 
 
+def _git_config_value(env: dict[str, str], key: str) -> str:
+    count = int(env.get("GIT_CONFIG_COUNT", "0"))
+    for index in range(count):
+        if env.get(f"GIT_CONFIG_KEY_{index}") == key:
+            return env[f"GIT_CONFIG_VALUE_{index}"]
+    pytest.fail(f"missing env-backed Git config key {key!r}")
+
+
 def test_request_execution_env_overlays_proxy_when_no_primary_env(tmp_path: Path) -> None:
     """When the primary ships no execution env, the worker still composes the proxy."""
     runtime_paths, expected_proxy = _runtime_paths_with_vault(tmp_path)
@@ -44,6 +52,40 @@ def test_request_execution_env_overlays_proxy_when_no_primary_env(tmp_path: Path
     # git and node ignore the curl/python bundles; they need their own keys.
     assert env["GIT_SSL_CAINFO"] == "/etc/agent-vault/ca.pem"
     assert env["NODE_EXTRA_CA_CERTS"] == "/etc/agent-vault/ca.pem"
+
+
+def test_request_execution_env_overlays_proxy_in_dedicated_worker_from_pod_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dedicated workers must use their pod-local Agent Vault token file."""
+    token_path = tmp_path / "token"
+    token_path.write_text("av_sess_worker_token\n", encoding="utf-8")
+    monkeypatch.setenv("MINDROOM_WORKER_EGRESS_PROXY_URL", "http://agent-vault:14322")
+    monkeypatch.setenv("MINDROOM_WORKER_EGRESS_PROXY_TOKEN_FILE", str(token_path))
+    monkeypatch.setenv("MINDROOM_WORKER_EGRESS_PROXY_VAULT", "agent-vault-worker")
+    monkeypatch.setenv("MINDROOM_WORKER_EGRESS_PROXY_CA_FILE", "/etc/agent-vault/ca.pem")
+
+    runtime_paths = resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path,
+        process_env={
+            "MINDROOM_SANDBOX_DEDICATED_WORKER_KEY": "worker-1",
+            "HTTP_PROXY": "http://mindroom-egress-proxy:3128",
+            "HTTPS_PROXY": "http://mindroom-egress-proxy:3128",
+            "http_proxy": "http://mindroom-egress-proxy:3128",
+            "https_proxy": "http://mindroom-egress-proxy:3128",
+        },
+    )
+
+    env = sandbox_exec.request_execution_env("shell", None, runtime_paths)
+
+    expected_proxy = "http://av_sess_worker_token:agent-vault-worker@agent-vault:14322"
+    assert env["HTTP_PROXY"] == expected_proxy
+    assert env["HTTPS_PROXY"] == expected_proxy
+    assert env["http_proxy"] == expected_proxy
+    assert env["https_proxy"] == expected_proxy
+    assert _git_config_value(env, "http.proxy") == expected_proxy
 
 
 def test_worker_proxy_execution_env_configures_git_proxy_auth(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fix dedicated worker shell/python execution so Agent Vault proxy credentials are composed from the worker pod's local token file and overlaid after any plain proxy env.

Without this, dedicated workers can run shell commands with `HTTPS_PROXY=http://egress-proxy:3128` instead of the token-bearing proxy URL. Squid then allows static hosts directly, but credential injection is skipped because the request never routes through the Agent Vault parent.

## Changes

- Compose worker-local Agent Vault proxy env from pod `os.environ` over runtime config env.
- Overlay that token-bearing proxy env last in `request_execution_env`.
- Add a regression test for dedicated-worker mode where runtime env has plain proxy values but pod env has the Agent Vault token file.

## Verification

- `uv run pytest tests/api/test_worker_egress_proxy_compose.py`
- pre-commit hooks passed except `ty`, skipped locally because this fresh worktree lacks optional dependency extras such as Playwright and psycopg.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected execution-environment proxy merging so Agent Vault–provided settings reliably overlay HTTP/HTTPS proxy values and related git proxy configuration for dedicated workers.

* **Tests**
  * Added a dedicated-worker test that simulates pod-local Agent Vault environment variables and verifies correct proxy overlay (including both uppercase/lowercase), CA bundle availability, and the expected git `http.proxy` setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->