### PR TITLE
Offload streaming response formatting

### DIFF
--- a/src/mindroom/matrix/mentions.py
+++ b/src/mindroom/matrix/mentions.py
@@ -114,6 +114,9 @@ def _mentioned_user_ids_from_replacements(replacements: list[_MentionReplacement
 
 def _scan_mention_tokens(text: str) -> list[_MentionToken]:
     """Return ordered mention tokens from one message body."""
+    if "@" not in text:
+        return []
+
     tokens = _scan_explicit_matrix_id_tokens(text)
     tokens.extend(
         _scan_entity_alias_tokens(

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -338,6 +338,75 @@ class _PreparedStreamingDelivery:
     had_warmup_suffix: bool
 
 
+@dataclass(frozen=True)
+class _StreamingDeliverySnapshot:
+    """Immutable state needed to format one outbound streaming payload."""
+
+    config: Config
+    runtime_paths: RuntimePaths
+    accumulated_text: str
+    event_id: str | None
+    effective_thread_id: str | None
+    reply_to_event_id: str | None
+    latest_thread_event_id: str | None
+    room_mode: bool
+    show_tool_calls: bool
+    tool_trace: list[ToolTraceEntry]
+    extra_content: dict[str, Any] | None
+    warmup_suffix_lines: tuple[Any, ...]
+    stream_status: str
+
+
+def _prepare_delivery_from_snapshot(snapshot: _StreamingDeliverySnapshot) -> _PreparedStreamingDelivery:
+    """Format one outbound payload from immutable stream state."""
+    text_to_send = snapshot.accumulated_text if snapshot.accumulated_text.strip() else _PROGRESS_PLACEHOLDER
+
+    response = interactive.parse_and_format_interactive(text_to_send, extract_mapping=True)
+    display_text = response.formatted_text
+
+    latest_for_message = (
+        snapshot.latest_thread_event_id if snapshot.event_id is None and not snapshot.room_mode else None
+    )
+    extra_content = dict(snapshot.extra_content or {})
+    extra_content[STREAM_STATUS_KEY] = snapshot.stream_status
+
+    content = format_message_with_mentions(
+        config=snapshot.config,
+        runtime_paths=snapshot.runtime_paths,
+        text=display_text,
+        thread_event_id=snapshot.effective_thread_id,
+        reply_to_event_id=snapshot.reply_to_event_id,
+        latest_thread_event_id=latest_for_message,
+        tool_trace=snapshot.tool_trace if snapshot.show_tool_calls else None,
+        extra_content=extra_content,
+    )
+    canonical_visible_body = content["body"]
+    if snapshot.warmup_suffix_lines:
+        content[STREAM_VISIBLE_BODY_KEY] = canonical_visible_body
+        warmup_suffix = "\n".join(line.text for line in snapshot.warmup_suffix_lines)
+        content[STREAM_WARMUP_SUFFIX_KEY] = warmup_suffix
+        display_text = f"{display_text}\n\n{warmup_suffix}" if display_text else warmup_suffix
+        content["body"] = f"{content['body']}\n\n{warmup_suffix}"
+        suffix_html = "".join(f"<p>{line.html}</p>" for line in snapshot.warmup_suffix_lines)
+        content["formatted_body"] = f"{content['formatted_body']}{suffix_html}"
+
+    return _PreparedStreamingDelivery(
+        content=content,
+        display_text=display_text,
+        committed_state=_CommittedDeliveryState(
+            accumulated_text=_normalize_stream_accumulated_text(snapshot.accumulated_text),
+            tool_trace=deepcopy(snapshot.tool_trace),
+            placeholder_progress_sent=not snapshot.accumulated_text.strip(),
+            rendered_body=canonical_visible_body,
+            visible_body_state=(
+                "placeholder_only" if canonical_visible_body == _PROGRESS_PLACEHOLDER else "visible_body"
+            ),
+            interactive_metadata=response.interactive_metadata,
+        ),
+        had_warmup_suffix=bool(snapshot.warmup_suffix_lines),
+    )
+
+
 @dataclass
 class StreamingResponse:
     """Manages a streaming response with incremental message updates."""
@@ -770,7 +839,7 @@ class StreamingResponse:
         capture_completions: tuple[asyncio.Future[None], ...] = (),
     ) -> bool:
         """Send new message or edit existing one."""
-        prepared_delivery = self._prepare_delivery(
+        prepared_delivery = await self._prepare_delivery_async(
             is_final=is_final,
             allow_empty_progress=allow_empty_progress,
             stream_status=stream_status,
@@ -860,68 +929,51 @@ class StreamingResponse:
             edit_content=edit_content,
         )
 
-    def _prepare_delivery(
+    def _delivery_snapshot(
+        self,
+        *,
+        is_final: bool,
+        allow_empty_progress: bool,
+        stream_status: str | None,
+    ) -> _StreamingDeliverySnapshot | None:
+        """Freeze all mutable stream state needed for one formatting pass."""
+        warmup_suffix_lines = self._warmup_state.render_lines(show_tool_calls=self.show_tool_calls)
+        if not self.accumulated_text.strip() and not allow_empty_progress and not warmup_suffix_lines:
+            return None
+
+        assert self.target is not None
+        return _StreamingDeliverySnapshot(
+            config=self.config,
+            runtime_paths=self.runtime_paths,
+            accumulated_text=self.accumulated_text,
+            event_id=self.event_id,
+            effective_thread_id=self.target.resolved_thread_id,
+            reply_to_event_id=self.target.reply_to_event_id,
+            latest_thread_event_id=self.latest_thread_event_id,
+            room_mode=self.room_mode,
+            show_tool_calls=self.show_tool_calls,
+            tool_trace=deepcopy(self.tool_trace),
+            extra_content=deepcopy(self.extra_content) if self.extra_content is not None else None,
+            warmup_suffix_lines=tuple(warmup_suffix_lines),
+            stream_status=self._resolve_stream_status(is_final=is_final, stream_status=stream_status),
+        )
+
+    async def _prepare_delivery_async(
         self,
         *,
         is_final: bool,
         allow_empty_progress: bool,
         stream_status: str | None,
     ) -> _PreparedStreamingDelivery | None:
-        """Freeze one exact outbound payload before awaiting Matrix I/O."""
-        warmup_suffix_lines = self._warmup_state.render_lines(show_tool_calls=self.show_tool_calls)
-        if not self.accumulated_text.strip() and not allow_empty_progress and not warmup_suffix_lines:
+        """Prepare one outbound payload without blocking the event loop on formatting."""
+        snapshot = self._delivery_snapshot(
+            is_final=is_final,
+            allow_empty_progress=allow_empty_progress,
+            stream_status=stream_status,
+        )
+        if snapshot is None:
             return None
-
-        assert self.target is not None
-        effective_thread_id = self.target.resolved_thread_id
-
-        text_to_send = self.accumulated_text if self.accumulated_text.strip() else _PROGRESS_PLACEHOLDER
-
-        # Format the text (handles interactive questions if present)
-        response = interactive.parse_and_format_interactive(text_to_send, extract_mapping=True)
-        display_text = response.formatted_text
-
-        # Only use latest_thread_event_id for the initial message (not edits)
-        latest_for_message = self.latest_thread_event_id if self.event_id is None and not self.room_mode else None
-        stream_status = self._resolve_stream_status(is_final=is_final, stream_status=stream_status)
-        extra_content = dict(self.extra_content or {})
-        extra_content[STREAM_STATUS_KEY] = stream_status
-
-        content = format_message_with_mentions(
-            config=self.config,
-            runtime_paths=self.runtime_paths,
-            text=display_text,
-            thread_event_id=effective_thread_id,
-            reply_to_event_id=self.target.reply_to_event_id,
-            latest_thread_event_id=latest_for_message,
-            tool_trace=self.tool_trace if self.show_tool_calls else None,
-            extra_content=extra_content,
-        )
-        canonical_visible_body = content["body"]
-        if warmup_suffix_lines:
-            content[STREAM_VISIBLE_BODY_KEY] = canonical_visible_body
-            warmup_suffix = "\n".join(line.text for line in warmup_suffix_lines)
-            content[STREAM_WARMUP_SUFFIX_KEY] = warmup_suffix
-            display_text = f"{display_text}\n\n{warmup_suffix}" if display_text else warmup_suffix
-            content["body"] = f"{content['body']}\n\n{warmup_suffix}"
-            suffix_html = "".join(f"<p>{line.html}</p>" for line in warmup_suffix_lines)
-            content["formatted_body"] = f"{content['formatted_body']}{suffix_html}"
-
-        return _PreparedStreamingDelivery(
-            content=content,
-            display_text=display_text,
-            committed_state=_CommittedDeliveryState(
-                accumulated_text=_normalize_stream_accumulated_text(self.accumulated_text),
-                tool_trace=deepcopy(self.tool_trace),
-                placeholder_progress_sent=not self.accumulated_text.strip(),
-                rendered_body=canonical_visible_body,
-                visible_body_state=(
-                    "placeholder_only" if canonical_visible_body == _PROGRESS_PLACEHOLDER else "visible_body"
-                ),
-                interactive_metadata=response.interactive_metadata,
-            ),
-            had_warmup_suffix=bool(warmup_suffix_lines),
-        )
+        return await asyncio.to_thread(_prepare_delivery_from_snapshot, snapshot)
 
     def _mark_delivery_committed(self, committed_state: _CommittedDeliveryState) -> None:
         """Snapshot the last non-terminal text/tool-trace state that actually reached Matrix."""
@@ -1462,7 +1514,7 @@ async def _drive_stream_delivery(  # noqa: C901, PLR0912
             if merged_request.phase_boundary_flush and (
                 streaming.chars_since_last_update > 0 and streaming.accumulated_text.strip()
             ):
-                prepared_phase_boundary_flush = streaming._prepare_delivery(
+                prepared_phase_boundary_flush = await streaming._prepare_delivery_async(
                     is_final=False,
                     allow_empty_progress=False,
                     stream_status=None,

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -351,7 +351,7 @@ class _StreamingDeliverySnapshot:
     latest_thread_event_id: str | None
     room_mode: bool
     show_tool_calls: bool
-    tool_trace: list[ToolTraceEntry]
+    tool_trace: tuple[ToolTraceEntry, ...]
     extra_content: dict[str, Any] | None
     warmup_suffix_lines: tuple[Any, ...]
     stream_status: str
@@ -369,6 +369,7 @@ def _prepare_delivery_from_snapshot(snapshot: _StreamingDeliverySnapshot) -> _Pr
     )
     extra_content = dict(snapshot.extra_content or {})
     extra_content[STREAM_STATUS_KEY] = snapshot.stream_status
+    tool_trace = list(snapshot.tool_trace)
 
     content = format_message_with_mentions(
         config=snapshot.config,
@@ -377,7 +378,7 @@ def _prepare_delivery_from_snapshot(snapshot: _StreamingDeliverySnapshot) -> _Pr
         thread_event_id=snapshot.effective_thread_id,
         reply_to_event_id=snapshot.reply_to_event_id,
         latest_thread_event_id=latest_for_message,
-        tool_trace=snapshot.tool_trace if snapshot.show_tool_calls else None,
+        tool_trace=tool_trace if snapshot.show_tool_calls else None,
         extra_content=extra_content,
     )
     canonical_visible_body = content["body"]
@@ -395,7 +396,7 @@ def _prepare_delivery_from_snapshot(snapshot: _StreamingDeliverySnapshot) -> _Pr
         display_text=display_text,
         committed_state=_CommittedDeliveryState(
             accumulated_text=_normalize_stream_accumulated_text(snapshot.accumulated_text),
-            tool_trace=deepcopy(snapshot.tool_trace),
+            tool_trace=tool_trace,
             placeholder_progress_sent=not snapshot.accumulated_text.strip(),
             rendered_body=canonical_visible_body,
             visible_body_state=(
@@ -952,7 +953,7 @@ class StreamingResponse:
             latest_thread_event_id=self.latest_thread_event_id,
             room_mode=self.room_mode,
             show_tool_calls=self.show_tool_calls,
-            tool_trace=deepcopy(self.tool_trace),
+            tool_trace=tuple(deepcopy(self.tool_trace)),
             extra_content=deepcopy(self.extra_content) if self.extra_content is not None else None,
             warmup_suffix_lines=tuple(warmup_suffix_lines),
             stream_status=self._resolve_stream_status(is_final=is_final, stream_status=stream_status),

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -36,7 +36,7 @@ from mindroom.orchestration.runtime import (
     classify_cancel_source,
     log_cancelled_response,
 )
-from mindroom.streaming_warmup import WorkerWarmupState
+from mindroom.streaming_warmup import RenderedWarmupLine, WorkerWarmupState
 from mindroom.timing import emit_timing_event
 from mindroom.tool_system.events import (
     StreamingToolTracker,
@@ -328,7 +328,7 @@ def interactive_response_for_visible_body(
     return visible_response
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class _PreparedStreamingDelivery:
     """One frozen non-terminal delivery attempt."""
 
@@ -338,7 +338,7 @@ class _PreparedStreamingDelivery:
     had_warmup_suffix: bool
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class _StreamingDeliverySnapshot:
     """Immutable state needed to format one outbound streaming payload."""
 
@@ -353,7 +353,7 @@ class _StreamingDeliverySnapshot:
     show_tool_calls: bool
     tool_trace: tuple[ToolTraceEntry, ...]
     extra_content: dict[str, Any] | None
-    warmup_suffix_lines: tuple[Any, ...]
+    warmup_suffix_lines: tuple[RenderedWarmupLine, ...]
     stream_status: str
 
 

--- a/src/mindroom/streaming_warmup.py
+++ b/src/mindroom/streaming_warmup.py
@@ -29,8 +29,8 @@ class _ActiveWarmup:
     last_event: WorkerReadyProgress
 
 
-@dataclass(frozen=True)
-class _RenderedWarmupLine:
+@dataclass(frozen=True, slots=True)
+class RenderedWarmupLine:
     """One warmup line rendered for plain-text and HTML Matrix bodies."""
 
     text: str
@@ -44,7 +44,7 @@ def _render_tool_labels(tool_labels: list[str]) -> tuple[str, str]:
     return plain, html
 
 
-def _render_worker_status_line(warmup: _ActiveWarmup, *, show_tool_calls: bool) -> _RenderedWarmupLine:
+def _render_worker_status_line(warmup: _ActiveWarmup, *, show_tool_calls: bool) -> RenderedWarmupLine:
     """Render one worker warmup line without leaking hidden tool metadata."""
     if show_tool_calls and warmup.tool_labels:
         labels_text, labels_html = _render_tool_labels(warmup.tool_labels)
@@ -60,18 +60,18 @@ def _render_worker_status_line(warmup: _ActiveWarmup, *, show_tool_calls: bool) 
     if phase == "failed":
         error = _shorten_warmup_error(warmup.last_event.error)
         suffix = "" if error.endswith((".", "!", "?")) else "."
-        return _RenderedWarmupLine(
+        return RenderedWarmupLine(
             text=f"⚠️ {failure_copy_text}: {error}{suffix}",
             html=f"⚠️ {failure_copy_html}: {escape(error)}{suffix}",
         )
     if phase == "cold_start":
-        return _RenderedWarmupLine(
+        return RenderedWarmupLine(
             text=f"⏳ {waiting_copy_text}",
             html=f"⏳ {waiting_copy_html}",
         )
 
     elapsed_seconds = max(1, int(warmup.last_event.elapsed_seconds))
-    return _RenderedWarmupLine(
+    return RenderedWarmupLine(
         text=f"⏳ {waiting_copy_text} {elapsed_seconds}s elapsed.",
         html=f"⏳ {waiting_copy_html} {elapsed_seconds}s elapsed.",
     )
@@ -121,7 +121,7 @@ class WorkerWarmupState:
         for stale_worker_key in stale_failed_worker_keys:
             self.active_warmups.pop(stale_worker_key, None)
 
-    def render_lines(self, *, show_tool_calls: bool) -> list[_RenderedWarmupLine]:
+    def render_lines(self, *, show_tool_calls: bool) -> list[RenderedWarmupLine]:
         """Render all active worker warmup notices as side-band suffix lines."""
         if not self.active_warmups:
             return []

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
+from typing import TYPE_CHECKING, NoReturn
+
+if TYPE_CHECKING:
+    import pytest
 
 from mindroom import constants as constants_mod
 from mindroom.config.agent import AgentConfig, TeamConfig
@@ -97,6 +101,23 @@ class TestMentionParsing:
 
         assert processed == "Hey @actual_calculator:localhost can you help with this?"
         assert mentions == ["@actual_calculator:localhost"]
+
+    def test_parse_without_at_skips_regex_scanners(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Plain text without @ cannot contain mentions, so skip regex scanner work."""
+        config = _make_config(_default_runtime_paths())
+
+        def fail_scan(*_args: object, **_kwargs: object) -> NoReturn:
+            msg = "mention regex scanner should not run without @"
+            raise AssertionError(msg)
+
+        monkeypatch.setattr("mindroom.matrix.mentions._scan_explicit_matrix_id_tokens", fail_scan)
+        monkeypatch.setattr("mindroom.matrix.mentions._scan_entity_alias_tokens", fail_scan)
+
+        processed, mentions, markdown = _parse_mentions_in_text("plain **markdown** text", config)
+
+        assert processed == "plain **markdown** text"
+        assert markdown == "plain **markdown** text"
+        assert mentions == []
 
     def test_parse_multiple_mentions(self) -> None:
         """Test parsing multiple agent mentions."""

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -271,6 +271,33 @@ async def test_nonterminal_delivery_formats_off_event_loop_thread(config: Config
     assert "<strong>world</strong>" in delivered_content["formatted_body"]
 
 
+def test_delivery_snapshot_isolates_tool_trace(config: Config) -> None:
+    """Snapshot formatting should not observe later live tool-trace mutations."""
+    streaming = StreamingResponse(
+        target=MessageTarget.resolve("!test:localhost", None, "$original_123", room_mode=True),
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+    )
+    streaming.accumulated_text = "Hello"
+    streaming.tool_trace = [ToolTraceEntry(type="tool_call_started", tool_name="search")]
+
+    snapshot = streaming._delivery_snapshot(
+        is_final=False,
+        allow_empty_progress=False,
+        stream_status=None,
+    )
+
+    assert snapshot is not None
+    streaming.tool_trace[0].type = "tool_call_completed"
+    streaming.tool_trace[0].result_preview = "done"
+    streaming.tool_trace.append(ToolTraceEntry(type="tool_call_started", tool_name="other"))
+
+    assert isinstance(snapshot.tool_trace, tuple)
+    assert len(snapshot.tool_trace) == 1
+    assert snapshot.tool_trace[0].type == "tool_call_started"
+    assert snapshot.tool_trace[0].result_preview is None
+
+
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("fake_clock")
 async def test_cancellation_mid_stream_appends_cancelled_note(config: Config) -> None:

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import itertools
 import tempfile
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
@@ -19,6 +20,7 @@ import pytest
 from agno.models.response import ToolExecution
 from agno.run.agent import RunContentEvent, ToolCallCompletedEvent, ToolCallStartedEvent
 
+from mindroom import streaming as streaming_mod
 from mindroom.cancellation import USER_STOP_CANCEL_MSG
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
@@ -36,9 +38,10 @@ from mindroom.streaming import (
     _CANCELLED_RESPONSE_NOTE,
     _PROGRESS_PLACEHOLDER,
     StreamingDeliveryError,
+    StreamingResponse,
     send_streaming_response,
 )
-from mindroom.tool_system.events import _TOOL_TRACE_KEY
+from mindroom.tool_system.events import _TOOL_TRACE_KEY, ToolTraceEntry
 from tests.conftest import (
     bind_runtime_paths,
     make_matrix_client_mock,
@@ -203,6 +206,69 @@ async def test_placeholder_progressive_edits_and_final_tool_trace(config: Config
     assert outcome.visible_body_state == "visible_body"
     assert outcome.visible_event_id == "$stream_1"
     assert outcome.visible_body_text == final.display_text
+
+
+@pytest.mark.asyncio
+async def test_nonterminal_delivery_formats_off_event_loop_thread(config: Config) -> None:
+    """Markdown and mention formatting should not block the stream owner's event loop."""
+    streaming = StreamingResponse(
+        target=MessageTarget.resolve("!test:localhost", None, "$original_123", room_mode=True),
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+    )
+    streaming.accumulated_text = "Hello **world**"
+
+    loop_thread_id = threading.get_ident()
+    format_thread_ids: list[int] = []
+    delivered_content: dict[str, Any] = {}
+    original_format = streaming_mod.format_message_with_mentions
+
+    def recording_format(
+        config: Config,
+        runtime_paths: object,
+        text: str,
+        thread_event_id: str | None = None,
+        reply_to_event_id: str | None = None,
+        latest_thread_event_id: str | None = None,
+        tool_trace: list[ToolTraceEntry] | None = None,
+        extra_content: dict[str, object] | None = None,
+    ) -> dict[str, Any]:
+        format_thread_ids.append(threading.get_ident())
+        return original_format(
+            config,
+            runtime_paths,
+            text,
+            thread_event_id=thread_event_id,
+            reply_to_event_id=reply_to_event_id,
+            latest_thread_event_id=latest_thread_event_id,
+            tool_trace=tool_trace,
+            extra_content=extra_content,
+        )
+
+    async def fake_send(
+        _client: object,
+        _room_id: str,
+        content: dict[str, Any],
+        *,
+        config: Config,
+    ) -> DeliveredMatrixEvent:
+        assert isinstance(config, Config)
+        delivered_content.update(content)
+        return DeliveredMatrixEvent(event_id="$stream_1", content_sent=dict(content))
+
+    with (
+        patch("mindroom.streaming.format_message_with_mentions", new=recording_format),
+        patch("mindroom.streaming.send_message_result", new=fake_send),
+    ):
+        sent = await streaming._send_or_edit_message(
+            make_matrix_client_mock(user_id="@mindroom_helper:localhost"),
+        )
+
+    assert sent is True
+    assert format_thread_ids
+    assert all(thread_id != loop_thread_id for thread_id in format_thread_ids)
+    assert delivered_content["body"] == "Hello **world**"
+    assert "<strong>world</strong>" in delivered_content["formatted_body"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- offload streaming response formatting from the asyncio loop using immutable delivery snapshots
- keep markdown/HTML rendering behavior unchanged while avoiding event-loop stalls during format work
- skip mention regex scanning when response text has no `@`

## Test Plan
- `uv run ruff check src/mindroom/streaming.py src/mindroom/matrix/mentions.py tests/test_streaming.py tests/test_mentions.py`
- `uv run pytest tests/test_streaming.py tests/test_streaming_behavior.py tests/test_mentions.py --no-cov -n0 -q`

## Notes
- Local pre-commit ran successfully with `SKIP=ty`; `ty` is blocked in this dev env by missing optional dependency packages unrelated to this diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved mention detection performance for messages without mention patterns
  * Enhanced streaming message delivery responsiveness and optimized formatting workflows

* **Tests**
  * Added tests validating mention detection optimization and streaming message delivery improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->