### PR TITLE
Fix inaccurate "Request Context" in per-message AI run metadata

### DIFF
--- a/src/mindroom/ai_run_metadata.py
+++ b/src/mindroom/ai_run_metadata.py
@@ -256,29 +256,31 @@ def build_ai_run_metadata_content(  # noqa: C901, PLR0912
         value is not None
         for value in (
             context_raw_input_tokens,
-            context_input_tokens,
             context_cache_read_tokens,
             context_cache_write_tokens,
         )
     )
-    resolved_context_input_tokens = context_input_tokens
+    # Provider usage counters are authoritative for context occupancy; the
+    # pre-flight `context_input_tokens` estimate is only a fallback when the
+    # provider reported nothing (for example a request that failed early).
+    resolved_context_input_tokens = _context_input_tokens_from_counts(
+        input_tokens=context_raw_input_tokens if explicit_context_scope else usage_input_tokens,
+        cache_read_tokens=(
+            context_cache_read_tokens
+            if explicit_context_scope
+            else _int_usage_value(usage_payload, "cache_read_tokens")
+        ),
+        cache_write_tokens=(
+            context_cache_write_tokens
+            if explicit_context_scope
+            else _int_usage_value(usage_payload, "cache_write_tokens")
+        ),
+        provider=provider,
+        configured_provider=model_config.provider if model_config is not None else None,
+        model_id=model_id,
+    )
     if resolved_context_input_tokens is None:
-        resolved_context_input_tokens = _context_input_tokens_from_counts(
-            input_tokens=context_raw_input_tokens if explicit_context_scope else usage_input_tokens,
-            cache_read_tokens=(
-                context_cache_read_tokens
-                if explicit_context_scope
-                else _int_usage_value(usage_payload, "cache_read_tokens")
-            ),
-            cache_write_tokens=(
-                context_cache_write_tokens
-                if explicit_context_scope
-                else _int_usage_value(usage_payload, "cache_write_tokens")
-            ),
-            provider=provider,
-            configured_provider=model_config.provider if model_config is not None else None,
-            model_id=model_id,
-        )
+        resolved_context_input_tokens = context_input_tokens
     resolved_context_cache_read_tokens = context_cache_read_tokens
     if resolved_context_cache_read_tokens is None and not explicit_context_scope:
         resolved_context_cache_read_tokens = _int_usage_value(usage_payload, "cache_read_tokens")

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -47,7 +47,7 @@ from mindroom.ai import (
     build_matrix_run_metadata,
     stream_agent_response,
 )
-from mindroom.ai_run_metadata import _serialize_metrics
+from mindroom.ai_run_metadata import _serialize_metrics, build_ai_run_metadata_content
 from mindroom.bot import AgentBot
 from mindroom.cancellation import USER_STOP_CANCEL_MSG
 from mindroom.config.agent import AgentConfig, AgentPrivateConfig, TeamConfig
@@ -275,6 +275,105 @@ def test_serialize_metrics_preserves_zero_usage_fields_from_metrics() -> None:
         "input_tokens": 6,
         "cache_read_tokens": 46449,
     }
