### PR TITLE
Include the registration URL in the Agent Vault missing-account error

### DIFF
--- a/src/mindroom/custom_tools/agent_vault_access.py
+++ b/src/mindroom/custom_tools/agent_vault_access.py
@@ -238,10 +238,12 @@ class AgentVaultAccessTools(Toolkit):
             await self._set_admin_role(vault, email, token)
             return False
         if response.status_code == 404:
+            register_url = urljoin(self._ui_base_url.rstrip("/") + "/", "login")
             msg = (
                 missing_account_message
                 or f"{email} does not have an Agent Vault account yet. "
-                "Register and verify at the vault UI first, then ask again."
+                f"Send the user this exact link to register and verify their email, "
+                f"then ask again: {register_url}"
             )
             raise _AgentVaultAccessError(msg)
         return self._raise_api_error("granting vault admin access", response)

--- a/tests/test_agent_vault_access_tool.py
+++ b/tests/test_agent_vault_access_tool.py
@@ -276,7 +276,7 @@ async def test_request_vault_access_reports_owner_account_setup_error(
     assert payload["status"] == "error"
     assert "configured worker token-mint owner account" in payload["error"]
     assert "operator" in payload["error"]
-    assert "Register and verify at the vault UI first, then ask again" not in payload["error"]
+    assert "register and verify their email" not in payload["error"]
     grant_calls = [body for path, body in api.calls if path.endswith("/users")]
     assert grant_calls == [{"email": "owner@example.test", "role": "admin"}]
 
@@ -313,6 +313,7 @@ async def test_request_vault_access_reports_unregistered_account(
 
     assert payload["status"] == "error"
     assert "does not have an Agent Vault account" in payload["error"]
+    assert "https://example.test/agent-vault/login" in payload["error"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

`request_vault_access` returns the vault UI link on success, but on the one failure path a new user actually hits — no Agent Vault account yet (404 from the grant API) — the error said only:

> Register and verify at the vault UI first, then ask again.

No URL. The agent relaying this error has nothing concrete to give the user, so it improvises directions to places that don't exist (e.g. telling the user the vault is "linked from the dashboard"). The skills that document the vault flow assume the tool error includes the link, which was true everywhere except this case.

## Fix

Build the login URL from the already-configured `_ui_base_url` (the same base the success path uses for the vault link) and include it in the missing-account error, phrased so the agent relays the exact link:

> `user@example.test` does not have an Agent Vault account yet. Send the user this exact link to register and verify their email, then ask again: `https://.../agent-vault/login`

The operator-provided `missing_account_message` override (used for the token-mint owner account) is unchanged, and the operator-facing warning in `agent_vault_access_grants.py` is left as-is since it surfaces in config-apply output, not to end users.

## Tests

- `test_request_vault_access_reports_unregistered_account` now asserts the login URL is present in the error.
- `test_request_vault_access_reports_owner_account_setup_error` still asserts owner-account failures don't look like requester signup work, updated to the new phrasing.

All 18 tests in `tests/test_agent_vault_access_tool.py` pass; pre-commit hooks pass.

## Summary by Sourcery

Include the Agent Vault registration URL in missing-account errors so agents can direct users to the correct signup page.

Bug Fixes:
- Ensure the missing-account error message for Agent Vault access includes a concrete login URL for user registration and email verification.

Tests:
- Update Agent Vault access tool tests to assert the presence of the login URL in missing-account errors and maintain coverage of owner-account setup error messaging.