### PR TITLE
Delete bot.py pass-through mock points; migrate tests to the ResponseRunner and gateway seams

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, cast
 from uuid import uuid4
@@ -27,11 +27,9 @@ from mindroom.hooks import (
     EVENT_REACTION_RECEIVED,
     EVENT_ROOM_MEMBER_JOINED,
     AgentLifecycleContext,
-    EnrichmentItem,
     HookContextSupport,
     HookRegistry,
     HookRegistryState,
-    MessageEnvelope,
     ReactionReceivedContext,
     RoomMemberJoinedContext,
     emit,
@@ -88,7 +86,7 @@ from .delivery_gateway import (
 )
 from .edit_regenerator import EditRegenerator, EditRegeneratorDeps
 from .entity_rooms import get_rooms_for_entity
-from .inbound_turn_normalizer import DispatchPayload, InboundTurnNormalizer, InboundTurnNormalizerDeps
+from .inbound_turn_normalizer import InboundTurnNormalizer, InboundTurnNormalizerDeps
 from .ingress_validation import IngressValidator, IngressValidatorDeps
 from .knowledge import KnowledgeAccessSupport
 from .logging_config import get_logger
@@ -118,7 +116,7 @@ from .turn_policy import IngressHookRunner, TurnPolicy, TurnPolicyDeps
 from .turn_store import TurnStore, TurnStoreDeps
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable, Sequence
+    from collections.abc import Awaitable, Callable
     from datetime import datetime
     from pathlib import Path
 
@@ -128,7 +126,6 @@ if TYPE_CHECKING:
     from mindroom.coalescing_batch import CoalescedBatch
     from mindroom.config.main import Config
     from mindroom.matrix.cache import AgentMessageSnapshot, ConversationEventCache, EventCacheWriteCoordinator
-    from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
     from mindroom.matrix.identity import MatrixID
     from mindroom.matrix.media import MatrixMediaEvent
     from mindroom.runtime_protocols import OrchestratorRuntime
@@ -351,10 +348,12 @@ class AgentBot:
             response_text: str,
             skip_mentions: bool = False,
         ) -> str | None:
