### PR TITLE
Update Sonnet defaults to Sonnet 5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Coding model training data often lags recent releases, so never trust memorized 
 
 | Provider | Use | Preferred model | Model string to use |
 | --- | --- | --- | --- |
-| Anthropic | Balanced default | Claude Sonnet 4.6 | `claude-sonnet-4-6` |
+| Anthropic | Balanced default | Claude Sonnet 5 | `claude-sonnet-5` |
 | Anthropic | Max intelligence | Claude Opus 4.8 | `claude-opus-4-8` |
 | Anthropic | Fast / cheap | Claude Haiku 4.5 | `claude-haiku-4-5` |
 | OpenAI | Frontier default | GPT-5.5 | `gpt-5.5` |
@@ -30,9 +30,9 @@ Coding model training data often lags recent releases, so never trust memorized 
 | Google (Gemini API) | Image generation / editing | Nano Banana 2 Preview | `gemini-3.1-flash-image-preview` |
 | Google (Gemini API) | Embeddings for `google` | Gemini Embedding 2 Preview | `gemini-embedding-2-preview` |
 
-For `anthropic`, prefer `claude-sonnet-4-6`, `claude-opus-4-8`, and `claude-haiku-4-5` unless you intentionally need a pinned snapshot ID.
+For `anthropic`, prefer `claude-sonnet-5`, `claude-opus-4-8`, and `claude-haiku-4-5` unless you intentionally need a pinned snapshot ID.
 For `vertexai_claude`, use the current Vertex AI request name from the provider docs instead of assuming the Anthropic API ID carries over unchanged.
-Current docs list bare Vertex IDs for current Claude models such as `claude-sonnet-4-6` and `claude-opus-4-8`, while some other Vertex models are still documented as dated snapshot IDs such as `claude-haiku-4-5@20251001`.
+Current docs list bare Vertex IDs for current Claude models such as `claude-sonnet-5` and `claude-opus-4-8`, while some other Vertex models are still documented as dated snapshot IDs such as `claude-haiku-4-5@20251001`.
 Do not assume `@default` or dated `@...` suffixes are universally required for Vertex AI Claude.
 For Gemini API text and coding work, prefer `gemini-3.5-flash` as the standard stable model unless you intentionally need the cheaper Flash-Lite tier.
 Use `gemini-3.1-pro-preview` only when you need the highest Gemini API intelligence tier and accept a preview model.
@@ -247,10 +247,10 @@ bot_accounts: []
 models:
   default:
     provider: anthropic
-    id: claude-sonnet-4-6
+    id: claude-sonnet-5
   sonnet:
     provider: anthropic
-    id: claude-sonnet-4-6
+    id: claude-sonnet-5
 
 router:
   model: default

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ agents:
 models:
   default:
     provider: anthropic
-    id: claude-sonnet-4-6
+    id: claude-sonnet-5
 
 mindroom_user:
   username: mindroom_user  # Set this before first run; the account-creation request is immutable after account creation

--- a/cluster/k8s/instance/default-config.yaml
+++ b/cluster/k8s/instance/default-config.yaml
@@ -403,7 +403,7 @@ models:
     context_window: 1000000
   sonnet:
     provider: openrouter
-    id: anthropic/claude-sonnet-4.6
+    id: anthropic/claude-sonnet-5
     context_window: 1000000
   haiku:
     provider: openrouter

--- a/config.yaml
+++ b/config.yaml
@@ -472,7 +472,7 @@ models:
     id: claude-opus-4-8
     provider: anthropic
   sonnet:
-    id: claude-sonnet-4-6
+    id: claude-sonnet-5
     provider: anthropic
   # --- OpenAI ---
   gpt55:

--- a/docs/architecture/matrix.md
+++ b/docs/architecture/matrix.md
@@ -102,7 +102,7 @@ Where `N` is 1-indexed per message and maps to `io.mindroom.tool_trace.events[N-
 
 ## Presence
 
-Agents set their Matrix presence with status messages containing model and role information (e.g., "🤖 Model: anthropic/claude-sonnet-4-6 | 💼 Code assistant | 🔧 5 tools available").
+Agents set their Matrix presence with status messages containing model and role information (e.g., "🤖 Model: anthropic/claude-sonnet-5 | 💼 Code assistant | 🔧 5 tools available").
 
 **Presence States:**
 - **online** - Agent running and ready

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -235,10 +235,10 @@ agents:
 models:
   default:
     provider: anthropic            # Required: openai, azure, anthropic, ollama, google, gemini, vertexai_claude, groq, cerebras, openrouter, deepseek
-    id: claude-sonnet-4-6            # Required: Model ID for the provider
+    id: claude-sonnet-5            # Required: Model ID for the provider
   sonnet:
     provider: anthropic            # Required: openai, azure, anthropic, ollama, google, gemini, vertexai_claude, groq, cerebras, openrouter, deepseek
-    id: claude-sonnet-4-6            # Required: Model ID for the provider
+    id: claude-sonnet-5            # Required: Model ID for the provider
     host: null                     # Optional: Host URL (e.g., for Ollama)
     api_key: null                  # Optional: API key (usually from env vars)
     extra_kwargs: null             # Optional: Provider-specific parameters

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -41,8 +41,8 @@ models:
   # Anthropic Claude
   sonnet:
     provider: anthropic
-    id: claude-sonnet-4-6
-    context_window: 200000
+    id: claude-sonnet-5
+    context_window: 1000000
 
   haiku:
     provider: anthropic
@@ -78,7 +78,7 @@ models:
   # Anthropic Claude on Vertex AI
   vertex_claude:
     provider: vertexai_claude
-    id: claude-sonnet-4-6
+    id: claude-sonnet-5
     extra_kwargs:
       project_id: your-gcp-project
       region: us-central1
@@ -92,7 +92,7 @@ models:
   # OpenRouter (access to many model providers)
   openrouter:
     provider: openrouter
-    id: anthropic/claude-sonnet-4.6
+    id: anthropic/claude-sonnet-5
 
   # Groq (fast inference)
   groq:
@@ -210,8 +210,8 @@ If needed, that replay plan can reduce raw replay, fall back to summary-only rep
 models:
   default:
     provider: anthropic
-    id: claude-sonnet-4-6
-    context_window: 200000  # 200K tokens
+    id: claude-sonnet-5
+    context_window: 1000000  # 1M tokens
 ```
 
 This is useful for models with smaller context windows or long-running conversations that accumulate persisted history.

