### PR TITLE
Cap google-genai below 2.9 so fresh installs work with pinned agno

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,9 @@ dependencies = [
   "fastapi[standard]>=0.116.1",
   "filetype>=1.2",
   "google-auth>=2.40.3",
-  "google-genai>=2",
+  # agno 2.6.12 imports the pre-2.9 google-genai streaming delta layout (google.genai.interactions.step_delta);
+  # google-genai >=2.9 removed it. Drop the cap when bumping agno to >=2.6.21 (which has a version compat shim).
+  "google-genai>=2,<2.9",
   "groq>=0.31",
   "httpx>=0.27",
   "humanize>=4.12.3",

--- a/uv.lock
+++ b/uv.lock
@@ -4207,7 +4207,7 @@ requires-dist = [
     { name = "google-auth-oauthlib", marker = "extra == 'google-drive'", specifier = ">=1.2.2" },
     { name = "google-auth-oauthlib", marker = "extra == 'google-sheets'", specifier = ">=1.2.2" },
     { name = "google-cloud-bigquery", marker = "extra == 'google-bigquery'" },
-    { name = "google-genai", specifier = ">=2" },
+    { name = "google-genai", specifier = ">=2,<2.9" },
     { name = "google-genai", marker = "extra == 'gemini'" },
     { name = "google-maps-places", marker = "extra == 'google-maps'" },
     { name = "google-search-results", marker = "extra == 'serpapi'", specifier = ">=2.4.2" },


### PR DESCRIPTION
## Problem

`uv tool install mindroom@latest` (2026.7.27) crashes at startup:

```
ImportError: cannot import name 'step_delta' from 'google.genai.interactions'
```

google-genai 2.10.0 (released 2026-06-24) removed the pre-2.9 streaming delta layout (`google/genai/_interactions/types/step_delta.py`), which our pinned `agno==2.6.12` imports unconditionally. agno itself only declares `google-genai>=1.52.0`, and our spec said `google-genai>=2`, so any lock-free install resolves 2.10.0 and dies on import. Our `uv.lock` was created before 2.10.0 existed (it holds 2.8.0), which is why dev environments never hit this.

## Fix

Cap `google-genai>=2,<2.9` — the boundary agno's own compat shim uses. Fresh resolution now lands on 2.8.0 with agno 2.6.12, matching the lock.

The cap can be dropped when agno is bumped to >=2.6.21, which ships `agno.utils.models._genai_compat` supporting both layouts (noted in a comment next to the pin).

## Verification

- `uv pip compile pyproject.toml --python-version 3.14` (lock-free, same as `uv tool install`) resolves `google-genai==2.8.0`
- `uv run python -c "from agno.models.google import Gemini"` — the exact import chain from the traceback — succeeds
- `pytest tests/test_model_loading.py tests/test_model_defaults.py`: 9 passed
- pre-commit passes

A new mindroom release is needed after merge for `uv tool install mindroom@latest` to pick this up.

## Summary by Sourcery

Cap the google-genai dependency version to avoid incompatibility with the currently pinned agno release and align fresh installs with the existing lockfile resolution.

Bug Fixes:
- Prevent startup crashes caused by google-genai 2.10.0 removing APIs still used by the pinned agno version.

Enhancements:
- Document the temporary google-genai version cap and the conditions under which it can be removed.

Build:
- Adjust runtime dependency constraints in pyproject.toml to require google-genai versions >=2,<2.9 for compatibility.