### PR TITLE
Introduce Config.resolve_entity resolved-entity view; convert history/compaction chain

### DIFF
--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -1516,7 +1516,7 @@ def create_agent(  # noqa: PLR0915, C901, PLR0912
         enable_agentic_culture = culture_settings.enable_agentic_culture
 
     # Shared history-policy source of truth with the team replay path.
-    history_settings = config.get_entity_history_settings(agent_name)
+    history_settings = config.resolve_entity(agent_name).history_settings
     history_policy = history_settings.policy
 
     compress_tool_results = (

--- a/src/mindroom/config/entity_view.py
+++ b/src/mindroom/config/entity_view.py
@@ -1,0 +1,48 @@
+"""Resolved per-entity config view produced by `Config.resolve_entity`."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import cached_property
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mindroom.config.main import Config
+    from mindroom.config.models import CompactionConfig
+    from mindroom.history.types import ResolvedHistorySettings
+
+
+@dataclass(frozen=True)
+class ResolvedEntityView:
+    """Resolved config values for one agent or team, or the defaults-only scope when `name` is None.
+
+    Every field is a resolved value: defaults applied and entity-vs-default fallbacks already collapsed.
+    Construction never validates `name`; each field raises the same error the underlying resolution
+    raises for unknown entities.
+    Views are cheap per-call snapshots over one loaded ``Config``; config hot-reload replaces the
+    ``Config`` object, so never store a view beyond the current operation.
+    """
+
+    _config: Config
+    name: str | None
+
+    @cached_property
+    def history_settings(self) -> ResolvedHistorySettings:
+        """Effective history replay settings for this scope."""
+        if self.name is None:
+            return self._config.get_default_history_settings()
+        return self._config.get_entity_history_settings(self.name)
+
+    @cached_property
+    def compaction_config(self) -> CompactionConfig:
+        """Effective destructive compaction config for this scope."""
+        if self.name is None:
+            return self._config.get_default_compaction_config()
+        return self._config.get_entity_compaction_config(self.name)
+
+    @cached_property
+    def has_authored_compaction_config(self) -> bool:
+        """Whether destructive compaction was explicitly configured for this scope."""
+        if self.name is None:
+            return self._config.has_authored_default_compaction_config()
+        return self._config.has_authored_entity_compaction_config(self.name)

--- a/src/mindroom/config/entity_view.py
+++ b/src/mindroom/config/entity_view.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import cached_property
 from typing import TYPE_CHECKING
 
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from mindroom.history.types import ResolvedHistorySettings
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, eq=False)
 class ResolvedEntityView:
     """Resolved config values for one agent or team, or the defaults-only scope when `name` is None.
 
@@ -21,9 +21,10 @@ class ResolvedEntityView:
     raises for unknown entities.
     Views are cheap per-call snapshots over one loaded ``Config``; config hot-reload replaces the
     ``Config`` object, so never store a view beyond the current operation.
+    Views compare by identity (``eq=False``): each `resolve_entity` call returns a fresh view.
     """
 
-    _config: Config
+    _config: Config = field(repr=False)
     name: str | None
 
     @cached_property

--- a/src/mindroom/config/main.py
+++ b/src/mindroom/config/main.py
@@ -32,6 +32,7 @@ from mindroom.agent_policy import (
 from mindroom.config.agent import AgentConfig, CultureConfig, RoomConfig, TeamConfig  # noqa: TC001
 from mindroom.config.approval import ToolApprovalConfig
 from mindroom.config.auth import AuthorizationConfig
+from mindroom.config.entity_view import ResolvedEntityView
 from mindroom.config.external_trigger_policy import ExternalTriggerPolicyConfig
 from mindroom.config.knowledge import KnowledgeBaseConfig
 from mindroom.config.matrix import (
@@ -1161,6 +1162,10 @@ class Config(BaseModel):
             msg = f"Unknown entity: {entity_name}"
             raise ValueError(msg)
         return self.defaults.compaction is not None or override is not None
+
+    def resolve_entity(self, entity_name: str | None) -> ResolvedEntityView:
+        """Return the resolved config view for one entity, or the defaults-only scope for None."""
+        return ResolvedEntityView(_config=self, name=entity_name)
 
     def get_model_context_window(self, model_name: str) -> int | None:
         """Return the configured context window for one model name, when known."""

--- a/src/mindroom/execution_preparation.py
+++ b/src/mindroom/execution_preparation.py
@@ -843,7 +843,7 @@ async def prepare_agent_execution_context(
         thread_history_render_limits=None,
         fallback_static_token_budget=_fallback_static_token_budget(
             context_window=runtime_model.context_window,
-            reserve_tokens=config.get_entity_compaction_config(agent_name).reserve_tokens,
+            reserve_tokens=config.resolve_entity(agent_name).compaction_config.reserve_tokens,
         ),
         attachment_context=_ThreadAttachmentContext(
             storage_path=runtime_paths.storage_root,
@@ -925,11 +925,9 @@ async def _prepare_bound_team_execution_context(
         ),
         fallback_static_token_budget=_fallback_static_token_budget(
             context_window=active_context_window,
-            reserve_tokens=(
-                config.get_entity_compaction_config(team_name).reserve_tokens
-                if team_name is not None and team_name in config.teams
-                else config.get_default_compaction_config().reserve_tokens
-            ),
+            reserve_tokens=config.resolve_entity(
+                team_name if team_name is not None and team_name in config.teams else None,
+            ).compaction_config.reserve_tokens,
         ),
         pipeline_timing=pipeline_timing,
     )

--- a/src/mindroom/history/manual.py
+++ b/src/mindroom/history/manual.py
@@ -115,14 +115,14 @@ def _resolve_active_compaction_settings(
             room_id=room_id,
             runtime_paths=runtime_paths if room_id is not None else None,
         )
-        return runtime_model, config.get_entity_compaction_config(agent_name)
+        return runtime_model, config.resolve_entity(agent_name).compaction_config
 
     if agent.team_id not in config.teams:
         runtime_model = config.resolve_runtime_model(
             entity_name=None,
             active_model_name=active_model_name,
         )
-        return runtime_model, config.get_default_compaction_config()
+        return runtime_model, config.resolve_entity(None).compaction_config
 
     runtime_model = config.resolve_runtime_model(
         entity_name=agent.team_id,
@@ -130,7 +130,7 @@ def _resolve_active_compaction_settings(
         room_id=room_id,
         runtime_paths=runtime_paths,
     )
-    return runtime_model, config.get_entity_compaction_config(agent.team_id)
+    return runtime_model, config.resolve_entity(agent.team_id).compaction_config
 
 
 def _validate_compaction_budget(

--- a/src/mindroom/history/runtime.py
+++ b/src/mindroom/history/runtime.py
@@ -1063,29 +1063,18 @@ def _resolve_entity_preparation_inputs(
     has_authored_compaction_config: bool | None = None,
     execution_plan: ResolvedHistoryExecutionPlan | None = None,
 ) -> HistoryPreparationInputs:
+    resolved_entity = config.resolve_entity(entity_name)
     resolved_history_settings = history_settings
     if resolved_history_settings is None:
-        resolved_history_settings = (
-            config.get_entity_history_settings(entity_name)
-            if entity_name is not None
-            else config.get_default_history_settings()
-        )
+        resolved_history_settings = resolved_entity.history_settings
 
     resolved_compaction_config = compaction_config
     if resolved_compaction_config is None:
-        resolved_compaction_config = (
-            config.get_entity_compaction_config(entity_name)
-            if entity_name is not None
-            else config.get_default_compaction_config()
-        )
+        resolved_compaction_config = resolved_entity.compaction_config
 
     resolved_has_authored_compaction_config = has_authored_compaction_config
     if resolved_has_authored_compaction_config is None:
-        resolved_has_authored_compaction_config = (
-            config.has_authored_entity_compaction_config(entity_name)
-            if entity_name is not None
-            else config.has_authored_default_compaction_config()
-        )
+        resolved_has_authored_compaction_config = resolved_entity.has_authored_compaction_config
 
     runtime_model = config.resolve_runtime_model(
         entity_name=entity_name,

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -1378,10 +1378,9 @@ def _create_team_instance(
         model,
         notice_text=config.get_prompt("QUEUED_MESSAGE_NOTICE_TEXT"),
     )
-    if configured_team_name is not None and configured_team_name in config.teams:
-        history_settings = config.get_entity_history_settings(configured_team_name)
-    else:
-        history_settings = config.get_default_history_settings()
+    history_settings = config.resolve_entity(
+        configured_team_name if configured_team_name is not None and configured_team_name in config.teams else None,
+    ).history_settings
     team_id = _resolve_team_instance_id(
         agents=agents,
         config=config,

--- a/tach.toml
+++ b/tach.toml
@@ -1262,11 +1262,16 @@ path = "mindroom.config.memory"
 depends_on = ["mindroom.path_globs"]
 
 [[modules]]
+path = "mindroom.config.entity_view"
+depends_on = []
+
+[[modules]]
 path = "mindroom.config.main"
 depends_on = [
     "mindroom.agent_policy",
     "mindroom.config.agent",
     "mindroom.config.auth",
+    "mindroom.config.entity_view",
     "mindroom.config.knowledge",
     "mindroom.config.matrix",
     "mindroom.config.memory",

--- a/tests/test_config_entity_view.py
+++ b/tests/test_config_entity_view.py
@@ -80,7 +80,7 @@ def test_defaults_scope_view_matches_default_accessors() -> None:
 def test_unauthored_compaction_reports_not_authored() -> None:
     config = Config(
         agents={"plain_agent": AgentConfig(display_name="Plain Agent")},
-        defaults=DefaultsConfig(tools=[]),
+        defaults=DefaultsConfig(tools=[], compaction=None),
         models={"default": ModelConfig(provider="openai", id="test-model")},
     )
 

--- a/tests/test_config_entity_view.py
+++ b/tests/test_config_entity_view.py
@@ -1,0 +1,88 @@
+"""Transition tests: `ResolvedEntityView` fields match the Config accessors they replace."""
+# ruff: noqa: D103
+
+from __future__ import annotations
+
+import pytest
+
+from mindroom.config.agent import AgentConfig, TeamConfig
+from mindroom.config.main import Config
+from mindroom.config.models import CompactionConfig, CompactionOverrideConfig, DefaultsConfig, ModelConfig
+
+
+def _representative_config() -> Config:
+    return Config(
+        agents={
+            "overriding_agent": AgentConfig(
+                display_name="Overriding Agent",
+                num_history_runs=7,
+                max_tool_calls_from_history=3,
+                compaction=CompactionOverrideConfig(threshold_percent=0.6),
+            ),
+            "inheriting_agent": AgentConfig(display_name="Inheriting Agent"),
+        },
+        teams={
+            "overriding_team": TeamConfig(
+                display_name="Overriding Team",
+                role="Team with authored overrides",
+                agents=["overriding_agent"],
+                num_history_messages=11,
+                compaction=CompactionOverrideConfig(enabled=False),
+            ),
+            "inheriting_team": TeamConfig(
+                display_name="Inheriting Team",
+                role="Team without authored overrides",
+                agents=["inheriting_agent"],
+            ),
+        },
+        defaults=DefaultsConfig(
+            tools=[],
+            num_history_runs=4,
+            max_tool_calls_from_history=9,
+            compaction=CompactionConfig(
+                enabled=False,
+                threshold_tokens=12_000,
+                reserve_tokens=2_048,
+                model="summary-model",
+            ),
+        ),
+        models={
+            "default": ModelConfig(provider="openai", id="test-model", context_window=48_000),
+            "summary-model": ModelConfig(provider="openai", id="summary-model-id", context_window=32_000),
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "entity_name",
+    ["overriding_agent", "inheriting_agent", "overriding_team", "inheriting_team"],
+)
+def test_view_fields_match_entity_accessors(entity_name: str) -> None:
+    config = _representative_config()
+    view = config.resolve_entity(entity_name)
+
+    assert view.name == entity_name
+    assert view.history_settings == config.get_entity_history_settings(entity_name)
+    assert view.compaction_config == config.get_entity_compaction_config(entity_name)
+    assert view.has_authored_compaction_config == config.has_authored_entity_compaction_config(entity_name)
+
+
+def test_defaults_scope_view_matches_default_accessors() -> None:
+    config = _representative_config()
+    view = config.resolve_entity(None)
+
+    assert view.name is None
+    assert view.history_settings == config.get_default_history_settings()
+    assert view.compaction_config == config.get_default_compaction_config()
+    assert view.has_authored_compaction_config == config.has_authored_default_compaction_config()
+
+
+def test_unknown_entity_raises_on_field_access() -> None:
+    view = _representative_config().resolve_entity("missing")
+
+    with pytest.raises(ValueError, match="Unknown entity: missing"):
+        _ = view.history_settings
+    with pytest.raises(ValueError, match="Unknown entity: missing"):
+        _ = view.compaction_config
+    with pytest.raises(ValueError, match="Unknown entity: missing"):
+        _ = view.has_authored_compaction_config

--- a/tests/test_config_entity_view.py
+++ b/tests/test_config_entity_view.py
@@ -77,6 +77,23 @@ def test_defaults_scope_view_matches_default_accessors() -> None:
     assert view.has_authored_compaction_config == config.has_authored_default_compaction_config()
 
 
+def test_unauthored_compaction_reports_not_authored() -> None:
+    config = Config(
+        agents={"plain_agent": AgentConfig(display_name="Plain Agent")},
+        defaults=DefaultsConfig(tools=[]),
+        models={"default": ModelConfig(provider="openai", id="test-model")},
+    )
+
+    assert config.resolve_entity("plain_agent").has_authored_compaction_config is False
+    assert config.resolve_entity(None).has_authored_compaction_config is False
+
+
+def test_resolve_entity_returns_a_fresh_view_per_call() -> None:
+    config = _representative_config()
+
+    assert config.resolve_entity("overriding_agent") is not config.resolve_entity("overriding_agent")
+
+
 def test_unknown_entity_raises_on_field_access() -> None:
     view = _representative_config().resolve_entity("missing")
 


### PR DESCRIPTION
## Summary

First PR of a staged migration that replaces the ~20 entity-keyed `Config` accessors (`get_agent_*`, `get_entity_*`) with one deep seam: `config.resolve_entity(name) -> ResolvedEntityView`.

- Adds `src/mindroom/config/entity_view.py`: a frozen, identity-compared (`eq=False`) dataclass whose `cached_property` fields are resolved values (defaults applied, entity-vs-default fallbacks collapsed). This PR carries the history/compaction fields: `history_settings`, `compaction_config`, `has_authored_compaction_config`.
- `resolve_entity(None)` resolves the defaults-only ad hoc scope (the old `get_default_*` branch), collapsing the `entity_name is not None` branching that every consumer repeated.
- Converts the heaviest consumer cluster: `history/runtime.py`, `history/manual.py`, `execution_preparation.py`, `teams.py`, `agents.py`.

## Design decisions

- **Behavior-preserving by construction**: every view field delegates to the accessor it will eventually replace; transition tests (`tests/test_config_entity_view.py`) assert field == accessor output across the override/inherit matrix, plus the unauthored-compaction False branch.
- **Hot-reload safety**: views are cheap per-call snapshots; no caller stores one beyond the current operation (documented on the class). Each `resolve_entity` call returns a fresh view.
- **Lazy validation**: construction never validates `name`; each field raises exactly the error the underlying resolution raises today (unknown entities, router outside history scope). This keeps explicit-override call paths bit-identical.
- **Runtime-dependent accessors stay on Config**: `resolve_runtime_model`, `get_entity_thread_mode`, `get_effective_entity_model_name` take `room_id`/`thread_id`/`runtime_paths` and per-room/thread overrides do not belong in a static entity view.

## Migration plan

Follow-up PRs convert remaining caller modules cluster-by-cluster (≤10 files each); the final PR deletes accessors that reach zero callers and carries the full accessor → view-field migration table.

## Testing

- `uv run pytest -q --no-cov`: 9009 passed, 61 skipped
- `SKIP=typescript-check uv run pre-commit run --all-files`: clean (typescript-check broken on this macOS host)
- `uv run tach check --dependencies --interfaces`: clean (tach.toml updated for the new module)
- Adversarial subagent review: no blockers; identity-eq/repr hardening and test-matrix findings addressed in follow-up commits on this branch.