### PR TITLE
Fix destructive compaction completion

### DIFF
--- a/src/mindroom/history/compaction.py
+++ b/src/mindroom/history/compaction.py
@@ -430,11 +430,7 @@ async def _rewrite_working_session_for_compaction(  # noqa: C901, PLR0912, PLR09
                 )
                 compactable_runs = [run for run in compactable_runs if _has_stable_run_id(run)]
             selected_run_ids = {run.run_id for run in compactable_runs if isinstance(run.run_id, str) and run.run_id}
-            if (
-                selection_state.force_compact_before_next_run
-                and compactable_runs
-                and len(selected_run_ids) == len(compactable_runs)
-            ):
+            if compactable_runs and len(selected_run_ids) == len(compactable_runs):
                 pending_selected_run_ids = selected_run_ids
         if not compactable_runs:
             break
@@ -513,6 +509,7 @@ async def _rewrite_working_session_for_compaction(  # noqa: C901, PLR0912, PLR09
             runs_before=runs_before,
             threshold_tokens=threshold_tokens,
             total_compacted_run_count=total_compacted_run_count,
+            force_remaining_runs=bool(pending_selected_run_ids),
         )
 
         if pending_selected_run_ids:
@@ -556,6 +553,7 @@ async def _emit_lifecycle_progress_after_persist(
     runs_before: int,
     threshold_tokens: int | None,
     total_compacted_run_count: int,
+    force_remaining_runs: bool = False,
 ) -> None:
     """Emit lifecycle progress after a compaction chunk has been durably persisted."""
     remaining_runs = runs_for_scope(completed_top_level_runs(working_session), scope)
