### PR TITLE
Migrate knowledge and culture accessor callers to resolve_entity

### DIFF
--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -401,7 +401,7 @@ def _file_mode_knowledge_instruction_block(
         "Available file-only sources:",
     ]
     source_lines: list[str] = []
-    for base_id in config.get_agent_knowledge_base_ids(agent_name):
+    for base_id in config.resolve_entity(agent_name).knowledge_base_ids:
         base_config = config.get_knowledge_base_config(base_id)
         if base_config.mode != "files":
             continue
@@ -965,7 +965,7 @@ def _resolve_agent_culture(
     cache_private: bool = False,
 ) -> tuple[CultureManager | None, _CultureAgentSettings | None]:
     """Resolve shared culture manager and feature flags for an agent."""
-    culture_assignment = config.get_agent_culture(agent_name)
+    culture_assignment = config.resolve_entity(agent_name).culture
     if culture_assignment is None:
         return None, None
 
@@ -1470,7 +1470,7 @@ def create_agent(  # noqa: PLR0915, C901, PLR0912
 
     knowledge_enabled = (
         not disable_runtime_capabilities
-        and bool(config.get_agent_knowledge_base_ids(agent_name))
+        and bool(config.resolve_entity(agent_name).knowledge_base_ids)
         and knowledge is not None
     )
     knowledge_sources = (

--- a/src/mindroom/config/entity_view.py
+++ b/src/mindroom/config/entity_view.py
@@ -7,6 +7,7 @@ from functools import cached_property
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from mindroom.config.agent import CultureConfig
     from mindroom.config.main import Config
     from mindroom.config.memory import MemoryBackend, MemorySearchConfig
     from mindroom.config.models import CompactionConfig, EffectiveToolConfig
@@ -52,14 +53,14 @@ class ResolvedEntityView:
 
     @cached_property
     def memory_backend(self) -> MemoryBackend:
-        """Effective memory backend; non-agent scopes inherit the global backend."""
+        """Effective memory backend; every non-agent scope (team, router, defaults) inherits the global backend."""
         if self.name is None:
             return self._config.memory.backend
         return self._config.get_agent_memory_backend(self.name)
 
     @cached_property
     def memory_search(self) -> MemorySearchConfig:
-        """Effective file-memory search settings; non-agent scopes inherit the global settings."""
+        """Effective file-memory search settings; every non-agent scope inherits the global settings."""
         if self.name is None:
             return self._config.memory.search
         return self._config.get_agent_memory_search(self.name)
@@ -104,6 +105,16 @@ class ResolvedEntityView:
     def deferred_tool_scope_incompatible_tools(self, authored_tool_name: str) -> list[str]:
         """Return expanded deferred tools invalid for this agent's effective execution scope."""
         return self._config.get_deferred_tool_scope_incompatible_tools(self._agent_name(), authored_tool_name)
+
+    @cached_property
+    def culture(self) -> tuple[str, CultureConfig] | None:
+        """Configured culture assignment for this agent, if any."""
+        return self._config.get_agent_culture(self._agent_name())
+
+    @cached_property
+    def knowledge_base_ids(self) -> list[str]:
+        """Shared and private knowledge base IDs assigned to this agent."""
+        return self._config.get_agent_knowledge_base_ids(self._agent_name())
 
     @cached_property
     def execution_scope(self) -> WorkerScope | None:

--- a/src/mindroom/knowledge/utils.py
+++ b/src/mindroom/knowledge/utils.py
@@ -366,7 +366,7 @@ def _schedule_refresh_for_availability(
 def _semantic_agent_knowledge_base_ids(agent_name: str, config: Config) -> tuple[str, ...]:
     return tuple(
         base_id
-        for base_id in config.get_agent_knowledge_base_ids(agent_name)
+        for base_id in config.resolve_entity(agent_name).knowledge_base_ids
         if config.get_knowledge_base_config(base_id).mode == "semantic"
     )
 

--- a/src/mindroom/orchestration/config_updates.py
+++ b/src/mindroom/orchestration/config_updates.py
@@ -154,7 +154,7 @@ def _get_changed_agents(
 
 def _culture_signature_for_agent(agent_name: str, config: Config) -> tuple[str, str, str] | None:
     """Return the relevant culture tuple used for restart decisions."""
-    assignment = config.get_agent_culture(agent_name)
+    assignment = config.resolve_entity(agent_name).culture
     if assignment is None:
         return None
     culture_name, culture_config = assignment

--- a/src/mindroom/runtime_resolution.py
+++ b/src/mindroom/runtime_resolution.py
@@ -228,7 +228,7 @@ def resolve_agent_runtime(
             ).is_relative_to(workspace_knowledge_root)
         }
         knowledge_paths: dict[str, Path] = {}
-        for base_id in config.get_agent_knowledge_base_ids(agent_name):
+        for base_id in config.resolve_entity(agent_name).knowledge_base_ids:
             base_config = config.get_knowledge_base_config(base_id)
             if config.get_private_knowledge_base_agent(base_id) is None:
                 knowledge_paths[base_id] = resolve_config_relative_path(base_config.path, runtime_paths).resolve()

--- a/tests/test_config_entity_view.py
+++ b/tests/test_config_entity_view.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 
 import pytest
 
-from mindroom.config.agent import AgentConfig, TeamConfig
+from mindroom.config.agent import AgentConfig, CultureConfig, TeamConfig
 from mindroom.config.main import Config
-from mindroom.config.memory import AgentMemorySearchConfig, MemoryConfig
+from mindroom.config.memory import AgentMemorySearchConfig, MemoryConfig, MemorySearchConfig
 from mindroom.config.models import CompactionConfig, CompactionOverrideConfig, DefaultsConfig, ModelConfig
 from mindroom.constants import ROUTER_AGENT_NAME
 
@@ -56,7 +56,14 @@ def _representative_config() -> Config:
             "default": ModelConfig(provider="openai", id="test-model", context_window=48_000),
             "summary-model": ModelConfig(provider="openai", id="summary-model-id", context_window=32_000),
         },
-        memory=MemoryConfig(backend="mem0"),
+        # Non-default global memory settings so inheritance assertions are non-degenerate.
+        memory=MemoryConfig(backend="none", search=MemorySearchConfig(include=["notes/**/*.md"])),
+        cultures={
+            "engineering": CultureConfig(
+                description="Write tests first",
+                agents=["overriding_agent"],
+            ),
+        },
     )
 
 
@@ -96,6 +103,8 @@ def test_view_agent_fields_match_agent_accessors(agent_name: str) -> None:
     )
     assert view.execution_scope == config.get_agent_execution_scope(agent_name)
     assert view.scope_label == config.get_agent_scope_label(agent_name)
