### PR TITLE
Add ToolRuntimeContext.resolve_worker_target and a public agent_execution_scope accessor

### DIFF
--- a/src/mindroom/config/main.py
+++ b/src/mindroom/config/main.py
@@ -1192,6 +1192,15 @@ class Config(BaseModel):
             return DEFAULT_WORKER_GRANTABLE_CREDENTIALS
         return frozenset(configured)
 
+    def agent_execution_scope(self, agent_name: str) -> WorkerScope | None:
+        """Return the derived execution scope for one agent.
+
+        Public accessor for tool-composition call sites (e.g. plugins that
+        build other registered tools at dispatch time and need the same
+        worker scoping as agent toolkit construction).
+        """
+        return self._agent_execution_scope(agent_name)
+
     def _agent_execution_scope(self, agent_name: str) -> WorkerScope | None:
         """Return the internal derived execution scope for one agent.
 

--- a/src/mindroom/tool_system/runtime_context.py
+++ b/src/mindroom/tool_system/runtime_context.py
@@ -98,8 +98,7 @@ class ToolRuntimeContext:
         Mirrors the inputs of agents._build_registered_agent_tool.
         """
         worker_scope = self.config.agent_execution_scope(self.agent_name)
-        agent_config = self.config.agents.get(self.agent_name)
-        routing_agent_is_private = agent_config is not None and agent_config.private is not None
+        routing_agent_is_private = self.config.get_agent(self.agent_name).private is not None
         if worker_scope == "user_agent":
             private_agent_names = frozenset({self.agent_name}) if routing_agent_is_private else frozenset()
         else:

--- a/src/mindroom/tool_system/runtime_context.py
+++ b/src/mindroom/tool_system/runtime_context.py
@@ -24,7 +24,7 @@ from mindroom.logging_config import get_logger
 from mindroom.message_target import MessageTarget
 from mindroom.tool_system.context_bound_streams import context_bound_async_stream
 from mindroom.tool_system.plugin_identity import validate_plugin_name
-from mindroom.tool_system.worker_routing import build_tool_execution_identity
+from mindroom.tool_system.worker_routing import build_tool_execution_identity, build_worker_target_from_runtime_env
 
 if TYPE_CHECKING:
     import asyncio
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
     from mindroom.matrix.identity import MatrixID
     from mindroom.runtime_protocols import OrchestratorRuntime
     from mindroom.scheduling import SchedulingRuntime
-    from mindroom.tool_system.worker_routing import ToolExecutionIdentity
+    from mindroom.tool_system.worker_routing import ResolvedWorkerTarget, ToolExecutionIdentity
     from mindroom.workers.models import WorkerReadyProgress
 
 _ToolContextReturn = TypeVar("_ToolContextReturn")
@@ -87,6 +87,30 @@ class ToolRuntimeContext:
     room_state_putter: HookRoomStatePutter | None = None
     message_received_depth: int = 0
     orchestrator: OrchestratorRuntime | None = None
+
+    def resolve_worker_target(self) -> ResolvedWorkerTarget:
+        """Resolve the worker target for toolkits built on behalf of this dispatch.
+
+        Tools that compose other registered tools at call time (plugins
+        building search backends, sub-toolkits) need the same worker target
+        that agent toolkit construction uses, so requester-scoped state —
+        OAuth MCP sessions, scoped credentials — resolves identically.
+        Mirrors the inputs of agents._build_registered_agent_tool.
+        """
+        worker_scope = self.config.agent_execution_scope(self.agent_name)
+        agent_config = self.config.agents.get(self.agent_name)
+        routing_agent_is_private = agent_config is not None and agent_config.private is not None
+        if worker_scope == "user_agent":
+            private_agent_names = frozenset({self.agent_name}) if routing_agent_is_private else frozenset()
+        else:
+            private_agent_names = None
+        return build_worker_target_from_runtime_env(
+            worker_scope,
+            self.agent_name,
+            execution_identity=build_execution_identity_from_runtime_context(self),
+            runtime_paths=self.runtime_paths,
+            private_agent_names=private_agent_names,
+        )
 
 
 @dataclass(frozen=True)

