### PR TITLE
Handle OpenAI audio format fallback

### DIFF
--- a/src/mindroom/media_fallback.py
+++ b/src/mindroom/media_fallback.py
@@ -40,9 +40,7 @@ _INLINE_MEDIA_FIELD_PATTERN = re.compile(
 )
 _INLINE_MEDIA_MIME_MISMATCH_PATTERN = re.compile(r"image was specified using the .* media type")
 _INLINE_MEDIA_GENERIC_UNSUPPORTED_PATTERN = re.compile(r"(?:inline media|media input) is not supported")
-_OPENAI_AUDIO_FORMAT_VALIDATION_PATTERN = re.compile(
-    r"(?:input_audio\.format|invalid value: ['\"][^'\"]+['\"].*supported values are: ['\"]wav['\"] and ['\"]mp3['\"])",
-)
+_OPENAI_AUDIO_FORMAT_VALIDATION_PATTERN = re.compile(r"\binput_audio\.format\b")
 _MEDIA_KIND_PATTERN = r"audio|image|video|file|document"
 _INLINE_MEDIA_UNSUPPORTED_PATTERNS = (
     re.compile(rf"(?P<kind>{_MEDIA_KIND_PATTERN}) input is not supported"),

--- a/src/mindroom/media_fallback.py
+++ b/src/mindroom/media_fallback.py
@@ -40,6 +40,9 @@ _INLINE_MEDIA_FIELD_PATTERN = re.compile(
 )
 _INLINE_MEDIA_MIME_MISMATCH_PATTERN = re.compile(r"image was specified using the .* media type")
 _INLINE_MEDIA_GENERIC_UNSUPPORTED_PATTERN = re.compile(r"(?:inline media|media input) is not supported")
+_OPENAI_AUDIO_FORMAT_VALIDATION_PATTERN = re.compile(
+    r"(?:input_audio\.format|invalid value: ['\"][^'\"]+['\"].*supported values are: ['\"]wav['\"] and ['\"]mp3['\"])",
+)
 _MEDIA_KIND_PATTERN = r"audio|image|video|file|document"
 _INLINE_MEDIA_UNSUPPORTED_PATTERNS = (
     re.compile(rf"(?P<kind>{_MEDIA_KIND_PATTERN}) input is not supported"),
@@ -231,6 +234,8 @@ def _media_validation_kinds_from_error(error_text: str) -> frozenset[MediaKind]:
     }
     if _INLINE_MEDIA_MIME_MISMATCH_PATTERN.search(lowered_error_text):
         kinds.add("image")
+    if _OPENAI_AUDIO_FORMAT_VALIDATION_PATTERN.search(lowered_error_text):
+        kinds.add("audio")
     return frozenset(kinds)
 
 

--- a/src/mindroom/media_fallback.py
+++ b/src/mindroom/media_fallback.py
@@ -40,7 +40,11 @@ _INLINE_MEDIA_FIELD_PATTERN = re.compile(
 )
 _INLINE_MEDIA_MIME_MISMATCH_PATTERN = re.compile(r"image was specified using the .* media type")
 _INLINE_MEDIA_GENERIC_UNSUPPORTED_PATTERN = re.compile(r"(?:inline media|media input) is not supported")
-_OPENAI_AUDIO_FORMAT_VALIDATION_PATTERN = re.compile(r"\binput_audio\.format\b")
+_OPENAI_AUDIO_FORMAT_FIELD_PATTERN = re.compile(r"\binput_audio\.format\b")
+_OPENAI_AUDIO_FORMAT_VALUE_PATTERN = re.compile(
+    r"invalid value: ['\"][^'\"]+['\"].*supported values are: ['\"]wav['\"] and ['\"]mp3['\"]",
+)
+_OPENAI_OUTPUT_FORMAT_PATTERN = re.compile(r"\boutput_format\b")
 _MEDIA_KIND_PATTERN = r"audio|image|video|file|document"
 _INLINE_MEDIA_UNSUPPORTED_PATTERNS = (
     re.compile(rf"(?P<kind>{_MEDIA_KIND_PATTERN}) input is not supported"),
@@ -232,7 +236,10 @@ def _media_validation_kinds_from_error(error_text: str) -> frozenset[MediaKind]:
     }
     if _INLINE_MEDIA_MIME_MISMATCH_PATTERN.search(lowered_error_text):
         kinds.add("image")
-    if _OPENAI_AUDIO_FORMAT_VALIDATION_PATTERN.search(lowered_error_text):
+    if _OPENAI_AUDIO_FORMAT_FIELD_PATTERN.search(lowered_error_text) or (
+        _OPENAI_AUDIO_FORMAT_VALUE_PATTERN.search(lowered_error_text)
+        and not _OPENAI_OUTPUT_FORMAT_PATTERN.search(lowered_error_text)
+    ):
         kinds.add("audio")
     return frozenset(kinds)
 

--- a/tests/test_media_fallback.py
+++ b/tests/test_media_fallback.py
@@ -155,6 +155,20 @@ def test_openai_invalid_audio_format_error_retries_without_caching() -> None:
     assert filtered.media_inputs == media
 
 
+def test_openai_supported_audio_values_without_audio_field_does_not_retry() -> None:
+    """Wav/mp3 validation text alone should not be treated as an audio input failure."""
+    reset_model_media_capability_cache()
+    media = _media_inputs()
+    route = _route()
+    error = "Invalid value: 'bin'. Supported values are: 'wav' and 'mp3'. parameter=output_format"
+
+    decision = retry_media_inputs_after_failure(route, error, media)
+
+    assert decision.should_retry is False
+    assert decision.media_inputs == media
+    assert filter_media_inputs_for_route(route, media).media_inputs == media
+
+
 def test_context_media_kinds_enable_retry_without_current_turn_media() -> None:
     """Media pinned to history messages should still trigger retry and teach the cache."""
     reset_model_media_capability_cache()

--- a/tests/test_media_fallback.py
+++ b/tests/test_media_fallback.py
@@ -131,6 +131,30 @@ def test_generic_media_error_retries_without_caching() -> None:
     assert filtered.media_inputs == media
 
 
+def test_openai_invalid_audio_format_error_retries_without_caching() -> None:
+    """OpenAI audio format validation errors should drop audio for the retry only."""
+    reset_model_media_capability_cache()
+    media = _media_inputs()
+    route = _route()
+    error = (
+        "litellm.BadRequestError: OpenAIException - Invalid value: 'bin'. "
+        "Supported values are: 'wav' and 'mp3'.. Received Model Group=gpt-5.5 "
+        "messages[3].content[1].input_audio.format"
+    )
+
+    decision = retry_media_inputs_after_failure(route, error, media)
+
+    assert decision.should_retry is True
+    assert decision.removed_kinds == frozenset({"audio"})
+    assert decision.media_inputs.audio == ()
+    assert decision.media_inputs.images == media.images
+    assert decision.media_inputs.files == media.files
+    assert decision.media_inputs.videos == media.videos
+
+    filtered = filter_media_inputs_for_route(route, media)
+    assert filtered.media_inputs == media
+
+
 def test_context_media_kinds_enable_retry_without_current_turn_media() -> None:
     """Media pinned to history messages should still trigger retry and teach the cache."""
     reset_model_media_capability_cache()

--- a/tests/test_media_fallback.py
+++ b/tests/test_media_fallback.py
@@ -155,6 +155,25 @@ def test_openai_invalid_audio_format_error_retries_without_caching() -> None:
     assert filtered.media_inputs == media
 
 
+def test_openai_invalid_audio_format_message_without_field_retries_without_caching() -> None:
+    """LiteLLM can omit OpenAI's input_audio.format field from the surfaced message."""
+    reset_model_media_capability_cache()
+    media = _media_inputs()
+    route = _route()
+    error = (
+        "litellm.BadRequestError: OpenAIException - Invalid value: 'bin'. "
+        "Supported values are: 'wav' and 'mp3'.. Received Model Group=gpt-5.5"
+    )
+
+    decision = retry_media_inputs_after_failure(route, error, media)
+
+    assert decision.should_retry is True
+    assert decision.removed_kinds == frozenset({"audio"})
+    assert decision.media_inputs.audio == ()
+    assert decision.media_inputs.images == media.images
+    assert filter_media_inputs_for_route(route, media).media_inputs == media
+
+
 def test_openai_supported_audio_values_without_audio_field_does_not_retry() -> None:
     """Wav/mp3 validation text alone should not be treated as an audio input failure."""
     reset_model_media_capability_cache()


### PR DESCRIPTION
## Summary
- detect OpenAI input audio format validation errors as audio media fallback triggers
- retry once without audio instead of surfacing raw `bin` format rejection
- add regression coverage for GPT-5.5/LiteLLM `input_audio.format` errors

## Tests
- `UV_CACHE_DIR=.uv-cache uv run pytest tests/test_media_fallback.py -q`
- `UV_CACHE_DIR=.uv-cache uv run ruff check src/mindroom/media_fallback.py tests/test_media_fallback.py`

## Summary by Sourcery

Handle OpenAI audio format validation errors as media fallback triggers and ensure requests are retried without audio instead of failing.

Bug Fixes:
- Treat OpenAI/LiteLLM invalid input_audio.format errors as audio validation failures that trigger a retry without audio media.

Tests:
- Add regression test covering OpenAI/LiteLLM invalid audio format errors and confirming audio is dropped only for the retry while preserving cache behavior.