+    assert view.culture == config.get_agent_culture(agent_name)
+    assert view.knowledge_base_ids == config.get_agent_knowledge_base_ids(agent_name)
 
 
 def test_agent_only_fields_raise_for_defaults_scope() -> None:


### PR DESCRIPTION
## Summary

Fourth PR of the `resolve_entity` migration (stacked on #1365).

- Adds `culture` and `knowledge_base_ids` to `ResolvedEntityView`, delegating to `get_agent_culture` / `get_agent_knowledge_base_ids`.
- Converts the last static entity-keyed callers outside `config/main.py`: `agents.py`, `runtime_resolution.py`, `knowledge/utils.py`, `orchestration/config_updates.py`.
- Applies PR-2 review feedback: the transition-test fixture now authors non-default global memory settings (`backend="none"`, custom search include) so the inheritance-direction assertions can no longer pass vacuously, and the memory field docstrings say plainly that every non-agent scope inherits the global settings.

After this PR, the only remaining production callers of entity-keyed accessors are `Config`-internal (validators, `resolve_runtime_model`) plus the deliberately excluded runtime-state-dependent methods (`get_entity_thread_mode`, `resolve_runtime_model`, `get_effective_entity_model_name`, `get_agent_delegation_closure`). The final PR moves accessor bodies behind the view and deletes the zero-caller public accessors, with the full migration table.

Behavior-preserving; one-line substitutions throughout.

## Testing

- `uv run pytest -q --no-cov`: 9016 passed, 61 skipped
- `SKIP=typescript-check uv run pre-commit run --all-files`: clean