### PR TITLE
Delete dead turn-policy/interactive patches from five dispatch-pipeline tests

### DIFF
--- a/tests/test_turn_dispatch_pipeline.py
+++ b/tests/test_turn_dispatch_pipeline.py
@@ -60,7 +60,6 @@ from mindroom.response_runner import (
     _ResponseGenerationOutcome,
 )
 from mindroom.teams import TeamIntent, TeamMode, TeamResolution
-from mindroom.thread_utils import AgentResponseDecision
 from mindroom.turn_controller import _IngressAdmissionOutcome, _PrecheckedEvent
 from mindroom.turn_policy import PreparedDispatch, ResponseAction, _DispatchPlan
 from tests.bot_helpers import (
@@ -1080,20 +1079,7 @@ class TestAgentBot(AgentBotTestBase):
             },
         )
 
-        with (
-            patch("mindroom.text_ingress_dispatch.is_dm_room", new_callable=AsyncMock, return_value=False),
-            patch(
-                "mindroom.turn_policy.decide_team_formation",
-                new_callable=MagicMock,
-                return_value=TeamResolution.none(),
-            ),
-            patch("mindroom.turn_policy.decide_agent_response", return_value=AgentResponseDecision(True)),
-            patch(
-                "mindroom.turn_controller.interactive.handle_text_response",
-                new_callable=AsyncMock,
-                return_value=None,
-            ),
-        ):
+        with patch("mindroom.text_ingress_dispatch.is_dm_room", new_callable=AsyncMock, return_value=False):
             await bot._on_message(room, event)
             await drain_coalescing(bot)
 
@@ -1163,14 +1149,7 @@ class TestAgentBot(AgentBotTestBase):
             },
         )
 
-        with (
-            patch("mindroom.text_ingress_dispatch.is_dm_room", new_callable=AsyncMock, return_value=False),
-            patch(
-                "mindroom.turn_controller.interactive.handle_text_response",
-                new_callable=AsyncMock,
-                return_value=None,
-            ),
-        ):
+        with patch("mindroom.text_ingress_dispatch.is_dm_room", new_callable=AsyncMock, return_value=False):
             await bot._on_message(room, event)
             await drain_coalescing(bot)
 
@@ -1252,7 +1231,6 @@ class TestAgentBot(AgentBotTestBase):
                 return_value=envelope,
             ),
             patch.object(bot._turn_controller, "_should_skip_deep_synthetic_full_dispatch", return_value=False),
-            patch("mindroom.turn_controller.interactive.handle_text_response", new=AsyncMock(return_value=None)),
             patch.object(
                 bot._response_runner,
                 "active_thread_ids_for_room",
@@ -1350,7 +1328,6 @@ class TestAgentBot(AgentBotTestBase):
                 new=AsyncMock(return_value=prepared_event),
             ),
             patch.object(bot._turn_controller, "_should_skip_deep_synthetic_full_dispatch", return_value=False),
-            patch("mindroom.turn_controller.interactive.handle_text_response", new=AsyncMock(return_value=None)),
             patch.object(
                 bot._conversation_resolver,
                 "coalescing_thread_id",
@@ -2066,12 +2043,6 @@ class TestAgentBot(AgentBotTestBase):
             patch("mindroom.bot.is_authorized_sender", return_value=True),
             patch("mindroom.ingress_validation.is_authorized_sender", return_value=True),
             patch("mindroom.text_ingress_dispatch.is_dm_room", new_callable=AsyncMock, return_value=False),
-            patch(
-                "mindroom.turn_policy.decide_team_formation",
-                new_callable=MagicMock,
-                return_value=TeamResolution.none(),
-            ),
-            patch("mindroom.turn_policy.decide_agent_response", return_value=AgentResponseDecision(True)),
             patch("mindroom.inbound_turn_normalizer.download_image", new_callable=AsyncMock, return_value=None),
             patch.object(ResponsePayloadPreparer, "_log_dispatch_latency"),
         ):


### PR DESCRIPTION
Part of the worst-offender test rewrite campaign (refactor prompt 07, deferred second half of #1393–#1398). One patch-target cluster per PR; this PR takes the `mindroom.turn_controller.interactive.handle_text_response` (29 sites) / `mindroom.turn_policy.decide_agent_response` (24 sites) cluster in `test_turn_dispatch_pipeline.py`, the worst patch-per-test file (2.2). Sibling of #1400 and #1401 (independent; no shared files).

## What changed

Pure patch deletion — no replacement fakes needed, because the real code already produces the stubbed values on every touched path:

- `interactive.handle_text_response` short-circuits to `None` for any body that isn't a single digit (`src/mindroom/interactive.py:543`), touching no global state. Every one of these tests sends prose (`"stop right now!"`, `"@CalculatorAgent Campground opened"`, …), so the `AsyncMock(return_value=None)` patch reproduced exactly what the real function does — while hiding the gate from the test.
- `decide_agent_response` returns `AgentResponseDecision(True)` unconditionally when the agent is explicitly mentioned (after authz/availability checks that these fixtures satisfy). The sibling test `test_human_forged_external_trigger_metadata_uses_human_sender_as_requester` already ran without the patch on the same message shape.
- In the media test, `decide_agent_response`/`decide_team_formation` patches were doubly dead: that test stubs `plan_turn` itself, so policy internals are never reached.

## Per-test disposition

| Test | Patches removed | Disposition |
|---|---|---|
| `test_external_trigger_to_private_agent_uses_trigger_owner_as_requester` | `decide_agent_response`, `decide_team_formation`, `handle_text_response` | (a) — real TurnPolicy now decides; mutation-verified |
| `test_human_forged_external_trigger_metadata_uses_human_sender_as_requester` | `handle_text_response` | (a) |
| `test_handle_message_inner_enqueues_active_thread_follow_up_as_coalescible_gate_event` | `handle_text_response` | (a) |
| `test_handle_message_inner_enqueues_trusted_hook_source_kind_as_gate_bypass` (2 params) | `handle_text_response` | (c) — patch was dead even as a stub: trusted-relay origins have `may_answer_interactive_prompt=False`, the gate is never reached |
| `test_media_download_failure_sends_terminal_error_without_placeholder` | `decide_agent_response`, `decide_team_formation` | (c) — dead under the test's own `plan_turn` stub |

The identical `handle_text_response` patches in the voice/file-sidecar preview tests (2 sites) are left for a later pass — same reasoning likely applies, but one reviewable batch per PR.

## Mutate-and-check evidence

Each applied to production, run, reverted by inverse edit:

- `turn_controller` interactive gate inverted (`if selection is not None:` → `is None`): tests 2 and 3 **FAILED** (message swallowed as interactive selection). Tests 1 and 4 unaffected — their origins never enter the gate (that's the (c) finding above).
- `decide_agent_response`: mentioned branch → `AgentResponseDecision(False, ...)`: test 1 **FAILED** (no dispatch). Under the old patch this mutation would have been invisible.
- `PendingEvent(source_kind=...)` in the enqueue path forced to `"message"`: test 4 **FAILED** both params.
- `inbound_turn_normalizer` image-failure message text changed: test 5 **FAILED** on the terminal error body.

## Counts

- Collected test count: unchanged.
- `patch(` calls in `test_turn_dispatch_pipeline.py`: 48 → 40; the file's `decide_agent_response` patch count is now 0.
- Full suite: 9119 passed, 61 skipped. Pre-commit clean (`SKIP=typescript-check`).