### PR TITLE
Accept multiple hostnames per request_network_access approval

### DIFF
--- a/docs/deployment/approved-egress.md
+++ b/docs/deployment/approved-egress.md
@@ -32,7 +32,7 @@ approvedEgress:
 The chart renders the proxy Deployment, Service, ServiceAccount, RBAC, allowlist ConfigMap, persistence PVC, worker egress NetworkPolicy, and proxy ingress NetworkPolicy.
 The chart also sets `MINDROOM_APPROVED_EGRESS_ENABLED`, `MINDROOM_APPROVED_EGRESS_API_URL`, `MINDROOM_APPROVED_EGRESS_ALLOWLIST_PATH`, `MINDROOM_APPROVED_EGRESS_TOKEN`, and `MINDROOM_APPROVED_EGRESS_MAX_TTL_SECONDS` on the MindRoom container.
 When `MINDROOM_APPROVED_EGRESS_ENABLED=true`, MindRoom adds `approved_egress` to defaults and requires Matrix approval for blocked-host `request_network_access` grant requests at runtime.
-Requests for static-allowlisted hostnames skip the approval card and return that no temporary grant is needed.
+Requests where every hostname is static-allowlisted skip the approval card and return that no temporary grant is needed.
 These runtime-derived entries are not written back to `config.yaml` by dashboard or API saves.
 Set `approvedEgress.manageRuntimeConfig: false` to keep the proxy wiring but skip the runtime config overlay, for example when the authored config assigns `approved_egress` to specific agents instead of `defaults.tools`.
 
@@ -110,9 +110,10 @@ The toolkit is built into MindRoom and uses the chart-provided policy API URL, t
 
 ## Runtime Behavior
 
-Agents call `request_network_access(hostname, ttl_minutes, reason)` when a worker needs one blocked external hostname.
-The tool rejects schemes, ports, paths, wildcards, IP literals, single-label names, localhost names, cluster-local names, and known metadata hostnames before it calls the policy API.
-If the hostname already matches the static allowlist, the tool reports that no dynamic grant is needed without sending a Matrix approval card.
+Agents call `request_network_access(hostnames, ttl_minutes, reason)` with every blocked external hostname the task needs, and a single Matrix approval covers the whole batch.
+The tool rejects schemes, ports, paths, wildcards, IP literals, single-label names, localhost names, cluster-local names, and known metadata hostnames before it calls the policy API, and one bad hostname fails the whole batch before any grant is created.
+The tool creates one policy grant per blocked hostname and skips hostnames the static allowlist already covers.
+If every requested hostname already matches the static allowlist, the tool reports that no dynamic grant is needed without sending a Matrix approval card.
 When `worker_scope: user_agent` is active, the tool creates a `worker_key` grant for the exact requester-owned worker.
 Shared or unscoped workers receive an `agent` grant.
 Requests for `worker_scope: user` are rejected because one user-scoped worker can serve multiple agents.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -16337,7 +16337,7 @@ approvedEgress:
 The chart renders the proxy Deployment, Service, ServiceAccount, RBAC, allowlist ConfigMap, persistence PVC, worker egress NetworkPolicy, and proxy ingress NetworkPolicy.
 The chart also sets `MINDROOM_APPROVED_EGRESS_ENABLED`, `MINDROOM_APPROVED_EGRESS_API_URL`, `MINDROOM_APPROVED_EGRESS_ALLOWLIST_PATH`, `MINDROOM_APPROVED_EGRESS_TOKEN`, and `MINDROOM_APPROVED_EGRESS_MAX_TTL_SECONDS` on the MindRoom container.
 When `MINDROOM_APPROVED_EGRESS_ENABLED=true`, MindRoom adds `approved_egress` to defaults and requires Matrix approval for blocked-host `request_network_access` grant requests at runtime.
-Requests for static-allowlisted hostnames skip the approval card and return that no temporary grant is needed.
+Requests where every hostname is static-allowlisted skip the approval card and return that no temporary grant is needed.
 These runtime-derived entries are not written back to `config.yaml` by dashboard or API saves.
 Set `approvedEgress.manageRuntimeConfig: false` to keep the proxy wiring but skip the runtime config overlay, for example when the authored config assigns `approved_egress` to specific agents instead of `defaults.tools`.
 
