### PR TITLE
Fix agent/team drift left by the turn-unification campaign

### DIFF
--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -587,7 +587,14 @@ class ResponseRunner:
             name="persist_interrupted_recorder",
             owner=self.deps.runtime,
         )
-        await asyncio.shield(offload)
+        try:
+            await asyncio.shield(offload)
+        except Exception:
+            # A snapshot-persist failure (e.g. sqlite locked) must not escape into
+            # the streaming error arms: they classify the adopted placeholder as
+            # pristine and would redact an already-delivered visible reply. Losing
+            # the replay snapshot is the lesser harm.
+            self.deps.logger.exception("Failed to persist interrupted replay state")
 
     def _record_stream_delivery_error(
         self,
@@ -1350,6 +1357,16 @@ class ResponseRunner:
                         await lifecycle.emit_session_started(session_started_watch)
                 if request.pipeline_timing is not None:
                     request.pipeline_timing.mark("streaming_complete")
+                if team_turn_recorder.outcome == "interrupted":
+                    await self._persist_interrupted_recorder_off_loop(
+                        recorder=team_turn_recorder,
+                        session_scope=session_scope,
+                        session_id=session_id,
+                        execution_identity=tool_dispatch.execution_identity,
+                        run_id=response_run_id,
+                        is_team=True,
+                        response_event_id=progress.tracked_event_id,
+                    )
                 delivery_kind: Literal["sent", "edited"] = "edited" if message_id else "sent"
                 finalize_request = FinalizeStreamedResponseRequest(
                     target=delivery_target,

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -2043,7 +2043,7 @@ async def team_response(  # noqa: C901, PLR0915
                 **_team_request_log_context(
                     ctx,
                     team_name=configured_team_name or team_name,
-                    prompt=message,
+                    prompt=continuation_state.active_prompt,
                     run_input=prepared_input,
                     metadata=run_metadata,
                 ),
@@ -2230,7 +2230,9 @@ async def team_response(  # noqa: C901, PLR0915
         )
         return CompletedAttempt(
             response_text=response_text,
-            replayable_text=response_text,
+            # Match the streaming path: the "No team response generated."
+            # fallback is display chrome, not replayable assistant text.
+            replayable_text=response_text if has_visible_output else "",
             has_visible_content=has_visible_output,
             is_empty=is_empty_run,
             session_id=response_session_id,
@@ -2574,6 +2576,12 @@ async def team_response_stream(  # noqa: C901, PLR0915
                 interrupted_tools=[pending.trace_entry for pending in pending_tools],
             )
 
+        def _record_interrupted_team_turn() -> None:
+            """Mark partial team work interrupted on an errored run, mirroring the agent path."""
+            _sync_live_turn_recorder()
+            if turn_recorder.assistant_text or turn_recorder.completed_tools or turn_recorder.interrupted_tools:
+                run.turn_state.record_interrupted_from_recorder(turn_recorder, run_metadata=run_metadata)
+
         def _start_tool(
             *,
             scope_key: str,
@@ -2718,7 +2726,7 @@ async def team_response_stream(  # noqa: C901, PLR0915
                 request_context=_team_request_log_context(
                     ctx,
                     team_name=configured_team_name or team_label,
-                    prompt=message,
+                    prompt=continuation_state.active_prompt,
                     run_input=stream_run_input,
                     metadata=run_metadata,
                 ),
@@ -2793,6 +2801,7 @@ async def team_response_stream(  # noqa: C901, PLR0915
                         # errored run's usage directly before ending the turn.
                         if run_metadata_collector is not None and event_metadata_content is not None:
                             run_metadata_collector.update(event_metadata_content)
+                        _record_interrupted_team_turn()
                         yield get_user_friendly_error_message(Exception(error_text), team_label)
                         yield AttemptResolved(HandledAttempt())
                         return
@@ -2880,6 +2889,7 @@ async def team_response_stream(  # noqa: C901, PLR0915
                                 tool_count=len(completed_tool_executions),
                             ),
                         )
+                    _record_interrupted_team_turn()
                     yield get_user_friendly_error_message(Exception(error_text), team_label)
                     yield AttemptResolved(HandledAttempt())
                     return

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -2582,6 +2582,19 @@ async def team_response_stream(  # noqa: C901, PLR0915
             if turn_recorder.assistant_text or turn_recorder.completed_tools or turn_recorder.interrupted_tools:
                 run.turn_state.record_interrupted_from_recorder(turn_recorder, run_metadata=run_metadata)
 
+        async def _capture_stream_interrupt(stream: AsyncIterator[Any]) -> AsyncGenerator[Any, None]:
+            """Record partial work interrupted when the model stream itself raises.
+
+            Mirrors the agent path's ``state.stream_exception`` capture: the raw
+            exception still propagates to the shared driver's friendly-error arm.
+            """
+            try:
+                async for event in stream:
+                    yield event
+            except Exception:
+                _record_interrupted_team_turn()
+                raise
+
         def _start_tool(
             *,
             scope_key: str,
@@ -2721,14 +2734,16 @@ async def team_response_stream(  # noqa: C901, PLR0915
                 if attempt_media_inputs.has_any()
                 else attempt_prompt
             )
-            raw_stream = stream_with_llm_request_log_context(
-                cast("AsyncGenerator[Any, None]", raw_stream),
-                request_context=_team_request_log_context(
-                    ctx,
-                    team_name=configured_team_name or team_label,
-                    prompt=continuation_state.active_prompt,
-                    run_input=stream_run_input,
-                    metadata=run_metadata,
+            raw_stream = _capture_stream_interrupt(
+                stream_with_llm_request_log_context(
+                    cast("AsyncGenerator[Any, None]", raw_stream),
+                    request_context=_team_request_log_context(
+                        ctx,
+                        team_name=configured_team_name or team_label,
+                        prompt=continuation_state.active_prompt,
+                        run_input=stream_run_input,
+                        metadata=run_metadata,
+                    ),
                 ),
             )
             async for event in raw_stream:

--- a/tests/test_response_runner_team_streaming.py
+++ b/tests/test_response_runner_team_streaming.py
@@ -1595,3 +1595,118 @@ async def test_generate_team_response_helper_uses_delivery_result_failure_reason
         )
 
     assert resolution is None
+
+
+@pytest.mark.asyncio
+async def test_generate_team_response_helper_persists_interrupted_history_after_errored_stream(
+    tmp_path: Path,
+) -> None:
+    """A stream ending normally with the recorder marked interrupted persists the replay snapshot.
+
+    Mirrors the agent path's post-transport persist arm: a mid-stream errored
+    run yields the friendly error and completes delivery, so only the
+    recorder outcome says the turn was interrupted.
+    """
+    runtime_paths = _runtime_paths(tmp_path)
+    config = bind_runtime_paths(_config_with_team(), runtime_paths)
+    bot = _make_bot(tmp_path, config=config, runtime_paths=runtime_paths, agent_name="ultimate")
+    storage = _SessionStorage()
+
+    with (
+        patch("mindroom.response_runner.should_use_streaming", new=AsyncMock(return_value=True)),
+        patch("mindroom.response_runner.team_response_stream") as mock_team_stream,
+        patch("mindroom.response_lifecycle.apply_post_response_effects", new=AsyncMock(return_value=None)),
+    ):
+        coordinator = _build_response_runner(
+            bot,
+            config=config,
+            runtime_paths=runtime_paths,
+            storage_path=tmp_path,
+            requester_id="@alice:localhost",
+            hook_registry=HookRegistry.empty(),
+            team_history_storage=storage,
+            message_target=MessageTarget.resolve("!test:localhost", "$thread-root", "$user_msg"),
+            orchestrator=_team_orchestrator(config, runtime_paths),
+        )
+
+        async def consume_delivery(request: object) -> StreamTransportOutcome:
+            async for _chunk in request.response_stream:
+                pass
+            return _stream_outcome("$team-final", "Team partial")
+
+        coordinator.deps.delivery_gateway.deliver_stream.side_effect = consume_delivery
+
+        def fake_team_response_stream(*_args: object, **kwargs: object) -> AsyncIterator[str]:
+            async def fake_stream() -> AsyncIterator[str]:
+                yield "Team partial"
+                recorder = kwargs["turn_recorder"]
+                assert isinstance(recorder, TurnRecorder)
+                recorder.record_interrupted(
+                    run_metadata=None,
+                    assistant_text="Team partial",
+                    completed_tools=[],
+                    interrupted_tools=[],
+                )
+
+            return fake_stream()
+
+        mock_team_stream.side_effect = fake_team_response_stream
+
+        await coordinator.generate_team_response_helper(
+            _response_request(prompt="Hello", user_id="@alice:localhost", thread_id="$thread-root"),
+            team_agents=[fixture_entity_matrix_id("general", "localhost", runtime_paths)],
+            team_mode="coordinate",
+        )
+
+    persisted_session = cast("TeamSession", storage.session)
+    assert persisted_session is not None
+    assert persisted_session.runs is not None
+    persisted_run = cast("TeamRunOutput", persisted_session.runs[0])
+    assert persisted_run.messages is not None
+    assert [(message.role, message.content) for message in persisted_run.messages] == [
+        ("user", "Hello"),
+        ("assistant", "Team partial\n\n(turn interrupted by the user before completion)"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_persist_interrupted_recorder_off_loop_swallows_persist_failure(tmp_path: Path) -> None:
+    """A snapshot-persist failure must not escape into the streaming error arms.
+
+    The generic except-Exception arm classifies the adopted placeholder as
+    pristine and would redact an already-delivered visible reply, so the
+    persist helper absorbs storage failures.
+    """
+    runtime_paths = _runtime_paths(tmp_path)
+    config = bind_runtime_paths(_config_with_team(), runtime_paths)
+    bot = _make_bot(tmp_path, config=config, runtime_paths=runtime_paths, agent_name="ultimate")
+    coordinator = _build_response_runner(
+        bot,
+        config=config,
+        runtime_paths=runtime_paths,
+        storage_path=tmp_path,
+        requester_id="@alice:localhost",
+        message_target=MessageTarget.resolve("!test:localhost", "$thread-root", "$user_msg"),
+        orchestrator=_team_orchestrator(config, runtime_paths),
+    )
+    recorder = TurnRecorder(user_message="Hello")
+    recorder.record_interrupted(
+        run_metadata=None,
+        assistant_text="partial",
+        completed_tools=[],
+        interrupted_tools=[],
+    )
+
+    with patch.object(
+        coordinator,
+        "_persist_interrupted_recorder",
+        side_effect=RuntimeError("database is locked"),
+    ):
+        await coordinator._persist_interrupted_recorder_off_loop(
+            recorder=recorder,
+            session_scope=coordinator.deps.state_writer.history_scope(),
+            session_id="session-1",
+            execution_identity=None,
+            run_id=None,
+            is_team=True,
+        )

--- a/tests/test_response_runner_team_streaming.py
+++ b/tests/test_response_runner_team_streaming.py
@@ -1617,7 +1617,6 @@ async def test_generate_team_response_helper_persists_interrupted_history_after_
     with (
         patch("mindroom.response_runner.should_use_streaming", new=AsyncMock(return_value=True)),
         patch("mindroom.response_runner.team_response_stream") as mock_team_stream,
-        patch("mindroom.response_lifecycle.apply_post_response_effects", new=AsyncMock(return_value=None)),
     ):
         coordinator = _build_response_runner(
             bot,
@@ -1630,6 +1629,7 @@ async def test_generate_team_response_helper_persists_interrupted_history_after_
             message_target=MessageTarget.resolve("!test:localhost", "$thread-root", "$user_msg"),
             orchestrator=_team_orchestrator(config, runtime_paths),
         )
+        _install_inert_post_response_effects(coordinator)
 
         async def consume_delivery(request: object) -> StreamTransportOutcome:
             async for _chunk in request.response_stream:

--- a/tests/test_response_runner_team_streaming.py
+++ b/tests/test_response_runner_team_streaming.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 from contextlib import suppress
 from dataclasses import replace
 from types import SimpleNamespace
@@ -1710,3 +1711,49 @@ async def test_persist_interrupted_recorder_off_loop_swallows_persist_failure(tm
             run_id=None,
             is_team=True,
         )
+
+
+@pytest.mark.asyncio
+async def test_persist_interrupted_recorder_off_loop_propagates_cancellation(tmp_path: Path) -> None:
+    """Cancellation of the awaiting turn still propagates through the persist guard."""
+    runtime_paths = _runtime_paths(tmp_path)
+    config = bind_runtime_paths(_config_with_team(), runtime_paths)
+    bot = _make_bot(tmp_path, config=config, runtime_paths=runtime_paths, agent_name="ultimate")
+    coordinator = _build_response_runner(
+        bot,
+        config=config,
+        runtime_paths=runtime_paths,
+        storage_path=tmp_path,
+        requester_id="@alice:localhost",
+        message_target=MessageTarget.resolve("!test:localhost", "$thread-root", "$user_msg"),
+        orchestrator=_team_orchestrator(config, runtime_paths),
+    )
+    recorder = TurnRecorder(user_message="Hello")
+    recorder.record_interrupted(
+        run_metadata=None,
+        assistant_text="partial",
+        completed_tools=[],
+        interrupted_tools=[],
+    )
+    release = threading.Event()
+
+    with patch.object(
+        coordinator,
+        "_persist_interrupted_recorder",
+        side_effect=lambda **_kwargs: release.wait(timeout=5),
+    ):
+        waiter = asyncio.get_running_loop().create_task(
+            coordinator._persist_interrupted_recorder_off_loop(
+                recorder=recorder,
+                session_scope=coordinator.deps.state_writer.history_scope(),
+                session_id="session-1",
+                execution_identity=None,
+                run_id=None,
+                is_team=True,
+            ),
+        )
+        await asyncio.sleep(0.05)
+        waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+        release.set()

--- a/tests/test_team_dynamic_continuation.py
+++ b/tests/test_team_dynamic_continuation.py
@@ -13,6 +13,7 @@ from agno.run.agent import RunOutput
 from agno.run.agent import ToolCallCompletedEvent as AgentToolCallCompletedEvent
 from agno.run.team import TeamRunOutput
 
+from mindroom import teams as teams_module
 from mindroom.dynamic_tool_continuation import DYNAMIC_TOOL_CONTINUATION_LIMIT
 from mindroom.history.turn_recorder import TurnRecorder
 from mindroom.knowledge.utils import _KnowledgeResolution
@@ -344,3 +345,86 @@ def test_team_members_are_built_with_dynamic_tool_continuation() -> None:
         )
 
     assert mock_create.call_args.kwargs["dynamic_tool_continuation"] is True
+
+
+@pytest.mark.asyncio
+async def test_team_response_logs_continuation_prompt_in_request_log_context() -> None:
+    """Continuation attempts log the active continuation prompt, not the original message."""
+    orchestrator, _config = _make_orchestrator()
+    mock_team = _make_test_team()
+    mock_team.arun = AsyncMock(
+        side_effect=[
+            _dynamic_tool_team_output(),
+            TeamRunOutput(content="Used the loaded tool."),
+        ],
+    )
+    logged_prompts: list[object] = []
+    real_log_context = teams_module._team_request_log_context
+
+    def capture_log_context(ctx: object, **kwargs: object) -> dict[str, object]:
+        logged_prompts.append(kwargs.get("prompt"))
+        return real_log_context(ctx, **kwargs)
+
+    patches = _team_patches(mock_team)
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patch("mindroom.teams._team_request_log_context", side_effect=capture_log_context),
+    ):
+        await team_response(
+            agent_names=["general"],
+            mode=TeamMode.COORDINATE,
+            message="Load the sleep tool and use it.",
+            turn_recorder=TurnRecorder(user_message="Load the sleep tool and use it."),
+            orchestrator=orchestrator,
+            execution_identity=None,
+            ctx=make_turn_context(run_id="run-1", session_id=None),
+        )
+
+    assert logged_prompts[0] == "Load the sleep tool and use it."
+    assert "DYNAMIC TOOL CALL COMPLETED" in str(logged_prompts[1])
+
+
+@pytest.mark.asyncio
+async def test_team_response_stream_logs_continuation_prompt_in_request_log_context() -> None:
+    """Streamed continuation attempts log the active continuation prompt (agent-path parity)."""
+    orchestrator, config = _make_orchestrator()
+
+    async def first_stream() -> AsyncIterator[object]:
+        yield _dynamic_tool_team_output()
+
+    async def second_stream() -> AsyncIterator[object]:
+        yield TeamRunOutput(content="Used the loaded tool.")
+
+    mock_team = _make_test_team()
+    mock_team.arun = MagicMock(side_effect=[first_stream(), second_stream()])
+    logged_prompts: list[object] = []
+    real_log_context = teams_module._team_request_log_context
+
+    def capture_log_context(ctx: object, **kwargs: object) -> dict[str, object]:
+        logged_prompts.append(kwargs.get("prompt"))
+        return real_log_context(ctx, **kwargs)
+
+    patches = _team_patches(mock_team)
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patch("mindroom.teams._team_request_log_context", side_effect=capture_log_context),
+    ):
+        _ = [
+            chunk
+            async for chunk in team_response_stream(
+                agent_ids=[entity_ids(config, runtime_paths_for(config))["general"]],
+                mode=TeamMode.COORDINATE,
+                message="Load the sleep tool and use it.",
+                turn_recorder=TurnRecorder(user_message="Load the sleep tool and use it."),
+                orchestrator=orchestrator,
+                execution_identity=None,
+                ctx=make_turn_context(session_id=None),
+            )
+        ]
+
+    assert logged_prompts[0] == "Load the sleep tool and use it."
+    assert "DYNAMIC TOOL CALL COMPLETED" in str(logged_prompts[1])

--- a/tests/test_team_empty_response_and_replay.py
+++ b/tests/test_team_empty_response_and_replay.py
@@ -420,3 +420,39 @@ async def test_team_response_stream_leaves_recorder_pending_when_error_has_no_pa
         ]
 
     assert recorder.outcome == "pending"
+
+
+@pytest.mark.asyncio
+async def test_team_response_stream_records_interrupted_turn_when_stream_raises() -> None:
+    """A raw exception from the model stream records partial work interrupted."""
+    orchestrator, config = _make_orchestrator()
+
+    stream_error = "transport died"
+
+    async def stream() -> AsyncIterator[object]:
+        yield AgentRunContentEvent(agent_name="GeneralAgent", content="Member answer")
+        raise RuntimeError(stream_error)
+
+    mock_team = _make_test_team()
+    mock_team.arun = MagicMock(return_value=stream())
+    recorder = TurnRecorder(user_message="Analyze this.")
+
+    patches = _team_patches(mock_team)
+    with patches[0], patches[1], patches[2]:
+        chunks = [
+            chunk
+            async for chunk in team_response_stream(
+                agent_ids=[entity_ids(config, runtime_paths_for(config))["general"]],
+                mode=TeamMode.COORDINATE,
+                message="Analyze this.",
+                turn_recorder=recorder,
+                orchestrator=orchestrator,
+                execution_identity=None,
+                ctx=make_turn_context(session_id="session-1"),
+            )
+        ]
+
+    rendered = "".join(chunk.content if hasattr(chunk, "content") else str(chunk) for chunk in chunks)
+    assert "transport died" in rendered
+    assert recorder.outcome == "interrupted"
+    assert "Member answer" in recorder.assistant_text

--- a/tests/test_team_empty_response_and_replay.py
+++ b/tests/test_team_empty_response_and_replay.py
@@ -7,7 +7,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from agno.models.message import Message
+from agno.models.response import ToolExecution
+from agno.run.agent import RunContentEvent as AgentRunContentEvent
+from agno.run.agent import RunOutput
 from agno.run.base import RunStatus
+from agno.run.team import RunErrorEvent as TeamRunErrorEvent
 from agno.run.team import TeamRunOutput
 
 from mindroom import ai_runtime
@@ -271,3 +275,148 @@ async def test_team_empty_retry_shares_budget_with_dynamic_continuations() -> No
     # plus LIMIT dynamic-tool runs, settling on the limit message.
     assert mock_team.arun.await_count == DYNAMIC_TOOL_CONTINUATION_LIMIT + 1
     assert "did not produce a final answer" in response
+
+
+@pytest.mark.asyncio
+async def test_team_response_records_empty_replayable_text_for_tool_only_run() -> None:
+    """A tool-only blocking run keeps the fallback placeholder out of the recorded turn."""
+    orchestrator, _config = _make_orchestrator()
+    mock_team = _make_test_team()
+    tool_only_run = TeamRunOutput(
+        content="",
+        run_id="team-run-1",
+        session_id="session-1",
+        member_responses=[
+            RunOutput(
+                agent_name="GeneralAgent",
+                content="",
+                tools=[
+                    ToolExecution(
+                        tool_call_id="call-1",
+                        tool_name="get_time",
+                        tool_args={},
+                        result="noon",
+                    ),
+                ],
+            ),
+        ],
+    )
+    tool_only_run.status = RunStatus.completed
+    mock_team.arun = AsyncMock(return_value=tool_only_run)
+    recorder = TurnRecorder(user_message="Run the tool.")
+
+    patches = _team_patches(mock_team)
+    with patches[0], patches[1], patches[2]:
+        response = await team_response(
+            agent_names=["general"],
+            mode=TeamMode.COORDINATE,
+            message="Run the tool.",
+            turn_recorder=recorder,
+            orchestrator=orchestrator,
+            execution_identity=None,
+            ctx=make_turn_context(session_id="session-1"),
+        )
+
+    # The visible response keeps the display chrome; the recorded turn does not
+    # replay it (matches the streaming path's event_has_visible guard).
+    assert "No team response generated." in response
+    assert recorder.outcome == "completed"
+    assert recorder.assistant_text == ""
+
+
+@pytest.mark.asyncio
+async def test_team_response_stream_records_interrupted_turn_when_stream_errors() -> None:
+    """A mid-stream team error with partial output marks the recorder interrupted."""
+    orchestrator, config = _make_orchestrator()
+
+    async def stream() -> AsyncIterator[object]:
+        yield AgentRunContentEvent(agent_name="GeneralAgent", content="Member answer")
+        yield TeamRunErrorEvent(content="provider exploded")
+
+    mock_team = _make_test_team()
+    mock_team.arun = MagicMock(return_value=stream())
+    recorder = TurnRecorder(user_message="Analyze this.")
+
+    patches = _team_patches(mock_team)
+    with patches[0], patches[1], patches[2]:
+        chunks = [
+            chunk
+            async for chunk in team_response_stream(
+                agent_ids=[entity_ids(config, runtime_paths_for(config))["general"]],
+                mode=TeamMode.COORDINATE,
+                message="Analyze this.",
+                turn_recorder=recorder,
+                orchestrator=orchestrator,
+                execution_identity=None,
+                ctx=make_turn_context(session_id="session-1"),
+            )
+        ]
+
+    rendered = "".join(chunk.content if hasattr(chunk, "content") else str(chunk) for chunk in chunks)
+    assert "error" in rendered.lower()
+    assert recorder.outcome == "interrupted"
+    assert "Member answer" in recorder.assistant_text
+
+
+@pytest.mark.asyncio
+async def test_team_response_stream_records_interrupted_turn_on_errored_run_output() -> None:
+    """A terminal errored run output after partial output marks the recorder interrupted."""
+    orchestrator, config = _make_orchestrator()
+    errored_run = TeamRunOutput(content="", run_id="team-run-1", session_id="session-1")
+    errored_run.status = RunStatus.error
+
+    async def stream() -> AsyncIterator[object]:
+        yield AgentRunContentEvent(agent_name="GeneralAgent", content="Member answer")
+        yield errored_run
+
+    mock_team = _make_test_team()
+    mock_team.arun = MagicMock(return_value=stream())
+    recorder = TurnRecorder(user_message="Analyze this.")
+
+    patches = _team_patches(mock_team)
+    with patches[0], patches[1], patches[2]:
+        _ = [
+            chunk
+            async for chunk in team_response_stream(
+                agent_ids=[entity_ids(config, runtime_paths_for(config))["general"]],
+                mode=TeamMode.COORDINATE,
+                message="Analyze this.",
+                turn_recorder=recorder,
+                orchestrator=orchestrator,
+                execution_identity=None,
+                ctx=make_turn_context(session_id="session-1"),
+            )
+        ]
+
+    assert recorder.outcome == "interrupted"
+    assert "Member answer" in recorder.assistant_text
+
+
+@pytest.mark.asyncio
+async def test_team_response_stream_leaves_recorder_pending_when_error_has_no_partial() -> None:
+    """A team error with no partial work records nothing for replay."""
+    orchestrator, config = _make_orchestrator()
+
+    async def stream() -> AsyncIterator[object]:
+        yield TeamRunErrorEvent(content="provider exploded")
+
+    mock_team = _make_test_team()
+    mock_team.arun = MagicMock(return_value=stream())
+    recorder = TurnRecorder(user_message="Analyze this.")
+
+    patches = _team_patches(mock_team)
+    with patches[0], patches[1], patches[2]:
+        _ = [
+            chunk
+            async for chunk in team_response_stream(
+                agent_ids=[entity_ids(config, runtime_paths_for(config))["general"]],
+                mode=TeamMode.COORDINATE,
+                message="Analyze this.",
+                turn_recorder=recorder,
+                orchestrator=orchestrator,
+                execution_identity=None,
+                ctx=make_turn_context(session_id="session-1"),
+            )
+        ]
+
+    assert recorder.outcome == "pending"

--- a/tests/test_team_media_fallback.py
+++ b/tests/test_team_media_fallback.py
@@ -2943,9 +2943,12 @@ async def test_team_response_stream_retries_errored_output_with_fresh_run_id() -
 
     call_run_ids: list[str | None] = []
     callback_run_ids: list[str] = []
+    recorder = _team_turn_recorder("Analyze this.")
+    outcomes_at_attempt_start: list[str] = []
 
     async def fake_stream_raw(*_args: object, **_kwargs: object) -> AsyncIterator[object]:
         call_run_ids.append(_kwargs["run_id"])
+        outcomes_at_attempt_start.append(recorder.outcome)
         if len(call_run_ids) == 1:
             yield TeamRunOutput(content="Error code: 500 - audio input is not supported", status=RunStatus.error)
             return
@@ -2973,7 +2976,7 @@ async def test_team_response_stream_retries_errored_output_with_fresh_run_id() -
             async for chunk in team_response_stream(
                 agent_ids=team_agent_ids,
                 message="Analyze this.",
-                turn_recorder=_team_turn_recorder("Analyze this."),
+                turn_recorder=recorder,
                 orchestrator=orchestrator,
                 execution_identity=None,
                 ctx=make_turn_context(run_id="run-789", session_id=None),
@@ -2989,6 +2992,10 @@ async def test_team_response_stream_retries_errored_output_with_fresh_run_id() -
     assert call_run_ids[1] is not None
     assert call_run_ids[1] != "run-789"
     assert callback_run_ids == [run_id for run_id in call_run_ids if run_id is not None]
+    # A retried errored attempt records nothing: interruption recording only
+    # fires after the retry decision is rejected.
+    assert outcomes_at_attempt_start == ["pending", "pending"]
+    assert recorder.outcome == "completed"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Context

All six post-campaign refactor prompts are merged (#1363–#1399). A deep multi-agent review workflow (7 dimension-scoped reviewers over the campaign-touched modules, every finding verified by 3 independent adversarial verifiers) confirmed 16 findings on main `68614c39a`. This PR fixes the four behavioral ones; the pure dead-code findings ship separately; one pre-existing exotic race is documented on #1378 instead of patched (see below).

## Fixes

**1. Team streaming errored runs never persisted partial work for replay** (major, 3/3 verifiers). When a streamed agent run errors mid-flight with partial output, `ai.py` records the turn recorder interrupted and the runner persists the replay snapshot post-transport. The team path took the same errored-run exits (`teams.py` errored terminal run output + `TeamRunErrorEvent`) but never called `record_interrupted`, and the team locked function had no post-transport persist arm — so a team's partial text and tool results silently vanished from replayed history while the identical agent scenario preserved them. Fixed with a `_record_interrupted_team_turn()` helper at both exits (syncs the live recorder, records interrupted only when partial work exists — same guard as the agent path) and the mirroring `outcome == "interrupted"` persist arm in `generate_team_response_helper_locked`.

**2. A snapshot-persist failure could redact an already-delivered visible reply** (major, 3/3 verifiers). The post-transport interrupted-replay persist runs inside the streaming try; a plain storage exception (sqlite locked, disk full) reached the generic `except Exception` arm, which builds a `PendingVisibleResponse` that classifies the adopted "Thinking..." placeholder as pristine — `finalize_streamed_response` would then redact the user's visible partial answer. The outer locked fallback documents this exact hazard; the inner arm violated it. Fixed at the shared helper: `_persist_interrupted_recorder_off_loop` now absorbs persist exceptions (losing the snapshot is strictly less harm than redacting delivered content). CancelledError propagation is unchanged.

**3. Blocking team turns recorded the "No team response generated." placeholder as replayable text** (3/3 verifiers). The streaming path guards this (`replayable_text=response_text if event_has_visible else ""` — the fallback "does not count" per `_has_visible_team_output`); the blocking path recorded header + placeholder for tool-only runs, which the interrupted-persist path would then replay as assistant text. Aligned with the streaming guard.

**4. Team request-log context logged the original user message on continuation attempts** (3/3 verifiers). Since #1370 enabled dynamic-tool continuation on teams, continuation attempts logged a stale `prompt` field while the agent path logs `continuation_state.active_prompt`. Both team envelopes now log the active per-attempt prompt.

## Deliberately not fixed here

The review also confirmed (2/3 verifiers) that the **agent pre-delivery cancel arm can redact a placeholder holding streamed content** when two independent cancellations land within the ≤10s forwarded-cancel window. Verifier git-archaeology showed the arm and both escape windows predate the campaigns (#687/#930), and it sits in the locked-pair terminal area where three consecutive review rounds each found a major — documented on #1378 (comment) for a dedicated PR rather than patched blind here.

## Behavior-preservation argument

Fixes 1 and 3 only change what is *recorded/persisted* for replay, matching the agent path and the streaming team path respectively; visible Matrix output is byte-identical. Fix 2 only changes the failure path of a persist that previously cascaded into redaction. Fix 4 changes a log field only. New tests cover all four (each fails on unfixed main): recorder outcomes at both errored exits, the runner persist arm end-to-end against session storage, the persist-failure guard, the tool-only blocking recorder text, and both log-context continuation prompts.

## Validation

- Full suite: `uv run pytest -q --no-cov` — 9127 passed, 61 skipped.
- `SKIP=typescript-check uv run pre-commit run --all-files` — all green (typescript-check broken on this host).
- Tach boundary hook green (no boundary moves).

## Adversarial review round (commit 1f1d53b76)

An independent adversarial review verified all four fixes (retry ordering, recorder-state parity, no visible-behavior change, no double-persist via `claim_interrupted_persistence`, CancelledError semantics under `asyncio.shield`, first-attempt log parity) and found one real gap: a **raw exception from the Agno stream iterator** (transport/network failure) reached the shared driver's friendly-error arm without recording — the agent path captures exactly that case via `state.stream_exception`. Fix 1 was therefore incomplete for Agno-*unsignaled* errors. The follow-up commit wraps the team stream so iterator exceptions record partial work interrupted before propagating, and pins two previously untested claims (CancelledError propagation through the persist guard; retried errored attempts record nothing).

Post-review validation: full suite 9129 passed, 61 skipped; pre-commit fully green.