@@ -571,6 +569,7 @@ async def _emit_lifecycle_progress_after_persist(
         not state.force_compact_before_next_run
         and available_history_budget is not None
         and after_tokens <= available_history_budget
+        and not force_remaining_runs
     ):
         runs_remaining = 0
     await progress_callback(

--- a/src/mindroom/history/compaction.py
+++ b/src/mindroom/history/compaction.py
@@ -237,7 +237,7 @@ async def compact_scope_history(
 ) -> tuple[HistoryScopeState, CompactionOutcome | None]:
     """Compact one scope by rewriting session.summary and session.runs."""
     visible_runs = runs_for_scope(completed_top_level_runs(session), scope)
-    compactable_runs = _select_runs_to_compact(
+    compactable_runs = _select_compaction_candidates(
         visible_runs=visible_runs,
         session=session,
         scope=scope,
@@ -246,6 +246,19 @@ async def compact_scope_history(
         available_history_budget=available_history_budget,
     )
     if not compactable_runs:
+        cleared_state = _persist_cleared_force_state_if_needed(
+            storage=storage,
+            session=session,
+            scope=scope,
+            state=state,
+        )
+        return cleared_state, None
+    selected_run_ids = _stable_compaction_run_ids(
+        compactable_runs,
+        session_id=session.session_id,
+        scope=scope,
+    )
+    if not selected_run_ids:
         cleared_state = _persist_cleared_force_state_if_needed(
             storage=storage,
             session=session,
@@ -285,6 +298,7 @@ async def compact_scope_history(
         state=state,
         history_settings=history_settings,
         available_history_budget=available_history_budget,
+        selected_run_ids=selected_run_ids,
         summary_input_budget=summary_input_budget,
         before_tokens=before_tokens,
         runs_before=before_run_count,
@@ -368,7 +382,7 @@ async def compact_scope_history(
 
 
 @timed("system_prompt_assembly.history_prepare.compaction.rewrite_working_session")
-async def _rewrite_working_session_for_compaction(  # noqa: C901, PLR0912, PLR0915
+async def _rewrite_working_session_for_compaction(  # noqa: C901
     *,
     storage: BaseDb,
     persisted_session: AgentSession | TeamSession,
@@ -380,6 +394,7 @@ async def _rewrite_working_session_for_compaction(  # noqa: C901, PLR0912, PLR09
     state: HistoryScopeState,
     history_settings: ResolvedHistorySettings,
     available_history_budget: int | None,
+    selected_run_ids: Sequence[str],
     summary_input_budget: int,
     before_tokens: int,
     runs_before: int,
@@ -396,42 +411,15 @@ async def _rewrite_working_session_for_compaction(  # noqa: C901, PLR0912, PLR09
     all_compacted_run_ids: list[str] = []
     all_compacted_run_id_set: set[str] = set()
     compacted_messages: list[Message] = []
-    pending_selected_run_ids: set[str] | None = None
+    pending_selected_run_ids = set(selected_run_ids)
 
-    while True:
+    while pending_selected_run_ids:
         working_visible_runs = runs_for_scope(completed_top_level_runs(working_session), scope)
-        if pending_selected_run_ids:
-            # Once a pass selects "all visible runs", keep compacting that original
-            # set even if the remaining raw history now fits the replay budget.
-            compactable_runs = [
-                run
-                for run in working_visible_runs
-                if isinstance(run.run_id, str) and run.run_id in pending_selected_run_ids
-            ]
-        else:
-            selection_state = (
-                state if total_compacted_run_count == 0 else replace(state, force_compact_before_next_run=False)
-            )
-            compactable_runs = _select_runs_to_compact(
-                visible_runs=working_visible_runs,
-                session=working_session,
-                scope=scope,
-                state=selection_state,
-                history_settings=history_settings,
-                available_history_budget=available_history_budget,
-            )
-            unremovable_run_count = sum(1 for run in compactable_runs if not _has_stable_run_id(run))
-            if unremovable_run_count:
-                logger.warning(
-                    "Compaction skipped runs without stable run IDs",
-                    session_id=session_id,
-                    scope=scope.key,
-                    skipped_runs=unremovable_run_count,
-                )
-                compactable_runs = [run for run in compactable_runs if _has_stable_run_id(run)]
-            selected_run_ids = {run.run_id for run in compactable_runs if isinstance(run.run_id, str) and run.run_id}
-            if compactable_runs and len(selected_run_ids) == len(compactable_runs):
-                pending_selected_run_ids = selected_run_ids
+        compactable_runs = [
+            run
+            for run in working_visible_runs
+            if isinstance(run.run_id, str) and run.run_id in pending_selected_run_ids
+        ]
         if not compactable_runs:
             break
 
@@ -484,8 +472,7 @@ async def _rewrite_working_session_for_compaction(  # noqa: C901, PLR0912, PLR09
                 all_compacted_run_ids.append(run_id)
         if collect_compaction_hook_messages:
             compacted_messages.extend(_messages_for_runs(included_runs, history_settings))
-        if pending_selected_run_ids is not None:
-            pending_selected_run_ids.difference_update(compacted_run_ids)
+        pending_selected_run_ids.difference_update(compacted_run_ids)
 
         record_compaction_chunk(
             storage=storage,
@@ -509,22 +496,8 @@ async def _rewrite_working_session_for_compaction(  # noqa: C901, PLR0912, PLR09
             runs_before=runs_before,
             threshold_tokens=threshold_tokens,
             total_compacted_run_count=total_compacted_run_count,
-            force_remaining_runs=bool(pending_selected_run_ids),
+            selected_runs_remaining=len(pending_selected_run_ids),
         )
-
-        if pending_selected_run_ids:
-            continue
-
-        if available_history_budget is None:
-            break
-
-        after_tokens = estimate_prompt_visible_history_tokens(
-            session=working_session,
-            scope=scope,
-            history_settings=history_settings,
-        )
-        if after_tokens <= available_history_budget:
-            break
 
     if total_compacted_run_count == 0:
         return None
@@ -553,7 +526,7 @@ async def _emit_lifecycle_progress_after_persist(
     runs_before: int,
     threshold_tokens: int | None,
     total_compacted_run_count: int,
-    force_remaining_runs: bool = False,
+    selected_runs_remaining: int,
 ) -> None:
     """Emit lifecycle progress after a compaction chunk has been durably persisted."""
     remaining_runs = runs_for_scope(completed_top_level_runs(working_session), scope)
@@ -564,14 +537,6 @@ async def _emit_lifecycle_progress_after_persist(
         scope=scope,
         history_settings=history_settings,
     )
-    runs_remaining = len(remaining_runs)
-    if (
-        not state.force_compact_before_next_run
-        and available_history_budget is not None
-        and after_tokens <= available_history_budget
-        and not force_remaining_runs
-    ):
-        runs_remaining = 0
     await progress_callback(
         CompactionLifecycleProgress(
             notice_event_id=lifecycle_notice_event_id,
@@ -584,7 +549,7 @@ async def _emit_lifecycle_progress_after_persist(
             history_budget_tokens=available_history_budget,
             runs_before=runs_before,
             compacted_run_count=total_compacted_run_count,
-            runs_remaining=runs_remaining,
+            runs_remaining=selected_runs_remaining,
             threshold_tokens=threshold_tokens,
         ),
     )
@@ -1358,7 +1323,7 @@ def _strip_stale_anthropic_replay_fields(messages: list[Message]) -> int:
     return modified
 
 
-def _select_runs_to_compact(
+def _select_compaction_candidates(
     *,
     visible_runs: list[RunOutput | TeamRunOutput],
     session: AgentSession | TeamSession,
@@ -1379,6 +1344,23 @@ def _select_runs_to_compact(
         history_settings=history_settings,
     )
     return visible_runs if current_tokens > available_history_budget else []
+
+
+def _stable_compaction_run_ids(
+    runs: Sequence[RunOutput | TeamRunOutput],
+    *,
+    session_id: str,
+    scope: HistoryScope,
+) -> tuple[str, ...]:
+    unremovable_run_count = sum(1 for run in runs if not _has_stable_run_id(run))
+    if unremovable_run_count:
+        logger.warning(
+            "Compaction skipped runs without stable run IDs",
+            session_id=session_id,
+            scope=scope.key,
+            skipped_runs=unremovable_run_count,
+        )
+    return tuple(run.run_id for run in runs if isinstance(run.run_id, str) and run.run_id)
 
 
 def _history_messages_for_session(

--- a/src/mindroom/history/summary_call.py
+++ b/src/mindroom/history/summary_call.py
@@ -208,7 +208,8 @@ async def generate_compaction_summary(
     """Issue one compaction summary call with tuned provider config and one timeout."""
     del timing_scope
     resolved_timeout = MINDROOM_COMPACTION_CHUNK_TIMEOUT_SECONDS if timeout_seconds is None else timeout_seconds
-    configure_summary_model(model, timeout_seconds=resolved_timeout)
+    configured_model = configure_summary_model(model, timeout_seconds=resolved_timeout)
+    summary_output_limit = _summary_output_token_limit(configured_model)
 
     async def _request_summary() -> ModelResponse:
         try:
@@ -256,7 +257,7 @@ async def generate_compaction_summary(
     if not normalized_text:
         msg = "summary generation returned no result"
         raise RuntimeError(msg)
-    if _summary_response_likely_truncated(response):
+    if _summary_response_likely_truncated(response, output_token_limit=summary_output_limit):
         msg = "compaction summary likely truncated at max tokens; refusing to persist incomplete summary"
         raise RuntimeError(msg)
     return SessionSummary(summary=normalized_text, updated_at=datetime.now(UTC))
@@ -273,9 +274,17 @@ def _normalize_compaction_summary_text(raw_text: str) -> str:
     return normalized
 
 
-def _summary_response_likely_truncated(response: ModelResponse) -> bool:
+def _summary_output_token_limit(model: Model) -> int | None:
+    if isinstance(model, Claude):
+        return model.max_tokens
+    return None
+
+
+def _summary_response_likely_truncated(response: ModelResponse, *, output_token_limit: int | None) -> bool:
+    if output_token_limit is None:
+        return False
     output_tokens = _response_output_tokens(response)
-    return output_tokens is not None and output_tokens >= SUMMARY_MAX_OUTPUT_TOKENS
+    return output_tokens is not None and output_tokens >= output_token_limit
 
 
 def _response_output_tokens(response: ModelResponse) -> int | None:

--- a/src/mindroom/history/summary_call.py
+++ b/src/mindroom/history/summary_call.py
@@ -65,28 +65,6 @@ _RETRYABLE_PROVIDER_ERROR_FRAGMENTS = (
     "request too large",
     "reduce the length",
 )
-_OUTPUT_LIMIT_FINISH_REASONS = frozenset(
-    {
-        "length",
-        "max_tokens",
-        "max_output_tokens",
-        "model_length",
-        "token_limit",
-        "stop_max_tokens",
-    },
-)
-_OUTPUT_LIMIT_REASON_KEYS = frozenset(
-    {
-        "finish_reason",
-        "finishReason",
-        "finish_message",
-        "finishMessage",
-        "stop_reason",
-        "stopReason",
-        "completion_reason",
-        "completionReason",
-    },
-)
 
 
 @dataclass(frozen=True)
@@ -278,7 +256,7 @@ async def generate_compaction_summary(
     if not normalized_text:
         msg = "summary generation returned no result"
         raise RuntimeError(msg)
-    if _summary_response_likely_truncated(response, normalized_text):
+    if _summary_response_likely_truncated(response):
         msg = "compaction summary likely truncated at max tokens; refusing to persist incomplete summary"
         raise RuntimeError(msg)
     return SessionSummary(summary=normalized_text, updated_at=datetime.now(UTC))
@@ -295,13 +273,9 @@ def _normalize_compaction_summary_text(raw_text: str) -> str:
     return normalized
 
 
-def _summary_response_likely_truncated(response: ModelResponse, normalized_text: str) -> bool:
-    if _response_reports_output_limit(response):
-        return True
+def _summary_response_likely_truncated(response: ModelResponse) -> bool:
     output_tokens = _response_output_tokens(response)
-    if output_tokens is None or output_tokens < SUMMARY_MAX_OUTPUT_TOKENS:
-        return False
-    return _summary_ends_mid_token(normalized_text)
+    return output_tokens is not None and output_tokens >= SUMMARY_MAX_OUTPUT_TOKENS
 
 
 def _response_output_tokens(response: ModelResponse) -> int | None:
@@ -310,30 +284,3 @@ def _response_output_tokens(response: ModelResponse) -> int | None:
     if response.response_usage is None:
         return None
     return response.response_usage.output_tokens
-
-
-def _response_reports_output_limit(response: ModelResponse) -> bool:
-    return any(_payload_reports_output_limit(payload) for payload in (response.provider_data, response.extra))
-
-
-def _payload_reports_output_limit(payload: object) -> bool:
-    if isinstance(payload, dict):
-        for key, value in payload.items():
-            if key in _OUTPUT_LIMIT_REASON_KEYS and _is_output_limit_reason(value):
-                return True
-            if _payload_reports_output_limit(value):
-                return True
-    if isinstance(payload, list):
-        return any(_payload_reports_output_limit(item) for item in payload)
-    return False
-
-
-def _is_output_limit_reason(value: object) -> bool:
-    if not isinstance(value, str):
-        return False
-    normalized = value.strip().lower().replace(" ", "_").replace("-", "_")
-    return normalized in _OUTPUT_LIMIT_FINISH_REASONS
-
-
-def _summary_ends_mid_token(text: str) -> bool:
-    return bool(text) and (text[-1].isalnum() or text[-1] in {"/", "_", "-"})

--- a/src/mindroom/history/summary_call.py
+++ b/src/mindroom/history/summary_call.py
@@ -65,6 +65,28 @@ _RETRYABLE_PROVIDER_ERROR_FRAGMENTS = (
     "request too large",
     "reduce the length",
 )
+_OUTPUT_LIMIT_FINISH_REASONS = frozenset(
+    {
+        "length",
+        "max_tokens",
+        "max_output_tokens",
+        "model_length",
+        "token_limit",
+        "stop_max_tokens",
+    },
+)
+_OUTPUT_LIMIT_REASON_KEYS = frozenset(
+    {
+        "finish_reason",
+        "finishReason",
+        "finish_message",
+        "finishMessage",
+        "stop_reason",
+        "stopReason",
+        "completion_reason",
+        "completionReason",
+    },
+)
 
 
 @dataclass(frozen=True)
@@ -256,6 +278,9 @@ async def generate_compaction_summary(
     if not normalized_text:
         msg = "summary generation returned no result"
         raise RuntimeError(msg)
+    if _summary_response_likely_truncated(response, normalized_text):
+        msg = "compaction summary likely truncated at max tokens; refusing to persist incomplete summary"
+        raise RuntimeError(msg)
     return SessionSummary(summary=normalized_text, updated_at=datetime.now(UTC))
 
 
@@ -268,3 +293,47 @@ def _normalize_compaction_summary_text(raw_text: str) -> str:
         if first_newline != -1:
             normalized = normalized[first_newline + 1 : -3].strip()
     return normalized
+
+
+def _summary_response_likely_truncated(response: ModelResponse, normalized_text: str) -> bool:
+    if _response_reports_output_limit(response):
+        return True
+    output_tokens = _response_output_tokens(response)
+    if output_tokens is None or output_tokens < SUMMARY_MAX_OUTPUT_TOKENS:
+        return False
+    return _summary_ends_mid_token(normalized_text)
+
+
+def _response_output_tokens(response: ModelResponse) -> int | None:
+    if response.output_tokens is not None:
+        return response.output_tokens
+    if response.response_usage is None:
+        return None
+    return response.response_usage.output_tokens
+
+
+def _response_reports_output_limit(response: ModelResponse) -> bool:
+    return any(_payload_reports_output_limit(payload) for payload in (response.provider_data, response.extra))
+
+
+def _payload_reports_output_limit(payload: object) -> bool:
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            if key in _OUTPUT_LIMIT_REASON_KEYS and _is_output_limit_reason(value):
+                return True
+            if _payload_reports_output_limit(value):
+                return True
+    if isinstance(payload, list):
+        return any(_payload_reports_output_limit(item) for item in payload)
+    return False
+
+
+def _is_output_limit_reason(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    normalized = value.strip().lower().replace(" ", "_").replace("-", "_")
+    return normalized in _OUTPUT_LIMIT_FINISH_REASONS
+
+
+def _summary_ends_mid_token(text: str) -> bool:
+    return bool(text) and (text[-1].isalnum() or text[-1] in {"/", "_", "-"})

--- a/src/mindroom/history/summary_call.py
+++ b/src/mindroom/history/summary_call.py
@@ -19,6 +19,11 @@ It enforces the call-side half of the compaction invariants
    (timeouts and the named context-length fragments), the shrink schedule
    (halving), and the give-up floor — no inline string matching at call sites.
 
+5. Output-capped summaries use an explicit retry signal.
+   ``generate_compaction_summary`` refuses to return a likely truncated summary,
+   and the retry wrapper can shrink input through ``SummaryRetryPolicy`` without
+   depending on owned error-message text.
+
 ``build_summary_request_messages`` is the single replaceable request builder; a
 future cache-friendly builder that reuses the active provider prefix (PR #861)
 plugs in behind it without another cross-cutting diff.
@@ -67,6 +72,10 @@ _RETRYABLE_PROVIDER_ERROR_FRAGMENTS = (
 )
 
 
+class _CompactionSummaryOutputLimitError(RuntimeError):
+    """Raised when the summary response reaches the configured output-token cap."""
+
+
 @dataclass(frozen=True)
 class SummaryRetryPolicy:
     """Explicit budget-shrink policy for failed compaction summary calls.
@@ -82,7 +91,7 @@ class SummaryRetryPolicy:
 
     def should_shrink(self, error: Exception) -> bool:
         """Return whether a smaller summary input may resolve this provider failure."""
-        if isinstance(error, TimeoutError):
+        if isinstance(error, TimeoutError | _CompactionSummaryOutputLimitError):
             return True
         message = str(error).lower()
         return any(fragment in message for fragment in _RETRYABLE_PROVIDER_ERROR_FRAGMENTS)
@@ -258,8 +267,8 @@ async def generate_compaction_summary(
         msg = "summary generation returned no result"
         raise RuntimeError(msg)
     if _summary_response_likely_truncated(response, output_token_limit=summary_output_limit):
-        msg = "compaction summary likely truncated at max tokens; refusing to persist incomplete summary"
-        raise RuntimeError(msg)
+        msg = "compaction summary hit configured output token limit; refusing to persist incomplete summary"
+        raise _CompactionSummaryOutputLimitError(msg)
     return SessionSummary(summary=normalized_text, updated_at=datetime.now(UTC))
 
 

--- a/tests/test_agno_history.py
+++ b/tests/test_agno_history.py
@@ -93,7 +93,7 @@ from mindroom.history.storage import (
     update_scope_seen_event_ids,
     write_scope_state,
 )
-from mindroom.history.summary_call import generate_compaction_summary
+from mindroom.history.summary_call import _CompactionSummaryOutputLimitError, generate_compaction_summary
 from mindroom.history.types import (
     CompactionLifecycleFailure,
     CompactionLifecycleProgress,
@@ -1213,6 +1213,66 @@ async def test_rewrite_retries_summary_with_smaller_chunk_after_timeout(tmp_path
         if len(summary_inputs) == 1:
             msg = f"compaction summary timed out after {MINDROOM_COMPACTION_CHUNK_TIMEOUT_SECONDS}s"
             raise RuntimeError(msg)
+        return SessionSummary(summary="merged summary", updated_at=datetime.now(UTC))
+
+    with patch(
+        "mindroom.history.compaction.generate_compaction_summary",
+        new=AsyncMock(side_effect=fake_summary),
+    ):
+        rewrite_result = await _rewrite_working_session_for_compaction(
+            storage=storage,
+            persisted_session=working_session,
+            working_session=working_session,
+            summary_model=FakeModel(id="summary-model", provider="fake"),
+            summary_model_name="summary-model",
+            session_id="session-1",
+            scope=scope,
+            state=HistoryScopeState(force_compact_before_next_run=True),
+            history_settings=ResolvedHistorySettings(
+                policy=HistoryPolicy(mode="all"),
+                max_tool_calls_from_history=None,
+            ),
+            available_history_budget=None,
+            selected_run_ids=("run-1",),
+            summary_input_budget=8_000,
+            before_tokens=0,
+            runs_before=1,
+            threshold_tokens=None,
+            summary_prompt=COMPACTION_SUMMARY_PROMPT,
+            lifecycle_notice_event_id=None,
+            progress_callback=None,
+            collect_compaction_hook_messages=False,
+        )
+
+    assert rewrite_result is not None
+    assert len(summary_inputs) == 2
+    assert estimate_text_tokens(summary_inputs[1]) < estimate_text_tokens(summary_inputs[0])
+
+
+@pytest.mark.asyncio
+async def test_rewrite_retries_summary_with_smaller_chunk_after_output_cap(tmp_path: Path) -> None:
+    config, runtime_paths = _make_config(tmp_path)
+    storage = create_session_storage("test_agent", config, runtime_paths, execution_identity=None)
+    scope = HistoryScope(kind="agent", scope_id="test_agent")
+    working_session = _session(
+        "session-1",
+        runs=[
+            _completed_run(
+                "run-1",
+                messages=[
+                    Message(role="user", content="u" * 8_000),
+                    Message(role="assistant", content="a" * 8_000),
+                ],
+            ),
+        ],
+    )
+    summary_inputs: list[str] = []
+
+    async def fake_summary(*, summary_input: str, **_kwargs: object) -> SessionSummary:
+        summary_inputs.append(summary_input)
+        if len(summary_inputs) == 1:
+            msg = "renamed owned output-limit signal"
+            raise _CompactionSummaryOutputLimitError(msg)
         return SessionSummary(summary="merged summary", updated_at=datetime.now(UTC))
 
     with patch(

--- a/tests/test_agno_history.py
+++ b/tests/test_agno_history.py
@@ -2468,7 +2468,7 @@ async def test_prepare_history_for_run_auto_compaction_runs_to_completion_before
 
 
 @pytest.mark.asyncio
-async def test_prepare_history_for_run_auto_compaction_stops_when_history_fits(
+async def test_prepare_history_for_run_auto_required_compaction_finishes_original_previous_runs(  # noqa: PLR0915
     tmp_path: Path,
 ) -> None:
     config, runtime_paths = _make_config(
@@ -2477,46 +2477,34 @@ async def test_prepare_history_for_run_auto_compaction_stops_when_history_fits(
         context_window=64_000,
     )
     storage = create_session_storage("test_agent", config, runtime_paths, execution_identity=None)
+    previous_runs = [
+        _completed_run(
+            f"run-{index:02}",
+            messages=[
+                Message(role="user", content=f"RUN-{index:02} user " + ("u" * 200)),
+                Message(role="assistant", content=f"RUN-{index:02} assistant " + ("a" * 200)),
+            ],
+        )
+        for index in range(1, 24)
+    ]
     session = _session(
         "session-1",
-        runs=[
-            _completed_run(
-                "run-1",
-                messages=[
-                    Message(role="user", content="u" * 200),
-                    Message(role="assistant", content="a" * 200),
-                ],
-            ),
-            _completed_run(
-                "run-2",
-                messages=[
-                    Message(role="user", content="u" * 200),
-                    Message(role="assistant", content="a" * 200),
-                ],
-            ),
-            _completed_run(
-                "run-3",
-                messages=[
-                    Message(role="user", content="u" * 200),
-                    Message(role="assistant", content="a" * 200),
-                ],
-            ),
-        ],
+        runs=previous_runs,
     )
+    scope = HistoryScope(kind="agent", scope_id="test_agent")
+    write_scope_state(session, scope, HistoryScopeState(compacted_run_ids=("prior-tombstone",)))
     storage.upsert_session(session)
     history_settings = ResolvedHistorySettings(
         policy=HistoryPolicy(mode="all"),
         max_tool_calls_from_history=None,
     )
-    scope = HistoryScope(kind="agent", scope_id="test_agent")
     visible_runs = list(session.runs or [])
     first_summary_text = "first pass summary"
-    second_summary_text = "second pass summary"
-    third_summary_text = "third pass summary"
+    summary_inputs: list[str] = []
 
     summary_input_budget = next(
         budget
-        for budget in range(1, 10_000)
+        for budget in range(1, 20_000)
         if len(
             _build_summary_input(
                 previous_summary=None,
@@ -2525,20 +2513,11 @@ async def test_prepare_history_for_run_auto_compaction_stops_when_history_fits(
                 max_input_tokens=budget,
             )[1],
         )
-        == 1
-        and len(
-            _build_summary_input(
-                previous_summary=first_summary_text,
-                compacted_runs=visible_runs[1:],
-                history_settings=history_settings,
-                max_input_tokens=budget,
-            )[1],
-        )
-        == 1
+        == 9
     )
     after_first_session = _session(
         "session-1",
-        runs=visible_runs[1:],
+        runs=visible_runs[9:],
         summary=SessionSummary(summary=first_summary_text, updated_at=datetime.now(UTC)),
     )
     replay_budget = estimate_prompt_visible_history_tokens(
@@ -2546,6 +2525,12 @@ async def test_prepare_history_for_run_auto_compaction_stops_when_history_fits(
         scope=scope,
         history_settings=history_settings,
     )
+    before_tokens = estimate_prompt_visible_history_tokens(
+        session=session,
+        scope=scope,
+        history_settings=history_settings,
+    )
+    assert before_tokens > replay_budget
 
     execution_plan = ResolvedHistoryExecutionPlan(
         authored_compaction_config=True,
@@ -2561,13 +2546,12 @@ async def test_prepare_history_for_run_auto_compaction_stops_when_history_fits(
         replay_budget_tokens=replay_budget,
         summary_input_budget_tokens=summary_input_budget,
     )
-    summary_mock = AsyncMock(
-        side_effect=[
-            SessionSummary(summary=first_summary_text, updated_at=datetime.now(UTC)),
-            SessionSummary(summary=second_summary_text, updated_at=datetime.now(UTC)),
-            SessionSummary(summary=third_summary_text, updated_at=datetime.now(UTC)),
-        ],
-    )
+
+    async def fake_summary(*, summary_input: str, **_kwargs: object) -> SessionSummary:
+        summary_inputs.append(summary_input)
+        summary_text = first_summary_text if len(summary_inputs) == 1 else f"summary chunk {len(summary_inputs)}"
+        return SessionSummary(summary=summary_text, updated_at=datetime.now(UTC))
+
     lifecycle = RecordingCompactionLifecycle()
 
     with (
@@ -2577,13 +2561,13 @@ async def test_prepare_history_for_run_auto_compaction_stops_when_history_fits(
         ),
         patch(
             "mindroom.history.compaction.generate_compaction_summary",
-            new=summary_mock,
+            new=AsyncMock(side_effect=fake_summary),
         ),
     ):
         prepared = await prepare_history_for_run_for_test(
             agent=_agent(db=storage),
             agent_name="test_agent",
-            full_prompt="Current prompt",
+            full_prompt="CURRENT-RUN prompt",
             session_id="session-1",
             runtime_paths=runtime_paths,
             config=config,
@@ -2598,16 +2582,51 @@ async def test_prepare_history_for_run_auto_compaction_stops_when_history_fits(
     persisted = get_agent_session(storage, "session-1")
     assert persisted is not None
     assert persisted.summary is not None
-    assert persisted.summary.summary == first_summary_text
-    assert [run.run_id for run in persisted.runs or []] == ["run-2", "run-3"]
-    assert summary_mock.await_count == 1
+    assert persisted.runs == []
+    assert len(summary_inputs) > 1
+    assert "RUN-09" in summary_inputs[0]
+    assert "RUN-10" not in summary_inputs[0]
+    assert all("CURRENT-RUN" not in summary_input for summary_input in summary_inputs)
     assert len(prepared.compaction_outcomes) == 1
-    assert prepared.compaction_outcomes[0].compacted_run_count == 1
+    outcome = prepared.compaction_outcomes[0]
+    assert outcome.compacted_run_count == 23
+    assert outcome.runs_after == 0
+    summary_only_tokens = estimate_session_summary_tokens(persisted.summary.summary)
+    assert outcome.after_tokens == summary_only_tokens
+    assert outcome.after_tokens < replay_budget
     state = read_scope_state(persisted, scope)
-    assert state.last_compacted_run_count == 1
+    assert state.last_compacted_run_count == 23
+    assert state.compacted_run_ids == (
+        "prior-tombstone",
+        *(f"run-{index:02}" for index in range(1, 24)),
+    )
     progress_events = [event for event in lifecycle.events if isinstance(event, CompactionLifecycleProgress)]
-    assert len(progress_events) == 1
-    assert progress_events[0].runs_remaining == 0
+    assert progress_events
+    assert progress_events[-1].runs_remaining > 0
+    assert isinstance(lifecycle.events[-1], CompactionLifecycleSuccess)
+
+    persisted.runs = [
+        _completed_run(
+            "run-24",
+            messages=[
+                Message(role="user", content="CURRENT-RUN user"),
+                Message(role="assistant", content="CURRENT-RUN assistant"),
+            ],
+        ),
+    ]
+    storage.upsert_session(persisted)
+    current_run_session = get_agent_session(storage, "session-1")
+    assert current_run_session is not None
+    assert [run.run_id for run in current_run_session.runs or []] == ["run-24"]
+    assert "run-24" not in read_scope_state(current_run_session, scope).compacted_run_ids
+    assert (
+        estimate_prompt_visible_history_tokens(
+            session=current_run_session,
+            scope=scope,
+            history_settings=history_settings,
+        )
+        > summary_only_tokens
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_agno_history.py
+++ b/tests/test_agno_history.py
@@ -1169,6 +1169,7 @@ async def test_rewrite_passes_full_summary_input_budget_into_chunk_construction(
                 max_tool_calls_from_history=None,
             ),
             available_history_budget=None,
+            selected_run_ids=tuple(f"run-{index}" for index in range(1, 6)),
             summary_input_budget=70_000,
             before_tokens=0,
             runs_before=len(runs),
@@ -1232,6 +1233,7 @@ async def test_rewrite_retries_summary_with_smaller_chunk_after_timeout(tmp_path
                 max_tool_calls_from_history=None,
             ),
             available_history_budget=None,
+            selected_run_ids=("run-1",),
             summary_input_budget=8_000,
             before_tokens=0,
             runs_before=1,
@@ -3731,6 +3733,7 @@ async def test_rewrite_working_session_for_compaction_strips_stale_replay_fields
                 max_tool_calls_from_history=None,
             ),
             available_history_budget=1,
+            selected_run_ids=("run-1", "run-2"),
             summary_input_budget=summary_input_budget,
             before_tokens=0,
             runs_before=2,
@@ -3753,7 +3756,7 @@ async def test_rewrite_working_session_for_compaction_strips_stale_replay_fields
 
 
 @pytest.mark.asyncio
-async def test_rewrite_working_session_for_compaction_ignores_runs_without_stable_ids(
+async def test_compact_scope_history_ignores_runs_without_stable_ids(
     tmp_path: Path,
 ) -> None:
     config, runtime_paths = _make_config(tmp_path)
@@ -3774,13 +3777,11 @@ async def test_rewrite_working_session_for_compaction_ignores_runs_without_stabl
         "mindroom.history.compaction.generate_compaction_summary",
         new=AsyncMock(return_value=SessionSummary(summary="summary", updated_at=datetime.now(UTC))),
     ) as mock_generate:
-        rewrite_result = await _rewrite_working_session_for_compaction(
+        next_state, outcome = await compact_scope_history(
             storage=storage,
-            persisted_session=working_session,
-            working_session=working_session,
+            session=working_session,
             summary_model=FakeModel(id="summary-model", provider="fake"),
             summary_model_name="summary-model",
-            session_id="session-1",
             scope=scope,
             state=HistoryScopeState(force_compact_before_next_run=True),
             history_settings=ResolvedHistorySettings(
@@ -3789,16 +3790,15 @@ async def test_rewrite_working_session_for_compaction_ignores_runs_without_stabl
             ),
             available_history_budget=1,
             summary_input_budget=16_000,
-            before_tokens=0,
-            runs_before=1,
+            active_context_window=64_000,
+            replay_window_tokens=64_000,
             threshold_tokens=None,
+            reserve_tokens=0,
             summary_prompt=COMPACTION_SUMMARY_PROMPT,
-            lifecycle_notice_event_id=None,
-            progress_callback=None,
-            collect_compaction_hook_messages=False,
         )
 
-    assert rewrite_result is None
+    assert outcome is None
+    assert next_state.force_compact_before_next_run is False
     assert mock_generate.await_count == 0
     assert working_session.summary is None
     assert working_session.runs == [unremovable_run]
@@ -3977,6 +3977,7 @@ async def test_rewrite_working_session_emits_progress_after_persisted_chunks(tmp
             state=HistoryScopeState(),
             history_settings=history_settings,
             available_history_budget=1,
+            selected_run_ids=("run-1", "run-2"),
             summary_input_budget=summary_input_budget,
             before_tokens=before_tokens,
             runs_before=2,

--- a/tests/test_compaction_invariants.py
+++ b/tests/test_compaction_invariants.py
@@ -448,6 +448,20 @@ async def test_generate_compaction_summary_applies_tuning_and_request_shape() ->
     ]
 
 
+@pytest.mark.asyncio
+async def test_generate_compaction_summary_rejects_likely_output_cap_truncation() -> None:
+    class _CappedSummaryModel(FakeModel):
+        async def aresponse(self, *_args: object, **_kwargs: object) -> ModelResponse:
+            return ModelResponse(content="durable summary ended midwor", output_tokens=SUMMARY_MAX_OUTPUT_TOKENS)
+
+    with pytest.raises(RuntimeError, match="likely truncated"):
+        await generate_compaction_summary(
+            model=_CappedSummaryModel(id="summary-model", provider="fake"),
+            summary_input="conversation payload",
+            summary_prompt="Summarize the conversation.",
+        )
+
+
 def test_build_summary_request_messages_is_the_single_request_seam() -> None:
     messages = build_summary_request_messages(summary_prompt="prompt", summary_input="input")
 

--- a/tests/test_compaction_invariants.py
+++ b/tests/test_compaction_invariants.py
@@ -64,15 +64,16 @@ _HISTORY_SETTINGS = ResolvedHistorySettings(policy=HistoryPolicy(mode="all"), ma
 class _RecordingClaude(Claude):
     """Claude double that records the request instead of calling Anthropic."""
 
-    def __init__(self, **kwargs: object) -> None:
+    def __init__(self, *, response: ModelResponse | None = None, **kwargs: object) -> None:
         super().__init__(**kwargs)  # type: ignore[arg-type]
+        self.response = response or ModelResponse(content="recorded summary")
         self.seen_messages: list[Message] = []
 
     async def aresponse(self, *_args: object, **kwargs: object) -> ModelResponse:
         messages = kwargs.get("messages")
         if isinstance(messages, list):
             self.seen_messages = list(messages)
-        return ModelResponse(content="recorded summary")
+        return self.response
 
 
 def _make_config(tmp_path: Path) -> tuple[Config, RuntimePaths]:
@@ -450,23 +451,58 @@ async def test_generate_compaction_summary_applies_tuning_and_request_shape() ->
 
 @pytest.mark.asyncio
 async def test_generate_compaction_summary_rejects_output_cap_truncation() -> None:
-    class _CappedSummaryModel(FakeModel):
-        async def aresponse(self, *_args: object, **_kwargs: object) -> ModelResponse:
-            return ModelResponse(content="durable summary ended cleanly.", output_tokens=SUMMARY_MAX_OUTPUT_TOKENS)
-
     with pytest.raises(RuntimeError, match="likely truncated"):
         await generate_compaction_summary(
-            model=_CappedSummaryModel(id="summary-model", provider="fake"),
+            model=_RecordingClaude(
+                id="claude-sonnet-4-6",
+                max_tokens=64_000,
+                response=ModelResponse(
+                    content="durable summary ended cleanly.",
+                    output_tokens=SUMMARY_MAX_OUTPUT_TOKENS,
+                ),
+            ),
             summary_input="conversation payload",
             summary_prompt="Summarize the conversation.",
         )
 
 
 @pytest.mark.asyncio
-async def test_generate_compaction_summary_allows_summary_below_output_cap() -> None:
+async def test_generate_compaction_summary_uses_configured_output_cap() -> None:
+    with pytest.raises(RuntimeError, match="likely truncated"):
+        await generate_compaction_summary(
+            model=_RecordingClaude(
+                id="claude-sonnet-4-6",
+                max_tokens=1_024,
+                response=ModelResponse(content="durable summary ended cleanly.", output_tokens=1_024),
+            ),
+            summary_input="conversation payload",
+            summary_prompt="Summarize the conversation.",
+        )
+
+
+@pytest.mark.asyncio
+async def test_generate_compaction_summary_allows_claude_summary_below_output_cap() -> None:
+    summary = await generate_compaction_summary(
+        model=_RecordingClaude(
+            id="claude-sonnet-4-6",
+            max_tokens=64_000,
+            response=ModelResponse(
+                content="durable summary ended cleanly.",
+                output_tokens=SUMMARY_MAX_OUTPUT_TOKENS - 1,
+            ),
+        ),
+        summary_input="conversation payload",
+        summary_prompt="Summarize the conversation.",
+    )
+
+    assert summary.summary == "durable summary ended cleanly."
+
+
+@pytest.mark.asyncio
+async def test_generate_compaction_summary_allows_unknown_provider_without_output_cap() -> None:
     class _UncappedSummaryModel(FakeModel):
         async def aresponse(self, *_args: object, **_kwargs: object) -> ModelResponse:
-            return ModelResponse(content="durable summary ended cleanly.", output_tokens=SUMMARY_MAX_OUTPUT_TOKENS - 1)
+            return ModelResponse(content="durable summary ended cleanly.", output_tokens=SUMMARY_MAX_OUTPUT_TOKENS + 1)
 
     summary = await generate_compaction_summary(
         model=_UncappedSummaryModel(id="summary-model", provider="fake"),

--- a/tests/test_compaction_invariants.py
+++ b/tests/test_compaction_invariants.py
@@ -48,6 +48,7 @@ from mindroom.history.summary_call import (
     DEFAULT_SUMMARY_RETRY_POLICY,
     SUMMARY_MAX_OUTPUT_TOKENS,
     SummaryRetryPolicy,
+    _CompactionSummaryOutputLimitError,
     build_summary_request_messages,
     configure_summary_model,
     generate_compaction_summary,
@@ -451,7 +452,7 @@ async def test_generate_compaction_summary_applies_tuning_and_request_shape() ->
 
 @pytest.mark.asyncio
 async def test_generate_compaction_summary_rejects_output_cap_truncation() -> None:
-    with pytest.raises(RuntimeError, match="likely truncated"):
+    with pytest.raises(RuntimeError, match="output token limit"):
         await generate_compaction_summary(
             model=_RecordingClaude(
                 id="claude-sonnet-4-6",
@@ -468,7 +469,7 @@ async def test_generate_compaction_summary_rejects_output_cap_truncation() -> No
 
 @pytest.mark.asyncio
 async def test_generate_compaction_summary_uses_configured_output_cap() -> None:
-    with pytest.raises(RuntimeError, match="likely truncated"):
+    with pytest.raises(RuntimeError, match="output token limit"):
         await generate_compaction_summary(
             model=_RecordingClaude(
                 id="claude-sonnet-4-6",
@@ -529,6 +530,14 @@ def test_retry_policy_shrinks_on_timeout_and_context_length_errors() -> None:
     policy = DEFAULT_SUMMARY_RETRY_POLICY
 
     assert policy.retry_budget(attempt=1, budget=16_000, error=TimeoutError()) == 8_000
+    assert (
+        policy.retry_budget(
+            attempt=1,
+            budget=16_000,
+            error=_CompactionSummaryOutputLimitError("renamed owned output-limit signal"),
+        )
+        == 8_000
+    )
     assert policy.retry_budget(attempt=1, budget=16_000, error=RuntimeError("context_length_exceeded")) == 8_000
     assert policy.retry_budget(attempt=1, budget=16_000, error=RuntimeError("request too large")) == 8_000
     assert (

--- a/tests/test_compaction_invariants.py
+++ b/tests/test_compaction_invariants.py
@@ -449,10 +449,10 @@ async def test_generate_compaction_summary_applies_tuning_and_request_shape() ->
 
 
 @pytest.mark.asyncio
-async def test_generate_compaction_summary_rejects_likely_output_cap_truncation() -> None:
+async def test_generate_compaction_summary_rejects_output_cap_truncation() -> None:
     class _CappedSummaryModel(FakeModel):
         async def aresponse(self, *_args: object, **_kwargs: object) -> ModelResponse:
-            return ModelResponse(content="durable summary ended midwor", output_tokens=SUMMARY_MAX_OUTPUT_TOKENS)
+            return ModelResponse(content="durable summary ended cleanly.", output_tokens=SUMMARY_MAX_OUTPUT_TOKENS)
 
     with pytest.raises(RuntimeError, match="likely truncated"):
         await generate_compaction_summary(
@@ -460,6 +460,21 @@ async def test_generate_compaction_summary_rejects_likely_output_cap_truncation(
             summary_input="conversation payload",
             summary_prompt="Summarize the conversation.",
         )
+
+
+@pytest.mark.asyncio
+async def test_generate_compaction_summary_allows_summary_below_output_cap() -> None:
+    class _UncappedSummaryModel(FakeModel):
+        async def aresponse(self, *_args: object, **_kwargs: object) -> ModelResponse:
+            return ModelResponse(content="durable summary ended cleanly.", output_tokens=SUMMARY_MAX_OUTPUT_TOKENS - 1)
+
+    summary = await generate_compaction_summary(
+        model=_UncappedSummaryModel(id="summary-model", provider="fake"),
+        summary_input="conversation payload",
+        summary_prompt="Summarize the conversation.",
+    )
+
+    assert summary.summary == "durable summary ended cleanly."
 
 
 def test_build_summary_request_messages_is_the_single_request_seam() -> None:


### PR DESCRIPTION
## Summary
- Pin automatic required compaction to the originally selected stable run IDs so chunked compaction removes the full prior persisted history instead of stopping at the budget threshold.
- Keep forced/manual multi-pass compaction behavior intact.
- Reject likely max-token-truncated compaction summaries instead of persisting incomplete summaries.

## Test Plan
- UV_CACHE_DIR=/private/tmp/uv-cache /Users/bas.nijholt/.local/bin/uv sync --all-extras
- COMPOSIO_CACHE_DIR=/private/tmp/composio-cache UV_CACHE_DIR=/private/tmp/uv-cache /Users/bas.nijholt/.local/bin/uv run --python 3.13 pytest -q --no-cov -n 0
- UV_CACHE_DIR=/private/tmp/uv-cache /Users/bas.nijholt/.local/bin/uv run --python 3.13 pytest tests/test_agno_history.py tests/test_compaction_invariants.py tests/test_compaction.py -q --no-cov -n 0
- ruff check src/mindroom/history/compaction.py src/mindroom/history/summary_call.py tests/test_agno_history.py tests/test_compaction_invariants.py
- ruff format --check src/mindroom/history/compaction.py src/mindroom/history/summary_call.py tests/test_agno_history.py tests/test_compaction_invariants.py
- git diff --check

## Notes
- Full pre-commit was run in the temp PR clone. All hooks passed except TypeScript type checking and bun.lock freshness because bun is not installed in this Codex sandbox. The earlier uvx temp-dir failure was resolved with UV_TOOL_DIR under /private/tmp.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved history compaction to better preserve previously selected runs during multi-pass compaction operations.
  * Added safeguards to detect and reject incomplete compaction summaries, preventing corrupted history state from being persisted.

* **Tests**
  * Updated compaction tests to verify correct handling of run preservation and truncation detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->