@@ -16415,9 +16415,10 @@ The toolkit is built into MindRoom and uses the chart-provided policy API URL, t
 
 ## Runtime Behavior
 
-Agents call `request_network_access(hostname, ttl_minutes, reason)` when a worker needs one blocked external hostname.
-The tool rejects schemes, ports, paths, wildcards, IP literals, single-label names, localhost names, cluster-local names, and known metadata hostnames before it calls the policy API.
-If the hostname already matches the static allowlist, the tool reports that no dynamic grant is needed without sending a Matrix approval card.
+Agents call `request_network_access(hostnames, ttl_minutes, reason)` with every blocked external hostname the task needs, and a single Matrix approval covers the whole batch.
+The tool rejects schemes, ports, paths, wildcards, IP literals, single-label names, localhost names, cluster-local names, and known metadata hostnames before it calls the policy API, and one bad hostname fails the whole batch before any grant is created.
+The tool creates one policy grant per blocked hostname and skips hostnames the static allowlist already covers.
+If every requested hostname already matches the static allowlist, the tool reports that no dynamic grant is needed without sending a Matrix approval card.
 When `worker_scope: user_agent` is active, the tool creates a `worker_key` grant for the exact requester-owned worker.
 Shared or unscoped workers receive an `agent` grant.
 Requests for `worker_scope: user` are rejected because one user-scoped worker can serve multiple agents.

--- a/skills/mindroom-docs/references/page__deployment__approved-egress__index.md
+++ b/skills/mindroom-docs/references/page__deployment__approved-egress__index.md
@@ -28,7 +28,7 @@ approvedEgress:
 The chart renders the proxy Deployment, Service, ServiceAccount, RBAC, allowlist ConfigMap, persistence PVC, worker egress NetworkPolicy, and proxy ingress NetworkPolicy.
 The chart also sets `MINDROOM_APPROVED_EGRESS_ENABLED`, `MINDROOM_APPROVED_EGRESS_API_URL`, `MINDROOM_APPROVED_EGRESS_ALLOWLIST_PATH`, `MINDROOM_APPROVED_EGRESS_TOKEN`, and `MINDROOM_APPROVED_EGRESS_MAX_TTL_SECONDS` on the MindRoom container.
 When `MINDROOM_APPROVED_EGRESS_ENABLED=true`, MindRoom adds `approved_egress` to defaults and requires Matrix approval for blocked-host `request_network_access` grant requests at runtime.
-Requests for static-allowlisted hostnames skip the approval card and return that no temporary grant is needed.
+Requests where every hostname is static-allowlisted skip the approval card and return that no temporary grant is needed.
 These runtime-derived entries are not written back to `config.yaml` by dashboard or API saves.
 Set `approvedEgress.manageRuntimeConfig: false` to keep the proxy wiring but skip the runtime config overlay, for example when the authored config assigns `approved_egress` to specific agents instead of `defaults.tools`.
 
@@ -106,9 +106,10 @@ The toolkit is built into MindRoom and uses the chart-provided policy API URL, t
 
 ## Runtime Behavior
 
-Agents call `request_network_access(hostname, ttl_minutes, reason)` when a worker needs one blocked external hostname.
-The tool rejects schemes, ports, paths, wildcards, IP literals, single-label names, localhost names, cluster-local names, and known metadata hostnames before it calls the policy API.
-If the hostname already matches the static allowlist, the tool reports that no dynamic grant is needed without sending a Matrix approval card.
+Agents call `request_network_access(hostnames, ttl_minutes, reason)` with every blocked external hostname the task needs, and a single Matrix approval covers the whole batch.
+The tool rejects schemes, ports, paths, wildcards, IP literals, single-label names, localhost names, cluster-local names, and known metadata hostnames before it calls the policy API, and one bad hostname fails the whole batch before any grant is created.
+The tool creates one policy grant per blocked hostname and skips hostnames the static allowlist already covers.
+If every requested hostname already matches the static allowlist, the tool reports that no dynamic grant is needed without sending a Matrix approval card.
 When `worker_scope: user_agent` is active, the tool creates a `worker_key` grant for the exact requester-owned worker.
 Shared or unscoped workers receive an `agent` grant.
 Requests for `worker_scope: user` are rejected because one user-scoped worker can serve multiple agents.

