### PR TITLE
fix: leave instead of kick when orphaned bot is own account

### DIFF
--- a/src/mindroom/matrix/room_cleanup.py
+++ b/src/mindroom/matrix/room_cleanup.py
@@ -113,7 +113,9 @@ async def _cleanup_orphaned_bots_in_room(
 
     removed_bots = []
 
-    for user_id in member_ids:
+    # Sweep the client's own account last — once it leaves the room it can no
+    # longer kick the remaining orphans.
+    for user_id in sorted(member_ids, key=lambda member_id: member_id == client.user_id):
         matrix_id = MatrixID.parse(user_id)
         agent_name = registry.current_entity_name_for_user_id(user_id)
         is_configured_current_bot = agent_name is not None and user_id in configured_bot_ids

--- a/src/mindroom/matrix/room_cleanup.py
+++ b/src/mindroom/matrix/room_cleanup.py
@@ -83,7 +83,7 @@ async def _cleanup_orphaned_bots_in_room(
         persisted_invited_rooms_by_bot: Preloaded persisted invited rooms keyed by bot Matrix user ID
 
     Returns:
-        List of bot Matrix user IDs that were kicked
+        List of bot Matrix user IDs that were removed from the room
 
     """
     # Never evict bots from the root space — the router is the creator/admin
@@ -111,7 +111,7 @@ async def _cleanup_orphaned_bots_in_room(
     if persisted_invited_rooms_by_bot is None:
         persisted_invited_rooms_by_bot = _load_all_persisted_invited_rooms(config, runtime_paths)
 
-    kicked_bots = []
+    removed_bots = []
 
     for user_id in member_ids:
         matrix_id = MatrixID.parse(user_id)
@@ -137,22 +137,45 @@ async def _cleanup_orphaned_bots_in_room(
                 configured_bots=sorted(configured_bot_ids),
             )
 
-            # Kick the bot
-            kick_response = await client.room_kick(room_id, user_id, reason="Bot no longer configured for this room")
+            if await _remove_orphaned_bot(client, room_id, matrix_id):
+                removed_bots.append(user_id)
 
-            if isinstance(kick_response, nio.RoomKickResponse):
-                logger.info("orphaned_bot_kicked", agent=matrix_id.username, room_id=room_id, user_id=user_id)
-                kicked_bots.append(user_id)
-            else:
-                logger.error(
-                    "orphaned_bot_kick_failed",
-                    agent=matrix_id.username,
-                    room_id=room_id,
-                    user_id=user_id,
-                    error=str(kick_response),
-                )
+    return removed_bots
 
-    return kicked_bots
+
+async def _remove_orphaned_bot(client: nio.AsyncClient, room_id: str, matrix_id: MatrixID) -> bool:
+    """Remove one orphaned bot from a room, returning True on success.
+
+    Matrix forbids kicking your own account (M_FORBIDDEN), so when the orphan
+    is the sweeping client itself it leaves the room instead of kicking.
+    """
+    user_id = matrix_id.full_id
+    if user_id == client.user_id:
+        leave_response = await client.room_leave(room_id)
+        if isinstance(leave_response, nio.RoomLeaveResponse):
+            logger.info("orphaned_bot_left", agent=matrix_id.username, room_id=room_id, user_id=user_id)
+            return True
+        logger.error(
+            "orphaned_bot_leave_failed",
+            agent=matrix_id.username,
+            room_id=room_id,
+            user_id=user_id,
+            error=str(leave_response),
+        )
+        return False
+
+    kick_response = await client.room_kick(room_id, user_id, reason="Bot no longer configured for this room")
+    if isinstance(kick_response, nio.RoomKickResponse):
+        logger.info("orphaned_bot_kicked", agent=matrix_id.username, room_id=room_id, user_id=user_id)
+        return True
+    logger.error(
+        "orphaned_bot_kick_failed",
+        agent=matrix_id.username,
+        room_id=room_id,
+        user_id=user_id,
+        error=str(kick_response),
+    )
+    return False
 
 
 async def cleanup_all_orphaned_bots(
@@ -166,7 +189,7 @@ async def cleanup_all_orphaned_bots(
     in the rooms that need cleaning.
 
     Returns:
-        Dictionary mapping room IDs to lists of kicked bot Matrix user IDs
+        Dictionary mapping room IDs to lists of removed bot Matrix user IDs
 
     """
     # Track what we're doing

--- a/tests/test_dm_room_preservation.py
+++ b/tests/test_dm_room_preservation.py
@@ -260,6 +260,58 @@ class TestDMPreservationDuringCleanup:
             client.room_leave.assert_called_once_with("!regular:server")
             client.room_kick.assert_not_called()
 
+    async def test_orphaned_bot_cleanup_kicks_other_orphans_before_self_leave(self, tmp_path: Path) -> None:
+        """Other orphans must be kicked before the client leaves, even when it is listed first."""
+        client = AsyncMock()
+        client.user_id = "@mindroom_self:server"
+        config = _config_with_runtime_paths(
+            tmp_path,
+            agents={
+                "configured_agent": AgentConfig(
+                    display_name="Configured Agent",
+                    role="Agent that should be in rooms",
+                ),
+            },
+        )
+        current_domain = config.get_domain(runtime_paths_for(config))
+        # The client's own account comes first so a naive sweep would leave before kicking
+        members = ["@mindroom_self:server", "@mindroom_orphaned:server"]
+
+        with (
+            patch(
+                "mindroom.matrix.room_cleanup.get_room_members",
+                return_value=members,
+            ),
+            patch(
+                "mindroom.matrix.room_cleanup._get_all_known_bot_user_ids",
+                return_value={"@mindroom_self:server", "@mindroom_orphaned:server"},
+            ),
+            patch(
+                "mindroom.matrix.room_cleanup.configured_bot_user_ids_for_room",
+                return_value={f"@mindroom_configured_agent:{current_domain}"},
+            ),
+        ):
+            client.room_kick = AsyncMock(return_value=nio.RoomKickResponse())
+            client.room_leave = AsyncMock(return_value=nio.RoomLeaveResponse())
+
+            removed_bots = await _cleanup_orphaned_bots_in_room(
+                client,
+                "!regular:server",
+                config,
+                runtime_paths_for(config),
+            )
+
+            assert removed_bots == ["@mindroom_orphaned:server", "@mindroom_self:server"]
+            client.room_kick.assert_called_once_with(
+                "!regular:server",
+                "@mindroom_orphaned:server",
+                reason="Bot no longer configured for this room",
+            )
+            client.room_leave.assert_called_once_with("!regular:server")
+            # The kick must happen while the client is still in the room
+            removal_order = [name for name, _, _ in client.mock_calls if name in ("room_kick", "room_leave")]
+            assert removal_order == ["room_kick", "room_leave"]
+
     async def test_orphaned_bot_cleanup_preserves_drifted_current_bot_username(self, tmp_path: Path) -> None:
         """Current managed bots with persisted username drift must not be treated as orphaned."""
         client = AsyncMock()

--- a/tests/test_dm_room_preservation.py
+++ b/tests/test_dm_room_preservation.py
@@ -216,6 +216,50 @@ class TestDMPreservationDuringCleanup:
                 reason="Bot no longer configured for this room",
             )
 
+    async def test_orphaned_bot_cleanup_leaves_when_orphan_is_own_account(self, tmp_path: Path) -> None:
+        """The sweeping client's own account must leave instead of kick (Matrix forbids self-kick)."""
+        client = AsyncMock()
+        client.user_id = "@mindroom_orphaned:server"
+        config = _config_with_runtime_paths(
+            tmp_path,
+            agents={
+                "configured_agent": AgentConfig(
+                    display_name="Configured Agent",
+                    role="Agent that should be in rooms",
+                ),
+            },
+        )
+        current_domain = config.get_domain(runtime_paths_for(config))
+        members = ["@user:server", "@mindroom_orphaned:server", f"@mindroom_configured_agent:{current_domain}"]
+
+        with (
+            patch(
+                "mindroom.matrix.room_cleanup.get_room_members",
+                return_value=members,
+            ),
+            patch(
+                "mindroom.matrix.room_cleanup._get_all_known_bot_user_ids",
+                return_value={"@mindroom_orphaned:server", f"@mindroom_configured_agent:{current_domain}"},
+            ),
+            patch(
+                "mindroom.matrix.room_cleanup.configured_bot_user_ids_for_room",
+                return_value={f"@mindroom_configured_agent:{current_domain}"},
+            ),
+        ):
+            client.room_leave = AsyncMock(return_value=nio.RoomLeaveResponse())
+
+            removed_bots = await _cleanup_orphaned_bots_in_room(
+                client,
+                "!regular:server",
+                config,
+                runtime_paths_for(config),
+            )
+
+            # Should leave the room itself instead of kicking its own account
+            assert removed_bots == ["@mindroom_orphaned:server"]
+            client.room_leave.assert_called_once_with("!regular:server")
+            client.room_kick.assert_not_called()
+
     async def test_orphaned_bot_cleanup_preserves_drifted_current_bot_username(self, tmp_path: Path) -> None:
         """Current managed bots with persisted username drift must not be treated as orphaned."""
         client = AsyncMock()


### PR DESCRIPTION
## Problem

The orphaned-bot room sweep (`_cleanup_orphaned_bots_in_room`) kicks every known MindRoom bot that is no longer configured for a room. When the orphaned bot is the sweeping client's own account, the homeserver rejects the kick with `M_FORBIDDEN` ("You cannot kick yourself") — the Matrix spec forbids self-kick. The result is a repeated `orphaned_bot_kick_failed` error on every startup cleanup pass, and the bot stays in the room forever; it never self-heals.

## Fix

When the orphan's user id equals `client.user_id`, call `client.room_leave(room_id)` instead of `room_kick`, treating `nio.RoomLeaveResponse` as success. Success is logged as a distinct `orphaned_bot_left` event (failure as `orphaned_bot_leave_failed`), and the user is still included in the returned removed-bots list. All other bots keep the existing kick path.

The leave-vs-kick branch is extracted into a `_remove_orphaned_bot` helper (also keeps `_cleanup_orphaned_bots_in_room` under the ruff C901 complexity limit).

## Tests

Added `test_orphaned_bot_cleanup_leaves_when_orphan_is_own_account`: the orphaned member is the client's own account — asserts `room_leave` is called, `room_kick` is not, and the return value includes the user.

- `uv run pytest tests/test_dm_room_preservation.py tests/test_room_invites.py -nauto` — 36 passed
- `uv run pre-commit run --files src/mindroom/matrix/room_cleanup.py tests/test_dm_room_preservation.py` — all hooks pass (ruff, ty, vulture, tach)