+
+
+def _metadata_config(provider: str, model_id: str) -> Config:
+    return Config(
+        agents={"general": AgentConfig(display_name="General")},
+        models={"default": ModelConfig(provider=provider, id=model_id, context_window=200_000)},
+    )
+
+
+def test_ai_run_metadata_prefers_provider_counters_over_estimate_for_cache_token_providers() -> None:
+    """Cache-token providers report context as raw input plus cache read/write, not the estimate."""
+    metadata = build_ai_run_metadata_content(
+        config=_metadata_config("vertexai_claude", "claude-sonnet-4-6"),
+        model_name="default",
+        run_id="run-1",
+        session_id="session-1",
+        status="completed",
+        model="claude-sonnet-4-6",
+        model_provider="google",
+        context_input_tokens=30_210,
+        context_raw_input_tokens=1_200,
+        context_cache_read_tokens=45_000,
+        context_cache_write_tokens=5_000,
+    )
+
+    context = metadata[AI_RUN_METADATA_KEY]["context"]
+    assert context["input_tokens"] == 51_200
+    assert context["cache_read_input_tokens"] == 45_000
+    assert context["cache_write_input_tokens"] == 5_000
+    assert context["uncached_input_tokens"] == 6_200
+    assert context["window_tokens"] == 200_000
+
+
+def test_ai_run_metadata_context_uses_raw_input_for_non_cache_token_providers() -> None:
+    """Providers whose input counter already includes cached tokens report raw input as the context."""
+    metadata = build_ai_run_metadata_content(
+        config=_metadata_config("openai", "test-model"),
+        model_name="default",
+        run_id="run-1",
+        session_id="session-1",
+        status="completed",
+        model="test-model",
+        model_provider="openai",
+        context_input_tokens=30_210,
+        context_raw_input_tokens=700,
+        context_cache_read_tokens=512,
+    )
+
+    context = metadata[AI_RUN_METADATA_KEY]["context"]
+    assert context["input_tokens"] == 700
+    assert context["cache_read_input_tokens"] == 512
+    assert context["uncached_input_tokens"] == 188
+    assert "cache_write_input_tokens" not in context
+
+
+def test_ai_run_metadata_context_falls_back_to_estimate_without_provider_counters() -> None:
+    """Without any provider usage counters, the pre-flight estimate still populates the context block."""
+    metadata = build_ai_run_metadata_content(
+        config=_metadata_config("anthropic", "claude-sonnet-4-6"),
+        model_name="default",
+        run_id="run-1",
+        session_id="session-1",
+        status="completed",
+        model="claude-sonnet-4-6",
+        model_provider="Anthropic",
+        context_input_tokens=30_210,
+    )
+
+    context = metadata[AI_RUN_METADATA_KEY]["context"]
+    assert context["input_tokens"] == 30_210
+    assert context["window_tokens"] == 200_000
+    assert "cache_read_input_tokens" not in context
+    assert "cache_write_input_tokens" not in context
+    assert "uncached_input_tokens" not in context
+
+
+def test_ai_run_metadata_context_regression_cached_prefix_sample() -> None:
+    """Regression: a 49,886-token cached prefix must not be reported as a 30,210-token context."""
+    metadata = build_ai_run_metadata_content(
+        config=_metadata_config("vertexai_claude", "claude-sonnet-4-6"),
+        model_name="default",
+        run_id="run-1",
+        session_id="session-1",
+        status="completed",
+        model="claude-sonnet-4-6",
+        model_provider="google",
+        metrics={"input_tokens": 3_277, "cache_read_tokens": 99_772, "cache_write_tokens": 49_886},
+        context_input_tokens=30_210,
+        context_raw_input_tokens=1_777,
+        context_cache_read_tokens=49_886,
+        context_cache_write_tokens=0,
+    )
+
+    context = metadata[AI_RUN_METADATA_KEY]["context"]
+    assert context["input_tokens"] == 51_663
+    assert context["cache_read_input_tokens"] == 49_886
+    assert context["uncached_input_tokens"] == 1_777
+    assert "cache_write_input_tokens" not in context
+    assert context["window_tokens"] == 200_000
 
 
 class _SessionStorage:
@@ -6993,9 +7092,13 @@ class TestUserIdPassthrough:
         assert payload["usage"]["cache_read_tokens"] == 640
         assert payload["usage"]["cache_write_tokens"] == 32
         assert payload["usage"]["reasoning_tokens"] == 24
-        assert payload["context"]["input_tokens"] == 1500
+        assert payload["context"]["input_tokens"] == 800
+        assert payload["context"]["cache_read_input_tokens"] == 640
+        assert payload["context"]["uncached_input_tokens"] == 160
+        assert payload["context"]["cache_write_input_tokens"] == 32
         assert payload["context"]["window_tokens"] == 2000
         assert "utilization_pct" not in payload["context"]
+        assert payload["prepared_context"] == {"tokens": 1500}
         assert payload["tools"]["count"] == 0
 
     @pytest.mark.asyncio
@@ -7846,11 +7949,11 @@ class TestUserIdPassthrough:
         assert payload["usage"]["total_tokens"] == 15
 
     @pytest.mark.asyncio
