### PR TITLE
Simplify team response owner policy

### DIFF
--- a/src/mindroom/team_scope.py
+++ b/src/mindroom/team_scope.py
@@ -11,13 +11,13 @@ if TYPE_CHECKING:
     from mindroom.config.agent import AgentConfig
 
 
-def requester_scoped_team_scope_id(scope_id: str, requester_user_id: str) -> str:
+def _requester_scoped_team_scope_id(scope_id: str, requester_user_id: str) -> str:
     """Return a requester-partitioned variant of one team history scope id."""
     requester_digest = hashlib.sha256(requester_user_id.encode("utf-8")).hexdigest()[:12]
     return f"{scope_id}_requester_{requester_digest}"
 
 
-def ad_hoc_team_member_names(member_names: Iterable[str | None]) -> tuple[str, ...]:
+def _ad_hoc_team_member_names(member_names: Iterable[str | None]) -> tuple[str, ...]:
     """Return stable team-scope member names from candidate agent names."""
     return tuple(sorted(name for name in member_names if name))
 
@@ -41,7 +41,7 @@ def ad_hoc_team_scope_id(
     missing_requester_message: str = "Private ad hoc team history scope requires requester identity",
 ) -> str | None:
     """Return the stable history scope id for one exact ad hoc team."""
-    stable_member_names = ad_hoc_team_member_names(member_names)
+    stable_member_names = _ad_hoc_team_member_names(member_names)
     if not stable_member_names:
         return None
 
@@ -50,4 +50,4 @@ def ad_hoc_team_scope_id(
         return scope_id
     if not requester_user_id:
         raise ValueError(missing_requester_message)
-    return requester_scoped_team_scope_id(scope_id, requester_user_id)
+    return _requester_scoped_team_scope_id(scope_id, requester_user_id)

--- a/src/mindroom/turn_policy.py
+++ b/src/mindroom/turn_policy.py
@@ -352,34 +352,51 @@ class TurnPolicy:
         if form_team.outcome is TeamOutcome.NONE:
             return None
 
-        responder_pool_ids = {responder.full_id for responder in responder_pool}
-        requires_shared_owner = self._requires_shared_owner_for_explicit_private_resolution(form_team)
-        shared_agent_responders = self._live_shared_agent_responders(responder_pool) if requires_shared_owner else []
-        if requires_shared_owner:
-            shared_responder_ids = {responder.full_id for responder in shared_agent_responders}
-            response_owners = [
-                member for member in form_team.eligible_members if member.full_id in shared_responder_ids
-            ]
-        else:
-            response_owners = [member for member in form_team.eligible_members if member.full_id in responder_pool_ids]
-        if (
-            not response_owners
-            and form_team.intent is TeamIntent.EXPLICIT_MEMBERS
-            and form_team.outcome is TeamOutcome.TEAM
-        ):
-            response_owners = shared_agent_responders or self._live_shared_agent_responders(responder_pool)
-        if (
-            not response_owners
-            and form_team.intent is TeamIntent.EXPLICIT_MEMBERS
-            and form_team.outcome is TeamOutcome.REJECT
-        ):
-            response_owners = shared_agent_responders if requires_shared_owner else responder_pool
-        if not response_owners and form_team.outcome is not TeamOutcome.TEAM and not requires_shared_owner:
-            response_owners = form_team.eligible_members
+        if self._requires_shared_owner_for_explicit_private_resolution(form_team):
+            return self._shared_owner_for_explicit_private_resolution(form_team, responder_pool)
 
+        response_owner = self._select_response_owner(
+            self._eligible_responder_owners(form_team, responder_pool),
+        )
+        if response_owner is not None:
+            return response_owner
+
+        if form_team.intent is TeamIntent.EXPLICIT_MEMBERS and form_team.outcome is TeamOutcome.REJECT:
+            # A reject can be visible even when no requested member is eligible;
+            # explicit configured-team rejects rely on this when the team bot is
+            # the only live responder.
+            return self._select_response_owner(responder_pool)
+
+        return None
+
+    @staticmethod
+    def _select_response_owner(response_owners: list[MatrixID]) -> MatrixID | None:
+        """Return the stable visible owner from one candidate set."""
         if not response_owners:
             return None
         return min(response_owners, key=lambda value: value.full_id)
+
+    @staticmethod
+    def _eligible_responder_owners(
+        form_team: TeamResolution,
+        responder_pool: list[MatrixID],
+    ) -> list[MatrixID]:
+        """Return eligible team members that are present in the live responder pool."""
+        responder_pool_ids = {responder.full_id for responder in responder_pool}
+        return [member for member in form_team.eligible_members if member.full_id in responder_pool_ids]
+
+    def _shared_owner_for_explicit_private_resolution(
+        self,
+        form_team: TeamResolution,
+        responder_pool: list[MatrixID],
+    ) -> MatrixID | None:
+        """Return a live shared-agent owner for a private explicit team or reject."""
+        shared_agent_responders = self._live_shared_agent_responders(responder_pool)
+        shared_responder_ids = {responder.full_id for responder in shared_agent_responders}
+        shared_eligible_owners = [
+            member for member in form_team.eligible_members if member.full_id in shared_responder_ids
+        ]
+        return self._select_response_owner(shared_eligible_owners or shared_agent_responders)
 
     def _requires_shared_owner_for_explicit_private_resolution(self, form_team: TeamResolution) -> bool:
         """Return whether a private ad hoc team resolution needs a shared visible owner."""


### PR DESCRIPTION
## Summary
- simplify response_owner_for_team_resolution into explicit owner-policy helpers
- keep private ad hoc team/reject visibility on live shared-agent responders
- make local-only team-scope helpers private

## Verification
- uv sync --all-extras
- uv run pytest tests/test_agent_response_logic.py --no-cov -n 0 -q
- uv run pytest tests/test_team_media_fallback.py -k "private_ad_hoc_team or private_agent or private_agents or delegate_to_private" --no-cov -n 0 -q
- uv run pytest tests/test_ai_user_id.py -k "explicit_private_ad_hoc_member or persisted_team_scope" --no-cov -n 0 -q
- uv run pytest tests/test_conversation_state_writer.py --no-cov -n 0 -q
- uv run pytest tests/test_multi_agent_bot.py -k "explicit_mentions_include_hidden_agent or only_unrequested_visible_bot_can_surface_reject or non_running_requested_member or unsupported_non_responders_for_reject_ownership" --no-cov -n 0 -q
- uv run tach check --dependencies --interfaces
- uv run ruff check src/mindroom/turn_policy.py src/mindroom/team_scope.py
- uv run ruff format --check src/mindroom/turn_policy.py src/mindroom/team_scope.py
- git diff --check
- PATH="/Users/bas.nijholt/.local/bin:/Users/bas.nijholt/.bun/bin:/Users/bas.nijholt/.codex/worktrees/44b2/mindroom/frontend/node_modules/.bin:$PATH" uv run pre-commit run --all-files
- uv run pytest --no-cov -n 0 -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal team scope helper functions for improved code clarity.
  * Streamlined team resolution owner selection logic to reduce complexity and improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->