### PR TITLE
Added reference to Local Mindroom button, where local Mindroom pair codes are generated. Prevents new users from having to hunt for it.

### DIFF
--- a/docs/installation/macos-app.md
+++ b/docs/installation/macos-app.md
@@ -24,7 +24,7 @@ Open **MindRoom** from `/Applications` or Spotlight.
 
 Use **Install MindRoom Runtime** to install the CLI runtime with bundled `uv`.
 Use **Initialize Hosted Config** for the default `chat.mindroom.chat` profile.
-Open `https://chat.mindroom.chat`, generate a local MindRoom pair code, and use **Pair Hosted MindRoom...** in the menu.
+Open `https://chat.mindroom.chat`, click the Local Mindroom icon on the left to generate a local MindRoom pair code, and use **Pair Hosted MindRoom...** in the menu.
 Use **Install/Ensure Service** to run `mindroom service install --no-confirm`.
 Use **Open Dashboard** to open `http://localhost:8765`.
 

--- a/docs/installation/macos-app.md
+++ b/docs/installation/macos-app.md
@@ -24,7 +24,7 @@ Open **MindRoom** from `/Applications` or Spotlight.
 
 Use **Install MindRoom Runtime** to install the CLI runtime with bundled `uv`.
 Use **Initialize Hosted Config** for the default `chat.mindroom.chat` profile.
-Open `https://chat.mindroom.chat`, click the Local Mindroom icon on the left to generate a local MindRoom pair code, and use **Pair Hosted MindRoom...** in the menu.
+Open `https://chat.mindroom.chat`, click the Local MindRoom icon on the left to generate a local MindRoom pair code, and use **Pair Hosted MindRoom...** in the menu.
 Use **Install/Ensure Service** to run `mindroom service install --no-confirm`.
 Use **Open Dashboard** to open `http://localhost:8765`.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated macOS installation instructions to clarify the step-by-step UI flow for generating a local MindRoom pair code during the first launch. Users should click the Local Mindroom icon on the left before using the "Pair Hosted MindRoom..." option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->