### PR TITLE
Cap OpenAI tool schemas before model calls

### DIFF
--- a/src/mindroom/agent_knowledge_descriptions.py
+++ b/src/mindroom/agent_knowledge_descriptions.py
@@ -5,17 +5,23 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from agno.agent import Agent
+from agno.tools import Toolkit
 from agno.tools.function import Function
 
 from mindroom.knowledge_source_descriptions import KnowledgeSourceDescription, KnowledgeWithSourceDescriptions
+from mindroom.logging_config import get_logger
 
 if TYPE_CHECKING:
     from agno.knowledge.knowledge import Knowledge
+    from agno.models.base import Model
     from agno.run import RunContext
     from agno.run.agent import RunOutput
     from agno.session import AgentSession
 
 _KNOWLEDGE_SEARCH_TOOL_NAME = "search_knowledge_base"
+_OPENAI_PROVIDER_VISIBLE_TOOL_LIMIT = 128
+
+logger = get_logger(__name__)
 
 
 def _normalize_description(value: str) -> str:
@@ -62,6 +68,126 @@ def _annotate_knowledge_search_tool(tools: list[Any], sources: tuple[KnowledgeSo
             tool.description = description
 
 
+def _uses_openai_tool_limit(model: Model | None) -> bool:
+    if model is None:
+        return False
+    return "openai" in model.get_provider().lower()
+
+
+def _dict_tool_name(tool: dict[Any, Any]) -> str:
+    function = tool.get("function")
+    if isinstance(function, dict):
+        name = function.get("name")
+        if isinstance(name, str):
+            return name
+    name = tool.get("name")
+    return name if isinstance(name, str) else ""
+
+
+def _toolkit_new_functions(
+    toolkit: Toolkit,
+    *,
+    seen_function_names: set[str],
+    async_mode: bool,
+) -> list[tuple[str, Function]]:
+    functions = toolkit.get_async_functions() if async_mode else toolkit.get_functions()
+    return [(name, function) for name, function in functions.items() if name not in seen_function_names]
+
+
+def _append_toolkit_with_cap(
+    limited_tools: list[Any],
+    omitted_function_names: list[str],
+    seen_function_names: set[str],
+    toolkit: Toolkit,
+    *,
+    async_mode: bool,
+) -> None:
+    new_functions = _toolkit_new_functions(
+        toolkit,
+        seen_function_names=seen_function_names,
+        async_mode=async_mode,
+    )
+    if len(seen_function_names) + len(new_functions) <= _OPENAI_PROVIDER_VISIBLE_TOOL_LIMIT:
+        limited_tools.append(toolkit)
+        seen_function_names.update(name for name, _function in new_functions)
+        return
+
+    remaining = _OPENAI_PROVIDER_VISIBLE_TOOL_LIMIT - len(seen_function_names)
+    if remaining > 0:
+        kept_functions = new_functions[:remaining]
+        limited_tools.extend(function for _name, function in kept_functions)
+        seen_function_names.update(name for name, _function in kept_functions)
+    omitted_function_names.extend(name for name, _function in new_functions[remaining:])
+
+
+def _standalone_tool_function_name(tool: object) -> str:
+    if isinstance(tool, Function):
+        return tool.name
+    if isinstance(tool, dict):
+        return _dict_tool_name(tool)
+    return ""
+
+
+def _append_standalone_tool_with_cap(
+    limited_tools: list[Any],
+    omitted_function_names: list[str],
+    seen_function_names: set[str],
+    tool: object,
+) -> None:
+    function_name = _standalone_tool_function_name(tool)
+    if function_name and function_name in seen_function_names:
+        limited_tools.append(tool)
+        return
+    if len(seen_function_names) < _OPENAI_PROVIDER_VISIBLE_TOOL_LIMIT:
+        limited_tools.append(tool)
+        seen_function_names.add(function_name or f"<unnamed:{len(seen_function_names)}>")
+        return
+    omitted_function_names.append(function_name or "<unnamed>")
+
+
+def _limit_provider_visible_tools_for_model(
+    model: Model | None,
+    tools: list[Any],
+    *,
+    async_mode: bool,
+) -> list[Any]:
+    """Cap provider-visible tools before OpenAI rejects the request payload."""
+    if not _uses_openai_tool_limit(model):
+        return tools
+
+    limited_tools: list[Any] = []
+    seen_function_names: set[str] = set()
+    omitted_function_names: list[str] = []
+
+    for tool in tools:
+        if isinstance(tool, Toolkit):
+            _append_toolkit_with_cap(
+                limited_tools,
+                omitted_function_names,
+                seen_function_names,
+                tool,
+                async_mode=async_mode,
+            )
+            continue
+
+        _append_standalone_tool_with_cap(
+            limited_tools,
+            omitted_function_names,
+            seen_function_names,
+            tool,
+        )
+
+    if omitted_function_names:
+        logger.warning(
+            "Capped provider-visible tool list for OpenAI model",
+            model_id=model.id if model is not None else None,
+            kept_tool_count=len(seen_function_names),
+            omitted_tool_count=len(omitted_function_names),
+            omitted_tool_names=omitted_function_names[:20],
+        )
+    return limited_tools
+
+
 class KnowledgeToolDescribingAgent(Agent):
     """Agent subclass that owns MindRoom's model-facing knowledge-search metadata."""
 
@@ -77,7 +203,7 @@ class KnowledgeToolDescribingAgent(Agent):
         """Return Agno tools with MindRoom knowledge-source metadata attached."""
         tools = super().get_tools(run_response, run_context, session, user_id=user_id)
         _annotate_knowledge_search_tool(tools, self.knowledge_sources)
-        return tools
+        return _limit_provider_visible_tools_for_model(self.model, tools, async_mode=False)
 
     async def aget_tools(
         self,
@@ -96,4 +222,4 @@ class KnowledgeToolDescribingAgent(Agent):
             check_mcp_tools=check_mcp_tools,
         )
         _annotate_knowledge_search_tool(tools, self.knowledge_sources)
-        return tools
+        return _limit_provider_visible_tools_for_model(self.model, tools, async_mode=True)

--- a/src/mindroom/agent_knowledge_descriptions.py
+++ b/src/mindroom/agent_knowledge_descriptions.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 
 _KNOWLEDGE_SEARCH_TOOL_NAME = "search_knowledge_base"
 _OPENAI_PROVIDER_VISIBLE_TOOL_LIMIT = 128
+_OPENAI_TOOL_LIMIT_PROVIDERS = frozenset({"azure", "azure chat", "openai", "openai chat"})
 
 logger = get_logger(__name__)
 
@@ -71,7 +72,7 @@ def _annotate_knowledge_search_tool(tools: list[Any], sources: tuple[KnowledgeSo
 def _uses_openai_tool_limit(model: Model | None) -> bool:
     if model is None:
         return False
-    return "openai" in model.get_provider().lower()
+    return model.get_provider().casefold() in _OPENAI_TOOL_LIMIT_PROVIDERS
 
 
 def _dict_tool_name(tool: dict[Any, Any]) -> str:
@@ -84,14 +85,9 @@ def _dict_tool_name(tool: dict[Any, Any]) -> str:
     return name if isinstance(name, str) else ""
 
 
-def _toolkit_new_functions(
-    toolkit: Toolkit,
-    *,
-    seen_function_names: set[str],
-    async_mode: bool,
-) -> list[tuple[str, Function]]:
+def _toolkit_functions(toolkit: Toolkit, *, async_mode: bool) -> list[tuple[str, Function]]:
     functions = toolkit.get_async_functions() if async_mode else toolkit.get_functions()
-    return [(name, function) for name, function in functions.items() if name not in seen_function_names]
+    return list(functions.items())
 
 
 def _append_toolkit_with_cap(
@@ -102,22 +98,22 @@ def _append_toolkit_with_cap(
     *,
     async_mode: bool,
 ) -> None:
-    new_functions = _toolkit_new_functions(
-        toolkit,
-        seen_function_names=seen_function_names,
-        async_mode=async_mode,
-    )
-    if len(seen_function_names) + len(new_functions) <= _OPENAI_PROVIDER_VISIBLE_TOOL_LIMIT:
+    functions = _toolkit_functions(toolkit, async_mode=async_mode)
+    has_duplicate_functions = any(name in seen_function_names for name, _function in functions)
+    if not has_duplicate_functions and len(seen_function_names) + len(functions) <= _OPENAI_PROVIDER_VISIBLE_TOOL_LIMIT:
         limited_tools.append(toolkit)
-        seen_function_names.update(name for name, _function in new_functions)
+        seen_function_names.update(name for name, _function in functions)
         return
 
-    remaining = _OPENAI_PROVIDER_VISIBLE_TOOL_LIMIT - len(seen_function_names)
-    if remaining > 0:
-        kept_functions = new_functions[:remaining]
-        limited_tools.extend(function for _name, function in kept_functions)
-        seen_function_names.update(name for name, _function in kept_functions)
-    omitted_function_names.extend(name for name, _function in new_functions[remaining:])
+    for name, function in functions:
+        if name in seen_function_names:
+            omitted_function_names.append(name)
+            continue
+        if len(seen_function_names) < _OPENAI_PROVIDER_VISIBLE_TOOL_LIMIT:
+            limited_tools.append(function)
+            seen_function_names.add(name)
+            continue
+        omitted_function_names.append(name)
 
 
 def _standalone_tool_function_name(tool: object) -> str:
@@ -136,7 +132,7 @@ def _append_standalone_tool_with_cap(
 ) -> None:
     function_name = _standalone_tool_function_name(tool)
     if function_name and function_name in seen_function_names:
-        limited_tools.append(tool)
+        omitted_function_names.append(function_name)
         return
     if len(seen_function_names) < _OPENAI_PROVIDER_VISIBLE_TOOL_LIMIT:
         limited_tools.append(tool)

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -3429,6 +3429,50 @@ def test_openai_agent_caps_provider_visible_tools_before_request(tmp_path: Path)
     assert [tool.name for tool in tools] == [f"tool_{index:03}" for index in range(128)]
 
 
+def test_azure_openai_agent_caps_provider_visible_tools_before_request(tmp_path: Path) -> None:
+    """Azure OpenAI uses the same provider-visible tool cap as OpenAI."""
+    config = _test_config()
+    config.models["default"] = ModelConfig(
+        provider="azure",
+        id="team-chat-deployment",
+        extra_kwargs={
+            "api_key": "sk-test",
+            "azure_endpoint": "https://example-resource.openai.azure.com",
+            "api_version": "2024-10-21",
+        },
+    )
+    config = _bind_runtime_paths(config, _runtime_paths(tmp_path))
+    agent = _create_agent_for_test("general", config)
+    agent.tools = [
+        Function(
+            name=f"tool_{index:03}",
+            description=f"Tool {index}",
+            entrypoint=lambda index=index: str(index),
+        )
+        for index in range(130)
+    ]
+    run_output = RunOutput(
+        run_id="run-azure-openai-tool-cap",
+        agent_id="general",
+        agent_name="GeneralAgent",
+        session_id="session-azure-openai-tool-cap",
+        input="hello",
+        content="ok",
+    )
+    run_context = RunContext(run_id="run-azure-openai-tool-cap", session_id="session-azure-openai-tool-cap")
+    session = AgentSession(
+        session_id="session-azure-openai-tool-cap",
+        agent_id="general",
+        created_at=1,
+        updated_at=1,
+    )
+
+    tools = [tool for tool in agent.get_tools(run_output, run_context, session) if isinstance(tool, Function)]
+
+    assert len(tools) == 128
+    assert [tool.name for tool in tools] == [f"tool_{index:03}" for index in range(128)]
+
+
 def test_openai_agent_splits_large_toolkit_at_provider_visible_tool_cap(tmp_path: Path) -> None:
     """Large toolkits, such as MCP servers, must be capped by their provider-visible functions."""
     config = _bind_runtime_paths(_test_config(), _runtime_paths(tmp_path))
@@ -3466,6 +3510,56 @@ def test_openai_agent_splits_large_toolkit_at_provider_visible_tool_cap(tmp_path
 
     assert len(tools) == 128
     assert [tool.name for tool in tools] == [f"tool_{index:03}" for index in range(128)]
+
+
+def test_openai_agent_omits_duplicate_names_and_counts_unnamed_tools(tmp_path: Path) -> None:
+    """Duplicate named tools are redundant, while unnamed tool schemas still consume cap slots."""
+    config = _bind_runtime_paths(_test_config(), _runtime_paths(tmp_path))
+    agent = _create_agent_for_test("general", config)
+    agent.tools = [
+        *[
+            Function(
+                name=f"tool_{index:03}",
+                description=f"Tool {index}",
+                entrypoint=lambda index=index: str(index),
+            )
+            for index in range(127)
+        ],
+        Function(
+            name="tool_005",
+            description="Duplicate tool",
+            entrypoint=lambda: "duplicate",
+        ),
+        {"type": "function", "function": {"description": "Unnamed tool"}},
+        {"type": "function", "function": {"description": "Second unnamed tool"}},
+    ]
+    run_output = RunOutput(
+        run_id="run-openai-duplicate-tool-cap",
+        agent_id="general",
+        agent_name="GeneralAgent",
+        session_id="session-openai-duplicate-tool-cap",
+        input="hello",
+        content="ok",
+    )
+    run_context = RunContext(run_id="run-openai-duplicate-tool-cap", session_id="session-openai-duplicate-tool-cap")
+    session = AgentSession(
+        session_id="session-openai-duplicate-tool-cap",
+        agent_id="general",
+        created_at=1,
+        updated_at=1,
+    )
+
+    tools = agent.get_tools(run_output, run_context, session)
+    function_names = [tool.name for tool in tools if isinstance(tool, Function)]
+    unnamed_tool_count = sum(
+        1
+        for tool in tools
+        if isinstance(tool, dict) and isinstance(tool.get("function"), dict) and "name" not in tool["function"]
+    )
+
+    assert len(tools) == 128
+    assert function_names.count("tool_005") == 1
+    assert unnamed_tool_count == 1
 
 
 @pytest.mark.anyio

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -19,6 +19,7 @@ from agno.learn import LearningMachine, LearningMode, UserMemoryConfig, UserProf
 from agno.run import RunContext
 from agno.run.agent import RunOutput
 from agno.session import AgentSession
+from agno.tools import Toolkit
 from agno.tools.function import Function
 from pydantic import ValidationError
 
@@ -3428,6 +3429,45 @@ def test_openai_agent_caps_provider_visible_tools_before_request(tmp_path: Path)
     assert [tool.name for tool in tools] == [f"tool_{index:03}" for index in range(128)]
 
 
+def test_openai_agent_splits_large_toolkit_at_provider_visible_tool_cap(tmp_path: Path) -> None:
+    """Large toolkits, such as MCP servers, must be capped by their provider-visible functions."""
+    config = _bind_runtime_paths(_test_config(), _runtime_paths(tmp_path))
+    agent = _create_agent_for_test("general", config)
+    agent.tools = [
+        Toolkit(
+            name="large_toolkit",
+            tools=[
+                Function(
+                    name=f"tool_{index:03}",
+                    description=f"Tool {index}",
+                    entrypoint=lambda index=index: str(index),
+                )
+                for index in range(130)
+            ],
+        ),
+    ]
+    run_output = RunOutput(
+        run_id="run-openai-toolkit-cap",
+        agent_id="general",
+        agent_name="GeneralAgent",
+        session_id="session-openai-toolkit-cap",
+        input="hello",
+        content="ok",
+    )
+    run_context = RunContext(run_id="run-openai-toolkit-cap", session_id="session-openai-toolkit-cap")
+    session = AgentSession(
+        session_id="session-openai-toolkit-cap",
+        agent_id="general",
+        created_at=1,
+        updated_at=1,
+    )
+
+    tools = [tool for tool in agent.get_tools(run_output, run_context, session) if isinstance(tool, Function)]
+
+    assert len(tools) == 128
+    assert [tool.name for tool in tools] == [f"tool_{index:03}" for index in range(128)]
+
+
 @pytest.mark.anyio
 async def test_async_openai_agent_caps_provider_visible_tools_before_request(tmp_path: Path) -> None:
     """The streaming Matrix path resolves async tools and must apply the same OpenAI cap."""
@@ -3452,6 +3492,46 @@ async def test_async_openai_agent_caps_provider_visible_tools_before_request(tmp
     run_context = RunContext(run_id="run-async-openai-tool-cap", session_id="session-async-openai-tool-cap")
     session = AgentSession(
         session_id="session-async-openai-tool-cap",
+        agent_id="general",
+        created_at=1,
+        updated_at=1,
+    )
+
+    tools = [tool for tool in await agent.aget_tools(run_output, run_context, session) if isinstance(tool, Function)]
+
+    assert len(tools) == 128
+    assert [tool.name for tool in tools] == [f"tool_{index:03}" for index in range(128)]
+
+
+@pytest.mark.anyio
+async def test_async_openai_agent_splits_large_toolkit_at_provider_visible_tool_cap(tmp_path: Path) -> None:
+    """The async streaming path must also cap oversized toolkit functions before dispatch."""
+    config = _bind_runtime_paths(_test_config(), _runtime_paths(tmp_path))
+    agent = _create_agent_for_test("general", config)
+    agent.tools = [
+        Toolkit(
+            name="large_toolkit",
+            tools=[
+                Function(
+                    name=f"tool_{index:03}",
+                    description=f"Tool {index}",
+                    entrypoint=lambda index=index: str(index),
+                )
+                for index in range(130)
+            ],
+        ),
+    ]
+    run_output = RunOutput(
+        run_id="run-async-openai-toolkit-cap",
+        agent_id="general",
+        agent_name="GeneralAgent",
+        session_id="session-async-openai-toolkit-cap",
+        input="hello",
+        content="ok",
+    )
+    run_context = RunContext(run_id="run-async-openai-toolkit-cap", session_id="session-async-openai-toolkit-cap")
+    session = AgentSession(
+        session_id="session-async-openai-toolkit-cap",
         agent_id="general",
         created_at=1,
         updated_at=1,

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -3394,6 +3394,75 @@ def test_agent_knowledge_search_tool_description_excludes_unavailable_sources(tm
     assert "legal" not in description
 
 
+def test_openai_agent_caps_provider_visible_tools_before_request(tmp_path: Path) -> None:
+    """OpenAI rejects requests with more than 128 tools, so cap before model dispatch."""
+    config = _bind_runtime_paths(_test_config(), _runtime_paths(tmp_path))
+    agent = _create_agent_for_test("general", config)
+    agent.tools = [
+        Function(
+            name=f"tool_{index:03}",
+            description=f"Tool {index}",
+            entrypoint=lambda index=index: str(index),
+        )
+        for index in range(130)
+    ]
+    run_output = RunOutput(
+        run_id="run-openai-tool-cap",
+        agent_id="general",
+        agent_name="GeneralAgent",
+        session_id="session-openai-tool-cap",
+        input="hello",
+        content="ok",
+    )
+    run_context = RunContext(run_id="run-openai-tool-cap", session_id="session-openai-tool-cap")
+    session = AgentSession(
+        session_id="session-openai-tool-cap",
+        agent_id="general",
+        created_at=1,
+        updated_at=1,
+    )
+
+    tools = [tool for tool in agent.get_tools(run_output, run_context, session) if isinstance(tool, Function)]
+
+    assert len(tools) == 128
+    assert [tool.name for tool in tools] == [f"tool_{index:03}" for index in range(128)]
+
+
+@pytest.mark.anyio
+async def test_async_openai_agent_caps_provider_visible_tools_before_request(tmp_path: Path) -> None:
+    """The streaming Matrix path resolves async tools and must apply the same OpenAI cap."""
+    config = _bind_runtime_paths(_test_config(), _runtime_paths(tmp_path))
+    agent = _create_agent_for_test("general", config)
+    agent.tools = [
+        Function(
+            name=f"tool_{index:03}",
+            description=f"Tool {index}",
+            entrypoint=lambda index=index: str(index),
+        )
+        for index in range(130)
+    ]
+    run_output = RunOutput(
+        run_id="run-async-openai-tool-cap",
+        agent_id="general",
+        agent_name="GeneralAgent",
+        session_id="session-async-openai-tool-cap",
+        input="hello",
+        content="ok",
+    )
+    run_context = RunContext(run_id="run-async-openai-tool-cap", session_id="session-async-openai-tool-cap")
+    session = AgentSession(
+        session_id="session-async-openai-tool-cap",
+        agent_id="general",
+        created_at=1,
+        updated_at=1,
+    )
+
+    tools = [tool for tool in await agent.aget_tools(run_output, run_context, session) if isinstance(tool, Function)]
+
+    assert len(tools) == 128
+    assert [tool.name for tool in tools] == [f"tool_{index:03}" for index in range(128)]
+
+
 def test_agent_accepts_custom_knowledge_protocol_without_source_metadata(tmp_path: Path) -> None:
     """Custom knowledge implementations need not expose Agno Knowledge metadata fields."""
 


### PR DESCRIPTION
## Summary
- cap OpenAI-family provider-visible tool lists to 128 unique function names before Agno sends the request
- apply the cap after direct tools, skills, learning, knowledge, and MCP tools are resolved, for both sync and async paths
- add regression coverage for the Matrix async path and sync path

## Tests
- `uv run ruff check src/mindroom/agent_knowledge_descriptions.py tests/test_agents.py`
- `uv run pytest tests/test_agents.py -q -k "openai_agent_caps_provider_visible_tools"`
- `uv run pytest tests/test_agents.py -q`
- `uv run tach check --dependencies --interfaces`

## Summary by Sourcery

Cap OpenAI provider-visible tools to a maximum of 128 unique functions before model dispatch for both sync and async agent paths.

New Features:
- Introduce provider-visible tool limiting logic that enforces a 128-function cap for OpenAI-family models, handling both toolkit and standalone tools.

Enhancements:
- Integrate tool capping into KnowledgeToolDescribingAgent sync and async tool resolution flows while preserving knowledge search annotations.
- Add logging for cases where tools are omitted due to the OpenAI cap, including counts and sample names.

Tests:
- Add sync and async tests to verify OpenAI agents cap provider-visible tools at 128 functions for the standard and streaming Matrix paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Limited the number of tools included in requests to OpenAI-backed models to match provider-visible caps.
  * Preserved deterministic tool ordering while trimming excess entries and omitting duplicates.
  * Added an in-app warning when tools are omitted, and applied the limit consistently for both synchronous and async request flows (including Azure OpenAI).

* **Tests**
  * Expanded sync and async coverage to verify exact cap behavior for large toolsets and duplicate/unnamed tool scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->