--- a/src/mindroom/tools/approved_egress.py
+++ b/src/mindroom/tools/approved_egress.py
@@ -43,6 +43,9 @@ _DEFAULT_MAX_TTL_SECONDS = 6 * 60 * 60
 _DEFAULT_POLICY_API_URL = "http://mindroom-egress-proxy:8080"
 _MAX_ALLOWLIST_ENTRIES_IN_TOOL_DESCRIPTION = 80
 _MAX_REASON_CHARS = 500
+# Keeps one approval card reviewable: the approver must be able to read every
+# hostname a single approval covers.
+_MAX_HOSTNAMES_PER_REQUEST = 20
 
 
 def _env_int(name: str, default: int) -> int:
@@ -75,29 +78,36 @@ def _static_allowlist_description() -> str:
 
 def _request_network_access_description() -> str:
     return (
-        "Request temporary worker egress to one exact external hostname. "
-        "Use this only when the worker needs a hostname that is not already allowed.\n\n"
+        "Request temporary worker egress to one or more exact external hostnames. "
+        "Batch every hostname the task needs into a single call so one approval covers all of them. "
+        "Use this only when the worker needs hostnames that are not already allowed.\n\n"
         f"{_static_allowlist_description()}"
     )
 
 
 def _request_network_access_is_approval_exempt(arguments: Mapping[str, object]) -> bool:
-    """True when the hostname is already statically allowed, so approval would be redundant.
+    """True when every requested hostname is already statically allowed, so approval would be redundant.
 
