### PR TITLE
Instrument tool call timing

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -553,6 +553,8 @@ When enabled, MindRoom writes JSONL request records under `debug.llm_request_log
 Those records include prompts, messages, tool schemas, model parameters, correlation IDs, requester metadata, and source Matrix event metadata.
 The same flag also records successful tool-call rows in `mindroom_data/tracking/tool_calls.jsonl` so tool activity can be correlated with LLM request logs.
 Tool failures are always recorded in `tool_calls.jsonl`, even when request logging is disabled.
+Tool-call rows include a `timing` object with result-ready, before-hook, approval, and tool-body durations when those phases are measured.
+Set `MINDROOM_TIMING=1` to emit additional structured debug timing events for stream-visible tool-call start, stream-visible tool-call completion, and full bridge completion.
 Audit logging remains enabled.
 Credential-bearing fields such as tokens, cookies, passwords, API keys, and authorization headers are redacted before log records are emitted.
 These artifacts can still contain sensitive non-credential prompt, argument, and result data.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,6 +6,7 @@ This directory contains utility scripts for MindRoom self-hosting.
 
 ### 🧪 Testing
 - **`testing/benchmark_matrix_throughput.py`** - Benchmark Matrix message throughput performance
+- **`testing/benchmark_tool_call_overhead.py`** - Benchmark synthetic tool-call bridge overhead
 
 ### 🔧 Utilities
 - **`utilities/cleanup_agent_edits.sh`** - Clean up agent-edited files in Matrix database
@@ -34,6 +35,11 @@ If you're looking for platform deployment scripts (infrastructure, database migr
 ### Benchmark Matrix performance
 ```bash
 ./scripts/testing/benchmark_matrix_throughput.py
+```
+
+### Benchmark tool-call overhead
+```bash
+uv run python scripts/testing/benchmark_tool_call_overhead.py --iterations 1000 --warmup 100
 ```
 
 ### Generate and sync managed avatars

--- a/scripts/testing/benchmark_tool_call_overhead.py
+++ b/scripts/testing/benchmark_tool_call_overhead.py
@@ -1,0 +1,163 @@
+"""Synthetic benchmark for MindRoom tool-call bridge overhead."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import math
+import time
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from mindroom.config.plugin import PluginEntryConfig
+from mindroom.hooks import (
+    EVENT_TOOL_AFTER_CALL,
+    EVENT_TOOL_BEFORE_CALL,
+    HookRegistry,
+    ToolAfterCallContext,
+    ToolBeforeCallContext,
+    hook,
+)
+from mindroom.tool_system.tool_hooks import build_tool_hook_bridge
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+
+async def _noop_async(value: int) -> int:
+    return value
+
+
+def _noop_sync(value: int) -> int:
+    return value
+
+
+@hook(EVENT_TOOL_BEFORE_CALL)
+async def _benchmark_before_hook(ctx: ToolBeforeCallContext) -> None:
+    if ctx.tool_name != "noop":
+        msg = f"unexpected benchmark tool: {ctx.tool_name}"
+        raise AssertionError(msg)
+
+
+@hook(EVENT_TOOL_AFTER_CALL)
+async def _benchmark_after_hook(ctx: ToolAfterCallContext) -> None:
+    if ctx.tool_name != "noop":
+        msg = f"unexpected benchmark tool: {ctx.tool_name}"
+        raise AssertionError(msg)
+
+
+def _registry_with_hooks() -> HookRegistry:
+    return HookRegistry.from_plugins(
+        [
+            SimpleNamespace(
+                name="tool-call-benchmark",
+                discovered_hooks=(_benchmark_before_hook, _benchmark_after_hook),
+                entry_config=PluginEntryConfig(path="./scripts/testing/benchmark_tool_call_overhead.py", settings={}),
+                plugin_order=0,
+            ),
+        ],
+    )
+
+
+def _nearest_rank(sorted_samples: Sequence[float], percentile: float) -> float:
+    if not sorted_samples:
+        return 0.0
+    index = max(math.ceil((percentile / 100) * len(sorted_samples)) - 1, 0)
+    return sorted_samples[min(index, len(sorted_samples) - 1)]
+
+
+def summarize_samples(samples: Sequence[float]) -> dict[str, float | int]:
+    """Return deterministic summary stats for elapsed millisecond samples."""
+    if not samples:
+        return {"count": 0, "mean_ms": 0.0, "p50_ms": 0.0, "p95_ms": 0.0, "max_ms": 0.0}
+    sorted_samples = sorted(samples)
+    return {
+        "count": len(samples),
+        "mean_ms": round(sum(samples) / len(samples), 3),
+        "p50_ms": round(_nearest_rank(sorted_samples, 50), 3),
+        "p95_ms": round(_nearest_rank(sorted_samples, 95), 3),
+        "max_ms": round(sorted_samples[-1], 3),
+    }
+
+
+async def _run_case(
+    *,
+    label: str,
+    func: Callable[..., Any],
+    hook_registry: HookRegistry,
+    iterations: int,
+    warmup: int,
+) -> dict[str, object]:
+    bridge = build_tool_hook_bridge(hook_registry, agent_name="benchmark")
+    for _ in range(warmup):
+        await bridge("noop", func, {"value": 1})
+
+    samples: list[float] = []
+    for _ in range(iterations):
+        started_at = time.perf_counter()
+        await bridge("noop", func, {"value": 1})
+        samples.append((time.perf_counter() - started_at) * 1000)
+    return {"case": label, **summarize_samples(samples)}
+
+
+async def _run_benchmark(iterations: int, warmup: int) -> list[dict[str, object]]:
+    return [
+        await _run_case(
+            label="async_no_hooks",
+            func=_noop_async,
+            hook_registry=HookRegistry.empty(),
+            iterations=iterations,
+            warmup=warmup,
+        ),
+        await _run_case(
+            label="sync_no_hooks",
+            func=_noop_sync,
+            hook_registry=HookRegistry.empty(),
+            iterations=iterations,
+            warmup=warmup,
+        ),
+        await _run_case(
+            label="async_with_hooks",
+            func=_noop_async,
+            hook_registry=_registry_with_hooks(),
+            iterations=iterations,
+            warmup=warmup,
+        ),
+        await _run_case(
+            label="sync_with_hooks",
+            func=_noop_sync,
+            hook_registry=_registry_with_hooks(),
+            iterations=iterations,
+            warmup=warmup,
+        ),
+    ]
+
+
+def main() -> None:
+    """Run the command-line benchmark and print JSON results."""
+    parser = argparse.ArgumentParser(description="Benchmark MindRoom tool-call bridge overhead.")
+    parser.add_argument("--iterations", type=int, default=1000)
+    parser.add_argument("--warmup", type=int, default=50)
+    args = parser.parse_args()
+    if args.iterations < 1:
+        parser.error("--iterations must be >= 1")
+    if args.warmup < 0:
+        parser.error("--warmup must be >= 0")
+
+    logging.getLogger().setLevel(logging.WARNING)
+    logging.getLogger("mindroom").setLevel(logging.WARNING)
+    logging.getLogger("mindroom.hooks").disabled = True
+    structlog.configure(
+        wrapper_class=structlog.make_filtering_bound_logger(logging.WARNING),
+        cache_logger_on_first_use=False,
+    )
+    results = asyncio.run(_run_benchmark(iterations=args.iterations, warmup=args.warmup))
+    print(json.dumps(results, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -1345,6 +1345,8 @@ When enabled, MindRoom writes JSONL request records under `debug.llm_request_log
 Those records include prompts, messages, tool schemas, model parameters, correlation IDs, requester metadata, and source Matrix event metadata.
 The same flag also records successful tool-call rows in `mindroom_data/tracking/tool_calls.jsonl` so tool activity can be correlated with LLM request logs.
 Tool failures are always recorded in `tool_calls.jsonl`, even when request logging is disabled.
