### PR TITLE
fix(matrix): collect offline tool calls with streaming semantics

### DIFF
--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -444,6 +444,103 @@ class _NonStreamingAttemptResult:
     user_error: Exception | None = None
 
 
+@dataclass
+class _CollectedStreamResponseState:
+    """State for collecting stream-shaped output into one final body."""
+
+    full_response: str = ""
+    canonical_final_body_candidate: str | None = None
+    tool_tracker: StreamingToolTracker = field(default_factory=StreamingToolTracker)
+    tool_trace: list[ToolTraceEntry] = field(default_factory=list)
+
+
+def _collect_stream_content_chunk(
+    state: _CollectedStreamResponseState,
+    chunk: str | RunContentEvent | RunCompletedEvent,
+) -> None:
+    """Append regular stream content or remember the final canonical body."""
+    if isinstance(chunk, str):
+        state.full_response += chunk
+    elif isinstance(chunk, RunContentEvent):
+        if chunk.content:
+            state.full_response += str(chunk.content)
+    elif chunk.content is not None:
+        state.canonical_final_body_candidate = str(chunk.content)
+
+
+def _collect_stream_tool_started(
+    state: _CollectedStreamResponseState,
+    event: ToolCallStartedEvent,
+    *,
+    show_tool_calls: bool,
+) -> None:
+    """Track a tool start while collecting a silent stream."""
+    if not show_tool_calls or event.tool is None:
+        return
+
+    tool_index = len(state.tool_trace) + 1
+    text_chunk, trace_entry = state.tool_tracker.start(event.tool, tool_index=tool_index)
+    if trace_entry is not None:
+        state.tool_trace.append(trace_entry)
+    state.full_response += text_chunk
+
+
+def _collect_stream_tool_completed(
+    state: _CollectedStreamResponseState,
+    event: ToolCallCompletedEvent,
+    *,
+    show_tool_calls: bool,
+) -> None:
+    """Track a tool completion while collecting a silent stream."""
+    completion = state.tool_tracker.complete(event.tool)
+    if completion is None or not show_tool_calls:
+        return
+
+    tool_name, result, pending_tool, completed_trace = completion
+    if pending_tool is None or pending_tool.visible_tool_index is None:
+        logger.warning(
+            "Missing pending tool start in collected streaming response; skipping completion marker",
+            tool_name=tool_name,
+        )
+        return
+
+    state.full_response, _ = complete_pending_tool_block(
+        state.full_response,
+        tool_name,
+        result,
+        tool_index=pending_tool.visible_tool_index,
+    )
+    if not state.tool_tracker.update_visible_trace_entry(state.tool_trace, pending_tool, completed_trace):
+        logger.warning(
+            "Missing tool trace slot in collected streaming response for completion",
+            tool_name=tool_name,
+            tool_index=pending_tool.visible_tool_index,
+            trace_len=len(state.tool_trace),
+        )
+
+
+async def _collect_streamed_response_content(
+    response_stream: AsyncIterator[AIStreamChunk],
+    *,
+    show_tool_calls: bool,
+    tool_trace_collector: list[ToolTraceEntry] | None = None,
+) -> str:
+    """Collect a streaming response into one final body without Matrix edits."""
+    state = _CollectedStreamResponseState()
+
+    async for chunk in response_stream:
+        if isinstance(chunk, str | RunContentEvent | RunCompletedEvent):
+            _collect_stream_content_chunk(state, chunk)
+        elif isinstance(chunk, ToolCallStartedEvent):
+            _collect_stream_tool_started(state, chunk, show_tool_calls=show_tool_calls)
+        elif isinstance(chunk, ToolCallCompletedEvent):
+            _collect_stream_tool_completed(state, chunk, show_tool_calls=show_tool_calls)
+
+    if tool_trace_collector is not None:
+        tool_trace_collector.extend(state.tool_trace)
+    return state.full_response or state.canonical_final_body_candidate or ""
+
+
 def _extract_response_content(response: RunOutput, *, show_tool_calls: bool = True) -> str:
     response_parts = []
 
