### PR TITLE
Rewrite five should_use_streaming patch sites against real streaming inputs

### DIFF
--- a/tests/ai_user_id_helpers.py
+++ b/tests/ai_user_id_helpers.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from typing import TYPE_CHECKING, TypeVar, cast
 from unittest.mock import AsyncMock, MagicMock
 
+import nio
 from agno.db.base import SessionType
 from agno.models.message import Message
 
@@ -270,6 +271,17 @@ def _open_team_scope_context(
     )
 
 
+def _mark_requester_online(client: AsyncMock, user_id: str, room_id: str = "!test:localhost") -> None:
+    """Make the requester show as online in the client's synced room cache.
+
+    ``should_use_streaming`` reads presence from ``client.rooms`` first, so this
+    drives the streaming decision through its real input instead of a patch.
+    """
+    room = nio.MatrixRoom(room_id, "@mindroom_general:localhost")
+    room.users[user_id] = nio.MatrixUser(user_id, presence="online")
+    client.rooms = {room_id: room}
+
+
 def _make_bot(
     tmp_path: Path,
     *,
@@ -280,6 +292,7 @@ def _make_bot(
     bot = MagicMock(spec=AgentBot)
     bot.logger = MagicMock()
     bot.stop_manager = MagicMock()
+    bot.stop_manager.add_stop_button = AsyncMock()
     bot.stop_manager.remove_stop_button = AsyncMock()
     bot.client = AsyncMock()
     bot.agent_name = agent_name
@@ -335,6 +348,7 @@ def _build_response_runner(
     message_target: MessageTarget | None = None,
     orchestrator: object | None = None,
     knowledge_access_support: SimpleNamespace | None = None,
+    enable_streaming: bool = True,
 ) -> ResponseRunner:
     """Build a real response runner for one bot-shaped test double."""
 
@@ -344,7 +358,7 @@ def _build_response_runner(
         return storage if storage is not None else MagicMock()
 
     bot.matrix_id = MagicMock(full_id="@mindroom_general:localhost", domain="localhost")
-    bot.enable_streaming = True
+    bot.enable_streaming = enable_streaming
     bot.show_tool_calls = False
     bot.orchestrator = orchestrator
     bot._conversation_resolver = MagicMock()

--- a/tests/response_runner_helpers.py
+++ b/tests/response_runner_helpers.py
@@ -1,0 +1,96 @@
+"""Shared bot/request scaffolding for the focused ResponseRunner test modules."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
+
+from mindroom.bot import AgentBot
+from mindroom.config.agent import AgentConfig
+from mindroom.config.auth import AuthorizationConfig
+from mindroom.config.main import Config
+from mindroom.config.models import ModelConfig
+from mindroom.hooks import MessageEnvelope
+from mindroom.matrix.users import AgentMatrixUser
+from mindroom.message_target import MessageTarget
+from mindroom.response_runner import ResponseRequest
+from tests.conftest import (
+    TEST_PASSWORD,
+    bind_runtime_paths,
+    install_runtime_cache_support,
+    make_matrix_client_mock,
+    message_origin,
+    runtime_paths_for,
+    test_runtime_paths,
+    wrap_extracted_collaborators,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+
+def _config(tmp_path: Path) -> Config:
+    return bind_runtime_paths(
+        Config(
+            agents={"general": AgentConfig(display_name="General", rooms=["!room:localhost"])},
+            teams={},
+            models={"default": ModelConfig(provider="openai", id="test-model")},
+            authorization=AuthorizationConfig(default_room_access=True),
+        ),
+        test_runtime_paths(tmp_path),
+    )
+
+
+def _bot(tmp_path: Path) -> AgentBot:
+    config = _config(tmp_path)
+    agent_user = AgentMatrixUser(
+        agent_name="general",
+        password=TEST_PASSWORD,
+        display_name="General",
+        user_id="@mindroom_general:localhost",
+    )
+    bot = AgentBot(agent_user, tmp_path, config, runtime_paths_for(config), rooms=["!room:localhost"])
+    bot.client = make_matrix_client_mock(user_id="@mindroom_general:localhost")
+    install_runtime_cache_support(bot)
+    wrap_extracted_collaborators(bot)
+    return bot
+
+
+def _target(*, thread_id: str | None = None, reply_to_event_id: str = "$event") -> MessageTarget:
+    return MessageTarget.resolve(
+        room_id="!room:localhost",
+        thread_id=thread_id,
+        reply_to_event_id=reply_to_event_id,
+        room_mode=thread_id is None,
+    )
+
+
+def _envelope(target: MessageTarget, *, source_event_id: str = "$event") -> MessageEnvelope:
+    return MessageEnvelope(
+        source_event_id=source_event_id,
+        room_id="!room:localhost",
+        target=target,
+        requester_id="@user:localhost",
+        sender_id="@user:localhost",
+        body="hello",
+        attachment_ids=(),
+        mentioned_agents=(),
+        agent_name="general",
+        source_kind="message",
+        origin=message_origin(sender_id="@user:localhost", requester_id="@user:localhost", source_kind="message"),
+    )
+
+
+def _plain_request(target: MessageTarget, *, source_event_id: str = "$event") -> ResponseRequest:
+    return ResponseRequest(
+        thread_history=[],
+        prompt="hello",
+        user_id="@user:localhost",
+        response_envelope=_envelope(target, source_event_id=source_event_id),
+    )
+
+
+@asynccontextmanager
+async def _noop_typing(*_args: object, **_kwargs: object) -> AsyncIterator[None]:
+    yield

--- a/tests/response_runner_helpers.py
+++ b/tests/response_runner_helpers.py
@@ -69,7 +69,7 @@ def _target(*, thread_id: str | None = None, reply_to_event_id: str = "$event") 
 def _envelope(target: MessageTarget, *, source_event_id: str = "$event") -> MessageEnvelope:
     return MessageEnvelope(
         source_event_id=source_event_id,
-        room_id="!room:localhost",
+        room_id=target.room_id,
         target=target,
         requester_id="@user:localhost",
         sender_id="@user:localhost",

--- a/tests/test_locked_turn_delivery.py
+++ b/tests/test_locked_turn_delivery.py
@@ -22,7 +22,7 @@ from tests.ai_user_id_helpers import (
 )
 from tests.conftest import bind_runtime_paths, patch_response_runner_module, unwrap_extracted_collaborator
 from tests.identity_helpers import fixture_entity_matrix_id
-from tests.test_response_runner_focused import _bot, _noop_typing, _plain_request, _target
+from tests.response_runner_helpers import _bot, _noop_typing, _plain_request, _target
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable

--- a/tests/test_response_runner_focused.py
+++ b/tests/test_response_runner_focused.py
@@ -9,7 +9,6 @@ orchestrator/bot boot, so shrinking ``response_runner.py`` has a safety net.
 from __future__ import annotations
 
 import asyncio
-from contextlib import asynccontextmanager
 from dataclasses import replace
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -19,21 +18,13 @@ import pytest
 from mindroom import background_tasks as background_tasks_module
 from mindroom import response_runner
 from mindroom.background_tasks import wait_for_background_tasks
-from mindroom.bot import AgentBot
-from mindroom.config.agent import AgentConfig
-from mindroom.config.auth import AuthorizationConfig
-from mindroom.config.main import Config
-from mindroom.config.models import ModelConfig
 from mindroom.constants import STREAM_STATUS_KEY, STREAM_STATUS_PENDING
 from mindroom.conversation_resolver import ConversationResolver, MessageContext
 from mindroom.delivery_gateway import DeliveryGateway
 from mindroom.final_delivery import FinalDeliveryOutcome, StreamTransportOutcome
 from mindroom.history.turn_recorder import TurnRecorder
-from mindroom.hooks import MessageEnvelope
 from mindroom.logging_config import get_logger
 from mindroom.matrix.cache import ThreadHistoryResult
-from mindroom.matrix.users import AgentMatrixUser
-from mindroom.message_target import MessageTarget
 from mindroom.post_response_effects import PostResponseEffectsDeps, ResponseOutcome, apply_post_response_effects
 from mindroom.response_attempt import ResponseAttemptDeps, ResponseAttemptRequest, ResponseAttemptRunner
 from mindroom.response_lifecycle import ResponseLifecycleCoordinator
@@ -43,18 +34,19 @@ from mindroom.stop import StopManager
 from mindroom.streaming import StreamingDeliveryError
 from mindroom.turn_policy import PreparedDispatch
 from tests.conftest import (
-    TEST_PASSWORD,
-    bind_runtime_paths,
-    install_runtime_cache_support,
     make_matrix_client_mock,
-    message_origin,
     patch_response_runner_module,
     replace_response_runner_deps,
     request_envelope,
-    runtime_paths_for,
-    test_runtime_paths,
     unwrap_extracted_collaborator,
-    wrap_extracted_collaborators,
+)
+from tests.response_runner_helpers import (
+    _bot,
+    _config,
+    _envelope,
+    _noop_typing,
+    _plain_request,
+    _target,
 )
 
 if TYPE_CHECKING:
@@ -63,57 +55,8 @@ if TYPE_CHECKING:
 
     from nio import AsyncClient
 
-
-def _config(tmp_path: Path) -> Config:
-    return bind_runtime_paths(
-        Config(
-            agents={"general": AgentConfig(display_name="General", rooms=["!room:localhost"])},
-            teams={},
-            models={"default": ModelConfig(provider="openai", id="test-model")},
-            authorization=AuthorizationConfig(default_room_access=True),
-        ),
-        test_runtime_paths(tmp_path),
-    )
-
-
-def _bot(tmp_path: Path) -> AgentBot:
-    config = _config(tmp_path)
-    agent_user = AgentMatrixUser(
-        agent_name="general",
-        password=TEST_PASSWORD,
-        display_name="General",
-        user_id="@mindroom_general:localhost",
-    )
-    bot = AgentBot(agent_user, tmp_path, config, runtime_paths_for(config), rooms=["!room:localhost"])
-    bot.client = make_matrix_client_mock(user_id="@mindroom_general:localhost")
-    install_runtime_cache_support(bot)
-    wrap_extracted_collaborators(bot)
-    return bot
-
-
-def _target(*, thread_id: str | None = None, reply_to_event_id: str = "$event") -> MessageTarget:
-    return MessageTarget.resolve(
-        room_id="!room:localhost",
-        thread_id=thread_id,
-        reply_to_event_id=reply_to_event_id,
-        room_mode=thread_id is None,
-    )
-
-
-def _envelope(target: MessageTarget, *, source_event_id: str = "$event") -> MessageEnvelope:
-    return MessageEnvelope(
-        source_event_id=source_event_id,
-        room_id="!room:localhost",
-        target=target,
-        requester_id="@user:localhost",
-        sender_id="@user:localhost",
-        body="hello",
-        attachment_ids=(),
-        mentioned_agents=(),
-        agent_name="general",
-        source_kind="message",
-        origin=message_origin(sender_id="@user:localhost", requester_id="@user:localhost", source_kind="message"),
-    )
+    from mindroom.hooks import MessageEnvelope
+    from mindroom.message_target import MessageTarget
 
 
 def _preparation(target: MessageTarget, envelope: MessageEnvelope) -> ResponsePayloadPreparation:
@@ -145,15 +88,6 @@ def _preparation(target: MessageTarget, envelope: MessageEnvelope) -> ResponsePa
     )
 
 
-def _plain_request(target: MessageTarget, *, source_event_id: str = "$event") -> ResponseRequest:
-    return ResponseRequest(
-        thread_history=[],
-        prompt="hello",
-        user_id="@user:localhost",
-        response_envelope=_envelope(target, source_event_id=source_event_id),
-    )
-
-
 def _completed_outcome(event_id: str = "$response", body: str = "ok") -> FinalDeliveryOutcome:
     return FinalDeliveryOutcome(
         terminal_status="completed",
@@ -162,11 +96,6 @@ def _completed_outcome(event_id: str = "$response", body: str = "ok") -> FinalDe
         final_visible_body=body,
         delivery_kind="sent",
     )
-
-
-@asynccontextmanager
-async def _noop_typing(*_args: object, **_kwargs: object) -> AsyncIterator[None]:
-    yield
 
 
 class RecordingStopManager(StopManager):

--- a/tests/test_response_runner_session_lifecycle.py
+++ b/tests/test_response_runner_session_lifecycle.py
@@ -69,6 +69,7 @@ from tests.ai_user_id_helpers import (
     _config_with_matrix_message,
     _knowledge_access_support,
     _make_bot,
+    _mark_requester_online,
     _open_agent_scope_context,
     _plugin,
     _prepared_prompt_result,
@@ -169,17 +170,17 @@ async def test_generate_response_emits_cancelled_hook_once_for_empty_prompt(
     runtime_paths = _runtime_paths(tmp_path)
     config = bind_runtime_paths(_config(), runtime_paths)
     bot = _make_bot(tmp_path, config=config, runtime_paths=runtime_paths)
+    if use_streaming:
+        _mark_requester_online(bot.client, "@alice:localhost")
 
-    with (
-        patch("mindroom.response_runner.should_use_streaming", new=AsyncMock(return_value=use_streaming)),
-        patch("mindroom.response_lifecycle.apply_post_response_effects", new=AsyncMock(return_value=None)),
-    ):
+    with patch("mindroom.response_lifecycle.apply_post_response_effects", new=AsyncMock(return_value=None)):
         coordinator = _build_response_runner(
             bot,
             config=config,
             runtime_paths=runtime_paths,
             storage_path=tmp_path,
             requester_id="@alice:localhost",
+            enable_streaming=use_streaming,
         )
         coordinator.deps.delivery_gateway.deps.response_hooks.emit_cancelled_response.reset_mock()
 
@@ -250,11 +251,9 @@ async def test_process_and_respond_streaming_preserves_user_stop_outcome(
     runtime_paths = _runtime_paths(tmp_path)
     config = bind_runtime_paths(_config(), runtime_paths)
     bot = _make_bot(tmp_path, config=config, runtime_paths=runtime_paths)
+    _mark_requester_online(bot.client, "@alice:localhost")
 
-    with (
-        patch("mindroom.response_runner.should_use_streaming", new=AsyncMock(return_value=True)),
-        patch("mindroom.response_lifecycle.apply_post_response_effects", new=AsyncMock(return_value=None)),
-    ):
+    with patch("mindroom.response_lifecycle.apply_post_response_effects", new=AsyncMock(return_value=None)):
         coordinator = _build_response_runner(
             bot,
             config=config,
@@ -356,10 +355,7 @@ async def test_process_and_respond_emits_session_started_after_first_persisted_t
 
     registry = HookRegistry.from_plugins([_plugin("session-hooks", [first, second])])
 
-    with (
-        patch("mindroom.response_runner.should_use_streaming", new=AsyncMock(return_value=False)),
-        patch("mindroom.response_runner.ai_response", new_callable=AsyncMock) as mock_ai,
-    ):
+    with patch("mindroom.response_runner.ai_response", new_callable=AsyncMock) as mock_ai:
         coordinator = _build_response_runner(
             bot,
             config=config,
@@ -378,6 +374,7 @@ async def test_process_and_respond_emits_session_started_after_first_persisted_t
                     is_refreshing=lambda _base_id: False,
                 ),
             ),
+            enable_streaming=False,
         )
 
         async def fake_ai_response(*_args: object, **_kwargs: object) -> str:
@@ -1308,7 +1305,6 @@ async def test_private_agent_response_runner_builds_execution_identity_from_requ
 
     with (
         patch("mindroom.response_runner.ai_response", new=AsyncMock(return_value="done")) as mock_ai_response,
-        patch("mindroom.response_runner.should_use_streaming", new=AsyncMock(return_value=False)),
         patch("mindroom.response_lifecycle.apply_post_response_effects", new=AsyncMock(return_value=None)),
     ):
         coordinator = _build_response_runner(
@@ -1318,6 +1314,7 @@ async def test_private_agent_response_runner_builds_execution_identity_from_requ
             storage_path=tmp_path,
             requester_id="@owner:localhost",
             message_target=target,
+            enable_streaming=False,
         )
         build_calls: list[dict[str, object]] = []
         original_build_execution_identity = coordinator.deps.tool_runtime.build_execution_identity
@@ -1715,10 +1712,8 @@ async def test_generate_response_locked_preserves_visible_stream_when_finalize_r
         correlation_id="corr-stream-cancel",
     )
 
-    with (
-        patch("mindroom.response_runner.should_use_streaming", new=AsyncMock(return_value=True)),
-        patch("mindroom.response_lifecycle.apply_post_response_effects", new=AsyncMock(return_value=None)),
-    ):
+    _mark_requester_online(bot.client, "@alice:localhost")
+    with patch("mindroom.response_lifecycle.apply_post_response_effects", new=AsyncMock(return_value=None)):
         coordinator = _build_response_runner(
             bot,
             config=config,


### PR DESCRIPTION
Part of the worst-offender test rewrite campaign (refactor prompt 07, deferred second half of #1393–#1398). One patch-target cluster per PR; this PR takes `mindroom.response_runner.should_use_streaming` (53 patch sites measured on `68614c39a`; 5 rewritten here).

## What changed

`should_use_streaming(client, room_id, requester_user_id, enable_streaming=...)` has two real inputs that fully determine its result in these tests: the `enable_streaming` runtime flag and the requester's presence in the client's synced room cache. The rewrites drive those inputs instead of patching the function:

- `_build_response_runner` gains `enable_streaming: bool = True` (was hard-coded `True`), so the off case is plain request construction.
- New `_mark_requester_online(client, user_id)` helper puts a real `nio.MatrixRoom`/`nio.MatrixUser` in `client.rooms`, so the on case flows through the real presence-cache branch of `is_user_online`.
- `_make_bot` now gives `stop_manager.add_stop_button` an `AsyncMock`: with the requester genuinely online, the stop-button gate (which shares the same presence input) activates. The old patches had these tests in an inconsistent world — streaming "on" (requires online) while the stop-button gate saw the user offline.

## Per-test disposition (all (a): behavior owned by the runner seam, streaming choice was a wrong-level patch)

| Test | Direction | Rewrite |
|---|---|---|
| `test_generate_response_emits_cancelled_hook_once_for_empty_prompt` (2 params) | both | parametrized `enable_streaming` + presence |
| `test_process_and_respond_streaming_preserves_user_stop_outcome` | on | presence input |
| `test_process_and_respond_emits_session_started_after_first_persisted_thread_response` | off | `enable_streaming=False` |
| `test_private_agent_response_runner_builds_execution_identity_from_requester` | off | `enable_streaming=False` |
| `test_generate_response_locked_preserves_visible_stream_when_finalize_returns_cancelled` | on | presence input |

## Mutate-and-check evidence

Each mutation applied to production, tests run, then reverted by inverse edit:

- `should_use_streaming`: `if not enable_streaming: return False` → `return True` — `test_private_agent_...` **FAILED** (`'$thinking' == '$msg_id'`). `test_...session_started_after_first_persisted...` survived this mutation because a streaming-path failure falls back to non-streaming in this fake (noted below), so it got its own mutation instead.
- `response_lifecycle._maybe_emit_session_started`: inverted the `_session_exists` guard — `test_...session_started_after_first_persisted...` **FAILED**.
- `is_user_online` room-cache branch: `is_online = True` → `False` — both streaming-on tests **FAILED** (streaming path never taken).
- `FinalDeliveryOutcome.cancelled_for_empty_prompt`: `failure_reason="empty_prompt"` → `"empty"` — empty-prompt test **FAILED** for both params.

## Side item folded in (per the prompt)

`tests/test_locked_turn_delivery.py` imported `_bot`, `_noop_typing`, `_plain_request`, `_target` from `tests/test_response_runner_focused.py` (a test module). Those helpers (plus their private deps `_config`, `_envelope`) moved verbatim to new `tests/response_runner_helpers.py`; both files import from it now.

## Counts

- Collected test count: unchanged (no tests merged, renamed, or deleted).
- Patch-lines in `test_response_runner_session_lifecycle.py`: 19 → 13 (`grep -cE 'with patch|patch\.object|= patch\('`); 6 `should_use_streaming` patch sites removed across 5 tests (one parametrized).
- Full suite: 9119 passed, 61 skipped. Pre-commit clean (`SKIP=typescript-check`, broken on this macOS host).

## Finding (step 5 of the prompt)

The streaming→non-streaming fallback means tests asserting non-streaming observable behavior can silently pass even when the streaming decision flips; worth remembering when judging what a `should_use_streaming` patch was actually pinning in the remaining ~45 sites.