### PR TITLE
fix: skip room invitations when membership fetch fails

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -553,6 +553,7 @@ Provides a narrow Matrix admin facade when MindRoom has a router-backed admin cl
 This facade is part of the supported hook contract and is intentionally not the raw Matrix client.
 It is `None` when no admin-capable client is bound.
 The available methods are `resolve_alias(alias)`, `create_room(name=..., alias_localpart=..., topic=..., power_user_ids=...)`, `invite_user(room_id, user_id)`, `get_room_members(room_id)`, `add_room_to_space(space_room_id, room_id)`, and `put_room_state(room_id, event_type, state_key, content)`.
+`get_room_members` returns `None` when the membership fetch fails, so callers can distinguish an unreadable room from a genuinely empty one.
 Rooms created via `create_room` are retained for the creating bot across room cleanup and restarts, the same way rooms it is invited to are kept.
 
 ### Transport objects

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -11414,6 +11414,7 @@ Provides a narrow Matrix admin facade when MindRoom has a router-backed admin cl
 This facade is part of the supported hook contract and is intentionally not the raw Matrix client.
 It is `None` when no admin-capable client is bound.
 The available methods are `resolve_alias(alias)`, `create_room(name=..., alias_localpart=..., topic=..., power_user_ids=...)`, `invite_user(room_id, user_id)`, `get_room_members(room_id)`, `add_room_to_space(space_room_id, room_id)`, and `put_room_state(room_id, event_type, state_key, content)`.
+`get_room_members` returns `None` when the membership fetch fails, so callers can distinguish an unreadable room from a genuinely empty one.
 Rooms created via `create_room` are retained for the creating bot across room cleanup and restarts, the same way rooms it is invited to are kept.
 
 ### Transport objects

--- a/skills/mindroom-docs/references/page__hooks__index.md
+++ b/skills/mindroom-docs/references/page__hooks__index.md
@@ -549,6 +549,7 @@ Provides a narrow Matrix admin facade when MindRoom has a router-backed admin cl
 This facade is part of the supported hook contract and is intentionally not the raw Matrix client.
 It is `None` when no admin-capable client is bound.
 The available methods are `resolve_alias(alias)`, `create_room(name=..., alias_localpart=..., topic=..., power_user_ids=...)`, `invite_user(room_id, user_id)`, `get_room_members(room_id)`, `add_room_to_space(space_room_id, room_id)`, and `put_room_state(room_id, event_type, state_key, content)`.
+`get_room_members` returns `None` when the membership fetch fails, so callers can distinguish an unreadable room from a genuinely empty one.
 Rooms created via `create_room` are retained for the creating bot across room cleanup and restarts, the same way rooms it is invited to are kept.
 
 ### Transport objects

--- a/src/mindroom/external_triggers/executor.py
+++ b/src/mindroom/external_triggers/executor.py
@@ -88,9 +88,12 @@ async def is_external_trigger_owner_joined_target_room(
     client: nio.AsyncClient,
     snapshot: TriggerDeliverySnapshot,
 ) -> bool:
-    """Return whether the trigger owner is currently joined to the delivery room."""
+    """Return whether the trigger owner is currently joined to the delivery room.
+
+    A failed membership fetch counts as not joined so delivery stays fail-closed.
+    """
     member_ids = await get_room_members(client, snapshot.resolved_room_id)
