### PR TITLE
Allow non-OAuth MCP tools on isolating worker scopes

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -162,10 +162,9 @@ agents:
 These per-agent overrides filter the already discovered catalog for that agent assignment.
 They are useful when one server exposes many tools but one agent should see only a focused subset.
 
-Non-OAuth MCP integrations are treated as shared-only integrations.
-Agents using `worker_scope: user` or `worker_scope: user_agent` cannot use non-OAuth `mcp_<server_id>` tools.
-Use unscoped execution or `worker_scope: shared` for unauthenticated MCP servers and static-header MCP servers.
-OAuth-backed remote MCP servers are the exception because MindRoom loads a scoped OAuth token for the current requester at tool-call time.
+MCP tools are available on every worker scope, including private per-user agents.
+Non-OAuth `mcp_<server_id>` tools always execute through the shared MCP server session; requester identity and requester credentials are never passed to the server.
+OAuth-backed remote MCP servers instead load a scoped OAuth token for the current requester at tool-call time and keep one session per requester scope.
 
 ## OAuth-Backed Remote MCP
 
@@ -432,8 +431,8 @@ If the catalog changed, MindRoom restarts the agents and teams that reference th
 
 - Phase 1 supports MCP tools only.
 - MCP resources and prompts are not exposed in MindRoom yet.
-- Non-OAuth MCP integrations are shared-only and cannot be used with `worker_scope: user` or `worker_scope: user_agent`.
-- OAuth-backed remote MCP integrations use requester-scoped OAuth credentials and can be used with isolating worker scopes.
+- Non-OAuth MCP integrations always use the shared server session, even on isolating worker scopes; per-requester isolation requires an OAuth-backed server.
+- OAuth-backed remote MCP integrations use requester-scoped OAuth credentials and sessions.
 - OAuth-backed remote MCP typed functions appear only after MindRoom has cached a requester-specific remote catalog.
 - `server_id` and `tool_prefix` must use letters, numbers, and underscores.
 - The final function name `<prefix>_<remote_tool_name>` must be 64 characters or fewer.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -97,8 +97,8 @@ Use [Sandbox Proxy Isolation](../deployment/sandbox-proxy.md) for deployment det
 ## Shared-Only Integrations
 
 Some dashboard integrations are restricted to shared or unscoped execution and cannot be used by agents with isolating worker scopes.
