### PR TITLE
Delete dead code left behind by the refactor campaigns

### DIFF
--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Mapping
 from contextlib import aclosing
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, cast
 from uuid import uuid4
 
@@ -41,7 +41,6 @@ from mindroom.history import (
     agent_tool_definition_payloads_for_logging,
     apply_replay_plan,
     close_agent_runtime_state_dbs,
-    compute_prompt_token_breakdown,
     note_prepared_history_timing,
     open_resolved_scope_session_context,
 )
@@ -297,11 +296,6 @@ def _render_system_enrichment_context(
     system_enrichment_items: Sequence[EnrichmentItem],
 ) -> str:
     return render_system_enrichment_block(system_enrichment_items)
-
-
-@timed("system_prompt_assembly.compaction_token_breakdown")
-def _compute_compaction_token_breakdown(agent: Agent, full_prompt: str) -> dict[str, int]:
-    return compute_prompt_token_breakdown(agent=agent, full_prompt=full_prompt)
 
 
 @dataclass
@@ -1174,10 +1168,6 @@ async def _prepare_agent_and_prompt(
     unseen_event_ids = prepared_execution.unseen_event_ids
     run_messages = prepared_execution.messages
 
-    if prepared_history.compaction_outcomes:
-        breakdown = _compute_compaction_token_breakdown(agent, render_prepared_messages_text(run_messages))
-        enriched_outcomes = [replace(o, **breakdown) for o in prepared_history.compaction_outcomes]
-        prepared_history = replace(prepared_history, compaction_outcomes=enriched_outcomes)
     logger.info(
         "Preparing agent and prompt",
         agent=agent_name,

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -63,7 +63,6 @@ from mindroom.stop import StopManager
 from mindroom.teams import TeamMode, TeamOutcome, resolve_configured_team
 from mindroom.timestamp_formatting import format_timestamp_ms
 from mindroom.tool_approval import is_process_active_approval_card
-from mindroom.tool_system.dynamic_toolkits import visible_tool_surface
 from mindroom.tool_system.runtime_context import ToolRuntimeSupport
 from mindroom.tool_system.worker_routing import tool_execution_identity
 
@@ -1864,22 +1863,6 @@ class AgentBot:
         receipt_time = time.monotonic()
         self._log_matrix_event_callback_started(room, event, callback_name="media")
         await self._turn_controller.handle_media_event(room, event, receipt_time=receipt_time)
-
-    def _agent_has_matrix_messaging_tool(self, agent_name: str, session_id: str | None = None) -> bool:
-        """Return whether an agent can issue Matrix message actions."""
-        try:
-            tool_names = [
-                entry.name
-                for entry in visible_tool_surface(
-                    agent_name=agent_name,
-                    config=self.config,
-                    session_id=session_id,
-                    enable_dynamic_tools_manager=False,
-                ).runtime_tool_configs
-            ]
-        except ValueError:
-            return False
-        return "matrix_message" in tool_names
 
     async def _run_regenerated_response(self, request: ResponseRequest) -> str | None:
         """Run one edit-regenerated turn through this bot's response path."""

--- a/src/mindroom/config/entity_view.py
+++ b/src/mindroom/config/entity_view.py
@@ -95,6 +95,11 @@ class ResolvedEntityView:
         return self._config._agent_tool_configs(self._agent_name())
 
     @property
+    def authored_tool_configs(self) -> list[EffectiveToolConfig]:
+        """Effective authored tool config entries before preset/implied expansion."""
+        return self._config._get_agent_authored_tool_configs(self._agent_name())
+
+    @property
     def authored_deferred_tool_configs(self) -> list[EffectiveToolConfig]:
         """One entry per authored deferred tool in effective order."""
         return self._config._agent_authored_deferred_tool_configs(self._agent_name())

--- a/src/mindroom/history/__init__.py
+++ b/src/mindroom/history/__init__.py
@@ -10,7 +10,6 @@ from mindroom.history.prompt_tokens import (
     StaticTokenEstimator,
     agent_static_token_estimator,
     agent_tool_definition_payloads_for_logging,
-    compute_prompt_token_breakdown,
     team_static_token_estimator,
     team_tool_definition_payloads_for_logging,
 )
@@ -80,7 +79,6 @@ __all__ = [
     "apply_replay_plan",
     "close_agent_runtime_state_dbs",
     "close_team_runtime_state_dbs",
-    "compute_prompt_token_breakdown",
     "context_budget_after_reserve",
     "create_scope_session_storage",
     "finalize_history_preparation",

--- a/src/mindroom/history/compaction.py
+++ b/src/mindroom/history/compaction.py
@@ -32,7 +32,6 @@ from mindroom.history.summary_call import DEFAULT_SUMMARY_RETRY_POLICY, generate
 from mindroom.history.types import (
     CompactionLifecycleProgress,
     CompactionOutcome,
-    HistoryPolicy,
     HistoryScope,
     HistoryScopeState,
     ResolvedHistorySettings,
@@ -170,7 +169,6 @@ async def compact_scope_history(
     summary_input_budget: int,
     summary_model: Model,
     summary_model_name: str,
-    active_context_window: int | None,
     replay_window_tokens: int | None,
     threshold_tokens: int | None,
     summary_prompt: str,
@@ -292,7 +290,6 @@ async def compact_scope_history(
         scope=scope,
         history_settings=history_settings,
     )
-    resolved_window_tokens = replay_window_tokens or active_context_window or 0
     outcome = CompactionOutcome(
         mode="manual" if state.force_compact_before_next_run else "auto",
         session_id=session.session_id,
@@ -301,7 +298,7 @@ async def compact_scope_history(
         summary_model=summary_model_name,
         before_tokens=before_tokens,
         after_tokens=after_tokens,
-        window_tokens=resolved_window_tokens,
+        window_tokens=replay_window_tokens or 0,
         threshold_tokens=threshold_tokens or 0,
         runs_before=before_run_count,
         runs_after=len(after_visible_runs),
@@ -588,9 +585,8 @@ def _build_summary_input(
     previous_summary: str | None,
     compacted_runs: Sequence[RunOutput | TeamRunOutput],
     max_input_tokens: int,
-    history_settings: ResolvedHistorySettings | None = None,
+    history_settings: ResolvedHistorySettings,
 ) -> tuple[str, list[RunOutput | TeamRunOutput]]:
-    resolved_history_settings = history_settings or _default_compaction_history_settings()
     summary_block = ""
     if previous_summary is not None and previous_summary.strip():
         escaped_summary = _escape_xml_content(previous_summary)
@@ -603,13 +599,13 @@ def _build_summary_input(
 
     included_runs: list[RunOutput | TeamRunOutput] = []
     for run in compacted_runs:
-        run_tokens = _estimate_serialized_run_tokens(run, resolved_history_settings)
+        run_tokens = _estimate_serialized_run_tokens(run, history_settings)
         if run_tokens > remaining:
             if not included_runs:
                 return _build_oversized_summary_input(
                     summary_block=summary_block,
                     compacted_runs=[run],
-                    history_settings=resolved_history_settings,
+                    history_settings=history_settings,
                     max_input_tokens=max_input_tokens,
                 )
             break
@@ -620,7 +616,7 @@ def _build_summary_input(
         return summary_block, []
 
     serialized_runs = "\n\n".join(
-        _serialize_run(run, index, resolved_history_settings) for index, run in enumerate(included_runs)
+        _serialize_run(run, index, history_settings) for index, run in enumerate(included_runs)
     )
     return _compose_summary_input(summary_block, serialized_runs), included_runs
 
@@ -697,13 +693,6 @@ def _serialize_run_excerpt(
 
     lines.append("</run>")
     return "\n".join(lines)
-
-
-def _default_compaction_history_settings() -> ResolvedHistorySettings:
-    return ResolvedHistorySettings(
-        policy=HistoryPolicy(mode="all"),
-        max_tool_calls_from_history=None,
-    )
 
 
 def _compaction_replay_messages(

--- a/src/mindroom/history/prompt_tokens.py
+++ b/src/mindroom/history/prompt_tokens.py
@@ -82,15 +82,6 @@ def _estimate_agent_non_prompt_static_tokens(agent: Agent) -> int:
     return static_tokens + _estimate_prepared_tool_definition_tokens(prepared_tools)
 
 
-def _estimate_tool_definition_tokens(agent: Agent) -> int:
-    """Estimate the model-visible tool schema and tool instructions for one agent."""
-    prepared_tools, tool_instructions = _prepare_tools_for_estimation(agent.tools)
-    return _estimate_prepared_tool_definition_tokens(
-        prepared_tools,
-        tool_instructions=tool_instructions,
-    )
-
-
 def estimate_team_static_tokens(team: Team, full_prompt: str) -> int:
     """Estimate the non-history team prompt using Agno's team system-message builder."""
     return team_static_token_estimator(team).estimate(full_prompt)
@@ -344,35 +335,3 @@ def _agent_prompt_estimation_inputs(agent: Agent) -> tuple[AgentSession, RunOutp
         session_state={},
     )
     return session, run_response, run_context
-
-
-def compute_prompt_token_breakdown(
-    agent: Agent | None = None,
-    team: Team | None = None,
-    full_prompt: str | None = None,
-) -> dict[str, int]:
-    """Compute token breakdown for system prompt, tool defs, and current prompt."""
-    breakdown: dict[str, int] = {}
-
-    if agent is not None:
-        sys_chars = len(agent.role or "")
-        instructions = agent.instructions
-        if isinstance(instructions, str):
-            sys_chars += len(instructions)
-        elif isinstance(instructions, list):
-            for instruction in instructions:
-                sys_chars += len(str(instruction))
-        breakdown["role_instructions_tokens"] = sys_chars // 4  # same floor as estimate_text_tokens
-
-    tool_tokens = 0
-    if agent is not None:
-        tool_tokens = _estimate_tool_definition_tokens(agent)
-    elif team is not None:
-        prepared_tools, _tool_instructions = _prepare_tools_for_estimation(team.tools)
-        tool_tokens = _estimate_prepared_tool_definition_tokens(prepared_tools)
-    breakdown["tool_definition_tokens"] = tool_tokens
-
-    if full_prompt is not None:
-        breakdown["current_prompt_tokens"] = estimate_text_tokens(full_prompt)
-
-    return breakdown

--- a/src/mindroom/history/runtime.py
+++ b/src/mindroom/history/runtime.py
@@ -293,7 +293,6 @@ async def prepare_scope_history(
     resolved_inputs: HistoryPreparationInputs,
     runtime_paths: RuntimePaths,
     config: Config,
-    compaction_outcomes_collector: list[CompactionOutcome] | None = None,
     scope_context: ScopeSessionContext | None = None,
     scope: HistoryScope | None = None,
     compaction_lifecycle: CompactionLifecycle | None = None,
@@ -390,8 +389,6 @@ async def prepare_scope_history(
         if pipeline_timing is not None:
             pipeline_timing.mark("required_compaction_ready")
             pipeline_timing.note(compaction_reply_outcome=compaction_reply_outcome)
-    if compaction_outcomes_collector is not None:
-        compaction_outcomes_collector.extend(compaction_outcomes)
     return PreparedScopeHistory(
         scope=scope_context.scope,
         session=scope_context.session,
@@ -531,7 +528,6 @@ async def _run_scope_compaction(
         summary_input_budget=execution_plan.summary_input_budget_tokens,
         summary_model=summary_model,
         summary_model_name=execution_plan.compaction_model_name,
-        active_context_window=resolved_inputs.active_context_window,
         replay_window_tokens=execution_plan.replay_window_tokens,
         threshold_tokens=execution_plan.trigger_threshold_tokens,
         summary_prompt=config.get_prompt("COMPACTION_SUMMARY_PROMPT"),
@@ -661,7 +657,6 @@ async def prepare_bound_scope_history(
     full_prompt: str,
     runtime_paths: RuntimePaths,
     config: Config,
-    compaction_outcomes_collector: list[CompactionOutcome] | None = None,
     scope_context: ScopeSessionContext | None = None,
     team_name: str | None = None,
     active_model_name: str | None = None,
@@ -724,7 +719,6 @@ async def prepare_bound_scope_history(
         resolved_inputs=resolved_inputs,
         runtime_paths=runtime_paths,
         config=config,
-        compaction_outcomes_collector=compaction_outcomes_collector,
         scope_context=scope_context,
         scope=bound_scope.scope,
         compaction_lifecycle=compaction_lifecycle,

--- a/src/mindroom/history/types.py
+++ b/src/mindroom/history/types.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import Literal, Protocol, TypedDict, TypeGuard, cast
+from typing import Literal, Protocol, TypedDict, cast
 
 _ScopeKind = Literal["agent", "team"]
 _HistoryMode = Literal["all", "runs", "messages"]
@@ -248,25 +248,9 @@ class CompactionLifecycle(Protocol):
         """Edit the lifecycle notice after failed compaction."""
 
 
-def _to_k(tokens: int) -> str:
-    """Abbreviate token counts: ``145826`` → ``~145K``, values <1000 as-is.
-
-    Uses floor rounding so nearby values do not jump across adjacent ``K``
-    buckets when this helper is used for compact auxiliary counts.
-    """
-    if tokens >= 1000:
-        return f"~{tokens // 1000}K"
-    return str(tokens)
-
-
 def _format_exact_tokens(tokens: int) -> str:
     """Format token counts exactly with thousands separators."""
     return f"{tokens:,}"
-
-
-def _should_render_overhead_tokens(tokens: int | None) -> TypeGuard[int]:
-    """Return whether one overhead segment should appear in the notice."""
-    return tokens is not None and tokens != 0
 
 
 @dataclass(frozen=True)
@@ -287,9 +271,6 @@ class CompactionOutcome:
     compacted_run_count: int
     compacted_at: str
     history_budget_tokens: int | None = None
-    role_instructions_tokens: int | None = None
-    tool_definition_tokens: int | None = None
-    current_prompt_tokens: int | None = None
     lifecycle_notice_event_id: str | None = None
     duration_ms: int | None = None
     status: _CompactionLifecycleStatus = "success"
@@ -315,12 +296,6 @@ class CompactionOutcome:
             meta["history_budget_tokens"] = self.history_budget_tokens
         if self.threshold_tokens:
             meta["threshold_tokens"] = self.threshold_tokens
-        if self.role_instructions_tokens is not None:
-            meta["role_instructions_tokens"] = self.role_instructions_tokens
-        if self.tool_definition_tokens is not None:
-            meta["tool_definition_tokens"] = self.tool_definition_tokens
-        if self.current_prompt_tokens is not None:
-            meta["current_prompt_tokens"] = self.current_prompt_tokens
         if self.lifecycle_notice_event_id is not None:
             meta["lifecycle_notice_event_id"] = self.lifecycle_notice_event_id
         if self.duration_ms is not None:
@@ -335,15 +310,6 @@ class CompactionOutcome:
         )
         if self.history_budget_tokens is not None:
             line1 += f" / {_format_exact_tokens(self.history_budget_tokens)} history budget"
-        overhead_parts: list[str] = []
-        if _should_render_overhead_tokens(self.role_instructions_tokens):
-            overhead_parts.append(f"{_to_k(self.role_instructions_tokens)} instructions")
-        if _should_render_overhead_tokens(self.tool_definition_tokens):
-            overhead_parts.append(f"{_to_k(self.tool_definition_tokens)} tools")
-        if _should_render_overhead_tokens(self.current_prompt_tokens):
-            overhead_parts.append(f"{_to_k(self.current_prompt_tokens)} prompt")
-        if overhead_parts:
-            return f"{line1}\n   Overhead: {' + '.join(overhead_parts)}"
         return line1
 
 

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -1679,7 +1679,7 @@ def _create_team_instance(
     team_display_name: str,
     scope_context: ScopeSessionContext | None,
     execution_identity: ToolExecutionIdentity | None,
-    model_name: str | None = None,
+    model_name: str,
     configured_team_name: str | None = None,
 ) -> Team:
     """Create a configured Team instance.
@@ -1694,7 +1694,7 @@ def _create_team_instance(
             is available for this request.
         execution_identity: Request execution identity used for provider-specific
             model behavior such as codex prompt-cache keying
-        model_name: Optional model name override
+        model_name: Resolved model name for the shared team model
         configured_team_name: Optional configured team id for stable team-scope history
 
     Returns:
@@ -1704,7 +1704,7 @@ def _create_team_instance(
     model = model_loading.get_model_instance(
         config,
         runtime_paths,
-        model_name or "default",
+        model_name,
         execution_identity=execution_identity,
     )
     # Coordinate-mode tool calls run through the shared team model in v1.

--- a/src/mindroom/tool_system/dynamic_toolkits.py
+++ b/src/mindroom/tool_system/dynamic_toolkits.py
@@ -206,7 +206,7 @@ def _visible_authored_tool_configs(
     visible_by_name: dict[str, EffectiveToolConfig] = {}
     hidden_deferred_by_name: dict[str, EffectiveToolConfig] = {}
 
-    for authored_entry in config._get_agent_authored_tool_configs(agent_name):
+    for authored_entry in config.resolve_entity(agent_name).authored_tool_configs:
         is_loaded_deferred = authored_entry.defer and authored_entry.name in loaded_deferred_tools
         is_visible_owner = not authored_entry.defer or is_loaded_deferred
         for tool_name in config.expand_tool_names([authored_entry.name]):

--- a/tests/ai_user_id_helpers.py
+++ b/tests/ai_user_id_helpers.py
@@ -50,11 +50,6 @@ from mindroom.team_scope import ad_hoc_team_scope_id
 from mindroom.tool_system.runtime_context import (
     ToolRuntimeSupport,
 )
-from tests.bot_helpers import (  # noqa: F401
-    _handled_response_event_id,
-    _stream_outcome,
-    _visible_response_event_id,
-)
 from tests.conftest import bind_runtime_paths as _bind_runtime_paths
 from tests.conftest import (
     make_event_cache_mock,

--- a/tests/ai_user_id_helpers.py
+++ b/tests/ai_user_id_helpers.py
@@ -25,7 +25,7 @@ from mindroom.constants import (
 )
 from mindroom.delivery_gateway import DeliveryGateway, DeliveryGatewayDeps, ResponseHookService
 from mindroom.entity_resolution import entity_identity_registry
-from mindroom.final_delivery import FinalDeliveryOutcome, StreamTransportOutcome
+from mindroom.final_delivery import StreamTransportOutcome
 from mindroom.history import PreparedHistoryState
 from mindroom.history.runtime import ScopeSessionContext
 from mindroom.history.types import HistoryScope
@@ -47,6 +47,11 @@ from mindroom.response_runner import (
 from mindroom.team_scope import ad_hoc_team_scope_id
 from mindroom.tool_system.runtime_context import (
     ToolRuntimeSupport,
+)
+from tests.bot_helpers import (  # noqa: F401
+    _handled_response_event_id,
+    _stream_outcome,
+    _visible_response_event_id,
 )
 from tests.conftest import bind_runtime_paths as _bind_runtime_paths
 from tests.conftest import (
@@ -75,35 +80,6 @@ def bind_runtime_paths(config: Config, runtime_paths: RuntimePaths) -> Config:
     bound = _bind_runtime_paths(config, runtime_paths)
     persist_entity_accounts(bound, runtime_paths)
     return bound
-
-
-def _stream_outcome(
-    event_id: str | None,
-    body: str,
-    *,
-    terminal_status: str = "completed",
-    visible_body_state: str = "visible_body",
-    failure_reason: str | None = None,
-) -> StreamTransportOutcome:
-    return StreamTransportOutcome(
-        last_physical_stream_event_id=event_id,
-        terminal_status=terminal_status,
-        rendered_body=body,
-        visible_body_state=visible_body_state,
-        failure_reason=failure_reason,
-    )
-
-
-def _visible_response_event_id(outcome: FinalDeliveryOutcome | str | None) -> str | None:
-    if isinstance(outcome, str) or outcome is None:
-        return outcome
-    return outcome.final_visible_event_id
-
-
-def _handled_response_event_id(outcome: FinalDeliveryOutcome | str | None) -> str | None:
-    if isinstance(outcome, str) or outcome is None:
-        return outcome
-    return outcome.event_id if outcome.mark_handled and outcome.is_visible_response and not outcome.suppressed else None
 
 
 def _set_gateway_method(gateway: DeliveryGateway, name: str, value: T) -> T:
@@ -287,7 +263,6 @@ def _make_bot(
     bot.config = config
     bot.runtime_paths = runtime_paths
     bot._knowledge_access_support = _knowledge_access_support()
-    bot._handle_interactive_question = AsyncMock()
     return bot
 
 

--- a/tests/bot_helpers.py
+++ b/tests/bot_helpers.py
@@ -36,15 +36,12 @@ from mindroom.dispatch_source import (
 )
 from mindroom.final_delivery import FinalDeliveryOutcome, StreamTransportOutcome
 from mindroom.handled_turns import HandledTurnState
-from mindroom.history import CompactionOutcome
 from mindroom.history.types import HistoryScope
 from mindroom.hooks import (
     EnrichmentItem,
     MessageEnvelope,
 )
-from mindroom.knowledge.availability import KnowledgeAvailability
 from mindroom.knowledge.indexing_config import IndexingSettings
-from mindroom.knowledge.manager import KnowledgeManager
 from mindroom.knowledge.utils import _KnowledgeResolution
 from mindroom.matrix.cache import ThreadHistoryResult
 from mindroom.matrix.client import ResolvedVisibleMessage
@@ -53,7 +50,6 @@ from mindroom.message_target import MessageTarget
 from mindroom.orchestration.config_updates import ConfigUpdatePlan
 from mindroom.response_runner import (
     ResponseRequest,
-    ResponseRunner,
 )
 from mindroom.runtime_support import StartupThreadPrewarmRegistry
 from mindroom.tool_approval import _shutdown_approval_store
@@ -66,7 +62,6 @@ from tests.conftest import (
     make_event_cache_write_coordinator_mock,
     make_matrix_client_mock,
     message_origin,
-    replace_response_runner_deps,
     replace_turn_controller_deps,
     runtime_paths_for,
     test_runtime_paths,
@@ -234,25 +229,10 @@ def _turn_store(bot: AgentBot | TeamBot) -> TurnStore:
     return unwrap_extracted_collaborator(bot._turn_store)
 
 
-def _mock_turn_store(bot: AgentBot | TeamBot, *, is_handled: bool = False) -> TurnStore:
-    """Patch the existing turn store in place for tests that only need dedupe control."""
-    turn_store = _turn_store(bot)
-    turn_store.is_handled = MagicMock(return_value=is_handled)
-    return turn_store
-
-
 def _set_turn_store_tracker(bot: AgentBot | TeamBot, tracker: MagicMock) -> MagicMock:
     """Swap the private handled-turn ledger behind one turn store for test assertions."""
     _turn_store(bot)._ledger = tracker
     return tracker
-
-
-def _replace_response_runner_runtime_deps(
-    bot: AgentBot,
-    **changes: object,
-) -> ResponseRunner:
-    """Rebuild the response coordinator with updated runtime-captured deps."""
-    return replace_response_runner_deps(bot, **changes)
 
 
 def _set_knowledge_for_agent(bot: AgentBot, knowledge_for_agent: MagicMock) -> MagicMock:
@@ -506,24 +486,6 @@ def _approval_reload_config(tmp_path: Path, *, include_code: bool) -> Config:
     )
 
 
-def _code_only_config(tmp_path: Path, *, rooms: list[str]) -> Config:
-    """Return one minimal config with only the code agent."""
-    return _runtime_bound_config(
-        Config(
-            agents={
-                "code": {
-                    "display_name": "CodeAgent",
-                    "role": "Writes code",
-                    "model": "default",
-                    "rooms": rooms,
-                },
-            },
-            models={"default": {"provider": "test", "id": "test-model"}},
-        ),
-        tmp_path,
-    )
-
-
 def _mock_approval_reload_bot(
     config: Config,
     *,
@@ -640,26 +602,6 @@ def _cleanup_recorder(event_order: list[str]) -> Callable[[], Awaitable[None]]:
         event_order.append("cleanup")
 
     return _cleanup
-
-
-def _mock_shared_knowledge_manager(
-    *,
-    base_id: str,
-    storage_root: Path,
-    knowledge_path: Path,
-    knowledge: object,
-) -> KnowledgeManager:
-    manager = MagicMock(spec=KnowledgeManager)
-    manager.base_id = base_id
-    manager.storage_path = storage_root
-    manager.knowledge_path = knowledge_path
-    manager._cached_persisted_indexing_state = SimpleNamespace(
-        status="complete",
-        availability=KnowledgeAvailability.READY.value,
-    )
-    manager.matches.return_value = True
-    manager.get_knowledge.return_value = knowledge
-    return manager
 
 
 def _hook_plugin(name: str, callbacks: list[object]) -> SimpleNamespace:
@@ -968,24 +910,6 @@ class _FailingStubVectorDb:
     ) -> list[Document]:
         _ = (query, limit, filters)
         raise RuntimeError(self.error_message)
-
-
-def _make_compaction_outcome(*, mode: str = "auto") -> CompactionOutcome:
-    return CompactionOutcome(
-        mode=mode,
-        session_id="!test:localhost:$thread_root_id",
-        scope="agent:general",
-        summary="## Goal\nPreserve <summary> & keep context.",
-        summary_model="compact-model",
-        before_tokens=30000,
-        after_tokens=12000,
-        window_tokens=200000,
-        threshold_tokens=100000,
-        runs_before=18,
-        runs_after=7,
-        compacted_run_count=12,
-        compacted_at="2026-03-22T20:15:00Z",
-    )
 
 
 class AgentBotTestBase:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,6 @@ from mindroom.edit_regenerator import EditRegenerator
 from mindroom.final_delivery import FinalDeliveryOutcome
 from mindroom.history import (
     CompactionLifecycle,
-    CompactionOutcome,
     HistoryScope,
     PreparedHistoryState,
     ResolvedHistorySettings,
@@ -163,7 +162,6 @@ async def prepare_history_for_run_for_test(
     runtime_paths: RuntimePaths,
     config: Config,
     execution_identity: "ToolExecutionIdentity | None",
-    compaction_outcomes_collector: list[CompactionOutcome] | None = None,
     storage: "BaseDb | None" = None,
     session: "AgentSession | TeamSession | None" = None,
     history_settings: ResolvedHistorySettings | None = None,
@@ -209,7 +207,6 @@ async def prepare_history_for_run_for_test(
         "resolved_inputs": resolved_inputs,
         "runtime_paths": runtime_paths,
         "config": config,
-        "compaction_outcomes_collector": compaction_outcomes_collector,
         "scope": resolved_scope,
         "compaction_lifecycle": compaction_lifecycle,
     }

--- a/tests/history_helpers.py
+++ b/tests/history_helpers.py
@@ -39,8 +39,10 @@ from mindroom.history.types import (
     CompactionLifecycleProgress,
     CompactionLifecycleStart,
     CompactionOutcome,
+    HistoryPolicy,
     HistoryScope,
     HistoryScopeState,
+    ResolvedHistorySettings,
 )
 from mindroom.hooks import (
     HookRegistry,
@@ -54,6 +56,11 @@ from tests.conftest import (
 )
 
 _DEFAULT_TEST_COMPACTION = CompactionConfig()
+
+_ALL_HISTORY_SETTINGS = ResolvedHistorySettings(
+    policy=HistoryPolicy(mode="all"),
+    max_tool_calls_from_history=None,
+)
 
 
 @dataclass

--- a/tests/test_ai_error_message_display.py
+++ b/tests/test_ai_error_message_display.py
@@ -211,7 +211,6 @@ class TestAIErrorDisplay:
             edited_messages.append((event_id, text))
 
         bot._edit_message = mock_edit_message
-        bot._handle_interactive_question = AsyncMock()
 
         # Mock stream_agent_response to yield an error message
         with patch("mindroom.response_runner.stream_agent_response") as mock_stream:
@@ -388,7 +387,6 @@ class TestAIErrorDisplay:
         """Collected non-streaming RunCancelledEvent should keep a user-stop label."""
         bot = _mock_bot(tmp_path)
         bot.config.agents["test_agent"].show_tool_calls = True
-        bot._handle_interactive_question = AsyncMock()
 
         edited_messages: list[tuple[str, str]] = []
 
@@ -451,7 +449,6 @@ class TestAIErrorDisplay:
     async def test_run_cancelled_event_preserves_user_stop_note_in_streaming(self, tmp_path: Path) -> None:
         """RunCancelledEvent should keep a user-stop label in the final streamed edit."""
         bot = _mock_bot(tmp_path)
-        bot._handle_interactive_question = AsyncMock()
 
         edited_messages: list[tuple[str, str]] = []
 

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -95,8 +95,10 @@ from tests.ai_user_id_helpers import (
     _response_request,
     _runtime_paths,
     _SessionStorage,
-    _stream_outcome,
     bind_runtime_paths,
+)
+from tests.bot_helpers import (
+    _stream_outcome,
 )
 from tests.conftest import (
     make_turn_context,

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -442,7 +442,6 @@ class TestUserIdPassthrough:
         bot.storage_path = tmp_path
         bot.runtime_paths = runtime_paths
         bot._knowledge_access_support = _knowledge_access_support()
-        bot._handle_interactive_question = AsyncMock()
         with patch("mindroom.response_runner.stream_agent_response") as mock_stream:
             coordinator = _build_response_runner(
                 bot,

--- a/tests/test_compact_context.py
+++ b/tests/test_compact_context.py
@@ -444,8 +444,8 @@ async def test_compact_context_can_use_compaction_model_window_when_active_model
 
 
 @pytest.mark.asyncio
-async def test_compaction_lifecycle_success_omits_zero_breakdown_fields_in_html_body(tmp_path: Path) -> None:
-    """Lifecycle completion edits should reuse the zero-filtered notice text."""
+async def test_compaction_lifecycle_success_edits_notice_with_html_body(tmp_path: Path) -> None:
+    """Lifecycle completion edits should reuse the outcome notice text."""
     config, runtime_paths = _make_config(tmp_path)
     bot = AgentBot(
         agent_user=AgentMatrixUser(
@@ -476,9 +476,6 @@ async def test_compaction_lifecycle_success_omits_zero_breakdown_fields_in_html_
         compacted_run_count=12,
         compacted_at="2026-01-01T00:00:00Z",
         history_budget_tokens=100_000,
-        role_instructions_tokens=0,
-        tool_definition_tokens=0,
-        current_prompt_tokens=62,
     )
 
     target = MessageTarget.resolve("!room:localhost", None, "$reply")
@@ -522,12 +519,9 @@ async def test_compaction_lifecycle_success_omits_zero_breakdown_fields_in_html_
     assert sent_content["io.mindroom.compaction"]["threshold_tokens"] == 80_000
     assert sent_content["io.mindroom.compaction"]["duration_ms"] == 123
     assert sent_content["body"] == outcome.format_notice()
-    assert sent_content["body"] == (
-        "\U0001f4e6 Compacted 12 runs: 30,000 \u2192 12,000 / 100,000 history budget\n   Overhead: 62 prompt"
-    )
+    assert sent_content["body"] == ("\U0001f4e6 Compacted 12 runs: 30,000 \u2192 12,000 / 100,000 history budget")
     assert sent_content["formatted_body"] == (
-        "<em>\U0001f4e6 Compacted 12 runs: 30,000 \u2192 12,000 / 100,000 history budget<br/>"
-        "   Overhead: 62 prompt</em>"
+        "<em>\U0001f4e6 Compacted 12 runs: 30,000 \u2192 12,000 / 100,000 history budget</em>"
     )
 
 

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -1,28 +1,19 @@
-"""Tests for history compaction token breakdown (ISSUE-074)."""
+"""Tests for compaction policy, outcome notices, and AI run metadata."""
 # ruff: noqa: D102
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
-from agno.agent import Agent
 from agno.db.base import SessionType
-from agno.models.message import Message
 from agno.session.team import TeamSession
-from agno.tools.function import Function
-from agno.tools.toolkit import Toolkit
 
-from mindroom.ai import _prepare_agent_and_prompt
 from mindroom.ai_run_metadata import build_ai_run_metadata_content
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.config.models import DefaultsConfig, ModelConfig
 from mindroom.constants import AI_RUN_METADATA_KEY
-from mindroom.execution_preparation import _PreparedExecutionContext
 from mindroom.history.policy import classify_compaction_decision
-from mindroom.history.prompt_tokens import _estimate_tool_definition_tokens, compute_prompt_token_breakdown
 from mindroom.history.runtime import create_scope_session_storage
 from mindroom.history.storage import read_scope_state, write_scope_state
 from mindroom.history.types import (
@@ -32,11 +23,9 @@ from mindroom.history.types import (
     PreparedHistoryState,
     ResolvedHistoryExecutionPlan,
     ResolvedReplayPlan,
-    _to_k,
 )
-from mindroom.memory import MemoryPromptParts
 from mindroom.tool_system.worker_routing import ToolExecutionIdentity
-from tests.conftest import bind_runtime_paths, make_turn_context, test_runtime_paths
+from tests.conftest import bind_runtime_paths, test_runtime_paths
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -45,17 +34,6 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _make_agent(
-    role: str = "Short role.",
-    instructions: list[str] | None = None,
-) -> MagicMock:
-    agent = MagicMock(spec=Agent)
-    agent.role = role
-    agent.instructions = instructions or []
-    agent.tools = None
-    return agent
 
 
 def _make_outcome(**overrides: object) -> CompactionOutcome:
@@ -167,31 +145,6 @@ def test_compaction_policy_classifies_trigger_and_required_modes() -> None:
 
 
 # ---------------------------------------------------------------------------
-# _to_k helper tests
-# ---------------------------------------------------------------------------
-
-
-class TestToK:
-    """Tests for _to_k floor-rounding helper."""
-
-    def test_boundary_values(self) -> None:
-        assert _to_k(0) == "0"
-        assert _to_k(999) == "999"
-        assert _to_k(1000) == "~1K"
-        assert _to_k(1499) == "~1K"
-        assert _to_k(1500) == "~1K"
-        assert _to_k(1999) == "~1K"
-        assert _to_k(2000) == "~2K"
-        assert _to_k(2500) == "~2K"
-        assert _to_k(3500) == "~3K"
-        assert _to_k(145826) == "~145K"
-
-    def test_no_fabricated_savings_at_boundary(self) -> None:
-        """before=1500, after=1499 must not show different K buckets."""
-        assert _to_k(1500) == _to_k(1499)
-
-
-# ---------------------------------------------------------------------------
 # CompactionOutcome tests
 # ---------------------------------------------------------------------------
 
@@ -209,45 +162,6 @@ class TestCompactionOutcome:
         notice = outcome.format_notice()
         assert notice == "\U0001f4e6 Compacted 12 runs: 1,500 \u2192 1,499 / 2,000 history budget"
 
-    def test_format_notice_uses_enriched_token_breakdown(self) -> None:
-        outcome = _make_outcome(
-            role_instructions_tokens=35_000,
-            tool_definition_tokens=15_000,
-            current_prompt_tokens=62_000,
-            window_tokens=128_000,
-        )
-        notice = outcome.format_notice()
-        assert notice == (
-            "\U0001f4e6 Compacted 12 runs: 30,000 \u2192 12,000 / 128,000 history budget\n"
-            "   Overhead: ~35K instructions + ~15K tools + ~62K prompt"
-        )
-
-    def test_format_notice_with_partial_breakdown(self) -> None:
-        outcome = _make_outcome(role_instructions_tokens=8_000)
-        notice = outcome.format_notice()
-        assert "~8K instructions" in notice
-        assert "tools" not in notice
-
-    def test_format_notice_suppresses_zero_valued_breakdown(self) -> None:
-        outcome = _make_outcome(
-            role_instructions_tokens=0,
-            tool_definition_tokens=0,
-            current_prompt_tokens=62_000,
-        )
-        notice = outcome.format_notice()
-        assert "instructions" not in notice
-        assert "tools" not in notice
-        assert "~62K prompt" in notice
-
-    def test_format_notice_all_zero_breakdown_omits_overhead_line(self) -> None:
-        outcome = _make_outcome(
-            role_instructions_tokens=0,
-            tool_definition_tokens=0,
-            current_prompt_tokens=0,
-        )
-        notice = outcome.format_notice()
-        assert "Overhead" not in notice
-
     def test_format_notice_omits_unknown_history_budget(self) -> None:
         outcome = _make_outcome(history_budget_tokens=None)
         notice = outcome.format_notice()
@@ -262,66 +176,12 @@ class TestCompactionOutcome:
         assert meta["history_budget_tokens"] == 100_000
         assert meta["threshold_tokens"] == 80_000
         assert meta["compacted_run_count"] == 12
-        assert "role_instructions_tokens" not in meta
-        assert "tool_definition_tokens" not in meta
-        assert "current_prompt_tokens" not in meta
 
     def test_to_notice_metadata_keeps_window_tokens_when_history_budget_unknown(self) -> None:
         outcome = _make_outcome(history_budget_tokens=None)
         meta = outcome.to_notice_metadata()
         assert meta["version"] == 3
         assert meta["window_tokens"] == 100_000
-
-    def test_to_notice_metadata_with_breakdown(self) -> None:
-        outcome = _make_outcome(
-            role_instructions_tokens=2_000,
-            tool_definition_tokens=1_500,
-            current_prompt_tokens=100,
-        )
-        meta = outcome.to_notice_metadata()
-        assert meta["version"] == 3
-        assert meta["history_budget_tokens"] == 100_000
-        assert meta["threshold_tokens"] == 80_000
-        assert meta["role_instructions_tokens"] == 2_000
-        assert meta["tool_definition_tokens"] == 1_500
-        assert meta["current_prompt_tokens"] == 100
-
-
-@pytest.mark.asyncio
-async def test_prepare_agent_and_prompt_omits_zero_breakdown_segments_in_notice(tmp_path: Path) -> None:
-    """Compaction notice enrichment should hide zero-valued overhead segments."""
-    config, runtime_paths = _make_prepare_config(tmp_path)
-    live_agent = _make_agent(role="", instructions=[])
-
-    prepared_execution = _PreparedExecutionContext(
-        messages=(Message(role="user", content="x" * 248),),
-        unseen_event_ids=[],
-        prepared_history=PreparedHistoryState(compaction_outcomes=[_make_outcome()]),
-    )
-
-    with (
-        patch("mindroom.ai.build_memory_prompt_parts", new=AsyncMock(return_value=MemoryPromptParts())),
-        patch("mindroom.ai.create_agent", return_value=live_agent),
-        patch(
-            "mindroom.ai.prepare_agent_execution_context",
-            new=AsyncMock(return_value=prepared_execution),
-        ),
-    ):
-        prepared_run = await _prepare_agent_and_prompt(
-            make_turn_context("test_agent"),
-            prompt="Current prompt",
-            runtime_paths=runtime_paths,
-            config=config,
-        )
-
-    prepared = prepared_run.prepared_history
-    outcome = prepared.compaction_outcomes[0]
-    assert outcome.role_instructions_tokens == 0
-    assert outcome.tool_definition_tokens == 0
-    assert outcome.current_prompt_tokens == 62
-    assert outcome.format_notice() == (
-        "\U0001f4e6 Compacted 12 runs: 30,000 \u2192 12,000 / 100,000 history budget\n   Overhead: 62 prompt"
-    )
 
 
 def test_ai_run_metadata_separates_compaction_and_prepared_context_tokens(tmp_path: Path) -> None:
@@ -507,76 +367,3 @@ def test_team_scope_storage_is_shared_across_requesters(tmp_path: Path) -> None:
     finally:
         first_storage.close()
         second_storage.close()
-
-
-# ---------------------------------------------------------------------------
-# Token estimation tests
-# ---------------------------------------------------------------------------
-
-
-class TestEstimateToolDefinitionTokens:
-    """Tests for estimate_tool_definition_tokens."""
-
-    def test_no_tools(self) -> None:
-        agent = _make_agent()
-        assert _estimate_tool_definition_tokens(agent) == 0
-
-    def test_with_toolkit(self) -> None:
-        func = Function(
-            name="test_func",
-            description="A test function",
-            parameters={"type": "object", "properties": {"x": {"type": "string"}}},
-        )
-        toolkit = Toolkit(name="test_toolkit")
-        toolkit.functions = {"test_func": func}
-        agent = _make_agent()
-        agent.tools = [toolkit]
-        tokens = _estimate_tool_definition_tokens(agent)
-        assert tokens > 0
-
-    def test_with_function(self) -> None:
-        func = Function(
-            name="calculator",
-            description="Does math",
-            parameters={"type": "object"},
-        )
-        agent = _make_agent()
-        agent.tools = [func]
-        tokens = _estimate_tool_definition_tokens(agent)
-        assert tokens > 0
-
-
-class TestComputePromptTokenBreakdown:
-    """Tests for compute_prompt_token_breakdown."""
-
-    def test_returns_all_keys(self) -> None:
-        agent = _make_agent(role="x" * 100, instructions=["y" * 50])
-        breakdown = compute_prompt_token_breakdown(agent=agent, full_prompt="z" * 200)
-        assert "role_instructions_tokens" in breakdown
-        assert "tool_definition_tokens" in breakdown
-        assert "current_prompt_tokens" in breakdown
-
-    def test_role_instructions_tokens_value(self) -> None:
-        agent = _make_agent(role="x" * 40, instructions=["y" * 60])
-        breakdown = compute_prompt_token_breakdown(agent=agent, full_prompt="prompt")
-        # (40 + 60) / 4 = 25
-        assert breakdown["role_instructions_tokens"] == 25
-
-    def test_current_prompt_tokens_value(self) -> None:
-        agent = _make_agent()
-        breakdown = compute_prompt_token_breakdown(agent=agent, full_prompt="x" * 120)
-        assert breakdown["current_prompt_tokens"] == 30
-
-    def test_team_tools_are_included(self) -> None:
-        team = MagicMock()
-        team.tools = [Function.from_callable(lambda value: value)]
-
-        breakdown = compute_prompt_token_breakdown(team=team, full_prompt="z" * 200)
-
-        assert breakdown["tool_definition_tokens"] > 0
-        assert breakdown["current_prompt_tokens"] == 50
-
-    def test_no_prompt(self) -> None:
-        agent = _make_agent()
-        breakdown = compute_prompt_token_breakdown(agent=agent)
-        assert "current_prompt_tokens" not in breakdown

--- a/tests/test_compaction_invariants.py
+++ b/tests/test_compaction_invariants.py
@@ -345,7 +345,6 @@ async def test_chunk_progress_survives_interruption_and_restart(tmp_path: Path) 
             summary_input_budget=10_000,
             summary_model=FakeModel(id="summary-model", provider="fake"),
             summary_model_name="summary-model",
-            active_context_window=64_000,
             replay_window_tokens=64_000,
             threshold_tokens=None,
             summary_prompt=COMPACTION_SUMMARY_PROMPT,

--- a/tests/test_dynamic_toolkits.py
+++ b/tests/test_dynamic_toolkits.py
@@ -802,6 +802,15 @@ def test_matrix_metadata_injection_is_loaded_state_aware(tmp_path: Path) -> None
     assert _agent_has_matrix_messaging_tool(config, "code", "thread-a")
 
 
+def test_openclaw_compat_implies_matrix_messaging_tool(tmp_path: Path) -> None:
+    """openclaw_compat should imply matrix_message availability without explicit config."""
+    raw = _base_config_data()
+    raw["agents"]["code"]["tools"] = ["openclaw_compat"]  # type: ignore[index]
+    config = _validated_config(tmp_path, raw)
+
+    assert _agent_has_matrix_messaging_tool(config, "code", None)
+
+
 def test_dynamic_prompt_splits_static_catalog_from_volatile_loaded_state(tmp_path: Path) -> None:
     """Prompt catalog text should remain stable while loaded-state suffix changes."""
     raw = _base_config_data()

--- a/tests/test_history_compaction_rewrite.py
+++ b/tests/test_history_compaction_rewrite.py
@@ -59,6 +59,7 @@ from tests.conftest import (
     prepare_history_for_run_for_test,
 )
 from tests.history_helpers import (  # noqa: F401
+    _ALL_HISTORY_SETTINGS,
     RecordingCompactionLifecycle,
     _agent,
     _close_test_storages,
@@ -415,6 +416,7 @@ async def test_compact_scope_history_emits_before_hook_for_each_persisted_chunk(
                 previous_summary=None,
                 compacted_runs=[first_run, second_run],
                 max_input_tokens=budget,
+                history_settings=_ALL_HISTORY_SETTINGS,
             )[1],
         )
         == 1
@@ -423,6 +425,7 @@ async def test_compact_scope_history_emits_before_hook_for_each_persisted_chunk(
                 previous_summary="merged summary",
                 compacted_runs=[second_run],
                 max_input_tokens=budget,
+                history_settings=_ALL_HISTORY_SETTINGS,
             )[1],
         )
         == 1
@@ -478,7 +481,6 @@ async def test_compact_scope_history_emits_before_hook_for_each_persisted_chunk(
             summary_input_budget=summary_input_budget,
             summary_model=FakeModel(id="summary-model", provider="fake"),
             summary_model_name="summary-model",
-            active_context_window=16_000,
             replay_window_tokens=16_000,
             threshold_tokens=1,
             summary_prompt=COMPACTION_SUMMARY_PROMPT,
@@ -1055,6 +1057,7 @@ async def test_rewrite_working_session_for_compaction_strips_stale_replay_fields
                 previous_summary=None,
                 compacted_runs=list(working_session.runs or []),
                 max_input_tokens=budget,
+                history_settings=_ALL_HISTORY_SETTINGS,
             )[1],
         )
         == 1
@@ -1062,6 +1065,7 @@ async def test_rewrite_working_session_for_compaction_strips_stale_replay_fields
             previous_summary=summary_text,
             compacted_runs=[remaining_run],
             max_input_tokens=budget,
+            history_settings=_ALL_HISTORY_SETTINGS,
         )[1]
         == []
     )
@@ -1141,7 +1145,6 @@ async def test_compact_scope_history_ignores_runs_without_stable_ids(
             ),
             available_history_budget=1,
             summary_input_budget=16_000,
-            active_context_window=64_000,
             replay_window_tokens=64_000,
             threshold_tokens=None,
             summary_prompt=COMPACTION_SUMMARY_PROMPT,
@@ -1206,6 +1209,7 @@ async def test_compact_scope_history_persists_sanitized_remaining_runs(tmp_path:
                 previous_summary=None,
                 compacted_runs=list(session.runs or []),
                 max_input_tokens=budget,
+                history_settings=_ALL_HISTORY_SETTINGS,
             )[1],
         )
         == 1
@@ -1213,6 +1217,7 @@ async def test_compact_scope_history_persists_sanitized_remaining_runs(tmp_path:
             previous_summary=summary_text,
             compacted_runs=[remaining_run],
             max_input_tokens=budget,
+            history_settings=_ALL_HISTORY_SETTINGS,
         )[1]
         == []
     )
@@ -1234,7 +1239,6 @@ async def test_compact_scope_history_persists_sanitized_remaining_runs(tmp_path:
             summary_input_budget=summary_input_budget,
             summary_model=FakeModel(id="summary-model", provider="fake"),
             summary_model_name="summary-model",
-            active_context_window=16_000,
             replay_window_tokens=16_000,
             threshold_tokens=1,
             summary_prompt=COMPACTION_SUMMARY_PROMPT,
@@ -1292,6 +1296,7 @@ async def test_rewrite_working_session_emits_progress_after_persisted_chunks(tmp
                 previous_summary=None,
                 compacted_runs=[first_run, second_run],
                 max_input_tokens=budget,
+                history_settings=_ALL_HISTORY_SETTINGS,
             )[1],
         )
         == 1
@@ -1300,6 +1305,7 @@ async def test_rewrite_working_session_emits_progress_after_persisted_chunks(tmp
                 previous_summary="merged summary",
                 compacted_runs=[second_run],
                 max_input_tokens=budget,
+                history_settings=_ALL_HISTORY_SETTINGS,
             )[1],
         )
         == 1

--- a/tests/test_history_prepare_integration.py
+++ b/tests/test_history_prepare_integration.py
@@ -12,7 +12,6 @@ from agno.agent import Agent
 from agno.models.message import Message
 from agno.run.agent import RunOutput
 from agno.session.summary import SessionSummary
-from agno.tools.function import Function
 from defusedxml.ElementTree import fromstring
 
 from mindroom.agent_storage import create_session_storage, get_agent_session
@@ -35,10 +34,7 @@ from mindroom.history.runtime import (
 from mindroom.history.storage import (
     update_scope_seen_event_ids,
 )
-from mindroom.history.types import (
-    CompactionOutcome,
-    HistoryScope,
-)
+from mindroom.history.types import HistoryScope
 from mindroom.memory import MemoryPromptParts
 from mindroom.token_budget import estimate_text_tokens, stable_serialize
 from tests.conftest import (
@@ -576,111 +572,6 @@ async def test_prepare_agent_and_prompt_keeps_matrix_current_sender_when_persist
     assert prepared_agent is live_agent
     assert prepared.replays_persisted_history is True
     assert full_prompt == 'Current message:\n<msg from="@alice:localhost"><![CDATA[Current prompt]]></msg>'
-
-
-def _make_test_compaction_outcome() -> CompactionOutcome:
-    return CompactionOutcome(
-        mode="auto",
-        session_id="session-1",
-        scope="agent:test_agent",
-        summary="Merged summary",
-        summary_model="summary-model",
-        before_tokens=30_000,
-        after_tokens=12_000,
-        window_tokens=128_000,
-        threshold_tokens=96_000,
-        runs_before=20,
-        runs_after=8,
-        compacted_run_count=12,
-        compacted_at="2026-01-01T00:00:00Z",
-    )
-
-
-@pytest.mark.asyncio
-async def test_prepare_agent_and_prompt_enriches_compaction_outcomes(
-    tmp_path: Path,
-) -> None:
-    config, runtime_paths = _make_config(tmp_path)
-
-    def search_docs(query: str) -> str:
-        return query
-
-    live_agent = _agent()
-    live_agent.role = "Engineer"
-    live_agent.instructions = ["Keep the response concise."]
-    live_agent.tools = [Function.from_callable(search_docs)]
-
-    original_outcome = _make_test_compaction_outcome()
-    prepared_execution = _PreparedExecutionContext(
-        messages=(Message(role="user", content="Current prompt"),),
-        unseen_event_ids=[],
-        prepared_history=PreparedHistoryState(compaction_outcomes=[original_outcome]),
-    )
-
-    with (
-        patch("mindroom.ai.build_memory_prompt_parts", new=AsyncMock(return_value=MemoryPromptParts())),
-        patch("mindroom.ai.create_agent", return_value=live_agent),
-        patch(
-            "mindroom.ai.prepare_agent_execution_context",
-            new=AsyncMock(return_value=prepared_execution),
-        ),
-    ):
-        prepared_run = await _prepare_agent_and_prompt(
-            make_turn_context("test_agent"),
-            prompt="Current prompt",
-            runtime_paths=runtime_paths,
-            config=config,
-        )
-
-    prepared = prepared_run.prepared_history
-    assert len(prepared.compaction_outcomes) == 1
-    assert prepared.compaction_outcomes[0] is not original_outcome
-    assert prepared.compaction_outcomes[0].role_instructions_tokens is not None
-    assert prepared.compaction_outcomes[0].tool_definition_tokens is not None
-    assert prepared.compaction_outcomes[0].current_prompt_tokens is not None
-
-
-@pytest.mark.asyncio
-async def test_prepare_agent_and_prompt_omits_zero_breakdown_segments_in_notice(
-    tmp_path: Path,
-) -> None:
-    config, runtime_paths = _make_config(tmp_path)
-    live_agent = _agent()
-    live_agent.role = ""
-    live_agent.instructions = []
-    live_agent.tools = None
-
-    original_outcome = _make_test_compaction_outcome()
-    prepared_execution = _PreparedExecutionContext(
-        messages=(Message(role="user", content="x" * 248),),
-        unseen_event_ids=[],
-        prepared_history=PreparedHistoryState(compaction_outcomes=[original_outcome]),
-    )
-
-    with (
-        patch("mindroom.ai.build_memory_prompt_parts", new=AsyncMock(return_value=MemoryPromptParts())),
-        patch("mindroom.ai.create_agent", return_value=live_agent),
-        patch(
-            "mindroom.ai.prepare_agent_execution_context",
-            new=AsyncMock(return_value=prepared_execution),
-        ),
-    ):
-        prepared_run = await _prepare_agent_and_prompt(
-            make_turn_context("test_agent"),
-            prompt="Current prompt",
-            runtime_paths=runtime_paths,
-            config=config,
-        )
-
-    prepared = prepared_run.prepared_history
-    outcome = prepared.compaction_outcomes[0]
-    assert outcome.role_instructions_tokens == 0
-    assert outcome.tool_definition_tokens == 0
-    assert outcome.current_prompt_tokens == 62
-    notice = outcome.format_notice()
-    assert "0 instructions" not in notice
-    assert "0 tools" not in notice
-    assert "62 prompt" in notice
 
 
 @pytest.mark.asyncio

--- a/tests/test_history_prepare_lifecycle.py
+++ b/tests/test_history_prepare_lifecycle.py
@@ -53,6 +53,7 @@ from tests.conftest import (
     prepare_history_for_run_for_test,
 )
 from tests.history_helpers import (  # noqa: F401
+    _ALL_HISTORY_SETTINGS,
     RecordingCompactionLifecycle,
     _agent,
     _close_test_storages,
@@ -545,6 +546,7 @@ async def test_prepare_history_for_run_forced_compaction_finishes_selected_runs_
                 previous_summary=previous_summary,
                 compacted_runs=compacted_runs,
                 max_input_tokens=budget,
+                history_settings=_ALL_HISTORY_SETTINGS,
             )[1],
         )
 
@@ -687,6 +689,7 @@ async def test_prepare_history_for_run_auto_compaction_runs_to_completion_before
                 previous_summary=previous_summary,
                 compacted_runs=compacted_runs,
                 max_input_tokens=budget,
+                history_settings=_ALL_HISTORY_SETTINGS,
             )[1],
         )
 
@@ -972,6 +975,7 @@ async def test_prepare_history_for_run_persists_successful_compaction_chunks_bef
                 previous_summary=previous_summary,
                 compacted_runs=compacted_runs,
                 max_input_tokens=budget,
+                history_settings=_ALL_HISTORY_SETTINGS,
             )[1],
         )
 

--- a/tests/test_history_prompt_tokens.py
+++ b/tests/test_history_prompt_tokens.py
@@ -22,7 +22,8 @@ from mindroom.history.compaction import (
 )
 from mindroom.history.prompt_tokens import (
     StaticTokenEstimator,
-    _estimate_tool_definition_tokens,
+    _estimate_prepared_tool_definition_tokens,
+    _prepare_tools_for_estimation,
     estimate_agent_static_tokens,
 )
 from mindroom.history.types import (
@@ -40,6 +41,12 @@ from tests.history_helpers import (  # noqa: F401
     _completed_run,
     _session,
 )
+
+
+def _tool_definition_tokens(tools: object) -> int:
+    """Estimate model-visible tool schema and instruction tokens for one tool list."""
+    prepared_tools, tool_instructions = _prepare_tools_for_estimation(tools)
+    return _estimate_prepared_tool_definition_tokens(prepared_tools, tool_instructions=tool_instructions)
 
 
 def test_estimate_static_tokens_includes_tool_definitions() -> None:
@@ -84,12 +91,12 @@ def test_estimate_static_tokens_includes_tool_definitions() -> None:
             "parameters": expected_export_tool.parameters,
         },
     ]
-    tool_tokens = _estimate_tool_definition_tokens(agent_with_tools)
+    tool_tokens = _tool_definition_tokens(agent_with_tools.tools)
     assert tool_tokens == (
         len(stable_serialize(expected_payloads)) // 4
         + estimate_text_tokens("Always cite the relevant document section when using search_docs.")
     )
-    assert _estimate_tool_definition_tokens(baseline_agent) == 0
+    assert _tool_definition_tokens(baseline_agent.tools) == 0
     assert tool_tokens > 0
 
 
@@ -165,7 +172,7 @@ def test_estimate_tool_definition_tokens_processes_functions_with_custom_paramet
     assert expected_tool.description == "Sync the current event draft into the shared calendar."
     assert expected_tool.parameters["additionalProperties"] is False
     assert (
-        _estimate_tool_definition_tokens(agent)
+        _tool_definition_tokens(agent.tools)
         == len(
             stable_serialize(
                 [
@@ -185,7 +192,7 @@ def test_estimate_tool_definition_tokens_ignores_empty_toolkit() -> None:
     agent = _agent()
     agent.tools = [Toolkit(name="empty")]
 
-    assert _estimate_tool_definition_tokens(agent) == 0
+    assert _tool_definition_tokens(agent.tools) == 0
 
 
 def test_estimate_prompt_visible_history_tokens_never_mutates_session_messages() -> None:

--- a/tests/test_history_summary_call.py
+++ b/tests/test_history_summary_call.py
@@ -36,6 +36,7 @@ from tests.conftest import (
     prepare_history_for_run_for_test,
 )
 from tests.history_helpers import (  # noqa: F401
+    _ALL_HISTORY_SETTINGS,
     RecordingModel,
     _agent,
     _close_test_storages,
@@ -417,6 +418,7 @@ def test_build_summary_input_advances_past_oversized_oldest_run() -> None:
         previous_summary=None,
         compacted_runs=[big_run, small_run],
         max_input_tokens=220,
+        history_settings=_ALL_HISTORY_SETTINGS,
     )
 
     assert [run.run_id for run in included_runs] == ["run-big"]
@@ -443,6 +445,7 @@ def test_build_summary_input_oversized_run_preserves_messages_before_tool_schema
         previous_summary=None,
         compacted_runs=[run],
         max_input_tokens=280,
+        history_settings=_ALL_HISTORY_SETTINGS,
     )
 
     assert [included_run.run_id for included_run in included_runs] == ["run-big-metadata"]
@@ -457,6 +460,7 @@ def test_build_summary_input_skips_when_previous_summary_cannot_be_preserved() -
         previous_summary="existing durable summary " * 50,
         compacted_runs=[run],
         max_input_tokens=50,
+        history_settings=_ALL_HISTORY_SETTINGS,
     )
 
     assert included_runs == []
@@ -470,6 +474,7 @@ def test_build_summary_input_preserves_previous_summary_text() -> None:
         previous_summary="Useful prior conversation.\n\n## Your Identity\nIDENTITY.md\nCurrent Date and Time",
         compacted_runs=[run],
         max_input_tokens=1_000,
+        history_settings=_ALL_HISTORY_SETTINGS,
     )
 
     assert included_runs == [run]

--- a/tests/test_history_team_scope.py
+++ b/tests/test_history_team_scope.py
@@ -408,6 +408,7 @@ def test_create_team_instance_enables_native_team_history_and_disables_members(t
             team_display_name="Team-alpha-zeta",
             scope_context=scope_context,
             execution_identity=None,
+            model_name="default",
             configured_team_name="pair",
         )
 
@@ -467,6 +468,7 @@ def test_create_team_instance_preserves_all_history_mode(tmp_path: Path) -> None
             team_display_name="Team-alpha-zeta",
             scope_context=scope_context,
             execution_identity=None,
+            model_name="default",
             configured_team_name="pair",
         )
 

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -622,29 +622,6 @@ class TestAgentBot(AgentBotTestBase):
             # With stop button support: initial + reaction + final
             assert bot.client.room_send.call_count >= 2
 
-    def test_agent_has_matrix_messaging_tool_when_openclaw_compat_enabled(
-        self,
-        mock_agent_user: AgentMatrixUser,
-        tmp_path: Path,
-    ) -> None:
-        """openclaw_compat should imply matrix_message availability without explicit config."""
-        config = _runtime_bound_config(
-            Config(
-                agents={
-                    "calculator": AgentConfig(
-                        display_name="CalculatorAgent",
-                        rooms=["!test:localhost"],
-                        tools=["openclaw_compat"],
-                        include_default_tools=False,
-                    ),
-                },
-            ),
-            tmp_path,
-        )
-        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-
-        assert bot._agent_has_matrix_messaging_tool("calculator") is True
-
     @pytest.mark.asyncio
     async def test_agent_bot_on_message_not_mentioned(self, mock_agent_user: AgentMatrixUser, tmp_path: Path) -> None:
         """Test agent bot not responding when not mentioned."""

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -588,7 +588,6 @@ class TestAgentBot(AgentBotTestBase):
             assert stream_ctx.reply_to_event_id == "event123"
             assert stream_kwargs["show_tool_calls"] is True
             assert stream_kwargs["run_metadata_collector"] == {}
-            assert "compaction_outcomes_collector" not in stream_kwargs
             mock_ai_response.assert_not_called()
             # With streaming and stop button: initial message + reaction + edits
             # Note: The exact count may vary based on implementation
@@ -617,7 +616,6 @@ class TestAgentBot(AgentBotTestBase):
             assert ai_kwargs["collect_streamed_response"] is True
             assert ai_kwargs["tool_trace_collector"] == []
             assert ai_kwargs["run_metadata_collector"] == {}
-            assert "compaction_outcomes_collector" not in ai_kwargs
             mock_stream_agent_response.assert_not_called()
             # With stop button support: initial + reaction + final
             assert bot.client.room_send.call_count >= 2

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -3200,6 +3200,7 @@ def test_create_team_instance_installs_notice_hook_on_team_model(tmp_path: Path)
             team_display_name="Queued Notice Team",
             scope_context=scope_context,
             execution_identity=None,
+            model_name="default",
         )
         messages = [Message(role="user", content="hello")]
         team.model.format_function_call_results(

--- a/tests/test_response_runner_agent.py
+++ b/tests/test_response_runner_agent.py
@@ -245,7 +245,6 @@ class TestAgentBot(AgentBotTestBase):
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = AsyncMock()
         _set_knowledge_for_agent(bot, MagicMock(return_value=None))
-        bot._handle_interactive_question = AsyncMock()
         mock_stream_agent_response = MagicMock()
 
         with patch(
@@ -421,7 +420,6 @@ class TestAgentBot(AgentBotTestBase):
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = AsyncMock()
         _set_knowledge_for_agent(bot, MagicMock(return_value=None))
-        bot._handle_interactive_question = AsyncMock()
         mock_stream_agent_response = MagicMock(return_value=mock_streaming_response())
         with patch(
             "mindroom.delivery_gateway.send_streaming_response",
@@ -511,7 +509,6 @@ class TestAgentBot(AgentBotTestBase):
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = AsyncMock()
         _set_knowledge_for_agent(bot, MagicMock(return_value=None))
-        bot._handle_interactive_question = AsyncMock()
 
         captured_collector: dict[str, Any] = {}
 
@@ -610,7 +607,6 @@ class TestAgentBot(AgentBotTestBase):
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = AsyncMock()
         _set_knowledge_for_agent(bot, MagicMock(return_value=None))
-        bot._handle_interactive_question = AsyncMock()
 
         def fake_stream_agent_response(*_args: object, **kwargs: object) -> AsyncGenerator[str, None]:
             async def _gen() -> AsyncGenerator[str, None]:
@@ -680,7 +676,6 @@ class TestAgentBot(AgentBotTestBase):
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = AsyncMock()
         _set_knowledge_for_agent(bot, MagicMock(return_value=None))
-        bot._handle_interactive_question = AsyncMock()
 
         def fake_stream_agent_response(*_args: object, **kwargs: object) -> AsyncGenerator[str, None]:
             async def _gen() -> AsyncGenerator[str, None]:
@@ -753,7 +748,6 @@ class TestAgentBot(AgentBotTestBase):
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = AsyncMock()
         _set_knowledge_for_agent(bot, MagicMock(return_value=None))
-        bot._handle_interactive_question = AsyncMock()
         mock_stream_agent_response = MagicMock(return_value=mock_streaming_response())
         with (
             patch(
@@ -1004,7 +998,6 @@ class TestAgentBot(AgentBotTestBase):
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = AsyncMock()
         _set_knowledge_for_agent(bot, MagicMock(return_value=None))
-        bot._handle_interactive_question = AsyncMock()
 
         running_task = asyncio.create_task(asyncio.sleep(60))
         done_task = asyncio.create_task(asyncio.sleep(0))
@@ -1464,7 +1457,6 @@ class TestAgentBot(AgentBotTestBase):
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = _make_matrix_client_mock()
         _set_knowledge_for_agent(bot, MagicMock(return_value=None))
-        bot._handle_interactive_question = AsyncMock()
 
         with (
             patch_response_runner_module(

--- a/tests/test_response_runner_session_lifecycle.py
+++ b/tests/test_response_runner_session_lifecycle.py
@@ -77,9 +77,11 @@ from tests.ai_user_id_helpers import (
     _runtime_paths,
     _SessionStorage,
     _set_gateway_method,
+    bind_runtime_paths,
+)
+from tests.bot_helpers import (
     _stream_outcome,
     _visible_response_event_id,
-    bind_runtime_paths,
 )
 from tests.conftest import (
     message_origin,

--- a/tests/test_response_runner_session_lifecycle.py
+++ b/tests/test_response_runner_session_lifecycle.py
@@ -762,7 +762,6 @@ async def test_process_and_respond_streaming_emits_session_started_after_persist
     bot.config = config
     bot.runtime_paths = runtime_paths
     bot._knowledge_access_support = _knowledge_access_support()
-    bot._handle_interactive_question = AsyncMock()
 
     storage = _SessionStorage()
     sequence: list[str] = []
@@ -1148,7 +1147,6 @@ async def test_process_and_respond_streaming_emits_session_started_after_persist
     bot.config = config
     bot.runtime_paths = runtime_paths
     bot._knowledge_access_support = _knowledge_access_support()
-    bot._handle_interactive_question = AsyncMock()
 
     storage = _SessionStorage()
     sequence: list[str] = []

--- a/tests/test_response_runner_team_streaming.py
+++ b/tests/test_response_runner_team_streaming.py
@@ -41,7 +41,6 @@ from tests.ai_user_id_helpers import (
     _config,
     _config_with_team,
     _config_with_team_matrix_message,
-    _handled_response_event_id,
     _install_inert_post_response_effects,
     _knowledge_access_support,
     _make_bot,
@@ -51,9 +50,12 @@ from tests.ai_user_id_helpers import (
     _runtime_paths,
     _SessionStorage,
     _set_gateway_method,
-    _stream_outcome,
     _team_orchestrator,
     bind_runtime_paths,
+)
+from tests.bot_helpers import (
+    _handled_response_event_id,
+    _stream_outcome,
 )
 from tests.identity_helpers import fixture_entity_matrix_id
 

--- a/tests/test_system_enrich.py
+++ b/tests/test_system_enrich.py
@@ -185,7 +185,6 @@ def _make_bot(tmp_path: Path) -> AgentBot:
     bot.client = MagicMock()
     bot.client.user_id = agent_user.user_id
     bot._knowledge_access_support.for_agent = MagicMock(return_value=None)
-    bot._handle_interactive_question = AsyncMock()
     return bot
 
 

--- a/tests/test_team_scheduler_context.py
+++ b/tests/test_team_scheduler_context.py
@@ -100,7 +100,6 @@ def _make_bot(tmp_path: Path) -> AgentBot:
     bot.client.user_id = agent_user.user_id
     bot.client.rooms = {"!team:localhost": MagicMock(room_id="!team:localhost")}
     bot.orchestrator = MagicMock(config=config)
-    bot._handle_interactive_question = AsyncMock()
     return install_runtime_cache_support(bot)
 
 


### PR DESCRIPTION
Pure dead-code removal left behind by the recent refactor campaigns; one item adds a tiny accessor to close a seam reach-around. Net -625/+78 lines. No behavior change.

Each item was verified against the base commit before deletion:

- **Write-only compaction token-breakdown enrichment** (`ai.py`, `history/types.py`, `history/prompt_tokens.py`): no production reader — the visible Matrix compaction notice is delivered inside `_run_scope_compaction_with_lifecycle` with the un-enriched outcome, and `ai_run_metadata.py` reads only `compaction_decision`/`compaction_reply_outcome`/`replay_plan`/`prepared_context_tokens`. Deleted the enrichment block in `_prepare_agent_and_prompt`, `compute_prompt_token_breakdown`, the `CompactionOutcome` fields `role_instructions_tokens`/`tool_definition_tokens`/`current_prompt_tokens`, the unreachable "Overhead: ..." branch in `format_notice`, the `to_notice_metadata` breakdown keys, and the now-orphaned `_to_k`/`_should_render_overhead_tokens` helpers. `_estimate_tool_definition_tokens` lost its last production caller and was deleted too; its tests were migrated to the live `_prepare_tools_for_estimation` + `_estimate_prepared_tool_definition_tokens` composition so schema-estimation coverage survives.
- **Kept `PreparedHistoryState.compaction_outcomes`**: after the enrichment block is gone it has no production reader outside `history/`, but ~40 tests assert on it as the prepare pipeline's observable output, so deleting the field would not be a contained diff. Left in place deliberately.
- **Dead `compaction_outcomes_collector` params** (`history/runtime.py`): grep shows no production caller passes them (`execution_preparation.py` omits the kwarg at both call sites) and no test passes a non-None value — deleted the params, the extend branch, the pass-through, and the conftest factory kwarg.
- **Dead or-fallback for window tokens** (`history/compaction.py`): `history/policy.py:33` sets `replay_window_tokens = active_context_window` verbatim and the sole caller passes both from the same resolution, so `replay_window_tokens or active_context_window` never engages — the `active_context_window` parameter of `compact_scope_history` is deleted.
- **Test-only default on `_build_summary_input`**: both production call sites always pass `history_settings`; only tests omitted it. The parameter is now required, `_default_compaction_history_settings` is deleted, and tests pass an explicit shared `_ALL_HISTORY_SETTINGS` (same values as the deleted default).
- **Dead Optional `model_name` on `_create_team_instance`** (`teams.py`): PR #1391 made the sole production caller (`build_materialized_team_instance`) pass a required `str`, so the `model_name or "default"` fallback was dead — the parameter is now required and the docstring fixed. The three direct test callers now pass `model_name="default"` explicitly.
- **Entity-view seam reach-around** (`tool_system/dynamic_toolkits.py`): it called the private `Config._get_agent_authored_tool_configs` directly, contradicting `config/entity_view.py`'s "only external consumer" contract. Added an `authored_tool_configs` property on `ResolvedEntityView` (same underlying call) and migrated the caller to `config.resolve_entity(...)`. `tach check --dependencies --interfaces` passes with no `tach.toml` change needed.
- **Dead `AgentBot._agent_has_matrix_messaging_tool`** (`bot.py`): zero production callers; the live implementation is the module-level function in `response_runner.py`. The existing `test_dynamic_toolkits.py` coverage did not include the openclaw_compat-implies-matrix_message case, so that test was rewritten against the live function before deleting the bot method and its bot-side test.
- **Vestigial `bot._handle_interactive_question = AsyncMock()` assignments**: production has zero references (`_handle_interactive_question` was removed in PR #510) — deleted all 17 no-op assignments across tests/.
- **Five dead helpers in `tests/bot_helpers.py`** (`_mock_turn_store`, `_replace_response_runner_runtime_deps`, `_code_only_config`, `_mock_shared_knowledge_manager`, `_make_compaction_outcome`): each appeared exactly once in the repo (its own def) — deleted along with the imports they orphaned.
- **Byte-identical helper duplication**: `_stream_outcome`, `_visible_response_event_id`, `_handled_response_event_id` were identical between `tests/bot_helpers.py` and `tests/ai_user_id_helpers.py`; the latter now imports them from the former. The duplication predates the monolith splits (it existed in both monoliths) — this just collapses it now that both are curated shared modules.

Validation: full `pytest -q --no-cov` passes, `SKIP=typescript-check pre-commit run --all-files` passes (typescript-check is broken on this macOS host), and `tach check --dependencies --interfaces` validates.

Adversarial review round: no blockers or majors; swept two assertions left vacuous by the collector-param deletion (tests/test_multi_agent_bot.py).
