### PR TITLE
Publish blocking run metadata only for turn-ending attempts (turn-unification follow-up)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,8 @@ Matrix sync callback
        -> ingress_lanes.py                                       (per-(room, sender) receipt-order FIFO; STT readiness waits here)
        -> coalescing.py                                          (text dispatches immediately; media-tailed batches debounce)
        -> text_ingress_dispatch.py + turn_policy.py              (ignore / route / respond decision, command execution)
-       -> response_runner.py -> ai.py                            (lifecycle lock, Agno agent/team run)
+       -> response_runner.py -> ai.py / teams.py                 (lifecycle lock, entity envelopes)
+            -> response_turn.py                                  (shared blocking/streaming turn drivers)
        -> streaming.py + delivery_gateway.py                     (progressive edits, Matrix send)
        -> turn_store.py / handled_turns.py                       (durable dedup so restarts don't double-reply)
 ```
@@ -94,6 +95,8 @@ Matrix sync callback
 | `handled_turns.py` | Disk-backed handled-turn ledger preventing duplicate responses |
 | `sync_restart_retry.py` | One-shot re-dispatch of responses cancelled by sync-restart recovery |
 | `response_runner.py` | Response lifecycle execution (locking, streaming vs non-streaming, cancellation, detached inbox responses, shutdown drains) |
+| `response_turn.py` | Shared blocking/streaming response-turn drivers behind the agent and team envelopes (attempt loop, dynamic-tool continuation, empty-run retry, interrupt recording) |
+| `response_terminal.py` | Pending-visible classification and terminal stream outcomes for failed or cancelled turns |
 | `response_attempt.py` | Runs one visible response attempt with placeholder and stop tracking |
 | `response_lifecycle.py` | Shared response lifecycle helpers and queued-notice state |
 | `execution_preparation.py` | Request-scoped execution preparation for prompts and persisted replay |

--- a/src/mindroom/response_turn.py
+++ b/src/mindroom/response_turn.py
@@ -578,11 +578,11 @@ def _settle_blocking_attempt(
     continuation_count: int,
 ) -> str | DynamicContinuationRunState:
     """Settle one blocking attempt: return final text or the advanced continuation."""
-    # The blocking envelope publishes run metadata before dispatching on the
-    # attempt outcome, so cancelled and errored runs still reach the collector.
-    if sinks.run_metadata_collector is not None and resolution.metadata_content is not None:
-        sinks.run_metadata_collector.update(resolution.metadata_content)
+    # The blocking envelope publishes run metadata before recording, and only
+    # for attempts that end the turn: a discarded empty run's or a superseded
+    # continuation attempt's payload must not ride out on a later resolution.
     if isinstance(resolution, CancelledAttempt):
+        _publish_run_metadata(sinks, resolution.metadata_content)
         run.turn_state.record_interrupted(
             sinks.turn_recorder,
             run_metadata=run.run_metadata,
@@ -594,6 +594,7 @@ def _settle_blocking_attempt(
             _persist_attempt_cancelled_replay(ctx, adapter.persist_standalone_replay, run, resolution)
         raise build_cancelled_error(resolution.reason)
     if isinstance(resolution, ErroredAttempt):
+        _publish_run_metadata(sinks, resolution.metadata_content)
         return resolution.user_message_text
     settle = _settle_completed_attempt(
         ctx,
@@ -607,6 +608,7 @@ def _settle_blocking_attempt(
     )
     if settle.keep_going:
         return settle.continuation
+    _publish_run_metadata(sinks, resolution.metadata_content)
     run.turn_state.record_completed(
         sinks.turn_recorder,
         run_metadata=run.run_metadata,
@@ -616,17 +618,26 @@ def _settle_blocking_attempt(
     return settle.response_text
 
 
+def _publish_run_metadata(sinks: TurnSinks, metadata_content: dict[str, Any] | None) -> None:
+    """Publish one attempt's run metadata payload to the caller's collector."""
+    if sinks.run_metadata_collector is not None and metadata_content is not None:
+        sinks.run_metadata_collector.update(metadata_content)
+
+
 @dataclass(frozen=True)
 class _CompletionSettle:
     """Driver-internal plan for finishing one completed attempt."""
 
     keep_going: bool
     continuation: DynamicContinuationRunState
-    # The streaming driver emits these as chunks; the blocking driver returns
-    # response_text. Both cover the same notice/limit/final-text decisions.
-    deliver_texts: tuple[str, ...]
+    # What the recorder persists as the turn's replayable assistant text; it
+    # can differ from response_text (e.g. tool-rendered visible output).
     recorded_text: str
     recorded_tools: tuple[ToolTraceEntry, ...]
+    # The turn's deliverable final text (notice, limit message, or terminal
+    # document): the blocking driver returns it; the streaming driver emits it
+    # as a final chunk when non-empty (live-streamed attempts leave it empty
+    # because their chunks already delivered the document).
     response_text: str
 
 
@@ -655,7 +666,6 @@ def _settle_completed_attempt(
             return _CompletionSettle(
                 keep_going=True,
                 continuation=continuation,
-                deliver_texts=(),
                 recorded_text="",
                 recorded_tools=(),
                 response_text="",
@@ -665,7 +675,6 @@ def _settle_completed_attempt(
         return _CompletionSettle(
             keep_going=False,
             continuation=continuation,
-            deliver_texts=(ai_runtime.EMPTY_RESPONSE_NOTICE,),
             recorded_text="",
             recorded_tools=(),
             response_text=ai_runtime.EMPTY_RESPONSE_NOTICE,
@@ -686,12 +695,10 @@ def _settle_completed_attempt(
                 continuation,
                 next_prompt=decision.next_prompt,
             ),
-            deliver_texts=(),
             recorded_text="",
             recorded_tools=(),
             response_text="",
         )
-    deliver_texts: tuple[str, ...] = (resolution.response_text,) if resolution.response_text else ()
     recorded_text = resolution.replayable_text
     response_text = resolution.response_text
     if decision.limit_message is not None:
@@ -704,13 +711,11 @@ def _settle_completed_attempt(
                 status=decision.continuation.status,
             )
         if not resolution.has_visible_content:
-            deliver_texts = (decision.limit_message,)
             recorded_text = decision.limit_message
             response_text = decision.limit_message
     return _CompletionSettle(
         keep_going=False,
         continuation=continuation,
-        deliver_texts=deliver_texts,
         recorded_text=recorded_text,
         recorded_tools=resolution.completed_tools,
         response_text=response_text,
@@ -757,8 +762,7 @@ async def stream_response_turn[ChunkT](  # noqa: C901, PLR0912
                             completed_tools=list(resolution.completed_tools),
                             interrupted_tools=list(resolution.interrupted_tools),
                         )
-                        if sinks.run_metadata_collector is not None and resolution.metadata_content is not None:
-                            sinks.run_metadata_collector.update(resolution.metadata_content)
+                        _publish_run_metadata(sinks, resolution.metadata_content)
                         if sinks.turn_recorder is None and adapter.persist_standalone_replay is not None:
                             _persist_attempt_cancelled_replay(
                                 ctx,
@@ -779,11 +783,10 @@ async def stream_response_turn[ChunkT](  # noqa: C901, PLR0912
                     )
                     continuation = settle.continuation
                     keep_going = settle.keep_going
-                    for deliver_text in settle.deliver_texts:
-                        yield adapter.make_text_chunk(deliver_text)
+                    if settle.response_text:
+                        yield adapter.make_text_chunk(settle.response_text)
                     if not keep_going:
-                        if sinks.run_metadata_collector is not None and resolution.metadata_content is not None:
-                            sinks.run_metadata_collector.update(resolution.metadata_content)
+                        _publish_run_metadata(sinks, resolution.metadata_content)
                         run.turn_state.record_completed(
                             sinks.turn_recorder,
                             run_metadata=run.run_metadata,

--- a/tests/test_response_turn.py
+++ b/tests/test_response_turn.py
@@ -547,6 +547,80 @@ def test_blocking_empty_retry_borrows_continuation_slot_within_shared_budget() -
     assert [discard.run_id for discard in log.discards] == ["run-empty"]
 
 
+def test_blocking_discarded_empty_run_metadata_stays_out_of_collector() -> None:
+    """A discarded empty run's payload must not ride out on a later resolution.
+
+    The retry's resolution owns the collector; here it errors without
+    metadata, so the collector must stay empty rather than describe a run
+    that was purged from session history.
+    """
+    log = _AdapterLog()
+    collector: dict[str, Any] = {}
+    attempts = 0
+
+    async def _attempt(
+        _run: TurnRunState,
+        _c: DynamicContinuationRunState,
+    ) -> CompletedAttempt | ErroredAttempt:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return CompletedAttempt(
+                is_empty=True,
+                run_id="run-empty",
+                metadata_content={"io.mindroom.ai_run": {"run_id": "run-empty", "status": "completed"}},
+            )
+        return ErroredAttempt("friendly error")
+
+    result = asyncio.run(
+        run_blocking_response_turn(
+            _ctx(),
+            _blocking_adapter(log, _attempt),
+            TurnSinks(run_metadata_collector=collector),
+            continuation=_continuation(),
+        ),
+    )
+
+    assert attempts == 2
+    assert result == "friendly error"
+    assert collector == {}
+
+
+def test_blocking_superseded_continuation_metadata_stays_out_of_collector() -> None:
+    """Only the terminal attempt's metadata reaches the collector on continuation."""
+    log = _AdapterLog()
+    collector: dict[str, Any] = {}
+    attempts = 0
+
+    async def _attempt(_run: TurnRunState, _c: DynamicContinuationRunState) -> CompletedAttempt:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return CompletedAttempt(
+                attempt_run_id="run-1",
+                tool_executions=(_dynamic_tool_execution(),),
+                metadata_content={"io.mindroom.ai_run": {"run_id": "run-1"}},
+            )
+        return CompletedAttempt(
+            response_text="final",
+            replayable_text="final",
+            has_visible_content=True,
+            metadata_content={"io.mindroom.ai_run": {"run_id": "run-2"}},
+        )
+
+    result = asyncio.run(
+        run_blocking_response_turn(
+            _ctx(),
+            _blocking_adapter(log, _attempt),
+            TurnSinks(run_metadata_collector=collector),
+            continuation=_continuation(),
+        ),
+    )
+
+    assert result == "final"
+    assert collector == {"io.mindroom.ai_run": {"run_id": "run-2"}}
+
+
 def test_blocking_unexpected_error_reraises_without_shaper() -> None:
     """Unexpected exceptions propagate when no error shaper is configured."""
     log = _AdapterLog()


### PR DESCRIPTION
## What

Post-merge follow-up to the turn-unification campaign (#1368–#1376), from a fresh-eyes review of merged main.

- **Bug fix**: the blocking driver published every attempt's run metadata before dispatching, so a discarded empty run's payload (or a superseded continuation attempt's) could ride out on a later resolution that carried none — wire metadata referencing a run purged from session history, marked `completed` under an error message. Publishing now happens per terminal arm (cancelled, errored, settled), matching the streaming driver, via one shared `_publish_run_metadata`. Pinned by two driver tests (discarded-empty payload stays out; only the terminal continuation attempt's payload lands).
- **Simplification**: `_CompletionSettle.deliver_texts` was provably always derivable from `response_text` at all four construction sites — deleted; the streaming driver emits `response_text` when non-empty. `recorded_text` gained the semantics comment its sibling had.
- **Docs**: CLAUDE.md's inbound-pipeline sketch and key-modules table now cover `response_turn.py` and `response_terminal.py` (the campaign's centerpiece was undiscoverable from the docs).

## Verification

Driver suite green (32 tests incl. 2 new pins); full suite green; pre-commit clean.

## Summary by Sourcery

Ensure blocking and streaming response turn drivers only publish run metadata for terminal attempts and align their text delivery behavior, while documenting the response-turn modules and adding tests to pin the new semantics.

Bug Fixes:
- Prevent discarded empty runs and superseded continuation attempts from leaking stale run metadata into the blocking driver's run-metadata collector.

Enhancements:
- Factor run metadata emission into a shared helper used by both blocking and streaming response turn drivers.
- Simplify completion-settle handling by deriving deliverable text from response_text and clarifying recorded text semantics.

Documentation:
- Extend CLAUDE.md pipeline sketch and key-modules table to cover response_turn.py and response_terminal.py.

Tests:
- Add blocking-driver tests to pin that discarded empty runs and superseded continuation attempts do not populate the run-metadata collector.