### PR TITLE
Remove compaction summary output cap

### DIFF
--- a/src/mindroom/history/summary_call.py
+++ b/src/mindroom/history/summary_call.py
@@ -6,13 +6,13 @@ It enforces the call-side half of the compaction invariants
 
 3. Summary calls get exactly one model configuration path.
    ``configure_summary_model`` applies all compaction-specific provider tuning in
-   one place: prompt-cache writes off, Claude thinking cleared (mandatory whenever
-   max_tokens is capped — a thinking budget at or above the cap is a 400 from
-   Anthropic), summary output capped at ``SUMMARY_MAX_OUTPUT_TOKENS``, SDK retries
-   disabled, and one SDK timeout coordinated with the outer chunk budget
+   one place: prompt-cache writes off, Claude thinking cleared (a thinking budget
+   at or above max_tokens is a 400 from Anthropic), SDK retries disabled, and
+   one SDK timeout coordinated with the outer chunk budget
    (``MINDROOM_COMPACTION_CHUNK_TIMEOUT_SECONDS``) instead of two uncoordinated
-   constants in two modules. Unknown providers pass through untouched and rely on
-   the outer chunk timeout alone.
+   constants in two modules. Claude summary output uses the loaded model's own
+   max_tokens as the truncation guard. Unknown providers pass through untouched
+   and rely on the outer chunk timeout alone.
 
 4. Budget shrinks deterministically on provider failure.
    ``SummaryRetryPolicy`` decides which error classes warrant a smaller retry
