### PR TITLE
Return one generation outcome from the process pair; wire team run metadata (turn unification 6/7)

### DIFF
--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -287,14 +287,11 @@ class PostLockRequestPreparationError(RuntimeError):
 
 @dataclass(frozen=True)
 class _ResponseGenerationOutcome:
-    """Everything one locked response generation produced, returned instead of out-params."""
+    """What one locked response generation produced, returned instead of out-params."""
 
     delivery: FinalDeliveryOutcome
     run_succeeded: bool
     attempt_run_ids: tuple[str, ...] = ()
-    compaction_outcomes: tuple[CompactionOutcome, ...] = ()
-    tool_trace: tuple[Any, ...] = ()
-    run_metadata_content: Mapping[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -1850,9 +1847,6 @@ class ResponseRunner:
                 delivery=delivery,
                 run_succeeded=turn_recorder.outcome == "completed",
                 attempt_run_ids=tuple(attempt_run_ids),
-                compaction_outcomes=tuple(compaction_outcomes),
-                tool_trace=tuple(tool_trace),
-                run_metadata_content=run_metadata_content,
             )
 
         try:
@@ -1997,9 +1991,6 @@ class ResponseRunner:
                 delivery=delivery,
                 run_succeeded=turn_recorder.outcome == "completed",
                 attempt_run_ids=tuple(attempt_run_ids),
-                compaction_outcomes=tuple(compaction_outcomes),
-                tool_trace=tuple(tool_trace),
-                run_metadata_content=run_metadata_content,
             )
 
         try:

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -291,19 +291,16 @@ class _ResponseGenerationOutcome:
 
     delivery: FinalDeliveryOutcome
     run_succeeded: bool
-    attempt_run_ids: tuple[str, ...] = ()
 
 
 def _generation_outcome(
     delivery: FinalDeliveryOutcome,
     turn_recorder: TurnRecorder,
-    attempt_run_ids: list[str],
 ) -> _ResponseGenerationOutcome:
-    """Assemble one generation outcome from the turn's recorder and run ids."""
+    """Assemble one generation outcome from the turn's recorder."""
     return _ResponseGenerationOutcome(
         delivery=delivery,
         run_succeeded=turn_recorder.outcome == "completed",
-        attempt_run_ids=tuple(attempt_run_ids),
     )
 
 
@@ -1816,6 +1813,7 @@ class ResponseRunner:
         run_id: str | None = None,
         response_kind: str = "ai",
         on_delivery_started: Callable[[str | None], None] | None = None,
+        attempt_run_id_collector: list[str] | None = None,
     ) -> _ResponseGenerationOutcome:
         """Process a message and send a response without streaming."""
         if request.pipeline_timing is not None:
@@ -1848,7 +1846,9 @@ class ResponseRunner:
         )
         tool_trace: list[Any] = []
         run_metadata_content: dict[str, Any] = {}
-        attempt_run_ids: list[str] = []
+        # The caller's list survives raising exit paths (cancellation, stream
+        # re-raises), unlike the returned outcome.
+        attempt_run_ids = attempt_run_id_collector if attempt_run_id_collector is not None else []
         active_event_ids = self._active_response_event_ids(request.room_id)
         turn_recorder = self._build_turn_recorder(
             user_message=request.prompt,
@@ -1857,7 +1857,7 @@ class ResponseRunner:
         )
 
         def build_outcome(delivery: FinalDeliveryOutcome) -> _ResponseGenerationOutcome:
-            return _generation_outcome(delivery, turn_recorder, attempt_run_ids)
+            return _generation_outcome(delivery, turn_recorder)
 
         try:
             try:
@@ -1953,6 +1953,7 @@ class ResponseRunner:
         run_id: str | None = None,
         response_kind: str = "ai",
         on_delivery_started: Callable[[str | None], None] | None = None,
+        attempt_run_id_collector: list[str] | None = None,
     ) -> _ResponseGenerationOutcome:
         """Process a message and send a streamed response."""
         if request.pipeline_timing is not None:
@@ -1984,7 +1985,9 @@ class ResponseRunner:
             create_storage=history_storage_factory,
         )
         run_metadata_content: dict[str, Any] = {}
-        attempt_run_ids: list[str] = []
+        # The caller's list survives raising exit paths (cancellation, stream
+        # re-raises), unlike the returned outcome.
+        attempt_run_ids = attempt_run_id_collector if attempt_run_id_collector is not None else []
         active_event_ids = self._active_response_event_ids(request.room_id)
         tool_trace: list[Any] = []
         transport_outcome: StreamTransportOutcome | None = None
@@ -1995,7 +1998,7 @@ class ResponseRunner:
         )
 
         def build_outcome(delivery: FinalDeliveryOutcome) -> _ResponseGenerationOutcome:
-            return _generation_outcome(delivery, turn_recorder, attempt_run_ids)
+            return _generation_outcome(delivery, turn_recorder)
 
         try:
             try:
@@ -2197,6 +2200,7 @@ class ResponseRunner:
         self._note_pipeline_metadata(request, response_kind="agent", used_streaming=use_streaming)
         final_delivery_outcome: FinalDeliveryOutcome | None = None
         generation: _ResponseGenerationOutcome | None = None
+        attempt_run_ids: list[str] = []
         response_run_id = str(uuid4())
         tracked_event_id: str | None = request.existing_event_id
         delivery_stage_started = False
@@ -2291,12 +2295,14 @@ class ResponseRunner:
                     delivery_request,
                     run_id=response_run_id,
                     on_delivery_started=note_delivery_started,
+                    attempt_run_id_collector=attempt_run_ids,
                 )
             else:
                 generation = await self.process_and_respond(
                     delivery_request,
                     run_id=response_run_id,
                     on_delivery_started=note_delivery_started,
+                    attempt_run_id_collector=attempt_run_ids,
                 )
             final_delivery_outcome = generation.delivery
 
@@ -2392,11 +2398,9 @@ class ResponseRunner:
                 )
         assert final_delivery_outcome is not None
         post_response_outcome = ResponseOutcome(
-            response_run_id=(
-                generation.attempt_run_ids[-1]
-                if generation is not None and generation.attempt_run_ids
-                else response_run_id
-            ),
+            # The live collector list also covers raising exit paths, where the
+            # returned generation outcome never materialized.
+            response_run_id=attempt_run_ids[-1] if attempt_run_ids else response_run_id,
             session_id=session_id,
             session_type=self.deps.state_writer.session_type_for_scope(self.deps.state_writer.history_scope()),
             execution_identity=execution_identity,

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -1152,6 +1152,15 @@ class ResponseRunner:
                                 and delivery_request.existing_event_is_placeholder,
                                 header=None,
                                 show_tool_calls=show_tool_calls,
+                                # The live collector dict: the turn driver fills it
+                                # at terminal settle, before the stream's final
+                                # edit snapshots extra_content, so the ai_run
+                                # metadata lands on the wire (mirrors the agent
+                                # streaming path).
+                                extra_content=_merge_response_extra_content(
+                                    team_run_metadata_content,
+                                    request.attachment_ids,
+                                ),
                                 streaming_cls=ReplacementStreamingResponse,
                                 pipeline_timing=request.pipeline_timing,
                                 visible_event_id_callback=_note_visible_response_event_id,

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -286,6 +286,18 @@ class PostLockRequestPreparationError(RuntimeError):
 
 
 @dataclass(frozen=True)
+class _ResponseGenerationOutcome:
+    """Everything one locked response generation produced, returned instead of out-params."""
+
+    delivery: FinalDeliveryOutcome
+    run_succeeded: bool
+    attempt_run_ids: tuple[str, ...] = ()
+    compaction_outcomes: tuple[CompactionOutcome, ...] = ()
+    tool_trace: tuple[Any, ...] = ()
+    run_metadata_content: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
 class _TeamResponseRequest:
     """Typed carrier for one team response request plus team-specific inputs."""
 
@@ -1037,6 +1049,7 @@ class ResponseRunner:
         response_run_id = str(uuid4())
         final_delivery_outcome: FinalDeliveryOutcome | None = None
         compaction_outcomes: list[CompactionOutcome] = []
+        team_run_metadata_content: dict[str, Any] = {}
         tracked_event_id: str | None = request.existing_event_id
         delivery_stage_started = False
         delivery_failure_reason: str | None = None
@@ -1103,6 +1116,7 @@ class ResponseRunner:
                             active_event_ids=active_event_ids,
                             response_sender_id=self.deps.matrix_full_id,
                             compaction_outcomes_collector=compaction_outcomes,
+                            run_metadata_collector=team_run_metadata_content,
                             compaction_lifecycle=compaction_lifecycle,
                             configured_team_name=self.deps.agent_name
                             if self.deps.agent_name in self.deps.runtime.config.teams
@@ -1163,7 +1177,8 @@ class ResponseRunner:
                     correlation_id=resolved_correlation_id,
                     tool_trace=None,
                     extra_content=_merge_response_extra_content(
-                        ai_run_extra_content_from_metadata(team_turn_recorder.run_metadata),
+                        team_run_metadata_content
+                        or ai_run_extra_content_from_metadata(team_turn_recorder.run_metadata),
                         request.attachment_ids,
                     ),
                     existing_event_id=request.existing_event_id,
@@ -1201,6 +1216,7 @@ class ResponseRunner:
                                     active_event_ids=active_event_ids,
                                     response_sender_id=self.deps.matrix_full_id,
                                     compaction_outcomes_collector=compaction_outcomes,
+                                    run_metadata_collector=team_run_metadata_content,
                                     compaction_lifecycle=compaction_lifecycle,
                                     configured_team_name=self.deps.agent_name
                                     if self.deps.agent_name in self.deps.runtime.config.teams
@@ -1274,7 +1290,8 @@ class ResponseRunner:
                             correlation_id=resolved_correlation_id,
                             tool_trace=None,
                             extra_content=_merge_response_extra_content(
-                                ai_run_extra_content_from_metadata(team_turn_recorder.run_metadata),
+                                team_run_metadata_content
+                                or ai_run_extra_content_from_metadata(team_turn_recorder.run_metadata),
                                 request.attachment_ids,
                             ),
                         ),
