### PR TITLE
Dissolve dead capability optionality; unify the completed-attempt settle (turn unification 8/8)

### DIFF
--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -75,9 +75,7 @@ from mindroom.response_turn import (
     BlockingTurnAdapter,
     CancelledAttempt,
     CompletedAttempt,
-    ContinuationCapability,
     DynamicContinuationRunState,
-    EmptyRunCapability,
     ErroredAttempt,
     HandledAttempt,
     ResponseTurnContext,
@@ -367,7 +365,7 @@ class _AgentTurnCallbacks:
     on_scope_opened: Callable[[ScopeSessionContext | None], None]
     release_attempt_entity: Callable[[ScopeSessionContext | None], None]
     close_runtime_dbs: Callable[[ScopeSessionContext | None], None]
-    empty_run: EmptyRunCapability
+    discard_empty_run: Callable[[ScopeSessionContext | None, EmptyRunDiscard], None]
     persist_standalone_replay: Callable[[ScopeSessionContext | None, StandaloneReplaySnapshot], None]
 
 
@@ -445,10 +443,7 @@ def _build_agent_turn_callbacks(
         on_scope_opened=_on_scope_opened,
         release_attempt_entity=_release_attempt_entity,
         close_runtime_dbs=_close_runtime_dbs,
-        empty_run=EmptyRunCapability(
-            notice_text=ai_runtime.EMPTY_RESPONSE_NOTICE,
-            discard=_discard_empty_run,
-        ),
+        discard_empty_run=_discard_empty_run,
         persist_standalone_replay=_persist_standalone_replay,
     )
 
@@ -1649,9 +1644,8 @@ async def ai_response(
         ),
         release_attempt_entity=callbacks.release_attempt_entity,
         close_runtime_dbs=callbacks.close_runtime_dbs,
+        discard_empty_run=callbacks.discard_empty_run,
         on_scope_opened=callbacks.on_scope_opened,
-        continuation=ContinuationCapability(),
-        empty_run=callbacks.empty_run,
         persist_standalone_replay=callbacks.persist_standalone_replay,
     )
     return await run_blocking_response_turn(
@@ -2242,11 +2236,10 @@ async def stream_agent_response(  # noqa: C901, PLR0915
         snapshot_partial=lambda: _streaming_partial_snapshot(holder),
         release_attempt_entity=callbacks.release_attempt_entity,
         close_runtime_dbs=callbacks.close_runtime_dbs,
+        discard_empty_run=callbacks.discard_empty_run,
         on_scope_opened=callbacks.on_scope_opened,
         finalize_attempt=_finalize_streaming_attempt,
         make_notice_chunk=lambda text: RunContentEvent(content=text),
-        continuation=ContinuationCapability(),
-        empty_run=callbacks.empty_run,
         persist_standalone_replay=callbacks.persist_standalone_replay,
     )
     response_stream = stream_response_turn(

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -2239,7 +2239,7 @@ async def stream_agent_response(  # noqa: C901, PLR0915
         discard_empty_run=callbacks.discard_empty_run,
         on_scope_opened=callbacks.on_scope_opened,
         finalize_attempt=_finalize_streaming_attempt,
-        make_notice_chunk=lambda text: RunContentEvent(content=text),
+        make_text_chunk=lambda text: RunContentEvent(content=text),
         persist_standalone_replay=callbacks.persist_standalone_replay,
     )
     response_stream = stream_response_turn(

--- a/src/mindroom/response_turn.py
+++ b/src/mindroom/response_turn.py
@@ -236,8 +236,10 @@ class TurnPartialSnapshot:
 class CompletedAttempt:
     """One attempt that ran to a terminal provider response."""
 
-    # Only blocking attempts set this; the streaming driver delivers via
-    # chunks and records replayable_text.
+    # The attempt's deliverable final text. Streaming attempts whose chunks
+    # already delivered the document leave it empty; otherwise the driver
+    # emits it only after the attempt settles (an in-attempt yield would leak
+    # text that an empty-run retry or continuation is about to supersede).
     response_text: str = ""
     replayable_text: str = ""
     has_visible_content: bool = False
@@ -341,7 +343,7 @@ class StreamingTurnAdapter[ChunkT]:
     release_attempt_entity: Callable[[ScopeSessionContext | None], None]
     close_runtime_dbs: Callable[[ScopeSessionContext | None], None]
     discard_empty_run: Callable[[ScopeSessionContext | None, EmptyRunDiscard], None]
-    make_notice_chunk: Callable[[str], ChunkT]
+    make_text_chunk: Callable[[str], ChunkT]
     on_scope_opened: Callable[[ScopeSessionContext | None], None] | None = None
     finalize_attempt: Callable[[ScopeSessionContext | None], None] | None = None
     unexpected_error_text: Callable[[Exception], str] | None = None
@@ -620,7 +622,9 @@ class _CompletionSettle:
 
     keep_going: bool
     continuation: DynamicContinuationRunState
-    notice_texts: tuple[str, ...]
+    # The streaming driver emits these as chunks; the blocking driver returns
+    # response_text. Both cover the same notice/limit/final-text decisions.
+    deliver_texts: tuple[str, ...]
     recorded_text: str
     recorded_tools: tuple[ToolTraceEntry, ...]
     response_text: str
@@ -651,7 +655,7 @@ def _settle_completed_attempt(
             return _CompletionSettle(
                 keep_going=True,
                 continuation=continuation,
-                notice_texts=(),
+                deliver_texts=(),
                 recorded_text="",
                 recorded_tools=(),
                 response_text="",
@@ -661,7 +665,7 @@ def _settle_completed_attempt(
         return _CompletionSettle(
             keep_going=False,
             continuation=continuation,
-            notice_texts=(ai_runtime.EMPTY_RESPONSE_NOTICE,),
+            deliver_texts=(ai_runtime.EMPTY_RESPONSE_NOTICE,),
             recorded_text="",
             recorded_tools=(),
             response_text=ai_runtime.EMPTY_RESPONSE_NOTICE,
@@ -682,12 +686,12 @@ def _settle_completed_attempt(
                 continuation,
                 next_prompt=decision.next_prompt,
             ),
-            notice_texts=(),
+            deliver_texts=(),
             recorded_text="",
             recorded_tools=(),
             response_text="",
         )
-    notice_texts: tuple[str, ...] = ()
+    deliver_texts: tuple[str, ...] = (resolution.response_text,) if resolution.response_text else ()
     recorded_text = resolution.replayable_text
     response_text = resolution.response_text
     if decision.limit_message is not None:
@@ -700,13 +704,13 @@ def _settle_completed_attempt(
                 status=decision.continuation.status,
             )
         if not resolution.has_visible_content:
-            notice_texts = (decision.limit_message,)
+            deliver_texts = (decision.limit_message,)
             recorded_text = decision.limit_message
             response_text = decision.limit_message
     return _CompletionSettle(
         keep_going=False,
         continuation=continuation,
-        notice_texts=notice_texts,
+        deliver_texts=deliver_texts,
         recorded_text=recorded_text,
         recorded_tools=resolution.completed_tools,
         response_text=response_text,
@@ -775,8 +779,8 @@ async def stream_response_turn[ChunkT](  # noqa: C901, PLR0912
                     )
                     continuation = settle.continuation
                     keep_going = settle.keep_going
-                    for notice_text in settle.notice_texts:
-                        yield adapter.make_notice_chunk(notice_text)
+                    for deliver_text in settle.deliver_texts:
+                        yield adapter.make_text_chunk(deliver_text)
                     if not keep_going:
                         if sinks.run_metadata_collector is not None and resolution.metadata_content is not None:
                             sinks.run_metadata_collector.update(resolution.metadata_content)
@@ -806,7 +810,7 @@ async def stream_response_turn[ChunkT](  # noqa: C901, PLR0912
         if adapter.unexpected_error_text is None:
             raise
         logger.exception("Response turn failed", entity=ctx.entity_label)
-        yield adapter.make_notice_chunk(adapter.unexpected_error_text(e))
+        yield adapter.make_text_chunk(adapter.unexpected_error_text(e))
         return
     finally:
         adapter.close_runtime_dbs(run.scope_context)

--- a/src/mindroom/response_turn.py
+++ b/src/mindroom/response_turn.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import asyncio
 from copy import deepcopy
 from dataclasses import dataclass, field, replace
-from typing import TYPE_CHECKING, Any, NoReturn, cast
+from typing import TYPE_CHECKING, Any, NoReturn
 from uuid import uuid4
 
 from mindroom import ai_runtime
@@ -52,9 +52,7 @@ __all__ = [
     "BlockingTurnAdapter",
     "CancelledAttempt",
     "CompletedAttempt",
-    "ContinuationCapability",
     "DynamicContinuationRunState",
-    "EmptyRunCapability",
     "EmptyRunDiscard",
     "ErroredAttempt",
     "HandledAttempt",
@@ -291,31 +289,12 @@ class AttemptResolved:
 
 
 @dataclass(frozen=True)
-class ContinuationCapability:
-    """Enable dynamic-tool continuations for the turn.
-
-    The iteration budget is always ``DYNAMIC_TOOL_CONTINUATION_LIMIT``:
-    ``continuation_decision_from_tools`` hardcodes that constant for its
-    continue/stop decision, so a per-adapter limit would silently desync
-    from the loop budget.
-    """
-
-
-@dataclass(frozen=True)
 class EmptyRunDiscard:
     """Identity of one empty completed run to purge from session history."""
 
     session_id: str | None
     run_id: str | None
     output_tokens: int | None
-
-
-@dataclass(frozen=True)
-class EmptyRunCapability:
-    """Enable the empty-completed-run guard with an entity-specific discard."""
-
-    notice_text: str
-    discard: Callable[[ScopeSessionContext | None, EmptyRunDiscard], None]
 
 
 @dataclass(frozen=True)
@@ -342,11 +321,10 @@ class BlockingTurnAdapter:
     snapshot_partial: Callable[[], TurnPartialSnapshot]
     release_attempt_entity: Callable[[ScopeSessionContext | None], None]
     close_runtime_dbs: Callable[[ScopeSessionContext | None], None]
+    discard_empty_run: Callable[[ScopeSessionContext | None, EmptyRunDiscard], None]
     on_scope_opened: Callable[[ScopeSessionContext | None], None] | None = None
     finalize_attempt: Callable[[ScopeSessionContext | None], None] | None = None
     unexpected_error_text: Callable[[Exception], str] | None = None
-    continuation: ContinuationCapability | None = None
-    empty_run: EmptyRunCapability | None = None
     persist_standalone_replay: Callable[[ScopeSessionContext | None, StandaloneReplaySnapshot], None] | None = None
 
 
@@ -362,12 +340,11 @@ class StreamingTurnAdapter[ChunkT]:
     snapshot_partial: Callable[[], TurnPartialSnapshot]
     release_attempt_entity: Callable[[ScopeSessionContext | None], None]
     close_runtime_dbs: Callable[[ScopeSessionContext | None], None]
+    discard_empty_run: Callable[[ScopeSessionContext | None, EmptyRunDiscard], None]
+    make_notice_chunk: Callable[[str], ChunkT]
     on_scope_opened: Callable[[ScopeSessionContext | None], None] | None = None
     finalize_attempt: Callable[[ScopeSessionContext | None], None] | None = None
-    make_notice_chunk: Callable[[str], ChunkT] | None = None
     unexpected_error_text: Callable[[Exception], str] | None = None
-    continuation: ContinuationCapability | None = None
-    empty_run: EmptyRunCapability | None = None
     persist_standalone_replay: Callable[[ScopeSessionContext | None, StandaloneReplaySnapshot], None] | None = None
 
 
@@ -383,20 +360,6 @@ def _raise_missing_stream_resolution(entity_label: str) -> NoReturn:
     # the turn silently: nothing recorded, no metadata published, no log.
     msg = f"streaming attempt for {entity_label!r} ended without yielding its AttemptResolved sentinel"
     raise RuntimeError(msg)
-
-
-def _effective_continuation_limit(
-    continuation: ContinuationCapability | None,
-    empty_run: EmptyRunCapability | None,
-) -> int:
-    """Return the turn's extra-iteration budget beyond the first attempt.
-
-    The empty-run one-shot retry borrows a continuation slot when continuations
-    are enabled; without them it still needs one slot of its own.
-    """
-    if continuation is not None:
-        return DYNAMIC_TOOL_CONTINUATION_LIMIT
-    return 1 if empty_run is not None else 0
 
 
 def _reset_turn_state_for_dynamic_continuation(
@@ -493,31 +456,22 @@ def _record_turn_cancelled_fallback(
     )
 
 
-@dataclass(frozen=True)
-class _EmptyRunOutcome:
-    """How the empty-run guard settled one empty completed attempt."""
-
-    retry_granted: bool
-    notice_text: str | None = None
-
-
 def _settle_empty_run(
     ctx: ResponseTurnContext,
-    empty_run: EmptyRunCapability,
+    discard_empty_run: Callable[[ScopeSessionContext | None, EmptyRunDiscard], None],
     release_attempt_entity: Callable[[ScopeSessionContext | None], None],
     run: TurnRunState,
     resolution: CompletedAttempt,
     *,
     continuation_count: int,
-    limit: int,
-) -> _EmptyRunOutcome:
-    """Discard one empty completed run and decide whether one retry is granted.
+) -> bool:
+    """Discard one empty completed run; return whether one retry is granted.
 
     The one-shot retry borrows a continuation slot so the outer loop's
     iteration budget stays authoritative; a granted retry closes the spent
     entity's runtime state exactly like the continuation handoff.
     """
-    empty_run.discard(
+    discard_empty_run(
         run.scope_context,
         EmptyRunDiscard(
             session_id=resolution.session_id or ctx.session_id,
@@ -525,11 +479,11 @@ def _settle_empty_run(
             output_tokens=resolution.output_tokens,
         ),
     )
-    if not run.empty_response_retried and continuation_count < limit:
+    if not run.empty_response_retried and continuation_count < DYNAMIC_TOOL_CONTINUATION_LIMIT:
         run.empty_response_retried = True
         release_attempt_entity(run.scope_context)
-        return _EmptyRunOutcome(retry_granted=True)
-    return _EmptyRunOutcome(retry_granted=False, notice_text=empty_run.notice_text)
+        return True
+    return False
 
 
 def _advance_turn_continuation(
@@ -565,13 +519,12 @@ async def run_blocking_response_turn(
 ) -> str:
     """Run one blocking response turn to a final user-visible text."""
     run = TurnRunState()
-    limit = _effective_continuation_limit(adapter.continuation, adapter.empty_run)
     try:
         with adapter.open_scope() as scope_context:
             run.scope_context = scope_context
             if adapter.on_scope_opened is not None:
                 adapter.on_scope_opened(scope_context)
-            for continuation_count in range(limit + 1):
+            for continuation_count in range(DYNAMIC_TOOL_CONTINUATION_LIMIT + 1):
                 try:
                     resolution = await adapter.run_attempt(run, continuation)
                     settled = _settle_blocking_attempt(
@@ -582,7 +535,6 @@ async def run_blocking_response_turn(
                         resolution,
                         continuation,
                         continuation_count=continuation_count,
-                        limit=limit,
                     )
                 finally:
                     if adapter.finalize_attempt is not None:
@@ -622,7 +574,6 @@ def _settle_blocking_attempt(
     continuation: DynamicContinuationRunState,
     *,
     continuation_count: int,
-    limit: int,
 ) -> str | DynamicContinuationRunState:
     """Settle one blocking attempt: return final text or the advanced continuation."""
     # The blocking envelope publishes run metadata before dispatching on the
@@ -642,72 +593,105 @@ def _settle_blocking_attempt(
         raise build_cancelled_error(resolution.reason)
     if isinstance(resolution, ErroredAttempt):
         return resolution.user_message_text
-    return _settle_completed_blocking_attempt(
+    settle = _settle_completed_attempt(
         ctx,
-        adapter,
         sinks,
         run,
         resolution,
         continuation,
+        discard_empty_run=adapter.discard_empty_run,
+        release_attempt_entity=adapter.release_attempt_entity,
         continuation_count=continuation_count,
-        limit=limit,
     )
+    if settle.keep_going:
+        return settle.continuation
+    run.turn_state.record_completed(
+        sinks.turn_recorder,
+        run_metadata=run.run_metadata,
+        assistant_text=settle.recorded_text,
+        completed_tools=list(settle.recorded_tools),
+    )
+    return settle.response_text
 
 
-def _settle_completed_blocking_attempt(
+@dataclass(frozen=True)
+class _CompletionSettle:
+    """Driver-internal plan for finishing one completed attempt."""
+
+    keep_going: bool
+    continuation: DynamicContinuationRunState
+    notice_texts: tuple[str, ...]
+    recorded_text: str
+    recorded_tools: tuple[ToolTraceEntry, ...]
+    response_text: str
+
+
+def _settle_completed_attempt(
     ctx: ResponseTurnContext,
-    adapter: BlockingTurnAdapter,
     sinks: TurnSinks,
     run: TurnRunState,
     resolution: CompletedAttempt,
     continuation: DynamicContinuationRunState,
     *,
+    discard_empty_run: Callable[[ScopeSessionContext | None, EmptyRunDiscard], None],
+    release_attempt_entity: Callable[[ScopeSessionContext | None], None],
     continuation_count: int,
-    limit: int,
-) -> str | DynamicContinuationRunState:
-    """Settle one completed blocking attempt into final text or a continuation."""
-    if resolution.is_empty and adapter.empty_run is not None:
-        empty_outcome = _settle_empty_run(
+) -> _CompletionSettle:
+    """Settle one completed attempt into a record/deliver plan or a continuation."""
+    if resolution.is_empty:
+        retry_granted = _settle_empty_run(
             ctx,
-            adapter.empty_run,
-            adapter.release_attempt_entity,
+            discard_empty_run,
+            release_attempt_entity,
             run,
             resolution,
             continuation_count=continuation_count,
-            limit=limit,
         )
-        if empty_outcome.retry_granted:
-            return continuation
-        run.turn_state.record_completed(
-            sinks.turn_recorder,
-            run_metadata=run.run_metadata,
-            assistant_text="",
-            completed_tools=[],
+        if retry_granted:
+            return _CompletionSettle(
+                keep_going=True,
+                continuation=continuation,
+                notice_texts=(),
+                recorded_text="",
+                recorded_tools=(),
+                response_text="",
+            )
+        # The notice falls through: run metadata and recorder completion
+        # still apply to this notice-only turn.
+        return _CompletionSettle(
+            keep_going=False,
+            continuation=continuation,
+            notice_texts=(ai_runtime.EMPTY_RESPONSE_NOTICE,),
+            recorded_text="",
+            recorded_tools=(),
+            response_text=ai_runtime.EMPTY_RESPONSE_NOTICE,
         )
-        assert empty_outcome.notice_text is not None
-        return empty_outcome.notice_text
-    decision = (
-        continuation_decision_from_tools(
-            resolution.tool_executions,
-            original_prompt=continuation.original_prompt,
-            continuation_count=continuation_count,
-        )
-        if adapter.continuation is not None
-        else None
+    decision = continuation_decision_from_tools(
+        resolution.tool_executions,
+        original_prompt=continuation.original_prompt,
+        continuation_count=continuation_count,
     )
-    response_text = resolution.response_text
-    replayable_text = resolution.replayable_text
-    if decision is not None:
-        if decision.should_continue:
-            return _advance_turn_continuation(
+    if decision.should_continue:
+        return _CompletionSettle(
+            keep_going=True,
+            continuation=_advance_turn_continuation(
                 sinks,
-                adapter.release_attempt_entity,
+                release_attempt_entity,
                 run,
                 resolution,
                 continuation,
                 next_prompt=decision.next_prompt,
-            )
-        if decision.limit_message is not None and decision.continuation is not None:
+            ),
+            notice_texts=(),
+            recorded_text="",
+            recorded_tools=(),
+            response_text="",
+        )
+    notice_texts: tuple[str, ...] = ()
+    recorded_text = resolution.replayable_text
+    response_text = resolution.response_text
+    if decision.limit_message is not None:
+        if decision.continuation is not None:
             logger.warning(
                 "Dynamic tool continuation limit reached",
                 entity=ctx.entity_label,
@@ -715,97 +699,21 @@ def _settle_completed_blocking_attempt(
                 tool_name=decision.continuation.tool_name,
                 status=decision.continuation.status,
             )
-        if decision.limit_message is not None and not resolution.has_visible_content:
+        if not resolution.has_visible_content:
+            notice_texts = (decision.limit_message,)
+            recorded_text = decision.limit_message
             response_text = decision.limit_message
-            replayable_text = decision.limit_message
-    run.turn_state.record_completed(
-        sinks.turn_recorder,
-        run_metadata=run.run_metadata,
-        assistant_text=replayable_text,
-        completed_tools=list(resolution.completed_tools),
-    )
-    return response_text
-
-
-@dataclass(frozen=True)
-class _StreamCompletionSettle:
-    """Driver-internal plan for finishing one completed streaming attempt."""
-
-    keep_going: bool
-    continuation: DynamicContinuationRunState
-    notice_texts: tuple[str, ...]
-    recorded_text: str
-
-
-def _settle_completed_stream_attempt(
-    ctx: ResponseTurnContext,
-    adapter: StreamingTurnAdapter[Any],
-    sinks: TurnSinks,
-    run: TurnRunState,
-    resolution: CompletedAttempt,
-    continuation: DynamicContinuationRunState,
-    *,
-    continuation_count: int,
-    limit: int,
-) -> _StreamCompletionSettle:
-    """Settle one completed streaming attempt into notices, recording text, and continuation."""
-    notice_texts: list[str] = []
-    keep_going = False
-    recorded_text = resolution.replayable_text
-    if resolution.is_empty and adapter.empty_run is not None:
-        empty_outcome = _settle_empty_run(
-            ctx,
-            adapter.empty_run,
-            adapter.release_attempt_entity,
-            run,
-            resolution,
-            continuation_count=continuation_count,
-            limit=limit,
-        )
-        if empty_outcome.retry_granted:
-            keep_going = True
-        else:
-            # The notice falls through: run metadata and recorder completion
-            # still apply to this notice-only turn.
-            assert empty_outcome.notice_text is not None
-            notice_texts.append(empty_outcome.notice_text)
-    if not keep_going and adapter.continuation is not None:
-        decision = continuation_decision_from_tools(
-            resolution.tool_executions,
-            original_prompt=continuation.original_prompt,
-            continuation_count=continuation_count,
-        )
-        if decision.should_continue:
-            continuation = _advance_turn_continuation(
-                sinks,
-                adapter.release_attempt_entity,
-                run,
-                resolution,
-                continuation,
-                next_prompt=decision.next_prompt,
-            )
-            keep_going = True
-        elif decision.limit_message is not None:
-            if decision.continuation is not None:
-                logger.warning(
-                    "Dynamic tool continuation limit reached during streaming",
-                    entity=ctx.entity_label,
-                    function_name=decision.continuation.function_name,
-                    tool_name=decision.continuation.tool_name,
-                    status=decision.continuation.status,
-                )
-            if not resolution.has_visible_content:
-                notice_texts.append(decision.limit_message)
-                recorded_text = decision.limit_message
-    return _StreamCompletionSettle(
-        keep_going=keep_going,
+    return _CompletionSettle(
+        keep_going=False,
         continuation=continuation,
-        notice_texts=tuple(notice_texts),
+        notice_texts=notice_texts,
         recorded_text=recorded_text,
+        recorded_tools=resolution.completed_tools,
+        response_text=response_text,
     )
 
 
-async def stream_response_turn[ChunkT](  # noqa: C901, PLR0912, PLR0915
+async def stream_response_turn[ChunkT](  # noqa: C901, PLR0912
     ctx: ResponseTurnContext,
     adapter: StreamingTurnAdapter[ChunkT],
     sinks: TurnSinks,
@@ -814,13 +722,12 @@ async def stream_response_turn[ChunkT](  # noqa: C901, PLR0912, PLR0915
 ) -> AsyncGenerator[ChunkT, None]:
     """Run one streaming response turn, yielding the attempt chunks as they arrive."""
     run = TurnRunState()
-    limit = _effective_continuation_limit(adapter.continuation, adapter.empty_run)
     try:
         with adapter.open_scope() as scope_context:
             run.scope_context = scope_context
             if adapter.on_scope_opened is not None:
                 adapter.on_scope_opened(scope_context)
-            for continuation_count in range(limit + 1):
+            for continuation_count in range(DYNAMIC_TOOL_CONTINUATION_LIMIT + 1):
                 resolution: StreamAttemptResolution | None = None
                 keep_going = False
                 try:
@@ -856,20 +763,19 @@ async def stream_response_turn[ChunkT](  # noqa: C901, PLR0912, PLR0915
                                 resolution,
                             )
                         raise build_cancelled_error(resolution.reason)
-                    settle = _settle_completed_stream_attempt(
+                    settle = _settle_completed_attempt(
                         ctx,
-                        adapter,
                         sinks,
                         run,
                         resolution,
                         continuation,
+                        discard_empty_run=adapter.discard_empty_run,
+                        release_attempt_entity=adapter.release_attempt_entity,
                         continuation_count=continuation_count,
-                        limit=limit,
                     )
                     continuation = settle.continuation
                     keep_going = settle.keep_going
                     for notice_text in settle.notice_texts:
-                        assert adapter.make_notice_chunk is not None
                         yield adapter.make_notice_chunk(notice_text)
                     if not keep_going:
                         if sinks.run_metadata_collector is not None and resolution.metadata_content is not None:
@@ -878,7 +784,7 @@ async def stream_response_turn[ChunkT](  # noqa: C901, PLR0912, PLR0915
                             sinks.turn_recorder,
                             run_metadata=run.run_metadata,
                             assistant_text=settle.recorded_text,
-                            completed_tools=list(resolution.completed_tools),
+                            completed_tools=list(settle.recorded_tools),
                         )
                 finally:
                     if adapter.finalize_attempt is not None:
@@ -900,7 +806,7 @@ async def stream_response_turn[ChunkT](  # noqa: C901, PLR0912, PLR0915
         if adapter.unexpected_error_text is None:
             raise
         logger.exception("Response turn failed", entity=ctx.entity_label)
-        yield cast("ChunkT", adapter.unexpected_error_text(e))
+        yield adapter.make_notice_chunk(adapter.unexpected_error_text(e))
         return
     finally:
         adapter.close_runtime_dbs(run.scope_context)

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -2889,9 +2889,13 @@ async def team_response_stream(  # noqa: C901, PLR0915
                         team_display_names=team_members.display_names,
                     )
                     event_has_visible = _has_visible_team_output(event)
-                    yield response_text
+                    # The driver emits response_text only after settling the
+                    # attempt: a pre-settle yield would leak the fallback
+                    # placeholder before an empty-run retry, or stale
+                    # first-attempt text before a dynamic-tool continuation.
                     yield AttemptResolved(
                         CompletedAttempt(
+                            response_text=response_text,
                             replayable_text=response_text if event_has_visible else "",
                             has_visible_content=event_has_visible,
                             is_empty=(
@@ -3139,7 +3143,7 @@ async def team_response_stream(  # noqa: C901, PLR0915
         release_attempt_entity=_release_team_attempt_members,
         close_runtime_dbs=_close_team_attempt_dbs,
         finalize_attempt=_finalize_team_stream_attempt,
-        make_notice_chunk=lambda text: text,
+        make_text_chunk=lambda text: text,
         unexpected_error_text=lambda e: get_user_friendly_error_message(e, team_label),
         discard_empty_run=discard_team_empty_run,
     )

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -85,9 +85,7 @@ from mindroom.response_turn import (
     BlockingTurnAdapter,
     CancelledAttempt,
     CompletedAttempt,
-    ContinuationCapability,
     DynamicContinuationRunState,
-    EmptyRunCapability,
     ErroredAttempt,
     HandledAttempt,
     ResponseTurnContext,
@@ -1400,12 +1398,60 @@ def _resolved_team_session_id(scope_context: ScopeSessionContext | None, session
     return None
 
 
-def _build_team_turn_capabilities(
+async def _ensure_attempt_team_members(
+    holder: _TeamTurnHolder,
+    agent_names: list[str],
+    orchestrator: OrchestratorRuntime,
+    execution_identity: ToolExecutionIdentity | None,
+    *,
+    session_id: str | None,
+    reason_prefix: str,
+    configured_team_name: str | None,
+) -> ResolvedExactTeamMembers:
+    """Return the turn's member set, rebuilding released members.
+
+    A continuation releases the spent members; the rebuild bakes the loaded
+    dynamic-tool schema into fresh member agents.
+    """
+    members = holder.team_members
+    if members is None:
+        members = await asyncio.to_thread(
+            _materialize_team_members,
+            agent_names,
+            orchestrator,
+            execution_identity,
+            session_id=session_id,
+            reason_prefix=reason_prefix,
+            configured_team_name=configured_team_name,
+        )
+        holder.team_members = members
+    return members
+
+
+def _initial_team_continuation(
+    *,
+    message: str,
+    current_timestamp_ms: float | None,
+    current_prompt_is_structured: bool,
+    run_id: str | None,
+) -> DynamicContinuationRunState:
+    """Build the continuation state for one team turn's first attempt."""
+    return DynamicContinuationRunState.initial(
+        prompt=message,
+        model_prompt=None,
+        current_timestamp_ms=current_timestamp_ms,
+        current_prompt_is_structured=current_prompt_is_structured,
+        run_id=run_id,
+        continuation_model_prompt_tail="",
+    )
+
+
+def _build_team_empty_run_discard(
     *,
     session_id: str | None,
     entity_name: str,
-) -> EmptyRunCapability:
-    """Build the empty-run guard capability for one team turn."""
+) -> Callable[[ScopeSessionContext | None, EmptyRunDiscard], None]:
+    """Build the empty-run discard callback for one team turn."""
 
     def _discard_empty_team_run(scope_context: ScopeSessionContext | None, discard: EmptyRunDiscard) -> None:
         resolved_session_id = _resolved_team_session_id(scope_context, discard.session_id or session_id)
@@ -1420,7 +1466,7 @@ def _build_team_turn_capabilities(
             output_tokens=discard.output_tokens,
         )
 
-    return EmptyRunCapability(notice_text=ai_runtime.EMPTY_RESPONSE_NOTICE, discard=_discard_empty_team_run)
+    return _discard_empty_team_run
 
 
 @dataclass
@@ -1951,20 +1997,15 @@ async def team_response(  # noqa: C901, PLR0915
         continuation_state: DynamicContinuationRunState,
     ) -> BlockingAttemptResolution:
         """Run one team attempt, including its media-fallback retries."""
-        attempt_members = holder.team_members
-        if attempt_members is None:
-            # A continuation released the spent members; rebuild them so the
-            # loaded dynamic-tool schema is baked into fresh member agents.
-            attempt_members = await asyncio.to_thread(
-                _materialize_team_members,
-                agent_names,
-                orchestrator,
-                execution_identity,
-                session_id=session_id,
-                reason_prefix=reason_prefix,
-                configured_team_name=configured_team_name,
-            )
-            holder.team_members = attempt_members
+        attempt_members = await _ensure_attempt_team_members(
+            holder,
+            agent_names,
+            orchestrator,
+            execution_identity,
+            session_id=session_id,
+            reason_prefix=reason_prefix,
+            configured_team_name=configured_team_name,
+        )
         attempt_agents = attempt_members.agents
         # Resolve the runtime model once so the Team instance and the run
         # metadata cannot disagree (thread overrides can change mid-turn).
@@ -2260,7 +2301,7 @@ async def team_response(  # noqa: C901, PLR0915
             entity_name=configured_team_name or team_name,
         )
 
-    team_empty_run = _build_team_turn_capabilities(
+    discard_team_empty_run = _build_team_empty_run_discard(
         session_id=session_id,
         entity_name=configured_team_name or team_name,
     )
@@ -2280,8 +2321,7 @@ async def team_response(  # noqa: C901, PLR0915
         close_runtime_dbs=_close_team_attempt_dbs,
         finalize_attempt=_finalize_team_attempt,
         unexpected_error_text=lambda e: get_user_friendly_error_message(e, team_name),
-        continuation=ContinuationCapability(),
-        empty_run=team_empty_run,
+        discard_empty_run=discard_team_empty_run,
     )
     return await run_blocking_response_turn(
         ResponseTurnContext(
@@ -2297,13 +2337,11 @@ async def team_response(  # noqa: C901, PLR0915
         ),
         adapter,
         TurnSinks(turn_recorder=turn_recorder, run_metadata_collector=run_metadata_collector),
-        continuation=DynamicContinuationRunState.initial(
-            prompt=message,
-            model_prompt=None,
+        continuation=_initial_team_continuation(
+            message=message,
             current_timestamp_ms=current_timestamp_ms,
             current_prompt_is_structured=current_prompt_is_structured,
             run_id=run_id,
-            continuation_model_prompt_tail="",
         ),
     )
 
@@ -3073,7 +3111,7 @@ async def team_response_stream(  # noqa: C901, PLR0915
             entity_name=configured_team_name or team_label,
         )
 
-    team_empty_run = _build_team_turn_capabilities(
+    discard_team_empty_run = _build_team_empty_run_discard(
         session_id=session_id,
         entity_name=configured_team_name or team_label,
     )
@@ -3103,8 +3141,7 @@ async def team_response_stream(  # noqa: C901, PLR0915
         finalize_attempt=_finalize_team_stream_attempt,
         make_notice_chunk=lambda text: text,
         unexpected_error_text=lambda e: get_user_friendly_error_message(e, team_label),
-        continuation=ContinuationCapability(),
-        empty_run=team_empty_run,
+        discard_empty_run=discard_team_empty_run,
     )
     response_stream = stream_response_turn(
         ResponseTurnContext(
@@ -3120,13 +3157,11 @@ async def team_response_stream(  # noqa: C901, PLR0915
         ),
         adapter,
         TurnSinks(turn_recorder=turn_recorder, run_metadata_collector=run_metadata_collector),
-        continuation=DynamicContinuationRunState.initial(
-            prompt=message,
-            model_prompt=None,
+        continuation=_initial_team_continuation(
+            message=message,
             current_timestamp_ms=current_timestamp_ms,
             current_prompt_is_structured=current_prompt_is_structured,
             run_id=run_id,
-            continuation_model_prompt_tail="",
         ),
     )
     # Close the driver generator deterministically when this wrapper unwinds so

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -2513,20 +2513,15 @@ async def team_response_stream(  # noqa: C901, PLR0915
         continuation_state: DynamicContinuationRunState,
     ) -> AsyncGenerator[_TeamStreamChunk | AttemptResolved, None]:
         """Stream one team attempt, ending with its ``AttemptResolved`` sentinel."""
-        attempt_members = holder.team_members
-        if attempt_members is None:
-            # A continuation released the spent members; rebuild them so the
-            # loaded dynamic-tool schema is baked into fresh member agents.
-            attempt_members = await asyncio.to_thread(
-                _materialize_team_members,
-                requested_agent_names,
-                orchestrator,
-                execution_identity,
-                session_id=session_id,
-                reason_prefix=reason_prefix,
-                configured_team_name=configured_team_name,
-            )
-            holder.team_members = attempt_members
+        attempt_members = await _ensure_attempt_team_members(
+            holder,
+            requested_agent_names,
+            orchestrator,
+            execution_identity,
+            session_id=session_id,
+            reason_prefix=reason_prefix,
+            configured_team_name=configured_team_name,
+        )
         attempt_agents = attempt_members.agents
         # Resolve the runtime model here and pass it down so the Team instance
         # and the run metadata cannot disagree: prepare re-resolves with the

--- a/tests/test_response_turn.py
+++ b/tests/test_response_turn.py
@@ -210,7 +210,7 @@ def _streaming_adapter(
         release_attempt_entity=lambda _scope: _bump(log, "released"),
         close_runtime_dbs=lambda _scope: _bump(log, "closed"),
         discard_empty_run=lambda _scope, discard: log.discards.append(discard),
-        make_notice_chunk=lambda text: f"notice:{text}",
+        make_text_chunk=lambda text: f"notice:{text}",
         finalize_attempt=lambda _scope: _bump(log, "finalized"),
         unexpected_error_text=unexpected_error_text,
         persist_standalone_replay=_persist if with_standalone_replay else None,
@@ -940,6 +940,111 @@ def test_streaming_unexpected_error_yields_shaped_notice_chunk() -> None:
     )
 
     assert chunks == ["chunk", "notice:shaped: boom"]
+
+
+def test_streaming_completed_response_text_is_emitted_after_settle() -> None:
+    """A resolution-carried final document is emitted once the attempt settles."""
+    log = _AdapterLog()
+
+    async def _attempt(
+        _run: TurnRunState,
+        _c: DynamicContinuationRunState,
+    ) -> AsyncGenerator[str | AttemptResolved, None]:
+        yield AttemptResolved(
+            CompletedAttempt(response_text="final doc", replayable_text="final doc", has_visible_content=True),
+        )
+
+    chunks = asyncio.run(
+        _collect(
+            stream_response_turn(
+                _ctx(),
+                _streaming_adapter(log, _attempt),
+                TurnSinks(),
+                continuation=_continuation(),
+            ),
+        ),
+    )
+
+    assert chunks == ["notice:final doc"]
+
+
+def test_streaming_empty_terminal_text_is_not_leaked_before_retry() -> None:
+    """An empty attempt's fallback document is superseded by the retry, not emitted.
+
+    Pre-fix, the team terminal branch yielded its formatted text before the
+    driver settled, so an empty run leaked "No team response generated."
+    ahead of the retry (or the empty notice).
+    """
+    log = _AdapterLog()
+    attempts = 0
+
+    async def _attempt(
+        _run: TurnRunState,
+        _c: DynamicContinuationRunState,
+    ) -> AsyncGenerator[str | AttemptResolved, None]:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            yield AttemptResolved(
+                CompletedAttempt(response_text="No team response generated.", is_empty=True, run_id="run-1"),
+            )
+            return
+        yield AttemptResolved(
+            CompletedAttempt(response_text="Recovered", replayable_text="Recovered", has_visible_content=True),
+        )
+
+    chunks = asyncio.run(
+        _collect(
+            stream_response_turn(
+                _ctx(),
+                _streaming_adapter(log, _attempt),
+                TurnSinks(),
+                continuation=_continuation(),
+            ),
+        ),
+    )
+
+    assert attempts == 2
+    assert chunks == ["notice:Recovered"]
+
+
+def test_streaming_continuation_does_not_emit_first_attempt_terminal_text() -> None:
+    """A dynamic-tool attempt's terminal text is superseded by the rerun's."""
+    log = _AdapterLog()
+    attempts = 0
+
+    async def _attempt(
+        _run: TurnRunState,
+        _c: DynamicContinuationRunState,
+    ) -> AsyncGenerator[str | AttemptResolved, None]:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            yield AttemptResolved(
+                CompletedAttempt(
+                    response_text="stale first-attempt text",
+                    attempt_run_id="run-1",
+                    tool_executions=(_dynamic_tool_execution(),),
+                ),
+            )
+            return
+        yield AttemptResolved(
+            CompletedAttempt(response_text="final", replayable_text="final", has_visible_content=True),
+        )
+
+    chunks = asyncio.run(
+        _collect(
+            stream_response_turn(
+                _ctx(),
+                _streaming_adapter(log, _attempt),
+                TurnSinks(),
+                continuation=_continuation(),
+            ),
+        ),
+    )
+
+    assert attempts == 2
+    assert chunks == ["notice:final"]
 
 
 def test_streaming_attempt_without_sentinel_raises() -> None:

--- a/tests/test_response_turn.py
+++ b/tests/test_response_turn.py
@@ -11,14 +11,13 @@ from typing import TYPE_CHECKING, Any, cast
 import pytest
 from agno.models.response import ToolExecution
 
+from mindroom.ai_runtime import EMPTY_RESPONSE_NOTICE
 from mindroom.response_turn import (
     AttemptResolved,
     BlockingTurnAdapter,
     CancelledAttempt,
     CompletedAttempt,
-    ContinuationCapability,
     DynamicContinuationRunState,
-    EmptyRunCapability,
     EmptyRunDiscard,
     ErroredAttempt,
     HandledAttempt,
@@ -39,8 +38,6 @@ if TYPE_CHECKING:
     from contextlib import AbstractContextManager
 
     from mindroom.history import ScopeSessionContext
-
-_DEFAULT_CONTINUATION = ContinuationCapability()
 
 
 @dataclass
@@ -174,8 +171,6 @@ def _blocking_adapter(
     log: _AdapterLog,
     run_attempt: Callable[[TurnRunState, DynamicContinuationRunState], Awaitable[Any]],
     *,
-    continuation: ContinuationCapability | None = _DEFAULT_CONTINUATION,
-    empty_run: EmptyRunCapability | None = None,
     with_standalone_replay: bool = True,
     unexpected_error_text: Callable[[Exception], str] | None = None,
 ) -> BlockingTurnAdapter:
@@ -188,10 +183,9 @@ def _blocking_adapter(
         snapshot_partial=lambda: log.snapshot,
         release_attempt_entity=lambda _scope: _bump(log, "released"),
         close_runtime_dbs=lambda _scope: _bump(log, "closed"),
+        discard_empty_run=lambda _scope, discard: log.discards.append(discard),
         finalize_attempt=lambda _scope: _bump(log, "finalized"),
         unexpected_error_text=unexpected_error_text,
-        continuation=continuation,
-        empty_run=empty_run,
         persist_standalone_replay=_persist if with_standalone_replay else None,
     )
 
@@ -203,8 +197,6 @@ def _streaming_adapter(
         AsyncGenerator[str | AttemptResolved, None],
     ],
     *,
-    continuation: ContinuationCapability | None = _DEFAULT_CONTINUATION,
-    empty_run: EmptyRunCapability | None = None,
     with_standalone_replay: bool = True,
     unexpected_error_text: Callable[[Exception], str] | None = None,
 ) -> StreamingTurnAdapter[str]:
@@ -217,24 +209,16 @@ def _streaming_adapter(
         snapshot_partial=lambda: log.snapshot,
         release_attempt_entity=lambda _scope: _bump(log, "released"),
         close_runtime_dbs=lambda _scope: _bump(log, "closed"),
-        finalize_attempt=lambda _scope: _bump(log, "finalized"),
+        discard_empty_run=lambda _scope, discard: log.discards.append(discard),
         make_notice_chunk=lambda text: f"notice:{text}",
+        finalize_attempt=lambda _scope: _bump(log, "finalized"),
         unexpected_error_text=unexpected_error_text,
-        continuation=continuation,
-        empty_run=empty_run,
         persist_standalone_replay=_persist if with_standalone_replay else None,
     )
 
 
 def _bump(log: _AdapterLog, attr: str) -> None:
     setattr(log, attr, getattr(log, attr) + 1)
-
-
-def _empty_run_capability(log: _AdapterLog) -> EmptyRunCapability:
-    return EmptyRunCapability(
-        notice_text="empty notice",
-        discard=lambda _scope, discard: log.discards.append(discard),
-    )
 
 
 async def _collect(stream: AsyncIterator[str]) -> list[str]:
@@ -517,42 +501,19 @@ def test_blocking_empty_run_grants_one_retry_then_notice() -> None:
     result = asyncio.run(
         run_blocking_response_turn(
             _ctx(),
-            _blocking_adapter(log, _attempt, empty_run=_empty_run_capability(log)),
+            _blocking_adapter(log, _attempt),
             TurnSinks(turn_recorder=cast("Any", recorder)),
             continuation=_continuation(),
         ),
     )
 
-    assert result == "empty notice"
+    assert result == EMPTY_RESPONSE_NOTICE
     assert attempts == 2
     assert [discard.run_id for discard in log.discards] == ["run-1", "run-2"]
     assert log.released == 1
     assert recorder.completed_calls == [
         {"run_metadata": None, "assistant_text": "", "completed_tools": []},
     ]
-
-
-def test_blocking_empty_run_without_continuation_still_retries_once() -> None:
-    """The empty-run guard has its own retry slot when continuations are disabled."""
-    log = _AdapterLog()
-    attempts = 0
-
-    async def _attempt(_run: TurnRunState, _c: DynamicContinuationRunState) -> CompletedAttempt:
-        nonlocal attempts
-        attempts += 1
-        return CompletedAttempt(is_empty=True)
-
-    result = asyncio.run(
-        run_blocking_response_turn(
-            _ctx(),
-            _blocking_adapter(log, _attempt, continuation=None, empty_run=_empty_run_capability(log)),
-            TurnSinks(),
-            continuation=_continuation(),
-        ),
-    )
-
-    assert result == "empty notice"
-    assert attempts == 2
 
 
 def test_blocking_empty_retry_borrows_continuation_slot_within_shared_budget() -> None:
@@ -573,7 +534,7 @@ def test_blocking_empty_retry_borrows_continuation_slot_within_shared_budget() -
     result = asyncio.run(
         run_blocking_response_turn(
             _ctx(),
-            _blocking_adapter(log, _attempt, empty_run=_empty_run_capability(log)),
+            _blocking_adapter(log, _attempt),
             TurnSinks(),
             continuation=_continuation(),
         ),
@@ -849,14 +810,14 @@ def test_streaming_empty_run_retries_then_yields_notice_and_records() -> None:
         _collect(
             stream_response_turn(
                 _ctx(),
-                _streaming_adapter(log, _attempt, empty_run=_empty_run_capability(log)),
+                _streaming_adapter(log, _attempt),
                 TurnSinks(turn_recorder=cast("Any", recorder)),
                 continuation=_continuation(),
             ),
         ),
     )
 
-    assert chunks == ["notice:empty notice"]
+    assert chunks == [f"notice:{EMPTY_RESPONSE_NOTICE}"]
     assert attempts == 2
     assert [discard.run_id for discard in log.discards] == ["run-1", "run-2"]
     # The notice-only turn still records an empty completion.
@@ -955,8 +916,8 @@ def test_streaming_finalize_runs_when_attempt_raises() -> None:
     assert log.closed == 1
 
 
-def test_streaming_unexpected_error_yields_shaped_text() -> None:
-    """Unexpected streaming exceptions become one shaped terminal chunk when configured."""
+def test_streaming_unexpected_error_yields_shaped_notice_chunk() -> None:
+    """Unexpected streaming exceptions become one shaped terminal notice chunk."""
     log = _AdapterLog()
 
     async def _attempt(
@@ -978,7 +939,7 @@ def test_streaming_unexpected_error_yields_shaped_text() -> None:
         ),
     )
 
-    assert chunks == ["chunk", "shaped: boom"]
+    assert chunks == ["chunk", "notice:shaped: boom"]
 
 
 def test_streaming_attempt_without_sentinel_raises() -> None:

--- a/tests/test_team_dynamic_continuation.py
+++ b/tests/test_team_dynamic_continuation.py
@@ -179,6 +179,8 @@ async def test_team_response_stream_continues_after_terminal_dynamic_tool_output
     assert "DYNAMIC TOOL CALL COMPLETED" in second_prompt
     rendered = "".join(chunk.content if hasattr(chunk, "content") else str(chunk) for chunk in chunks)
     assert "Used the loaded tool." in rendered
+    # The superseded first attempt's fallback document must not leak.
+    assert "No team response generated." not in rendered
     assert recorder.outcome == "completed"
     assert "Used the loaded tool." in recorder.assistant_text
 

--- a/tests/test_team_empty_response_and_replay.py
+++ b/tests/test_team_empty_response_and_replay.py
@@ -137,6 +137,8 @@ async def test_team_response_stream_yields_fallback_notice_when_retry_is_also_em
     assert mock_team.arun.call_count == 2
     rendered = "".join(chunk.content if hasattr(chunk, "content") else str(chunk) for chunk in chunks)
     assert ai_runtime.EMPTY_RESPONSE_NOTICE in rendered
+    # The discarded attempts' fallback documents must not leak ahead of the notice.
+    assert "No team response generated." not in rendered
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Post-campaign simplification (turn unification 8/8), **stacked on #1375**, addressing the overengineering/DRY findings from the holistic stack review.

- **The capability optionality was fiction** — every adapter passed `continuation=ContinuationCapability()` and the same empty-run capability with the same notice constant, so the `None` branches were dead configuration surface. `ContinuationCapability` and `EmptyRunCapability` are dissolved: the drivers always run the continuation budget (`DYNAMIC_TOOL_CONTINUATION_LIMIT`) and the empty-run guard, adapters carry a required `discard_empty_run` callable, the notice text lives in the driver, and `make_notice_chunk` is required on the streaming adapter (which also removes the `cast("ChunkT", ...)` type lie on the unexpected-error yield — behavior-identical, teams' notice chunk is the identity function).
- **One completed-attempt settle** — the empty-run settle + continuation decision + limit-message substitution skeleton existed twice (blocking and streaming copies, ~45 near-identical lines). It is now one `_settle_completed_attempt` returning a record/deliver plan; the drivers keep their deliberately different cancel orderings (preserved pre-seam semantics) and delivery encodings.
- **teams.py hoists** — `_ensure_attempt_team_members` (the duplicated release-rebuild block) and `_initial_team_continuation` (mirrors `_initial_agent_continuation`).

Net: **−105 lines**, `response_turn.py` shrinks by ~100.

## Behavior

Preserving except two trivia, disclosed: the limit-reached warning loses its "during streaming" suffix (one log message instead of two), and the shaped unexpected-error chunk goes through `make_notice_chunk` (team-only path; identity function, same yielded value).

## Considered and rejected

- Unifying the blocking/streaming CancelledAttempt orderings: the publish-before-record vs record-before-publish asymmetry is preserved pre-seam behavior with observable metadata-fallback differences; unifying is a behavior change with no user value.
- A shared agent/team discard-closure factory and a shared blocking metadata-builder wrapper: both sides already call the canonical builders; parametrizing SessionType + a session-fallback flag would add knobs, not remove complexity.
- Hoisting the team `ResponseTurnContext` construction: the "duplication" is 9 kwargs of pure forwarding; a helper would take the same 9 parameters.

## Verification

Full suite: 9066 passed, 61 skipped (4 errors are the docker-postgres cache fixtures failing to boot a container on this host — zero diff on those files across the stack, and they passed on the same host earlier in the day). Pre-commit clean, `tach check` clean.

## Bug fix (review round 3, found by external review)

The streaming team terminal-output branch yielded its formatted document **before** the shared driver settled the attempt, so an empty fallback leaked `No team response generated.` ahead of the retry/notice, and a dynamic-tool continuation leaked stale first-attempt text ahead of the rerun's. Severity context: the branch only fires on `yield_run_output`-shaped streams, which real Agno team streams never produce (the same production-dead path #1372 identified), so the live Matrix path was unaffected — but the ordering was wrong. The attempt now carries the document on `CompletedAttempt.response_text` and the driver emits the settle plan's `deliver_texts` only when the attempt is final; `make_notice_chunk` → `make_text_chunk`. Pinned at driver level (no leak before empty retry or continuation) and team level (fallback document absent from the rendered stream).

## Round 3 (delta review)

Both commits verdicted safe to merge by an independent delta review (capability dissolution confirmed behavior-preserving — all production adapters had both capabilities on; the unified settle reproduces both drivers' recording/substitution semantics, with the sole divergence unreachable by construction). One cosmetic miss fixed in e7ef52ecb: the streaming attempt kept the inline release-rebuild block (`requested_agent_names` spelling dodged the mechanical replacement); it now routes through `_ensure_attempt_team_members` like the blocking path.