+Tool-call rows include a `timing` object with result-ready, before-hook, approval, and tool-body durations when those phases are measured.
+Set `MINDROOM_TIMING=1` to emit additional structured debug timing events for stream-visible tool-call start, stream-visible tool-call completion, and full bridge completion.
 Audit logging remains enabled.
 Credential-bearing fields such as tokens, cookies, passwords, API keys, and authorization headers are redacted before log records are emitted.
 These artifacts can still contain sensitive non-credential prompt, argument, and result data.

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -549,6 +549,8 @@ When enabled, MindRoom writes JSONL request records under `debug.llm_request_log
 Those records include prompts, messages, tool schemas, model parameters, correlation IDs, requester metadata, and source Matrix event metadata.
 The same flag also records successful tool-call rows in `mindroom_data/tracking/tool_calls.jsonl` so tool activity can be correlated with LLM request logs.
 Tool failures are always recorded in `tool_calls.jsonl`, even when request logging is disabled.
+Tool-call rows include a `timing` object with result-ready, before-hook, approval, and tool-body durations when those phases are measured.
+Set `MINDROOM_TIMING=1` to emit additional structured debug timing events for stream-visible tool-call start, stream-visible tool-call completion, and full bridge completion.
 Audit logging remains enabled.
 Credential-bearing fields such as tokens, cookies, passwords, API keys, and authorization headers are redacted before log records are emitted.
 These artifacts can still contain sensitive non-credential prompt, argument, and result data.

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -1838,6 +1838,15 @@ async def _process_stream_events(  # noqa: C901, PLR0912, PLR0915
                 continue
 
             if isinstance(event, ToolCallCompletedEvent):
+                tool_execution = event.tool
+                emit_timing_event(
+                    "Dispatch tool-call timing",
+                    phase="agno_tool_call_completed",
+                    agent_name=agent_name,
+                    tool_name=tool_execution.tool_name if tool_execution is not None else None,
+                    tool_call_id=tool_execution_call_id(tool_execution) if tool_execution is not None else None,
+                    show_tool_calls=show_tool_calls,
+                )
                 _track_stream_tool_completed(
                     state,
                     event,

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -52,7 +52,7 @@ from mindroom.history import (
     team_tool_definition_payloads_for_logging,
     update_scope_seen_event_ids,
 )
-from mindroom.history.interrupted_replay import split_interrupted_tool_trace
+from mindroom.history.interrupted_replay import split_interrupted_tool_trace, tool_execution_call_id
 from mindroom.hooks import EnrichmentItem, render_system_enrichment_block
 from mindroom.knowledge import KnowledgeAvailabilityDetail, resolve_agent_knowledge_access
 from mindroom.llm_request_logging import (
@@ -76,6 +76,7 @@ from mindroom.team_exact_members import (
     resolve_live_shared_agent_names,
     resolve_team_materializable_agent_names,
 )
+from mindroom.timing import emit_timing_event
 from mindroom.tool_system.events import (
     StreamingToolTracker,
     StructuredStreamChunk,
@@ -2298,6 +2299,24 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
                     tool=tool,
                 )
 
+            def _emit_tool_timing(
+                *,
+                phase: str,
+                tool_scope: Literal["member", "team"],
+                agent_name: str | None,
+                tool: ToolExecution | None,
+            ) -> None:
+                emit_timing_event(
+                    "Dispatch tool-call timing",
+                    phase=phase,
+                    team_name=configured_team_name or team_label,
+                    tool_scope=tool_scope,
+                    agent_name=agent_name,
+                    tool_name=tool.tool_name if tool is not None else None,
+                    tool_call_id=tool_execution_call_id(tool),
+                    show_tool_calls=show_tool_calls,
+                )
+
             try:
                 for retried_after_media_fallback in (False, True):
                     canonical_per_member = dict.fromkeys(display_names, "")
@@ -2471,10 +2490,22 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
                         elif isinstance(event, AgentToolCallStartedEvent):
                             member_name = event.agent_name
                             if member_name:
+                                _emit_tool_timing(
+                                    phase="agno_tool_call_started",
+                                    tool_scope="member",
+                                    agent_name=member_name,
+                                    tool=event.tool,
+                                )
                                 _start_tool_for_member(member_name, event.tool)
                         elif isinstance(event, AgentToolCallCompletedEvent):
                             member_name = event.agent_name
                             if member_name:
+                                _emit_tool_timing(
+                                    phase="agno_tool_call_completed",
+                                    tool_scope="member",
+                                    agent_name=member_name,
+                                    tool=event.tool,
+                                )
                                 _complete_tool_for_member(member_name, event.tool)
                         elif isinstance(event, TeamRunContentEvent):
                             if event.content:
@@ -2484,12 +2515,24 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
                             else:
                                 logger.debug("Empty team consensus event received")
                         elif isinstance(event, TeamToolCallStartedEvent):
+                            _emit_tool_timing(
+                                phase="agno_tool_call_started",
+                                tool_scope="team",
+                                agent_name=None,
+                                tool=event.tool,
+                            )
                             _start_tool(
                                 scope_key="team",
                                 apply_visible_text=_append_to_visible_consensus,
                                 tool=event.tool,
                             )
                         elif isinstance(event, TeamToolCallCompletedEvent):
+                            _emit_tool_timing(
+                                phase="agno_tool_call_completed",
+                                tool_scope="team",
+                                agent_name=None,
+                                tool=event.tool,
+                            )
                             _complete_tool(
                                 scope_key="team",
                                 get_visible_text=_get_visible_consensus,

--- a/src/mindroom/tool_system/tool_calls.py
+++ b/src/mindroom/tool_system/tool_calls.py
@@ -42,6 +42,7 @@ class _ToolCallRecordDict(TypedDict, total=False):
 
     timestamp: str
     tool_name: str
+    tool_call_id: str
     agent_name: str | None
     channel: str | None
     room_id: str | None
@@ -54,9 +55,30 @@ class _ToolCallRecordDict(TypedDict, total=False):
     arguments: _JsonValue
     success: bool
     result: _JsonValue
+    timing: _JsonValue
     error_type: str
     error_message: str
     traceback: str
+
+
+@dataclass(frozen=True, slots=True)
+class ToolCallTiming:
+    """Optional phase timing breakdown for one tool call."""
+
+    before_hooks_ms: float | None = None
+    approval_ms: float | None = None
+    tool_body_ms: float | None = None
+    result_ready_ms: float | None = None
+
+    def as_dict(self) -> dict[str, float]:
+        """Return JSON-safe timing fields, omitting phases that were not measured."""
+        fields = {
+            "approval_ms": self.approval_ms,
+            "before_hooks_ms": self.before_hooks_ms,
+            "result_ready_ms": self.result_ready_ms,
+            "tool_body_ms": self.tool_body_ms,
+        }
+        return {key: _sanitize_duration_ms(value) for key, value in fields.items() if value is not None}
 
 
 @dataclass(frozen=True, slots=True)
@@ -65,6 +87,7 @@ class _ToolCallRecord:
 
     timestamp: str
     tool_name: str
+    tool_call_id: str | None
     agent_name: str | None
     channel: str | None
     room_id: str | None
@@ -76,6 +99,7 @@ class _ToolCallRecord:
     duration_ms: float
     arguments: _JsonValue
     success: bool
+    timing: ToolCallTiming | None = None
     result: _JsonValue | None = None
     error_type: str | None = None
     error_message: str | None = None
@@ -92,18 +116,21 @@ class _ToolCallRecord:
             "arguments": self.arguments,
             "success": self.success,
         }
-        if self.agent_name is not None:
-            record["agent_name"] = self.agent_name
-        if self.channel is not None:
-            record["channel"] = self.channel
-        if self.room_id is not None:
-            record["room_id"] = self.room_id
-        if self.thread_id is not None:
-            record["thread_id"] = self.thread_id
-        if self.requester_id is not None:
-            record["requester_id"] = self.requester_id
-        if self.session_id is not None:
-            record["session_id"] = self.session_id
+        if self.tool_call_id is not None:
+            record["tool_call_id"] = self.tool_call_id
+        context_fields: dict[str, str | None] = {
+            "agent_name": self.agent_name,
+            "channel": self.channel,
+            "room_id": self.room_id,
+            "thread_id": self.thread_id,
+            "requester_id": self.requester_id,
+            "session_id": self.session_id,
+        }
+        record.update({key: value for key, value in context_fields.items() if value is not None})
+        if self.timing is not None:
+            timing = self.timing.as_dict()
+            if timing:
+                record["timing"] = cast("_JsonValue", timing)
         if self.success or self.result is not None:
             record["result"] = self.result
         optional_fields: tuple[tuple[str, str | None], ...] = (
@@ -166,6 +193,8 @@ def _build_tool_failure_record(
     arguments: dict[str, object],
     error: BaseException,
     duration_ms: float,
+    tool_call_id: str | None = None,
+    timing: ToolCallTiming | None = None,
     agent_name: str | None,
     channel: str | None,
     room_id: str | None,
@@ -179,6 +208,7 @@ def _build_tool_failure_record(
     return _ToolCallRecord(
         timestamp=datetime.now(UTC).isoformat().replace("+00:00", "Z"),
         tool_name=tool_name,
+        tool_call_id=tool_call_id,
         agent_name=agent_name,
         channel=channel,
         room_id=room_id,
@@ -190,6 +220,7 @@ def _build_tool_failure_record(
         duration_ms=_sanitize_duration_ms(duration_ms),
         arguments=sanitize_failure_value(arguments),
         success=False,
+        timing=timing,
         error_type=type(error).__name__,
         error_message=_safe_error_message(error),
         traceback=_safe_traceback(error),
@@ -202,6 +233,8 @@ def _build_tool_success_record(
     arguments: dict[str, object],
     result: object,
     duration_ms: float,
+    tool_call_id: str | None = None,
+    timing: ToolCallTiming | None = None,
     agent_name: str | None,
     channel: str | None,
     room_id: str | None,
@@ -215,6 +248,7 @@ def _build_tool_success_record(
     return _ToolCallRecord(
         timestamp=datetime.now(UTC).isoformat().replace("+00:00", "Z"),
         tool_name=tool_name,
+        tool_call_id=tool_call_id,
         agent_name=agent_name,
         channel=channel,
         room_id=room_id,
@@ -226,6 +260,7 @@ def _build_tool_success_record(
         duration_ms=_sanitize_duration_ms(duration_ms),
         arguments=sanitize_failure_value(arguments),
         success=True,
+        timing=timing,
         result=sanitize_failure_value(result),
     )
 
@@ -268,6 +303,8 @@ def record_tool_failure(
     arguments: dict[str, object],
     error: BaseException,
     duration_ms: float,
+    tool_call_id: str | None = None,
+    timing: ToolCallTiming | None = None,
     agent_name: str | None,
     room_id: str | None,
     thread_id: str | None,
@@ -284,6 +321,8 @@ def record_tool_failure(
         arguments=arguments,
         error=error,
         duration_ms=duration_ms,
+        tool_call_id=tool_call_id,
+        timing=timing,
         agent_name=agent_name,
         channel=execution_identity.channel if execution_identity is not None else None,
         room_id=room_id,
@@ -317,6 +356,8 @@ def record_tool_success(
     arguments: dict[str, object],
     result: object,
     duration_ms: float,
+    tool_call_id: str | None = None,
+    timing: ToolCallTiming | None = None,
     agent_name: str | None,
     room_id: str | None,
     thread_id: str | None,
@@ -333,6 +374,8 @@ def record_tool_success(
         arguments=arguments,
         result=result,
         duration_ms=duration_ms,
+        tool_call_id=tool_call_id,
+        timing=timing,
         agent_name=agent_name,
         channel=execution_identity.channel if execution_identity is not None else None,
         room_id=room_id,

--- a/src/mindroom/tool_system/tool_calls.py
+++ b/src/mindroom/tool_system/tool_calls.py
@@ -42,7 +42,6 @@ class _ToolCallRecordDict(TypedDict, total=False):
 
     timestamp: str
     tool_name: str
-    tool_call_id: str
     agent_name: str | None
     channel: str | None
     room_id: str | None
@@ -87,7 +86,6 @@ class _ToolCallRecord:
 
     timestamp: str
     tool_name: str
-    tool_call_id: str | None
     agent_name: str | None
     channel: str | None
     room_id: str | None
@@ -116,8 +114,6 @@ class _ToolCallRecord:
             "arguments": self.arguments,
             "success": self.success,
         }
-        if self.tool_call_id is not None:
-            record["tool_call_id"] = self.tool_call_id
         context_fields: dict[str, str | None] = {
             "agent_name": self.agent_name,
             "channel": self.channel,
@@ -193,7 +189,6 @@ def _build_tool_failure_record(
     arguments: dict[str, object],
     error: BaseException,
     duration_ms: float,
-    tool_call_id: str | None = None,
     timing: ToolCallTiming | None = None,
     agent_name: str | None,
     channel: str | None,
@@ -208,7 +203,6 @@ def _build_tool_failure_record(
     return _ToolCallRecord(
         timestamp=datetime.now(UTC).isoformat().replace("+00:00", "Z"),
         tool_name=tool_name,
-        tool_call_id=tool_call_id,
         agent_name=agent_name,
         channel=channel,
         room_id=room_id,
@@ -233,7 +227,6 @@ def _build_tool_success_record(
     arguments: dict[str, object],
     result: object,
     duration_ms: float,
-    tool_call_id: str | None = None,
     timing: ToolCallTiming | None = None,
     agent_name: str | None,
     channel: str | None,
@@ -248,7 +241,6 @@ def _build_tool_success_record(
     return _ToolCallRecord(
         timestamp=datetime.now(UTC).isoformat().replace("+00:00", "Z"),
         tool_name=tool_name,
-        tool_call_id=tool_call_id,
         agent_name=agent_name,
         channel=channel,
         room_id=room_id,
@@ -303,7 +295,6 @@ def record_tool_failure(
     arguments: dict[str, object],
     error: BaseException,
     duration_ms: float,
-    tool_call_id: str | None = None,
     timing: ToolCallTiming | None = None,
     agent_name: str | None,
     room_id: str | None,
@@ -321,7 +312,6 @@ def record_tool_failure(
         arguments=arguments,
         error=error,
         duration_ms=duration_ms,
-        tool_call_id=tool_call_id,
         timing=timing,
         agent_name=agent_name,
         channel=execution_identity.channel if execution_identity is not None else None,
@@ -356,7 +346,6 @@ def record_tool_success(
     arguments: dict[str, object],
     result: object,
     duration_ms: float,
-    tool_call_id: str | None = None,
     timing: ToolCallTiming | None = None,
     agent_name: str | None,
     room_id: str | None,
@@ -374,7 +363,6 @@ def record_tool_success(
         arguments=arguments,
         result=result,
         duration_ms=duration_ms,
-        tool_call_id=tool_call_id,
         timing=timing,
         agent_name=agent_name,
         channel=execution_identity.channel if execution_identity is not None else None,

--- a/src/mindroom/tool_system/tool_hooks.py
+++ b/src/mindroom/tool_system/tool_hooks.py
@@ -445,10 +445,6 @@ async def _emit_after_call(
     await emit(hook_registry, EVENT_TOOL_AFTER_CALL, after_context)
 
 
-def _blocked_tool_result(*, tool_name: str, reason: str) -> str:
-    return _format_declined_result(tool_name, reason)
-
-
 async def _maybe_block_for_tool_approval(
     *,
     resolved_context: _ResolvedToolContext,
@@ -475,17 +471,14 @@ async def _maybe_block_for_tool_approval(
         )
     except ToolApprovalScriptError:
         logger.warning("Tool approval policy failed", exc_info=True)
-        return _blocked_tool_result(
-            tool_name=tool_name,
-            reason=_APPROVAL_POLICY_FAILURE_REASON,
-        )
+        return _format_declined_result(tool_name, _APPROVAL_POLICY_FAILURE_REASON)
 
     if approval_decision is None or approval_decision.status == "approved":
         return None
 
-    return _blocked_tool_result(
-        tool_name=tool_name,
-        reason=_approval_status_reason(approval_decision.status, approval_decision.reason),
+    return _format_declined_result(
+        tool_name,
+        _approval_status_reason(approval_decision.status, approval_decision.reason),
     )
 
 
@@ -524,10 +517,7 @@ async def _maybe_block_for_before_hooks(
     if not before_context.declined:
         return None
 
-    return _blocked_tool_result(
-        tool_name=tool_name,
-        reason=before_context.decline_reason,
-    )
+    return _format_declined_result(tool_name, before_context.decline_reason)
 
 
 async def _finish_blocked_tool_call(

--- a/src/mindroom/tool_system/tool_hooks.py
+++ b/src/mindroom/tool_system/tool_hooks.py
@@ -445,42 +445,15 @@ async def _emit_after_call(
     await emit(hook_registry, EVENT_TOOL_AFTER_CALL, after_context)
 
 
-async def _blocked_tool_result(
-    *,
-    hook_registry: HookRegistry,
-    resolved_context: _ResolvedToolContext,
-    hook_arguments: dict[str, Any] | None,
-    args: dict[str, Any],
-    tool_name: str,
-    reason: str,
-    has_after_hooks: bool,
-    started_at: float,
-) -> str:
-    result = _format_declined_result(tool_name, reason)
-    if has_after_hooks:
-        await _emit_after_call(
-            hook_registry=hook_registry,
-            resolved_context=resolved_context,
-            hook_arguments=hook_arguments,
-            args=args,
-            tool_name=tool_name,
-            result=result,
-            error=None,
-            blocked=True,
-            duration_ms=(time.perf_counter() - started_at) * 1000,
-        )
-    return result
+def _blocked_tool_result(*, tool_name: str, reason: str) -> str:
+    return _format_declined_result(tool_name, reason)
 
 
 async def _maybe_block_for_tool_approval(
     *,
-    hook_registry: HookRegistry,
     resolved_context: _ResolvedToolContext,
-    hook_arguments: dict[str, Any] | None,
     args: dict[str, Any],
     tool_name: str,
-    has_after_hooks: bool,
-    started_at: float,
     workflow_origin: ToolCallWorkflowOrigin | None,
 ) -> str | None:
     if resolved_context.config is None or resolved_context.runtime_paths is None:
@@ -502,29 +475,17 @@ async def _maybe_block_for_tool_approval(
         )
     except ToolApprovalScriptError:
         logger.warning("Tool approval policy failed", exc_info=True)
-        return await _blocked_tool_result(
-            hook_registry=hook_registry,
-            resolved_context=resolved_context,
-            hook_arguments=hook_arguments,
-            args=args,
+        return _blocked_tool_result(
             tool_name=tool_name,
             reason=_APPROVAL_POLICY_FAILURE_REASON,
-            has_after_hooks=has_after_hooks,
-            started_at=started_at,
         )
 
     if approval_decision is None or approval_decision.status == "approved":
         return None
 
-    return await _blocked_tool_result(
-        hook_registry=hook_registry,
-        resolved_context=resolved_context,
-        hook_arguments=hook_arguments,
-        args=args,
+    return _blocked_tool_result(
         tool_name=tool_name,
         reason=_approval_status_reason(approval_decision.status, approval_decision.reason),
-        has_after_hooks=has_after_hooks,
-        started_at=started_at,
     )
 
 
@@ -536,8 +497,6 @@ async def _maybe_block_for_before_hooks(
     args: dict[str, Any],
     tool_name: str,
     has_before_hooks: bool,
-    has_after_hooks: bool,
-    started_at: float,
 ) -> str | None:
     if not has_before_hooks:
         return None
@@ -565,16 +524,44 @@ async def _maybe_block_for_before_hooks(
     if not before_context.declined:
         return None
 
-    return await _blocked_tool_result(
+    return _blocked_tool_result(
+        tool_name=tool_name,
+        reason=before_context.decline_reason,
+    )
+
+
+async def _finish_blocked_tool_call(
+    *,
+    timing: _ToolBridgeTiming,
+    hook_registry: HookRegistry,
+    resolved_context: _ResolvedToolContext,
+    hook_arguments: dict[str, Any] | None,
+    args: dict[str, Any],
+    tool_name: str,
+    blocked_result: str,
+    has_after_hooks: bool,
+    outcome: str,
+) -> str:
+    duration_ms = timing.mark_result_ready()
+    await _maybe_emit_after_call_timed(
+        has_after_hooks=has_after_hooks,
+        timing=timing,
         hook_registry=hook_registry,
         resolved_context=resolved_context,
         hook_arguments=hook_arguments,
         args=args,
         tool_name=tool_name,
-        reason=before_context.decline_reason,
-        has_after_hooks=has_after_hooks,
-        started_at=started_at,
+        result=blocked_result,
+        error=None,
+        blocked=True,
+        duration_ms=duration_ms,
     )
+    timing.emit_finish(
+        tool_name=tool_name,
+        agent_name=resolved_context.agent_name or None,
+        outcome=outcome,
+    )
+    return blocked_result
 
 
 @dataclass(slots=True)
@@ -715,38 +702,42 @@ async def _execute_bridge(
         args=args,
         tool_name=tool_name,
         has_before_hooks=has_before_hooks,
-        has_after_hooks=has_after_hooks,
-        started_at=started_at,
     )
     if has_before_hooks:
         timing.before_hooks_ms = elapsed_ms_since(before_hooks_started_at, clock=time.perf_counter, ndigits=2)
     if blocked_result is not None:
-        timing.emit_finish(
+        return await _finish_blocked_tool_call(
+            timing=timing,
+            hook_registry=hook_registry,
+            resolved_context=resolved_context,
+            hook_arguments=hook_arguments,
+            args=args,
             tool_name=tool_name,
-            agent_name=resolved_context.agent_name or None,
+            blocked_result=blocked_result,
+            has_after_hooks=has_after_hooks,
             outcome="blocked_before_hooks",
         )
-        return blocked_result
 
     approval_started_at = time.perf_counter()
     blocked_result = await _maybe_block_for_tool_approval(
-        hook_registry=hook_registry,
         resolved_context=resolved_context,
-        hook_arguments=hook_arguments,
         args=args,
         tool_name=tool_name,
-        has_after_hooks=has_after_hooks,
-        started_at=started_at,
         workflow_origin=workflow_origin,
     )
     timing.approval_ms = elapsed_ms_since(approval_started_at, clock=time.perf_counter, ndigits=2)
     if blocked_result is not None:
-        timing.emit_finish(
+        return await _finish_blocked_tool_call(
+            timing=timing,
+            hook_registry=hook_registry,
+            resolved_context=resolved_context,
+            hook_arguments=hook_arguments,
+            args=args,
             tool_name=tool_name,
-            agent_name=resolved_context.agent_name or None,
+            blocked_result=blocked_result,
+            has_after_hooks=has_after_hooks,
             outcome="blocked_approval",
         )
-        return blocked_result
 
     result: _ToolHookResult = None
     error: BaseException | None = None

--- a/src/mindroom/tool_system/tool_hooks.py
+++ b/src/mindroom/tool_system/tool_hooks.py
@@ -587,6 +587,7 @@ class _ToolBridgeTiming:
     after_hooks_ms: float | None = None
 
     def record_timing(self) -> ToolCallTiming:
+        """Return phases persisted to tool_calls.jsonl; after hooks stay debug-event only."""
         return ToolCallTiming(
             before_hooks_ms=self.before_hooks_ms,
             approval_ms=self.approval_ms,
@@ -595,7 +596,7 @@ class _ToolBridgeTiming:
         )
 
     def mark_result_ready(self) -> float:
-        duration_ms = (time.perf_counter() - self.started_at) * 1000
+        duration_ms = elapsed_ms_since(self.started_at, clock=time.perf_counter, ndigits=2)
         self.result_ready_ms = duration_ms
         return duration_ms
 

--- a/src/mindroom/tool_system/tool_hooks.py
+++ b/src/mindroom/tool_system/tool_hooks.py
@@ -42,7 +42,7 @@ from mindroom.tool_system.runtime_context import (
     get_tool_runtime_context,
     resolve_tool_runtime_hook_bindings,
 )
-from mindroom.tool_system.tool_calls import record_tool_failure, record_tool_success
+from mindroom.tool_system.tool_calls import ToolCallTiming, record_tool_failure, record_tool_success
 from mindroom.tool_system.worker_routing import active_tool_execution_identity
 
 if TYPE_CHECKING:
@@ -253,6 +253,7 @@ def _record_debug_tool_success(
     arguments: dict[str, object],
     result: object,
     duration_ms: float,
+    timing: ToolCallTiming | None,
     resolved_context: _ResolvedToolContext,
     dispatch_context: ToolDispatchContext | None,
 ) -> None:
@@ -263,6 +264,7 @@ def _record_debug_tool_success(
         arguments=arguments,
         result=result,
         duration_ms=duration_ms,
+        timing=timing,
         agent_name=resolved_context.agent_name or None,
         room_id=resolved_context.room_id,
         thread_id=resolved_context.thread_id,
@@ -575,6 +577,100 @@ async def _maybe_block_for_before_hooks(
     )
 
 
+@dataclass(slots=True)
+class _ToolBridgeTiming:
+    started_at: float
+    before_hooks_ms: float | None = None
+    approval_ms: float | None = None
+    tool_body_ms: float | None = None
+    result_ready_ms: float | None = None
+    after_hooks_ms: float | None = None
+
+    def record_timing(self) -> ToolCallTiming:
+        return ToolCallTiming(
+            before_hooks_ms=self.before_hooks_ms,
+            approval_ms=self.approval_ms,
+            tool_body_ms=self.tool_body_ms,
+            result_ready_ms=self.result_ready_ms,
+        )
+
+    def mark_result_ready(self) -> float:
+        duration_ms = (time.perf_counter() - self.started_at) * 1000
+        self.result_ready_ms = duration_ms
+        return duration_ms
+
+    def emit_finish(self, *, tool_name: str, agent_name: str | None, outcome: str) -> None:
+        emit_timing_event(
+            "Tool hook dispatch timing",
+            phase="bridge_finish",
+            tool_name=tool_name,
+            agent_name=agent_name,
+            outcome=outcome,
+            before_hooks_ms=self.before_hooks_ms,
+            approval_ms=self.approval_ms,
+            tool_body_ms=self.tool_body_ms,
+            result_ready_ms=self.result_ready_ms,
+            after_hooks_ms=self.after_hooks_ms,
+            total_bridge_ms=elapsed_ms_since(self.started_at, clock=time.perf_counter, ndigits=2),
+        )
+
+
+async def _emit_after_call_timed(
+    *,
+    hook_registry: HookRegistry,
+    resolved_context: _ResolvedToolContext,
+    hook_arguments: dict[str, Any] | None,
+    args: dict[str, Any],
+    tool_name: str,
+    result: _ToolHookResult,
+    error: BaseException | None,
+    blocked: bool,
+    duration_ms: float,
+) -> float:
+    started_at = time.perf_counter()
+    await _emit_after_call(
+        hook_registry=hook_registry,
+        resolved_context=resolved_context,
+        hook_arguments=hook_arguments,
+        args=args,
+        tool_name=tool_name,
+        result=result,
+        error=error,
+        blocked=blocked,
+        duration_ms=duration_ms,
+    )
+    return elapsed_ms_since(started_at, clock=time.perf_counter, ndigits=2)
+
+
+async def _maybe_emit_after_call_timed(
+    *,
+    has_after_hooks: bool,
+    timing: _ToolBridgeTiming,
+    hook_registry: HookRegistry,
+    resolved_context: _ResolvedToolContext,
+    hook_arguments: dict[str, Any] | None,
+    args: dict[str, Any],
+    tool_name: str,
+    result: _ToolHookResult,
+    error: BaseException | None,
+    blocked: bool,
+    duration_ms: float,
+) -> None:
+    if not has_after_hooks:
+        return
+    timing.after_hooks_ms = await _emit_after_call_timed(
+        hook_registry=hook_registry,
+        resolved_context=resolved_context,
+        hook_arguments=hook_arguments,
+        args=args,
+        tool_name=tool_name,
+        result=result,
+        error=error,
+        blocked=blocked,
+        duration_ms=duration_ms,
+    )
+
+
 async def _execute_bridge(
     *,
     hook_registry: HookRegistry,
@@ -590,6 +686,7 @@ async def _execute_bridge(
     workflow_origin: ToolCallWorkflowOrigin | None,
 ) -> _ToolHookResult:
     started_at = time.perf_counter()
+    timing = _ToolBridgeTiming(started_at=started_at)
     effective_dispatch_context = _explicit_bridge_dispatch_context(dispatch_context) or _ambient_tool_dispatch_context()
     bridge_context = _ToolHookBridgeContext(
         agent_name=agent_name,
@@ -609,6 +706,7 @@ async def _execute_bridge(
         has_after_hooks=has_after_hooks,
     )
     hook_arguments = deepcopy(args) if has_before_hooks or has_after_hooks else None
+    before_hooks_started_at = time.perf_counter()
     blocked_result = await _maybe_block_for_before_hooks(
         hook_registry=hook_registry,
         resolved_context=resolved_context,
@@ -619,9 +717,17 @@ async def _execute_bridge(
         has_after_hooks=has_after_hooks,
         started_at=started_at,
     )
+    if has_before_hooks:
+        timing.before_hooks_ms = elapsed_ms_since(before_hooks_started_at, clock=time.perf_counter, ndigits=2)
     if blocked_result is not None:
+        timing.emit_finish(
+            tool_name=tool_name,
+            agent_name=resolved_context.agent_name or None,
+            outcome="blocked_before_hooks",
+        )
         return blocked_result
 
+    approval_started_at = time.perf_counter()
     blocked_result = await _maybe_block_for_tool_approval(
         hook_registry=hook_registry,
         resolved_context=resolved_context,
@@ -632,11 +738,18 @@ async def _execute_bridge(
         started_at=started_at,
         workflow_origin=workflow_origin,
     )
+    timing.approval_ms = elapsed_ms_since(approval_started_at, clock=time.perf_counter, ndigits=2)
     if blocked_result is not None:
+        timing.emit_finish(
+            tool_name=tool_name,
+            agent_name=resolved_context.agent_name or None,
+            outcome="blocked_approval",
+        )
         return blocked_result
 
     result: _ToolHookResult = None
     error: BaseException | None = None
+    tool_body_started_at = time.perf_counter()
     try:
         result = await _call_tool(
             func,
@@ -644,39 +757,50 @@ async def _execute_bridge(
             tool_name=tool_name,
             agent_name=resolved_context.agent_name or None,
         )
+        timing.tool_body_ms = elapsed_ms_since(tool_body_started_at, clock=time.perf_counter, ndigits=2)
     except OAuthConnectionRequired as exc:
+        timing.tool_body_ms = elapsed_ms_since(tool_body_started_at, clock=time.perf_counter, ndigits=2)
         result = oauth_connection_required_payload(exc)
-        duration_ms = (time.perf_counter() - started_at) * 1000
+        duration_ms = timing.mark_result_ready()
         _record_debug_tool_success(
             tool_name=tool_name,
             arguments=args,
             result=result,
             duration_ms=duration_ms,
+            timing=timing.record_timing(),
             resolved_context=resolved_context,
             dispatch_context=effective_dispatch_context,
         )
-        if has_after_hooks:
-            after_context = ToolAfterCallContext(
-                **resolved_context.hook_context_kwargs(
-                    hook_arguments if hook_arguments is not None else deepcopy(args),
-                ),
-                tool_name=tool_name,
-                result=result,
-                error=None,
-                blocked=False,
-                duration_ms=duration_ms,
-            )
-            await emit(hook_registry, EVENT_TOOL_AFTER_CALL, after_context)
+        await _maybe_emit_after_call_timed(
+            has_after_hooks=has_after_hooks,
+            timing=timing,
+            hook_registry=hook_registry,
+            resolved_context=resolved_context,
+            hook_arguments=hook_arguments,
+            args=args,
+            tool_name=tool_name,
+            result=result,
+            error=None,
+            blocked=False,
+            duration_ms=duration_ms,
+        )
+        timing.emit_finish(
+            tool_name=tool_name,
+            agent_name=resolved_context.agent_name or None,
+            outcome="oauth_connection_required",
+        )
         return result
     except BaseException as exc:
         error = exc
-        duration_ms = (time.perf_counter() - started_at) * 1000
+        timing.tool_body_ms = elapsed_ms_since(tool_body_started_at, clock=time.perf_counter, ndigits=2)
+        duration_ms = timing.mark_result_ready()
         try:
             failure_record = record_tool_failure(
                 tool_name=tool_name,
                 arguments=args,
                 error=error,
                 duration_ms=duration_ms,
+                timing=timing.record_timing(),
                 agent_name=resolved_context.agent_name or None,
                 room_id=resolved_context.room_id,
                 thread_id=resolved_context.thread_id,
@@ -706,41 +830,54 @@ async def _execute_bridge(
                 correlation_id=resolved_context.correlation_id,
                 channel=resolved_context.channel,
             )
-        if has_after_hooks:
-            await _emit_after_call(
-                hook_registry=hook_registry,
-                resolved_context=resolved_context,
-                hook_arguments=hook_arguments,
-                args=args,
-                tool_name=tool_name,
-                result=None,
-                error=error,
-                blocked=False,
-                duration_ms=duration_ms,
-            )
-        raise
-
-    duration_ms = (time.perf_counter() - started_at) * 1000
-    _record_debug_tool_success(
-        tool_name=tool_name,
-        arguments=args,
-        result=result,
-        duration_ms=duration_ms,
-        resolved_context=resolved_context,
-        dispatch_context=effective_dispatch_context,
-    )
-    if has_after_hooks:
-        await _emit_after_call(
+        await _maybe_emit_after_call_timed(
+            has_after_hooks=has_after_hooks,
+            timing=timing,
             hook_registry=hook_registry,
             resolved_context=resolved_context,
             hook_arguments=hook_arguments,
             args=args,
             tool_name=tool_name,
-            result=result,
+            result=None,
             error=error,
             blocked=False,
             duration_ms=duration_ms,
         )
+        timing.emit_finish(
+            tool_name=tool_name,
+            agent_name=resolved_context.agent_name or None,
+            outcome="error",
+        )
+        raise
+
+    duration_ms = timing.mark_result_ready()
+    _record_debug_tool_success(
+        tool_name=tool_name,
+        arguments=args,
+        result=result,
+        duration_ms=duration_ms,
+        timing=timing.record_timing(),
+        resolved_context=resolved_context,
+        dispatch_context=effective_dispatch_context,
+    )
+    await _maybe_emit_after_call_timed(
+        has_after_hooks=has_after_hooks,
+        timing=timing,
+        hook_registry=hook_registry,
+        resolved_context=resolved_context,
+        hook_arguments=hook_arguments,
+        args=args,
+        tool_name=tool_name,
+        result=result,
+        error=error,
+        blocked=False,
+        duration_ms=duration_ms,
+    )
+    timing.emit_finish(
+        tool_name=tool_name,
+        agent_name=resolved_context.agent_name or None,
+        outcome="success",
+    )
     return result
 
 

--- a/tests/test_dispatch_timing_instrumentation.py
+++ b/tests/test_dispatch_timing_instrumentation.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import nio
 import pytest
 from agno.models.response import ToolExecution
-from agno.run.agent import ToolCallStartedEvent
+from agno.run.agent import ToolCallCompletedEvent, ToolCallStartedEvent
 
 from mindroom import ai as ai_module
 from mindroom.config.main import Config
@@ -36,14 +36,28 @@ def _record_timing_event(
 
 @pytest.mark.asyncio
 async def test_stream_processing_marks_tool_call_started() -> None:
-    """AI stream processing should mark the handoff from model stream to tool dispatch."""
+    """AI stream processing should mark tool dispatch start and completion."""
     timing_events: list[tuple[str, dict[str, object]]] = []
 
     async def stream() -> AsyncIterator[object]:
+        tool = ToolExecution(
+            tool_name="run_shell_command",
+            tool_args={"cmd": "date +%s.%N"},
+            tool_call_id="call-1",
+        )
+        yield ToolCallStartedEvent(tool=tool)
         yield ToolCallStartedEvent(
             tool=ToolExecution(
                 tool_name="run_shell_command",
                 tool_args={"cmd": "date +%s.%N"},
+            ),
+        )
+        yield ToolCallCompletedEvent(
+            tool=ToolExecution(
+                tool_name="run_shell_command",
+                tool_args={"cmd": "date +%s.%N"},
+                tool_call_id="call-1",
+                result="ok",
             ),
         )
 
@@ -66,7 +80,7 @@ async def test_stream_processing_marks_tool_call_started() -> None:
             )
         ]
 
-    assert len(chunks) == 1
+    assert len(chunks) == 3
     assert timing_events == [
         (
             "Dispatch tool-call timing",
@@ -74,7 +88,27 @@ async def test_stream_processing_marks_tool_call_started() -> None:
                 "phase": "agno_tool_call_started",
                 "agent_name": "code",
                 "tool_name": "run_shell_command",
+                "tool_call_id": "call-1",
+                "show_tool_calls": True,
+            },
+        ),
+        (
+            "Dispatch tool-call timing",
+            {
+                "phase": "agno_tool_call_started",
+                "agent_name": "code",
+                "tool_name": "run_shell_command",
                 "tool_call_id": None,
+                "show_tool_calls": True,
+            },
+        ),
+        (
+            "Dispatch tool-call timing",
+            {
+                "phase": "agno_tool_call_completed",
+                "agent_name": "code",
+                "tool_name": "run_shell_command",
+                "tool_call_id": "call-1",
                 "show_tool_calls": True,
             },
         ),
@@ -295,9 +329,18 @@ async def test_tool_hook_bridge_marks_hook_and_tool_entry() -> None:
         ("Tool hook dispatch timing", "before_hooks_start"),
         ("Tool hook dispatch timing", "before_hooks_finish"),
         ("Tool hook dispatch timing", "tool_entry"),
+        ("Tool hook dispatch timing", "bridge_finish"),
     ]
     before_finish = timing_events[2][1]
     assert before_finish["tool_name"] == "echo"
     assert before_finish["agent_name"] == "code"
     assert before_finish["declined"] is False
     assert isinstance(before_finish["duration_ms"], float)
+    bridge_finish = timing_events[-1][1]
+    assert bridge_finish["tool_name"] == "echo"
+    assert bridge_finish["agent_name"] == "code"
+    assert bridge_finish["outcome"] == "success"
+    assert isinstance(bridge_finish["result_ready_ms"], float)
+    assert isinstance(bridge_finish["total_bridge_ms"], float)
+    assert isinstance(bridge_finish["before_hooks_ms"], float)
+    assert isinstance(bridge_finish["tool_body_ms"], float)

--- a/tests/test_dispatch_timing_instrumentation.py
+++ b/tests/test_dispatch_timing_instrumentation.py
@@ -15,11 +15,19 @@ from agno.run.agent import ToolCallCompletedEvent, ToolCallStartedEvent
 from mindroom import ai as ai_module
 from mindroom.config.main import Config
 from mindroom.config.plugin import PluginEntryConfig
-from mindroom.hooks import EVENT_TOOL_BEFORE_CALL, HookRegistry, ToolBeforeCallContext, hook
+from mindroom.hooks import (
+    EVENT_TOOL_AFTER_CALL,
+    EVENT_TOOL_BEFORE_CALL,
+    HookRegistry,
+    ToolAfterCallContext,
+    ToolBeforeCallContext,
+    hook,
+)
 from mindroom.matrix.cache.thread_writes import ThreadOutboundWritePolicy
 from mindroom.matrix.client_delivery import send_message_result
 from mindroom.media_inputs import MediaInputs
 from mindroom.streaming import _queue_delivery_request
+from mindroom.tool_system import tool_hooks as tool_hooks_module
 from mindroom.tool_system.tool_hooks import build_tool_hook_bridge
 
 if TYPE_CHECKING:
@@ -344,3 +352,65 @@ async def test_tool_hook_bridge_marks_hook_and_tool_entry() -> None:
     assert isinstance(bridge_finish["total_bridge_ms"], float)
     assert isinstance(bridge_finish["before_hooks_ms"], float)
     assert isinstance(bridge_finish["tool_body_ms"], float)
+
+
+@pytest.mark.asyncio
+async def test_tool_hook_bridge_times_blocked_after_hooks_separately(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Blocked calls should not attribute after-hook latency to the blocking phase."""
+    timing_events: list[tuple[str, dict[str, object]]] = []
+    after_seen: list[tuple[bool, object | None, float]] = []
+
+    @hook(EVENT_TOOL_BEFORE_CALL)
+    async def before(ctx: ToolBeforeCallContext) -> None:
+        ctx.decline("policy blocked the tool")
+
+    @hook(EVENT_TOOL_AFTER_CALL)
+    async def after(ctx: ToolAfterCallContext) -> None:
+        after_seen.append((ctx.blocked, ctx.result, ctx.duration_ms))
+
+    registry = HookRegistry.from_plugins(
+        [
+            SimpleNamespace(
+                name="tool-policy",
+                discovered_hooks=(before, after),
+                entry_config=PluginEntryConfig(path="./plugins/tool-policy", settings={}),
+                plugin_order=0,
+            ),
+        ],
+    )
+    bridge = build_tool_hook_bridge(registry, agent_name="code")
+    next_func = AsyncMock(return_value="should not run")
+    perf_counter = Mock(
+        side_effect=[
+            100.000,  # bridge start
+            100.001,  # outer before-hooks start
+            100.002,  # before-hooks timing event start
+            100.003,  # before-hooks timing event finish
+            100.004,  # outer before-hooks finish
+            100.005,  # result ready
+            100.006,  # after-hooks start
+            100.026,  # after-hooks finish
+            100.027,  # bridge finish
+        ],
+    )
+    monkeypatch.setattr(tool_hooks_module.time, "perf_counter", perf_counter)
+
+    with patch(
+        "mindroom.tool_system.tool_hooks.emit_timing_event",
+        side_effect=lambda *args, **kwargs: _record_timing_event(timing_events, *args, **kwargs),
+    ):
+        result = await bridge("read_file", next_func, {"path": "secret.txt"})
+
+    assert next_func.await_count == 0
+    assert after_seen == [(True, result, 5.0)]
+    bridge_finish = next(
+        event_data
+        for event_name, event_data in timing_events
+        if event_name == "Tool hook dispatch timing" and event_data["phase"] == "bridge_finish"
+    )
+    assert bridge_finish["outcome"] == "blocked_before_hooks"
+    assert bridge_finish["before_hooks_ms"] == 3.0
+    assert bridge_finish["result_ready_ms"] == 5.0
+    assert bridge_finish["after_hooks_ms"] == 20.0
+    assert bridge_finish["approval_ms"] is None
+    assert bridge_finish["tool_body_ms"] is None

--- a/tests/test_team_media_fallback.py
+++ b/tests/test_team_media_fallback.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import tempfile
+from contextlib import nullcontext
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -22,6 +23,8 @@ from agno.run.team import RunCancelledEvent as TeamRunCancelledEvent
 from agno.run.team import RunContentEvent as TeamRunContentEvent
 from agno.run.team import RunErrorEvent as TeamRunErrorEvent
 from agno.run.team import TeamRunOutput
+from agno.run.team import ToolCallCompletedEvent as TeamToolCallCompletedEvent
+from agno.run.team import ToolCallStartedEvent as TeamToolCallStartedEvent
 from agno.team import Team as AgnoTeam
 from agno.team._run import _cleanup_and_store
 from agno.utils.message import get_text_from_message
@@ -54,6 +57,7 @@ from mindroom.team_exact_members import (
 from mindroom.teams import (
     TeamMode,
     _materialize_team_members,
+    _PreparedMaterializedTeamExecution,
     _team_response_stream_raw,
     build_materialized_team_instance,
     materialize_exact_team_members,
@@ -1987,6 +1991,160 @@ async def test_team_response_stream_records_hidden_interrupted_tool_state() -> N
         "  result: /app\n\n"
         "[interrupted]"
     )
+
+
+@pytest.mark.asyncio
+async def test_team_response_stream_marks_tool_call_timing_for_agent_and_team_tools() -> None:
+    """Streaming team tool events should emit the same debug timing marks as agent streams."""
+    config = _build_test_config()
+    runtime_paths = runtime_paths_for(config)
+    orchestrator = MagicMock()
+    orchestrator.config = config
+    orchestrator.runtime_paths = runtime_paths
+    orchestrator.knowledge_managers = {}
+    orchestrator.agent_bots = {"general": MagicMock(running=True)}
+    timing_events: list[tuple[str, dict[str, object]]] = []
+
+    fake_agent = _make_test_agent("GeneralAgent")
+    team_members = ResolvedExactTeamMembers(
+        requested_agent_names=["general"],
+        agents=[fake_agent],
+        display_names=["GeneralAgent"],
+        materialized_agent_names={"general"},
+        failed_agent_names=[],
+    )
+
+    async def fake_stream_raw(*_args: object, **_kwargs: object) -> AsyncIterator[object]:
+        yield AgentToolCallStartedEvent(
+            agent_name="GeneralAgent",
+            tool=ToolExecution(
+                tool_name="run_shell_command",
+                tool_args={"cmd": "pwd"},
+                tool_call_id="agent-call-1",
+            ),
+        )
+        yield AgentToolCallCompletedEvent(
+            agent_name="GeneralAgent",
+            tool=ToolExecution(
+                tool_name="run_shell_command",
+                tool_args={"cmd": "pwd"},
+                tool_call_id="agent-call-1",
+                result="/app",
+            ),
+        )
+        yield TeamToolCallStartedEvent(
+            tool=ToolExecution(
+                tool_name="delegate_task",
+                tool_args={"agent": "general"},
+                tool_call_id="team-call-1",
+            ),
+        )
+        yield TeamToolCallCompletedEvent(
+            tool=ToolExecution(
+                tool_name="delegate_task",
+                tool_args={"agent": "general"},
+                tool_call_id="team-call-1",
+                result="delegated",
+            ),
+        )
+        yield TeamRunContentEvent(content="Done")
+
+    team_agent_ids = [
+        fixture_entity_matrix_id(
+            "general",
+            config.get_domain(runtime_paths),
+            runtime_paths,
+        ),
+    ]
+
+    with (
+        patch("mindroom.teams._materialize_team_members", return_value=team_members),
+        patch("mindroom.teams.open_bound_scope_session_context", return_value=nullcontext(None)),
+        patch("mindroom.teams._create_team_instance", return_value=_make_test_team()),
+        patch(
+            "mindroom.teams.prepare_materialized_team_execution",
+            new=AsyncMock(
+                return_value=_PreparedMaterializedTeamExecution(
+                    messages=(Message(role="user", content="Analyze this."),),
+                    run_metadata={},
+                    unseen_event_ids=[],
+                ),
+            ),
+        ),
+        patch("mindroom.teams._team_response_stream_raw", new=AsyncMock(side_effect=fake_stream_raw)),
+        patch(
+            "mindroom.teams.emit_timing_event",
+            side_effect=lambda event_name, **event_data: timing_events.append((event_name, event_data)),
+            create=True,
+        ),
+    ):
+        chunks = [
+            chunk
+            async for chunk in team_response_stream(
+                agent_ids=team_agent_ids,
+                message="Analyze this.",
+                turn_recorder=TurnRecorder(user_message="Analyze this."),
+                orchestrator=orchestrator,
+                execution_identity=None,
+                mode=TeamMode.COORDINATE,
+                session_id="session-team-stream",
+                run_id="run-456",
+                reply_to_event_id="e1",
+                show_tool_calls=True,
+            )
+        ]
+
+    assert chunks
+    assert timing_events == [
+        (
+            "Dispatch tool-call timing",
+            {
+                "phase": "agno_tool_call_started",
+                "team_name": "Team (GeneralAgent)",
+                "tool_scope": "member",
+                "agent_name": "GeneralAgent",
+                "tool_name": "run_shell_command",
+                "tool_call_id": "agent-call-1",
+                "show_tool_calls": True,
+            },
+        ),
+        (
+            "Dispatch tool-call timing",
+            {
+                "phase": "agno_tool_call_completed",
+                "team_name": "Team (GeneralAgent)",
+                "tool_scope": "member",
+                "agent_name": "GeneralAgent",
+                "tool_name": "run_shell_command",
+                "tool_call_id": "agent-call-1",
+                "show_tool_calls": True,
+            },
+        ),
+        (
+            "Dispatch tool-call timing",
+            {
+                "phase": "agno_tool_call_started",
+                "team_name": "Team (GeneralAgent)",
+                "tool_scope": "team",
+                "agent_name": None,
+                "tool_name": "delegate_task",
+                "tool_call_id": "team-call-1",
+                "show_tool_calls": True,
+            },
+        ),
+        (
+            "Dispatch tool-call timing",
+            {
+                "phase": "agno_tool_call_completed",
+                "team_name": "Team (GeneralAgent)",
+                "tool_scope": "team",
+                "agent_name": None,
+                "tool_name": "delegate_task",
+                "tool_call_id": "team-call-1",
+                "show_tool_calls": True,
+            },
+        ),
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_call_benchmark.py
+++ b/tests/test_tool_call_benchmark.py
@@ -5,6 +5,28 @@ from __future__ import annotations
 from scripts.testing.benchmark_tool_call_overhead import summarize_samples
 
 
+def test_summarize_samples_reports_zeroes_for_empty_samples() -> None:
+    """Empty benchmark runs should still emit a complete summary shape."""
+    assert summarize_samples([]) == {
+        "count": 0,
+        "mean_ms": 0.0,
+        "p50_ms": 0.0,
+        "p95_ms": 0.0,
+        "max_ms": 0.0,
+    }
+
+
+def test_summarize_samples_reports_single_sample_for_all_percentiles() -> None:
+    """Single-sample summaries should not overrun percentile indexing."""
+    assert summarize_samples([1.2345]) == {
+        "count": 1,
+        "mean_ms": 1.234,
+        "p50_ms": 1.234,
+        "p95_ms": 1.234,
+        "max_ms": 1.234,
+    }
+
+
 def test_summarize_samples_reports_nearest_rank_percentiles() -> None:
     """Benchmark summaries should stay deterministic for small sample sets."""
     summary = summarize_samples([4.0, 1.0, 3.0, 2.0])

--- a/tests/test_tool_call_benchmark.py
+++ b/tests/test_tool_call_benchmark.py
@@ -1,0 +1,18 @@
+"""Tests for synthetic tool-call benchmark helpers."""
+
+from __future__ import annotations
+
+from scripts.testing.benchmark_tool_call_overhead import summarize_samples
+
+
+def test_summarize_samples_reports_nearest_rank_percentiles() -> None:
+    """Benchmark summaries should stay deterministic for small sample sets."""
+    summary = summarize_samples([4.0, 1.0, 3.0, 2.0])
+
+    assert summary == {
+        "count": 4,
+        "mean_ms": 2.5,
+        "p50_ms": 2.0,
+        "p95_ms": 4.0,
+        "max_ms": 4.0,
+    }

--- a/tests/test_tool_calls.py
+++ b/tests/test_tool_calls.py
@@ -439,7 +439,6 @@ def test_tool_call_records_include_success_and_failure_rows(tmp_path: Path) -> N
         arguments={"api_key": "secret"},
         result={"authorization": "Bearer hidden-token", "ok": True},
         duration_ms=5.0,
-        tool_call_id="call-1",
         timing=ToolCallTiming(
             before_hooks_ms=1.111,
             approval_ms=2.222,
@@ -475,7 +474,6 @@ def test_tool_call_records_include_success_and_failure_rows(tmp_path: Path) -> N
     assert success_record.success is True
     assert success_record.result == {"authorization": "***redacted***", "ok": True}
     assert success_record.reply_to_event_id == "$reply"
-    assert success_record.tool_call_id == "call-1"
     assert success_record.timing == ToolCallTiming(
         before_hooks_ms=1.111,
         approval_ms=2.222,
@@ -489,7 +487,6 @@ def test_tool_call_records_include_success_and_failure_rows(tmp_path: Path) -> N
     assert len(records) == 2
     assert records[0]["success"] is True
     assert records[0]["reply_to_event_id"] == "$reply"
-    assert records[0]["tool_call_id"] == "call-1"
     assert records[0]["timing"] == {
         "approval_ms": 2.22,
         "before_hooks_ms": 1.11,
@@ -500,8 +497,55 @@ def test_tool_call_records_include_success_and_failure_rows(tmp_path: Path) -> N
     assert records[1]["success"] is False
     assert records[1]["reply_to_event_id"] == "$reply"
     assert records[1]["error_type"] == "RuntimeError"
+    assert "timing" not in records[1]
     for key in ("agent_name", "channel", "room_id", "thread_id", "requester_id", "session_id", "correlation_id"):
         assert records[0][key] == records[1][key]
+
+
+def test_tool_call_records_omit_timing_when_none(tmp_path: Path) -> None:
+    """Tool-call rows should omit timing when no phases were measured."""
+    runtime_paths = test_runtime_paths(tmp_path)
+    log_path = tracking_dir(runtime_paths) / "tool_calls.jsonl"
+
+    success_record = record_tool_success(
+        tool_name="echo",
+        arguments={},
+        result="ok",
+        duration_ms=1.0,
+        timing=None,
+        agent_name="code",
+        room_id="!room:localhost",
+        thread_id="$resolved-thread",
+        reply_to_event_id="$reply-success",
+        requester_id="@user:localhost",
+        session_id="session-1",
+        correlation_id="corr-no-timing",
+        execution_identity=_execution_identity(),
+        runtime_paths=runtime_paths,
+    )
+    failure_record = record_tool_failure(
+        tool_name="explode",
+        arguments={},
+        error=RuntimeError("boom"),
+        duration_ms=2.0,
+        timing=None,
+        agent_name="code",
+        room_id="!room:localhost",
+        thread_id="$resolved-thread",
+        reply_to_event_id="$reply-failure",
+        requester_id="@user:localhost",
+        session_id="session-1",
+        correlation_id="corr-no-timing",
+        execution_identity=_execution_identity(),
+        runtime_paths=runtime_paths,
+    )
+
+    assert "timing" not in success_record.as_dict()
+    assert "timing" not in failure_record.as_dict()
+
+    records = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines() if line]
+    assert len(records) == 2
+    assert all("timing" not in record for record in records)
 
 
 def test_record_tool_failure_logs_secondary_write_errors(tmp_path: Path) -> None:

--- a/tests/test_tool_calls.py
+++ b/tests/test_tool_calls.py
@@ -502,12 +502,12 @@ def test_tool_call_records_include_success_and_failure_rows(tmp_path: Path) -> N
         assert records[0][key] == records[1][key]
 
 
-def test_tool_call_records_omit_timing_when_none(tmp_path: Path) -> None:
+def test_tool_call_records_omit_timing_without_measured_phases(tmp_path: Path) -> None:
     """Tool-call rows should omit timing when no phases were measured."""
     runtime_paths = test_runtime_paths(tmp_path)
     log_path = tracking_dir(runtime_paths) / "tool_calls.jsonl"
 
-    success_record = record_tool_success(
+    none_success_record = record_tool_success(
         tool_name="echo",
         arguments={},
         result="ok",
@@ -523,7 +523,7 @@ def test_tool_call_records_omit_timing_when_none(tmp_path: Path) -> None:
         execution_identity=_execution_identity(),
         runtime_paths=runtime_paths,
     )
-    failure_record = record_tool_failure(
+    none_failure_record = record_tool_failure(
         tool_name="explode",
         arguments={},
         error=RuntimeError("boom"),
@@ -539,12 +539,46 @@ def test_tool_call_records_omit_timing_when_none(tmp_path: Path) -> None:
         execution_identity=_execution_identity(),
         runtime_paths=runtime_paths,
     )
+    empty_success_record = record_tool_success(
+        tool_name="empty-timing",
+        arguments={},
+        result="ok",
+        duration_ms=3.0,
+        timing=ToolCallTiming(),
+        agent_name="code",
+        room_id="!room:localhost",
+        thread_id="$resolved-thread",
+        reply_to_event_id="$reply-empty-success",
+        requester_id="@user:localhost",
+        session_id="session-1",
+        correlation_id="corr-empty-timing",
+        execution_identity=_execution_identity(),
+        runtime_paths=runtime_paths,
+    )
+    empty_failure_record = record_tool_failure(
+        tool_name="empty-timing-failure",
+        arguments={},
+        error=RuntimeError("boom"),
+        duration_ms=4.0,
+        timing=ToolCallTiming(),
+        agent_name="code",
+        room_id="!room:localhost",
+        thread_id="$resolved-thread",
+        reply_to_event_id="$reply-empty-failure",
+        requester_id="@user:localhost",
+        session_id="session-1",
+        correlation_id="corr-empty-timing",
+        execution_identity=_execution_identity(),
+        runtime_paths=runtime_paths,
+    )
 
-    assert "timing" not in success_record.as_dict()
-    assert "timing" not in failure_record.as_dict()
+    assert "timing" not in none_success_record.as_dict()
+    assert "timing" not in none_failure_record.as_dict()
+    assert "timing" not in empty_success_record.as_dict()
+    assert "timing" not in empty_failure_record.as_dict()
 
     records = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines() if line]
-    assert len(records) == 2
+    assert len(records) == 4
     assert all("timing" not in record for record in records)
 
 

--- a/tests/test_tool_calls.py
+++ b/tests/test_tool_calls.py
@@ -12,6 +12,7 @@ import pytest
 from mindroom.constants import tracking_dir
 from mindroom.tool_system import tool_calls
 from mindroom.tool_system.tool_calls import (
+    ToolCallTiming,
     _build_tool_failure_record,
     _build_tool_success_record,
     record_tool_failure,
@@ -438,6 +439,13 @@ def test_tool_call_records_include_success_and_failure_rows(tmp_path: Path) -> N
         arguments={"api_key": "secret"},
         result={"authorization": "Bearer hidden-token", "ok": True},
         duration_ms=5.0,
+        tool_call_id="call-1",
+        timing=ToolCallTiming(
+            before_hooks_ms=1.111,
+            approval_ms=2.222,
+            tool_body_ms=3.333,
+            result_ready_ms=6.666,
+        ),
         agent_name="code",
         room_id="!room:localhost",
         thread_id="$resolved-thread",
@@ -467,6 +475,13 @@ def test_tool_call_records_include_success_and_failure_rows(tmp_path: Path) -> N
     assert success_record.success is True
     assert success_record.result == {"authorization": "***redacted***", "ok": True}
     assert success_record.reply_to_event_id == "$reply"
+    assert success_record.tool_call_id == "call-1"
+    assert success_record.timing == ToolCallTiming(
+        before_hooks_ms=1.111,
+        approval_ms=2.222,
+        tool_body_ms=3.333,
+        result_ready_ms=6.666,
+    )
     assert failure_record.success is False
     assert failure_record.reply_to_event_id == "$reply"
 
@@ -474,6 +489,13 @@ def test_tool_call_records_include_success_and_failure_rows(tmp_path: Path) -> N
     assert len(records) == 2
     assert records[0]["success"] is True
     assert records[0]["reply_to_event_id"] == "$reply"
+    assert records[0]["tool_call_id"] == "call-1"
+    assert records[0]["timing"] == {
+        "approval_ms": 2.22,
+        "before_hooks_ms": 1.11,
+        "result_ready_ms": 6.67,
+        "tool_body_ms": 3.33,
+    }
     assert records[0]["result"] == {"authorization": "***redacted***", "ok": True}
     assert records[1]["success"] is False
     assert records[1]["reply_to_event_id"] == "$reply"

--- a/tests/test_tool_hooks.py
+++ b/tests/test_tool_hooks.py
@@ -528,6 +528,7 @@ async def test_tool_hook_bridge_records_failures_without_registered_hooks(tmp_pa
         "success",
         "error_type",
         "error_message",
+        "timing",
         "traceback",
     }
     assert records[0]["tool_name"] == "explode"
@@ -541,6 +542,9 @@ async def test_tool_hook_bridge_records_failures_without_registered_hooks(tmp_pa
     assert records[0]["correlation_id"] == "corr-runtime"
     assert records[0]["success"] is False
     assert records[0]["error_type"] == "ValueError"
+    assert isinstance(records[0]["timing"]["approval_ms"], float)
+    assert isinstance(records[0]["timing"]["result_ready_ms"], float)
+    assert isinstance(records[0]["timing"]["tool_body_ms"], float)
     assert records[0]["arguments"] == {
         "api_key": "***redacted***",
         "nested": [{"refresh_token": "***redacted***"}],


### PR DESCRIPTION
## Summary
- Add per-tool-call timing breakdowns for before hooks, approval, tool body, and result readiness.
- Emit timing events for stream-visible tool-call completion and bridge completion.
- Add a synthetic benchmark helper for raw tool-call bridge overhead.

## Testing
- `uv sync --all-extras`
- `uv run pytest -q`
- `uv run pytest tests/test_tool_calls.py tests/test_tool_hooks.py tests/test_dispatch_timing_instrumentation.py tests/test_tool_call_benchmark.py -q`
- `uv run pytest tests/test_tool_call_benchmark.py -q`
- `uv run pre-commit run --all-files`
- `uv run python scripts/testing/benchmark_tool_call_overhead.py --iterations 2 --warmup 1`

## Summary by Sourcery

Instrument per-phase timing for tool-call execution and dispatch, and add tooling to benchmark and document the overhead.

New Features:
- Capture structured timing breakdowns for tool calls, including before hooks, approval, tool body, and result readiness, and persist them in tool-call records.
- Emit additional timing events for stream-visible tool-call start and completion, as well as full bridge completion outcomes.
- Introduce a synthetic benchmark script and helpers to measure tool-call bridge overhead under different hook configurations.

Enhancements:
- Extend tool-call records with tool_call_id and timing metadata to improve correlation with stream events and debug logs.
- Refine hook dispatch to conditionally time after-call hooks and centralize timing event emission for different bridge outcomes.

Documentation:
- Update configuration documentation and reference materials to describe the new timing fields in tool-call logs and the MINDROOM_TIMING flag for debug timing events.

Tests:
- Add and update tests to cover dispatch timing events, tool-call timing persistence, hook timing instrumentation, and benchmark summary helpers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured, per-phase timing breakdowns for tool calls (now persisted for successful outcomes) and emitted additional stream-visible timing events, including completion and overall bridge finish details.
  * Added an environment flag to enable extra debug timing output.
  * Added a standalone benchmark script to measure tool-call bridge overhead.
* **Documentation**
  * Updated debug logging documentation to describe the new timing fields and timing-mode behavior.
* **Bug Fixes**
  * Improved streaming instrumentation so tool-call start and completion timing events are consistently reported.
* **Tests**
  * Expanded timing instrumentation and record-persistence coverage, including new benchmark and timing-serialization cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->