### PR TITLE
Fix external trigger runtime rebind after reload

### DIFF
--- a/src/mindroom/entity_resolution.py
+++ b/src/mindroom/entity_resolution.py
@@ -224,6 +224,11 @@ def entity_identity_registry(config: Config, runtime_paths: RuntimePaths) -> Ent
     return EntityIdentityRegistry(current_ids=current_ids)
 
 
+def current_entity_id(entity_name: str, runtime_paths: RuntimePaths) -> MatrixID:
+    """Return one persisted Matrix ID without resolving unrelated configured entities."""
+    return _persisted_entity_matrix_id(entity_name, _matrix_domain(runtime_paths), runtime_paths)
+
+
 def _persisted_entity_id_map(config: Config, runtime_paths: RuntimePaths) -> dict[str, MatrixID]:
     domain = _matrix_domain(runtime_paths)
     return {

--- a/src/mindroom/external_triggers/executor.py
+++ b/src/mindroom/external_triggers/executor.py
@@ -9,7 +9,7 @@ from mindroom.constants import ORIGINAL_SENDER_KEY, SOURCE_KIND_KEY
 from mindroom.dispatch_source import EXTERNAL_TRIGGER_SOURCE_KIND
 from mindroom.hooks.sender import send_and_track_message
 from mindroom.matrix.client_room_admin import get_room_members
-from mindroom.matrix.mentions import parse_mentions_in_text
+from mindroom.matrix.mentions import format_entity_mention
 from mindroom.matrix.message_builder import build_message_content, markdown_to_html
 
 if TYPE_CHECKING:
@@ -63,8 +63,8 @@ async def execute_external_trigger(
             caller_label="external_trigger",
         )
 
-    plain_target, mentioned_user_ids, markdown_target = parse_mentions_in_text(
-        f"@{snapshot.target.agent}",
+    plain_target, mentioned_user_ids, markdown_target = format_entity_mention(
+        snapshot.target.agent,
         config,
         runtime_paths,
     )

--- a/src/mindroom/matrix/mentions.py
+++ b/src/mindroom/matrix/mentions.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from mindroom.constants import ROUTER_AGENT_NAME
-from mindroom.entity_resolution import entity_identity_registry
+from mindroom.entity_resolution import current_entity_id, entity_identity_registry
 from mindroom.matrix.identity import MatrixID, parse_current_matrix_user_id
 from mindroom.matrix.message_builder import build_message_content, markdown_to_html
 from mindroom.matrix_identifiers import unnamespaced_agent_name_from_username_localpart
@@ -101,6 +101,20 @@ def resolve_mentioned_user_ids_from_text(
         allow_generated_agent_localparts=False,
     )
     return _mentioned_user_ids_from_replacements(replacements)
+
+
+def format_entity_mention(
+    entity_name: str,
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> tuple[str, list[str], str]:
+    """Return one configured entity mention without resolving unrelated entities."""
+    resolution = _entity_mention_resolution_from_user_id(
+        entity_name,
+        current_entity_id(entity_name, runtime_paths).full_id,
+        config=config,
+    )
+    return resolution.plain_text, [resolution.user_id], resolution.markdown_text
 
 
 def _mentioned_user_ids_from_replacements(replacements: list[_MentionReplacement]) -> list[str]:
@@ -278,8 +292,21 @@ def _entity_mention_resolution(
     config: Config,
 ) -> _MentionResolution:
     """Return rendering data for one resolved local agent or team mention."""
+    return _entity_mention_resolution_from_user_id(
+        entity_name,
+        registry.current_id(entity_name).full_id,
+        config=config,
+    )
+
+
+def _entity_mention_resolution_from_user_id(
+    entity_name: str,
+    resolved_user_id: str,
+    *,
+    config: Config,
+) -> _MentionResolution:
+    """Return rendering data for one resolved entity user ID."""
     entity_config = config.agents.get(entity_name) or config.teams[entity_name]
-    resolved_user_id = registry.current_id(entity_name).full_id
     return _MentionResolution(
         plain_text=resolved_user_id,
         markdown_text=f"[@{entity_config.display_name}](https://matrix.to/#/{resolved_user_id})",

--- a/src/mindroom/matrix/stale_stream_cleanup.py
+++ b/src/mindroom/matrix/stale_stream_cleanup.py
@@ -23,7 +23,12 @@ from mindroom.constants import (
     STREAM_VISIBLE_BODY_KEY,
     STREAM_WARMUP_SUFFIX_KEY,
 )
-from mindroom.entity_resolution import current_internal_sender_ids, entity_identity_registry
+from mindroom.entity_resolution import (
+    MissingManagedEntityAccountError,
+    current_entity_id,
+    current_internal_sender_ids,
+    entity_identity_registry,
+)
 from mindroom.logging_config import get_logger
 from mindroom.matrix.client_delivery import edit_message_result, send_message_result
 from mindroom.matrix.client_room_admin import get_joined_rooms
@@ -1559,8 +1564,7 @@ def _build_auto_resume_content(
     runtime_paths: RuntimePaths,
 ) -> dict[str, object]:
     """Build the router-authored visible resume relay for one interrupted agent."""
-    matrix_id = entity_identity_registry(config, runtime_paths).current_ids.get(interrupted_thread.agent_name)
-    target_user_id = matrix_id.full_id if matrix_id is not None else None
+    target_user_id = _current_configured_entity_user_id(interrupted_thread.agent_name, config, runtime_paths)
     display_name = _entity_display_name(interrupted_thread.agent_name, config)
 
     body = _AUTO_RESUME_MESSAGE
@@ -1587,6 +1591,21 @@ def _build_auto_resume_content(
         latest_thread_event_id=interrupted_thread.target_event_id,
         extra_content=extra_content,
     )
+
+
+def _current_configured_entity_user_id(
+    entity_name: str,
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> str | None:
+    """Return one configured entity user ID without resolving unrelated entities."""
+    if entity_name not in config.agents and entity_name not in config.teams:
+        return None
+    try:
+        return current_entity_id(entity_name, runtime_paths).full_id
+    except MissingManagedEntityAccountError:
+        logger.debug("auto_resume_target_entity_account_unavailable", entity_name=entity_name)
+        return None
 
 
 def _entity_display_name(agent_name: str, config: Config) -> str:

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -1313,6 +1313,32 @@ class _MultiAgentOrchestrator:
         elif plan.mindroom_user_changed:
             self._validate_entity_accounts(new_config)
 
+    async def _finalize_config_reload(
+        self,
+        *,
+        new_config: Config,
+        current_config: Config,
+        changed_entities: set[str],
+        added_entities: set[str],
+        removed_entities: set[str],
+        plugin_changes: tuple[str, ...],
+    ) -> None:
+        """Publish post-reload runtime services and external trigger delivery binding."""
+        await self._sync_runtime_support_services(
+            new_config,
+            start_watcher=self.running,
+            previous_config=current_config,
+        )
+        await self._approval_transport.mark_startup_runtime_support_ready()
+        self._external_trigger_runtime.bind_if_ready(new_config, self.agent_bots)
+        await self._emit_config_reloaded(
+            new_config=new_config,
+            changed_entities=changed_entities,
+            added_entities=added_entities,
+            removed_entities=removed_entities,
+            plugin_changes=plugin_changes,
+        )
+
     async def _apply_config_update_plan(
         self,
         current_config: Config,
@@ -1360,15 +1386,9 @@ class _MultiAgentOrchestrator:
             await self._update_unchanged_bots(plan)
 
             if plan.only_support_service_changes:
-                await self._sync_runtime_support_services(
-                    new_config,
-                    start_watcher=self.running,
-                    previous_config=current_config,
-                )
-                await self._approval_transport.mark_startup_runtime_support_ready()
-                self._external_trigger_runtime.bind_if_ready(self.config, self.agent_bots)
-                await self._emit_config_reloaded(
+                await self._finalize_config_reload(
                     new_config=new_config,
+                    current_config=current_config,
                     changed_entities=set(),
                     added_entities=plan.added_entities,
                     removed_entities=plan.removed_entities,
@@ -1391,15 +1411,9 @@ class _MultiAgentOrchestrator:
                     agent_names=permanently_failed_entities,
                 )
 
-            await self._sync_runtime_support_services(
-                new_config,
-                start_watcher=self.running,
-                previous_config=current_config,
-            )
-            await self._approval_transport.mark_startup_runtime_support_ready()
-            self._external_trigger_runtime.bind_if_ready(self.config, self.agent_bots)
-            await self._emit_config_reloaded(
+            await self._finalize_config_reload(
                 new_config=new_config,
+                current_config=current_config,
                 changed_entities=changed_entities,
                 added_entities=plan.added_entities,
                 removed_entities=plan.removed_entities,

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -1297,8 +1297,6 @@ class _MultiAgentOrchestrator:
         if plan.matrix_space_changed or plan.room_metadata_changed:
             room_ids = await self._ensure_rooms_exist()
             await self._ensure_root_space(room_ids)
-        if not plan.only_support_service_changes:
-            self._external_trigger_runtime.bind_if_ready(self.config, self.agent_bots)
 
     async def _prepare_accounts_for_config_update(self, new_config: Config, plan: ConfigUpdatePlan) -> None:
         """Prepare or validate managed Matrix accounts before publishing a reloaded config."""

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -1399,6 +1399,7 @@ class _MultiAgentOrchestrator:
                 previous_config=current_config,
             )
             await self._approval_transport.mark_startup_runtime_support_ready()
+            self._external_trigger_runtime.bind_if_ready(self.config, self.agent_bots)
             await self._emit_config_reloaded(
                 new_config=new_config,
                 changed_entities=changed_entities,

--- a/tests/test_external_trigger_executor.py
+++ b/tests/test_external_trigger_executor.py
@@ -18,11 +18,12 @@ from mindroom.dispatch_source import (
     source_kind_bypasses_coalescing,
     source_kind_from_content,
 )
-from mindroom.entity_resolution import entity_identity_registry
+from mindroom.entity_resolution import MissingManagedEntityAccountError, current_entity_id, entity_identity_registry
 from mindroom.external_triggers.executor import _build_external_trigger_text, execute_external_trigger
 from mindroom.external_triggers.models import ExternalTriggerPayload
 from mindroom.external_triggers.store import ExternalTriggerTarget, TriggerDeliverySnapshot
 from mindroom.matrix.client_delivery import DeliveredMatrixEvent
+from mindroom.matrix.identity import managed_account_key
 from mindroom.matrix.state import MatrixState
 from tests.conftest import bind_runtime_paths, runtime_paths_for, test_runtime_paths
 
@@ -41,6 +42,25 @@ def _config(tmp_path: Path) -> Config:
         ),
         test_runtime_paths(tmp_path),
     )
+
+
+def _config_with_unprepared_stale_agent(tmp_path: Path) -> Config:
+    config = bind_runtime_paths(
+        Config(
+            agents={
+                "research": AgentConfig(display_name="Research"),
+                "ops": AgentConfig(display_name="Ops"),
+                "mindtest": AgentConfig(display_name="MindTest"),
+            },
+            models={"default": ModelConfig(provider="test", id="test-model")},
+        ),
+        test_runtime_paths(tmp_path),
+    )
+    runtime_paths = runtime_paths_for(config)
+    state = MatrixState.load(runtime_paths)
+    state.accounts.pop(managed_account_key("mindtest"))
+    state.save(runtime_paths)
+    return config
 
 
 def _snapshot(
@@ -252,6 +272,37 @@ async def test_execute_external_trigger_only_parses_configured_target_mention(
     assert "@ops" in content["formatted_body"]
     assert "(at)ops" not in content["body"]
     assert "(at)ops" not in content["formatted_body"]
+
+
+@pytest.mark.asyncio
+async def test_execute_external_trigger_target_mention_ignores_unprepared_unrelated_entity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Delivery should not resolve every configured entity when mentioning the exact target."""
+    config = _config_with_unprepared_stale_agent(tmp_path)
+    runtime_paths = runtime_paths_for(config)
+    with pytest.raises(MissingManagedEntityAccountError, match="mindtest"):
+        entity_identity_registry(config, runtime_paths)
+    send_and_track_message = AsyncMock(
+        return_value=DeliveredMatrixEvent(event_id="$matrix-event", content_sent={}),
+    )
+    monkeypatch.setattr("mindroom.external_triggers.executor.send_and_track_message", send_and_track_message)
+
+    event_id = await execute_external_trigger(
+        client=AsyncMock(),
+        snapshot=_snapshot(),
+        payload=_payload(),
+        config=config,
+        runtime_paths=runtime_paths,
+        conversation_cache=_conversation_cache(),
+    )
+
+    assert event_id == "$matrix-event"
+    content: dict[str, Any] = send_and_track_message.await_args.args[2]
+    assert content["m.mentions"]["user_ids"] == [current_entity_id("research", runtime_paths).full_id]
+    assert "mindtest" not in content["body"]
+    assert "mindtest" not in content["formatted_body"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_orchestrator.py
+++ b/tests/test_mcp_orchestrator.py
@@ -804,12 +804,41 @@ async def test_apply_config_update_plan_unbinds_runtime_before_restarted_entity_
         patch.object(orchestrator, "_sync_runtime_support_services", new=AsyncMock()),
         patch.object(orchestrator._approval_transport, "mark_startup_runtime_support_ready", new=AsyncMock()),
         patch.object(orchestrator, "_emit_config_reloaded", new=AsyncMock()),
-        patch.object(orchestrator._external_trigger_runtime, "bind_if_ready"),
+        patch.object(orchestrator._external_trigger_runtime, "bind_if_ready") as mock_bind_runtime,
     ):
         updated = await orchestrator._apply_config_update_plan(current_config, plan, ())
 
     assert updated is True
     assert external_trigger_runtime_bound is False
+    mock_bind_runtime.assert_called_once_with(new_config, orchestrator.agent_bots)
+
+
+@pytest.mark.asyncio
+async def test_reconcile_post_update_rooms_does_not_bind_trigger_runtime(tmp_path: Path) -> None:
+    """Room reconciliation should not bind trigger runtime before support services settle."""
+    orchestrator = _MultiAgentOrchestrator(runtime_paths=_runtime_paths(tmp_path))
+    config = _config_with_code_agent(tmp_path)
+    orchestrator.config = config
+    plan = ConfigUpdatePlan(
+        new_config=config,
+        changed_mcp_servers=set(),
+        configured_entities={ROUTER_AGENT_NAME, "code"},
+        entities_to_restart={"code"},
+        new_entities=set(),
+        removed_entities=set(),
+        mindroom_user_changed=False,
+        matrix_room_access_changed=False,
+        matrix_space_changed=False,
+        authorization_changed=False,
+    )
+
+    with (
+        patch.object(orchestrator, "_setup_rooms_and_memberships", new=AsyncMock()),
+        patch.object(orchestrator._external_trigger_runtime, "bind_if_ready") as mock_bind_runtime,
+    ):
+        await orchestrator._reconcile_post_update_rooms(plan, changed_entities=set())
+
+    mock_bind_runtime.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -878,7 +907,8 @@ async def test_apply_config_update_plan_rebinds_trigger_runtime_after_support_se
         updated = await orchestrator._apply_config_update_plan(current_config, plan, ())
 
     assert updated is True
-    assert call_order == ["rooms", "support", "bind"]
+    assert call_order.count("bind") == 1
+    assert call_order.index("rooms") < call_order.index("support") < call_order.index("bind")
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_orchestrator.py
+++ b/tests/test_mcp_orchestrator.py
@@ -804,11 +804,81 @@ async def test_apply_config_update_plan_unbinds_runtime_before_restarted_entity_
         patch.object(orchestrator, "_sync_runtime_support_services", new=AsyncMock()),
         patch.object(orchestrator._approval_transport, "mark_startup_runtime_support_ready", new=AsyncMock()),
         patch.object(orchestrator, "_emit_config_reloaded", new=AsyncMock()),
+        patch.object(orchestrator._external_trigger_runtime, "bind_if_ready"),
     ):
         updated = await orchestrator._apply_config_update_plan(current_config, plan, ())
 
     assert updated is True
     assert external_trigger_runtime_bound is False
+
+
+@pytest.mark.asyncio
+async def test_apply_config_update_plan_rebinds_trigger_runtime_after_support_services(
+    tmp_path: Path,
+) -> None:
+    """Config reloads should finish with trigger runtime bound to the final API snapshot."""
+    orchestrator = _MultiAgentOrchestrator(runtime_paths=_runtime_paths(tmp_path))
+    current_config = _config_with_code_agent(tmp_path)
+    new_config = _config_with_code_agent(tmp_path, role="Write better code")
+    orchestrator.config = current_config
+    orchestrator.agent_bots = {
+        ROUTER_AGENT_NAME: MagicMock(spec=AgentBot),
+        "code": MagicMock(spec=AgentBot),
+    }
+    plan = ConfigUpdatePlan(
+        new_config=new_config,
+        changed_mcp_servers=set(),
+        configured_entities={ROUTER_AGENT_NAME, "code"},
+        entities_to_restart={"code"},
+        new_entities=set(),
+        removed_entities=set(),
+        mindroom_user_changed=False,
+        matrix_room_access_changed=False,
+        matrix_space_changed=False,
+        authorization_changed=False,
+    )
+    call_order: list[str] = []
+
+    async def reconcile_rooms(_plan: ConfigUpdatePlan, _changed_entities: set[str]) -> None:
+        call_order.append("rooms")
+
+    async def sync_support_services(
+        _config: Config,
+        *,
+        start_watcher: bool,
+        previous_config: Config | None = None,
+    ) -> None:
+        assert start_watcher is False
+        assert previous_config is current_config
+        call_order.append("support")
+
+    def bind_runtime(_config: Config | None, _bots: object) -> None:
+        assert _config is new_config
+        call_order.append("bind")
+
+    with (
+        patch.object(orchestrator, "_prepare_accounts_for_config_update", new=AsyncMock()),
+        patch.object(orchestrator._startup_maintenance, "cancel", new=AsyncMock(return_value=False)),
+        patch.object(orchestrator, "_stop_entities_before_mcp_sync", new=AsyncMock(return_value=set())),
+        patch.object(orchestrator.plugin_watch, "sync_roots"),
+        patch.object(orchestrator, "_activate_hook_registry"),
+        patch.object(orchestrator, "_sync_mcp_manager", new=AsyncMock(return_value=set())),
+        patch.object(orchestrator, "_sync_event_cache_service", new=AsyncMock()),
+        patch("mindroom.api.config_lifecycle._publish_runtime_config_into_app", return_value=True),
+        patch.object(orchestrator, "_update_unchanged_bots", new=AsyncMock()),
+        patch.object(orchestrator._external_trigger_runtime, "unbind"),
+        patch("mindroom.orchestrator.stop_entities", new=AsyncMock()),
+        patch.object(orchestrator, "_create_and_start_entities", new=AsyncMock(return_value=EntityStartResults())),
+        patch.object(orchestrator, "_reconcile_post_update_rooms", side_effect=reconcile_rooms),
+        patch.object(orchestrator, "_sync_runtime_support_services", side_effect=sync_support_services),
+        patch.object(orchestrator._approval_transport, "mark_startup_runtime_support_ready", new=AsyncMock()),
+        patch.object(orchestrator, "_emit_config_reloaded", new=AsyncMock()),
+        patch.object(orchestrator._external_trigger_runtime, "bind_if_ready", side_effect=bind_runtime),
+    ):
+        updated = await orchestrator._apply_config_update_plan(current_config, plan, ())
+
+    assert updated is True
+    assert call_order == ["rooms", "support", "bind"]
 
 
 @pytest.mark.asyncio
@@ -946,7 +1016,9 @@ async def test_update_config_stops_mcp_entities_before_syncing_manager(tmp_path:
         ),
         patch.object(orchestrator, "_reconcile_post_update_rooms", new=AsyncMock()),
         patch.object(orchestrator, "_sync_runtime_support_services", new=AsyncMock()),
+        patch.object(orchestrator._approval_transport, "mark_startup_runtime_support_ready", new=AsyncMock()),
         patch.object(orchestrator, "_emit_config_reloaded", new=AsyncMock()),
+        patch.object(orchestrator._external_trigger_runtime, "bind_if_ready"),
     ):
         await orchestrator.config_reload.update_config()
 

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -22,13 +22,16 @@ from mindroom.constants import (
     STREAM_STATUS_KEY,
 )
 from mindroom.dispatch_source import TRUSTED_INTERNAL_RELAY_SOURCE_KIND
+from mindroom.entity_resolution import MissingManagedEntityAccountError, entity_identity_registry
 from mindroom.matrix import stale_stream_cleanup as stale_stream_cleanup_module
 from mindroom.matrix.client import ResolvedVisibleMessage
+from mindroom.matrix.identity import managed_account_key
 from mindroom.matrix.stale_stream_cleanup import (
     InterruptedThread,
     auto_resume_interrupted_threads,
     cleanup_stale_streaming_messages,
 )
+from mindroom.matrix.state import MatrixState
 from mindroom.matrix.thread_projection import latest_visible_thread_event_id_by_thread
 from mindroom.orchestrator import _MultiAgentOrchestrator
 from mindroom.streaming import build_restart_interrupted_body
@@ -696,6 +699,46 @@ async def test_auto_resume_sends_correctly_threaded_messages(tmp_path: Path) -> 
     assert second_content["m.relates_to"]["event_id"] == "$thread-two"
     assert second_content[ORIGINAL_SENDER_KEY] == USER_ID
     mock_sleep.assert_awaited_once_with(2.0)
+
+
+@pytest.mark.asyncio
+async def test_auto_resume_target_mention_ignores_unprepared_unrelated_entity(tmp_path: Path) -> None:
+    """Auto-resume should mention the target without resolving every configured entity."""
+    config = _make_config(tmp_path)
+    runtime_paths = runtime_paths_for(config)
+    config.agents["stale"] = config.agents["other"].model_copy(update={"display_name": "Stale Agent"})
+    state = MatrixState.load(runtime_paths)
+    state.accounts.pop(managed_account_key("stale"), None)
+    state.save(runtime_paths)
+    with pytest.raises(MissingManagedEntityAccountError, match="stale"):
+        entity_identity_registry(config, runtime_paths)
+    client = AsyncMock(spec=nio.AsyncClient)
+    interrupted = [
+        InterruptedThread(
+            room_id=ROOM_ID,
+            thread_id="$thread-one",
+            target_event_id="$target-one",
+            partial_text="One",
+            agent_name="test_agent",
+            original_sender_id=USER_ID,
+        ),
+    ]
+
+    with patch(
+        "mindroom.matrix.stale_stream_cleanup.send_message_result",
+        new=AsyncMock(return_value=delivered_matrix_event("$resume1")),
+    ) as mock_send:
+        resumed_count = await auto_resume_interrupted_threads(
+            client,
+            interrupted,
+            config=config,
+            runtime_paths=runtime_paths,
+        )
+
+    assert resumed_count == 1
+    content = mock_send.await_args.args[2]
+    assert content["body"] == f"@Test Agent {AUTO_RESUME_MESSAGE}"
+    assert content["m.mentions"] == {"user_ids": [BOT_USER_ID]}
 
 
 def test_select_threads_to_resume_returns_all_unique_threads_when_unlimited() -> None:


### PR DESCRIPTION
## Summary
- rebind external trigger runtime at the end of config reloads, after support services settle and the API snapshot is published
- consolidate reload finalization into one orchestrator path so reload branches cannot forget or prematurely bind trigger runtime
- resolve external-trigger target mentions through targeted entity lookup instead of building the full entity registry
- reuse the targeted entity lookup in auto-resume so unrelated unprepared entities do not break resume delivery

## Tests
- uv run pytest tests/test_mcp_orchestrator.py::test_apply_config_update_plan_rebinds_trigger_runtime_after_support_services -n 0 --no-cov -v
- uv run pytest tests/test_mcp_orchestrator.py::test_trigger_support_only_reload_publishes_api_config_before_binding_runtime tests/api/test_api.py::test_config_reload_uses_source_fingerprint_from_validated_source -n 0 --no-cov -v
- uv run pytest tests/test_stale_stream_cleanup.py::test_auto_resume_sends_correctly_threaded_messages tests/test_stale_stream_cleanup.py::test_auto_resume_target_mention_ignores_unprepared_unrelated_entity -n 0 --no-cov -v
- uv run pytest tests/test_stale_stream_cleanup.py tests/test_external_trigger_executor.py tests/test_mentions.py tests/test_entity_resolution.py -n auto --no-cov
- uv run pytest tests/test_mcp_orchestrator.py tests/test_external_trigger_runtime_binding.py -n auto --no-cov -v
- uv run pytest tests/api/test_external_triggers_api.py tests/test_external_trigger_store.py tests/test_mcp_orchestrator.py tests/test_external_trigger_runtime_binding.py -n auto --no-cov
- uv run pre-commit run --all-files
- uv run pytest -n auto --no-cov

## Summary by Sourcery

Ensure external trigger runtime is rebound to the final API snapshot at the end of configuration reloads.

Bug Fixes:
- Rebind the external trigger runtime after runtime support services are ready during normal configuration reloads to keep it aligned with the final API snapshot.

Tests:
- Add regression tests to verify the external trigger runtime is rebound after support services during config reload and remains unbound when the router is removed.
- Update existing config reload tests to assert that external trigger runtime binding is invoked during reload completion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration reload behavior so runtime updates now happen in the correct order.
  * External triggers are now reconnected after support services are ready, helping ensure reloaded settings take effect consistently.
  * Updated reload handling to avoid unexpected trigger activity during configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
