### PR TITLE
Stop interrupted turns from poisoning history with raw tool traces; guard empty replies

### DIFF
--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -366,6 +366,41 @@ def _advance_dynamic_continuation(
     return advanced_state, turn_state
 
 
+def _discard_empty_run_and_grant_retry(
+    *,
+    agent: Agent | None,
+    scope_context: ScopeSessionContext | None,
+    session_id: str,
+    run_id: str | None,
+    entity_name: str,
+    output_tokens: int | None,
+    empty_response_retried: bool,
+    continuation_count: int,
+) -> bool:
+    """Discard one empty completed run and decide whether one retry is granted.
+
+    Shared by the blocking and streaming loops so the empty-retry handoff stays
+    identical across both paths. The one-shot retry borrows a dynamic-continuation
+    slot so the outer loop's iteration budget stays authoritative; a granted retry
+    closes the spent agent's runtime state DBs exactly like the continuation handoff.
+    """
+    ai_runtime.discard_empty_completed_run(
+        scope_context=scope_context,
+        session_id=session_id,
+        run_id=run_id,
+        session_type=SessionType.AGENT,
+        entity_name=entity_name,
+        output_tokens=output_tokens,
+    )
+    if empty_response_retried or continuation_count >= DYNAMIC_TOOL_CONTINUATION_LIMIT:
+        return False
+    close_agent_runtime_state_dbs(
+        agent,
+        shared_scope_storage=scope_context.storage if scope_context is not None else None,
+    )
+    return True
+
+
 @timed("system_prompt_assembly.system_enrichment_render")
 def _render_system_enrichment_context(
     system_enrichment_items: Sequence[EnrichmentItem],
@@ -1657,18 +1692,18 @@ async def ai_response(  # noqa: C901, PLR0915
                     agent_name,
                 )
             if ai_runtime.is_empty_completed_run(response):
-                ai_runtime.discard_empty_completed_run(
+                if _discard_empty_run_and_grant_retry(
+                    agent=agent,
                     scope_context=scope_context,
                     session_id=response.session_id or session_id,
                     run_id=response.run_id,
-                    session_type=SessionType.AGENT,
                     entity_name=agent_name,
                     output_tokens=_usage_metric_int(response.metrics, "output_tokens"),
-                )
-                # The one-shot retry borrows a dynamic-continuation slot so the
-                # outer loop's iteration budget stays authoritative.
-                if not empty_response_retried and continuation_count < DYNAMIC_TOOL_CONTINUATION_LIMIT:
+                    empty_response_retried=empty_response_retried,
+                    continuation_count=continuation_count,
+                ):
                     empty_response_retried = True
+                    agent = None
                     return None
                 if turn_recorder is not None:
                     turn_state.record_completed(
@@ -2309,18 +2344,18 @@ async def stream_agent_response(  # noqa: C901, PLR0915
                 if _stream_completed_without_visible_output(state) and not state.completed_tool_executions:
                     completed_event = state.completed_run_event
                     assert completed_event is not None
-                    ai_runtime.discard_empty_completed_run(
+                    if _discard_empty_run_and_grant_retry(
+                        agent=agent,
                         scope_context=scope_context,
                         session_id=completed_event.session_id or session_id,
                         run_id=completed_event.run_id,
-                        session_type=SessionType.AGENT,
                         entity_name=agent_name,
                         output_tokens=state.request_metric_totals.get("output_tokens"),
-                    )
-                    # The one-shot retry borrows a dynamic-continuation slot so the
-                    # outer loop's iteration budget stays authoritative.
-                    if not empty_response_retried and continuation_count < DYNAMIC_TOOL_CONTINUATION_LIMIT:
+                        empty_response_retried=empty_response_retried,
+                        continuation_count=continuation_count,
+                    ):
                         empty_response_retried = True
+                        agent = None
                         keep_going = True
                         return
                     # The notice must fall through: the run-metadata recording and

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -1525,6 +1525,7 @@ async def ai_response(  # noqa: C901, PLR0915
     agent: Agent | None = None
     scope_context: ScopeSessionContext | None = None
     standalone_interrupted_replay_persisted = False
+    empty_response_retried = False
     turn_state = AITurnState()
     unseen_event_ids: list[str] = []
     metadata: dict[str, Any] | None = None
@@ -1536,9 +1537,9 @@ async def ai_response(  # noqa: C901, PLR0915
         except ValueError as e:
             return get_user_friendly_error_message(e, agent_name)
 
-        async def _run_blocking_attempt(continuation_count: int) -> str | None:  # noqa: C901, PLR0912
+        async def _run_blocking_attempt(continuation_count: int) -> str | None:  # noqa: C901, PLR0911, PLR0912, PLR0915
             """Run one agent attempt; return final text, or None to continue the turn."""
-            nonlocal agent, attempt, continuation_state, metadata, run_extra_content
+            nonlocal agent, attempt, continuation_state, empty_response_retried, metadata, run_extra_content
             nonlocal standalone_interrupted_replay_persisted, turn_state, unseen_event_ids
             try:
                 run_context = await _prepare_agent_run_context(
@@ -1655,6 +1656,26 @@ async def ai_response(  # noqa: C901, PLR0915
                     Exception(str(response.content or "Unknown agent error")),
                     agent_name,
                 )
+            if ai_runtime.is_empty_completed_run(response):
+                ai_runtime.discard_empty_completed_run(
+                    scope_context=scope_context,
+                    session_id=response.session_id or session_id,
+                    run_id=response.run_id,
+                    session_type=SessionType.AGENT,
+                    entity_name=agent_name,
+                    output_tokens=_usage_metric_int(response.metrics, "output_tokens"),
+                )
+                if not empty_response_retried and continuation_count < DYNAMIC_TOOL_CONTINUATION_LIMIT:
+                    empty_response_retried = True
+                    return None
+                if turn_recorder is not None:
+                    turn_state.record_completed(
+                        turn_recorder,
+                        run_metadata=metadata,
+                        assistant_text="",
+                        completed_tools=[],
+                    )
+                return ai_runtime.EMPTY_RESPONSE_NOTICE
 
             continuation_decision = continuation_decision_from_tools(
                 response.tools,
@@ -2089,6 +2110,7 @@ async def stream_agent_response(  # noqa: C901, PLR0915
     agent: Agent | None = None
     scope_context: ScopeSessionContext | None = None
     standalone_interrupted_replay_persisted = False
+    empty_response_retried = False
     turn_state = AITurnState()
     unseen_event_ids: list[str] = []
     metadata: dict[str, Any] | None = None
@@ -2107,8 +2129,9 @@ async def stream_agent_response(  # noqa: C901, PLR0915
             continuation_count: int,
         ) -> AsyncGenerator[AIStreamChunk, None]:
             """Stream one agent attempt; set keep_going when the turn should continue."""
-            nonlocal agent, attempt, continuation_state, keep_going, metadata, run_extra_content
-            nonlocal standalone_interrupted_replay_persisted, state, turn_state, unseen_event_ids
+            nonlocal agent, attempt, continuation_state, empty_response_retried, keep_going, metadata
+            nonlocal run_extra_content, standalone_interrupted_replay_persisted, state, turn_state
+            nonlocal unseen_event_ids
             try:
                 run_context = await _prepare_agent_run_context(
                     agent_name=agent_name,
@@ -2280,6 +2303,23 @@ async def stream_agent_response(  # noqa: C901, PLR0915
                         _raise_agent_run_cancelled(state.cancelled_run_event.reason)
 
                     break
+
+                if _stream_completed_without_visible_output(state) and not state.completed_tool_executions:
+                    completed_event = state.completed_run_event
+                    assert completed_event is not None
+                    ai_runtime.discard_empty_completed_run(
+                        scope_context=scope_context,
+                        session_id=completed_event.session_id or session_id,
+                        run_id=completed_event.run_id,
+                        session_type=SessionType.AGENT,
+                        entity_name=agent_name,
+                        output_tokens=state.request_metric_totals.get("output_tokens"),
+                    )
+                    if not empty_response_retried and continuation_count < DYNAMIC_TOOL_CONTINUATION_LIMIT:
+                        empty_response_retried = True
+                        keep_going = True
+                        return
+                    yield RunContentEvent(content=ai_runtime.EMPTY_RESPONSE_NOTICE)
 
                 continuation_decision = continuation_decision_from_tools(
                     state.completed_tool_executions,

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -1665,6 +1665,8 @@ async def ai_response(  # noqa: C901, PLR0915
                     entity_name=agent_name,
                     output_tokens=_usage_metric_int(response.metrics, "output_tokens"),
                 )
+                # The one-shot retry borrows a dynamic-continuation slot so the
+                # outer loop's iteration budget stays authoritative.
                 if not empty_response_retried and continuation_count < DYNAMIC_TOOL_CONTINUATION_LIMIT:
                     empty_response_retried = True
                     return None
@@ -2315,10 +2317,14 @@ async def stream_agent_response(  # noqa: C901, PLR0915
                         entity_name=agent_name,
                         output_tokens=state.request_metric_totals.get("output_tokens"),
                     )
+                    # The one-shot retry borrows a dynamic-continuation slot so the
+                    # outer loop's iteration budget stays authoritative.
                     if not empty_response_retried and continuation_count < DYNAMIC_TOOL_CONTINUATION_LIMIT:
                         empty_response_retried = True
                         keep_going = True
                         return
+                    # The notice must fall through: the run-metadata recording and
+                    # recorder completion below still apply to this notice-only turn.
                     yield RunContentEvent(content=ai_runtime.EMPTY_RESPONSE_NOTICE)
 
                 continuation_decision = continuation_decision_from_tools(

--- a/src/mindroom/ai_runtime.py
+++ b/src/mindroom/ai_runtime.py
@@ -12,6 +12,7 @@ from uuid import uuid4
 from agno.db.base import SessionType
 from agno.models.message import Message
 from agno.run.agent import RunOutput
+from agno.run.base import RunStatus
 from agno.run.team import TeamRunOutput
 from agno.session.agent import AgentSession
 from agno.session.team import TeamSession
@@ -29,13 +30,16 @@ if TYPE_CHECKING:
     from mindroom.history import ScopeSessionContext
 
 __all__ = [
+    "EMPTY_RESPONSE_NOTICE",
     "ModelRunInput",
     "append_inline_media_fallback_to_run_input",
     "attach_media_to_run_input",
     "cached_agent_run",
     "cleanup_queued_notice_state",
     "copy_run_input",
+    "discard_empty_completed_run",
     "install_queued_message_notice_hook",
+    "is_empty_completed_run",
     "media_inputs_from_run_input",
     "next_retry_run_id",
     "note_attempt_run_id",
@@ -49,6 +53,8 @@ type ModelRunInput = str | Sequence[Message]
 
 _QUEUED_MESSAGE_NOTICE_MARKER_KEY = "mindroom_queued_message_notice"
 _QUEUED_MESSAGE_NOTICE_HOOK_ATTR = "_mindroom_queued_message_notice_hook_installed"
+
+EMPTY_RESPONSE_NOTICE = "The model returned an empty response — please try again."
 
 
 def _normalize_run_input(run_input: ModelRunInput) -> list[Message]:
@@ -292,6 +298,89 @@ def scrub_queued_notice_session_context(
             entity=entity_name,
             session_id=scope_context.session.session_id,
             session_type="team" if isinstance(scope_context.session, TeamSession) else "agent",
+        )
+
+
+def is_empty_completed_run(response: RunOutput | TeamRunOutput) -> bool:
+    """Return whether one run completed with no tool calls and no visible content."""
+    if response.status is not RunStatus.completed or response.tools:
+        return False
+    content = response.content
+    if content is None:
+        return True
+    return isinstance(content, str) and not content.strip()
+
+
+def _remove_run_from_session(session: AgentSession | TeamSession, *, run_id: str) -> bool:
+    """Remove one run from a mutable session run list by run id."""
+    runs = session.runs or []
+    kept = [run for run in runs if not (isinstance(run, (RunOutput, TeamRunOutput)) and run.run_id == run_id)]
+    if len(kept) == len(runs):
+        return False
+    session.runs = kept
+    return True
+
+
+def _remove_run_from_session_storage(
+    storage: BaseDb,
+    session_id: str,
+    *,
+    run_id: str,
+    session_type: SessionType,
+) -> bool:
+    """Remove one run from a persisted Agno session."""
+    raw_session = storage.get_session(session_id, session_type)
+    if raw_session is None:
+        return False
+    session = _load_session_for_cleanup(
+        cast("AgentSession | TeamSession | dict[str, object]", raw_session),
+        session_type=session_type,
+    )
+    if session is None or not _remove_run_from_session(session, run_id=run_id):
+        return False
+    storage.upsert_session(session)
+    return True
+
+
+def discard_empty_completed_run(
+    *,
+    scope_context: ScopeSessionContext | None,
+    session_id: str,
+    run_id: str | None,
+    session_type: SessionType,
+    entity_name: str,
+    output_tokens: int | None,
+) -> None:
+    """Log one empty completed model response and purge its run from session history.
+
+    A persisted assistant turn with no content teaches the model that ending the
+    turn immediately is the expected continuation, so the run is removed from both
+    the loaded session and storage before the next prompt is built.
+    """
+    logger.warning(
+        "model_returned_empty_response",
+        entity=entity_name,
+        session_id=session_id,
+        run_id=run_id,
+        output_tokens=output_tokens,
+    )
+    if scope_context is None or not run_id:
+        return
+    try:
+        if scope_context.session is not None:
+            _remove_run_from_session(scope_context.session, run_id=run_id)
+        _remove_run_from_session_storage(
+            scope_context.storage,
+            session_id,
+            run_id=run_id,
+            session_type=session_type,
+        )
+    except Exception:
+        logger.exception(
+            "Failed to remove empty run from session history",
+            entity=entity_name,
+            session_id=session_id,
+            run_id=run_id,
         )
 
 

--- a/src/mindroom/history/interrupted_replay.py
+++ b/src/mindroom/history/interrupted_replay.py
@@ -26,7 +26,6 @@ from mindroom.tool_system.events import (
     ToolTraceEntry,
     format_tool_completed_event,
     format_tool_started_event,
-    render_tool_trace_for_context,
 )
 
 if TYPE_CHECKING:
@@ -40,7 +39,6 @@ if TYPE_CHECKING:
 _INTERRUPTED_REPLAY_STATE_KEY = "mindroom_replay_state"
 _ORIGINAL_STATUS_KEY = "mindroom_original_status"
 _INTERRUPTED_REPLAY_STATE = "interrupted"
-_INTERRUPTED_RESPONSE_MARKER = "[interrupted]"
 _TRACE_METADATA_KEYS = (
     "room_id",
     "thread_id",
@@ -124,16 +122,23 @@ def split_interrupted_tool_trace(
     return completed, interrupted
 
 
-def _render_interrupted_tool_trace(events: Sequence[ToolTraceEntry]) -> str:
-    lines: list[str] = []
-    for event in events:
-        lines.append(f"[tool:{event.tool_name} interrupted]")
-        if event.args_preview:
-            lines.append(f"  args: {event.args_preview}")
-        lines.append("  result: <interrupted before completion>")
-        if event.truncated:
-            lines.append("  (truncated)")
-    return "\n".join(lines)
+def _render_interruption_summary(snapshot: InterruptedReplaySnapshot) -> str:
+    """Render one prose interruption summary safe for model-facing assistant history.
+
+    Raw tool traces here read as machine-formatted terminal turns and teach the model
+    to end subsequent turns with empty content, so only tool names are listed.
+    """
+    details: list[str] = []
+    if snapshot.completed_tools:
+        names = ", ".join(entry.tool_name for entry in snapshot.completed_tools)
+        details.append(f"{len(snapshot.completed_tools)} tool call(s) had completed: {names}")
+    if snapshot.interrupted_tools:
+        names = ", ".join(entry.tool_name for entry in snapshot.interrupted_tools)
+        details.append(f"{len(snapshot.interrupted_tools)} tool call(s) were still running: {names}")
+    summary = "(turn interrupted by the user before completion"
+    if details:
+        summary += "; " + "; ".join(details)
+    return summary + ")"
 
 
 def _render_interrupted_replay_content(snapshot: InterruptedReplaySnapshot) -> str:
@@ -141,15 +146,8 @@ def _render_interrupted_replay_content(snapshot: InterruptedReplaySnapshot) -> s
     parts: list[str] = []
     if snapshot.partial_text:
         parts.append(snapshot.partial_text)
-    tool_parts: list[str] = []
-    if snapshot.completed_tools:
-        tool_parts.append(render_tool_trace_for_context(list(snapshot.completed_tools)))
-    if snapshot.interrupted_tools:
-        tool_parts.append(_render_interrupted_tool_trace(snapshot.interrupted_tools))
-    if tool_parts:
-        parts.append("\n".join(tool_parts))
-    parts.append(_INTERRUPTED_RESPONSE_MARKER)
-    return "\n\n".join(part for part in parts if part)
+    parts.append(_render_interruption_summary(snapshot))
+    return "\n\n".join(parts)
 
 
 def _interrupted_replay_metadata(snapshot: InterruptedReplaySnapshot) -> dict[str, Any]:

--- a/src/mindroom/tool_system/events.py
+++ b/src/mindroom/tool_system/events.py
@@ -624,20 +624,3 @@ def build_tool_trace_content(tool_trace: Sequence[ToolTraceEntry] | None) -> dic
         payload["content_truncated"] = True
 
     return {_TOOL_TRACE_KEY: payload}
-
-
-def render_tool_trace_for_context(events: list[ToolTraceEntry]) -> str:
-    """Render trace events as text for inclusion in conversation-history prompt."""
-    lines: list[str] = []
-    for event in events:
-        status = "completed" if event.type == "tool_call_completed" else "started"
-        lines.append(f"[tool:{event.tool_name} {status}]")
-        if event.args_preview:
-            lines.append(f"  args: {redact_sensitive_text(event.args_preview)}")
-        if event.result_preview is not None:
-            lines.append(f"  result: {redact_sensitive_text(event.result_preview)}")
-        elif status == "started":
-            lines.append("  result: <not yet returned>")
-        if event.truncated:
-            lines.append("  (truncated)")
-    return "\n".join(lines)

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -1405,7 +1405,7 @@ async def test_process_and_respond_streaming_persists_interrupted_history_when_d
     assert persisted_run.messages is not None
     assert [(message.role, message.content) for message in persisted_run.messages] == [
         ("user", "Hello"),
-        ("assistant", "Partial answer\n\n[interrupted]"),
+        ("assistant", "Partial answer\n\n(turn interrupted by the user before completion)"),
     ]
 
 
@@ -1477,7 +1477,8 @@ async def test_process_and_respond_streaming_persists_interrupted_history_when_m
         ("user", "Hello"),
         (
             "assistant",
-            "Partial answer\n\n[tool:run_shell_command completed]\n  args: cmd=pwd\n  result: /app\n\n[interrupted]",
+            "Partial answer\n\n(turn interrupted by the user before completion; "
+            "1 tool call(s) had completed: run_shell_command)",
         ),
     ]
 
@@ -1560,9 +1561,10 @@ async def test_process_and_respond_streaming_delivery_failure_with_visible_tools
     persisted_run = cast("RunOutput", persisted_session.runs[0])
     assistant_text = cast("str", persisted_run.messages[1].content)
     assert "🔧 `run_shell_command` [1]" not in assistant_text
-    assert assistant_text.count("[tool:run_shell_command completed]") == 1
+    assert assistant_text.count("run_shell_command") == 1
     assert assistant_text == (
-        "Partial answer\n\n[tool:run_shell_command completed]\n  args: cmd=pwd\n  result: /app\n\n[interrupted]"
+        "Partial answer\n\n(turn interrupted by the user before completion; "
+        "1 tool call(s) had completed: run_shell_command)"
     )
 
 
@@ -1790,7 +1792,7 @@ async def test_generate_response_locked_persists_minimal_interrupted_history_aft
     assert persisted_run.messages[0].role == "user"
     assert "Hello" in cast("str", persisted_run.messages[0].content)
     assert [(message.role, message.content) for message in persisted_run.messages[-1:]] == [
-        ("assistant", "[interrupted]"),
+        ("assistant", "(turn interrupted by the user before completion)"),
     ]
 
 
@@ -3370,7 +3372,7 @@ async def test_generate_team_response_helper_persists_interrupted_history_when_s
     assert persisted_run.messages is not None
     assert [(message.role, message.content) for message in persisted_run.messages] == [
         ("user", "Hello"),
-        ("assistant", "Team hello\n\n[interrupted]"),
+        ("assistant", "Team hello\n\n(turn interrupted by the user before completion)"),
     ]
 
 
@@ -3454,13 +3456,11 @@ async def test_generate_team_response_helper_stream_delivery_failure_with_visibl
     persisted_run = cast("TeamRunOutput", persisted_session.runs[0])
     assistant_text = cast("str", persisted_run.messages[1].content)
     assert "🔧 `run_shell_command` [1]" not in assistant_text
-    assert assistant_text.count("[tool:run_shell_command completed]") == 1
+    assert assistant_text.count("run_shell_command") == 1
     assert assistant_text == (
         "🤝 **Team Response** (General):\n\nTeam hello\n\n"
-        "[tool:run_shell_command completed]\n"
-        "  args: cmd=pwd\n"
-        "  result: /app\n\n"
-        "[interrupted]"
+        "(turn interrupted by the user before completion; "
+        "1 tool call(s) had completed: run_shell_command)"
     )
 
 
@@ -3538,7 +3538,7 @@ async def test_generate_team_response_helper_persists_minimal_interrupted_histor
     assert persisted_run.messages[0].role == "user"
     assert "Hello" in cast("str", persisted_run.messages[0].content)
     assert [(message.role, message.content) for message in persisted_run.messages[-1:]] == [
-        ("assistant", "[interrupted]"),
+        ("assistant", "(turn interrupted by the user before completion)"),
     ]
 
 
@@ -3600,7 +3600,7 @@ async def test_generate_team_response_helper_persists_interrupted_history_when_f
     assert persisted_run.messages is not None
     assert [(message.role, message.content) for message in persisted_run.messages] == [
         ("user", "Hello"),
-        ("assistant", "🤝 Team Response:\n\nTeam hello\n\n[interrupted]"),
+        ("assistant", "🤝 Team Response:\n\nTeam hello\n\n(turn interrupted by the user before completion)"),
     ]
 
 
@@ -3732,7 +3732,7 @@ async def test_generate_team_response_helper_preserves_structured_stream_cancel_
     assert persisted_run.messages is not None
     assert [(message.role, message.content) for message in persisted_run.messages] == [
         ("user", "Hello"),
-        ("assistant", "Team hello\n\n[interrupted]"),
+        ("assistant", "Team hello\n\n(turn interrupted by the user before completion)"),
     ]
 
 
@@ -3983,7 +3983,7 @@ async def test_generate_team_response_helper_persists_original_user_message_for_
     assert persisted_run.messages is not None
     assert [(message.role, message.content) for message in persisted_run.messages] == [
         ("user", "Hello"),
-        ("assistant", "[interrupted]"),
+        ("assistant", "(turn interrupted by the user before completion)"),
     ]
 
 
@@ -5172,7 +5172,8 @@ class TestUserIdPassthrough:
             ("user", "test"),
             (
                 "assistant",
-                "Half done\n\n[tool:run_shell_command completed]\n  args: cmd=pwd\n  result: /app\n\n[interrupted]",
+                "Half done\n\n(turn interrupted by the user before completion; "
+                "1 tool call(s) had completed: run_shell_command)",
             ),
         ]
 
@@ -5226,7 +5227,7 @@ class TestUserIdPassthrough:
         assert persisted_run.messages is not None
         assert [(message.role, message.content) for message in persisted_run.messages] == [
             ("user", "test"),
-            ("assistant", "Half done\n\n[interrupted]"),
+            ("assistant", "Half done\n\n(turn interrupted by the user before completion)"),
         ]
 
     @pytest.mark.asyncio
@@ -5282,10 +5283,8 @@ class TestUserIdPassthrough:
             ("user", "test"),
             (
                 "assistant",
-                "Half done\n\n[tool:run_shell_command interrupted]\n"
-                "  args: cmd=pwd\n"
-                "  result: <interrupted before completion>\n\n"
-                "[interrupted]",
+                "Half done\n\n(turn interrupted by the user before completion; "
+                "1 tool call(s) were still running: run_shell_command)",
             ),
         ]
 
@@ -7527,14 +7526,9 @@ class TestUserIdPassthrough:
             ("user", "test"),
             (
                 "assistant",
-                "Half done\n\n"
-                "[tool:run_shell_command completed]\n"
-                "  args: cmd=pwd\n"
-                "  result: /app\n"
-                "[tool:save_file interrupted]\n"
-                "  args: file_name=main.py\n"
-                "  result: <interrupted before completion>\n\n"
-                "[interrupted]",
+                "Half done\n\n(turn interrupted by the user before completion; "
+                "1 tool call(s) had completed: run_shell_command; "
+                "1 tool call(s) were still running: save_file)",
             ),
         ]
 
@@ -7612,14 +7606,9 @@ class TestUserIdPassthrough:
             ("user", "test"),
             (
                 "assistant",
-                "Half done\n\n"
-                "[tool:run_shell_command completed]\n"
-                "  args: cmd=pwd\n"
-                "  result: /app\n"
-                "[tool:run_shell_command interrupted]\n"
-                "  args: cmd=ls\n"
-                "  result: <interrupted before completion>\n\n"
-                "[interrupted]",
+                "Half done\n\n(turn interrupted by the user before completion; "
+                "1 tool call(s) had completed: run_shell_command; "
+                "1 tool call(s) were still running: run_shell_command)",
             ),
         ]
 
@@ -7678,7 +7667,7 @@ class TestUserIdPassthrough:
         assert persisted_run.messages is not None
         assert [(message.role, message.content) for message in persisted_run.messages] == [
             ("user", "test"),
-            ("assistant", "Half done\n\n[interrupted]"),
+            ("assistant", "Half done\n\n(turn interrupted by the user before completion)"),
         ]
 
     @pytest.mark.asyncio

--- a/tests/test_empty_response_guard.py
+++ b/tests/test_empty_response_guard.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from agno.db.base import SessionType
+from agno.db.base import BaseDb, SessionType
 from agno.models.message import Message
 from agno.models.response import ToolExecution
 from agno.run.agent import RunCompletedEvent, RunContentEvent, RunOutput
@@ -182,6 +182,31 @@ async def test_ai_response_retries_once_after_empty_completed_run(tmp_path: Path
 
 
 @pytest.mark.asyncio
+async def test_ai_response_closes_spent_agent_state_dbs_before_empty_retry(tmp_path: Path) -> None:
+    """The empty-retry handoff must close the discarded attempt's runtime DB handles."""
+    empty_agent = _mock_agent(_completed_run("run-empty", None))
+    empty_agent.db = MagicMock(spec=BaseDb)
+    recovered_agent = _mock_agent(_completed_run("run-good", "Recovered"))
+
+    with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
+        mock_prepare.side_effect = [
+            _prepared_prompt_result(empty_agent),
+            _prepared_prompt_result(recovered_agent),
+        ]
+
+        result = await ai_response(
+            agent_name="general",
+            prompt="test",
+            session_id="session-1",
+            runtime_paths=_runtime_paths(tmp_path),
+            config=_config(),
+        )
+
+    assert result == "Recovered"
+    empty_agent.db.close.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_ai_response_returns_fallback_notice_when_retry_is_also_empty(tmp_path: Path) -> None:
     """Two consecutive empty responses should surface a visible notice, never a blank reply."""
     first_agent = _mock_agent(_completed_run("run-empty-1", None))
@@ -268,6 +293,43 @@ async def test_stream_agent_response_retries_once_after_empty_completed_stream(t
     assert contents == ["Recovered"]
     empty_agent.arun.assert_called_once()
     recovered_agent.arun.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_stream_agent_response_closes_spent_agent_state_dbs_before_empty_retry(tmp_path: Path) -> None:
+    """The streamed empty-retry handoff must close the discarded attempt's runtime DB handles too."""
+
+    async def empty_stream() -> AsyncIterator[object]:
+        yield RunCompletedEvent(content=None)
+
+    async def recovered_stream() -> AsyncIterator[object]:
+        yield RunContentEvent(content="Recovered")
+        yield RunCompletedEvent(content="Recovered")
+
+    empty_agent = _mock_streaming_agent(empty_stream())
+    empty_agent.db = MagicMock(spec=BaseDb)
+    recovered_agent = _mock_streaming_agent(recovered_stream())
+
+    with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
+        mock_prepare.side_effect = [
+            _prepared_prompt_result(empty_agent),
+            _prepared_prompt_result(recovered_agent),
+        ]
+
+        chunks = [
+            chunk
+            async for chunk in stream_agent_response(
+                agent_name="general",
+                prompt="test",
+                session_id="session-1",
+                runtime_paths=_runtime_paths(tmp_path),
+                config=_config(),
+            )
+        ]
+
+    contents = [cast("str", chunk.content) for chunk in chunks if isinstance(chunk, RunContentEvent)]
+    assert contents == ["Recovered"]
+    empty_agent.db.close.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_empty_response_guard.py
+++ b/tests/test_empty_response_guard.py
@@ -26,6 +26,7 @@ from mindroom.config.models import ModelConfig
 from mindroom.constants import resolve_runtime_paths
 from mindroom.history import PreparedHistoryState
 from mindroom.history.runtime import ScopeSessionContext
+from mindroom.history.turn_recorder import TurnRecorder
 from mindroom.history.types import HistoryScope
 
 if TYPE_CHECKING:
@@ -206,6 +207,33 @@ async def test_ai_response_returns_fallback_notice_when_retry_is_also_empty(tmp_
 
 
 @pytest.mark.asyncio
+async def test_ai_response_fallback_notice_stays_out_of_the_turn_recorder(tmp_path: Path) -> None:
+    """The delivery-only notice must never be recorded as model text it could replay from history."""
+    recorder = TurnRecorder(user_message="test")
+    first_agent = _mock_agent(_completed_run("run-empty-1", None))
+    second_agent = _mock_agent(_completed_run("run-empty-2", None))
+
+    with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
+        mock_prepare.side_effect = [
+            _prepared_prompt_result(first_agent),
+            _prepared_prompt_result(second_agent),
+        ]
+
+        result = await ai_response(
+            agent_name="general",
+            prompt="test",
+            session_id="session-1",
+            runtime_paths=_runtime_paths(tmp_path),
+            config=_config(),
+            turn_recorder=recorder,
+        )
+
+    assert result == EMPTY_RESPONSE_NOTICE
+    assert recorder.outcome == "completed"
+    assert recorder.assistant_text == ""
+
+
+@pytest.mark.asyncio
 async def test_stream_agent_response_retries_once_after_empty_completed_stream(tmp_path: Path) -> None:
     """One empty completed stream should trigger exactly one fresh streaming attempt."""
 
@@ -273,3 +301,38 @@ async def test_stream_agent_response_yields_fallback_notice_when_retry_is_also_e
     assert contents == [EMPTY_RESPONSE_NOTICE]
     first_agent.arun.assert_called_once()
     second_agent.arun.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_stream_agent_response_fallback_notice_stays_out_of_the_turn_recorder(tmp_path: Path) -> None:
+    """The streamed delivery-only notice must never be recorded as model text either."""
+
+    async def empty_stream() -> AsyncIterator[object]:
+        yield RunCompletedEvent(content=None)
+
+    recorder = TurnRecorder(user_message="test")
+    first_agent = _mock_streaming_agent(empty_stream())
+    second_agent = _mock_streaming_agent(empty_stream())
+
+    with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
+        mock_prepare.side_effect = [
+            _prepared_prompt_result(first_agent),
+            _prepared_prompt_result(second_agent),
+        ]
+
+        chunks = [
+            chunk
+            async for chunk in stream_agent_response(
+                agent_name="general",
+                prompt="test",
+                session_id="session-1",
+                runtime_paths=_runtime_paths(tmp_path),
+                config=_config(),
+                turn_recorder=recorder,
+            )
+        ]
+
+    contents = [cast("str", chunk.content) for chunk in chunks if isinstance(chunk, RunContentEvent)]
+    assert contents == [EMPTY_RESPONSE_NOTICE]
+    assert recorder.outcome == "completed"
+    assert recorder.assistant_text == ""

--- a/tests/test_empty_response_guard.py
+++ b/tests/test_empty_response_guard.py
@@ -1,0 +1,275 @@
+"""Tests for the empty-completed-response guard (retry, fallback notice, history scrub)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from agno.db.base import SessionType
+from agno.models.message import Message
+from agno.models.response import ToolExecution
+from agno.run.agent import RunCompletedEvent, RunContentEvent, RunOutput
+from agno.run.base import RunStatus
+from agno.session.agent import AgentSession
+
+from mindroom.agent_storage import create_state_storage, get_agent_session
+from mindroom.ai import _PreparedAgentRun, ai_response, stream_agent_response
+from mindroom.ai_runtime import (
+    EMPTY_RESPONSE_NOTICE,
+    discard_empty_completed_run,
+    is_empty_completed_run,
+)
+from mindroom.config.agent import AgentConfig
+from mindroom.config.main import Config
+from mindroom.config.models import ModelConfig
+from mindroom.constants import resolve_runtime_paths
+from mindroom.history import PreparedHistoryState
+from mindroom.history.runtime import ScopeSessionContext
+from mindroom.history.types import HistoryScope
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+    from mindroom.constants import RuntimePaths
+
+
+def _runtime_paths(tmp_path: Path) -> RuntimePaths:
+    return resolve_runtime_paths(config_path=tmp_path / "config.yaml", storage_path=tmp_path)
+
+
+def _config() -> Config:
+    return Config(
+        agents={"general": AgentConfig(display_name="General")},
+        models={"default": ModelConfig(provider="openai", id="test-model")},
+    )
+
+
+def _mock_agent(run_output: RunOutput) -> MagicMock:
+    agent = MagicMock()
+    agent.model = MagicMock()
+    agent.model.__class__.__name__ = "OpenAIChat"
+    agent.model.id = "test-model"
+    agent.name = "GeneralAgent"
+    agent.add_history_to_context = False
+    agent.arun = AsyncMock(return_value=run_output)
+    return agent
+
+
+def _mock_streaming_agent(stream: AsyncIterator[object]) -> MagicMock:
+    agent = MagicMock()
+    agent.model = MagicMock()
+    agent.model.__class__.__name__ = "OpenAIChat"
+    agent.model.id = "test-model"
+    agent.name = "GeneralAgent"
+    agent.add_history_to_context = False
+    agent.arun = MagicMock(return_value=stream)
+    return agent
+
+
+def _prepared_prompt_result(agent: object) -> _PreparedAgentRun:
+    return _PreparedAgentRun(
+        agent=agent,
+        messages=(Message(role="user", content="test prompt"),),
+        unseen_event_ids=[],
+        prepared_history=PreparedHistoryState(prepared_context_tokens=None),
+        runtime_model_name="default",
+    )
+
+
+def _completed_run(run_id: str, content: str | None) -> RunOutput:
+    return RunOutput(
+        run_id=run_id,
+        agent_id="general",
+        session_id="session-1",
+        content=content,
+        messages=[Message(role="assistant", content=content)],
+        status=RunStatus.completed,
+    )
+
+
+def test_is_empty_completed_run_detects_contentless_completed_runs() -> None:
+    """Completed runs with no tool calls and no visible content are empty."""
+    assert is_empty_completed_run(_completed_run("r1", None))
+    assert is_empty_completed_run(_completed_run("r1", ""))
+    assert is_empty_completed_run(_completed_run("r1", "  \n"))
+
+
+def test_is_empty_completed_run_ignores_runs_with_content_tools_or_other_status() -> None:
+    """Real responses, tool-only runs, and non-completed statuses are not empty."""
+    assert not is_empty_completed_run(_completed_run("r1", "hello"))
+
+    tool_run = _completed_run("r1", None)
+    tool_run.tools = [ToolExecution(tool_name="run_shell_command", tool_args={"cmd": "pwd"}, result="/app")]
+    assert not is_empty_completed_run(tool_run)
+
+    errored = _completed_run("r1", None)
+    errored.status = RunStatus.error
+    assert not is_empty_completed_run(errored)
+
+
+def test_discard_empty_completed_run_removes_run_from_loaded_session_and_storage(tmp_path: Path) -> None:
+    """The empty run must disappear from both the in-memory session and persisted history."""
+    storage = create_state_storage(
+        "general",
+        tmp_path,
+        subdir="sessions",
+        session_table="general_sessions",
+    )
+    try:
+        session = AgentSession(
+            session_id="session-1",
+            agent_id="general",
+            runs=[
+                _completed_run("run-good", "First response"),
+                _completed_run("run-empty", None),
+            ],
+            metadata={},
+            created_at=1,
+            updated_at=1,
+        )
+        storage.upsert_session(session)
+        scope_context = ScopeSessionContext(
+            scope=HistoryScope(kind="agent", scope_id="general"),
+            storage=storage,
+            session=session,
+        )
+
+        discard_empty_completed_run(
+            scope_context=scope_context,
+            session_id="session-1",
+            run_id="run-empty",
+            session_type=SessionType.AGENT,
+            entity_name="general",
+            output_tokens=2,
+        )
+
+        assert session.runs is not None
+        assert [run.run_id for run in session.runs] == ["run-good"]
+        persisted = get_agent_session(storage, "session-1")
+        assert persisted is not None
+        assert persisted.runs is not None
+        assert [run.run_id for run in persisted.runs] == ["run-good"]
+    finally:
+        storage.close()
+
+
+@pytest.mark.asyncio
+async def test_ai_response_retries_once_after_empty_completed_run(tmp_path: Path) -> None:
+    """One empty completed response should trigger exactly one fresh model attempt."""
+    empty_agent = _mock_agent(_completed_run("run-empty", None))
+    recovered_agent = _mock_agent(_completed_run("run-good", "Recovered"))
+
+    with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
+        mock_prepare.side_effect = [
+            _prepared_prompt_result(empty_agent),
+            _prepared_prompt_result(recovered_agent),
+        ]
+
+        result = await ai_response(
+            agent_name="general",
+            prompt="test",
+            session_id="session-1",
+            runtime_paths=_runtime_paths(tmp_path),
+            config=_config(),
+        )
+
+    assert result == "Recovered"
+    empty_agent.arun.assert_called_once()
+    recovered_agent.arun.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_ai_response_returns_fallback_notice_when_retry_is_also_empty(tmp_path: Path) -> None:
+    """Two consecutive empty responses should surface a visible notice, never a blank reply."""
+    first_agent = _mock_agent(_completed_run("run-empty-1", None))
+    second_agent = _mock_agent(_completed_run("run-empty-2", ""))
+
+    with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
+        mock_prepare.side_effect = [
+            _prepared_prompt_result(first_agent),
+            _prepared_prompt_result(second_agent),
+        ]
+
+        result = await ai_response(
+            agent_name="general",
+            prompt="test",
+            session_id="session-1",
+            runtime_paths=_runtime_paths(tmp_path),
+            config=_config(),
+        )
+
+    assert result == EMPTY_RESPONSE_NOTICE
+    first_agent.arun.assert_called_once()
+    second_agent.arun.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_stream_agent_response_retries_once_after_empty_completed_stream(tmp_path: Path) -> None:
+    """One empty completed stream should trigger exactly one fresh streaming attempt."""
+
+    async def empty_stream() -> AsyncIterator[object]:
+        yield RunCompletedEvent(content=None)
+
+    async def recovered_stream() -> AsyncIterator[object]:
+        yield RunContentEvent(content="Recovered")
+        yield RunCompletedEvent(content="Recovered")
+
+    empty_agent = _mock_streaming_agent(empty_stream())
+    recovered_agent = _mock_streaming_agent(recovered_stream())
+
+    with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
+        mock_prepare.side_effect = [
+            _prepared_prompt_result(empty_agent),
+            _prepared_prompt_result(recovered_agent),
+        ]
+
+        chunks = [
+            chunk
+            async for chunk in stream_agent_response(
+                agent_name="general",
+                prompt="test",
+                session_id="session-1",
+                runtime_paths=_runtime_paths(tmp_path),
+                config=_config(),
+            )
+        ]
+
+    contents = [cast("str", chunk.content) for chunk in chunks if isinstance(chunk, RunContentEvent)]
+    assert contents == ["Recovered"]
+    empty_agent.arun.assert_called_once()
+    recovered_agent.arun.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_stream_agent_response_yields_fallback_notice_when_retry_is_also_empty(tmp_path: Path) -> None:
+    """Two consecutive empty streams should end with a visible notice, never a blank edit."""
+
+    async def empty_stream() -> AsyncIterator[object]:
+        yield RunCompletedEvent(content=None)
+
+    first_agent = _mock_streaming_agent(empty_stream())
+    second_agent = _mock_streaming_agent(empty_stream())
+
+    with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
+        mock_prepare.side_effect = [
+            _prepared_prompt_result(first_agent),
+            _prepared_prompt_result(second_agent),
+        ]
+
+        chunks = [
+            chunk
+            async for chunk in stream_agent_response(
+                agent_name="general",
+                prompt="test",
+                session_id="session-1",
+                runtime_paths=_runtime_paths(tmp_path),
+                config=_config(),
+            )
+        ]
+
+    contents = [cast("str", chunk.content) for chunk in chunks if isinstance(chunk, RunContentEvent)]
+    assert contents == [EMPTY_RESPONSE_NOTICE]
+    first_agent.arun.assert_called_once()
+    second_agent.arun.assert_called_once()

--- a/tests/test_interrupted_replay.py
+++ b/tests/test_interrupted_replay.py
@@ -80,7 +80,7 @@ def test_split_interrupted_tool_trace_keeps_missing_terminal_state_as_interrupte
     assert [entry.tool_name for entry in interrupted] == ["noop"]
 
 
-def test_build_interrupted_replay_run_creates_completed_agent_run_with_marker_and_tools() -> None:
+def test_build_interrupted_replay_run_creates_completed_agent_run_with_summary_and_tools() -> None:
     """Interrupted snapshots should replay through the normal completed history lane."""
     snapshot = InterruptedReplaySnapshot(
         user_message="Please continue",
@@ -122,15 +122,50 @@ def test_build_interrupted_replay_run_creates_completed_agent_run_with_marker_an
         (
             "assistant",
             "Half done\n\n"
-            "[tool:run_shell_command completed]\n"
-            "  args: cmd=pwd\n"
-            "  result: /app\n"
-            "[tool:save_file interrupted]\n"
-            "  args: file_name=main.py\n"
-            "  result: <interrupted before completion>\n\n"
-            "[interrupted]",
+            "(turn interrupted by the user before completion; "
+            "1 tool call(s) had completed: run_shell_command; "
+            "1 tool call(s) were still running: save_file)",
         ),
     ]
+
+
+def test_interrupted_replay_content_contains_no_raw_tool_trace() -> None:
+    """Replay assistant content must stay prose-safe: no raw tool logs or payload dumps."""
+    snapshot = InterruptedReplaySnapshot(
+        user_message="Please continue",
+        partial_text="Half done",
+        completed_tools=(
+            ToolTraceEntry(
+                type="tool_call_completed",
+                tool_name="get_attachment",
+                args_preview="attachment_id=abc, mindroom_output_path=scratch/voice.m4a",
+                result_preview='{"attachment": {"id": "abc"}}',
+            ),
+        ),
+        interrupted_tools=(),
+        seen_event_ids=(),
+        source_event_id=None,
+        source_event_ids=(),
+        source_event_prompts=(),
+        response_event_id=None,
+    )
+
+    run = _build_interrupted_replay_run(
+        snapshot=snapshot,
+        run_id="run-123",
+        scope_id="test_agent",
+        session_id="session-1",
+        is_team=False,
+    )
+
+    content = _assistant_text(run)
+    assert "[tool:" not in content
+    assert "result:" not in content
+    assert "[interrupted]" not in content
+    assert '{"attachment"' not in content
+    assert content.startswith("Half done")
+    assert "turn interrupted by the user before completion" in content
+    assert "get_attachment" in content
 
 
 def test_build_interrupted_replay_run_tracks_replay_and_seen_event_metadata() -> None:
@@ -365,6 +400,6 @@ def test_persist_interrupted_replay_snapshot_keeps_minimal_interrupted_turn(tmp_
         assert persisted is not None
         assert persisted.runs is not None
         assert len(persisted.runs) == 1
-        assert _assistant_text(persisted.runs[0]) == "[interrupted]"
+        assert _assistant_text(persisted.runs[0]) == "(turn interrupted by the user before completion)"
     finally:
         storage.close()

--- a/tests/test_partial_reply_context.py
+++ b/tests/test_partial_reply_context.py
@@ -31,7 +31,6 @@ from mindroom.execution_preparation import (
     _sanitize_thread_history_for_replay,
 )
 from mindroom.history.interrupted_replay import (
-    _INTERRUPTED_RESPONSE_MARKER,
     InterruptedReplaySnapshot,
     _render_interrupted_replay_content,
 )
@@ -338,7 +337,7 @@ class TestCleanPartialReplyBody:
         ]
 
         assert rendered[0] == rendered[1] == rendered[2]
-        assert rendered[0] == f"Partial answer\n\n{_INTERRUPTED_RESPONSE_MARKER}".encode()
+        assert rendered[0] == b"Partial answer\n\n(turn interrupted by the user before completion)"
 
 
 class TestUnseenMessagesPartialReplies:

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -36,7 +36,6 @@ from mindroom.delivery_gateway import DeliveryGateway, DeliveryGatewayDeps, Fina
 from mindroom.dispatch_source import MESSAGE_SOURCE_KIND
 from mindroom.final_delivery import FinalDeliveryOutcome, StreamTransportOutcome
 from mindroom.history.interrupted_replay import (
-    _INTERRUPTED_RESPONSE_MARKER,
     InterruptedReplaySnapshot,
     _render_interrupted_replay_content,
 )
@@ -90,6 +89,7 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterator
 
 IN_PROGRESS_MARKER = " ⋯"
+_INTERRUPTION_SUMMARY = "(turn interrupted by the user before completion)"
 
 
 async def _aiter(*events: object) -> AsyncIterator[object]:
@@ -717,19 +717,19 @@ class TestStreamingBehavior:
     def test_clean_partial_reply_text_normalises_user_stop_label_to_interrupted_marker(self) -> None:
         """User-stop labels should collapse to the canonical interrupted replay marker."""
         assert _render_cleaned_interrupted_replay(f"Draft answer\n\n{_CANCELLED_RESPONSE_NOTE}") == (
-            f"Draft answer\n\n{_INTERRUPTED_RESPONSE_MARKER}"
+            f"Draft answer\n\n{_INTERRUPTION_SUMMARY}"
         )
 
     def test_clean_partial_reply_text_normalises_restart_label_to_interrupted_marker(self) -> None:
         """Restart labels should collapse to the canonical interrupted replay marker."""
         assert _render_cleaned_interrupted_replay(build_restart_interrupted_body("Draft answer")) == (
-            f"Draft answer\n\n{_INTERRUPTED_RESPONSE_MARKER}"
+            f"Draft answer\n\n{_INTERRUPTION_SUMMARY}"
         )
 
     def test_clean_partial_reply_text_normalises_new_interrupted_label_to_interrupted_marker(self) -> None:
         """Generic interruption labels should collapse to the canonical interrupted replay marker."""
         assert _render_cleaned_interrupted_replay(f"Draft answer\n\n{_INTERRUPTED_RESPONSE_NOTE}") == (
-            f"Draft answer\n\n{_INTERRUPTED_RESPONSE_MARKER}"
+            f"Draft answer\n\n{_INTERRUPTION_SUMMARY}"
         )
 
     @pytest.mark.asyncio

--- a/tests/test_team_media_fallback.py
+++ b/tests/test_team_media_fallback.py
@@ -1498,10 +1498,8 @@ async def test_team_response_records_interrupted_snapshot_for_cancelled_runs() -
     assert _render_interrupted_replay_content(snapshot) == (
         "**GeneralAgent**: Half done\n\n\n"
         "*No team consensus - showing individual responses only*\n\n"
-        "[tool:run_shell_command completed]\n"
-        "  args: cmd=pwd\n"
-        "  result: /app\n\n"
-        "[interrupted]"
+        "(turn interrupted by the user before completion; "
+        "1 tool call(s) had completed: run_shell_command)"
     )
 
 
@@ -1566,10 +1564,8 @@ async def test_team_response_records_incomplete_cancelled_tools_as_interrupted()
     assert _render_interrupted_replay_content(snapshot) == (
         "**GeneralAgent**: Half done\n\n\n"
         "*No team consensus - showing individual responses only*\n\n"
-        "[tool:run_shell_command interrupted]\n"
-        "  args: cmd=pwd\n"
-        "  result: <interrupted before completion>\n\n"
-        "[interrupted]"
+        "(turn interrupted by the user before completion; "
+        "1 tool call(s) were still running: run_shell_command)"
     )
 
 
@@ -1986,10 +1982,8 @@ async def test_team_response_stream_records_hidden_interrupted_tool_state() -> N
     assert _render_interrupted_replay_content(snapshot) == (
         "**GeneralAgent**: Half done\n\n\n"
         "*No team consensus - showing individual responses only*\n\n"
-        "[tool:run_shell_command completed]\n"
-        "  args: cmd=pwd\n"
-        "  result: /app\n\n"
-        "[interrupted]"
+        "(turn interrupted by the user before completion; "
+        "1 tool call(s) had completed: run_shell_command)"
     )
 
 
@@ -2213,7 +2207,8 @@ async def test_team_response_stream_records_interrupted_snapshot_after_external_
     snapshot = recorder.interrupted_snapshot()
     assert snapshot.user_message == "Analyze this."
     assert _render_interrupted_replay_content(snapshot) == (
-        "**GeneralAgent**: Half done\n\n\n*No team consensus - showing individual responses only*\n\n[interrupted]"
+        "**GeneralAgent**: Half done\n\n\n*No team consensus - showing individual responses only*\n\n"
+        "(turn interrupted by the user before completion)"
     )
 
 
@@ -2311,12 +2306,12 @@ async def test_team_response_stream_preserves_pending_tool_scope_for_same_named_
 
     snapshot = recorder.interrupted_snapshot()
     assert snapshot.user_message == "Analyze this."
-    content = _render_interrupted_replay_content(snapshot)
-    assert "[tool:run_shell_command completed]" in content
-    assert "args: cmd=pwd" in content
-    assert "[tool:run_shell_command interrupted]" in content
-    assert "args: cmd=ls" in content
-    assert "args: cmd=pwd\n  result: <interrupted before completion>" not in content
+    assert [(tool.tool_name, tool.args_preview) for tool in snapshot.completed_tools] == [
+        ("run_shell_command", "cmd=pwd"),
+    ]
+    assert [(tool.tool_name, tool.args_preview) for tool in snapshot.interrupted_tools] == [
+        ("run_shell_command", "cmd=ls"),
+    ]
 
 
 @pytest.mark.asyncio
@@ -2398,13 +2393,9 @@ async def test_team_response_stream_preserves_pending_tool_identity_within_membe
     assert _render_interrupted_replay_content(snapshot) == (
         "**GeneralAgent**: General started\n\n\n"
         "*No team consensus - showing individual responses only*\n\n"
-        "[tool:run_shell_command completed]\n"
-        "  args: cmd=pwd\n"
-        "  result: /app\n"
-        "[tool:run_shell_command interrupted]\n"
-        "  args: cmd=ls\n"
-        "  result: <interrupted before completion>\n\n"
-        "[interrupted]"
+        "(turn interrupted by the user before completion; "
+        "1 tool call(s) had completed: run_shell_command; "
+        "1 tool call(s) were still running: run_shell_command)"
     )
 
 

--- a/tests/test_tool_events.py
+++ b/tests/test_tool_events.py
@@ -19,7 +19,6 @@ from mindroom.tool_system.events import (
     extract_tool_completed_info,
     format_tool_combined,
     format_tool_completed_event,
-    render_tool_trace_for_context,
 )
 
 TEST_CURSOR = "cursor_1234567890"
@@ -148,16 +147,12 @@ def test_format_tool_combined_redacts_sensitive_args_and_results() -> None:
     )
 
     payload = build_tool_trace_content([trace])
-    rendered = render_tool_trace_for_context([trace])
 
     assert payload is not None
     trace_event = payload[_TOOL_TRACE_KEY]["events"][0]
     assert "auth-secret" not in trace_event["args_preview"]
     assert "plain-secret-one" not in trace_event["args_preview"]
     assert "result-secret" not in trace_event["result_preview"]
-    assert "auth-secret" not in rendered
-    assert "plain-secret-one" not in rendered
-    assert "result-secret" not in rendered
     assert "***redacted***" in trace_event["args_preview"]
     assert "***redacted***" in trace_event["result_preview"]
 
@@ -472,64 +467,6 @@ def test_build_tool_trace_content_redacts_raw_trace_entries() -> None:
     event = payload[_TOOL_TRACE_KEY]["events"][0]
     assert event["args_preview"] == "api_key=***redacted***"
     assert event["result_preview"] == "token=***redacted***"
-
-
-def test_render_tool_trace_for_context_pins_started_and_completed_format() -> None:
-    """Renderer should emit the planned context marker format."""
-    rendered = render_tool_trace_for_context(
-        [
-            ToolTraceEntry(
-                type="tool_call_completed",
-                tool_name="run_shell_command",
-                args_preview="cmd=pwd",
-                result_preview="/app",
-            ),
-            ToolTraceEntry(
-                type="tool_call_started",
-                tool_name="save_file",
-                args_preview="file_name=a.py",
-                truncated=True,
-            ),
-        ],
-    )
-
-    assert rendered == (
-        "[tool:run_shell_command completed]\n"
-        "  args: cmd=pwd\n"
-        "  result: /app\n"
-        "[tool:save_file started]\n"
-        "  args: file_name=a.py\n"
-        "  result: <not yet returned>\n"
-        "  (truncated)"
-    )
-
-
-def test_render_tool_trace_for_context_omits_missing_optional_fields() -> None:
-    """Renderer should avoid empty args/result lines for completed events without previews."""
-    rendered = render_tool_trace_for_context(
-        [ToolTraceEntry(type="tool_call_completed", tool_name="save_file")],
-    )
-
-    assert rendered == "[tool:save_file completed]"
-
-
-def test_render_tool_trace_for_context_redacts_raw_trace_entries() -> None:
-    """Context renderer should redact entries even when caller supplied raw previews."""
-    rendered = render_tool_trace_for_context(
-        [
-            ToolTraceEntry(
-                type="tool_call_completed",
-                tool_name="call_api",
-                args_preview="api_key=plain-arg-secret",
-                result_preview="token=plain-result-secret",
-            ),
-        ],
-    )
-
-    assert "plain-arg-secret" not in rendered
-    assert "plain-result-secret" not in rendered
-    assert "api_key=***redacted***" in rendered
-    assert "token=***redacted***" in rendered
 
 
 def test_format_tool_started_with_empty_args() -> None:


### PR DESCRIPTION
## Bug (observed live in prod, 2026-07-01)

After pressing **Stop** during an in-flight agent turn, every subsequent model call in that thread returned empty content (2–7 output tokens, no tool calls, status COMPLETED), producing blank replies indefinitely. A parallel thread with the same agent/model/user responded normally — the cause was thread-local session history.

## Root cause

`_render_interrupted_replay_content` persisted the interrupted turn as a plain assistant message containing the raw rendered tool trace (`[tool:get_attachment completed] / args: ... / result: {...large JSON...}`) ending in a bare `[interrupted]` marker, inside a `RunStatus.completed` run. The model pattern-matches that machine-formatted assistant turn as a terminal no-op and subsequent completions degenerate to empty. Each empty run then persisted a contentless assistant message, compounding the problem — and nothing was logged.

## Changes

**1. Model-safe interrupted-replay content** (`history/interrupted_replay.py`)
- Keeps the model's real partial prose.
- Replaces the raw tool trace + `[interrupted]` marker with a one-sentence prose summary that lists only tool names, e.g. `(turn interrupted by the user before completion; 1 tool call(s) had completed: get_attachment)`. No args/result payload dumps in assistant content.
- Run metadata (replay state, seen-event ids, etc.) is unchanged.
- Removes the now-orphaned `render_tool_trace_for_context` helper.

**2. Empty-final-response guard** (`ai.py` + `ai_runtime.py`, both streaming and non-streaming agent paths)
- A run that completes with no tool calls and effectively empty content triggers exactly one fresh attempt.
- If the retry is also empty, a visible fallback notice ("The model returned an empty response — please try again.") is delivered instead of silently editing the placeholder to blank.
- In both cases the empty run is scrubbed from the loaded session and persisted storage, so contentless assistant messages never enter model history.
- A structured `model_returned_empty_response` WARNING is logged with entity, session_id, run_id, and output_tokens — this failure mode was previously invisible in logs.

## Tests

- New `tests/test_empty_response_guard.py`: emptiness predicate, history scrub (in-memory + storage), retry-once and fallback-notice behavior for both `ai_response` and `stream_agent_response`.
- `test_interrupted_replay.py`: replay content contains no `[tool:` lines, raw `result:` payloads, or `[interrupted]` marker; metadata retention unchanged.
- Updated all tests pinning the old replay format (agent + team paths).

Full suite: 9032 passed, 30 skipped. The only 2 failures are in the untracked WIP `tests/test_team_execution_attempt.py`, unrelated to this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clearer fallback for empty assistant responses, including automatic retry behavior and a visible notice when no content is returned.
  * Improved interrupted turn replay text with a concise summary of completed and still-running tool calls.

* **Bug Fixes**
  * Reduced confusing marker-style output in interrupted/cancelled conversations.
  * Improved handling of empty completed runs in both streamed and non-streamed responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->