@@ -52,7 +52,6 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-SUMMARY_MAX_OUTPUT_TOKENS = 4096
 _COMPACTION_CANCEL_DRAIN_TIMEOUT_SECONDS = 1.0
 
 _RETRYABLE_PROVIDER_ERROR_FRAGMENTS = (
@@ -72,7 +71,7 @@ _RETRYABLE_PROVIDER_ERROR_FRAGMENTS = (
 )
 
 
-class _CompactionSummaryOutputLimitError(RuntimeError):
+class CompactionSummaryOutputLimitError(RuntimeError):
     """Raised when the summary response reaches the configured output-token cap."""
 
 
@@ -91,7 +90,7 @@ class SummaryRetryPolicy:
 
     def should_shrink(self, error: Exception) -> bool:
         """Return whether a smaller summary input may resolve this provider failure."""
-        if isinstance(error, TimeoutError | _CompactionSummaryOutputLimitError):
+        if isinstance(error, TimeoutError | CompactionSummaryOutputLimitError):
             return True
         message = str(error).lower()
         return any(fragment in message for fragment in _RETRYABLE_PROVIDER_ERROR_FRAGMENTS)
@@ -128,9 +127,6 @@ def configure_summary_model(model: Model, *, timeout_seconds: float | None = Non
     model.cache_system_prompt = False
     model.extended_cache_time = False
     model.thinking = None
-    model.max_tokens = (
-        min(model.max_tokens, SUMMARY_MAX_OUTPUT_TOKENS) if model.max_tokens else SUMMARY_MAX_OUTPUT_TOKENS
-    )
     model.timeout = min(model.timeout, resolved_timeout) if model.timeout else resolved_timeout
     client_params = dict(model.client_params or {})
     client_params["max_retries"] = 0
@@ -268,7 +264,7 @@ async def generate_compaction_summary(
         raise RuntimeError(msg)
     if _summary_response_likely_truncated(response, output_token_limit=summary_output_limit):
         msg = "compaction summary hit configured output token limit; refusing to persist incomplete summary"
-        raise _CompactionSummaryOutputLimitError(msg)
+        raise CompactionSummaryOutputLimitError(msg)
     return SessionSummary(summary=normalized_text, updated_at=datetime.now(UTC))
 
 

--- a/tach.toml
+++ b/tach.toml
@@ -2623,8 +2623,8 @@ from = ["mindroom.memory._backend"]
 # explicit budget-shrink retry policy. Tested in tests/test_compaction_invariants.py.
 [[interfaces]]
 expose = [
+    "CompactionSummaryOutputLimitError",
     "DEFAULT_SUMMARY_RETRY_POLICY",
-    "SUMMARY_MAX_OUTPUT_TOKENS",
     "SummaryRetryPolicy",
     "build_summary_request_messages",
     "configure_summary_model",

--- a/tests/test_agno_history.py
+++ b/tests/test_agno_history.py
@@ -95,7 +95,7 @@ from mindroom.history.storage import (
     update_scope_seen_event_ids,
     write_scope_state,
 )
-from mindroom.history.summary_call import _CompactionSummaryOutputLimitError, generate_compaction_summary
+from mindroom.history.summary_call import CompactionSummaryOutputLimitError, generate_compaction_summary
 from mindroom.history.types import (
     CompactionLifecycleFailure,
     CompactionLifecycleProgress,
@@ -1275,7 +1275,7 @@ async def test_rewrite_retries_summary_with_smaller_chunk_after_output_cap(tmp_p
         summary_inputs.append(summary_input)
         if len(summary_inputs) == 1:
             msg = "renamed owned output-limit signal"
-            raise _CompactionSummaryOutputLimitError(msg)
+            raise CompactionSummaryOutputLimitError(msg)
         return SessionSummary(summary="merged summary", updated_at=datetime.now(UTC))
 
     with patch(

--- a/tests/test_compaction_invariants.py
+++ b/tests/test_compaction_invariants.py
@@ -46,9 +46,8 @@ from mindroom.history.storage import (
 )
 from mindroom.history.summary_call import (
     DEFAULT_SUMMARY_RETRY_POLICY,
-    SUMMARY_MAX_OUTPUT_TOKENS,
+    CompactionSummaryOutputLimitError,
     SummaryRetryPolicy,
-    _CompactionSummaryOutputLimitError,
     build_summary_request_messages,
     configure_summary_model,
     generate_compaction_summary,
@@ -376,7 +375,7 @@ def test_configure_summary_model_tunes_claude_in_one_place() -> None:
     assert model.cache_system_prompt is False
     assert model.extended_cache_time is False
     assert model.thinking is None
-    assert model.max_tokens == SUMMARY_MAX_OUTPUT_TOKENS
+    assert model.max_tokens == 64_000
     assert model.timeout == MINDROOM_COMPACTION_CHUNK_TIMEOUT_SECONDS
     assert model.client_params == {"max_retries": 0, "custom": "keep"}
 
@@ -397,12 +396,12 @@ def test_configure_summary_model_tunes_vertexai_claude() -> None:
     assert model.cache_system_prompt is False
     assert model.extended_cache_time is False
     assert model.thinking is None
-    assert model.max_tokens == SUMMARY_MAX_OUTPUT_TOKENS
+    assert model.max_tokens == 8192
     assert model.timeout == MINDROOM_COMPACTION_CHUNK_TIMEOUT_SECONDS
     assert model.client_params == {"max_retries": 0}
 
 
-def test_configure_summary_model_only_caps_downward() -> None:
+def test_configure_summary_model_preserves_authored_output_cap() -> None:
     model = Claude(id="claude-sonnet-4-6", max_tokens=1024, timeout=30.0)
 
     configure_summary_model(model)
@@ -441,7 +440,7 @@ async def test_generate_compaction_summary_applies_tuning_and_request_shape() ->
     assert model.cache_system_prompt is False
     assert model.extended_cache_time is False
     assert model.thinking is None
-    assert model.max_tokens == SUMMARY_MAX_OUTPUT_TOKENS
+    assert model.max_tokens == 64_000
     assert model.timeout == MINDROOM_COMPACTION_CHUNK_TIMEOUT_SECONDS
     assert model.client_params == {"max_retries": 0}
     assert [(message.role, message.content) for message in model.seen_messages] == [
@@ -459,7 +458,7 @@ async def test_generate_compaction_summary_rejects_output_cap_truncation() -> No
                 max_tokens=64_000,
                 response=ModelResponse(
                     content="durable summary ended cleanly.",
-                    output_tokens=SUMMARY_MAX_OUTPUT_TOKENS,
+                    output_tokens=64_000,
                 ),
             ),
             summary_input="conversation payload",
@@ -489,7 +488,7 @@ async def test_generate_compaction_summary_allows_claude_summary_below_output_ca
             max_tokens=64_000,
             response=ModelResponse(
                 content="durable summary ended cleanly.",
-                output_tokens=SUMMARY_MAX_OUTPUT_TOKENS - 1,
+                output_tokens=63_999,
             ),
         ),
         summary_input="conversation payload",
@@ -500,10 +499,27 @@ async def test_generate_compaction_summary_allows_claude_summary_below_output_ca
 
 
 @pytest.mark.asyncio
+async def test_generate_compaction_summary_allows_full_history_summary_above_four_k() -> None:
+    summary = await generate_compaction_summary(
+        model=_RecordingClaude(
+            id="claude-sonnet-4-6",
+            response=ModelResponse(
+                content="durable full-history summary ended cleanly.",
+                output_tokens=4_097,
+            ),
+        ),
+        summary_input="conversation payload",
+        summary_prompt="Summarize the conversation.",
+    )
+
+    assert summary.summary == "durable full-history summary ended cleanly."
+
+
+@pytest.mark.asyncio
 async def test_generate_compaction_summary_allows_unknown_provider_without_output_cap() -> None:
     class _UncappedSummaryModel(FakeModel):
         async def aresponse(self, *_args: object, **_kwargs: object) -> ModelResponse:
-            return ModelResponse(content="durable summary ended cleanly.", output_tokens=SUMMARY_MAX_OUTPUT_TOKENS + 1)
+            return ModelResponse(content="durable summary ended cleanly.", output_tokens=64_001)
 
     summary = await generate_compaction_summary(
         model=_UncappedSummaryModel(id="summary-model", provider="fake"),
@@ -534,7 +550,7 @@ def test_retry_policy_shrinks_on_timeout_and_context_length_errors() -> None:
         policy.retry_budget(
             attempt=1,
             budget=16_000,
-            error=_CompactionSummaryOutputLimitError("renamed owned output-limit signal"),
+            error=CompactionSummaryOutputLimitError("renamed owned output-limit signal"),
         )
         == 8_000
     )

--- a/tests/test_compaction_invariants.py
+++ b/tests/test_compaction_invariants.py
@@ -503,6 +503,7 @@ async def test_generate_compaction_summary_allows_full_history_summary_above_fou
     summary = await generate_compaction_summary(
         model=_RecordingClaude(
             id="claude-sonnet-4-6",
+            max_tokens=8192,
             response=ModelResponse(
                 content="durable full-history summary ended cleanly.",
                 output_tokens=4_097,
@@ -513,6 +514,24 @@ async def test_generate_compaction_summary_allows_full_history_summary_above_fou
     )
 
     assert summary.summary == "durable full-history summary ended cleanly."
+
+
+@pytest.mark.asyncio
+async def test_generate_compaction_summary_uses_claude_default_output_cap() -> None:
+    model = _RecordingClaude(id="claude-sonnet-4-6")
+    default_output_cap = model.max_tokens
+    assert default_output_cap is not None
+    model.response = ModelResponse(
+        content="durable summary ended cleanly.",
+        output_tokens=default_output_cap,
+    )
+
+    with pytest.raises(RuntimeError, match="output token limit"):
+        await generate_compaction_summary(
+            model=model,
+            summary_input="conversation payload",
+            summary_prompt="Summarize the conversation.",
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Remove the hidden 4096-token clamp from compaction summary Claude calls.
- Preserve the configured/default model `max_tokens` and use that value only as the truncation guard.
- Add regression coverage for summaries above 4096 tokens and update Tach interface exports for the public output-limit error.

## Test Plan
- `UV_CACHE_DIR=/private/tmp/codex-uv-cache /Users/bas.nijholt/.local/bin/uv run pytest tests/test_compaction_invariants.py tests/test_agno_history.py::test_rewrite_retries_summary_with_smaller_chunk_after_output_cap -q --no-cov`
- `UV_CACHE_DIR=/private/tmp/codex-uv-cache /Users/bas.nijholt/.local/bin/uv run tach check --dependencies --interfaces`
- `COMPOSIO_CACHE_DIR=/private/tmp/codex-composio-cache UV_CACHE_DIR=/private/tmp/codex-uv-cache /Users/bas.nijholt/.local/bin/uv run pytest -q --no-cov`
- `PATH=/Users/bas.nijholt/.local/bin:/Users/bas.nijholt/.bun/bin:$PATH UV_CACHE_DIR=/private/tmp/codex-uv-cache UV_TOOL_DIR=/private/tmp/codex-uv-tools TMPDIR=/private/tmp BUN_INSTALL_CACHE_DIR=/private/tmp/codex-bun-cache COMPOSIO_CACHE_DIR=/private/tmp/codex-composio-cache /Users/bas.nijholt/.local/bin/uv run pre-commit run --all-files`