-The current shared-only integrations are `spotify`, `homeassistant`, and non-OAuth configured `mcp_<server_id>` tools.
-OAuth-backed remote MCP tools are requester-scoped and can be used with isolating worker scopes.
+The current shared-only integrations are `spotify` and `homeassistant`.
+MCP `mcp_<server_id>` tools work on isolating worker scopes: OAuth-backed servers are requester-scoped, while non-OAuth servers always call through the shared server session without requester credentials.
 
 ## Automatic Dependency Installation
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -2841,8 +2841,8 @@ Use [Sandbox Proxy Isolation](https://docs.mindroom.chat/deployment/sandbox-prox
 ## Shared-Only Integrations
 
 Some dashboard integrations are restricted to shared or unscoped execution and cannot be used by agents with isolating worker scopes.
-The current shared-only integrations are `spotify`, `homeassistant`, and non-OAuth configured `mcp_<server_id>` tools.
-OAuth-backed remote MCP tools are requester-scoped and can be used with isolating worker scopes.
+The current shared-only integrations are `spotify` and `homeassistant`.
+MCP `mcp_<server_id>` tools work on isolating worker scopes: OAuth-backed servers are requester-scoped, while non-OAuth servers always call through the shared server session without requester credentials.
 
 ## Automatic Dependency Installation
 
@@ -9645,10 +9645,9 @@ agents:
 These per-agent overrides filter the already discovered catalog for that agent assignment.
 They are useful when one server exposes many tools but one agent should see only a focused subset.
 
-Non-OAuth MCP integrations are treated as shared-only integrations.
-Agents using `worker_scope: user` or `worker_scope: user_agent` cannot use non-OAuth `mcp_<server_id>` tools.
-Use unscoped execution or `worker_scope: shared` for unauthenticated MCP servers and static-header MCP servers.
-OAuth-backed remote MCP servers are the exception because MindRoom loads a scoped OAuth token for the current requester at tool-call time.
+MCP tools are available on every worker scope, including private per-user agents.
+Non-OAuth `mcp_<server_id>` tools always execute through the shared MCP server session; requester identity and requester credentials are never passed to the server.
+OAuth-backed remote MCP servers instead load a scoped OAuth token for the current requester at tool-call time and keep one session per requester scope.
 
 ## OAuth-Backed Remote MCP
 
@@ -9915,8 +9914,8 @@ If the catalog changed, MindRoom restarts the agents and teams that reference th
 
 - Phase 1 supports MCP tools only.
 - MCP resources and prompts are not exposed in MindRoom yet.
-- Non-OAuth MCP integrations are shared-only and cannot be used with `worker_scope: user` or `worker_scope: user_agent`.
-- OAuth-backed remote MCP integrations use requester-scoped OAuth credentials and can be used with isolating worker scopes.
+- Non-OAuth MCP integrations always use the shared server session, even on isolating worker scopes; per-requester isolation requires an OAuth-backed server.
+- OAuth-backed remote MCP integrations use requester-scoped OAuth credentials and sessions.
 - OAuth-backed remote MCP typed functions appear only after MindRoom has cached a requester-specific remote catalog.
 - `server_id` and `tool_prefix` must use letters, numbers, and underscores.
 - The final function name `<prefix>_<remote_tool_name>` must be 64 characters or fewer.

--- a/skills/mindroom-docs/references/page__mcp__index.md
+++ b/skills/mindroom-docs/references/page__mcp__index.md
@@ -158,10 +158,9 @@ agents:
 These per-agent overrides filter the already discovered catalog for that agent assignment.
 They are useful when one server exposes many tools but one agent should see only a focused subset.
 
-Non-OAuth MCP integrations are treated as shared-only integrations.
-Agents using `worker_scope: user` or `worker_scope: user_agent` cannot use non-OAuth `mcp_<server_id>` tools.
-Use unscoped execution or `worker_scope: shared` for unauthenticated MCP servers and static-header MCP servers.
-OAuth-backed remote MCP servers are the exception because MindRoom loads a scoped OAuth token for the current requester at tool-call time.
+MCP tools are available on every worker scope, including private per-user agents.
+Non-OAuth `mcp_<server_id>` tools always execute through the shared MCP server session; requester identity and requester credentials are never passed to the server.
+OAuth-backed remote MCP servers instead load a scoped OAuth token for the current requester at tool-call time and keep one session per requester scope.
 
 ## OAuth-Backed Remote MCP
 
@@ -428,8 +427,8 @@ If the catalog changed, MindRoom restarts the agents and teams that reference th
 
 - Phase 1 supports MCP tools only.
 - MCP resources and prompts are not exposed in MindRoom yet.
-- Non-OAuth MCP integrations are shared-only and cannot be used with `worker_scope: user` or `worker_scope: user_agent`.
-- OAuth-backed remote MCP integrations use requester-scoped OAuth credentials and can be used with isolating worker scopes.
+- Non-OAuth MCP integrations always use the shared server session, even on isolating worker scopes; per-requester isolation requires an OAuth-backed server.
+- OAuth-backed remote MCP integrations use requester-scoped OAuth credentials and sessions.
 - OAuth-backed remote MCP typed functions appear only after MindRoom has cached a requester-specific remote catalog.
 - `server_id` and `tool_prefix` must use letters, numbers, and underscores.
 - The final function name `<prefix>_<remote_tool_name>` must be 64 characters or fewer.

--- a/skills/mindroom-docs/references/page__tools__index.md
+++ b/skills/mindroom-docs/references/page__tools__index.md
@@ -93,8 +93,8 @@ Use [Sandbox Proxy Isolation](https://docs.mindroom.chat/deployment/sandbox-prox
 ## Shared-Only Integrations
 
 Some dashboard integrations are restricted to shared or unscoped execution and cannot be used by agents with isolating worker scopes.
-The current shared-only integrations are `spotify`, `homeassistant`, and non-OAuth configured `mcp_<server_id>` tools.
-OAuth-backed remote MCP tools are requester-scoped and can be used with isolating worker scopes.
+The current shared-only integrations are `spotify` and `homeassistant`.
+MCP `mcp_<server_id>` tools work on isolating worker scopes: OAuth-backed servers are requester-scoped, while non-OAuth servers always call through the shared server session without requester credentials.
 
 ## Automatic Dependency Installation
 

--- a/src/mindroom/api/tools.py
+++ b/src/mindroom/api/tools.py
@@ -159,15 +159,12 @@ def _annotate_execution_scope_support(
     tools: list[dict[str, Any]],
     *,
     execution_scope: WorkerScope | None,
-    config: Config,
 ) -> None:
     """Expose whether each tool is supported for the requested execution scope."""
     unsupported_tools = set(
         unsupported_shared_only_integration_names(
             [tool["name"] for tool in tools],
             execution_scope,
-            configured_mcp_server_ids=config.mcp_servers,
-            oauth_mcp_server_ids=config.oauth_mcp_server_ids(),
         ),
     )
     for tool in tools:
@@ -346,7 +343,6 @@ async def get_registered_tools(
     _annotate_execution_scope_support(
         tools,
         execution_scope=context.execution_scope,
-        config=config,
     )
     _annotate_dashboard_configuration_support(
         tools,

--- a/src/mindroom/config/main.py
+++ b/src/mindroom/config/main.py
@@ -690,15 +690,12 @@ class Config(BaseModel):
     def validate_shared_only_integration_assignments(self) -> Config:
         """Reject shared-only integrations on isolating scopes for static and dynamic tool assignments."""
         invalid_assignments: list[str] = []
-        oauth_mcp_server_ids = self.oauth_mcp_server_ids()
         for agent_name in sorted(self.agents):
             scope_label = self.get_agent_scope_label(agent_name)
             execution_scope = self.get_agent_execution_scope(agent_name)
             unsupported_tools = unsupported_shared_only_integration_names(
                 self._get_agent_eager_tools(agent_name),
                 execution_scope,
-                configured_mcp_server_ids=self.mcp_servers,
-                oauth_mcp_server_ids=oauth_mcp_server_ids,
             )
             invalid_assignments.extend(
                 f"{agent_name} -> {tool_name} ({scope_label})" for tool_name in unsupported_tools
@@ -1185,14 +1182,6 @@ class Config(BaseModel):
         return unsupported_shared_only_integration_names(
             self.expand_tool_names([authored_tool_name]),
             execution_scope,
-            configured_mcp_server_ids=self.mcp_servers,
-            oauth_mcp_server_ids=self.oauth_mcp_server_ids(),
-        )
-
-    def oauth_mcp_server_ids(self) -> frozenset[str]:
-        """Return configured MCP server ids backed by requester-scoped OAuth."""
-        return frozenset(
-            server_id for server_id, server_config in self.mcp_servers.items() if server_config.auth is not None
         )
 
     def get_agent_scope_incompatible_deferred_tools(self, agent_name: str) -> dict[str, list[str]]:

--- a/src/mindroom/mcp/registry.py
+++ b/src/mindroom/mcp/registry.py
@@ -38,7 +38,6 @@ logger = get_logger(__name__)
 
 _MCP_TOOL_PREFIX = "mcp_"
 _MCP_TOOL_NAMES: set[str] = set()
-_MCP_OAUTH_TOOL_NAMES: set[str] = set()
 _MCP_TOOL_FACTORY_MARKER = "__mindroom_mcp_tool_factory__"
 # MindRoomMCPToolkit declares these constructor args for every MCP tool; metadata
 # mirrors that contract even though credentials are used only by OAuth-backed servers.
@@ -63,11 +62,6 @@ def mcp_server_id_from_tool_name(tool_name: str) -> str | None:
         return None
     server_id = tool_name.removeprefix(_MCP_TOOL_PREFIX)
     return server_id or None
-
-
-def mcp_tool_name_is_oauth_backed(tool_name: str) -> bool:
-    """Return whether one registry-owned MCP tool uses requester-scoped OAuth."""
-    return tool_name in _MCP_OAUTH_TOOL_NAMES
 
 
 def _registered_mcp_tool_names() -> set[str]:
@@ -244,15 +238,6 @@ def sync_mcp_tool_registry(config: Config | None) -> None:
     )
     _MCP_TOOL_NAMES.clear()
     _MCP_TOOL_NAMES.update(desired_tool_names)
-    _MCP_OAUTH_TOOL_NAMES.clear()
-    if config is not None:
-        _MCP_OAUTH_TOOL_NAMES.update(
-            mcp_tool_name(server_id)
-            for server_id, server_config in config.mcp_servers.items()
-            if server_config.enabled
-            and server_config.auth is not None
-            and mcp_tool_name(server_id) in desired_tool_names
-        )
 
 
 def resolved_mcp_tool_state(

--- a/src/mindroom/tool_system/worker_routing.py
+++ b/src/mindroom/tool_system/worker_routing.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Literal, cast
 from mindroom.tool_system.context_bound_streams import context_bound_async_stream
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Awaitable, Callable, Collection, Iterator
+    from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
 
     from mindroom.constants import RuntimePaths
 
@@ -383,35 +383,14 @@ def worker_scope_allows_shared_only_integrations(worker_scope: WorkerScope | Non
     return worker_scope in (None, "shared")
 
 
-def _requires_shared_only_integration_scope(
-    name: str,
-    *,
-    configured_mcp_server_ids: Collection[str] | None = None,
-    oauth_mcp_server_ids: Collection[str] | None = None,
-) -> bool:
-    """Return whether a tool or dashboard integration is restricted to shared scope."""
-    if name in _SHARED_ONLY_INTEGRATION_NAMES:
-        return True
+def _requires_shared_only_integration_scope(name: str) -> bool:
+    """Return whether a tool or dashboard integration is restricted to shared scope.
 
-    from mindroom.mcp.registry import (  # noqa: PLC0415
-        mcp_server_id_from_tool_name,
-        mcp_tool_name,
-        mcp_tool_name_is_oauth_backed,
-    )
-
-    server_id = mcp_server_id_from_tool_name(name)
-    if server_id is not None:
-        return not (
-            mcp_tool_name_is_oauth_backed(name)
-            or (oauth_mcp_server_ids is not None and server_id in oauth_mcp_server_ids)
-        )
-    if configured_mcp_server_ids is None:
-        return False
-    for server_id in configured_mcp_server_ids:
-        if name != mcp_tool_name(server_id):
-            continue
-        return oauth_mcp_server_ids is None or server_id not in oauth_mcp_server_ids
-    return False
+    MCP registry tools are supported on every scope: OAuth-backed servers use
+    requester-scoped sessions, and non-OAuth servers always execute through the
+    shared server session without requester credentials.
+    """
+    return name in _SHARED_ONLY_INTEGRATION_NAMES
 
 
 def supports_tool_name_for_worker_scope(name: str, worker_scope: WorkerScope | None) -> bool:
@@ -424,22 +403,11 @@ def supports_tool_name_for_worker_scope(name: str, worker_scope: WorkerScope | N
 def unsupported_shared_only_integration_names(
     names: list[str],
     worker_scope: WorkerScope | None,
-    *,
-    configured_mcp_server_ids: Collection[str] | None = None,
-    oauth_mcp_server_ids: Collection[str] | None = None,
 ) -> list[str]:
     """Return shared-only integration names that are invalid for the effective execution scope."""
     if worker_scope_allows_shared_only_integrations(worker_scope):
         return []
-    return [
-        name
-        for name in names
-        if _requires_shared_only_integration_scope(
-            name,
-            configured_mcp_server_ids=configured_mcp_server_ids,
-            oauth_mcp_server_ids=oauth_mcp_server_ids,
-        )
-    ]
+    return [name for name in names if _requires_shared_only_integration_scope(name)]
 
 
 def tool_stays_local(name: str) -> bool:

--- a/tach.toml
+++ b/tach.toml
@@ -2308,7 +2308,6 @@ depends_on = ["mindroom.tool_system.plugin_imports"]
 [[modules]]
 path = "mindroom.tool_system.worker_routing"
 depends_on = [
-    "mindroom.mcp.registry",
     "mindroom.tool_system.context_bound_streams",
 ]
 

--- a/tests/test_mcp_config.py
+++ b/tests/test_mcp_config.py
@@ -168,29 +168,57 @@ def test_config_accepts_top_level_mcp_servers(tmp_path: Path) -> None:
     assert "mcp_chrome_devtools" in config.get_agent_available_tools("code")
 
 
-def test_config_rejects_mcp_tools_on_user_scoped_agents(tmp_path: Path) -> None:
-    """Keep MCP tools restricted to shared-scope integrations."""
+def test_config_allows_non_oauth_mcp_tools_on_private_per_user_agents(tmp_path: Path) -> None:
+    """Private per-user agents may list non-OAuth MCP tools; calls use the shared MCP session."""
     runtime_paths = _runtime_paths(tmp_path)
-    with pytest.raises(ValueError, match="Shared-only integrations"):
-        Config.validate_with_runtime(
-            {
-                "mcp_servers": {
-                    "demo": {
-                        "transport": "stdio",
-                        "command": "npx",
-                    },
-                },
-                "agents": {
-                    "code": {
-                        "display_name": "Code",
-                        "role": "Write code",
-                        "worker_scope": "user",
-                        "tools": ["mcp_demo"],
-                    },
+    config = Config.validate_with_runtime(
+        {
+            "mcp_servers": {
+                "demo": {
+                    "transport": "stdio",
+                    "command": "npx",
                 },
             },
-            runtime_paths,
-        )
+            "agents": {
+                "code": {
+                    "display_name": "Code",
+                    "role": "Write code",
+                    "private": {"per": "user_agent"},
+                    "tools": ["mcp_demo"],
+                },
+            },
+        },
+        runtime_paths,
+    )
+
+    assert config.get_agent_execution_scope("code") == "user_agent"
+    assert "mcp_demo" in config.get_agent_available_tools("code")
+
+
+def test_config_allows_non_oauth_mcp_tools_on_user_scoped_agents(tmp_path: Path) -> None:
+    """Non-OAuth MCP tools are valid on isolating worker scopes and stay shared-session at runtime."""
+    runtime_paths = _runtime_paths(tmp_path)
+    config = Config.validate_with_runtime(
+        {
+            "mcp_servers": {
+                "demo": {
+                    "transport": "stdio",
+                    "command": "npx",
+                },
+            },
+            "agents": {
+                "code": {
+                    "display_name": "Code",
+                    "role": "Write code",
+                    "worker_scope": "user",
+                    "tools": ["mcp_demo"],
+                },
+            },
+        },
+        runtime_paths,
+    )
+
+    assert "mcp_demo" in config.get_agent_available_tools("code")
 
 
 def test_config_allows_oauth_mcp_tools_on_user_scoped_agents(tmp_path: Path) -> None:

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
 
     from mindroom.constants import RuntimePaths
     from mindroom.mcp.types import MCPServerState
-    from mindroom.tool_system.worker_routing import ResolvedWorkerTarget
+    from mindroom.tool_system.worker_routing import ResolvedWorkerTarget, WorkerScope
 
 
 _MessageHandler = Callable[[object], Awaitable[None]]
@@ -259,7 +259,7 @@ def _oauth_mcp_config() -> MCPServerConfig:
     )
 
 
-def _worker_target(requester_id: str) -> ResolvedWorkerTarget:
+def _worker_target(requester_id: str, *, worker_scope: WorkerScope = "user") -> ResolvedWorkerTarget:
     identity = ToolExecutionIdentity(
         channel="matrix",
         agent_name="code",
@@ -271,7 +271,7 @@ def _worker_target(requester_id: str) -> ResolvedWorkerTarget:
         tenant_id="tenant",
         account_id=None,
     )
-    return resolve_worker_target("user", "code", identity)
+    return resolve_worker_target(worker_scope, "code", identity)
 
 
 def _shared_worker_target(requester_id: str, *, agent_name: str = "code") -> ResolvedWorkerTarget:
@@ -421,6 +421,55 @@ async def test_mcp_manager_syncs_catalog_and_calls_tool(monkeypatch: pytest.Monk
     assert changed == {"demo"}
     result = await manager.call_tool("demo", "echo", {"value": "ping"})
     assert result.content == "pong"
+
+
+@pytest.mark.asyncio
+async def test_mcp_manager_non_oauth_calls_use_shared_session_without_requester_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Non-OAuth MCP calls from isolating scopes share one session and never resolve requester credentials."""
+    _patch_manager(monkeypatch)
+
+    def _fail_credential_resolution(*_args: object, **_kwargs: object) -> object:
+        pytest.fail("non-OAuth MCP calls must not resolve requester-scoped credentials")
+
+    monkeypatch.setattr(
+        "mindroom.mcp.manager.refresh_scoped_oauth_credentials_with_result",
+        _fail_credential_resolution,
+    )
+    monkeypatch.setattr("mindroom.mcp.manager.load_scoped_credentials", _fail_credential_resolution)
+    _FakeClientSession.tool_list = [_tool("echo")]
+    _FakeClientSession.planned_tool_results = [
+        CallToolResult(content=[mcp_types.TextContent(type="text", text="pong-alice")]),
+        CallToolResult(content=[mcp_types.TextContent(type="text", text="pong-bob")]),
+    ]
+    runtime_paths = _runtime_paths(tmp_path)
+    credentials_manager = get_runtime_credentials_manager(runtime_paths)
+    manager = MCPServerManager(runtime_paths)
+    config = _ConfigStub({"demo": MCPServerConfig(transport="stdio", command="npx")})
+    await manager.sync_servers(config)
+
+    alice_result = await manager.call_tool(
+        "demo",
+        "echo",
+        {"value": "ping"},
+        credentials_manager=credentials_manager,
+        worker_target=_worker_target("@alice:example.test", worker_scope="user_agent"),
+    )
+    bob_result = await manager.call_tool(
+        "demo",
+        "echo",
+        {"value": "ping"},
+        credentials_manager=credentials_manager,
+        worker_target=_worker_target("@bob:example.test", worker_scope="user_agent"),
+    )
+
+    assert alice_result.content == "pong-alice"
+    assert bob_result.content == "pong-bob"
+    assert len(_FakeClientSession.sessions) == 1
+    assert _FakeClientSession.transport_extra_headers == [{}]
+    assert manager._scoped_states == {}
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_registry.py
+++ b/tests/test_mcp_registry.py
@@ -30,7 +30,11 @@ from mindroom.tool_system.metadata import (
     ToolStatus,
     get_tool_by_name,
 )
-from mindroom.tool_system.worker_routing import supports_tool_name_for_worker_scope
+from mindroom.tool_system.worker_routing import (
+    ToolExecutionIdentity,
+    resolve_worker_target,
+    supports_tool_name_for_worker_scope,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -349,6 +353,28 @@ def test_mcp_tool_registry_returns_empty_toolkit_without_bound_manager(tmp_path:
     assert toolkit.async_functions == {}
 
 
+def test_non_oauth_mcp_toolkit_builds_for_private_per_user_worker_target(tmp_path: Path) -> None:
+    """Tool construction accepts isolating worker targets for non-OAuth MCP tools."""
+    config = _config(tmp_path)
+    sync_mcp_tool_registry(config)
+    identity = ToolExecutionIdentity(
+        channel="matrix",
+        agent_name="code",
+        requester_id="@alice:example.test",
+        room_id="!room:example.test",
+        thread_id="$thread",
+        resolved_thread_id="$thread",
+        session_id=None,
+        tenant_id="tenant",
+        account_id=None,
+    )
+    worker_target = resolve_worker_target("user_agent", "code", identity)
+
+    toolkit = get_tool_by_name("mcp_demo", _runtime_paths(tmp_path), worker_target=worker_target)
+
+    assert toolkit.name == "mcp_demo"
+
+
 def _bind_failed_manager(tmp_path: Path, server_config: MCPServerConfig) -> None:
     manager = MCPServerManager(_runtime_paths(tmp_path))
     state = MCPServerState(server_id="demo", config=server_config)
@@ -408,12 +434,13 @@ def test_non_oauth_mcp_toolkit_declares_constructor_managed_init_args(tmp_path: 
     )
 
 
-def test_mcp_tool_names_are_shared_only(tmp_path: Path) -> None:
-    """Treat all MCP registry tools as shared-only integrations."""
+def test_non_oauth_mcp_tool_names_are_supported_on_isolating_scope(tmp_path: Path) -> None:
+    """Non-OAuth MCP registry tools are scope-agnostic; calls always use the shared server session."""
     sync_mcp_tool_registry(_config(tmp_path))
 
     assert mcp_server_id_from_tool_name("mcp_demo") == "demo"
-    assert supports_tool_name_for_worker_scope("mcp_demo", "user") is False
+    assert supports_tool_name_for_worker_scope("mcp_demo", "user") is True
+    assert supports_tool_name_for_worker_scope("mcp_demo", "user_agent") is True
 
 
 def test_oauth_mcp_tool_names_are_supported_on_isolating_scope(tmp_path: Path) -> None:


### PR DESCRIPTION
Supersedes #1352, which accidentally displayed 11 already-merged commits from #1342 because its branch forked from a pre-squash-merge base; this branch is rebased onto current main and contains only the MCP scope change.

## Summary

Private per-user agents (`private.per: user_agent`) and agents with `worker_scope: user`/`user_agent` may now list non-OAuth `mcp_<server_id>` tools.

The runtime call path was already safe by construction: `MCPServerManager.call_tool` routes non-OAuth servers through the shared base session and ignores `credentials_manager`/`worker_target` entirely, so no requester identity or credentials ever reach the server. MCP toolkits also execute in the primary runtime, not in workers. The only thing rejecting this configuration was the shared-only classification in `_requires_shared_only_integration_scope`.

## Changes

- **Core fix**: drop the MCP branch from `_requires_shared_only_integration_scope` so it reduces to the static `spotify`/`homeassistant` set. That one seam feeds config validation, deferred-tool loading, `get_tool_by_name` construction, and dashboard scope annotations, so all of them now accept MCP tools on any scope.
- **Dead-code removal**: `mcp_tool_name_is_oauth_backed`, `_MCP_OAUTH_TOOL_NAMES`, `Config.oauth_mcp_server_ids`, and the `configured_mcp_server_ids`/`oauth_mcp_server_ids` kwargs had no remaining callers and are removed, along with the `worker_routing -> mcp.registry` tach dependency.
- **Docs**: `docs/mcp.md` and `docs/tools/index.md` now state that non-OAuth MCP is shared-session on every scope rather than forbidden.

## Unchanged behavior

- OAuth-backed MCP stays requester-scoped: per-requester tokens and sessions, verified by existing manager tests.
- The unsafe server-description gate (`MCP description requires OAuth auth`) is untouched.
- Private-agent isolation of files, memory, and credentials is untouched.

## Tests (test-first)

1. Regression test (private `per: user_agent` agent + non-OAuth `mcp_demo`) confirmed failing with the old "Shared-only integrations" error before the fix.
2. New coverage: config acceptance for private per-user and user-scoped agents, toolkit construction with a `user_agent` worker target, and a manager-level test proving two requesters on isolating scopes share one session, send no auth headers, create no scoped states, and never resolve requester credentials (credential resolution is monkeypatched to fail the test).
3. Full suite green before rebase; after rebasing onto current main, targeted MCP + API suites (324 tests), `tach check --dependencies --interfaces`, and pre-commit all pass.