### PR TITLE
Propagate ResponseTurnContext through the team envelope and prepare chain (turn-context sweep 2/4)

### DIFF
--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -1118,10 +1118,6 @@ async def _prepare_agent_and_prompt(
     )
     _mark_pipeline_timing(pipeline_timing, "memory_prepare_ready")
 
-    resolved_session_id = ctx.session_id
-    if resolved_session_id is None and scope_context is not None and scope_context.session is not None:
-        resolved_session_id = scope_context.session.session_id
-
     _mark_pipeline_timing(pipeline_timing, "agent_build_start")
 
     def _resolve_model_and_build_agent() -> tuple[ResolvedRuntimeModel, Agent]:
@@ -1140,7 +1136,7 @@ async def _prepare_agent_and_prompt(
             agent_name,
             config,
             runtime_paths,
-            session_id=resolved_session_id,
+            session_id=ctx.session_id,
             history_storage=scope_context.storage if scope_context is not None else None,
             active_model_name=runtime_model.model_name,
             knowledge=knowledge,

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -116,7 +116,6 @@ __all__ = [
     "ResponseTurnContext",
     "ai_response",
     "build_matrix_run_metadata",
-    "resolve_run_correlation_id",
     "stream_agent_response",
 ]
 AIStreamChunk = str | RunContentEvent | RunCompletedEvent | ToolCallStartedEvent | ToolCallCompletedEvent
@@ -701,23 +700,6 @@ def _extract_interrupted_partial_text(
     if _is_run_cancelled_boilerplate(stripped):
         return ""
     return stripped
-
-
-def resolve_run_correlation_id(
-    correlation_id: str | None,
-    *,
-    reply_to_event_id: str | None,
-    matrix_run_metadata: dict[str, Any] | None,
-) -> str:
-    """Return the authoritative correlation ID for one persisted model run."""
-    if correlation_id:
-        return correlation_id
-    metadata_correlation_id = matrix_run_metadata.get("correlation_id") if matrix_run_metadata is not None else None
-    if isinstance(metadata_correlation_id, str) and metadata_correlation_id:
-        return metadata_correlation_id
-    if reply_to_event_id:
-        return reply_to_event_id
-    return uuid4().hex
 
 
 def _request_stream_retry(

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -90,7 +90,7 @@ from mindroom.timing import DispatchPipelineTiming, emit_timing_event, timed, ti
 from mindroom.tool_system.events import StreamingToolTracker, complete_pending_tool_block, format_tool_combined
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, AsyncIterator, Callable, Collection, Sequence
+    from collections.abc import AsyncGenerator, AsyncIterator, Callable, Sequence
     from contextlib import AbstractContextManager
 
     from agno.agent import Agent
@@ -113,6 +113,7 @@ logger = get_logger(__name__)
 
 __all__ = [
     "AIStreamChunk",
+    "ResponseTurnContext",
     "ai_response",
     "build_matrix_run_metadata",
     "resolve_run_correlation_id",
@@ -277,13 +278,6 @@ class _MediaAttempt:
         )
         self.attempt_media_inputs = retry_media_inputs
         self.attempt_run_id = ai_runtime.next_retry_run_id(run_id)
-
-
-def _prompt_current_sender_id(user_id: str | None, *, include_openai_compat_guidance: bool) -> str | None:
-    """Return the Matrix current sender ID when prompt formatting should include it."""
-    if include_openai_compat_guidance:
-        return None
-    return user_id
 
 
 def _build_timing_scope(
@@ -463,19 +457,19 @@ def _streaming_partial_snapshot(holder: _AgentTurnHolder) -> TurnPartialSnapshot
 class _AgentRunContext:
     """Prepared state shared by one top-level agent response lifecycle."""
 
-    agent_name: str
-    prompt: str
+    turn: ResponseTurnContext
     session_id: str
+    prompt: str
     model_prompt: str | None
-    room_id: str | None
-    thread_id: str | None
-    reply_to_event_id: str | None
-    requester_id: str | None
-    correlation_id: str
     prepared_run: _PreparedAgentRun
     run_input: list[Message]
     metadata: dict[str, Any] | None
     inline_media_fallback_prompt: str
+
+    @property
+    def agent_name(self) -> str:
+        """Return the agent name; agent turns label the context with it."""
+        return self.turn.entity_label
 
 
 @dataclass(frozen=True)
@@ -897,14 +891,9 @@ def _select_streaming_usage_metrics(
 
 
 def _attempt_request_log_context(
+    ctx: ResponseTurnContext,
     *,
-    agent_id: str,
     session_id: str,
-    room_id: str | None,
-    thread_id: str | None,
-    reply_to_event_id: str | None,
-    requester_id: str | None,
-    correlation_id: str,
     prompt: str,
     model_prompt: str | None,
     attempt_prompt: ai_runtime.ModelRunInput,
@@ -912,13 +901,13 @@ def _attempt_request_log_context(
 ) -> dict[str, object]:
     """Build request-log context for the exact prompt used by one provider attempt."""
     return build_llm_request_log_context(
-        agent_id=agent_id,
+        agent_id=ctx.entity_label,
         session_id=session_id,
-        room_id=room_id,
-        thread_id=thread_id,
-        reply_to_event_id=reply_to_event_id,
-        requester_id=requester_id,
-        correlation_id=correlation_id,
+        room_id=ctx.room_id,
+        thread_id=ctx.thread_id,
+        reply_to_event_id=ctx.reply_to_event_id,
+        requester_id=ctx.requester_id,
+        correlation_id=ctx.correlation_id,
         prompt=prompt,
         model_prompt=model_prompt,
         full_prompt=render_prepared_messages_text(ai_runtime.copy_run_input(attempt_prompt)),
@@ -955,7 +944,6 @@ async def _run_non_streaming_agent_attempts(
     *,
     run_context: _AgentRunContext,
     attempt: _MediaAttempt,
-    user_id: str | None,
     run_id: str | None,
     run_id_callback: Callable[[str], None] | None,
     scope_context: ScopeSessionContext | None,
@@ -972,13 +960,8 @@ async def _run_non_streaming_agent_attempts(
                     pipeline_timing.mark("model_request_sent", overwrite=True)
                 with bind_llm_request_log_context(
                     **_attempt_request_log_context(
-                        agent_id=run_context.agent_name,
+                        run_context.turn,
                         session_id=run_context.session_id,
-                        room_id=run_context.room_id,
-                        thread_id=run_context.thread_id,
-                        reply_to_event_id=run_context.reply_to_event_id,
-                        requester_id=run_context.requester_id,
-                        correlation_id=run_context.correlation_id,
                         prompt=run_context.prompt,
                         model_prompt=run_context.model_prompt,
                         attempt_prompt=attempt.attempt_prompt,
@@ -989,7 +972,7 @@ async def _run_non_streaming_agent_attempts(
                         agent,
                         attempt.attempt_prompt,
                         run_context.session_id,
-                        user_id=user_id,
+                        user_id=run_context.turn.requester_id,
                         run_id=attempt.attempt_run_id,
                         run_id_callback=run_id_callback,
                         media=attempt.attempt_media_inputs,
@@ -1076,20 +1059,12 @@ def _assert_agent_target(agent_name: str, config: Config) -> None:
         raise ValueError(msg)
 
 
-def _current_sender_id_kwargs(
-    user_id: str | None,
-    *,
-    include_openai_compat_guidance: bool,
-) -> dict[str, str | None]:
-    """Return prompt-preparation kwargs without Matrix sender metadata for OpenAI-compatible calls."""
-    if include_openai_compat_guidance:
-        return {"current_sender_id": None}
-    return {
-        "current_sender_id": _prompt_current_sender_id(
-            user_id,
-            include_openai_compat_guidance=include_openai_compat_guidance,
-        ),
-    }
+def _require_turn_session_id(ctx: ResponseTurnContext) -> str:
+    """Return the turn's session id; agent response turns always run with one."""
+    if not ctx.session_id:
+        msg = "agent response turns require ResponseTurnContext.session_id"
+        raise ValueError(msg)
+    return ctx.session_id
 
 
 def _mark_pipeline_timing(pipeline_timing: DispatchPipelineTiming | None, label: str) -> None:
@@ -1100,36 +1075,31 @@ def _mark_pipeline_timing(pipeline_timing: DispatchPipelineTiming | None, label:
 
 @timed("system_prompt_assembly")
 async def _prepare_agent_and_prompt(
-    agent_name: str,
+    ctx: ResponseTurnContext,
+    *,
     prompt: str,
     runtime_paths: RuntimePaths,
     config: Config,
-    session_id: str | None = None,
     scope_context: ScopeSessionContext | None = None,
     thread_history: Sequence[ResolvedVisibleMessage] | None = None,
-    room_id: str | None = None,
-    thread_id: str | None = None,
     knowledge: Knowledge | None = None,
     include_interactive_questions: bool = True,
-    reply_to_event_id: str | None = None,
-    active_event_ids: Collection[str] = frozenset(),
     execution_identity: ToolExecutionIdentity | None = None,
     compaction_outcomes_collector: list[CompactionOutcome] | None = None,
     compaction_lifecycle: CompactionLifecycle | None = None,
     delegation_depth: int = 0,
     refresh_scheduler: KnowledgeRefreshScheduler | None = None,
-    system_enrichment_items: Sequence[EnrichmentItem] = (),
     include_openai_compat_guidance: bool = False,
     model_prompt: str | None = None,
     current_timestamp_ms: float | None = None,
     current_prompt_is_structured: bool = False,
-    current_sender_id: str | None = None,
     pipeline_timing: DispatchPipelineTiming | None = None,
 ) -> _PreparedAgentRun:
     """Prepare agent and full prompt for AI processing.
 
     Returns the prepared run input plus history bookkeeping for one agent turn.
     """
+    agent_name = ctx.entity_label
     _assert_agent_target(agent_name, config)
     storage_path = runtime_paths.storage_root
     _mark_pipeline_timing(pipeline_timing, "memory_prepare_start")
@@ -1148,7 +1118,7 @@ async def _prepare_agent_and_prompt(
     )
     _mark_pipeline_timing(pipeline_timing, "memory_prepare_ready")
 
-    resolved_session_id = session_id
+    resolved_session_id = ctx.session_id
     if resolved_session_id is None and scope_context is not None and scope_context.session is not None:
         resolved_session_id = scope_context.session.session_id
 
@@ -1162,8 +1132,8 @@ async def _prepare_agent_and_prompt(
         """
         runtime_model = config.resolve_runtime_model(
             entity_name=agent_name,
-            room_id=room_id,
-            thread_id=thread_id,
+            room_id=ctx.room_id,
+            thread_id=ctx.thread_id,
             runtime_paths=runtime_paths,
         )
         agent = create_agent(
@@ -1185,10 +1155,10 @@ async def _prepare_agent_and_prompt(
 
     runtime_model, agent = await asyncio.to_thread(_resolve_model_and_build_agent)
     _append_additional_context(agent, prompt_parts.session_preamble)
-    if system_enrichment_items:
+    if ctx.system_enrichment_items:
         _append_additional_context(
             agent,
-            _render_system_enrichment_context(system_enrichment_items),
+            _render_system_enrichment_context(ctx.system_enrichment_items),
         )
     _mark_pipeline_timing(pipeline_timing, "agent_build_ready")
 
@@ -1200,13 +1170,13 @@ async def _prepare_agent_and_prompt(
         thread_history=thread_history,
         runtime_paths=runtime_paths,
         config=config,
-        room_id=room_id,
-        thread_id=thread_id,
-        reply_to_event_id=reply_to_event_id,
-        active_event_ids=active_event_ids,
+        room_id=ctx.room_id,
+        thread_id=ctx.thread_id,
+        reply_to_event_id=ctx.reply_to_event_id,
+        active_event_ids=ctx.active_event_ids,
         compaction_outcomes_collector=compaction_outcomes_collector,
         compaction_lifecycle=compaction_lifecycle,
-        current_sender_id=current_sender_id,
+        current_sender_id=None if include_openai_compat_guidance else ctx.requester_id,
         current_timestamp_ms=current_timestamp_ms,
         current_prompt_is_structured=current_prompt_is_structured,
         include_openai_compat_guidance=include_openai_compat_guidance,
@@ -1240,34 +1210,25 @@ async def _prepare_agent_and_prompt(
 
 
 async def _prepare_agent_run_context(
+    ctx: ResponseTurnContext,
     *,
-    agent_name: str,
     prompt: str,
     session_id: str,
     runtime_paths: RuntimePaths,
     config: Config,
     scope_context: ScopeSessionContext | None,
     thread_history: Sequence[ResolvedVisibleMessage] | None,
-    room_id: str | None,
-    thread_id: str | None,
     knowledge: Knowledge | None,
     include_interactive_questions: bool,
     include_openai_compat_guidance: bool,
-    reply_to_event_id: str | None,
-    active_event_ids: Collection[str],
     execution_identity: ToolExecutionIdentity | None,
     compaction_outcomes_collector: list[CompactionOutcome] | None,
     compaction_lifecycle: CompactionLifecycle | None,
     delegation_depth: int,
     refresh_scheduler: KnowledgeRefreshScheduler | None,
-    system_enrichment_items: Sequence[EnrichmentItem],
     model_prompt: str | None,
     current_timestamp_ms: float | None,
     current_prompt_is_structured: bool,
-    user_id: str | None,
-    requester_id: str | None,
-    correlation_id: str,
-    matrix_run_metadata: dict[str, Any] | None,
     turn_recorder: TurnRecorder | None,
     pipeline_timing: DispatchPipelineTiming | None,
 ) -> _AgentRunContext:
@@ -1275,33 +1236,23 @@ async def _prepare_agent_run_context(
     if pipeline_timing is not None:
         pipeline_timing.mark("ai_prepare_start", overwrite=True)
     prepared_run = await _prepare_agent_and_prompt(
-        agent_name,
-        prompt,
-        runtime_paths,
-        config,
-        session_id,
-        scope_context,
-        thread_history,
-        room_id,
-        thread_id,
-        knowledge,
+        ctx,
+        prompt=prompt,
+        runtime_paths=runtime_paths,
+        config=config,
+        scope_context=scope_context,
+        thread_history=thread_history,
+        knowledge=knowledge,
         include_interactive_questions=include_interactive_questions,
-        reply_to_event_id=reply_to_event_id,
-        active_event_ids=active_event_ids,
         execution_identity=execution_identity,
         compaction_outcomes_collector=compaction_outcomes_collector,
         compaction_lifecycle=compaction_lifecycle,
         delegation_depth=delegation_depth,
         refresh_scheduler=refresh_scheduler,
-        system_enrichment_items=system_enrichment_items,
         include_openai_compat_guidance=include_openai_compat_guidance,
         model_prompt=model_prompt,
         current_timestamp_ms=current_timestamp_ms,
         current_prompt_is_structured=current_prompt_is_structured,
-        **_current_sender_id_kwargs(
-            user_id,
-            include_openai_compat_guidance=include_openai_compat_guidance,
-        ),
         pipeline_timing=pipeline_timing,
     )
     if pipeline_timing is not None:
@@ -1317,29 +1268,24 @@ async def _prepare_agent_run_context(
 
     run_extra_content = build_prepared_history_metadata_content(prepared_run.prepared_history)
     metadata = build_matrix_run_metadata(
-        reply_to_event_id,
+        ctx.reply_to_event_id,
         prepared_run.unseen_event_ids,
-        room_id=room_id,
-        thread_id=thread_id,
-        requester_id=requester_id,
-        correlation_id=correlation_id,
+        room_id=ctx.room_id,
+        thread_id=ctx.thread_id,
+        requester_id=ctx.requester_id,
+        correlation_id=ctx.correlation_id,
         tools_schema=agent_tool_definition_payloads_for_logging(agent) if agent.model is not None else [],
         model_params=model_params_payload(agent.model) if agent.model is not None else {},
-        extra_metadata=deep_merge_metadata(matrix_run_metadata, run_extra_content),
+        extra_metadata=deep_merge_metadata(ctx.matrix_run_metadata, run_extra_content),
     )
     if turn_recorder is not None:
         turn_recorder.set_run_metadata(metadata)
 
     return _AgentRunContext(
-        agent_name=agent_name,
-        prompt=prompt,
+        turn=ctx,
         session_id=session_id,
+        prompt=prompt,
         model_prompt=model_prompt,
-        room_id=room_id,
-        thread_id=thread_id,
-        reply_to_event_id=reply_to_event_id,
-        requester_id=requester_id,
-        correlation_id=correlation_id,
         prepared_run=prepared_run,
         run_input=prepared_run.run_input,
         metadata=metadata,
@@ -1348,27 +1294,19 @@ async def _prepare_agent_run_context(
 
 
 async def ai_response(
-    agent_name: str,
+    ctx: ResponseTurnContext,
     prompt: str,
-    session_id: str,
     runtime_paths: RuntimePaths,
     config: Config,
     thread_history: Sequence[ResolvedVisibleMessage] | None = None,
     model_prompt: str | None = None,
     current_timestamp_ms: float | None = None,
     current_prompt_is_structured: bool = False,
-    thread_id: str | None = None,
-    room_id: str | None = None,
     knowledge: Knowledge | None = None,
-    user_id: str | None = None,
-    run_id: str | None = None,
     run_id_callback: Callable[[str], None] | None = None,
     include_interactive_questions: bool = True,
     include_openai_compat_guidance: bool = False,
     media: MediaInputs | None = None,
-    reply_to_event_id: str | None = None,
-    correlation_id: str | None = None,
-    active_event_ids: Collection[str] = frozenset(),
     show_tool_calls: bool = True,
     collect_streamed_response: bool = False,
     tool_trace_collector: list[ToolTraceEntry] | None = None,
@@ -1378,28 +1316,23 @@ async def ai_response(
     compaction_lifecycle: CompactionLifecycle | None = None,
     delegation_depth: int = 0,
     refresh_scheduler: KnowledgeRefreshScheduler | None = None,
-    matrix_run_metadata: dict[str, Any] | None = None,
-    system_enrichment_items: Sequence[EnrichmentItem] = (),
     turn_recorder: TurnRecorder | None = None,
     pipeline_timing: DispatchPipelineTiming | None = None,
 ) -> str:
     """Generates a response using the specified agno Agent with memory integration.
 
     Args:
-        agent_name: Name of the agent to use
+        ctx: Per-turn identity constants for this response turn. ``entity_label``
+            names the agent, ``session_id`` is required, and ``requester_id`` is
+            the Matrix sender used for Agno learning and prompt attribution.
         prompt: User prompt
-        session_id: Session ID for conversation tracking
         runtime_paths: Runtime config/storage paths for agent data and config-aware tools
         config: Application configuration
         thread_history: Optional thread history
         model_prompt: Optional model-facing current-turn prompt additions.
         current_timestamp_ms: Optional source Matrix event timestamp in milliseconds.
         current_prompt_is_structured: Whether the current prompt already carries trusted message tags.
-        thread_id: Optional resolved Matrix thread ID for request-log correlation and run metadata.
-        room_id: Optional Matrix room ID for caller context
         knowledge: Optional shared knowledge base for RAG-enabled agents
-        user_id: Matrix user ID of the sender, used by Agno's LearningMachine
-        run_id: Explicit Agno run identifier used for graceful stop/cancel handling.
         run_id_callback: Optional callback that receives the active Agno run_id
             before each real run attempt starts.
         include_interactive_questions: Whether to include the interactive
@@ -1408,11 +1341,6 @@ async def ai_response(
         include_openai_compat_guidance: Whether to omit Matrix-style sender
             attribution for OpenAI-compatible prompt formatting.
         media: Optional multimodal inputs (audio/images/files/videos)
-        reply_to_event_id: Matrix event ID of the triggering message, stored
-            in run metadata for unseen message tracking and edit cleanup.
-        correlation_id: Stable cross-sink trace ID for this response lifecycle.
-        active_event_ids: Live self-authored Matrix event IDs still tracked as
-            actively streaming for this bot in the current room.
         show_tool_calls: Whether to include tool call details inline in the response text.
         collect_streamed_response: Whether to use stream-shaped execution internally
             and collect chunks into one final response body.
@@ -1430,10 +1358,6 @@ async def ai_response(
         delegation_depth: Current nested delegation depth for delegated-agent runs.
         refresh_scheduler: Optional runtime-owned shared knowledge refresh scheduler
             passed through to delegated child agents.
-        matrix_run_metadata: Optional Matrix-specific run metadata persisted with the run
-            for unseen-message tracking, coalesced edit regeneration, and cleanup.
-        system_enrichment_items: Optional system-prompt enrichment items for this run.
-        model_prompt: Optional model-facing current-turn prompt additions.
         turn_recorder: Optional lifecycle-owned recorder updated with trusted turn state.
         pipeline_timing: Optional dispatch timing collector updated with AI-stage milestones.
 
@@ -1441,31 +1365,24 @@ async def ai_response(
         Agent response string
 
     """
-    logger.info("AI request", agent=agent_name, room_id=room_id)
+    agent_name = ctx.entity_label
+    logger.info("AI request", agent=agent_name, room_id=ctx.room_id)
     if collect_streamed_response:
         return await _collect_streamed_response_content(
             stream_agent_response(
-                agent_name=agent_name,
+                ctx,
                 prompt=prompt,
-                session_id=session_id,
                 runtime_paths=runtime_paths,
                 config=config,
                 thread_history=thread_history,
                 model_prompt=model_prompt,
                 current_timestamp_ms=current_timestamp_ms,
                 current_prompt_is_structured=current_prompt_is_structured,
-                thread_id=thread_id,
-                room_id=room_id,
                 knowledge=knowledge,
-                user_id=user_id,
-                run_id=run_id,
                 run_id_callback=run_id_callback,
                 include_interactive_questions=include_interactive_questions,
                 include_openai_compat_guidance=include_openai_compat_guidance,
                 media=media,
-                reply_to_event_id=reply_to_event_id,
-                correlation_id=correlation_id,
-                active_event_ids=active_event_ids,
                 show_tool_calls=show_tool_calls,
                 run_metadata_collector=run_metadata_collector,
                 execution_identity=execution_identity,
@@ -1473,8 +1390,6 @@ async def ai_response(
                 compaction_lifecycle=compaction_lifecycle,
                 delegation_depth=delegation_depth,
                 refresh_scheduler=refresh_scheduler,
-                matrix_run_metadata=matrix_run_metadata,
-                system_enrichment_items=system_enrichment_items,
                 turn_recorder=turn_recorder,
                 pipeline_timing=pipeline_timing,
             ),
@@ -1482,22 +1397,18 @@ async def ai_response(
             tool_trace_collector=tool_trace_collector,
         )
 
+    session_id = _require_turn_session_id(ctx)
     # Bind the timing scope for this turn; asyncio task contexts isolate it and
     # the next turn in a reused task overwrites it.
     timing_scope.set(
         _build_timing_scope(
-            reply_to_event_id=reply_to_event_id,
-            run_id=run_id,
+            reply_to_event_id=ctx.reply_to_event_id,
+            run_id=ctx.run_id,
             session_id=session_id,
             agent_name=agent_name,
         ),
     )
     media_inputs = media or MediaInputs()
-    resolved_correlation_id = resolve_run_correlation_id(
-        correlation_id,
-        reply_to_event_id=reply_to_event_id,
-        matrix_run_metadata=matrix_run_metadata,
-    )
     try:
         _assert_agent_target(agent_name, config)
     except ValueError as e:
@@ -1521,33 +1432,24 @@ async def ai_response(
         """Run one agent attempt, including its media-fallback retries."""
         try:
             run_context = await _prepare_agent_run_context(
-                agent_name=agent_name,
+                ctx,
                 prompt=continuation_state.active_prompt,
                 session_id=session_id,
                 runtime_paths=runtime_paths,
                 config=config,
                 scope_context=run.scope_context,
                 thread_history=thread_history,
-                room_id=room_id,
-                thread_id=thread_id,
                 knowledge=knowledge,
                 include_interactive_questions=include_interactive_questions,
                 include_openai_compat_guidance=include_openai_compat_guidance,
-                reply_to_event_id=reply_to_event_id,
-                active_event_ids=active_event_ids,
                 execution_identity=execution_identity,
                 compaction_outcomes_collector=compaction_outcomes_collector,
                 compaction_lifecycle=compaction_lifecycle,
                 delegation_depth=delegation_depth,
                 refresh_scheduler=refresh_scheduler,
-                system_enrichment_items=system_enrichment_items,
                 model_prompt=continuation_state.active_model_prompt,
                 current_timestamp_ms=continuation_state.active_current_timestamp_ms,
                 current_prompt_is_structured=continuation_state.active_current_prompt_is_structured,
-                user_id=user_id,
-                requester_id=user_id,
-                correlation_id=resolved_correlation_id,
-                matrix_run_metadata=matrix_run_metadata,
                 turn_recorder=turn_recorder,
                 pipeline_timing=pipeline_timing,
             )
@@ -1570,7 +1472,6 @@ async def ai_response(
         attempt_result = await _run_non_streaming_agent_attempts(
             run_context=run_context,
             attempt=attempt,
-            user_id=user_id,
             run_id=continuation_state.active_run_id,
             run_id_callback=run_id_callback,
             scope_context=run.scope_context,
@@ -1649,17 +1550,7 @@ async def ai_response(
         persist_standalone_replay=callbacks.persist_standalone_replay,
     )
     return await run_blocking_response_turn(
-        ResponseTurnContext(
-            entity_label=agent_name,
-            session_id=session_id,
-            run_id=run_id,
-            correlation_id=resolved_correlation_id,
-            reply_to_event_id=reply_to_event_id,
-            room_id=room_id,
-            thread_id=thread_id,
-            requester_id=user_id,
-            matrix_run_metadata=matrix_run_metadata,
-        ),
+        ctx,
         adapter,
         TurnSinks(turn_recorder=turn_recorder, run_metadata_collector=run_metadata_collector),
         continuation=_initial_agent_continuation(
@@ -1667,7 +1558,7 @@ async def ai_response(
             model_prompt=model_prompt,
             current_timestamp_ms=current_timestamp_ms,
             current_prompt_is_structured=current_prompt_is_structured,
-            run_id=run_id,
+            run_id=ctx.run_id,
         ),
     )
 
@@ -1803,7 +1694,6 @@ async def _stream_agent_attempt_chunks(
     attempt: _MediaAttempt,
     state: _StreamingAttemptState,
     show_tool_calls: bool,
-    user_id: str | None,
     run_id_callback: Callable[[str], None] | None,
     retried_after_media_fallback: bool,
     state_updated: Callable[[], None] | None,
@@ -1816,13 +1706,8 @@ async def _stream_agent_attempt_chunks(
             pipeline_timing.mark("model_request_sent", overwrite=True)
         ai_runtime.note_attempt_run_id(run_id_callback, attempt.attempt_run_id)
         request_context = _attempt_request_log_context(
-            agent_id=run_context.agent_name,
+            run_context.turn,
             session_id=run_context.session_id,
-            room_id=run_context.room_id,
-            thread_id=run_context.thread_id,
-            reply_to_event_id=run_context.reply_to_event_id,
-            requester_id=run_context.requester_id,
-            correlation_id=run_context.correlation_id,
             prompt=run_context.prompt,
             model_prompt=run_context.model_prompt,
             attempt_prompt=attempt.attempt_prompt,
@@ -1836,7 +1721,7 @@ async def _stream_agent_attempt_chunks(
             stream_generator = agent.arun(
                 prepared_input,
                 session_id=run_context.session_id,
-                user_id=user_id,
+                user_id=run_context.turn.requester_id,
                 run_id=attempt.attempt_run_id,
                 stream=True,
                 stream_events=True,
@@ -1876,27 +1761,19 @@ async def _stream_agent_attempt_chunks(
 
 
 async def stream_agent_response(  # noqa: C901, PLR0915
-    agent_name: str,
+    ctx: ResponseTurnContext,
     prompt: str,
-    session_id: str,
     runtime_paths: RuntimePaths,
     config: Config,
     thread_history: Sequence[ResolvedVisibleMessage] | None = None,
     model_prompt: str | None = None,
     current_timestamp_ms: float | None = None,
     current_prompt_is_structured: bool = False,
-    thread_id: str | None = None,
-    room_id: str | None = None,
     knowledge: Knowledge | None = None,
-    user_id: str | None = None,
-    run_id: str | None = None,
     run_id_callback: Callable[[str], None] | None = None,
     include_interactive_questions: bool = True,
     include_openai_compat_guidance: bool = False,
     media: MediaInputs | None = None,
-    reply_to_event_id: str | None = None,
-    correlation_id: str | None = None,
-    active_event_ids: Collection[str] = frozenset(),
     show_tool_calls: bool = True,
     run_metadata_collector: dict[str, Any] | None = None,
     execution_identity: ToolExecutionIdentity | None = None,
@@ -1904,28 +1781,23 @@ async def stream_agent_response(  # noqa: C901, PLR0915
     compaction_lifecycle: CompactionLifecycle | None = None,
     delegation_depth: int = 0,
     refresh_scheduler: KnowledgeRefreshScheduler | None = None,
-    matrix_run_metadata: dict[str, Any] | None = None,
-    system_enrichment_items: Sequence[EnrichmentItem] = (),
     turn_recorder: TurnRecorder | None = None,
     pipeline_timing: DispatchPipelineTiming | None = None,
 ) -> AsyncIterator[AIStreamChunk]:
     """Generate streaming AI response using Agno's streaming API.
 
     Args:
-        agent_name: Name of the agent to use
+        ctx: Per-turn identity constants for this response turn. ``entity_label``
+            names the agent, ``session_id`` is required, and ``requester_id`` is
+            the Matrix sender used for Agno learning and prompt attribution.
         prompt: User prompt
-        session_id: Session ID for conversation tracking
         runtime_paths: Runtime config/storage paths for agent data and config-aware tools
         config: Application configuration
         thread_history: Optional thread history
         model_prompt: Optional model-facing current-turn prompt additions.
         current_timestamp_ms: Optional source Matrix event timestamp in milliseconds.
         current_prompt_is_structured: Whether the current prompt already carries trusted message tags.
-        thread_id: Optional resolved Matrix thread ID for request-log correlation and run metadata.
-        room_id: Optional Matrix room ID for caller context
         knowledge: Optional shared knowledge base for RAG-enabled agents
-        user_id: Matrix user ID of the sender, used by Agno's LearningMachine
-        run_id: Explicit Agno run identifier used for graceful stop/cancel handling.
         run_id_callback: Optional callback that receives the active Agno run_id
             before each real streaming attempt starts.
         include_interactive_questions: Whether to include the interactive
@@ -1934,11 +1806,6 @@ async def stream_agent_response(  # noqa: C901, PLR0915
         include_openai_compat_guidance: Whether to omit Matrix-style sender
             attribution for OpenAI-compatible prompt formatting.
         media: Optional multimodal inputs (audio/images/files/videos)
-        reply_to_event_id: Matrix event ID of the triggering message, stored
-            in run metadata for unseen message tracking and edit cleanup.
-        correlation_id: Stable cross-sink trace ID for this response lifecycle.
-        active_event_ids: Live self-authored Matrix event IDs still tracked as
-            actively streaming for this bot in the current room.
         show_tool_calls: Whether to include tool call details inline in the streamed response.
         run_metadata_collector: Optional mapping that receives versioned
             run/model/token metadata for Matrix message content.
@@ -1952,10 +1819,6 @@ async def stream_agent_response(  # noqa: C901, PLR0915
         delegation_depth: Current nested delegation depth for delegated-agent runs.
         refresh_scheduler: Optional runtime-owned shared knowledge refresh scheduler
             passed through to delegated child agents.
-        matrix_run_metadata: Optional Matrix-specific run metadata persisted with the run
-            for unseen-message tracking, coalesced edit regeneration, and cleanup.
-        system_enrichment_items: Optional system-prompt enrichment items for this run.
-        model_prompt: Optional model-facing current-turn prompt additions.
         turn_recorder: Optional lifecycle-owned recorder updated with trusted turn state.
         pipeline_timing: Optional dispatch timing collector updated with AI-stage milestones.
 
@@ -1963,23 +1826,20 @@ async def stream_agent_response(  # noqa: C901, PLR0915
         Streaming chunks/events as they become available
 
     """
-    logger.info("AI streaming request", agent=agent_name, room_id=room_id)
+    agent_name = ctx.entity_label
+    logger.info("AI streaming request", agent=agent_name, room_id=ctx.room_id)
+    session_id = _require_turn_session_id(ctx)
     # Bind the timing scope for this turn; asyncio task contexts isolate it and
     # the next turn in a reused task overwrites it.
     timing_scope.set(
         _build_timing_scope(
-            reply_to_event_id=reply_to_event_id,
-            run_id=run_id,
+            reply_to_event_id=ctx.reply_to_event_id,
+            run_id=ctx.run_id,
             session_id=session_id,
             agent_name=agent_name,
         ),
     )
     media_inputs = media or MediaInputs()
-    resolved_correlation_id = resolve_run_correlation_id(
-        correlation_id,
-        reply_to_event_id=reply_to_event_id,
-        matrix_run_metadata=matrix_run_metadata,
-    )
     try:
         _assert_agent_target(agent_name, config)
     except ValueError as e:
@@ -2016,33 +1876,24 @@ async def stream_agent_response(  # noqa: C901, PLR0915
         """Stream one agent attempt, ending with its ``AttemptResolved`` sentinel."""
         try:
             run_context = await _prepare_agent_run_context(
-                agent_name=agent_name,
+                ctx,
                 prompt=continuation_state.active_prompt,
                 session_id=session_id,
                 runtime_paths=runtime_paths,
                 config=config,
                 scope_context=run.scope_context,
                 thread_history=thread_history,
-                room_id=room_id,
-                thread_id=thread_id,
                 knowledge=knowledge,
                 include_interactive_questions=include_interactive_questions,
                 include_openai_compat_guidance=include_openai_compat_guidance,
-                reply_to_event_id=reply_to_event_id,
-                active_event_ids=active_event_ids,
                 execution_identity=execution_identity,
                 compaction_outcomes_collector=compaction_outcomes_collector,
                 compaction_lifecycle=compaction_lifecycle,
                 delegation_depth=delegation_depth,
                 refresh_scheduler=refresh_scheduler,
-                system_enrichment_items=system_enrichment_items,
                 model_prompt=continuation_state.active_model_prompt,
                 current_timestamp_ms=continuation_state.active_current_timestamp_ms,
                 current_prompt_is_structured=continuation_state.active_current_prompt_is_structured,
-                user_id=user_id,
-                requester_id=user_id,
-                correlation_id=resolved_correlation_id,
-                matrix_run_metadata=matrix_run_metadata,
                 turn_recorder=turn_recorder,
                 pipeline_timing=pipeline_timing,
             )
@@ -2092,7 +1943,6 @@ async def stream_agent_response(  # noqa: C901, PLR0915
                 attempt=attempt,
                 state=state,
                 show_tool_calls=show_tool_calls,
-                user_id=user_id,
                 run_id_callback=run_id_callback,
                 retried_after_media_fallback=retried_after_media_fallback,
                 state_updated=_sync_live_turn_recorder,
@@ -2243,17 +2093,7 @@ async def stream_agent_response(  # noqa: C901, PLR0915
         persist_standalone_replay=callbacks.persist_standalone_replay,
     )
     response_stream = stream_response_turn(
-        ResponseTurnContext(
-            entity_label=agent_name,
-            session_id=session_id,
-            run_id=run_id,
-            correlation_id=resolved_correlation_id,
-            reply_to_event_id=reply_to_event_id,
-            room_id=room_id,
-            thread_id=thread_id,
-            requester_id=user_id,
-            matrix_run_metadata=matrix_run_metadata,
-        ),
+        ctx,
         adapter,
         TurnSinks(turn_recorder=turn_recorder, run_metadata_collector=run_metadata_collector),
         continuation=_initial_agent_continuation(
@@ -2261,7 +2101,7 @@ async def stream_agent_response(  # noqa: C901, PLR0915
             model_prompt=model_prompt,
             current_timestamp_ms=current_timestamp_ms,
             current_prompt_is_structured=current_prompt_is_structured,
-            run_id=run_id,
+            run_id=ctx.run_id,
         ),
     )
     # Close the driver generator deterministically when this wrapper unwinds so

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -458,6 +458,8 @@ class _AgentRunContext:
     """Prepared state shared by one top-level agent response lifecycle."""
 
     turn: ResponseTurnContext
+    # turn.session_id narrowed to non-None once at the entry boundary; read
+    # this field, not turn.session_id, wherever a str is required.
     session_id: str
     prompt: str
     model_prompt: str | None

--- a/src/mindroom/api/openai_compat.py
+++ b/src/mindroom/api/openai_compat.py
@@ -834,6 +834,17 @@ async def _prepare_openai_team_prompt(
 ) -> _PreparedOpenAITeamPrompt:
     """Prepare the final prompt for one OpenAI-compatible team run."""
     prepared_execution = await prepare_materialized_team_execution(
+        ResponseTurnContext(
+            entity_label=team_name,
+            session_id=None,
+            run_id=None,
+            correlation_id=uuid4().hex,
+            reply_to_event_id=None,
+            room_id=None,
+            thread_id=None,
+            requester_id=execution_identity.requester_id if execution_identity is not None else None,
+            matrix_run_metadata=None,
+        ),
         scope_context=scope_context,
         agents=agents,
         team=team,
@@ -842,17 +853,10 @@ async def _prepare_openai_team_prompt(
         config=config,
         runtime_paths=runtime_paths,
         active_model_name=config.resolve_runtime_model(entity_name=team_name).model_name,
-        reply_to_event_id=None,
-        active_event_ids=frozenset(),
         response_sender_id=None,
         current_sender_id=None,
-        room_id=None,
-        thread_id=None,
-        requester_id=execution_identity.requester_id if execution_identity is not None else None,
-        correlation_id=uuid4().hex,
         compaction_outcomes_collector=None,
         configured_team_name=team_name,
-        matrix_run_metadata=None,
     )
     return _PreparedOpenAITeamPrompt(
         prompt=render_prepared_team_messages_text(prepared_execution.messages),

--- a/src/mindroom/api/openai_compat.py
+++ b/src/mindroom/api/openai_compat.py
@@ -29,7 +29,7 @@ from pydantic import BaseModel, Field
 from starlette.background import BackgroundTask
 
 from mindroom.agent_run_context import prepend_knowledge_availability_notice
-from mindroom.ai import AIStreamChunk, ai_response, stream_agent_response
+from mindroom.ai import AIStreamChunk, ResponseTurnContext, ai_response, stream_agent_response
 from mindroom.api import config_lifecycle
 from mindroom.api.openai_request_parsing import (
     AUTO_MODEL_NAME,
@@ -571,6 +571,21 @@ async def chat_completions(  # noqa: C901, PLR0912
 # ---------------------------------------------------------------------------
 
 
+def _openai_agent_turn_context(agent_name: str, *, session_id: str) -> ResponseTurnContext:
+    """Build the turn context for one OpenAI-compatible agent completion."""
+    return ResponseTurnContext(
+        entity_label=agent_name,
+        session_id=session_id,
+        run_id=None,
+        correlation_id=uuid4().hex,
+        reply_to_event_id=None,
+        room_id=None,
+        thread_id=None,
+        requester_id=None,
+        matrix_run_metadata=None,
+    )
+
+
 async def _non_stream_completion(
     agent_name: str,
     prompt: str,
@@ -585,18 +600,14 @@ async def _non_stream_completion(
 ) -> JSONResponse:
     """Handle non-streaming chat completion."""
     response_text = await ai_response(
-        agent_name=agent_name,
+        _openai_agent_turn_context(agent_name, session_id=session_id),
         prompt=prompt,
-        session_id=session_id,
         runtime_paths=runtime_paths,
         config=config,
         thread_history=thread_history,
-        room_id=None,
         knowledge=knowledge,
-        user_id=None,
         include_interactive_questions=False,
         include_openai_compat_guidance=True,
-        active_event_ids=set(),
         execution_identity=execution_identity,
         refresh_scheduler=refresh_scheduler,
     )
@@ -643,18 +654,14 @@ async def _stream_completion(  # noqa: C901, PLR0915
         stream_with_tool_execution_identity(
             execution_identity,
             stream_factory=lambda: stream_agent_response(
-                agent_name=agent_name,
+                _openai_agent_turn_context(agent_name, session_id=session_id),
                 prompt=prompt,
-                session_id=session_id,
                 runtime_paths=runtime_paths,
                 config=config,
                 thread_history=thread_history,
-                room_id=None,
                 knowledge=knowledge,
-                user_id=None,
                 include_interactive_questions=False,
                 include_openai_compat_guidance=True,
-                active_event_ids=set(),
                 execution_identity=execution_identity,
                 refresh_scheduler=refresh_scheduler,
             ),

--- a/src/mindroom/custom_tools/delegate.py
+++ b/src/mindroom/custom_tools/delegate.py
@@ -15,7 +15,7 @@ from agno.tools import Toolkit
 
 from mindroom.agent_descriptions import describe_agent
 from mindroom.agent_run_context import append_knowledge_availability_enrichment
-from mindroom.ai import ai_response
+from mindroom.ai import ResponseTurnContext, ai_response
 from mindroom.knowledge import resolve_agent_knowledge_access
 from mindroom.logging_config import get_logger
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, get_tool_runtime_context, tool_runtime_context
@@ -142,23 +142,31 @@ class DelegateTools(Toolkit):
                 room_id=room_id,
                 runtime_context=runtime_context,
             )
+            delegated_correlation_id = (
+                delegated_runtime_context.correlation_id if delegated_runtime_context is not None else None
+            )
+            turn_ctx = ResponseTurnContext(
+                entity_label=agent_name,
+                session_id=session_id,
+                run_id=None,
+                correlation_id=delegated_correlation_id or uuid4().hex,
+                reply_to_event_id=None,
+                room_id=room_id,
+                thread_id=None,
+                requester_id=execution_identity.requester_id if execution_identity is not None else None,
+                matrix_run_metadata=None,
+                system_enrichment_items=tuple(system_enrichment_items),
+            )
             with tool_runtime_context(delegated_runtime_context):
                 response = await ai_response(
-                    agent_name=agent_name,
+                    turn_ctx,
                     prompt=task,
-                    session_id=session_id,
                     runtime_paths=self._runtime_paths,
                     config=self._config,
                     knowledge=knowledge_resolution.knowledge,
-                    user_id=execution_identity.requester_id if execution_identity is not None else None,
-                    room_id=room_id,
-                    correlation_id=(
-                        delegated_runtime_context.correlation_id if delegated_runtime_context is not None else None
-                    ),
                     include_interactive_questions=False,
                     execution_identity=execution_identity,
                     delegation_depth=self._delegation_depth + 1,
-                    system_enrichment_items=system_enrichment_items,
                     refresh_scheduler=self._refresh_scheduler,
                 )
         except Exception as e:

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -1211,6 +1211,21 @@ class ResponseRunner:
         progress = _DeliveryProgress(tracked_event_id=request.existing_event_id)
         matrix_run_metadata = _materialize_matrix_run_metadata(request.matrix_run_metadata)
         active_event_ids = self._active_response_event_ids(request.room_id)
+        # Team entries refine entity_label to the materialized team label and
+        # append the knowledge-availability enrichment before the turn runs.
+        team_turn_ctx = ResponseTurnContext(
+            entity_label=self.deps.agent_name,
+            session_id=session_id,
+            run_id=response_run_id,
+            correlation_id=resolved_correlation_id,
+            reply_to_event_id=request.reply_to_event_id,
+            room_id=request.room_id,
+            thread_id=resolved_target.resolved_thread_id,
+            requester_id=requester_user_id or execution_identity.requester_id,
+            matrix_run_metadata=matrix_run_metadata,
+            active_event_ids=frozenset(active_event_ids),
+            system_enrichment_items=tuple(request.system_enrichment_items),
+        )
         team_turn_recorder = self._build_turn_recorder(
             user_message=request.prompt,
             reply_to_event_id=request.reply_to_event_id,
@@ -1254,29 +1269,23 @@ class ResponseRunner:
                             message=model_message,
                             orchestrator=orchestrator,
                             execution_identity=tool_dispatch.execution_identity,
+                            ctx=team_turn_ctx,
                             mode=mode,
                             thread_history=model_thread_history,
                             model_name=model_name,
                             media=resolved_request.media,
                             show_tool_calls=show_tool_calls,
-                            session_id=session_id,
-                            run_id=response_run_id,
                             run_id_callback=_note_attempt_run_id,
                             user_id=requester_user_id,
-                            reply_to_event_id=request.reply_to_event_id,
                             current_timestamp_ms=request.current_timestamp_ms,
                             current_prompt_is_structured=request.current_prompt_is_structured,
-                            correlation_id=resolved_correlation_id,
-                            active_event_ids=active_event_ids,
                             response_sender_id=self.deps.matrix_full_id,
                             run_metadata_collector=team_run_metadata_content,
                             compaction_lifecycle=compaction_lifecycle,
                             configured_team_name=self.deps.agent_name
                             if self.deps.agent_name in self.deps.runtime.config.teams
                             else None,
-                            system_enrichment_items=request.system_enrichment_items,
                             reason_prefix=team_request.reason_prefix,
-                            matrix_run_metadata=matrix_run_metadata,
                             pipeline_timing=request.pipeline_timing,
                             turn_recorder=team_turn_recorder,
                         )
@@ -1363,27 +1372,21 @@ class ResponseRunner:
                                     message=model_message,
                                     orchestrator=orchestrator,
                                     execution_identity=tool_dispatch.execution_identity,
+                                    ctx=team_turn_ctx,
                                     thread_history=model_thread_history,
                                     model_name=model_name,
                                     media=resolved_request.media,
-                                    session_id=session_id,
-                                    run_id=response_run_id,
                                     run_id_callback=_note_attempt_run_id,
                                     user_id=requester_user_id,
-                                    reply_to_event_id=request.reply_to_event_id,
                                     current_timestamp_ms=request.current_timestamp_ms,
                                     current_prompt_is_structured=request.current_prompt_is_structured,
-                                    correlation_id=resolved_correlation_id,
-                                    active_event_ids=active_event_ids,
                                     response_sender_id=self.deps.matrix_full_id,
                                     run_metadata_collector=team_run_metadata_content,
                                     compaction_lifecycle=compaction_lifecycle,
                                     configured_team_name=self.deps.agent_name
                                     if self.deps.agent_name in self.deps.runtime.config.teams
                                     else None,
-                                    system_enrichment_items=request.system_enrichment_items,
                                     reason_prefix=team_request.reason_prefix,
-                                    matrix_run_metadata=matrix_run_metadata,
                                     pipeline_timing=request.pipeline_timing,
                                     turn_recorder=team_turn_recorder,
                                 )

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -13,7 +13,7 @@ from agno.session.team import TeamSession
 
 from mindroom.agent_run_context import append_knowledge_availability_enrichment
 from mindroom.agents import show_tool_calls_for_agent
-from mindroom.ai import ai_response, build_matrix_run_metadata, stream_agent_response
+from mindroom.ai import ResponseTurnContext, ai_response, build_matrix_run_metadata, stream_agent_response
 from mindroom.ai_run_metadata import ai_run_extra_content_from_metadata
 from mindroom.background_tasks import create_background_task
 from mindroom.constants import ATTACHMENT_IDS_KEY, ORIGINAL_SENDER_KEY, ROUTER_AGENT_NAME
@@ -844,6 +844,30 @@ class ResponseRunner:
     def _correlation_id_for_request(self, request: ResponseRequest) -> str:
         """Resolve the correlation id for one request."""
         return request.correlation_id or request.reply_to_event_id or request.response_envelope.source_event_id
+
+    def _agent_turn_context(
+        self,
+        request: ResponseRequest,
+        *,
+        runtime: _PreparedResponseRuntime,
+        run_id: str | None,
+        active_event_ids: set[str],
+        system_enrichment_items: Sequence[EnrichmentItem],
+    ) -> ResponseTurnContext:
+        """Build the per-turn identity context for one agent response."""
+        return ResponseTurnContext(
+            entity_label=self.deps.agent_name,
+            session_id=runtime.session_id,
+            run_id=run_id,
+            correlation_id=self._correlation_id_for_request(request),
+            reply_to_event_id=request.reply_to_event_id,
+            room_id=request.room_id,
+            thread_id=runtime.resolved_target.resolved_thread_id,
+            requester_id=request.user_id,
+            matrix_run_metadata=_materialize_matrix_run_metadata(request.matrix_run_metadata),
+            active_event_ids=frozenset(active_event_ids),
+            system_enrichment_items=tuple(system_enrichment_items),
+        )
 
     def _notify_sync_restart_cancelled(
         self,
@@ -1778,27 +1802,24 @@ class ResponseRunner:
                 request.system_enrichment_items,
                 knowledge_resolution.unavailable,
             )
-            matrix_run_metadata = _materialize_matrix_run_metadata(request.matrix_run_metadata)
             return await ai_response(
-                agent_name=self.deps.agent_name,
+                self._agent_turn_context(
+                    request,
+                    runtime=runtime,
+                    run_id=run_id,
+                    active_event_ids=active_event_ids,
+                    system_enrichment_items=system_enrichment_items,
+                ),
                 prompt=request.prompt,
-                session_id=runtime.session_id,
                 runtime_paths=self.deps.runtime_paths,
                 config=self.deps.runtime.config,
                 thread_history=request.thread_history,
                 model_prompt=runtime.model_prompt,
                 current_timestamp_ms=request.current_timestamp_ms,
                 current_prompt_is_structured=request.current_prompt_is_structured,
-                thread_id=runtime.resolved_target.resolved_thread_id,
-                room_id=request.room_id,
                 knowledge=knowledge_resolution.knowledge,
-                user_id=request.user_id,
-                run_id=run_id,
                 run_id_callback=note_attempt_run_id,
                 media=runtime.media_inputs,
-                reply_to_event_id=request.reply_to_event_id,
-                correlation_id=self._correlation_id_for_request(request),
-                active_event_ids=active_event_ids,
                 show_tool_calls=show_tool_calls,
                 collect_streamed_response=show_tool_calls,
                 tool_trace_collector=tool_trace,
@@ -1810,8 +1831,6 @@ class ResponseRunner:
                     if self.deps.runtime.orchestrator is not None
                     else None
                 ),
-                matrix_run_metadata=matrix_run_metadata,
-                system_enrichment_items=system_enrichment_items,
                 turn_recorder=turn_recorder,
                 pipeline_timing=pipeline_timing,
             )
@@ -1870,27 +1889,24 @@ class ResponseRunner:
             request.system_enrichment_items,
             knowledge_resolution.unavailable,
         )
-        matrix_run_metadata = _materialize_matrix_run_metadata(request.matrix_run_metadata)
         response_stream = stream_agent_response(
-            agent_name=self.deps.agent_name,
+            self._agent_turn_context(
+                request,
+                runtime=runtime,
+                run_id=run_id,
+                active_event_ids=active_event_ids,
+                system_enrichment_items=system_enrichment_items,
+            ),
             prompt=request.prompt,
-            session_id=runtime.session_id,
             runtime_paths=self.deps.runtime_paths,
             config=self.deps.runtime.config,
             thread_history=request.thread_history,
             model_prompt=runtime.model_prompt,
             current_timestamp_ms=request.current_timestamp_ms,
             current_prompt_is_structured=request.current_prompt_is_structured,
-            thread_id=runtime.resolved_target.resolved_thread_id,
-            room_id=request.room_id,
             knowledge=knowledge_resolution.knowledge,
-            user_id=request.user_id,
-            run_id=run_id,
             run_id_callback=note_attempt_run_id,
             media=runtime.media_inputs,
-            reply_to_event_id=request.reply_to_event_id,
-            correlation_id=self._correlation_id_for_request(request),
-            active_event_ids=active_event_ids,
             show_tool_calls=self._show_tool_calls(),
             run_metadata_collector=run_metadata_content,
             execution_identity=runtime.tool_dispatch.execution_identity,
@@ -1900,8 +1916,6 @@ class ResponseRunner:
                 if self.deps.runtime.orchestrator is not None
                 else None
             ),
-            matrix_run_metadata=matrix_run_metadata,
-            system_enrichment_items=system_enrichment_items,
             turn_recorder=turn_recorder,
             pipeline_timing=pipeline_timing,
         )

--- a/src/mindroom/response_turn.py
+++ b/src/mindroom/response_turn.py
@@ -9,9 +9,11 @@ a recorder. This module owns that lifecycle exactly once; ``mindroom.ai`` and
 ``mindroom.teams`` supply thin adapters carrying the entity-specific attempt
 bodies as injected callables.
 
-Every ``ResponseTurnContext`` field is consumed by the drivers themselves;
-state that only the attempt bodies need stays captured inside the adapter
-closures and never crosses this seam.
+``ResponseTurnContext`` is the per-turn identity carrier built once by the
+caller that owns the turn: the drivers consume its Matrix-identity fields,
+while ``active_event_ids`` and ``system_enrichment_items`` ride along for the
+entity prepare chains. Mutable per-turn state (collectors, recorders,
+callbacks) stays out of it and crosses via ``TurnSinks`` or the adapters.
 """
 
 from __future__ import annotations

--- a/src/mindroom/response_turn.py
+++ b/src/mindroom/response_turn.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
 
     from mindroom.history import ScopeSessionContext
     from mindroom.history.turn_recorder import TurnRecorder
+    from mindroom.hooks import EnrichmentItem
     from mindroom.tool_system.events import ToolTraceEntry
 
 logger = get_logger(__name__)
@@ -184,7 +185,13 @@ class DynamicContinuationRunState:
 
 @dataclass(frozen=True)
 class ResponseTurnContext:
-    """Per-turn Matrix identity constants consumed by the turn drivers."""
+    """Per-turn Matrix identity constants for one response turn.
+
+    Built once by the caller that owns the turn, then passed unchanged through
+    the entity envelope, its prepare chain, and the turn drivers. For agent
+    turns ``entity_label`` is the configured agent name; team turns refine it
+    to the materialized team label via ``dataclasses.replace``.
+    """
 
     entity_label: str
     session_id: str | None
@@ -195,6 +202,8 @@ class ResponseTurnContext:
     thread_id: str | None
     requester_id: str | None
     matrix_run_metadata: dict[str, Any] | None
+    active_event_ids: frozenset[str] = frozenset()
+    system_enrichment_items: tuple[EnrichmentItem, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -33,7 +33,6 @@ from mindroom import ai_runtime, model_loading
 from mindroom.agent_run_context import append_knowledge_availability_enrichment
 from mindroom.agent_storage import get_team_session
 from mindroom.agents import create_agent, enable_all_history_replay
-from mindroom.ai import resolve_run_correlation_id
 from mindroom.ai_run_metadata import (
     build_ai_run_metadata_content,
     build_model_request_metrics_fallback,
@@ -62,7 +61,7 @@ from mindroom.history.interrupted_replay import (
     split_interrupted_tool_trace,
     tool_execution_call_id,
 )
-from mindroom.hooks import EnrichmentItem, render_system_enrichment_block
+from mindroom.hooks import render_system_enrichment_block
 from mindroom.knowledge import KnowledgeAvailabilityDetail, resolve_agent_knowledge_access
 from mindroom.llm_request_logging import (
     bind_llm_request_log_context,
@@ -112,7 +111,7 @@ from mindroom.tool_system.events import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, AsyncIterator, Callable, Collection, Sequence
+    from collections.abc import AsyncGenerator, AsyncIterator, Callable, Sequence
 
     import nio
     from agno.db.base import BaseDb
@@ -142,26 +141,21 @@ def _team_run_input_text(run_input: str | list[Message]) -> str:
 
 
 def _team_request_log_context(
+    ctx: ResponseTurnContext,
     *,
     team_name: str,
-    session_id: str | None,
-    room_id: str | None,
-    thread_id: str | None,
-    reply_to_event_id: str | None,
-    requester_id: str | None,
-    correlation_id: str,
     prompt: str,
     run_input: str | list[Message],
     metadata: dict[str, object] | None,
 ) -> dict[str, object]:
     return build_llm_request_log_context(
         agent_id=team_name,
-        session_id=session_id or "",
-        room_id=room_id,
-        thread_id=thread_id,
-        reply_to_event_id=reply_to_event_id,
-        requester_id=requester_id,
-        correlation_id=correlation_id,
+        session_id=ctx.session_id or "",
+        room_id=ctx.room_id,
+        thread_id=ctx.thread_id,
+        reply_to_event_id=ctx.reply_to_event_id,
+        requester_id=ctx.requester_id,
+        correlation_id=ctx.correlation_id,
         prompt=prompt,
         model_prompt=None,
         full_prompt=_team_run_input_text(run_input),
@@ -1831,6 +1825,7 @@ def build_materialized_team_instance(
 
 
 async def prepare_materialized_team_execution(
+    ctx: ResponseTurnContext,
     *,
     scope_context: ScopeSessionContext | None,
     agents: list[Agent],
@@ -1840,35 +1835,27 @@ async def prepare_materialized_team_execution(
     config: Config,
     runtime_paths: RuntimePaths,
     active_model_name: str | None,
-    reply_to_event_id: str | None,
-    active_event_ids: Collection[str],
     response_sender_id: str | None,
     current_sender_id: str | None,
-    room_id: str | None,
-    thread_id: str | None,
-    requester_id: str | None,
-    correlation_id: str | None,
     compaction_outcomes_collector: list[CompactionOutcome] | None,
     configured_team_name: str | None,
     current_timestamp_ms: float | None = None,
     current_prompt_is_structured: bool = False,
     compaction_lifecycle: CompactionLifecycle | None = None,
     thread_history_render_limits: ThreadHistoryRenderLimits | None = None,
-    matrix_run_metadata: dict[str, Any] | None = None,
     pipeline_timing: DispatchPipelineTiming | None = None,
-    system_enrichment_items: Sequence[EnrichmentItem] = (),
 ) -> _PreparedMaterializedTeamExecution:
     """Prepare one materialized team for execution."""
-    if system_enrichment_items:
-        rendered_system_context = render_system_enrichment_block(system_enrichment_items)
+    if ctx.system_enrichment_items:
+        rendered_system_context = render_system_enrichment_block(ctx.system_enrichment_items)
         _append_additional_context(team, rendered_system_context)
         for agent in agents:
             _append_additional_context(agent, rendered_system_context)
     runtime_model = config.resolve_runtime_model(
         entity_name=configured_team_name,
         active_model_name=active_model_name,
-        room_id=room_id,
-        thread_id=thread_id,
+        room_id=ctx.room_id,
+        thread_id=ctx.thread_id,
         runtime_paths=runtime_paths,
     )
     prepared_execution = await prepare_bound_team_run_context(
@@ -1882,9 +1869,9 @@ async def prepare_materialized_team_execution(
         entity_name=configured_team_name,
         active_model_name=active_model_name,
         active_context_window=runtime_model.context_window,
-        room_id=room_id,
-        reply_to_event_id=reply_to_event_id,
-        active_event_ids=active_event_ids,
+        room_id=ctx.room_id,
+        reply_to_event_id=ctx.reply_to_event_id,
+        active_event_ids=ctx.active_event_ids,
         response_sender_id=response_sender_id,
         current_sender_id=current_sender_id,
         current_timestamp_ms=current_timestamp_ms,
@@ -1900,15 +1887,15 @@ async def prepare_materialized_team_execution(
         note_prepared_history_timing(pipeline_timing, prepared_history)
     run_extra_content = build_prepared_history_metadata_content(prepared_history)
     run_metadata = build_matrix_run_metadata(
-        reply_to_event_id,
+        ctx.reply_to_event_id,
         prepared_execution.unseen_event_ids,
-        room_id=room_id,
-        thread_id=thread_id,
-        requester_id=requester_id,
-        correlation_id=correlation_id,
+        room_id=ctx.room_id,
+        thread_id=ctx.thread_id,
+        requester_id=ctx.requester_id,
+        correlation_id=ctx.correlation_id,
         tools_schema=team_tool_definition_payloads_for_logging(team),
         model_params=model_params_payload(team.model) if team.model is not None else {},
-        extra_metadata=deep_merge_metadata(matrix_run_metadata, run_extra_content),
+        extra_metadata=deep_merge_metadata(ctx.matrix_run_metadata, run_extra_content),
     )
     return _PreparedMaterializedTeamExecution(
         messages=prepared_execution.messages,
@@ -1925,31 +1912,30 @@ async def team_response(  # noqa: C901, PLR0915
     message: str,
     orchestrator: OrchestratorRuntime,
     execution_identity: ToolExecutionIdentity | None,
+    ctx: ResponseTurnContext,
     thread_history: Sequence[ResolvedVisibleMessage] | None = None,
     model_name: str | None = None,
     media: MediaInputs | None = None,
-    session_id: str | None = None,
-    run_id: str | None = None,
     run_id_callback: Callable[[str], None] | None = None,
     user_id: str | None = None,
-    reply_to_event_id: str | None = None,
     current_timestamp_ms: float | None = None,
     current_prompt_is_structured: bool = False,
-    correlation_id: str | None = None,
-    active_event_ids: Collection[str] = frozenset(),
     response_sender_id: str | None = None,
     compaction_outcomes_collector: list[CompactionOutcome] | None = None,
     compaction_lifecycle: CompactionLifecycle | None = None,
     run_metadata_collector: dict[str, Any] | None = None,
     configured_team_name: str | None = None,
-    matrix_run_metadata: dict[str, Any] | None = None,
-    system_enrichment_items: Sequence[EnrichmentItem] = (),
     pipeline_timing: DispatchPipelineTiming | None = None,
     *,
     turn_recorder: TurnRecorder,
     reason_prefix: str = "Team request",
 ) -> str:
-    """Create a team and execute response."""
+    """Create a team and execute response.
+
+    ``ctx`` carries the per-turn Matrix identity; this entry refines its
+    ``entity_label`` to the materialized team label and appends the
+    knowledge-availability enrichment before the turn runs.
+    """
     assert orchestrator.config is not None
     requested_agent_names = _requested_team_agent_names(agent_names)
     allow_direct_private_agents = _allow_direct_private_team_agents(
@@ -1961,18 +1947,6 @@ async def team_response(  # noqa: C901, PLR0915
         allow_direct_private_agents=allow_direct_private_agents,
     )
     unavailable_bases: dict[str, KnowledgeAvailabilityDetail] = {}
-    room_id = execution_identity.room_id if execution_identity is not None else None
-    thread_id = (
-        execution_identity.resolved_thread_id or execution_identity.thread_id
-        if execution_identity is not None
-        else None
-    )
-    requester_id = user_id or (execution_identity.requester_id if execution_identity is not None else None)
-    correlation_id = resolve_run_correlation_id(
-        correlation_id,
-        reply_to_event_id=reply_to_event_id,
-        matrix_run_metadata=matrix_run_metadata,
-    )
     try:
         # Member agent builds walk the filesystem (workspace scaffolding,
         # context files, session storage); keep them off the event loop (#1260).
@@ -1981,24 +1955,27 @@ async def team_response(  # noqa: C901, PLR0915
             agent_names,
             orchestrator,
             execution_identity,
-            session_id=session_id,
+            session_id=ctx.session_id,
             unavailable_bases=unavailable_bases,
             reason_prefix=reason_prefix,
             configured_team_name=configured_team_name,
         )
     except ValueError as exc:
         return str(exc)
-    system_enrichment_items = append_knowledge_availability_enrichment(
-        system_enrichment_items,
-        unavailable_bases,
-    )
     agents = team_members.agents
 
     agent_list = ", ".join(str(a.name) for a in agents if a.name)
     team_name = f"Team ({agent_list})"
+    ctx = replace(
+        ctx,
+        entity_label=team_name,
+        system_enrichment_items=append_knowledge_availability_enrichment(
+            ctx.system_enrichment_items,
+            unavailable_bases,
+        ),
+    )
     base_media_inputs = media or MediaInputs()
     config = orchestrator.config
-    enrichment_items = system_enrichment_items
     holder = _TeamTurnHolder(team_members=team_members)
 
     async def _run_team_attempt(  # noqa: C901, PLR0912, PLR0915
@@ -2011,7 +1988,7 @@ async def team_response(  # noqa: C901, PLR0915
             agent_names,
             orchestrator,
             execution_identity,
-            session_id=session_id,
+            session_id=ctx.session_id,
             reason_prefix=reason_prefix,
             configured_team_name=configured_team_name,
         )
@@ -2023,8 +2000,8 @@ async def team_response(  # noqa: C901, PLR0915
         attempt_model_name = config.resolve_runtime_model(
             entity_name=configured_team_name,
             active_model_name=model_name,
-            room_id=room_id,
-            thread_id=thread_id,
+            room_id=ctx.room_id,
+            thread_id=ctx.thread_id,
             runtime_paths=orchestrator.runtime_paths,
         ).model_name
         team = build_materialized_team_instance(
@@ -2040,6 +2017,7 @@ async def team_response(  # noqa: C901, PLR0915
         )
         holder.team = team
         prepared_execution = await prepare_materialized_team_execution(
+            ctx,
             scope_context=run.scope_context,
             agents=attempt_agents,
             team=team,
@@ -2048,23 +2026,15 @@ async def team_response(  # noqa: C901, PLR0915
             config=config,
             runtime_paths=orchestrator.runtime_paths,
             active_model_name=attempt_model_name,
-            reply_to_event_id=reply_to_event_id,
-            active_event_ids=active_event_ids,
             response_sender_id=response_sender_id,
             current_sender_id=user_id,
-            room_id=room_id,
-            thread_id=thread_id,
-            requester_id=requester_id,
-            correlation_id=correlation_id,
             compaction_outcomes_collector=compaction_outcomes_collector,
             current_timestamp_ms=continuation_state.active_current_timestamp_ms,
             current_prompt_is_structured=continuation_state.active_current_prompt_is_structured,
             compaction_lifecycle=compaction_lifecycle,
             configured_team_name=configured_team_name,
             thread_history_render_limits=_MATRIX_TEAM_THREAD_HISTORY_RENDER_LIMITS,
-            matrix_run_metadata=matrix_run_metadata,
             pipeline_timing=pipeline_timing,
-            system_enrichment_items=enrichment_items,
         )
         prompt = prepared_execution.prepared_prompt
         run.unseen_event_ids = prepared_execution.unseen_event_ids
@@ -2091,13 +2061,8 @@ async def team_response(  # noqa: C901, PLR0915
             )
             with bind_llm_request_log_context(
                 **_team_request_log_context(
+                    ctx,
                     team_name=configured_team_name or team_name,
-                    session_id=session_id,
-                    room_id=room_id,
-                    thread_id=thread_id,
-                    reply_to_event_id=reply_to_event_id,
-                    requester_id=requester_id,
-                    correlation_id=correlation_id,
                     prompt=message,
                     run_input=prepared_input,
                     metadata=run_metadata,
@@ -2105,7 +2070,7 @@ async def team_response(  # noqa: C901, PLR0915
             ):
                 return await team.arun(
                     prepared_input,
-                    session_id=session_id,
+                    session_id=ctx.session_id,
                     run_id=current_run_id,
                     user_id=user_id,
                     metadata=run_metadata,
@@ -2180,7 +2145,7 @@ async def team_response(  # noqa: C901, PLR0915
                     _cleanup_team_notice_state(
                         run_output=response,
                         scope_context=run.scope_context,
-                        session_id=session_id,
+                        session_id=ctx.session_id,
                         entity_name=configured_team_name or team_name,
                     )
                     _scrub_team_retry_notice_state(
@@ -2209,7 +2174,7 @@ async def team_response(  # noqa: C901, PLR0915
                 config=config,
                 prepared_execution=prepared_execution,
                 response=response,
-                session_id=session_id,
+                session_id=ctx.session_id,
                 tool_count=len(run_tool_executions),
             )
         if isinstance(response, (TeamRunOutput, RunOutput)) and is_cancelled_run_output(response):
@@ -2232,10 +2197,10 @@ async def team_response(  # noqa: C901, PLR0915
                 ),
                 metadata_content=metadata_content,
             )
-        if reply_to_event_id:
+        if ctx.reply_to_event_id:
             _persist_bound_seen_event_ids(
                 scope_context=run.scope_context,
-                session_id=session_id,
+                session_id=ctx.session_id,
                 event_ids=_run_metadata_seen_event_ids(run_metadata),
             )
 
@@ -2308,19 +2273,19 @@ async def team_response(  # noqa: C901, PLR0915
         _cleanup_team_notice_state(
             run_output=holder.last_response,
             scope_context=scope_context,
-            session_id=session_id,
+            session_id=ctx.session_id,
             entity_name=configured_team_name or team_name,
         )
 
     discard_team_empty_run = _build_team_empty_run_discard(
-        session_id=session_id,
+        session_id=ctx.session_id,
         entity_name=configured_team_name or team_name,
     )
     _release_team_attempt_members, _close_team_attempt_dbs = _build_team_runtime_db_callbacks(holder)
     adapter = BlockingTurnAdapter(
         open_scope=lambda: open_bound_scope_session_context(
             agents=agents,
-            session_id=session_id,
+            session_id=ctx.session_id,
             runtime_paths=orchestrator.runtime_paths,
             config=config,
             execution_identity=execution_identity,
@@ -2335,24 +2300,14 @@ async def team_response(  # noqa: C901, PLR0915
         discard_empty_run=discard_team_empty_run,
     )
     return await run_blocking_response_turn(
-        ResponseTurnContext(
-            entity_label=team_name,
-            session_id=session_id,
-            run_id=run_id,
-            correlation_id=correlation_id,
-            reply_to_event_id=reply_to_event_id,
-            room_id=room_id,
-            thread_id=thread_id,
-            requester_id=requester_id,
-            matrix_run_metadata=matrix_run_metadata,
-        ),
+        ctx,
         adapter,
         TurnSinks(turn_recorder=turn_recorder, run_metadata_collector=run_metadata_collector),
         continuation=_initial_team_continuation(
             message=message,
             current_timestamp_ms=current_timestamp_ms,
             current_prompt_is_structured=current_prompt_is_structured,
-            run_id=run_id,
+            run_id=ctx.run_id,
         ),
     )
 
@@ -2423,27 +2378,21 @@ async def team_response_stream(  # noqa: C901, PLR0915
     message: str,
     orchestrator: OrchestratorRuntime,
     execution_identity: ToolExecutionIdentity | None,
+    ctx: ResponseTurnContext,
     mode: TeamMode = TeamMode.COORDINATE,
     thread_history: Sequence[ResolvedVisibleMessage] | None = None,
     model_name: str | None = None,
     media: MediaInputs | None = None,
     show_tool_calls: bool = True,
-    session_id: str | None = None,
-    run_id: str | None = None,
     run_id_callback: Callable[[str], None] | None = None,
     user_id: str | None = None,
-    reply_to_event_id: str | None = None,
     current_timestamp_ms: float | None = None,
     current_prompt_is_structured: bool = False,
-    correlation_id: str | None = None,
-    active_event_ids: Collection[str] = frozenset(),
     response_sender_id: str | None = None,
     compaction_outcomes_collector: list[CompactionOutcome] | None = None,
     compaction_lifecycle: CompactionLifecycle | None = None,
     run_metadata_collector: dict[str, Any] | None = None,
     configured_team_name: str | None = None,
-    matrix_run_metadata: dict[str, Any] | None = None,
-    system_enrichment_items: Sequence[EnrichmentItem] = (),
     pipeline_timing: DispatchPipelineTiming | None = None,
     *,
     turn_recorder: TurnRecorder,
@@ -2453,7 +2402,10 @@ async def team_response_stream(  # noqa: C901, PLR0915
 
     Renders a header and per-member sections, optionally adding a team
     consensus if present. Rebuilds the entire document as new events
-    arrive so the final shape matches the non-stream style.
+    arrive so the final shape matches the non-stream style. ``ctx`` carries
+    the per-turn Matrix identity; this entry refines its ``entity_label``
+    to the materialized team label and appends the knowledge-availability
+    enrichment before the turn runs.
     """
     assert orchestrator.config is not None
     requested_agent_names = _requested_team_agent_names(
@@ -2468,18 +2420,6 @@ async def team_response_stream(  # noqa: C901, PLR0915
         allow_direct_private_agents=allow_direct_private_agents,
     )
     unavailable_bases: dict[str, KnowledgeAvailabilityDetail] = {}
-    room_id = execution_identity.room_id if execution_identity is not None else None
-    thread_id = (
-        execution_identity.resolved_thread_id or execution_identity.thread_id
-        if execution_identity is not None
-        else None
-    )
-    requester_id = user_id or (execution_identity.requester_id if execution_identity is not None else None)
-    correlation_id = resolve_run_correlation_id(
-        correlation_id,
-        reply_to_event_id=reply_to_event_id,
-        matrix_run_metadata=matrix_run_metadata,
-    )
     try:
         # Member agent builds walk the filesystem (workspace scaffolding,
         # context files, session storage); keep them off the event loop (#1260).
@@ -2488,7 +2428,7 @@ async def team_response_stream(  # noqa: C901, PLR0915
             requested_agent_names,
             orchestrator,
             execution_identity,
-            session_id=session_id,
+            session_id=ctx.session_id,
             unavailable_bases=unavailable_bases,
             reason_prefix=reason_prefix,
             configured_team_name=configured_team_name,
@@ -2496,16 +2436,19 @@ async def team_response_stream(  # noqa: C901, PLR0915
     except ValueError as exc:
         yield str(exc)
         return
-    system_enrichment_items = append_knowledge_availability_enrichment(
-        system_enrichment_items,
-        unavailable_bases,
-    )
     agent_names = team_members.display_names
     display_names = team_members.display_names
     team_label = f"Team ({', '.join(agent_names)})"
+    ctx = replace(
+        ctx,
+        entity_label=team_label,
+        system_enrichment_items=append_knowledge_availability_enrichment(
+            ctx.system_enrichment_items,
+            unavailable_bases,
+        ),
+    )
     base_media_inputs = media or MediaInputs()
     config = orchestrator.config
-    enrichment_items = system_enrichment_items
     holder = _TeamTurnHolder(team_members=team_members)
 
     async def _run_team_stream_attempt(  # noqa: C901, PLR0912, PLR0915
@@ -2518,7 +2461,7 @@ async def team_response_stream(  # noqa: C901, PLR0915
             requested_agent_names,
             orchestrator,
             execution_identity,
-            session_id=session_id,
+            session_id=ctx.session_id,
             reason_prefix=reason_prefix,
             configured_team_name=configured_team_name,
         )
@@ -2530,8 +2473,8 @@ async def team_response_stream(  # noqa: C901, PLR0915
         attempt_model_name = config.resolve_runtime_model(
             entity_name=configured_team_name,
             active_model_name=model_name,
-            room_id=room_id,
-            thread_id=thread_id,
+            room_id=ctx.room_id,
+            thread_id=ctx.thread_id,
             runtime_paths=orchestrator.runtime_paths,
         ).model_name
         team = build_materialized_team_instance(
@@ -2547,6 +2490,7 @@ async def team_response_stream(  # noqa: C901, PLR0915
         )
         holder.team = team
         prepared_execution = await prepare_materialized_team_execution(
+            ctx,
             scope_context=run.scope_context,
             agents=attempt_agents,
             team=team,
@@ -2555,23 +2499,15 @@ async def team_response_stream(  # noqa: C901, PLR0915
             config=config,
             runtime_paths=orchestrator.runtime_paths,
             active_model_name=attempt_model_name,
-            reply_to_event_id=reply_to_event_id,
-            active_event_ids=active_event_ids,
             response_sender_id=response_sender_id,
             current_sender_id=user_id,
-            room_id=room_id,
-            thread_id=thread_id,
-            requester_id=requester_id,
-            correlation_id=correlation_id,
             compaction_outcomes_collector=compaction_outcomes_collector,
             current_timestamp_ms=continuation_state.active_current_timestamp_ms,
             current_prompt_is_structured=continuation_state.active_current_prompt_is_structured,
             compaction_lifecycle=compaction_lifecycle,
             configured_team_name=configured_team_name,
             thread_history_render_limits=_MATRIX_TEAM_THREAD_HISTORY_RENDER_LIMITS,
-            matrix_run_metadata=matrix_run_metadata,
             pipeline_timing=pipeline_timing,
-            system_enrichment_items=enrichment_items,
         )
         prepared_prompt = prepared_execution.prepared_prompt
         run.unseen_event_ids = prepared_execution.unseen_event_ids
@@ -2792,7 +2728,7 @@ async def team_response_stream(  # noqa: C901, PLR0915
                 prompt=attempt_prompt,
                 metadata=run_metadata,
                 media=attempt_media_inputs,
-                session_id=session_id,
+                session_id=ctx.session_id,
                 run_id=attempt_run_id,
                 user_id=user_id,
             )
@@ -2804,13 +2740,8 @@ async def team_response_stream(  # noqa: C901, PLR0915
             raw_stream = stream_with_llm_request_log_context(
                 cast("AsyncGenerator[Any, None]", raw_stream),
                 request_context=_team_request_log_context(
+                    ctx,
                     team_name=configured_team_name or team_label,
-                    session_id=session_id,
-                    room_id=room_id,
-                    thread_id=thread_id,
-                    reply_to_event_id=reply_to_event_id,
-                    requester_id=requester_id,
-                    correlation_id=correlation_id,
                     prompt=message,
                     run_input=stream_run_input,
                     metadata=run_metadata,
@@ -2821,7 +2752,7 @@ async def team_response_stream(  # noqa: C901, PLR0915
                     _cleanup_team_notice_state(
                         run_output=event,
                         scope_context=run.scope_context,
-                        session_id=session_id,
+                        session_id=ctx.session_id,
                         entity_name=configured_team_name or team_label,
                     )
                     event_tool_executions = _collect_team_tool_executions(event)
@@ -2831,7 +2762,7 @@ async def team_response_stream(  # noqa: C901, PLR0915
                             config=config,
                             prepared_execution=prepared_execution,
                             response=event,
-                            session_id=session_id,
+                            session_id=ctx.session_id,
                             tool_count=len(event_tool_executions),
                         )
 
@@ -2890,11 +2821,11 @@ async def team_response_stream(  # noqa: C901, PLR0915
                         yield AttemptResolved(HandledAttempt())
                         return
 
-                    if reply_to_event_id:
+                    if ctx.reply_to_event_id:
                         _persist_bound_seen_event_ids(
                             scope_context=run.scope_context,
-                            session_id=session_id,
-                            event_ids=[reply_to_event_id, *unseen_event_ids],
+                            session_id=ctx.session_id,
+                            event_ids=[ctx.reply_to_event_id, *unseen_event_ids],
                         )
                     response_text = _format_terminal_team_response(
                         event,
@@ -2968,7 +2899,7 @@ async def team_response_stream(  # noqa: C901, PLR0915
                                 completed_run_event=None,
                                 usage=usage,
                                 run_id=event.run_id or attempt_run_id,
-                                session_id=event.session_id or session_id,
+                                session_id=event.session_id or ctx.session_id,
                                 status=RunStatus.error,
                                 tool_count=len(completed_tool_executions),
                             ),
@@ -2986,7 +2917,7 @@ async def team_response_stream(  # noqa: C901, PLR0915
                             completed_run_event=None,
                             usage=usage,
                             run_id=event.run_id or attempt_run_id,
-                            session_id=event.session_id or session_id,
+                            session_id=event.session_id or ctx.session_id,
                             status=RunStatus.cancelled,
                             tool_count=len(completed_tool_executions),
                         )
@@ -3094,11 +3025,11 @@ async def team_response_stream(  # noqa: C901, PLR0915
 
             if media_fallback_retry_requested:
                 continue
-            if emitted_output and reply_to_event_id:
+            if emitted_output and ctx.reply_to_event_id:
                 _persist_bound_seen_event_ids(
                     scope_context=run.scope_context,
-                    session_id=session_id,
-                    event_ids=[reply_to_event_id, *unseen_event_ids],
+                    session_id=ctx.session_id,
+                    event_ids=[ctx.reply_to_event_id, *unseen_event_ids],
                 )
             # Real Agno team streams end without a terminal run output, so this
             # is the resolution point where the empty-run guard must fire.
@@ -3111,7 +3042,7 @@ async def team_response_stream(  # noqa: C901, PLR0915
                     usage=usage,
                     run_id=(completed_run_event.run_id if completed_run_event is not None else None) or attempt_run_id,
                     session_id=(completed_run_event.session_id if completed_run_event is not None else None)
-                    or session_id,
+                    or ctx.session_id,
                     status=RunStatus.completed,
                     tool_count=len(completed_tool_executions),
                 )
@@ -3140,12 +3071,12 @@ async def team_response_stream(  # noqa: C901, PLR0915
         _cleanup_team_notice_state(
             run_output=None,
             scope_context=scope_context,
-            session_id=session_id,
+            session_id=ctx.session_id,
             entity_name=configured_team_name or team_label,
         )
 
     discard_team_empty_run = _build_team_empty_run_discard(
-        session_id=session_id,
+        session_id=ctx.session_id,
         entity_name=configured_team_name or team_label,
     )
 
@@ -3161,7 +3092,7 @@ async def team_response_stream(  # noqa: C901, PLR0915
     adapter = StreamingTurnAdapter[_TeamStreamChunk](
         open_scope=lambda: open_bound_scope_session_context(
             agents=team_members.agents,
-            session_id=session_id,
+            session_id=ctx.session_id,
             runtime_paths=orchestrator.runtime_paths,
             config=config,
             execution_identity=execution_identity,
@@ -3177,24 +3108,14 @@ async def team_response_stream(  # noqa: C901, PLR0915
         discard_empty_run=discard_team_empty_run,
     )
     response_stream = stream_response_turn(
-        ResponseTurnContext(
-            entity_label=team_label,
-            session_id=session_id,
-            run_id=run_id,
-            correlation_id=correlation_id,
-            reply_to_event_id=reply_to_event_id,
-            room_id=room_id,
-            thread_id=thread_id,
-            requester_id=requester_id,
-            matrix_run_metadata=matrix_run_metadata,
-        ),
+        ctx,
         adapter,
         TurnSinks(turn_recorder=turn_recorder, run_metadata_collector=run_metadata_collector),
         continuation=_initial_team_continuation(
             message=message,
             current_timestamp_ms=current_timestamp_ms,
             current_prompt_is_structured=current_prompt_is_structured,
-            run_id=run_id,
+            run_id=ctx.run_id,
         ),
     )
     # Close the driver generator deterministically when this wrapper unwinds so

--- a/tach.toml
+++ b/tach.toml
@@ -2848,6 +2848,7 @@ from = ["mindroom.runtime_resolution"]
 [[interfaces]]
 expose = [
     "AIStreamChunk",
+    "ResponseTurnContext",
     "build_matrix_run_metadata",
     "ai_response",
     "resolve_run_correlation_id",

--- a/tach.toml
+++ b/tach.toml
@@ -2851,7 +2851,6 @@ expose = [
     "ResponseTurnContext",
     "build_matrix_run_metadata",
     "ai_response",
-    "resolve_run_correlation_id",
     "stream_agent_response",
 ]
 from = ["mindroom.ai"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ from contextlib import ExitStack, contextmanager
 from dataclasses import replace
 from itertools import count
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import nio
@@ -36,6 +36,7 @@ from aioresponses import aioresponses
 
 import mindroom.bot  # noqa: F401
 from mindroom.agent_storage import get_agent_session, get_team_session
+from mindroom.ai import ResponseTurnContext
 from mindroom.bot import AgentBot, TeamBot
 from mindroom.config.main import Config, load_config
 from mindroom.constants import RuntimePaths, resolve_runtime_paths, safe_replace
@@ -56,7 +57,7 @@ from mindroom.history import (
 )
 from mindroom.history.runtime import _resolve_history_scope, open_scope_session_context
 from mindroom.history.types import ResolvedHistoryExecutionPlan
-from mindroom.hooks import MessageEnvelope
+from mindroom.hooks import EnrichmentItem, MessageEnvelope
 from mindroom.ingress_validation import IngressValidator
 from mindroom.interactive import InteractiveMetadata
 from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
@@ -953,6 +954,36 @@ def create_mock_room(
     else:
         room.users = {}
     return room
+
+
+def make_turn_context(
+    entity_label: str = "test_agent",
+    *,
+    session_id: str | None = "test_session",
+    run_id: str | None = None,
+    correlation_id: str = "corr-test",
+    reply_to_event_id: str | None = None,
+    room_id: str | None = None,
+    thread_id: str | None = None,
+    requester_id: str | None = None,
+    matrix_run_metadata: dict[str, Any] | None = None,
+    active_event_ids: frozenset[str] = frozenset(),
+    system_enrichment_items: tuple[EnrichmentItem, ...] = (),
+) -> ResponseTurnContext:
+    """Build one response-turn context with test defaults."""
+    return ResponseTurnContext(
+        entity_label=entity_label,
+        session_id=session_id,
+        run_id=run_id,
+        correlation_id=correlation_id,
+        reply_to_event_id=reply_to_event_id,
+        room_id=room_id,
+        thread_id=thread_id,
+        requester_id=requester_id,
+        matrix_run_metadata=matrix_run_metadata,
+        active_event_ids=active_event_ids,
+        system_enrichment_items=system_enrichment_items,
+    )
 
 
 def make_visible_message(

--- a/tests/test_ai_stream_collection.py
+++ b/tests/test_ai_stream_collection.py
@@ -11,6 +11,7 @@ from agno.run.agent import RunContentEvent, ToolCallCompletedEvent, ToolCallStar
 from mindroom.ai import _collect_streamed_response_content, ai_response
 from mindroom.config.main import Config
 from mindroom.tool_system.events import ToolTraceEntry
+from tests.conftest import make_turn_context
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
@@ -82,7 +83,7 @@ async def test_ai_response_honors_hidden_tool_marker_collection_opt_in(monkeypat
     """Explicit stream collection should still work when inline tool markers are hidden."""
     seen_kwargs: dict[str, object] = {}
 
-    async def fake_stream_agent_response(**kwargs: object) -> AsyncGenerator[object, None]:
+    async def fake_stream_agent_response(_ctx: object, **kwargs: object) -> AsyncGenerator[object, None]:
         seen_kwargs.update(kwargs)
         yield RunContentEvent(content="Before.")
         yield ToolCallStartedEvent(tool=ToolExecution(tool_name="read_file", tool_args={"path": "README.md"}))
@@ -95,9 +96,8 @@ async def test_ai_response_honors_hidden_tool_marker_collection_opt_in(monkeypat
 
     trace: list[ToolTraceEntry] = []
     body = await ai_response(
-        agent_name="general",
+        make_turn_context("general", session_id="session"),
         prompt="Read",
-        session_id="session",
         runtime_paths=cast("RuntimePaths", object()),
         config=Config(),
         show_tool_calls=False,

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -4900,6 +4900,49 @@ class TestUserIdPassthrough:
         assert mock_agent.additional_context == "existing context\n\nsession preamble\n\nsystem enrichment"
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("include_openai_compat_guidance", "expected_sender"),
+        [(True, None), (False, "@alice:example.com")],
+    )
+    async def test_prepare_agent_and_prompt_derives_current_sender_from_requester(
+        self,
+        tmp_path: Path,
+        include_openai_compat_guidance: bool,
+        expected_sender: str | None,
+    ) -> None:
+        """OpenAI-compatible preparation suppresses the Matrix sender; Matrix turns keep it."""
+        config = _config()
+        mock_agent = MagicMock()
+        prepared_execution = _PreparedExecutionContext(
+            messages=(Message(role="user", content="prepared prompt"),),
+            unseen_event_ids=[],
+            prepared_history=PreparedHistoryState(),
+        )
+
+        with (
+            patch(
+                "mindroom.ai.build_memory_prompt_parts",
+                new_callable=AsyncMock,
+                return_value=MemoryPromptParts(),
+            ),
+            patch("mindroom.ai.create_agent", return_value=mock_agent),
+            patch(
+                "mindroom.ai.prepare_agent_execution_context",
+                new=AsyncMock(return_value=prepared_execution),
+            ) as mock_prepare_execution,
+        ):
+            await _prepare_agent_and_prompt(
+                make_turn_context("general", requester_id="@alice:example.com"),
+                prompt="test",
+                runtime_paths=_runtime_paths(tmp_path),
+                config=config,
+                include_openai_compat_guidance=include_openai_compat_guidance,
+            )
+
+        assert mock_prepare_execution.await_args is not None
+        assert mock_prepare_execution.await_args.kwargs["current_sender_id"] == expected_sender
+
+    @pytest.mark.asyncio
     async def test_ai_response_passes_config_path_to_prepare_agent(self, tmp_path: Path) -> None:
         """Non-streaming replies should build agents against the orchestrator-owned config file."""
         config_path = tmp_path / "custom-config.yaml"

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -128,7 +128,13 @@ from mindroom.tool_system.worker_routing import (
     tool_execution_identity,
 )
 from tests.conftest import bind_runtime_paths as _bind_runtime_paths
-from tests.conftest import make_event_cache_mock, make_visible_message, message_origin, request_envelope
+from tests.conftest import (
+    make_event_cache_mock,
+    make_turn_context,
+    make_visible_message,
+    message_origin,
+    request_envelope,
+)
 from tests.identity_helpers import fixture_entity_matrix_id, persist_entity_accounts
 
 if TYPE_CHECKING:
@@ -2395,8 +2401,8 @@ async def test_process_and_respond_uses_resolved_thread_id_for_ai_logging_contex
             requester_id="@alice:localhost",
         )
 
-        async def fake_ai_response(*_args: object, **kwargs: object) -> str:
-            assert kwargs["thread_id"] == "$resolved-thread"
+        async def fake_ai_response(*args: object, **_kwargs: object) -> str:
+            assert args[0].thread_id == "$resolved-thread"
             return "Hello!"
 
         mock_ai.side_effect = fake_ai_response
@@ -2428,8 +2434,8 @@ async def test_process_and_respond_streaming_uses_resolved_thread_id_for_ai_logg
             requester_id="@alice:localhost",
         )
 
-        def fake_stream_agent_response(*_args: object, **kwargs: object) -> AsyncIterator[str]:
-            assert kwargs["thread_id"] == "$resolved-thread"
+        def fake_stream_agent_response(*args: object, **_kwargs: object) -> AsyncIterator[str]:
+            assert args[0].thread_id == "$resolved-thread"
 
             async def fake_stream() -> AsyncIterator[str]:
                 yield "Hello!"
@@ -2621,9 +2627,9 @@ async def test_generate_response_preserves_model_prompt_in_persisted_session(
     storage = _SessionStorage()
 
     async def fake_prepare_agent_and_prompt(
-        _agent_name: str,
-        prompt: str,
+        _ctx: object,
         *_args: object,
+        prompt: str,
         model_prompt: str | None = None,
         **_kwargs: object,
     ) -> _PreparedAgentRun:
@@ -2734,10 +2740,10 @@ async def test_generate_response_passes_resolved_correlation_id_to_ai_response(t
     runtime_paths = _runtime_paths(tmp_path)
     config = bind_runtime_paths(_config(), runtime_paths)
     bot = _make_bot(tmp_path, config=config, runtime_paths=runtime_paths)
-    seen_kwargs: dict[str, object] = {}
+    seen_ctx: list[object] = []
 
-    async def fake_ai_response(*_args: object, **kwargs: object) -> str:
-        seen_kwargs.update(kwargs)
+    async def fake_ai_response(*args: object, **_kwargs: object) -> str:
+        seen_ctx.append(args[0])
         return "Hello"
 
     with (
@@ -2764,8 +2770,10 @@ async def test_generate_response_passes_resolved_correlation_id_to_ai_response(t
             ),
         )
 
-    assert seen_kwargs["reply_to_event_id"] == "$original"
-    assert seen_kwargs["correlation_id"] == "$edit"
+    assert seen_ctx
+    ctx = seen_ctx[-1]
+    assert ctx.reply_to_event_id == "$original"
+    assert ctx.correlation_id == "$edit"
 
 
 @pytest.mark.asyncio
@@ -2779,9 +2787,9 @@ async def test_generate_response_preserves_retry_model_prompt(tmp_path: Path) ->
     seen_run_ids: list[str | None] = []
 
     async def fake_prepare_agent_and_prompt(
-        _agent_name: str,
-        prompt: str,
+        _ctx: object,
         *_args: object,
+        prompt: str,
         model_prompt: str | None = None,
         **_kwargs: object,
     ) -> _PreparedAgentRun:
@@ -4557,7 +4565,7 @@ class TestUserIdPassthrough:
             )
 
             mock_ai.assert_called_once()
-            assert mock_ai.call_args.kwargs["user_id"] == "@alice:localhost"
+            assert mock_ai.call_args.args[0].requester_id == "@alice:localhost"
             assert callable(mock_ai.call_args.kwargs["run_id_callback"])
 
     @pytest.mark.asyncio
@@ -4612,7 +4620,7 @@ class TestUserIdPassthrough:
             )
 
             mock_stream.assert_called_once()
-            assert mock_stream.call_args.kwargs["user_id"] == "@bob:localhost"
+            assert mock_stream.call_args.args[0].requester_id == "@bob:localhost"
             assert callable(mock_stream.call_args.kwargs["run_id_callback"])
 
     @pytest.mark.asyncio
@@ -4763,12 +4771,10 @@ class TestUserIdPassthrough:
             mock_prepare.return_value = _prepared_prompt_result(mock_agent)
 
             await ai_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1", requester_id="@user:localhost"),
                 prompt="test",
-                session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=_config(),
-                user_id="@user:localhost",
             )
 
             mock_agent.arun.assert_called_once()
@@ -4791,12 +4797,10 @@ class TestUserIdPassthrough:
             mock_prepare.return_value = _prepared_prompt_result(mock_agent)
 
             await ai_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1", run_id="run-123"),
                 prompt="test",
-                session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=_config(),
-                run_id="run-123",
             )
 
             mock_agent.arun.assert_called_once()
@@ -4820,7 +4824,7 @@ class TestUserIdPassthrough:
             patch("mindroom.ai.create_agent", return_value=mock_agent) as mock_create_agent,
         ):
             prepared_run = await _prepare_agent_and_prompt(
-                agent_name="general",
+                make_turn_context("general"),
                 prompt="test",
                 runtime_paths=runtime_paths,
                 config=config,
@@ -4871,12 +4875,14 @@ class TestUserIdPassthrough:
             ) as mock_prepare_execution,
         ):
             prepared_run = await _prepare_agent_and_prompt(
-                agent_name="general",
+                make_turn_context(
+                    "general",
+                    system_enrichment_items=(EnrichmentItem(key="k", text="v", cache_policy="stable"),),
+                ),
                 prompt="raw prompt",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=config,
                 model_prompt="model metadata",
-                system_enrichment_items=(EnrichmentItem(key="k", text="v", cache_policy="stable"),),
             )
 
         agent = prepared_run.agent
@@ -4909,15 +4915,14 @@ class TestUserIdPassthrough:
             mock_prepare.return_value = _prepared_prompt_result(mock_agent)
 
             await ai_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1"),
                 prompt="test",
-                session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path, config_path=config_path),
                 config=_config(),
                 include_openai_compat_guidance=True,
             )
 
-        assert mock_prepare.call_args.args[2].config_path == config_path
+        assert mock_prepare.await_args.kwargs["runtime_paths"].config_path == config_path
         assert mock_prepare.await_args.kwargs["include_openai_compat_guidance"] is True
 
     @pytest.mark.asyncio
@@ -4935,16 +4940,15 @@ class TestUserIdPassthrough:
             mock_prepare.return_value = _prepared_prompt_result(mock_agent)
 
             await ai_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1", requester_id="user-123"),
                 prompt="test",
-                session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=_config(),
-                user_id="user-123",
                 include_openai_compat_guidance=True,
             )
 
-        assert mock_prepare.await_args.kwargs["current_sender_id"] is None
+        prepare_ctx = mock_prepare.await_args.args[0]
+        assert prepare_ctx.requester_id == "user-123"
         assert mock_prepare.await_args.kwargs["include_openai_compat_guidance"] is True
 
     @pytest.mark.asyncio
@@ -4962,15 +4966,15 @@ class TestUserIdPassthrough:
             mock_prepare.return_value = _prepared_prompt_result(mock_agent)
 
             await ai_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1", requester_id="@alice:example.com"),
                 prompt="test",
-                session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=_config(),
-                user_id="@alice:example.com",
             )
 
-        assert mock_prepare.await_args.kwargs["current_sender_id"] == "@alice:example.com"
+        prepare_ctx = mock_prepare.await_args.args[0]
+        assert prepare_ctx.requester_id == "@alice:example.com"
+        assert mock_prepare.await_args.kwargs.get("include_openai_compat_guidance", False) is False
 
     @pytest.mark.asyncio
     async def test_ai_response_passes_raw_prompt_separately_from_model_prompt(self, tmp_path: Path) -> None:
@@ -4987,15 +4991,14 @@ class TestUserIdPassthrough:
             mock_prepare.return_value = _prepared_prompt_result(mock_agent)
 
             await ai_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1"),
                 prompt="raw prompt",
                 model_prompt="model metadata",
-                session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=_config(),
             )
 
-        assert mock_prepare.await_args.args[1] == "raw prompt"
+        assert mock_prepare.await_args.kwargs["prompt"] == "raw prompt"
         assert mock_prepare.await_args.kwargs["model_prompt"] == "model metadata"
 
     @pytest.mark.asyncio
@@ -5016,16 +5019,15 @@ class TestUserIdPassthrough:
             _ = [
                 chunk
                 async for chunk in stream_agent_response(
-                    agent_name="general",
+                    make_turn_context("general", session_id="session1"),
                     prompt="test",
-                    session_id="session1",
                     runtime_paths=_runtime_paths(tmp_path, config_path=config_path),
                     config=_config(),
                     include_openai_compat_guidance=True,
                 )
             ]
 
-        assert mock_prepare.call_args.args[2].config_path == config_path
+        assert mock_prepare.await_args.kwargs["runtime_paths"].config_path == config_path
         assert mock_prepare.await_args.kwargs["include_openai_compat_guidance"] is True
 
     @pytest.mark.asyncio
@@ -5045,17 +5047,16 @@ class TestUserIdPassthrough:
             _ = [
                 chunk
                 async for chunk in stream_agent_response(
-                    agent_name="general",
+                    make_turn_context("general", session_id="session1", requester_id="user-123"),
                     prompt="test",
-                    session_id="session1",
                     runtime_paths=_runtime_paths(tmp_path),
                     config=_config(),
-                    user_id="user-123",
                     include_openai_compat_guidance=True,
                 )
             ]
 
-        assert mock_prepare.await_args.kwargs["current_sender_id"] is None
+        prepare_ctx = mock_prepare.await_args.args[0]
+        assert prepare_ctx.requester_id == "user-123"
         assert mock_prepare.await_args.kwargs["include_openai_compat_guidance"] is True
 
     @pytest.mark.asyncio
@@ -5075,16 +5076,15 @@ class TestUserIdPassthrough:
             _ = [
                 chunk
                 async for chunk in stream_agent_response(
-                    agent_name="general",
+                    make_turn_context("general", session_id="session1", requester_id="@alice:example.com"),
                     prompt="test",
-                    session_id="session1",
                     runtime_paths=_runtime_paths(tmp_path),
                     config=_config(),
-                    user_id="@alice:example.com",
                 )
             ]
 
-        assert mock_prepare.await_args.kwargs["current_sender_id"] == "@alice:example.com"
+        prepare_ctx = mock_prepare.await_args.args[0]
+        assert prepare_ctx.requester_id == "@alice:example.com"
 
     @pytest.mark.asyncio
     async def test_stream_agent_response_passes_user_id_to_agent_arun(self, tmp_path: Path) -> None:
@@ -5107,12 +5107,10 @@ class TestUserIdPassthrough:
             _chunks = [
                 chunk
                 async for chunk in stream_agent_response(
-                    agent_name="general",
+                    make_turn_context("general", session_id="session1", requester_id="@user:localhost"),
                     prompt="test",
-                    session_id="session1",
                     runtime_paths=_runtime_paths(tmp_path),
                     config=_config(),
-                    user_id="@user:localhost",
                 )
             ]
 
@@ -5139,12 +5137,10 @@ class TestUserIdPassthrough:
             _chunks = [
                 chunk
                 async for chunk in stream_agent_response(
-                    agent_name="general",
+                    make_turn_context("general", session_id="session1", run_id="run-456"),
                     prompt="test",
-                    session_id="session1",
                     runtime_paths=_runtime_paths(tmp_path),
                     config=_config(),
-                    run_id="run-456",
                 )
             ]
 
@@ -5177,9 +5173,8 @@ class TestUserIdPassthrough:
 
             with pytest.raises(asyncio.CancelledError):
                 await ai_response(
-                    agent_name="general",
+                    make_turn_context("general", session_id="session1"),
                     prompt="test",
-                    session_id="session1",
                     runtime_paths=_runtime_paths(tmp_path),
                     config=_config(),
                 )
@@ -5218,12 +5213,10 @@ class TestUserIdPassthrough:
 
             with pytest.raises(asyncio.CancelledError):
                 await ai_response(
-                    agent_name="general",
+                    make_turn_context("general", session_id="session1", correlation_id="e1", reply_to_event_id="e1"),
                     prompt="test",
-                    session_id="session1",
                     runtime_paths=_runtime_paths(tmp_path),
                     config=_config(),
-                    reply_to_event_id="e1",
                     show_tool_calls=False,
                 )
 
@@ -5286,12 +5279,10 @@ class TestUserIdPassthrough:
 
             with pytest.raises(asyncio.CancelledError):
                 await ai_response(
-                    agent_name="general",
+                    make_turn_context("general", session_id="session1", correlation_id="e1", reply_to_event_id="e1"),
                     prompt="test",
-                    session_id="session1",
                     runtime_paths=_runtime_paths(tmp_path),
                     config=_config(),
-                    reply_to_event_id="e1",
                     show_tool_calls=False,
                 )
 
@@ -5340,12 +5331,10 @@ class TestUserIdPassthrough:
 
             with pytest.raises(asyncio.CancelledError):
                 await ai_response(
-                    agent_name="general",
+                    make_turn_context("general", session_id="session1", correlation_id="e1", reply_to_event_id="e1"),
                     prompt="test",
-                    session_id="session1",
                     runtime_paths=_runtime_paths(tmp_path),
                     config=_config(),
-                    reply_to_event_id="e1",
                     show_tool_calls=False,
                 )
 
@@ -5399,12 +5388,10 @@ class TestUserIdPassthrough:
 
             with pytest.raises(asyncio.CancelledError):
                 await ai_response(
-                    agent_name="general",
+                    make_turn_context("general", session_id="session1", correlation_id="e1", reply_to_event_id="e1"),
                     prompt="test",
-                    session_id="session1",
                     runtime_paths=_runtime_paths(tmp_path),
                     config=_config(),
-                    reply_to_event_id="e1",
                     show_tool_calls=False,
                     turn_recorder=recorder,
                 )
@@ -5436,9 +5423,8 @@ class TestUserIdPassthrough:
             mock_prepare.return_value = _prepared_prompt_result(mock_agent)
 
             response = await ai_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1"),
                 prompt="test",
-                session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=_config(),
             )
@@ -5454,9 +5440,8 @@ class TestUserIdPassthrough:
             return_value="friendly-error",
         ) as mock_friendly_error:
             response = await ai_response(
-                agent_name="ultimate",
+                make_turn_context("ultimate", session_id="session1"),
                 prompt="test",
-                session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=_config_with_team(),
             )
@@ -5477,9 +5462,8 @@ class TestUserIdPassthrough:
             chunks = [
                 chunk
                 async for chunk in stream_agent_response(
-                    agent_name="ultimate",
+                    make_turn_context("ultimate", session_id="session1"),
                     prompt="test",
-                    session_id="session1",
                     runtime_paths=_runtime_paths(tmp_path),
                     config=_config_with_team(),
                 )
@@ -5510,9 +5494,8 @@ class TestUserIdPassthrough:
         with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
             mock_prepare.return_value = _prepared_prompt_result(mock_agent)
             await ai_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1"),
                 prompt="test",
-                session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=_config(),
                 media=MediaInputs(files=[pdf_file, zip_file]),
@@ -5544,9 +5527,8 @@ class TestUserIdPassthrough:
             _chunks = [
                 _chunk
                 async for _chunk in stream_agent_response(
-                    agent_name="general",
+                    make_turn_context("general", session_id="session1"),
                     prompt="test",
-                    session_id="session1",
                     runtime_paths=_runtime_paths(tmp_path),
                     config=_config(),
                     media=MediaInputs(files=[pdf_file, zip_file]),
@@ -5590,9 +5572,8 @@ class TestUserIdPassthrough:
         with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
             mock_prepare.return_value = _prepared_prompt_result(mock_agent)
             response = await ai_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1"),
                 prompt="test",
-                session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=_config(),
                 media=MediaInputs(files=[document_file]),
@@ -5648,17 +5629,15 @@ class TestUserIdPassthrough:
                 _prepared_prompt_result(second_agent),
             ]
             first_response = await ai_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1"),
                 prompt="test",
-                session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=_config(),
                 media=MediaInputs(audio=[audio_input], images=[image_input]),
             )
             second_response = await ai_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1"),
                 prompt="test again",
-                session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=_config(),
                 media=MediaInputs(audio=[audio_input], images=[image_input]),
@@ -5727,10 +5706,9 @@ class TestUserIdPassthrough:
         ):
             mock_prepare.return_value = _prepared_prompt_result(mock_agent, prompt=prepared_prompt)
             response = await ai_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1"),
                 prompt="raw prompt",
                 model_prompt="expanded prompt",
-                session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=_config(),
                 media=MediaInputs(files=[document_file]),
@@ -5738,7 +5716,7 @@ class TestUserIdPassthrough:
 
         assert response == "Recovered response"
         mock_prepare.assert_awaited_once()
-        assert mock_prepare.await_args.args[1] == "raw prompt"
+        assert mock_prepare.await_args.kwargs["prompt"] == "raw prompt"
         assert mock_prepare.await_args.kwargs["model_prompt"] == "expanded prompt"
         assert len(logged_contexts) == 2
         assert logged_contexts[0]["agent_id"] == "general"
@@ -5802,12 +5780,10 @@ class TestUserIdPassthrough:
         ):
             mock_prepare.return_value = _prepared_prompt_result(mock_agent)
             response = await ai_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1", run_id="run-123"),
                 prompt="test",
-                session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=_config(),
-                run_id="run-123",
                 run_id_callback=callback_run_ids.append,
                 media=MediaInputs(audio=[MagicMock(name="audio_input")]),
             )
@@ -5848,16 +5824,19 @@ class TestUserIdPassthrough:
 
             with pytest.raises(asyncio.CancelledError):
                 await ai_response(
-                    agent_name="general",
+                    make_turn_context(
+                        "general",
+                        session_id="session1",
+                        run_id="run-123",
+                        correlation_id="$event:localhost",
+                        reply_to_event_id="$event:localhost",
+                        room_id="!room:localhost",
+                        thread_id="$thread:localhost",
+                        requester_id="@alice:localhost",
+                    ),
                     prompt="test",
-                    session_id="session1",
                     runtime_paths=_runtime_paths(tmp_path),
                     config=_config(),
-                    room_id="!room:localhost",
-                    thread_id="$thread:localhost",
-                    user_id="@alice:localhost",
-                    reply_to_event_id="$event:localhost",
-                    run_id="run-123",
                     run_id_callback=callback_run_ids.append,
                     media=MediaInputs(audio=[MagicMock(name="audio_input")]),
                 )
@@ -5913,9 +5892,8 @@ class TestUserIdPassthrough:
             chunks = [
                 chunk
                 async for chunk in stream_agent_response(
-                    agent_name="general",
+                    make_turn_context("general", session_id="session1"),
                     prompt="test",
-                    session_id="session1",
                     runtime_paths=_runtime_paths(tmp_path),
                     config=_config(),
                     media=MediaInputs(files=[document_file]),
@@ -5977,10 +5955,9 @@ class TestUserIdPassthrough:
             chunks = [
                 chunk
                 async for chunk in stream_agent_response(
-                    agent_name="general",
+                    make_turn_context("general", session_id="session1"),
                     prompt="raw prompt",
                     model_prompt="expanded prompt",
-                    session_id="session1",
                     runtime_paths=_runtime_paths(tmp_path),
                     config=_config(),
                     media=MediaInputs(files=[document_file]),
@@ -5989,7 +5966,7 @@ class TestUserIdPassthrough:
 
         assert any(isinstance(chunk, RunContentEvent) and chunk.content == "Recovered stream" for chunk in chunks)
         mock_prepare.assert_awaited_once()
-        assert mock_prepare.await_args.args[1] == "raw prompt"
+        assert mock_prepare.await_args.kwargs["prompt"] == "raw prompt"
         assert mock_prepare.await_args.kwargs["model_prompt"] == "expanded prompt"
         assert len(logged_contexts) == 2
         assert logged_contexts[0]["agent_id"] == "general"
@@ -6088,15 +6065,18 @@ class TestUserIdPassthrough:
             chunks = [
                 chunk
                 async for chunk in stream_agent_response(
-                    agent_name="general",
+                    make_turn_context(
+                        "general",
+                        session_id="session1",
+                        correlation_id="$reply:example.com",
+                        reply_to_event_id="$reply:example.com",
+                        room_id="!room:example.com",
+                        thread_id="$thread:example.com",
+                    ),
                     prompt="raw prompt",
                     model_prompt="expanded prompt",
-                    session_id="session1",
                     runtime_paths=_runtime_paths(tmp_path),
                     config=config,
-                    room_id="!room:example.com",
-                    thread_id="$thread:example.com",
-                    reply_to_event_id="$reply:example.com",
                 )
             ]
 
@@ -6147,12 +6127,10 @@ class TestUserIdPassthrough:
             chunks = [
                 chunk
                 async for chunk in stream_agent_response(
-                    agent_name="general",
+                    make_turn_context("general", session_id="session1", run_id="run-456"),
                     prompt="test",
-                    session_id="session1",
                     runtime_paths=_runtime_paths(tmp_path),
                     config=_config(),
-                    run_id="run-456",
                     run_id_callback=callback_run_ids.append,
                     media=MediaInputs(audio=[MagicMock(name="audio_input")]),
                 )
@@ -6203,12 +6181,10 @@ class TestUserIdPassthrough:
                 _chunks = [
                     chunk
                     async for chunk in stream_agent_response(
-                        agent_name="general",
+                        make_turn_context("general", session_id="session1", run_id="run-456"),
                         prompt="test",
-                        session_id="session1",
                         runtime_paths=_runtime_paths(tmp_path),
                         config=_config(),
-                        run_id="run-456",
                         run_id_callback=callback_run_ids.append,
                         media=MediaInputs(audio=[MagicMock(name="audio_input")]),
                     )
@@ -6315,9 +6291,8 @@ class TestUserIdPassthrough:
         ):
             mock_prepare.return_value = _prepared_prompt_result(mock_agent)
             response = await ai_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1"),
                 prompt="test",
-                session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=_config(),
                 media=MediaInputs(files=[document_file]),
@@ -6369,9 +6344,8 @@ class TestUserIdPassthrough:
             chunks = [
                 chunk
                 async for chunk in stream_agent_response(
-                    agent_name="general",
+                    make_turn_context("general", session_id="session1"),
                     prompt="test",
-                    session_id="session1",
                     runtime_paths=_runtime_paths(tmp_path),
                     config=_config(),
                     media=MediaInputs(files=[document_file]),
@@ -6446,9 +6420,8 @@ class TestUserIdPassthrough:
             chunks = [
                 chunk
                 async for chunk in stream_agent_response(
-                    agent_name="general",
+                    make_turn_context("general", session_id="session1"),
                     prompt="test",
-                    session_id="session1",
                     runtime_paths=_runtime_paths(tmp_path),
                     config=_config(),
                 )
@@ -6476,9 +6449,8 @@ class TestUserIdPassthrough:
 
             # Call without user_id
             await ai_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1"),
                 prompt="test",
-                session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=_config(),
             )
@@ -6510,9 +6482,8 @@ class TestUserIdPassthrough:
             mock_prepare.return_value = _prepared_prompt_result(mock_agent)
             tool_trace: list[object] = []
             response = await ai_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1"),
                 prompt="test",
-                session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=_config(),
                 show_tool_calls=False,
@@ -6574,12 +6545,10 @@ class TestUserIdPassthrough:
             tool_trace: list[object] = []
             run_ids: list[str] = []
             response = await ai_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1", run_id="run-1"),
                 prompt="test",
-                session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=_config(),
-                run_id="run-1",
                 model_prompt="test\n\nUse attachment att_1.",
                 run_id_callback=run_ids.append,
                 show_tool_calls=False,
@@ -6590,7 +6559,7 @@ class TestUserIdPassthrough:
         assert mock_prepare.await_count == 2
         assert mock_prepare.await_args_list[0].kwargs["model_prompt"] == "test\n\nUse attachment att_1."
         assert mock_prepare.await_args_list[1].kwargs["model_prompt"] == "Use attachment att_1."
-        assert "Continue the same task" in mock_prepare.await_args_list[1].args[1]
+        assert "Continue the same task" in mock_prepare.await_args_list[1].kwargs["prompt"]
         first_agent.arun.assert_awaited_once()
         second_agent.arun.assert_awaited_once()
         assert run_ids[0] == "run-1"
@@ -6662,12 +6631,10 @@ class TestUserIdPassthrough:
 
             with pytest.raises(asyncio.CancelledError):
                 await ai_response(
-                    agent_name="general",
+                    make_turn_context("general", session_id="session1", run_id="run-1"),
                     prompt="test",
-                    session_id="session1",
                     runtime_paths=_runtime_paths(tmp_path),
                     config=_config(),
-                    run_id="run-1",
                     show_tool_calls=False,
                     turn_recorder=recorder,
                 )
@@ -6728,12 +6695,10 @@ class TestUserIdPassthrough:
             chunks = [
                 chunk
                 async for chunk in stream_agent_response(
-                    agent_name="general",
+                    make_turn_context("general", session_id="session1", run_id="run-1"),
                     prompt="test",
-                    session_id="session1",
                     runtime_paths=_runtime_paths(tmp_path),
                     config=_config(),
-                    run_id="run-1",
                     model_prompt="test\n\nUse attachment att_1.",
                     run_id_callback=run_ids.append,
                     show_tool_calls=False,
@@ -6744,7 +6709,7 @@ class TestUserIdPassthrough:
         assert mock_prepare.await_count == 2
         assert mock_prepare.await_args_list[0].kwargs["model_prompt"] == "test\n\nUse attachment att_1."
         assert mock_prepare.await_args_list[1].kwargs["model_prompt"] == "Use attachment att_1."
-        assert "Continue the same task" in mock_prepare.await_args_list[1].args[1]
+        assert "Continue the same task" in mock_prepare.await_args_list[1].kwargs["prompt"]
         first_agent.arun.assert_called_once()
         second_agent.arun.assert_called_once()
         assert run_ids[0] == "run-1"
@@ -6815,12 +6780,10 @@ class TestUserIdPassthrough:
 
             with pytest.raises(asyncio.CancelledError):
                 async for _chunk in stream_agent_response(
-                    agent_name="general",
+                    make_turn_context("general", session_id="session1", run_id="run-1"),
                     prompt="test",
-                    session_id="session1",
                     runtime_paths=_runtime_paths(tmp_path),
                     config=_config(),
-                    run_id="run-1",
                     show_tool_calls=False,
                     turn_recorder=recorder,
                 ):
@@ -6868,9 +6831,8 @@ class TestUserIdPassthrough:
         with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
             mock_prepare.side_effect = prepared_runs
             response = await ai_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1"),
                 prompt="test",
-                session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=_config(),
             )
@@ -6921,9 +6883,8 @@ class TestUserIdPassthrough:
             chunks = [
                 chunk
                 async for chunk in stream_agent_response(
-                    agent_name="general",
+                    make_turn_context("general", session_id="session1"),
                     prompt="test",
-                    session_id="session1",
                     runtime_paths=_runtime_paths(tmp_path),
                     config=_config(),
                     show_tool_calls=False,
@@ -6977,9 +6938,8 @@ class TestUserIdPassthrough:
             mock_prepare.return_value = _prepared_prompt_result(mock_agent, prepared_context_tokens=1500)
             run_metadata: dict[str, object] = {}
             await ai_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1"),
                 prompt="test",
-                session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=config,
                 run_metadata_collector=run_metadata,
@@ -7029,10 +6989,13 @@ class TestUserIdPassthrough:
         ):
             mock_prepare.return_value = _prepared_prompt_result(mock_agent, prepared_context_tokens=1234)
             await ai_response(
-                agent_name="general",
+                make_turn_context(
+                    "general",
+                    session_id="session1",
+                    correlation_id="$event",
+                    reply_to_event_id="$event",
+                ),
                 prompt="test",
-                session_id="session1",
-                reply_to_event_id="$event",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=_config(),
                 turn_recorder=recorder,
@@ -7079,9 +7042,8 @@ class TestUserIdPassthrough:
             mock_prepare.return_value = _prepared_prompt_result(mock_agent)
             run_metadata: dict[str, object] = {}
             await ai_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1"),
                 prompt="test",
-                session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=config,
                 run_metadata_collector=run_metadata,
@@ -7195,9 +7157,8 @@ class TestUserIdPassthrough:
             mock_prepare.return_value = _prepared_prompt_result(mock_agent)
             run_metadata: dict[str, object] = {}
             async for _chunk in stream_agent_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1"),
                 prompt="test",
-                session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=config,
                 run_metadata_collector=run_metadata,
@@ -7238,9 +7199,8 @@ class TestUserIdPassthrough:
         with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
             mock_prepare.return_value = _prepared_prompt_result(mock_agent)
             async for _chunk in stream_agent_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1"),
                 prompt="test",
-                session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=_config(),
                 turn_recorder=recorder,
@@ -7277,9 +7237,8 @@ class TestUserIdPassthrough:
         with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
             mock_prepare.return_value = _prepared_prompt_result(mock_agent)
             async for _chunk in stream_agent_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1"),
                 prompt="test",
-                session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=_config(),
                 turn_recorder=recorder,
@@ -7316,9 +7275,8 @@ class TestUserIdPassthrough:
         with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
             mock_prepare.return_value = _prepared_prompt_result(mock_agent)
             async for _chunk in stream_agent_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1"),
                 prompt="test",
-                session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=_config(),
                 turn_recorder=recorder,
@@ -7362,10 +7320,8 @@ class TestUserIdPassthrough:
             mock_prepare.return_value = _prepared_prompt_result(mock_agent, runtime_model_name="large")
             run_metadata: dict[str, object] = {}
             await ai_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1", room_id="!test:localhost"),
                 prompt="test",
-                session_id="session1",
-                room_id="!test:localhost",
                 runtime_paths=runtime_paths,
                 config=config,
                 run_metadata_collector=run_metadata,
@@ -7428,10 +7384,8 @@ class TestUserIdPassthrough:
             mock_prepare.return_value = _prepared_prompt_result(mock_agent, runtime_model_name="large")
             run_metadata: dict[str, object] = {}
             async for _chunk in stream_agent_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1", room_id="!test:localhost"),
                 prompt="test",
-                session_id="session1",
-                room_id="!test:localhost",
                 runtime_paths=runtime_paths,
                 config=config,
                 run_metadata_collector=run_metadata,
@@ -7463,10 +7417,13 @@ class TestUserIdPassthrough:
         with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
             mock_prepare.return_value = _prepared_prompt_result(mock_agent, prepared_context_tokens=5678)
             async for _chunk in stream_agent_response(
-                agent_name="general",
+                make_turn_context(
+                    "general",
+                    session_id="session1",
+                    correlation_id="$event",
+                    reply_to_event_id="$event",
+                ),
                 prompt="test",
-                session_id="session1",
-                reply_to_event_id="$event",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=_config(),
                 turn_recorder=recorder,
@@ -7515,9 +7472,8 @@ class TestUserIdPassthrough:
             run_metadata: dict[str, object] = {}
             with pytest.raises(asyncio.CancelledError):
                 async for _chunk in stream_agent_response(
-                    agent_name="general",
+                    make_turn_context("general", session_id="session1"),
                     prompt="test",
-                    session_id="session1",
                     runtime_paths=_runtime_paths(tmp_path),
                     config=config,
                     run_metadata_collector=run_metadata,
@@ -7581,12 +7537,10 @@ class TestUserIdPassthrough:
             mock_prepare.return_value = _prepared_prompt_result(mock_agent)
             with pytest.raises(asyncio.CancelledError):
                 async for _chunk in stream_agent_response(
-                    agent_name="general",
+                    make_turn_context("general", session_id="session1", correlation_id="e1", reply_to_event_id="e1"),
                     prompt="test",
-                    session_id="session1",
                     runtime_paths=_runtime_paths(tmp_path),
                     config=_config(),
-                    reply_to_event_id="e1",
                     show_tool_calls=False,
                 ):
                     pass
@@ -7662,12 +7616,10 @@ class TestUserIdPassthrough:
             mock_prepare.return_value = _prepared_prompt_result(mock_agent)
             with pytest.raises(asyncio.CancelledError):
                 async for _chunk in stream_agent_response(
-                    agent_name="general",
+                    make_turn_context("general", session_id="session1", correlation_id="e1", reply_to_event_id="e1"),
                     prompt="test",
-                    session_id="session1",
                     runtime_paths=_runtime_paths(tmp_path),
                     config=_config(),
-                    reply_to_event_id="e1",
                     show_tool_calls=False,
                 ):
                     pass
@@ -7708,12 +7660,10 @@ class TestUserIdPassthrough:
 
         async def consume_stream() -> None:
             async for _chunk in stream_agent_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1", correlation_id="e1", reply_to_event_id="e1"),
                 prompt="test",
-                session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=_config(),
-                reply_to_event_id="e1",
                 show_tool_calls=False,
             ):
                 first_chunk_seen.set()
@@ -7778,9 +7728,8 @@ class TestUserIdPassthrough:
             mock_prepare.return_value = _prepared_prompt_result(mock_agent)
             run_metadata: dict[str, object] = {}
             async for _chunk in stream_agent_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1"),
                 prompt="test",
-                session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=config,
                 run_metadata_collector=run_metadata,
@@ -7831,9 +7780,8 @@ class TestUserIdPassthrough:
             mock_prepare.return_value = _prepared_prompt_result(mock_agent)
             run_metadata: dict[str, object] = {}
             async for _chunk in stream_agent_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1"),
                 prompt="test",
-                session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=config,
                 run_metadata_collector=run_metadata,
@@ -7891,9 +7839,8 @@ class TestUserIdPassthrough:
             mock_prepare.return_value = _prepared_prompt_result(mock_agent, prepared_context_tokens=900)
             run_metadata: dict[str, object] = {}
             async for _chunk in stream_agent_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1"),
                 prompt="test",
-                session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=config,
                 run_metadata_collector=run_metadata,
@@ -7956,9 +7903,8 @@ class TestUserIdPassthrough:
             mock_prepare.return_value = _prepared_prompt_result(mock_agent)
             run_metadata: dict[str, object] = {}
             async for _chunk in stream_agent_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1"),
                 prompt="test",
-                session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=config,
                 run_metadata_collector=run_metadata,
@@ -8024,9 +7970,8 @@ class TestUserIdPassthrough:
             mock_prepare.return_value = _prepared_prompt_result(mock_agent, prepared_context_tokens=900)
             run_metadata: dict[str, object] = {}
             async for _chunk in stream_agent_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1"),
                 prompt="test",
-                session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=config,
                 run_metadata_collector=run_metadata,
@@ -8083,9 +8028,8 @@ class TestUserIdPassthrough:
             mock_prepare.return_value = _prepared_prompt_result(mock_agent)
             run_metadata: dict[str, object] = {}
             async for _chunk in stream_agent_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1"),
                 prompt="test",
-                session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=config,
                 run_metadata_collector=run_metadata,
@@ -8145,9 +8089,8 @@ class TestUserIdPassthrough:
             mock_prepare.return_value = _prepared_prompt_result(mock_agent)
             run_metadata: dict[str, object] = {}
             async for _chunk in stream_agent_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1"),
                 prompt="test",
-                session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=config,
                 run_metadata_collector=run_metadata,

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -2998,8 +2998,9 @@ async def test_generate_team_response_passes_resolved_correlation_id_to_team_res
             team_mode="coordinate",
         )
 
-    assert seen_kwargs["reply_to_event_id"] == "$original"
-    assert seen_kwargs["correlation_id"] == "$edit"
+    ctx = seen_kwargs["ctx"]
+    assert ctx.reply_to_event_id == "$original"
+    assert ctx.correlation_id == "$edit"
 
 
 @pytest.mark.asyncio
@@ -3079,7 +3080,7 @@ async def test_generate_team_response_preserves_retry_model_prompt(tmp_path: Pat
 
     async def fake_team_response(*_args: object, **kwargs: object) -> str:
         model_message = cast("str", kwargs["message"])
-        run_id = cast("str | None", kwargs.get("run_id"))
+        run_id = cast("str | None", kwargs["ctx"].run_id)
         seen_run_ids.append(run_id)
         run_id_callback = cast("Callable[[str], None]", kwargs["run_id_callback"])
         if run_id is not None:
@@ -3278,7 +3279,7 @@ async def test_generate_team_response_helper_streaming_emits_session_started_aft
 
         def fake_team_response_stream(*_args: object, **kwargs: object) -> AsyncIterator[str]:
             async def fake_stream() -> AsyncIterator[str]:
-                session_id = kwargs["session_id"]
+                session_id = kwargs["ctx"].session_id
                 assert isinstance(session_id, str)
                 storage.session = TeamSession(
                     session_id=session_id,
@@ -4130,7 +4131,7 @@ async def test_generate_team_response_helper_emits_session_started_after_persist
 
         async def fake_team_response(*_args: object, **kwargs: object) -> str:
             cancel_message = "cancel"
-            session_id = kwargs["session_id"]
+            session_id = kwargs["ctx"].session_id
             assert isinstance(session_id, str)
             storage.session = TeamSession(
                 session_id=session_id,
@@ -4225,7 +4226,7 @@ async def test_generate_team_response_helper_streaming_emits_session_started_aft
         def fake_team_response_stream(*_args: object, **kwargs: object) -> AsyncIterator[str]:
             async def fake_stream() -> AsyncIterator[str]:
                 cancel_message = "cancel"
-                session_id = kwargs["session_id"]
+                session_id = kwargs["ctx"].session_id
                 assert isinstance(session_id, str)
                 storage.session = TeamSession(
                     session_id=session_id,
@@ -4291,7 +4292,7 @@ async def test_generate_team_response_helper_uses_persisted_team_scope_for_sessi
         )
 
         async def fake_team_response(*_args: object, **kwargs: object) -> str:
-            session_id = kwargs["session_id"]
+            session_id = kwargs["ctx"].session_id
             assert isinstance(session_id, str)
             storage.session = TeamSession(
                 session_id=session_id,

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -36,7 +36,7 @@ from mindroom.history.types import (
 )
 from mindroom.memory import MemoryPromptParts
 from mindroom.tool_system.worker_routing import ToolExecutionIdentity
-from tests.conftest import bind_runtime_paths, test_runtime_paths
+from tests.conftest import bind_runtime_paths, make_turn_context, test_runtime_paths
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -308,10 +308,10 @@ async def test_prepare_agent_and_prompt_omits_zero_breakdown_segments_in_notice(
         ),
     ):
         prepared_run = await _prepare_agent_and_prompt(
-            "test_agent",
-            "Current prompt",
-            runtime_paths,
-            config,
+            make_turn_context("test_agent"),
+            prompt="Current prompt",
+            runtime_paths=runtime_paths,
+            config=config,
             compaction_outcomes_collector=None,
         )
 

--- a/tests/test_delegate_tools.py
+++ b/tests/test_delegate_tools.py
@@ -189,16 +189,17 @@ class TestDelegateTools:
 
             assert mock_ai_response.await_count == 1
             call_kwargs = mock_ai_response.await_args.kwargs
-            assert call_kwargs["agent_name"] == "code"
+            call_ctx = mock_ai_response.await_args.args[0]
+            assert call_ctx.entity_label == "code"
             assert call_kwargs["prompt"] == "Write a hello world program"
             assert call_kwargs["runtime_paths"] == tools._runtime_paths
             assert call_kwargs["config"] == tools._config
             assert call_kwargs["knowledge"] is None
-            assert call_kwargs["user_id"] is None
+            assert call_ctx.requester_id is None
             assert call_kwargs["include_interactive_questions"] is False
             assert call_kwargs["execution_identity"] is None
             assert call_kwargs["delegation_depth"] == 1
-            assert call_kwargs["session_id"].startswith("delegate:leader:code:")
+            assert call_ctx.session_id.startswith("delegate:leader:code:")
             assert result == "Here is the generated code: print('hello')"
 
     @pytest.mark.asyncio
@@ -325,7 +326,8 @@ class TestDelegateKnowledge:
             assert args == ("researcher", config, runtime_paths)
             assert kwargs["execution_identity"] is None
             ai_kwargs = mock_ai_response.await_args.kwargs
-            assert ai_kwargs["agent_name"] == "researcher"
+            ai_ctx = mock_ai_response.await_args.args[0]
+            assert ai_ctx.entity_label == "researcher"
             assert ai_kwargs["config"] == config
             assert ai_kwargs["runtime_paths"] == runtime_paths
             assert ai_kwargs["knowledge"] is mock_knowledge
@@ -440,7 +442,7 @@ class TestDelegateKnowledge:
             return_value="done",
         ) as mock_ai_response:
             await tools.delegate_task("worker", "do work")
-            assert mock_ai_response.await_args.kwargs["agent_name"] == "worker"
+            assert mock_ai_response.await_args.args[0].entity_label == "worker"
             assert mock_ai_response.await_args.kwargs["knowledge"] is None
 
     @pytest.mark.asyncio
@@ -487,7 +489,8 @@ class TestDelegateKnowledge:
             await tools.delegate_task("worker", "do work")
 
         call_kwargs = mock_ai_response.await_args.kwargs
-        assert call_kwargs["agent_name"] == "worker"
+        call_ctx = mock_ai_response.await_args.args[0]
+        assert call_ctx.entity_label == "worker"
         assert call_kwargs["config"] == config
         assert call_kwargs["runtime_paths"] == runtime_paths
         delegated_identity = call_kwargs["execution_identity"]
@@ -497,10 +500,10 @@ class TestDelegateKnowledge:
         assert delegated_identity.requester_id == "@alice:example.org"
         assert delegated_identity.room_id == "!room:example.org"
         assert delegated_identity.thread_id == "$thread"
-        assert delegated_identity.session_id == call_kwargs["session_id"]
+        assert delegated_identity.session_id == call_ctx.session_id
         assert delegated_identity.session_id.startswith("delegate:leader:worker:")
-        assert call_kwargs["room_id"] == "!room:example.org"
-        assert call_kwargs["user_id"] == "@alice:example.org"
+        assert call_ctx.room_id == "!room:example.org"
+        assert call_ctx.requester_id == "@alice:example.org"
         assert call_kwargs["delegation_depth"] == 1
 
     @pytest.mark.asyncio
@@ -553,15 +556,15 @@ class TestDelegateKnowledge:
             correlation_id="corr-parent",
         )
 
-        async def fake_ai_response(**kwargs: object) -> str:
+        async def fake_ai_response(ctx: object, **_kwargs: object) -> str:
             context = get_tool_runtime_context()
             assert context is not None
             assert context.agent_name == "worker"
-            assert context.session_id == kwargs["session_id"]
+            assert context.session_id == ctx.session_id
             assert context.room_id == "!room:example.org"
-            assert kwargs["room_id"] == "!room:example.org"
+            assert ctx.room_id == "!room:example.org"
             assert context.correlation_id == "corr-parent"
-            assert kwargs["correlation_id"] == "corr-parent"
+            assert ctx.correlation_id == "corr-parent"
             assert context.active_model_name == "default"
             return "done"
 
@@ -636,13 +639,13 @@ class TestDelegateKnowledge:
             session_id="session-1",
         )
 
-        async def fake_ai_response(**kwargs: object) -> str:
+        async def fake_ai_response(ctx: object, **_kwargs: object) -> str:
             context = get_tool_runtime_context()
             assert context is not None
             assert context.agent_name == "worker"
             assert context.room_id == "!room:example.org"
             assert context.active_model_name == "large"
-            assert kwargs["room_id"] == "!room:example.org"
+            assert ctx.room_id == "!room:example.org"
             return "done"
 
         with (

--- a/tests/test_empty_response_guard.py
+++ b/tests/test_empty_response_guard.py
@@ -30,6 +30,7 @@ from mindroom.history import PreparedHistoryState
 from mindroom.history.runtime import ScopeSessionContext
 from mindroom.history.turn_recorder import TurnRecorder
 from mindroom.history.types import HistoryScope
+from tests.conftest import make_turn_context
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -228,9 +229,8 @@ async def test_ai_response_retries_once_after_empty_completed_run(tmp_path: Path
         ]
 
         result = await ai_response(
-            agent_name="general",
+            make_turn_context("general", session_id="session-1"),
             prompt="test",
-            session_id="session-1",
             runtime_paths=_runtime_paths(tmp_path),
             config=_config(),
         )
@@ -254,9 +254,8 @@ async def test_ai_response_closes_spent_agent_state_dbs_before_empty_retry(tmp_p
         ]
 
         result = await ai_response(
-            agent_name="general",
+            make_turn_context("general", session_id="session-1"),
             prompt="test",
-            session_id="session-1",
             runtime_paths=_runtime_paths(tmp_path),
             config=_config(),
         )
@@ -278,9 +277,8 @@ async def test_ai_response_returns_fallback_notice_when_retry_is_also_empty(tmp_
         ]
 
         result = await ai_response(
-            agent_name="general",
+            make_turn_context("general", session_id="session-1"),
             prompt="test",
-            session_id="session-1",
             runtime_paths=_runtime_paths(tmp_path),
             config=_config(),
         )
@@ -304,9 +302,8 @@ async def test_ai_response_fallback_notice_stays_out_of_the_turn_recorder(tmp_pa
         ]
 
         result = await ai_response(
-            agent_name="general",
+            make_turn_context("general", session_id="session-1"),
             prompt="test",
-            session_id="session-1",
             runtime_paths=_runtime_paths(tmp_path),
             config=_config(),
             turn_recorder=recorder,
@@ -340,9 +337,8 @@ async def test_stream_agent_response_retries_once_after_empty_completed_stream(t
         chunks = [
             chunk
             async for chunk in stream_agent_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session-1"),
                 prompt="test",
-                session_id="session-1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=_config(),
             )
@@ -378,9 +374,8 @@ async def test_stream_agent_response_closes_spent_agent_state_dbs_before_empty_r
         chunks = [
             chunk
             async for chunk in stream_agent_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session-1"),
                 prompt="test",
-                session_id="session-1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=_config(),
             )
@@ -410,9 +405,8 @@ async def test_stream_agent_response_yields_fallback_notice_when_retry_is_also_e
         chunks = [
             chunk
             async for chunk in stream_agent_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session-1"),
                 prompt="test",
-                session_id="session-1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=_config(),
             )
@@ -444,9 +438,8 @@ async def test_stream_agent_response_fallback_notice_stays_out_of_the_turn_recor
         chunks = [
             chunk
             async for chunk in stream_agent_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session-1"),
                 prompt="test",
-                session_id="session-1",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=_config(),
                 turn_recorder=recorder,

--- a/tests/test_event_loop_offloading.py
+++ b/tests/test_event_loop_offloading.py
@@ -18,7 +18,7 @@ from mindroom.constants import resolve_runtime_paths
 from mindroom.history import PreparedHistoryState
 from mindroom.memory import MemoryPromptParts
 from mindroom.memory._file_backend import FileMemoryBackend
-from tests.conftest import bind_runtime_paths, test_runtime_paths
+from tests.conftest import bind_runtime_paths, make_turn_context, test_runtime_paths
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -69,7 +69,12 @@ async def test_prepare_agent_and_prompt_builds_agent_off_event_loop(
     config = Config.model_validate({"agents": {"general": {"display_name": "General", "role": "test"}}})
     runtime_paths = test_runtime_paths(tmp_path)
     prepare_task = asyncio.get_running_loop().create_task(
-        ai_module._prepare_agent_and_prompt("general", "hello", runtime_paths, config),
+        ai_module._prepare_agent_and_prompt(
+            make_turn_context("general"),
+            prompt="hello",
+            runtime_paths=runtime_paths,
+            config=config,
+        ),
     )
     await asyncio.to_thread(build_started.wait, 5.0)
 

--- a/tests/test_history_prepare_integration.py
+++ b/tests/test_history_prepare_integration.py
@@ -44,6 +44,7 @@ from mindroom.token_budget import estimate_text_tokens, stable_serialize
 from tests.conftest import (
     FakeModel,
     bind_runtime_paths,
+    make_turn_context,
     make_visible_message,
 )
 from tests.history_helpers import (  # noqa: F401
@@ -264,10 +265,10 @@ async def test_prepare_agent_and_prompt_budgets_persisted_replay_against_primary
         ),
     ):
         await _prepare_agent_and_prompt(
-            "test_agent",
-            "Current prompt",
-            runtime_paths,
-            config,
+            make_turn_context("test_agent"),
+            prompt="Current prompt",
+            runtime_paths=runtime_paths,
+            config=config,
             thread_history=thread_history,
         )
 
@@ -312,11 +313,10 @@ async def test_prepare_agent_and_prompt_uses_room_resolved_agent_model_for_execu
         ),
     ):
         await _prepare_agent_and_prompt(
-            "test_agent",
-            "Current prompt",
-            runtime_paths,
-            config,
-            room_id="!room:localhost",
+            make_turn_context("test_agent", room_id="!room:localhost"),
+            prompt="Current prompt",
+            runtime_paths=runtime_paths,
+            config=config,
         )
 
     assert mock_create_agent.call_args is not None
@@ -348,10 +348,10 @@ async def test_prepare_agent_and_prompt_uses_thread_history_when_persisted_repla
         ),
     ):
         prepared_run = await _prepare_agent_and_prompt(
-            "test_agent",
-            "Current prompt",
-            runtime_paths,
-            config,
+            make_turn_context("test_agent"),
+            prompt="Current prompt",
+            runtime_paths=runtime_paths,
+            config=config,
             thread_history=thread_history,
         )
 
@@ -397,10 +397,10 @@ async def test_prepare_agent_and_prompt_caps_thread_fallback_to_active_window(tm
         ),
     ):
         prepared_run = await _prepare_agent_and_prompt(
-            "test_agent",
-            "Current prompt",
-            runtime_paths,
-            config,
+            make_turn_context("test_agent"),
+            prompt="Current prompt",
+            runtime_paths=runtime_paths,
+            config=config,
             thread_history=thread_history,
         )
 
@@ -435,13 +435,15 @@ async def test_prepare_agent_and_prompt_uses_full_thread_fallback_for_threaded_m
         ),
     ):
         prepared_run = await _prepare_agent_and_prompt(
-            "test_agent",
-            "What was that?",
-            runtime_paths,
-            config,
+            make_turn_context(
+                "test_agent",
+                reply_to_event_id="$current",
+                requester_id="@alice:localhost",
+            ),
+            prompt="What was that?",
+            runtime_paths=runtime_paths,
+            config=config,
             thread_history=thread_history,
-            reply_to_event_id="$current",
-            current_sender_id="@alice:localhost",
         )
 
     assert prepared_run.prepared_history.replays_persisted_history is False
@@ -485,10 +487,10 @@ async def test_prepare_agent_and_prompt_trims_oversized_full_thread_fallback(
         ),
     ):
         prepared_run = await _prepare_agent_and_prompt(
-            "test_agent",
-            "Current prompt",
-            runtime_paths,
-            config,
+            make_turn_context("test_agent"),
+            prompt="Current prompt",
+            runtime_paths=runtime_paths,
+            config=config,
             thread_history=thread_history,
         )
 
@@ -528,11 +530,10 @@ async def test_prepare_agent_and_prompt_skips_thread_fallback_for_summary_only_r
         patch("mindroom.ai.build_memory_prompt_parts", new=AsyncMock(return_value=MemoryPromptParts())),
     ):
         prepared_run = await _prepare_agent_and_prompt(
-            "test_agent",
-            "Current prompt",
-            runtime_paths,
-            config,
-            session_id="session-1",
+            make_turn_context("test_agent", session_id="session-1"),
+            prompt="Current prompt",
+            runtime_paths=runtime_paths,
+            config=config,
             scope_context=scope_context,
             thread_history=thread_history,
         )
@@ -563,11 +564,10 @@ async def test_prepare_agent_and_prompt_keeps_matrix_current_sender_when_persist
         ),
     ):
         prepared_run = await _prepare_agent_and_prompt(
-            "test_agent",
-            "Current prompt",
-            runtime_paths,
-            config,
-            current_sender_id="@alice:localhost",
+            make_turn_context("test_agent", requester_id="@alice:localhost"),
+            prompt="Current prompt",
+            runtime_paths=runtime_paths,
+            config=config,
         )
 
     prepared_agent = prepared_run.agent
@@ -627,10 +627,10 @@ async def test_prepare_agent_and_prompt_syncs_enriched_compaction_outcomes_back_
         ),
     ):
         prepared_run = await _prepare_agent_and_prompt(
-            "test_agent",
-            "Current prompt",
-            runtime_paths,
-            config,
+            make_turn_context("test_agent"),
+            prompt="Current prompt",
+            runtime_paths=runtime_paths,
+            config=config,
             compaction_outcomes_collector=collector,
         )
 
@@ -673,10 +673,10 @@ async def test_prepare_agent_and_prompt_populates_empty_collector_with_enriched_
         ),
     ):
         prepared_run = await _prepare_agent_and_prompt(
-            "test_agent",
-            "Current prompt",
-            runtime_paths,
-            config,
+            make_turn_context("test_agent"),
+            prompt="Current prompt",
+            runtime_paths=runtime_paths,
+            config=config,
             compaction_outcomes_collector=collector,
         )
 
@@ -719,10 +719,10 @@ async def test_prepare_agent_and_prompt_enriches_compaction_outcomes_without_col
         ),
     ):
         prepared_run = await _prepare_agent_and_prompt(
-            "test_agent",
-            "Current prompt",
-            runtime_paths,
-            config,
+            make_turn_context("test_agent"),
+            prompt="Current prompt",
+            runtime_paths=runtime_paths,
+            config=config,
             compaction_outcomes_collector=None,
         )
 
@@ -760,10 +760,10 @@ async def test_prepare_agent_and_prompt_omits_zero_breakdown_segments_in_notice(
         ),
     ):
         prepared_run = await _prepare_agent_and_prompt(
-            "test_agent",
-            "Current prompt",
-            runtime_paths,
-            config,
+            make_turn_context("test_agent"),
+            prompt="Current prompt",
+            runtime_paths=runtime_paths,
+            config=config,
             compaction_outcomes_collector=None,
         )
 
@@ -800,10 +800,10 @@ async def test_prepare_agent_and_prompt_keeps_empty_collector_when_no_compaction
         ),
     ):
         prepared_run = await _prepare_agent_and_prompt(
-            "test_agent",
-            "Current prompt",
-            runtime_paths,
-            config,
+            make_turn_context("test_agent"),
+            prompt="Current prompt",
+            runtime_paths=runtime_paths,
+            config=config,
             compaction_outcomes_collector=collector,
         )
 
@@ -889,17 +889,16 @@ async def test_prepare_agent_and_prompt_uses_native_history_with_unseen_thread_c
             patch("mindroom.ai.build_memory_prompt_parts", new=AsyncMock(return_value=MemoryPromptParts())),
         ):
             prepared_run = await _prepare_agent_and_prompt(
-                "test_agent",
-                "Current prompt",
-                runtime_paths,
-                config,
+                make_turn_context("test_agent", reply_to_event_id="event-3"),
+                prompt="Current prompt",
+                runtime_paths=runtime_paths,
+                config=config,
                 scope_context=scope_context,
                 thread_history=[
                     make_visible_message(event_id="event-1", sender="alice", body="Already seen"),
                     make_visible_message(event_id="event-2", sender="alice", body="Fresh follow-up"),
                     make_visible_message(event_id="event-3", sender="alice", body="Current message body"),
                 ],
-                reply_to_event_id="event-3",
             )
 
     agent = prepared_run.agent
@@ -982,11 +981,10 @@ async def test_prepare_agent_and_prompt_keeps_prior_request_message_prefix_byte_
     ):
         for prompt in ("First prompt", "Second prompt", "Third prompt"):
             prepared_run = await _prepare_agent_and_prompt(
-                "test_agent",
-                prompt,
-                runtime_paths,
-                config,
-                session_id="session-1",
+                make_turn_context("test_agent", session_id="session-1"),
+                prompt=prompt,
+                runtime_paths=runtime_paths,
+                config=config,
             )
             await prepared_run.agent.arun(prepared_run.run_input, session_id="session-1")
             recorded_requests.append(
@@ -1067,14 +1065,16 @@ async def test_prepare_agent_and_prompt_timestamps_current_turn_without_duplicat
     ):
         for prompt in ("First prompt", "Second prompt", "Third prompt"):
             prepared_run = await _prepare_agent_and_prompt(
-                "test_agent",
-                prompt,
-                runtime_paths,
-                config,
-                session_id="session-1",
+                make_turn_context(
+                    "test_agent",
+                    session_id="session-1",
+                    requester_id="@alice:localhost",
+                ),
+                prompt=prompt,
+                runtime_paths=runtime_paths,
+                config=config,
                 model_prompt=model_prompt_by_prompt[prompt],
                 current_timestamp_ms=timestamp_by_prompt[prompt],
-                current_sender_id="@alice:localhost",
             )
             await prepared_run.agent.arun(prepared_run.run_input, session_id="session-1")
             recorded_requests.append(

--- a/tests/test_issue_154_logging_integration.py
+++ b/tests/test_issue_154_logging_integration.py
@@ -6,6 +6,7 @@ import json
 import logging
 import re
 import time
+import uuid
 from dataclasses import dataclass
 from json import JSONDecodeError
 from types import SimpleNamespace
@@ -38,6 +39,7 @@ from mindroom.tool_system.worker_routing import build_tool_execution_identity
 from mindroom.turn_policy import PreparedDispatch, ResponseAction
 from tests.conftest import (
     bind_runtime_paths,
+    make_turn_context,
     replace_turn_controller_deps,
     request_envelope,
     runtime_paths_for,
@@ -299,18 +301,21 @@ async def test_cross_sink_correlation_invariant_for_matrix_turn_processing_log( 
             ),
         ):
             response = await ai_response(
-                agent_name="general",
+                make_turn_context(
+                    "general",
+                    session_id=target.session_id or "session-1",
+                    correlation_id=request.reply_to_event_id or "corr-test",
+                    reply_to_event_id=request.reply_to_event_id,
+                    room_id=request.room_id,
+                    thread_id=request.thread_id,
+                    requester_id=request.user_id,
+                    matrix_run_metadata=request.matrix_run_metadata,
+                ),
                 prompt=request.prompt,
                 model_prompt="model prompt",
-                session_id=target.session_id or "session-1",
                 runtime_paths=runtime_paths,
                 config=config,
-                room_id=request.room_id,
-                thread_id=request.thread_id,
-                reply_to_event_id=request.reply_to_event_id,
-                user_id=request.user_id,
                 execution_identity=dispatch_context.execution_identity,
-                matrix_run_metadata=request.matrix_run_metadata,
             )
         assert response == "Done"
         return "$response:localhost"
@@ -469,16 +474,19 @@ async def test_streaming_tool_call_shares_correlation_id_across_streaming_sinks(
         chunks = [
             chunk
             async for chunk in stream_agent_response(
-                agent_name="general",
+                make_turn_context(
+                    "general",
+                    session_id="!room:localhost:$thread:localhost",
+                    correlation_id="$event:localhost",
+                    reply_to_event_id="$event:localhost",
+                    room_id="!room:localhost",
+                    thread_id="$thread:localhost",
+                    requester_id="@user:localhost",
+                ),
                 prompt="hello",
                 model_prompt="model prompt",
-                session_id="!room:localhost:$thread:localhost",
                 runtime_paths=runtime_paths,
                 config=config,
-                room_id="!room:localhost",
-                thread_id="$thread:localhost",
-                reply_to_event_id="$event:localhost",
-                user_id="@user:localhost",
                 execution_identity=execution_identity,
             )
         ]
@@ -542,14 +550,18 @@ async def test_non_matrix_request_mints_uuid_correlation_id_across_sinks(tmp_pat
             return_value=[{"name": "demo_tool", "description": "Echo"}],
         ),
     ):
+        expected_correlation_id = uuid.uuid4().hex
         response = await ai_response(
-            agent_name="general",
+            make_turn_context(
+                "general",
+                session_id="openai-session",
+                correlation_id=expected_correlation_id,
+                requester_id="@api-user:localhost",
+            ),
             prompt="hello",
             model_prompt="model prompt",
-            session_id="openai-session",
             runtime_paths=runtime_paths,
             config=config,
-            user_id="@api-user:localhost",
             execution_identity=execution_identity,
         )
 
@@ -561,6 +573,7 @@ async def test_non_matrix_request_mints_uuid_correlation_id_across_sinks(tmp_pat
 
     assert isinstance(correlation_id, str)
     assert re.fullmatch(r"[0-9a-f]{32}", correlation_id)
+    assert correlation_id == expected_correlation_id
     assert tool_entry["correlation_id"] == correlation_id
     assert metadata["correlation_id"] == correlation_id
     assert "reply_to_event_id" not in metadata

--- a/tests/test_memory_integration.py
+++ b/tests/test_memory_integration.py
@@ -15,6 +15,7 @@ from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
 from mindroom.constants import RuntimePaths, resolve_runtime_paths
 from mindroom.memory import MemoryPromptParts
+from tests.conftest import make_turn_context
 from tests.identity_helpers import persist_entity_accounts
 
 if TYPE_CHECKING:
@@ -81,12 +82,10 @@ class TestMemoryIntegration:
             patch("mindroom.ai.create_agent", return_value=MagicMock()),
         ):
             response = await ai_response(
-                agent_name="general",
+                make_turn_context("general", session_id="test_session", room_id="!test:room"),
                 prompt="What is 2+2?",
-                session_id="test_session",
                 runtime_paths=runtime_paths,
                 config=config,
-                room_id="!test:room",
             )
 
             # Verify response
@@ -129,12 +128,10 @@ class TestMemoryIntegration:
             patch("mindroom.ai.create_agent", return_value=MagicMock()),
         ):
             await ai_response(
-                agent_name="general",
+                make_turn_context("general", session_id="test_session", room_id=None),
                 prompt="Hello",
-                session_id="test_session",
                 runtime_paths=runtime_paths,
                 config=config,
-                room_id=None,
             )
 
             # Verify memory enhancement remains agent-scoped
@@ -161,9 +158,8 @@ class TestMemoryIntegration:
             patch("mindroom.memory._backend.create_memory_instance", return_value=mock_memory),
         ):
             response = await ai_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session"),
                 prompt="Test",
-                session_id="session",
                 runtime_paths=self._runtime_paths(tmp_path),
                 config=config,
             )
@@ -188,9 +184,8 @@ class TestMemoryIntegration:
         ):
             # First interaction
             await ai_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session1"),
                 prompt="Remember this: A=1",
-                session_id="session1",
                 runtime_paths=self._runtime_paths(tmp_path),
                 config=config,
             )
@@ -205,9 +200,8 @@ class TestMemoryIntegration:
             mock_memory.search.return_value = {"results": [{"memory": "Remember this: A=1", "id": "1"}]}
 
             await ai_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session2"),
                 prompt="What is A?",
-                session_id="session2",
                 runtime_paths=self._runtime_paths(tmp_path),
                 config=config,
             )

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -2544,22 +2544,24 @@ class TestAgentBot:
         # Should call AI and send response based on streaming mode
         if enable_streaming:
             mock_stream_agent_response.assert_called_once()
+            stream_args = mock_stream_agent_response.call_args.args
             stream_kwargs = mock_stream_agent_response.call_args.kwargs
-            assert stream_kwargs["agent_name"] == "calculator"
+            stream_ctx = stream_args[0]
+            assert stream_ctx.entity_label == "calculator"
             assert stream_kwargs["prompt"] == f"{mention_id}: What's 2+2?"
             assert stream_kwargs["model_prompt"] == f"{mention_id}: What's 2+2?"
             assert stream_kwargs["current_timestamp_ms"] == 1_774_019_700_000.0
-            assert stream_kwargs["session_id"] == "!test:localhost:$thread_root_id"
+            assert stream_ctx.session_id == "!test:localhost:$thread_root_id"
             assert stream_kwargs["runtime_paths"].storage_root == runtime_paths_for(config).storage_root
             assert stream_kwargs["config"] == config
             assert stream_kwargs["thread_history"] == []
-            assert stream_kwargs["room_id"] == "!test:localhost"
+            assert stream_ctx.room_id == "!test:localhost"
             assert stream_kwargs["knowledge"] is None
-            assert stream_kwargs["user_id"] == "@user:localhost"
-            assert isinstance(stream_kwargs["run_id"], str)
-            assert stream_kwargs["run_id"]
+            assert stream_ctx.requester_id == "@user:localhost"
+            assert isinstance(stream_ctx.run_id, str)
+            assert stream_ctx.run_id
             assert stream_kwargs["media"] == MediaInputs()
-            assert stream_kwargs["reply_to_event_id"] == "event123"
+            assert stream_ctx.reply_to_event_id == "event123"
             assert stream_kwargs["show_tool_calls"] is True
             assert stream_kwargs["run_metadata_collector"] == {}
             assert "compaction_outcomes_collector" not in stream_kwargs
@@ -2569,22 +2571,24 @@ class TestAgentBot:
             assert bot.client.room_send.call_count >= 2
         else:
             mock_ai_response.assert_called_once()
+            ai_args = mock_ai_response.call_args.args
             ai_kwargs = mock_ai_response.call_args.kwargs
-            assert ai_kwargs["agent_name"] == "calculator"
+            ai_ctx = ai_args[0]
+            assert ai_ctx.entity_label == "calculator"
             assert ai_kwargs["prompt"] == f"{mention_id}: What's 2+2?"
             assert ai_kwargs["model_prompt"] == f"{mention_id}: What's 2+2?"
             assert ai_kwargs["current_timestamp_ms"] == 1_774_019_700_000.0
-            assert ai_kwargs["session_id"] == "!test:localhost:$thread_root_id"
+            assert ai_ctx.session_id == "!test:localhost:$thread_root_id"
             assert ai_kwargs["runtime_paths"].storage_root == runtime_paths_for(config).storage_root
             assert ai_kwargs["config"] == config
             assert ai_kwargs["thread_history"] == []
-            assert ai_kwargs["room_id"] == "!test:localhost"
+            assert ai_ctx.room_id == "!test:localhost"
             assert ai_kwargs["knowledge"] is None
-            assert ai_kwargs["user_id"] == "@user:localhost"
-            assert isinstance(ai_kwargs["run_id"], str)
-            assert ai_kwargs["run_id"]
+            assert ai_ctx.requester_id == "@user:localhost"
+            assert isinstance(ai_ctx.run_id, str)
+            assert ai_ctx.run_id
             assert ai_kwargs["media"] == MediaInputs()
-            assert ai_kwargs["reply_to_event_id"] == "event123"
+            assert ai_ctx.reply_to_event_id == "event123"
             assert ai_kwargs["show_tool_calls"] is True
             assert ai_kwargs["collect_streamed_response"] is True
             assert ai_kwargs["tool_trace_collector"] == []
@@ -3390,7 +3394,7 @@ class TestAgentBot:
                     ),
                 )
 
-            assert mock_ai_response.call_args.kwargs["active_event_ids"] == {"$active"}
+            assert mock_ai_response.call_args.args[0].active_event_ids == frozenset({"$active"})
         finally:
             running_task.cancel()
             other_room_task.cancel()
@@ -3527,7 +3531,7 @@ class TestAgentBot:
                         ),
                     )
 
-            assert mock_stream.call_args.kwargs["active_event_ids"] == {"$active"}
+            assert mock_stream.call_args.args[0].active_event_ids == frozenset({"$active"})
         finally:
             running_task.cancel()
             other_room_task.cancel()

--- a/tests/test_multi_agent_e2e.py
+++ b/tests/test_multi_agent_e2e.py
@@ -185,7 +185,8 @@ async def test_agent_processes_direct_mention(  # noqa: PLR0915
         # Verify AI was called with separate raw and model-facing prompts.
         mock_ai.assert_called_once()
         ai_kwargs = mock_ai.call_args.kwargs
-        assert ai_kwargs["agent_name"] == "calculator"
+        ai_ctx = mock_ai.call_args.args[0]
+        assert ai_ctx.entity_label == "calculator"
         assert (
             ai_kwargs["prompt"]
             == f"@mindroom_calculator:{config.get_domain(runtime_paths_for(config))} What's 15% of 200?"
@@ -195,15 +196,15 @@ async def test_agent_processes_direct_mention(  # noqa: PLR0915
             == f"@mindroom_calculator:{config.get_domain(runtime_paths_for(config))} What's 15% of 200?"
         )
         assert ai_kwargs["current_timestamp_ms"] == 1234567890.0
-        assert ai_kwargs["session_id"] == f"{test_room_id}:$thread_root:localhost"
+        assert ai_ctx.session_id == f"{test_room_id}:$thread_root:localhost"
         assert ai_kwargs["thread_history"] == []
         assert ai_kwargs["runtime_paths"].storage_root == runtime_paths_for(config).storage_root
         assert ai_kwargs["config"] == config
-        assert ai_kwargs["room_id"] == test_room_id
+        assert ai_ctx.room_id == test_room_id
         assert ai_kwargs["knowledge"] is None
-        assert ai_kwargs["user_id"] == test_user_id
+        assert ai_ctx.requester_id == test_user_id
         assert ai_kwargs["media"] == MediaInputs()
-        assert ai_kwargs["reply_to_event_id"] == "$test_event:localhost"
+        assert ai_ctx.reply_to_event_id == "$test_event:localhost"
         assert ai_kwargs["show_tool_calls"] is True
         assert ai_kwargs["run_metadata_collector"] == {}
 
@@ -537,22 +538,23 @@ async def test_agent_responds_in_threads_based_on_participation(  # noqa: PLR091
             # Should process the message with explicit mention
             mock_ai.assert_called_once()
             ai_kwargs = mock_ai.call_args.kwargs
-            assert ai_kwargs["agent_name"] == "calculator"
+            ai_ctx = mock_ai.call_args.args[0]
+            assert ai_ctx.entity_label == "calculator"
             assert ai_kwargs["prompt"] == f"@mindroom_calculator:{domain} What about 20% of 300?"
             assert ai_kwargs["model_prompt"] == f"@mindroom_calculator:{domain} What about 20% of 300?"
             assert ai_kwargs["current_timestamp_ms"] == 1234567890.0
-            assert ai_kwargs["session_id"] == f"{test_room_id}:{thread_root_id}"
+            assert ai_ctx.session_id == f"{test_room_id}:{thread_root_id}"
             assert ai_kwargs["thread_history"][0].body.startswith("[")
             assert ai_kwargs["thread_history"][0].body.endswith("What's 10% of 100?")
             assert ai_kwargs["thread_history"][1].body == "10% of 100 is 10"
             assert ai_kwargs["thread_history"][2].body == "I can also help"
             assert ai_kwargs["runtime_paths"].storage_root == runtime_paths_for(config).storage_root
             assert ai_kwargs["config"] == config
-            assert ai_kwargs["room_id"] == test_room_id
+            assert ai_ctx.room_id == test_room_id
             assert ai_kwargs["knowledge"] is None
-            assert ai_kwargs["user_id"] == test_user_id
+            assert ai_ctx.requester_id == test_user_id
             assert ai_kwargs["media"] == MediaInputs()
-            assert ai_kwargs["reply_to_event_id"] == f"$test_event2:{domain}"
+            assert ai_ctx.reply_to_event_id == f"$test_event2:{domain}"
             assert ai_kwargs["show_tool_calls"] is True
             assert ai_kwargs["tool_trace_collector"] == []
             assert ai_kwargs["run_metadata_collector"] == {}

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -2890,21 +2890,22 @@ class TestTeamCompletion:
         assert prepared.run_metadata is run_metadata
         assert mock_prepare.await_count == 1
         preparation_kwargs = mock_prepare.await_args.kwargs
+        preparation_ctx = mock_prepare.await_args.args[0]
         assert preparation_kwargs["agents"] == mock_agents
         assert preparation_kwargs["team"] is mock_team
         assert preparation_kwargs["message"] == "Build it"
         assert preparation_kwargs["thread_history"] == []
-        assert preparation_kwargs["reply_to_event_id"] is None
-        assert preparation_kwargs["active_event_ids"] == frozenset()
+        assert preparation_ctx.reply_to_event_id is None
+        assert preparation_ctx.active_event_ids == frozenset()
         assert preparation_kwargs["response_sender_id"] is None
         assert preparation_kwargs["current_sender_id"] is None
-        assert preparation_kwargs["room_id"] is None
-        assert preparation_kwargs["thread_id"] is None
-        assert preparation_kwargs["requester_id"] is None
-        assert re.fullmatch(r"[0-9a-f]{32}", preparation_kwargs["correlation_id"])
+        assert preparation_ctx.room_id is None
+        assert preparation_ctx.thread_id is None
+        assert preparation_ctx.requester_id is None
+        assert re.fullmatch(r"[0-9a-f]{32}", preparation_ctx.correlation_id)
         assert preparation_kwargs["compaction_outcomes_collector"] is None
         assert preparation_kwargs["configured_team_name"] == "super_team"
-        assert preparation_kwargs["matrix_run_metadata"] is None
+        assert preparation_ctx.matrix_run_metadata is None
         assert preparation_kwargs["active_model_name"] == "default"
 
     def test_team_listed_in_models(self, team_app_client: TestClient) -> None:
@@ -3065,10 +3066,10 @@ class TestTeamCompletion:
         prepared_correlation_ids: list[str] = []
         request_log_contexts: list[dict[str, object]] = []
 
-        async def mock_prepare_team_execution(**kwargs: object) -> SimpleNamespace:
-            correlation_id = kwargs["correlation_id"]
+        async def mock_prepare_team_execution(ctx: object, **_kwargs: object) -> SimpleNamespace:
+            correlation_id = ctx.correlation_id
             assert isinstance(correlation_id, str)
-            assert kwargs["requester_id"] is None
+            assert ctx.requester_id is None
             prepared_correlation_ids.append(correlation_id)
             return _prepared_team_execution_context(
                 final_prompt="Build it",
@@ -3327,10 +3328,10 @@ class TestTeamCompletion:
         prepared_correlation_ids: list[str] = []
         request_log_contexts: list[dict[str, object]] = []
 
-        async def mock_prepare_team_execution(**kwargs: object) -> SimpleNamespace:
-            correlation_id = kwargs["correlation_id"]
+        async def mock_prepare_team_execution(ctx: object, **_kwargs: object) -> SimpleNamespace:
+            correlation_id = ctx.correlation_id
             assert isinstance(correlation_id, str)
-            assert kwargs["requester_id"] is None
+            assert ctx.requester_id is None
             prepared_correlation_ids.append(correlation_id)
             return _prepared_team_execution_context(
                 final_prompt="Build it",

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -1058,6 +1058,25 @@ class TestChatCompletions:
             assert mock_ai.call_args.kwargs["include_interactive_questions"] is False
             assert mock_ai.call_args.args[0].active_event_ids == frozenset()
 
+    def test_agent_completion_mints_fresh_uuid_correlation_id(self, app_client: TestClient) -> None:
+        """Each OpenAI-compatible agent completion mints its own uuid-hex correlation id."""
+        with patch("mindroom.api.openai_compat.ai_response", new_callable=AsyncMock) as mock_ai:
+            mock_ai.return_value = "Response"
+
+            for _ in range(2):
+                app_client.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "general",
+                        "messages": [{"role": "user", "content": "Hi"}],
+                    },
+                )
+
+            first_ctx, second_ctx = (call.args[0] for call in mock_ai.call_args_list)
+            assert re.fullmatch(r"[0-9a-f]{32}", first_ctx.correlation_id)
+            assert re.fullmatch(r"[0-9a-f]{32}", second_ctx.correlation_id)
+            assert first_ctx.correlation_id != second_ctx.correlation_id
+
     def test_passes_knowledge_none(self, app_client: TestClient) -> None:
         """Passes knowledge=None when agent has no knowledge_bases."""
         with patch("mindroom.api.openai_compat.ai_response", new_callable=AsyncMock) as mock_ai:

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -1023,7 +1023,7 @@ class TestChatCompletions:
         """Cancellation after lock acquisition must not leave the OpenAI session locked."""
         completion_lock = asyncio.Lock()
 
-        async def cancelled_response(**_kwargs: object) -> str:
+        async def cancelled_response(_ctx: object, **_kwargs: object) -> str:
             raise asyncio.CancelledError
 
         with (
@@ -1056,7 +1056,7 @@ class TestChatCompletions:
 
             assert "include_default_tools" not in mock_ai.call_args.kwargs
             assert mock_ai.call_args.kwargs["include_interactive_questions"] is False
-            assert mock_ai.call_args.kwargs["active_event_ids"] == set()
+            assert mock_ai.call_args.args[0].active_event_ids == frozenset()
 
     def test_passes_knowledge_none(self, app_client: TestClient) -> None:
         """Passes knowledge=None when agent has no knowledge_bases."""
@@ -1087,7 +1087,7 @@ class TestChatCompletions:
                 },
             )
 
-            assert mock_ai.call_args.kwargs["user_id"] is None
+            assert mock_ai.call_args.args[0].requester_id is None
 
     def test_request_body_user_is_not_used_for_openai_execution_identity(self, app_client: TestClient) -> None:
         """The OpenAI user field should not become credential-routing identity."""
@@ -1359,7 +1359,7 @@ class TestChatCompletions:
         observed_session_ids: list[str] = []
 
         async def _capture(*args: object, **kwargs: object) -> str:  # noqa: ARG001
-            observed_session_ids.append(kwargs["session_id"])
+            observed_session_ids.append(args[0].session_id)
             return "Response"
 
         with patch("mindroom.api.openai_compat.ai_response", new_callable=AsyncMock) as mock_ai:
@@ -1391,7 +1391,7 @@ class TestChatCompletions:
         observed_session_ids: list[str] = []
 
         async def _capture(*args: object, **kwargs: object) -> str:  # noqa: ARG001
-            observed_session_ids.append(kwargs["session_id"])
+            observed_session_ids.append(args[0].session_id)
             return "Response"
 
         with patch("mindroom.api.openai_compat.ai_response", new_callable=AsyncMock) as mock_ai:
@@ -1540,7 +1540,7 @@ class TestStreamingCompletion:
     def test_streaming_sse_format(self, app_client: TestClient) -> None:
         """Streaming returns valid SSE format."""
 
-        async def mock_stream(**_kw: object) -> AsyncIterator[RunContentEvent]:
+        async def mock_stream(_ctx: object, **_kw: object) -> AsyncIterator[RunContentEvent]:
             yield RunContentEvent(content="Hello ")
             yield RunContentEvent(content="world!")
 
@@ -1584,7 +1584,7 @@ class TestStreamingCompletion:
     def test_streaming_passes_include_interactive_questions_false(self, app_client: TestClient) -> None:
         """Streaming disables interactive question prompting for OpenAI compatibility."""
 
-        async def mock_stream(**_kw: object) -> AsyncIterator[RunContentEvent]:
+        async def mock_stream(_ctx: object, **_kw: object) -> AsyncIterator[RunContentEvent]:
             yield RunContentEvent(content="ok")
 
         with patch("mindroom.api.openai_compat.stream_agent_response", side_effect=mock_stream) as mock_stream_fn:
@@ -1600,12 +1600,12 @@ class TestStreamingCompletion:
         assert response.status_code == 200
         assert "include_default_tools" not in mock_stream_fn.call_args.kwargs
         assert mock_stream_fn.call_args.kwargs["include_interactive_questions"] is False
-        assert mock_stream_fn.call_args.kwargs["active_event_ids"] == set()
+        assert mock_stream_fn.call_args.args[0].active_event_ids == frozenset()
 
     def test_streaming_consistent_id(self, app_client: TestClient) -> None:
         """All streaming chunks have the same completion ID."""
 
-        async def mock_stream(**_kw: object) -> AsyncIterator[RunContentEvent]:
+        async def mock_stream(_ctx: object, **_kw: object) -> AsyncIterator[RunContentEvent]:
             yield RunContentEvent(content="test")
 
         with patch("mindroom.api.openai_compat.stream_agent_response", side_effect=mock_stream):
@@ -1634,7 +1634,7 @@ class TestStreamingCompletion:
         """Worker-routing identity must stay active after the first streamed event."""
         observed_session_ids: list[str | None] = []
 
-        async def mock_stream(**_kw: object) -> AsyncIterator[RunContentEvent]:
+        async def mock_stream(_ctx: object, **_kw: object) -> AsyncIterator[RunContentEvent]:
             identity = get_tool_execution_identity()
             observed_session_ids.append(identity.session_id if identity is not None else None)
             yield RunContentEvent(content="Hello ")
@@ -1673,7 +1673,7 @@ class TestStreamingCompletion:
         )
         observed_final_identities: list[ToolExecutionIdentity | None] = []
 
-        async def mock_stream(**_kw: object) -> AsyncIterator[RunContentEvent]:
+        async def mock_stream(_ctx: object, **_kw: object) -> AsyncIterator[RunContentEvent]:
             try:
                 assert get_tool_execution_identity() == execution_identity
                 yield RunContentEvent(content="Hello")
@@ -1703,7 +1703,7 @@ class TestStreamingCompletion:
     def test_streaming_cached_response(self, app_client: TestClient) -> None:
         """Cached full response (string) is streamed correctly."""
 
-        async def mock_stream(**_kw: object) -> AsyncIterator[str]:
+        async def mock_stream(_ctx: object, **_kw: object) -> AsyncIterator[str]:
             yield "This is a cached response"
 
         with patch("mindroom.api.openai_compat.stream_agent_response", side_effect=mock_stream):
@@ -1724,7 +1724,7 @@ class TestStreamingCompletion:
     def test_streaming_first_event_error_returns_500(self, app_client: TestClient) -> None:
         """If first stream event is an error string, return HTTP 500 instead of SSE."""
 
-        async def mock_stream(**_kw: object) -> AsyncIterator[str]:
+        async def mock_stream(_ctx: object, **_kw: object) -> AsyncIterator[str]:
             yield "❌ Authentication failed (openai): Invalid API key"
 
         with patch("mindroom.api.openai_compat.stream_agent_response", side_effect=mock_stream):
@@ -1759,7 +1759,7 @@ class TestStreamingCompletion:
             result="3 results",
         )
 
-        async def mock_stream(**_kw: object) -> AsyncIterator[object]:
+        async def mock_stream(_ctx: object, **_kw: object) -> AsyncIterator[object]:
             yield RunContentEvent(content="Let me search. ")
             yield ToolCallStartedEvent(tool=tool_started)
             yield ToolCallCompletedEvent(tool=tool_completed)
@@ -1811,7 +1811,7 @@ class TestStreamingCompletion:
             result="</tool><i>boom</i>" + ("x" * 600),
         )
 
-        async def mock_stream(**_kw: object) -> AsyncIterator[object]:
+        async def mock_stream(_ctx: object, **_kw: object) -> AsyncIterator[object]:
             yield ToolCallStartedEvent(tool=tool_started)
             yield ToolCallCompletedEvent(tool=tool_completed)
 
@@ -1875,7 +1875,7 @@ class TestStreamingCompletion:
             result="two-result",
         )
 
-        async def mock_stream(**_kw: object) -> AsyncIterator[object]:
+        async def mock_stream(_ctx: object, **_kw: object) -> AsyncIterator[object]:
             yield RunContentEvent(content="Start ")
             yield ToolCallStartedEvent(tool=first_started)
             yield ToolCallCompletedEvent(tool=first_completed)
@@ -2678,7 +2678,7 @@ class TestAutoRouting:
     def test_auto_streaming(self, app_client: TestClient) -> None:
         """Auto model works with streaming, chunks carry resolved agent name."""
 
-        async def mock_stream(**_kw: object) -> AsyncIterator[RunContentEvent]:
+        async def mock_stream(_ctx: object, **_kw: object) -> AsyncIterator[RunContentEvent]:
             yield RunContentEvent(content="Streamed!")
 
         with (
@@ -2755,10 +2755,10 @@ class TestAutoRouting:
                 headers={"X-LibreChat-Conversation-Id": "conv-abc"},
             )
 
-            # ai_response should receive agent_name="code", not "auto"
-            assert mock_ai.call_args.kwargs["agent_name"] == "code"
+            # ai_response should receive entity_label="code", not "auto"
+            assert mock_ai.call_args.args[0].entity_label == "code"
             # Session ID should use the resolved model name with LibreChat IDs.
-            session_id = mock_ai.call_args.kwargs["session_id"]
+            session_id = mock_ai.call_args.args[0].session_id
             assert session_id.endswith(":conv-abc:code")
             assert "auto" not in session_id
 
@@ -5170,7 +5170,7 @@ class TestKnowledgeIntegration:
         """Knowledge is passed through in streaming mode too."""
         mock_knowledge = MagicMock()
 
-        async def mock_stream(**_kw: object) -> AsyncIterator[RunContentEvent]:
+        async def mock_stream(_ctx: object, **_kw: object) -> AsyncIterator[RunContentEvent]:
             yield RunContentEvent(content="Streamed!")
 
         with (

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -85,6 +85,7 @@ from tests.conftest import (
     install_runtime_cache_support,
     make_event_cache_mock,
     make_event_cache_write_coordinator_mock,
+    make_turn_context,
     message_origin,
     prepared_dispatch_result,
     request_envelope,
@@ -2933,13 +2934,9 @@ async def test_ai_response_preserves_stale_notice_before_prepare(tmp_path: Path)
     observed_notice_counts: list[int] = []
 
     async def fake_prepare(
-        _agent_name: str,
-        _prompt: str,
-        _runtime_paths: object,
-        _config: object,
-        _session_id: str | None = None,
+        _ctx: object,
+        *,
         scope_context: object | None = None,
-        *_args: object,
         **_kwargs: object,
     ) -> _PreparedAgentRun:
         assert scope_context is not None
@@ -2971,9 +2968,8 @@ async def test_ai_response_preserves_stale_notice_before_prepare(tmp_path: Path)
         patch("mindroom.ai.close_agent_runtime_state_dbs"),
     ):
         response = await ai_response(
-            agent_name="general",
+            make_turn_context("general", session_id="session-1"),
             prompt="hello",
-            session_id="session-1",
             runtime_paths=runtime_paths_for(config),
             config=config,
         )
@@ -3036,9 +3032,8 @@ async def test_ai_response_preserves_notice_in_run_output_and_session(tmp_path: 
         queued_message_signal_context(_StaticQueuedState(pending=True)),
     ):
         response = await ai_response(
-            agent_name="general",
+            make_turn_context("general", session_id="session-1"),
             prompt="hello",
-            session_id="session-1",
             runtime_paths=runtime_paths_for(config),
             config=config,
         )
@@ -3089,9 +3084,8 @@ async def test_ai_response_preserves_notice_in_session_after_exception(tmp_path:
         queued_message_signal_context(_StaticQueuedState(pending=True)),
     ):
         response = await ai_response(
-            agent_name="general",
+            make_turn_context("general", session_id="session-1"),
             prompt="hello",
-            session_id="session-1",
             runtime_paths=runtime_paths_for(config),
             config=config,
         )
@@ -3144,9 +3138,8 @@ async def test_stream_agent_response_preserves_notice_in_session(tmp_path: Path)
         chunks = [
             chunk
             async for chunk in stream_agent_response(
-                agent_name="general",
+                make_turn_context("general", session_id="session-1"),
                 prompt="hello",
-                session_id="session-1",
                 runtime_paths=runtime_paths_for(config),
                 config=config,
             )

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -2119,8 +2119,8 @@ class TestStreamingBehavior:
         bot.client.room_send.return_value = mock_send_response
         pipeline_timing = DispatchPipelineTiming(source_event_id="$request", room_id="!test:localhost")
 
-        async def fake_stream_agent_response(*_args: object, **kwargs: object) -> AsyncIterator[str]:
-            system_enrichment_items = kwargs["system_enrichment_items"]
+        async def fake_stream_agent_response(*args: object, **_kwargs: object) -> AsyncIterator[str]:
+            system_enrichment_items = args[0].system_enrichment_items
             assert len(system_enrichment_items) == 1
             assert (
                 f"Knowledge base `{base_id}` is initializing and unavailable for semantic search this turn."
@@ -2186,8 +2186,8 @@ class TestStreamingBehavior:
             base_id="fresh_turn_docs",
         )
 
-        async def fake_ai_response(*_args: object, **kwargs: object) -> str:
-            system_enrichment_items = kwargs["system_enrichment_items"]
+        async def fake_ai_response(*args: object, **_kwargs: object) -> str:
+            system_enrichment_items = args[0].system_enrichment_items
             assert len(system_enrichment_items) == 1
             assert "Knowledge base `fresh_turn_docs` is initializing" in system_enrichment_items[0].text
             return "handled"

--- a/tests/test_system_enrich.py
+++ b/tests/test_system_enrich.py
@@ -51,6 +51,7 @@ from mindroom.teams import TeamMode, build_materialized_team_instance, prepare_m
 from tests.conftest import (
     TEST_PASSWORD,
     bind_runtime_paths,
+    make_turn_context,
     message_origin,
     patch_response_runner_module,
     request_envelope,
@@ -347,11 +348,10 @@ async def test_prepare_agent_and_prompt_applies_system_enrichment_to_agent_addit
         ),
     ):
         prepared_run = await _prepare_agent_and_prompt(
-            agent_name="code",
+            make_turn_context("code", system_enrichment_items=system_items),
             prompt="prompt",
             runtime_paths=runtime_paths_for(config),
             config=config,
-            system_enrichment_items=system_items,
         )
 
     agent = prepared_run.agent
@@ -551,8 +551,8 @@ async def test_process_and_respond_threads_system_enrichment_items(tmp_path: Pat
         EnrichmentItem(key="omega", text="volatile", cache_policy="volatile"),
     )
 
-    async def fake_ai_response(*_args: object, **kwargs: object) -> str:
-        assert kwargs["system_enrichment_items"] == system_items
+    async def fake_ai_response(*args: object, **_kwargs: object) -> str:
+        assert args[0].system_enrichment_items == system_items
         return "handled"
 
     with (
@@ -601,8 +601,8 @@ async def test_process_and_respond_streaming_threads_system_enrichment_items(tmp
         EnrichmentItem(key="omega", text="volatile", cache_policy="volatile"),
     )
 
-    async def fake_stream_agent_response(*_args: object, **kwargs: object) -> AsyncIterator[str]:
-        assert kwargs["system_enrichment_items"] == system_items
+    async def fake_stream_agent_response(*args: object, **_kwargs: object) -> AsyncIterator[str]:
+        assert args[0].system_enrichment_items == system_items
         yield "stream chunk"
 
     async def fake_send_streaming_response(*args: object, **_kwargs: object) -> StreamTransportOutcome:

--- a/tests/test_system_enrich.py
+++ b/tests/test_system_enrich.py
@@ -432,6 +432,15 @@ async def test_prepare_materialized_team_execution_applies_system_enrichment_to_
             execution_identity=None,
         )
         await prepare_materialized_team_execution(
+            make_turn_context(
+                room_id="!room:localhost",
+                thread_id="$thread",
+                requester_id="@user:localhost",
+                correlation_id="$event",
+                reply_to_event_id="$event",
+                active_event_ids=frozenset(),
+                system_enrichment_items=system_items,
+            ),
             scope_context=scope_context,
             agents=team_members.agents,
             team=team,
@@ -440,17 +449,10 @@ async def test_prepare_materialized_team_execution_applies_system_enrichment_to_
             config=config,
             runtime_paths=runtime_paths,
             active_model_name=None,
-            room_id="!room:localhost",
-            thread_id="$thread",
-            requester_id="@user:localhost",
-            correlation_id="$event",
-            reply_to_event_id="$event",
-            active_event_ids=frozenset(),
             response_sender_id="@mindroom_code:localhost",
             current_sender_id=None,
             compaction_outcomes_collector=[],
             configured_team_name=None,
-            system_enrichment_items=system_items,
         )
 
     assert team is prepared_team
@@ -518,6 +520,13 @@ async def test_prepare_materialized_team_execution_returns_prompt_helpers(tmp_pa
             execution_identity=None,
         )
         prepared_execution = await prepare_materialized_team_execution(
+            make_turn_context(
+                room_id=None,
+                thread_id=None,
+                requester_id=None,
+                reply_to_event_id="$event",
+                active_event_ids=frozenset(),
+            ),
             scope_context=scope_context,
             agents=team_members.agents,
             team=team,
@@ -526,12 +535,6 @@ async def test_prepare_materialized_team_execution_returns_prompt_helpers(tmp_pa
             config=config,
             runtime_paths=runtime_paths,
             active_model_name=None,
-            room_id=None,
-            thread_id=None,
-            requester_id=None,
-            correlation_id=None,
-            reply_to_event_id="$event",
-            active_event_ids=frozenset(),
             response_sender_id="@mindroom_code:localhost",
             current_sender_id=None,
             compaction_outcomes_collector=[],

--- a/tests/test_team_dynamic_continuation.py
+++ b/tests/test_team_dynamic_continuation.py
@@ -26,7 +26,7 @@ from mindroom.teams import (
     team_response,
     team_response_stream,
 )
-from tests.conftest import runtime_paths_for
+from tests.conftest import make_turn_context, runtime_paths_for
 from tests.identity_helpers import entity_ids
 from tests.test_team_media_fallback import _build_test_config, _make_test_agent, _make_test_team
 
@@ -96,7 +96,7 @@ async def test_team_response_continues_after_member_dynamic_tool_load() -> None:
             turn_recorder=recorder,
             orchestrator=orchestrator,
             execution_identity=None,
-            run_id="run-1",
+            ctx=make_turn_context(run_id="run-1"),
             run_id_callback=run_ids.append,
         )
 
@@ -135,6 +135,7 @@ async def test_team_response_returns_limit_message_after_dynamic_tool_limit() ->
             turn_recorder=recorder,
             orchestrator=orchestrator,
             execution_identity=None,
+            ctx=make_turn_context(),
         )
 
     assert mock_team.arun.await_count == DYNAMIC_TOOL_CONTINUATION_LIMIT + 1
@@ -169,6 +170,7 @@ async def test_team_response_stream_continues_after_terminal_dynamic_tool_output
                 turn_recorder=recorder,
                 orchestrator=orchestrator,
                 execution_identity=None,
+                ctx=make_turn_context(),
             )
         ]
 
@@ -217,6 +219,7 @@ async def test_team_response_stream_continues_after_streamed_member_dynamic_tool
                 turn_recorder=recorder,
                 orchestrator=orchestrator,
                 execution_identity=None,
+                ctx=make_turn_context(),
             )
         ]
 
@@ -261,6 +264,7 @@ async def test_team_response_stream_continues_from_hidden_member_dynamic_tool() 
                 turn_recorder=recorder,
                 orchestrator=orchestrator,
                 execution_identity=None,
+                ctx=make_turn_context(),
                 show_tool_calls=False,
             )
         ]

--- a/tests/test_team_dynamic_continuation.py
+++ b/tests/test_team_dynamic_continuation.py
@@ -96,7 +96,7 @@ async def test_team_response_continues_after_member_dynamic_tool_load() -> None:
             turn_recorder=recorder,
             orchestrator=orchestrator,
             execution_identity=None,
-            ctx=make_turn_context(run_id="run-1"),
+            ctx=make_turn_context(run_id="run-1", session_id=None),
             run_id_callback=run_ids.append,
         )
 
@@ -135,7 +135,7 @@ async def test_team_response_returns_limit_message_after_dynamic_tool_limit() ->
             turn_recorder=recorder,
             orchestrator=orchestrator,
             execution_identity=None,
-            ctx=make_turn_context(),
+            ctx=make_turn_context(session_id=None),
         )
 
     assert mock_team.arun.await_count == DYNAMIC_TOOL_CONTINUATION_LIMIT + 1
@@ -170,7 +170,7 @@ async def test_team_response_stream_continues_after_terminal_dynamic_tool_output
                 turn_recorder=recorder,
                 orchestrator=orchestrator,
                 execution_identity=None,
-                ctx=make_turn_context(),
+                ctx=make_turn_context(session_id=None),
             )
         ]
 
@@ -219,7 +219,7 @@ async def test_team_response_stream_continues_after_streamed_member_dynamic_tool
                 turn_recorder=recorder,
                 orchestrator=orchestrator,
                 execution_identity=None,
-                ctx=make_turn_context(),
+                ctx=make_turn_context(session_id=None),
             )
         ]
 
@@ -264,7 +264,7 @@ async def test_team_response_stream_continues_from_hidden_member_dynamic_tool() 
                 turn_recorder=recorder,
                 orchestrator=orchestrator,
                 execution_identity=None,
-                ctx=make_turn_context(),
+                ctx=make_turn_context(session_id=None),
                 show_tool_calls=False,
             )
         ]

--- a/tests/test_team_empty_response_and_replay.py
+++ b/tests/test_team_empty_response_and_replay.py
@@ -15,7 +15,7 @@ from mindroom.dynamic_tool_continuation import DYNAMIC_TOOL_CONTINUATION_LIMIT
 from mindroom.history.turn_recorder import TurnRecorder
 from mindroom.knowledge.utils import _KnowledgeResolution
 from mindroom.teams import TeamMode, team_response, team_response_stream
-from tests.conftest import runtime_paths_for
+from tests.conftest import make_turn_context, runtime_paths_for
 from tests.identity_helpers import entity_ids
 from tests.test_team_dynamic_continuation import _dynamic_tool_team_output
 from tests.test_team_media_fallback import _build_test_config, _make_test_agent, _make_test_team
@@ -74,7 +74,7 @@ async def test_team_response_retries_once_after_empty_completed_run() -> None:
             turn_recorder=TurnRecorder(user_message="Say something."),
             orchestrator=orchestrator,
             execution_identity=None,
-            session_id="session-1",
+            ctx=make_turn_context(session_id="session-1"),
         )
 
     assert "Recovered answer" in response
@@ -98,7 +98,7 @@ async def test_team_response_returns_fallback_notice_when_retry_is_also_empty() 
             turn_recorder=recorder,
             orchestrator=orchestrator,
             execution_identity=None,
-            session_id="session-1",
+            ctx=make_turn_context(session_id="session-1"),
         )
 
     assert response == ai_runtime.EMPTY_RESPONSE_NOTICE
@@ -130,7 +130,7 @@ async def test_team_response_stream_yields_fallback_notice_when_retry_is_also_em
                 turn_recorder=TurnRecorder(user_message="Say something."),
                 orchestrator=orchestrator,
                 execution_identity=None,
-                session_id="session-1",
+                ctx=make_turn_context(session_id="session-1"),
             )
         ]
 
@@ -169,7 +169,7 @@ async def test_team_response_stream_empty_event_stream_retries_then_notices() ->
                 turn_recorder=recorder,
                 orchestrator=orchestrator,
                 execution_identity=None,
-                session_id="session-1",
+                ctx=make_turn_context(session_id="session-1"),
             )
         ]
 
@@ -199,7 +199,7 @@ async def test_team_response_discards_whitespace_only_completed_run() -> None:
             turn_recorder=TurnRecorder(user_message="Say something."),
             orchestrator=orchestrator,
             execution_identity=None,
-            session_id="session-1",
+            ctx=make_turn_context(session_id="session-1"),
         )
 
     assert "Recovered answer" in response
@@ -235,7 +235,7 @@ async def test_team_response_ignores_history_messages_for_empty_detection() -> N
             turn_recorder=TurnRecorder(user_message="Say something."),
             orchestrator=orchestrator,
             execution_identity=None,
-            session_id="session-1",
+            ctx=make_turn_context(session_id="session-1"),
         )
 
     assert "Recovered answer" in response
@@ -264,7 +264,7 @@ async def test_team_empty_retry_shares_budget_with_dynamic_continuations() -> No
             turn_recorder=TurnRecorder(user_message="Keep loading tools."),
             orchestrator=orchestrator,
             execution_identity=None,
-            session_id="session-1",
+            ctx=make_turn_context(session_id="session-1"),
         )
 
     # The empty retry borrows one continuation slot: 1 discarded empty run

--- a/tests/test_team_media_fallback.py
+++ b/tests/test_team_media_fallback.py
@@ -288,7 +288,7 @@ async def test_team_response_retries_without_inline_media_on_validation_error() 
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=None,
-            ctx=make_turn_context(),
+            ctx=make_turn_context(session_id=None),
             media=MediaInputs(audio=[audio_input]),
         )
 
@@ -336,7 +336,7 @@ async def test_team_response_retries_errored_plain_run_output_with_fresh_run_id(
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=None,
-            ctx=make_turn_context(run_id="run-123"),
+            ctx=make_turn_context(run_id="run-123", session_id=None),
             media=MediaInputs(audio=[MagicMock(name="audio_input")]),
             run_id_callback=callback_run_ids.append,
         )
@@ -846,7 +846,7 @@ async def test_prepare_materialized_team_execution_scrubs_queued_notices_when_ca
             new=AsyncMock(side_effect=fake_prepare_bound_team_execution_context),
         ):
             await prepare_materialized_team_execution(
-                make_turn_context(),
+                make_turn_context(session_id=None),
                 scope_context=scope_context,
                 agents=[fake_agent],
                 team=mock_team,
@@ -883,7 +883,7 @@ async def test_prepare_materialized_team_execution_forwards_explicit_thread_hist
         new=AsyncMock(side_effect=fake_prepare_bound_team_execution_context),
     ):
         await prepare_materialized_team_execution(
-            make_turn_context(),
+            make_turn_context(session_id=None),
             scope_context=None,
             agents=[fake_agent],
             team=mock_team,
@@ -924,6 +924,7 @@ async def test_prepare_materialized_team_execution_appends_system_enrichment_con
         await prepare_materialized_team_execution(
             make_turn_context(
                 system_enrichment_items=(EnrichmentItem(key="weather", text="72F and sunny"),),
+                session_id=None,
             ),
             scope_context=None,
             agents=[fake_agent],
@@ -976,7 +977,7 @@ async def test_prepare_materialized_team_execution_carries_compaction_metadata_a
         new=AsyncMock(side_effect=fake_prepare_bound_team_run_context),
     ):
         prepared = await prepare_materialized_team_execution(
-            make_turn_context(reply_to_event_id="$event", room_id="!room:localhost"),
+            make_turn_context(reply_to_event_id="$event", room_id="!room:localhost", session_id=None),
             scope_context=None,
             agents=[fake_agent],
             team=mock_team,
@@ -1382,7 +1383,7 @@ async def test_team_response_passes_run_id_to_team_arun() -> None:
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=None,
-            ctx=make_turn_context(run_id="run-123"),
+            ctx=make_turn_context(run_id="run-123", session_id=None),
         )
 
     assert "Recovered team response" in response
@@ -1421,7 +1422,7 @@ async def test_team_response_raises_cancelled_error_for_cancelled_runs() -> None
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=None,
-            ctx=make_turn_context(run_id="run-123"),
+            ctx=make_turn_context(run_id="run-123", session_id=None),
         )
 
 
@@ -1593,7 +1594,7 @@ async def test_team_response_returns_friendly_error_for_error_status() -> None:
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=None,
-            ctx=make_turn_context(),
+            ctx=make_turn_context(session_id=None),
         )
 
     assert response == "friendly-team-error"
@@ -1756,7 +1757,7 @@ async def test_team_response_retries_errored_run_output_with_fresh_run_id() -> N
             turn_recorder=recorder,
             orchestrator=orchestrator,
             execution_identity=None,
-            ctx=make_turn_context(run_id="run-123"),
+            ctx=make_turn_context(run_id="run-123", session_id=None),
             media=MediaInputs(audio=[MagicMock(name="audio_input")]),
             run_id_callback=lambda current_run_id: (
                 callback_run_ids.append(current_run_id),
@@ -1888,7 +1889,7 @@ async def test_team_response_stream_raises_cancelled_error_for_team_run_cancelle
                     turn_recorder=recorder,
                     orchestrator=orchestrator,
                     execution_identity=None,
-                    ctx=make_turn_context(run_id="run-456"),
+                    ctx=make_turn_context(run_id="run-456", session_id=None),
                     mode=TeamMode.COORDINATE,
                 )
             ]
@@ -2595,7 +2596,7 @@ async def test_team_response_stream_emits_team_run_output_fallback() -> None:
                 turn_recorder=_team_turn_recorder("Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=None,
-                ctx=make_turn_context(run_id="run-789"),
+                ctx=make_turn_context(run_id="run-789", session_id=None),
                 mode=TeamMode.COORDINATE,
             )
         ]
@@ -2726,7 +2727,7 @@ async def test_team_response_stream_emits_plain_run_output_fallback_with_team_fo
                 turn_recorder=_team_turn_recorder("Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=None,
-                ctx=make_turn_context(),
+                ctx=make_turn_context(session_id=None),
                 mode=TeamMode.COORDINATE,
             )
         ]
@@ -2784,7 +2785,7 @@ async def test_team_response_stream_raises_cancelled_error_for_team_run_output_f
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=None,
-            ctx=make_turn_context(run_id="run-789"),
+            ctx=make_turn_context(run_id="run-789", session_id=None),
             mode=TeamMode.COORDINATE,
         ):
             pass
@@ -2838,7 +2839,7 @@ async def test_team_response_stream_returns_friendly_error_for_errored_run_outpu
                 turn_recorder=_team_turn_recorder("Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=None,
-                ctx=make_turn_context(),
+                ctx=make_turn_context(session_id=None),
                 mode=TeamMode.COORDINATE,
             )
         ]
@@ -2894,7 +2895,7 @@ async def test_team_response_stream_returns_friendly_error_for_errored_plain_run
                 turn_recorder=_team_turn_recorder("Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=None,
-                ctx=make_turn_context(),
+                ctx=make_turn_context(session_id=None),
                 mode=TeamMode.COORDINATE,
             )
         ]
@@ -2956,7 +2957,7 @@ async def test_team_response_stream_retries_errored_output_with_fresh_run_id() -
                 turn_recorder=_team_turn_recorder("Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=None,
-                ctx=make_turn_context(run_id="run-789"),
+                ctx=make_turn_context(run_id="run-789", session_id=None),
                 mode=TeamMode.COORDINATE,
                 media=MediaInputs(audio=[MagicMock(name="audio_input")]),
                 run_id_callback=callback_run_ids.append,
@@ -3223,7 +3224,7 @@ async def test_team_response_rejects_missing_materialized_members() -> None:
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=None,
-            ctx=make_turn_context(),
+            ctx=make_turn_context(session_id=None),
         )
 
     assert response == "Team request includes agent 'research' that could not be materialized for this request."
@@ -3500,7 +3501,7 @@ async def test_team_response_rejects_non_running_materialized_members() -> None:
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=None,
-            ctx=make_turn_context(),
+            ctx=make_turn_context(session_id=None),
         )
 
     assert response == "Team request includes agent 'research' that could not be materialized for this request."
@@ -3542,7 +3543,7 @@ async def test_team_response_rejects_request_time_materialization_failure() -> N
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=None,
-            ctx=make_turn_context(),
+            ctx=make_turn_context(session_id=None),
             reason_prefix="Team 'summary'",
         )
 
@@ -3583,7 +3584,7 @@ async def test_team_stream_rejects_missing_materialized_members() -> None:
                 turn_recorder=_team_turn_recorder("Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=None,
-                ctx=make_turn_context(),
+                ctx=make_turn_context(session_id=None),
             )
         ]
 
@@ -3631,7 +3632,7 @@ async def test_team_stream_rejects_request_time_materialization_failure() -> Non
                 turn_recorder=_team_turn_recorder("Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=None,
-                ctx=make_turn_context(),
+                ctx=make_turn_context(session_id=None),
                 reason_prefix="Team 'summary'",
             )
         ]
@@ -3674,7 +3675,7 @@ async def test_team_stream_retries_without_inline_media_on_setup_error() -> None
                 turn_recorder=_team_turn_recorder("Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=None,
-                ctx=make_turn_context(),
+                ctx=make_turn_context(session_id=None),
                 media=MediaInputs(audio=[audio_input]),
             )
         ]
@@ -3730,7 +3731,7 @@ async def test_team_stream_retries_without_inline_media_on_streamed_run_error() 
                 turn_recorder=_team_turn_recorder("Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=None,
-                ctx=make_turn_context(),
+                ctx=make_turn_context(session_id=None),
                 media=MediaInputs(audio=[audio_input]),
             )
         ]
@@ -3972,7 +3973,7 @@ async def test_team_response_materializes_private_agent_with_execution_identity(
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=identity,
-            ctx=make_turn_context(),
+            ctx=make_turn_context(session_id=None),
         )
 
     assert "Team response" in response
@@ -4005,7 +4006,7 @@ async def test_team_response_rejects_private_agent_with_non_matrix_execution_ide
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=identity,
-            ctx=make_turn_context(),
+            ctx=make_turn_context(session_id=None),
         )
 
 
@@ -4034,7 +4035,7 @@ async def test_team_response_rejects_private_agent_with_empty_requester_identity
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=identity,
-            ctx=make_turn_context(),
+            ctx=make_turn_context(session_id=None),
         )
 
 
@@ -4054,7 +4055,7 @@ async def test_team_response_rejects_private_agents_even_when_private_member_is_
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=None,
-            ctx=make_turn_context(),
+            ctx=make_turn_context(session_id=None),
         )
 
 
@@ -4079,7 +4080,7 @@ async def test_team_response_stream_rejects_private_agents_even_when_private_mem
                 turn_recorder=_team_turn_recorder("Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=None,
-                ctx=make_turn_context(),
+                ctx=make_turn_context(session_id=None),
             )
         ]
 
@@ -4122,7 +4123,7 @@ async def test_team_response_stream_materializes_private_agent_with_execution_id
                 turn_recorder=_team_turn_recorder("Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=identity,
-                ctx=make_turn_context(),
+                ctx=make_turn_context(session_id=None),
             )
         ]
 
@@ -4171,7 +4172,7 @@ async def test_team_response_rejects_members_that_delegate_to_private_agents() -
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=None,
-            ctx=make_turn_context(),
+            ctx=make_turn_context(session_id=None),
         )
 
 
@@ -4205,7 +4206,7 @@ async def test_team_response_ignores_router_in_direct_team_member_list() -> None
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=None,
-            ctx=make_turn_context(),
+            ctx=make_turn_context(session_id=None),
         )
 
     assert "General response" in response
@@ -4245,7 +4246,7 @@ async def test_team_response_stream_ignores_router_in_direct_team_member_list() 
                 turn_recorder=_team_turn_recorder("Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=None,
-                ctx=make_turn_context(),
+                ctx=make_turn_context(session_id=None),
             )
         ]
 
@@ -4335,7 +4336,7 @@ async def test_team_response_materializes_members_with_request_execution_identit
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=identity,
-            ctx=make_turn_context(),
+            ctx=make_turn_context(session_id=None),
         )
 
     assert "General response" in response

--- a/tests/test_team_media_fallback.py
+++ b/tests/test_team_media_fallback.py
@@ -67,7 +67,13 @@ from mindroom.teams import (
 )
 from mindroom.timing import DispatchPipelineTiming
 from mindroom.tool_system.worker_routing import ToolExecutionIdentity
-from tests.conftest import bind_runtime_paths, make_visible_message, runtime_paths_for, test_runtime_paths
+from tests.conftest import (
+    bind_runtime_paths,
+    make_turn_context,
+    make_visible_message,
+    runtime_paths_for,
+    test_runtime_paths,
+)
 from tests.identity_helpers import entity_ids, fixture_entity_matrix_id, persist_entity_accounts
 
 if TYPE_CHECKING:
@@ -282,6 +288,7 @@ async def test_team_response_retries_without_inline_media_on_validation_error() 
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=None,
+            ctx=make_turn_context(),
             media=MediaInputs(audio=[audio_input]),
         )
 
@@ -329,8 +336,8 @@ async def test_team_response_retries_errored_plain_run_output_with_fresh_run_id(
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=None,
+            ctx=make_turn_context(run_id="run-123"),
             media=MediaInputs(audio=[MagicMock(name="audio_input")]),
-            run_id="run-123",
             run_id_callback=callback_run_ids.append,
         )
 
@@ -426,8 +433,8 @@ async def test_team_response_retry_scrubs_queued_notice_before_second_attempt() 
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=None,
+            ctx=make_turn_context(session_id="session-retry-clean"),
             media=MediaInputs(audio=[MagicMock(name="audio_input")]),
-            session_id="session-retry-clean",
         )
 
     assert attempts == 2
@@ -471,7 +478,7 @@ async def test_team_response_fallback_run_output_cleans_queued_notice_before_for
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=None,
-            session_id="session-123",
+            ctx=make_turn_context(session_id="session-123"),
         )
 
     assert "Recovered team response" in response
@@ -513,7 +520,7 @@ async def test_team_response_fallback_run_output_error_uses_friendly_error() -> 
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=None,
-            session_id="session-123",
+            ctx=make_turn_context(session_id="session-123"),
         )
 
     assert response == "friendly-team-error"
@@ -547,7 +554,7 @@ async def test_team_response_uses_compaction_aware_member_execution() -> None:
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=None,
-            session_id="session-123",
+            ctx=make_turn_context(session_id="session-123"),
             compaction_outcomes_collector=collector,
         )
 
@@ -594,7 +601,7 @@ async def test_team_response_prefers_persisted_history_over_thread_context_fallb
             thread_history=[make_visible_message(sender="user", body="Old thread context")],
             orchestrator=orchestrator,
             execution_identity=None,
-            session_id="session-123",
+            ctx=make_turn_context(session_id="session-123"),
         )
 
     assert "Recovered team response" in response
@@ -660,8 +667,7 @@ async def test_team_response_preserves_unseen_matrix_thread_context_with_persist
             thread_history=thread_history,
             orchestrator=orchestrator,
             execution_identity=None,
-            session_id="session-123",
-            reply_to_event_id="event-3",
+            ctx=make_turn_context(session_id="session-123", reply_to_event_id="event-3"),
             response_sender_id="@mindroom_team:example.org",
         )
 
@@ -769,7 +775,7 @@ async def test_team_response_scrubs_queued_notices_before_prepare_and_after_run(
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=None,
-            session_id="session-queued",
+            ctx=make_turn_context(session_id="session-queued"),
         )
 
     assert "Recovered team response" in response
@@ -840,6 +846,7 @@ async def test_prepare_materialized_team_execution_scrubs_queued_notices_when_ca
             new=AsyncMock(side_effect=fake_prepare_bound_team_execution_context),
         ):
             await prepare_materialized_team_execution(
+                make_turn_context(),
                 scope_context=scope_context,
                 agents=[fake_agent],
                 team=mock_team,
@@ -848,12 +855,6 @@ async def test_prepare_materialized_team_execution_scrubs_queued_notices_when_ca
                 config=config,
                 runtime_paths=runtime_paths,
                 active_model_name=None,
-                room_id=None,
-                thread_id=None,
-                requester_id=None,
-                correlation_id=None,
-                reply_to_event_id=None,
-                active_event_ids=frozenset(),
                 response_sender_id=None,
                 current_sender_id=None,
                 compaction_outcomes_collector=None,
@@ -882,6 +883,7 @@ async def test_prepare_materialized_team_execution_forwards_explicit_thread_hist
         new=AsyncMock(side_effect=fake_prepare_bound_team_execution_context),
     ):
         await prepare_materialized_team_execution(
+            make_turn_context(),
             scope_context=None,
             agents=[fake_agent],
             team=mock_team,
@@ -890,12 +892,6 @@ async def test_prepare_materialized_team_execution_forwards_explicit_thread_hist
             config=config,
             runtime_paths=runtime_paths,
             active_model_name=None,
-            room_id=None,
-            thread_id=None,
-            requester_id=None,
-            correlation_id=None,
-            reply_to_event_id=None,
-            active_event_ids=frozenset(),
             response_sender_id=None,
             current_sender_id=None,
             compaction_outcomes_collector=None,
@@ -926,6 +922,9 @@ async def test_prepare_materialized_team_execution_appends_system_enrichment_con
         new=AsyncMock(side_effect=fake_prepare_bound_team_execution_context),
     ):
         await prepare_materialized_team_execution(
+            make_turn_context(
+                system_enrichment_items=(EnrichmentItem(key="weather", text="72F and sunny"),),
+            ),
             scope_context=None,
             agents=[fake_agent],
             team=mock_team,
@@ -934,17 +933,10 @@ async def test_prepare_materialized_team_execution_appends_system_enrichment_con
             config=config,
             runtime_paths=runtime_paths,
             active_model_name=None,
-            reply_to_event_id=None,
-            active_event_ids=frozenset(),
             response_sender_id=None,
             current_sender_id=None,
-            room_id=None,
-            thread_id=None,
-            requester_id=None,
-            correlation_id=None,
             compaction_outcomes_collector=None,
             configured_team_name=None,
-            system_enrichment_items=(EnrichmentItem(key="weather", text="72F and sunny"),),
         )
 
     assert mock_team.additional_context.startswith("team configured context\n\n")
@@ -984,6 +976,7 @@ async def test_prepare_materialized_team_execution_carries_compaction_metadata_a
         new=AsyncMock(side_effect=fake_prepare_bound_team_run_context),
     ):
         prepared = await prepare_materialized_team_execution(
+            make_turn_context(reply_to_event_id="$event", room_id="!room:localhost"),
             scope_context=None,
             agents=[fake_agent],
             team=mock_team,
@@ -992,14 +985,8 @@ async def test_prepare_materialized_team_execution_carries_compaction_metadata_a
             config=config,
             runtime_paths=runtime_paths,
             active_model_name=None,
-            reply_to_event_id="$event",
-            active_event_ids=frozenset(),
             response_sender_id=None,
             current_sender_id=None,
-            room_id="!room:localhost",
-            thread_id=None,
-            requester_id=None,
-            correlation_id=None,
             compaction_outcomes_collector=None,
             configured_team_name=None,
             pipeline_timing=timing,
@@ -1182,7 +1169,7 @@ async def test_team_response_scrubs_queued_notices_after_run_exception() -> None
             message="Analyze this.",
             orchestrator=orchestrator,
             execution_identity=None,
-            session_id="session-queued-error",
+            ctx=make_turn_context(session_id="session-queued-error"),
             turn_recorder=_team_turn_recorder("Analyze this."),
         )
 
@@ -1282,7 +1269,7 @@ async def test_team_response_stream_scrubs_queued_notices_after_stream_exception
                 message="Analyze this.",
                 orchestrator=orchestrator,
                 execution_identity=None,
-                session_id="session-stream-queued-error",
+                ctx=make_turn_context(session_id="session-stream-queued-error"),
                 turn_recorder=_team_turn_recorder("Analyze this."),
             )
         ]
@@ -1348,8 +1335,7 @@ async def test_team_response_persists_seen_event_ids_for_matrix_runs() -> None:
             ],
             orchestrator=orchestrator,
             execution_identity=None,
-            session_id="session-456",
-            reply_to_event_id="event-2",
+            ctx=make_turn_context(session_id="session-456", reply_to_event_id="event-2"),
             response_sender_id="@mindroom_team:example.org",
         )
 
@@ -1396,7 +1382,7 @@ async def test_team_response_passes_run_id_to_team_arun() -> None:
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=None,
-            run_id="run-123",
+            ctx=make_turn_context(run_id="run-123"),
         )
 
     assert "Recovered team response" in response
@@ -1435,7 +1421,7 @@ async def test_team_response_raises_cancelled_error_for_cancelled_runs() -> None
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=None,
-            run_id="run-123",
+            ctx=make_turn_context(run_id="run-123"),
         )
 
 
@@ -1490,9 +1476,11 @@ async def test_team_response_records_interrupted_snapshot_for_cancelled_runs() -
             turn_recorder=recorder,
             orchestrator=orchestrator,
             execution_identity=None,
-            session_id="session-team",
-            run_id="run-123",
-            reply_to_event_id="e1",
+            ctx=make_turn_context(
+                session_id="session-team",
+                run_id="run-123",
+                reply_to_event_id="e1",
+            ),
         )
 
     snapshot = recorder.interrupted_snapshot()
@@ -1556,9 +1544,11 @@ async def test_team_response_records_incomplete_cancelled_tools_as_interrupted()
             turn_recorder=recorder,
             orchestrator=orchestrator,
             execution_identity=None,
-            session_id="session-team",
-            run_id="run-123",
-            reply_to_event_id="e1",
+            ctx=make_turn_context(
+                session_id="session-team",
+                run_id="run-123",
+                reply_to_event_id="e1",
+            ),
         )
 
     snapshot = recorder.interrupted_snapshot()
@@ -1603,6 +1593,7 @@ async def test_team_response_returns_friendly_error_for_error_status() -> None:
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=None,
+            ctx=make_turn_context(),
         )
 
     assert response == "friendly-team-error"
@@ -1653,9 +1644,11 @@ async def test_team_response_with_turn_recorder_defers_interrupted_persistence_t
             message="Analyze this.",
             orchestrator=orchestrator,
             execution_identity=None,
-            session_id="session-team",
-            run_id="run-123",
-            reply_to_event_id="e1",
+            ctx=make_turn_context(
+                session_id="session-team",
+                run_id="run-123",
+                reply_to_event_id="e1",
+            ),
             turn_recorder=recorder,
         )
 
@@ -1717,9 +1710,11 @@ async def test_team_response_with_turn_recorder_preserves_unseen_event_ids_on_ca
                 message="Analyze this.",
                 orchestrator=orchestrator,
                 execution_identity=None,
-                session_id="session-team",
-                run_id="run-123",
-                reply_to_event_id="e1",
+                ctx=make_turn_context(
+                    session_id="session-team",
+                    run_id="run-123",
+                    reply_to_event_id="e1",
+                ),
                 turn_recorder=recorder,
             )
 
@@ -1761,8 +1756,8 @@ async def test_team_response_retries_errored_run_output_with_fresh_run_id() -> N
             turn_recorder=recorder,
             orchestrator=orchestrator,
             execution_identity=None,
+            ctx=make_turn_context(run_id="run-123"),
             media=MediaInputs(audio=[MagicMock(name="audio_input")]),
-            run_id="run-123",
             run_id_callback=lambda current_run_id: (
                 callback_run_ids.append(current_run_id),
                 recorder.set_run_id(current_run_id),
@@ -1822,9 +1817,8 @@ async def test_team_response_tracks_retry_run_id_after_hard_cancellation() -> No
             turn_recorder=recorder,
             orchestrator=orchestrator,
             execution_identity=None,
-            session_id="session-team",
+            ctx=make_turn_context(session_id="session-team", run_id="run-123"),
             media=MediaInputs(audio=[MagicMock(name="audio_input")]),
-            run_id="run-123",
             run_id_callback=lambda current_run_id: (
                 callback_run_ids.append(current_run_id),
                 recorder.set_run_id(current_run_id),
@@ -1894,8 +1888,8 @@ async def test_team_response_stream_raises_cancelled_error_for_team_run_cancelle
                     turn_recorder=recorder,
                     orchestrator=orchestrator,
                     execution_identity=None,
+                    ctx=make_turn_context(run_id="run-456"),
                     mode=TeamMode.COORDINATE,
-                    run_id="run-456",
                 )
             ]
 
@@ -1971,10 +1965,12 @@ async def test_team_response_stream_records_hidden_interrupted_tool_state() -> N
             turn_recorder=recorder,
             orchestrator=orchestrator,
             execution_identity=None,
+            ctx=make_turn_context(
+                session_id="session-team-stream",
+                run_id="run-456",
+                reply_to_event_id="e1",
+            ),
             mode=TeamMode.COORDINATE,
-            session_id="session-team-stream",
-            run_id="run-456",
-            reply_to_event_id="e1",
             show_tool_calls=False,
         ):
             pass
@@ -2088,10 +2084,12 @@ async def test_team_response_stream_marks_tool_call_timing_for_agent_and_team_to
                 turn_recorder=TurnRecorder(user_message="Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=None,
+                ctx=make_turn_context(
+                    session_id="session-team-stream",
+                    run_id="run-456",
+                    reply_to_event_id="e1",
+                ),
                 mode=TeamMode.COORDINATE,
-                session_id="session-team-stream",
-                run_id="run-456",
-                reply_to_event_id="e1",
                 show_tool_calls=True,
             )
         ]
@@ -2189,10 +2187,12 @@ async def test_team_response_stream_records_interrupted_snapshot_after_external_
             turn_recorder=recorder,
             orchestrator=orchestrator,
             execution_identity=None,
+            ctx=make_turn_context(
+                session_id="session-team-stream",
+                run_id="run-999",
+                reply_to_event_id="e1",
+            ),
             mode=TeamMode.COORDINATE,
-            session_id="session-team-stream",
-            run_id="run-999",
-            reply_to_event_id="e1",
             show_tool_calls=False,
         ):
             first_chunk_seen.set()
@@ -2304,10 +2304,12 @@ async def test_team_response_stream_preserves_pending_tool_scope_for_same_named_
             turn_recorder=recorder,
             orchestrator=orchestrator,
             execution_identity=None,
+            ctx=make_turn_context(
+                session_id="session-team-stream",
+                run_id="run-789",
+                reply_to_event_id="e1",
+            ),
             mode=TeamMode.COORDINATE,
-            session_id="session-team-stream",
-            run_id="run-789",
-            reply_to_event_id="e1",
             show_tool_calls=False,
         ):
             pass
@@ -2388,10 +2390,12 @@ async def test_team_response_stream_preserves_pending_tool_identity_within_membe
             turn_recorder=recorder,
             orchestrator=orchestrator,
             execution_identity=None,
+            ctx=make_turn_context(
+                session_id="session-team-stream",
+                run_id="run-789",
+                reply_to_event_id="e1",
+            ),
             mode=TeamMode.COORDINATE,
-            session_id="session-team-stream",
-            run_id="run-789",
-            reply_to_event_id="e1",
             show_tool_calls=False,
         ):
             pass
@@ -2464,9 +2468,8 @@ async def test_team_response_stream_does_not_retry_after_hidden_tool_progress_on
                 turn_recorder=_team_turn_recorder("Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=None,
+                ctx=make_turn_context(session_id="session-team-stream", run_id="run-789"),
                 mode=TeamMode.COORDINATE,
-                session_id="session-team-stream",
-                run_id="run-789",
                 show_tool_calls=False,
                 media=MediaInputs(images=(object(),)),
             )
@@ -2533,9 +2536,8 @@ async def test_team_response_stream_does_not_retry_after_hidden_tool_progress_on
                 turn_recorder=_team_turn_recorder("Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=None,
+                ctx=make_turn_context(session_id="session-team-stream", run_id="run-789"),
                 mode=TeamMode.COORDINATE,
-                session_id="session-team-stream",
-                run_id="run-789",
                 show_tool_calls=False,
                 media=MediaInputs(images=(object(),)),
             )
@@ -2593,8 +2595,8 @@ async def test_team_response_stream_emits_team_run_output_fallback() -> None:
                 turn_recorder=_team_turn_recorder("Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=None,
+                ctx=make_turn_context(run_id="run-789"),
                 mode=TeamMode.COORDINATE,
-                run_id="run-789",
             )
         ]
 
@@ -2654,9 +2656,8 @@ async def test_team_response_stream_marks_successful_event_stream_completed() ->
                 turn_recorder=recorder,
                 orchestrator=orchestrator,
                 execution_identity=None,
+                ctx=make_turn_context(session_id="session-team-stream", run_id="run-456"),
                 mode=TeamMode.COORDINATE,
-                session_id="session-team-stream",
-                run_id="run-456",
                 show_tool_calls=False,
             )
         ]
@@ -2725,6 +2726,7 @@ async def test_team_response_stream_emits_plain_run_output_fallback_with_team_fo
                 turn_recorder=_team_turn_recorder("Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=None,
+                ctx=make_turn_context(),
                 mode=TeamMode.COORDINATE,
             )
         ]
@@ -2782,8 +2784,8 @@ async def test_team_response_stream_raises_cancelled_error_for_team_run_output_f
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=None,
+            ctx=make_turn_context(run_id="run-789"),
             mode=TeamMode.COORDINATE,
-            run_id="run-789",
         ):
             pass
 
@@ -2836,6 +2838,7 @@ async def test_team_response_stream_returns_friendly_error_for_errored_run_outpu
                 turn_recorder=_team_turn_recorder("Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=None,
+                ctx=make_turn_context(),
                 mode=TeamMode.COORDINATE,
             )
         ]
@@ -2891,6 +2894,7 @@ async def test_team_response_stream_returns_friendly_error_for_errored_plain_run
                 turn_recorder=_team_turn_recorder("Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=None,
+                ctx=make_turn_context(),
                 mode=TeamMode.COORDINATE,
             )
         ]
@@ -2952,9 +2956,9 @@ async def test_team_response_stream_retries_errored_output_with_fresh_run_id() -
                 turn_recorder=_team_turn_recorder("Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=None,
+                ctx=make_turn_context(run_id="run-789"),
                 mode=TeamMode.COORDINATE,
                 media=MediaInputs(audio=[MagicMock(name="audio_input")]),
-                run_id="run-789",
                 run_id_callback=callback_run_ids.append,
             )
         ]
@@ -3034,10 +3038,9 @@ async def test_team_response_stream_tracks_retry_run_id_after_hard_cancellation(
                 turn_recorder=recorder,
                 orchestrator=orchestrator,
                 execution_identity=None,
+                ctx=make_turn_context(session_id="session-team-stream", run_id="run-789"),
                 mode=TeamMode.COORDINATE,
-                session_id="session-team-stream",
                 media=MediaInputs(audio=[MagicMock(name="audio_input")]),
-                run_id="run-789",
                 run_id_callback=lambda current_run_id: (
                     callback_run_ids.append(current_run_id),
                     recorder.set_run_id(current_run_id),
@@ -3144,7 +3147,7 @@ async def test_team_response_stream_retry_scrubs_queued_notice_before_second_att
                 turn_recorder=_team_turn_recorder("Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=None,
-                session_id="session-stream-retry-clean",
+                ctx=make_turn_context(session_id="session-stream-retry-clean"),
                 media=MediaInputs(audio=[MagicMock(name="audio_input")]),
                 configured_team_name="super_team",
             )
@@ -3220,6 +3223,7 @@ async def test_team_response_rejects_missing_materialized_members() -> None:
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=None,
+            ctx=make_turn_context(),
         )
 
     assert response == "Team request includes agent 'research' that could not be materialized for this request."
@@ -3262,7 +3266,7 @@ async def test_team_response_stream_uses_compaction_aware_member_execution() -> 
                 turn_recorder=_team_turn_recorder("Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=None,
-                session_id="session-123",
+                ctx=make_turn_context(session_id="session-123"),
                 compaction_outcomes_collector=collector,
             )
         ]
@@ -3320,7 +3324,7 @@ async def test_team_response_stream_prefers_persisted_history_over_thread_contex
                 thread_history=[make_visible_message(sender="user", body="Old thread context")],
                 orchestrator=orchestrator,
                 execution_identity=None,
-                session_id="session-123",
+                ctx=make_turn_context(session_id="session-123"),
             )
         ]
 
@@ -3394,8 +3398,7 @@ async def test_team_response_stream_preserves_unseen_matrix_thread_context_with_
                 ],
                 orchestrator=orchestrator,
                 execution_identity=None,
-                session_id="session-789",
-                reply_to_event_id="event-3",
+                ctx=make_turn_context(session_id="session-789", reply_to_event_id="event-3"),
                 response_sender_id="@mindroom_team:example.org",
             )
         ]
@@ -3445,7 +3448,7 @@ async def test_team_response_stream_preserves_assistant_context_in_team_prompt()
                 turn_recorder=_team_turn_recorder("Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=None,
-                session_id="session-123",
+                ctx=make_turn_context(session_id="session-123"),
                 response_sender_id="@mindroom_team:example.org",
             )
         ]
@@ -3497,6 +3500,7 @@ async def test_team_response_rejects_non_running_materialized_members() -> None:
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=None,
+            ctx=make_turn_context(),
         )
 
     assert response == "Team request includes agent 'research' that could not be materialized for this request."
@@ -3538,6 +3542,7 @@ async def test_team_response_rejects_request_time_materialization_failure() -> N
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=None,
+            ctx=make_turn_context(),
             reason_prefix="Team 'summary'",
         )
 
@@ -3578,6 +3583,7 @@ async def test_team_stream_rejects_missing_materialized_members() -> None:
                 turn_recorder=_team_turn_recorder("Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=None,
+                ctx=make_turn_context(),
             )
         ]
 
@@ -3625,6 +3631,7 @@ async def test_team_stream_rejects_request_time_materialization_failure() -> Non
                 turn_recorder=_team_turn_recorder("Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=None,
+                ctx=make_turn_context(),
                 reason_prefix="Team 'summary'",
             )
         ]
@@ -3667,6 +3674,7 @@ async def test_team_stream_retries_without_inline_media_on_setup_error() -> None
                 turn_recorder=_team_turn_recorder("Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=None,
+                ctx=make_turn_context(),
                 media=MediaInputs(audio=[audio_input]),
             )
         ]
@@ -3722,6 +3730,7 @@ async def test_team_stream_retries_without_inline_media_on_streamed_run_error() 
                 turn_recorder=_team_turn_recorder("Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=None,
+                ctx=make_turn_context(),
                 media=MediaInputs(audio=[audio_input]),
             )
         ]
@@ -3963,6 +3972,7 @@ async def test_team_response_materializes_private_agent_with_execution_identity(
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=identity,
+            ctx=make_turn_context(),
         )
 
     assert "Team response" in response
@@ -3995,6 +4005,7 @@ async def test_team_response_rejects_private_agent_with_non_matrix_execution_ide
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=identity,
+            ctx=make_turn_context(),
         )
 
 
@@ -4023,6 +4034,7 @@ async def test_team_response_rejects_private_agent_with_empty_requester_identity
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=identity,
+            ctx=make_turn_context(),
         )
 
 
@@ -4042,6 +4054,7 @@ async def test_team_response_rejects_private_agents_even_when_private_member_is_
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=None,
+            ctx=make_turn_context(),
         )
 
 
@@ -4066,6 +4079,7 @@ async def test_team_response_stream_rejects_private_agents_even_when_private_mem
                 turn_recorder=_team_turn_recorder("Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=None,
+                ctx=make_turn_context(),
             )
         ]
 
@@ -4108,6 +4122,7 @@ async def test_team_response_stream_materializes_private_agent_with_execution_id
                 turn_recorder=_team_turn_recorder("Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=identity,
+                ctx=make_turn_context(),
             )
         ]
 
@@ -4156,6 +4171,7 @@ async def test_team_response_rejects_members_that_delegate_to_private_agents() -
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=None,
+            ctx=make_turn_context(),
         )
 
 
@@ -4189,6 +4205,7 @@ async def test_team_response_ignores_router_in_direct_team_member_list() -> None
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=None,
+            ctx=make_turn_context(),
         )
 
     assert "General response" in response
@@ -4228,6 +4245,7 @@ async def test_team_response_stream_ignores_router_in_direct_team_member_list() 
                 turn_recorder=_team_turn_recorder("Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=None,
+                ctx=make_turn_context(),
             )
         ]
 
@@ -4265,7 +4283,7 @@ async def test_team_response_forwards_session_and_user_id_to_team_run() -> None:
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=None,
-            session_id="session-123",
+            ctx=make_turn_context(session_id="session-123"),
             user_id="@alice:example.org",
         )
 
@@ -4317,6 +4335,7 @@ async def test_team_response_materializes_members_with_request_execution_identit
             turn_recorder=_team_turn_recorder("Analyze this."),
             orchestrator=orchestrator,
             execution_identity=identity,
+            ctx=make_turn_context(),
         )
 
     assert "General response" in response

--- a/tests/test_team_run_metadata.py
+++ b/tests/test_team_run_metadata.py
@@ -19,7 +19,7 @@ from agno.run.team import TeamRunOutput
 from mindroom.history.turn_recorder import TurnRecorder
 from mindroom.knowledge.utils import _KnowledgeResolution
 from mindroom.teams import TeamMode, team_response, team_response_stream
-from tests.conftest import runtime_paths_for
+from tests.conftest import make_turn_context, runtime_paths_for
 from tests.identity_helpers import entity_ids
 from tests.test_team_media_fallback import _build_test_config, _make_test_agent, _make_test_team
 
@@ -93,7 +93,7 @@ async def test_team_response_collects_run_metadata() -> None:
             turn_recorder=TurnRecorder(user_message="Analyze this."),
             orchestrator=orchestrator,
             execution_identity=None,
-            session_id="session-1",
+            ctx=make_turn_context(session_id="session-1"),
             run_metadata_collector=collector,
         )
 
@@ -135,7 +135,7 @@ async def test_team_response_usage_aggregates_member_metrics() -> None:
             turn_recorder=TurnRecorder(user_message="Analyze this."),
             orchestrator=orchestrator,
             execution_identity=None,
-            session_id="session-1",
+            ctx=make_turn_context(session_id="session-1"),
             run_metadata_collector=collector,
         )
 
@@ -164,7 +164,7 @@ async def test_team_response_collects_cancelled_run_metadata() -> None:
             turn_recorder=TurnRecorder(user_message="Analyze this."),
             orchestrator=orchestrator,
             execution_identity=None,
-            session_id="session-1",
+            ctx=make_turn_context(session_id="session-1"),
             run_metadata_collector=collector,
         )
 
@@ -206,7 +206,7 @@ async def test_team_response_stream_collects_run_metadata_from_completed_event()
                 turn_recorder=TurnRecorder(user_message="Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=None,
-                session_id="session-1",
+                ctx=make_turn_context(session_id="session-1"),
                 run_metadata_collector=collector,
             )
         ]
@@ -251,7 +251,7 @@ async def test_team_response_stream_falls_back_to_model_request_totals() -> None
                 turn_recorder=TurnRecorder(user_message="Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=None,
-                session_id="session-1",
+                ctx=make_turn_context(session_id="session-1"),
                 run_metadata_collector=collector,
             )
         ]
@@ -297,7 +297,7 @@ async def test_team_response_stream_publishes_usage_when_stream_errors() -> None
                 turn_recorder=TurnRecorder(user_message="Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=None,
-                session_id="session-1",
+                ctx=make_turn_context(session_id="session-1"),
                 run_metadata_collector=collector,
             )
         ]
@@ -333,7 +333,7 @@ async def test_team_response_stream_collects_run_metadata_from_terminal_output()
                 turn_recorder=TurnRecorder(user_message="Analyze this."),
                 orchestrator=orchestrator,
                 execution_identity=None,
-                session_id="session-1",
+                ctx=make_turn_context(session_id="session-1"),
                 run_metadata_collector=collector,
             )
         ]

--- a/tests/test_team_scheduler_context.py
+++ b/tests/test_team_scheduler_context.py
@@ -128,9 +128,9 @@ async def test_team_non_streaming_has_scheduler_context(tmp_path: Path) -> None:
 
     async def fake_team_response(*_args: object, **_kwargs: object) -> str:
         assert get_tool_runtime_context() is not None
-        assert _kwargs["session_id"] == "!team:localhost:$thread_root"
+        assert _kwargs["ctx"].session_id == "!team:localhost:$thread_root"
         assert _kwargs["user_id"] == "@user:localhost"
-        assert _kwargs["run_id"] == response_run_id
+        assert _kwargs["ctx"].run_id == response_run_id
         return "team non-streaming response"
 
     with (
@@ -283,9 +283,9 @@ async def test_team_streaming_has_scheduler_context(tmp_path: Path) -> None:
 
     async def fake_team_response_stream(*_args: object, **_kwargs: object) -> AsyncIterator[str]:
         assert get_tool_runtime_context() is not None
-        assert _kwargs["session_id"] == "!team:localhost:$thread_root"
+        assert _kwargs["ctx"].session_id == "!team:localhost:$thread_root"
         assert _kwargs["user_id"] == "@user:localhost"
-        assert _kwargs["run_id"] == response_run_id
+        assert _kwargs["ctx"].run_id == response_run_id
         yield "stream chunk"
 
     with (


### PR DESCRIPTION
## Turn-context sweep 2/4: propagate `ResponseTurnContext` through the team envelope and prepare chain

Stacked on #1380. Same shape as the agent-side conversion, applied to the team chain.

### What changed

- **`team_response` / `team_response_stream` take `ctx` positionally** (after `execution_identity`), deleting 7 params each: `session_id`, `run_id`, `reply_to_event_id`, `correlation_id`, `active_event_ids`, `matrix_run_metadata`, `system_enrichment_items`. The in-function derivations of `room_id`/`thread_id`/`requester_id` from `execution_identity` are gone — the caller supplies them on the context.
- **The entries refine the incoming context** via `dataclasses.replace`: `entity_label` becomes the materialized team label (`"Team (a, b)"` — exactly what the old code constructed for the driver context), and `system_enrichment_items` gets the knowledge-availability enrichment appended after member materialization. The caller's provisional `entity_label` is deliberately overwritten.
- **`prepare_materialized_team_execution` takes `ctx`**, deleting 8 params (`reply_to_event_id`, `active_event_ids`, `room_id`, `thread_id`, `requester_id`, `correlation_id`, `matrix_run_metadata`, `system_enrichment_items`). Run metadata is built from context fields. `_team_request_log_context` likewise.
- **`resolve_run_correlation_id` deleted** from `mindroom.ai` (and its tach interface): after the teams conversion it had zero callers. Its fallback chain lives on at the boundaries — callers that could pass None now mint `uuid4().hex` explicitly (openai team prepare already did).
- **Callers build the context**: `response_runner.generate_team_response_helper_locked` (one construction feeding both the streaming and blocking team calls) and `api/openai_compat._prepare_openai_team_prompt`.
- `user_id` stays a parameter on the team entries: it is the raw Agno identity for `team.arun` and the prompt `current_sender_id`, distinct from the resolved `ctx.requester_id` (`user_id or execution_identity.requester_id`).

### Behavior preservation

Intended behavior-preserving. Parity notes for review:
- Old in-entry derivations vs new caller-built fields: `execution_identity.room_id` is `target.room_id` (== `request.room_id`), `execution_identity.resolved_thread_id or .thread_id` is `target.resolved_thread_id` (both set from the same value in `build_execution_identity`), and `requester_user_id or execution_identity.requester_id` matches the old `user_id or execution_identity.requester_id` including the empty-string-falsy case.
- The old `resolve_run_correlation_id` fallback arms (metadata correlation → reply_to) were dead for every caller: response_runner always passed a resolved id; openai passed None with no reply_to/metadata (→ uuid); tests that exercised the reply_to fallback now pass that value explicitly.
- The locked-pair terminal arms in `response_runner.py` remain untouched.

Part of the stacked series 1/4 → 2/4 (this) → 3/4 execution_preparation chain → 4/4 collector conversion.
