### PR TITLE
Fix resolve_worker_target team-dispatch crash and consolidate the toolkit worker-target recipe

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -411,6 +411,21 @@ def needs_runtime_tools() -> type[Toolkit]:
     return NeedsRuntimeTools
 ```
 
+### Dispatch-time worker targets
+
+`WORKER_TARGET` covers toolkits that receive their worker target at construction.
+Tools that compose other registered tools while handling a call (for example building a sub-toolkit with `get_tool_by_name`) resolve the same target from the live runtime context instead:
+
+```python
+from mindroom.tool_system.runtime_context import get_tool_runtime_context
+
+context = get_tool_runtime_context()
+worker_target = context.resolve_worker_target()
+```
+
+This returns the exact worker target that agent toolkit construction uses, so requester-scoped state such as OAuth MCP sessions and scoped credentials resolves identically.
+`resolve_worker_target()` raises `ValueError` for team and router dispatches, because those contexts have no single agent execution scope to mirror; catch it if your tool can run inside a team.
+
 ## MCP via plugins (advanced)
 
 MindRoom supports native MCP servers in `config.yaml` — see [MCP](mcp.md) for the normal setup path.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -10687,6 +10687,21 @@ def needs_runtime_tools() -> type[Toolkit]:
     return NeedsRuntimeTools
 ```
 
