### PR TITLE
Keep workers alive on proxy transport timeouts

### DIFF
--- a/src/mindroom/tool_system/worker_proxy_client.py
+++ b/src/mindroom/tool_system/worker_proxy_client.py
@@ -121,6 +121,9 @@ def _record_proxy_exception_for_worker(
     if _is_request_level_proxy_http_error(exc):
         worker_manager.touch_worker(worker_handle.worker_key)
         return
+    if isinstance(exc, httpx.TransportError):
+        worker_manager.touch_worker(worker_handle.worker_key)
+        return
     worker_manager.record_failure(worker_handle.worker_key, str(exc))
 
 

--- a/src/mindroom/tool_system/worker_proxy_client.py
+++ b/src/mindroom/tool_system/worker_proxy_client.py
@@ -121,10 +121,20 @@ def _record_proxy_exception_for_worker(
     if _is_request_level_proxy_http_error(exc):
         worker_manager.touch_worker(worker_handle.worker_key)
         return
-    if isinstance(exc, httpx.TransportError):
+    if _is_request_level_proxy_transport_error(exc):
         worker_manager.touch_worker(worker_handle.worker_key)
         return
     worker_manager.record_failure(worker_handle.worker_key, str(exc))
+
+
+def _is_request_level_proxy_transport_error(exc: Exception) -> bool:
+    """Return whether one transport failure should not mark the worker failed."""
+    if isinstance(exc, httpx.TimeoutException):
+        return True
+    if isinstance(exc, httpx.ConnectError):
+        message = str(exc).casefold()
+        return "timed out" in message or "timeout" in message
+    return False
 
 
 def _is_request_level_proxy_http_error(exc: Exception) -> bool:

--- a/tests/test_sandbox_proxy.py
+++ b/tests/test_sandbox_proxy.py
@@ -441,17 +441,9 @@ def test_worker_proxy_client_records_worker_success() -> None:
     assert manager.failures == []
 
 
-@pytest.mark.parametrize(
-    "exception_factory",
-    [
-        lambda request: httpx.ConnectError("[Errno 110] Connection timed out", request=request),
-        lambda request: httpx.ReadTimeout("timed out", request=request),
-    ],
-)
-def test_worker_proxy_transport_timeout_keeps_ready_worker_alive(
+def _run_worker_proxy_request_with_exception(
     exception_factory: Callable[[httpx.Request], Exception],
-) -> None:
-    """A transient proxy transport timeout must not evict the shared worker for sibling streams."""
+) -> _TrackingWorkerManager:
     manager = _TrackingWorkerManager()
     handle = WorkerHandle(
         worker_id="worker-1",
@@ -498,8 +490,57 @@ def test_worker_proxy_transport_timeout_keeps_ready_worker_alive(
             client_factory=_TimeoutClient,
         )
 
+    return manager
+
+
+@pytest.mark.parametrize(
+    "exception_factory",
+    [
+        lambda request: httpx.ConnectError("[Errno 110] Connection timed out", request=request),
+        lambda request: httpx.ReadTimeout("timed out", request=request),
+        lambda request: httpx.WriteTimeout("timed out", request=request),
+    ],
+)
+def test_worker_proxy_transport_timeout_keeps_ready_worker_alive(
+    exception_factory: Callable[[httpx.Request], Exception],
+) -> None:
+    """A transient proxy transport timeout must not evict the shared worker for sibling streams."""
+    manager = _run_worker_proxy_request_with_exception(exception_factory)
+
     assert manager.touched == ["agent:test"]
     assert manager.failures == []
+
+
+@pytest.mark.parametrize(
+    ("exception_factory", "failure_reason"),
+    [
+        (
+            lambda request: httpx.ConnectError("connection refused", request=request),
+            "connection refused",
+        ),
+        (
+            lambda request: httpx.RemoteProtocolError("malformed worker response", request=request),
+            "malformed worker response",
+        ),
+        (
+            lambda request: httpx.ReadError("worker read failed", request=request),
+            "worker read failed",
+        ),
+        (
+            lambda request: httpx.WriteError("worker write failed", request=request),
+            "worker write failed",
+        ),
+    ],
+)
+def test_worker_proxy_malformed_transport_errors_record_worker_failure(
+    exception_factory: Callable[[httpx.Request], Exception],
+    failure_reason: str,
+) -> None:
+    """Malformed proxy transport failures must evict the broken shared worker."""
+    manager = _run_worker_proxy_request_with_exception(exception_factory)
+
+    assert manager.touched == []
+    assert manager.failures == [("agent:test", failure_reason)]
 
 
 class _MinimalModel(Model):

--- a/tests/test_sandbox_proxy.py
+++ b/tests/test_sandbox_proxy.py
@@ -441,6 +441,67 @@ def test_worker_proxy_client_records_worker_success() -> None:
     assert manager.failures == []
 
 
+@pytest.mark.parametrize(
+    "exception_factory",
+    [
+        lambda request: httpx.ConnectError("[Errno 110] Connection timed out", request=request),
+        lambda request: httpx.ReadTimeout("timed out", request=request),
+    ],
+)
+def test_worker_proxy_transport_timeout_keeps_ready_worker_alive(
+    exception_factory: Callable[[httpx.Request], Exception],
+) -> None:
+    """A transient proxy transport timeout must not evict the shared worker for sibling streams."""
+    manager = _TrackingWorkerManager()
+    handle = WorkerHandle(
+        worker_id="worker-1",
+        worker_key="agent:test",
+        endpoint="http://worker/api/sandbox-runner/execute",
+        auth_token=_TEST_AUTH_TOKEN,
+        status="ready",
+        backend_name="kubernetes",
+        last_used_at=0.0,
+        created_at=0.0,
+    )
+
+    class _TimeoutClient:
+        def __init__(self, *, timeout: float) -> None:
+            _ = timeout
+
+        def __enter__(self) -> Self:
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+            return
+
+        def post(self, url: str, *, json: dict[str, Any], headers: dict[str, str]) -> _FakeResponse:
+            _ = json, headers
+            request = httpx.Request("POST", url)
+            raise exception_factory(request)
+
+    with pytest.raises(httpx.TransportError):
+        execute_worker_proxy_request(
+            config=WorkerProxyClientConfig(
+                proxy_url=None,
+                proxy_token=None,
+                proxy_timeout_seconds=7.0,
+                credential_lease_ttl_seconds=60,
+                credential_policy={},
+            ),
+            payload={"tool_name": "shell", "function_name": "run_shell_command"},
+            credentials_manager=None,
+            tool_name="shell",
+            function_name="run_shell_command",
+            worker_target=None,
+            worker_handle=handle,
+            worker_manager=manager,
+            client_factory=_TimeoutClient,
+        )
+
+    assert manager.touched == ["agent:test"]
+    assert manager.failures == []
+
+
 class _MinimalModel(Model):
     """Minimal model surface for exercising Agno's async tool execution path."""
 


### PR DESCRIPTION
## Summary
- Treat worker proxy transport errors/timeouts as request-level failures, not worker corruption.
- Keep the shared worker alive by touching lifecycle metadata instead of calling `record_failure`, so one timed-out tool call cannot scale the worker deployment to zero and interrupt sibling streams.
- Add regression coverage for `ConnectError` (`[Errno 110] Connection timed out`) and `ReadTimeout`.

## Why
Staging load testing showed the shared user-agent worker marked `failed` with `[Errno 110] Connection timed out` during concurrent prompts. The old proxy client classified any transport exception as worker failure, and the Kubernetes backend responds to `record_failure` by scaling the worker deployment to zero. That makes one transient proxy timeout a blast-radius event for other in-flight streams.

## Verification
- `uv run pytest tests/test_sandbox_proxy.py::test_worker_proxy_transport_timeout_keeps_ready_worker_alive -q`
- `uv run pytest tests/test_sandbox_proxy.py -q` -> 143 passed, 1 skipped
- `uv run ruff check src/mindroom/tool_system/worker_proxy_client.py tests/test_sandbox_proxy.py`
- Commit hooks passed except `ty`, skipped with `SKIP=ty` because the fresh worktree venv lacks unrelated optional extras (`playwright`, `psycopg`, `claude_agent_sdk`, etc.); touched-file ruff and affected tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error handling for temporary network timeouts. The system now properly distinguishes transient connectivity issues from persistent worker failures, preventing workers from being incorrectly removed during brief network disruptions. This improves system resilience and ensures workers remain available to process requests after temporary network issues resolve, enhancing overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->