### PR TITLE
Clarify delegate tool target allowlist

### DIFF
--- a/src/mindroom/custom_tools/delegate.py
+++ b/src/mindroom/custom_tools/delegate.py
@@ -78,16 +78,14 @@ class DelegateTools(Toolkit):
             f"Allowed delegate targets for this caller: {available_targets}.\n"
             "Do not use any other agent names.\n"
             "Use this when you need one listed specialist agent to handle a specific subtask.\n"
-            "The delegated agent runs independently with no shared history."
+            "The delegated agent runs independently with no shared conversation history."
         )
 
     async def delegate_task(self, agent_name: str, task: str) -> str:
         """Delegate a task to one allowed agent and return its response.
 
-        Use this when you need a listed specialist agent to handle a specific subtask.
-        Choose agent_name from the allowed targets in this tool description.
-        Do not use unlisted agent names.
-        The delegated agent runs independently with no shared history.
+        The runtime-generated tool description lists caller-specific allowed
+        targets and model guidance.
 
         Args:
             agent_name: Name of the agent to delegate to (must be one of your configured targets).

--- a/src/mindroom/custom_tools/delegate.py
+++ b/src/mindroom/custom_tools/delegate.py
@@ -57,6 +57,7 @@ class DelegateTools(Toolkit):
             instructions=self._build_instructions(),
             tools=[self.delegate_task],
         )
+        self.async_functions["delegate_task"].description = self._build_delegate_task_description()
 
     def _build_instructions(self) -> str:
         """Build toolkit instructions listing available delegation targets."""
@@ -69,10 +70,23 @@ class DelegateTools(Toolkit):
             agent_descriptions="\n\n".join(lines),
         )
 
-    async def delegate_task(self, agent_name: str, task: str) -> str:
-        """Delegate a task to another agent and return its response.
+    def _build_delegate_task_description(self) -> str:
+        """Build the model-facing function description with this caller's allowlist."""
+        available_targets = ", ".join(self._delegate_to)
+        return (
+            "Delegate a task to one allowed agent and return its response.\n"
+            f"Allowed delegate targets for this caller: {available_targets}.\n"
+            "Do not use any other agent names.\n"
+            "Use this when you need one listed specialist agent to handle a specific subtask.\n"
+            "The delegated agent runs independently with no shared history."
+        )
 
-        Use this when you need a specialist agent to handle a specific subtask.
+    async def delegate_task(self, agent_name: str, task: str) -> str:
+        """Delegate a task to one allowed agent and return its response.
+
+        Use this when you need a listed specialist agent to handle a specific subtask.
+        Choose agent_name from the allowed targets in this tool description.
+        Do not use unlisted agent names.
         The delegated agent runs independently with no shared history.
 
         Args:

--- a/tests/test_delegate_tools.py
+++ b/tests/test_delegate_tools.py
@@ -18,6 +18,7 @@ from mindroom.custom_tools.delegate import MAX_DELEGATION_DEPTH, DelegateTools
 from mindroom.knowledge.availability import KnowledgeAvailability
 from mindroom.knowledge.indexing_config import IndexingSettings
 from mindroom.knowledge.utils import _KnowledgeResolution
+from mindroom.tool_schema_cache import process_function_schema_for_prompt
 from mindroom.tool_system.metadata import TOOL_METADATA
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, get_tool_runtime_context, tool_runtime_context
 from mindroom.tool_system.worker_routing import ToolExecutionIdentity
@@ -138,6 +139,16 @@ class TestDelegateTools:
         assert "research" in instructions
         assert "Generate code" in instructions
         assert "Research topics" in instructions
+
+    def test_model_facing_tool_description_lists_allowed_targets(self, tools: DelegateTools) -> None:
+        """Test that the model-visible function description includes delegation targets."""
+        function = tools.async_functions["delegate_task"].model_copy(deep=True)
+
+        process_function_schema_for_prompt(function, strict=False)
+
+        assert function.description is not None
+        assert "Allowed delegate targets for this caller: code, research." in function.description
+        assert "Do not use any other agent names." in function.description
 
     @pytest.mark.asyncio
     async def test_delegate_to_unknown_agent(self, tools: DelegateTools) -> None:

--- a/tests/test_delegate_tools.py
+++ b/tests/test_delegate_tools.py
@@ -147,8 +147,14 @@ class TestDelegateTools:
         process_function_schema_for_prompt(function, strict=False)
 
         assert function.description is not None
-        assert "Allowed delegate targets for this caller: code, research." in function.description
-        assert "Do not use any other agent names." in function.description
+        description = function.description
+        assert "Allowed delegate targets for this caller:" in description
+        for target in ("code", "research"):
+            assert target in description
+        assert "Do not use any other agent names." in description
+        assert "Use this when" in description
+        assert "delegated agent runs independently" in description
+        assert "no shared conversation history" in description
 
     @pytest.mark.asyncio
     async def test_delegate_to_unknown_agent(self, tools: DelegateTools) -> None:


### PR DESCRIPTION
## Summary
- Put the allowed delegate targets directly in the model-facing `delegate_task` tool description.
- Keep the existing runtime rejection for unlisted targets.
- Add regression coverage for processed tool schema text.

## Tests
- `uv run pytest tests/test_delegate_tools.py::TestDelegateTools::test_model_facing_tool_description_lists_allowed_targets -q`
- `uv run pytest tests/test_delegate_tools.py -q`
- `uv run pre-commit run --all-files`
- `uv run pytest -q`

## Summary by Sourcery

Clarify and surface the allowed delegate targets in the model-facing delegate_task tool description and add regression coverage for the processed schema text.

Enhancements:
- Generate the delegate_task function description dynamically to include the caller-specific allowed delegate targets and guidance on valid agent names.

Tests:
- Add tests asserting that the processed model-facing delegate_task tool description lists the allowed targets and related guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the model-facing delegation guidance to explicitly list the approved delegate targets and to clearly instruct the model not to use any other agent names.
  * Refined the generated tool description to provide more consistent, caller-specific runtime instructions for when delegation should be used.
* **Tests**
  * Added coverage to verify the exported delegation tool schema includes the allowed-targets section and the “Do not use any other agent names” restriction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->