### PR TITLE
Extract shared response-turn drivers; adopt on the agent path (turn unification 1/7)

### DIFF
--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Mapping
+from contextlib import aclosing
 from dataclasses import dataclass, field, replace
-from typing import TYPE_CHECKING, Any, NoReturn, cast
+from typing import TYPE_CHECKING, Any, cast
 from uuid import uuid4
 
 from agno.db.base import SessionType
@@ -31,16 +32,6 @@ from mindroom.ai_run_metadata import (
     build_prepared_history_metadata_content,
     empty_request_metric_totals,
 )
-from mindroom.ai_turn_state import AITurnState
-from mindroom.cancellation import build_cancelled_error
-from mindroom.constants import (
-    MATRIX_EVENT_ID_METADATA_KEY,
-    MATRIX_SEEN_EVENT_IDS_METADATA_KEY,
-    MATRIX_SOURCE_EVENT_IDS_METADATA_KEY,
-    MATRIX_SOURCE_EVENT_PROMPTS_METADATA_KEY,
-    RuntimePaths,
-)
-from mindroom.dynamic_tool_continuation import DYNAMIC_TOOL_CONTINUATION_LIMIT, continuation_decision_from_tools
 from mindroom.error_handling import get_user_friendly_error_message
 from mindroom.execution_preparation import prepare_agent_execution_context, render_prepared_messages_text
 from mindroom.history import (
@@ -78,22 +69,44 @@ from mindroom.media_fallback import (
 from mindroom.media_inputs import MediaInputs, MediaKind
 from mindroom.memory import MemoryPromptParts, build_memory_prompt_parts, strip_user_turn_time_prefix
 from mindroom.metadata_merge import deep_merge_metadata
+from mindroom.response_turn import (
+    AttemptResolved,
+    BlockingTurnAdapter,
+    CancelledAttempt,
+    CompletedAttempt,
+    ContinuationCapability,
+    DynamicContinuationRunState,
+    EmptyRunCapability,
+    ErroredAttempt,
+    HandledAttempt,
+    ResponseTurnContext,
+    StreamingTurnAdapter,
+    TurnPartialSnapshot,
+    TurnSinks,
+    build_matrix_run_metadata,
+    run_blocking_response_turn,
+    stream_response_turn,
+)
 from mindroom.timing import DispatchPipelineTiming, emit_timing_event, timed, timing_scope
 from mindroom.tool_system.events import StreamingToolTracker, complete_pending_tool_block, format_tool_combined
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, AsyncIterator, Callable, Collection, Sequence
+    from contextlib import AbstractContextManager
 
     from agno.agent import Agent
     from agno.knowledge.knowledge import Knowledge
     from agno.models.base import Model
     from agno.models.response import ToolExecution
 
+    from mindroom.ai_turn_state import AITurnState
     from mindroom.config.main import Config, ResolvedRuntimeModel
+    from mindroom.constants import RuntimePaths
     from mindroom.history import CompactionLifecycle
     from mindroom.history.turn_recorder import TurnRecorder
     from mindroom.knowledge.refresh_scheduler import KnowledgeRefreshScheduler
     from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
+    from mindroom.response_turn import EmptyRunDiscard, StandaloneReplaySnapshot, TurnRunState
     from mindroom.tool_system.events import ToolTraceEntry
     from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
@@ -150,55 +163,26 @@ def _model_prompt_tail_after_raw_prompt(*, raw_prompt: str, model_prompt: str | 
     return model_prompt_tail
 
 
-@dataclass(frozen=True)
-class _DynamicContinuationRunState:
-    """Prompt and run identity for a dynamic-tool continuation sequence."""
-
-    original_prompt: str
-    active_prompt: str
-    active_model_prompt: str | None
-    active_current_timestamp_ms: float | None
-    active_current_prompt_is_structured: bool
-    active_run_id: str | None
-    continuation_model_prompt_tail: str
-
-    @classmethod
-    def initial(
-        cls,
-        *,
-        prompt: str,
-        model_prompt: str | None,
-        current_timestamp_ms: float | None,
-        current_prompt_is_structured: bool,
-        run_id: str | None,
-    ) -> _DynamicContinuationRunState:
-        return cls(
-            original_prompt=prompt,
-            active_prompt=prompt,
-            active_model_prompt=model_prompt,
-            active_current_timestamp_ms=current_timestamp_ms,
-            active_current_prompt_is_structured=current_prompt_is_structured,
-            active_run_id=run_id,
-            continuation_model_prompt_tail=_model_prompt_tail_after_raw_prompt(
-                raw_prompt=prompt,
-                model_prompt=model_prompt,
-            ),
-        )
-
-    def advance(
-        self,
-        *,
-        continuation_prompt: str,
-        previous_run_id: str | None,
-    ) -> _DynamicContinuationRunState:
-        return replace(
-            self,
-            active_prompt=continuation_prompt,
-            active_model_prompt=self.continuation_model_prompt_tail or None,
-            active_current_timestamp_ms=None,
-            active_current_prompt_is_structured=False,
-            active_run_id=ai_runtime.next_retry_run_id(previous_run_id),
-        )
+def _initial_agent_continuation(
+    *,
+    prompt: str,
+    model_prompt: str | None,
+    current_timestamp_ms: float | None,
+    current_prompt_is_structured: bool,
+    run_id: str | None,
+) -> DynamicContinuationRunState:
+    """Build the initial continuation state for one agent response turn."""
+    return DynamicContinuationRunState.initial(
+        prompt=prompt,
+        model_prompt=model_prompt,
+        current_timestamp_ms=current_timestamp_ms,
+        current_prompt_is_structured=current_prompt_is_structured,
+        run_id=run_id,
+        continuation_model_prompt_tail=_model_prompt_tail_after_raw_prompt(
+            raw_prompt=prompt,
+            model_prompt=model_prompt,
+        ),
+    )
 
 
 @dataclass(frozen=True)
@@ -317,90 +301,6 @@ def _build_timing_scope(
     return "unknown"
 
 
-def _reset_turn_state_for_dynamic_continuation(
-    *,
-    turn_recorder: TurnRecorder | None,
-    run_metadata: dict[str, Any] | None,
-    completed_tools_for_turn: Sequence[ToolTraceEntry],
-) -> AITurnState:
-    turn_state = AITurnState(prior_completed_tools=completed_tools_for_turn)
-    turn_state.sync_partial(
-        turn_recorder,
-        run_metadata=run_metadata,
-        assistant_text="",
-        completed_tools=[],
-        interrupted_tools=[],
-    )
-    return turn_state
-
-
-def _advance_dynamic_continuation(
-    *,
-    agent: Agent | None,
-    scope_context: ScopeSessionContext | None,
-    continuation_state: _DynamicContinuationRunState,
-    next_prompt: str | None,
-    previous_run_id: str | None,
-    turn_recorder: TurnRecorder | None,
-    run_metadata: dict[str, Any] | None,
-    completed_tools_for_turn: Sequence[ToolTraceEntry],
-) -> tuple[_DynamicContinuationRunState, AITurnState]:
-    """Close the spent agent and prepare run state for one more continuation.
-
-    Shared by the blocking and streaming loops so the continuation handoff stays
-    identical across both paths.
-    """
-    close_agent_runtime_state_dbs(
-        agent,
-        shared_scope_storage=scope_context.storage if scope_context is not None else None,
-    )
-    advanced_state = continuation_state.advance(
-        continuation_prompt=next_prompt or continuation_state.original_prompt,
-        previous_run_id=previous_run_id,
-    )
-    turn_state = _reset_turn_state_for_dynamic_continuation(
-        turn_recorder=turn_recorder,
-        run_metadata=run_metadata,
-        completed_tools_for_turn=completed_tools_for_turn,
-    )
-    return advanced_state, turn_state
-
-
-def _discard_empty_run_and_grant_retry(
-    *,
-    agent: Agent | None,
-    scope_context: ScopeSessionContext | None,
-    session_id: str,
-    run_id: str | None,
-    entity_name: str,
-    output_tokens: int | None,
-    empty_response_retried: bool,
-    continuation_count: int,
-) -> bool:
-    """Discard one empty completed run and decide whether one retry is granted.
-
-    Shared by the blocking and streaming loops so the empty-retry handoff stays
-    identical across both paths. The one-shot retry borrows a dynamic-continuation
-    slot so the outer loop's iteration budget stays authoritative; a granted retry
-    closes the spent agent's runtime state DBs exactly like the continuation handoff.
-    """
-    ai_runtime.discard_empty_completed_run(
-        scope_context=scope_context,
-        session_id=session_id,
-        run_id=run_id,
-        session_type=SessionType.AGENT,
-        entity_name=entity_name,
-        output_tokens=output_tokens,
-    )
-    if empty_response_retried or continuation_count >= DYNAMIC_TOOL_CONTINUATION_LIMIT:
-        return False
-    close_agent_runtime_state_dbs(
-        agent,
-        shared_scope_storage=scope_context.storage if scope_context is not None else None,
-    )
-    return True
-
-
 @timed("system_prompt_assembly.system_enrichment_render")
 def _render_system_enrichment_context(
     system_enrichment_items: Sequence[EnrichmentItem],
@@ -446,6 +346,116 @@ class _StreamingAttemptState:
     @property
     def completed_tools(self) -> list[ToolTraceEntry]:
         return self.tool_tracker.completed_tools
+
+
+@dataclass
+class _AgentTurnHolder:
+    """Live per-turn agent state shared between attempt closures and adapter callbacks."""
+
+    agent: Agent | None = None
+    attempt: _MediaAttempt | None = None
+    state: _StreamingAttemptState | None = None
+    attempt_started: bool = False
+
+
+@dataclass(frozen=True)
+class _AgentTurnCallbacks:
+    """Adapter callbacks shared by the blocking and streaming agent turns."""
+
+    open_scope: Callable[[], AbstractContextManager[ScopeSessionContext | None]]
+    on_scope_opened: Callable[[ScopeSessionContext | None], None]
+    release_attempt_entity: Callable[[ScopeSessionContext | None], None]
+    close_runtime_dbs: Callable[[ScopeSessionContext | None], None]
+    empty_run: EmptyRunCapability
+    persist_standalone_replay: Callable[[ScopeSessionContext | None, StandaloneReplaySnapshot], None]
+
+
+def _build_agent_turn_callbacks(
+    holder: _AgentTurnHolder,
+    *,
+    agent_name: str,
+    prompt: str,
+    session_id: str,
+    runtime_paths: RuntimePaths,
+    config: Config,
+    execution_identity: ToolExecutionIdentity | None,
+) -> _AgentTurnCallbacks:
+    """Build the entity-specific turn-driver callbacks for one agent response."""
+
+    def _open_scope() -> AbstractContextManager[ScopeSessionContext | None]:
+        return open_resolved_scope_session_context(
+            agent_name=agent_name,
+            scope=HistoryScope(kind="agent", scope_id=agent_name),
+            session_id=session_id,
+            runtime_paths=runtime_paths,
+            config=config,
+            execution_identity=execution_identity,
+        )
+
+    def _on_scope_opened(scope_context: ScopeSessionContext | None) -> None:
+        ai_runtime.scrub_queued_notice_session_context(
+            scope_context=scope_context,
+            entity_name=agent_name,
+        )
+
+    def _close_runtime_dbs(scope_context: ScopeSessionContext | None) -> None:
+        close_agent_runtime_state_dbs(
+            holder.agent,
+            shared_scope_storage=scope_context.storage if scope_context is not None else None,
+        )
+
+    def _release_attempt_entity(scope_context: ScopeSessionContext | None) -> None:
+        _close_runtime_dbs(scope_context)
+        holder.agent = None
+
+    def _discard_empty_run(scope_context: ScopeSessionContext | None, discard: EmptyRunDiscard) -> None:
+        ai_runtime.discard_empty_completed_run(
+            scope_context=scope_context,
+            session_id=discard.session_id or session_id,
+            run_id=discard.run_id,
+            session_type=SessionType.AGENT,
+            entity_name=agent_name,
+            output_tokens=discard.output_tokens,
+        )
+
+    def _persist_standalone_replay(
+        scope_context: ScopeSessionContext | None,
+        snapshot: StandaloneReplaySnapshot,
+    ) -> None:
+        persist_interrupted_replay(
+            scope_context=scope_context,
+            session_id=snapshot.session_id or session_id,
+            run_id=snapshot.run_id,
+            user_message=prompt,
+            partial_text=snapshot.partial_text,
+            completed_tools=snapshot.completed_tools,
+            interrupted_tools=snapshot.interrupted_tools,
+            run_metadata=snapshot.run_metadata,
+            is_team=False,
+        )
+
+    return _AgentTurnCallbacks(
+        open_scope=_open_scope,
+        on_scope_opened=_on_scope_opened,
+        release_attempt_entity=_release_attempt_entity,
+        close_runtime_dbs=_close_runtime_dbs,
+        empty_run=EmptyRunCapability(
+            notice_text=ai_runtime.EMPTY_RESPONSE_NOTICE,
+            discard=_discard_empty_run,
+        ),
+        persist_standalone_replay=_persist_standalone_replay,
+    )
+
+
+def _streaming_partial_snapshot(holder: _AgentTurnHolder) -> TurnPartialSnapshot:
+    """Return the live partial-output view of one streaming agent turn."""
+    state = holder.state or _StreamingAttemptState()
+    return TurnPartialSnapshot(
+        assistant_text=state.assistant_text,
+        completed_tools=tuple(state.completed_tools),
+        interrupted_tools=tuple(pending.trace_entry for pending in state.pending_tools),
+        attempt_run_id=holder.attempt.attempt_run_id if holder.attempt is not None else None,
+    )
 
 
 @dataclass(frozen=True)
@@ -697,73 +707,6 @@ def _extract_interrupted_partial_text(
     if _is_run_cancelled_boilerplate(stripped):
         return ""
     return stripped
-
-
-def _raise_agent_run_cancelled(reason: str | None) -> NoReturn:
-    """Raise the canonical agent cancellation error."""
-    raise build_cancelled_error(reason)
-
-
-def _normalized_string_list(values: object) -> list[str]:
-    if not isinstance(values, list):
-        return []
-    normalized: list[str] = []
-    for value in values:
-        if isinstance(value, str) and value and value not in normalized:
-            normalized.append(value)
-    return normalized
-
-
-def build_matrix_run_metadata(
-    reply_to_event_id: str | None,
-    unseen_event_ids: list[str],
-    *,
-    room_id: str | None = None,
-    thread_id: str | None = None,
-    requester_id: str | None = None,
-    correlation_id: str | None = None,
-    tools_schema: list[dict[str, object]] | None = None,
-    model_params: dict[str, Any] | None = None,
-    extra_metadata: dict[str, Any] | None = None,
-) -> dict[str, Any] | None:
-    """Build metadata dict for a run, tracking consumed Matrix event ids."""
-    metadata = dict(extra_metadata or {})
-    if room_id is not None:
-        metadata["room_id"] = room_id
-    if thread_id is not None:
-        metadata["thread_id"] = thread_id
-    if reply_to_event_id is not None:
-        metadata["reply_to_event_id"] = reply_to_event_id
-    if requester_id is not None:
-        metadata["requester_id"] = requester_id
-    if correlation_id is not None:
-        metadata["correlation_id"] = correlation_id
-    if tools_schema is not None:
-        metadata["tools_schema"] = tools_schema
-    else:
-        metadata.setdefault("tools_schema", [])
-    if model_params is not None:
-        metadata["model_params"] = model_params
-    else:
-        metadata.setdefault("model_params", {})
-    source_event_ids = _normalized_string_list(metadata.get(MATRIX_SOURCE_EVENT_IDS_METADATA_KEY))
-    if reply_to_event_id:
-        seen_event_ids = _normalized_string_list(
-            [
-                reply_to_event_id,
-                *source_event_ids,
-                *_normalized_string_list(metadata.get(MATRIX_SEEN_EVENT_IDS_METADATA_KEY)),
-                *unseen_event_ids,
-            ],
-        )
-        metadata[MATRIX_EVENT_ID_METADATA_KEY] = reply_to_event_id
-        metadata[MATRIX_SEEN_EVENT_IDS_METADATA_KEY] = seen_event_ids
-    if MATRIX_SOURCE_EVENT_PROMPTS_METADATA_KEY in metadata and not isinstance(
-        metadata[MATRIX_SOURCE_EVENT_PROMPTS_METADATA_KEY],
-        dict,
-    ):
-        metadata.pop(MATRIX_SOURCE_EVENT_PROMPTS_METADATA_KEY, None)
-    return metadata or None
 
 
 def resolve_run_correlation_id(
@@ -1405,7 +1348,7 @@ async def _prepare_agent_run_context(
     )
 
 
-async def ai_response(  # noqa: C901, PLR0915
+async def ai_response(
     agent_name: str,
     prompt: str,
     session_id: str,
@@ -1551,288 +1494,185 @@ async def ai_response(  # noqa: C901, PLR0915
         ),
     )
     media_inputs = media or MediaInputs()
-    resolved_requester_id = user_id
     resolved_correlation_id = resolve_run_correlation_id(
         correlation_id,
         reply_to_event_id=reply_to_event_id,
         matrix_run_metadata=matrix_run_metadata,
     )
-    agent: Agent | None = None
-    scope_context: ScopeSessionContext | None = None
-    standalone_interrupted_replay_persisted = False
-    empty_response_retried = False
-    turn_state = AITurnState()
-    unseen_event_ids: list[str] = []
-    metadata: dict[str, Any] | None = None
-    run_extra_content: dict[str, Any] | None = None
-    attempt: _MediaAttempt | None = None
     try:
+        _assert_agent_target(agent_name, config)
+    except ValueError as e:
+        return get_user_friendly_error_message(e, agent_name)
+
+    holder = _AgentTurnHolder()
+    callbacks = _build_agent_turn_callbacks(
+        holder,
+        agent_name=agent_name,
+        prompt=prompt,
+        session_id=session_id,
+        runtime_paths=runtime_paths,
+        config=config,
+        execution_identity=execution_identity,
+    )
+
+    async def _run_blocking_attempt(
+        run: TurnRunState,
+        continuation_state: DynamicContinuationRunState,
+    ) -> CompletedAttempt | CancelledAttempt | ErroredAttempt:
+        """Run one agent attempt, including its media-fallback retries."""
         try:
-            _assert_agent_target(agent_name, config)
-        except ValueError as e:
-            return get_user_friendly_error_message(e, agent_name)
-
-        async def _run_blocking_attempt(continuation_count: int) -> str | None:  # noqa: C901, PLR0911, PLR0912, PLR0915
-            """Run one agent attempt; return final text, or None to continue the turn."""
-            nonlocal agent, attempt, continuation_state, empty_response_retried, metadata, run_extra_content
-            nonlocal standalone_interrupted_replay_persisted, turn_state, unseen_event_ids
-            try:
-                run_context = await _prepare_agent_run_context(
-                    agent_name=agent_name,
-                    prompt=continuation_state.active_prompt,
-                    session_id=session_id,
-                    runtime_paths=runtime_paths,
-                    config=config,
-                    scope_context=scope_context,
-                    thread_history=thread_history,
-                    room_id=room_id,
-                    thread_id=thread_id,
-                    knowledge=knowledge,
-                    include_interactive_questions=include_interactive_questions,
-                    include_openai_compat_guidance=include_openai_compat_guidance,
-                    reply_to_event_id=reply_to_event_id,
-                    active_event_ids=active_event_ids,
-                    execution_identity=execution_identity,
-                    compaction_outcomes_collector=compaction_outcomes_collector,
-                    compaction_lifecycle=compaction_lifecycle,
-                    delegation_depth=delegation_depth,
-                    refresh_scheduler=refresh_scheduler,
-                    system_enrichment_items=system_enrichment_items,
-                    model_prompt=continuation_state.active_model_prompt,
-                    current_timestamp_ms=continuation_state.active_current_timestamp_ms,
-                    current_prompt_is_structured=continuation_state.active_current_prompt_is_structured,
-                    user_id=user_id,
-                    requester_id=resolved_requester_id,
-                    correlation_id=resolved_correlation_id,
-                    matrix_run_metadata=matrix_run_metadata,
-                    turn_recorder=turn_recorder,
-                    pipeline_timing=pipeline_timing,
-                )
-            except Exception as e:
-                logger.exception("Error preparing agent", agent=agent_name)
-                return get_user_friendly_error_message(e, agent_name)
-            prepared_run = run_context.prepared_run
-            agent = prepared_run.agent
-            run_input = run_context.run_input
-            unseen_event_ids = prepared_run.unseen_event_ids
-            metadata = run_context.metadata
-            run_extra_content = run_context.run_extra_content
-
-            attempt = _MediaAttempt.initial(
-                run_input,
-                media_inputs,
-                agent.model,
-                fallback_prompt=run_context.inline_media_fallback_prompt,
-                run_id=continuation_state.active_run_id,
-            )
-            attempt_result = await _run_non_streaming_agent_attempts(
-                run_context=run_context,
-                attempt=attempt,
+            run_context = await _prepare_agent_run_context(
+                agent_name=agent_name,
+                prompt=continuation_state.active_prompt,
+                session_id=session_id,
+                runtime_paths=runtime_paths,
+                config=config,
+                scope_context=run.scope_context,
+                thread_history=thread_history,
+                room_id=room_id,
+                thread_id=thread_id,
+                knowledge=knowledge,
+                include_interactive_questions=include_interactive_questions,
+                include_openai_compat_guidance=include_openai_compat_guidance,
+                reply_to_event_id=reply_to_event_id,
+                active_event_ids=active_event_ids,
+                execution_identity=execution_identity,
+                compaction_outcomes_collector=compaction_outcomes_collector,
+                compaction_lifecycle=compaction_lifecycle,
+                delegation_depth=delegation_depth,
+                refresh_scheduler=refresh_scheduler,
+                system_enrichment_items=system_enrichment_items,
+                model_prompt=continuation_state.active_model_prompt,
+                current_timestamp_ms=continuation_state.active_current_timestamp_ms,
+                current_prompt_is_structured=continuation_state.active_current_prompt_is_structured,
                 user_id=user_id,
-                run_id=continuation_state.active_run_id,
-                run_id_callback=run_id_callback,
-                scope_context=scope_context,
+                requester_id=user_id,
+                correlation_id=resolved_correlation_id,
+                matrix_run_metadata=matrix_run_metadata,
+                turn_recorder=turn_recorder,
                 pipeline_timing=pipeline_timing,
             )
-            attempt = attempt_result.attempt
-            if attempt_result.user_error is not None:
-                return get_user_friendly_error_message(attempt_result.user_error, agent_name)
-            response = cast("RunOutput", attempt_result.response)
+        except Exception as e:
+            logger.exception("Error preparing agent", agent=agent_name)
+            return ErroredAttempt(get_user_friendly_error_message(e, agent_name))
+        prepared_run = run_context.prepared_run
+        holder.agent = prepared_run.agent
+        run.unseen_event_ids = prepared_run.unseen_event_ids
+        run.run_metadata = run_context.metadata
+        run.run_extra_content = run_context.run_extra_content
 
-            response_tool_trace = _extract_tool_trace(response)
-            if tool_trace_collector is not None:
-                tool_trace_collector.extend(response_tool_trace)
-            if run_metadata_collector is not None:
-                run_metadata = build_ai_run_metadata_content(
-                    config=config,
-                    model_name=prepared_run.runtime_model_name,
-                    run_id=response.run_id,
-                    session_id=response.session_id or session_id,
-                    status=response.status,
-                    model=response.model,
-                    model_provider=response.model_provider,
-                    metrics=response.metrics,
-                    context_input_tokens=prepared_run.prepared_history.prepared_context_tokens,
-                    tool_count=len(response.tools) if response.tools is not None else 0,
-                    prepared_history=prepared_run.prepared_history,
-                )
-                run_metadata_collector.update(run_metadata)
+        attempt = _MediaAttempt.initial(
+            run_context.run_input,
+            media_inputs,
+            prepared_run.agent.model,
+            fallback_prompt=run_context.inline_media_fallback_prompt,
+            run_id=continuation_state.active_run_id,
+        )
+        holder.attempt = attempt
+        attempt_result = await _run_non_streaming_agent_attempts(
+            run_context=run_context,
+            attempt=attempt,
+            user_id=user_id,
+            run_id=continuation_state.active_run_id,
+            run_id_callback=run_id_callback,
+            scope_context=run.scope_context,
+            pipeline_timing=pipeline_timing,
+        )
+        if attempt_result.user_error is not None:
+            return ErroredAttempt(get_user_friendly_error_message(attempt_result.user_error, agent_name))
+        response = cast("RunOutput", attempt_result.response)
 
-            if response.status == RunStatus.cancelled:
-                partial_text = _extract_interrupted_partial_text(
-                    response.content,
-                    messages=response.messages,
-                )
-                completed_tools, interrupted_tools = _extract_cancelled_tool_trace(response)
-                if turn_recorder is not None:
-                    turn_state.record_interrupted(
-                        turn_recorder,
-                        run_metadata=metadata,
-                        assistant_text=partial_text,
-                        completed_tools=completed_tools,
-                        interrupted_tools=interrupted_tools,
-                    )
-                if turn_recorder is None:
-                    persist_interrupted_replay(
-                        scope_context=scope_context,
-                        session_id=response.session_id or session_id,
-                        run_id=response.run_id or attempt.attempt_run_id or str(uuid4()),
-                        user_message=prompt,
-                        partial_text=partial_text,
-                        completed_tools=turn_state.completed_tools_for(completed_tools),
-                        interrupted_tools=interrupted_tools,
-                        run_metadata=metadata,
-                        is_team=False,
-                    )
-                    standalone_interrupted_replay_persisted = True
-                _raise_agent_run_cancelled(response.content)
-            if response.status == RunStatus.error:
-                return get_user_friendly_error_message(
+        response_tool_trace = _extract_tool_trace(response)
+        if tool_trace_collector is not None:
+            tool_trace_collector.extend(response_tool_trace)
+        metadata_content: dict[str, Any] | None = None
+        if run_metadata_collector is not None:
+            metadata_content = build_ai_run_metadata_content(
+                config=config,
+                model_name=prepared_run.runtime_model_name,
+                run_id=response.run_id,
+                session_id=response.session_id or session_id,
+                status=response.status,
+                model=response.model,
+                model_provider=response.model_provider,
+                metrics=response.metrics,
+                context_input_tokens=prepared_run.prepared_history.prepared_context_tokens,
+                tool_count=len(response.tools) if response.tools is not None else 0,
+                prepared_history=prepared_run.prepared_history,
+            )
+
+        if response.status == RunStatus.cancelled:
+            partial_text = _extract_interrupted_partial_text(
+                response.content,
+                messages=response.messages,
+            )
+            completed_tools, interrupted_tools = _extract_cancelled_tool_trace(response)
+            return CancelledAttempt(
+                reason=response.content,
+                partial_text=partial_text,
+                completed_tools=tuple(completed_tools),
+                interrupted_tools=tuple(interrupted_tools),
+                session_id=response.session_id,
+                run_id=response.run_id or attempt.attempt_run_id,
+                metadata_content=metadata_content,
+            )
+        if response.status == RunStatus.error:
+            return ErroredAttempt(
+                get_user_friendly_error_message(
                     Exception(str(response.content or "Unknown agent error")),
                     agent_name,
-                )
-            if ai_runtime.is_empty_completed_run(response):
-                if _discard_empty_run_and_grant_retry(
-                    agent=agent,
-                    scope_context=scope_context,
-                    session_id=response.session_id or session_id,
-                    run_id=response.run_id,
-                    entity_name=agent_name,
-                    output_tokens=_usage_metric_int(response.metrics, "output_tokens"),
-                    empty_response_retried=empty_response_retried,
-                    continuation_count=continuation_count,
-                ):
-                    empty_response_retried = True
-                    agent = None
-                    return None
-                if turn_recorder is not None:
-                    turn_state.record_completed(
-                        turn_recorder,
-                        run_metadata=metadata,
-                        assistant_text="",
-                        completed_tools=[],
-                    )
-                return ai_runtime.EMPTY_RESPONSE_NOTICE
-
-            continuation_decision = continuation_decision_from_tools(
-                response.tools,
-                original_prompt=continuation_state.original_prompt,
-                continuation_count=continuation_count,
-            )
-            completed_tools_for_turn = turn_state.completed_tools_for(response_tool_trace)
-            if continuation_decision.should_continue:
-                continuation_state, turn_state = _advance_dynamic_continuation(
-                    agent=agent,
-                    scope_context=scope_context,
-                    continuation_state=continuation_state,
-                    next_prompt=continuation_decision.next_prompt,
-                    previous_run_id=attempt.attempt_run_id,
-                    turn_recorder=turn_recorder,
-                    run_metadata=metadata,
-                    completed_tools_for_turn=completed_tools_for_turn,
-                )
-                agent = None
-                return None
-            if continuation_decision.limit_message is not None and continuation_decision.continuation is not None:
-                logger.warning(
-                    "Dynamic tool continuation limit reached",
-                    agent=agent_name,
-                    function_name=continuation_decision.continuation.function_name,
-                    tool_name=continuation_decision.continuation.tool_name,
-                    status=continuation_decision.continuation.status,
-                )
-
-            response_text = _extract_response_content(response, show_tool_calls=show_tool_calls)
-            if continuation_decision.limit_message is not None and not response.content:
-                response_text = continuation_decision.limit_message
-            if turn_recorder is not None:
-                replayable_response_text = _extract_replayable_response_text(response)
-                if continuation_decision.limit_message is not None and not response.content:
-                    replayable_response_text = continuation_decision.limit_message
-                turn_state.record_completed(
-                    turn_recorder,
-                    run_metadata=metadata,
-                    assistant_text=replayable_response_text,
-                    completed_tools=response_tool_trace,
-                )
-            return response_text
-
-        with open_resolved_scope_session_context(
-            agent_name=agent_name,
-            scope=HistoryScope(kind="agent", scope_id=agent_name),
-            session_id=session_id,
-            runtime_paths=runtime_paths,
-            config=config,
-            execution_identity=execution_identity,
-        ) as opened_scope_context:
-            scope_context = opened_scope_context
-            ai_runtime.scrub_queued_notice_session_context(
-                scope_context=scope_context,
-                entity_name=agent_name,
-            )
-            continuation_state = _DynamicContinuationRunState.initial(
-                prompt=prompt,
-                model_prompt=model_prompt,
-                current_timestamp_ms=current_timestamp_ms,
-                current_prompt_is_structured=current_prompt_is_structured,
-                run_id=run_id,
-            )
-            for continuation_count in range(DYNAMIC_TOOL_CONTINUATION_LIMIT + 1):
-                attempt_text = await _run_blocking_attempt(continuation_count)
-                if attempt_text is not None:
-                    return attempt_text
-            # The continuation loop always returns on its final iteration: at
-            # continuation_count == DYNAMIC_TOOL_CONTINUATION_LIMIT the decision
-            # carries a limit_message and never asks to continue.
-            msg = "dynamic tool continuation loop must return within its iteration budget"
-            raise AssertionError(msg)
-    except asyncio.CancelledError:
-        if turn_recorder is not None:
-            turn_state.record_interrupted_from_recorder(
-                turn_recorder,
-                run_metadata=(
-                    metadata
-                    if metadata is not None
-                    else turn_recorder.run_metadata
-                    or build_matrix_run_metadata(
-                        reply_to_event_id,
-                        unseen_event_ids,
-                        room_id=room_id,
-                        thread_id=thread_id,
-                        requester_id=resolved_requester_id,
-                        correlation_id=resolved_correlation_id,
-                        extra_metadata=deep_merge_metadata(matrix_run_metadata, run_extra_content),
-                    )
                 ),
+                metadata_content=metadata_content,
             )
-        elif not standalone_interrupted_replay_persisted:
-            persist_interrupted_replay(
-                scope_context=scope_context,
-                session_id=session_id,
-                run_id=(attempt.attempt_run_id if attempt is not None else run_id) or str(uuid4()),
-                user_message=prompt,
-                partial_text="",
-                completed_tools=turn_state.completed_tools_for([]),
-                interrupted_tools=[],
-                run_metadata=metadata
-                if metadata is not None
-                else build_matrix_run_metadata(
-                    reply_to_event_id,
-                    unseen_event_ids,
-                    room_id=room_id,
-                    thread_id=thread_id,
-                    requester_id=resolved_requester_id,
-                    correlation_id=resolved_correlation_id,
-                    extra_metadata=deep_merge_metadata(matrix_run_metadata, run_extra_content),
-                ),
-                is_team=False,
-            )
-        raise
-    finally:
-        close_agent_runtime_state_dbs(
-            agent,
-            shared_scope_storage=scope_context.storage if scope_context is not None else None,
+        return CompletedAttempt(
+            response_text=_extract_response_content(response, show_tool_calls=show_tool_calls),
+            replayable_text=_extract_replayable_response_text(response),
+            has_visible_content=bool(response.content),
+            is_empty=ai_runtime.is_empty_completed_run(response),
+            session_id=response.session_id,
+            run_id=response.run_id,
+            attempt_run_id=attempt.attempt_run_id,
+            output_tokens=_usage_metric_int(response.metrics, "output_tokens"),
+            tool_executions=tuple(response.tools or ()),
+            completed_tools=tuple(response_tool_trace),
+            metadata_content=metadata_content,
         )
+
+    adapter = BlockingTurnAdapter(
+        open_scope=callbacks.open_scope,
+        run_attempt=_run_blocking_attempt,
+        snapshot_partial=lambda: TurnPartialSnapshot(
+            attempt_run_id=holder.attempt.attempt_run_id if holder.attempt is not None else None,
+        ),
+        release_attempt_entity=callbacks.release_attempt_entity,
+        close_runtime_dbs=callbacks.close_runtime_dbs,
+        on_scope_opened=callbacks.on_scope_opened,
+        continuation=ContinuationCapability(),
+        empty_run=callbacks.empty_run,
+        persist_standalone_replay=callbacks.persist_standalone_replay,
+    )
+    return await run_blocking_response_turn(
+        ResponseTurnContext(
+            entity_label=agent_name,
+            session_id=session_id,
+            run_id=run_id,
+            correlation_id=resolved_correlation_id,
+            reply_to_event_id=reply_to_event_id,
+            room_id=room_id,
+            thread_id=thread_id,
+            requester_id=user_id,
+            matrix_run_metadata=matrix_run_metadata,
+        ),
+        adapter,
+        TurnSinks(turn_recorder=turn_recorder, run_metadata_collector=run_metadata_collector),
+        continuation=_initial_agent_continuation(
+            prompt=prompt,
+            model_prompt=model_prompt,
+            current_timestamp_ms=current_timestamp_ms,
+            current_prompt_is_structured=current_prompt_is_structured,
+            run_id=run_id,
+        ),
+    )
 
 
 @timed("model_request_to_completion")
@@ -2138,397 +1978,299 @@ async def stream_agent_response(  # noqa: C901, PLR0915
         ),
     )
     media_inputs = media or MediaInputs()
-    resolved_requester_id = user_id
     resolved_correlation_id = resolve_run_correlation_id(
         correlation_id,
         reply_to_event_id=reply_to_event_id,
         matrix_run_metadata=matrix_run_metadata,
     )
-    agent: Agent | None = None
-    scope_context: ScopeSessionContext | None = None
-    standalone_interrupted_replay_persisted = False
-    empty_response_retried = False
-    turn_state = AITurnState()
-    unseen_event_ids: list[str] = []
-    metadata: dict[str, Any] | None = None
-    run_extra_content: dict[str, Any] | None = None
-    attempt: _MediaAttempt | None = None
-    state = _StreamingAttemptState()
-
     try:
-        try:
-            _assert_agent_target(agent_name, config)
-        except ValueError as e:
-            yield get_user_friendly_error_message(e, agent_name)
+        _assert_agent_target(agent_name, config)
+    except ValueError as e:
+        yield get_user_friendly_error_message(e, agent_name)
+        return
+
+    holder = _AgentTurnHolder(state=_StreamingAttemptState())
+    callbacks = _build_agent_turn_callbacks(
+        holder,
+        agent_name=agent_name,
+        prompt=prompt,
+        session_id=session_id,
+        runtime_paths=runtime_paths,
+        config=config,
+        execution_identity=execution_identity,
+    )
+
+    def _finalize_streaming_attempt(scope_context: ScopeSessionContext | None) -> None:
+        if not holder.attempt_started:
             return
+        holder.attempt_started = False
+        ai_runtime.cleanup_queued_notice_state(
+            run_output=None,
+            storage=scope_context.storage if scope_context is not None else None,
+            session_id=session_id,
+            session_type=SessionType.AGENT,
+            entity_name=agent_name,
+        )
 
-        async def _run_streaming_attempt(  # noqa: C901, PLR0912, PLR0915
-            continuation_count: int,
-        ) -> AsyncGenerator[AIStreamChunk, None]:
-            """Stream one agent attempt; set keep_going when the turn should continue."""
-            nonlocal agent, attempt, continuation_state, empty_response_retried, keep_going, metadata
-            nonlocal run_extra_content, standalone_interrupted_replay_persisted, state, turn_state
-            nonlocal unseen_event_ids
-            try:
-                run_context = await _prepare_agent_run_context(
-                    agent_name=agent_name,
-                    prompt=continuation_state.active_prompt,
-                    session_id=session_id,
-                    runtime_paths=runtime_paths,
-                    config=config,
-                    scope_context=scope_context,
-                    thread_history=thread_history,
-                    room_id=room_id,
-                    thread_id=thread_id,
-                    knowledge=knowledge,
-                    include_interactive_questions=include_interactive_questions,
-                    include_openai_compat_guidance=include_openai_compat_guidance,
-                    reply_to_event_id=reply_to_event_id,
-                    active_event_ids=active_event_ids,
-                    execution_identity=execution_identity,
-                    compaction_outcomes_collector=compaction_outcomes_collector,
-                    compaction_lifecycle=compaction_lifecycle,
-                    delegation_depth=delegation_depth,
-                    refresh_scheduler=refresh_scheduler,
-                    system_enrichment_items=system_enrichment_items,
-                    model_prompt=continuation_state.active_model_prompt,
-                    current_timestamp_ms=continuation_state.active_current_timestamp_ms,
-                    current_prompt_is_structured=continuation_state.active_current_prompt_is_structured,
-                    user_id=user_id,
-                    requester_id=resolved_requester_id,
-                    correlation_id=resolved_correlation_id,
-                    matrix_run_metadata=matrix_run_metadata,
-                    turn_recorder=turn_recorder,
-                    pipeline_timing=pipeline_timing,
-                )
-            except Exception as e:
-                logger.exception("Error preparing agent for streaming", agent=agent_name)
-                yield get_user_friendly_error_message(e, agent_name)
-                return
-            prepared_run = run_context.prepared_run
-            agent = prepared_run.agent
-            run_input = run_context.run_input
-            unseen_event_ids = prepared_run.unseen_event_ids
-            prepared_context_input_tokens = prepared_run.prepared_history.prepared_context_tokens
-            metadata = run_context.metadata
-            run_extra_content = run_context.run_extra_content
-
-            attempt = _MediaAttempt.initial(
-                run_input,
-                media_inputs,
-                agent.model,
-                fallback_prompt=run_context.inline_media_fallback_prompt,
-                run_id=continuation_state.active_run_id,
+    async def _run_streaming_attempt(  # noqa: C901, PLR0915
+        run: TurnRunState,
+        continuation_state: DynamicContinuationRunState,
+    ) -> AsyncGenerator[AIStreamChunk | AttemptResolved, None]:
+        """Stream one agent attempt, ending with its ``AttemptResolved`` sentinel."""
+        try:
+            run_context = await _prepare_agent_run_context(
+                agent_name=agent_name,
+                prompt=continuation_state.active_prompt,
+                session_id=session_id,
+                runtime_paths=runtime_paths,
+                config=config,
+                scope_context=run.scope_context,
+                thread_history=thread_history,
+                room_id=room_id,
+                thread_id=thread_id,
+                knowledge=knowledge,
+                include_interactive_questions=include_interactive_questions,
+                include_openai_compat_guidance=include_openai_compat_guidance,
+                reply_to_event_id=reply_to_event_id,
+                active_event_ids=active_event_ids,
+                execution_identity=execution_identity,
+                compaction_outcomes_collector=compaction_outcomes_collector,
+                compaction_lifecycle=compaction_lifecycle,
+                delegation_depth=delegation_depth,
+                refresh_scheduler=refresh_scheduler,
+                system_enrichment_items=system_enrichment_items,
+                model_prompt=continuation_state.active_model_prompt,
+                current_timestamp_ms=continuation_state.active_current_timestamp_ms,
+                current_prompt_is_structured=continuation_state.active_current_prompt_is_structured,
+                user_id=user_id,
+                requester_id=user_id,
+                correlation_id=resolved_correlation_id,
+                matrix_run_metadata=matrix_run_metadata,
+                turn_recorder=turn_recorder,
+                pipeline_timing=pipeline_timing,
             )
+        except Exception as e:
+            logger.exception("Error preparing agent for streaming", agent=agent_name)
+            yield get_user_friendly_error_message(e, agent_name)
+            yield AttemptResolved(HandledAttempt())
+            return
+        prepared_run = run_context.prepared_run
+        holder.agent = prepared_run.agent
+        run.unseen_event_ids = prepared_run.unseen_event_ids
+        prepared_context_input_tokens = prepared_run.prepared_history.prepared_context_tokens
+        run.run_metadata = run_context.metadata
+        run.run_extra_content = run_context.run_extra_content
+
+        attempt = _MediaAttempt.initial(
+            run_context.run_input,
+            media_inputs,
+            prepared_run.agent.model,
+            fallback_prompt=run_context.inline_media_fallback_prompt,
+            run_id=continuation_state.active_run_id,
+        )
+        holder.attempt = attempt
+        holder.attempt_started = True
+        turn_state = run.turn_state
+        state = _StreamingAttemptState()
+
+        for retried_after_media_fallback in (False, True):
             state = _StreamingAttemptState()
+            holder.state = state
 
-            try:
-                for retried_after_media_fallback in (False, True):
-                    state = _StreamingAttemptState()
-
-                    def _sync_live_turn_recorder(
-                        *,
-                        state_ref: _StreamingAttemptState = state,
-                        turn_state_ref: AITurnState = turn_state,
-                        metadata_ref: dict[str, Any] | None = metadata,
-                    ) -> None:
-                        turn_state_ref.sync_partial(
-                            turn_recorder,
-                            run_metadata=metadata_ref,
-                            assistant_text=state_ref.assistant_text,
-                            completed_tools=state_ref.completed_tools,
-                            interrupted_tools=[pending.trace_entry for pending in state_ref.pending_tools],
-                        )
-
-                    async for stream_chunk in _stream_agent_attempt_chunks(
-                        run_context=run_context,
-                        attempt=attempt,
-                        state=state,
-                        show_tool_calls=show_tool_calls,
-                        user_id=user_id,
-                        run_id_callback=run_id_callback,
-                        retried_after_media_fallback=retried_after_media_fallback,
-                        state_updated=_sync_live_turn_recorder,
-                        pipeline_timing=pipeline_timing,
-                    ):
-                        yield stream_chunk
-
-                    if state.media_fallback_retry_requested:
-                        attempt.retry(
-                            run_input,
-                            fallback_prompt=run_context.inline_media_fallback_prompt,
-                            extra_removed_kinds=state.media_fallback_removed_kinds,
-                            retry_media_inputs=state.media_fallback_retry_inputs or MediaInputs(),
-                            run_id=continuation_state.active_run_id,
-                        )
-                        continue
-
-                    run_error = state.user_error or state.stream_exception
-                    if run_error is not None:
-                        if state.assistant_text or state.completed_tools or state.pending_tools:
-                            interrupted_tools = [pending.trace_entry for pending in state.pending_tools]
-                            if turn_recorder is not None:
-                                turn_state.record_interrupted(
-                                    turn_recorder,
-                                    run_metadata=metadata,
-                                    assistant_text=state.assistant_text,
-                                    completed_tools=state.completed_tools,
-                                    interrupted_tools=interrupted_tools,
-                                )
-                            elif not standalone_interrupted_replay_persisted:
-                                persist_interrupted_replay(
-                                    scope_context=scope_context,
-                                    session_id=session_id,
-                                    run_id=attempt.attempt_run_id or str(uuid4()),
-                                    user_message=prompt,
-                                    partial_text=state.assistant_text,
-                                    completed_tools=turn_state.completed_tools_for(state.completed_tools),
-                                    interrupted_tools=interrupted_tools,
-                                    run_metadata=metadata,
-                                    is_team=False,
-                                )
-                                standalone_interrupted_replay_persisted = True
-                        yield get_user_friendly_error_message(run_error, agent_name)
-                        return
-
-                    if state.cancelled_run_event is not None:
-                        interrupted_tools = [pending.trace_entry for pending in state.pending_tools]
-                        if turn_recorder is not None:
-                            turn_state.record_interrupted(
-                                turn_recorder,
-                                run_metadata=metadata,
-                                assistant_text=state.assistant_text,
-                                completed_tools=state.completed_tools,
-                                interrupted_tools=interrupted_tools,
-                            )
-                        if run_metadata_collector is not None:
-                            fallback_metrics = build_model_request_metrics_fallback(
-                                state.request_metric_totals,
-                                state.first_token_latency,
-                                state.observed_request_metric_fields,
-                            )
-                            cancelled_metadata = build_ai_run_metadata_content(
-                                config=config,
-                                model_name=prepared_run.runtime_model_name,
-                                run_id=state.cancelled_run_event.run_id,
-                                session_id=state.cancelled_run_event.session_id or session_id,
-                                status=RunStatus.cancelled,
-                                model=state.latest_model_id,
-                                model_provider=state.latest_model_provider,
-                                metrics=fallback_metrics,
-                                context_input_tokens=prepared_context_input_tokens,
-                                context_raw_input_tokens=state.latest_request_input_tokens,
-                                context_cache_read_tokens=state.latest_request_cache_read_tokens,
-                                context_cache_write_tokens=state.latest_request_cache_write_tokens,
-                                tool_count=state.observed_tool_calls,
-                                prepared_history=prepared_run.prepared_history,
-                            )
-                            run_metadata_collector.update(cancelled_metadata)
-                        if turn_recorder is None:
-                            persist_interrupted_replay(
-                                scope_context=scope_context,
-                                session_id=state.cancelled_run_event.session_id or session_id,
-                                run_id=state.cancelled_run_event.run_id or attempt.attempt_run_id or str(uuid4()),
-                                user_message=prompt,
-                                partial_text=state.assistant_text,
-                                completed_tools=turn_state.completed_tools_for(state.completed_tools),
-                                interrupted_tools=interrupted_tools,
-                                run_metadata=metadata,
-                                is_team=False,
-                            )
-                            standalone_interrupted_replay_persisted = True
-                        _raise_agent_run_cancelled(state.cancelled_run_event.reason)
-
-                    break
-
-                if _stream_completed_without_visible_output(state) and not state.completed_tool_executions:
-                    completed_event = state.completed_run_event
-                    assert completed_event is not None
-                    if _discard_empty_run_and_grant_retry(
-                        agent=agent,
-                        scope_context=scope_context,
-                        session_id=completed_event.session_id or session_id,
-                        run_id=completed_event.run_id,
-                        entity_name=agent_name,
-                        output_tokens=state.request_metric_totals.get("output_tokens"),
-                        empty_response_retried=empty_response_retried,
-                        continuation_count=continuation_count,
-                    ):
-                        empty_response_retried = True
-                        agent = None
-                        keep_going = True
-                        return
-                    # The notice must fall through: the run-metadata recording and
-                    # recorder completion below still apply to this notice-only turn.
-                    yield RunContentEvent(content=ai_runtime.EMPTY_RESPONSE_NOTICE)
-
-                continuation_decision = continuation_decision_from_tools(
-                    state.completed_tool_executions,
-                    original_prompt=continuation_state.original_prompt,
-                    continuation_count=continuation_count,
+            def _sync_live_turn_recorder(
+                *,
+                state_ref: _StreamingAttemptState = state,
+                turn_state_ref: AITurnState = turn_state,
+                metadata_ref: dict[str, Any] | None = run.run_metadata,
+            ) -> None:
+                turn_state_ref.sync_partial(
+                    turn_recorder,
+                    run_metadata=metadata_ref,
+                    assistant_text=state_ref.assistant_text,
+                    completed_tools=state_ref.completed_tools,
+                    interrupted_tools=[pending.trace_entry for pending in state_ref.pending_tools],
                 )
-                completed_tools_for_turn = turn_state.completed_tools_for(state.completed_tools)
-                if continuation_decision.should_continue:
-                    continuation_state, turn_state = _advance_dynamic_continuation(
-                        agent=agent,
-                        scope_context=scope_context,
-                        continuation_state=continuation_state,
-                        next_prompt=continuation_decision.next_prompt,
-                        previous_run_id=attempt.attempt_run_id,
-                        turn_recorder=turn_recorder,
-                        run_metadata=metadata,
-                        completed_tools_for_turn=completed_tools_for_turn,
-                    )
-                    agent = None
-                    keep_going = True
-                    return
-                if continuation_decision.limit_message is not None and continuation_decision.continuation is not None:
-                    logger.warning(
-                        "Dynamic tool continuation limit reached during streaming",
-                        agent=agent_name,
-                        function_name=continuation_decision.continuation.function_name,
-                        tool_name=continuation_decision.continuation.tool_name,
-                        status=continuation_decision.continuation.status,
-                    )
-                    if not state.assistant_text and not state.canonical_final_body_candidate:
-                        state.assistant_text = continuation_decision.limit_message
-                        yield RunContentEvent(content=continuation_decision.limit_message)
 
+            async for stream_chunk in _stream_agent_attempt_chunks(
+                run_context=run_context,
+                attempt=attempt,
+                state=state,
+                show_tool_calls=show_tool_calls,
+                user_id=user_id,
+                run_id_callback=run_id_callback,
+                retried_after_media_fallback=retried_after_media_fallback,
+                state_updated=_sync_live_turn_recorder,
+                pipeline_timing=pipeline_timing,
+            ):
+                yield stream_chunk
+
+            if state.media_fallback_retry_requested:
+                attempt.retry(
+                    run_context.run_input,
+                    fallback_prompt=run_context.inline_media_fallback_prompt,
+                    extra_removed_kinds=state.media_fallback_removed_kinds,
+                    retry_media_inputs=state.media_fallback_retry_inputs or MediaInputs(),
+                    run_id=continuation_state.active_run_id,
+                )
+                continue
+
+            run_error = state.user_error or state.stream_exception
+            if run_error is not None:
+                if state.assistant_text or state.completed_tools or state.pending_tools:
+                    interrupted_tools = [pending.trace_entry for pending in state.pending_tools]
+                    if turn_recorder is not None:
+                        turn_state.record_interrupted(
+                            turn_recorder,
+                            run_metadata=run.run_metadata,
+                            assistant_text=state.assistant_text,
+                            completed_tools=state.completed_tools,
+                            interrupted_tools=interrupted_tools,
+                        )
+                    elif not run.standalone_replay_persisted:
+                        persist_interrupted_replay(
+                            scope_context=run.scope_context,
+                            session_id=session_id,
+                            run_id=attempt.attempt_run_id or str(uuid4()),
+                            user_message=prompt,
+                            partial_text=state.assistant_text,
+                            completed_tools=turn_state.completed_tools_for(state.completed_tools),
+                            interrupted_tools=interrupted_tools,
+                            run_metadata=run.run_metadata,
+                            is_team=False,
+                        )
+                        run.standalone_replay_persisted = True
+                yield get_user_friendly_error_message(run_error, agent_name)
+                yield AttemptResolved(HandledAttempt())
+                return
+
+            if state.cancelled_run_event is not None:
+                cancelled_metadata: dict[str, Any] | None = None
                 if run_metadata_collector is not None:
                     fallback_metrics = build_model_request_metrics_fallback(
                         state.request_metric_totals,
                         state.first_token_latency,
                         state.observed_request_metric_fields,
                     )
-                    final_status = (
-                        RunStatus.error if _stream_completed_without_visible_output(state) else RunStatus.completed
-                    )
-                    usage_metrics, usage_metrics_fallback = _select_streaming_usage_metrics(
-                        state.completed_run_event.metrics if state.completed_run_event is not None else None,
-                        fallback_metrics,
-                    )
-                    run_metadata = build_ai_run_metadata_content(
+                    cancelled_metadata = build_ai_run_metadata_content(
                         config=config,
                         model_name=prepared_run.runtime_model_name,
-                        run_id=state.completed_run_event.run_id if state.completed_run_event is not None else None,
-                        session_id=(
-                            state.completed_run_event.session_id
-                            if state.completed_run_event is not None
-                            and state.completed_run_event.session_id is not None
-                            else session_id
-                        ),
-                        status=final_status,
+                        run_id=state.cancelled_run_event.run_id,
+                        session_id=state.cancelled_run_event.session_id or session_id,
+                        status=RunStatus.cancelled,
                         model=state.latest_model_id,
                         model_provider=state.latest_model_provider,
-                        metrics=usage_metrics,
-                        metrics_fallback=usage_metrics_fallback,
+                        metrics=fallback_metrics,
                         context_input_tokens=prepared_context_input_tokens,
                         context_raw_input_tokens=state.latest_request_input_tokens,
                         context_cache_read_tokens=state.latest_request_cache_read_tokens,
                         context_cache_write_tokens=state.latest_request_cache_write_tokens,
-                        tool_count=(
-                            len(state.completed_run_event.tools)
-                            if state.completed_run_event is not None and state.completed_run_event.tools is not None
-                            else state.observed_tool_calls
-                        ),
+                        tool_count=state.observed_tool_calls,
                         prepared_history=prepared_run.prepared_history,
                     )
-                    run_metadata_collector.update(run_metadata)
-                if turn_recorder is not None:
-                    final_visible_body = state.assistant_text or state.canonical_final_body_candidate or ""
-                    turn_state.record_completed(
-                        turn_recorder,
-                        run_metadata=metadata,
-                        assistant_text=final_visible_body,
-                        completed_tools=state.completed_tools,
-                    )
-                return
-            finally:
-                ai_runtime.cleanup_queued_notice_state(
-                    run_output=None,
-                    storage=scope_context.storage if scope_context is not None else None,
-                    session_id=session_id,
-                    session_type=SessionType.AGENT,
-                    entity_name=agent_name,
+                yield AttemptResolved(
+                    CancelledAttempt(
+                        reason=state.cancelled_run_event.reason,
+                        partial_text=state.assistant_text,
+                        completed_tools=tuple(state.completed_tools),
+                        interrupted_tools=tuple(pending.trace_entry for pending in state.pending_tools),
+                        session_id=state.cancelled_run_event.session_id,
+                        run_id=state.cancelled_run_event.run_id or attempt.attempt_run_id,
+                        metadata_content=cancelled_metadata,
+                    ),
                 )
+                return
 
-        with open_resolved_scope_session_context(
-            agent_name=agent_name,
-            scope=HistoryScope(kind="agent", scope_id=agent_name),
-            session_id=session_id,
-            runtime_paths=runtime_paths,
-            config=config,
-            execution_identity=execution_identity,
-        ) as opened_scope_context:
-            scope_context = opened_scope_context
-            ai_runtime.scrub_queued_notice_session_context(
-                scope_context=scope_context,
-                entity_name=agent_name,
+            break
+
+        metadata_content: dict[str, Any] | None = None
+        if run_metadata_collector is not None:
+            fallback_metrics = build_model_request_metrics_fallback(
+                state.request_metric_totals,
+                state.first_token_latency,
+                state.observed_request_metric_fields,
             )
-            continuation_state = _DynamicContinuationRunState.initial(
-                prompt=prompt,
-                model_prompt=model_prompt,
-                current_timestamp_ms=current_timestamp_ms,
-                current_prompt_is_structured=current_prompt_is_structured,
-                run_id=run_id,
+            final_status = RunStatus.error if _stream_completed_without_visible_output(state) else RunStatus.completed
+            usage_metrics, usage_metrics_fallback = _select_streaming_usage_metrics(
+                state.completed_run_event.metrics if state.completed_run_event is not None else None,
+                fallback_metrics,
             )
-            for continuation_count in range(DYNAMIC_TOOL_CONTINUATION_LIMIT + 1):
-                keep_going = False
-                async for stream_chunk in _run_streaming_attempt(continuation_count):
-                    yield stream_chunk
-                if not keep_going:
-                    return
-            # The continuation loop always returns on its final iteration: at
-            # continuation_count == DYNAMIC_TOOL_CONTINUATION_LIMIT the decision
-            # carries a limit_message and never asks to continue.
-            msg = "dynamic tool continuation loop must return within its iteration budget"
-            raise AssertionError(msg)
-    except asyncio.CancelledError:
-        interrupted_tools = [pending.trace_entry for pending in state.pending_tools]
-        if turn_recorder is not None:
-            turn_state.record_interrupted(
-                turn_recorder,
-                run_metadata=metadata
-                if metadata is not None
-                else turn_recorder.run_metadata
-                or build_matrix_run_metadata(
-                    reply_to_event_id,
-                    unseen_event_ids,
-                    room_id=room_id,
-                    thread_id=thread_id,
-                    requester_id=resolved_requester_id,
-                    correlation_id=resolved_correlation_id,
-                    extra_metadata=deep_merge_metadata(matrix_run_metadata, run_extra_content),
+            metadata_content = build_ai_run_metadata_content(
+                config=config,
+                model_name=prepared_run.runtime_model_name,
+                run_id=state.completed_run_event.run_id if state.completed_run_event is not None else None,
+                session_id=(
+                    state.completed_run_event.session_id
+                    if state.completed_run_event is not None and state.completed_run_event.session_id is not None
+                    else session_id
                 ),
-                assistant_text=state.assistant_text,
-                completed_tools=state.completed_tools,
-                interrupted_tools=interrupted_tools,
-            )
-        elif not standalone_interrupted_replay_persisted:
-            persist_interrupted_replay(
-                scope_context=scope_context,
-                session_id=session_id,
-                run_id=(attempt.attempt_run_id if attempt is not None else run_id) or str(uuid4()),
-                user_message=prompt,
-                partial_text=state.assistant_text,
-                completed_tools=turn_state.completed_tools_for(state.completed_tools),
-                interrupted_tools=interrupted_tools,
-                run_metadata=metadata
-                if metadata is not None
-                else build_matrix_run_metadata(
-                    reply_to_event_id,
-                    unseen_event_ids,
-                    room_id=room_id,
-                    thread_id=thread_id,
-                    requester_id=resolved_requester_id,
-                    correlation_id=resolved_correlation_id,
-                    extra_metadata=deep_merge_metadata(matrix_run_metadata, run_extra_content),
+                status=final_status,
+                model=state.latest_model_id,
+                model_provider=state.latest_model_provider,
+                metrics=usage_metrics,
+                metrics_fallback=usage_metrics_fallback,
+                context_input_tokens=prepared_context_input_tokens,
+                context_raw_input_tokens=state.latest_request_input_tokens,
+                context_cache_read_tokens=state.latest_request_cache_read_tokens,
+                context_cache_write_tokens=state.latest_request_cache_write_tokens,
+                tool_count=(
+                    len(state.completed_run_event.tools)
+                    if state.completed_run_event is not None and state.completed_run_event.tools is not None
+                    else state.observed_tool_calls
                 ),
-                is_team=False,
+                prepared_history=prepared_run.prepared_history,
             )
-        raise
-    finally:
-        close_agent_runtime_state_dbs(
-            agent,
-            shared_scope_storage=scope_context.storage if scope_context is not None else None,
+        yield AttemptResolved(
+            CompletedAttempt(
+                replayable_text=state.assistant_text or state.canonical_final_body_candidate or "",
+                has_visible_content=bool(state.assistant_text or state.canonical_final_body_candidate),
+                is_empty=_stream_completed_without_visible_output(state) and not state.completed_tool_executions,
+                session_id=state.completed_run_event.session_id if state.completed_run_event is not None else None,
+                run_id=state.completed_run_event.run_id if state.completed_run_event is not None else None,
+                attempt_run_id=attempt.attempt_run_id,
+                output_tokens=state.request_metric_totals.get("output_tokens"),
+                tool_executions=tuple(state.completed_tool_executions),
+                completed_tools=tuple(state.completed_tools),
+                metadata_content=metadata_content,
+            ),
         )
+
+    adapter = StreamingTurnAdapter[AIStreamChunk](
+        open_scope=callbacks.open_scope,
+        run_attempt=_run_streaming_attempt,
+        snapshot_partial=lambda: _streaming_partial_snapshot(holder),
+        release_attempt_entity=callbacks.release_attempt_entity,
+        close_runtime_dbs=callbacks.close_runtime_dbs,
+        on_scope_opened=callbacks.on_scope_opened,
+        finalize_attempt=_finalize_streaming_attempt,
+        make_notice_chunk=lambda text: RunContentEvent(content=text),
+        continuation=ContinuationCapability(),
+        empty_run=callbacks.empty_run,
+        persist_standalone_replay=callbacks.persist_standalone_replay,
+    )
+    response_stream = stream_response_turn(
+        ResponseTurnContext(
+            entity_label=agent_name,
+            session_id=session_id,
+            run_id=run_id,
+            correlation_id=resolved_correlation_id,
+            reply_to_event_id=reply_to_event_id,
+            room_id=room_id,
+            thread_id=thread_id,
+            requester_id=user_id,
+            matrix_run_metadata=matrix_run_metadata,
+        ),
+        adapter,
+        TurnSinks(turn_recorder=turn_recorder, run_metadata_collector=run_metadata_collector),
+        continuation=_initial_agent_continuation(
+            prompt=prompt,
+            model_prompt=model_prompt,
+            current_timestamp_ms=current_timestamp_ms,
+            current_prompt_is_structured=current_prompt_is_structured,
+            run_id=run_id,
+        ),
+    )
+    # Close the driver generator deterministically when this wrapper unwinds so
+    # its cleanup does not wait for event-loop async-generator finalization.
+    async with aclosing(response_stream) as closing_stream:
+        async for chunk in closing_stream:
+            yield chunk

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -71,6 +71,7 @@ from mindroom.memory import MemoryPromptParts, build_memory_prompt_parts, strip_
 from mindroom.metadata_merge import deep_merge_metadata
 from mindroom.response_turn import (
     AttemptResolved,
+    BlockingAttemptResolution,
     BlockingTurnAdapter,
     CancelledAttempt,
     CompletedAttempt,
@@ -354,8 +355,8 @@ class _AgentTurnHolder:
 
     agent: Agent | None = None
     attempt: _MediaAttempt | None = None
-    state: _StreamingAttemptState | None = None
-    attempt_started: bool = False
+    state: _StreamingAttemptState | None = None  # streaming turns only
+    attempt_started: bool = False  # streaming turns only
 
 
 @dataclass(frozen=True)
@@ -407,6 +408,11 @@ def _build_agent_turn_callbacks(
     def _release_attempt_entity(scope_context: ScopeSessionContext | None) -> None:
         _close_runtime_dbs(scope_context)
         holder.agent = None
+        # Cancel snapshots taken between this release and the next attempt must
+        # not see the spent attempt's partials; its completed tools already
+        # carried over via the turn state.
+        holder.attempt = None
+        holder.state = None
 
     def _discard_empty_run(scope_context: ScopeSessionContext | None, discard: EmptyRunDiscard) -> None:
         ai_runtime.discard_empty_completed_run(
@@ -474,7 +480,6 @@ class _AgentRunContext:
     prepared_run: _PreparedAgentRun
     run_input: list[Message]
     metadata: dict[str, Any] | None
-    run_extra_content: dict[str, Any] | None
     inline_media_fallback_prompt: str
 
 
@@ -1343,7 +1348,6 @@ async def _prepare_agent_run_context(
         prepared_run=prepared_run,
         run_input=prepared_run.run_input,
         metadata=metadata,
-        run_extra_content=run_extra_content,
         inline_media_fallback_prompt=config.get_prompt("INLINE_MEDIA_FALLBACK_PROMPT"),
     )
 
@@ -1518,7 +1522,7 @@ async def ai_response(
     async def _run_blocking_attempt(
         run: TurnRunState,
         continuation_state: DynamicContinuationRunState,
-    ) -> CompletedAttempt | CancelledAttempt | ErroredAttempt:
+    ) -> BlockingAttemptResolution:
         """Run one agent attempt, including its media-fallback retries."""
         try:
             run_context = await _prepare_agent_run_context(
@@ -1559,7 +1563,6 @@ async def ai_response(
         holder.agent = prepared_run.agent
         run.unseen_event_ids = prepared_run.unseen_event_ids
         run.run_metadata = run_context.metadata
-        run.run_extra_content = run_context.run_extra_content
 
         attempt = _MediaAttempt.initial(
             run_context.run_input,
@@ -2012,7 +2015,7 @@ async def stream_agent_response(  # noqa: C901, PLR0915
             entity_name=agent_name,
         )
 
-    async def _run_streaming_attempt(  # noqa: C901, PLR0915
+    async def _run_streaming_attempt(  # noqa: C901
         run: TurnRunState,
         continuation_state: DynamicContinuationRunState,
     ) -> AsyncGenerator[AIStreamChunk | AttemptResolved, None]:
@@ -2059,7 +2062,6 @@ async def stream_agent_response(  # noqa: C901, PLR0915
         run.unseen_event_ids = prepared_run.unseen_event_ids
         prepared_context_input_tokens = prepared_run.prepared_history.prepared_context_tokens
         run.run_metadata = run_context.metadata
-        run.run_extra_content = run_context.run_extra_content
 
         attempt = _MediaAttempt.initial(
             run_context.run_input,

--- a/src/mindroom/response_turn.py
+++ b/src/mindroom/response_turn.py
@@ -1,0 +1,887 @@
+"""Shared response-turn drivers for the agent and team envelopes.
+
+One inbound response turn has the same lifecycle regardless of which entity
+answers it: open the scope session, run prepared attempts (each attempt owns
+its own media-fallback retries), decide whether the turn continues after a
+dynamic-tool call or a discarded empty run, record the outcome on the turn
+recorder, and persist an interrupted replay when the turn is cancelled without
+a recorder. This module owns that lifecycle exactly once; ``mindroom.ai`` and
+``mindroom.teams`` supply thin adapters carrying the entity-specific attempt
+bodies as injected callables.
+
+Every ``ResponseTurnContext`` field is consumed by the drivers themselves;
+state that only the attempt bodies need stays captured inside the adapter
+closures and never crosses this seam.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field, replace
+from typing import TYPE_CHECKING, Any, NoReturn, cast
+from uuid import uuid4
+
+from mindroom import ai_runtime
+from mindroom.ai_turn_state import AITurnState
+from mindroom.cancellation import build_cancelled_error
+from mindroom.constants import (
+    MATRIX_EVENT_ID_METADATA_KEY,
+    MATRIX_SEEN_EVENT_IDS_METADATA_KEY,
+    MATRIX_SOURCE_EVENT_IDS_METADATA_KEY,
+    MATRIX_SOURCE_EVENT_PROMPTS_METADATA_KEY,
+)
+from mindroom.dynamic_tool_continuation import DYNAMIC_TOOL_CONTINUATION_LIMIT, continuation_decision_from_tools
+from mindroom.logging_config import get_logger
+from mindroom.metadata_merge import deep_merge_metadata
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable
+    from contextlib import AbstractContextManager
+
+    from agno.models.response import ToolExecution
+
+    from mindroom.history import ScopeSessionContext
+    from mindroom.history.turn_recorder import TurnRecorder
+    from mindroom.tool_system.events import ToolTraceEntry
+
+logger = get_logger(__name__)
+
+__all__ = [
+    "AttemptResolved",
+    "BlockingAttemptResolution",
+    "BlockingTurnAdapter",
+    "CancelledAttempt",
+    "CompletedAttempt",
+    "ContinuationCapability",
+    "DynamicContinuationRunState",
+    "EmptyRunCapability",
+    "EmptyRunDiscard",
+    "ErroredAttempt",
+    "HandledAttempt",
+    "ResponseTurnContext",
+    "StandaloneReplaySnapshot",
+    "StreamAttemptResolution",
+    "StreamingTurnAdapter",
+    "TurnPartialSnapshot",
+    "TurnRunState",
+    "TurnSinks",
+    "build_matrix_run_metadata",
+    "run_blocking_response_turn",
+    "stream_response_turn",
+]
+
+
+def _normalized_string_list(values: object) -> list[str]:
+    if not isinstance(values, list):
+        return []
+    normalized: list[str] = []
+    for value in values:
+        if isinstance(value, str) and value and value not in normalized:
+            normalized.append(value)
+    return normalized
+
+
+def build_matrix_run_metadata(
+    reply_to_event_id: str | None,
+    unseen_event_ids: list[str],
+    *,
+    room_id: str | None = None,
+    thread_id: str | None = None,
+    requester_id: str | None = None,
+    correlation_id: str | None = None,
+    tools_schema: list[dict[str, object]] | None = None,
+    model_params: dict[str, Any] | None = None,
+    extra_metadata: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Build metadata dict for a run, tracking consumed Matrix event ids."""
+    metadata = dict(extra_metadata or {})
+    if room_id is not None:
+        metadata["room_id"] = room_id
+    if thread_id is not None:
+        metadata["thread_id"] = thread_id
+    if reply_to_event_id is not None:
+        metadata["reply_to_event_id"] = reply_to_event_id
+    if requester_id is not None:
+        metadata["requester_id"] = requester_id
+    if correlation_id is not None:
+        metadata["correlation_id"] = correlation_id
+    if tools_schema is not None:
+        metadata["tools_schema"] = tools_schema
+    else:
+        metadata.setdefault("tools_schema", [])
+    if model_params is not None:
+        metadata["model_params"] = model_params
+    else:
+        metadata.setdefault("model_params", {})
+    source_event_ids = _normalized_string_list(metadata.get(MATRIX_SOURCE_EVENT_IDS_METADATA_KEY))
+    if reply_to_event_id:
+        seen_event_ids = _normalized_string_list(
+            [
+                reply_to_event_id,
+                *source_event_ids,
+                *_normalized_string_list(metadata.get(MATRIX_SEEN_EVENT_IDS_METADATA_KEY)),
+                *unseen_event_ids,
+            ],
+        )
+        metadata[MATRIX_EVENT_ID_METADATA_KEY] = reply_to_event_id
+        metadata[MATRIX_SEEN_EVENT_IDS_METADATA_KEY] = seen_event_ids
+    if MATRIX_SOURCE_EVENT_PROMPTS_METADATA_KEY in metadata and not isinstance(
+        metadata[MATRIX_SOURCE_EVENT_PROMPTS_METADATA_KEY],
+        dict,
+    ):
+        metadata.pop(MATRIX_SOURCE_EVENT_PROMPTS_METADATA_KEY, None)
+    return metadata or None
+
+
+@dataclass(frozen=True)
+class DynamicContinuationRunState:
+    """Prompt and run identity for a dynamic-tool continuation sequence."""
+
+    original_prompt: str
+    active_prompt: str
+    active_model_prompt: str | None
+    active_current_timestamp_ms: float | None
+    active_current_prompt_is_structured: bool
+    active_run_id: str | None
+    continuation_model_prompt_tail: str
+
+    @classmethod
+    def initial(
+        cls,
+        *,
+        prompt: str,
+        model_prompt: str | None,
+        current_timestamp_ms: float | None,
+        current_prompt_is_structured: bool,
+        run_id: str | None,
+        continuation_model_prompt_tail: str,
+    ) -> DynamicContinuationRunState:
+        """Build the continuation state for one turn's first attempt."""
+        return cls(
+            original_prompt=prompt,
+            active_prompt=prompt,
+            active_model_prompt=model_prompt,
+            active_current_timestamp_ms=current_timestamp_ms,
+            active_current_prompt_is_structured=current_prompt_is_structured,
+            active_run_id=run_id,
+            continuation_model_prompt_tail=continuation_model_prompt_tail,
+        )
+
+    def advance(
+        self,
+        *,
+        continuation_prompt: str,
+        previous_run_id: str | None,
+    ) -> DynamicContinuationRunState:
+        """Return the continuation state for one more same-turn attempt."""
+        return replace(
+            self,
+            active_prompt=continuation_prompt,
+            active_model_prompt=self.continuation_model_prompt_tail or None,
+            active_current_timestamp_ms=None,
+            active_current_prompt_is_structured=False,
+            active_run_id=ai_runtime.next_retry_run_id(previous_run_id),
+        )
+
+
+@dataclass(frozen=True)
+class ResponseTurnContext:
+    """Per-turn Matrix identity constants consumed by the turn drivers."""
+
+    entity_label: str
+    session_id: str | None
+    run_id: str | None
+    correlation_id: str
+    reply_to_event_id: str | None
+    room_id: str | None
+    thread_id: str | None
+    requester_id: str | None
+    matrix_run_metadata: dict[str, Any] | None
+
+
+@dataclass(frozen=True)
+class TurnSinks:
+    """Mutable turn outputs owned by the caller and updated by the drivers."""
+
+    turn_recorder: TurnRecorder | None = None
+    run_metadata_collector: dict[str, Any] | None = None
+
+
+@dataclass
+class TurnRunState:
+    """Driver-owned mutable state shared with the adapter attempt bodies."""
+
+    turn_state: AITurnState = field(default_factory=AITurnState)
+    scope_context: ScopeSessionContext | None = None
+    run_metadata: dict[str, Any] | None = None
+    run_extra_content: dict[str, Any] | None = None
+    unseen_event_ids: list[str] = field(default_factory=list)
+    standalone_replay_persisted: bool = False
+    empty_response_retried: bool = False
+
+
+@dataclass(frozen=True)
+class TurnPartialSnapshot:
+    """Live partial-output view used when a turn is cancelled from outside."""
+
+    assistant_text: str = ""
+    completed_tools: tuple[ToolTraceEntry, ...] = ()
+    interrupted_tools: tuple[ToolTraceEntry, ...] = ()
+    attempt_run_id: str | None = None
+
+
+@dataclass(frozen=True)
+class CompletedAttempt:
+    """One attempt that ran to a terminal provider response."""
+
+    response_text: str = ""
+    replayable_text: str = ""
+    has_visible_content: bool = False
+    is_empty: bool = False
+    session_id: str | None = None
+    run_id: str | None = None
+    attempt_run_id: str | None = None
+    output_tokens: int | None = None
+    tool_executions: tuple[ToolExecution, ...] = ()
+    completed_tools: tuple[ToolTraceEntry, ...] = ()
+    metadata_content: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class CancelledAttempt:
+    """One attempt whose provider run reported cancellation."""
+
+    reason: str | None = None
+    partial_text: str = ""
+    completed_tools: tuple[ToolTraceEntry, ...] = ()
+    interrupted_tools: tuple[ToolTraceEntry, ...] = ()
+    session_id: str | None = None
+    run_id: str | None = None
+    metadata_content: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class ErroredAttempt:
+    """One attempt that resolved to user-facing error text (blocking only)."""
+
+    user_message_text: str
+    metadata_content: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class HandledAttempt:
+    """One streaming attempt that already emitted and recorded its own terminal output."""
+
+
+BlockingAttemptResolution = CompletedAttempt | CancelledAttempt | ErroredAttempt
+StreamAttemptResolution = CompletedAttempt | CancelledAttempt | HandledAttempt
+
+
+@dataclass(frozen=True)
+class AttemptResolved:
+    """Sentinel a streaming attempt yields last to report its resolution."""
+
+    resolution: StreamAttemptResolution
+
+
+@dataclass(frozen=True)
+class ContinuationCapability:
+    """Enable dynamic-tool continuations with one iteration budget."""
+
+    limit: int = DYNAMIC_TOOL_CONTINUATION_LIMIT
+
+
+@dataclass(frozen=True)
+class EmptyRunDiscard:
+    """Identity of one empty completed run to purge from session history."""
+
+    session_id: str | None
+    run_id: str | None
+    output_tokens: int | None
+
+
+@dataclass(frozen=True)
+class EmptyRunCapability:
+    """Enable the empty-completed-run guard with an entity-specific discard."""
+
+    notice_text: str
+    discard: Callable[[ScopeSessionContext | None, EmptyRunDiscard], None]
+
+
+@dataclass(frozen=True)
+class StandaloneReplaySnapshot:
+    """Interrupted-turn state persisted when no turn recorder is attached."""
+
+    session_id: str | None
+    run_id: str
+    partial_text: str
+    completed_tools: list[ToolTraceEntry]
+    interrupted_tools: list[ToolTraceEntry]
+    run_metadata: dict[str, Any] | None
+
+
+@dataclass(frozen=True)
+class BlockingTurnAdapter:
+    """Entity-specific callbacks for one blocking response turn."""
+
+    open_scope: Callable[[], AbstractContextManager[ScopeSessionContext | None]]
+    run_attempt: Callable[
+        [TurnRunState, DynamicContinuationRunState],
+        Awaitable[BlockingAttemptResolution],
+    ]
+    snapshot_partial: Callable[[], TurnPartialSnapshot]
+    release_attempt_entity: Callable[[ScopeSessionContext | None], None]
+    close_runtime_dbs: Callable[[ScopeSessionContext | None], None]
+    on_scope_opened: Callable[[ScopeSessionContext | None], None] | None = None
+    finalize_attempt: Callable[[ScopeSessionContext | None], None] | None = None
+    unexpected_error_text: Callable[[Exception], str] | None = None
+    continuation: ContinuationCapability | None = None
+    empty_run: EmptyRunCapability | None = None
+    persist_standalone_replay: Callable[[ScopeSessionContext | None, StandaloneReplaySnapshot], None] | None = None
+
+
+@dataclass(frozen=True)
+class StreamingTurnAdapter[ChunkT]:
+    """Entity-specific callbacks for one streaming response turn."""
+
+    open_scope: Callable[[], AbstractContextManager[ScopeSessionContext | None]]
+    run_attempt: Callable[
+        [TurnRunState, DynamicContinuationRunState],
+        AsyncIterator[ChunkT | AttemptResolved],
+    ]
+    snapshot_partial: Callable[[], TurnPartialSnapshot]
+    release_attempt_entity: Callable[[ScopeSessionContext | None], None]
+    close_runtime_dbs: Callable[[ScopeSessionContext | None], None]
+    on_scope_opened: Callable[[ScopeSessionContext | None], None] | None = None
+    finalize_attempt: Callable[[ScopeSessionContext | None], None] | None = None
+    make_notice_chunk: Callable[[str], ChunkT] | None = None
+    unexpected_error_text: Callable[[Exception], str] | None = None
+    continuation: ContinuationCapability | None = None
+    empty_run: EmptyRunCapability | None = None
+    persist_standalone_replay: Callable[[ScopeSessionContext | None, StandaloneReplaySnapshot], None] | None = None
+
+
+def _raise_continuation_budget_exhausted() -> NoReturn:
+    # The continuation loop always settles on its final iteration: at the limit
+    # the decision carries a limit_message and never asks to continue.
+    msg = "dynamic tool continuation loop must return within its iteration budget"
+    raise AssertionError(msg)
+
+
+def _effective_continuation_limit(
+    continuation: ContinuationCapability | None,
+    empty_run: EmptyRunCapability | None,
+) -> int:
+    """Return the turn's extra-iteration budget beyond the first attempt.
+
+    The empty-run one-shot retry borrows a continuation slot when continuations
+    are enabled; without them it still needs one slot of its own.
+    """
+    if continuation is not None:
+        return continuation.limit
+    return 1 if empty_run is not None else 0
+
+
+def _reset_turn_state_for_dynamic_continuation(
+    *,
+    turn_recorder: TurnRecorder | None,
+    run_metadata: dict[str, Any] | None,
+    completed_tools_for_turn: list[ToolTraceEntry],
+) -> AITurnState:
+    turn_state = AITurnState(prior_completed_tools=completed_tools_for_turn)
+    turn_state.sync_partial(
+        turn_recorder,
+        run_metadata=run_metadata,
+        assistant_text="",
+        completed_tools=[],
+        interrupted_tools=[],
+    )
+    return turn_state
+
+
+def _fallback_matrix_run_metadata(ctx: ResponseTurnContext, run: TurnRunState) -> dict[str, Any] | None:
+    """Build run metadata for interruptions that fire before prepare finished."""
+    return build_matrix_run_metadata(
+        ctx.reply_to_event_id,
+        run.unseen_event_ids,
+        room_id=ctx.room_id,
+        thread_id=ctx.thread_id,
+        requester_id=ctx.requester_id,
+        correlation_id=ctx.correlation_id,
+        extra_metadata=deep_merge_metadata(ctx.matrix_run_metadata, run.run_extra_content),
+    )
+
+
+def _persist_attempt_cancelled_replay(
+    ctx: ResponseTurnContext,
+    persist: Callable[[ScopeSessionContext | None, StandaloneReplaySnapshot], None],
+    run: TurnRunState,
+    resolution: CancelledAttempt,
+) -> None:
+    """Persist the standalone interrupted replay for one cancelled attempt."""
+    persist(
+        run.scope_context,
+        StandaloneReplaySnapshot(
+            session_id=resolution.session_id or ctx.session_id,
+            run_id=resolution.run_id or str(uuid4()),
+            partial_text=resolution.partial_text,
+            completed_tools=run.turn_state.completed_tools_for(resolution.completed_tools),
+            interrupted_tools=list(resolution.interrupted_tools),
+            run_metadata=run.run_metadata,
+        ),
+    )
+    run.standalone_replay_persisted = True
+
+
+def _record_turn_cancelled_fallback(
+    ctx: ResponseTurnContext,
+    persist: Callable[[ScopeSessionContext | None, StandaloneReplaySnapshot], None] | None,
+    sinks: TurnSinks,
+    run: TurnRunState,
+    snapshot: TurnPartialSnapshot,
+    *,
+    use_recorder_state: bool,
+) -> None:
+    """Record an externally cancelled turn on the recorder or as a standalone replay."""
+    recorder = sinks.turn_recorder
+    if recorder is not None:
+        run_metadata = (
+            run.run_metadata
+            if run.run_metadata is not None
+            else recorder.run_metadata or _fallback_matrix_run_metadata(ctx, run)
+        )
+        if use_recorder_state:
+            run.turn_state.record_interrupted_from_recorder(recorder, run_metadata=run_metadata)
+        else:
+            run.turn_state.record_interrupted(
+                recorder,
+                run_metadata=run_metadata,
+                assistant_text=snapshot.assistant_text,
+                completed_tools=list(snapshot.completed_tools),
+                interrupted_tools=list(snapshot.interrupted_tools),
+            )
+        return
+    if run.standalone_replay_persisted or persist is None:
+        return
+    persist(
+        run.scope_context,
+        StandaloneReplaySnapshot(
+            session_id=ctx.session_id,
+            run_id=(snapshot.attempt_run_id or ctx.run_id) or str(uuid4()),
+            partial_text=snapshot.assistant_text,
+            completed_tools=run.turn_state.completed_tools_for(snapshot.completed_tools),
+            interrupted_tools=list(snapshot.interrupted_tools),
+            run_metadata=run.run_metadata if run.run_metadata is not None else _fallback_matrix_run_metadata(ctx, run),
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class _EmptyRunOutcome:
+    """How the empty-run guard settled one empty completed attempt."""
+
+    retry_granted: bool
+    notice_text: str | None = None
+
+
+def _settle_empty_run(
+    ctx: ResponseTurnContext,
+    empty_run: EmptyRunCapability,
+    release_attempt_entity: Callable[[ScopeSessionContext | None], None],
+    run: TurnRunState,
+    resolution: CompletedAttempt,
+    *,
+    continuation_count: int,
+    limit: int,
+) -> _EmptyRunOutcome:
+    """Discard one empty completed run and decide whether one retry is granted.
+
+    The one-shot retry borrows a continuation slot so the outer loop's
+    iteration budget stays authoritative; a granted retry closes the spent
+    entity's runtime state exactly like the continuation handoff.
+    """
+    empty_run.discard(
+        run.scope_context,
+        EmptyRunDiscard(
+            session_id=resolution.session_id or ctx.session_id,
+            run_id=resolution.run_id,
+            output_tokens=resolution.output_tokens,
+        ),
+    )
+    if not run.empty_response_retried and continuation_count < limit:
+        run.empty_response_retried = True
+        release_attempt_entity(run.scope_context)
+        return _EmptyRunOutcome(retry_granted=True)
+    return _EmptyRunOutcome(retry_granted=False, notice_text=empty_run.notice_text)
+
+
+def _advance_turn_continuation(
+    sinks: TurnSinks,
+    release_attempt_entity: Callable[[ScopeSessionContext | None], None],
+    run: TurnRunState,
+    resolution: CompletedAttempt,
+    continuation: DynamicContinuationRunState,
+    *,
+    next_prompt: str | None,
+) -> DynamicContinuationRunState:
+    """Close the spent attempt entity and prepare run state for one more continuation."""
+    completed_tools_for_turn = run.turn_state.completed_tools_for(resolution.completed_tools)
+    release_attempt_entity(run.scope_context)
+    advanced = continuation.advance(
+        continuation_prompt=next_prompt or continuation.original_prompt,
+        previous_run_id=resolution.attempt_run_id,
+    )
+    run.turn_state = _reset_turn_state_for_dynamic_continuation(
+        turn_recorder=sinks.turn_recorder,
+        run_metadata=run.run_metadata,
+        completed_tools_for_turn=completed_tools_for_turn,
+    )
+    return advanced
+
+
+async def run_blocking_response_turn(
+    ctx: ResponseTurnContext,
+    adapter: BlockingTurnAdapter,
+    sinks: TurnSinks,
+    *,
+    continuation: DynamicContinuationRunState,
+) -> str:
+    """Run one blocking response turn to a final user-visible text."""
+    run = TurnRunState()
+    limit = _effective_continuation_limit(adapter.continuation, adapter.empty_run)
+    try:
+        with adapter.open_scope() as scope_context:
+            run.scope_context = scope_context
+            if adapter.on_scope_opened is not None:
+                adapter.on_scope_opened(scope_context)
+            for continuation_count in range(limit + 1):
+                try:
+                    resolution = await adapter.run_attempt(run, continuation)
+                    settled = _settle_blocking_attempt(
+                        ctx,
+                        adapter,
+                        sinks,
+                        run,
+                        resolution,
+                        continuation,
+                        continuation_count=continuation_count,
+                        limit=limit,
+                    )
+                finally:
+                    if adapter.finalize_attempt is not None:
+                        adapter.finalize_attempt(run.scope_context)
+                if isinstance(settled, str):
+                    return settled
+                continuation = settled
+            _raise_continuation_budget_exhausted()
+    except asyncio.CancelledError:
+        # The blocking envelope re-records from the recorder's canonical state so
+        # an in-attempt cancellation (recorded above with attempt-local partials)
+        # and an external task cancel converge on the same interrupted turn.
+        _record_turn_cancelled_fallback(
+            ctx,
+            adapter.persist_standalone_replay,
+            sinks,
+            run,
+            adapter.snapshot_partial(),
+            use_recorder_state=True,
+        )
+        raise
+    except Exception as e:
+        if adapter.unexpected_error_text is None:
+            raise
+        logger.exception("Response turn failed", entity=ctx.entity_label)
+        return adapter.unexpected_error_text(e)
+    finally:
+        adapter.close_runtime_dbs(run.scope_context)
+
+
+def _settle_blocking_attempt(
+    ctx: ResponseTurnContext,
+    adapter: BlockingTurnAdapter,
+    sinks: TurnSinks,
+    run: TurnRunState,
+    resolution: BlockingAttemptResolution,
+    continuation: DynamicContinuationRunState,
+    *,
+    continuation_count: int,
+    limit: int,
+) -> str | DynamicContinuationRunState:
+    """Settle one blocking attempt: return final text or the advanced continuation."""
+    # The blocking envelope publishes run metadata before dispatching on the
+    # attempt outcome, so cancelled and errored runs still reach the collector.
+    if sinks.run_metadata_collector is not None and resolution.metadata_content is not None:
+        sinks.run_metadata_collector.update(resolution.metadata_content)
+    if isinstance(resolution, CancelledAttempt):
+        run.turn_state.record_interrupted(
+            sinks.turn_recorder,
+            run_metadata=run.run_metadata,
+            assistant_text=resolution.partial_text,
+            completed_tools=list(resolution.completed_tools),
+            interrupted_tools=list(resolution.interrupted_tools),
+        )
+        if sinks.turn_recorder is None and adapter.persist_standalone_replay is not None:
+            _persist_attempt_cancelled_replay(ctx, adapter.persist_standalone_replay, run, resolution)
+        raise build_cancelled_error(resolution.reason)
+    if isinstance(resolution, ErroredAttempt):
+        return resolution.user_message_text
+    return _settle_completed_blocking_attempt(
+        ctx,
+        adapter,
+        sinks,
+        run,
+        resolution,
+        continuation,
+        continuation_count=continuation_count,
+        limit=limit,
+    )
+
+
+def _settle_completed_blocking_attempt(
+    ctx: ResponseTurnContext,
+    adapter: BlockingTurnAdapter,
+    sinks: TurnSinks,
+    run: TurnRunState,
+    resolution: CompletedAttempt,
+    continuation: DynamicContinuationRunState,
+    *,
+    continuation_count: int,
+    limit: int,
+) -> str | DynamicContinuationRunState:
+    """Settle one completed blocking attempt into final text or a continuation."""
+    if resolution.is_empty and adapter.empty_run is not None:
+        empty_outcome = _settle_empty_run(
+            ctx,
+            adapter.empty_run,
+            adapter.release_attempt_entity,
+            run,
+            resolution,
+            continuation_count=continuation_count,
+            limit=limit,
+        )
+        if empty_outcome.retry_granted:
+            return continuation
+        run.turn_state.record_completed(
+            sinks.turn_recorder,
+            run_metadata=run.run_metadata,
+            assistant_text="",
+            completed_tools=[],
+        )
+        assert empty_outcome.notice_text is not None
+        return empty_outcome.notice_text
+    decision = (
+        continuation_decision_from_tools(
+            resolution.tool_executions,
+            original_prompt=continuation.original_prompt,
+            continuation_count=continuation_count,
+        )
+        if adapter.continuation is not None
+        else None
+    )
+    response_text = resolution.response_text
+    replayable_text = resolution.replayable_text
+    if decision is not None:
+        if decision.should_continue:
+            return _advance_turn_continuation(
+                sinks,
+                adapter.release_attempt_entity,
+                run,
+                resolution,
+                continuation,
+                next_prompt=decision.next_prompt,
+            )
+        if decision.limit_message is not None and decision.continuation is not None:
+            logger.warning(
+                "Dynamic tool continuation limit reached",
+                entity=ctx.entity_label,
+                function_name=decision.continuation.function_name,
+                tool_name=decision.continuation.tool_name,
+                status=decision.continuation.status,
+            )
+        if decision.limit_message is not None and not resolution.has_visible_content:
+            response_text = decision.limit_message
+            replayable_text = decision.limit_message
+    run.turn_state.record_completed(
+        sinks.turn_recorder,
+        run_metadata=run.run_metadata,
+        assistant_text=replayable_text,
+        completed_tools=list(resolution.completed_tools),
+    )
+    return response_text
+
+
+@dataclass(frozen=True)
+class _StreamCompletionSettle:
+    """Driver-internal plan for finishing one completed streaming attempt."""
+
+    keep_going: bool
+    continuation: DynamicContinuationRunState
+    notice_texts: tuple[str, ...]
+    recorded_text: str
+
+
+def _settle_completed_stream_attempt(
+    ctx: ResponseTurnContext,
+    adapter: StreamingTurnAdapter[Any],
+    sinks: TurnSinks,
+    run: TurnRunState,
+    resolution: CompletedAttempt,
+    continuation: DynamicContinuationRunState,
+    *,
+    continuation_count: int,
+    limit: int,
+) -> _StreamCompletionSettle:
+    """Settle one completed streaming attempt into notices, recording text, and continuation."""
+    notice_texts: list[str] = []
+    keep_going = False
+    recorded_text = resolution.replayable_text
+    if resolution.is_empty and adapter.empty_run is not None:
+        empty_outcome = _settle_empty_run(
+            ctx,
+            adapter.empty_run,
+            adapter.release_attempt_entity,
+            run,
+            resolution,
+            continuation_count=continuation_count,
+            limit=limit,
+        )
+        if empty_outcome.retry_granted:
+            keep_going = True
+        else:
+            # The notice falls through: run metadata and recorder completion
+            # still apply to this notice-only turn.
+            assert empty_outcome.notice_text is not None
+            notice_texts.append(empty_outcome.notice_text)
+    if not keep_going and adapter.continuation is not None:
+        decision = continuation_decision_from_tools(
+            resolution.tool_executions,
+            original_prompt=continuation.original_prompt,
+            continuation_count=continuation_count,
+        )
+        if decision.should_continue:
+            continuation = _advance_turn_continuation(
+                sinks,
+                adapter.release_attempt_entity,
+                run,
+                resolution,
+                continuation,
+                next_prompt=decision.next_prompt,
+            )
+            keep_going = True
+        elif decision.limit_message is not None:
+            if decision.continuation is not None:
+                logger.warning(
+                    "Dynamic tool continuation limit reached during streaming",
+                    entity=ctx.entity_label,
+                    function_name=decision.continuation.function_name,
+                    tool_name=decision.continuation.tool_name,
+                    status=decision.continuation.status,
+                )
+            if not resolution.has_visible_content:
+                notice_texts.append(decision.limit_message)
+                recorded_text = decision.limit_message
+    return _StreamCompletionSettle(
+        keep_going=keep_going,
+        continuation=continuation,
+        notice_texts=tuple(notice_texts),
+        recorded_text=recorded_text,
+    )
+
+
+async def stream_response_turn[ChunkT](  # noqa: C901, PLR0912
+    ctx: ResponseTurnContext,
+    adapter: StreamingTurnAdapter[ChunkT],
+    sinks: TurnSinks,
+    *,
+    continuation: DynamicContinuationRunState,
+) -> AsyncGenerator[ChunkT, None]:
+    """Run one streaming response turn, yielding the attempt chunks as they arrive."""
+    run = TurnRunState()
+    limit = _effective_continuation_limit(adapter.continuation, adapter.empty_run)
+    try:
+        with adapter.open_scope() as scope_context:
+            run.scope_context = scope_context
+            if adapter.on_scope_opened is not None:
+                adapter.on_scope_opened(scope_context)
+            for continuation_count in range(limit + 1):
+                resolution: StreamAttemptResolution | None = None
+                keep_going = False
+                try:
+                    async for item in adapter.run_attempt(run, continuation):
+                        if isinstance(item, AttemptResolved):
+                            # The sentinel must be the attempt's final yield; never
+                            # break out of this loop, so attempt cleanup stays
+                            # deterministic at generator return.
+                            resolution = item.resolution
+                            continue
+                        yield item
+                    if resolution is None or isinstance(resolution, HandledAttempt):
+                        return
+                    if isinstance(resolution, CancelledAttempt):
+                        # The streaming envelope records the interruption before
+                        # publishing cancelled run metadata to the collector.
+                        run.turn_state.record_interrupted(
+                            sinks.turn_recorder,
+                            run_metadata=run.run_metadata,
+                            assistant_text=resolution.partial_text,
+                            completed_tools=list(resolution.completed_tools),
+                            interrupted_tools=list(resolution.interrupted_tools),
+                        )
+                        if sinks.run_metadata_collector is not None and resolution.metadata_content is not None:
+                            sinks.run_metadata_collector.update(resolution.metadata_content)
+                        if sinks.turn_recorder is None and adapter.persist_standalone_replay is not None:
+                            _persist_attempt_cancelled_replay(
+                                ctx,
+                                adapter.persist_standalone_replay,
+                                run,
+                                resolution,
+                            )
+                        raise build_cancelled_error(resolution.reason)
+                    settle = _settle_completed_stream_attempt(
+                        ctx,
+                        adapter,
+                        sinks,
+                        run,
+                        resolution,
+                        continuation,
+                        continuation_count=continuation_count,
+                        limit=limit,
+                    )
+                    continuation = settle.continuation
+                    keep_going = settle.keep_going
+                    for notice_text in settle.notice_texts:
+                        assert adapter.make_notice_chunk is not None
+                        yield adapter.make_notice_chunk(notice_text)
+                    if not keep_going:
+                        if sinks.run_metadata_collector is not None and resolution.metadata_content is not None:
+                            sinks.run_metadata_collector.update(resolution.metadata_content)
+                        run.turn_state.record_completed(
+                            sinks.turn_recorder,
+                            run_metadata=run.run_metadata,
+                            assistant_text=settle.recorded_text,
+                            completed_tools=list(resolution.completed_tools),
+                        )
+                finally:
+                    if adapter.finalize_attempt is not None:
+                        adapter.finalize_attempt(run.scope_context)
+                if not keep_going:
+                    return
+            _raise_continuation_budget_exhausted()
+    except asyncio.CancelledError:
+        _record_turn_cancelled_fallback(
+            ctx,
+            adapter.persist_standalone_replay,
+            sinks,
+            run,
+            adapter.snapshot_partial(),
+            use_recorder_state=False,
+        )
+        raise
+    except Exception as e:
+        if adapter.unexpected_error_text is None:
+            raise
+        logger.exception("Response turn failed", entity=ctx.entity_label)
+        yield cast("ChunkT", adapter.unexpected_error_text(e))
+        return
+    finally:
+        adapter.close_runtime_dbs(run.scope_context)

--- a/src/mindroom/response_turn.py
+++ b/src/mindroom/response_turn.py
@@ -17,6 +17,7 @@ closures and never crosses this seam.
 from __future__ import annotations
 
 import asyncio
+from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, NoReturn, cast
 from uuid import uuid4
@@ -32,7 +33,6 @@ from mindroom.constants import (
 )
 from mindroom.dynamic_tool_continuation import DYNAMIC_TOOL_CONTINUATION_LIMIT, continuation_decision_from_tools
 from mindroom.logging_config import get_logger
-from mindroom.metadata_merge import deep_merge_metadata
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable
@@ -209,12 +209,16 @@ class TurnSinks:
 
 @dataclass
 class TurnRunState:
-    """Driver-owned mutable state shared with the adapter attempt bodies."""
+    """Driver-owned mutable state shared with the adapter attempt bodies.
+
+    Attempt bodies must set ``run_metadata`` and ``unseen_event_ids`` once
+    prepare finishes; interruption recording falls back to rebuilt metadata
+    while they are still unset.
+    """
 
     turn_state: AITurnState = field(default_factory=AITurnState)
     scope_context: ScopeSessionContext | None = None
     run_metadata: dict[str, Any] | None = None
-    run_extra_content: dict[str, Any] | None = None
     unseen_event_ids: list[str] = field(default_factory=list)
     standalone_replay_persisted: bool = False
     empty_response_retried: bool = False
@@ -234,6 +238,8 @@ class TurnPartialSnapshot:
 class CompletedAttempt:
     """One attempt that ran to a terminal provider response."""
 
+    # Only blocking attempts set this; the streaming driver delivers via
+    # chunks and records replayable_text.
     response_text: str = ""
     replayable_text: str = ""
     has_visible_content: bool = False
@@ -286,9 +292,13 @@ class AttemptResolved:
 
 @dataclass(frozen=True)
 class ContinuationCapability:
-    """Enable dynamic-tool continuations with one iteration budget."""
+    """Enable dynamic-tool continuations for the turn.
 
-    limit: int = DYNAMIC_TOOL_CONTINUATION_LIMIT
+    The iteration budget is always ``DYNAMIC_TOOL_CONTINUATION_LIMIT``:
+    ``continuation_decision_from_tools`` hardcodes that constant for its
+    continue/stop decision, so a per-adapter limit would silently desync
+    from the loop budget.
+    """
 
 
 @dataclass(frozen=True)
@@ -368,6 +378,13 @@ def _raise_continuation_budget_exhausted() -> NoReturn:
     raise AssertionError(msg)
 
 
+def _raise_missing_stream_resolution(entity_label: str) -> NoReturn:
+    # A streaming attempt that returns without its sentinel would otherwise end
+    # the turn silently: nothing recorded, no metadata published, no log.
+    msg = f"streaming attempt for {entity_label!r} ended without yielding its AttemptResolved sentinel"
+    raise RuntimeError(msg)
+
+
 def _effective_continuation_limit(
     continuation: ContinuationCapability | None,
     empty_run: EmptyRunCapability | None,
@@ -378,7 +395,7 @@ def _effective_continuation_limit(
     are enabled; without them it still needs one slot of its own.
     """
     if continuation is not None:
-        return continuation.limit
+        return DYNAMIC_TOOL_CONTINUATION_LIMIT
     return 1 if empty_run is not None else 0
 
 
@@ -408,7 +425,7 @@ def _fallback_matrix_run_metadata(ctx: ResponseTurnContext, run: TurnRunState) -
         thread_id=ctx.thread_id,
         requester_id=ctx.requester_id,
         correlation_id=ctx.correlation_id,
-        extra_metadata=deep_merge_metadata(ctx.matrix_run_metadata, run.run_extra_content),
+        extra_metadata=deepcopy(ctx.matrix_run_metadata),
     )
 
 
@@ -788,7 +805,7 @@ def _settle_completed_stream_attempt(
     )
 
 
-async def stream_response_turn[ChunkT](  # noqa: C901, PLR0912
+async def stream_response_turn[ChunkT](  # noqa: C901, PLR0912, PLR0915
     ctx: ResponseTurnContext,
     adapter: StreamingTurnAdapter[ChunkT],
     sinks: TurnSinks,
@@ -815,7 +832,9 @@ async def stream_response_turn[ChunkT](  # noqa: C901, PLR0912
                             resolution = item.resolution
                             continue
                         yield item
-                    if resolution is None or isinstance(resolution, HandledAttempt):
+                    if resolution is None:
+                        _raise_missing_stream_resolution(ctx.entity_label)
+                    if isinstance(resolution, HandledAttempt):
                         return
                     if isinstance(resolution, CancelledAttempt):
                         # The streaming envelope records the interruption before

--- a/tach.toml
+++ b/tach.toml
@@ -93,7 +93,6 @@ depends_on = [
     "mindroom.constants",
     "mindroom.dynamic_tool_continuation",
     "mindroom.logging_config",
-    "mindroom.metadata_merge",
 ]
 visibility = [
     "mindroom.ai",

--- a/tach.toml
+++ b/tach.toml
@@ -62,13 +62,9 @@ path = "mindroom.ai"
 depends_on = [
     "mindroom.agents",
     "mindroom.ai_run_metadata",
-    "mindroom.ai_turn_state",
     "mindroom.ai_runtime",
-    "mindroom.cancellation",
-    "mindroom.constants",
     "mindroom.credentials",
     "mindroom.credentials_sync",
-    "mindroom.dynamic_tool_continuation",
     "mindroom.error_handling",
     "mindroom.execution_preparation",
     "mindroom.history",
@@ -80,9 +76,28 @@ depends_on = [
     "mindroom.media_inputs",
     "mindroom.memory",
     "mindroom.metadata_merge",
+    "mindroom.response_turn",
     "mindroom.timing",
     "mindroom.tool_system.events",
     "mindroom.user_turn_time",
+]
+
+# The shared response-turn drivers own the turn lifecycle for both the agent
+# and (after adoption) team envelopes; entity modules inject adapters.
+[[modules]]
+path = "mindroom.response_turn"
+depends_on = [
+    "mindroom.ai_runtime",
+    "mindroom.ai_turn_state",
+    "mindroom.cancellation",
+    "mindroom.constants",
+    "mindroom.dynamic_tool_continuation",
+    "mindroom.logging_config",
+    "mindroom.metadata_merge",
+]
+visibility = [
+    "mindroom.ai",
+    "mindroom.teams",
 ]
 
 [[modules]]
@@ -94,12 +109,12 @@ depends_on = [
 [[modules]]
 path = "mindroom.ai_turn_state"
 depends_on = []
-visibility = ["mindroom.ai"]
+visibility = ["mindroom.response_turn"]
 
 [[modules]]
 path = "mindroom.dynamic_tool_continuation"
 depends_on = []
-visibility = ["mindroom.ai"]
+visibility = ["mindroom.response_turn"]
 
 [[modules]]
 path = "mindroom.agents"
@@ -198,6 +213,7 @@ visibility = [
     "mindroom.execution_preparation",
     "mindroom.history.runtime",
     "mindroom.response_lifecycle",
+    "mindroom.response_turn",
     "mindroom.teams",
     "mindroom.thread_summary",
     "mindroom.topic_generator",

--- a/tests/test_issue_154_logging_integration.py
+++ b/tests/test_issue_154_logging_integration.py
@@ -118,6 +118,7 @@ class _InvokeAgent:
             status=RunStatus.completed,
             model=self.model.id,
             model_provider="openai",
+            metrics=None,
         )
 
 

--- a/tests/test_response_turn.py
+++ b/tests/test_response_turn.py
@@ -555,6 +555,37 @@ def test_blocking_empty_run_without_continuation_still_retries_once() -> None:
     assert attempts == 2
 
 
+def test_blocking_empty_retry_borrows_continuation_slot_within_shared_budget() -> None:
+    """One empty retry plus dynamic-tool continuations share the iteration budget."""
+    log = _AdapterLog()
+    attempts = 0
+
+    async def _attempt(_run: TurnRunState, _c: DynamicContinuationRunState) -> CompletedAttempt:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return CompletedAttempt(is_empty=True, run_id="run-empty")
+        return CompletedAttempt(
+            attempt_run_id=f"run-{attempts}",
+            tool_executions=(_dynamic_tool_execution(),),
+        )
+
+    result = asyncio.run(
+        run_blocking_response_turn(
+            _ctx(),
+            _blocking_adapter(log, _attempt, empty_run=_empty_run_capability(log)),
+            TurnSinks(),
+            continuation=_continuation(),
+        ),
+    )
+
+    # Attempt 1 spends the empty retry; attempts 2-4 continue; attempt 5 sits
+    # at the decision limit and settles with the limit message.
+    assert attempts == 5
+    assert "did not produce a final answer" in result
+    assert [discard.run_id for discard in log.discards] == ["run-empty"]
+
+
 def test_blocking_unexpected_error_reraises_without_shaper() -> None:
     """Unexpected exceptions propagate when no error shaper is configured."""
     log = _AdapterLog()
@@ -695,6 +726,40 @@ def test_streaming_cancelled_attempt_records_updates_collector_and_raises() -> N
     assert len(log.persisted) == 1
     assert log.finalized == 1
     assert log.closed == 1
+
+
+def test_streaming_cancelled_attempt_with_recorder_records_twice() -> None:
+    """An in-attempt stream cancel records inline, then again from the live snapshot."""
+    log = _AdapterLog()
+    recorder = _FakeTurnRecorder()
+    log.snapshot = TurnPartialSnapshot(assistant_text="snapshot partial")
+
+    async def _attempt(
+        run: TurnRunState,
+        _c: DynamicContinuationRunState,
+    ) -> AsyncGenerator[str | AttemptResolved, None]:
+        run.run_metadata = {"room_id": "!room"}
+        yield "partial"
+        yield AttemptResolved(CancelledAttempt(reason="stop", partial_text="attempt partial"))
+
+    async def _run() -> None:
+        async for _chunk in stream_response_turn(
+            _ctx(),
+            _streaming_adapter(log, _attempt),
+            TurnSinks(turn_recorder=cast("Any", recorder)),
+            continuation=_continuation(),
+        ):
+            pass
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(_run())
+
+    assert len(recorder.interrupted_calls) == 2
+    assert recorder.interrupted_calls[0]["assistant_text"] == "attempt partial"
+    # Unlike blocking, the streaming outer handler re-records from the live
+    # snapshot rather than the recorder's canonical state.
+    assert recorder.interrupted_calls[1]["assistant_text"] == "snapshot partial"
+    assert log.persisted == []
 
 
 def test_streaming_external_cancel_records_snapshot_partials() -> None:
@@ -914,6 +979,64 @@ def test_streaming_unexpected_error_yields_shaped_text() -> None:
     )
 
     assert chunks == ["chunk", "shaped: boom"]
+
+
+def test_streaming_attempt_without_sentinel_raises() -> None:
+    """A streaming attempt that never yields its sentinel fails loudly."""
+    log = _AdapterLog()
+    recorder = _FakeTurnRecorder()
+
+    async def _attempt(
+        _run: TurnRunState,
+        _c: DynamicContinuationRunState,
+    ) -> AsyncGenerator[str | AttemptResolved, None]:
+        yield "chunk"
+
+    async def _run() -> None:
+        async for _chunk in stream_response_turn(
+            _ctx(),
+            _streaming_adapter(log, _attempt),
+            TurnSinks(turn_recorder=cast("Any", recorder)),
+            continuation=_continuation(),
+        ):
+            pass
+
+    with pytest.raises(RuntimeError, match="AttemptResolved sentinel"):
+        asyncio.run(_run())
+    assert recorder.completed_calls == []
+    assert log.finalized == 1
+    assert log.closed == 1
+
+
+def test_streaming_aclose_runs_cleanup_without_recording() -> None:
+    """Closing the driver generator mid-stream cleans up and records nothing."""
+    log = _AdapterLog()
+    recorder = _FakeTurnRecorder()
+
+    async def _attempt(
+        _run: TurnRunState,
+        _c: DynamicContinuationRunState,
+    ) -> AsyncGenerator[str | AttemptResolved, None]:
+        yield "first"
+        yield "second"
+        yield AttemptResolved(CompletedAttempt(replayable_text="full", has_visible_content=True))
+
+    async def _run() -> None:
+        stream = stream_response_turn(
+            _ctx(),
+            _streaming_adapter(log, _attempt),
+            TurnSinks(turn_recorder=cast("Any", recorder)),
+            continuation=_continuation(),
+        )
+        assert await anext(stream) == "first"
+        await stream.aclose()
+
+    asyncio.run(_run())
+
+    assert log.closed == 1
+    assert log.finalized == 1
+    assert recorder.completed_calls == []
+    assert recorder.interrupted_calls == []
 
 
 def test_stream_resolution_union_covers_handled() -> None:

--- a/tests/test_response_turn.py
+++ b/tests/test_response_turn.py
@@ -1,0 +1,922 @@
+"""Driver-level tests for the shared response-turn seam."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, cast
+
+import pytest
+from agno.models.response import ToolExecution
+
+from mindroom.response_turn import (
+    AttemptResolved,
+    BlockingTurnAdapter,
+    CancelledAttempt,
+    CompletedAttempt,
+    ContinuationCapability,
+    DynamicContinuationRunState,
+    EmptyRunCapability,
+    EmptyRunDiscard,
+    ErroredAttempt,
+    HandledAttempt,
+    ResponseTurnContext,
+    StandaloneReplaySnapshot,
+    StreamAttemptResolution,
+    StreamingTurnAdapter,
+    TurnPartialSnapshot,
+    TurnRunState,
+    TurnSinks,
+    run_blocking_response_turn,
+    stream_response_turn,
+)
+from mindroom.tool_system.events import ToolTraceEntry
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Mapping, Sequence
+    from contextlib import AbstractContextManager
+
+    from mindroom.history import ScopeSessionContext
+
+_DEFAULT_CONTINUATION = ContinuationCapability()
+
+
+@dataclass
+class _FakeTurnRecorder:
+    """Minimal TurnRecorder double tracking recorded outcomes."""
+
+    run_metadata: dict[str, Any] | None = None
+    assistant_text: str = ""
+    completed_tools: list[ToolTraceEntry] = field(default_factory=list)
+    interrupted_tools: list[ToolTraceEntry] = field(default_factory=list)
+    completed_calls: list[dict[str, Any]] = field(default_factory=list)
+    interrupted_calls: list[dict[str, Any]] = field(default_factory=list)
+    synced_calls: list[dict[str, Any]] = field(default_factory=list)
+
+    def sync_partial_state(
+        self,
+        *,
+        run_metadata: Mapping[str, Any] | None,
+        assistant_text: str,
+        completed_tools: Sequence[ToolTraceEntry],
+        interrupted_tools: Sequence[ToolTraceEntry],
+    ) -> None:
+        self.synced_calls.append(
+            {
+                "run_metadata": run_metadata,
+                "assistant_text": assistant_text,
+                "completed_tools": list(completed_tools),
+                "interrupted_tools": list(interrupted_tools),
+            },
+        )
+        self.assistant_text = assistant_text
+        self.completed_tools = list(completed_tools)
+        self.interrupted_tools = list(interrupted_tools)
+
+    def record_completed(
+        self,
+        *,
+        run_metadata: Mapping[str, Any] | None,
+        assistant_text: str,
+        completed_tools: Sequence[ToolTraceEntry],
+    ) -> None:
+        self.completed_calls.append(
+            {
+                "run_metadata": run_metadata,
+                "assistant_text": assistant_text,
+                "completed_tools": list(completed_tools),
+            },
+        )
+
+    def record_interrupted(
+        self,
+        *,
+        run_metadata: Mapping[str, Any] | None,
+        assistant_text: str,
+        completed_tools: Sequence[ToolTraceEntry],
+        interrupted_tools: Sequence[ToolTraceEntry],
+    ) -> None:
+        self.interrupted_calls.append(
+            {
+                "run_metadata": run_metadata,
+                "assistant_text": assistant_text,
+                "completed_tools": list(completed_tools),
+                "interrupted_tools": list(interrupted_tools),
+            },
+        )
+
+
+def _trace(tool_name: str) -> ToolTraceEntry:
+    return ToolTraceEntry(type="tool_call_completed", tool_name=tool_name)
+
+
+def _dynamic_tool_execution(tool_name: str = "sleep") -> ToolExecution:
+    return ToolExecution(
+        tool_call_id="call-load_tool",
+        tool_name="load_tool",
+        tool_args={"tool_name": tool_name},
+        result=json.dumps({"status": "loaded", "tool": "dynamic_tools", "tool_name": tool_name}),
+        stop_after_tool_call=True,
+    )
+
+
+def _ctx(**overrides: object) -> ResponseTurnContext:
+    values: dict[str, Any] = {
+        "entity_label": "helper",
+        "session_id": "session-1",
+        "run_id": "run-1",
+        "correlation_id": "corr-1",
+        "reply_to_event_id": "$reply",
+        "room_id": "!room",
+        "thread_id": "$thread",
+        "requester_id": "@user:hs",
+        "matrix_run_metadata": {"correlation_id": "corr-1"},
+    }
+    values.update(overrides)
+    return ResponseTurnContext(**values)
+
+
+def _continuation(prompt: str = "hello") -> DynamicContinuationRunState:
+    return DynamicContinuationRunState.initial(
+        prompt=prompt,
+        model_prompt=None,
+        current_timestamp_ms=None,
+        current_prompt_is_structured=False,
+        run_id="run-1",
+        continuation_model_prompt_tail="",
+    )
+
+
+@dataclass
+class _AdapterLog:
+    """Call log shared by the fake adapter callbacks."""
+
+    scope: Any = None
+    released: int = 0
+    closed: int = 0
+    finalized: int = 0
+    discards: list[EmptyRunDiscard] = field(default_factory=list)
+    persisted: list[StandaloneReplaySnapshot] = field(default_factory=list)
+    snapshot: TurnPartialSnapshot = field(default_factory=TurnPartialSnapshot)
+
+
+def _open_scope_factory(log: _AdapterLog) -> Callable[[], AbstractContextManager[ScopeSessionContext]]:
+    def _open() -> AbstractContextManager[ScopeSessionContext]:
+        log.scope = object()
+        return contextlib.nullcontext(cast("ScopeSessionContext", log.scope))
+
+    return _open
+
+
+def _blocking_adapter(
+    log: _AdapterLog,
+    run_attempt: Callable[[TurnRunState, DynamicContinuationRunState], Awaitable[Any]],
+    *,
+    continuation: ContinuationCapability | None = _DEFAULT_CONTINUATION,
+    empty_run: EmptyRunCapability | None = None,
+    with_standalone_replay: bool = True,
+    unexpected_error_text: Callable[[Exception], str] | None = None,
+) -> BlockingTurnAdapter:
+    def _persist(_scope: ScopeSessionContext | None, snapshot: StandaloneReplaySnapshot) -> None:
+        log.persisted.append(snapshot)
+
+    return BlockingTurnAdapter(
+        open_scope=_open_scope_factory(log),
+        run_attempt=run_attempt,
+        snapshot_partial=lambda: log.snapshot,
+        release_attempt_entity=lambda _scope: _bump(log, "released"),
+        close_runtime_dbs=lambda _scope: _bump(log, "closed"),
+        finalize_attempt=lambda _scope: _bump(log, "finalized"),
+        unexpected_error_text=unexpected_error_text,
+        continuation=continuation,
+        empty_run=empty_run,
+        persist_standalone_replay=_persist if with_standalone_replay else None,
+    )
+
+
+def _streaming_adapter(
+    log: _AdapterLog,
+    run_attempt: Callable[
+        [TurnRunState, DynamicContinuationRunState],
+        AsyncGenerator[str | AttemptResolved, None],
+    ],
+    *,
+    continuation: ContinuationCapability | None = _DEFAULT_CONTINUATION,
+    empty_run: EmptyRunCapability | None = None,
+    with_standalone_replay: bool = True,
+    unexpected_error_text: Callable[[Exception], str] | None = None,
+) -> StreamingTurnAdapter[str]:
+    def _persist(_scope: ScopeSessionContext | None, snapshot: StandaloneReplaySnapshot) -> None:
+        log.persisted.append(snapshot)
+
+    return StreamingTurnAdapter[str](
+        open_scope=_open_scope_factory(log),
+        run_attempt=run_attempt,
+        snapshot_partial=lambda: log.snapshot,
+        release_attempt_entity=lambda _scope: _bump(log, "released"),
+        close_runtime_dbs=lambda _scope: _bump(log, "closed"),
+        finalize_attempt=lambda _scope: _bump(log, "finalized"),
+        make_notice_chunk=lambda text: f"notice:{text}",
+        unexpected_error_text=unexpected_error_text,
+        continuation=continuation,
+        empty_run=empty_run,
+        persist_standalone_replay=_persist if with_standalone_replay else None,
+    )
+
+
+def _bump(log: _AdapterLog, attr: str) -> None:
+    setattr(log, attr, getattr(log, attr) + 1)
+
+
+def _empty_run_capability(log: _AdapterLog) -> EmptyRunCapability:
+    return EmptyRunCapability(
+        notice_text="empty notice",
+        discard=lambda _scope, discard: log.discards.append(discard),
+    )
+
+
+async def _collect(stream: AsyncIterator[str]) -> list[str]:
+    return [chunk async for chunk in stream]
+
+
+def test_blocking_completion_records_and_updates_collector() -> None:
+    """A completed blocking attempt records the turn and publishes run metadata once."""
+    log = _AdapterLog()
+    recorder = _FakeTurnRecorder()
+    collector: dict[str, Any] = {}
+    trace = _trace("search")
+
+    async def _attempt(run: TurnRunState, _c: DynamicContinuationRunState) -> CompletedAttempt:
+        run.run_metadata = {"room_id": "!room"}
+        return CompletedAttempt(
+            response_text="visible",
+            replayable_text="replayable",
+            has_visible_content=True,
+            completed_tools=(trace,),
+            metadata_content={"io.mindroom.ai_run": {"usage": 1}},
+        )
+
+    result = asyncio.run(
+        run_blocking_response_turn(
+            _ctx(),
+            _blocking_adapter(log, _attempt),
+            TurnSinks(turn_recorder=cast("Any", recorder), run_metadata_collector=collector),
+            continuation=_continuation(),
+        ),
+    )
+
+    assert result == "visible"
+    assert collector == {"io.mindroom.ai_run": {"usage": 1}}
+    assert recorder.completed_calls == [
+        {
+            "run_metadata": {"room_id": "!room"},
+            "assistant_text": "replayable",
+            "completed_tools": [trace],
+        },
+    ]
+    assert log.finalized == 1
+    assert log.closed == 1
+
+
+def test_blocking_completion_skips_collector_without_metadata_content() -> None:
+    """No collector update happens when the attempt resolved without metadata."""
+    log = _AdapterLog()
+    collector: dict[str, Any] = {}
+
+    async def _attempt(_run: TurnRunState, _c: DynamicContinuationRunState) -> CompletedAttempt:
+        return CompletedAttempt(response_text="done", replayable_text="done", has_visible_content=True)
+
+    result = asyncio.run(
+        run_blocking_response_turn(
+            _ctx(),
+            _blocking_adapter(log, _attempt),
+            TurnSinks(turn_recorder=None, run_metadata_collector=collector),
+            continuation=_continuation(),
+        ),
+    )
+
+    assert result == "done"
+    assert collector == {}
+
+
+def test_blocking_errored_attempt_returns_user_text() -> None:
+    """An errored attempt short-circuits to its user-facing text."""
+    log = _AdapterLog()
+
+    async def _attempt(_run: TurnRunState, _c: DynamicContinuationRunState) -> ErroredAttempt:
+        return ErroredAttempt("friendly error")
+
+    result = asyncio.run(
+        run_blocking_response_turn(
+            _ctx(),
+            _blocking_adapter(log, _attempt),
+            TurnSinks(),
+            continuation=_continuation(),
+        ),
+    )
+
+    assert result == "friendly error"
+
+
+def test_blocking_cancelled_attempt_records_persists_and_raises() -> None:
+    """A cancelled attempt without recorder persists one standalone replay and raises."""
+    log = _AdapterLog()
+
+    async def _attempt(run: TurnRunState, _c: DynamicContinuationRunState) -> CancelledAttempt:
+        run.run_metadata = {"room_id": "!room"}
+        return CancelledAttempt(
+            reason="user stop",
+            partial_text="partial",
+            completed_tools=(_trace("search"),),
+            interrupted_tools=(_trace("browse"),),
+            session_id="session-live",
+            run_id="run-live",
+        )
+
+    async def _run() -> None:
+        await run_blocking_response_turn(
+            _ctx(),
+            _blocking_adapter(log, _attempt),
+            TurnSinks(),
+            continuation=_continuation(),
+        )
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(_run())
+
+    assert len(log.persisted) == 1
+    snapshot = log.persisted[0]
+    assert snapshot.session_id == "session-live"
+    assert snapshot.run_id == "run-live"
+    assert snapshot.partial_text == "partial"
+    assert snapshot.run_metadata == {"room_id": "!room"}
+    assert log.finalized == 1
+    assert log.closed == 1
+
+
+def test_blocking_cancelled_attempt_with_recorder_records_twice() -> None:
+    """An in-attempt cancellation records once inline and once from the outer handler."""
+    log = _AdapterLog()
+    recorder = _FakeTurnRecorder()
+
+    async def _attempt(run: TurnRunState, _c: DynamicContinuationRunState) -> CancelledAttempt:
+        run.run_metadata = {"room_id": "!room"}
+        return CancelledAttempt(reason="stop", partial_text="partial")
+
+    async def _run() -> None:
+        await run_blocking_response_turn(
+            _ctx(),
+            _blocking_adapter(log, _attempt),
+            TurnSinks(turn_recorder=cast("Any", recorder)),
+            continuation=_continuation(),
+        )
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(_run())
+
+    assert len(recorder.interrupted_calls) == 2
+    assert recorder.interrupted_calls[0]["assistant_text"] == "partial"
+    # The outer handler re-records from the recorder's canonical state.
+    assert recorder.interrupted_calls[1]["run_metadata"] == {"room_id": "!room"}
+    assert log.persisted == []
+
+
+def test_blocking_external_cancel_builds_fallback_metadata() -> None:
+    """An external cancel before prepare persists a replay with rebuilt run metadata."""
+    log = _AdapterLog()
+    log.snapshot = TurnPartialSnapshot(attempt_run_id=None)
+
+    async def _attempt(_run: TurnRunState, _c: DynamicContinuationRunState) -> CompletedAttempt:
+        raise asyncio.CancelledError
+
+    async def _run() -> None:
+        await run_blocking_response_turn(
+            _ctx(),
+            _blocking_adapter(log, _attempt),
+            TurnSinks(),
+            continuation=_continuation(),
+        )
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(_run())
+
+    assert len(log.persisted) == 1
+    snapshot = log.persisted[0]
+    assert snapshot.run_id == "run-1"
+    assert snapshot.partial_text == ""
+    run_metadata = snapshot.run_metadata
+    assert run_metadata is not None
+    assert run_metadata["room_id"] == "!room"
+    assert run_metadata["correlation_id"] == "corr-1"
+    assert run_metadata["reply_to_event_id"] == "$reply"
+
+
+def test_blocking_external_cancel_skips_persist_after_inline_persist() -> None:
+    """The standalone replay is not persisted twice for one cancelled turn."""
+    log = _AdapterLog()
+
+    async def _attempt(run: TurnRunState, _c: DynamicContinuationRunState) -> CancelledAttempt:
+        run.run_metadata = {"room_id": "!room"}
+        return CancelledAttempt(reason="stop")
+
+    async def _run() -> None:
+        await run_blocking_response_turn(
+            _ctx(),
+            _blocking_adapter(log, _attempt),
+            TurnSinks(),
+            continuation=_continuation(),
+        )
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(_run())
+
+    assert len(log.persisted) == 1
+
+
+def test_blocking_continuation_advances_and_resets_turn_state() -> None:
+    """A dynamic-tool attempt releases the entity and reruns with the continuation prompt."""
+    log = _AdapterLog()
+    recorder = _FakeTurnRecorder()
+    prompts: list[str] = []
+    first_trace = _trace("load_tool")
+
+    async def _attempt(
+        _run: TurnRunState,
+        continuation: DynamicContinuationRunState,
+    ) -> CompletedAttempt:
+        prompts.append(continuation.active_prompt)
+        if len(prompts) == 1:
+            return CompletedAttempt(
+                attempt_run_id="run-1",
+                tool_executions=(_dynamic_tool_execution(),),
+                completed_tools=(first_trace,),
+            )
+        return CompletedAttempt(
+            response_text="final",
+            replayable_text="final",
+            has_visible_content=True,
+            completed_tools=(_trace("sleep"),),
+        )
+
+    result = asyncio.run(
+        run_blocking_response_turn(
+            _ctx(),
+            _blocking_adapter(log, _attempt),
+            TurnSinks(turn_recorder=cast("Any", recorder)),
+            continuation=_continuation("original ask"),
+        ),
+    )
+
+    assert result == "final"
+    assert len(prompts) == 2
+    assert prompts[0] == "original ask"
+    assert "DYNAMIC TOOL CALL COMPLETED" in prompts[1]
+    assert log.released == 1
+    assert log.finalized == 2
+    # The continuation reset synced empty partial state carrying the prior tools.
+    assert recorder.synced_calls[-1]["completed_tools"] == [first_trace]
+    # The final recording carries the first attempt's tools plus the second's.
+    assert recorder.completed_calls[-1]["completed_tools"] == [first_trace, _trace("sleep")]
+
+
+def test_blocking_continuation_limit_returns_limit_message() -> None:
+    """Hitting the continuation limit surfaces the limit message when nothing is visible."""
+    log = _AdapterLog()
+
+    async def _attempt(_run: TurnRunState, _c: DynamicContinuationRunState) -> CompletedAttempt:
+        return CompletedAttempt(
+            attempt_run_id="run-1",
+            tool_executions=(_dynamic_tool_execution(),),
+        )
+
+    result = asyncio.run(
+        run_blocking_response_turn(
+            _ctx(),
+            _blocking_adapter(log, _attempt),
+            TurnSinks(),
+            continuation=_continuation(),
+        ),
+    )
+
+    assert "did not produce a final answer" in result
+
+
+def test_blocking_empty_run_grants_one_retry_then_notice() -> None:
+    """The empty-run guard discards, retries once, then falls back to the notice."""
+    log = _AdapterLog()
+    recorder = _FakeTurnRecorder()
+    attempts = 0
+
+    async def _attempt(_run: TurnRunState, _c: DynamicContinuationRunState) -> CompletedAttempt:
+        nonlocal attempts
+        attempts += 1
+        return CompletedAttempt(is_empty=True, session_id="session-live", run_id=f"run-{attempts}")
+
+    result = asyncio.run(
+        run_blocking_response_turn(
+            _ctx(),
+            _blocking_adapter(log, _attempt, empty_run=_empty_run_capability(log)),
+            TurnSinks(turn_recorder=cast("Any", recorder)),
+            continuation=_continuation(),
+        ),
+    )
+
+    assert result == "empty notice"
+    assert attempts == 2
+    assert [discard.run_id for discard in log.discards] == ["run-1", "run-2"]
+    assert log.released == 1
+    assert recorder.completed_calls == [
+        {"run_metadata": None, "assistant_text": "", "completed_tools": []},
+    ]
+
+
+def test_blocking_empty_run_without_continuation_still_retries_once() -> None:
+    """The empty-run guard has its own retry slot when continuations are disabled."""
+    log = _AdapterLog()
+    attempts = 0
+
+    async def _attempt(_run: TurnRunState, _c: DynamicContinuationRunState) -> CompletedAttempt:
+        nonlocal attempts
+        attempts += 1
+        return CompletedAttempt(is_empty=True)
+
+    result = asyncio.run(
+        run_blocking_response_turn(
+            _ctx(),
+            _blocking_adapter(log, _attempt, continuation=None, empty_run=_empty_run_capability(log)),
+            TurnSinks(),
+            continuation=_continuation(),
+        ),
+    )
+
+    assert result == "empty notice"
+    assert attempts == 2
+
+
+def test_blocking_unexpected_error_reraises_without_shaper() -> None:
+    """Unexpected exceptions propagate when no error shaper is configured."""
+    log = _AdapterLog()
+
+    async def _attempt(_run: TurnRunState, _c: DynamicContinuationRunState) -> CompletedAttempt:
+        msg = "boom"
+        raise RuntimeError(msg)
+
+    async def _run() -> None:
+        await run_blocking_response_turn(
+            _ctx(),
+            _blocking_adapter(log, _attempt),
+            TurnSinks(),
+            continuation=_continuation(),
+        )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        asyncio.run(_run())
+    assert log.closed == 1
+
+
+def test_blocking_unexpected_error_uses_shaper_when_configured() -> None:
+    """Unexpected exceptions become user-facing text through the configured shaper."""
+    log = _AdapterLog()
+
+    async def _attempt(_run: TurnRunState, _c: DynamicContinuationRunState) -> CompletedAttempt:
+        msg = "boom"
+        raise RuntimeError(msg)
+
+    result = asyncio.run(
+        run_blocking_response_turn(
+            _ctx(),
+            _blocking_adapter(log, _attempt, unexpected_error_text=lambda e: f"shaped: {e}"),
+            TurnSinks(),
+            continuation=_continuation(),
+        ),
+    )
+
+    assert result == "shaped: boom"
+
+
+def test_streaming_turn_yields_chunks_and_filters_sentinel() -> None:
+    """The streaming driver forwards attempt chunks and never leaks the sentinel."""
+    log = _AdapterLog()
+    recorder = _FakeTurnRecorder()
+
+    async def _attempt(
+        run: TurnRunState,
+        _c: DynamicContinuationRunState,
+    ) -> AsyncGenerator[str | AttemptResolved, None]:
+        run.run_metadata = {"room_id": "!room"}
+        yield "hello "
+        yield "world"
+        yield AttemptResolved(
+            CompletedAttempt(replayable_text="hello world", has_visible_content=True),
+        )
+
+    chunks = asyncio.run(
+        _collect(
+            stream_response_turn(
+                _ctx(),
+                _streaming_adapter(log, _attempt),
+                TurnSinks(turn_recorder=cast("Any", recorder)),
+                continuation=_continuation(),
+            ),
+        ),
+    )
+
+    assert chunks == ["hello ", "world"]
+    assert recorder.completed_calls[-1]["assistant_text"] == "hello world"
+    assert log.finalized == 1
+
+
+def test_streaming_handled_attempt_ends_turn_without_recording() -> None:
+    """A handled attempt (self-reported error) ends the turn without recording."""
+    log = _AdapterLog()
+    recorder = _FakeTurnRecorder()
+
+    async def _attempt(
+        _run: TurnRunState,
+        _c: DynamicContinuationRunState,
+    ) -> AsyncGenerator[str | AttemptResolved, None]:
+        yield "friendly error"
+        yield AttemptResolved(HandledAttempt())
+
+    chunks = asyncio.run(
+        _collect(
+            stream_response_turn(
+                _ctx(),
+                _streaming_adapter(log, _attempt),
+                TurnSinks(turn_recorder=cast("Any", recorder)),
+                continuation=_continuation(),
+            ),
+        ),
+    )
+
+    assert chunks == ["friendly error"]
+    assert recorder.completed_calls == []
+    assert log.finalized == 1
+
+
+def test_streaming_cancelled_attempt_records_updates_collector_and_raises() -> None:
+    """A cancelled streaming attempt records, publishes metadata, persists, and raises."""
+    log = _AdapterLog()
+    collector: dict[str, Any] = {}
+
+    async def _attempt(
+        run: TurnRunState,
+        _c: DynamicContinuationRunState,
+    ) -> AsyncGenerator[str | AttemptResolved, None]:
+        run.run_metadata = {"room_id": "!room"}
+        yield "partial"
+        yield AttemptResolved(
+            CancelledAttempt(
+                reason="stop",
+                partial_text="partial",
+                metadata_content={"io.mindroom.ai_run": {"status": "cancelled"}},
+            ),
+        )
+
+    collected: list[str] = []
+
+    async def _run() -> None:
+        async for chunk in stream_response_turn(
+            _ctx(),
+            _streaming_adapter(log, _attempt),
+            TurnSinks(run_metadata_collector=collector),
+            continuation=_continuation(),
+        ):
+            # A comprehension would lose the chunks yielded before the cancel.
+            collected.append(chunk)  # noqa: PERF401
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(_run())
+
+    assert collected == ["partial"]
+    assert collector == {"io.mindroom.ai_run": {"status": "cancelled"}}
+    assert len(log.persisted) == 1
+    assert log.finalized == 1
+    assert log.closed == 1
+
+
+def test_streaming_external_cancel_records_snapshot_partials() -> None:
+    """An external cancel records the adapter's live partial snapshot."""
+    log = _AdapterLog()
+    recorder = _FakeTurnRecorder()
+    log.snapshot = TurnPartialSnapshot(
+        assistant_text="live partial",
+        completed_tools=(_trace("search"),),
+        interrupted_tools=(_trace("browse"),),
+        attempt_run_id="run-live",
+    )
+
+    async def _attempt(
+        _run: TurnRunState,
+        _c: DynamicContinuationRunState,
+    ) -> AsyncGenerator[str | AttemptResolved, None]:
+        yield "chunk"
+        raise asyncio.CancelledError
+
+    collected: list[str] = []
+
+    async def _run() -> None:
+        async for chunk in stream_response_turn(
+            _ctx(),
+            _streaming_adapter(log, _attempt),
+            TurnSinks(turn_recorder=cast("Any", recorder)),
+            continuation=_continuation(),
+        ):
+            # A comprehension would lose the chunks yielded before the cancel.
+            collected.append(chunk)  # noqa: PERF401
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(_run())
+
+    assert collected == ["chunk"]
+    assert len(recorder.interrupted_calls) == 1
+    assert recorder.interrupted_calls[0]["assistant_text"] == "live partial"
+    assert recorder.interrupted_calls[0]["interrupted_tools"] == [_trace("browse")]
+    assert log.finalized == 1
+
+
+def test_streaming_external_cancel_without_recorder_persists_snapshot() -> None:
+    """A recorder-less external cancel persists the standalone replay from the snapshot."""
+    log = _AdapterLog()
+    log.snapshot = TurnPartialSnapshot(assistant_text="live partial", attempt_run_id="run-live")
+
+    async def _attempt(
+        _run: TurnRunState,
+        _c: DynamicContinuationRunState,
+    ) -> AsyncGenerator[str | AttemptResolved, None]:
+        yield "chunk"
+        raise asyncio.CancelledError
+
+    async def _run() -> None:
+        async for _chunk in stream_response_turn(
+            _ctx(),
+            _streaming_adapter(log, _attempt),
+            TurnSinks(),
+            continuation=_continuation(),
+        ):
+            pass
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(_run())
+
+    assert len(log.persisted) == 1
+    assert log.persisted[0].partial_text == "live partial"
+    assert log.persisted[0].run_id == "run-live"
+
+
+def test_streaming_empty_run_retries_then_yields_notice_and_records() -> None:
+    """The streaming empty-run guard retries once, then yields the notice and records."""
+    log = _AdapterLog()
+    recorder = _FakeTurnRecorder()
+    attempts = 0
+
+    async def _attempt(
+        _run: TurnRunState,
+        _c: DynamicContinuationRunState,
+    ) -> AsyncGenerator[str | AttemptResolved, None]:
+        nonlocal attempts
+        attempts += 1
+        yield AttemptResolved(CompletedAttempt(is_empty=True, run_id=f"run-{attempts}"))
+
+    chunks = asyncio.run(
+        _collect(
+            stream_response_turn(
+                _ctx(),
+                _streaming_adapter(log, _attempt, empty_run=_empty_run_capability(log)),
+                TurnSinks(turn_recorder=cast("Any", recorder)),
+                continuation=_continuation(),
+            ),
+        ),
+    )
+
+    assert chunks == ["notice:empty notice"]
+    assert attempts == 2
+    assert [discard.run_id for discard in log.discards] == ["run-1", "run-2"]
+    # The notice-only turn still records an empty completion.
+    assert recorder.completed_calls[-1]["assistant_text"] == ""
+
+
+def test_streaming_continuation_advances_then_finishes() -> None:
+    """A streamed dynamic-tool attempt continues the turn and streams the second attempt."""
+    log = _AdapterLog()
+    prompts: list[str] = []
+
+    async def _attempt(
+        _run: TurnRunState,
+        continuation: DynamicContinuationRunState,
+    ) -> AsyncGenerator[str | AttemptResolved, None]:
+        prompts.append(continuation.active_prompt)
+        if len(prompts) == 1:
+            yield "loading tool"
+            yield AttemptResolved(
+                CompletedAttempt(attempt_run_id="run-1", tool_executions=(_dynamic_tool_execution(),)),
+            )
+            return
+        yield "final answer"
+        yield AttemptResolved(CompletedAttempt(replayable_text="final answer", has_visible_content=True))
+
+    chunks = asyncio.run(
+        _collect(
+            stream_response_turn(
+                _ctx(),
+                _streaming_adapter(log, _attempt),
+                TurnSinks(),
+                continuation=_continuation("original ask"),
+            ),
+        ),
+    )
+
+    assert chunks == ["loading tool", "final answer"]
+    assert len(prompts) == 2
+    assert "DYNAMIC TOOL CALL COMPLETED" in prompts[1]
+    assert log.released == 1
+    assert log.finalized == 2
+
+
+def test_streaming_continuation_limit_yields_limit_message() -> None:
+    """Hitting the continuation limit mid-stream yields the limit notice chunk."""
+    log = _AdapterLog()
+
+    async def _attempt(
+        _run: TurnRunState,
+        _c: DynamicContinuationRunState,
+    ) -> AsyncGenerator[str | AttemptResolved, None]:
+        yield AttemptResolved(
+            CompletedAttempt(attempt_run_id="run-1", tool_executions=(_dynamic_tool_execution(),)),
+        )
+
+    chunks = asyncio.run(
+        _collect(
+            stream_response_turn(
+                _ctx(),
+                _streaming_adapter(log, _attempt),
+                TurnSinks(),
+                continuation=_continuation(),
+            ),
+        ),
+    )
+
+    assert len(chunks) == 1
+    assert chunks[0].startswith("notice:")
+    assert "did not produce a final answer" in chunks[0]
+
+
+def test_streaming_finalize_runs_when_attempt_raises() -> None:
+    """The per-attempt finalize hook runs even when the attempt raises mid-stream."""
+    log = _AdapterLog()
+
+    async def _attempt(
+        _run: TurnRunState,
+        _c: DynamicContinuationRunState,
+    ) -> AsyncGenerator[str | AttemptResolved, None]:
+        yield "chunk"
+        msg = "stream blew up"
+        raise RuntimeError(msg)
+
+    async def _run() -> None:
+        async for _chunk in stream_response_turn(
+            _ctx(),
+            _streaming_adapter(log, _attempt),
+            TurnSinks(),
+            continuation=_continuation(),
+        ):
+            pass
+
+    with pytest.raises(RuntimeError, match="stream blew up"):
+        asyncio.run(_run())
+    assert log.finalized == 1
+    assert log.closed == 1
+
+
+def test_streaming_unexpected_error_yields_shaped_text() -> None:
+    """Unexpected streaming exceptions become one shaped terminal chunk when configured."""
+    log = _AdapterLog()
+
+    async def _attempt(
+        _run: TurnRunState,
+        _c: DynamicContinuationRunState,
+    ) -> AsyncGenerator[str | AttemptResolved, None]:
+        yield "chunk"
+        msg = "boom"
+        raise RuntimeError(msg)
+
+    chunks = asyncio.run(
+        _collect(
+            stream_response_turn(
+                _ctx(),
+                _streaming_adapter(log, _attempt, unexpected_error_text=lambda e: f"shaped: {e}"),
+                TurnSinks(),
+                continuation=_continuation(),
+            ),
+        ),
+    )
+
+    assert chunks == ["chunk", "shaped: boom"]
+
+
+def test_stream_resolution_union_covers_handled() -> None:
+    """The streaming resolution union accepts the handled sentinel."""
+    resolution: StreamAttemptResolution = HandledAttempt()
+    assert isinstance(resolution, HandledAttempt)


### PR DESCRIPTION
## What

First PR of the turn-unification campaign (design approved 2026-07-01): the \"run one response turn\" envelope currently exists four times with drift (`ai_response`/`stream_agent_response` in ai.py, `team_response`/`team_response_stream` in teams.py). This PR extracts the shared lifecycle into one deep seam, `src/mindroom/response_turn.py`, and adopts it on the **agent path only**:

- `run_blocking_response_turn` / `stream_response_turn` own: scope-session open, the attempt loop, dynamic-tool continuation, the empty-run one-shot retry, run-metadata publication to the collector, recorder completion/interruption, the standalone interrupted-replay fallback (with the double-record/flag semantics preserved), and runtime-DB close.
- `ai_response` / `stream_agent_response` keep their exact public signatures and become wrappers that build `BlockingTurnAdapter` / `StreamingTurnAdapter` closures. The inner attempt bodies (`_MediaAttempt`, `_run_non_streaming_agent_attempts`, `_stream_agent_attempt_chunks`, `_process_stream_events`) stay in ai.py by design — they are the essential agent/team difference.
- Optional capability slots (`continuation`, `empty_run`, `persist_standalone_replay`, `unexpected_error_text`) let the team path adopt behavior-preservingly in the next PR and then close its feature gaps one capability at a time.
- Streaming attempts report their outcome via a final `AttemptResolved` sentinel; the driver never breaks out of the attempt iterator, so attempt cleanup stays deterministic. The wrapper closes the driver generator via `aclosing` so cleanup does not wait for event-loop async-gen finalization.

## Behavior

**Behavior-preserving.** Known intentional non-observable deltas:
- The per-driver collector-update ordering asymmetry (blocking publishes before outcome dispatch; streaming publishes at terminal settle) is preserved exactly and documented in the driver.
- `logger.warning(\"Dynamic tool continuation limit reached\")` now logs `entity=` instead of `agent=`.
- One test fake gained a `metrics=None` field (`tests/test_issue_154_logging_integration.py`) because the resolution dataclass reads `response.metrics` unconditionally; real `RunOutput` always has it.

Deviations from the approved plan (both smaller-change wins): `resolve_run_correlation_id` stays in ai.py (wrapper concern; teams already import it from there), and `DynamicContinuationRunState.initial` takes a pre-computed `continuation_model_prompt_tail` so the seam module avoids a `mindroom.memory` dependency.

## Verification

- Full suite: 9027 passed, 61 skipped (unchanged except the one fake noted above).
- Pinning suites pass unmodified: tests/test_ai_user_id.py (157), tests/test_empty_response_guard.py, tests/test_streaming_behavior.py, tests/test_response_runner_focused.py, tests/test_media_fallback.py.
- New: tests/test_response_turn.py (24 driver-level tests with fake adapters: cancelled double-record + flag suppression, fallback metadata build, continuation advance/limit, empty-run retry/notice, sentinel filtering, finalize-on-raise, error-shaper on/off).
- `SKIP=typescript-check uv run pre-commit run --all-files` clean; `uv run tach check --dependencies --interfaces` clean (tach.toml updated in this PR: new `mindroom.response_turn` module; `ai_turn_state`/`dynamic_tool_continuation` visibility moved to it; `mindroom.ai` deps updated).

## Stacking

PR 1 of 7. The next PRs stack on this branch: team adoption (behavior-preserving) → team continuation → team run metadata → team empty-guard/standalone replay → response_runner process-pair collapse → locked-pair collapse. GitHub squash-merges mean each subsequent branch needs main merged forward after each merge.

## Review-fix round (holistic stack review, 2026-07-02)

- **Dropped `ContinuationCapability.limit`**: the continue/stop decision in `continuation_decision_from_tools` hardcodes `DYNAMIC_TOOL_CONTINUATION_LIMIT`, so any non-default limit would silently desync from the loop budget (values < 4 could exhaust the loop and trip the budget assertion). The capability became a pure marker.
- **Deleted dead `TurnRunState.run_extra_content`**: prepared-history extra content is already merged into run metadata at prepare time, so the interruption fallback could only ever observe `None`.
- **Missing-sentinel enforcement**: a streaming attempt that ends without yielding `AttemptResolved` now raises instead of silently ending the turn unrecorded.
- **Stale-snapshot race**: releasing the attempt entity between continuation attempts now also clears the holder's attempt/state, so a cancel landing in that window records empty partials instead of the spent attempt's text plus double-counted tools.
- New driver tests: streaming in-attempt cancel double-record, empty retry borrowing a continuation slot, `aclose()` cleanup, missing sentinel.

**Known micro-delta vs pre-seam behavior** (disclosed, not fixed): a task cancel landing exactly at the streaming limit-notice yield now records `""` as the interrupted partial instead of the limit message (pre-seam mutated the live state before yielding). The window is one suspension point inside an already doubly-degenerate turn.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared response-turn flow for AI replies, improving consistency across blocking and streaming responses.
  * Improved handling for streamed output, including cleaner partial updates and final response completion.

* **Bug Fixes**
  * Better cancellation handling, with more reliable cleanup and replay recording.
  * Improved empty-response handling so retries and fallback notices work more predictably.
  * More stable continuation behavior for longer multi-step AI interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->