-    async def test_stream_agent_response_uses_prepared_context_estimate_for_context(
+    async def test_stream_agent_response_prefers_latest_request_counters_over_estimate(
         self,
         tmp_path: Path,
     ) -> None:
-        """Streaming context metadata should use the prepared full-context estimate when available."""
+        """Streaming context metadata should prefer real request counters over the prepared estimate."""
         mock_agent = MagicMock()
         mock_agent.model = MagicMock()
         mock_agent.model.__class__.__name__ = "OpenAIChat"
@@ -7907,11 +8010,12 @@ class TestUserIdPassthrough:
         assert payload["usage"]["total_tokens"] == 890
         assert payload["usage"]["cache_read_tokens"] == 576
         assert payload["usage"]["reasoning_tokens"] == 48
-        assert payload["context"]["input_tokens"] == 900
+        assert payload["context"]["input_tokens"] == 120
         assert payload["context"]["cache_read_input_tokens"] == 64
-        assert payload["context"]["uncached_input_tokens"] == 836
+        assert payload["context"]["uncached_input_tokens"] == 56
         assert "cached_input_tokens" not in payload["context"]
         assert payload["context"]["window_tokens"] == 1000
+        assert payload["prepared_context"] == {"tokens": 900}
 
     @pytest.mark.asyncio
     async def test_stream_agent_response_does_not_backfill_latest_context_cache_from_usage(
@@ -8038,7 +8142,8 @@ class TestUserIdPassthrough:
         assert payload["usage"]["input_tokens"] == 820
         assert payload["usage"]["output_tokens"] == 70
         assert payload["usage"]["total_tokens"] == 890
-        assert payload["context"]["input_tokens"] == 900
+        assert payload["context"]["input_tokens"] == 120
+        assert payload["prepared_context"] == {"tokens": 900}
 
     @pytest.mark.asyncio
     async def test_stream_agent_response_context_counts_latest_anthropic_cache_tokens(self, tmp_path: Path) -> None:

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -341,6 +341,7 @@ def test_ai_run_metadata_context_falls_back_to_estimate_without_provider_counter
         model="claude-sonnet-4-6",
         model_provider="Anthropic",
         context_input_tokens=30_210,
+        prepared_history=PreparedHistoryState(prepared_context_tokens=30_210),
     )
 
     context = metadata[AI_RUN_METADATA_KEY]["context"]
@@ -349,6 +350,7 @@ def test_ai_run_metadata_context_falls_back_to_estimate_without_provider_counter
     assert "cache_read_input_tokens" not in context
     assert "cache_write_input_tokens" not in context
     assert "uncached_input_tokens" not in context
+    assert metadata[AI_RUN_METADATA_KEY]["prepared_context"] == {"tokens": 30_210}
 
 
 def test_ai_run_metadata_context_regression_cached_prefix_sample() -> None:


### PR DESCRIPTION
## Bug

Every Matrix reply carries `io.mindroom.ai_run` metadata whose `context` block is rendered in the UI as **"Request Context"** and **"Request Cache"**. For cache-token providers (Anthropic / Bedrock / Vertex Claude) it significantly understated real context-window occupancy:

1. Both `ai.py` call sites (non-stream and stream finalize) pass `context_input_tokens=prepared_history.prepared_context_tokens` — a pre-flight `chars // 4` estimate.
2. `build_ai_run_metadata_content` used that estimate **verbatim** whenever present. The accurate path — `_context_input_tokens_from_counts`, which computes `raw_input + cache_read + cache_write` from real provider counters — was only reached as a fallback when the estimate was missing.
3. Downstream, `_build_context_payload` clamps `cache_read_input_tokens = min(actual_cache_read, context_input_tokens)` and drops `cache_write_input_tokens` when it exceeds the (artificially small) uncached remainder. With the understated estimate this fabricated "cache read == context, not read 0" and hid the cache-write count entirely.

Real-world sample: metadata showed `context.input_tokens = 30,210 / 200,000 (15.1%)` while the same payload's usage counters showed `cache_write = 49,886` and `cache_read = 99,772` (three requests sharing one 49,886-token cached prefix). True last-request context was ≈51.7K tokens (~26%) — understated by ~40%.

## Fix

In `build_ai_run_metadata_content`, the counters-derived context value is now authoritative: it is computed first (from the explicit latest-request counters when the streaming path passes them, otherwise from the usage payload), and the `context_input_tokens` estimate is used strictly as a fallback when the provider reported nothing (e.g. a request that failed before completion).

- The explicit-context-scope guard now keys off the three raw counter arguments only, so the estimate no longer suppresses the usage-payload path on the non-streaming path either.
- The `prepared_context` payload is unchanged and still preserves the pre-flight estimate separately.
- The defensive bounds in `_build_context_payload` are kept as-is; with an accurate `context.input_tokens` the `min()` clamp no longer binds and `cache_write_input_tokens` is no longer silently dropped in the common case.
- No changes to the streaming pipeline or the estimate computation.

## Tests

New direct unit tests for `build_ai_run_metadata_content`:
- vertexai_claude with counters **and** estimate present: `context.input_tokens == raw_input + cache_read + cache_write`, cache read unclamped, cache write present.
- openai-style provider (input already includes cache): `context.input_tokens == raw_input`.
- No provider counters at all: falls back to the estimate (previous behavior preserved).
- Regression test with the reported sample shape: estimate 30,210, final request raw input 1,777 + cache_read 49,886 → reported context 51,663 (~26%), not 30,210.

Updated the existing streaming/non-streaming integration tests to the new preference (they now also assert `prepared_context` still carries the estimate). Full suite: 9081 passed, 61 skipped.

## Summary by Sourcery

Correct AI run context metadata to derive context window occupancy from provider usage counters and only fall back to pre-flight estimates when counters are unavailable.

Bug Fixes:
- Fix inaccurate context and cache token reporting for cache-token providers by preferring raw input plus cache read/write counters over estimates.
- Ensure non-cache-token providers report context based on raw input counters instead of combined cached estimates.
- Preserve behavior for runs without provider counters by using the existing context token estimate as a fallback.

Enhancements:
- Keep pre-flight prepared context estimates alongside the new accurate context values for debugging and observability.
- Maintain defensive bounds in context payload construction so cache read/write and uncached portions are reported consistently with the resolved context.

Tests:
- Add unit tests covering provider-counter precedence, non-cache-token providers, fallback behavior without counters, and a regression scenario with large cached prefixes.
- Update streaming and non-streaming integration tests to assert the new context calculation behavior and preservation of prepared context estimates.