### PR TITLE
Clarify scheduler new-thread mode docs

### DIFF
--- a/docs/chat-commands.md
+++ b/docs/chat-commands.md
@@ -70,7 +70,7 @@ Show the welcome message for the current room, listing available agents and team
 
 Schedule a one-time or recurring task using natural language.
 
-Tasks run in the current room or thread scope.
+Tasks run in the same scope where they were created: the room timeline for room-level schedules, or the current thread for threaded schedules.
 
 ```
 !schedule <natural-language-request>

--- a/docs/chat-commands.md
+++ b/docs/chat-commands.md
@@ -70,7 +70,7 @@ Show the welcome message for the current room, listing available agents and team
 
 Schedule a one-time or recurring task using natural language.
 
-Tasks run in the thread where they were created.
+Tasks run in the current room or thread scope.
 
 ```
 !schedule <natural-language-request>

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -6,7 +6,8 @@ icon: lucide/calendar
 
 Schedule agents or teams to perform tasks at specific times or intervals using natural language.
 
-Tasks run in the thread where they were created.
+By default, tasks run in the current room or thread scope.
+The `scheduler` tool can pass `new_thread=True` to create a fresh room-level thread root every time the schedule fires.
 
 ## Commands
 

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -6,8 +6,8 @@ icon: lucide/calendar
 
 Schedule agents or teams to perform tasks at specific times or intervals using natural language.
 
-By default, tasks run in the current room or thread scope.
-The `scheduler` tool can pass `new_thread=True` to create a fresh room-level thread root every time the schedule fires.
+By default, tasks run in the same scope where they were created: the room timeline for room-level schedules, or the current thread for threaded schedules.
+The `schedule()` tool accepts `new_thread=True` to post each fire as a top-level room message that can become its own thread, instead of continuing in the current thread.
 
 ## Commands
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -12871,7 +12871,7 @@ Show the welcome message for the current room, listing available agents and team
 
 Schedule a one-time or recurring task using natural language.
 
-Tasks run in the current room or thread scope.
+Tasks run in the same scope where they were created: the room timeline for room-level schedules, or the current thread for threaded schedules.
 
 ```
 !schedule <natural-language-request>
@@ -13349,8 +13349,8 @@ This is used for structured live rendering where the full document is rebuilt on
 
 Schedule agents or teams to perform tasks at specific times or intervals using natural language.
 
-By default, tasks run in the current room or thread scope.
-The `scheduler` tool can pass `new_thread=True` to create a fresh room-level thread root every time the schedule fires.
+By default, tasks run in the same scope where they were created: the room timeline for room-level schedules, or the current thread for threaded schedules.
+The `schedule()` tool accepts `new_thread=True` to post each fire as a top-level room message that can become its own thread, instead of continuing in the current thread.
 
 ## Commands
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -12871,7 +12871,7 @@ Show the welcome message for the current room, listing available agents and team
 
 Schedule a one-time or recurring task using natural language.
 
-Tasks run in the thread where they were created.
+Tasks run in the current room or thread scope.
 
 ```
 !schedule <natural-language-request>
@@ -13349,7 +13349,8 @@ This is used for structured live rendering where the full document is rebuilt on
 
 Schedule agents or teams to perform tasks at specific times or intervals using natural language.
 
-Tasks run in the thread where they were created.
+By default, tasks run in the current room or thread scope.
+The `scheduler` tool can pass `new_thread=True` to create a fresh room-level thread root every time the schedule fires.
 
 ## Commands
 

--- a/skills/mindroom-docs/references/page__chat-commands__index.md
+++ b/skills/mindroom-docs/references/page__chat-commands__index.md
@@ -66,7 +66,7 @@ Show the welcome message for the current room, listing available agents and team
 
 Schedule a one-time or recurring task using natural language.
 
-Tasks run in the current room or thread scope.
+Tasks run in the same scope where they were created: the room timeline for room-level schedules, or the current thread for threaded schedules.
 
 ```
 !schedule <natural-language-request>

--- a/skills/mindroom-docs/references/page__chat-commands__index.md
+++ b/skills/mindroom-docs/references/page__chat-commands__index.md
@@ -66,7 +66,7 @@ Show the welcome message for the current room, listing available agents and team
 
 Schedule a one-time or recurring task using natural language.
 
-Tasks run in the thread where they were created.
+Tasks run in the current room or thread scope.
 
 ```
 !schedule <natural-language-request>

--- a/skills/mindroom-docs/references/page__scheduling__index.md
+++ b/skills/mindroom-docs/references/page__scheduling__index.md
@@ -2,7 +2,8 @@
 
 Schedule agents or teams to perform tasks at specific times or intervals using natural language.
 
-Tasks run in the thread where they were created.
+By default, tasks run in the current room or thread scope.
+The `scheduler` tool can pass `new_thread=True` to create a fresh room-level thread root every time the schedule fires.
 
 ## Commands
 

--- a/skills/mindroom-docs/references/page__scheduling__index.md
+++ b/skills/mindroom-docs/references/page__scheduling__index.md
@@ -2,8 +2,8 @@
 
 Schedule agents or teams to perform tasks at specific times or intervals using natural language.
 
-By default, tasks run in the current room or thread scope.
-The `scheduler` tool can pass `new_thread=True` to create a fresh room-level thread root every time the schedule fires.
+By default, tasks run in the same scope where they were created: the room timeline for room-level schedules, or the current thread for threaded schedules.
+The `schedule()` tool accepts `new_thread=True` to post each fire as a top-level room message that can become its own thread, instead of continuing in the current thread.
 
 ## Commands
 


### PR DESCRIPTION
## Summary
- Clarify that scheduled tasks default to the current room or thread scope.
- Document that `scheduler.schedule(..., new_thread=True)` creates a fresh room-level thread root on each fire.
- Regenerate `skills/mindroom-docs/references` for the docs changes.

## Test Plan
- `uv run pytest -q -n 0 --no-cov`
- `uv run pytest tests/test_scheduler_tool.py::test_scheduler_tool_uses_shared_backend tests/test_schedule_agent_validation.py::test_schedule_with_no_agent_mentions tests/test_scheduling_executor.py::test_fire_new_thread_task_posts_room_level_message tests/test_workflow_scheduling.py::TestExecuteScheduledWorkflow::test_execute_workflow_new_thread_posts_room_level_message -q -n 0 --no-cov`
- `uv run pre-commit run --all-files`

## Summary by Sourcery

Clarify scheduler task execution scope and document new-thread scheduling behavior in user-facing docs.

Documentation:
- Clarify that scheduled tasks default to running in the current room or thread scope in scheduling and chat command documentation.
- Document that using the scheduler tool with new_thread=True creates a new room-level thread root each time a schedule fires.
- Regenerate mindroom reference documentation to reflect the updated scheduling behavior descriptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how scheduled commands run by default, noting they execute in the current room or thread scope.
  * Updated scheduling guidance to explain that schedules can optionally start a fresh room-level thread each time they fire.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->