### PR TITLE
Allow private triggers in dynamic rooms

### DIFF
--- a/docs/external-triggers.md
+++ b/docs/external-triggers.md
@@ -75,9 +75,11 @@ Admin-created triggers are still owned by the admin requester, but admins can ch
 
 Non-admin callers can create triggers only for the current agent and current room in the live Matrix tool context, but can still choose either `target_thread_id` or `new_thread` inside that room.
 
-The target room must already be configured for the target agent or team.
+For shared agents and teams, the target room must already be configured for the target entity.
 
-Triggers do not widen static room membership.
+For private agents, a trigger created by that same private agent may target the current live Matrix room even when the room is dynamically provisioned and not listed in `rooms`.
+
+Triggers do not create rooms or make agents join rooms.
 
 No new Matrix room is created for a trigger.
 
@@ -163,7 +165,11 @@ An admin-created trigger for another private agent still wakes the admin's priva
 
 The API does not store private workspace paths, worker keys, OAuth tokens, or serialized execution identities.
 
-The target agent must still be configured for the target room, and the router plus target transport bot must be joined before delivery.
+Shared target agents must still be configured for the target room.
+
+Private target agents created from their current live room may use that room even when it is not listed in `rooms`.
+
+The router plus target transport bot must be joined before delivery.
 
 ## Idempotency
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -13473,9 +13473,11 @@ Admin-created triggers are still owned by the admin requester, but admins can ch
 
 Non-admin callers can create triggers only for the current agent and current room in the live Matrix tool context, but can still choose either `target_thread_id` or `new_thread` inside that room.
 
-The target room must already be configured for the target agent or team.
+For shared agents and teams, the target room must already be configured for the target entity.
 
-Triggers do not widen static room membership.
+For private agents, a trigger created by that same private agent may target the current live Matrix room even when the room is dynamically provisioned and not listed in `rooms`.
+
+Triggers do not create rooms or make agents join rooms.
 
 No new Matrix room is created for a trigger.
 
@@ -13561,7 +13563,11 @@ An admin-created trigger for another private agent still wakes the admin's priva
 
 The API does not store private workspace paths, worker keys, OAuth tokens, or serialized execution identities.
 
-The target agent must still be configured for the target room, and the router plus target transport bot must be joined before delivery.
+Shared target agents must still be configured for the target room.
+
+Private target agents created from their current live room may use that room even when it is not listed in `rooms`.
+
+The router plus target transport bot must be joined before delivery.
 
 ## Idempotency
 

--- a/skills/mindroom-docs/references/page__external-triggers__index.md
+++ b/skills/mindroom-docs/references/page__external-triggers__index.md
@@ -71,9 +71,11 @@ Admin-created triggers are still owned by the admin requester, but admins can ch
 
 Non-admin callers can create triggers only for the current agent and current room in the live Matrix tool context, but can still choose either `target_thread_id` or `new_thread` inside that room.
 
-The target room must already be configured for the target agent or team.
+For shared agents and teams, the target room must already be configured for the target entity.
 
-Triggers do not widen static room membership.
+For private agents, a trigger created by that same private agent may target the current live Matrix room even when the room is dynamically provisioned and not listed in `rooms`.
+
+Triggers do not create rooms or make agents join rooms.
 
 No new Matrix room is created for a trigger.
 
@@ -159,7 +161,11 @@ An admin-created trigger for another private agent still wakes the admin's priva
 
 The API does not store private workspace paths, worker keys, OAuth tokens, or serialized execution identities.
 
-The target agent must still be configured for the target room, and the router plus target transport bot must be joined before delivery.
+Shared target agents must still be configured for the target room.
+
+Private target agents created from their current live room may use that room even when it is not listed in `rooms`.
+
+The router plus target transport bot must be joined before delivery.
 
 ## Idempotency
 

--- a/src/mindroom/external_triggers/store.py
+++ b/src/mindroom/external_triggers/store.py
@@ -406,7 +406,7 @@ class ExternalTriggerStore:
 
     def _validate_record_against_config(self, record: ExternalTriggerRecord, config: Config) -> None:
         _validate_owner(record.owner_user_id, config, self._runtime_paths)
-        _validate_target(record.target, config, self._runtime_paths)
+        _validate_target(record, config, self._runtime_paths)
 
     def _read_records(self) -> _SerializedTriggerRecords:
         try:
@@ -507,8 +507,9 @@ def _validate_owner(owner_user_id: str, config: Config, runtime_paths: RuntimePa
         raise ExternalTriggerStoreError(msg)
 
 
-def _validate_target(target: ExternalTriggerTarget, config: Config, runtime_paths: RuntimePaths) -> None:
+def _validate_target(record: ExternalTriggerRecord, config: Config, runtime_paths: RuntimePaths) -> None:
     """Require a configured entity and an already configured target room."""
+    target = record.target
     if target.agent not in config.agents and target.agent not in config.teams:
         msg = f"external trigger target references unknown agent or team: {target.agent}"
         raise ExternalTriggerStoreError(msg)
@@ -521,9 +522,34 @@ def _validate_target(target: ExternalTriggerTarget, config: Config, runtime_path
         runtime_paths,
         room_aliases=(target.room_id,),
     )
-    if target.agent not in configured_entities:
-        msg = "external trigger target room must already be configured for the target entity"
-        raise ExternalTriggerStoreError(msg)
+    if target.agent in configured_entities:
+        return
+    if _targets_private_current_room(record, config, runtime_paths):
+        return
+    msg = "external trigger target room must already be configured for the target entity"
+    raise ExternalTriggerStoreError(msg)
+
+
+def _targets_private_current_room(
+    record: ExternalTriggerRecord,
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> bool:
+    """Allow private current-agent triggers for dynamic rooms created outside config."""
+    target = record.target
+    if target.agent != record.created_by_agent_name:
+        return False
+    agent_config = config.agents.get(target.agent)
+    if agent_config is None or agent_config.private is None:
+        return False
+    return _room_ids_match(target.room_id, record.created_in_room_id, runtime_paths)
+
+
+def _room_ids_match(left: str, right: str, runtime_paths: RuntimePaths) -> bool:
+    """Return whether two room references resolve to the same live room."""
+    if left == right:
+        return True
+    return resolve_room_id(left, runtime_paths) == resolve_room_id(right, runtime_paths)
 
 
 def _validate_record_update(record: ExternalTriggerRecord) -> ExternalTriggerRecord:

--- a/src/mindroom/external_triggers/store.py
+++ b/src/mindroom/external_triggers/store.py
@@ -508,7 +508,7 @@ def _validate_owner(owner_user_id: str, config: Config, runtime_paths: RuntimePa
 
 
 def _validate_target(record: ExternalTriggerRecord, config: Config, runtime_paths: RuntimePaths) -> None:
-    """Require a configured entity and an already configured target room."""
+    """Require a configured entity and a deliverable room target."""
     target = record.target
     if target.agent not in config.agents and target.agent not in config.teams:
         msg = f"external trigger target references unknown agent or team: {target.agent}"
@@ -546,7 +546,7 @@ def _targets_private_current_room(
 
 
 def _room_ids_match(left: str, right: str, runtime_paths: RuntimePaths) -> bool:
-    """Return whether two room references resolve to the same live room."""
+    """Return whether two room references match after best-effort alias resolution."""
     if left == right:
         return True
     return resolve_room_id(left, runtime_paths) == resolve_room_id(right, runtime_paths)

--- a/tests/test_external_trigger_manager_tool.py
+++ b/tests/test_external_trigger_manager_tool.py
@@ -179,6 +179,33 @@ def test_private_agent_create_trigger_accepts_current_dynamic_room(tmp_path: Pat
     }
 
 
+def test_private_agent_create_trigger_rejects_other_dynamic_room(tmp_path: Path) -> None:
+    """Private agents may not bind triggers to a different dynamic room."""
+    config = _config(admin_users=["@admin:example.org"], private_watcher=True)
+    config.agents["watcher"].rooms = []
+    tool = ExternalTriggerManagerTools()
+
+    with tool_runtime_context(
+        _context(
+            tmp_path,
+            requester_id="@admin:example.org",
+            room_id="!private:example.org",
+            config=config,
+        ),
+    ):
+        payload = _payload(
+            tool.create_trigger(
+                "private-other-room",
+                public_key=_PUBLIC_KEY,
+                key_id="campground-main",
+                target_room_id="!other:example.org",
+            ),
+        )
+
+    assert payload["status"] == "error"
+    assert "target room must already be configured" in payload["message"]
+
+
 def test_non_admin_cannot_target_other_agent_or_room(tmp_path: Path) -> None:
     """Non-admin callers can only create triggers for the current agent and room."""
     tool = ExternalTriggerManagerTools()

--- a/tests/test_external_trigger_manager_tool.py
+++ b/tests/test_external_trigger_manager_tool.py
@@ -179,6 +179,32 @@ def test_private_agent_create_trigger_accepts_current_dynamic_room(tmp_path: Pat
     }
 
 
+def test_shared_agent_create_trigger_rejects_current_dynamic_room(tmp_path: Path) -> None:
+    """Shared agents still need a configured target room, even when it is the current room."""
+    config = _config()
+    config.agents["watcher"].rooms = []
+    tool = ExternalTriggerManagerTools()
+
+    with tool_runtime_context(
+        _context(
+            tmp_path,
+            requester_id="@owner:example.org",
+            room_id="!private:example.org",
+            config=config,
+        ),
+    ):
+        payload = _payload(
+            tool.create_trigger(
+                "shared-dynamic-campground",
+                public_key=_PUBLIC_KEY,
+                key_id="campground-main",
+            ),
+        )
+
+    assert payload["status"] == "error"
+    assert "target room must already be configured" in payload["message"]
+
+
 def test_private_agent_create_trigger_rejects_other_dynamic_room(tmp_path: Path) -> None:
     """Private agents may not bind triggers to a different dynamic room."""
     config = _config(admin_users=["@admin:example.org"], private_watcher=True)
@@ -199,6 +225,34 @@ def test_private_agent_create_trigger_rejects_other_dynamic_room(tmp_path: Path)
                 public_key=_PUBLIC_KEY,
                 key_id="campground-main",
                 target_room_id="!other:example.org",
+            ),
+        )
+
+    assert payload["status"] == "error"
+    assert "target room must already be configured" in payload["message"]
+
+
+def test_admin_cross_target_private_agent_rejects_current_dynamic_room(tmp_path: Path) -> None:
+    """Admins may not use a creator's dynamic room for a different private target agent."""
+    config = _config(admin_users=["@admin:example.org"], private_other=True)
+    config.agents["other"].rooms = []
+    tool = ExternalTriggerManagerTools()
+
+    with tool_runtime_context(
+        _context(
+            tmp_path,
+            requester_id="@admin:example.org",
+            room_id="!private:example.org",
+            config=config,
+        ),
+    ):
+        payload = _payload(
+            tool.create_trigger(
+                "private-cross-target-dynamic-room",
+                public_key=_PUBLIC_KEY,
+                key_id="campground-main",
+                target_agent="other",
+                target_room_id="!private:example.org",
             ),
         )
 

--- a/tests/test_external_trigger_manager_tool.py
+++ b/tests/test_external_trigger_manager_tool.py
@@ -74,11 +74,12 @@ def _context(
     tmp_path: Path,
     *,
     requester_id: str = "@owner:example.org",
+    room_id: str = "lobby",
     config: Config | None = None,
 ) -> ToolRuntimeContext:
     return ToolRuntimeContext(
         agent_name="watcher",
-        room_id="lobby",
+        room_id=room_id,
         thread_id="$thread",
         resolved_thread_id="$thread",
         requester_id=requester_id,
@@ -141,6 +142,39 @@ def test_private_agent_create_trigger_uses_owner_as_scope_owner(tmp_path: Path) 
         "agent": "watcher",
         "new_thread": False,
         "room_id": "lobby",
+        "thread_id": None,
+    }
+
+
+def test_private_agent_create_trigger_accepts_current_dynamic_room(tmp_path: Path) -> None:
+    """Private agents may bind triggers to their current live room without static rooms config."""
+    config = _config(private_watcher=True)
+    config.agents["watcher"].rooms = []
+    tool = ExternalTriggerManagerTools()
+
+    with tool_runtime_context(
+        _context(
+            tmp_path,
+            requester_id="@owner:example.org",
+            room_id="!private:example.org",
+            config=config,
+        ),
+    ):
+        payload = _payload(
+            tool.create_trigger(
+                "private-dynamic-campground",
+                public_key=_PUBLIC_KEY,
+                key_id="campground-main",
+                allowed_kinds=["campground.availability"],
+            ),
+        )
+
+    assert payload["status"] == "ok"
+    assert payload["trigger"]["owner_user_id"] == "@owner:example.org"
+    assert payload["trigger"]["target"] == {
+        "agent": "watcher",
+        "new_thread": False,
+        "room_id": "!private:example.org",
         "thread_id": None,
     }
 


### PR DESCRIPTION
## Summary
- allow private current-agent external triggers to target the current live Matrix room even when it is not statically listed in rooms
- keep static-room validation for shared agents and teams
- document the private dynamic-room exception and regenerate mindroom-docs references

## Test plan
- uv run pytest tests/test_external_trigger_manager_tool.py tests/test_external_trigger_store.py -n auto --no-cov -q
- uv run pre-commit run --all-files
- uv run pytest tests/test_external_trigger_manager_tool.py tests/test_external_trigger_store.py tests/test_external_trigger_executor.py tests/api/test_external_triggers_api.py tests/test_ai_user_id.py::test_private_agent_response_runner_builds_execution_identity_from_requester tests/test_multi_agent_bot.py::TestAgentBot::test_resolve_response_action_allows_explicit_private_agent_mention tests/test_multi_agent_bot.py::TestAgentBot::test_external_trigger_to_private_agent_uses_trigger_owner_as_requester tests/test_multi_agent_bot.py::TestAgentBot::test_human_forged_external_trigger_metadata_uses_human_sender_as_requester -n auto --no-cov -q
- uv run pytest -n auto --no-cov -q

## Summary by Sourcery

Allow private agents to bind external triggers to their current dynamic Matrix room while preserving strict room validation for shared agents and teams.

New Features:
- Permit private agent external triggers to target the current live Matrix room even when that room is not statically configured.

Enhancements:
- Relax trigger target validation to treat matching private-agent current rooms as valid while keeping existing checks for misconfigured entities.
- Clarify documentation that shared agents still require statically configured rooms, while private agents may use their current dynamic room, and regenerate mindroom-docs references.

Tests:
- Add coverage to ensure private agents can create triggers bound to their current dynamic room without static room configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified when external triggers can target a room, including rules for shared vs. private agents.
  * Added explicit notes that triggers do not create rooms or change room membership.
  * Documented the delivery requirement that the router and target transport bot must already be joined.

* **Bug Fixes**
  * Improved trigger validation so private agents can use their current live room even when it is not listed in configured rooms.
  * Trigger creation now behaves correctly for dynamic room setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->