### PR TITLE
Rewrite four apply_post_response_effects patch sites against the collaborator seam

### DIFF
--- a/tests/ai_user_id_helpers.py
+++ b/tests/ai_user_id_helpers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from copy import deepcopy
+from dataclasses import replace
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, TypeVar, cast
 from unittest.mock import AsyncMock, MagicMock
@@ -37,7 +38,7 @@ from mindroom.hooks.registry import HookRegistryState
 from mindroom.knowledge.utils import KnowledgeAvailabilityDetail, _KnowledgeResolution
 from mindroom.matrix.cache.thread_history_result import thread_history_result
 from mindroom.message_target import MessageTarget
-from mindroom.post_response_effects import PostResponseEffectsSupport
+from mindroom.post_response_effects import PostResponseEffectsDeps, PostResponseEffectsSupport
 from mindroom.response_payload_preparation import ResponsePayloadPreparer
 from mindroom.response_runner import (
     ResponseRequest,
@@ -56,7 +57,7 @@ from tests.conftest import (
 from tests.identity_helpers import persist_entity_accounts
 
 if TYPE_CHECKING:
-    from collections.abc import Generator, Iterable
+    from collections.abc import Callable, Generator, Iterable
     from pathlib import Path
 
     from agno.knowledge.knowledge import Knowledge
@@ -520,4 +521,40 @@ def _response_request(
         media=media,
         user_id=user_id,
         correlation_id=correlation_id,
+    )
+
+
+class _InertPostResponseEffects(PostResponseEffectsSupport):
+    """Post-response support whose per-response deps carry no side effects.
+
+    The real ``apply_post_response_effects`` still runs; every effect it guards
+    on (interactive registration, memory persistence, run-metadata linkage,
+    thread summaries) is absent from the built deps, so tests exercise the
+    lifecycle without patching the module function.
+    """
+
+    def build_deps(
+        self,
+        *,
+        room_id: str,
+        interactive_agent_name: str,
+        queue_memory_persistence: Callable[[], None] | None = None,
+        persist_response_event_id: Callable[[str, str], None] | None = None,
+    ) -> PostResponseEffectsDeps:
+        del room_id, interactive_agent_name, queue_memory_persistence, persist_response_event_id
+        return PostResponseEffectsDeps(logger=self.logger)
+
+
+def _install_inert_post_response_effects(coordinator: ResponseRunner) -> None:
+    """Swap the post-response collaborator for the inert variant at the deps seam."""
+    support = coordinator.deps.post_response_effects
+    coordinator.deps = replace(
+        coordinator.deps,
+        post_response_effects=_InertPostResponseEffects(
+            runtime=support.runtime,
+            logger=support.logger,
+            runtime_paths=support.runtime_paths,
+            delivery_gateway=support.delivery_gateway,
+            conversation_cache=support.conversation_cache,
+        ),
     )

--- a/tests/test_response_runner_team_streaming.py
+++ b/tests/test_response_runner_team_streaming.py
@@ -42,6 +42,7 @@ from tests.ai_user_id_helpers import (
     _config_with_team,
     _config_with_team_matrix_message,
     _handled_response_event_id,
+    _install_inert_post_response_effects,
     _knowledge_access_support,
     _make_bot,
     _open_team_scope_context,
@@ -116,7 +117,6 @@ async def test_generate_team_response_appends_matrix_tool_prompt_context(tmp_pat
     with (
         patch("mindroom.response_runner.should_use_streaming", new=AsyncMock(return_value=False)),
         patch("mindroom.response_runner.team_response", new=AsyncMock(side_effect=fake_team_response)),
-        patch("mindroom.response_lifecycle.apply_post_response_effects", new=AsyncMock(return_value=None)),
     ):
         coordinator = _build_response_runner(
             bot,
@@ -127,6 +127,7 @@ async def test_generate_team_response_appends_matrix_tool_prompt_context(tmp_pat
             message_target=MessageTarget.resolve("!test:localhost", "$thread-root", "$user_msg"),
             orchestrator=_team_orchestrator(config, runtime_paths),
         )
+        _install_inert_post_response_effects(coordinator)
 
         await coordinator.generate_team_response_helper(
             _response_request(prompt="Hello", user_id="@alice:localhost", thread_id="$thread-root"),
@@ -165,7 +166,6 @@ async def test_generate_team_response_allows_explicit_private_ad_hoc_member(tmp_
     with (
         patch("mindroom.response_runner.should_use_streaming", new=AsyncMock(return_value=False)),
         patch("mindroom.response_runner.team_response", new=AsyncMock(side_effect=fake_team_response)),
-        patch("mindroom.response_lifecycle.apply_post_response_effects", new=AsyncMock(return_value=None)),
     ):
         coordinator = _build_response_runner(
             bot,
@@ -176,6 +176,7 @@ async def test_generate_team_response_allows_explicit_private_ad_hoc_member(tmp_
             message_target=MessageTarget.resolve("!test:localhost", "$thread-root", "$user_msg"),
             orchestrator=_team_orchestrator(config, runtime_paths),
         )
+        _install_inert_post_response_effects(coordinator)
 
         await coordinator.generate_team_response_helper(
             _response_request(prompt="Hello", user_id="@alice:localhost", thread_id="$thread-root"),
@@ -211,7 +212,6 @@ async def test_generate_team_response_passes_resolved_correlation_id_to_team_res
     with (
         patch("mindroom.response_runner.should_use_streaming", new=AsyncMock(return_value=False)),
         patch("mindroom.response_runner.team_response", new=AsyncMock(side_effect=fake_team_response)),
-        patch("mindroom.response_lifecycle.apply_post_response_effects", new=AsyncMock(return_value=None)),
     ):
         coordinator = _build_response_runner(
             bot,
@@ -222,6 +222,7 @@ async def test_generate_team_response_passes_resolved_correlation_id_to_team_res
             message_target=MessageTarget.resolve("!test:localhost", "$thread-root", "$original"),
             orchestrator=_team_orchestrator(config, runtime_paths),
         )
+        _install_inert_post_response_effects(coordinator)
 
         await coordinator.generate_team_response_helper(
             _response_request(
@@ -560,7 +561,6 @@ async def test_generate_team_response_helper_persists_interrupted_history_when_s
     with (
         patch("mindroom.response_runner.should_use_streaming", new=AsyncMock(return_value=True)),
         patch("mindroom.response_runner.team_response_stream") as mock_team_stream,
-        patch("mindroom.response_lifecycle.apply_post_response_effects", new=AsyncMock(return_value=None)),
     ):
         coordinator = _build_response_runner(
             bot,
@@ -573,6 +573,7 @@ async def test_generate_team_response_helper_persists_interrupted_history_when_s
             message_target=MessageTarget.resolve("!test:localhost", "$thread-root", "$user_msg"),
             orchestrator=_team_orchestrator(config, runtime_paths),
         )
+        _install_inert_post_response_effects(coordinator)
 
         async def consume_delivery_and_fail(request: object) -> StreamTransportOutcome:
             accumulated = ""


### PR DESCRIPTION
Part of the worst-offender test rewrite campaign (refactor prompt 07, deferred second half of #1393–#1398). One patch-target cluster per PR; this PR takes `mindroom.response_lifecycle.apply_post_response_effects` (31 patch sites measured on `68614c39a`; 4 rewritten here). Sibling of #1400 (independent, no stacking; both add to `ai_user_id_helpers.py`, so whichever merges second may need a trivial import-region rebase).

## What changed

The table in the refactor prompt names `PostResponseEffectsSupport` as the owning seam. Every effect inside `apply_post_response_effects` (interactive registration, run-metadata linkage, memory persistence, thread summaries) is guarded on a field of the `PostResponseEffectsDeps` that `PostResponseEffectsSupport.build_deps` constructs. So instead of patching the module function to an `AsyncMock`, tests now swap the collaborator:

- `_InertPostResponseEffects(PostResponseEffectsSupport)` — typed subclass whose `build_deps` returns `PostResponseEffectsDeps(logger=...)` only. The **real** `apply_post_response_effects` still runs each test, exercising its guard logic instead of being stubbed out.
- `_install_inert_post_response_effects(coordinator)` — rebuilds `coordinator.deps` with the inert support via `dataclasses.replace`, preserving `conversation_cache` and the other support fields the runner reads directly.

## Per-test disposition (all (a): the patch bypassed the collaborator that owns effect construction)

1. `test_generate_team_response_appends_matrix_tool_prompt_context`
2. `test_generate_team_response_allows_explicit_private_ad_hoc_member`
3. `test_generate_team_response_passes_resolved_correlation_id_to_team_response`
4. `test_generate_team_response_helper_persists_interrupted_history_when_stream_delivery_fails`

Each: drop the `apply_post_response_effects` patch line, add one `_install_inert_post_response_effects(coordinator)` call. The `should_use_streaming` / `team_response` patches in the same stacks are a different cluster (#1400's target and an accepted module-boundary patch respectively) and are deliberately untouched — one idea per PR.

## Mutate-and-check evidence

Each mutation applied to production, the test run, then reverted by inverse edit:

- Team `_append_matrix_prompt_context` call site: `include_context=include_matrix_prompt_context` → `False` — test 1 **FAILED**.
- `allow_direct_private_agents`: `and bool(execution_identity.requester_id)` → `and not bool(...)` — test 2 **FAILED**.
- `team_turn_ctx`: `correlation_id=response_identity.correlation_id` → `None` — test 3 **FAILED**.
- `interrupted_replay._render_interruption_summary`: truncated the summary string — test 4 **FAILED**.

## Counts

- Collected test count: unchanged (no tests merged, renamed, or deleted).
- `apply_post_response_effects` patch sites in `test_response_runner_team_streaming.py`: 16 → 12.
- Full suite: 9119 passed, 61 skipped. Pre-commit clean (`SKIP=typescript-check`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved response-handling test support for team streaming scenarios, making behavior around post-response effects more consistent and reliable across coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->