@@ -1363,7 +1380,8 @@ class ResponseRunner:
                     correlation_id=resolved_correlation_id,
                     tool_trace=error.tool_trace if show_tool_calls else None,
                     extra_content=_merge_response_extra_content(
-                        ai_run_extra_content_from_metadata(team_turn_recorder.run_metadata),
+                        team_run_metadata_content
+                        or ai_run_extra_content_from_metadata(team_turn_recorder.run_metadata),
                         request.attachment_ids,
                     ),
                     existing_event_id=request.existing_event_id,
@@ -1397,7 +1415,8 @@ class ResponseRunner:
                     correlation_id=resolved_correlation_id,
                     tool_trace=None,
                     extra_content=_merge_response_extra_content(
-                        ai_run_extra_content_from_metadata(team_turn_recorder.run_metadata),
+                        team_run_metadata_content
+                        or ai_run_extra_content_from_metadata(team_turn_recorder.run_metadata),
                         request.attachment_ids,
                     ),
                     existing_event_id=request.existing_event_id,
@@ -1412,6 +1431,7 @@ class ResponseRunner:
                 session_id=session_id,
                 session_type=SessionType.TEAM,
                 execution_identity=tool_dispatch.execution_identity,
+                run_succeeded=team_turn_recorder.outcome == "completed",
                 interactive_target=resolved_target,
                 thread_summary_room_id=(request.room_id if resolved_target.resolved_thread_id is not None else None),
                 thread_summary_thread_id=resolved_target.resolved_thread_id,
@@ -1783,11 +1803,8 @@ class ResponseRunner:
         *,
         run_id: str | None = None,
         response_kind: str = "ai",
-        compaction_outcomes_collector: list[CompactionOutcome] | None = None,
-        run_success_collector: list[bool] | None = None,
-        attempt_run_id_collector: list[str] | None = None,
         on_delivery_started: Callable[[str | None], None] | None = None,
-    ) -> FinalDeliveryOutcome:
+    ) -> _ResponseGenerationOutcome:
         """Process a message and send a response without streaming."""
         if request.pipeline_timing is not None:
             request.pipeline_timing.mark("response_runtime_start")
@@ -1820,12 +1837,23 @@ class ResponseRunner:
         tool_trace: list[Any] = []
         compaction_outcomes: list[CompactionOutcome] = []
         run_metadata_content: dict[str, Any] = {}
+        attempt_run_ids: list[str] = []
         active_event_ids = self._active_response_event_ids(request.room_id)
         turn_recorder = self._build_turn_recorder(
             user_message=request.prompt,
             reply_to_event_id=request.reply_to_event_id,
             matrix_run_metadata=_materialize_matrix_run_metadata(request.matrix_run_metadata),
         )
+
+        def build_outcome(delivery: FinalDeliveryOutcome) -> _ResponseGenerationOutcome:
+            return _ResponseGenerationOutcome(
+                delivery=delivery,
+                run_succeeded=turn_recorder.outcome == "completed",
+                attempt_run_ids=tuple(attempt_run_ids),
+                compaction_outcomes=tuple(compaction_outcomes),
+                tool_trace=tuple(tool_trace),
+                run_metadata_content=run_metadata_content,
+            )
 
         try:
             try:
@@ -1838,7 +1866,7 @@ class ResponseRunner:
                     tool_trace=tool_trace,
                     run_metadata_content=run_metadata_content,
                     compaction_outcomes=compaction_outcomes,
-                    attempt_run_id_collector=attempt_run_id_collector if attempt_run_id_collector is not None else [],
+                    attempt_run_id_collector=attempt_run_ids,
                     pipeline_timing=request.pipeline_timing,
                 )
             finally:
@@ -1854,22 +1882,26 @@ class ResponseRunner:
                 interrupted_message="Non-streaming response interrupted — traceback for diagnosis",
             )
             if request.existing_event_id:
-                return await self.deps.delivery_gateway.deliver_cancelled_visible_note(
-                    CancelledVisibleNoteRequest(
-                        target=runtime.resolved_target,
-                        event_id=request.existing_event_id,
-                        existing_event_is_placeholder=request.existing_event_is_placeholder,
-                        cancel_source=cancel_source,
-                        response_kind=response_kind,
-                        response_envelope=response_envelope,
-                        correlation_id=correlation_id,
+                return build_outcome(
+                    await self.deps.delivery_gateway.deliver_cancelled_visible_note(
+                        CancelledVisibleNoteRequest(
+                            target=runtime.resolved_target,
+                            event_id=request.existing_event_id,
+                            existing_event_is_placeholder=request.existing_event_is_placeholder,
+                            cancel_source=cancel_source,
+                            response_kind=response_kind,
+                            response_envelope=response_envelope,
+                            correlation_id=correlation_id,
+                        ),
                     ),
                 )
             failure_reason = cancel_failure_reason(cancel_source)
-            return FinalDeliveryOutcome(
-                terminal_status="cancelled",
-                event_id=None,
-                failure_reason=failure_reason,
+            return build_outcome(
+                FinalDeliveryOutcome(
+                    terminal_status="cancelled",
+                    event_id=None,
+                    failure_reason=failure_reason,
+                ),
             )
         except Exception as error:
             self.deps.logger.exception("Error in non-streaming response", error=str(error))
@@ -1909,25 +1941,16 @@ class ResponseRunner:
         if request.pipeline_timing is not None:
             request.pipeline_timing.mark_first_visible_reply("final")
             request.pipeline_timing.mark("response_complete")
-        if run_success_collector is not None:
-            run_success_collector.append(turn_recorder.outcome == "completed")
-        if compaction_outcomes_collector is not None:
-            compaction_outcomes_collector.extend(compaction_outcomes)
-        return delivery
+        return build_outcome(delivery)
 
-    async def process_and_respond_streaming(  # noqa: C901, PLR0912, PLR0915
+    async def process_and_respond_streaming(  # noqa: C901, PLR0915
         self,
         request: ResponseRequest,
         *,
         run_id: str | None = None,
         response_kind: str = "ai",
-        compaction_outcomes_collector: list[CompactionOutcome] | None = None,
-        run_success_collector: list[bool] | None = None,
-        attempt_run_id_collector: list[str] | None = None,
         on_delivery_started: Callable[[str | None], None] | None = None,
-        tool_trace_collector: list[Any] | None = None,
-        run_metadata_content_collector: dict[str, Any] | None = None,
-    ) -> FinalDeliveryOutcome:
+    ) -> _ResponseGenerationOutcome:
         """Process a message and send a streamed response."""
         if request.pipeline_timing is not None:
             request.pipeline_timing.mark("response_runtime_start")
@@ -1958,15 +1981,26 @@ class ResponseRunner:
             create_storage=history_storage_factory,
         )
         compaction_outcomes: list[CompactionOutcome] = []
-        run_metadata_content = run_metadata_content_collector if run_metadata_content_collector is not None else {}
+        run_metadata_content: dict[str, Any] = {}
+        attempt_run_ids: list[str] = []
         active_event_ids = self._active_response_event_ids(request.room_id)
-        tool_trace = tool_trace_collector if tool_trace_collector is not None else []
+        tool_trace: list[Any] = []
         transport_outcome: StreamTransportOutcome | None = None
         turn_recorder = self._build_turn_recorder(
             user_message=request.prompt,
             reply_to_event_id=request.reply_to_event_id,
             matrix_run_metadata=_materialize_matrix_run_metadata(request.matrix_run_metadata),
         )
+
+        def build_outcome(delivery: FinalDeliveryOutcome) -> _ResponseGenerationOutcome:
+            return _ResponseGenerationOutcome(
+                delivery=delivery,
+                run_succeeded=turn_recorder.outcome == "completed",
+                attempt_run_ids=tuple(attempt_run_ids),
+                compaction_outcomes=tuple(compaction_outcomes),
+                tool_trace=tuple(tool_trace),
+                run_metadata_content=run_metadata_content,
+            )
 
         try:
             try:
@@ -1979,7 +2013,7 @@ class ResponseRunner:
                     tool_trace=tool_trace,
                     run_metadata_content=run_metadata_content,
                     compaction_outcomes=compaction_outcomes,
-                    attempt_run_id_collector=attempt_run_id_collector if attempt_run_id_collector is not None else [],
+                    attempt_run_id_collector=attempt_run_ids,
                     pipeline_timing=request.pipeline_timing,
                 )
             finally:
@@ -2013,26 +2047,24 @@ class ResponseRunner:
                     is_team=False,
                     response_event_id=error.event_id,
                 )
-            if run_success_collector is not None:
-                run_success_collector.append(turn_recorder.outcome == "completed")
-            if compaction_outcomes_collector is not None:
-                compaction_outcomes_collector.extend(compaction_outcomes)
             response_extra_content = _merge_response_extra_content(
                 run_metadata_content,
                 request.attachment_ids,
             )
