### PR TITLE
Fix OAuth MCP refresh token rotation race

### DIFF
--- a/src/mindroom/api/oauth.py
+++ b/src/mindroom/api/oauth.py
@@ -29,6 +29,7 @@ from mindroom.oauth.service import (
     oauth_credentials_usable,
     oauth_provider_service_account_configured,
     oauth_success_redirect_url,
+    refresh_scoped_oauth_credentials,
     sanitized_oauth_token_result,
 )
 
@@ -431,7 +432,13 @@ async def status(provider_id: str, request: Request, agent_name: str | None = No
     credentials_usable = oauth_credentials_usable(provider, runtime_paths, credentials)
     if credentials_usable and has_client_config and not has_service_account_config:
         try:
-            refreshed_credentials = await provider.refresh_token_data(credentials, runtime_paths)
+            refreshed_credentials = await refresh_scoped_oauth_credentials(
+                provider,
+                runtime_paths,
+                credentials_manager=target.base_manager,
+                worker_target=worker_target,
+                allowed_shared_services=target.allowed_shared_services,
+            )
         except OAuthProviderError as exc:
             logger.warning(
                 "oauth_token_refresh_failed",
@@ -439,15 +446,8 @@ async def status(provider_id: str, request: Request, agent_name: str | None = No
                 error_type=type(exc).__name__,
             )
         else:
-            if refreshed_credentials is not None:
-                save_scoped_credentials(
-                    provider.credential_service,
-                    refreshed_credentials,
-                    credentials_manager=target.base_manager,
-                    worker_target=worker_target,
-                )
-                credentials = refreshed_credentials
-                credentials_usable = oauth_credentials_usable(provider, runtime_paths, credentials)
+            credentials = refreshed_credentials or {}
+            credentials_usable = oauth_credentials_usable(provider, runtime_paths, credentials)
     connected = has_service_account_config or credentials_usable
     if client_config_resolution is not None:
         client_config_service = client_config_resolution.service

--- a/src/mindroom/credentials.py
+++ b/src/mindroom/credentials.py
@@ -49,6 +49,7 @@ __all__ = [
     "load_worker_grantable_shared_credentials",
     "runtime_credentials_manager_key",
     "save_scoped_credentials",
+    "scoped_credentials_path",
     "sync_shared_credentials_to_worker",
     "validate_service_name",
 ]
@@ -672,6 +673,49 @@ def _primary_runtime_scoped_credentials_manager(
     return manager.for_primary_runtime_scope(identity.requester_id, agent_name)
 
 
+def _scoped_credentials_target_manager(
+    service: str,
+    *,
+    credentials_manager: CredentialsManager,
+    worker_target: ResolvedWorkerTarget | None,
+) -> CredentialsManager:
+    manager = credentials_manager
+    if worker_target is None or worker_target.worker_scope is None:
+        return manager if manager.shared_base_path != manager.base_path else manager.shared_manager()
+
+    if credential_service_policy(service, worker_target.worker_scope).uses_local_shared_credentials:
+        return manager.shared_manager()
+
+    primary_runtime_manager = _primary_runtime_scoped_credentials_manager(
+        service,
+        manager=manager,
+        worker_target=worker_target,
+    )
+    if primary_runtime_manager is not None:
+        return primary_runtime_manager
+
+    worker_manager = _resolve_worker_credentials_manager(
+        credentials_manager=manager,
+        worker_target=worker_target,
+    )
+    return worker_manager or manager.shared_manager()
+
+
+def scoped_credentials_path(
+    service: str,
+    *,
+    credentials_manager: CredentialsManager,
+    worker_target: ResolvedWorkerTarget | None,
+) -> Path:
+    """Return the file path that scoped credential writes target for one service."""
+    normalized_service = validate_service_name(service)
+    return _scoped_credentials_target_manager(
+        normalized_service,
+        credentials_manager=credentials_manager,
+        worker_target=worker_target,
+    ).get_credentials_path(normalized_service)
+
+
 def load_scoped_credentials(
     service: str,
     *,
@@ -738,31 +782,13 @@ def save_scoped_credentials(
     worker_target: ResolvedWorkerTarget | None,
 ) -> None:
     """Save credentials for a service to the current worker scope when available."""
-    manager = credentials_manager
-    if worker_target is None or worker_target.worker_scope is None:
-        target_manager = manager if manager.shared_base_path != manager.base_path else manager.shared_manager()
-        target_manager.save_credentials(service, credentials)
-        return
-
-    if credential_service_policy(service, worker_target.worker_scope).uses_local_shared_credentials:
-        manager.shared_manager().save_credentials(service, credentials)
-        return
-
-    primary_runtime_manager = _primary_runtime_scoped_credentials_manager(
-        service,
-        manager=manager,
+    normalized_service = validate_service_name(service)
+    target_manager = _scoped_credentials_target_manager(
+        normalized_service,
+        credentials_manager=credentials_manager,
         worker_target=worker_target,
     )
-    if primary_runtime_manager is not None:
-        primary_runtime_manager.save_credentials(service, credentials)
-        return
-
-    worker_manager = _resolve_worker_credentials_manager(
-        credentials_manager=manager,
-        worker_target=worker_target,
-    )
-    target_manager = worker_manager or manager.shared_manager()
-    target_manager.save_credentials(service, credentials)
+    target_manager.save_credentials(normalized_service, credentials)
 
 
 def delete_scoped_credentials(
@@ -772,28 +798,10 @@ def delete_scoped_credentials(
     worker_target: ResolvedWorkerTarget | None,
 ) -> None:
     """Delete credentials for a service from the current worker scope when available."""
-    manager = credentials_manager
-    if worker_target is None or worker_target.worker_scope is None:
-        target_manager = manager if manager.shared_base_path != manager.base_path else manager.shared_manager()
-        target_manager.delete_credentials(service)
-        return
-
-    if credential_service_policy(service, worker_target.worker_scope).uses_local_shared_credentials:
-        manager.shared_manager().delete_credentials(service)
-        return
-
-    primary_runtime_manager = _primary_runtime_scoped_credentials_manager(
-        service,
-        manager=manager,
+    normalized_service = validate_service_name(service)
+    target_manager = _scoped_credentials_target_manager(
+        normalized_service,
+        credentials_manager=credentials_manager,
         worker_target=worker_target,
     )
-    if primary_runtime_manager is not None:
-        primary_runtime_manager.delete_credentials(service)
-        return
-
-    worker_manager = _resolve_worker_credentials_manager(
-        credentials_manager=manager,
-        worker_target=worker_target,
-    )
-    target_manager = worker_manager or manager.shared_manager()
-    target_manager.delete_credentials(service)
+    target_manager.delete_credentials(normalized_service)

--- a/src/mindroom/file_locks.py
+++ b/src/mindroom/file_locks.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
 
 _DEFAULT_POLL_SECONDS = 0.1
 
+__all__ = ["advisory_file_lock", "async_exclusive_file_lock"]
+
 
 def _open_lock_file(lock_path: Path) -> TextIO:
     lock_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/mindroom/mcp/manager.py
+++ b/src/mindroom/mcp/manager.py
@@ -376,18 +376,6 @@ class MCPServerManager:
                 worker_target=worker_target,
             )
             credentials = refresh_result.credentials
-        except OAuthRefreshRejectedError as exc:
-            failed_credentials = load_scoped_credentials(
-                provider.credential_service,
-                credentials_manager=manager,
-                worker_target=worker_target,
-            )
-            self._log_oauth_refresh_failure(state, provider.id, failed_credentials or {}, exc)
-            raise self._oauth_connection_required(
-                state,
-                worker_target,
-                reason=_OAUTH_REFRESH_REJECTED_REASON,
-            ) from exc
         except OAuthProviderError as exc:
             failed_credentials = load_scoped_credentials(
                 provider.credential_service,
@@ -395,7 +383,12 @@ class MCPServerManager:
                 worker_target=worker_target,
             )
             self._log_oauth_refresh_failure(state, provider.id, failed_credentials or {}, exc)
-            raise self._oauth_connection_required(state, worker_target) from exc
+            reason = _OAUTH_REFRESH_REJECTED_REASON if isinstance(exc, OAuthRefreshRejectedError) else None
+            raise self._oauth_connection_required(
+                state,
+                worker_target,
+                reason=reason,
+            ) from exc
         if not oauth_credentials_usable(provider, self.runtime_paths, credentials):
             raise self._oauth_connection_required(state, worker_target)
         assert credentials is not None

--- a/src/mindroom/mcp/manager.py
+++ b/src/mindroom/mcp/manager.py
@@ -35,7 +35,7 @@ from mindroom.oauth.service import (
     build_oauth_reconnect_instruction,
     oauth_connect_url,
     oauth_credentials_usable,
-    refresh_scoped_oauth_credentials,
+    refresh_scoped_oauth_credentials_with_result,
 )
 from mindroom.tool_system.catalog import TOOL_METADATA, ensure_tool_registry_loaded, get_tool_by_name
 from mindroom.tool_system.dynamic_toolkits import visible_tool_surface
@@ -374,12 +374,13 @@ class MCPServerManager:
             worker_target=worker_target,
         )
         try:
-            credentials = await refresh_scoped_oauth_credentials(
+            refresh_result = await refresh_scoped_oauth_credentials_with_result(
                 provider,
                 self.runtime_paths,
                 credentials_manager=manager,
                 worker_target=worker_target,
             )
+            credentials = refresh_result.credentials
         except OAuthRefreshRejectedError as exc:
             self._log_oauth_refresh_failure(state, provider.id, previous_credentials or {}, exc)
             raise self._oauth_connection_required(
@@ -393,7 +394,7 @@ class MCPServerManager:
         if not oauth_credentials_usable(provider, self.runtime_paths, credentials):
             raise self._oauth_connection_required(state, worker_target)
         assert credentials is not None
-        if previous_credentials is not None and credentials != previous_credentials:
+        if refresh_result.refreshed:
             logger.info(
                 "MCP OAuth token refreshed",
                 provider_id=provider.id,

--- a/src/mindroom/mcp/manager.py
+++ b/src/mindroom/mcp/manager.py
@@ -368,11 +368,6 @@ class MCPServerManager:
     ) -> str:
         provider = mcp_oauth_provider(state.server_id, state.config)
         manager = credentials_manager or get_runtime_credentials_manager(self.runtime_paths)
-        previous_credentials = load_scoped_credentials(
-            provider.credential_service,
-            credentials_manager=manager,
-            worker_target=worker_target,
-        )
         try:
             refresh_result = await refresh_scoped_oauth_credentials_with_result(
                 provider,
@@ -382,14 +377,24 @@ class MCPServerManager:
             )
             credentials = refresh_result.credentials
         except OAuthRefreshRejectedError as exc:
-            self._log_oauth_refresh_failure(state, provider.id, previous_credentials or {}, exc)
+            failed_credentials = load_scoped_credentials(
+                provider.credential_service,
+                credentials_manager=manager,
+                worker_target=worker_target,
+            )
+            self._log_oauth_refresh_failure(state, provider.id, failed_credentials or {}, exc)
             raise self._oauth_connection_required(
                 state,
                 worker_target,
                 reason=_OAUTH_REFRESH_REJECTED_REASON,
             ) from exc
         except OAuthProviderError as exc:
-            self._log_oauth_refresh_failure(state, provider.id, previous_credentials or {}, exc)
+            failed_credentials = load_scoped_credentials(
+                provider.credential_service,
+                credentials_manager=manager,
+                worker_target=worker_target,
+            )
+            self._log_oauth_refresh_failure(state, provider.id, failed_credentials or {}, exc)
             raise self._oauth_connection_required(state, worker_target) from exc
         if not oauth_credentials_usable(provider, self.runtime_paths, credentials):
             raise self._oauth_connection_required(state, worker_target)

--- a/src/mindroom/mcp/manager.py
+++ b/src/mindroom/mcp/manager.py
@@ -15,7 +15,7 @@ from authlib.common.errors import AuthlibBaseError
 from httpx import HTTPError
 from mcp import ClientSession
 
-from mindroom.credentials import get_runtime_credentials_manager, load_scoped_credentials, save_scoped_credentials
+from mindroom.credentials import get_runtime_credentials_manager, load_scoped_credentials
 from mindroom.logging_config import get_logger
 from mindroom.mcp.config import (
     MCPServerConfig,
@@ -35,6 +35,7 @@ from mindroom.oauth.service import (
     build_oauth_reconnect_instruction,
     oauth_connect_url,
     oauth_credentials_usable,
+    refresh_scoped_oauth_credentials,
 )
 from mindroom.tool_system.catalog import TOOL_METADATA, ensure_tool_registry_loaded, get_tool_by_name
 from mindroom.tool_system.dynamic_toolkits import visible_tool_surface
@@ -367,40 +368,38 @@ class MCPServerManager:
     ) -> str:
         provider = mcp_oauth_provider(state.server_id, state.config)
         manager = credentials_manager or get_runtime_credentials_manager(self.runtime_paths)
-        credentials = load_scoped_credentials(
+        previous_credentials = load_scoped_credentials(
             provider.credential_service,
             credentials_manager=manager,
             worker_target=worker_target,
         )
-        if not oauth_credentials_usable(provider, self.runtime_paths, credentials):
-            raise self._oauth_connection_required(state, worker_target)
-        assert credentials is not None
         try:
-            refreshed_credentials = await provider.refresh_token_data(credentials, self.runtime_paths)
+            credentials = await refresh_scoped_oauth_credentials(
+                provider,
+                self.runtime_paths,
+                credentials_manager=manager,
+                worker_target=worker_target,
+            )
         except OAuthRefreshRejectedError as exc:
-            self._log_oauth_refresh_failure(state, provider.id, credentials, exc)
+            self._log_oauth_refresh_failure(state, provider.id, previous_credentials or {}, exc)
             raise self._oauth_connection_required(
                 state,
                 worker_target,
                 reason=_OAUTH_REFRESH_REJECTED_REASON,
             ) from exc
         except OAuthProviderError as exc:
-            self._log_oauth_refresh_failure(state, provider.id, credentials, exc)
+            self._log_oauth_refresh_failure(state, provider.id, previous_credentials or {}, exc)
             raise self._oauth_connection_required(state, worker_target) from exc
-        if refreshed_credentials is not None:
-            save_scoped_credentials(
-                provider.credential_service,
-                refreshed_credentials,
-                credentials_manager=manager,
-                worker_target=worker_target,
-            )
+        if not oauth_credentials_usable(provider, self.runtime_paths, credentials):
+            raise self._oauth_connection_required(state, worker_target)
+        assert credentials is not None
+        if previous_credentials is not None and credentials != previous_credentials:
             logger.info(
                 "MCP OAuth token refreshed",
                 provider_id=provider.id,
                 server_id=state.server_id,
-                expires_at=self._oauth_refreshed_expires_at(refreshed_credentials),
+                expires_at=self._oauth_refreshed_expires_at(credentials),
             )
-            credentials = refreshed_credentials
         token = credentials.get("token") or credentials.get("access_token")
         if not isinstance(token, str) or not token:
             raise self._oauth_connection_required(state, worker_target)

--- a/src/mindroom/mcp/registry.py
+++ b/src/mindroom/mcp/registry.py
@@ -40,6 +40,8 @@ _MCP_TOOL_PREFIX = "mcp_"
 _MCP_TOOL_NAMES: set[str] = set()
 _MCP_OAUTH_TOOL_NAMES: set[str] = set()
 _MCP_TOOL_FACTORY_MARKER = "__mindroom_mcp_tool_factory__"
+# MindRoomMCPToolkit declares these constructor args for every MCP tool; metadata
+# mirrors that contract even though credentials are used only by OAuth-backed servers.
 _MCP_MANAGED_INIT_ARGS = (
     ToolManagedInitArg.RUNTIME_PATHS,
     ToolManagedInitArg.CREDENTIALS_MANAGER,

--- a/src/mindroom/mcp/registry.py
+++ b/src/mindroom/mcp/registry.py
@@ -40,7 +40,7 @@ _MCP_TOOL_PREFIX = "mcp_"
 _MCP_TOOL_NAMES: set[str] = set()
 _MCP_OAUTH_TOOL_NAMES: set[str] = set()
 _MCP_TOOL_FACTORY_MARKER = "__mindroom_mcp_tool_factory__"
-_MCP_OAUTH_MANAGED_INIT_ARGS = (
+_MCP_MANAGED_INIT_ARGS = (
     ToolManagedInitArg.RUNTIME_PATHS,
     ToolManagedInitArg.CREDENTIALS_MANAGER,
     ToolManagedInitArg.WORKER_TARGET,
@@ -157,7 +157,7 @@ def _tool_metadata(server_id: str, server_config: MCPServerConfig) -> ToolMetada
         agent_override_fields=_tool_override_fields(),
         authored_override_validator=ToolAuthoredOverrideValidator.MCP,
         function_names=function_names,
-        managed_init_args=_MCP_OAUTH_MANAGED_INIT_ARGS if is_oauth else (),
+        managed_init_args=_MCP_MANAGED_INIT_ARGS,
     )
 
 

--- a/src/mindroom/oauth/client.py
+++ b/src/mindroom/oauth/client.py
@@ -281,6 +281,8 @@ class ScopedOAuthClientMixin:
             if self.creds.expired and self.creds.refresh_token:
                 self.creds.refresh(google_requests.Request())
                 refreshed = dict(token_data)
+                # Google auth refresh updates access-token state and preserves the
+                # stored refresh token, unlike rotating MCP provider refreshes.
                 refreshed["token"] = self.creds.token
                 refreshed_expires_at = self._expires_at_from_credentials(self.creds)
                 if refreshed_expires_at is not None:

--- a/src/mindroom/oauth/service.py
+++ b/src/mindroom/oauth/service.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 import math
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urlencode, urlparse
+
+from authlib.common.errors import AuthlibBaseError
+from httpx import HTTPStatusError
 
 from mindroom.credential_policy import credential_service_policy
 from mindroom.credentials import load_scoped_credentials, save_scoped_credentials, validate_service_name
@@ -15,7 +19,6 @@ from mindroom.oauth.providers import OAuthClaimValidationError, OAuthProviderErr
 from mindroom.oauth.state import consume_opaque_oauth_state, issue_opaque_oauth_state, read_opaque_oauth_state
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
     from pathlib import Path
 
     from mindroom.constants import RuntimePaths
@@ -228,45 +231,41 @@ def _refresh_token_value(credentials: Mapping[str, Any] | None) -> str | None:
 
 
 def _is_recoverable_stale_refresh_rejection(exc: OAuthProviderError) -> bool:
-    for value in _oauth_error_values(exc):
-        if any(code in value.lower() for code in _RECOVERABLE_REFRESH_ERROR_CODES):
-            return True
-    return False
+    error_code = _oauth_error_code(exc)
+    return error_code in _RECOVERABLE_REFRESH_ERROR_CODES
 
 
-def _oauth_error_values(exc: BaseException) -> tuple[str, ...]:
-    values: list[str] = []
+def _oauth_error_code(exc: BaseException) -> str | None:
     current: BaseException | None = exc
     while current is not None:
-        values.append(str(current))
-        for attribute_name in ("error", "error_code", "code", "description"):
-            value = getattr(current, attribute_name, None)
-            if isinstance(value, str):
-                values.append(value)
-        response = getattr(current, "response", None)
-        if response is not None:
-            values.extend(_oauth_error_response_values(response))
+        if isinstance(current, OAuthProviderError):
+            error_code = _normalized_oauth_error_code(current.oauth_error)
+            if error_code is not None:
+                return error_code
+        if isinstance(current, AuthlibBaseError):
+            error_code = _normalized_oauth_error_code(current.error)
+            if error_code is not None:
+                return error_code
+        if isinstance(current, HTTPStatusError):
+            error_code = _oauth_error_response_code(current)
+            if error_code is not None:
+                return error_code
         current = current.__cause__ if isinstance(current.__cause__, BaseException) else None
-    return tuple(value for value in values if value)
+    return None
 
 
-def _oauth_error_response_values(response: object) -> tuple[str, ...]:
-    status_code = getattr(response, "status_code", None)
-    values = [str(status_code)] if isinstance(status_code, int) else []
-    json_method = getattr(response, "json", None)
-    if not callable(json_method):
-        return tuple(values)
+def _normalized_oauth_error_code(value: object) -> str | None:
+    return value.strip().lower() if isinstance(value, str) and value.strip() else None
+
+
+def _oauth_error_response_code(exc: HTTPStatusError) -> str | None:
     try:
-        payload = json_method()
-    except ValueError:
-        return tuple(values)
-    if not isinstance(payload, dict):
-        return tuple(values)
-    for key in ("error", "error_description", "message"):
-        value = payload.get(key)
-        if isinstance(value, str):
-            values.append(value)
-    return tuple(values)
+        payload = exc.response.json()
+    except (ValueError, UnicodeDecodeError):
+        return None
+    if not isinstance(payload, Mapping):
+        return None
+    return _normalized_oauth_error_code(payload.get("error"))
 
 
 def oauth_credential_target_payload(

--- a/src/mindroom/oauth/service.py
+++ b/src/mindroom/oauth/service.py
@@ -8,17 +8,25 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urlencode, urlparse
 
+from mindroom.credential_policy import credential_service_policy
+from mindroom.credentials import load_scoped_credentials, save_scoped_credentials, validate_service_name
+from mindroom.file_locks import async_exclusive_file_lock
 from mindroom.oauth.providers import OAuthClaimValidationError, OAuthProviderError, OAuthTokenResult
 from mindroom.oauth.state import consume_opaque_oauth_state, issue_opaque_oauth_state, read_opaque_oauth_state
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from pathlib import Path
+
     from mindroom.constants import RuntimePaths
+    from mindroom.credentials import CredentialsManager
     from mindroom.oauth.providers import OAuthClientConfig, OAuthProvider
     from mindroom.tool_system.worker_routing import ResolvedWorkerTarget
 
 _OAUTH_CONNECT_TOKEN_TTL_SECONDS = 600
 _OAUTH_CONNECT_TOKEN_KIND = "conversation_oauth_connect"  # noqa: S105
 _OAUTH_ACCESS_TOKEN_EXPIRY_SKEW_SECONDS = 60
+_RECOVERABLE_REFRESH_ERROR_CODES = frozenset({"invalid_grant", "invalid_refresh_token"})
 _GOOGLE_SERVICE_ACCOUNT_PROVIDER_IDS = frozenset(
     {
         "google_calendar",
@@ -45,6 +53,25 @@ _SCOPE_IMPLICATIONS = {
     ),
 }
 
+__all__ = [
+    "OAuthConnectTarget",
+    "build_oauth_connect_instruction",
+    "build_oauth_reconnect_instruction",
+    "consume_oauth_connect_token",
+    "lookup_oauth_connect_token",
+    "oauth_connect_url",
+    "oauth_credential_target_payload",
+    "oauth_credentials_have_required_scopes",
+    "oauth_credentials_match_client_id",
+    "oauth_credentials_satisfy_identity_policy",
+    "oauth_credentials_usable",
+    "oauth_provider_service_account_configured",
+    "oauth_success_redirect_url",
+    "refresh_scoped_oauth_credentials",
+    "sanitized_oauth_token_result",
+    "scoped_oauth_credentials_refresh_lock_path",
+]
+
 
 @dataclass(frozen=True)
 class OAuthConnectTarget:
@@ -56,6 +83,190 @@ class OAuthConnectTarget:
     worker_scope: str
     worker_key: str
     requester_id: str | None
+
+
+def scoped_oauth_credentials_refresh_lock_path(
+    service: str,
+    *,
+    credentials_manager: CredentialsManager,
+    worker_target: ResolvedWorkerTarget | None,
+) -> Path:
+    """Return the per-scope lock file for one OAuth credential refresh."""
+    credentials_path = _scoped_oauth_credentials_path(
+        service,
+        credentials_manager=credentials_manager,
+        worker_target=worker_target,
+    )
+    return credentials_path.with_name(f"{credentials_path.name}.oauth-refresh.lock")
+
+
+async def refresh_scoped_oauth_credentials(
+    provider: OAuthProvider,
+    runtime_paths: RuntimePaths,
+    *,
+    credentials_manager: CredentialsManager,
+    worker_target: ResolvedWorkerTarget | None,
+    allowed_shared_services: frozenset[str] | None = None,
+) -> dict[str, Any] | None:
+    """Refresh one scoped OAuth credential under a per-scope advisory file lock."""
+    lock_path = scoped_oauth_credentials_refresh_lock_path(
+        provider.credential_service,
+        credentials_manager=credentials_manager,
+        worker_target=worker_target,
+    )
+    async with async_exclusive_file_lock(lock_path):
+        credentials = load_scoped_credentials(
+            provider.credential_service,
+            credentials_manager=credentials_manager,
+            worker_target=worker_target,
+            allowed_shared_services=allowed_shared_services,
+        )
+        if credentials is None:
+            return None
+        if not oauth_credentials_usable(provider, runtime_paths, credentials):
+            return credentials
+        return await _refresh_scoped_oauth_credentials_locked(
+            provider,
+            runtime_paths,
+            credentials=credentials,
+            credentials_manager=credentials_manager,
+            worker_target=worker_target,
+            allowed_shared_services=allowed_shared_services,
+        )
+
+
+def _scoped_oauth_credentials_path(
+    service: str,
+    *,
+    credentials_manager: CredentialsManager,
+    worker_target: ResolvedWorkerTarget | None,
+) -> Path:
+    normalized_service = validate_service_name(service)
+    if worker_target is None or worker_target.worker_scope is None:
+        target_manager = (
+            credentials_manager
+            if credentials_manager.shared_base_path != credentials_manager.base_path
+            else credentials_manager.shared_manager()
+        )
+        return target_manager.get_credentials_path(normalized_service)
+
+    policy = credential_service_policy(normalized_service, worker_target.worker_scope)
+    if policy.uses_local_shared_credentials:
+        return credentials_manager.shared_manager().get_credentials_path(normalized_service)
+
+    if policy.uses_primary_runtime_scoped_credentials:
+        identity = worker_target.execution_identity
+        if identity is None or identity.requester_id is None:
+            msg = f"Primary-runtime scoped credentials for {normalized_service} require a requester identity"
+            raise ValueError(msg)
+        agent_name = worker_target.routing_agent_name if worker_target.worker_scope == "user_agent" else None
+        return credentials_manager.for_primary_runtime_scope(identity.requester_id, agent_name).get_credentials_path(
+            normalized_service,
+        )
+
+    if worker_target.worker_key is None:
+        return credentials_manager.shared_manager().get_credentials_path(normalized_service)
+    return credentials_manager.for_worker(worker_target.worker_key).get_credentials_path(normalized_service)
+
+
+async def _refresh_scoped_oauth_credentials_locked(
+    provider: OAuthProvider,
+    runtime_paths: RuntimePaths,
+    *,
+    credentials: dict[str, Any],
+    credentials_manager: CredentialsManager,
+    worker_target: ResolvedWorkerTarget | None,
+    allowed_shared_services: frozenset[str] | None,
+) -> dict[str, Any]:
+    attempted_refresh_token = _refresh_token_value(credentials)
+    try:
+        refreshed_credentials = await provider.refresh_token_data(credentials, runtime_paths)
+    except OAuthProviderError as exc:
+        if attempted_refresh_token is None or not _is_recoverable_stale_refresh_rejection(exc):
+            raise
+        latest_credentials = load_scoped_credentials(
+            provider.credential_service,
+            credentials_manager=credentials_manager,
+            worker_target=worker_target,
+            allowed_shared_services=allowed_shared_services,
+        )
+        latest_refresh_token = _refresh_token_value(latest_credentials)
+        if (
+            latest_credentials is None
+            or latest_refresh_token is None
+            or latest_refresh_token == attempted_refresh_token
+            or not oauth_credentials_usable(provider, runtime_paths, latest_credentials)
+        ):
+            raise
+        refreshed_credentials = await provider.refresh_token_data(latest_credentials, runtime_paths)
+        if refreshed_credentials is None:
+            return latest_credentials
+        save_scoped_credentials(
+            provider.credential_service,
+            refreshed_credentials,
+            credentials_manager=credentials_manager,
+            worker_target=worker_target,
+        )
+        return refreshed_credentials
+
+    if refreshed_credentials is None:
+        return credentials
+    save_scoped_credentials(
+        provider.credential_service,
+        refreshed_credentials,
+        credentials_manager=credentials_manager,
+        worker_target=worker_target,
+    )
+    return refreshed_credentials
+
+
+def _refresh_token_value(credentials: Mapping[str, Any] | None) -> str | None:
+    if credentials is None:
+        return None
+    refresh_token = credentials.get("refresh_token")
+    return refresh_token if isinstance(refresh_token, str) and refresh_token else None
+
+
+def _is_recoverable_stale_refresh_rejection(exc: OAuthProviderError) -> bool:
+    for value in _oauth_error_values(exc):
+        if any(code in value.lower() for code in _RECOVERABLE_REFRESH_ERROR_CODES):
+            return True
+    return False
+
+
+def _oauth_error_values(exc: BaseException) -> tuple[str, ...]:
+    values: list[str] = []
+    current: BaseException | None = exc
+    while current is not None:
+        values.append(str(current))
+        for attribute_name in ("error", "error_code", "code", "description"):
+            value = getattr(current, attribute_name, None)
+            if isinstance(value, str):
+                values.append(value)
+        response = getattr(current, "response", None)
+        if response is not None:
+            values.extend(_oauth_error_response_values(response))
+        current = current.__cause__ if isinstance(current.__cause__, BaseException) else None
+    return tuple(value for value in values if value)
+
+
+def _oauth_error_response_values(response: object) -> tuple[str, ...]:
+    status_code = getattr(response, "status_code", None)
+    values = [str(status_code)] if isinstance(status_code, int) else []
+    json_method = getattr(response, "json", None)
+    if not callable(json_method):
+        return tuple(values)
+    try:
+        payload = json_method()
+    except ValueError:
+        return tuple(values)
+    if not isinstance(payload, dict):
+        return tuple(values)
+    for key in ("error", "error_description", "message"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            values.append(value)
+    return tuple(values)
 
 
 def oauth_credential_target_payload(

--- a/src/mindroom/oauth/service.py
+++ b/src/mindroom/oauth/service.py
@@ -12,8 +12,7 @@ from urllib.parse import urlencode, urlparse
 from authlib.common.errors import AuthlibBaseError
 from httpx import HTTPStatusError
 
-from mindroom.credential_policy import credential_service_policy
-from mindroom.credentials import load_scoped_credentials, save_scoped_credentials, validate_service_name
+from mindroom.credentials import load_scoped_credentials, save_scoped_credentials, scoped_credentials_path
 from mindroom.file_locks import async_exclusive_file_lock
 from mindroom.oauth.providers import OAuthClaimValidationError, OAuthProviderError, OAuthTokenResult
 from mindroom.oauth.state import consume_opaque_oauth_state, issue_opaque_oauth_state, read_opaque_oauth_state
@@ -58,6 +57,7 @@ _SCOPE_IMPLICATIONS = {
 
 __all__ = [
     "OAuthConnectTarget",
+    "OAuthCredentialsRefreshResult",
     "build_oauth_connect_instruction",
     "build_oauth_reconnect_instruction",
     "consume_oauth_connect_token",
@@ -71,6 +71,7 @@ __all__ = [
     "oauth_provider_service_account_configured",
     "oauth_success_redirect_url",
     "refresh_scoped_oauth_credentials",
+    "refresh_scoped_oauth_credentials_with_result",
     "sanitized_oauth_token_result",
     "scoped_oauth_credentials_refresh_lock_path",
 ]
@@ -88,6 +89,14 @@ class OAuthConnectTarget:
     requester_id: str | None
 
 
+@dataclass(frozen=True)
+class OAuthCredentialsRefreshResult:
+    """Result of one locked scoped OAuth credential refresh attempt."""
+
+    credentials: dict[str, Any] | None
+    refreshed: bool
+
+
 def scoped_oauth_credentials_refresh_lock_path(
     service: str,
     *,
@@ -95,7 +104,7 @@ def scoped_oauth_credentials_refresh_lock_path(
     worker_target: ResolvedWorkerTarget | None,
 ) -> Path:
     """Return the per-scope lock file for one OAuth credential refresh."""
-    credentials_path = _scoped_oauth_credentials_path(
+    credentials_path = scoped_credentials_path(
         service,
         credentials_manager=credentials_manager,
         worker_target=worker_target,
@@ -112,6 +121,26 @@ async def refresh_scoped_oauth_credentials(
     allowed_shared_services: frozenset[str] | None = None,
 ) -> dict[str, Any] | None:
     """Refresh one scoped OAuth credential under a per-scope advisory file lock."""
+    return (
+        await refresh_scoped_oauth_credentials_with_result(
+            provider,
+            runtime_paths,
+            credentials_manager=credentials_manager,
+            worker_target=worker_target,
+            allowed_shared_services=allowed_shared_services,
+        )
+    ).credentials
+
+
+async def refresh_scoped_oauth_credentials_with_result(
+    provider: OAuthProvider,
+    runtime_paths: RuntimePaths,
+    *,
+    credentials_manager: CredentialsManager,
+    worker_target: ResolvedWorkerTarget | None,
+    allowed_shared_services: frozenset[str] | None = None,
+) -> OAuthCredentialsRefreshResult:
+    """Refresh one scoped OAuth credential and report whether this call saved new credentials."""
     lock_path = scoped_oauth_credentials_refresh_lock_path(
         provider.credential_service,
         credentials_manager=credentials_manager,
@@ -125,9 +154,9 @@ async def refresh_scoped_oauth_credentials(
             allowed_shared_services=allowed_shared_services,
         )
         if credentials is None:
-            return None
+            return OAuthCredentialsRefreshResult(credentials=None, refreshed=False)
         if not oauth_credentials_usable(provider, runtime_paths, credentials):
-            return credentials
+            return OAuthCredentialsRefreshResult(credentials=credentials, refreshed=False)
         return await _refresh_scoped_oauth_credentials_locked(
             provider,
             runtime_paths,
@@ -138,40 +167,6 @@ async def refresh_scoped_oauth_credentials(
         )
 
 
-def _scoped_oauth_credentials_path(
-    service: str,
-    *,
-    credentials_manager: CredentialsManager,
-    worker_target: ResolvedWorkerTarget | None,
-) -> Path:
-    normalized_service = validate_service_name(service)
-    if worker_target is None or worker_target.worker_scope is None:
-        target_manager = (
-            credentials_manager
-            if credentials_manager.shared_base_path != credentials_manager.base_path
-            else credentials_manager.shared_manager()
-        )
-        return target_manager.get_credentials_path(normalized_service)
-
-    policy = credential_service_policy(normalized_service, worker_target.worker_scope)
-    if policy.uses_local_shared_credentials:
-        return credentials_manager.shared_manager().get_credentials_path(normalized_service)
-
-    if policy.uses_primary_runtime_scoped_credentials:
-        identity = worker_target.execution_identity
-        if identity is None or identity.requester_id is None:
-            msg = f"Primary-runtime scoped credentials for {normalized_service} require a requester identity"
-            raise ValueError(msg)
-        agent_name = worker_target.routing_agent_name if worker_target.worker_scope == "user_agent" else None
-        return credentials_manager.for_primary_runtime_scope(identity.requester_id, agent_name).get_credentials_path(
-            normalized_service,
-        )
-
-    if worker_target.worker_key is None:
-        return credentials_manager.shared_manager().get_credentials_path(normalized_service)
-    return credentials_manager.for_worker(worker_target.worker_key).get_credentials_path(normalized_service)
-
-
 async def _refresh_scoped_oauth_credentials_locked(
     provider: OAuthProvider,
     runtime_paths: RuntimePaths,
@@ -180,7 +175,7 @@ async def _refresh_scoped_oauth_credentials_locked(
     credentials_manager: CredentialsManager,
     worker_target: ResolvedWorkerTarget | None,
     allowed_shared_services: frozenset[str] | None,
-) -> dict[str, Any]:
+) -> OAuthCredentialsRefreshResult:
     attempted_refresh_token = _refresh_token_value(credentials)
     try:
         refreshed_credentials = await provider.refresh_token_data(credentials, runtime_paths)
@@ -203,24 +198,24 @@ async def _refresh_scoped_oauth_credentials_locked(
             raise
         refreshed_credentials = await provider.refresh_token_data(latest_credentials, runtime_paths)
         if refreshed_credentials is None:
-            return latest_credentials
+            return OAuthCredentialsRefreshResult(credentials=latest_credentials, refreshed=False)
         save_scoped_credentials(
             provider.credential_service,
             refreshed_credentials,
             credentials_manager=credentials_manager,
             worker_target=worker_target,
         )
-        return refreshed_credentials
+        return OAuthCredentialsRefreshResult(credentials=refreshed_credentials, refreshed=True)
 
     if refreshed_credentials is None:
-        return credentials
+        return OAuthCredentialsRefreshResult(credentials=credentials, refreshed=False)
     save_scoped_credentials(
         provider.credential_service,
         refreshed_credentials,
         credentials_manager=credentials_manager,
         worker_target=worker_target,
     )
-    return refreshed_credentials
+    return OAuthCredentialsRefreshResult(credentials=refreshed_credentials, refreshed=True)
 
 
 def _refresh_token_value(credentials: Mapping[str, Any] | None) -> str | None:

--- a/src/mindroom/oauth/service.py
+++ b/src/mindroom/oauth/service.py
@@ -4,13 +4,9 @@ from __future__ import annotations
 
 import math
 import time
-from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urlencode, urlparse
-
-from authlib.common.errors import AuthlibBaseError
-from httpx import HTTPStatusError
 
 from mindroom.credentials import load_scoped_credentials, save_scoped_credentials, scoped_credentials_path
 from mindroom.file_locks import async_exclusive_file_lock
@@ -18,6 +14,7 @@ from mindroom.oauth.providers import OAuthClaimValidationError, OAuthProviderErr
 from mindroom.oauth.state import consume_opaque_oauth_state, issue_opaque_oauth_state, read_opaque_oauth_state
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from pathlib import Path
 
     from mindroom.constants import RuntimePaths
@@ -226,41 +223,12 @@ def _refresh_token_value(credentials: Mapping[str, Any] | None) -> str | None:
 
 
 def _is_recoverable_stale_refresh_rejection(exc: OAuthProviderError) -> bool:
-    error_code = _oauth_error_code(exc)
+    error_code = _normalized_oauth_error_code(exc.oauth_error)
     return error_code in _RECOVERABLE_REFRESH_ERROR_CODES
-
-
-def _oauth_error_code(exc: BaseException) -> str | None:
-    current: BaseException | None = exc
-    while current is not None:
-        if isinstance(current, OAuthProviderError):
-            error_code = _normalized_oauth_error_code(current.oauth_error)
-            if error_code is not None:
-                return error_code
-        if isinstance(current, AuthlibBaseError):
-            error_code = _normalized_oauth_error_code(current.error)
-            if error_code is not None:
-                return error_code
-        if isinstance(current, HTTPStatusError):
-            error_code = _oauth_error_response_code(current)
-            if error_code is not None:
-                return error_code
-        current = current.__cause__ if isinstance(current.__cause__, BaseException) else None
-    return None
 
 
 def _normalized_oauth_error_code(value: object) -> str | None:
     return value.strip().lower() if isinstance(value, str) and value.strip() else None
-
-
-def _oauth_error_response_code(exc: HTTPStatusError) -> str | None:
-    try:
-        payload = exc.response.json()
-    except (ValueError, UnicodeDecodeError):
-        return None
-    if not isinstance(payload, Mapping):
-        return None
-    return _normalized_oauth_error_code(payload.get("error"))
 
 
 def oauth_credential_target_payload(

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -534,6 +534,50 @@ class TestCredentialsManager:
         assert shared_credentials is None
         assert worker_credentials == {"token": "worker-token", "_source": "ui"}
 
+    @pytest.mark.parametrize("worker_scope", [None, "shared", "user", "user_agent"])
+    def test_scoped_credentials_path_matches_save_and_delete_target(
+        self,
+        temp_credentials_dir: Path,
+        worker_scope: str | None,
+    ) -> None:
+        """Scoped path resolution should be the write-path source of truth."""
+        manager = CredentialsManager(temp_credentials_dir)
+        execution_identity = ToolExecutionIdentity(
+            channel="matrix",
+            agent_name="general",
+            requester_id="@alice:example.org",
+            room_id="!room:example.org",
+            thread_id=None,
+            resolved_thread_id=None,
+            session_id=None,
+            tenant_id="tenant-123",
+            account_id="account-456",
+        )
+        worker_target = _worker_target(worker_scope, "general", execution_identity)
+        credentials_path = credentials_module.scoped_credentials_path(
+            "mcp_demo_oauth",
+            credentials_manager=manager,
+            worker_target=worker_target,
+        )
+
+        save_scoped_credentials(
+            "mcp_demo_oauth",
+            {"token": "scoped-token", "_source": "oauth"},
+            credentials_manager=manager,
+            worker_target=worker_target,
+        )
+
+        assert credentials_path.exists()
+        assert credentials_path.read_text(encoding="utf-8")
+
+        credentials_module.delete_scoped_credentials(
+            "mcp_demo_oauth",
+            credentials_manager=manager,
+            worker_target=worker_target,
+        )
+
+        assert not credentials_path.exists()
+
     def test_load_scoped_credentials_shared_scope_inherits_shared_ui_credentials(
         self,
         temp_credentials_dir: Path,

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 from collections.abc import AsyncIterator, Awaitable, Callable, Generator, Mapping
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING, ClassVar, Self
+from typing import TYPE_CHECKING, Any, ClassVar, Self
 from unittest.mock import patch
 
 import mcp.types as mcp_types
@@ -25,7 +26,12 @@ from mindroom.mcp.errors import MCPProtocolError, MCPTimeoutError, MCPToolCallEr
 from mindroom.mcp.manager import MCPServerManager, _discovery_retry_delay_seconds
 from mindroom.mcp.toolkit import bind_mcp_server_manager
 from mindroom.mcp.transports import _MCPTransportHandle
-from mindroom.oauth.providers import OAuthConnectionRequired, oauth_connection_required_payload
+from mindroom.oauth.providers import (
+    OAuthClientConfig,
+    OAuthConnectionRequired,
+    OAuthRefreshRejectedError,
+    oauth_connection_required_payload,
+)
 from mindroom.tool_system import dynamic_toolkits as dynamic_toolkits_module
 from mindroom.tool_system.dynamic_toolkits import get_loaded_tools_for_session
 from mindroom.tool_system.worker_routing import ToolExecutionIdentity, resolve_worker_target
@@ -41,6 +47,20 @@ if TYPE_CHECKING:
 
 
 _MessageHandler = Callable[[object], Awaitable[None]]
+ACCESS_0 = "access-refresh-0"
+ACCESS_1 = "access-refresh-1"
+ACCESS_2 = "access-refresh-2"
+CHAIN_0 = "refresh-0"
+CHAIN_1 = "refresh-1"
+CHAIN_2 = "refresh-2"
+ALICE_ACCESS_0 = "access-alice-refresh-0"
+ALICE_ACCESS_1 = "access-alice-refresh-1"
+ALICE_CHAIN_0 = "alice-refresh-0"
+BOB_ACCESS_0 = "access-bob-refresh-0"
+BOB_ACCESS_1 = "access-bob-refresh-1"
+BOB_CHAIN_0 = "bob-refresh-0"
+INVALID_GRANT = "invalid_grant"
+INVALID_ROTATION = "invalid_refresh_token"
 
 
 class _ConfigStub:
@@ -252,18 +272,45 @@ def _worker_target(requester_id: str) -> ResolvedWorkerTarget:
     return resolve_worker_target("user", "code", identity)
 
 
-def _save_mcp_oauth_credentials(runtime_paths: RuntimePaths, worker_target: ResolvedWorkerTarget, token: str) -> None:
+def _shared_worker_target(requester_id: str, *, agent_name: str = "code") -> ResolvedWorkerTarget:
+    identity = ToolExecutionIdentity(
+        channel="matrix",
+        agent_name=agent_name,
+        requester_id=requester_id,
+        room_id="!room:example.test",
+        thread_id="$thread",
+        resolved_thread_id="$thread",
+        session_id=None,
+        tenant_id="tenant",
+        account_id=None,
+    )
+    return resolve_worker_target("shared", agent_name, identity)
+
+
+def _save_mcp_oauth_credentials(
+    runtime_paths: RuntimePaths,
+    worker_target: ResolvedWorkerTarget,
+    token: str,
+    *,
+    refresh_token: str | None = None,
+    expires_at: float | None = None,
+) -> None:
     credentials_manager = get_runtime_credentials_manager(runtime_paths)
     credentials_manager.save_credentials("mcp_demo_oauth_client", {"client_id": "public-client"})
+    credentials: dict[str, Any] = {
+        "token": token,
+        "client_id": "public-client",
+        "scopes": [],
+        "_source": "oauth",
+        "_oauth_provider": "mcp_demo",
+    }
+    if refresh_token is not None:
+        credentials["refresh_token"] = refresh_token
+    if expires_at is not None:
+        credentials["expires_at"] = expires_at
     save_scoped_credentials(
         "mcp_demo_oauth",
-        {
-            "token": token,
-            "client_id": "public-client",
-            "scopes": [],
-            "_source": "oauth",
-            "_oauth_provider": "mcp_demo",
-        },
+        credentials,
         credentials_manager=credentials_manager,
         worker_target=worker_target,
     )
@@ -293,6 +340,59 @@ def _save_expiring_mcp_oauth_credentials(
         credentials_manager=credentials_manager,
         worker_target=worker_target,
     )
+
+
+class _FakeMcpOAuthProvider:
+    id = "mcp_demo"
+    display_name = "Demo MCP"
+    credential_service = "mcp_demo_oauth"
+    scopes: tuple[str, ...] = ()
+    claim_validator = None
+
+    def __init__(self, refresh: Callable[[Mapping[str, Any]], Awaitable[dict[str, Any] | None]]) -> None:
+        self._refresh = refresh
+
+    def client_config(self, _runtime_paths: RuntimePaths) -> OAuthClientConfig:
+        return OAuthClientConfig(
+            client_id="public-client",
+            client_secret=None,
+            redirect_uri="http://localhost/callback",
+        )
+
+    def resolved_allowed_email_domains(self, _runtime_paths: RuntimePaths) -> tuple[str, ...]:
+        return ()
+
+    def resolved_allowed_hosted_domains(self, _runtime_paths: RuntimePaths) -> tuple[str, ...]:
+        return ()
+
+    async def refresh_token_data(
+        self,
+        token_data: Mapping[str, Any],
+        _runtime_paths: RuntimePaths,
+    ) -> dict[str, Any] | None:
+        return await self._refresh(token_data)
+
+
+def _refresh_needed(credentials: Mapping[str, Any]) -> bool:
+    expires_at = credentials.get("expires_at")
+    return (
+        not isinstance(expires_at, bool)
+        and isinstance(expires_at, int | float)
+        and time.time() + 60 >= float(expires_at)
+        and isinstance(credentials.get("refresh_token"), str)
+    )
+
+
+def _refreshed_credentials(refresh_token: str, *, expires_at: float | None = None) -> dict[str, Any]:
+    return {
+        "token": f"access-{refresh_token}",
+        "refresh_token": refresh_token,
+        "client_id": "public-client",
+        "scopes": [],
+        "expires_at": expires_at if expires_at is not None else time.time() + 3600,
+        "_source": "oauth",
+        "_oauth_provider": "mcp_demo",
+    }
 
 
 @pytest.mark.asyncio
@@ -479,6 +579,268 @@ async def test_mcp_manager_logs_successful_oauth_refresh_and_persists_credential
         and call.kwargs == {"provider_id": "mcp_demo", "server_id": "demo", "expires_at": 1300.0}
         for call in mock_logger.info.call_args_list
     )
+
+
+@pytest.mark.asyncio
+async def test_mcp_manager_serializes_oauth_refresh_read_modify_write_per_scope(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Concurrent refreshes for one credential scope should share one persisted rotation head."""
+    runtime_paths = _runtime_paths(tmp_path)
+    worker_target = _shared_worker_target("@alice:example.test")
+    _save_mcp_oauth_credentials(
+        runtime_paths,
+        worker_target,
+        ACCESS_0,
+        refresh_token=CHAIN_0,
+        expires_at=900.0,
+    )
+    manager = MCPServerManager(runtime_paths)
+    await manager.sync_servers(_ConfigStub({"demo": _oauth_mcp_config()}))
+    credentials_manager = get_runtime_credentials_manager(runtime_paths)
+    seen_refresh_tokens: list[str] = []
+    active_refreshes = 0
+    max_active_refreshes = 0
+
+    async def refresh(credentials: Mapping[str, Any]) -> dict[str, Any] | None:
+        nonlocal active_refreshes, max_active_refreshes
+        if not _refresh_needed(credentials):
+            return None
+        refresh_token = str(credentials["refresh_token"])
+        seen_refresh_tokens.append(refresh_token)
+        active_refreshes += 1
+        max_active_refreshes = max(max_active_refreshes, active_refreshes)
+        await asyncio.sleep(0.05)
+        active_refreshes -= 1
+        if refresh_token == CHAIN_0:
+            return _refreshed_credentials(CHAIN_1)
+        if refresh_token == CHAIN_1:
+            return _refreshed_credentials(CHAIN_2)
+        pytest.fail(f"unexpected refresh token: {refresh_token}")
+
+    provider = _FakeMcpOAuthProvider(refresh)
+    monkeypatch.setattr("mindroom.mcp.manager.mcp_oauth_provider", lambda *_args: provider)
+    state = manager._require_state("demo")
+
+    first_token, second_token = await asyncio.gather(
+        manager._oauth_access_token(state, credentials_manager=credentials_manager, worker_target=worker_target),
+        manager._oauth_access_token(state, credentials_manager=credentials_manager, worker_target=worker_target),
+    )
+
+    stored_credentials = load_scoped_credentials(
+        "mcp_demo_oauth",
+        credentials_manager=credentials_manager,
+        worker_target=worker_target,
+    )
+    assert first_token == ACCESS_1
+    assert second_token == ACCESS_1
+    assert stored_credentials is not None
+    assert stored_credentials["refresh_token"] == CHAIN_1
+    assert seen_refresh_tokens == [CHAIN_0]
+    assert max_active_refreshes == 1
+
+
+@pytest.mark.asyncio
+async def test_mcp_manager_recovers_from_stale_oauth_refresh_token_rejection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A stale-token rejection should re-read a newer stored token and retry once."""
+    runtime_paths = _runtime_paths(tmp_path)
+    worker_target = _shared_worker_target("@alice:example.test")
+    _save_mcp_oauth_credentials(
+        runtime_paths,
+        worker_target,
+        ACCESS_0,
+        refresh_token=CHAIN_0,
+        expires_at=900.0,
+    )
+    credentials_manager = get_runtime_credentials_manager(runtime_paths)
+    manager = MCPServerManager(runtime_paths)
+    await manager.sync_servers(_ConfigStub({"demo": _oauth_mcp_config()}))
+    seen_refresh_tokens: list[str] = []
+
+    async def refresh(credentials: Mapping[str, Any]) -> dict[str, Any] | None:
+        refresh_token = str(credentials["refresh_token"])
+        seen_refresh_tokens.append(refresh_token)
+        if refresh_token == CHAIN_0:
+            save_scoped_credentials(
+                "mcp_demo_oauth",
+                _refreshed_credentials(CHAIN_1),
+                credentials_manager=credentials_manager,
+                worker_target=worker_target,
+            )
+            message = INVALID_GRANT
+            raise OAuthRefreshRejectedError(message, oauth_error=INVALID_GRANT)
+        if refresh_token == CHAIN_1:
+            return _refreshed_credentials(CHAIN_2)
+        pytest.fail(f"unexpected refresh token: {refresh_token}")
+
+    provider = _FakeMcpOAuthProvider(refresh)
+    monkeypatch.setattr("mindroom.mcp.manager.mcp_oauth_provider", lambda *_args: provider)
+
+    access_token = await manager._oauth_access_token(
+        manager._require_state("demo"),
+        credentials_manager=credentials_manager,
+        worker_target=worker_target,
+    )
+
+    stored_credentials = load_scoped_credentials(
+        "mcp_demo_oauth",
+        credentials_manager=credentials_manager,
+        worker_target=worker_target,
+    )
+    assert access_token == ACCESS_2
+    assert stored_credentials is not None
+    assert stored_credentials["refresh_token"] == CHAIN_2
+    assert seen_refresh_tokens == [CHAIN_0, CHAIN_1]
+
+
+@pytest.mark.asyncio
+async def test_mcp_manager_surfaces_connection_required_for_terminal_oauth_refresh_rejection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A dead refresh token should not retry indefinitely when storage has no newer token."""
+    runtime_paths = _runtime_paths(tmp_path)
+    worker_target = _shared_worker_target("@alice:example.test")
+    _save_mcp_oauth_credentials(
+        runtime_paths,
+        worker_target,
+        ACCESS_0,
+        refresh_token=CHAIN_0,
+        expires_at=900.0,
+    )
+    credentials_manager = get_runtime_credentials_manager(runtime_paths)
+    manager = MCPServerManager(runtime_paths)
+    await manager.sync_servers(_ConfigStub({"demo": _oauth_mcp_config()}))
+    seen_refresh_tokens: list[str] = []
+
+    async def refresh(credentials: Mapping[str, Any]) -> dict[str, Any] | None:
+        seen_refresh_tokens.append(str(credentials["refresh_token"]))
+        message = INVALID_ROTATION
+        raise OAuthRefreshRejectedError(message, oauth_error=INVALID_ROTATION)
+
+    provider = _FakeMcpOAuthProvider(refresh)
+    monkeypatch.setattr("mindroom.mcp.manager.mcp_oauth_provider", lambda *_args: provider)
+
+    with pytest.raises(OAuthConnectionRequired) as exc_info:
+        await manager._oauth_access_token(
+            manager._require_state("demo"),
+            credentials_manager=credentials_manager,
+            worker_target=worker_target,
+        )
+
+    assert exc_info.value.reason == "oauth_refresh_rejected"
+    assert seen_refresh_tokens == [CHAIN_0]
+
+
+@pytest.mark.asyncio
+async def test_mcp_manager_preserves_non_rotating_oauth_refresh_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Providers that do not rotate refresh tokens should keep the existing token."""
+    runtime_paths = _runtime_paths(tmp_path)
+    worker_target = _shared_worker_target("@alice:example.test")
+    _save_mcp_oauth_credentials(
+        runtime_paths,
+        worker_target,
+        ACCESS_0,
+        refresh_token=CHAIN_0,
+        expires_at=900.0,
+    )
+    credentials_manager = get_runtime_credentials_manager(runtime_paths)
+    manager = MCPServerManager(runtime_paths)
+    await manager.sync_servers(_ConfigStub({"demo": _oauth_mcp_config()}))
+
+    async def refresh(credentials: Mapping[str, Any]) -> dict[str, Any] | None:
+        assert credentials["refresh_token"] == CHAIN_0
+        return _refreshed_credentials(CHAIN_0)
+
+    provider = _FakeMcpOAuthProvider(refresh)
+    monkeypatch.setattr("mindroom.mcp.manager.mcp_oauth_provider", lambda *_args: provider)
+
+    access_token = await manager._oauth_access_token(
+        manager._require_state("demo"),
+        credentials_manager=credentials_manager,
+        worker_target=worker_target,
+    )
+
+    stored_credentials = load_scoped_credentials(
+        "mcp_demo_oauth",
+        credentials_manager=credentials_manager,
+        worker_target=worker_target,
+    )
+    assert access_token == ACCESS_0
+    assert stored_credentials is not None
+    assert stored_credentials["refresh_token"] == CHAIN_0
+
+
+@pytest.mark.asyncio
+async def test_mcp_manager_oauth_refresh_lock_is_per_scope(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Different credential scopes should refresh concurrently instead of sharing one global lock."""
+    runtime_paths = _runtime_paths(tmp_path)
+    alice_target = _worker_target("@alice:example.test")
+    bob_target = _worker_target("@bob:example.test")
+    _save_mcp_oauth_credentials(
+        runtime_paths,
+        alice_target,
+        ALICE_ACCESS_0,
+        refresh_token=ALICE_CHAIN_0,
+        expires_at=900.0,
+    )
+    _save_mcp_oauth_credentials(
+        runtime_paths,
+        bob_target,
+        BOB_ACCESS_0,
+        refresh_token=BOB_CHAIN_0,
+        expires_at=900.0,
+    )
+    credentials_manager = get_runtime_credentials_manager(runtime_paths)
+    manager = MCPServerManager(runtime_paths)
+    await manager.sync_servers(_ConfigStub({"demo": _oauth_mcp_config()}))
+    both_refreshes_entered = asyncio.Event()
+    release_refreshes = asyncio.Event()
+    active_refreshes = 0
+    max_active_refreshes = 0
+
+    async def refresh(credentials: Mapping[str, Any]) -> dict[str, Any] | None:
+        nonlocal active_refreshes, max_active_refreshes
+        refresh_token = str(credentials["refresh_token"])
+        active_refreshes += 1
+        max_active_refreshes = max(max_active_refreshes, active_refreshes)
+        if active_refreshes == 2:
+            both_refreshes_entered.set()
+        await both_refreshes_entered.wait()
+        release_refreshes.set()
+        active_refreshes -= 1
+        if refresh_token == ALICE_CHAIN_0:
+            return _refreshed_credentials(ALICE_CHAIN_0.replace("-0", "-1"))
+        if refresh_token == BOB_CHAIN_0:
+            return _refreshed_credentials(BOB_CHAIN_0.replace("-0", "-1"))
+        pytest.fail(f"unexpected refresh token: {refresh_token}")
+
+    provider = _FakeMcpOAuthProvider(refresh)
+    monkeypatch.setattr("mindroom.mcp.manager.mcp_oauth_provider", lambda *_args: provider)
+    state = manager._require_state("demo")
+
+    alice_task = asyncio.create_task(
+        manager._oauth_access_token(state, credentials_manager=credentials_manager, worker_target=alice_target),
+    )
+    bob_task = asyncio.create_task(
+        manager._oauth_access_token(state, credentials_manager=credentials_manager, worker_target=bob_target),
+    )
+    await asyncio.wait_for(release_refreshes.wait(), timeout=1)
+    alice_token, bob_token = await asyncio.gather(alice_task, bob_task)
+
+    assert alice_token == ALICE_ACCESS_1
+    assert bob_token == BOB_ACCESS_1
+    assert max_active_refreshes == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -594,6 +594,33 @@ async def test_mcp_manager_logs_successful_oauth_refresh_and_persists_credential
 
 
 @pytest.mark.asyncio
+async def test_mcp_manager_does_not_eagerly_load_oauth_credentials_for_success_logging(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Successful OAuth resolution should not do a second load just for failure diagnostics."""
+    runtime_paths = _runtime_paths(tmp_path)
+    worker_target = _shared_worker_target("@alice:example.test")
+    _save_mcp_oauth_credentials(runtime_paths, worker_target, ACCESS_0, expires_at=time.time() + 3600)
+    credentials_manager = get_runtime_credentials_manager(runtime_paths)
+    manager = MCPServerManager(runtime_paths)
+    await manager.sync_servers(_ConfigStub({"demo": _oauth_mcp_config()}))
+
+    def fail_eager_diagnostic_load(*_args: object, **_kwargs: object) -> dict[str, Any]:
+        pytest.fail("manager should not eagerly load credentials only for failure logging")
+
+    monkeypatch.setattr("mindroom.mcp.manager.load_scoped_credentials", fail_eager_diagnostic_load)
+
+    access_token = await manager._oauth_access_token(
+        manager._require_state("demo"),
+        credentials_manager=credentials_manager,
+        worker_target=worker_target,
+    )
+
+    assert access_token == ACCESS_0
+
+
+@pytest.mark.asyncio
 async def test_mcp_manager_serializes_oauth_refresh_read_modify_write_per_scope(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -32,6 +32,7 @@ from mindroom.oauth.providers import (
     OAuthRefreshRejectedError,
     oauth_connection_required_payload,
 )
+from mindroom.oauth.service import refresh_scoped_oauth_credentials
 from mindroom.tool_system import dynamic_toolkits as dynamic_toolkits_module
 from mindroom.tool_system.dynamic_toolkits import get_loaded_tools_for_session
 from mindroom.tool_system.worker_routing import ToolExecutionIdentity, resolve_worker_target
@@ -61,6 +62,7 @@ BOB_ACCESS_1 = "access-bob-refresh-1"
 BOB_CHAIN_0 = "bob-refresh-0"
 INVALID_GRANT = "invalid_grant"
 INVALID_ROTATION = "invalid_refresh_token"
+TEMPORARILY_UNAVAILABLE = "temporarily_unavailable"
 
 
 class _ConfigStub:
@@ -395,6 +397,16 @@ def _refreshed_credentials(refresh_token: str, *, expires_at: float | None = Non
     }
 
 
+def _rotation_index(refresh_token: object) -> int:
+    if refresh_token == CHAIN_0:
+        return 0
+    if refresh_token == CHAIN_1:
+        return 1
+    if refresh_token == CHAIN_2:
+        return 2
+    pytest.fail(f"unexpected refresh token: {refresh_token}")
+
+
 @pytest.mark.asyncio
 async def test_mcp_manager_syncs_catalog_and_calls_tool(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Discover a catalog and forward tool calls through the cached session."""
@@ -637,14 +649,17 @@ async def test_mcp_manager_serializes_oauth_refresh_read_modify_write_per_scope(
     assert second_token == ACCESS_1
     assert stored_credentials is not None
     assert stored_credentials["refresh_token"] == CHAIN_1
+    assert _rotation_index(CHAIN_1) - _rotation_index(stored_credentials["refresh_token"]) < 2
     assert seen_refresh_tokens == [CHAIN_0]
     assert max_active_refreshes == 1
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("oauth_error_code", [INVALID_GRANT, INVALID_ROTATION])
 async def test_mcp_manager_recovers_from_stale_oauth_refresh_token_rejection(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    oauth_error_code: str,
 ) -> None:
     """A stale-token rejection should re-read a newer stored token and retry once."""
     runtime_paths = _runtime_paths(tmp_path)
@@ -671,8 +686,7 @@ async def test_mcp_manager_recovers_from_stale_oauth_refresh_token_rejection(
                 credentials_manager=credentials_manager,
                 worker_target=worker_target,
             )
-            message = INVALID_GRANT
-            raise OAuthRefreshRejectedError(message, oauth_error=INVALID_GRANT)
+            raise OAuthRefreshRejectedError(oauth_error_code, oauth_error=oauth_error_code)
         if refresh_token == CHAIN_1:
             return _refreshed_credentials(CHAIN_2)
         pytest.fail(f"unexpected refresh token: {refresh_token}")
@@ -695,6 +709,65 @@ async def test_mcp_manager_recovers_from_stale_oauth_refresh_token_rejection(
     assert stored_credentials is not None
     assert stored_credentials["refresh_token"] == CHAIN_2
     assert seen_refresh_tokens == [CHAIN_0, CHAIN_1]
+
+
+@pytest.mark.asyncio
+async def test_mcp_manager_does_not_retry_stale_refresh_when_only_description_mentions_recoverable_code(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Only structured OAuth error codes should trigger stale-token recovery."""
+    runtime_paths = _runtime_paths(tmp_path)
+    worker_target = _shared_worker_target("@alice:example.test")
+    _save_mcp_oauth_credentials(
+        runtime_paths,
+        worker_target,
+        ACCESS_0,
+        refresh_token=CHAIN_0,
+        expires_at=900.0,
+    )
+    credentials_manager = get_runtime_credentials_manager(runtime_paths)
+    manager = MCPServerManager(runtime_paths)
+    await manager.sync_servers(_ConfigStub({"demo": _oauth_mcp_config()}))
+    seen_refresh_tokens: list[str] = []
+
+    async def refresh(credentials: Mapping[str, Any]) -> dict[str, Any] | None:
+        refresh_token = str(credentials["refresh_token"])
+        seen_refresh_tokens.append(refresh_token)
+        if refresh_token == CHAIN_0:
+            save_scoped_credentials(
+                "mcp_demo_oauth",
+                _refreshed_credentials(CHAIN_1),
+                credentials_manager=credentials_manager,
+                worker_target=worker_target,
+            )
+            msg = "OAuth provider description mentioned invalid_grant"
+            raise OAuthRefreshRejectedError(
+                msg,
+                oauth_error=TEMPORARILY_UNAVAILABLE,
+                oauth_error_description="retry later; invalid_grant is unrelated text",
+            )
+        pytest.fail(f"unexpected retry with refresh token: {refresh_token}")
+
+    provider = _FakeMcpOAuthProvider(refresh)
+    monkeypatch.setattr("mindroom.mcp.manager.mcp_oauth_provider", lambda *_args: provider)
+
+    with pytest.raises(OAuthConnectionRequired) as exc_info:
+        await manager._oauth_access_token(
+            manager._require_state("demo"),
+            credentials_manager=credentials_manager,
+            worker_target=worker_target,
+        )
+
+    stored_credentials = load_scoped_credentials(
+        "mcp_demo_oauth",
+        credentials_manager=credentials_manager,
+        worker_target=worker_target,
+    )
+    assert exc_info.value.reason == "oauth_refresh_rejected"
+    assert stored_credentials is not None
+    assert stored_credentials["refresh_token"] == CHAIN_1
+    assert seen_refresh_tokens == [CHAIN_0]
 
 
 @pytest.mark.asyncio
@@ -733,7 +806,84 @@ async def test_mcp_manager_surfaces_connection_required_for_terminal_oauth_refre
         )
 
     assert exc_info.value.reason == "oauth_refresh_rejected"
+    assert len(seen_refresh_tokens) == 1
     assert seen_refresh_tokens == [CHAIN_0]
+
+
+@pytest.mark.asyncio
+async def test_scoped_oauth_refresh_lock_releases_after_noop_returns(
+    tmp_path: Path,
+) -> None:
+    """The per-scope refresh lock should release after missing or unusable credentials."""
+    runtime_paths = _runtime_paths(tmp_path)
+    worker_target = _shared_worker_target("@alice:example.test")
+    credentials_manager = get_runtime_credentials_manager(runtime_paths)
+    refresh_calls = 0
+
+    async def refresh(_credentials: Mapping[str, Any]) -> dict[str, Any] | None:
+        nonlocal refresh_calls
+        refresh_calls += 1
+        return _refreshed_credentials(CHAIN_1)
+
+    provider = _FakeMcpOAuthProvider(refresh)
+
+    missing_credentials = await asyncio.wait_for(
+        refresh_scoped_oauth_credentials(
+            provider,
+            runtime_paths,
+            credentials_manager=credentials_manager,
+            worker_target=worker_target,
+        ),
+        timeout=1,
+    )
+    assert missing_credentials is None
+
+    save_scoped_credentials(
+        "mcp_demo_oauth",
+        {
+            "token": ACCESS_0,
+            "refresh_token": CHAIN_0,
+            "client_id": "wrong-client",
+            "scopes": [],
+            "_source": "oauth",
+            "_oauth_provider": "mcp_demo",
+            "expires_at": 900.0,
+        },
+        credentials_manager=credentials_manager,
+        worker_target=worker_target,
+    )
+    unusable_credentials = await asyncio.wait_for(
+        refresh_scoped_oauth_credentials(
+            provider,
+            runtime_paths,
+            credentials_manager=credentials_manager,
+            worker_target=worker_target,
+        ),
+        timeout=1,
+    )
+    assert unusable_credentials is not None
+    assert unusable_credentials["client_id"] == "wrong-client"
+
+    _save_mcp_oauth_credentials(
+        runtime_paths,
+        worker_target,
+        ACCESS_0,
+        refresh_token=CHAIN_0,
+        expires_at=900.0,
+    )
+    refreshed_credentials = await asyncio.wait_for(
+        refresh_scoped_oauth_credentials(
+            provider,
+            runtime_paths,
+            credentials_manager=credentials_manager,
+            worker_target=worker_target,
+        ),
+        timeout=1,
+    )
+
+    assert refreshed_credentials is not None
+    assert refreshed_credentials["refresh_token"] == CHAIN_1
+    assert refresh_calls == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -635,10 +635,11 @@ async def test_mcp_manager_serializes_oauth_refresh_read_modify_write_per_scope(
     monkeypatch.setattr("mindroom.mcp.manager.mcp_oauth_provider", lambda *_args: provider)
     state = manager._require_state("demo")
 
-    first_token, second_token = await asyncio.gather(
-        manager._oauth_access_token(state, credentials_manager=credentials_manager, worker_target=worker_target),
-        manager._oauth_access_token(state, credentials_manager=credentials_manager, worker_target=worker_target),
-    )
+    with patch("mindroom.mcp.manager.logger") as mock_logger:
+        first_token, second_token = await asyncio.gather(
+            manager._oauth_access_token(state, credentials_manager=credentials_manager, worker_target=worker_target),
+            manager._oauth_access_token(state, credentials_manager=credentials_manager, worker_target=worker_target),
+        )
 
     stored_credentials = load_scoped_credentials(
         "mcp_demo_oauth",
@@ -652,6 +653,10 @@ async def test_mcp_manager_serializes_oauth_refresh_read_modify_write_per_scope(
     assert _rotation_index(CHAIN_1) - _rotation_index(stored_credentials["refresh_token"]) < 2
     assert seen_refresh_tokens == [CHAIN_0]
     assert max_active_refreshes == 1
+    refresh_log_calls = [
+        call for call in mock_logger.info.call_args_list if call.args == ("MCP OAuth token refreshed",)
+    ]
+    assert len(refresh_log_calls) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_registry.py
+++ b/tests/test_mcp_registry.py
@@ -22,7 +22,14 @@ from mindroom.mcp.registry import (
 )
 from mindroom.mcp.toolkit import bind_mcp_server_manager
 from mindroom.mcp.types import MCPServerState
-from mindroom.tool_system.metadata import TOOL_METADATA, TOOL_REGISTRY, SetupType, ToolStatus, get_tool_by_name
+from mindroom.tool_system.metadata import (
+    TOOL_METADATA,
+    TOOL_REGISTRY,
+    SetupType,
+    ToolManagedInitArg,
+    ToolStatus,
+    get_tool_by_name,
+)
 from mindroom.tool_system.worker_routing import supports_tool_name_for_worker_scope
 
 if TYPE_CHECKING:
@@ -388,6 +395,17 @@ def test_mcp_tool_registry_fails_when_required_server_unavailable(tmp_path: Path
 
     with pytest.raises(MCPTimeoutError, match="startup timed out"):
         get_tool_by_name("mcp_demo", _runtime_paths(tmp_path), worker_target=None)
+
+
+def test_non_oauth_mcp_toolkit_declares_constructor_managed_init_args(tmp_path: Path) -> None:
+    """Non-OAuth MCP tools still expose the shared MCP toolkit constructor contract."""
+    sync_mcp_tool_registry(_config(tmp_path))
+
+    assert TOOL_METADATA["mcp_demo"].managed_init_args == (
+        ToolManagedInitArg.RUNTIME_PATHS,
+        ToolManagedInitArg.CREDENTIALS_MANAGER,
+        ToolManagedInitArg.WORKER_TARGET,
+    )
 
 
 def test_mcp_tool_names_are_shared_only(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Serialize OAuth-backed MCP scoped credential refreshes with a per-scope file lock and re-read persisted credentials inside the lock.
- Add one stale-token recovery retry for invalid_grant / invalid_refresh_token when the stored refresh token changed.
- Route API OAuth status refresh through the same locked helper and cover rotating, terminal rejection, non-rotating, and per-scope lock behavior.
- Address review feedback by removing the success-path diagnostic credential reload, simplifying stale-refresh error classification to structured provider errors, and documenting the non-rotating Google refresh path as out of scope for this MCP race fix.
- Pin the dynamic MCP managed-init-arg contract for non-OAuth MCP tools so metadata stays aligned with the shared MCP toolkit constructor.

## Test Plan
- [x] `/Users/bas.nijholt/.local/bin/uv run pytest --no-cov -n 0 tests/test_mcp_manager.py tests/test_credentials.py tests/api/test_oauth_api.py tests/test_mcp_registry.py`
- [x] `/Users/bas.nijholt/.local/bin/uv run ruff check src/mindroom/mcp/manager.py src/mindroom/oauth/service.py src/mindroom/oauth/client.py src/mindroom/mcp/registry.py tests/test_mcp_manager.py tests/test_mcp_registry.py`
- [x] `/Users/bas.nijholt/.local/bin/uv run tach check --dependencies --interfaces`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved OAuth credential refresh workflow with enhanced error recovery for stale tokens and better credential management organization.

* **Tests**
  * Expanded test coverage to verify OAuth refresh behavior under concurrent access, error scenarios, and credential scope locking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
