### PR TITLE
Regenerate tools_metadata.json for Google Scholar tool

### DIFF
--- a/src/mindroom/tools_metadata.json
+++ b/src/mindroom/tools_metadata.json
@@ -10538,6 +10538,7 @@
       "icon": "SiGooglescholar",
       "icon_color": "text-blue-500",
       "name": "google_scholar",
+      "requires_room_context": false,
       "setup_type": "none",
       "status": "available"
     },


### PR DESCRIPTION
## Summary
- Fixes the `test (3.13)` pytest failure on main ([failing run](https://github.com/mindroom-ai/mindroom/actions/runs/28549344474/job/84642533986)).
- #1351 added the `google_scholar` tool but the committed `src/mindroom/tools_metadata.json` was not regenerated, so the `google_scholar` entry was missing the `requires_room_context: false` field and `test_export_tools_metadata_json` failed.
- Regenerated the file with the command from the test's assertion message.

## Test plan
- `uv run pytest tests/test_tools_metadata.py -n 0 --no-cov` — 30 passed.

## Summary by Sourcery

Regenerate the tools metadata JSON to reflect the current set of tools and their attributes.

Bug Fixes:
- Include the missing google_scholar entry details in tools_metadata.json so tests expecting up-to-date metadata pass.

Chores:
- Update the generated tools_metadata.json artifact to stay in sync with recent tool additions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Google Scholar tool configuration to properly reflect that it does not require room context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->