-            return await self.deps.delivery_gateway.finalize_streamed_response(
-                FinalizeStreamedResponseRequest(
-                    target=runtime.resolved_target,
-                    stream_transport_outcome=stream_transport_outcome,
-                    initial_delivery_kind="edited" if request.existing_event_id else "sent",
-                    response_kind=response_kind,
-                    response_envelope=response_envelope,
-                    correlation_id=correlation_id,
-                    tool_trace=error.tool_trace if self._show_tool_calls() else None,
-                    extra_content=response_extra_content,
-                    existing_event_id=request.existing_event_id,
-                    existing_event_is_placeholder=request.existing_event_is_placeholder,
+            return build_outcome(
+                await self.deps.delivery_gateway.finalize_streamed_response(
+                    FinalizeStreamedResponseRequest(
+                        target=runtime.resolved_target,
+                        stream_transport_outcome=stream_transport_outcome,
+                        initial_delivery_kind="edited" if request.existing_event_id else "sent",
+                        response_kind=response_kind,
+                        response_envelope=response_envelope,
+                        correlation_id=correlation_id,
+                        tool_trace=error.tool_trace if self._show_tool_calls() else None,
+                        extra_content=response_extra_content,
+                        existing_event_id=request.existing_event_id,
+                        existing_event_is_placeholder=request.existing_event_is_placeholder,
+                    ),
                 ),
             )
         except asyncio.CancelledError as exc:
@@ -2047,31 +2079,33 @@ class ResponseRunner:
             raise
         except Exception as error:
             self.deps.logger.exception("Error in streaming response", error=str(error))
-            return await self.deps.delivery_gateway.finalize_streamed_response(
-                FinalizeStreamedResponseRequest(
-                    target=runtime.resolved_target,
-                    stream_transport_outcome=build_terminal_stream_transport_outcome(
-                        PendingVisibleResponse(
-                            tracked_event_id=request.existing_event_id,
-                            run_message_id=None,
-                            existing_event_id=request.existing_event_id,
-                            existing_event_is_placeholder=request.existing_event_is_placeholder,
+            return build_outcome(
+                await self.deps.delivery_gateway.finalize_streamed_response(
+                    FinalizeStreamedResponseRequest(
+                        target=runtime.resolved_target,
+                        stream_transport_outcome=build_terminal_stream_transport_outcome(
+                            PendingVisibleResponse(
+                                tracked_event_id=request.existing_event_id,
+                                run_message_id=None,
+                                existing_event_id=request.existing_event_id,
+                                existing_event_is_placeholder=request.existing_event_is_placeholder,
+                            ),
+                            terminal_status="error",
+                            failure_reason=str(error),
+                            placeholder_body=PROGRESS_PLACEHOLDER,
                         ),
-                        terminal_status="error",
-                        failure_reason=str(error),
-                        placeholder_body=PROGRESS_PLACEHOLDER,
+                        initial_delivery_kind="edited" if request.existing_event_id else "sent",
+                        response_kind=response_kind,
+                        response_envelope=response_envelope,
+                        correlation_id=correlation_id,
+                        tool_trace=list(tool_trace) if self._show_tool_calls() else None,
+                        extra_content=_merge_response_extra_content(
+                            run_metadata_content,
+                            request.attachment_ids,
+                        ),
+                        existing_event_id=request.existing_event_id,
+                        existing_event_is_placeholder=request.existing_event_is_placeholder,
                     ),
-                    initial_delivery_kind="edited" if request.existing_event_id else "sent",
-                    response_kind=response_kind,
-                    response_envelope=response_envelope,
-                    correlation_id=correlation_id,
-                    tool_trace=list(tool_trace) if self._show_tool_calls() else None,
-                    extra_content=_merge_response_extra_content(
-                        run_metadata_content,
-                        request.attachment_ids,
-                    ),
-                    existing_event_id=request.existing_event_id,
-                    existing_event_is_placeholder=request.existing_event_is_placeholder,
                 ),
             )
 
@@ -2098,12 +2132,7 @@ class ResponseRunner:
         if request.pipeline_timing is not None:
             request.pipeline_timing.mark_first_visible_reply("final")
             request.pipeline_timing.mark("response_complete")
-
-        if run_success_collector is not None:
-            run_success_collector.append(turn_recorder.outcome == "completed")
-        if compaction_outcomes_collector is not None:
-            compaction_outcomes_collector.extend(compaction_outcomes)
-        return delivery
+        return build_outcome(delivery)
 
     async def generate_response(self, request: ResponseRequest) -> str | None:
         """Generate and send/edit an agent response with lifecycle locking."""
@@ -2173,17 +2202,13 @@ class ResponseRunner:
         )
         self._note_pipeline_metadata(request, response_kind="agent", used_streaming=use_streaming)
         final_delivery_outcome: FinalDeliveryOutcome | None = None
-        compaction_outcomes: list[CompactionOutcome] = []
-        run_successes: list[bool] = []
+        generation: _ResponseGenerationOutcome | None = None
         response_run_id = str(uuid4())
         tracked_event_id: str | None = request.existing_event_id
         delivery_stage_started = False
         delivery_failure_reason: str | None = None
         delivery_cancelled = False
         early_delivery_error: BaseException | None = None
-        tool_trace: list[Any] = []
-        run_metadata_content: dict[str, Any] = {}
-        attempt_run_ids: list[str] = []
         request = self._request_with_locked_target(request, resolved_target)
         resolved_correlation_id = self._correlation_id_for_request(request)
         resolved_response_envelope = request.response_envelope
@@ -2263,30 +2288,23 @@ class ResponseRunner:
             )
 
         async def generate(message_id: str | None) -> None:
-            nonlocal final_delivery_outcome, tracked_event_id
+            nonlocal final_delivery_outcome, generation, tracked_event_id
             if message_id is not None:
                 tracked_event_id = message_id
             delivery_request = self._request_for_delivery(normalized_request, message_id=message_id)
             if use_streaming:
-                final_delivery_outcome = await self.process_and_respond_streaming(
+                generation = await self.process_and_respond_streaming(
                     delivery_request,
                     run_id=response_run_id,
-                    compaction_outcomes_collector=compaction_outcomes,
-                    run_success_collector=run_successes,
-                    attempt_run_id_collector=attempt_run_ids,
                     on_delivery_started=note_delivery_started,
-                    tool_trace_collector=tool_trace,
-                    run_metadata_content_collector=run_metadata_content,
                 )
             else:
-                final_delivery_outcome = await self.process_and_respond(
+                generation = await self.process_and_respond(
                     delivery_request,
                     run_id=response_run_id,
-                    compaction_outcomes_collector=compaction_outcomes,
-                    run_success_collector=run_successes,
-                    attempt_run_id_collector=attempt_run_ids,
                     on_delivery_started=note_delivery_started,
                 )
+            final_delivery_outcome = generation.delivery
 
         thinking_msg = None
         if not request.existing_event_id and not self._has_queued_forced_compaction(
@@ -2380,11 +2398,19 @@ class ResponseRunner:
                 )
         assert final_delivery_outcome is not None
         post_response_outcome = ResponseOutcome(
-            response_run_id=attempt_run_ids[-1] if attempt_run_ids else response_run_id,
+            response_run_id=(
+                generation.attempt_run_ids[-1]
+                if generation is not None and generation.attempt_run_ids
+                else response_run_id
+            ),
             session_id=session_id,
             session_type=self.deps.state_writer.session_type_for_scope(self.deps.state_writer.history_scope()),
             execution_identity=execution_identity,
-            run_succeeded=run_successes[-1] if run_successes else final_delivery_outcome.terminal_status == "completed",
+            run_succeeded=(
+                generation.run_succeeded
+                if generation is not None
+                else final_delivery_outcome.terminal_status == "completed"
+            ),
             interactive_target=resolved_target,
             thread_summary_room_id=(request.room_id if resolved_target.resolved_thread_id is not None else None),
             thread_summary_thread_id=resolved_target.resolved_thread_id,

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -92,7 +92,7 @@ if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths
     from mindroom.conversation_resolver import ConversationResolver
     from mindroom.conversation_state_writer import ConversationStateWriter
-    from mindroom.history import CompactionOutcome, HistoryScope
+    from mindroom.history import HistoryScope
     from mindroom.hooks import EnrichmentItem, MessageEnvelope
     from mindroom.knowledge import KnowledgeAccessSupport
     from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
@@ -292,6 +292,19 @@ class _ResponseGenerationOutcome:
     delivery: FinalDeliveryOutcome
     run_succeeded: bool
     attempt_run_ids: tuple[str, ...] = ()
+
+
+def _generation_outcome(
+    delivery: FinalDeliveryOutcome,
+    turn_recorder: TurnRecorder,
+    attempt_run_ids: list[str],
+) -> _ResponseGenerationOutcome:
+    """Assemble one generation outcome from the turn's recorder and run ids."""
+    return _ResponseGenerationOutcome(
+        delivery=delivery,
+        run_succeeded=turn_recorder.outcome == "completed",
+        attempt_run_ids=tuple(attempt_run_ids),
+    )
 
 
 @dataclass(frozen=True)
@@ -1045,7 +1058,6 @@ class ResponseRunner:
             raise RuntimeError(msg)
         response_run_id = str(uuid4())
         final_delivery_outcome: FinalDeliveryOutcome | None = None
-        compaction_outcomes: list[CompactionOutcome] = []
         team_run_metadata_content: dict[str, Any] = {}
         tracked_event_id: str | None = request.existing_event_id
         delivery_stage_started = False
@@ -1112,7 +1124,6 @@ class ResponseRunner:
                             correlation_id=resolved_correlation_id,
                             active_event_ids=active_event_ids,
                             response_sender_id=self.deps.matrix_full_id,
-                            compaction_outcomes_collector=compaction_outcomes,
                             run_metadata_collector=team_run_metadata_content,
                             compaction_lifecycle=compaction_lifecycle,
                             configured_team_name=self.deps.agent_name
@@ -1212,7 +1223,6 @@ class ResponseRunner:
                                     correlation_id=resolved_correlation_id,
                                     active_event_ids=active_event_ids,
                                     response_sender_id=self.deps.matrix_full_id,
-                                    compaction_outcomes_collector=compaction_outcomes,
                                     run_metadata_collector=team_run_metadata_content,
                                     compaction_lifecycle=compaction_lifecycle,
                                     configured_team_name=self.deps.agent_name
@@ -1587,7 +1597,6 @@ class ResponseRunner:
         turn_recorder: TurnRecorder,
         tool_trace: list[Any],
         run_metadata_content: dict[str, Any],
-        compaction_outcomes: list[CompactionOutcome],
         attempt_run_id_collector: list[str],
         pipeline_timing: DispatchPipelineTiming | None = None,
     ) -> str:
@@ -1639,7 +1648,6 @@ class ResponseRunner:
                 tool_trace_collector=tool_trace,
                 run_metadata_collector=run_metadata_content,
                 execution_identity=runtime.tool_dispatch.execution_identity,
-                compaction_outcomes_collector=compaction_outcomes,
                 compaction_lifecycle=compaction_lifecycle,
                 refresh_scheduler=(
                     self.deps.runtime.orchestrator.knowledge_refresh_scheduler
@@ -1681,7 +1689,6 @@ class ResponseRunner:
         turn_recorder: TurnRecorder,
         tool_trace: list[Any],
         run_metadata_content: dict[str, Any],
-        compaction_outcomes: list[CompactionOutcome],
         attempt_run_id_collector: list[str],
         pipeline_timing: DispatchPipelineTiming | None = None,
     ) -> StreamTransportOutcome:
@@ -1731,7 +1738,6 @@ class ResponseRunner:
             show_tool_calls=self._show_tool_calls(),
             run_metadata_collector=run_metadata_content,
             execution_identity=runtime.tool_dispatch.execution_identity,
-            compaction_outcomes_collector=compaction_outcomes,
             compaction_lifecycle=compaction_lifecycle,
             refresh_scheduler=(
                 self.deps.runtime.orchestrator.knowledge_refresh_scheduler
@@ -1832,7 +1838,6 @@ class ResponseRunner:
             create_storage=history_storage_factory,
         )
         tool_trace: list[Any] = []
-        compaction_outcomes: list[CompactionOutcome] = []
         run_metadata_content: dict[str, Any] = {}
         attempt_run_ids: list[str] = []
         active_event_ids = self._active_response_event_ids(request.room_id)
@@ -1843,11 +1848,7 @@ class ResponseRunner:
         )
 
         def build_outcome(delivery: FinalDeliveryOutcome) -> _ResponseGenerationOutcome:
-            return _ResponseGenerationOutcome(
-                delivery=delivery,
-                run_succeeded=turn_recorder.outcome == "completed",
-                attempt_run_ids=tuple(attempt_run_ids),
-            )
+            return _generation_outcome(delivery, turn_recorder, attempt_run_ids)
 
         try:
             try:
@@ -1859,7 +1860,6 @@ class ResponseRunner:
                     turn_recorder=turn_recorder,
                     tool_trace=tool_trace,
                     run_metadata_content=run_metadata_content,
-                    compaction_outcomes=compaction_outcomes,
                     attempt_run_id_collector=attempt_run_ids,
                     pipeline_timing=request.pipeline_timing,
                 )
@@ -1974,7 +1974,6 @@ class ResponseRunner:
             thread_id=runtime.resolved_target.resolved_thread_id,
             create_storage=history_storage_factory,
         )
-        compaction_outcomes: list[CompactionOutcome] = []
         run_metadata_content: dict[str, Any] = {}
         attempt_run_ids: list[str] = []
         active_event_ids = self._active_response_event_ids(request.room_id)
@@ -1987,11 +1986,7 @@ class ResponseRunner:
         )
 
         def build_outcome(delivery: FinalDeliveryOutcome) -> _ResponseGenerationOutcome:
-            return _ResponseGenerationOutcome(
-                delivery=delivery,
-                run_succeeded=turn_recorder.outcome == "completed",
-                attempt_run_ids=tuple(attempt_run_ids),
-            )
+            return _generation_outcome(delivery, turn_recorder, attempt_run_ids)
 
         try:
             try:
@@ -2003,7 +1998,6 @@ class ResponseRunner:
                     turn_recorder=turn_recorder,
                     tool_trace=tool_trace,
                     run_metadata_content=run_metadata_content,
-                    compaction_outcomes=compaction_outcomes,
                     attempt_run_id_collector=attempt_run_ids,
                     pipeline_timing=request.pipeline_timing,
                 )

--- a/tests/test_ai_error_message_display.py
+++ b/tests/test_ai_error_message_display.py
@@ -316,8 +316,8 @@ class TestAIErrorDisplay:
         event_id, text = edited_messages[0]
         assert event_id == "$thinking_msg"
         assert text == _CANCELLED_RESPONSE_NOTE
-        assert outcome.terminal_status == "cancelled"
-        assert outcome.failure_reason == "cancelled_by_user"
+        assert outcome.delivery.terminal_status == "cancelled"
+        assert outcome.delivery.failure_reason == "cancelled_by_user"
 
     @pytest.mark.asyncio
     async def test_cancelled_run_status_preserves_user_stop_note(self, tmp_path: Path) -> None:
@@ -380,8 +380,8 @@ class TestAIErrorDisplay:
         event_id, text = edited_messages[0]
         assert event_id == "$thinking_msg"
         assert text == _CANCELLED_RESPONSE_NOTE
-        assert outcome.terminal_status == "cancelled"
-        assert outcome.failure_reason == "cancelled_by_user"
+        assert outcome.delivery.terminal_status == "cancelled"
+        assert outcome.delivery.failure_reason == "cancelled_by_user"
 
     @pytest.mark.asyncio
     async def test_collected_stream_cancelled_event_preserves_user_stop_note(self, tmp_path: Path) -> None:
@@ -444,8 +444,8 @@ class TestAIErrorDisplay:
         event_id, text = edited_messages[0]
         assert event_id == "$thinking_msg"
         assert text == _CANCELLED_RESPONSE_NOTE
-        assert outcome.terminal_status == "cancelled"
-        assert outcome.failure_reason == "cancelled_by_user"
+        assert outcome.delivery.terminal_status == "cancelled"
+        assert outcome.delivery.failure_reason == "cancelled_by_user"
 
     @pytest.mark.asyncio
     async def test_run_cancelled_event_preserves_user_stop_note_in_streaming(self, tmp_path: Path) -> None:
@@ -504,8 +504,8 @@ class TestAIErrorDisplay:
         event_id, text = edited_messages[-1]
         assert event_id == "$thinking_msg"
         assert text == f"Partial answer\n\n{_CANCELLED_RESPONSE_NOTE}"
-        assert outcome.terminal_status == "cancelled"
-        assert outcome.failure_reason == "cancelled_by_user"
+        assert outcome.delivery.terminal_status == "cancelled"
+        assert outcome.delivery.failure_reason == "cancelled_by_user"
 
     @pytest.mark.asyncio
     async def test_various_error_messages_are_user_friendly(self, tmp_path: Path) -> None:
@@ -629,10 +629,10 @@ class TestAIErrorDisplay:
             _build_response_runner(bot)
             mock_ai.return_value = "Response without knowledge"
 
-            delivery = await bot._response_runner.process_and_respond(
+            generation = await bot._response_runner.process_and_respond(
                 _response_request(),
             )
 
-        assert delivery.event_id == "$response_id"
+        assert generation.delivery.event_id == "$response_id"
         assert mock_ai.call_args.kwargs["knowledge"] is None
         bot.logger.exception.assert_not_called()

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -1331,12 +1331,12 @@ async def test_process_and_respond_streaming_emits_session_started_after_persist
 
         mock_stream.side_effect = fake_stream_agent_response
 
-        delivery = await coordinator.process_and_respond_streaming(
+        generation = await coordinator.process_and_respond_streaming(
             _response_request(prompt="Hello", user_id="@bob:localhost", thread_id="$thread-root"),
         )
 
-    assert delivery.event_id == "$terminal"
-    assert delivery.response_text == "Hello!"
+    assert generation.delivery.event_id == "$terminal"
+    assert generation.delivery.response_text == "Hello!"
     assert sequence == [
         "stream",
         "deliver:Hello!",
@@ -1392,12 +1392,12 @@ async def test_process_and_respond_streaming_persists_interrupted_history_when_d
 
         mock_stream.side_effect = fake_stream_agent_response
 
-        delivery = await coordinator.process_and_respond_streaming(
+        generation = await coordinator.process_and_respond_streaming(
             _response_request(prompt="Hello", user_id="@bob:localhost", thread_id="$thread-root"),
         )
 
-    assert delivery.event_id == "$terminal"
-    assert delivery.failure_reason == "boom"
+    assert generation.delivery.event_id == "$terminal"
+    assert generation.delivery.failure_reason == "boom"
     persisted_session = cast("AgentSession", storage.session)
     assert persisted_session is not None
     assert persisted_session.runs is not None
@@ -1459,12 +1459,12 @@ async def test_process_and_respond_streaming_persists_interrupted_history_when_m
 
         coordinator.deps.delivery_gateway.deliver_stream.side_effect = consume_delivery
 
-        delivery = await coordinator.process_and_respond_streaming(
+        generation = await coordinator.process_and_respond_streaming(
             _response_request(prompt="Hello", user_id="@bob:localhost", thread_id="$thread-root"),
             run_id="run-1",
         )
 
-    assert delivery.event_id == "$streamed"
+    assert generation.delivery.event_id == "$streamed"
     persisted_session = cast("AgentSession", storage.session)
     assert persisted_session is not None
     assert persisted_session.runs is not None
@@ -1550,11 +1550,11 @@ async def test_process_and_respond_streaming_delivery_failure_with_visible_tools
 
         mock_stream.side_effect = fake_stream_agent_response
 
-        delivery = await coordinator.process_and_respond_streaming(
+        generation = await coordinator.process_and_respond_streaming(
             _response_request(prompt="Hello", user_id="@bob:localhost", thread_id="$thread-root"),
         )
 
-    assert delivery.event_id == "$terminal"
+    assert generation.delivery.event_id == "$terminal"
     persisted_session = cast("AgentSession", storage.session)
     assert persisted_session is not None
     assert persisted_session.runs is not None
@@ -1627,15 +1627,15 @@ async def test_process_and_respond_emits_session_started_after_persisted_cancell
 
         mock_ai.side_effect = fake_ai_response
 
-        delivery = await coordinator.process_and_respond(
+        generation = await coordinator.process_and_respond(
             replace(
                 _response_request(prompt="Hello", user_id="@alice:localhost", thread_id="$thread-root"),
                 existing_event_id="$thinking",
             ),
         )
 
-    assert delivery.terminal_status == "cancelled"
-    assert _visible_response_event_id(delivery) == "$thinking"
+    assert generation.delivery.terminal_status == "cancelled"
+    assert _visible_response_event_id(generation.delivery) == "$thinking"
     assert sequence == [
         "ai",
         "started:!test:localhost:$thread-root:$thread-root",

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -3305,6 +3305,75 @@ async def test_generate_team_response_helper_streaming_emits_session_started_aft
 
 
 @pytest.mark.asyncio
+async def test_generate_team_response_helper_streaming_delivery_carries_live_metadata_collector(
+    tmp_path: Path,
+) -> None:
+    """The team streaming delivery request carries the live metadata collector.
+
+    The turn driver fills the collector at terminal settle, before the
+    stream's final edit snapshots extra_content; without the live dict the
+    ai_run payload never reaches Matrix in streaming mode (the finalize
+    happy path sends no extra edit).
+    """
+    runtime_paths = _runtime_paths(tmp_path)
+    config = bind_runtime_paths(_config_with_team(), runtime_paths)
+    bot = MagicMock(spec=AgentBot)
+    bot.logger = MagicMock()
+    bot.stop_manager = MagicMock()
+    bot.stop_manager.remove_stop_button = AsyncMock()
+    bot.client = AsyncMock()
+    bot.agent_name = "ultimate"
+    bot.storage_path = tmp_path
+    bot.config = config
+    bot.runtime_paths = runtime_paths
+    bot._knowledge_access_support = _knowledge_access_support()
+
+    captured_extra_content: list[object] = []
+
+    with (
+        patch("mindroom.response_runner.should_use_streaming", new=AsyncMock(return_value=True)),
+        patch("mindroom.response_runner.team_response_stream") as mock_team_stream,
+    ):
+        coordinator = _build_response_runner(
+            bot,
+            config=config,
+            runtime_paths=runtime_paths,
+            storage_path=tmp_path,
+            requester_id="@alice:localhost",
+            message_target=MessageTarget.resolve("!test:localhost", "$thread-root", "$user_msg"),
+            orchestrator=_team_orchestrator(config, runtime_paths),
+        )
+
+        async def consume_delivery(request: object) -> StreamTransportOutcome:
+            async for _chunk in request.response_stream:
+                pass
+            # Snapshot after stream exhaustion, like the real final edit.
+            captured_extra_content.append(request.extra_content)
+            return _stream_outcome("$team-final", "Team hello")
+
+        coordinator.deps.delivery_gateway.deliver_stream.side_effect = consume_delivery
+
+        def fake_team_response_stream(*_args: object, **kwargs: object) -> AsyncIterator[str]:
+            async def fake_stream() -> AsyncIterator[str]:
+                collector = kwargs["run_metadata_collector"]
+                assert isinstance(collector, dict)
+                collector["io.mindroom.ai_run"] = {"usage": {"output_tokens": 5}}
+                yield "Team hello"
+
+            return fake_stream()
+
+        mock_team_stream.side_effect = fake_team_response_stream
+
+        await coordinator.generate_team_response_helper(
+            _response_request(prompt="Hello", user_id="@alice:localhost", thread_id="$thread-root"),
+            team_agents=[fixture_entity_matrix_id("general", "localhost", runtime_paths)],
+            team_mode="coordinate",
+        )
+
+    assert captured_extra_content == [{"io.mindroom.ai_run": {"usage": {"output_tokens": 5}}}]
+
+
+@pytest.mark.asyncio
 async def test_generate_team_response_helper_persists_interrupted_history_when_stream_delivery_fails(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_edit_response_regeneration.py
+++ b/tests/test_edit_response_regeneration.py
@@ -43,7 +43,7 @@ from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.state import MatrixState
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
-from mindroom.response_runner import ResponseRequest
+from mindroom.response_runner import ResponseRequest, _ResponseGenerationOutcome
 from mindroom.thread_utils import create_session_id
 from tests.conftest import (
     bind_runtime_paths,
@@ -3073,7 +3073,7 @@ async def test_handle_message_edit_recovers_missing_ledger_row_from_persisted_ru
     conversation_target = MessageTarget.resolve("!test:example.com", None, "$primary:example.com")
     history_scope = _agent_history_scope("test_agent")
 
-    async def process_and_respond(*args: object, **kwargs: object) -> FinalDeliveryOutcome:
+    async def process_and_respond(*args: object, **kwargs: object) -> _ResponseGenerationOutcome:
         request = args[0]
         assert isinstance(request, ResponseRequest)
         storage.session = AgentSession(
@@ -3089,12 +3089,15 @@ async def test_handle_message_edit_recovers_missing_ledger_row_from_persisted_ru
                 ),
             ],
         )
-        return _outcome(
-            "final_visible_delivery",
-            terminal_status="completed",
-            final_visible_event_id="$response:example.com",
-            final_visible_body="ok",
-            delivery_kind="sent",
+        return _ResponseGenerationOutcome(
+            delivery=_outcome(
+                "final_visible_delivery",
+                terminal_status="completed",
+                final_visible_event_id="$response:example.com",
+                final_visible_body="ok",
+                delivery_kind="sent",
+            ),
+            run_succeeded=True,
         )
 
     with (
@@ -3527,7 +3530,7 @@ async def test_handle_message_edit_prefers_persisted_response_event_id_after_res
         conversation_target=stored_target,
     )
 
-    async def process_and_respond(*_args: object, **kwargs: object) -> FinalDeliveryOutcome:
+    async def process_and_respond(*_args: object, **kwargs: object) -> _ResponseGenerationOutcome:
         storage = bot._conversation_state_writer.create_storage(None)
         try:
             storage.upsert_session(
@@ -3556,12 +3559,15 @@ async def test_handle_message_edit_prefers_persisted_response_event_id_after_res
             )
         finally:
             storage.close()
-        return _outcome(
-            "final_visible_delivery",
-            terminal_status="completed",
-            final_visible_event_id="$response-new:example.com",
-            final_visible_body="ok",
-            delivery_kind="sent",
+        return _ResponseGenerationOutcome(
+            delivery=_outcome(
+                "final_visible_delivery",
+                terminal_status="completed",
+                final_visible_event_id="$response-new:example.com",
+                final_visible_body="ok",
+                delivery_kind="sent",
+            ),
+            run_succeeded=True,
         )
 
     with (

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -2562,7 +2562,7 @@ class TestAgentBot:
             assert stream_kwargs["reply_to_event_id"] == "event123"
             assert stream_kwargs["show_tool_calls"] is True
             assert stream_kwargs["run_metadata_collector"] == {}
-            assert stream_kwargs["compaction_outcomes_collector"] == []
+            assert "compaction_outcomes_collector" not in stream_kwargs
             mock_ai_response.assert_not_called()
             # With streaming and stop button: initial message + reaction + edits
             # Note: The exact count may vary based on implementation
@@ -2589,7 +2589,7 @@ class TestAgentBot:
             assert ai_kwargs["collect_streamed_response"] is True
             assert ai_kwargs["tool_trace_collector"] == []
             assert ai_kwargs["run_metadata_collector"] == {}
-            assert ai_kwargs["compaction_outcomes_collector"] == []
+            assert "compaction_outcomes_collector" not in ai_kwargs
             mock_stream_agent_response.assert_not_called()
             # With stop button support: initial + reaction + final
             assert bot.client.room_send.call_count >= 2

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -131,6 +131,7 @@ from mindroom.response_runner import (
     ResponseRequest,
     ResponseRunner,
     _merge_response_extra_content,
+    _ResponseGenerationOutcome,
 )
 from mindroom.runtime_shutdown import ORDERLY_SHUTDOWN
 from mindroom.runtime_state import get_runtime_state, reset_runtime_state, set_runtime_ready
@@ -2622,7 +2623,7 @@ class TestAgentBot:
             typing_indicator=_noop_typing_indicator,
             ai_response=mock_ai,
         ):
-            delivery = await bot._response_runner.process_and_respond(
+            generation = await bot._response_runner.process_and_respond(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Please send an update",
@@ -2638,7 +2639,7 @@ class TestAgentBot:
                 ),
             )
 
-        assert delivery.event_id == "$response"
+        assert generation.delivery.event_id == "$response"
         assert mock_ai.call_args.kwargs["prompt"] == "Please send an update"
         model_prompt = mock_ai.call_args.kwargs["model_prompt"]
         assert "[Matrix metadata for tool calls]" in model_prompt
@@ -2676,7 +2677,7 @@ class TestAgentBot:
             typing_indicator=_noop_typing_indicator,
             ai_response=mock_ai,
         ):
-            delivery = await bot._response_runner.process_and_respond(
+            generation = await bot._response_runner.process_and_respond(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Please send an update",
@@ -2692,7 +2693,7 @@ class TestAgentBot:
                 ),
             )
 
-        assert delivery.event_id == "$response"
+        assert generation.delivery.event_id == "$response"
         assert mock_ai.call_args.kwargs["prompt"] == "Please send an update"
         model_prompt = mock_ai.call_args.kwargs["model_prompt"]
         assert "[Matrix metadata for tool calls]" in model_prompt
@@ -2739,7 +2740,7 @@ class TestAgentBot:
                 typing_indicator=_noop_typing_indicator,
                 stream_agent_response=mock_stream_agent_response,
             ):
-                delivery = await bot._response_runner.process_and_respond_streaming(
+                generation = await bot._response_runner.process_and_respond_streaming(
                     _response_request(
                         room_id="!test:localhost",
                         prompt="Please reply in thread",
@@ -2755,7 +2756,7 @@ class TestAgentBot:
                     ),
                 )
 
-        assert delivery.event_id == "$response"
+        assert generation.delivery.event_id == "$response"
         assert mock_stream_agent_response.call_args.kwargs["prompt"] == "Please reply in thread"
         model_prompt = mock_stream_agent_response.call_args.kwargs["model_prompt"]
         assert "[Matrix metadata for tool calls]" in model_prompt
@@ -2913,7 +2914,7 @@ class TestAgentBot:
                 typing_indicator=_noop_typing_indicator,
                 stream_agent_response=mock_stream_agent_response,
             ):
-                delivery = await bot._response_runner.process_and_respond_streaming(
+                generation = await bot._response_runner.process_and_respond_streaming(
                     _response_request(
                         room_id="!test:localhost",
                         prompt="Hello",
@@ -2929,7 +2930,7 @@ class TestAgentBot:
                     ),
                 )
 
-        assert delivery.event_id == "$response"
+        assert generation.delivery.event_id == "$response"
         bot._knowledge_access_support.resolve_for_agent.assert_called_once()
         args, kwargs = bot._knowledge_access_support.resolve_for_agent.call_args
         assert args == ("calculator",)
@@ -3258,7 +3259,7 @@ class TestAgentBot:
                 stream_agent_response=mock_stream_agent_response,
             ),
         ):
-            delivery = await bot._response_runner.process_and_respond_streaming(
+            generation = await bot._response_runner.process_and_respond_streaming(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Please continue",
@@ -3274,10 +3275,10 @@ class TestAgentBot:
                 ),
             )
 
-        assert _visible_response_event_id(delivery) == "$terminal"
-        assert _handled_response_event_id(delivery) == "$terminal"
-        assert delivery.delivery_kind is None
-        assert "Response interrupted by an error" in delivery.response_text
+        assert _visible_response_event_id(generation.delivery) == "$terminal"
+        assert _handled_response_event_id(generation.delivery) == "$terminal"
+        assert generation.delivery.delivery_kind is None
+        assert "Response interrupted by an error" in generation.delivery.response_text
 
     @pytest.mark.asyncio
     async def test_process_and_respond_applies_before_and_after_hooks_non_streaming(
@@ -3319,7 +3320,7 @@ class TestAgentBot:
             typing_indicator=_noop_typing_indicator,
             ai_response=mock_ai,
         ):
-            delivery = await bot._response_runner.process_and_respond(
+            generation = await bot._response_runner.process_and_respond(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Please send an update",
@@ -3331,7 +3332,7 @@ class TestAgentBot:
                 ),
             )
 
-        assert delivery.event_id == "$response"
+        assert generation.delivery.event_id == "$response"
         assert before_calls == 1
         assert bot.client.room_send.await_args.kwargs["content"]["body"] == "Handled [hooked]"
         assert after_results == []
@@ -3449,7 +3450,7 @@ class TestAgentBot:
                 typing_indicator=_noop_typing_indicator,
                 stream_agent_response=mock_stream_agent_response,
             ):
-                delivery = await bot._response_runner.process_and_respond_streaming(
+                generation = await bot._response_runner.process_and_respond_streaming(
                     _response_request(
                         room_id="!test:localhost",
                         prompt="Please reply in thread",
@@ -3461,7 +3462,7 @@ class TestAgentBot:
                     ),
                 )
 
-        assert delivery.event_id == "$response"
+        assert generation.delivery.event_id == "$response"
         assert before_calls == 0
         mock_edit_message.assert_not_awaited()
         assert after_results == []
@@ -4432,7 +4433,7 @@ class TestAgentBot:
                 rendered_body=None,
                 visible_body_state="none",
             )
-            delivery = await bot._response_runner.process_and_respond_streaming(
+            generation = await bot._response_runner.process_and_respond_streaming(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Please reply in thread",
@@ -4450,10 +4451,10 @@ class TestAgentBot:
                 ),
             )
 
-        assert delivery.terminal_status == "completed"
-        assert _visible_response_event_id(delivery) == "$existing"
-        assert _handled_response_event_id(delivery) == "$existing"
-        assert delivery.mark_handled is True
+        assert generation.delivery.terminal_status == "completed"
+        assert _visible_response_event_id(generation.delivery) == "$existing"
+        assert _handled_response_event_id(generation.delivery) == "$existing"
+        assert generation.delivery.mark_handled is True
 
     def test_response_outcome_prefers_terminal_status_over_delivery_kind(self) -> None:
         """Pipeline outcome summaries must not report cancelled or error states as plain send/edit success."""
@@ -5530,7 +5531,7 @@ class TestAgentBot:
             typing_indicator=noop_typing_indicator,
             ai_response=mock_ai,
         ):
-            delivery = await bot._response_runner.process_and_respond(
+            generation = await bot._response_runner.process_and_respond(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Summarize README",
@@ -5546,7 +5547,7 @@ class TestAgentBot:
                 ),
             )
 
-        assert delivery.event_id == "$response"
+        assert generation.delivery.event_id == "$response"
         assert mock_ai.call_args.kwargs["show_tool_calls"] is False
         assert mock_ai.call_args.kwargs["collect_streamed_response"] is False
         assert "io.mindroom.tool_trace" not in bot.client.room_send.await_args.kwargs["content"]
@@ -5599,7 +5600,7 @@ class TestAgentBot:
             typing_indicator=noop_typing_indicator,
             ai_response=AsyncMock(side_effect=fake_ai_response),
         ):
-            delivery = await bot._response_runner.process_and_respond(
+            generation = await bot._response_runner.process_and_respond(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Check status",
@@ -5615,7 +5616,7 @@ class TestAgentBot:
                 ),
             )
 
-        assert delivery.event_id == "$response"
+        assert generation.delivery.event_id == "$response"
         content = bot.client.room_send.await_args.kwargs["content"]
         assert content["body"] == "Final answer"
         assert content[TOOL_TRACE_CONTENT_KEY]["events"] == [
@@ -5685,11 +5686,14 @@ class TestAgentBot:
                 ResponseRunner,
                 "process_and_respond",
                 new=AsyncMock(
-                    return_value=FinalDeliveryOutcome(
-                        terminal_status="completed",
-                        event_id="$response",
-                        is_visible_response=True,
-                        final_visible_body="ok",
+                    return_value=_ResponseGenerationOutcome(
+                        delivery=FinalDeliveryOutcome(
+                            terminal_status="completed",
+                            event_id="$response",
+                            is_visible_response=True,
+                            final_visible_body="ok",
+                        ),
+                        run_succeeded=True,
                     ),
                 ),
             ) as mock_process,
@@ -5803,11 +5807,14 @@ class TestAgentBot:
                 ResponseRunner,
                 "process_and_respond",
                 new=AsyncMock(
-                    return_value=FinalDeliveryOutcome(
-                        terminal_status="completed",
-                        event_id="$response",
-                        is_visible_response=True,
-                        final_visible_body="ok",
+                    return_value=_ResponseGenerationOutcome(
+                        delivery=FinalDeliveryOutcome(
+                            terminal_status="completed",
+                            event_id="$response",
+                            is_visible_response=True,
+                            final_visible_body="ok",
+                        ),
+                        run_succeeded=True,
                     ),
                 ),
             ) as mock_process,
@@ -5899,12 +5906,15 @@ class TestAgentBot:
                 ResponseRunner,
                 "process_and_respond_streaming",
                 new=AsyncMock(
-                    return_value=FinalDeliveryOutcome(
-                        terminal_status="completed",
-                        event_id="$thinking",
-                        is_visible_response=True,
-                        final_visible_body="",
-                        delivery_kind="edited",
+                    return_value=_ResponseGenerationOutcome(
+                        delivery=FinalDeliveryOutcome(
+                            terminal_status="completed",
+                            event_id="$thinking",
+                            is_visible_response=True,
+                            final_visible_body="",
+                            delivery_kind="edited",
+                        ),
+                        run_succeeded=True,
                     ),
                 ),
             ) as mock_process,
@@ -6001,11 +6011,14 @@ class TestAgentBot:
                 ResponseRunner,
                 "process_and_respond",
                 new=AsyncMock(
-                    return_value=FinalDeliveryOutcome(
-                        terminal_status="completed",
-                        event_id="$response",
-                        is_visible_response=True,
-                        final_visible_body="ok",
+                    return_value=_ResponseGenerationOutcome(
+                        delivery=FinalDeliveryOutcome(
+                            terminal_status="completed",
+                            event_id="$response",
+                            is_visible_response=True,
+                            final_visible_body="ok",
+                        ),
+                        run_succeeded=True,
                     ),
                 ),
             ) as mock_process,
@@ -6116,12 +6129,15 @@ class TestAgentBot:
                 ResponseRunner,
                 "process_and_respond",
                 new=AsyncMock(
-                    return_value=FinalDeliveryOutcome(
-                        terminal_status="completed",
-                        event_id="$thinking",
-                        is_visible_response=True,
-                        final_visible_body="ok",
-                        delivery_kind="edited",
+                    return_value=_ResponseGenerationOutcome(
+                        delivery=FinalDeliveryOutcome(
+                            terminal_status="completed",
+                            event_id="$thinking",
+                            is_visible_response=True,
+                            final_visible_body="ok",
+                            delivery_kind="edited",
+                        ),
+                        run_succeeded=True,
                     ),
                 ),
             ),
@@ -6509,11 +6525,14 @@ class TestAgentBot:
                 ResponseRunner,
                 "process_and_respond",
                 new=AsyncMock(
-                    return_value=FinalDeliveryOutcome(
-                        terminal_status="completed",
-                        event_id="$response",
-                        is_visible_response=True,
-                        final_visible_body="ok",
+                    return_value=_ResponseGenerationOutcome(
+                        delivery=FinalDeliveryOutcome(
+                            terminal_status="completed",
+                            event_id="$response",
+                            is_visible_response=True,
+                            final_visible_body="ok",
+                        ),
+                        run_succeeded=True,
                     ),
                 ),
             ),
@@ -11876,11 +11895,14 @@ class TestAgentBot:
                 ResponseRunner,
                 "process_and_respond",
                 new=AsyncMock(
-                    return_value=FinalDeliveryOutcome(
-                        terminal_status="completed",
-                        event_id="$response",
-                        is_visible_response=True,
-                        final_visible_body="ok",
+                    return_value=_ResponseGenerationOutcome(
+                        delivery=FinalDeliveryOutcome(
+                            terminal_status="completed",
+                            event_id="$response",
+                            is_visible_response=True,
+                            final_visible_body="ok",
+                        ),
+                        run_succeeded=True,
                     ),
                 ),
             ) as mock_process,

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -70,7 +70,12 @@ from mindroom.post_response_effects import (
 from mindroom.prompts import QUEUED_MESSAGE_NOTICE_TEXT
 from mindroom.response_lifecycle import _QueuedMessageState
 from mindroom.response_payload_preparation import DispatchPayloadInputs, ResponsePayloadPreparation
-from mindroom.response_runner import PostLockRequestPreparationError, ResponseRequest, ResponseRunner
+from mindroom.response_runner import (
+    PostLockRequestPreparationError,
+    ResponseRequest,
+    ResponseRunner,
+    _ResponseGenerationOutcome,
+)
 from mindroom.teams import TeamMode, _create_team_instance
 from mindroom.turn_controller import _PrecheckedEvent
 from mindroom.turn_policy import PreparedDispatch, ResponseAction, _DispatchPlan
@@ -1122,12 +1127,15 @@ async def test_generate_response_waits_for_lock_before_starting_placeholder_life
                 ResponseRunner,
                 "process_and_respond",
                 new=AsyncMock(
-                    return_value=FinalDeliveryOutcome(
-                        terminal_status="completed",
-                        event_id="$response",
-                        is_visible_response=True,
-                        final_visible_body="ok",
-                        delivery_kind="sent",
+                    return_value=_ResponseGenerationOutcome(
+                        delivery=FinalDeliveryOutcome(
+                            terminal_status="completed",
+                            event_id="$response",
+                            is_visible_response=True,
+                            final_visible_body="ok",
+                            delivery_kind="sent",
+                        ),
+                        run_succeeded=True,
                     ),
                 ),
             ),
@@ -1260,14 +1268,17 @@ async def test_generate_response_uses_post_lock_reproof_target(tmp_path: Path) -
     async def fake_process_and_respond(
         request: ResponseRequest,
         **_kwargs: object,
-    ) -> FinalDeliveryOutcome:
+    ) -> _ResponseGenerationOutcome:
         observed_delivery_targets.append(request.response_envelope.target)
-        return FinalDeliveryOutcome(
-            terminal_status="completed",
-            event_id="$response",
-            is_visible_response=True,
-            final_visible_body="ok",
-            delivery_kind="sent",
+        return _ResponseGenerationOutcome(
+            delivery=FinalDeliveryOutcome(
+                terminal_status="completed",
+                event_id="$response",
+                is_visible_response=True,
+                final_visible_body="ok",
+                delivery_kind="sent",
+            ),
+            run_succeeded=True,
         )
 
     with (
@@ -1333,14 +1344,17 @@ async def test_generate_response_keeps_locked_target_when_payload_preparation_re
     async def fake_process_and_respond(
         request: ResponseRequest,
         **_kwargs: object,
-    ) -> FinalDeliveryOutcome:
+    ) -> _ResponseGenerationOutcome:
         observed_delivery_targets.append(request.response_envelope.target)
-        return FinalDeliveryOutcome(
-            terminal_status="completed",
-            event_id="$response",
-            is_visible_response=True,
-            final_visible_body="ok",
-            delivery_kind="sent",
+        return _ResponseGenerationOutcome(
+            delivery=FinalDeliveryOutcome(
+                terminal_status="completed",
+                event_id="$response",
+                is_visible_response=True,
+                final_visible_body="ok",
+                delivery_kind="sent",
+            ),
+            run_succeeded=True,
         )
 
     def fake_build_lifecycle(**kwargs: object) -> _NoopResponseLifecycle:

--- a/tests/test_response_payload_preparation.py
+++ b/tests/test_response_payload_preparation.py
@@ -26,7 +26,7 @@ from mindroom.matrix.cache import ThreadHistoryResult
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
 from mindroom.response_payload_preparation import DispatchPayloadInputs, ResponsePayloadPreparation
-from mindroom.response_runner import ResponseRequest
+from mindroom.response_runner import ResponseRequest, _ResponseGenerationOutcome
 from mindroom.turn_policy import PreparedDispatch
 from tests.conftest import (
     TEST_PASSWORD,
@@ -320,13 +320,16 @@ async def test_generate_response_invokes_preparer_exactly_once_under_lock(tmp_pa
         await response_function(None)
         return "$response"
 
-    async def fake_process_and_respond(_request: ResponseRequest, **_kwargs: object) -> FinalDeliveryOutcome:
-        return FinalDeliveryOutcome(
-            terminal_status="completed",
-            event_id="$response",
-            is_visible_response=True,
-            final_visible_body="ok",
-            delivery_kind="sent",
+    async def fake_process_and_respond(_request: ResponseRequest, **_kwargs: object) -> _ResponseGenerationOutcome:
+        return _ResponseGenerationOutcome(
+            delivery=FinalDeliveryOutcome(
+                terminal_status="completed",
+                event_id="$response",
+                is_visible_response=True,
+                final_visible_body="ok",
+                delivery_kind="sent",
+            ),
+            run_succeeded=True,
         )
 
     with (

--- a/tests/test_response_runner_focused.py
+++ b/tests/test_response_runner_focused.py
@@ -38,7 +38,7 @@ from mindroom.post_response_effects import PostResponseEffectsDeps, ResponseOutc
 from mindroom.response_attempt import ResponseAttemptDeps, ResponseAttemptRequest, ResponseAttemptRunner
 from mindroom.response_lifecycle import ResponseLifecycleCoordinator
 from mindroom.response_payload_preparation import DispatchPayloadInputs, ResponsePayloadPreparation
-from mindroom.response_runner import ResponseRequest
+from mindroom.response_runner import ResponseRequest, _ResponseGenerationOutcome
 from mindroom.stop import StopManager
 from mindroom.streaming import StreamingDeliveryError
 from mindroom.turn_policy import PreparedDispatch
@@ -247,14 +247,14 @@ async def test_concurrent_requests_serialize_and_refresh_history_under_lock(tmp_
         await response_function(None)  # type: ignore[operator]
         return "$response"
 
-    async def fake_process_and_respond(request: ResponseRequest, **_kwargs: object) -> FinalDeliveryOutcome:
+    async def fake_process_and_respond(request: ResponseRequest, **_kwargs: object) -> _ResponseGenerationOutcome:
         turn = _turn(request)
         events.append(f"respond_start:{turn}")
         if turn == 1:
             first_turn_started.set()
             await gate.wait()
         events.append(f"respond_end:{turn}")
-        return _completed_outcome()
+        return _ResponseGenerationOutcome(delivery=_completed_outcome(), run_succeeded=True)
 
     def _request_for(turn: int) -> ResponseRequest:
         target = _target(thread_id="$thread", reply_to_event_id=f"$event{turn}")
@@ -507,9 +507,9 @@ async def test_non_streaming_response_delivers_through_deliver_final(tmp_path: P
             typing_indicator=_noop_typing,
         ),
     ):
-        delivery = await coordinator.process_and_respond(_plain_request(_target()))
+        generation = await coordinator.process_and_respond(_plain_request(_target()))
 
-    assert delivery.event_id == "$response"
+    assert generation.delivery.event_id == "$response"
     deliver_final.assert_awaited_once()
     final_request = deliver_final.await_args.args[0]
     assert final_request.response_text == "final text"
@@ -543,9 +543,9 @@ async def test_streaming_response_streams_then_finalizes_through_gateway(tmp_pat
             typing_indicator=_noop_typing,
         ),
     ):
-        delivery = await coordinator.process_and_respond_streaming(_plain_request(_target()))
+        generation = await coordinator.process_and_respond_streaming(_plain_request(_target()))
 
-    assert delivery.event_id == "$stream"
+    assert generation.delivery.event_id == "$stream"
     deliver_stream.assert_awaited_once()
     assert deliver_stream.await_args.args[0].existing_event_id is None
     finalize.assert_awaited_once()
@@ -600,10 +600,10 @@ async def test_streaming_midstream_failure_persists_partial_and_finalizes_error(
             typing_indicator=_noop_typing,
         ),
     ):
-        delivery = await coordinator.process_and_respond_streaming(_plain_request(_target()))
+        generation = await coordinator.process_and_respond_streaming(_plain_request(_target()))
 
     # The failure does not propagate: it is logged and becomes a finalized error outcome.
-    assert delivery is error_outcome
+    assert generation.delivery is error_outcome
     coordinator.deps.logger.exception.assert_called_once_with("Error in streaming response", error="boom")
     finalize.assert_awaited_once()
     assert finalize.await_args.args[0].stream_transport_outcome is error_transport
@@ -706,7 +706,7 @@ async def test_agent_streaming_sync_restart_cancelled_outcome_registers_retry(tm
         patch.object(
             coordinator,
             "process_and_respond_streaming",
-            new=AsyncMock(return_value=cancelled_outcome),
+            new=AsyncMock(return_value=_ResponseGenerationOutcome(delivery=cancelled_outcome, run_succeeded=False)),
         ),
         patch_response_runner_module(
             should_use_streaming=AsyncMock(return_value=True),

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -2042,7 +2042,7 @@ class TestStreamingBehavior:
                 typing_indicator=noop_typing,
             ),
         ):
-            delivery = await bot._response_runner.process_and_respond_streaming(
+            generation = await bot._response_runner.process_and_respond_streaming(
                 ResponseRequest(
                     thread_history=[],
                     prompt="Continue",
@@ -2052,7 +2052,7 @@ class TestStreamingBehavior:
                 ),
             )
 
-        assert delivery.event_id == "$stream_1"
+        assert generation.delivery.event_id == "$stream_1"
         assert sent_contents
         first_content = sent_contents[0]
         assert first_content["m.relates_to"]["rel_type"] == "m.thread"
@@ -2218,7 +2218,7 @@ class TestStreamingBehavior:
                 typing_indicator=_noop_typing_indicator,
             ),
         ):
-            delivery = await bot._response_runner.process_and_respond(
+            generation = await bot._response_runner.process_and_respond(
                 ResponseRequest(
                     thread_history=[],
                     prompt="Please check the docs",
@@ -2232,7 +2232,7 @@ class TestStreamingBehavior:
                 ),
             )
 
-        assert delivery.event_id == "$response"
+        assert generation.delivery.event_id == "$response"
         assert sync_git_source.await_count == 0
         assert reindex_all.await_count == 0
 

--- a/tests/test_system_enrich.py
+++ b/tests/test_system_enrich.py
@@ -573,7 +573,7 @@ async def test_process_and_respond_threads_system_enrichment_items(tmp_path: Pat
             ai_response=AsyncMock(side_effect=fake_ai_response),
         ),
     ):
-        delivery = await bot._response_runner.process_and_respond(
+        generation = await bot._response_runner.process_and_respond(
             ResponseRequest(
                 thread_history=[],
                 prompt="Please reply",
@@ -588,8 +588,8 @@ async def test_process_and_respond_threads_system_enrichment_items(tmp_path: Pat
             ),
         )
 
-    assert delivery.event_id == "$response"
-    assert delivery.response_text == "handled"
+    assert generation.delivery.event_id == "$response"
+    assert generation.delivery.response_text == "handled"
 
 
 @pytest.mark.asyncio
@@ -625,7 +625,7 @@ async def test_process_and_respond_streaming_threads_system_enrichment_items(tmp
             stream_agent_response=fake_stream_agent_response,
         ),
     ):
-        delivery = await bot._response_runner.process_and_respond_streaming(
+        generation = await bot._response_runner.process_and_respond_streaming(
             ResponseRequest(
                 thread_history=[],
                 prompt="Please reply",
@@ -640,5 +640,5 @@ async def test_process_and_respond_streaming_threads_system_enrichment_items(tmp
             ),
         )
 
-    assert delivery.event_id == "$response"
-    assert delivery.response_text == "stream chunk"
+    assert generation.delivery.event_id == "$response"
+    assert generation.delivery.response_text == "stream chunk"


### PR DESCRIPTION
## What

Sixth PR of the turn-unification campaign, **stacked on #1373**. Layer-2 part 1:

- The five mutable collector out-params on `process_and_respond` / `process_and_respond_streaming` (`compaction_outcomes_collector`, `run_success_collector`, `attempt_run_id_collector`, `tool_trace_collector`, `run_metadata_content_collector`) are replaced by one frozen `_ResponseGenerationOutcome` return value (delivery, run_succeeded, attempt_run_ids, compaction_outcomes, tool_trace, run_metadata_content) — every exit path, including the cancelled/error arms, returns it. This is the collector→return-value conversion from the companion Refactor-2 prompt, applied where it bites.
- `generate_response_locked` consumes the outcome directly (no more `attempt_run_ids[-1]` / `run_successes[-1]` read-backs from lists mutated three layers down).
- **Team run-metadata wiring (completes #1372's story; the review flagged the feature as inert):** the team locked helper now passes `run_metadata_collector` into both team calls, and all four team extra-content sites prefer the collected `io.mindroom.ai_run` payload, falling back to the recorder's prepared-context metadata when no terminal metrics exist.
- **Team `run_succeeded` is now real** (flagged behavior change from the approved design): team `ResponseOutcome.run_succeeded` reflects the recorder outcome instead of the dataclass default `True`, so success-only post-response effects stop firing for failed/interrupted team turns.

## Scope note (honest deviation from the design doc)

The design's more aggressive option — routing the team inner closure wholesale through the process pair — is deliberately **not** done here: after PRs 3–5 the remaining team closure differences (delivery-target derivation, placeholder-only streaming gate, member fan-out prep) make that reroute a poor complexity trade right now. PR 7 collapses the locked pair's duplicated cancellation state machine and arms instead.

## Verification

- Full suite: 9055 passed, 61 skipped; pre-commit clean (the new dataclass went private per the module-privacy hook).
- Mechanical test migration in 9 files (`.delivery.` re-anchors and stub wraps) — no assertions loosened, no production fallbacks; performed and verified by a subagent, then re-verified with the full gate.

## Stacking

PR 6 of 7 — base `turn-seam-05-empty-replay` (#1373).

## Review-fix round (holistic stack review, 2026-07-02)

- **Deleted the write-only compaction plumbing**: removing the compaction out-param left every layer still filling `compaction_outcomes` lists nobody reads — the whole response_runner chain is gone (the deep `ai.py`/`teams.py` collector params keep their Optional defaults; no caller passes a collector anymore).
- The duplicated `build_outcome` closures now delegate to one module-level `_generation_outcome`, so the `run_succeeded` semantics live in one place.
- Considered and skipped: extracting the ~40-line byte-similar process-pair prologue — a helper would have to return a six-field bundle for two call sites, adding indirection without reducing complexity.

## Round 3 (live smoke + inline threads)

- **Live-smoke fix (e76f19dfb)**: the team streaming delivery request carried no `extra_content`, so the ai_run metadata filled the collector but never reached Matrix in streaming mode — only offline requesters (non-streamed path) saw the payload, which is also why the earlier smoke passed. The request now carries the live collector dict exactly like the agent streaming path; pinned by a runner-level test asserting the delivery request's `extra_content` is the collector the team stream filled.
- **Inline threads fix (7ccda9df6)**: attempt run ids moved back to a caller-owned collector (`attempt_run_id_collector`) so they survive raising exit paths (stream cancellation re-raises, pre-delivery propagation) like the pre-refactor out-param; the outcome dropped the now-redundant field. Pinned by the post-delivery-failure test asserting `ResponseOutcome.response_run_id` carries the real attempt id.
