### PR TITLE
Serve tool availability previews for unsaved draft agents

### DIFF
--- a/src/mindroom/api/dashboard_credential_scope.py
+++ b/src/mindroom/api/dashboard_credential_scope.py
@@ -164,7 +164,19 @@ def resolve_dashboard_agent_execution_scope_request(
         )
 
     if agent_name not in config.agents:
-        raise HTTPException(status_code=404, detail=f"Unknown agent: {agent_name}")
+        if not allow_draft_override:
+            raise HTTPException(status_code=404, detail=f"Unknown agent: {agent_name}")
+        # A draft agent exists only in the dashboard's unsaved config, so resolve it
+        # as an agent-less scope preview: no persisted policy, no per-agent
+        # authorization, and never an authoritative credential status.
+        return _DashboardAgentExecutionScopeResolution(
+            agent_name=None,
+            persisted_policy=None,
+            persisted_execution_scope=None,
+            requested_execution_scope=execution_scope_override if execution_scope_override_provided else None,
+            execution_scope_override_provided=execution_scope_override_provided,
+            draft_scope_preview=True,
+        )
 
     persisted_policy = resolve_agent_policy_from_data(
         agent_name,

--- a/src/mindroom/api/dashboard_credential_scope.py
+++ b/src/mindroom/api/dashboard_credential_scope.py
@@ -173,7 +173,9 @@ def resolve_dashboard_agent_execution_scope_request(
             agent_name=None,
             persisted_policy=None,
             persisted_execution_scope=None,
-            requested_execution_scope=execution_scope_override if execution_scope_override_provided else None,
+            requested_execution_scope=(
+                execution_scope_override if execution_scope_override_provided else config.defaults.worker_scope
+            ),
             execution_scope_override_provided=execution_scope_override_provided,
             draft_scope_preview=True,
         )

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -1612,16 +1612,21 @@ def test_get_tools_explicit_unscoped_override_does_not_fall_back_to_saved_scope(
     assert tools_by_name["homeassistant"]["dashboard_configuration_supported"] is False
 
 
-def test_get_tools_unknown_agent_rejected(test_client: TestClient) -> None:
-    """Tool preview should reject unknown agents instead of falling back to shared state."""
+def test_get_tools_unknown_agent_previews_draft_scope(test_client: TestClient) -> None:
+    """Tool preview should serve unsaved draft agents as a non-authoritative scope preview."""
     config = _config_with_worker_scope("shared")
     runtime_paths = main._app_runtime_paths(main.app)
 
     with patch("mindroom.api.tools._read_tools_runtime_config", return_value=(config, runtime_paths)):
-        response = test_client.get("/api/tools/?agent_name=missing")
+        response = test_client.get("/api/tools/?agent_name=draft_agent&execution_scope=user")
 
-    assert response.status_code == 404
-    assert response.json()["detail"] == "Unknown agent: missing"
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status_authoritative"] is False
+    tools_by_name = {tool["name"]: tool for tool in payload["tools"]}
+    assert "calculator" in tools_by_name
+    assert tools_by_name["homeassistant"]["execution_scope_supported"] is False
+    assert tools_by_name["calculator"]["execution_scope_supported"] is True
 
 
 def test_get_tools_requires_agent_reply_permission_for_agent_scoped_status(test_client: TestClient) -> None:

--- a/tests/api/test_dashboard_credential_scope.py
+++ b/tests/api/test_dashboard_credential_scope.py
@@ -130,19 +130,23 @@ class TestResolveDashboardAgentExecutionScopeRequest:
         assert resolution.agent_name is None
         assert resolution.persisted_policy is None
         assert resolution.requested_execution_scope == "user_agent"
+        assert resolution.execution_scope_override_provided is True
         assert resolution.draft_scope_preview is True
 
-    def test_unknown_agent_without_override_resolves_as_unscoped_preview(self) -> None:
-        """An unknown draft agent without an override previews the unscoped target."""
+    def test_unknown_agent_without_override_previews_default_worker_scope(self) -> None:
+        """An unknown draft agent without an override previews the default worker scope."""
+        config = _config()
+        config.defaults.worker_scope = "user"
         resolution = resolve_dashboard_agent_execution_scope_request(
-            config=_config(),
+            config=config,
             agent_name="draft_agent",
             execution_scope_override_provided=False,
             execution_scope_override=None,
             allow_draft_override=True,
         )
         assert resolution.agent_name is None
-        assert resolution.requested_execution_scope is None
+        assert resolution.requested_execution_scope == "user"
+        assert resolution.execution_scope_override_provided is False
         assert resolution.draft_scope_preview is True
 
     def test_agent_without_override_uses_persisted_scope(self) -> None:

--- a/tests/api/test_dashboard_credential_scope.py
+++ b/tests/api/test_dashboard_credential_scope.py
@@ -118,6 +118,33 @@ class TestResolveDashboardAgentExecutionScopeRequest:
             )
         assert exc_info.value.status_code == 404
 
+    def test_unknown_agent_with_drafts_allowed_resolves_as_scope_preview(self) -> None:
+        """An unknown (unsaved draft) agent resolves as an agent-less scope preview."""
+        resolution = resolve_dashboard_agent_execution_scope_request(
+            config=_config(),
+            agent_name="draft_agent",
+            execution_scope_override_provided=True,
+            execution_scope_override="user_agent",
+            allow_draft_override=True,
+        )
+        assert resolution.agent_name is None
+        assert resolution.persisted_policy is None
+        assert resolution.requested_execution_scope == "user_agent"
+        assert resolution.draft_scope_preview is True
+
+    def test_unknown_agent_without_override_resolves_as_unscoped_preview(self) -> None:
+        """An unknown draft agent without an override previews the unscoped target."""
+        resolution = resolve_dashboard_agent_execution_scope_request(
+            config=_config(),
+            agent_name="draft_agent",
+            execution_scope_override_provided=False,
+            execution_scope_override=None,
+            allow_draft_override=True,
+        )
+        assert resolution.agent_name is None
+        assert resolution.requested_execution_scope is None
+        assert resolution.draft_scope_preview is True
+
     def test_agent_without_override_uses_persisted_scope(self) -> None:
         """Without an override the persisted agent scope is used."""
         resolution = resolve_dashboard_agent_execution_scope_request(


### PR DESCRIPTION
## Problem

In the dashboard, creating a new agent shows this in the Tools section:

> No tools are available. Please configure tools in the Tools tab first.

The tools only appear after saving the config.

## Cause

`addAgent` refreshes draft agent policies, so the agent editor immediately calls `GET /api/tools?agent_name=<new-agent>&execution_scope=...`. The new agent exists only in the frontend's unsaved draft, so `resolve_dashboard_agent_execution_scope_request` raised `404 Unknown agent`, and the frontend's `useFetchData` fell back to an empty tool list — rendering the misleading empty-state message.

## Fix

When `allow_draft_override=True` (only the tools preview route), an unknown agent now resolves as an agent-less draft scope preview:

- `agent_name=None` in the resolution, so per-agent credential authorization and requester-scoped credential inspection are skipped (the same information is already available via an agent-less `/api/tools` request, so nothing new is exposed).
- `draft_scope_preview=True`, so `status_authoritative=False` and statuses come from the existing shared-credential preview path.
- The requested `execution_scope` override still drives `execution_scope_supported` annotations, so scope-restricted tools render correctly for drafts.

Credential write routes keep `allow_draft_override=False` and still reject unknown agents with 404.

## Tests

- New resolver tests for unknown draft agents (with and without a scope override).
- Rewrote `test_get_tools_unknown_agent_rejected` → `test_get_tools_unknown_agent_previews_draft_scope` asserting the 200 preview with scope annotations.
- `tests/api/`: 704 passed, 30 skipped. Pre-commit clean.

## Summary by Sourcery

Handle unknown dashboard agents used in tool previews as draft scope previews instead of hard errors.

Bug Fixes:
- Serve tool availability for unsaved draft agents by treating unknown agents in preview requests as non-authoritative scope previews instead of returning 404.

Enhancements:
- Extend dashboard agent execution scope resolution to support agent-less draft scope previews when draft overrides are allowed.

Tests:
- Add resolver tests covering unknown draft agents with and without execution scope overrides.
- Update API tools test to assert draft-scope previews for unknown agents and verify execution_scope_supported annotations.