-            return await self._send_response(
-                target=target,
-                response_text=response_text,
-                skip_mentions=skip_mentions,
+            return await self._delivery_gateway.send_text(
+                SendTextRequest(
+                    target=target,
+                    response_text=response_text,
+                    skip_mentions=skip_mentions,
+                ),
             )
 
         self._room_lifecycle = BotRoomLifecycle(
@@ -507,7 +506,7 @@ class AgentBot:
                 resolver=self._conversation_resolver,
                 turn_store=self._turn_store,
                 ingress_hook_runner=self._ingress_hook_runner,
-                generate_response=lambda **kwargs: self._generate_response(**kwargs),
+                generate_response=lambda request: self._run_regenerated_response(request),
                 timestamp_formatter=lambda timestamp_ms: format_timestamp_ms(
                     timestamp_ms,
                     timezone=self.config.timezone,
@@ -1882,135 +1881,9 @@ class AgentBot:
             return False
         return "matrix_message" in tool_names
 
-    async def _generate_team_response_helper(
-        self,
-        team_agents: list[MatrixID],
-        team_mode: str,
-        thread_history: Sequence[ResolvedVisibleMessage],
-        requester_user_id: str,
-        existing_event_id: str | None = None,
-        existing_event_is_placeholder: bool = False,
-        *,
-        payload: DispatchPayload,
-        response_envelope: MessageEnvelope,
-        system_enrichment_items: tuple[EnrichmentItem, ...] = (),
-        correlation_id: str | None = None,
-        reason_prefix: str = "Team request",
-        matrix_run_metadata: dict[str, Any] | None = None,
-        current_timestamp_ms: float | None = None,
-        current_prompt_is_structured: bool = False,
-        on_lifecycle_lock_acquired: Callable[[], None] | None = None,
-    ) -> str | None:
-        """Generate a team response (shared between preformed teams and TeamBot)."""
-        return await self._response_runner.generate_team_response_helper(
-            ResponseRequest(
-                thread_history=thread_history,
-                prompt=payload.prompt,
-                model_prompt=payload.model_prompt,
-                existing_event_id=existing_event_id,
-                existing_event_is_placeholder=existing_event_is_placeholder,
-                user_id=requester_user_id,
-                media=payload.media,
-                attachment_ids=tuple(payload.attachment_ids) if payload.attachment_ids is not None else None,
-                response_envelope=response_envelope,
-                correlation_id=correlation_id,
-                matrix_run_metadata=matrix_run_metadata,
-                system_enrichment_items=system_enrichment_items,
-                current_timestamp_ms=current_timestamp_ms,
-                current_prompt_is_structured=current_prompt_is_structured,
-                on_lifecycle_lock_acquired=on_lifecycle_lock_acquired,
-            ),
-            team_agents=team_agents,
-            team_mode=team_mode,
-            reason_prefix=reason_prefix,
-        )
-
-    async def _generate_response(
-        self,
-        prompt: str,
-        thread_history: Sequence[ResolvedVisibleMessage],
-        *,
-        response_envelope: MessageEnvelope,
-        existing_event_id: str | None = None,
-        existing_event_is_placeholder: bool = False,
-        user_id: str | None = None,
-        media: MediaInputs | None = None,
-        attachment_ids: list[str] | None = None,
-        model_prompt: str | None = None,
-        system_enrichment_items: tuple[EnrichmentItem, ...] = (),
-        correlation_id: str | None = None,
-        matrix_run_metadata: dict[str, Any] | None = None,
-        current_timestamp_ms: float | None = None,
-        current_prompt_is_structured: bool = False,
-        on_lifecycle_lock_acquired: Callable[[], None] | None = None,
-    ) -> str | None:
-        """Generate and send/edit a response using AI.
-
-        Args:
-            prompt: The prompt to send to the AI
-            thread_history: Thread history for context
-            existing_event_id: If provided, edit this message instead of sending a new one
-                             (used for placeholders and interactive acknowledgments)
-            existing_event_is_placeholder: Whether `existing_event_id` points at a
-                             provisional visible event that may be cleaned up on suppression
-            user_id: User ID of the sender for identifying user messages in history
-            media: Optional multimodal inputs (audio/images/files/videos)
-            attachment_ids: Attachment IDs available for tool-side file processing
-            model_prompt: Optional model-facing prompt for the live request and persisted history.
-            system_enrichment_items: Hook-provided transient system prompt fragments to
-                apply for this response.
-            response_envelope: Normalized inbound envelope for response hooks.
-            correlation_id: Optional request correlation ID propagated to hook logging.
-            matrix_run_metadata: Optional Matrix-specific run metadata persisted with the run
-                for unseen-message tracking, coalesced edit regeneration, and cleanup.
-            current_timestamp_ms: Optional source Matrix event timestamp in milliseconds.
-            current_prompt_is_structured: Whether the current prompt already carries trusted message tags.
-            on_lifecycle_lock_acquired: Optional callback that runs after the response
-                lifecycle lock is acquired and before response generation starts.
-
-        Returns:
-            Event ID of the visible response, or None if no visible response landed.
-
-        """
-        return await self._response_runner.generate_response(
-            ResponseRequest(
-                thread_history=thread_history,
-                prompt=prompt,
-                model_prompt=model_prompt,
-                existing_event_id=existing_event_id,
-                existing_event_is_placeholder=existing_event_is_placeholder,
-                user_id=user_id,
-                media=media,
-                attachment_ids=tuple(attachment_ids) if attachment_ids is not None else None,
-                response_envelope=response_envelope,
-                correlation_id=correlation_id,
-                matrix_run_metadata=matrix_run_metadata,
-                system_enrichment_items=system_enrichment_items,
-                current_timestamp_ms=current_timestamp_ms,
-                current_prompt_is_structured=current_prompt_is_structured,
-                on_lifecycle_lock_acquired=on_lifecycle_lock_acquired,
-            ),
-        )
-
-    async def _send_response(
-        self,
-        *,
-        target: MessageTarget,
-        response_text: str,
-        skip_mentions: bool = False,
-        tool_trace: list[ToolTraceEntry] | None = None,
-        extra_content: dict[str, Any] | None = None,
-    ) -> _MatrixEventId | None:
-        """Send a response message to a room."""
-        return await self._delivery_gateway.send_text(
-            SendTextRequest(
-                target=target,
-                response_text=response_text,
-                skip_mentions=skip_mentions,
-                tool_trace=tool_trace,
-                extra_content=extra_content,
-            ),
-        )
+    async def _run_regenerated_response(self, request: ResponseRequest) -> str | None:
+        """Run one edit-regenerated turn through this bot's response path."""
+        return await self._response_runner.generate_response(request)
 
     async def _hook_send_message(
         self,
@@ -2161,56 +2034,22 @@ class TeamBot(AgentBot):
         registry = entity_identity_registry(self.config, self.runtime_paths)
         return [registry.current_id(agent_name) for agent_name in team_config.agents]
 
-    async def _generate_response(
-        self,
-        prompt: str,
-        thread_history: Sequence[ResolvedVisibleMessage],
-        *,
-        response_envelope: MessageEnvelope,
-        existing_event_id: str | None = None,
-        existing_event_is_placeholder: bool = False,
-        user_id: str | None = None,
-        media: MediaInputs | None = None,
-        attachment_ids: list[str] | None = None,
-        model_prompt: str | None = None,
-        system_enrichment_items: tuple[EnrichmentItem, ...] = (),
-        correlation_id: str | None = None,
-        matrix_run_metadata: dict[str, Any] | None = None,
-        current_timestamp_ms: float | None = None,
-        current_prompt_is_structured: bool = False,
-        on_lifecycle_lock_acquired: Callable[[], None] | None = None,
-    ) -> str | None:
-        """Generate a team response instead of individual agent response."""
-        target = response_envelope.target
-        if not prompt.strip():
+    async def _run_regenerated_response(self, request: ResponseRequest) -> str | None:
+        """Run one edit-regenerated turn through the configured team path."""
+        target = request.response_envelope.target
+        if not request.prompt.strip():
             return await self._response_runner.generate_response_for_empty_prompt(
-                ResponseRequest(
-                    thread_history=thread_history,
-                    prompt=prompt,
-                    model_prompt=model_prompt,
-                    existing_event_id=existing_event_id,
-                    existing_event_is_placeholder=existing_event_is_placeholder,
-                    user_id=user_id,
-                    media=media,
-                    attachment_ids=tuple(attachment_ids) if attachment_ids is not None else None,
-                    response_envelope=response_envelope,
-                    correlation_id=correlation_id,
-                    matrix_run_metadata=matrix_run_metadata,
-                    system_enrichment_items=system_enrichment_items,
-                    current_timestamp_ms=current_timestamp_ms,
-                    current_prompt_is_structured=current_prompt_is_structured,
-                    on_lifecycle_lock_acquired=on_lifecycle_lock_acquired,
-                ),
+                request,
                 response_kind="team",
             )
         assert self.client is not None
         memory_prompt, memory_thread_history, model_prompt_text, model_thread_history = (
             prepare_memory_and_model_context(
-                prompt,
-                thread_history,
+                request.prompt,
+                request.thread_history,
                 config=self.config,
                 runtime_paths=self.runtime_paths,
-                model_prompt=model_prompt,
+                model_prompt=request.model_prompt,
             )
         )
 
@@ -2227,18 +2066,20 @@ class TeamBot(AgentBot):
         if team_resolution.outcome is not TeamOutcome.TEAM:
             assert team_resolution.reason is not None
             response_event_id: str | None
-            if existing_event_id:
+            if request.existing_event_id:
                 edited = await self._edit_message(
                     room_id=target.room_id,
-                    event_id=existing_event_id,
+                    event_id=request.existing_event_id,
                     new_text=team_resolution.reason,
                     thread_id=target.resolved_thread_id,
                 )
-                response_event_id = existing_event_id if edited else None
+                response_event_id = request.existing_event_id if edited else None
             else:
-                response_event_id = await self._send_response(
-                    target=response_envelope.target,
-                    response_text=team_resolution.reason,
+                response_event_id = await self._delivery_gateway.send_text(
+                    SendTextRequest(
+                        target=target,
+                        response_text=team_resolution.reason,
+                    ),
                 )
             return response_event_id
         assert team_resolution.mode is not None
@@ -2251,7 +2092,7 @@ class TeamBot(AgentBot):
         session_id = target.session_id
         execution_identity = self._tool_runtime_support.build_execution_identity(
             target=target,
-            user_id=user_id,
+            user_id=request.user_id,
             session_id=session_id,
         )
         with tool_execution_identity(execution_identity):
@@ -2264,34 +2105,24 @@ class TeamBot(AgentBot):
                     self.config,
                     self.runtime_paths,
                     memory_thread_history,
-                    user_id,
+                    request.user_id,
                     execution_identity=execution_identity,
                 ),
                 name=f"memory_save_team_{session_id}",
                 owner=self._runtime_view,
             )
 
-        media_inputs = media or MediaInputs()
-
-        return await self._generate_team_response_helper(
-            payload=DispatchPayload(
+        return await self._response_runner.generate_team_response_helper(
+            replace(
+                request,
                 prompt=memory_prompt,
                 model_prompt=model_prompt_text,
-                media=media_inputs,
-                attachment_ids=attachment_ids,
+                thread_history=model_thread_history,
+                media=request.media or MediaInputs(),
+                user_id=request.user_id or "",
+                correlation_id=request.correlation_id or target.reply_to_event_id,
             ),
             team_agents=team_resolution.eligible_members,
             team_mode=team_resolution.mode.value,
-            thread_history=model_thread_history,
-            requester_user_id=user_id or "",
-            existing_event_id=existing_event_id,
-            existing_event_is_placeholder=existing_event_is_placeholder,
-            response_envelope=response_envelope,
-            system_enrichment_items=system_enrichment_items,
-            correlation_id=correlation_id or target.reply_to_event_id,
             reason_prefix=f"Team '{self.agent_name}'",
-            matrix_run_metadata=matrix_run_metadata,
-            current_timestamp_ms=current_timestamp_ms,
-            current_prompt_is_structured=current_prompt_is_structured,
-            on_lifecycle_lock_acquired=on_lifecycle_lock_acquired,
         )

--- a/src/mindroom/commands/config_confirmation.py
+++ b/src/mindroom/commands/config_confirmation.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 import nio
 
 from mindroom.config.matrix import ignore_unverified_devices_for_config
+from mindroom.delivery_gateway import SendTextRequest
 from mindroom.logging_config import get_logger
 from mindroom.matrix.message_builder import build_reaction_content
 
@@ -418,8 +419,10 @@ async def handle_confirmation_reaction(
         thread_id=pending_change.thread_id,
         reply_to_event_id=event.reacts_to,
     )
-    await bot._send_response(
-        target=target,
-        response_text=response_text,
-        skip_mentions=True,
+    await bot._delivery_gateway.send_text(
+        SendTextRequest(
+            target=target,
+            response_text=response_text,
+            skip_mentions=True,
+        ),
     )

--- a/src/mindroom/edit_regenerator.py
+++ b/src/mindroom/edit_regenerator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Protocol
 
 from mindroom.coalescing_batch import coalesced_prompt, tagged_coalesced_prompt
 from mindroom.conversation_resolver import MessageContext
@@ -12,19 +12,18 @@ from mindroom.entity_resolution import entity_identity_registry
 from mindroom.handled_turns import HandledTurnRecord, HandledTurnState
 from mindroom.hooks import hook_ingress_policy
 from mindroom.matrix.client_visible_messages import extract_visible_edit_body
+from mindroom.response_runner import ResponseRequest
 from mindroom.runtime_protocols import SupportsClientConfig  # noqa: TC001
 from mindroom.timestamp_formatting import normalize_timestamp_ms
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
+    from collections.abc import Callable
 
     import nio
     import structlog
 
     from mindroom.constants import RuntimePaths
     from mindroom.conversation_resolver import ConversationResolver
-    from mindroom.hooks import MessageEnvelope
-    from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
     from mindroom.matrix.event_info import EventInfo
     from mindroom.message_target import MessageTarget
     from mindroom.turn_policy import IngressHookRunner
@@ -34,21 +33,7 @@ if TYPE_CHECKING:
 class _GenerateResponse(Protocol):
     """Minimal response-generation surface needed for edit regeneration."""
 
-    async def __call__(
-        self,
-        *,
-        prompt: str,
-        thread_history: Sequence[ResolvedVisibleMessage],
-        existing_event_id: str | None = None,
-        existing_event_is_placeholder: bool = False,
-        user_id: str | None = None,
-        response_envelope: MessageEnvelope,
-        correlation_id: str | None = None,
-        matrix_run_metadata: dict[str, Any] | None = None,
-        current_timestamp_ms: float | None = None,
-        current_prompt_is_structured: bool = False,
-        on_lifecycle_lock_acquired: Callable[[], None] | None = None,
-    ) -> str | None:
+    async def __call__(self, request: ResponseRequest) -> str | None:
         """Generate or regenerate a response for one handled turn."""
 
 
@@ -291,22 +276,23 @@ class EditRegenerator:
             return
 
         regenerated_event_id = await self.deps.generate_response(
-            prompt=regeneration_prompt,
-            thread_history=context.thread_history,
-            existing_event_id=response_event_id,
-            existing_event_is_placeholder=False,
-            user_id=requester_user_id,
-            response_envelope=envelope,
-            correlation_id=event.event_id,
-            matrix_run_metadata=regeneration_matrix_run_metadata,
-            current_timestamp_ms=normalize_timestamp_ms(event.server_timestamp),
-            current_prompt_is_structured=current_prompt_is_structured,
-            on_lifecycle_lock_acquired=lambda: self.deps.turn_store.remove_stale_runs_for_edit(
-                loaded_turn=replace(
-                    loaded_turn,
-                    record=regeneration_turn_record,
+            ResponseRequest(
+                thread_history=context.thread_history,
+                prompt=regeneration_prompt,
+                response_envelope=envelope,
+                existing_event_id=response_event_id,
+                user_id=requester_user_id,
+                correlation_id=event.event_id,
+                matrix_run_metadata=regeneration_matrix_run_metadata,
+                current_timestamp_ms=normalize_timestamp_ms(event.server_timestamp),
+                current_prompt_is_structured=current_prompt_is_structured,
+                on_lifecycle_lock_acquired=lambda: self.deps.turn_store.remove_stale_runs_for_edit(
+                    loaded_turn=replace(
+                        loaded_turn,
+                        record=regeneration_turn_record,
+                    ),
+                    requester_user_id=requester_user_id,
                 ),
-                requester_user_id=requester_user_id,
             ),
         )
 

--- a/tach.toml
+++ b/tach.toml
@@ -854,6 +854,7 @@ depends_on = [
     "mindroom.hooks",
     "mindroom.matrix.client_visible_messages",
     "mindroom.matrix.identity",
+    "mindroom.response_runner",
     "mindroom.runtime_protocols",
     "mindroom.timestamp_formatting",
 ]
@@ -2197,6 +2198,7 @@ path = "mindroom.commands.config_confirmation"
 depends_on = [
     "mindroom.commands.config_commands",
     "mindroom.config.matrix",
+    "mindroom.delivery_gateway",
     "mindroom.logging_config",
 ]
 

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -470,7 +470,6 @@ def _make_bot(
     bot.config = config
     bot.runtime_paths = runtime_paths
     bot._knowledge_access_support = _knowledge_access_support()
-    bot._send_response = AsyncMock(return_value="$response_id")
     bot._handle_interactive_question = AsyncMock()
     return bot
 
@@ -955,7 +954,6 @@ async def test_process_and_respond_emits_session_started_after_first_persisted_t
     bot.config = config
     bot.runtime_paths = runtime_paths
     bot._knowledge_access_support = _knowledge_access_support()
-    bot._send_response = AsyncMock(return_value="$response_id")
 
     storage = _SessionStorage()
     sequence: list[tuple[str, str | None, str | None, str | None]] = []
@@ -1057,7 +1055,6 @@ async def test_process_and_respond_applies_session_started_agent_and_room_scopes
     bot.config = config
     bot.runtime_paths = runtime_paths
     bot._knowledge_access_support = _knowledge_access_support()
-    bot._send_response = AsyncMock(return_value="$response_id")
 
     storage = _SessionStorage()
     sequence: list[str] = []
@@ -1127,7 +1124,6 @@ async def test_process_and_respond_does_not_emit_session_started_without_persist
     bot.config = config
     bot.runtime_paths = runtime_paths
     bot._knowledge_access_support = _knowledge_access_support()
-    bot._send_response = AsyncMock(return_value="$response_id")
 
     storage = _SessionStorage()
     sequence: list[str] = []
@@ -1239,7 +1235,6 @@ async def test_session_started_hooks_continue_after_timeout(tmp_path: Path) -> N
     bot.config = config
     bot.runtime_paths = runtime_paths
     bot._knowledge_access_support = _knowledge_access_support()
-    bot._send_response = AsyncMock(return_value="$response_id")
 
     storage = _SessionStorage()
     sequence: list[str] = []
@@ -1693,7 +1688,6 @@ async def test_process_and_respond_emits_session_started_after_persisted_cancell
     bot.config = config
     bot.runtime_paths = runtime_paths
     bot._knowledge_access_support = _knowledge_access_support()
-    bot._send_response = AsyncMock(return_value="$response_id")
 
     storage = _SessionStorage()
     sequence: list[str] = []
@@ -4647,7 +4641,6 @@ class TestUserIdPassthrough:
         bot.config = config
         bot.runtime_paths = runtime_paths
         bot._knowledge_access_support = _knowledge_access_support()
-        bot._send_response = AsyncMock(return_value="$response_id")
         with patch("mindroom.response_runner.ai_response") as mock_ai:
             coordinator = _build_response_runner(
                 bot,

--- a/tests/test_bot_scheduling.py
+++ b/tests/test_bot_scheduling.py
@@ -137,7 +137,13 @@ async def _execute_command(
 
 
 @pytest.fixture
-def mock_agent_bot() -> AgentBot:
+def send_response_mock() -> AsyncMock:
+    """Delivery seam mock installed on mock_agent_bot."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_agent_bot(send_response_mock: AsyncMock) -> AgentBot:
     """Create a mock agent bot for testing."""
     agent_user = AgentMatrixUser(
         agent_name="general",
@@ -161,9 +167,8 @@ def mock_agent_bot() -> AgentBot:
     install_runtime_cache_support(bot)
     sync_bot_runtime_state(bot)
     bot.logger = MagicMock()
-    bot._send_response = AsyncMock()
     _sync_turn_policy_runtime(bot)
-    install_send_response_mock(bot, bot._send_response)
+    install_send_response_mock(bot, send_response_mock)
     bot._conversation_cache.get_thread_history = AsyncMock(return_value=thread_history_result([], is_full_history=True))
     bot._conversation_cache.get_dispatch_thread_history = AsyncMock(
         return_value=thread_history_result([], is_full_history=True),
@@ -178,7 +183,7 @@ class TestBotScheduleCommands:
     """Test bot handling of schedule commands."""
 
     @pytest.mark.asyncio
-    async def test_handle_schedule_command(self, mock_agent_bot: AgentBot) -> None:
+    async def test_handle_schedule_command(self, mock_agent_bot: AgentBot, send_response_mock: AsyncMock) -> None:
         """Test bot handles schedule command correctly."""
         room = MagicMock()
         room.room_id = "!test:server"
@@ -218,8 +223,8 @@ class TestBotScheduleCommands:
             assert call_kwargs["mentioned_agents"] == []
 
             # Verify response was sent
-            mock_agent_bot._send_response.assert_called_once()
-            call_args = mock_agent_bot._send_response.call_args
+            send_response_mock.assert_called_once()
+            call_args = send_response_mock.call_args
             assert "✅ Scheduled: 5 minutes from now" in call_args.kwargs["response_text"]
 
     @pytest.mark.asyncio
@@ -247,7 +252,11 @@ class TestBotScheduleCommands:
             assert call_args[1]["full_text"] == "tomorrow"
 
     @pytest.mark.asyncio
-    async def test_handle_list_schedules_command(self, mock_agent_bot: AgentBot) -> None:
+    async def test_handle_list_schedules_command(
+        self,
+        mock_agent_bot: AgentBot,
+        send_response_mock: AsyncMock,
+    ) -> None:
         """Test bot handles list schedules command."""
         _sync_turn_policy_runtime(mock_agent_bot)
         room = MagicMock()
@@ -272,7 +281,7 @@ class TestBotScheduleCommands:
                 config=mock_agent_bot.config,
             )
 
-            mock_agent_bot._send_response.assert_called_once()
+            send_response_mock.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_handle_cancel_schedule_command(self, mock_agent_bot: AgentBot) -> None:
@@ -301,7 +310,11 @@ class TestBotScheduleCommands:
             )
 
     @pytest.mark.asyncio
-    async def test_handle_cancel_all_scheduled_tasks(self, mock_agent_bot: AgentBot) -> None:
+    async def test_handle_cancel_all_scheduled_tasks(
+        self,
+        mock_agent_bot: AgentBot,
+        send_response_mock: AsyncMock,
+    ) -> None:
         """Test bot handles cancel all scheduled tasks command."""
         _sync_turn_policy_runtime(mock_agent_bot)
         room = MagicMock()
@@ -329,12 +342,16 @@ class TestBotScheduleCommands:
                 matrix_admin=None,
             )
 
-        mock_agent_bot._send_response.assert_called_once()
-        call_args = mock_agent_bot._send_response.call_args
+        send_response_mock.assert_called_once()
+        call_args = send_response_mock.call_args
         assert "✅ Cancelled 3 scheduled task(s)" in call_args.kwargs["response_text"]
 
     @pytest.mark.asyncio
-    async def test_handle_edit_schedule_command(self, mock_agent_bot: AgentBot) -> None:
+    async def test_handle_edit_schedule_command(
+        self,
+        mock_agent_bot: AgentBot,
+        send_response_mock: AsyncMock,
+    ) -> None:
         """Test bot handles edit schedule command."""
         _sync_turn_policy_runtime(mock_agent_bot)
         room = MagicMock()
@@ -369,12 +386,16 @@ class TestBotScheduleCommands:
             assert edit_kwargs["scheduled_by"] == "@user:server"
             assert edit_kwargs["thread_id"] == "$thread123"
 
-        mock_agent_bot._send_response.assert_called_once()
-        call_args = mock_agent_bot._send_response.call_args
+        send_response_mock.assert_called_once()
+        call_args = send_response_mock.call_args
         assert "✅ Updated task `task123`." in call_args.kwargs["response_text"]
 
     @pytest.mark.asyncio
-    async def test_schedule_command_auto_creates_thread(self, mock_agent_bot: AgentBot) -> None:
+    async def test_schedule_command_auto_creates_thread(
+        self,
+        mock_agent_bot: AgentBot,
+        send_response_mock: AsyncMock,
+    ) -> None:
         """Test that schedule commands auto-create threads when used in main room."""
         _sync_turn_policy_runtime(mock_agent_bot)
         room = MagicMock()
@@ -395,8 +416,8 @@ class TestBotScheduleCommands:
             await _execute_command(mock_agent_bot, room, event, "@user:server", command)
 
         # Should successfully schedule the task (auto-creates thread)
-        mock_agent_bot._send_response.assert_called_once()
-        call_args = mock_agent_bot._send_response.call_args
+        send_response_mock.assert_called_once()
+        call_args = send_response_mock.call_args
         assert "✅" in call_args.kwargs["response_text"] or "Task ID" in call_args.kwargs["response_text"]
         target = call_args[1].get("target")
         assert target is not None
@@ -405,7 +426,11 @@ class TestBotScheduleCommands:
         assert target.resolved_thread_id == event.event_id
 
     @pytest.mark.asyncio
-    async def test_command_response_uses_provided_stable_target(self, mock_agent_bot: AgentBot) -> None:
+    async def test_command_response_uses_provided_stable_target(
+        self,
+        mock_agent_bot: AgentBot,
+        send_response_mock: AsyncMock,
+    ) -> None:
         """Command delivery should use the resolved command target instead of rebuilding from the command event."""
         _sync_turn_policy_runtime(mock_agent_bot)
         room = MagicMock()
@@ -429,8 +454,8 @@ class TestBotScheduleCommands:
             target=stable_target,
         )
 
-        mock_agent_bot._send_response.assert_called_once()
-        delivered_target = mock_agent_bot._send_response.await_args.kwargs["target"]
+        send_response_mock.assert_called_once()
+        delivered_target = send_response_mock.await_args.kwargs["target"]
         assert delivered_target == stable_target
         assert delivered_target.resolved_thread_id is None
 
@@ -585,9 +610,9 @@ class TestCommandHandling:
         bot.client.user_id = bot.agent_user.user_id
         sync_bot_runtime_state(bot)
         bot.logger = MagicMock()
-        bot._generate_response = AsyncMock()
+        generate_response = AsyncMock()
         _sync_turn_policy_runtime(bot)
-        install_generate_response_mock(bot, bot._generate_response)
+        install_generate_response_mock(bot, generate_response)
         bot._conversation_resolver.extract_dispatch_context = AsyncMock()
 
         # Create a room and event
@@ -606,7 +631,7 @@ class TestCommandHandling:
         await drain_coalescing(bot)
 
         # Verify the agent didn't try to process the command
-        bot._generate_response.assert_not_called()
+        generate_response.assert_not_called()
         # Debug logging has been removed, so we just verify the behavior
 
     @pytest.mark.asyncio
@@ -837,9 +862,9 @@ class TestCommandHandling:
             bot.client.user_id = bot.agent_user.user_id
             sync_bot_runtime_state(bot)
             bot.logger = MagicMock()
-            bot._send_response = AsyncMock(return_value="$router_reply")
+            send_response = AsyncMock(return_value="$router_reply")
             _sync_turn_policy_runtime(bot)
-            install_send_response_mock(bot, bot._send_response)
+            install_send_response_mock(bot, send_response)
 
             room = nio.MatrixRoom(room_id="!test:server", own_user_id=bot.client.user_id)
             room.users = {
@@ -871,8 +896,8 @@ class TestCommandHandling:
                 await bot._on_message(room, event)
                 await drain_coalescing(bot)
 
-            bot._send_response.assert_called_once()
-            assert bot._send_response.await_args.kwargs["response_text"] == (
+            send_response.assert_called_once()
+            assert send_response.await_args.kwargs["response_text"] == (
                 "❌ Unknown command. Try !help for available commands."
             )
 
@@ -910,11 +935,11 @@ class TestCommandHandling:
         bot.client.user_id = bot.agent_user.user_id
         sync_bot_runtime_state(bot)
         bot.logger = MagicMock()
-        bot._send_response = AsyncMock(return_value="$placeholder")
-        bot._generate_response = AsyncMock(return_value="$response")
+        send_response = AsyncMock(return_value="$placeholder")
+        generate_response = AsyncMock(return_value="$response")
         _sync_turn_policy_runtime(bot)
-        install_send_response_mock(bot, bot._send_response)
-        install_generate_response_mock(bot, bot._generate_response)
+        install_send_response_mock(bot, send_response)
+        install_generate_response_mock(bot, generate_response)
         _sync_turn_policy_runtime(bot)
 
         # Mock context extraction to say agent is mentioned
@@ -949,7 +974,7 @@ class TestCommandHandling:
             await drain_coalescing(bot)
 
             # Verify the agent processed the message
-            bot._generate_response.assert_called_once()
+            generate_response.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_agents_ignore_error_messages_from_other_agents(self) -> None:
@@ -978,9 +1003,9 @@ class TestCommandHandling:
             bot.client.user_id = "@mindroom_general:localhost"  # Set the bot's user ID
             sync_bot_runtime_state(bot)
             bot.logger = MagicMock()
-            bot._generate_response = AsyncMock()
+            generate_response = AsyncMock()
             _sync_turn_policy_runtime(bot)
-            install_generate_response_mock(bot, bot._generate_response)
+            install_generate_response_mock(bot, generate_response)
 
             # Mock context extraction
             mock_context = _message_context(
@@ -1011,7 +1036,7 @@ class TestCommandHandling:
                 await drain_coalescing(bot)
 
             # Verify the agent didn't try to process the error message
-            bot._generate_response.assert_not_called()
+            generate_response.assert_not_called()
             # Check log calls - should be caught by the general agent message check
             debug_calls = [call[0][0] for call in bot.logger.debug.call_args_list]
             assert "ignore_unmentioned_agent_event" in debug_calls
@@ -1104,9 +1129,9 @@ class TestCommandHandling:
         bot.client.user_id = "@mindroom_finance:localhost"
         sync_bot_runtime_state(bot)
         bot.logger = MagicMock()
-        bot._generate_response = AsyncMock()
+        generate_response = AsyncMock()
         _sync_turn_policy_runtime(bot)
-        install_generate_response_mock(bot, bot._generate_response)
+        install_generate_response_mock(bot, generate_response)
 
         # Mock context extraction for router's error message
         mock_context = _message_context(
@@ -1137,7 +1162,7 @@ class TestCommandHandling:
             await drain_coalescing(bot)
 
         # Verify finance agent did NOT process the message
-        bot._generate_response.assert_not_called()
+        generate_response.assert_not_called()
 
         # Verify it was caught early by the agent message check
         debug_calls = [call[0][0] for call in bot.logger.debug.call_args_list]
@@ -1305,11 +1330,11 @@ class TestCommandHandling:
         bot.client.user_id = "@mindroom_news:localhost"
         sync_bot_runtime_state(bot)
         bot.logger = MagicMock()
-        bot._generate_response = AsyncMock()
-        bot._send_response = AsyncMock()
+        generate_response = AsyncMock()
+        send_response = AsyncMock()
         _sync_turn_policy_runtime(bot)
-        install_send_response_mock(bot, bot._send_response)
-        install_generate_response_mock(bot, bot._generate_response)
+        install_send_response_mock(bot, send_response)
+        install_generate_response_mock(bot, generate_response)
         bot.orchestrator = MagicMock()
         sync_bot_runtime_state(bot)
 
@@ -1384,8 +1409,8 @@ class TestCommandHandling:
         mock_interactive.assert_not_awaited()
 
         # Verify news agent did NOT form a team or respond
-        bot._generate_response.assert_not_called()
-        bot._send_response.assert_not_called()
+        generate_response.assert_not_called()
+        send_response.assert_not_called()
         mock_team.assert_not_called()
 
         # Verify it was logged as being ignored
@@ -1419,9 +1444,9 @@ class TestCommandHandling:
         bot.client.user_id = "@mindroom_finance:localhost"
         sync_bot_runtime_state(bot)
         bot.logger = MagicMock()
-        bot._generate_response = AsyncMock()
+        generate_response = AsyncMock()
         _sync_turn_policy_runtime(bot)
-        install_generate_response_mock(bot, bot._generate_response)
+        install_generate_response_mock(bot, generate_response)
 
         # Create thread history that mimics the real scenario
         thread_history = [
@@ -1512,7 +1537,7 @@ class TestCommandHandling:
         mock_interactive.assert_not_awaited()
 
         # Verify finance agent did NOT respond to router's error
-        bot._generate_response.assert_not_called()
+        generate_response.assert_not_called()
 
         # Verify it was logged as being ignored
         debug_calls = [call[0][0] for call in bot.logger.debug.call_args_list]
@@ -1543,9 +1568,9 @@ class TestCommandHandling:
         bot.client.user_id = "@mindroom_general:localhost"
         sync_bot_runtime_state(bot)
         bot.logger = MagicMock()
-        bot._generate_response = AsyncMock()
+        generate_response = AsyncMock()
         _sync_turn_policy_runtime(bot)
-        install_generate_response_mock(bot, bot._generate_response)
+        install_generate_response_mock(bot, generate_response)
 
         # Mock context extraction - no agents mentioned
         mock_context = _message_context(
@@ -1573,7 +1598,7 @@ class TestCommandHandling:
             await drain_coalescing(bot)
 
         # Verify the agent didn't try to process the message
-        bot._generate_response.assert_not_called()
+        generate_response.assert_not_called()
         # Check debug calls for the new log message
         debug_calls = [call[0][0] for call in bot.logger.debug.call_args_list]
         assert "ignore_unmentioned_agent_event" in debug_calls
@@ -2034,10 +2059,9 @@ class TestRouterSkipsSingleAgent:
         bot.client.user_id = bot.agent_user.user_id
         bot.logger = MagicMock()
         wrap_extracted_collaborators(bot, "_turn_policy")
-        bot._turn_controller._execute_command = AsyncMock()
         _sync_turn_policy_runtime(bot)
-        bot._send_response = AsyncMock()
-        _sync_turn_policy_runtime(bot)
+        send_response = AsyncMock()
+        install_send_response_mock(bot, send_response)
         bot._turn_controller._execute_command = AsyncMock()
 
         # Room with router + one agent + a human
@@ -2073,7 +2097,7 @@ class TestRouterSkipsSingleAgent:
         # This ensures commands work properly in single-responder rooms.
         bot._turn_controller._execute_command.assert_called_once()
         # Router should not send a response for unknown commands (handled by _handle_command)
-        bot._send_response.assert_not_called()
+        send_response.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_router_handles_schedule_command_in_single_agent_room(self) -> None:
@@ -2106,9 +2130,6 @@ class TestRouterSkipsSingleAgent:
         bot.client.user_id = bot.agent_user.user_id
         bot.logger = MagicMock()
         wrap_extracted_collaborators(bot, "_turn_policy")
-        bot._turn_controller._execute_command = AsyncMock()
-        _sync_turn_policy_runtime(bot)
-        bot._send_response = AsyncMock()
         _sync_turn_policy_runtime(bot)
         bot._turn_controller._execute_command = AsyncMock()
 

--- a/tests/test_config_commands.py
+++ b/tests/test_config_commands.py
@@ -29,6 +29,7 @@ from mindroom.commands.parsing import Command, CommandType, _CommandParser
 from mindroom.config.auth import AuthorizationConfig
 from mindroom.config.main import Config, ConfigRuntimeValidationError
 from mindroom.constants import resolve_runtime_paths
+from mindroom.delivery_gateway import SendTextRequest
 from mindroom.handled_turns import HandledTurnState
 from mindroom.hooks import HookRegistry
 from mindroom.matrix.state import MatrixState
@@ -808,7 +809,7 @@ async def test_handle_confirmation_reaction_respects_disabled_config_command(tmp
         _conversation_resolver=SimpleNamespace(
             build_message_target=MagicMock(return_value=target),
         ),
-        _send_response=AsyncMock(),
+        _delivery_gateway=MagicMock(send_text=AsyncMock(return_value="$event")),
     )
     room = SimpleNamespace(room_id="!room:example.org")
     event = SimpleNamespace(sender="@admin:example.org", key="✅", reacts_to="$preview")
@@ -830,10 +831,12 @@ async def test_handle_confirmation_reaction_respects_disabled_config_command(tmp
         await handle_confirmation_reaction(bot, room, event, pending_change)
 
     mock_apply.assert_not_awaited()
-    bot._send_response.assert_awaited_once_with(
-        target=target,
-        response_text="❌ Config command disabled.",
-        skip_mentions=True,
+    bot._delivery_gateway.send_text.assert_awaited_once_with(
+        SendTextRequest(
+            target=target,
+            response_text="❌ Config command disabled.",
+            skip_mentions=True,
+        ),
     )
 
 
@@ -853,7 +856,7 @@ async def test_handle_confirmation_reaction_requires_current_admin(tmp_path: Pat
         _conversation_resolver=SimpleNamespace(
             build_message_target=MagicMock(return_value=target),
         ),
-        _send_response=AsyncMock(),
+        _delivery_gateway=MagicMock(send_text=AsyncMock(return_value="$event")),
     )
     room = SimpleNamespace(room_id="!room:example.org")
     event = SimpleNamespace(sender="@admin:example.org", key="✅", reacts_to="$preview")
@@ -875,10 +878,12 @@ async def test_handle_confirmation_reaction_requires_current_admin(tmp_path: Pat
         await handle_confirmation_reaction(bot, room, event, pending_change)
 
     mock_apply.assert_not_awaited()
-    bot._send_response.assert_awaited_once_with(
-        target=target,
-        response_text="❌ Admin only.",
-        skip_mentions=True,
+    bot._delivery_gateway.send_text.assert_awaited_once_with(
+        SendTextRequest(
+            target=target,
+            response_text="❌ Admin only.",
+            skip_mentions=True,
+        ),
     )
 
 
@@ -899,7 +904,7 @@ async def test_handle_confirmation_reaction_accepts_alias_backed_requester(tmp_p
         _conversation_resolver=SimpleNamespace(
             build_message_target=MagicMock(return_value=target),
         ),
-        _send_response=AsyncMock(),
+        _delivery_gateway=MagicMock(send_text=AsyncMock(return_value="$event")),
     )
     room = SimpleNamespace(room_id="!room:example.org")
     event = SimpleNamespace(sender="@telegram_admin:example.org", key="✅", reacts_to="$preview")
@@ -929,10 +934,12 @@ async def test_handle_confirmation_reaction_accepts_alias_backed_requester(tmp_p
         False,
         runtime_paths=bot.runtime_paths,
     )
-    bot._send_response.assert_awaited_once_with(
-        target=target,
-        response_text="✅ Configuration updated successfully.",
-        skip_mentions=True,
+    bot._delivery_gateway.send_text.assert_awaited_once_with(
+        SendTextRequest(
+            target=target,
+            response_text="✅ Configuration updated successfully.",
+            skip_mentions=True,
+        ),
     )
 
 

--- a/tests/test_config_reload.py
+++ b/tests/test_config_reload.py
@@ -1377,8 +1377,8 @@ async def test_queued_config_reload_waits_for_in_flight_response_without_event_i
         runtime_paths=runtime_paths_for(config),
     )
     setup_test_bot(bot, AsyncMock())
-    bot._send_response = AsyncMock(return_value=None)
-    install_send_response_mock(bot, bot._send_response)
+    send_response = AsyncMock(return_value=None)
+    install_send_response_mock(bot, send_response)
 
     response_started = asyncio.Event()
     release_response = asyncio.Event()
@@ -1403,7 +1403,7 @@ async def test_queued_config_reload_waits_for_in_flight_response_without_event_i
 
     try:
         await asyncio.wait_for(response_started.wait(), timeout=1)
-        bot._send_response.assert_awaited_once()
+        send_response.assert_awaited_once()
         assert bot.in_flight_response_count == 1
 
         orchestrator.config_reload.request_reload()
@@ -2377,7 +2377,7 @@ async def test_in_flight_response_count_nonzero_during_send_response(
     tmp_path: Path,
     mock_agent_users: dict[str, AgentMatrixUser],
 ) -> None:
-    """in_flight_response_count must be >0 even while _send_response is still awaiting."""
+    """in_flight_response_count must be >0 even while the visible send is still awaiting."""
     config = _runtime_bound_config(
         Config(
             agents={"agent1": AgentConfig(display_name="Agent 1")},
@@ -2401,8 +2401,8 @@ async def test_in_flight_response_count_nonzero_during_send_response(
         await release_send.wait()
         return "$msg"
 
-    bot._send_response = AsyncMock(side_effect=slow_send)
-    install_send_response_mock(bot, bot._send_response)
+    send_response = AsyncMock(side_effect=slow_send)
+    install_send_response_mock(bot, send_response)
 
     async def response_function(message_id: str | None) -> None:
         pass
@@ -2417,7 +2417,7 @@ async def test_in_flight_response_count_nonzero_during_send_response(
 
     try:
         await asyncio.wait_for(send_entered.wait(), timeout=1)
-        # _send_response is blocked, but the pre-tracking sentinel must be visible
+        # The visible send is blocked, but the pre-tracking sentinel must be visible
         assert bot.in_flight_response_count >= 1
     finally:
         release_send.set()
@@ -2502,8 +2502,8 @@ async def test_run_cancellable_response_marks_thinking_placeholder_pending(
         captured_send["extra_content"] = extra_content
         return "$thinking"
 
-    bot._send_response = AsyncMock(side_effect=fake_send_response)
-    install_send_response_mock(bot, bot._send_response)
+    send_response = AsyncMock(side_effect=fake_send_response)
+    install_send_response_mock(bot, send_response)
 
     async def response_function(message_id: str | None) -> None:
         assert message_id == "$thinking"

--- a/tests/test_dm_functionality.py
+++ b/tests/test_dm_functionality.py
@@ -340,8 +340,8 @@ class TestDMIntegration:
             else "@mindroom_researcher:localhost"
         )
         bot.orchestrator = orchestrator
-        bot._generate_response = AsyncMock()
-        install_generate_response_mock(bot, bot._generate_response)
+        generate_response = AsyncMock()
+        install_generate_response_mock(bot, generate_response)
 
         # Mock helper functions
         async def mock_handle(*args: object, **kwargs: object) -> None:
@@ -405,8 +405,8 @@ class TestDMIntegration:
             await drain_coalescing(bot)
 
             # Verify the bot decided to respond even though not configured for the room
-            bot._generate_response.assert_called_once()
-            call_args = bot._generate_response.call_args
+            generate_response.assert_called_once()
+            call_args = generate_response.call_args
             assert call_args.kwargs["response_envelope"].target.room_id == "!dm:localhost"
             assert call_args.kwargs["prompt"] == "Hello researcher, can you help?"
 
@@ -438,8 +438,8 @@ class TestDMIntegration:
         bot.client = AsyncMock()
         bot.client.user_id = entity_ids(config, runtime_paths_for(config))["test_agent"].full_id
         bot.logger = MagicMock()
-        bot._generate_response = AsyncMock()
-        install_generate_response_mock(bot, bot._generate_response)
+        generate_response = AsyncMock()
+        install_generate_response_mock(bot, generate_response)
 
         async def mock_handle(*args: object, **kwargs: object) -> None:
             pass
@@ -498,7 +498,7 @@ class TestDMIntegration:
             await drain_coalescing(bot)
 
             # Verify the bot decided to respond in the DM room
-            bot._generate_response.assert_called_once()
-            call_args = bot._generate_response.call_args
+            generate_response.assert_called_once()
+            call_args = generate_response.call_args
             assert call_args[1]["response_envelope"].target.room_id == "!dm:localhost"
             assert call_args[1]["prompt"] == "Hello agent!"

--- a/tests/test_edit_event_handling.py
+++ b/tests/test_edit_event_handling.py
@@ -17,6 +17,7 @@ from mindroom.matrix.users import AgentMatrixUser
 from mindroom.turn_controller import _PrecheckedEvent
 from tests.conftest import (
     bind_runtime_paths,
+    install_generate_response_mock,
     install_runtime_cache_support,
     replace_turn_controller_deps,
     wrap_extracted_collaborators,
@@ -390,11 +391,10 @@ async def test_regular_agent_ignores_edits(tmp_path: Path) -> None:
         "sender": "@user:example.com",
     }
 
-    # Mock the generate_response method
-    with (
-        patch.object(bot, "_generate_response", new_callable=AsyncMock) as mock_generate,
-        patch.object(bot._turn_store, "load_turn", return_value=None),
-    ):
+    # Mock the generate_response seam covering both dispatch and edit-regeneration paths
+    mock_generate = AsyncMock()
+    install_generate_response_mock(bot, mock_generate)
+    with patch.object(bot._turn_store, "load_turn", return_value=None):
         # Process the edit event
         await bot._on_message(room, edit_event)
 

--- a/tests/test_edit_regenerator.py
+++ b/tests/test_edit_regenerator.py
@@ -209,15 +209,15 @@ async def test_simple_edit_regenerates_and_records_new_response(tmp_path: Path) 
     await _handle_edit(harness, event, event_info)
 
     harness.generate_response.assert_awaited_once()
-    call_kwargs = harness.generate_response.await_args.kwargs
-    assert call_kwargs["prompt"] == "what is 3+3?"
-    assert call_kwargs["existing_event_id"] == RESPONSE_EVENT_ID
-    assert call_kwargs["existing_event_is_placeholder"] is False
-    assert call_kwargs["user_id"] == USER_ID
-    assert call_kwargs["correlation_id"] == EDIT_EVENT_ID
-    assert call_kwargs["matrix_run_metadata"] == RUN_METADATA
-    assert call_kwargs["current_timestamp_ms"] == float(event.server_timestamp)
-    assert call_kwargs["thread_history"] == harness.context.thread_history
+    request = harness.generate_response.await_args.args[0]
+    assert request.prompt == "what is 3+3?"
+    assert request.existing_event_id == RESPONSE_EVENT_ID
+    assert request.existing_event_is_placeholder is False
+    assert request.user_id == USER_ID
+    assert request.correlation_id == EDIT_EVENT_ID
+    assert request.matrix_run_metadata == RUN_METADATA
+    assert request.current_timestamp_ms == float(event.server_timestamp)
+    assert request.thread_history == harness.context.thread_history
 
     envelope_kwargs = harness.resolver.build_message_envelope.call_args.kwargs
     assert envelope_kwargs["body"] == "what is 3+3?"
@@ -247,7 +247,7 @@ async def test_lifecycle_lock_callback_removes_stale_runs(tmp_path: Path) -> Non
 
     await _handle_edit(harness, event, event_info)
 
-    on_lock_acquired = harness.generate_response.await_args.kwargs["on_lifecycle_lock_acquired"]
+    on_lock_acquired = harness.generate_response.await_args.args[0].on_lifecycle_lock_acquired
     harness.turn_store.remove_stale_runs_for_edit.assert_not_called()
     on_lock_acquired()
     harness.turn_store.remove_stale_runs_for_edit.assert_called_once()
@@ -271,7 +271,7 @@ async def test_coalesced_edit_rebuilds_combined_prompt(tmp_path: Path) -> None:
     await _handle_edit(harness, event, event_info)
 
     expected_prompt = coalesced_prompt(["edited first message", "second message"])
-    assert harness.generate_response.await_args.kwargs["prompt"] == expected_prompt
+    assert harness.generate_response.await_args.args[0].prompt == expected_prompt
 
     metadata_call = harness.turn_store.build_run_metadata.call_args
     handled_turn = metadata_call.args[0]
@@ -309,7 +309,7 @@ async def test_coalesced_edit_preserves_tagged_source_metadata(tmp_path: Path) -
 
     await _handle_edit(harness, event, event_info)
 
-    assert harness.generate_response.await_args.kwargs["prompt"] == (
+    assert harness.generate_response.await_args.args[0].prompt == (
         "The user sent the following messages in quick succession. "
         "Treat them as one turn and respond once:\n\n"
         "<messages>\n"
@@ -319,7 +319,7 @@ async def test_coalesced_edit_preserves_tagged_source_metadata(tmp_path: Path) -
         "<![CDATA[second message]]></msg>\n"
         "</messages>"
     )
-    assert harness.generate_response.await_args.kwargs["current_prompt_is_structured"] is True
+    assert harness.generate_response.await_args.args[0].current_prompt_is_structured is True
 
     handled_turn = harness.turn_store.build_run_metadata.call_args.args[0]
     assert handled_turn.source_event_metadata == record.source_event_metadata
@@ -501,7 +501,7 @@ async def test_edit_context_realigned_to_recorded_thread_root(tmp_path: Path) ->
         THREAD_ID,
         caller_label="edit_regeneration_context",
     )
-    assert harness.generate_response.await_args.kwargs["thread_history"] == refetched_history
+    assert harness.generate_response.await_args.args[0].thread_history == refetched_history
 
 
 @pytest.mark.asyncio

--- a/tests/test_edit_response_regeneration.py
+++ b/tests/test_edit_response_regeneration.py
@@ -266,13 +266,12 @@ def _handled_response_event_id(outcome: FinalDeliveryOutcome | str | None) -> st
 
 def _generate_response_with_locked_callback(
     response_event_id: str | None,
-) -> Callable[..., Awaitable[str | None]]:
+) -> Callable[[ResponseRequest], Awaitable[str | None]]:
     """Execute locked edit cleanup in mocked response generation paths."""
 
-    async def _generate_response(*_args: object, **kwargs: object) -> str | None:
-        locked_callback = kwargs.get("on_lifecycle_lock_acquired")
-        if locked_callback is not None:
-            locked_callback()
+    async def _generate_response(request: ResponseRequest) -> str | None:
+        if request.on_lifecycle_lock_acquired is not None:
+            request.on_lifecycle_lock_acquired()
         return response_event_id
 
     return _generate_response
@@ -715,6 +714,8 @@ async def test_handle_message_edit_reuses_persisted_target_and_thread_scope(
         "sender": "@user:example.com",
     }
 
+    mock_generate_response = AsyncMock(side_effect=_generate_response_with_locked_callback("$response:example.com"))
+    replace_edit_regenerator_deps(bot, generate_response=mock_generate_response)
     with (
         patch.object(bot._conversation_resolver, "extract_message_context", new_callable=AsyncMock) as mock_context,
         patch.object(
@@ -728,12 +729,6 @@ async def test_handle_message_edit_reuses_persisted_target_and_thread_scope(
             "_remove_stale_runs_for_turn_record",
             return_value=True,
         ) as mock_remove_stale_runs,
-        patch.object(
-            bot,
-            "_generate_response",
-            new_callable=AsyncMock,
-            side_effect=_generate_response_with_locked_callback("$response:example.com"),
-        ) as mock_generate_response,
     ):
         mock_context.return_value = MagicMock(
             am_i_mentioned=False,
@@ -757,8 +752,8 @@ async def test_handle_message_edit_reuses_persisted_target_and_thread_scope(
         caller_label="edit_regeneration_context",
     )
     mock_remove_stale_runs.assert_called_once()
-    call_kwargs = mock_generate_response.call_args.kwargs
-    response_target = call_kwargs["response_envelope"].target
+    request = mock_generate_response.call_args.args[0]
+    response_target = request.response_envelope.target
     assert response_target.reply_to_event_id == "$router-echo:example.com"
     assert response_target.resolved_thread_id == stored_target.resolved_thread_id
     assert response_target == stored_target
@@ -1057,9 +1052,10 @@ async def test_bot_ignores_edit_without_previous_response(tmp_path: Path) -> Non
     }
 
     # Mock the methods
+    mock_generate = AsyncMock()
+    install_generate_response_mock(bot, mock_generate)
     with (
         patch.object(bot._conversation_resolver, "extract_message_context", new_callable=AsyncMock),
-        patch.object(bot, "_generate_response", new_callable=AsyncMock) as mock_generate,
         patch.object(bot, "_edit_message", new_callable=AsyncMock) as mock_edit,
     ):
         # Process the edit event
@@ -1373,6 +1369,8 @@ async def test_handle_message_edit_rebuilds_coalesced_prompt_for_non_primary_edi
         "sender": "@user:example.com",
     }
 
+    mock_generate_response = AsyncMock(side_effect=_generate_response_with_locked_callback("$response:example.com"))
+    replace_edit_regenerator_deps(bot, generate_response=mock_generate_response)
     with (
         patch.object(bot._conversation_resolver, "extract_message_context", new_callable=AsyncMock) as mock_context,
         patch.object(
@@ -1380,12 +1378,6 @@ async def test_handle_message_edit_rebuilds_coalesced_prompt_for_non_primary_edi
             "create_storage",
         ) as mock_create_storage,
         patch("mindroom.turn_store.remove_run_by_event_id", return_value=True) as mock_remove_run,
-        patch.object(
-            bot,
-            "_generate_response",
-            new_callable=AsyncMock,
-            side_effect=_generate_response_with_locked_callback("$response:example.com"),
-        ) as mock_generate_response,
     ):
         mock_context.return_value = MagicMock(
             am_i_mentioned=False,
@@ -1404,15 +1396,15 @@ async def test_handle_message_edit_rebuilds_coalesced_prompt_for_non_primary_edi
         )
 
         mock_generate_response.assert_awaited_once()
-        call_kwargs = mock_generate_response.call_args.kwargs
-        assert call_kwargs["prompt"] == (
+        request = mock_generate_response.call_args.args[0]
+        assert request.prompt == (
             "The user sent the following messages in quick succession. "
             "Treat them as one turn and respond once:\n\nupdated first\nprimary"
         )
-        response_target = call_kwargs["response_envelope"].target
+        response_target = request.response_envelope.target
         assert response_target.reply_to_event_id == "$primary:example.com"
         assert response_target == stored_target
-        assert call_kwargs["matrix_run_metadata"] == {
+        assert request.matrix_run_metadata == {
             "matrix_source_event_ids": ["$first:example.com", "$primary:example.com"],
             "matrix_source_event_prompts": {
                 "$first:example.com": "updated first",
@@ -1524,6 +1516,8 @@ async def test_handle_message_edit_reuses_existing_response_without_placeholder_
         "sender": "@user:example.com",
     }
 
+    mock_generate_response = AsyncMock(side_effect=_generate_response_with_locked_callback("$response:example.com"))
+    replace_edit_regenerator_deps(bot, generate_response=mock_generate_response)
     with (
         patch.object(bot._conversation_resolver, "extract_message_context", new_callable=AsyncMock) as mock_context,
         patch.object(
@@ -1531,12 +1525,6 @@ async def test_handle_message_edit_reuses_existing_response_without_placeholder_
             "create_storage",
         ),
         patch("mindroom.turn_store.remove_run_by_event_id", return_value=False) as mock_remove_run,
-        patch.object(
-            bot,
-            "_generate_response",
-            new_callable=AsyncMock,
-            side_effect=_generate_response_with_locked_callback("$response:example.com"),
-        ) as mock_generate_response,
     ):
         mock_context.return_value = MagicMock(
             am_i_mentioned=True,
@@ -1555,11 +1543,11 @@ async def test_handle_message_edit_reuses_existing_response_without_placeholder_
         )
 
         mock_generate_response.assert_awaited_once()
-        call_kwargs = mock_generate_response.call_args.kwargs
-        response_target = call_kwargs["response_envelope"].target
+        request = mock_generate_response.call_args.args[0]
+        response_target = request.response_envelope.target
         assert response_target.reply_to_event_id == "$original:example.com"
-        assert call_kwargs["existing_event_id"] == "$response:example.com"
-        assert call_kwargs["existing_event_is_placeholder"] is False
+        assert request.existing_event_id == "$response:example.com"
+        assert request.existing_event_is_placeholder is False
         assert response_target == stored_target
         assert _response_event_id(bot, "$original:example.com") == "$response:example.com"
         mock_remove_run.assert_called_once()
@@ -1644,6 +1632,8 @@ async def test_handle_message_edit_does_not_remark_response_when_regeneration_is
         "sender": "@user:example.com",
     }
 
+    mock_generate_response = AsyncMock(side_effect=_generate_response_with_locked_callback(None))
+    replace_edit_regenerator_deps(bot, generate_response=mock_generate_response)
     with (
         patch.object(bot._conversation_resolver, "extract_message_context", new_callable=AsyncMock) as mock_context,
         patch.object(
@@ -1651,12 +1641,6 @@ async def test_handle_message_edit_does_not_remark_response_when_regeneration_is
             "create_storage",
         ),
         patch("mindroom.turn_store.remove_run_by_event_id", return_value=False) as mock_remove_run,
-        patch.object(
-            bot,
-            "_generate_response",
-            new_callable=AsyncMock,
-            side_effect=_generate_response_with_locked_callback(None),
-        ) as mock_generate_response,
     ):
         mock_context.return_value = MagicMock(
             am_i_mentioned=True,
@@ -1759,12 +1743,13 @@ async def test_handle_message_edit_does_not_mark_regeneration_success_when_exist
         "sender": "@user:example.com",
     }
 
-    async def fail_visible_update(*_args: object, **kwargs: object) -> str | None:
-        locked_callback = kwargs.get("on_lifecycle_lock_acquired")
-        if locked_callback is not None:
-            locked_callback()
+    async def fail_visible_update(request: ResponseRequest) -> str | None:
+        if request.on_lifecycle_lock_acquired is not None:
+            request.on_lifecycle_lock_acquired()
         return "$response:example.com"
 
+    mock_generate_response = AsyncMock(side_effect=fail_visible_update)
+    replace_edit_regenerator_deps(bot, generate_response=mock_generate_response)
     with (
         patch.object(bot._conversation_resolver, "extract_message_context", new_callable=AsyncMock) as mock_context,
         patch.object(
@@ -1772,12 +1757,6 @@ async def test_handle_message_edit_does_not_mark_regeneration_success_when_exist
             "create_storage",
         ),
         patch("mindroom.turn_store.remove_run_by_event_id", return_value=False) as mock_remove_run,
-        patch.object(
-            bot,
-            "_generate_response",
-            new_callable=AsyncMock,
-            side_effect=fail_visible_update,
-        ) as mock_generate_response,
     ):
         mock_context.return_value = MagicMock(
             am_i_mentioned=True,
@@ -1897,6 +1876,8 @@ async def test_handle_message_edit_rebuilds_coalesced_prompt_from_persisted_run_
         ],
     )
 
+    mock_generate_response = AsyncMock(side_effect=_generate_response_with_locked_callback("$response:example.com"))
+    replace_edit_regenerator_deps(bot, generate_response=mock_generate_response)
     with (
         patch.object(bot._conversation_resolver, "extract_message_context", new_callable=AsyncMock) as mock_context,
         patch.object(
@@ -1910,12 +1891,6 @@ async def test_handle_message_edit_rebuilds_coalesced_prompt_from_persisted_run_
             return_value=storage,
         ),
         patch("mindroom.turn_store.remove_run_by_event_id", return_value=True) as mock_remove_run,
-        patch.object(
-            bot,
-            "_generate_response",
-            new_callable=AsyncMock,
-            side_effect=_generate_response_with_locked_callback("$response:example.com"),
-        ) as mock_generate_response,
     ):
         mock_context.return_value = MagicMock(
             am_i_mentioned=False,
@@ -1934,15 +1909,15 @@ async def test_handle_message_edit_rebuilds_coalesced_prompt_from_persisted_run_
         )
 
         mock_generate_response.assert_awaited_once()
-        call_kwargs = mock_generate_response.call_args.kwargs
-        assert call_kwargs["prompt"] == (
+        request = mock_generate_response.call_args.args[0]
+        assert request.prompt == (
             "The user sent the following messages in quick succession. "
             "Treat them as one turn and respond once:\n\nupdated first\nprimary"
         )
-        response_target = call_kwargs["response_envelope"].target
+        response_target = request.response_envelope.target
         assert response_target.reply_to_event_id == "$primary:example.com"
         assert response_target == stored_target
-        assert call_kwargs["matrix_run_metadata"] == {
+        assert request.matrix_run_metadata == {
             "matrix_source_event_ids": ["$first:example.com", "$primary:example.com"],
             "matrix_source_event_prompts": {
                 "$first:example.com": "updated first",
@@ -2207,15 +2182,11 @@ async def test_handle_message_edit_uses_persisted_interrupted_response_event_id_
         "sender": "@user:example.com",
     }
 
+    mock_generate_response = AsyncMock(return_value=_delivery_resolution(None))
+    replace_edit_regenerator_deps(bot, generate_response=mock_generate_response)
     with (
         patch.object(bot._conversation_state_writer, "create_storage", return_value=storage),
         patch.object(bot._conversation_resolver, "extract_message_context", new_callable=AsyncMock) as mock_context,
-        patch.object(
-            bot,
-            "_generate_response",
-            new_callable=AsyncMock,
-            return_value=_delivery_resolution(None),
-        ) as mock_generate_response,
     ):
         mock_context.return_value = MagicMock(
             am_i_mentioned=False,
@@ -2235,9 +2206,9 @@ async def test_handle_message_edit_uses_persisted_interrupted_response_event_id_
         )
 
     mock_generate_response.assert_awaited_once()
-    call_kwargs = mock_generate_response.call_args.kwargs
-    assert call_kwargs["existing_event_id"] == "$partial-response:example.com"
-    assert call_kwargs["response_envelope"].target.reply_to_event_id == "$original:example.com"
+    request = mock_generate_response.call_args.args[0]
+    assert request.existing_event_id == "$partial-response:example.com"
+    assert request.response_envelope.target.reply_to_event_id == "$original:example.com"
     assert _response_event_id(bot, "$original:example.com") == "$partial-response:example.com"
 
 
@@ -2345,15 +2316,11 @@ async def test_handle_message_edit_uses_persisted_interrupted_response_event_id_
         "sender": "@user:example.com",
     }
 
+    mock_generate_response = AsyncMock(return_value=_delivery_resolution(None))
+    replace_edit_regenerator_deps(bot, generate_response=mock_generate_response)
     with (
         patch.object(bot._conversation_state_writer, "create_storage", return_value=storage),
         patch.object(bot._conversation_resolver, "extract_message_context", new_callable=AsyncMock) as mock_context,
-        patch.object(
-            bot,
-            "_generate_response",
-            new_callable=AsyncMock,
-            return_value=_delivery_resolution(None),
-        ) as mock_generate_response,
     ):
         mock_context.return_value = MagicMock(
             am_i_mentioned=False,
@@ -2373,14 +2340,14 @@ async def test_handle_message_edit_uses_persisted_interrupted_response_event_id_
         )
 
     mock_generate_response.assert_awaited_once()
-    call_kwargs = mock_generate_response.call_args.kwargs
-    assert call_kwargs["existing_event_id"] == "$partial-response:example.com"
-    assert call_kwargs["response_envelope"].target.reply_to_event_id == "$anchor:example.com"
-    assert call_kwargs["prompt"] == (
+    request = mock_generate_response.call_args.args[0]
+    assert request.existing_event_id == "$partial-response:example.com"
+    assert request.response_envelope.target.reply_to_event_id == "$anchor:example.com"
+    assert request.prompt == (
         "The user sent the following messages in quick succession. "
         "Treat them as one turn and respond once:\n\nupdated first\nanchor"
     )
-    assert call_kwargs["matrix_run_metadata"] == {
+    assert request.matrix_run_metadata == {
         MATRIX_SOURCE_EVENT_IDS_METADATA_KEY: ["$first:example.com", "$anchor:example.com"],
         "matrix_source_event_prompts": {
             "$first:example.com": "updated first",
@@ -2504,15 +2471,11 @@ async def test_team_handle_message_edit_uses_persisted_interrupted_response_even
         "sender": "@user:example.com",
     }
 
+    mock_generate_response = AsyncMock(return_value=_delivery_resolution(None))
+    replace_edit_regenerator_deps(bot, generate_response=mock_generate_response)
     with (
         patch.object(bot._conversation_state_writer, "create_storage", return_value=storage),
         patch.object(bot._conversation_resolver, "extract_message_context", new_callable=AsyncMock) as mock_context,
-        patch.object(
-            bot,
-            "_generate_response",
-            new_callable=AsyncMock,
-            return_value=_delivery_resolution(None),
-        ) as mock_generate_response,
     ):
         mock_context.return_value = MagicMock(
             am_i_mentioned=True,
@@ -2532,9 +2495,9 @@ async def test_team_handle_message_edit_uses_persisted_interrupted_response_even
         )
 
     mock_generate_response.assert_awaited_once()
-    call_kwargs = mock_generate_response.call_args.kwargs
-    assert call_kwargs["existing_event_id"] == "$team-partial-response:example.com"
-    assert call_kwargs["response_envelope"].target.reply_to_event_id == "$original:example.com"
+    request = mock_generate_response.call_args.args[0]
+    assert request.existing_event_id == "$team-partial-response:example.com"
+    assert request.response_envelope.target.reply_to_event_id == "$original:example.com"
     assert _response_event_id(bot, "$original:example.com") == "$team-partial-response:example.com"
 
 
@@ -2659,9 +2622,9 @@ async def test_edit_regenerator_preserves_interactive_selection_run_metadata(tmp
         )
 
     generate_response.assert_awaited_once()
-    call_kwargs = generate_response.call_args.kwargs
-    assert call_kwargs["response_envelope"].target.reply_to_event_id == "$selection:example.com"
-    assert call_kwargs["matrix_run_metadata"] == {
+    request = generate_response.call_args.args[0]
+    assert request.response_envelope.target.reply_to_event_id == "$selection:example.com"
+    assert request.matrix_run_metadata == {
         MATRIX_SOURCE_EVENT_IDS_METADATA_KEY: ["$selection:example.com"],
         **_run_response_context_metadata(
             response_owner="test_agent",
@@ -2960,26 +2923,21 @@ async def test_handle_message_edit_skips_when_turn_context_was_not_recorded(
     }
     cleanup_called = False
 
-    async def generate_response_with_locked_cleanup(*_args: object, **kwargs: object) -> str | None:
+    async def generate_response_with_locked_cleanup(request: ResponseRequest) -> str | None:
         nonlocal cleanup_called
-        locked_cleanup = kwargs["on_lifecycle_lock_acquired"]
-        assert locked_cleanup is not None
-        locked_cleanup()
+        assert request.on_lifecycle_lock_acquired is not None
+        request.on_lifecycle_lock_acquired()
         cleanup_called = True
         return _delivery_resolution("$response:example.com")
 
+    mock_generate_response = AsyncMock(side_effect=generate_response_with_locked_cleanup)
+    replace_edit_regenerator_deps(bot, generate_response=mock_generate_response)
     with (
         patch.object(bot._conversation_resolver, "extract_message_context", new_callable=AsyncMock) as mock_context,
         patch.object(
             bot._turn_store,
             "_remove_stale_runs_for_turn_record",
         ) as mock_recorded_cleanup,
-        patch.object(
-            bot,
-            "_generate_response",
-            new_callable=AsyncMock,
-            side_effect=generate_response_with_locked_cleanup,
-        ) as mock_generate_response,
     ):
         mock_context.return_value = MagicMock(
             am_i_mentioned=False,
@@ -3113,30 +3071,32 @@ async def test_handle_message_edit_recovers_missing_ledger_row_from_persisted_ru
             should_use_streaming=AsyncMock(return_value=False),
         ),
     ):
-        resolution = await bot._generate_response(
-            prompt="primary",
-            thread_history=[],
-            user_id="@user:example.com",
-            response_envelope=request_envelope(
-                room_id="!test:example.com",
-                reply_to_event_id="$primary:example.com",
+        resolution = await bot._response_runner.generate_response(
+            ResponseRequest(
                 prompt="primary",
+                thread_history=[],
                 user_id="@user:example.com",
-                target=conversation_target,
-                agent_name=bot.agent_name,
-            ),
-            matrix_run_metadata={
-                "matrix_source_event_ids": ["$first:example.com", "$primary:example.com"],
-                "matrix_source_event_prompts": {
-                    "$first:example.com": "first",
-                    "$primary:example.com": "primary",
-                },
-                **_run_response_context_metadata(
-                    response_owner=bot.agent_name,
-                    history_scope=history_scope,
-                    conversation_target=conversation_target,
+                response_envelope=request_envelope(
+                    room_id="!test:example.com",
+                    reply_to_event_id="$primary:example.com",
+                    prompt="primary",
+                    user_id="@user:example.com",
+                    target=conversation_target,
+                    agent_name=bot.agent_name,
                 ),
-            },
+                matrix_run_metadata={
+                    "matrix_source_event_ids": ["$first:example.com", "$primary:example.com"],
+                    "matrix_source_event_prompts": {
+                        "$first:example.com": "first",
+                        "$primary:example.com": "primary",
+                    },
+                    **_run_response_context_metadata(
+                        response_owner=bot.agent_name,
+                        history_scope=history_scope,
+                        conversation_target=conversation_target,
+                    ),
+                },
+            ),
         )
 
     assert _handled_response_event_id(resolution) == "$response:example.com"
@@ -3145,6 +3105,8 @@ async def test_handle_message_edit_recovers_missing_ledger_row_from_persisted_ru
     assert persisted_metadata is not None
     assert persisted_metadata["matrix_response_event_id"] == "$response:example.com"
 
+    mock_generate_response = AsyncMock(return_value=_delivery_resolution(None))
+    replace_edit_regenerator_deps(bot, generate_response=mock_generate_response)
     with (
         patch.object(bot._conversation_resolver, "extract_message_context", new_callable=AsyncMock) as mock_context,
         patch.object(
@@ -3153,12 +3115,6 @@ async def test_handle_message_edit_recovers_missing_ledger_row_from_persisted_ru
             return_value=storage,
         ),
         patch("mindroom.turn_store.remove_run_by_event_id", return_value=True),
-        patch.object(
-            bot,
-            "_generate_response",
-            new_callable=AsyncMock,
-            return_value=_delivery_resolution(None),
-        ) as mock_generate_response,
     ):
         mock_context.return_value = MagicMock(
             am_i_mentioned=False,
@@ -3177,13 +3133,13 @@ async def test_handle_message_edit_recovers_missing_ledger_row_from_persisted_ru
         )
 
         mock_generate_response.assert_awaited_once()
-        call_kwargs = mock_generate_response.call_args.kwargs
-        assert call_kwargs["prompt"] == (
+        request = mock_generate_response.call_args.args[0]
+        assert request.prompt == (
             "The user sent the following messages in quick succession. "
             "Treat them as one turn and respond once:\n\nupdated first\nprimary"
         )
-        assert call_kwargs["response_envelope"].target == conversation_target
-        assert call_kwargs["matrix_run_metadata"] == {
+        assert request.response_envelope.target == conversation_target
+        assert request.matrix_run_metadata == {
             "matrix_source_event_ids": ["$first:example.com", "$primary:example.com"],
             "matrix_source_event_prompts": {
                 "$first:example.com": "updated first",
@@ -3306,6 +3262,8 @@ async def test_handle_message_edit_recovers_threaded_turn_using_resolved_context
         ),
     )
 
+    mock_generate_response = AsyncMock(return_value=_delivery_resolution(None))
+    replace_edit_regenerator_deps(bot, generate_response=mock_generate_response)
     with (
         patch.object(
             bot._conversation_resolver,
@@ -3327,12 +3285,6 @@ async def test_handle_message_edit_recovers_threaded_turn_using_resolved_context
             side_effect=[threaded_storage, room_storage],
         ),
         patch("mindroom.turn_store.remove_run_by_event_id", return_value=True),
-        patch.object(
-            bot,
-            "_generate_response",
-            new_callable=AsyncMock,
-            return_value=_delivery_resolution(None),
-        ) as mock_generate_response,
     ):
         await bot._edit_regenerator.handle_message_edit(
             room,
@@ -3342,10 +3294,10 @@ async def test_handle_message_edit_recovers_threaded_turn_using_resolved_context
         )
 
     mock_generate_response.assert_awaited_once()
-    call_kwargs = mock_generate_response.call_args.kwargs
-    response_target = call_kwargs["response_envelope"].target
+    request = mock_generate_response.call_args.args[0]
+    response_target = request.response_envelope.target
     assert response_target.resolved_thread_id == "$thread_root:example.com"
-    assert call_kwargs["existing_event_id"] == "$response:example.com"
+    assert request.existing_event_id == "$response:example.com"
     assert response_target.reply_to_event_id == "$primary:example.com"
 
 
@@ -3449,6 +3401,8 @@ async def test_handle_message_edit_recovers_missing_single_turn_without_rerunnin
         ],
     )
 
+    mock_generate_response = AsyncMock(side_effect=_generate_response_with_locked_callback("$response:example.com"))
+    replace_edit_regenerator_deps(bot, generate_response=mock_generate_response)
     with (
         patch.object(bot._conversation_resolver, "extract_message_context", new_callable=AsyncMock) as mock_context,
         patch.object(
@@ -3457,12 +3411,6 @@ async def test_handle_message_edit_recovers_missing_single_turn_without_rerunnin
             return_value=storage,
         ),
         patch("mindroom.turn_store.remove_run_by_event_id", return_value=True),
-        patch.object(
-            bot,
-            "_generate_response",
-            new_callable=AsyncMock,
-            side_effect=_generate_response_with_locked_callback("$response:example.com"),
-        ) as mock_generate_response,
     ):
         mock_context.return_value = MagicMock(
             am_i_mentioned=False,
@@ -3481,10 +3429,10 @@ async def test_handle_message_edit_recovers_missing_single_turn_without_rerunnin
         )
 
     mock_generate_response.assert_awaited_once()
-    call_kwargs = mock_generate_response.call_args.kwargs
-    assert call_kwargs["existing_event_id"] == "$response:example.com"
-    assert call_kwargs["response_envelope"].target.reply_to_event_id == "$original:example.com"
-    assert call_kwargs["prompt"] == "updated question"
+    request = mock_generate_response.call_args.args[0]
+    assert request.existing_event_id == "$response:example.com"
+    assert request.response_envelope.target.reply_to_event_id == "$original:example.com"
+    assert request.prompt == "updated question"
     assert _response_event_id(bot, "$original:example.com") == "$response:example.com"
 
 
@@ -3580,23 +3528,25 @@ async def test_handle_message_edit_prefers_persisted_response_event_id_after_res
         patch("mindroom.response_runner.mark_auto_flush_dirty_session"),
         patch.object(Config, "_agent_memory_backend", return_value="none"),
     ):
-        resolution = await bot._generate_response(
-            prompt="original",
-            thread_history=[],
-            user_id="@user:example.com",
-            response_envelope=request_envelope(
-                room_id="!test:example.com",
-                reply_to_event_id="$original:example.com",
+        resolution = await bot._response_runner.generate_response(
+            ResponseRequest(
                 prompt="original",
+                thread_history=[],
                 user_id="@user:example.com",
-                agent_name=bot.agent_name,
-            ),
-            matrix_run_metadata={
-                "matrix_source_event_ids": ["$original:example.com"],
-                "matrix_source_event_prompts": {
-                    "$original:example.com": "original",
+                response_envelope=request_envelope(
+                    room_id="!test:example.com",
+                    reply_to_event_id="$original:example.com",
+                    prompt="original",
+                    user_id="@user:example.com",
+                    agent_name=bot.agent_name,
+                ),
+                matrix_run_metadata={
+                    "matrix_source_event_ids": ["$original:example.com"],
+                    "matrix_source_event_prompts": {
+                        "$original:example.com": "original",
+                    },
                 },
-            },
+            ),
         )
 
     assert _handled_response_event_id(resolution) == "$response-new:example.com"
@@ -3660,6 +3610,8 @@ async def test_handle_message_edit_prefers_persisted_response_event_id_after_res
         "sender": "@user:example.com",
     }
 
+    mock_generate_response = AsyncMock(return_value=_delivery_resolution(None))
+    replace_edit_regenerator_deps(restarted_bot, generate_response=mock_generate_response)
     with (
         patch.object(
             restarted_bot._conversation_resolver,
@@ -3667,12 +3619,6 @@ async def test_handle_message_edit_prefers_persisted_response_event_id_after_res
             new_callable=AsyncMock,
         ) as mock_context,
         patch("mindroom.turn_store.remove_run_by_event_id", return_value=True),
-        patch.object(
-            restarted_bot,
-            "_generate_response",
-            new_callable=AsyncMock,
-            return_value=_delivery_resolution(None),
-        ) as mock_generate_response,
     ):
         mock_context.return_value = MagicMock(
             am_i_mentioned=True,
@@ -3691,9 +3637,9 @@ async def test_handle_message_edit_prefers_persisted_response_event_id_after_res
         )
 
     mock_generate_response.assert_awaited_once()
-    call_kwargs = mock_generate_response.call_args.kwargs
-    assert call_kwargs["existing_event_id"] == "$response-new:example.com"
-    assert call_kwargs["response_envelope"].target.session_id == "!test:example.com"
+    request = mock_generate_response.call_args.args[0]
+    assert request.existing_event_id == "$response-new:example.com"
+    assert request.response_envelope.target.session_id == "!test:example.com"
     assert _response_event_id(restarted_bot, "$original:example.com") == "$response-new:example.com"
 
 

--- a/tests/test_interactive_thread_fix.py
+++ b/tests/test_interactive_thread_fix.py
@@ -22,6 +22,7 @@ from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.final_delivery import FinalDeliveryOutcome, StreamTransportOutcome
 from mindroom.matrix.users import AgentMatrixUser
+from mindroom.response_runner import ResponseRequest
 from tests.conftest import (
     bind_runtime_paths,
     delivered_matrix_side_effect,
@@ -129,17 +130,19 @@ async def test_interactive_question_preserves_thread_root_in_streaming(tmp_path:
         user_message_id = "$user_original_message"
         thread_id = user_message_id
 
-        resolution = await bot._generate_response(
-            prompt="Test prompt",
-            thread_history=[],
-            user_id="@user:localhost",
-            response_envelope=request_envelope(
-                room_id=room_id,
-                reply_to_event_id=user_message_id,
-                thread_id=thread_id,
+        resolution = await bot._response_runner.generate_response(
+            ResponseRequest(
                 prompt="Test prompt",
+                thread_history=[],
                 user_id="@user:localhost",
-                agent_name="general",
+                response_envelope=request_envelope(
+                    room_id=room_id,
+                    reply_to_event_id=user_message_id,
+                    thread_id=thread_id,
+                    prompt="Test prompt",
+                    user_id="@user:localhost",
+                    agent_name="general",
+                ),
             ),
         )
         if scheduled_tasks:
@@ -232,17 +235,19 @@ async def test_interactive_question_preserves_thread_root_in_non_streaming(tmp_p
         room_id = "!test:localhost"
         user_message_id = "$user_thread_start"
         thread_id = user_message_id
-        resolution = await bot._generate_response(
-            prompt="Test prompt",
-            thread_history=[],
-            user_id="@user:localhost",
-            response_envelope=request_envelope(
-                room_id=room_id,
-                reply_to_event_id=user_message_id,
-                thread_id=thread_id,
+        resolution = await bot._response_runner.generate_response(
+            ResponseRequest(
                 prompt="Test prompt",
+                thread_history=[],
                 user_id="@user:localhost",
-                agent_name="general",
+                response_envelope=request_envelope(
+                    room_id=room_id,
+                    reply_to_event_id=user_message_id,
+                    thread_id=thread_id,
+                    prompt="Test prompt",
+                    user_id="@user:localhost",
+                    agent_name="general",
+                ),
             ),
         )
         if scheduled_tasks:
@@ -323,16 +328,18 @@ async def test_interactive_question_without_thread_streaming(tmp_path: Path) -> 
         install_runtime_cache_support(bot)
 
         room_id = "!test:localhost"
-        resolution = await bot._generate_response(
-            prompt="Test prompt",
-            thread_history=[],
-            user_id="@user:localhost",
-            response_envelope=request_envelope(
-                room_id=room_id,
-                reply_to_event_id="$some_message",
+        resolution = await bot._response_runner.generate_response(
+            ResponseRequest(
                 prompt="Test prompt",
+                thread_history=[],
                 user_id="@user:localhost",
-                agent_name="general",
+                response_envelope=request_envelope(
+                    room_id=room_id,
+                    reply_to_event_id="$some_message",
+                    prompt="Test prompt",
+                    user_id="@user:localhost",
+                    agent_name="general",
+                ),
             ),
         )
 

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -4853,10 +4853,10 @@ async def test_thread_history_guard_does_not_interfere_with_normal_dispatch(tmp_
     )
     dispatch = _prepared_dispatch(event_id="$m1", body="hello")
     dispatch.context.thread_history = []
-    bot._send_response = AsyncMock(return_value="$placeholder")
-    bot._generate_response = AsyncMock(return_value="$response")
-    install_send_response_mock(bot, bot._send_response)
-    install_generate_response_mock(bot, bot._generate_response)
+    send_response = AsyncMock(return_value="$placeholder")
+    generate_response = AsyncMock(return_value="$response")
+    install_send_response_mock(bot, send_response)
+    install_generate_response_mock(bot, generate_response)
 
     with (
         patch.object(
@@ -5159,10 +5159,10 @@ async def test_newer_command_does_not_suppress_older_message(tmp_path: Path) -> 
         latest_event_id="$m2",
     )
     _set_context_histories(dispatch, [newer_cmd])
-    bot._send_response = AsyncMock(return_value="$placeholder")
-    bot._generate_response = AsyncMock(return_value="$response")
-    install_send_response_mock(bot, bot._send_response)
-    install_generate_response_mock(bot, bot._generate_response)
+    send_response = AsyncMock(return_value="$placeholder")
+    generate_response = AsyncMock(return_value="$response")
+    install_send_response_mock(bot, send_response)
+    install_generate_response_mock(bot, generate_response)
 
     action_mock = AsyncMock(return_value=_respond_dispatch_plan())
     with (
@@ -5209,10 +5209,10 @@ async def test_newer_command_with_whitespace_does_not_suppress(tmp_path: Path) -
         latest_event_id="$m2",
     )
     _set_context_histories(dispatch, [newer_cmd])
-    bot._send_response = AsyncMock(return_value="$placeholder")
-    bot._generate_response = AsyncMock(return_value="$response")
-    install_send_response_mock(bot, bot._send_response)
-    install_generate_response_mock(bot, bot._generate_response)
+    send_response = AsyncMock(return_value="$placeholder")
+    generate_response = AsyncMock(return_value="$response")
+    install_send_response_mock(bot, send_response)
+    install_generate_response_mock(bot, generate_response)
 
     action_mock = AsyncMock(return_value=_respond_dispatch_plan())
     with (
@@ -5267,10 +5267,10 @@ async def test_scheduled_event_not_suppressed(tmp_path: Path) -> None:
         latest_event_id="$s2",
     )
     _set_context_histories(dispatch, [newer_msg])
-    bot._send_response = AsyncMock(return_value="$placeholder")
-    bot._generate_response = AsyncMock(return_value="$response")
-    install_send_response_mock(bot, bot._send_response)
-    install_generate_response_mock(bot, bot._generate_response)
+    send_response = AsyncMock(return_value="$placeholder")
+    generate_response = AsyncMock(return_value="$response")
+    install_send_response_mock(bot, send_response)
+    install_generate_response_mock(bot, generate_response)
 
     action_mock = AsyncMock(return_value=_respond_dispatch_plan())
     with (
@@ -5317,10 +5317,10 @@ async def test_hook_event_not_suppressed(tmp_path: Path) -> None:
         latest_event_id="$h2",
     )
     _set_context_histories(dispatch, [newer_msg])
-    bot._send_response = AsyncMock(return_value="$placeholder")
-    bot._generate_response = AsyncMock(return_value="$response")
-    install_send_response_mock(bot, bot._send_response)
-    install_generate_response_mock(bot, bot._generate_response)
+    send_response = AsyncMock(return_value="$placeholder")
+    generate_response = AsyncMock(return_value="$response")
+    install_send_response_mock(bot, send_response)
+    install_generate_response_mock(bot, generate_response)
 
     action_mock = AsyncMock(return_value=_respond_dispatch_plan())
     with (
@@ -5369,10 +5369,10 @@ async def test_multiple_scheduled_fires_not_suppressed(tmp_path: Path) -> None:
         latest_event_id="$s2",
     )
     _set_context_histories(dispatch, [second_fire_msg])
-    bot._send_response = AsyncMock(return_value="$placeholder")
-    bot._generate_response = AsyncMock(return_value="$response")
-    install_send_response_mock(bot, bot._send_response)
-    install_generate_response_mock(bot, bot._generate_response)
+    send_response = AsyncMock(return_value="$placeholder")
+    generate_response = AsyncMock(return_value="$response")
+    install_send_response_mock(bot, send_response)
+    install_generate_response_mock(bot, generate_response)
 
     action_mock = AsyncMock(return_value=_respond_dispatch_plan())
     with (

--- a/tests/test_mention_exclusion.py
+++ b/tests/test_mention_exclusion.py
@@ -94,10 +94,10 @@ async def test_agent_ignores_user_message_mentioning_other_agents(tmp_path) -> N
         },
     }
 
-    general_bot._send_response = AsyncMock(return_value="$placeholder")
-    general_bot._generate_response = AsyncMock()
-    install_send_response_mock(general_bot, general_bot._send_response)
-    install_generate_response_mock(general_bot, general_bot._generate_response)
+    send_response = AsyncMock(return_value="$placeholder")
+    generate_response = AsyncMock()
+    install_send_response_mock(general_bot, send_response)
+    install_generate_response_mock(general_bot, generate_response)
 
     mock_context = MessageContext(
         am_i_mentioned=False,
@@ -117,7 +117,7 @@ async def test_agent_ignores_user_message_mentioning_other_agents(tmp_path) -> N
     await general_bot._coalescing_gate.drain_all()
 
     # GeneralAgent should NOT generate a response because ResearchAgent is mentioned
-    general_bot._generate_response.assert_not_called()
+    generate_response.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -187,10 +187,10 @@ async def test_agent_responds_when_mentioned_along_with_others(tmp_path) -> None
         },
     }
 
-    general_bot._send_response = AsyncMock(return_value="$placeholder")
-    general_bot._generate_response = AsyncMock(return_value="$response")
-    install_send_response_mock(general_bot, general_bot._send_response)
-    install_generate_response_mock(general_bot, general_bot._generate_response)
+    send_response = AsyncMock(return_value="$placeholder")
+    generate_response = AsyncMock(return_value="$response")
+    install_send_response_mock(general_bot, send_response)
+    install_generate_response_mock(general_bot, generate_response)
 
     mock_context = MessageContext(
         am_i_mentioned=True,
@@ -214,4 +214,4 @@ async def test_agent_responds_when_mentioned_along_with_others(tmp_path) -> None
         await general_bot._coalescing_gate.drain_all()
 
     # GeneralAgent SHOULD generate a response because it's mentioned
-    general_bot._generate_response.assert_called_once()
+    generate_response.assert_called_once()

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -3588,14 +3588,16 @@ class TestAgentBot:
                 team_response=AsyncMock(return_value="Team reply"),
             ),
         ):
-            resolution = await bot._generate_team_response_helper(
+            resolution = await bot._response_runner.generate_team_response_helper(
+                ResponseRequest(
+                    thread_history=[],
+                    user_id="@user:localhost",
+                    prompt="team prompt",
+                    response_envelope=_hook_envelope(body="team prompt", source_event_id="$team-root"),
+                    correlation_id="corr-team",
+                ),
                 team_agents=[matrix_ids["calculator"], matrix_ids["general"]],
                 team_mode="collaborate",
-                thread_history=[],
-                requester_user_id="@user:localhost",
-                payload=DispatchPayload(prompt="team prompt"),
-                response_envelope=_hook_envelope(body="team prompt", source_event_id="$team-root"),
-                correlation_id="corr-team",
             )
 
         assert _handled_response_event_id(resolution) == "$team"
@@ -3637,14 +3639,16 @@ class TestAgentBot:
                 team_response=AsyncMock(return_value="Team reply"),
             ),
         ):
-            resolution = await bot._generate_team_response_helper(
+            resolution = await bot._response_runner.generate_team_response_helper(
+                ResponseRequest(
+                    thread_history=[],
+                    user_id="@user:localhost",
+                    prompt="team prompt",
+                    response_envelope=_hook_envelope(body="team prompt", source_event_id="$team-root"),
+                    correlation_id="corr-team",
+                ),
                 team_agents=[matrix_ids["calculator"], matrix_ids["general"]],
                 team_mode="collaborate",
-                thread_history=[],
-                requester_user_id="@user:localhost",
-                payload=DispatchPayload(prompt="team prompt"),
-                response_envelope=_hook_envelope(body="team prompt", source_event_id="$team-root"),
-                correlation_id="corr-team",
             )
 
         assert _handled_response_event_id(resolution) == "$team"
@@ -3684,20 +3688,20 @@ class TestAgentBot:
                 team_response=mock_team_response,
             ),
         ):
-            resolution = await bot._generate_team_response_helper(
-                team_agents=[matrix_ids["calculator"], matrix_ids["general"]],
-                team_mode="collaborate",
-                thread_history=[],
-                requester_user_id="@user:localhost",
-                payload=DispatchPayload(
+            resolution = await bot._response_runner.generate_team_response_helper(
+                ResponseRequest(
+                    thread_history=[],
+                    user_id="@user:localhost",
                     prompt="Summarize the latest invoice.",
                     model_prompt="Available attachment IDs: att_invoice. Use tool calls to inspect or process them.",
+                    response_envelope=_hook_envelope(
+                        body="Summarize the latest invoice.",
+                        source_event_id="$team-root",
+                    ),
+                    correlation_id="corr-team",
                 ),
-                response_envelope=_hook_envelope(
-                    body="Summarize the latest invoice.",
-                    source_event_id="$team-root",
-                ),
-                correlation_id="corr-team",
+                team_agents=[matrix_ids["calculator"], matrix_ids["general"]],
+                team_mode="collaborate",
             )
 
         assert _handled_response_event_id(resolution) == "$team"
@@ -3744,20 +3748,20 @@ class TestAgentBot:
                 team_response=mock_team_response,
             ),
         ):
-            resolution = await bot._generate_team_response_helper(
-                team_agents=[matrix_ids["calculator"], matrix_ids["general"]],
-                team_mode="collaborate",
-                thread_history=[],
-                requester_user_id="@user:localhost",
-                payload=DispatchPayload(
+            resolution = await bot._response_runner.generate_team_response_helper(
+                ResponseRequest(
+                    thread_history=[],
+                    user_id="@user:localhost",
                     prompt="What time is it?",
                     model_prompt=timestamped_prompt,
+                    response_envelope=_hook_envelope(
+                        body="What time is it?",
+                        source_event_id="$team-root",
+                    ),
+                    correlation_id="corr-team",
                 ),
-                response_envelope=_hook_envelope(
-                    body="What time is it?",
-                    source_event_id="$team-root",
-                ),
-                correlation_id="corr-team",
+                team_agents=[matrix_ids["calculator"], matrix_ids["general"]],
+                team_mode="collaborate",
             )
 
         assert _handled_response_event_id(resolution) == "$team"
@@ -3834,14 +3838,16 @@ class TestAgentBot:
                 team_response=AsyncMock(return_value="Team reply"),
             ),
         ):
-            resolution = await bot._generate_team_response_helper(
+            resolution = await bot._response_runner.generate_team_response_helper(
+                ResponseRequest(
+                    thread_history=[],
+                    user_id="@user:localhost",
+                    prompt="team prompt",
+                    response_envelope=envelope,
+                    correlation_id="corr-team",
+                ),
                 team_agents=[matrix_ids["calculator"], matrix_ids["general"]],
                 team_mode="collaborate",
-                thread_history=[],
-                requester_user_id="@user:localhost",
-                payload=DispatchPayload(prompt="team prompt"),
-                response_envelope=envelope,
-                correlation_id="corr-team",
             )
 
         assert _handled_response_event_id(resolution) == "$team"
@@ -3905,14 +3911,16 @@ class TestAgentBot:
             ),
             patch("mindroom.bot.resolve_configured_team", return_value=resolution),
         ):
-            delivery_resolution = await bot._generate_response(
-                prompt="Team, summarize this thread",
-                thread_history=[],
-                existing_event_id="$existing",
-                existing_event_is_placeholder=True,
-                user_id="@alice:localhost",
-                response_envelope=_hook_envelope(body="hello", source_event_id="$event", thread_id="$thread"),
-                correlation_id="corr-nonteam-fallback",
+            delivery_resolution = await bot._run_regenerated_response(
+                ResponseRequest(
+                    prompt="Team, summarize this thread",
+                    thread_history=[],
+                    existing_event_id="$existing",
+                    existing_event_is_placeholder=True,
+                    user_id="@alice:localhost",
+                    response_envelope=_hook_envelope(body="hello", source_event_id="$event", thread_id="$thread"),
+                    correlation_id="corr-nonteam-fallback",
+                ),
             )
 
         bot._delivery_gateway.deliver_final.assert_not_awaited()
@@ -3990,7 +3998,8 @@ class TestAgentBot:
                 reason="not materializable",
             )
 
-        bot._send_response = AsyncMock(return_value="$reject")
+        send_response = AsyncMock(return_value="$reject")
+        install_send_response_mock(bot, send_response)
 
         with (
             patch.object(
@@ -4000,17 +4009,19 @@ class TestAgentBot:
             ),
             patch("mindroom.bot.resolve_configured_team", side_effect=capture_resolve_configured_team),
         ):
-            result = await bot._generate_response(
-                prompt="Team, summarize this thread",
-                thread_history=[],
-                user_id="@alice:localhost",
-                response_envelope=request_envelope(
-                    room_id="!test:localhost",
-                    reply_to_event_id="$event",
-                    thread_id="$thread",
+            result = await bot._run_regenerated_response(
+                ResponseRequest(
                     prompt="Team, summarize this thread",
+                    thread_history=[],
                     user_id="@alice:localhost",
-                    agent_name=bot.agent_name,
+                    response_envelope=request_envelope(
+                        room_id="!test:localhost",
+                        reply_to_event_id="$event",
+                        thread_id="$thread",
+                        prompt="Team, summarize this thread",
+                        user_id="@alice:localhost",
+                        agent_name=bot.agent_name,
+                    ),
                 ),
             )
 
@@ -4525,19 +4536,21 @@ class TestAgentBot:
             patch("mindroom.bot.interactive.register_interactive_question") as mock_register,
             patch("mindroom.bot.interactive.add_reaction_buttons", new_callable=AsyncMock) as mock_add_buttons,
         ):
-            resolution = await bot._generate_team_response_helper(
+            resolution = await bot._response_runner.generate_team_response_helper(
+                ResponseRequest(
+                    thread_history=[],
+                    user_id="@user:localhost",
+                    prompt="team prompt",
+                    response_envelope=request_envelope(
+                        room_id="!test:localhost",
+                        reply_to_event_id="$team-root",
+                        prompt="team prompt",
+                        user_id="@user:localhost",
+                        agent_name=bot.agent_name,
+                    ),
+                ),
                 team_agents=[matrix_ids["calculator"], matrix_ids["general"]],
                 team_mode="collaborate",
-                thread_history=[],
-                requester_user_id="@user:localhost",
-                payload=DispatchPayload(prompt="team prompt"),
-                response_envelope=request_envelope(
-                    room_id="!test:localhost",
-                    reply_to_event_id="$team-root",
-                    prompt="team prompt",
-                    user_id="@user:localhost",
-                    agent_name=bot.agent_name,
-                ),
             )
 
         assert _handled_response_event_id(resolution) == "$team"
@@ -5718,18 +5731,20 @@ class TestAgentBot:
                 new=AsyncMock(return_value=thread_history_result(thread_history, is_full_history=True)),
             ),
         ):
-            await bot._generate_response(
-                prompt="What time is it?",
-                thread_history=thread_history,
-                user_id="@alice:localhost",
-                current_timestamp_ms=int(current_turn_time.timestamp() * 1000),
-                response_envelope=request_envelope(
-                    room_id="!test:localhost",
-                    reply_to_event_id="$event",
-                    thread_id="$thread",
+            await bot._response_runner.generate_response(
+                ResponseRequest(
                     prompt="What time is it?",
+                    thread_history=thread_history,
                     user_id="@alice:localhost",
-                    agent_name=bot.agent_name,
+                    current_timestamp_ms=int(current_turn_time.timestamp() * 1000),
+                    response_envelope=request_envelope(
+                        room_id="!test:localhost",
+                        reply_to_event_id="$event",
+                        thread_id="$thread",
+                        prompt="What time is it?",
+                        user_id="@alice:localhost",
+                        agent_name=bot.agent_name,
+                    ),
                 ),
             )
 
@@ -5838,18 +5853,20 @@ class TestAgentBot:
                 new=AsyncMock(return_value=thread_history_result(thread_history, is_full_history=True)),
             ),
         ):
-            await bot._generate_response(
-                prompt="What time is it?",
-                thread_history=thread_history,
-                user_id="@alice:localhost",
-                current_timestamp_ms=int(current_turn_time.timestamp() * 1000),
-                response_envelope=request_envelope(
-                    room_id="!test:localhost",
-                    reply_to_event_id="$event",
-                    thread_id="$thread",
+            await bot._response_runner.generate_response(
+                ResponseRequest(
                     prompt="What time is it?",
+                    thread_history=thread_history,
                     user_id="@alice:localhost",
-                    agent_name=bot.agent_name,
+                    current_timestamp_ms=int(current_turn_time.timestamp() * 1000),
+                    response_envelope=request_envelope(
+                        room_id="!test:localhost",
+                        reply_to_event_id="$event",
+                        thread_id="$thread",
+                        prompt="What time is it?",
+                        user_id="@alice:localhost",
+                        agent_name=bot.agent_name,
+                    ),
                 ),
             )
 
@@ -5933,16 +5950,18 @@ class TestAgentBot:
                 store_conversation_memory=fake_store_conversation_memory,
             ),
         ):
-            await bot._generate_response(
-                prompt="Continue",
-                thread_history=[],
-                user_id="@alice:localhost",
-                response_envelope=request_envelope(
-                    room_id="!test:localhost",
-                    reply_to_event_id="$event",
+            await bot._response_runner.generate_response(
+                ResponseRequest(
                     prompt="Continue",
+                    thread_history=[],
                     user_id="@alice:localhost",
-                    agent_name=bot.agent_name,
+                    response_envelope=request_envelope(
+                        room_id="!test:localhost",
+                        reply_to_event_id="$event",
+                        prompt="Continue",
+                        user_id="@alice:localhost",
+                        agent_name=bot.agent_name,
+                    ),
                 ),
             )
 
@@ -6044,17 +6063,19 @@ class TestAgentBot:
             ),
         ):
             async with bot._conversation_resolver.turn_thread_cache_scope():
-                resolution = await bot._generate_response(
-                    prompt="Continue",
-                    thread_history=stale_history,
-                    user_id="@alice:localhost",
-                    response_envelope=request_envelope(
-                        room_id="!test:localhost",
-                        reply_to_event_id="$event",
-                        thread_id="$thread",
+                resolution = await bot._response_runner.generate_response(
+                    ResponseRequest(
                         prompt="Continue",
+                        thread_history=stale_history,
                         user_id="@alice:localhost",
-                        agent_name=bot.agent_name,
+                        response_envelope=request_envelope(
+                            room_id="!test:localhost",
+                            reply_to_event_id="$event",
+                            thread_id="$thread",
+                            prompt="Continue",
+                            user_id="@alice:localhost",
+                            agent_name=bot.agent_name,
+                        ),
                     ),
                 )
 
@@ -6157,12 +6178,14 @@ class TestAgentBot:
             ),
             patch("mindroom.delivery_gateway.send_message_result", new=AsyncMock(side_effect=record_send)),
         ):
-            await bot._generate_response(
-                prompt="Continue",
-                thread_history=[],
-                user_id="@alice:localhost",
-                response_envelope=envelope,
-                correlation_id="$request:localhost",
+            await bot._response_runner.generate_response(
+                ResponseRequest(
+                    prompt="Continue",
+                    thread_history=[],
+                    user_id="@alice:localhost",
+                    response_envelope=envelope,
+                    correlation_id="$request:localhost",
+                ),
             )
 
         if scheduled_tasks:
@@ -6244,17 +6267,19 @@ class TestAgentBot:
                 new_callable=AsyncMock,
             ) as mock_thread_summary,
         ):
-            await bot._generate_response(
-                prompt="Summarize this thread",
-                thread_history=thread_history,
-                user_id="@alice:localhost",
-                response_envelope=request_envelope(
-                    room_id="!test:localhost",
-                    reply_to_event_id="$event",
-                    thread_id="$thread",
+            await bot._response_runner.generate_response(
+                ResponseRequest(
                     prompt="Summarize this thread",
+                    thread_history=thread_history,
                     user_id="@alice:localhost",
-                    agent_name=bot.agent_name,
+                    response_envelope=request_envelope(
+                        room_id="!test:localhost",
+                        reply_to_event_id="$event",
+                        thread_id="$thread",
+                        prompt="Summarize this thread",
+                        user_id="@alice:localhost",
+                        agent_name=bot.agent_name,
+                    ),
                 ),
             )
 
@@ -6367,11 +6392,13 @@ class TestAgentBot:
                 new=AsyncMock(return_value="$notice"),
             ) as mock_send_compaction_lifecycle_start,
         ):
-            await bot._generate_response(
-                prompt="Start a thread here",
-                thread_history=[],
-                user_id="@alice:localhost",
-                response_envelope=response_envelope,
+            await bot._response_runner.generate_response(
+                ResponseRequest(
+                    prompt="Start a thread here",
+                    thread_history=[],
+                    user_id="@alice:localhost",
+                    response_envelope=response_envelope,
+                ),
             )
 
         if scheduled_tasks:
@@ -6425,16 +6452,18 @@ class TestAgentBot:
             ai_response=AsyncMock(side_effect=fake_ai_response),
             apply_post_response_effects=AsyncMock(side_effect=fake_apply_post_response_effects),
         ):
-            await bot._generate_response(
-                prompt="Please answer",
-                thread_history=[],
-                user_id="@alice:localhost",
-                response_envelope=request_envelope(
-                    room_id="!test:localhost",
-                    reply_to_event_id="$event",
+            await bot._response_runner.generate_response(
+                ResponseRequest(
                     prompt="Please answer",
+                    thread_history=[],
                     user_id="@alice:localhost",
-                    agent_name=bot.agent_name,
+                    response_envelope=request_envelope(
+                        room_id="!test:localhost",
+                        reply_to_event_id="$event",
+                        prompt="Please answer",
+                        user_id="@alice:localhost",
+                        agent_name=bot.agent_name,
+                    ),
                 ),
             )
 
@@ -6483,16 +6512,18 @@ class TestAgentBot:
                 apply_post_response_effects=AsyncMock(side_effect=fake_apply_post_response_effects),
             ),
         ):
-            await bot._generate_response(
-                prompt="Please answer",
-                thread_history=[],
-                user_id="@alice:localhost",
-                response_envelope=request_envelope(
-                    room_id="!test:localhost",
-                    reply_to_event_id="$event",
+            await bot._response_runner.generate_response(
+                ResponseRequest(
                     prompt="Please answer",
+                    thread_history=[],
                     user_id="@alice:localhost",
-                    agent_name=bot.agent_name,
+                    response_envelope=request_envelope(
+                        room_id="!test:localhost",
+                        reply_to_event_id="$event",
+                        prompt="Please answer",
+                        user_id="@alice:localhost",
+                        agent_name=bot.agent_name,
+                    ),
                 ),
             )
 
@@ -6553,17 +6584,19 @@ class TestAgentBot:
             ),
         ):
             task = asyncio.create_task(
-                bot._generate_response(
-                    prompt="Summarize this thread",
-                    thread_history=[],
-                    user_id="@alice:localhost",
-                    response_envelope=request_envelope(
-                        room_id="!test:localhost",
-                        reply_to_event_id="$event",
-                        thread_id="$thread",
+                bot._response_runner.generate_response(
+                    ResponseRequest(
                         prompt="Summarize this thread",
+                        thread_history=[],
                         user_id="@alice:localhost",
-                        agent_name=bot.agent_name,
+                        response_envelope=request_envelope(
+                            room_id="!test:localhost",
+                            reply_to_event_id="$event",
+                            thread_id="$thread",
+                            prompt="Summarize this thread",
+                            user_id="@alice:localhost",
+                            agent_name=bot.agent_name,
+                        ),
                     ),
                 ),
             )
@@ -6642,23 +6675,25 @@ class TestAgentBot:
                 return_value=_ResponderAvailability(materializable_agent_names={"general"}, live_entity_names=None),
             ),
             patch("mindroom.bot.resolve_configured_team", return_value=resolution),
-            patch.object(bot, "_generate_team_response_helper", new=AsyncMock(side_effect=fail_helper)),
+            patch.object(bot._response_runner, "generate_team_response_helper", new=AsyncMock(side_effect=fail_helper)),
             patch.object(bot._conversation_cache, "get_dispatch_thread_history", AsyncMock(return_value=history)),
             patch("mindroom.bot.create_background_task", side_effect=schedule_background_task),
             patch("mindroom.bot.store_conversation_memory", side_effect=fake_store_conversation_memory),
             pytest.raises(RuntimeError, match="boom"),
         ):
-            await bot._generate_response(
-                prompt="Team, summarize this thread",
-                thread_history=[],
-                user_id="@alice:localhost",
-                response_envelope=request_envelope(
-                    room_id="!test:localhost",
-                    reply_to_event_id="$event",
-                    thread_id="$thread",
+            await bot._run_regenerated_response(
+                ResponseRequest(
                     prompt="Team, summarize this thread",
+                    thread_history=[],
                     user_id="@alice:localhost",
-                    agent_name=bot.agent_name,
+                    response_envelope=request_envelope(
+                        room_id="!test:localhost",
+                        reply_to_event_id="$event",
+                        thread_id="$thread",
+                        prompt="Team, summarize this thread",
+                        user_id="@alice:localhost",
+                        agent_name=bot.agent_name,
+                    ),
                 ),
             )
 
@@ -6744,8 +6779,8 @@ class TestAgentBot:
             ),
             patch("mindroom.bot.resolve_configured_team", return_value=resolution),
             patch.object(
-                bot,
-                "_generate_team_response_helper",
+                bot._response_runner,
+                "generate_team_response_helper",
                 new=AsyncMock(return_value="$response"),
             ),
             patch.object(
@@ -6760,17 +6795,19 @@ class TestAgentBot:
             patch("mindroom.bot.create_background_task", side_effect=schedule_background_task),
             patch("mindroom.bot.store_conversation_memory", side_effect=fake_store_conversation_memory),
         ):
-            await bot._generate_response(
-                prompt="Team, summarize this thread",
-                thread_history=thread_history,
-                user_id="@alice:localhost",
-                response_envelope=request_envelope(
-                    room_id="!test:localhost",
-                    reply_to_event_id="$event",
-                    thread_id="$thread",
+            await bot._run_regenerated_response(
+                ResponseRequest(
                     prompt="Team, summarize this thread",
+                    thread_history=thread_history,
                     user_id="@alice:localhost",
-                    agent_name=bot.agent_name,
+                    response_envelope=request_envelope(
+                        room_id="!test:localhost",
+                        reply_to_event_id="$event",
+                        thread_id="$thread",
+                        prompt="Team, summarize this thread",
+                        user_id="@alice:localhost",
+                        agent_name=bot.agent_name,
+                    ),
                 ),
             )
 
@@ -6878,17 +6915,19 @@ class TestAgentBot:
                 new_callable=AsyncMock,
             ) as mock_thread_summary,
         ):
-            resolution = await bot._generate_response(
-                prompt="Team, summarize this thread",
-                thread_history=[],
-                user_id="@alice:localhost",
-                response_envelope=request_envelope(
-                    room_id="!test:localhost",
-                    reply_to_event_id="$event",
-                    thread_id="$thread",
+            resolution = await bot._run_regenerated_response(
+                ResponseRequest(
                     prompt="Team, summarize this thread",
+                    thread_history=[],
                     user_id="@alice:localhost",
-                    agent_name=bot.agent_name,
+                    response_envelope=request_envelope(
+                        room_id="!test:localhost",
+                        reply_to_event_id="$event",
+                        thread_id="$thread",
+                        prompt="Team, summarize this thread",
+                        user_id="@alice:localhost",
+                        agent_name=bot.agent_name,
+                    ),
                 ),
             )
 
@@ -6985,16 +7024,22 @@ class TestAgentBot:
                 ),
             ) as mock_send_streaming_response,
         ):
-            resolution = await bot._generate_team_response_helper(
-                payload=DispatchPayload(prompt="Continue"),
+            resolution = await bot._response_runner.generate_team_response_helper(
+                ResponseRequest(
+                    prompt="Continue",
+                    thread_history=[],
+                    user_id="@alice:localhost",
+                    existing_event_id="$placeholder",
+                    existing_event_is_placeholder=True,
+                    response_envelope=_hook_envelope(
+                        body="Continue",
+                        source_event_id="$event",
+                        thread_id="$thread_root",
+                    ),
+                    correlation_id="corr-team-stream",
+                ),
                 team_agents=[bot.matrix_id],
                 team_mode="coordinate",
-                thread_history=[],
-                requester_user_id="@alice:localhost",
-                existing_event_id="$placeholder",
-                existing_event_is_placeholder=True,
-                response_envelope=_hook_envelope(body="Continue", source_event_id="$event", thread_id="$thread_root"),
-                correlation_id="corr-team-stream",
             )
 
         assert _handled_response_event_id(resolution) == "$placeholder"
@@ -7063,20 +7108,22 @@ class TestAgentBot:
                 team_response_stream=fake_team_response_stream,
             ),
         ):
-            resolution = await bot._generate_team_response_helper(
-                payload=DispatchPayload(prompt="Continue"),
+            resolution = await bot._response_runner.generate_team_response_helper(
+                ResponseRequest(
+                    prompt="Continue",
+                    thread_history=[],
+                    user_id="@alice:localhost",
+                    existing_event_id="$placeholder",
+                    existing_event_is_placeholder=True,
+                    response_envelope=_hook_envelope(
+                        body="Continue",
+                        source_event_id="$event",
+                        thread_id="$thread_root",
+                    ),
+                    correlation_id="corr-team-stream-suppress",
+                ),
                 team_agents=[bot.matrix_id],
                 team_mode="coordinate",
-                thread_history=[],
-                requester_user_id="@alice:localhost",
-                existing_event_id="$placeholder",
-                existing_event_is_placeholder=True,
-                response_envelope=_hook_envelope(
-                    body="Continue",
-                    source_event_id="$event",
-                    thread_id="$thread_root",
-                ),
-                correlation_id="corr-team-stream-suppress",
             )
 
         assert resolution == "$placeholder"
@@ -7112,20 +7159,22 @@ class TestAgentBot:
             ),
             patch.object(bot._conversation_cache, "get_thread_history", AsyncMock(return_value=history)),
         ):
-            resolution = await bot._generate_team_response_helper(
-                payload=DispatchPayload(prompt="Continue"),
+            resolution = await bot._response_runner.generate_team_response_helper(
+                ResponseRequest(
+                    prompt="Continue",
+                    thread_history=[],
+                    user_id="@alice:localhost",
+                    existing_event_id="$placeholder",
+                    existing_event_is_placeholder=True,
+                    response_envelope=_hook_envelope(
+                        body="Continue",
+                        source_event_id="$event",
+                        thread_id="$thread_root",
+                    ),
+                    correlation_id="corr-team-suppress",
+                ),
                 team_agents=[bot.matrix_id],
                 team_mode="coordinate",
-                thread_history=[],
-                requester_user_id="@alice:localhost",
-                existing_event_id="$placeholder",
-                existing_event_is_placeholder=True,
-                response_envelope=_hook_envelope(
-                    body="Continue",
-                    source_event_id="$event",
-                    thread_id="$thread_root",
-                ),
-                correlation_id="corr-team-suppress",
             )
 
         assert resolution is None
@@ -7548,7 +7597,7 @@ class TestAgentBot:
         mock_agent_user: AgentMatrixUser,
         tmp_path: Path,
     ) -> None:
-        """Image messages should call _generate_response with images payload."""
+        """Image messages should reach response generation with an images payload."""
         config = self._config_for_storage(tmp_path)
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         _wrap_extracted_collaborators(bot)
@@ -7568,8 +7617,8 @@ class TestAgentBot:
                 has_non_agent_mentions=False,
             ),
         )
-        bot._generate_response = AsyncMock(return_value="$response")
-        install_generate_response_mock(bot, bot._generate_response)
+        generate_response = AsyncMock(return_value="$response")
+        install_generate_response_mock(bot, generate_response)
 
         room = MagicMock()
         room.room_id = "!test:localhost"
@@ -7612,8 +7661,8 @@ class TestAgentBot:
             await bot._on_media_message(room, event)
             await drain_coalescing(bot)
 
-        bot._generate_response.assert_awaited_once()
-        generate_kwargs = bot._generate_response.await_args.kwargs
+        generate_response.assert_awaited_once()
+        generate_kwargs = generate_response.await_args.kwargs
         response_target = generate_kwargs["response_envelope"].target
         assert response_target.room_id == "!test:localhost"
         assert "Attachments sent with the current message" not in generate_kwargs["prompt"]
@@ -8099,8 +8148,8 @@ class TestAgentBot:
                 ),
             ),
         )
-        bot._generate_response = AsyncMock(return_value="$response")
-        install_generate_response_mock(bot, bot._generate_response)
+        generate_response = AsyncMock(return_value="$response")
+        install_generate_response_mock(bot, generate_response)
         _replace_turn_policy_deps(bot, resolver=bot._conversation_resolver)
         _set_turn_store_tracker(bot, tracker)
 
@@ -8170,8 +8219,8 @@ class TestAgentBot:
         converted_records = mock_records_to_media.call_args.args[0]
         assert [record.attachment_id for record in converted_records] == [current_attachment_id]
 
-        bot._generate_response.assert_awaited_once()
-        generate_kwargs = bot._generate_response.await_args.kwargs
+        generate_response.assert_awaited_once()
+        generate_kwargs = generate_response.await_args.kwargs
         assert generate_kwargs["attachment_ids"] == [current_attachment_id, history_attachment_id]
         assert current_attachment_id not in generate_kwargs["prompt"]
         assert history_attachment_id not in generate_kwargs["prompt"]
@@ -8617,8 +8666,8 @@ class TestAgentBot:
                 has_non_agent_mentions=False,
             ),
         )
-        bot._generate_response = AsyncMock()
-        install_generate_response_mock(bot, bot._generate_response)
+        generate_response = AsyncMock()
+        install_generate_response_mock(bot, generate_response)
 
         room = MagicMock()
         room.room_id = "!test:localhost"
@@ -8641,7 +8690,7 @@ class TestAgentBot:
             await bot._on_media_message(room, event)
             await drain_coalescing(bot)
 
-        bot._generate_response.assert_not_called()
+        generate_response.assert_not_called()
         tracker.record_handled_turn.assert_not_called()
 
     @pytest.mark.asyncio
@@ -8650,7 +8699,7 @@ class TestAgentBot:
         mock_agent_user: AgentMatrixUser,
         tmp_path: Path,
     ) -> None:
-        """File messages should call _generate_response with a local media path in prompt."""
+        """File messages should reach response generation with a local media path in prompt."""
         config = self._config_for_storage(tmp_path)
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = AsyncMock()
@@ -8669,8 +8718,8 @@ class TestAgentBot:
                 has_non_agent_mentions=False,
             ),
         )
-        bot._generate_response = AsyncMock(return_value="$response")
-        install_generate_response_mock(bot, bot._generate_response)
+        generate_response = AsyncMock(return_value="$response")
+        install_generate_response_mock(bot, generate_response)
 
         room = MagicMock()
         room.room_id = "!test:localhost"
@@ -8715,8 +8764,8 @@ class TestAgentBot:
             await bot._on_media_message(room, event)
             await drain_coalescing(bot)
 
-        bot._generate_response.assert_awaited_once()
-        generate_kwargs = bot._generate_response.await_args.kwargs
+        generate_response.assert_awaited_once()
+        generate_kwargs = generate_response.await_args.kwargs
         attachment_id = _attachment_id_for_event("$file_event")
         response_target = generate_kwargs["response_envelope"].target
         assert response_target.room_id == "!test:localhost"
@@ -8779,8 +8828,8 @@ class TestAgentBot:
                 has_non_agent_mentions=False,
             ),
         )
-        bot._generate_response = AsyncMock()
-        install_generate_response_mock(bot, bot._generate_response)
+        generate_response = AsyncMock()
+        install_generate_response_mock(bot, generate_response)
 
         room = MagicMock()
         room.room_id = "!test:localhost"
@@ -8808,7 +8857,7 @@ class TestAgentBot:
             await bot._on_media_message(room, event)
             await drain_coalescing(bot)
 
-        bot._generate_response.assert_not_called()
+        generate_response.assert_not_called()
         tracker.record_handled_turn.assert_not_called()
 
     @pytest.mark.asyncio
@@ -8923,7 +8972,8 @@ class TestAgentBot:
             assert target.room_id in bot.client.rooms
             return "$welcome"
 
-        bot._send_response = AsyncMock(side_effect=fake_send_response)
+        send_response = AsyncMock(side_effect=fake_send_response)
+        install_send_response_mock(bot, send_response)
         with (
             patch(
                 "mindroom.bot_room_lifecycle.generate_welcome_message_for_room",
@@ -8937,7 +8987,7 @@ class TestAgentBot:
 
         assert "!welcome:localhost" in bot.client.rooms
         bot.client.join.assert_awaited_once_with("!welcome:localhost")
-        bot._send_response.assert_awaited_once()
+        send_response.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_router_routes_file_messages_with_sender_metadata(
@@ -9063,8 +9113,8 @@ class TestAgentBot:
         bot = AgentBot(agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = AsyncMock()
         _set_turn_store_tracker(bot, MagicMock())
-        bot._send_response = AsyncMock(return_value="$route")
-        install_send_response_mock(bot, bot._send_response)
+        send_response = AsyncMock(return_value="$route")
+        install_send_response_mock(bot, send_response)
 
         room = nio.MatrixRoom(room_id="!test:localhost", own_user_id="@mindroom_router:localhost")
         event = nio.RoomMessageFile.from_dict(
@@ -9121,7 +9171,7 @@ class TestAgentBot:
 
         mock_register_file.assert_awaited_once()
         assert mock_register_file.await_args.kwargs["thread_id"] is None
-        sent_extra_content = bot._send_response.await_args.kwargs["extra_content"]
+        sent_extra_content = send_response.await_args.kwargs["extra_content"]
         assert sent_extra_content[ATTACHMENT_IDS_KEY] == [attachment_record.attachment_id]
 
     @pytest.mark.asyncio
@@ -9153,8 +9203,8 @@ class TestAgentBot:
         bot = AgentBot(agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = AsyncMock()
         _set_turn_store_tracker(bot, MagicMock())
-        bot._send_response = AsyncMock(return_value="$route")
-        install_send_response_mock(bot, bot._send_response)
+        send_response = AsyncMock(return_value="$route")
+        install_send_response_mock(bot, send_response)
 
         room = nio.MatrixRoom(room_id="!test:localhost", own_user_id="@mindroom_router:localhost")
         event = nio.RoomMessageImage.from_dict(
@@ -9198,7 +9248,7 @@ class TestAgentBot:
 
         mock_register_image.assert_awaited_once()
         assert mock_register_image.await_args.kwargs["thread_id"] is None
-        sent_extra_content = bot._send_response.await_args.kwargs["extra_content"]
+        sent_extra_content = send_response.await_args.kwargs["extra_content"]
         assert sent_extra_content[ATTACHMENT_IDS_KEY] == [attachment_record.attachment_id]
 
     @pytest.mark.asyncio
@@ -9245,10 +9295,10 @@ class TestAgentBot:
         router_tracker.has_responded.return_value = False
         general_tracker = _set_turn_store_tracker(general_bot, MagicMock())
         general_tracker.has_responded.return_value = False
-        router_bot._send_response = AsyncMock(return_value="$route")
-        install_send_response_mock(router_bot, router_bot._send_response)
-        general_bot._generate_response = AsyncMock()
-        install_generate_response_mock(general_bot, general_bot._generate_response)
+        router_send_response = AsyncMock(return_value="$route")
+        install_send_response_mock(router_bot, router_send_response)
+        general_generate_response = AsyncMock()
+        install_generate_response_mock(general_bot, general_generate_response)
 
         message_context = MessageContext(
             am_i_mentioned=False,
@@ -9330,7 +9380,7 @@ class TestAgentBot:
         mock_register.assert_awaited_once()
         assert mock_register.await_args.kwargs["room_id"] == "!test:localhost"
         assert mock_register.await_args.kwargs["thread_id"] == "$file_once"
-        general_bot._generate_response.assert_not_called()
+        general_generate_response.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_router_dispatch_parity_text_and_image_route_under_same_conditions(self, tmp_path: Path) -> None:
@@ -9566,8 +9616,8 @@ class TestAgentBot:
         tracker = MagicMock()
         tracker.has_responded.return_value = False
         _set_turn_store_tracker(bot, tracker)
-        bot._generate_response = AsyncMock(return_value="$response")
-        install_generate_response_mock(bot, bot._generate_response)
+        generate_response = AsyncMock(return_value="$response")
+        install_generate_response_mock(bot, generate_response)
 
         # Simulate the routing mention event in a thread rooted at the image
         room = nio.MatrixRoom(room_id="!test:localhost", own_user_id="@mindroom_calculator:localhost")
@@ -9629,8 +9679,8 @@ class TestAgentBot:
             await drain_coalescing(bot)
 
         mock_resolve_attachment_ids.assert_awaited_once()
-        bot._generate_response.assert_awaited_once()
-        call_kwargs = bot._generate_response.call_args.kwargs
+        generate_response.assert_awaited_once()
+        call_kwargs = generate_response.call_args.kwargs
         # The root image is a thread-history attachment now, so it is pinned to
         # its history message instead of riding the current-turn media inputs.
         assert list(call_kwargs["media"].images) == []
@@ -12443,8 +12493,8 @@ class TestAgentBot:
         bot.client = _make_matrix_client_mock()
         tracker = _set_turn_store_tracker(bot, MagicMock())
         tracker.has_responded.return_value = False
-        bot._generate_response = AsyncMock(return_value="$response")
-        install_generate_response_mock(bot, bot._generate_response)
+        generate_response = AsyncMock(return_value="$response")
+        install_generate_response_mock(bot, generate_response)
         room = _matrix_room(
             room_id="!room:localhost",
             own_user_id=mock_agent_user.user_id,
@@ -12488,8 +12538,8 @@ class TestAgentBot:
             await bot._on_message(room, event)
             await drain_coalescing(bot)
 
-        bot._generate_response.assert_awaited_once()
-        generate_kwargs = bot._generate_response.await_args.kwargs
+        generate_response.assert_awaited_once()
+        generate_kwargs = generate_response.await_args.kwargs
         assert generate_kwargs["user_id"] == "@owner:localhost"
         assert generate_kwargs["response_envelope"].requester_id == "@owner:localhost"
 
@@ -12526,8 +12576,8 @@ class TestAgentBot:
         bot.client = _make_matrix_client_mock()
         tracker = _set_turn_store_tracker(bot, MagicMock())
         tracker.has_responded.return_value = False
-        bot._generate_response = AsyncMock(return_value="$response")
-        install_generate_response_mock(bot, bot._generate_response)
+        generate_response = AsyncMock(return_value="$response")
+        install_generate_response_mock(bot, generate_response)
         room = _matrix_room(
             room_id="!room:localhost",
             own_user_id=mock_agent_user.user_id,
@@ -12565,8 +12615,8 @@ class TestAgentBot:
             await bot._on_message(room, event)
             await drain_coalescing(bot)
 
-        bot._generate_response.assert_awaited_once()
-        generate_kwargs = bot._generate_response.await_args.kwargs
+        generate_response.assert_awaited_once()
+        generate_kwargs = generate_response.await_args.kwargs
         assert generate_kwargs["user_id"] == "@mallory:localhost"
         assert generate_kwargs["response_envelope"].requester_id == "@mallory:localhost"
 
@@ -13442,8 +13492,8 @@ class TestAgentBot:
         )
         bot._edit_message = AsyncMock(return_value=True)
         install_edit_message_mock(bot, bot._edit_message)
-        bot._generate_response = AsyncMock()
-        install_generate_response_mock(bot, bot._generate_response)
+        generate_response = AsyncMock()
+        install_generate_response_mock(bot, generate_response)
         bot._delivery_gateway.send_text = AsyncMock(return_value="$error")
         wrap_extracted_collaborators(bot, "_turn_policy")
         bot._turn_policy.plan_turn = AsyncMock(
@@ -13469,7 +13519,7 @@ class TestAgentBot:
             await bot._on_media_message(room, event)
             await drain_coalescing(bot)
 
-        bot._generate_response.assert_not_called()
+        generate_response.assert_not_called()
         bot._edit_message.assert_not_awaited()
         bot._delivery_gateway.send_text.assert_awaited_once()
         assert bot._delivery_gateway.send_text.await_args.args[0].response_text == (

--- a/tests/test_multiple_edits.py
+++ b/tests/test_multiple_edits.py
@@ -21,6 +21,7 @@ from tests.conftest import (
     drain_coalescing,
     install_runtime_cache_support,
     make_matrix_client_mock,
+    replace_edit_regenerator_deps,
     runtime_paths_for,
     test_runtime_paths,
 )
@@ -159,13 +160,10 @@ async def test_agent_regenerates_on_multiple_edits(tmp_path: Path) -> None:
     edit1_event.source = edit1_event.__dict__["source"]
 
     # Process first edit and verify regeneration happens through the shared response helper.
-    with patch.object(
-        bot,
-        "_generate_response",
-        new=AsyncMock(return_value=_delivery_resolution("$response123")),
-    ) as mock_generate_response:
-        await bot._on_message(room, edit1_event)
-        await drain_coalescing(bot)
+    mock_generate_response = AsyncMock(return_value=_delivery_resolution("$response123"))
+    replace_edit_regenerator_deps(bot, generate_response=mock_generate_response)
+    await bot._on_message(room, edit1_event)
+    await drain_coalescing(bot)
 
     assert mock_generate_response.await_count == 1
 
@@ -199,13 +197,10 @@ async def test_agent_regenerates_on_multiple_edits(tmp_path: Path) -> None:
     edit2_event.source = edit2_event.__dict__["source"]
 
     # Process second edit and verify regeneration happens again.
-    with patch.object(
-        bot,
-        "_generate_response",
-        new=AsyncMock(return_value=_delivery_resolution("$response123")),
-    ) as mock_generate_response:
-        await bot._on_message(room, edit2_event)
-        await drain_coalescing(bot)
+    mock_generate_response = AsyncMock(return_value=_delivery_resolution("$response123"))
+    replace_edit_regenerator_deps(bot, generate_response=mock_generate_response)
+    await bot._on_message(room, edit2_event)
+    await drain_coalescing(bot)
 
     assert mock_generate_response.await_count == 1
 
@@ -239,12 +234,9 @@ async def test_agent_regenerates_on_multiple_edits(tmp_path: Path) -> None:
     bot.client.room_send.reset_mock()
 
     # Process third edit and verify regeneration still happens.
-    with patch.object(
-        bot,
-        "_generate_response",
-        new=AsyncMock(return_value=_delivery_resolution("$response123")),
-    ) as mock_generate_response:
-        await bot._on_message(room, edit3_event)
-        await drain_coalescing(bot)
+    mock_generate_response = AsyncMock(return_value=_delivery_resolution("$response123"))
+    replace_edit_regenerator_deps(bot, generate_response=mock_generate_response)
+    await bot._on_message(room, edit3_event)
+    await drain_coalescing(bot)
 
     assert mock_generate_response.await_count == 1

--- a/tests/test_preformed_team_routing.py
+++ b/tests/test_preformed_team_routing.py
@@ -23,11 +23,13 @@ from mindroom.constants import STREAM_STATUS_KEY
 from mindroom.matrix.cache.thread_history_result import thread_history_result
 from mindroom.matrix.client import DeliveredMatrixEvent
 from mindroom.matrix.users import AgentMatrixUser
+from mindroom.response_runner import ResponseRequest
 from mindroom.tool_system.worker_routing import get_tool_execution_identity
 from tests.conftest import (
     bind_runtime_paths,
     drain_coalescing,
     install_runtime_cache_support,
+    install_send_response_mock,
     make_matrix_client_mock,
     make_visible_message,
     patch_response_runner_module,
@@ -268,16 +270,18 @@ async def test_preformed_team_bot_schedules_memory_save_for_all_file_members(
             nio.RoomSendResponse.from_dict({"event_id": "$placeholder"}, "!room:localhost"),
             nio.RoomSendResponse.from_dict({"event_id": "$edit"}, "!room:localhost"),
         ]
-        await bot._generate_response(
-            prompt="@team remember this",
-            thread_history=thread_history,
-            user_id="@user:localhost",
-            response_envelope=request_envelope(
-                room_id="!room:localhost",
-                reply_to_event_id="$evt1",
+        await bot._run_regenerated_response(
+            ResponseRequest(
                 prompt="@team remember this",
+                thread_history=thread_history,
                 user_id="@user:localhost",
-                agent_name=bot.agent_name,
+                response_envelope=request_envelope(
+                    room_id="!room:localhost",
+                    reply_to_event_id="$evt1",
+                    prompt="@team remember this",
+                    user_id="@user:localhost",
+                    agent_name=bot.agent_name,
+                ),
             ),
         )
 
@@ -316,7 +320,8 @@ async def test_preformed_team_rejection_edits_existing_message(config_with_team:
     install_runtime_cache_support(bot)
     bot.orchestrator = MagicMock()
     bot.orchestrator.agent_bots = {"a1": MagicMock()}
-    bot._send_response = AsyncMock(return_value="$new_response")
+    send_response = AsyncMock(return_value="$new_response")
+    install_send_response_mock(bot, send_response)
 
     with patch(
         "mindroom.delivery_gateway.edit_message_result",
@@ -327,17 +332,19 @@ async def test_preformed_team_rejection_edits_existing_message(config_with_team:
             ),
         ),
     ) as mock_edit:
-        resolution = await bot._generate_response(
-            prompt="@t1 please retry",
-            thread_history=[],
-            existing_event_id="$existing_response",
-            user_id="@user:localhost",
-            response_envelope=request_envelope(
-                room_id="!room:localhost",
-                reply_to_event_id="$evt1",
+        resolution = await bot._run_regenerated_response(
+            ResponseRequest(
                 prompt="@t1 please retry",
+                thread_history=[],
+                existing_event_id="$existing_response",
                 user_id="@user:localhost",
-                agent_name=bot.agent_name,
+                response_envelope=request_envelope(
+                    room_id="!room:localhost",
+                    reply_to_event_id="$evt1",
+                    prompt="@t1 please retry",
+                    user_id="@user:localhost",
+                    agent_name=bot.agent_name,
+                ),
             ),
         )
 
@@ -346,7 +353,7 @@ async def test_preformed_team_rejection_edits_existing_message(config_with_team:
     assert (
         mock_edit.await_args.args[4] == "Team 't1' includes agent 'a2' that could not be materialized for this request."
     )
-    bot._send_response.assert_not_awaited()
+    send_response.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_presence_based_streaming.py
+++ b/tests/test_presence_based_streaming.py
@@ -13,6 +13,7 @@ from mindroom.bot import AgentBot, create_bot_for_entity
 from mindroom.config.main import Config
 from mindroom.matrix.presence import is_user_online, should_use_streaming
 from mindroom.matrix.users import AgentMatrixUser
+from mindroom.response_runner import ResponseRequest
 from tests.conftest import (
     bind_runtime_paths,
     delivered_matrix_event,
@@ -329,17 +330,19 @@ class TestBotIntegration:
             patch("mindroom.streaming.send_message_result", side_effect=mock_send_message_result),
             patch("mindroom.streaming.edit_message_result", side_effect=mock_edit_message_result),
         ):
-            await bot._generate_response(
-                prompt="Hello bot",
-                thread_history=[],
-                user_id="@user:localhost",
-                response_envelope=request_envelope(
-                    room_id="!test:localhost",
-                    reply_to_event_id="$msg123",
-                    thread_id="$thread123",
+            await bot._response_runner.generate_response(
+                ResponseRequest(
                     prompt="Hello bot",
+                    thread_history=[],
                     user_id="@user:localhost",
-                    agent_name="test_agent",
+                    response_envelope=request_envelope(
+                        room_id="!test:localhost",
+                        reply_to_event_id="$msg123",
+                        thread_id="$thread123",
+                        prompt="Hello bot",
+                        user_id="@user:localhost",
+                        agent_name="test_agent",
+                    ),
                 ),
             )
 
@@ -396,17 +399,19 @@ class TestBotIntegration:
         install_runtime_cache_support(bot)
 
         # Simulate a message from a user
-        await bot._generate_response(
-            prompt="Hello bot",
-            thread_history=[],
-            user_id="@user:localhost",
-            response_envelope=request_envelope(
-                room_id="!test:localhost",
-                reply_to_event_id="$msg123",
-                thread_id="$thread123",
+        await bot._response_runner.generate_response(
+            ResponseRequest(
                 prompt="Hello bot",
+                thread_history=[],
                 user_id="@user:localhost",
-                agent_name="test_agent",
+                response_envelope=request_envelope(
+                    room_id="!test:localhost",
+                    reply_to_event_id="$msg123",
+                    thread_id="$thread123",
+                    prompt="Hello bot",
+                    user_id="@user:localhost",
+                    agent_name="test_agent",
+                ),
             ),
         )
 

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -55,7 +55,6 @@ from mindroom.final_delivery import FinalDeliveryOutcome
 from mindroom.history.runtime import open_bound_scope_session_context
 from mindroom.history.types import HistoryScope
 from mindroom.hooks import MessageEnvelope
-from mindroom.inbound_turn_normalizer import DispatchPayload
 from mindroom.interactive import InteractiveMetadata
 from mindroom.matrix.cache import ThreadHistoryResult
 from mindroom.matrix.client import ResolvedVisibleMessage
@@ -908,11 +907,13 @@ async def test_generate_response_sets_queued_signal_for_human_ingress(tmp_path: 
             new=AsyncMock(return_value="$response"),
         ) as mock_locked:
             task = asyncio.create_task(
-                bot._generate_response(
-                    prompt="hello",
-                    thread_history=[],
-                    user_id="@user:localhost",
-                    response_envelope=response_envelope,
+                bot._response_runner.generate_response(
+                    ResponseRequest(
+                        prompt="hello",
+                        thread_history=[],
+                        user_id="@user:localhost",
+                        response_envelope=response_envelope,
+                    ),
                 ),
             )
             await asyncio.wait_for(queued_signal.wait(), timeout=0.2)
@@ -969,11 +970,13 @@ async def test_generate_response_skips_signal_for_non_human_prompt_ingress(
             new=AsyncMock(return_value="$response"),
         ):
             task = asyncio.create_task(
-                bot._generate_response(
-                    prompt="hello",
-                    thread_history=[],
-                    user_id="@user:localhost",
-                    response_envelope=response_envelope,
+                bot._response_runner.generate_response(
+                    ResponseRequest(
+                        prompt="hello",
+                        thread_history=[],
+                        user_id="@user:localhost",
+                        response_envelope=response_envelope,
+                    ),
                 ),
             )
             with pytest.raises(asyncio.TimeoutError):
@@ -1039,11 +1042,13 @@ async def test_generate_response_sets_queued_signal_for_trusted_router_relay(tmp
             new=AsyncMock(return_value="$response"),
         ):
             task = asyncio.create_task(
-                bot._generate_response(
-                    prompt="hello",
-                    thread_history=[],
-                    user_id="@user:localhost",
-                    response_envelope=response_envelope,
+                bot._response_runner.generate_response(
+                    ResponseRequest(
+                        prompt="hello",
+                        thread_history=[],
+                        user_id="@user:localhost",
+                        response_envelope=response_envelope,
+                    ),
                 ),
             )
             await asyncio.wait_for(queued_signal.wait(), timeout=0.2)
@@ -1079,21 +1084,25 @@ async def test_generate_response_detects_active_turn_before_lock_is_held(tmp_pat
         patch.object(ResponseRunner, "generate_response_locked", new=fake_generate_response_locked),
     ):
         first_task = asyncio.create_task(
-            bot._generate_response(
-                prompt="hello",
-                thread_history=[],
-                user_id="first",
-                response_envelope=first_envelope,
+            bot._response_runner.generate_response(
+                ResponseRequest(
+                    prompt="hello",
+                    thread_history=[],
+                    user_id="first",
+                    response_envelope=first_envelope,
+                ),
             ),
         )
         await lock.first_waiting.wait()
 
         second_task = asyncio.create_task(
-            bot._generate_response(
-                prompt="stop",
-                thread_history=[],
-                user_id="second",
-                response_envelope=second_envelope,
+            bot._response_runner.generate_response(
+                ResponseRequest(
+                    prompt="stop",
+                    thread_history=[],
+                    user_id="second",
+                    response_envelope=second_envelope,
+                ),
             ),
         )
 
@@ -1150,11 +1159,13 @@ async def test_generate_response_waits_for_lock_before_starting_placeholder_life
             patch("mindroom.response_lifecycle.apply_post_response_effects", new=AsyncMock()),
         ):
             task = asyncio.create_task(
-                bot._generate_response(
-                    prompt="hello",
-                    thread_history=[],
-                    user_id="@user:localhost",
-                    response_envelope=response_envelope,
+                bot._response_runner.generate_response(
+                    ResponseRequest(
+                        prompt="hello",
+                        thread_history=[],
+                        user_id="@user:localhost",
+                        response_envelope=response_envelope,
+                    ),
                 ),
             )
             await asyncio.sleep(0.05)
@@ -1601,13 +1612,15 @@ async def test_generate_team_response_helper_sets_queued_signal(tmp_path: Path) 
             new=AsyncMock(return_value="$team-response"),
         ) as mock_locked:
             task = asyncio.create_task(
-                bot._generate_team_response_helper(
+                bot._response_runner.generate_team_response_helper(
+                    ResponseRequest(
+                        thread_history=[],
+                        prompt="hello",
+                        user_id="@user:localhost",
+                        response_envelope=response_envelope,
+                    ),
                     team_agents=[],
                     team_mode="coordinate",
-                    thread_history=[],
-                    requester_user_id="@user:localhost",
-                    payload=DispatchPayload(prompt="hello"),
-                    response_envelope=response_envelope,
                 ),
             )
             await asyncio.wait_for(queued_signal.wait(), timeout=0.2)
@@ -1647,20 +1660,24 @@ async def test_generate_response_without_reservation_does_not_drain_human_backlo
     try:
         with patch.object(ResponseRunner, "generate_response_locked", new=fake_locked):
             task_b = asyncio.create_task(
-                bot._generate_response(
-                    prompt="hello",
-                    thread_history=[],
-                    user_id="@user:localhost",
-                    response_envelope=response_envelope_b,
+                bot._response_runner.generate_response(
+                    ResponseRequest(
+                        prompt="hello",
+                        thread_history=[],
+                        user_id="@user:localhost",
+                        response_envelope=response_envelope_b,
+                    ),
                 ),
             )
             await asyncio.wait_for(queued_signal.wait(), timeout=0.2)
             task_c = asyncio.create_task(
-                bot._generate_response(
-                    prompt="hello again",
-                    thread_history=[],
-                    user_id="@user:localhost",
-                    response_envelope=response_envelope_c,
+                bot._response_runner.generate_response(
+                    ResponseRequest(
+                        prompt="hello again",
+                        thread_history=[],
+                        user_id="@user:localhost",
+                        response_envelope=response_envelope_c,
+                    ),
                 ),
             )
             for _ in range(20):
@@ -1710,24 +1727,28 @@ async def test_generate_team_response_without_reservation_does_not_drain_human_b
     try:
         with patch.object(ResponseRunner, "generate_team_response_helper_locked", new=fake_locked):
             task_b = asyncio.create_task(
-                bot._generate_team_response_helper(
+                bot._response_runner.generate_team_response_helper(
+                    ResponseRequest(
+                        thread_history=[],
+                        prompt="hello",
+                        user_id="@user:localhost",
+                        response_envelope=response_envelope_b,
+                    ),
                     team_agents=[],
                     team_mode="coordinate",
-                    thread_history=[],
-                    requester_user_id="@user:localhost",
-                    payload=DispatchPayload(prompt="hello"),
-                    response_envelope=response_envelope_b,
                 ),
             )
             await asyncio.wait_for(queued_signal.wait(), timeout=0.2)
             task_c = asyncio.create_task(
-                bot._generate_team_response_helper(
+                bot._response_runner.generate_team_response_helper(
+                    ResponseRequest(
+                        thread_history=[],
+                        prompt="hello again",
+                        user_id="@user:localhost",
+                        response_envelope=response_envelope_c,
+                    ),
                     team_agents=[],
                     team_mode="coordinate",
-                    thread_history=[],
-                    requester_user_id="@user:localhost",
-                    payload=DispatchPayload(prompt="hello again"),
-                    response_envelope=response_envelope_c,
                 ),
             )
             for _ in range(20):

--- a/tests/test_response_tracking_regression.py
+++ b/tests/test_response_tracking_regression.py
@@ -215,8 +215,8 @@ class TestResponseTrackingRegression:
             return_value=dispatch_context_result(mock_context),
         )
 
-        bot._send_response = AsyncMock(return_value="$response_456")
-        install_send_response_mock(bot, bot._send_response)
+        send_response = AsyncMock(return_value="$response_456")
+        install_send_response_mock(bot, send_response)
 
         # Mock constants to make router handle commands
         with patch("mindroom.constants.ROUTER_AGENT_NAME", "router"):
@@ -224,8 +224,8 @@ class TestResponseTrackingRegression:
             await bot._on_message(mock_room, unknown_command_event)
             await drain_coalescing(bot)
 
-        bot._send_response.assert_awaited_once()
-        assert "❌ Unknown command" in bot._send_response.await_args.kwargs["response_text"]
+        send_response.assert_awaited_once()
+        assert "❌ Unknown command" in send_response.await_args.kwargs["response_text"]
 
         # IMPORTANT: Check if event was marked as responded
         # This should be True after the fix in bot.py at line 371

--- a/tests/test_room_invites.py
+++ b/tests/test_room_invites.py
@@ -28,6 +28,7 @@ from mindroom.orchestrator import _MultiAgentOrchestrator
 from tests.conftest import (
     TEST_PASSWORD,
     bind_runtime_paths,
+    install_send_response_mock,
     make_matrix_client_mock,
     runtime_paths_for,
     test_runtime_paths,
@@ -311,7 +312,8 @@ async def test_router_deduplicates_concurrent_invite_callbacks(
             end=None,
         ),
     )
-    bot._send_response = AsyncMock(return_value="$welcome")
+    send_response = AsyncMock(return_value="$welcome")
+    install_send_response_mock(bot, send_response)
 
     room = MagicMock(room_id="!router-invited:localhost")
     room.canonical_alias = None
@@ -326,7 +328,7 @@ async def test_router_deduplicates_concurrent_invite_callbacks(
 
     join_room.assert_awaited_once_with(bot.client, "!router-invited:localhost")
     bot.client.room_messages.assert_awaited_once()
-    bot._send_response.assert_awaited_once()
+    send_response.assert_awaited_once()
     assert bot._room_lifecycle.invited_rooms == {"!router-invited:localhost"}
 
 
@@ -356,7 +358,8 @@ async def test_router_duplicate_invite_retries_failed_welcome_delivery(
             end=None,
         ),
     )
-    bot._send_response = AsyncMock(side_effect=[None, "$welcome"])
+    send_response = AsyncMock(side_effect=[None, "$welcome"])
+    install_send_response_mock(bot, send_response)
 
     join_room = AsyncMock(return_value=True)
     monkeypatch.setattr("mindroom.bot_room_lifecycle.is_authorized_sender", lambda *_args, **_kwargs: True)
@@ -371,7 +374,7 @@ async def test_router_duplicate_invite_retries_failed_welcome_delivery(
 
     join_room.assert_awaited_once_with(bot.client, "!router-invited:localhost")
     assert bot.client.room_messages.await_count == 2
-    assert bot._send_response.await_count == 2
+    assert send_response.await_count == 2
     assert bot._room_lifecycle.invited_rooms == {"!router-invited:localhost"}
 
 
@@ -399,7 +402,8 @@ async def test_router_welcome_send_is_idempotent_for_concurrent_empty_room_check
             end=None,
         ),
     )
-    bot._send_response = AsyncMock(return_value="$welcome")
+    send_response = AsyncMock(return_value="$welcome")
+    install_send_response_mock(bot, send_response)
 
     await asyncio.gather(
         bot._send_welcome_message_if_empty("!empty:localhost"),
@@ -408,7 +412,7 @@ async def test_router_welcome_send_is_idempotent_for_concurrent_empty_room_check
     )
 
     bot.client.room_messages.assert_awaited_once()
-    bot._send_response.assert_awaited_once()
+    send_response.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -435,13 +439,14 @@ async def test_router_welcome_send_retries_after_delivery_failure(
             end=None,
         ),
     )
-    bot._send_response = AsyncMock(side_effect=[None, "$welcome"])
+    send_response = AsyncMock(side_effect=[None, "$welcome"])
+    install_send_response_mock(bot, send_response)
 
     await bot._send_welcome_message_if_empty("!empty:localhost")
     await bot._send_welcome_message_if_empty("!empty:localhost")
 
     assert bot.client.room_messages.await_count == 2
-    assert bot._send_response.await_count == 2
+    assert send_response.await_count == 2
 
 
 @pytest.mark.asyncio
@@ -483,11 +488,12 @@ async def test_router_auto_welcome_lists_ad_hoc_present_responder(tmp_path: Path
             end=None,
         ),
     )
-    bot._send_response = AsyncMock(return_value="$welcome")
+    send_response = AsyncMock(return_value="$welcome")
+    install_send_response_mock(bot, send_response)
 
     await bot._send_welcome_message_if_empty("!adhoc:localhost", "@alice:localhost")
 
-    response_text = bot._send_response.await_args.kwargs["response_text"]
+    response_text = send_response.await_args.kwargs["response_text"]
     assert "\u2022 **@code**: Writes code" in response_text
     bot.client.joined_members.assert_awaited_once_with("!adhoc:localhost")
 
@@ -526,11 +532,12 @@ async def test_router_startup_welcome_without_requester_omits_responder_list(tmp
             end=None,
         ),
     )
-    bot._send_response = AsyncMock(return_value="$welcome")
+    send_response = AsyncMock(return_value="$welcome")
+    install_send_response_mock(bot, send_response)
 
     await bot._send_welcome_message_if_empty("!startup:localhost")
 
-    response_text = bot._send_response.await_args.kwargs["response_text"]
+    response_text = send_response.await_args.kwargs["response_text"]
     assert "\U0001f9e0 **Available agents and teams in this room:**" not in response_text
     assert "@mindroom_code" not in response_text
 
@@ -589,7 +596,8 @@ async def test_router_invite_welcome_filters_ad_hoc_responders_for_inviter(
             end=None,
         ),
     )
-    bot._send_response = AsyncMock(return_value="$welcome")
+    send_response = AsyncMock(return_value="$welcome")
+    install_send_response_mock(bot, send_response)
     monkeypatch.setattr("mindroom.bot_room_lifecycle.join_room", AsyncMock(return_value=True))
 
     room = MagicMock(room_id="!adhoc:localhost")
@@ -598,7 +606,7 @@ async def test_router_invite_welcome_filters_ad_hoc_responders_for_inviter(
 
     await bot._on_invite(room, event)
 
-    response_text = bot._send_response.await_args.kwargs["response_text"]
+    response_text = send_response.await_args.kwargs["response_text"]
     assert "\u2022 **@code**: Writes code" in response_text
     assert "@mindroom_research" not in response_text
 

--- a/tests/test_skip_mentions.py
+++ b/tests/test_skip_mentions.py
@@ -109,7 +109,7 @@ def _context_bot(tmp_path: Path, config: Config | None = None) -> AgentBot:
 
 @pytest.mark.asyncio
 async def test_send_response_with_skip_mentions(tmp_path: Path) -> None:
-    """Test that _send_response adds metadata when skip_mentions is True."""
+    """Test that the delivery gateway's send_text adds metadata when skip_mentions is True."""
     config = bind_runtime_paths(
         Config(agents={"email_agent": AgentConfig(display_name="Email Agent")}),
         test_runtime_paths(tmp_path),
@@ -143,18 +143,19 @@ async def test_send_response_with_skip_mentions(tmp_path: Path) -> None:
             "mindroom.delivery_gateway.send_message_result",
             new=AsyncMock(side_effect=delivered_matrix_side_effect("$response123")),
         ) as mock_send:
-            # Call the actual _send_response method with skip_mentions=True
+            # Call the actual delivery gateway send_text with skip_mentions=True
             target = bot._conversation_resolver.build_message_target(
                 room_id=room.room_id,
                 thread_id=None,
                 reply_to_event_id=event.event_id,
                 event_source=event.source,
             )
-            await AgentBot._send_response(
-                bot,
-                target=target,
-                response_text="✅ Scheduled. Will notify @email_agent",
-                skip_mentions=True,
+            await bot._delivery_gateway.send_text(
+                SendTextRequest(
+                    target=target,
+                    response_text="✅ Scheduled. Will notify @email_agent",
+                    skip_mentions=True,
+                ),
             )
 
             # Check that send_message was called with content that has skip_mentions

--- a/tests/test_stop_emoji_reuse.py
+++ b/tests/test_stop_emoji_reuse.py
@@ -17,7 +17,13 @@ from mindroom.logging_config import setup_logging
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
 from mindroom.stop import StopManager
-from tests.conftest import bind_runtime_paths, orchestrator_runtime_paths, runtime_paths_for, test_runtime_paths
+from tests.conftest import (
+    bind_runtime_paths,
+    install_send_response_mock,
+    orchestrator_runtime_paths,
+    runtime_paths_for,
+    test_runtime_paths,
+)
 from tests.identity_helpers import entity_ids, persist_entity_accounts
 
 
@@ -70,8 +76,8 @@ async def test_stop_emoji_only_stops_during_generation(tmp_path: Path) -> None:
     bot.client.user_id = agent_user.user_id
     bot.logger = MagicMock()
     bot.stop_manager = StopManager()
-    bot._send_response = AsyncMock(return_value="$stopping:example.com")
-    bot._generate_response = AsyncMock(return_value="$response:example.com")
+    send_response = AsyncMock(return_value="$stopping:example.com")
+    install_send_response_mock(bot, send_response)
 
     # Create a room and reaction event
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id=agent_user.user_id)
@@ -122,7 +128,7 @@ async def test_stop_emoji_only_stops_during_generation(tmp_path: Path) -> None:
 
         # Should NOT have called interactive.handle_reaction since it was handled as stop
         mock_handle_reaction.assert_not_called()
-        bot._send_response.assert_not_awaited()
+        send_response.assert_not_awaited()
 
         # The task should have been cancelled
         task.cancel.assert_called_once_with(msg=USER_STOP_CANCEL_MSG)
@@ -146,7 +152,8 @@ async def test_stop_emoji_hard_cancels_and_schedules_agno_cleanup_when_run_id_pr
     bot.client.user_id = agent_user.user_id
     bot.logger = MagicMock()
     bot.stop_manager = StopManager()
-    bot._send_response = AsyncMock(return_value="$stopping:example.com")
+    send_response = AsyncMock(return_value="$stopping:example.com")
+    install_send_response_mock(bot, send_response)
 
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id=agent_user.user_id)
     reaction_event = nio.ReactionEvent.from_dict(
@@ -180,7 +187,7 @@ async def test_stop_emoji_hard_cancels_and_schedules_agno_cleanup_when_run_id_pr
 
     mock_schedule_cancel.assert_called_once_with("$message:example.com", "run-123")
     task.cancel.assert_called_once_with(msg=USER_STOP_CANCEL_MSG)
-    bot._send_response.assert_not_awaited()
+    send_response.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -201,7 +208,8 @@ async def test_stop_emoji_threaded_target_sends_no_acknowledgement(tmp_path: Pat
     bot.client.user_id = agent_user.user_id
     bot.logger = MagicMock()
     bot.stop_manager = StopManager()
-    bot._send_response = AsyncMock(return_value="$stopping:example.com")
+    send_response = AsyncMock(return_value="$stopping:example.com")
+    install_send_response_mock(bot, send_response)
 
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id=agent_user.user_id)
     reaction_event = nio.ReactionEvent.from_dict(
@@ -235,7 +243,7 @@ async def test_stop_emoji_threaded_target_sends_no_acknowledgement(tmp_path: Pat
 
     mock_schedule_cancel.assert_called_once_with("$message:example.com", "run-123")
     task.cancel.assert_called_once_with(msg=USER_STOP_CANCEL_MSG)
-    bot._send_response.assert_not_awaited()
+    send_response.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -759,7 +767,8 @@ async def test_stop_reaction_blocked_by_reply_permissions(tmp_path: Path) -> Non
         },
     )
 
-    bot._send_response = AsyncMock()
+    send_response = AsyncMock()
+    install_send_response_mock(bot, send_response)
 
     with patch("mindroom.bot.is_authorized_sender", return_value=True):
         await bot._on_reaction(room, reaction_event)
@@ -767,4 +776,4 @@ async def test_stop_reaction_blocked_by_reply_permissions(tmp_path: Path) -> Non
     # Task should NOT have been cancelled — sender is disallowed
     task.cancel.assert_not_called()
     # No confirmation message should have been sent
-    bot._send_response.assert_not_called()
+    send_response.assert_not_called()

--- a/tests/test_streaming_edits.py
+++ b/tests/test_streaming_edits.py
@@ -21,6 +21,7 @@ from tests.conftest import (
     drain_coalescing,
     install_runtime_cache_support,
     make_matrix_client_mock,
+    replace_edit_regenerator_deps,
     runtime_paths_for,
     test_runtime_paths,
 )
@@ -192,13 +193,10 @@ class TestStreamingEdits:
         }
 
         # Process edit - bot SHOULD regenerate its response.
-        with patch.object(
-            bot,
-            "_generate_response",
-            new=AsyncMock(return_value=_delivery_resolution("$response123")),
-        ) as mock_generate_response:
-            await bot._on_message(mock_room, edit_event1)
-            await drain_coalescing(bot)
+        mock_generate_response = AsyncMock(return_value=_delivery_resolution("$response123"))
+        replace_edit_regenerator_deps(bot, generate_response=mock_generate_response)
+        await bot._on_message(mock_room, edit_event1)
+        await drain_coalescing(bot)
         assert mock_generate_response.await_count == 1
 
         # Edit event 2 - another streaming update
@@ -226,13 +224,10 @@ class TestStreamingEdits:
         mock_ai_response.reset_mock()
 
         # Process second edit - bot should regenerate again.
-        with patch.object(
-            bot,
-            "_generate_response",
-            new=AsyncMock(return_value=_delivery_resolution("$response123")),
-        ) as mock_generate_response:
-            await bot._on_message(mock_room, edit_event2)
-            await drain_coalescing(bot)
+        mock_generate_response = AsyncMock(return_value=_delivery_resolution("$response123"))
+        replace_edit_regenerator_deps(bot, generate_response=mock_generate_response)
+        await bot._on_message(mock_room, edit_event2)
+        await drain_coalescing(bot)
         assert mock_generate_response.await_count == 1
 
     @pytest.mark.asyncio

--- a/tests/test_team_scheduler_context.py
+++ b/tests/test_team_scheduler_context.py
@@ -17,12 +17,11 @@ from mindroom.constants import STREAM_STATUS_ERROR, STREAM_STATUS_KEY
 from mindroom.dispatch_source import MESSAGE_SOURCE_KIND
 from mindroom.final_delivery import StreamTransportOutcome
 from mindroom.hooks import MessageEnvelope
-from mindroom.inbound_turn_normalizer import DispatchPayload
 from mindroom.matrix.client import DeliveredMatrixEvent
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
 from mindroom.orchestration.runtime import SYNC_RESTART_CANCEL_MSG
-from mindroom.response_runner import ResponseRunner
+from mindroom.response_runner import ResponseRequest, ResponseRunner
 from mindroom.streaming import _INTERRUPTED_RESPONSE_NOTE, build_restart_interrupted_body
 from mindroom.tool_system.runtime_context import get_tool_runtime_context
 from tests.conftest import (
@@ -101,7 +100,6 @@ def _make_bot(tmp_path: Path) -> AgentBot:
     bot.client.user_id = agent_user.user_id
     bot.client.rooms = {"!team:localhost": MagicMock(room_id="!team:localhost")}
     bot.orchestrator = MagicMock(config=config)
-    bot._send_response = AsyncMock(return_value="$team_response")
     bot._handle_interactive_question = AsyncMock()
     return install_runtime_cache_support(bot)
 
@@ -145,14 +143,16 @@ async def test_team_non_streaming_has_scheduler_context(tmp_path: Path) -> None:
             team_response=fake_team_response,
         ),
     ):
-        await bot._generate_team_response_helper(
-            payload=DispatchPayload(prompt="Please coordinate and schedule a reminder"),
+        await bot._response_runner.generate_team_response_helper(
+            ResponseRequest(
+                thread_history=[],
+                prompt="Please coordinate and schedule a reminder",
+                user_id="@user:localhost",
+                response_envelope=_response_envelope(),
+                correlation_id="corr-team-non-streaming",
+            ),
             team_agents=team_agents,
             team_mode="coordinate",
-            thread_history=[],
-            requester_user_id="@user:localhost",
-            response_envelope=_response_envelope(),
-            correlation_id="corr-team-non-streaming",
         )
 
 
@@ -191,14 +191,16 @@ async def test_team_non_streaming_cancellation_edits_placeholder(tmp_path: Path)
             team_response=fake_team_response,
         ),
     ):
-        await bot._generate_team_response_helper(
-            payload=DispatchPayload(prompt="Please coordinate and schedule a reminder"),
+        await bot._response_runner.generate_team_response_helper(
+            ResponseRequest(
+                thread_history=[],
+                prompt="Please coordinate and schedule a reminder",
+                user_id="@user:localhost",
+                response_envelope=_response_envelope(),
+                correlation_id="corr-team-cancelled",
+            ),
             team_agents=team_agents,
             team_mode="coordinate",
-            thread_history=[],
-            requester_user_id="@user:localhost",
-            response_envelope=_response_envelope(),
-            correlation_id="corr-team-cancelled",
         )
 
     assert mock_edit.await_args.args[2] == "$thinking"
@@ -241,14 +243,16 @@ async def test_team_non_streaming_sync_restart_edits_placeholder_with_restart_no
             team_response=fake_team_response,
         ),
     ):
-        await bot._generate_team_response_helper(
-            payload=DispatchPayload(prompt="Please coordinate and schedule a reminder"),
+        await bot._response_runner.generate_team_response_helper(
+            ResponseRequest(
+                thread_history=[],
+                prompt="Please coordinate and schedule a reminder",
+                user_id="@user:localhost",
+                response_envelope=_response_envelope(),
+                correlation_id="corr-team-restart",
+            ),
             team_agents=team_agents,
             team_mode="coordinate",
-            thread_history=[],
-            requester_user_id="@user:localhost",
-            response_envelope=_response_envelope(),
-            correlation_id="corr-team-restart",
         )
 
     assert mock_edit.await_args.args[2] == "$thinking"
@@ -304,14 +308,16 @@ async def test_team_streaming_has_scheduler_context(tmp_path: Path) -> None:
             team_response_stream=fake_team_response_stream,
         ),
     ):
-        await bot._generate_team_response_helper(
-            payload=DispatchPayload(prompt="Please collaborate and schedule a reminder"),
+        await bot._response_runner.generate_team_response_helper(
+            ResponseRequest(
+                thread_history=[],
+                prompt="Please collaborate and schedule a reminder",
+                user_id="@user:localhost",
+                response_envelope=_response_envelope(),
+                correlation_id="corr-team-streaming",
+            ),
             team_agents=team_agents,
             team_mode="collaborate",
-            thread_history=[],
-            requester_user_id="@user:localhost",
-            response_envelope=_response_envelope(),
-            correlation_id="corr-team-streaming",
         )
 
 
@@ -346,14 +352,16 @@ async def test_team_late_cancellation_during_post_effects_propagates(tmp_path: P
         ),
     ):
         task = asyncio.create_task(
-            bot._generate_team_response_helper(
-                payload=DispatchPayload(prompt="Please coordinate and schedule a reminder"),
+            bot._response_runner.generate_team_response_helper(
+                ResponseRequest(
+                    thread_history=[],
+                    prompt="Please coordinate and schedule a reminder",
+                    user_id="@user:localhost",
+                    response_envelope=_response_envelope(),
+                    correlation_id="corr-team-late-cancel",
+                ),
                 team_agents=team_agents,
                 team_mode="coordinate",
-                thread_history=[],
-                requester_user_id="@user:localhost",
-                response_envelope=_response_envelope(),
-                correlation_id="corr-team-late-cancel",
             ),
         )
         await started.wait()

--- a/tests/test_thread_mode.py
+++ b/tests/test_thread_mode.py
@@ -21,6 +21,7 @@ from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig, RouterConfig
 from mindroom.constants import ROUTER_AGENT_NAME, resolve_runtime_paths
 from mindroom.conversation_resolver import MessageContext
+from mindroom.delivery_gateway import SendTextRequest
 from mindroom.matrix.cache import ThreadHistoryResult, thread_history_result
 from mindroom.matrix.cache.event_cache import ThreadCacheState
 from mindroom.matrix.cache.thread_reads import ThreadReadMode
@@ -1071,7 +1072,7 @@ class TestExtractMessageContextRoomMode:
 
 
 class TestSendResponseRoomMode:
-    """Test _send_response skips thread relation in room mode."""
+    """Test the delivery gateway's send_text skips thread relation in room mode."""
 
     @pytest.mark.asyncio
     async def test_room_mode_no_thread_metadata(
@@ -1080,7 +1081,7 @@ class TestSendResponseRoomMode:
         assistant_user: AgentMatrixUser,
         tmp_path: Path,
     ) -> None:
-        """In room mode, _send_response should not add thread relation metadata."""
+        """In room mode, send_text should not add thread relation metadata."""
         bot = _agent_bot(config=room_mode_config, agent_user=assistant_user, storage_path=tmp_path)
         bot.client = AsyncMock()
 
@@ -1096,9 +1097,11 @@ class TestSendResponseRoomMode:
                 thread_id=None,
                 reply_to_event_id="$event123",
             )
-            event_id = await bot._send_response(
-                target=target,
-                response_text="Hello!",
+            event_id = await bot._delivery_gateway.send_text(
+                SendTextRequest(
+                    target=target,
+                    response_text="Hello!",
+                ),
             )
 
         assert event_id == "$response_event"
@@ -1270,8 +1273,8 @@ class TestCommandThreadContextRoomMode:
         )
         bot = _agent_bot(config=config, agent_user=router_user, storage_path=tmp_path)
         bot.client = AsyncMock()
-        bot._send_response = AsyncMock(return_value="$reply")
-        install_send_response_mock(bot, bot._send_response)
+        send_response = AsyncMock(return_value="$reply")
+        install_send_response_mock(bot, send_response)
 
         room = _matrix_room("!room:localhost")
 
@@ -1306,7 +1309,7 @@ class TestCommandThreadContextRoomMode:
             )
 
         assert mock_schedule.await_args.kwargs["thread_id"] is None
-        assert bot._send_response.await_args.kwargs["target"].resolved_thread_id is None
+        assert send_response.await_args.kwargs["target"].resolved_thread_id is None
 
     @pytest.mark.asyncio
     async def test_router_command_uses_stable_dispatch_target_without_deriving_context(
@@ -1329,8 +1332,8 @@ class TestCommandThreadContextRoomMode:
         )
         bot = _agent_bot(config=config, agent_user=router_user, storage_path=tmp_path)
         bot.client = AsyncMock()
-        bot._send_response = AsyncMock(return_value="$reply")
-        install_send_response_mock(bot, bot._send_response)
+        send_response = AsyncMock(return_value="$reply")
+        install_send_response_mock(bot, send_response)
 
         room = _matrix_room("!room:localhost")
         event = nio.RoomMessageText.from_dict(
@@ -1365,7 +1368,7 @@ class TestCommandThreadContextRoomMode:
             )
 
         assert mock_schedule.await_args.kwargs["thread_id"] == "$stable_thread"
-        assert bot._send_response.await_args.kwargs["target"].resolved_thread_id == "$stable_thread"
+        assert send_response.await_args.kwargs["target"].resolved_thread_id == "$stable_thread"
 
 
 class TestExtractedModuleLoggerRebinding:

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -35,6 +35,7 @@ from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig, RouterConfig
 from mindroom.constants import STREAM_STATUS_COMPLETED, STREAM_STATUS_KEY, STREAM_STATUS_STREAMING
+from mindroom.delivery_gateway import SendTextRequest
 from mindroom.hooks import EVENT_AGENT_STARTED
 from mindroom.matrix import thread_bookkeeping
 from mindroom.matrix.cache import ThreadHistoryResult, thread_writes
@@ -7643,16 +7644,16 @@ class TestThreadingBehavior:
         # Initialize the bot (to set up components it needs)
 
         # Mock interactive.handle_text_response to return None (not an interactive response)
-        # Mock _generate_response to capture the call and send a test response
-        bot._generate_response = AsyncMock()
-        install_generate_response_mock(bot, bot._generate_response)
+        # Mock response generation to capture the call and send a test response
+        generate_response = AsyncMock()
+        install_generate_response_mock(bot, generate_response)
         with patch("mindroom.turn_controller.interactive.handle_text_response", AsyncMock(return_value=None)):
             # Process the message
             await bot._on_message(room, event)
             await drain_coalescing(bot)
 
-            # Check that _generate_response was called
-            bot._generate_response.assert_called_once()
+            # Check that response generation was called
+            generate_response.assert_called_once()
 
             # Now simulate the response being sent
             target = bot._conversation_resolver.build_message_target(
@@ -7661,9 +7662,11 @@ class TestThreadingBehavior:
                 reply_to_event_id=event.event_id,
                 event_source=event.source,
             )
-            await bot._send_response(
-                target=target,
-                response_text="I can help you with that!",
+            await bot._delivery_gateway.send_text(
+                SendTextRequest(
+                    target=target,
+                    response_text="I can help you with that!",
+                ),
             )
 
         # Check the final response content.
@@ -10071,8 +10074,8 @@ class TestThreadingBehavior:
         # Initialize response tracking
 
         # Mock interactive.handle_text_response and generate_response
-        bot._generate_response = AsyncMock()
-        install_generate_response_mock(bot, bot._generate_response)
+        generate_response = AsyncMock()
+        install_generate_response_mock(bot, generate_response)
         with (
             patch("mindroom.turn_controller.interactive.handle_text_response", AsyncMock(return_value=None)),
             patch(
@@ -10092,8 +10095,8 @@ class TestThreadingBehavior:
             await bot._on_message(room, event)
             await drain_coalescing(bot)
 
-            # Check that _generate_response was called
-            bot._generate_response.assert_called_once()
+            # Check that response generation was called
+            generate_response.assert_called_once()
 
             # Now simulate the response being sent
             target = bot._conversation_resolver.build_message_target(
@@ -10102,9 +10105,11 @@ class TestThreadingBehavior:
                 reply_to_event_id=event.event_id,
                 event_source=event.source,
             )
-            await bot._send_response(
-                target=target,
-                response_text="I can help with that complex question!",
+            await bot._delivery_gateway.send_text(
+                SendTextRequest(
+                    target=target,
+                    response_text="I can help with that complex question!",
+                ),
             )
 
         # Check the final response content.

--- a/tests/test_voice_bot_threading.py
+++ b/tests/test_voice_bot_threading.py
@@ -65,7 +65,13 @@ def _agent_bot(*, agent_user: AgentMatrixUser, storage_path: Path, config: Confi
 
 
 @pytest.fixture
-def mock_home_bot() -> AgentBot:
+def generate_response_mock() -> AsyncMock:
+    """Generation seam mock installed on mock_home_bot."""
+    return AsyncMock(return_value="$response")
+
+
+@pytest.fixture
+def mock_home_bot(generate_response_mock: AsyncMock) -> AgentBot:
     """Create a single-agent bot for audio threading tests."""
     tmpdir = Path(tempfile.mkdtemp())
     agent_user = AgentMatrixUser(
@@ -89,8 +95,7 @@ def mock_home_bot() -> AgentBot:
     sync_bot_runtime_state(bot)
     bot.logger = MagicMock()
     replace_turn_controller_deps(bot, logger=bot.logger)
-    bot._generate_response = AsyncMock(return_value="$response")
-    install_generate_response_mock(bot, bot._generate_response)
+    install_generate_response_mock(bot, generate_response_mock)
     return bot
 
 
@@ -325,7 +330,10 @@ def _install_test_coalescing_gate(bot: AgentBot, *, debounce_seconds: float = 0.
 
 
 @pytest.mark.asyncio
-async def test_voice_message_in_main_room_creates_thread(mock_home_bot: AgentBot) -> None:
+async def test_voice_message_in_main_room_creates_thread(
+    mock_home_bot: AgentBot,
+    generate_response_mock: AsyncMock,
+) -> None:
     """Audio in the main room should reply in a thread rooted at the audio event."""
     bot = mock_home_bot
     mock_context = MessageContext(
@@ -362,8 +370,8 @@ async def test_voice_message_in_main_room_creates_thread(mock_home_bot: AgentBot
         await bot._on_media_message(room, voice_event)
         await drain_coalescing(bot)
 
-    bot._generate_response.assert_called_once()
-    call_kwargs = bot._generate_response.call_args.kwargs
+    generate_response_mock.assert_called_once()
+    call_kwargs = generate_response_mock.call_args.kwargs
     response_target = call_kwargs["response_envelope"].target
     assert response_target.reply_to_event_id == "$voice123"
     assert response_target.resolved_thread_id == "$voice123"
@@ -371,7 +379,10 @@ async def test_voice_message_in_main_room_creates_thread(mock_home_bot: AgentBot
 
 
 @pytest.mark.asyncio
-async def test_voice_message_in_thread_continues_thread(mock_home_bot: AgentBot) -> None:
+async def test_voice_message_in_thread_continues_thread(
+    mock_home_bot: AgentBot,
+    generate_response_mock: AsyncMock,
+) -> None:
     """Audio in an existing thread should keep using that thread root."""
     bot = mock_home_bot
     mock_context = MessageContext(
@@ -415,8 +426,8 @@ async def test_voice_message_in_thread_continues_thread(mock_home_bot: AgentBot)
         await bot._on_media_message(room, voice_event)
         await drain_coalescing(bot)
 
-    bot._generate_response.assert_called_once()
-    call_kwargs = bot._generate_response.call_args.kwargs
+    generate_response_mock.assert_called_once()
+    call_kwargs = generate_response_mock.call_args.kwargs
     response_target = call_kwargs["response_envelope"].target
     assert response_target.reply_to_event_id == "$voice456"
     assert response_target.resolved_thread_id == "$thread_root"
@@ -429,6 +440,7 @@ async def test_voice_message_in_thread_continues_thread(mock_home_bot: AgentBot)
 @pytest.mark.asyncio
 async def test_voice_plain_reply_to_thread_message_stays_threaded_transitively(
     mock_home_bot: AgentBot,
+    generate_response_mock: AsyncMock,
 ) -> None:
     """Plain-reply audio should inherit thread context transitively from the replied-to event."""
     bot = mock_home_bot
@@ -473,8 +485,8 @@ async def test_voice_plain_reply_to_thread_message_stays_threaded_transitively(
         await bot._on_media_message(room, voice_event)
         await drain_coalescing(bot)
 
-    bot._generate_response.assert_called_once()
-    call_kwargs = bot._generate_response.call_args.kwargs
+    generate_response_mock.assert_called_once()
+    call_kwargs = generate_response_mock.call_args.kwargs
     response_target = call_kwargs["response_envelope"].target
     assert response_target.reply_to_event_id == "$voice789"
     assert response_target.resolved_thread_id == "$thread_root"

--- a/tests/test_voice_command_processing.py
+++ b/tests/test_voice_command_processing.py
@@ -161,12 +161,12 @@ def _make_visible_router_echo_scenario(
     bot.client = AsyncMock()
     bot.client.rooms = {}
     _install_voice_thread_dispatch_mocks(bot)
-    bot._send_response = AsyncMock()
+    send_response = AsyncMock()
     if send_response_side_effect is not None:
-        bot._send_response.side_effect = send_response_side_effect
+        send_response.side_effect = send_response_side_effect
     else:
-        bot._send_response.return_value = send_response_return
-    install_send_response_mock(bot, bot._send_response)
+        send_response.return_value = send_response_return
+    install_send_response_mock(bot, send_response)
 
     room_user_ids = [
         "@mindroom_router:localhost",
@@ -301,8 +301,8 @@ async def test_router_processes_own_sidecar_commands_using_original_sender(tmp_p
             ).encode("utf-8"),
         ),
     )
-    bot._send_response = AsyncMock(return_value="$reply")
-    install_send_response_mock(bot, bot._send_response)
+    send_response = AsyncMock(return_value="$reply")
+    install_send_response_mock(bot, send_response)
 
     room = _make_room("@mindroom_router:example.com", "@mindroom_home:localhost", "@alice:example.com")
     event = nio.Event.parse_event(
@@ -384,8 +384,8 @@ async def test_router_parses_sidecar_schedule_command_from_canonical_body(tmp_pa
             ).encode("utf-8"),
         ),
     )
-    bot._send_response = AsyncMock(return_value="$reply")
-    install_send_response_mock(bot, bot._send_response)
+    send_response = AsyncMock(return_value="$reply")
+    install_send_response_mock(bot, send_response)
 
     room = _make_room("@mindroom_router:example.com", "@mindroom_home:localhost", "@alice:example.com")
     event = nio.Event.parse_event(
@@ -472,8 +472,8 @@ async def test_router_treats_sidecar_skill_command_as_unknown_command(tmp_path) 
             ).encode("utf-8"),
         ),
     )
-    bot._send_response = AsyncMock(return_value="$fallback")
-    install_send_response_mock(bot, bot._send_response)
+    send_response = AsyncMock(return_value="$fallback")
+    install_send_response_mock(bot, send_response)
 
     room = _make_room(
         "@mindroom_router:example.com",
@@ -510,10 +510,8 @@ async def test_router_treats_sidecar_skill_command_as_unknown_command(tmp_path) 
         await bot._coalescing_gate.drain_all()
 
     mock_interactive.assert_awaited_once()
-    bot._send_response.assert_awaited_once()
-    assert bot._send_response.await_args.kwargs["response_text"] == (
-        "❌ Unknown command. Try !help for available commands."
-    )
+    send_response.assert_awaited_once()
+    assert send_response.await_args.kwargs["response_text"] == ("❌ Unknown command. Try !help for available commands.")
 
 
 @pytest.mark.asyncio
@@ -742,8 +740,8 @@ async def test_router_ignores_audio_events_from_internal_agents(tmp_path) -> Non
     bot.logger = MagicMock()
     replace_turn_controller_deps(bot, logger=bot.logger)
     bot.client = MagicMock()
-    bot._send_response = AsyncMock()
-    install_send_response_mock(bot, bot._send_response)
+    send_response = AsyncMock()
+    install_send_response_mock(bot, send_response)
 
     room = _make_room(
         "@mindroom_router:example.com",
@@ -766,7 +764,7 @@ async def test_router_ignores_audio_events_from_internal_agents(tmp_path) -> Non
 
     mock_voice.assert_not_called()
     mock_download_audio.assert_not_called()
-    bot._send_response.assert_not_called()
+    send_response.assert_not_called()
     turn_store.record_turn.assert_called_once_with(
         HandledTurnState.from_source_event_id("$agent_audio_event"),
     )
@@ -800,8 +798,8 @@ async def test_agent_handles_audio_without_router_when_voice_disabled(tmp_path) 
     bot.client = AsyncMock()
     bot.client.rooms = {}
     bot.client.user_id = "@mindroom_home:localhost"
-    bot._generate_response = AsyncMock(return_value="$response")
-    install_generate_response_mock(bot, bot._generate_response)
+    generate_response = AsyncMock(return_value="$response")
+    install_generate_response_mock(bot, generate_response)
     _install_voice_thread_dispatch_mocks(bot)
 
     room = _make_room("@mindroom_home:localhost", "@alice:example.com")
@@ -818,8 +816,8 @@ async def test_agent_handles_audio_without_router_when_voice_disabled(tmp_path) 
         await bot._on_media_message(room, event)
         await drain_coalescing(bot)
 
-    bot._generate_response.assert_called_once()
-    call_kwargs = bot._generate_response.call_args.kwargs
+    generate_response.assert_called_once()
+    call_kwargs = generate_response.call_args.kwargs
     expected_attachment_id = _attachment_id_for_event("$voice_event")
     assert call_kwargs["response_envelope"].target.reply_to_event_id == "$voice_event"
     assert call_kwargs["prompt"].startswith(f"{VOICE_PREFIX}[Attached voice message]")
@@ -873,8 +871,8 @@ async def test_agent_handles_audio_with_router_present_in_single_agent_room(tmp_
     bot.client = AsyncMock()
     bot.client.rooms = {}
     bot.client.user_id = "@mindroom_home:localhost"
-    bot._generate_response = AsyncMock(return_value="$response")
-    install_generate_response_mock(bot, bot._generate_response)
+    generate_response = AsyncMock(return_value="$response")
+    install_generate_response_mock(bot, generate_response)
     _install_voice_thread_dispatch_mocks(bot)
 
     room = _make_room("@mindroom_router:localhost", "@mindroom_home:localhost", "@alice:example.com")
@@ -892,7 +890,7 @@ async def test_agent_handles_audio_with_router_present_in_single_agent_room(tmp_
         await drain_coalescing(bot)
 
     mock_download_audio.assert_called_once()
-    bot._generate_response.assert_called_once()
+    generate_response.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -908,6 +906,8 @@ async def test_router_and_agent_share_audio_normalization_when_router_is_present
     )
 
     bots: list[AgentBot] = []
+    send_response_mocks: list[AsyncMock] = []
+    generate_response_mocks: list[AsyncMock] = []
     for agent_name in (ROUTER_AGENT_NAME, "home"):
         agent_user = MagicMock()
         agent_user.user_id = f"@mindroom_{agent_name}:localhost"
@@ -926,12 +926,14 @@ async def test_router_and_agent_share_audio_normalization_when_router_is_present
         bot.client = AsyncMock()
         bot.client.rooms = {}
         bot.client.user_id = agent_user.user_id
-        bot._send_response = AsyncMock(return_value="$router_response")
-        bot._generate_response = AsyncMock(return_value=f"${agent_name}_response")
-        install_send_response_mock(bot, bot._send_response)
-        install_generate_response_mock(bot, bot._generate_response)
+        send_response = AsyncMock(return_value="$router_response")
+        generate_response = AsyncMock(return_value=f"${agent_name}_response")
+        install_send_response_mock(bot, send_response)
+        install_generate_response_mock(bot, generate_response)
         _install_voice_thread_dispatch_mocks(bot)
         bots.append(bot)
+        send_response_mocks.append(send_response)
+        generate_response_mocks.append(generate_response)
 
     room = _make_room("@mindroom_router:localhost", "@mindroom_home:localhost", "@alice:example.com")
     event = _make_voice_event(sender="@alice:example.com")
@@ -950,8 +952,8 @@ async def test_router_and_agent_share_audio_normalization_when_router_is_present
 
     assert mock_download_audio.await_count == 1
     assert mock_voice.await_count == 1
-    bots[0]._send_response.assert_not_called()
-    assert bots[1]._generate_response.await_count == 1
+    send_response_mocks[0].assert_not_called()
+    assert generate_response_mocks[1].await_count == 1
 
 
 @pytest.mark.asyncio
@@ -1224,8 +1226,8 @@ async def test_router_routes_transcribed_audio_when_multiple_agents_are_present(
     bot.logger = MagicMock()
     replace_turn_controller_deps(bot, logger=bot.logger)
     bot.client = AsyncMock()
-    bot._send_response = AsyncMock(return_value="$response")
-    install_send_response_mock(bot, bot._send_response)
+    send_response = AsyncMock(return_value="$response")
+    install_send_response_mock(bot, send_response)
     _install_voice_thread_dispatch_mocks(bot)
 
     room = _make_room(
@@ -1296,6 +1298,7 @@ async def test_transcribed_mentions_target_the_mentioned_agent_when_router_absen
     event = _make_voice_event(sender="@alice:example.com")
 
     bots: list[AgentBot] = []
+    generate_response_mocks: list[AsyncMock] = []
     for agent_name in ("home", "research"):
         agent_user = MagicMock()
         agent_user.user_id = f"@mindroom_{agent_name}:localhost"
@@ -1314,10 +1317,11 @@ async def test_transcribed_mentions_target_the_mentioned_agent_when_router_absen
         bot.client = AsyncMock()
         bot.client.rooms = {}
         bot.client.user_id = f"@mindroom_{agent_name}:localhost"
-        bot._generate_response = AsyncMock(return_value=f"${agent_name}_response")
-        install_generate_response_mock(bot, bot._generate_response)
+        generate_response = AsyncMock(return_value=f"${agent_name}_response")
+        install_generate_response_mock(bot, generate_response)
         _install_voice_thread_dispatch_mocks(bot)
         bots.append(bot)
+        generate_response_mocks.append(generate_response)
 
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
@@ -1333,9 +1337,9 @@ async def test_transcribed_mentions_target_the_mentioned_agent_when_router_absen
 
     assert mock_download_audio.await_count == 1
     assert mock_voice.await_count == 1
-    assert bots[0]._generate_response.await_count == 0
-    assert bots[1]._generate_response.await_count == 1
-    call_kwargs = bots[1]._generate_response.call_args.kwargs
+    assert generate_response_mocks[0].await_count == 0
+    assert generate_response_mocks[1].await_count == 1
+    call_kwargs = generate_response_mocks[1].call_args.kwargs
     assert call_kwargs["response_envelope"].target.reply_to_event_id == "$voice_event"
     assert call_kwargs["prompt"].startswith(f"{VOICE_PREFIX}@research summarize this audio")
     assert call_kwargs["attachment_ids"] == [_attachment_id_for_event("$voice_event")]
@@ -1370,6 +1374,7 @@ async def test_caption_mentions_still_target_agent_when_stt_drops_the_mention(tm
     )
 
     bots: list[AgentBot] = []
+    generate_response_mocks: list[AsyncMock] = []
     for agent_name in ("home", "research"):
         agent_user = MagicMock()
         agent_user.user_id = f"@mindroom_{agent_name}:localhost"
@@ -1388,10 +1393,11 @@ async def test_caption_mentions_still_target_agent_when_stt_drops_the_mention(tm
         bot.client = AsyncMock()
         bot.client.rooms = {}
         bot.client.user_id = f"@mindroom_{agent_name}:localhost"
-        bot._generate_response = AsyncMock(return_value=f"${agent_name}_response")
-        install_generate_response_mock(bot, bot._generate_response)
+        generate_response = AsyncMock(return_value=f"${agent_name}_response")
+        install_generate_response_mock(bot, generate_response)
         _install_voice_thread_dispatch_mocks(bot)
         bots.append(bot)
+        generate_response_mocks.append(generate_response)
 
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
@@ -1407,9 +1413,9 @@ async def test_caption_mentions_still_target_agent_when_stt_drops_the_mention(tm
 
     assert mock_download_audio.await_count == 1
     assert mock_voice.await_count == 1
-    assert bots[0]._generate_response.await_count == 0
-    assert bots[1]._generate_response.await_count == 1
-    call_kwargs = bots[1]._generate_response.call_args.kwargs
+    assert generate_response_mocks[0].await_count == 0
+    assert generate_response_mocks[1].await_count == 1
+    call_kwargs = generate_response_mocks[1].call_args.kwargs
     assert call_kwargs["response_envelope"].target.reply_to_event_id == "$voice_event"
     assert call_kwargs["prompt"].startswith(f"{VOICE_PREFIX}summarize this audio")
     assert call_kwargs["attachment_ids"] == [_attachment_id_for_event("$voice_event")]


### PR DESCRIPTION
## Summary

First PR of the test-seam migration (refactor 4, follows the turn-unification campaign #1368–#1383). Deletes the three `bot.py` flat-kwarg adapters that survived only as test mock points, and moves every test that faked them onto the deep seams that already exist.

### Production (net −180 lines in bot.py)

- **Deleted** `AgentBot._generate_response` (67 lines, pure field-shuffle into `ResponseRequest` → `ResponseRunner.generate_response`), `AgentBot._generate_team_response_helper`, and `AgentBot._send_response`. TurnController has built `ResponseRequest` itself since the turn unification; these had no production value beyond being patchable.
- **`EditRegeneratorDeps.generate_response`** now takes one positional `ResponseRequest`, built by `EditRegenerator` itself (the one remaining production caller of the old flat signature). New runtime dep `edit_regenerator → response_runner` added to `tach.toml`.
- The agent/team polymorphism the old override provided lives in one small hook, `_run_regenerated_response(request)`: AgentBot forwards to the runner; TeamBot keeps its configured-team logic (renamed from its `_generate_response` override, now request-shaped, delegating to `ResponseRunner.generate_team_response_helper` via `dataclasses.replace`).
- Room-lifecycle welcome sends and `commands/config_confirmation.py` call `DeliveryGateway.send_text(SendTextRequest(...))` directly.

### Tests (26 files)

- `bot._generate_response = AsyncMock()` / `bot._send_response = AsyncMock()` attribute stashing is gone. Tests now hold a **local mock** installed at the owning seam: `install_generate_response_mock` (runner boundary), `install_send_response_mock` (gateway boundary), or `replace_edit_regenerator_deps(generate_response=...)` (edit seam, request-shaped).
- Tests that **drove** the deleted methods directly now drive the seam: `runner.generate_response(ResponseRequest(...))`, `runner.generate_team_response_helper(ResponseRequest(...), team_agents=..., team_mode=...)`, `gateway.send_text(SendTextRequest(...))`, or `TeamBot._run_regenerated_response(request)` for the configured-team logic.
- Several previously **dead mocks** (assigned but no longer consulted by production) were found: not-called assertions that had become vacuous are reinstalled at the real seam (restoring their regression value); fully vestigial ones deleted (7 in `test_ai_user_id.py`, 1 each in `test_stop_emoji_reuse.py` / `test_bot_scheduling.py` — details in commit).

### Verification

- Full suite: **9112 passed, 61 skipped; collected count 9173 unchanged from main** (no test lost).
- `SKIP=typescript-check pre-commit run --all-files` clean; `tach check --dependencies --interfaces` clean.
- **Mutation spot-checks** (break behavior → migrated tests must fail): room-lifecycle send silently dropped → 7 failures in `test_room_invites.py`; edit-regen `existing_event_id` dropped → 9 failures across edit tests; TeamBot rejection send dropped → 1 failure; config-confirmation send dropped → 3 failures. All reverted.