--- a/tests/test_resolve_tool_worker_target.py
+++ b/tests/test_resolve_tool_worker_target.py
@@ -53,7 +53,7 @@ def test_private_user_agent_scope_resolves_requester_scoped_target(tmp_path: Pat
 
 
 def test_resolution_matches_agent_construction_recipe(tmp_path: Path) -> None:
-    """The method matches build_worker_target_from_runtime_env with agent-construction inputs."""
+    """The method matches build_worker_target_from_runtime_env fed literal agent-construction inputs."""
     config = Config(
         agents={
             "mind": {
@@ -63,24 +63,25 @@ def test_resolution_matches_agent_construction_recipe(tmp_path: Path) -> None:
             "helper": {"display_name": "Helper"},
         },
     )
-    for agent_name in ("mind", "helper"):
-        context = _context(config, agent_name, tmp_path)
-        worker_scope = config.agent_execution_scope(agent_name)
-        agent_config = config.agents.get(agent_name)
-        is_private = agent_config is not None and agent_config.private is not None
-        if worker_scope == "user_agent":
-            private_agent_names = frozenset({agent_name}) if is_private else frozenset()
-        else:
-            private_agent_names = None
-        expected = build_worker_target_from_runtime_env(
-            worker_scope,
-            agent_name,
-            execution_identity=build_execution_identity_from_runtime_context(context),
-            runtime_paths=context.runtime_paths,
-            private_agent_names=private_agent_names,
-        )
 
-        assert context.resolve_worker_target() == expected
+    mind_context = _context(config, "mind", tmp_path)
+    assert mind_context.resolve_worker_target() == build_worker_target_from_runtime_env(
+        "user_agent",
+        "mind",
+        execution_identity=build_execution_identity_from_runtime_context(mind_context),
+        runtime_paths=mind_context.runtime_paths,
+        private_agent_names=frozenset({"mind"}),
+    )
+
+    helper_context = _context(config, "helper", tmp_path)
+    assert config.agent_execution_scope("helper") is None
+    assert helper_context.resolve_worker_target() == build_worker_target_from_runtime_env(
+        None,
+        "helper",
+        execution_identity=build_execution_identity_from_runtime_context(helper_context),
+        runtime_paths=helper_context.runtime_paths,
+        private_agent_names=None,
+    )
 
 
 def test_public_execution_scope_accessor_matches_internal(tmp_path: Path) -> None:

--- a/tests/test_resolve_tool_worker_target.py
+++ b/tests/test_resolve_tool_worker_target.py
@@ -1,0 +1,99 @@
+"""Tests for the public tool-runtime worker-target resolution API."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+from mindroom.config.main import Config
+from mindroom.constants import resolve_primary_runtime_paths
+from mindroom.tool_system.runtime_context import (
+    ToolRuntimeContext,
+    build_execution_identity_from_runtime_context,
+)
+from mindroom.tool_system.worker_routing import build_worker_target_from_runtime_env
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _context(config: Config, agent_name: str, tmp_path: Path) -> ToolRuntimeContext:
+    return ToolRuntimeContext(
+        agent_name=agent_name,
+        room_id="!room:localhost",
+        thread_id="$thread",
+        resolved_thread_id="$thread",
+        requester_id="@user:localhost",
+        client=AsyncMock(),
+        config=config,
+        runtime_paths=resolve_primary_runtime_paths(config_path=tmp_path / "config.yaml"),
+        event_cache=AsyncMock(),
+        conversation_cache=AsyncMock(),
+    )
+
+
+def test_private_user_agent_scope_resolves_requester_scoped_target(tmp_path: Path) -> None:
+    """A private user_agent-scoped agent resolves a requester-scoped target."""
+    config = Config(
+        agents={
+            "mind": {
+                "display_name": "Mind",
+                "private": {"per": "user_agent", "root": "workspace/mind_data"},
+            },
+        },
+    )
+    context = _context(config, "mind", tmp_path)
+
+    target = context.resolve_worker_target()
+
+    assert target.worker_scope == "user_agent"
+    assert target.routing_agent_name == "mind"
+    assert target.worker_key
+    assert target.private_agent_names == frozenset({"mind"})
+
+
+def test_resolution_matches_agent_construction_recipe(tmp_path: Path) -> None:
+    """The method matches build_worker_target_from_runtime_env with agent-construction inputs."""
+    config = Config(
+        agents={
+            "mind": {
+                "display_name": "Mind",
+                "private": {"per": "user_agent", "root": "workspace/mind_data"},
+            },
+            "helper": {"display_name": "Helper"},
+        },
+    )
+    for agent_name in ("mind", "helper"):
+        context = _context(config, agent_name, tmp_path)
+        worker_scope = config.agent_execution_scope(agent_name)
+        agent_config = config.agents.get(agent_name)
+        is_private = agent_config is not None and agent_config.private is not None
+        if worker_scope == "user_agent":
+            private_agent_names = frozenset({agent_name}) if is_private else frozenset()
+        else:
+            private_agent_names = None
+        expected = build_worker_target_from_runtime_env(
+            worker_scope,
+            agent_name,
+            execution_identity=build_execution_identity_from_runtime_context(context),
+            runtime_paths=context.runtime_paths,
+            private_agent_names=private_agent_names,
+        )
+
+        assert context.resolve_worker_target() == expected
+
+
+def test_public_execution_scope_accessor_matches_internal(tmp_path: Path) -> None:
+    """The public accessor delegates to the internal derivation."""
+    del tmp_path
+    config = Config(
+        agents={
+            "mind": {
+                "display_name": "Mind",
+                "private": {"per": "user_agent", "root": "workspace/mind_data"},
+            },
+            "helper": {"display_name": "Helper"},
+        },
+    )
+    for agent_name in ("mind", "helper"):
+        assert config.agent_execution_scope(agent_name) == config._agent_execution_scope(agent_name)

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -263,3 +263,4 @@ AgentVaultAccessTools  # unused class (src/mindroom/custom_tools/agent_vault_acc
 _agent_vault_access_tools  # unused function (src/mindroom/tools/__init__.py)
 _.apply_derived_defaults  # unused method (src/mindroom/custom_tools/todo.py)
 _.exactly_one_of_title_or_sub_template  # unused method (src/mindroom/custom_tools/todo.py)
+_.resolve_worker_target  # plugin-facing API method (src/mindroom/tool_system/runtime_context.py)


### PR DESCRIPTION
## Why

Tools that compose other registered tools at dispatch time — plugins building search backends or sub-toolkits via `get_tool_by_name` — need the same worker target that agent toolkit construction uses, so requester-scoped state (OAuth MCP sessions, scoped credentials) resolves identically. Discovered live: an OAuth-backed MCP toolkit built with `worker_target=None` lands on the unscoped session and reports 'not connected' even for requesters whose interactive session is connected (mindroom-ai/deep-research-plugin#11).

Without a public API, out-of-tree plugins must reconstruct the recipe from private internals (`Config._agent_execution_scope`) behind defensive `getattr` probing that degrades silently on version skew.

## What

- **`ToolRuntimeContext.resolve_worker_target()`** — one typed call mirroring `agents._build_registered_agent_tool`'s inputs: execution scope, routing agent, execution identity, runtime env tenant/account, and the private-agent set.
- **`Config.agent_execution_scope`** — public accessor delegating to the internal derivation.

## Testing

New tests: private user_agent-scoped agent resolves a requester-scoped target with the right private-agent set; golden parity with `build_worker_target_from_runtime_env` called with agent-construction inputs for both private and shared agents; accessor parity. All pre-commit hooks pass (ruff, ty, vulture, privata, tach).

## Downstream

Once this ships in a runtime release, deep-research-plugin replaces its reconstruction helpers with `context.resolve_worker_target()` — typed, direct, failing loudly on incompatible runtimes instead of degrading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public way to look up an agent’s execution scope.
  * Added worker-target resolution from runtime context for toolkit and routing use.

* **Tests**
  * Added coverage for private-agent scope handling, worker-target resolution consistency, and the new public scope accessor.

* **Chores**
  * Updated internal API allowlists to include the new worker-target resolution entry point.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->