--- a/docs/dev/agent_configuration.md
+++ b/docs/dev/agent_configuration.md
@@ -56,7 +56,7 @@ models:
 
   openrouter:
     provider: "openrouter"
-    id: "anthropic/claude-sonnet-4-6"
+    id: "anthropic/claude-sonnet-5"
 ```
 
 Each model entry supports these fields:
@@ -635,7 +635,7 @@ models:
 
   smart:
     provider: "anthropic"
-    id: "claude-sonnet-4-6"
+    id: "claude-sonnet-5"
 
 # Agent configurations
 agents:

--- a/docs/superpowers/specs/2026-06-07-dynamic-workflows-design.md
+++ b/docs/superpowers/specs/2026-06-07-dynamic-workflows-design.md
@@ -219,12 +219,12 @@ participants:
   - id: critic
     kind: ephemeral_agent
     name: Source Critic
-    model: claude-sonnet-4-6
+    model: claude-sonnet-5
     tools: []
   - id: writer
     kind: ephemeral_agent
     name: Report Writer
-    model: claude-sonnet-4-6
+    model: claude-sonnet-5
     tools: []
 workflow:
   - id: plan
@@ -255,7 +255,7 @@ permissions:
   max_total_agents: 3
   models:
     - claude-haiku-4-5
-    - claude-sonnet-4-6
+    - claude-sonnet-5
   tools: []
   data:
     matrix_history: none

--- a/docs/tools/agent-orchestration.md
+++ b/docs/tools/agent-orchestration.md
@@ -239,7 +239,7 @@ create_workflow(
                 "id": "writer",
                 "kind": "ephemeral_agent",
                 "name": "Report Writer",
-                "model": "claude-sonnet-4-6",
+                "model": "claude-sonnet-5",
                 "tools": ["duckduckgo", "website"],
             },
         ],
@@ -256,7 +256,7 @@ create_workflow(
             "max_runtime_seconds": 1800,
             "max_concurrent_agents": 4,
             "max_total_agents": 8,
-            "models": ["claude-sonnet-4-6"],
+            "models": ["claude-sonnet-5"],
             "tools": ["duckduckgo", "website"],
             "data": {"matrix_history": "none", "attachments": "none", "knowledge_bases": []},
         },
@@ -574,7 +574,7 @@ agents:
     model: default
     tools:
       - claude_agent:
-          model: claude-sonnet-4-6
+          model: claude-sonnet-5
           cwd: /workspace/project
           permission_mode: acceptEdits
           continue_conversation: true
@@ -585,7 +585,7 @@ agents:
 ```json
 {
   "api_key": "sk-ant-or-proxy-key",
-  "model": "claude-sonnet-4-6",
+  "model": "claude-sonnet-5",
   "permission_mode": "default",
   "continue_conversation": true,
   "session_ttl_minutes": 60,

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -1027,10 +1027,10 @@ agents:
 models:
   default:
     provider: anthropic            # Required: openai, azure, anthropic, ollama, google, gemini, vertexai_claude, groq, cerebras, openrouter, deepseek
-    id: claude-sonnet-4-6            # Required: Model ID for the provider
+    id: claude-sonnet-5            # Required: Model ID for the provider
   sonnet:
     provider: anthropic            # Required: openai, azure, anthropic, ollama, google, gemini, vertexai_claude, groq, cerebras, openrouter, deepseek
-    id: claude-sonnet-4-6            # Required: Model ID for the provider
+    id: claude-sonnet-5            # Required: Model ID for the provider
     host: null                     # Optional: Host URL (e.g., for Ollama)
     api_key: null                  # Optional: API key (usually from env vars)
     extra_kwargs: null             # Optional: Provider-specific parameters
@@ -2133,8 +2133,8 @@ models:
   # Anthropic Claude
   sonnet:
     provider: anthropic
-    id: claude-sonnet-4-6
-    context_window: 200000
+    id: claude-sonnet-5
+    context_window: 1000000
 
   haiku:
     provider: anthropic
@@ -2170,7 +2170,7 @@ models:
   # Anthropic Claude on Vertex AI
   vertex_claude:
     provider: vertexai_claude
-    id: claude-sonnet-4-6
+    id: claude-sonnet-5
     extra_kwargs:
       project_id: your-gcp-project
       region: us-central1
@@ -2184,7 +2184,7 @@ models:
   # OpenRouter (access to many model providers)
   openrouter:
     provider: openrouter
-    id: anthropic/claude-sonnet-4.6
+    id: anthropic/claude-sonnet-5
 
   # Groq (fast inference)
   groq:
@@ -2302,8 +2302,8 @@ If needed, that replay plan can reduce raw replay, fall back to summary-only rep
 models:
   default:
     provider: anthropic
-    id: claude-sonnet-4-6
-    context_window: 200000  # 200K tokens
+    id: claude-sonnet-5
+    context_window: 1000000  # 1M tokens
 ```
 
 This is useful for models with smaller context windows or long-running conversations that accumulate persisted history.
@@ -8473,7 +8473,7 @@ create_workflow(
                 "id": "writer",
                 "kind": "ephemeral_agent",
                 "name": "Report Writer",
-                "model": "claude-sonnet-4-6",
+                "model": "claude-sonnet-5",
                 "tools": ["duckduckgo", "website"],
             },
         ],
@@ -8490,7 +8490,7 @@ create_workflow(
             "max_runtime_seconds": 1800,
             "max_concurrent_agents": 4,
             "max_total_agents": 8,
-            "models": ["claude-sonnet-4-6"],
+            "models": ["claude-sonnet-5"],
             "tools": ["duckduckgo", "website"],
             "data": {"matrix_history": "none", "attachments": "none", "knowledge_bases": []},
         },
@@ -8808,7 +8808,7 @@ agents:
     model: default
     tools:
       - claude_agent:
-          model: claude-sonnet-4-6
+          model: claude-sonnet-5
           cwd: /workspace/project
           permission_mode: acceptEdits
           continue_conversation: true
@@ -8819,7 +8819,7 @@ agents:
 ```json
 {
   "api_key": "sk-ant-or-proxy-key",
-  "model": "claude-sonnet-4-6",
+  "model": "claude-sonnet-5",
   "permission_mode": "default",
   "continue_conversation": true,
   "session_ttl_minutes": 60,
@@ -14382,7 +14382,7 @@ Where `N` is 1-indexed per message and maps to `io.mindroom.tool_trace.events[N-
 
 ## Presence
 
-Agents set their Matrix presence with status messages containing model and role information (e.g., "🤖 Model: anthropic/claude-sonnet-4-6 | 💼 Code assistant | 🔧 5 tools available").
+Agents set their Matrix presence with status messages containing model and role information (e.g., "🤖 Model: anthropic/claude-sonnet-5 | 💼 Code assistant | 🔧 5 tools available").
 
 **Presence States:**
 - **online** - Agent running and ready

--- a/skills/mindroom-docs/references/page__architecture__matrix__index.md
+++ b/skills/mindroom-docs/references/page__architecture__matrix__index.md
@@ -98,7 +98,7 @@ Where `N` is 1-indexed per message and maps to `io.mindroom.tool_trace.events[N-
 
 ## Presence
 
-Agents set their Matrix presence with status messages containing model and role information (e.g., "🤖 Model: anthropic/claude-sonnet-4-6 | 💼 Code assistant | 🔧 5 tools available").
+Agents set their Matrix presence with status messages containing model and role information (e.g., "🤖 Model: anthropic/claude-sonnet-5 | 💼 Code assistant | 🔧 5 tools available").
 
 **Presence States:**
 - **online** - Agent running and ready

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -231,10 +231,10 @@ agents:
 models:
   default:
     provider: anthropic            # Required: openai, azure, anthropic, ollama, google, gemini, vertexai_claude, groq, cerebras, openrouter, deepseek
-    id: claude-sonnet-4-6            # Required: Model ID for the provider
+    id: claude-sonnet-5            # Required: Model ID for the provider
   sonnet:
     provider: anthropic            # Required: openai, azure, anthropic, ollama, google, gemini, vertexai_claude, groq, cerebras, openrouter, deepseek
-    id: claude-sonnet-4-6            # Required: Model ID for the provider
+    id: claude-sonnet-5            # Required: Model ID for the provider
     host: null                     # Optional: Host URL (e.g., for Ollama)
     api_key: null                  # Optional: API key (usually from env vars)
     extra_kwargs: null             # Optional: Provider-specific parameters

--- a/skills/mindroom-docs/references/page__configuration__models__index.md
+++ b/skills/mindroom-docs/references/page__configuration__models__index.md
@@ -37,8 +37,8 @@ models:
   # Anthropic Claude
   sonnet:
     provider: anthropic
-    id: claude-sonnet-4-6
-    context_window: 200000
+    id: claude-sonnet-5
+    context_window: 1000000
 
   haiku:
     provider: anthropic
@@ -74,7 +74,7 @@ models:
   # Anthropic Claude on Vertex AI
   vertex_claude:
     provider: vertexai_claude
-    id: claude-sonnet-4-6
+    id: claude-sonnet-5
     extra_kwargs:
       project_id: your-gcp-project
       region: us-central1
@@ -88,7 +88,7 @@ models:
   # OpenRouter (access to many model providers)
   openrouter:
     provider: openrouter
-    id: anthropic/claude-sonnet-4.6
+    id: anthropic/claude-sonnet-5
 
   # Groq (fast inference)
   groq:
@@ -206,8 +206,8 @@ If needed, that replay plan can reduce raw replay, fall back to summary-only rep
 models:
   default:
     provider: anthropic
-    id: claude-sonnet-4-6
-    context_window: 200000  # 200K tokens
+    id: claude-sonnet-5
+    context_window: 1000000  # 1M tokens
 ```
 
 This is useful for models with smaller context windows or long-running conversations that accumulate persisted history.

--- a/skills/mindroom-docs/references/page__tools__agent-orchestration__index.md
+++ b/skills/mindroom-docs/references/page__tools__agent-orchestration__index.md
@@ -235,7 +235,7 @@ create_workflow(
                 "id": "writer",
                 "kind": "ephemeral_agent",
                 "name": "Report Writer",
-                "model": "claude-sonnet-4-6",
+                "model": "claude-sonnet-5",
                 "tools": ["duckduckgo", "website"],
             },
         ],
@@ -252,7 +252,7 @@ create_workflow(
             "max_runtime_seconds": 1800,
             "max_concurrent_agents": 4,
             "max_total_agents": 8,
-            "models": ["claude-sonnet-4-6"],
+            "models": ["claude-sonnet-5"],
             "tools": ["duckduckgo", "website"],
             "data": {"matrix_history": "none", "attachments": "none", "knowledge_bases": []},
         },
@@ -570,7 +570,7 @@ agents:
     model: default
     tools:
       - claude_agent:
-          model: claude-sonnet-4-6
+          model: claude-sonnet-5
           cwd: /workspace/project
           permission_mode: acceptEdits
           continue_conversation: true
@@ -581,7 +581,7 @@ agents:
 ```json
 {
   "api_key": "sk-ant-or-proxy-key",
-  "model": "claude-sonnet-4-6",
+  "model": "claude-sonnet-5",
   "permission_mode": "default",
   "continue_conversation": true,
   "session_ttl_minutes": 60,

--- a/src/mindroom/model_defaults.py
+++ b/src/mindroom/model_defaults.py
@@ -69,10 +69,10 @@ class ModelPreset:
 
 
 _ANTHROPIC_OPUS = "claude-opus-4-8"
-_ANTHROPIC_SONNET = "claude-sonnet-4-6"
+_ANTHROPIC_SONNET = "claude-sonnet-5"
 _ANTHROPIC_HAIKU = "claude-haiku-4-5"
 AWS_BEDROCK_CLAUDE_OPUS = "anthropic.claude-opus-4-8"
-_AWS_BEDROCK_CLAUDE_SONNET = "global.anthropic.claude-sonnet-4-6"
+_AWS_BEDROCK_CLAUDE_SONNET = "global.anthropic.claude-sonnet-5"
 _AWS_BEDROCK_CLAUDE_HAIKU = "global.anthropic.claude-haiku-4-5"
 CODEX_GPT = "gpt-5.5"
 _OPENAI_GPT = "gpt-5.5"
@@ -88,7 +88,7 @@ GOOGLE_IMAGEN_ULTRA = "imagen-4.0-ultra-generate-001"
 GOOGLE_VEO = "veo-2.0-generate-001"
 
 _OPENROUTER_CLAUDE_OPUS = "anthropic/claude-opus-4.8"
-_OPENROUTER_CLAUDE_SONNET = "anthropic/claude-sonnet-4.6"
+_OPENROUTER_CLAUDE_SONNET = "anthropic/claude-sonnet-5"
 _OPENROUTER_CLAUDE_HAIKU = "anthropic/claude-haiku-4.5"
 _OPENROUTER_GEMINI_FLASH = "google/gemini-3.5-flash"
 _OPENROUTER_GEMINI_LITE = "google/gemini-3.1-flash-lite-preview"

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -78,7 +78,7 @@ def _invoke_with_runtime(
 
 def _write_minimal_runtime_config(path: Path) -> None:
     path.write_text(
-        "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
+        "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-5\n"
         "agents:\n  general:\n    display_name: General Agent\n    model: default\n"
         "router:\n  model: default\n"
         "matrix_space:\n  enabled: false\n"
@@ -395,7 +395,7 @@ class TestConfigInit:
         config = yaml.safe_load(target.read_text())
         assert "mindroom_user" not in config
         assert config["models"]["default"]["provider"] == "vertexai_claude"
-        assert config["models"]["default"]["id"] == "claude-sonnet-4-6"
+        assert config["models"]["default"]["id"] == "claude-sonnet-5"
 
         env_content = (tmp_path / ".env").read_text()
         assert "MATRIX_HOMESERVER=https://mindroom.chat" in env_content
@@ -935,7 +935,7 @@ class TestConfigInit:
         assert result.exit_code == 0
         config = yaml.safe_load(target.read_text())
         assert config["models"]["default"]["provider"] == "anthropic"
-        assert config["models"]["default"]["id"] == "claude-sonnet-4-6"
+        assert config["models"]["default"]["id"] == "claude-sonnet-5"
         assert config["models"]["default"]["context_window"] == 1_000_000
 
         env_content = (tmp_path / ".env").read_text()
@@ -949,7 +949,7 @@ class TestConfigInit:
         assert result.exit_code == 0
         config = yaml.safe_load(target.read_text())
         assert config["models"]["default"]["provider"] == "openrouter"
-        assert config["models"]["default"]["id"] == "anthropic/claude-sonnet-4.6"
+        assert config["models"]["default"]["id"] == "anthropic/claude-sonnet-5"
         assert config["models"]["default"]["context_window"] == 1_000_000
 
     def test_init_azure_preset_uses_azure_openai_models(self, tmp_path: Path) -> None:
@@ -988,7 +988,7 @@ class TestConfigInit:
 
         config_text = target.read_text(encoding="utf-8")
         assert "# sonnet:" in config_text
-        assert "#   id: global.anthropic.claude-sonnet-4-6" in config_text
+        assert "#   id: global.anthropic.claude-sonnet-5" in config_text
         assert "# haiku:" in config_text
         assert "#   id: global.anthropic.claude-haiku-4-5" in config_text
 
@@ -1058,7 +1058,7 @@ class TestConfigInit:
 
         config = yaml.safe_load(target.read_text())
         assert config["models"]["default"]["provider"] == "anthropic"
-        assert config["models"]["default"]["id"] == "claude-sonnet-4-6"
+        assert config["models"]["default"]["id"] == "claude-sonnet-5"
         assert config["models"]["default"]["context_window"] == 1_000_000
         assert config["memory"]["embedder"]["provider"] == "sentence_transformers"
         assert config["memory"]["embedder"]["config"]["model"] == "sentence-transformers/all-MiniLM-L6-v2"
@@ -1075,7 +1075,7 @@ class TestConfigInit:
         assert result.exit_code == 0
         config = yaml.safe_load(target.read_text())
         assert config["models"]["default"]["provider"] == "vertexai_claude"
-        assert config["models"]["default"]["id"] == "claude-sonnet-4-6"
+        assert config["models"]["default"]["id"] == "claude-sonnet-5"
         assert config["models"]["default"]["context_window"] == 1_000_000
 
         env_content = (tmp_path / ".env").read_text()
@@ -1454,7 +1454,7 @@ class TestConfigValidate:
         """Config validate reports success for a valid config."""
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
-            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
+            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-5\n"
             "agents:\n  assistant:\n    display_name: Assistant\n    model: default\n"
             "router:\n  model: default\n",
         )
@@ -1487,7 +1487,7 @@ class TestConfigValidate:
         )
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
-            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
+            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-5\n"
             "agents:\n  assistant:\n    display_name: Assistant\n    model: default\n"
             "router:\n  model: default\n"
             "plugins:\n  - ./plugins/bad-name\n",
@@ -1509,7 +1509,7 @@ class TestConfigValidate:
         )
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
-            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
+            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-5\n"
             "agents:\n  assistant:\n    display_name: Assistant\n    model: default\n"
             "router:\n  model: default\n"
             "plugins:\n  - ./plugins/bad-manifest\n",
@@ -1525,7 +1525,7 @@ class TestConfigValidate:
         """Config validate should stay strict about missing plugin paths."""
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
-            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
+            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-5\n"
             "agents:\n  assistant:\n    display_name: Assistant\n    model: default\n"
             "router:\n  model: default\n"
             "plugins:\n  - ./plugins/this-plugin-does-not-exist\n",
@@ -1575,7 +1575,7 @@ class TestConfigValidate:
         """Config validate should warn about missing Vertex AI project settings."""
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
-            "models:\n  default:\n    provider: vertexai_claude\n    id: claude-sonnet-4-6\n"
+            "models:\n  default:\n    provider: vertexai_claude\n    id: claude-sonnet-5\n"
             "agents:\n  assistant:\n    display_name: Assistant\n    model: default\n"
             "router:\n  model: default\n",
         )
@@ -1802,7 +1802,7 @@ class TestRunErrorHandling:
         )
         bad_cfg = tmp_path / "config.yaml"
         bad_cfg.write_text(
-            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
+            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-5\n"
             "agents:\n  assistant:\n    display_name: Assistant\n    model: default\n"
             "router:\n  model: default\n"
             "plugins:\n  - ./plugins/bad-name\n",
@@ -1820,7 +1820,7 @@ class TestRunErrorHandling:
         """Run should let the orchestrator start when an optional plugin path is missing."""
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
-            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
+            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-5\n"
             "agents:\n  assistant:\n    display_name: Assistant\n    model: default\n"
             "router:\n  model: default\n"
             "plugins:\n  - ./plugins/this-plugin-does-not-exist\n",
@@ -1850,7 +1850,7 @@ class TestRunErrorHandling:
         """Permanent startup failures should not dump an implementation traceback."""
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
-            "models:\n  default:\n    provider: vertexai_claude\n    id: claude-sonnet-4-6\n"
+            "models:\n  default:\n    provider: vertexai_claude\n    id: claude-sonnet-5\n"
             "agents:\n  assistant:\n    display_name: Assistant\n    model: default\n"
             "router:\n  model: default\n",
             encoding="utf-8",
@@ -1871,7 +1871,7 @@ class TestRunErrorHandling:
         """Avatar generation should exit cleanly when generation fails."""
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
-            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
+            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-5\n"
             "agents:\n  a:\n    display_name: A\n    model: default\n"
             "router:\n  model: default\n"
             "matrix_space:\n  enabled: false\n"
@@ -2010,7 +2010,7 @@ class TestRunApiFlags:
     @staticmethod
     def _write_minimal_config(path: Path) -> None:
         path.write_text(
-            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
+            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-5\n"
             "agents:\n  a:\n    display_name: A\n    model: default\n"
             "router:\n  model: default\n"
             "matrix_space:\n  enabled: false\n",
@@ -2033,7 +2033,7 @@ class TestRunApiFlags:
         """Run passes api=True, port=8765, host=0.0.0.0 by default."""
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
-            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
+            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-5\n"
             "agents:\n  a:\n    display_name: A\n    model: default\n"
             "router:\n  model: default\n"
             "matrix_space:\n  enabled: false\n",
@@ -2052,7 +2052,7 @@ class TestRunApiFlags:
         """Run --no-api passes api=False to bot main."""
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
-            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
+            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-5\n"
             "agents:\n  a:\n    display_name: A\n    model: default\n"
             "router:\n  model: default\n"
             "matrix_space:\n  enabled: false\n",
@@ -2067,7 +2067,7 @@ class TestRunApiFlags:
         """Run --api-port and --api-host are forwarded to bot main."""
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
-            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
+            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-5\n"
             "agents:\n  a:\n    display_name: A\n    model: default\n"
             "router:\n  model: default\n"
             "matrix_space:\n  enabled: false\n",
@@ -2141,7 +2141,7 @@ class TestRunApiFlags:
         """Run should thread `--storage-path` through the explicit runtime context."""
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
-            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
+            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-5\n"
             "agents:\n  a:\n    display_name: A\n    model: default\n"
             "router:\n  model: default\n"
             "matrix_space:\n  enabled: false\n",
@@ -2205,7 +2205,7 @@ class TestAvatarsCommands:
         """Avatar generation command should invoke the generation workflow."""
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
-            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
+            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-5\n"
             "agents:\n  a:\n    display_name: A\n    model: default\n"
             "router:\n  model: default\n"
             "matrix_space:\n  enabled: false\n",
@@ -2221,7 +2221,7 @@ class TestAvatarsCommands:
         """Avatar generation command should expose an explicit force flag."""
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
-            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
+            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-5\n"
             "agents:\n  a:\n    display_name: A\n    model: default\n"
             "router:\n  model: default\n"
             "matrix_space:\n  enabled: false\n",
@@ -2239,7 +2239,7 @@ class TestAvatarsCommands:
         """Avatar sync command should invoke the Matrix sync workflow."""
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
-            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
+            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-5\n"
             "agents:\n  a:\n    display_name: A\n    model: default\n"
             "router:\n  model: default\n"
             "matrix_space:\n  enabled: false\n",
@@ -2257,7 +2257,7 @@ class TestAvatarsCommands:
         """Avatar sync command should expose an explicit force flag."""
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
-            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
+            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-5\n"
             "agents:\n  a:\n    display_name: A\n    model: default\n"
             "router:\n  model: default\n"
             "matrix_space:\n  enabled: false\n",
@@ -2275,7 +2275,7 @@ class TestAvatarsCommands:
         """Unexpected avatar sync failures should propagate for debugging."""
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
-            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
+            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-5\n"
             "agents:\n  a:\n    display_name: A\n    model: default\n"
             "router:\n  model: default\n"
             "matrix_space:\n  enabled: false\n",
@@ -2297,7 +2297,7 @@ class TestAvatarsCommands:
         """Avatar sync should fail when the router account has not been initialized yet."""
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
-            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
+            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-5\n"
             "agents:\n  a:\n    display_name: A\n    model: default\n"
             "router:\n  model: default\n"
             "matrix_space:\n  enabled: false\n",
@@ -2317,18 +2317,18 @@ class TestAvatarsCommands:
 # ---------------------------------------------------------------------------
 
 _VALID_CONFIG = (
-    "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
+    "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-5\n"
     "agents:\n  assistant:\n    display_name: Assistant\n    model: default\n"
     "router:\n  model: default\n"
 )
 _VALID_VERTEXAI_CLAUDE_CONFIG = (
-    "models:\n  default:\n    provider: vertexai_claude\n    id: claude-sonnet-4-6\n"
+    "models:\n  default:\n    provider: vertexai_claude\n    id: claude-sonnet-5\n"
     "agents:\n  assistant:\n    display_name: Assistant\n    model: default\n"
     "router:\n  model: default\n"
 )
 _VALID_MULTI_VERTEXAI_CLAUDE_CONFIG = (
     "models:\n"
-    "  default:\n    provider: vertexai_claude\n    id: claude-sonnet-4-6\n"
+    "  default:\n    provider: vertexai_claude\n    id: claude-sonnet-5\n"
     "  fast:\n    provider: vertexai_claude\n    id: claude-haiku-4-5\n"
     "agents:\n  assistant:\n    display_name: Assistant\n    model: default\n"
     "router:\n  model: default\n"
@@ -2555,7 +2555,7 @@ class TestDoctor:
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
             "models:\n"
-            "  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
+            "  default:\n    provider: anthropic\n    id: claude-sonnet-5\n"
             "  fast:\n    provider: anthropic\n    id: claude-haiku-4-5\n"
             "  gpt:\n    provider: openai\n    id: gpt-4o\n"
             "agents:\n  a:\n    display_name: A\n    model: default\n"
@@ -2609,16 +2609,16 @@ class TestDoctor:
 
         result = _invoke_with_runtime(["doctor"], cfg, storage_path=storage)
         assert result.exit_code == 0
-        assert "vertexai_claude connection valid for claude-sonnet-4-6" in result.output
-        assert called["model_id"] == "claude-sonnet-4-6"
+        assert "vertexai_claude connection valid for claude-sonnet-5" in result.output
+        assert called["model_id"] == "claude-sonnet-5"
         assert called["client_kwargs"] == {
-            "id": "claude-sonnet-4-6",
+            "id": "claude-sonnet-5",
             "project_id": "mindroom-test",
             "region": "us-central1",
             "timeout": 10,
         }
         assert called["kwargs"] == {
-            "model": "claude-sonnet-4-6",
+            "model": "claude-sonnet-5",
             "max_tokens": 1,
             "messages": [{"role": "user", "content": "Reply with OK."}],
             "timeout": 10,
@@ -2671,7 +2671,7 @@ class TestDoctor:
         assert result.exit_code == 0
         assert called["adc_path"] == str((tmp_path / "adc.json").resolve())
         assert called["client_kwargs"] == {
-            "id": "claude-sonnet-4-6",
+            "id": "claude-sonnet-5",
             "project_id": "mindroom-test",
             "region": "us-central1",
             "timeout": 10,
@@ -2715,10 +2715,10 @@ class TestDoctor:
 
         result = _invoke_with_runtime(["doctor"], cfg, storage_path=storage)
         assert result.exit_code == 0
-        assert "vertexai_claude connection valid for claude-sonnet-4-6" in result.output
+        assert "vertexai_claude connection valid for claude-sonnet-5" in result.output
         assert "vertexai_claude connection valid for claude-haiku-4-5" in result.output
-        assert created_models == ["claude-sonnet-4-6", "claude-haiku-4-5"]
-        assert requested_models == ["claude-sonnet-4-6", "claude-haiku-4-5"]
+        assert created_models == ["claude-sonnet-5", "claude-haiku-4-5"]
+        assert requested_models == ["claude-sonnet-5", "claude-haiku-4-5"]
 
     def test_vertexai_claude_missing_env_is_warning(
         self,
@@ -2799,7 +2799,7 @@ class TestDoctor:
 
         assert result.exit_code == 1
         output = normalize_console_output(result.output)
-        assert "vertexai_claude connection failed for claude-sonnet-4-6" in output
+        assert "vertexai_claude connection failed for claude-sonnet-5" in output
         assert "GOOGLE_APPLICATION_CREDENTIALS points to a file that does not exist" in output
 
     def test_vertexai_claude_invalid_adc_file_is_failure(
@@ -2823,7 +2823,7 @@ class TestDoctor:
 
         assert result.exit_code == 1
         output = normalize_console_output(result.output)
-        assert "vertexai_claude connection failed for claude-sonnet-4-6" in output
+        assert "vertexai_claude connection failed for claude-sonnet-5" in output
         assert "Failed to load GOOGLE_APPLICATION_CREDENTIALS" in output
 
     def test_vertexai_claude_api_rejection_is_failure(
@@ -2861,7 +2861,7 @@ class TestDoctor:
 
         result = _invoke_with_runtime(["doctor"], cfg, storage_path=storage)
         assert result.exit_code == 1
-        assert "vertexai_claude connection failed for claude-sonnet-4-6" in result.output
+        assert "vertexai_claude connection failed for claude-sonnet-5" in result.output
         assert "HTTP 403" in result.output
 
     def test_custom_base_url_validation(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -2908,7 +2908,7 @@ class TestDoctor:
         """Doctor checks ollama embedder reachability via /api/tags."""
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
-            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
+            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-5\n"
             "agents:\n  a:\n    display_name: A\n    model: default\n"
             "router:\n  model: default\n"
             "memory:\n"
@@ -2934,7 +2934,7 @@ class TestDoctor:
         """Doctor validates configured memory LLM API key."""
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
-            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
+            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-5\n"
             "agents:\n  a:\n    display_name: A\n    model: default\n"
             "router:\n  model: default\n"
             "memory:\n"
@@ -2961,7 +2961,7 @@ class TestDoctor:
         """Doctor warns when memory LLM API key is not set."""
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
-            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
+            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-5\n"
             "agents:\n  a:\n    display_name: A\n    model: default\n"
             "router:\n  model: default\n"
             "memory:\n"
@@ -2987,7 +2987,7 @@ class TestDoctor:
         """Doctor uses openai_base_url from mem0 LLM config when host is absent."""
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
-            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
+            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-5\n"
             "agents:\n  a:\n    display_name: A\n    model: default\n"
             "router:\n  model: default\n"
             "memory:\n"
@@ -3028,7 +3028,7 @@ class TestDoctor:
         """Doctor validates custom OpenAI embedder hosts using /embeddings."""
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
-            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
+            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-5\n"
             "agents:\n  a:\n    display_name: A\n    model: default\n"
             "router:\n  model: default\n"
             "memory:\n"
@@ -3064,7 +3064,7 @@ class TestDoctor:
         """Doctor adds a local-network hint for .local routing failures."""
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
-            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
+            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-5\n"
             "agents:\n  a:\n    display_name: A\n    model: default\n"
             "router:\n  model: default\n"
             "memory:\n"
@@ -3101,7 +3101,7 @@ class TestDoctor:
         """Doctor validates sentence-transformers embedders by loading the local model."""
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
-            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-4-6\n"
+            "models:\n  default:\n    provider: anthropic\n    id: claude-sonnet-5\n"
             "agents:\n  a:\n    display_name: A\n    model: default\n"
             "router:\n  model: default\n"
             "memory:\n"

--- a/tests/test_model_defaults.py
+++ b/tests/test_model_defaults.py
@@ -63,6 +63,24 @@ def test_saas_default_uses_current_gemini_flash() -> None:
     assert old_preview_model not in {preset.id for preset in model_defaults.SAAS_MODEL_PRESETS.values()}
 
 
+def test_sonnet_presets_use_current_generation() -> None:
+    """Sonnet presets should track the current provider-specific Sonnet generation."""
+    bedrock_alternatives = dict(model_defaults.CONFIG_INIT_MODEL_ALTERNATIVES["bedrock_claude"])
+
+    assert model_defaults.CONFIG_INIT_MODEL_PRESETS["anthropic"].id == "claude-sonnet-5"
+    assert model_defaults.CONFIG_INIT_MODEL_PRESETS["vertexai_claude"].id == "claude-sonnet-5"
+    assert model_defaults.CONFIG_INIT_MODEL_PRESETS["openrouter"].id == "anthropic/claude-sonnet-5"
+    assert model_defaults.SAAS_MODEL_PRESETS["sonnet"].id == "anthropic/claude-sonnet-5"
+    assert bedrock_alternatives["sonnet"].id == "global.anthropic.claude-sonnet-5"
+    assert "claude-sonnet-4-6" not in {
+        model_defaults.CONFIG_INIT_MODEL_PRESETS["anthropic"].id,
+        model_defaults.CONFIG_INIT_MODEL_PRESETS["vertexai_claude"].id,
+        model_defaults.CONFIG_INIT_MODEL_PRESETS["openrouter"].id,
+        model_defaults.SAAS_MODEL_PRESETS["sonnet"].id,
+        bedrock_alternatives["sonnet"].id,
+    }
+
+
 def test_config_init_openrouter_alternatives_cover_saas_openrouter_models() -> None:
     """Config init should comment every non-default OpenRouter model alias we expose elsewhere."""
     openrouter_saas_aliases = {


### PR DESCRIPTION
## Summary
- Update Anthropic, Vertex Claude, Bedrock Claude, and OpenRouter Sonnet defaults to Sonnet 5.
- Refresh docs, generated config examples, SaaS defaults, and mindroom-docs references.
- Add regression coverage for provider-specific Sonnet 5 preset IDs.

## Test Plan
- [x] uv sync --all-extras
- [x] uv run pytest
- [x] uv run pre-commit run --all-files

## Summary by Sourcery

Update Claude Sonnet defaults across the codebase to use the latest Sonnet 5 generation instead of the previous Sonnet 4.6 variants.

Enhancements:
- Align Anthropic, Vertex AI Claude, Bedrock Claude, and OpenRouter Sonnet preset IDs with the Sonnet 5 generation in model defaults and sample configs.
- Refresh user- and SaaS-facing configuration examples, documentation, and reference materials to reference Claude Sonnet 5 and its 1M-token context window.

Tests:
- Add regression coverage to assert that all Sonnet-related presets and Bedrock alternatives consistently point to provider-specific Sonnet 5 IDs and no longer reference Sonnet 4.6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated model defaults and configuration examples to use Claude Sonnet 5 across supported providers.
  * Clarified guidance for choosing the correct model identifier in different environments.

* **Documentation**
  * Refreshed setup and architecture examples to match the latest model names and settings.
  * Updated example context window values where shown.

* **Tests**
  * Adjusted automated checks to reflect the new default model identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->