-    Fails closed: anything that is not a provably allowlisted hostname keeps the
-    Matrix approval card. The tool re-checks the allowlist at execution and
+    Fails closed: anything that is not a provably allowlisted hostname list keeps
+    the Matrix approval card. The tool re-checks the allowlist at execution and
     returns the no-grant result, so a skipped card can only mint a grant if the
     allowlist itself shrinks between this check and execution — an accepted
     operator-edit race measured in microseconds.
     """
-    hostname = arguments.get("hostname")
-    if not isinstance(hostname, str):
+    hostnames = arguments.get("hostnames")
+    if not isinstance(hostnames, list) or not hostnames:
         return False
-    try:
-        host = canonical_hostname(hostname)
-    except ValueError:
-        return False
-    return is_hostname_allowed(host, resolve_worker_egress_policy())
+    policy = resolve_worker_egress_policy()
+    for hostname in hostnames:
+        if not isinstance(hostname, str):
+            return False
+        try:
+            host = canonical_hostname(hostname)
+        except ValueError:
+            return False
+        if not is_hostname_allowed(host, policy):
+            return False
+    return True
 
 
 register_tool_approval_exemption("request_network_access", _request_network_access_is_approval_exempt)
@@ -149,6 +159,20 @@ def _normalize_reason(value: str) -> str:
         msg = "reason must not be empty"
         raise ValueError(msg)
     return normalized[:_MAX_REASON_CHARS]
+
+
+def _canonical_hostnames(hostnames: list[str]) -> list[str]:
+    """Canonicalize and dedupe the requested hostnames, rejecting the whole batch on any bad entry."""
+    if isinstance(hostnames, str) or not isinstance(hostnames, list):
+        msg = "hostnames must be a list of hostnames"
+        raise TypeError(msg)
+    if not hostnames:
+        msg = "hostnames must not be empty"
+        raise ValueError(msg)
+    if len(hostnames) > _MAX_HOSTNAMES_PER_REQUEST:
+        msg = f"request at most {_MAX_HOSTNAMES_PER_REQUEST} hostnames per call"
+        raise ValueError(msg)
+    return list(dict.fromkeys(canonical_hostname(hostname) for hostname in hostnames))
 
 
 def _effective_ttl_seconds(requested_ttl_seconds: int) -> int:
@@ -247,10 +271,10 @@ class _ApprovedEgressTools(Toolkit):
         super().__init__(
             name="approved_egress",
             instructions=(
-                "Use this tool when a worker needs temporary access to an external hostname that the egress proxy "
-                "blocks. Request one exact hostname, a TTL in minutes, and a concise reason. The "
-                "request_network_access tool definition lists static allowlist patterns that do not need an approval "
-                "request."
+                "Use this tool when a worker needs temporary access to external hostnames that the egress proxy "
+                "blocks. Request every needed exact hostname in one call so a single approval covers all of them, "
+                "with a TTL in minutes and a concise reason. The request_network_access tool definition lists "
+                "static allowlist patterns that do not need an approval request."
             ),
             tools=[self.request_network_access],
         )
@@ -260,14 +284,20 @@ class _ApprovedEgressTools(Toolkit):
 
     async def request_network_access(
         self,
-        hostname: str,
+        hostnames: list[str],
         ttl_minutes: int,
         reason: str,
     ) -> str:
-        """Request temporary worker egress to one exact external hostname."""
-        host = canonical_hostname(hostname)
-        if is_hostname_allowed(host, resolve_worker_egress_policy()):
-            return f"{host} is already allowed by the static egress allowlist. No temporary grant was created."
+        """Request temporary worker egress to one or more exact external hostnames."""
+        hosts = _canonical_hostnames(hostnames)
+        policy = resolve_worker_egress_policy()
+        already_allowed = [host for host in hosts if is_hostname_allowed(host, policy)]
+        blocked = [host for host in hosts if host not in already_allowed]
+        if not blocked:
+            return (
+                f"Already allowed by the static egress allowlist: {', '.join(already_allowed)}. "
+                "No temporary grant was created."
+            )
         normalized_reason = _normalize_reason(reason)
         requested_ttl_seconds = ttl_minutes * 60
         effective_ttl_seconds = _effective_ttl_seconds(requested_ttl_seconds)
@@ -277,27 +307,39 @@ class _ApprovedEgressTools(Toolkit):
             msg = "request_network_access requires a live MindRoom Matrix tool context"
             raise RuntimeError(msg)
         subject = _grant_subject(context)
-        payload: dict[str, object] = {
-            "hostname": host,
-            "subject_type": subject.subject_type,
-            "subject": subject.subject,
-            "agent_name": context.agent_name,
-            "requester_id": context.requester_id,
-            "room_id": context.room_id,
-            "thread_id": context.resolved_thread_id or context.thread_id,
-            "ttl_seconds": effective_ttl_seconds,
-            "approved_by": context.requester_id,
-            "reason": normalized_reason,
-        }
-        grant = await asyncio.to_thread(
-            _post_grant,
-            payload,
-        )
-        expiry = grant.get("expires_at")
+        granted: list[str] = []
+        expiry: object = None
+        for host in blocked:
+            payload: dict[str, object] = {
+                "hostname": host,
+                "subject_type": subject.subject_type,
+                "subject": subject.subject,
+                "agent_name": context.agent_name,
+                "requester_id": context.requester_id,
+                "room_id": context.room_id,
+                "thread_id": context.resolved_thread_id or context.thread_id,
+                "ttl_seconds": effective_ttl_seconds,
+                "approved_by": context.requester_id,
+                "reason": normalized_reason,
+            }
+            try:
+                grant = await asyncio.to_thread(_post_grant, payload)
+            except RuntimeError as exc:
+                if granted:
+                    msg = f"created grants for {', '.join(granted)} but failed to grant {host}: {exc}"
+                    raise RuntimeError(msg) from exc
+                raise
+            granted.append(host)
+            expiry = grant.get("expires_at")
         capped = " Deployment policy capped the requested TTL." if effective_ttl_seconds < requested_ttl_seconds else ""
+        skipped = (
+            f" Already allowed by the static egress allowlist (no grant needed): {', '.join(already_allowed)}."
+            if already_allowed
+            else ""
+        )
         return (
-            f"Approved temporary network access to {host} for {effective_ttl_seconds // 60} minutes. "
-            f"Expires at Unix time {expiry}.{capped}"
+            f"Approved temporary network access to {', '.join(granted)} for {effective_ttl_seconds // 60} minutes. "
+            f"Expires at Unix time {expiry}.{capped}{skipped}"
         )
 
 

--- a/src/mindroom/tools/approved_egress.py
+++ b/src/mindroom/tools/approved_egress.py
@@ -324,7 +324,7 @@ class _ApprovedEgressTools(Toolkit):
             }
             try:
                 grant = await asyncio.to_thread(_post_grant, payload)
-            except RuntimeError as exc:
+            except (RuntimeError, OSError) as exc:
                 if granted:
                     msg = f"created grants for {', '.join(granted)} but failed to grant {host}: {exc}"
                     raise RuntimeError(msg) from exc

--- a/src/mindroom/tools/approved_egress.py
+++ b/src/mindroom/tools/approved_egress.py
@@ -308,7 +308,7 @@ class _ApprovedEgressTools(Toolkit):
             raise RuntimeError(msg)
         subject = _grant_subject(context)
         granted: list[str] = []
-        expiry: object = None
+        expiries: list[object] = []
         for host in blocked:
             payload: dict[str, object] = {
                 "hostname": host,
@@ -330,7 +330,14 @@ class _ApprovedEgressTools(Toolkit):
                     raise RuntimeError(msg) from exc
                 raise
             granted.append(host)
-            expiry = grant.get("expires_at")
+            expiries.append(grant.get("expires_at"))
+        expiry_note = (
+            f"Expires at Unix time {expiries[0]}."
+            if all(expiry == expiries[0] for expiry in expiries)
+            else " ".join(
+                f"{host} expires at Unix time {expiry}." for host, expiry in zip(granted, expiries, strict=True)
+            )
+        )
         capped = " Deployment policy capped the requested TTL." if effective_ttl_seconds < requested_ttl_seconds else ""
         skipped = (
             f" Already allowed by the static egress allowlist (no grant needed): {', '.join(already_allowed)}."
@@ -339,7 +346,7 @@ class _ApprovedEgressTools(Toolkit):
         )
         return (
             f"Approved temporary network access to {', '.join(granted)} for {effective_ttl_seconds // 60} minutes. "
-            f"Expires at Unix time {expiry}.{capped}{skipped}"
+            f"{expiry_note}{capped}{skipped}"
         )
 
 

--- a/tests/test_approved_egress_tool.py
+++ b/tests/test_approved_egress_tool.py
@@ -54,11 +54,82 @@ def test_request_network_access_rejects_internal_hostname_before_grant(
     with pytest.raises(ValueError, match="points at an internal name"):
         asyncio.run(
             _approved_egress_tool().request_network_access(
-                "metadata.google.internal",
+                ["metadata.google.internal"],
                 5,
                 "Need metadata",
             ),
         )
+
+
+def test_request_network_access_rejects_whole_batch_on_one_bad_hostname(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One invalid hostname must fail the whole batch before any grant is created."""
+
+    def post_grant(_payload: dict[str, object]) -> dict[str, object]:
+        msg = "a rejected batch should not create any grant"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(approved_egress_module, "_post_grant", post_grant)
+
+    with pytest.raises(ValueError, match="points at an internal name"):
+        asyncio.run(
+            _approved_egress_tool().request_network_access(
+                ["docs.example.com", "metadata.google.internal"],
+                5,
+                "Need docs and metadata",
+            ),
+        )
+
+
+def test_request_network_access_rejects_bare_string_hostnames(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bare string must not be iterated as characters."""
+
+    def post_grant(_payload: dict[str, object]) -> dict[str, object]:
+        msg = "a rejected batch should not create any grant"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(approved_egress_module, "_post_grant", post_grant)
+
+    with pytest.raises(TypeError, match="hostnames must be a list"):
+        asyncio.run(
+            _approved_egress_tool().request_network_access(
+                "docs.example.com",  # type: ignore[arg-type]
+                5,
+                "Need docs",
+            ),
+        )
+
+
+def test_request_network_access_rejects_empty_hostnames(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty hostname list is a caller error, not a silent no-op."""
+
+    def post_grant(_payload: dict[str, object]) -> dict[str, object]:
+        msg = "an empty batch should not create any grant"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(approved_egress_module, "_post_grant", post_grant)
+
+    with pytest.raises(ValueError, match="hostnames must not be empty"):
+        asyncio.run(_approved_egress_tool().request_network_access([], 5, "Need nothing"))
+
+
+def test_request_network_access_caps_batch_size(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Oversized batches must fail so one approval card stays reviewable."""
+
+    def post_grant(_payload: dict[str, object]) -> dict[str, object]:
+        msg = "an oversized batch should not create any grant"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(approved_egress_module, "_post_grant", post_grant)
+    hostnames = [f"host{index}.example.com" for index in range(21)]
+
+    with pytest.raises(ValueError, match="at most 20 hostnames"):
+        asyncio.run(_approved_egress_tool().request_network_access(hostnames, 5, "Need many hosts"))
 
 
 def test_effective_ttl_rejects_non_integer_max_ttl_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -86,13 +157,13 @@ def test_request_network_access_skips_grant_when_static_allowed(
 
     result = asyncio.run(
         _approved_egress_tool().request_network_access(
-            "docs.example.com",
+            ["docs.example.com", "api.example.com"],
             5,
             "Need documentation",
         ),
     )
 
-    assert "docs.example.com is already allowed" in result
+    assert "Already allowed by the static egress allowlist: docs.example.com, api.example.com" in result
     assert "No temporary grant was created" in result
 
 
@@ -153,7 +224,7 @@ def test_request_network_access_posts_worker_key_grant(
     try:
         result = asyncio.run(
             _approved_egress_tool().request_network_access(
-                "docs.example.com",
+                ["docs.example.com"],
                 5,
                 "Need docs",
             ),
@@ -272,7 +343,7 @@ def test_request_network_access_posts_grant_without_blocking_event_loop(
     async def invoke_tool() -> str:
         task = asyncio.create_task(
             _approved_egress_tool().request_network_access(
-                "docs.example.com",
+                ["docs.example.com"],
                 5,
                 "Need docs",
             ),
@@ -284,3 +355,74 @@ def test_request_network_access_posts_grant_without_blocking_event_loop(
     result = asyncio.run(invoke_tool())
 
     assert result.startswith("Approved temporary network access to docs.example.com")
+
+
+def _shared_worker_context() -> SimpleNamespace:
+    config = Config(
+        agents={"assistant": AgentConfig(display_name="Assistant", worker_scope="shared")},
+        models={"default": ModelConfig(provider="openai", id="test-model")},
+    )
+    return SimpleNamespace(
+        agent_name="assistant",
+        room_id="!room:server",
+        resolved_thread_id=None,
+        thread_id="$thread",
+        requester_id="@user:server",
+        config=config,
+        runtime_paths=object(),
+    )
+
+
+def test_request_network_access_posts_one_grant_per_blocked_hostname(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One call dedupes hostnames, skips static-allowed ones, and grants each blocked one."""
+    monkeypatch.setenv("MINDROOM_APPROVED_EGRESS_ALLOWLIST", ".example.com")
+    payloads: list[dict[str, object]] = []
+
+    def post_grant(payload: dict[str, object]) -> dict[str, object]:
+        payloads.append(payload)
+        return {"expires_at": 123}
+
+    monkeypatch.setattr(approved_egress_module, "_post_grant", post_grant)
+    monkeypatch.setattr(approved_egress_module, "get_tool_runtime_context", _shared_worker_context)
+
+    result = asyncio.run(
+        _approved_egress_tool().request_network_access(
+            ["api.other.test", "docs.example.com", "cdn.other.test", "api.other.test"],
+            5,
+            "Need APIs",
+        ),
+    )
+
+    assert [payload["hostname"] for payload in payloads] == ["api.other.test", "cdn.other.test"]
+    assert all(payload["ttl_seconds"] == 300 for payload in payloads)
+    assert result.startswith("Approved temporary network access to api.other.test, cdn.other.test for 5 minutes.")
+    assert "Already allowed by the static egress allowlist (no grant needed): docs.example.com." in result
+
+
+def test_request_network_access_reports_partial_grants_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A mid-batch policy failure must report which hostnames already received grants."""
+
+    def post_grant(payload: dict[str, object]) -> dict[str, object]:
+        if payload["hostname"] == "cdn.other.test":
+            msg = "policy service is down"
+            raise RuntimeError(msg)
+        return {"expires_at": 123}
+
+    monkeypatch.setattr(approved_egress_module, "_post_grant", post_grant)
+    monkeypatch.setattr(approved_egress_module, "get_tool_runtime_context", _shared_worker_context)
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"created grants for api\.other\.test but failed to grant cdn\.other\.test: policy service is down",
+    ):
+        asyncio.run(
+            _approved_egress_tool().request_network_access(
+                ["api.other.test", "cdn.other.test"],
+                5,
+                "Need APIs",
+            ),
+        )

--- a/tests/test_approved_egress_tool.py
+++ b/tests/test_approved_egress_tool.py
@@ -401,6 +401,30 @@ def test_request_network_access_posts_one_grant_per_blocked_hostname(
     assert "Already allowed by the static egress allowlist (no grant needed): docs.example.com." in result
 
 
+def test_request_network_access_reports_per_host_expiry_when_grants_differ(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Differing grant expiries must be reported per hostname, not as one shared timestamp."""
+    expiries = iter([123, 124])
+
+    def post_grant(_payload: dict[str, object]) -> dict[str, object]:
+        return {"expires_at": next(expiries)}
+
+    monkeypatch.setattr(approved_egress_module, "_post_grant", post_grant)
+    monkeypatch.setattr(approved_egress_module, "get_tool_runtime_context", _shared_worker_context)
+
+    result = asyncio.run(
+        _approved_egress_tool().request_network_access(
+            ["api.other.test", "cdn.other.test"],
+            5,
+            "Need APIs",
+        ),
+    )
+
+    assert "api.other.test expires at Unix time 123." in result
+    assert "cdn.other.test expires at Unix time 124." in result
+
+
 def test_request_network_access_reports_partial_grants_on_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_approved_egress_tool.py
+++ b/tests/test_approved_egress_tool.py
@@ -425,15 +425,17 @@ def test_request_network_access_reports_per_host_expiry_when_grants_differ(
     assert "cdn.other.test expires at Unix time 124." in result
 
 
+@pytest.mark.parametrize("failure", [RuntimeError, OSError])
 def test_request_network_access_reports_partial_grants_on_failure(
     monkeypatch: pytest.MonkeyPatch,
+    failure: type[Exception],
 ) -> None:
-    """A mid-batch policy failure must report which hostnames already received grants."""
+    """A mid-batch policy or socket failure must report which hostnames already received grants."""
 
     def post_grant(payload: dict[str, object]) -> dict[str, object]:
         if payload["hostname"] == "cdn.other.test":
             msg = "policy service is down"
-            raise RuntimeError(msg)
+            raise failure(msg)
         return {"expires_at": 123}
 
     monkeypatch.setattr(approved_egress_module, "_post_grant", post_grant)

--- a/tests/test_egress_policy.py
+++ b/tests/test_egress_policy.py
@@ -275,7 +275,7 @@ def test_tool_and_worker_provisioning_resolve_the_same_policy(monkeypatch: pytes
 
     result = asyncio.run(
         approved_egress_module.approved_egress_tools()().request_network_access(
-            "docs.example.com",
+            ["docs.example.com"],
             5,
             "Need docs",
         ),
@@ -302,10 +302,10 @@ def test_tool_static_allow_short_circuit_agrees_with_policy_decision(
 
     result = asyncio.run(
         approved_egress_module.approved_egress_tools()().request_network_access(
-            "docs.example.com",
+            ["docs.example.com"],
             5,
             "Need docs",
         ),
     )
 
-    assert "docs.example.com is already allowed" in result
+    assert "Already allowed by the static egress allowlist: docs.example.com" in result

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -2404,22 +2404,26 @@ async def test_evaluate_tool_approval_rule_action_requires_approval(tmp_path: Pa
 
 
 @pytest.mark.parametrize(
-    ("hostname", "expected"),
+    ("hostnames", "expected"),
     [
-        ("docs.example.com", False),
-        ("docs.other.test", True),
-        (123, True),
-        ("https://docs.example.com", True),
+        (["docs.example.com"], False),
+        (["docs.example.com", "api.example.com"], False),
+        (["docs.example.com", "docs.other.test"], True),
+        (["docs.other.test"], True),
+        ([123], True),
+        (["https://docs.example.com"], True),
+        ("docs.example.com", True),
+        ([], True),
     ],
 )
 @pytest.mark.asyncio
 async def test_evaluate_tool_approval_honors_tool_approval_exemption(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
-    hostname: object,
+    hostnames: object,
     expected: bool,
 ) -> None:
-    """request_network_access calls for statically allowlisted hostnames need no approval."""
+    """request_network_access calls where every hostname is statically allowlisted need no approval."""
     monkeypatch.setenv("MINDROOM_APPROVED_EGRESS_ALLOWLIST", ".example.com")
     runtime_paths = test_runtime_paths(tmp_path)
     config = bind_runtime_paths(
@@ -2435,7 +2439,7 @@ async def test_evaluate_tool_approval_honors_tool_approval_exemption(
         config,
         runtime_paths,
         "request_network_access",
-        {"hostname": hostname, "ttl_minutes": 5, "reason": "Need docs."},
+        {"hostnames": hostnames, "ttl_minutes": 5, "reason": "Need docs."},
         "code",
     )
 

--- a/tests/test_tool_hooks.py
+++ b/tests/test_tool_hooks.py
@@ -1648,14 +1648,14 @@ async def test_request_network_access_static_allowlist_skips_matrix_approval(
 
     result = await FunctionCall(
         function=function,
-        arguments={"hostname": "docs.example.com", "ttl_minutes": ttl_minutes, "reason": "Need docs."},
+        arguments={"hostnames": ["docs.example.com"], "ttl_minutes": ttl_minutes, "reason": "Need docs."},
         call_id="call-1",
     ).aexecute()
 
     assert result.status == "success"
     assert (
         result.result
-        == "docs.example.com is already allowed by the static egress allowlist. No temporary grant was created."
+        == "Already allowed by the static egress allowlist: docs.example.com. No temporary grant was created."
     )
     client.room_send.assert_not_awaited()
 
@@ -1665,7 +1665,7 @@ async def test_request_network_access_blocked_host_still_uses_matrix_approval(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Blocked egress requests should still go through Matrix approval before reaching the tool."""
+    """Batches containing any blocked hostname should still go through Matrix approval before reaching the tool."""
     runtime_paths = test_runtime_paths(tmp_path)
     monkeypatch.setenv("MINDROOM_APPROVED_EGRESS_ALLOWLIST", ".example.com")
     config = _request_network_access_config(runtime_paths)
@@ -1676,7 +1676,7 @@ async def test_request_network_access_blocked_host_still_uses_matrix_approval(
     result = await bridge(
         "request_network_access",
         toolkit.async_functions["request_network_access"].entrypoint,
-        {"hostname": "docs.other.test", "ttl_minutes": 5, "reason": "Need docs."},
+        {"hostnames": ["docs.example.com", "docs.other.test"], "ttl_minutes": 5, "reason": "Need docs."},
     )
 
     assert result == (


### PR DESCRIPTION
## Summary

`request_network_access` now takes `hostnames: list[str]` instead of a single `hostname`, so one tool call — and therefore one Matrix approval card — covers every blocked hostname a task needs. The tool posts one policy-API grant per blocked hostname under that single approval; the proxy's `/grants` API is unchanged.

## Behavior

- Hostnames are canonicalized and deduped up front; one invalid hostname rejects the whole batch before any grant is created.
- Batches are capped at 20 hostnames so a single approval card stays reviewable.
- Statically allowlisted hostnames in the batch are skipped (no grant) and reported in the result; grants are only minted for blocked hosts.
- The approval exemption skips the card only when **every** hostname is statically allowlisted. Non-list input, empty lists, non-string entries, invalid hostnames, or any blocked host all fail closed to the approval card.
- A mid-batch policy failure raises an error naming the hostnames that already received grants, so a retry can request only the missing ones.

## Tests

- New coverage: one grant per blocked hostname with dedup and static-allow skipping, whole-batch rejection on one bad hostname, bare-string and empty-list rejection, batch-size cap, partial-grant failure reporting, and exemption behavior for mixed/empty/non-list batches.
- Verified the Agno-generated tool schema advertises `hostnames` as a required `array` of `string`.
- Full backend suite: 9091 passed, 61 skipped. Pre-commit hooks (ruff, ty, vulture, tach, docs regeneration) all pass.