+### Dispatch-time worker targets
+
+`WORKER_TARGET` covers toolkits that receive their worker target at construction.
+Tools that compose other registered tools while handling a call (for example building a sub-toolkit with `get_tool_by_name`) resolve the same target from the live runtime context instead:
+
+```python
+from mindroom.tool_system.runtime_context import get_tool_runtime_context
+
+context = get_tool_runtime_context()
+worker_target = context.resolve_worker_target()
+```
+
+This returns the exact worker target that agent toolkit construction uses, so requester-scoped state such as OAuth MCP sessions and scoped credentials resolves identically.
+`resolve_worker_target()` raises `ValueError` for team and router dispatches, because those contexts have no single agent execution scope to mirror; catch it if your tool can run inside a team.
+
 ## MCP via plugins (advanced)
 
 MindRoom supports native MCP servers in `config.yaml` — see [MCP](https://docs.mindroom.chat/mcp/) for the normal setup path.

--- a/skills/mindroom-docs/references/page__plugins__index.md
+++ b/skills/mindroom-docs/references/page__plugins__index.md
@@ -407,6 +407,21 @@ def needs_runtime_tools() -> type[Toolkit]:
     return NeedsRuntimeTools
 ```
 
+### Dispatch-time worker targets
+
+`WORKER_TARGET` covers toolkits that receive their worker target at construction.
+Tools that compose other registered tools while handling a call (for example building a sub-toolkit with `get_tool_by_name`) resolve the same target from the live runtime context instead:
+
+```python
+from mindroom.tool_system.runtime_context import get_tool_runtime_context
+
+context = get_tool_runtime_context()
+worker_target = context.resolve_worker_target()
+```
+
+This returns the exact worker target that agent toolkit construction uses, so requester-scoped state such as OAuth MCP sessions and scoped credentials resolves identically.
+`resolve_worker_target()` raises `ValueError` for team and router dispatches, because those contexts have no single agent execution scope to mirror; catch it if your tool can run inside a team.
+
 ## MCP via plugins (advanced)
 
 MindRoom supports native MCP servers in `config.yaml` — see [MCP](https://docs.mindroom.chat/mcp/) for the normal setup path.

--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -53,7 +53,7 @@ from mindroom.tool_system.skills import build_agent_skills
 from mindroom.tool_system.tool_hooks import build_tool_hook_bridge, prepend_tool_hook_bridge
 from mindroom.tool_system.worker_routing import (
     agent_workspace_root_path,
-    build_worker_target_from_runtime_env,
+    build_agent_toolkit_worker_target,
     resolve_agent_owned_path,
     shared_storage_root,
 )
@@ -480,16 +480,12 @@ def _build_registered_agent_tool(
     runtime_overrides: dict[str, object] | None,
 ) -> Toolkit:
     """Build one registered toolkit using the resolved routing inputs for this agent."""
-    worker_target = build_worker_target_from_runtime_env(
+    worker_target = build_agent_toolkit_worker_target(
         worker_scope,
         agent_name,
+        is_private=routing_agent_is_private,
         execution_identity=execution_identity,
         runtime_paths=runtime_paths,
-        private_agent_names=(
-            frozenset({agent_name})
-            if worker_scope == "user_agent" and routing_agent_is_private
-            else (frozenset() if worker_scope == "user_agent" else None)
-        ),
     )
 
     return get_tool_by_name(

--- a/src/mindroom/config/main.py
+++ b/src/mindroom/config/main.py
@@ -1192,15 +1192,6 @@ class Config(BaseModel):
             return DEFAULT_WORKER_GRANTABLE_CREDENTIALS
         return frozenset(configured)
 
-    def agent_execution_scope(self, agent_name: str) -> WorkerScope | None:
-        """Return the derived execution scope for one agent.
-
-        Public accessor for tool-composition call sites (e.g. plugins that
-        build other registered tools at dispatch time and need the same
-        worker scoping as agent toolkit construction).
-        """
-        return self._agent_execution_scope(agent_name)
-
     def _agent_execution_scope(self, agent_name: str) -> WorkerScope | None:
         """Return the internal derived execution scope for one agent.
 

--- a/src/mindroom/tool_system/runtime_context.py
+++ b/src/mindroom/tool_system/runtime_context.py
@@ -24,7 +24,7 @@ from mindroom.logging_config import get_logger
 from mindroom.message_target import MessageTarget
 from mindroom.tool_system.context_bound_streams import context_bound_async_stream
 from mindroom.tool_system.plugin_identity import validate_plugin_name
-from mindroom.tool_system.worker_routing import build_tool_execution_identity, build_worker_target_from_runtime_env
+from mindroom.tool_system.worker_routing import build_agent_toolkit_worker_target, build_tool_execution_identity
 
 if TYPE_CHECKING:
     import asyncio
@@ -95,20 +95,25 @@ class ToolRuntimeContext:
         building search backends, sub-toolkits) need the same worker target
         that agent toolkit construction uses, so requester-scoped state —
         OAuth MCP sessions, scoped credentials — resolves identically.
-        Mirrors the inputs of agents._build_registered_agent_tool.
+
+        Raises:
+            ValueError: For team and router dispatches, whose contexts carry
+                the entity name and therefore have no single agent execution
+                scope for a composed toolkit to mirror.
+
         """
-        worker_scope = self.config.agent_execution_scope(self.agent_name)
-        routing_agent_is_private = self.config.get_agent(self.agent_name).private is not None
-        if worker_scope == "user_agent":
-            private_agent_names = frozenset({self.agent_name}) if routing_agent_is_private else frozenset()
-        else:
-            private_agent_names = None
-        return build_worker_target_from_runtime_env(
-            worker_scope,
+        if self.agent_name not in self.config.agents:
+            msg = (
+                f"resolve_worker_target requires an agent dispatch; {self.agent_name!r} is not a configured agent. "
+                "Team and router dispatches have no single agent execution scope."
+            )
+            raise ValueError(msg)
+        return build_agent_toolkit_worker_target(
+            self.config.resolve_entity(self.agent_name).execution_scope,
             self.agent_name,
+            is_private=self.config.get_agent(self.agent_name).private is not None,
             execution_identity=build_execution_identity_from_runtime_context(self),
             runtime_paths=self.runtime_paths,
-            private_agent_names=private_agent_names,
         )
 
 

--- a/src/mindroom/tool_system/worker_routing.py
+++ b/src/mindroom/tool_system/worker_routing.py
@@ -378,6 +378,32 @@ def build_worker_target_from_runtime_env(
     )
 
 
+def build_agent_toolkit_worker_target(
+    worker_scope: WorkerScope | None,
+    agent_name: str,
+    *,
+    is_private: bool,
+    execution_identity: ToolExecutionIdentity | None,
+    runtime_paths: RuntimePaths,
+) -> ResolvedWorkerTarget:
+    """Build the worker target used when constructing one agent's registered toolkits.
+
+    Single source of truth for the `private_agent_names` derivation shared by
+    agent toolkit construction and dispatch-time tool composition.
+    """
+    if worker_scope == "user_agent":
+        private_agent_names = frozenset({agent_name}) if is_private else frozenset()
+    else:
+        private_agent_names = None
+    return build_worker_target_from_runtime_env(
+        worker_scope,
+        agent_name,
+        execution_identity=execution_identity,
+        runtime_paths=runtime_paths,
+        private_agent_names=private_agent_names,
+    )
+
+
 def worker_scope_allows_shared_only_integrations(worker_scope: WorkerScope | None) -> bool:
     """Return whether a worker scope can use shared-only dashboard integrations."""
     return worker_scope in (None, "shared")

--- a/tach.toml
+++ b/tach.toml
@@ -3364,6 +3364,7 @@ expose = [
     "agent_state_root_path",
     "agent_workspace_relative_path",
     "agent_workspace_root_path",
+    "build_agent_toolkit_worker_target",
     "build_tool_execution_identity",
     "build_worker_target_from_runtime_env",
     "get_tool_execution_identity",

--- a/tests/test_resolve_tool_worker_target.py
+++ b/tests/test_resolve_tool_worker_target.py
@@ -5,13 +5,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock
 
+import pytest
+
 from mindroom.config.main import Config
 from mindroom.constants import resolve_primary_runtime_paths
-from mindroom.tool_system.runtime_context import (
-    ToolRuntimeContext,
-    build_execution_identity_from_runtime_context,
-)
-from mindroom.tool_system.worker_routing import build_worker_target_from_runtime_env
+from mindroom.tool_system.runtime_context import ToolRuntimeContext
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -33,7 +31,7 @@ def _context(config: Config, agent_name: str, tmp_path: Path) -> ToolRuntimeCont
 
 
 def test_private_user_agent_scope_resolves_requester_scoped_target(tmp_path: Path) -> None:
-    """A private user_agent-scoped agent resolves a requester-scoped target."""
+    """A private user_agent-scoped agent resolves a requester-scoped target isolating itself."""
     config = Config(
         agents={
             "mind": {
@@ -52,49 +50,46 @@ def test_private_user_agent_scope_resolves_requester_scoped_target(tmp_path: Pat
     assert target.private_agent_names == frozenset({"mind"})
 
 
-def test_resolution_matches_agent_construction_recipe(tmp_path: Path) -> None:
-    """The method matches build_worker_target_from_runtime_env fed literal agent-construction inputs."""
+def test_authored_user_agent_scope_resolves_without_private_isolation(tmp_path: Path) -> None:
+    """A shared agent with authored worker_scope=user_agent gets a requester-scoped key and no private set."""
+    config = Config(agents={"scoped": {"display_name": "Scoped", "worker_scope": "user_agent"}})
+    context = _context(config, "scoped", tmp_path)
+
+    target = context.resolve_worker_target()
+
+    assert target.worker_scope == "user_agent"
+    assert target.routing_agent_name == "scoped"
+    assert target.worker_key
+    assert target.private_agent_names == frozenset()
+
+
+def test_unscoped_agent_resolves_shared_target(tmp_path: Path) -> None:
+    """An agent without any worker scope resolves an unscoped target."""
+    config = Config(agents={"helper": {"display_name": "Helper"}})
+    context = _context(config, "helper", tmp_path)
+
+    target = context.resolve_worker_target()
+
+    assert target.worker_scope is None
+    assert target.routing_agent_name == "helper"
+    assert target.worker_key is None
+    assert target.private_agent_names is None
+
+
+def test_team_dispatch_raises_a_purposeful_error(tmp_path: Path) -> None:
+    """A team-named dispatch context fails loudly instead of resolving a wrong scope."""
     config = Config(
-        agents={
-            "mind": {
-                "display_name": "Mind",
-                "private": {"per": "user_agent", "root": "workspace/mind_data"},
+        agents={"code": {"display_name": "Code"}},
+        teams={
+            "super_team": {
+                "display_name": "Super Team",
+                "role": "Collaborative engineering assistant",
+                "agents": ["code"],
+                "mode": "collaborate",
             },
-            "helper": {"display_name": "Helper"},
         },
     )
+    context = _context(config, "super_team", tmp_path)
 
-    mind_context = _context(config, "mind", tmp_path)
-    assert mind_context.resolve_worker_target() == build_worker_target_from_runtime_env(
-        "user_agent",
-        "mind",
-        execution_identity=build_execution_identity_from_runtime_context(mind_context),
-        runtime_paths=mind_context.runtime_paths,
-        private_agent_names=frozenset({"mind"}),
-    )
-
-    helper_context = _context(config, "helper", tmp_path)
-    assert config.agent_execution_scope("helper") is None
-    assert helper_context.resolve_worker_target() == build_worker_target_from_runtime_env(
-        None,
-        "helper",
-        execution_identity=build_execution_identity_from_runtime_context(helper_context),
-        runtime_paths=helper_context.runtime_paths,
-        private_agent_names=None,
-    )
-
-
-def test_public_execution_scope_accessor_matches_internal(tmp_path: Path) -> None:
-    """The public accessor delegates to the internal derivation."""
-    del tmp_path
-    config = Config(
-        agents={
-            "mind": {
-                "display_name": "Mind",
-                "private": {"per": "user_agent", "root": "workspace/mind_data"},
-            },
-            "helper": {"display_name": "Helper"},
-        },
-    )
-    for agent_name in ("mind", "helper"):
-        assert config.agent_execution_scope(agent_name) == config._agent_execution_scope(agent_name)
+    with pytest.raises(ValueError, match="requires an agent dispatch"):
+        context.resolve_worker_target()

--- a/tests/test_resolve_tool_worker_target.py
+++ b/tests/test_resolve_tool_worker_target.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from mindroom.config.main import Config
-from mindroom.constants import resolve_primary_runtime_paths
+from mindroom.constants import ROUTER_AGENT_NAME, resolve_primary_runtime_paths
 from mindroom.tool_system.runtime_context import ToolRuntimeContext
 
 if TYPE_CHECKING:
@@ -90,6 +90,15 @@ def test_team_dispatch_raises_a_purposeful_error(tmp_path: Path) -> None:
         },
     )
     context = _context(config, "super_team", tmp_path)
+
+    with pytest.raises(ValueError, match="requires an agent dispatch"):
+        context.resolve_worker_target()
+
+
+def test_router_dispatch_raises_a_purposeful_error(tmp_path: Path) -> None:
+    """A router-named dispatch context fails loudly like any non-agent dispatch."""
+    config = Config(agents={"code": {"display_name": "Code"}})
+    context = _context(config, ROUTER_AGENT_NAME, tmp_path)
 
     with pytest.raises(ValueError, match="requires an agent dispatch"):
         context.resolve_worker_target()


### PR DESCRIPTION
Follow-up to #1389, addressing the review findings tracked in #1395.

## Why

`resolve_worker_target()` crashed for every tool dispatched during a team run: TeamBot dispatch contexts carry the team name (`ToolRuntimeSupport` is built with the bot's own name and the team path passes no member override), so the first line hit `Config.get_agent(<team>)` and raised `ValueError: Unknown agent: super_team. Available agents: code` (reproduced live).

The `private_agent_names` recipe also existed in two production copies (`agents._build_registered_agent_tool` and `resolve_worker_target`) plus a third restatement in the parity test, and `Config.agent_execution_scope` duplicated the already-public `resolve_entity(...).execution_scope` surface.

## What

- **`worker_routing.build_agent_toolkit_worker_target()`** — single source of truth for the scope → `private_agent_names` derivation, called by both `agents._build_registered_agent_tool` and `ToolRuntimeContext.resolve_worker_target`, so parity holds by construction. Exposed in the `tach.toml` interface.
- **`resolve_worker_target()` fails purposefully for team and router dispatches** with a clear message. No silent unscoped fallback: teams may contain authored `worker_scope: user_agent` members, so any scope guessed at dispatch time could land requester-scoped state on the wrong session — the exact bug class #1389 fixed.
- **Removed `Config.agent_execution_scope`** — the method now uses the established `resolve_entity(...).execution_scope` surface (same pattern as `api/openai_request_parsing.py` and `tools/approved_egress.py`).
- **Tests rewritten as behavior tests**: private `user_agent`, authored `user_agent` (empty private set), unscoped, and the team-dispatch error — replacing the self-referential parity test and the `del tmp_path` accessor test.
- **Docs**: new "Dispatch-time worker targets" section in `docs/plugins.md` documenting `get_tool_runtime_context().resolve_worker_target()`, its parity guarantee, and the team/router error contract (skill references regenerated).

Not included: the pre-existing latent team-name crash in `tools/approved_egress.py` `_grant_subject` (same class, noted in #1395); it predates #1389 and deserves its own decision about grant subjects under teams.

## Testing

Full backend suite: **9118 passed, 61 skipped**. All pre-commit hooks pass (ruff, ty, vulture, tach `--dependencies --interfaces`, module privacy). New tests cover all three scope branches and the team-dispatch error.

Closes #1395


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guidance on how worker targets are resolved at dispatch time for tools and nested tool compositions.
* **Bug Fixes**
  * Improved worker-target resolution to better match the active agent context.
  * Requests without a single agent scope now fail clearly instead of resolving incorrectly.
* **Documentation**
  * Expanded plugin and reference docs with examples and clearer behavior notes for scoped sessions and dispatch contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->