@@ -1377,6 +1474,44 @@ async def ai_response(  # noqa: C901, PLR0915
 
     """
     logger.info("AI request", agent=agent_name, room_id=room_id)
+    if show_tool_calls:
+        return await _collect_streamed_response_content(
+            stream_agent_response(
+                agent_name=agent_name,
+                prompt=prompt,
+                session_id=session_id,
+                runtime_paths=runtime_paths,
+                config=config,
+                thread_history=thread_history,
+                model_prompt=model_prompt,
+                thread_id=thread_id,
+                room_id=room_id,
+                knowledge=knowledge,
+                user_id=user_id,
+                run_id=run_id,
+                run_id_callback=run_id_callback,
+                include_interactive_questions=include_interactive_questions,
+                include_openai_compat_guidance=include_openai_compat_guidance,
+                media=media,
+                reply_to_event_id=reply_to_event_id,
+                correlation_id=correlation_id,
+                active_event_ids=active_event_ids,
+                show_tool_calls=show_tool_calls,
+                run_metadata_collector=run_metadata_collector,
+                execution_identity=execution_identity,
+                compaction_outcomes_collector=compaction_outcomes_collector,
+                compaction_lifecycle=compaction_lifecycle,
+                delegation_depth=delegation_depth,
+                refresh_scheduler=refresh_scheduler,
+                matrix_run_metadata=matrix_run_metadata,
+                system_enrichment_items=system_enrichment_items,
+                turn_recorder=turn_recorder,
+                pipeline_timing=pipeline_timing,
+            ),
+            show_tool_calls=show_tool_calls,
+            tool_trace_collector=tool_trace_collector,
+        )
+
     timing_scope = _build_timing_scope(
         reply_to_event_id=reply_to_event_id,
         run_id=run_id,

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -1407,6 +1407,7 @@ async def ai_response(  # noqa: C901, PLR0915
     correlation_id: str | None = None,
     active_event_ids: Collection[str] = frozenset(),
     show_tool_calls: bool = True,
+    collect_streamed_response: bool = False,
     tool_trace_collector: list[ToolTraceEntry] | None = None,
     run_metadata_collector: dict[str, Any] | None = None,
     execution_identity: ToolExecutionIdentity | None = None,
@@ -1448,6 +1449,8 @@ async def ai_response(  # noqa: C901, PLR0915
         active_event_ids: Live self-authored Matrix event IDs still tracked as
             actively streaming for this bot in the current room.
         show_tool_calls: Whether to include tool call details inline in the response text.
+        collect_streamed_response: Whether to use stream-shaped execution internally
+            and collect chunks into one final response body.
         tool_trace_collector: Optional list that receives structured tool-trace
             entries from this run.
         run_metadata_collector: Optional mapping that receives versioned
@@ -1474,7 +1477,7 @@ async def ai_response(  # noqa: C901, PLR0915
 
     """
     logger.info("AI request", agent=agent_name, room_id=room_id)
-    if show_tool_calls:
+    if collect_streamed_response and show_tool_calls:
         return await _collect_streamed_response_content(
             stream_agent_response(
                 agent_name=agent_name,

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -492,8 +492,11 @@ def _collect_stream_tool_completed(
     show_tool_calls: bool,
 ) -> None:
     """Track a tool completion while collecting a silent stream."""
+    if not show_tool_calls:
+        return
+
     completion = state.tool_tracker.complete(event.tool)
-    if completion is None or not show_tool_calls:
+    if completion is None:
         return
 
     tool_name, result, pending_tool, completed_trace = completion
@@ -1477,7 +1480,7 @@ async def ai_response(  # noqa: C901, PLR0915
 
     """
     logger.info("AI request", agent=agent_name, room_id=room_id)
-    if collect_streamed_response and show_tool_calls:
+    if collect_streamed_response:
         return await _collect_streamed_response_content(
             stream_agent_response(
                 agent_name=agent_name,

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -1580,6 +1580,8 @@ class ResponseRunner:
             turn_recorder.set_run_id(current_run_id)
             attempt_run_id_collector.append(current_run_id)
 
+        show_tool_calls = self._show_tool_calls()
+
         async def build_response_text() -> str:
             knowledge_resolution = self.deps.knowledge_access.resolve_for_agent(
                 self.deps.agent_name,
@@ -1608,7 +1610,8 @@ class ResponseRunner:
                 reply_to_event_id=request.reply_to_event_id,
                 correlation_id=self._correlation_id_for_request(request),
                 active_event_ids=active_event_ids,
-                show_tool_calls=self._show_tool_calls(),
+                show_tool_calls=show_tool_calls,
+                collect_streamed_response=show_tool_calls,
                 tool_trace_collector=tool_trace,
                 run_metadata_collector=run_metadata_content,
                 execution_identity=runtime.tool_dispatch.execution_identity,

--- a/tests/test_ai_error_message_display.py
+++ b/tests/test_ai_error_message_display.py
@@ -384,6 +384,70 @@ class TestAIErrorDisplay:
         assert outcome.failure_reason == "cancelled_by_user"
 
     @pytest.mark.asyncio
+    async def test_collected_stream_cancelled_event_preserves_user_stop_note(self, tmp_path: Path) -> None:
+        """Collected non-streaming RunCancelledEvent should keep a user-stop label."""
+        bot = _mock_bot(tmp_path)
+        bot.config.agents["test_agent"].show_tool_calls = True
+        bot._handle_interactive_question = AsyncMock()
+
+        edited_messages: list[tuple[str, str]] = []
+
+        async def mock_gateway_edit_message(
+            client: object,  # noqa: ARG001
+            room_id: str,  # noqa: ARG001
+            event_id: str,
+            content: dict[str, object],
+            text: str,
+            **_kwargs: object,
+        ) -> DeliveredMatrixEvent:
+            edited_messages.append((event_id, text))
+            return DeliveredMatrixEvent(event_id="$edit", content_sent=content)
+
+        mock_agent = MagicMock()
+        mock_agent.model = MagicMock()
+        mock_agent.model.id = "test-model"
+        mock_agent.name = "Test Agent"
+        mock_agent.add_history_to_context = False
+
+        async def fake_arun_stream(*_args: object, **_kwargs: object) -> AsyncIterator[object]:
+            yield RunContentEvent(content="Partial answer")
+            current_task = asyncio.current_task()
+            assert current_task is not None
+            request_task_cancel(current_task, cancel_msg=USER_STOP_CANCEL_MSG)
+            yield RunCancelledEvent(
+                run_id="run-2",
+                session_id="session-1",
+                reason="Run run-2 was cancelled",
+            )
+
+        with (
+            patch(
+                "mindroom.ai.open_resolved_scope_session_context",
+                new=lambda **_kwargs: nullcontext(
+                    SimpleNamespace(storage=MagicMock(), session=None),
+                ),
+            ),
+            patch("mindroom.ai._prepare_agent_and_prompt", new=AsyncMock(return_value=_prepared_run(mock_agent))),
+            patch(
+                "mindroom.delivery_gateway.edit_message_result",
+                new=AsyncMock(side_effect=mock_gateway_edit_message),
+            ),
+        ):
+            _build_response_runner(bot)
+            mock_agent.arun = MagicMock(return_value=fake_arun_stream())
+
+            outcome = await bot._response_runner.process_and_respond(
+                _response_request(existing_event_id="$thinking_msg"),
+            )
+
+        assert len(edited_messages) == 1
+        event_id, text = edited_messages[0]
+        assert event_id == "$thinking_msg"
+        assert text == _CANCELLED_RESPONSE_NOTE
+        assert outcome.terminal_status == "cancelled"
+        assert outcome.failure_reason == "cancelled_by_user"
+
+    @pytest.mark.asyncio
     async def test_run_cancelled_event_preserves_user_stop_note_in_streaming(self, tmp_path: Path) -> None:
         """RunCancelledEvent should keep a user-stop label in the final streamed edit."""
         bot = _mock_bot(tmp_path)

--- a/tests/test_ai_error_message_display.py
+++ b/tests/test_ai_error_message_display.py
@@ -321,8 +321,9 @@ class TestAIErrorDisplay:
 
     @pytest.mark.asyncio
     async def test_cancelled_run_status_preserves_user_stop_note(self, tmp_path: Path) -> None:
-        """RunStatus.cancelled should keep a user-stop label when the task is already cancelling."""
+        """Legacy non-streaming RunStatus.cancelled should keep a user-stop label."""
         bot = _mock_bot(tmp_path)
+        bot.config.agents["test_agent"].show_tool_calls = False
 
         edited_messages: list[tuple[str, str]] = []
 

--- a/tests/test_ai_stream_collection.py
+++ b/tests/test_ai_stream_collection.py
@@ -2,17 +2,20 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import pytest
 from agno.models.response import ToolExecution
 from agno.run.agent import RunContentEvent, ToolCallCompletedEvent, ToolCallStartedEvent
 
-from mindroom.ai import _collect_streamed_response_content
+from mindroom.ai import _collect_streamed_response_content, ai_response
+from mindroom.config.main import Config
 from mindroom.tool_system.events import ToolTraceEntry
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
+
+    from mindroom.constants import RuntimePaths
 
 
 @pytest.mark.asyncio
@@ -72,3 +75,36 @@ async def test_collect_streamed_response_can_hide_tool_markers() -> None:
 
     assert body == "Before. After."
     assert trace == []
+
+
+@pytest.mark.asyncio
+async def test_ai_response_honors_hidden_tool_marker_collection_opt_in(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Explicit stream collection should still work when inline tool markers are hidden."""
+    seen_kwargs: dict[str, object] = {}
+
+    async def fake_stream_agent_response(**kwargs: object) -> AsyncGenerator[object, None]:
+        seen_kwargs.update(kwargs)
+        yield RunContentEvent(content="Before.")
+        yield ToolCallStartedEvent(tool=ToolExecution(tool_name="read_file", tool_args={"path": "README.md"}))
+        yield ToolCallCompletedEvent(
+            tool=ToolExecution(tool_name="read_file", tool_args={"path": "README.md"}, result="content"),
+        )
+        yield RunContentEvent(content=" After.")
+
+    monkeypatch.setattr("mindroom.ai.stream_agent_response", fake_stream_agent_response)
+
+    trace: list[ToolTraceEntry] = []
+    body = await ai_response(
+        agent_name="general",
+        prompt="Read",
+        session_id="session",
+        runtime_paths=cast("RuntimePaths", object()),
+        config=Config(),
+        show_tool_calls=False,
+        collect_streamed_response=True,
+        tool_trace_collector=trace,
+    )
+
+    assert body == "Before. After."
+    assert trace == []
+    assert seen_kwargs["show_tool_calls"] is False

--- a/tests/test_ai_stream_collection.py
+++ b/tests/test_ai_stream_collection.py
@@ -1,0 +1,74 @@
+"""Tests for collecting stream-shaped AI output into one final response."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from agno.models.response import ToolExecution
+from agno.run.agent import RunContentEvent, ToolCallCompletedEvent, ToolCallStartedEvent
+
+from mindroom.ai import _collect_streamed_response_content
+from mindroom.tool_system.events import ToolTraceEntry
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+
+@pytest.mark.asyncio
+async def test_collect_streamed_response_preserves_tool_marker_order() -> None:
+    """Silent collection should keep the same relative tool placement as streaming delivery."""
+
+    async def stream() -> AsyncGenerator[object, None]:
+        yield RunContentEvent(content="Before tool.\n")
+        yield ToolCallStartedEvent(
+            tool=ToolExecution(tool_name="run_shell_command", tool_args={"cmd": "git status"}),
+        )
+        yield RunContentEvent(content="\nAfter tool.")
+        yield ToolCallCompletedEvent(
+            tool=ToolExecution(
+                tool_name="run_shell_command",
+                tool_args={"cmd": "git status"},
+                result="clean",
+            ),
+        )
+
+    trace: list[ToolTraceEntry] = []
+    body = await _collect_streamed_response_content(
+        stream(),
+        show_tool_calls=True,
+        tool_trace_collector=trace,
+    )
+
+    assert body.index("Before tool.") < body.index("run_shell_command") < body.index("After tool.")
+    assert trace == [
+        ToolTraceEntry(
+            type="tool_call_completed",
+            tool_name="run_shell_command",
+            args_preview="cmd=git status",
+            result_preview="clean",
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_collect_streamed_response_can_hide_tool_markers() -> None:
+    """The collector still supports hidden-tool-call responses."""
+
+    async def stream() -> AsyncGenerator[object, None]:
+        yield RunContentEvent(content="Before.")
+        yield ToolCallStartedEvent(tool=ToolExecution(tool_name="read_file", tool_args={"path": "README.md"}))
+        yield ToolCallCompletedEvent(
+            tool=ToolExecution(tool_name="read_file", tool_args={"path": "README.md"}, result="content"),
+        )
+        yield RunContentEvent(content=" After.")
+
+    trace: list[ToolTraceEntry] = []
+    body = await _collect_streamed_response_content(
+        stream(),
+        show_tool_calls=False,
+        tool_trace_collector=trace,
+    )
+
+    assert body == "Before. After."
+    assert trace == []

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -2507,6 +2507,7 @@ async def test_generate_response_preserves_model_prompt_in_persisted_session(
     """Persisted model prompts should stay intact so later turns can reuse provider cache prefixes."""
     runtime_paths = _runtime_paths(tmp_path)
     config = bind_runtime_paths(_config(), runtime_paths)
+    config.agents["general"].show_tool_calls = False
     bot = _make_bot(tmp_path, config=config, runtime_paths=runtime_paths)
     storage = _SessionStorage()
 
@@ -2663,6 +2664,7 @@ async def test_generate_response_preserves_retry_model_prompt(tmp_path: Path) ->
     """Retry runs should keep the model-facing prompt that Agno persisted."""
     runtime_paths = _runtime_paths(tmp_path)
     config = bind_runtime_paths(_config(), runtime_paths)
+    config.agents["general"].show_tool_calls = False
     bot = _make_bot(tmp_path, config=config, runtime_paths=runtime_paths)
     storage = _SessionStorage()
     seen_run_ids: list[str | None] = []

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -57,6 +57,7 @@ from mindroom.constants import (
     STREAM_STATUS_COMPLETED,
     STREAM_STATUS_KEY,
     STREAM_STATUS_PENDING,
+    TOOL_TRACE_CONTENT_KEY,
     VOICE_RAW_AUDIO_FALLBACK_KEY,
     RuntimePaths,
     resolve_runtime_paths,
@@ -5544,6 +5545,81 @@ class TestAgentBot:
         assert delivery.event_id == "$response"
         assert mock_ai.call_args.kwargs["show_tool_calls"] is False
         assert "io.mindroom.tool_trace" not in bot.client.room_send.await_args.kwargs["content"]
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_visible_tool_calls_are_passed_to_ai_response(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """Offline/non-streaming runs should let ai_response use the stream-equivalent path."""
+
+        @asynccontextmanager
+        async def noop_typing_indicator(*_args: object, **_kwargs: object) -> AsyncGenerator[None]:
+            yield
+
+        config = _runtime_bound_config(
+            Config(
+                agents={
+                    "calculator": AgentConfig(
+                        display_name="CalculatorAgent",
+                        rooms=["!test:localhost"],
+                        show_tool_calls=True,
+                    ),
+                },
+            ),
+            tmp_path,
+        )
+        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        bot.client = AsyncMock()
+        bot.client.room_send.return_value = _room_send_response("$response")
+        _install_runtime_cache_support(bot)
+        _set_knowledge_for_agent(bot, MagicMock(return_value=None))
+
+        async def fake_ai_response(*_args: object, **kwargs: object) -> str:
+            assert kwargs["show_tool_calls"] is True
+            collector = kwargs["tool_trace_collector"]
+            collector.append(
+                ToolTraceEntry(
+                    type="tool_call_completed",
+                    tool_name="run_shell_command",
+                    args_preview="cmd=git status",
+                    result_preview="clean",
+                ),
+            )
+            return "Final answer"
+
+        with patch_response_runner_module(
+            typing_indicator=noop_typing_indicator,
+            ai_response=AsyncMock(side_effect=fake_ai_response),
+        ):
+            delivery = await bot._response_runner.process_and_respond(
+                _response_request(
+                    room_id="!test:localhost",
+                    prompt="Check status",
+                    reply_to_event_id="$event",
+                    thread_history=[],
+                    user_id="@user:localhost",
+                    response_envelope=request_envelope(
+                        room_id="!test:localhost",
+                        reply_to_event_id="$event",
+                        prompt="Check status",
+                        user_id="@user:localhost",
+                    ),
+                ),
+            )
+
+        assert delivery.event_id == "$response"
+        content = bot.client.room_send.await_args.kwargs["content"]
+        assert content["body"] == "Final answer"
+        assert content[TOOL_TRACE_CONTENT_KEY]["events"] == [
+            {
+                "type": "tool_call_completed",
+                "tool_name": "run_shell_command",
+                "args_preview": "cmd=git status",
+                "result_preview": "clean",
+            },
+        ]
 
     @pytest.mark.asyncio
     async def test_generate_response_prefixes_user_turns_with_local_datetime(

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -5544,6 +5544,7 @@ class TestAgentBot:
 
         assert delivery.event_id == "$response"
         assert mock_ai.call_args.kwargs["show_tool_calls"] is False
+        assert mock_ai.call_args.kwargs["collect_streamed_response"] is False
         assert "io.mindroom.tool_trace" not in bot.client.room_send.await_args.kwargs["content"]
 
     @pytest.mark.asyncio
@@ -5578,6 +5579,7 @@ class TestAgentBot:
 
         async def fake_ai_response(*_args: object, **kwargs: object) -> str:
             assert kwargs["show_tool_calls"] is True
+            assert kwargs["collect_streamed_response"] is True
             collector = kwargs["tool_trace_collector"]
             collector.append(
                 ToolTraceEntry(


### PR DESCRIPTION
## Summary
- Cherry-picks `46d1e1f0e` to collect non-streaming visible tool calls through stream-shaped execution.
- Keeps direct `ai_response` callers on the legacy non-streaming path by default.
- Opts `ResponseRunner` into collected streaming only when Matrix-visible tool traces are enabled.

## Test Plan
- `uv sync --all-extras` in a clean verification worktree
- `uv run pytest` in the clean verification worktree: 8658 passed, 30 skipped
- `uv run pre-commit run --all-files` in the clean verification worktree