-    return snapshot.owner_user_id in member_ids
+    return member_ids is not None and snapshot.owner_user_id in member_ids
 
 
 def _external_trigger_content_metadata(

--- a/src/mindroom/hooks/matrix_admin.py
+++ b/src/mindroom/hooks/matrix_admin.py
@@ -64,8 +64,8 @@ class _BoundHookMatrixAdmin:
         """Invite one user into one room."""
         return await invite_to_room(self.client, room_id, user_id)
 
-    async def get_room_members(self, room_id: str) -> set[str]:
-        """Return the current joined members for one room."""
+    async def get_room_members(self, room_id: str) -> set[str] | None:
+        """Return the current joined members for one room, or ``None`` when the fetch fails."""
         return await get_room_members(self.client, room_id)
 
     async def add_room_to_space(self, space_room_id: str, room_id: str) -> bool:

--- a/src/mindroom/hooks/types.py
+++ b/src/mindroom/hooks/types.py
@@ -130,8 +130,8 @@ class HookMatrixAdmin(Protocol):
     async def invite_user(self, room_id: str, user_id: str) -> bool:
         """Invite one user into one room."""
 
-    async def get_room_members(self, room_id: str) -> set[str]:
-        """Return joined members for one room."""
+    async def get_room_members(self, room_id: str) -> set[str] | None:
+        """Return joined members for one room, or ``None`` when the fetch fails."""
 
     async def add_room_to_space(self, space_room_id: str, room_id: str) -> bool:
         """Link one room into one Space."""

--- a/src/mindroom/matrix/client_room_admin.py
+++ b/src/mindroom/matrix/client_room_admin.py
@@ -535,13 +535,13 @@ async def join_room(client: nio.AsyncClient, room_id: str) -> bool:
     return False
 
 
-async def get_room_members(client: nio.AsyncClient, room_id: str) -> set[str]:
-    """Get the current members of a room."""
+async def get_room_members(client: nio.AsyncClient, room_id: str) -> set[str] | None:
+    """Get the current members of a room, or ``None`` when the fetch fails."""
     response = await client.joined_members(room_id)
     if isinstance(response, nio.JoinedMembersResponse):
         return {member.user_id for member in response.members}
-    logger.warning("matrix_room_members_fetch_failed", room_id=room_id)
-    return set()
+    logger.warning("matrix_room_members_fetch_failed", room_id=room_id, error=str(response))
+    return None
 
 
 async def get_joined_rooms(client: nio.AsyncClient) -> list[str] | None:

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -1530,6 +1530,9 @@ class _MultiAgentOrchestrator:
             return
 
         current_members = await get_room_members(router_bot.client, root_space_id)
+        if current_members is None:
+            logger.warning("room_invitations_skipped_members_unavailable", room_id=root_space_id)
+            return
         for user_id in sorted(invite_user_ids):
             log_context = {"user_id": user_id, "room_id": root_space_id}
             await self._invite_user_if_missing(
@@ -1588,6 +1591,9 @@ class _MultiAgentOrchestrator:
         authorized_user_ids.discard(user_id)
         for room_id in joined_rooms:
             room_members = await get_room_members(router_bot.client, room_id)
+            if room_members is None:
+                logger.warning("room_invitations_skipped_members_unavailable", room_id=room_id)
+                continue
             await self._invite_user_if_missing(
                 room_id,
                 user_id,
@@ -1665,6 +1671,9 @@ class _MultiAgentOrchestrator:
                 continue
 
             current_members = await get_room_members(router_bot.client, room_id)
+            if current_members is None:
+                logger.warning("room_invitations_skipped_members_unavailable", room_id=room_id)
+                continue
             await self._invite_authorized_users_to_room(room_id, current_members, authorized_user_ids, config)
             if configured_bots:
                 await self._invite_configured_bots_to_room(room_id, current_members, configured_bots)

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -808,6 +808,7 @@ class TestMultiAgentOrchestrator:
                     "global_users": ["@alice:localhost"],
                     "default_room_access": False,
                 },
+                mindroom_user={"username": "mindroom_user", "display_name": "MindRoomUser"},
             ),
             tmp_path,
         )
@@ -817,6 +818,10 @@ class TestMultiAgentOrchestrator:
         router_bot = MagicMock()
         router_bot.client = AsyncMock()
         orchestrator.agent_bots = {"router": router_bot}
+
+        state = MatrixState.load(runtime_paths=orchestrator.runtime_paths)
+        state.add_account(INTERNAL_USER_ACCOUNT_KEY, "mindroom_user", "internal-password")
+        state.save(runtime_paths=orchestrator.runtime_paths)
 
         room_members: dict[str, set[str] | None] = {
             "!room1:localhost": None,
@@ -838,7 +843,10 @@ class TestMultiAgentOrchestrator:
             await orchestrator._ensure_room_invitations()
 
         invited_users_by_room = {(call.args[1], call.args[2]) for call in mock_invite.await_args_list}
-        assert invited_users_by_room == {("!room2:localhost", "@alice:localhost")}
+        assert invited_users_by_room == {
+            ("!room2:localhost", "@mindroom_user:localhost"),
+            ("!room2:localhost", "@alice:localhost"),
+        }
 
     @pytest.mark.asyncio
     async def test_ensure_room_invitations_invites_authorized_users_to_standalone_rooms(

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -794,6 +794,53 @@ class TestMultiAgentOrchestrator:
         }
 
     @pytest.mark.asyncio
+    async def test_ensure_room_invitations_skips_room_when_members_fetch_fails(self, tmp_path: Path) -> None:
+        """A failed membership fetch must skip that room instead of inviting everyone into it."""
+        config = _runtime_bound_config(
+            Config(
+                agents={
+                    "general": AgentConfig(
+                        display_name="GeneralAgent",
+                        rooms=["!room1:localhost", "!room2:localhost"],
+                    ),
+                },
+                authorization={
+                    "global_users": ["@alice:localhost"],
+                    "default_room_access": False,
+                },
+            ),
+            tmp_path,
+        )
+        orchestrator = _MultiAgentOrchestrator(runtime_paths=runtime_paths_for(config))
+        orchestrator.config = config
+
+        router_bot = MagicMock()
+        router_bot.client = AsyncMock()
+        orchestrator.agent_bots = {"router": router_bot}
+
+        room_members: dict[str, set[str] | None] = {
+            "!room1:localhost": None,
+            "!room2:localhost": {"@mindroom_general:localhost", "@mindroom_router:localhost"},
+        }
+
+        async def mock_get_room_members(_client: AsyncMock, room_id: str) -> set[str] | None:
+            return room_members[room_id]
+
+        mock_invite = AsyncMock(return_value=True)
+
+        with (
+            patch("mindroom.constants.runtime_matrix_homeserver", return_value="http://localhost:8008"),
+            patch("mindroom.orchestrator.is_authorized_sender", side_effect=is_authorized_sender_for_test),
+            patch("mindroom.orchestrator.get_joined_rooms", new=AsyncMock(return_value=list(room_members))),
+            patch("mindroom.orchestrator.get_room_members", side_effect=mock_get_room_members),
+            patch("mindroom.orchestrator.invite_to_room", mock_invite),
+        ):
+            await orchestrator._ensure_room_invitations()
+
+        invited_users_by_room = {(call.args[1], call.args[2]) for call in mock_invite.await_args_list}
+        assert invited_users_by_room == {("!room2:localhost", "@alice:localhost")}
+
+    @pytest.mark.asyncio
     async def test_ensure_room_invitations_invites_authorized_users_to_standalone_rooms(
         self,
         tmp_path: Path,


### PR DESCRIPTION
## Problem

`get_room_members()` in `src/mindroom/matrix/client_room_admin.py` returned an empty `set()` when `client.joined_members()` failed, which is indistinguishable from a genuinely empty room.

A homeserver can hold a room in an inconsistent state: the room appears in the client's `/joined_rooms`, but `/joined_members` returns a body that fails client-side validation (`'joined' is a required property`). When that happens during startup room-invitation reconciliation, `_ensure_room_invitations()` sees an empty member set and tries to invite every configured bot and authorized user into the room. The homeserver rejects each invite with `M_FORBIDDEN` ("You must be joined in the room you are trying to invite from"), producing 2N+ error logs on every restart for N such stale rooms — and inviting users into a room whose membership couldn't be read is wrong regardless of the log noise.

## Fix

Make the failure distinguishable and skip the work that can't be done safely:

- `get_room_members()` now returns `set[str] | None`, with `None` on fetch failure — following the precedent of its sibling `get_joined_rooms()` in the same module. The failure log now includes the error response.
- `_ensure_room_invitations()` and `_invite_internal_user_to_rooms()` log a single `room_invitations_skipped_members_unavailable` warning for the affected room and continue to the next room.
- `_ensure_root_space()` skips root-space invites when the space membership is unknown.
- `is_external_trigger_owner_joined_target_room()` treats a failed fetch as not-joined, preserving its existing fail-closed behavior (now explicit rather than an accident of the empty set).
- The hook `matrix_admin` facade and `HookMatrixAdmin` protocol propagate `set[str] | None` so plugins can also distinguish an unreadable room from an empty one (documented in `docs/hooks.md`).
- `room_cleanup.py` needs no behavior change: it already treated a falsy member set as "unavailable" and skipped with its own warning, and `None` flows through the same guard.

## Tests

Added `test_ensure_room_invitations_skips_room_when_members_fetch_fails`: with two joined rooms where the membership fetch fails for one, no invites are attempted for the failing room while the healthy room is still reconciled normally.

Ran the test files covering all touched paths (`test_orchestrator_runtime.py`, `test_room_invites.py`, `test_matrix_spaces.py`, `test_hook_matrix_admin.py`, `api/test_external_triggers_api.py`, `test_dm_room_preservation.py`): 163 passed, 4 skipped. Pre-commit (ruff, ty, vulture) passes.