### PR TITLE
Use Anthropic server-side tool search (defer_loading) for deferred tools on Claude models

### DIFF
--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -21,6 +21,7 @@ from mindroom import agent_storage, constants, model_loading
 from mindroom.agent_descriptions import describe_agent
 from mindroom.agent_knowledge_descriptions import KnowledgeToolDescribingAgent as Agent
 from mindroom.agent_knowledge_descriptions import knowledge_source_descriptions
+from mindroom.claude_prompt_cache import install_claude_deferred_tool_search, native_tool_search_supported
 from mindroom.credentials import get_runtime_credentials_manager
 from mindroom.entity_resolution import entity_identity_registry
 from mindroom.hooks import HookRegistry
@@ -129,6 +130,9 @@ class _AgentToolAssembly:
     loaded_tools: tuple[str, ...]
     hidden_toolkits: frozenset[str]
     selected_dynamic_tools: tuple[str, ...]
+    # Wire-level function names to send with defer_loading on the native
+    # Anthropic tool-search path; empty on the homegrown dynamic-tools path.
+    deferred_wire_tool_names: frozenset[str]
 
 
 @dataclass(frozen=True)
@@ -1099,7 +1103,19 @@ def _resolve_agent_dynamic_tool_selection(
     config: Config,
     session_id: str | None,
     delegation_depth: int,
+    native_deferred_tools: bool,
 ) -> VisibleToolSurface:
+    if native_deferred_tools:
+        # Anthropic server-side tool search: attach every authored deferred
+        # tool so discovered calls execute, skip the dynamic-tools manager,
+        # and never touch session loaded-tool state.
+        return visible_tool_surface(
+            agent_name=agent_name,
+            config=config,
+            loaded_tools=_visible_deferred_tool_names(config, agent_name),
+            delegation_depth=delegation_depth,
+            enable_dynamic_tools_manager=False,
+        )
     return resolve_dynamic_tool_selection(
         agent_name=agent_name,
         config=config,
@@ -1199,6 +1215,7 @@ def _assemble_agent_toolkits(
     delegation_depth: int,
     refresh_scheduler: KnowledgeRefreshScheduler | None,
     dynamic_tool_continuation: bool,
+    native_deferred_tools: bool,
 ) -> _AgentToolAssembly:
     """Assemble runtime toolkits and the dynamic-tool visibility for one agent instance."""
     plugins = _load_agent_plugins(config, runtime_paths)
@@ -1220,24 +1237,21 @@ def _assemble_agent_toolkits(
         config=config,
         session_id=session_id,
         delegation_depth=delegation_depth,
+        native_deferred_tools=native_deferred_tools,
     )
     hidden_toolkits = _context_hidden_toolkits(execution_identity)
-    resolved_tool_configs = {
-        entry.name: entry.tool_config_overrides for entry in dynamic_tool_selection.runtime_tool_configs
-    }
+    resolved_tool_configs = {entry.name: entry for entry in dynamic_tool_selection.runtime_tool_configs}
     if disable_runtime_capabilities:
         resolved_tool_configs = {}
     elif disabled_tool_names:
         resolved_tool_configs = {
-            tool_name: overrides
-            for tool_name, overrides in resolved_tool_configs.items()
+            tool_name: entry
+            for tool_name, entry in resolved_tool_configs.items()
             if tool_name not in disabled_tool_names
         }
     if hidden_toolkits:
         resolved_tool_configs = {
-            tool_name: overrides
-            for tool_name, overrides in resolved_tool_configs.items()
-            if tool_name not in hidden_toolkits
+            tool_name: entry for tool_name, entry in resolved_tool_configs.items() if tool_name not in hidden_toolkits
         }
     loaded_tools = (
         ()
@@ -1258,7 +1272,8 @@ def _assemble_agent_toolkits(
         )
     entity_view = config.resolve_entity(agent_name)
     tools: list[Toolkit] = []
-    for tool_name in resolved_tool_configs:
+    deferred_wire_tool_names: set[str] = set()
+    for tool_name, tool_entry in resolved_tool_configs.items():
         try:
             runtime_overrides = entity_view.tool_runtime_overrides(tool_name)
             with _agent_create_timing("toolkit_build.one", tool_name=tool_name):
@@ -1270,7 +1285,7 @@ def _assemble_agent_toolkits(
                     worker_tools=worker_tools,
                     runtime_overrides=runtime_overrides,
                     agent_runtime=agent_runtime,
-                    tool_config_overrides=resolved_tool_configs.get(tool_name),
+                    tool_config_overrides=tool_entry.tool_config_overrides,
                     session_id=session_id,
                     execution_identity=execution_identity,
                     delegation_depth=delegation_depth,
@@ -1284,7 +1299,13 @@ def _assemble_agent_toolkits(
                     execution_identity=execution_identity,
                 )
             if toolkit:
-                tools.append(prepend_tool_hook_bridge(toolkit, tool_hook_bridge))
+                toolkit = prepend_tool_hook_bridge(toolkit, tool_hook_bridge)
+                tools.append(toolkit)
+                # initial deferred tools were always loaded, so they stay in
+                # the rendered prompt prefix as plain non-deferred tools.
+                if native_deferred_tools and tool_entry.defer and not tool_entry.initial:
+                    deferred_wire_tool_names.update(toolkit.get_functions())
+                    deferred_wire_tool_names.update(toolkit.get_async_functions())
         except (ValueError, ImportError) as exc:
             logger.warning(
                 "Could not load tool for agent construction",
@@ -1297,6 +1318,7 @@ def _assemble_agent_toolkits(
         loaded_tools=loaded_tools,
         hidden_toolkits=hidden_toolkits,
         selected_dynamic_tools=dynamic_tool_selection.loaded_tools,
+        deferred_wire_tool_names=frozenset(deferred_wire_tool_names),
     )
 
 
@@ -1392,6 +1414,7 @@ def _build_agent_instructions(
     disable_runtime_capabilities: bool,
     hidden_toolkits: frozenset[str],
     loaded_tools: tuple[str, ...],
+    native_deferred_tools: bool,
 ) -> list[str]:
     """Accumulate the configured and runtime instruction blocks for one agent instance."""
     instructions = list(agent_config.instructions)
@@ -1399,12 +1422,15 @@ def _build_agent_instructions(
     if skills and skills.get_skill_names():
         instructions.append(config.get_prompt("SKILLS_TOOL_USAGE_PROMPT"))
 
+    # Anthropic's server-side tool search replaces the load_tool catalog and
+    # loaded-state prompt blocks, so the native path emits neither.
+    enable_dynamic_tools_manager = session_id is not None and not native_deferred_tools
     dynamic_tooling_block = None
     if not disable_runtime_capabilities:
         dynamic_tooling_block = _build_dynamic_tooling_instruction_block(
             config,
             agent_name,
-            enable_dynamic_tools_manager=session_id is not None,
+            enable_dynamic_tools_manager=enable_dynamic_tools_manager,
             hidden_tool_names=hidden_toolkits,
         )
     if dynamic_tooling_block is not None:
@@ -1435,7 +1461,7 @@ def _build_agent_instructions(
             config,
             agent_name,
             loaded_tools=loaded_tools,
-            enable_dynamic_tools_manager=session_id is not None,
+            enable_dynamic_tools_manager=enable_dynamic_tools_manager,
             hidden_tool_names=hidden_toolkits,
         )
     if dynamic_tooling_state_suffix is not None:
@@ -1582,6 +1608,14 @@ def create_agent(
         ensure_default_agent_workspaces(config, runtime_paths.storage_root)
     defaults = config.defaults
 
+    # Gate on this agent's resolved runtime model (thread overrides and team
+    # members resolve per agent), not on any surrounding team's model.
+    runtime_model_config = config.models.get(active_model_name or agent_config.model or "default")
+    native_deferred_tools = runtime_model_config is not None and native_tool_search_supported(
+        runtime_model_config.provider,
+        runtime_model_config.id,
+    )
+
     tool_assembly = _assemble_agent_toolkits(
         agent_name,
         config,
@@ -1595,6 +1629,7 @@ def create_agent(
         delegation_depth=delegation_depth,
         refresh_scheduler=refresh_scheduler,
         dynamic_tool_continuation=dynamic_tool_continuation,
+        native_deferred_tools=native_deferred_tools,
     )
     storage = _open_agent_session_storage(
         agent_name,
@@ -1626,11 +1661,14 @@ def create_agent(
 
     # Create agent with defaults applied
     model = _load_agent_model_instance(config, runtime_paths, role_context.model_name, execution_identity)
+    if tool_assembly.deferred_wire_tool_names:
+        install_claude_deferred_tool_search(model, deferred_tool_names=tool_assembly.deferred_wire_tool_names)
     logger.info(
         "create_agent",
         agent=agent_name,
         model_class=model.__class__.__name__,
         model_id=model.id,
+        native_deferred_tools=sorted(tool_assembly.deferred_wire_tool_names),
     )
 
     workspace = agent_runtime.workspace
@@ -1655,6 +1693,7 @@ def create_agent(
         disable_runtime_capabilities=disable_runtime_capabilities,
         hidden_toolkits=tool_assembly.hidden_toolkits,
         loaded_tools=tool_assembly.loaded_tools,
+        native_deferred_tools=native_deferred_tools,
     )
 
     _log_toolkits_without_unique_model_functions(tool_assembly.tools, agent_name=agent_name)

--- a/src/mindroom/claude_prompt_cache.py
+++ b/src/mindroom/claude_prompt_cache.py
@@ -46,7 +46,7 @@ from typing import Any, cast
 
 from agno.models.anthropic import Claude as AnthropicClaude
 
-from mindroom.model_defaults import NATIVE_TOOL_SEARCH_MODEL_ID_PREFIXES
+from mindroom.model_defaults import TOOL_SEARCH_UNSUPPORTED_MODEL_ID_PREFIXES
 
 _PROMPT_CACHE_HOOK_ATTR = "_mindroom_claude_prompt_cache_hook_installed"
 _DEFERRED_TOOL_NAMES_ATTR = "_mindroom_claude_deferred_tool_names"
@@ -62,11 +62,16 @@ _NATIVE_TOOL_SEARCH_PROVIDERS = frozenset({"anthropic", "vertexai_claude"})
 
 
 def native_tool_search_supported(provider: str, model_id: str) -> bool:
-    """Return whether one authored provider/model pair supports server-side tool search."""
+    """Return whether one authored provider/model pair supports server-side tool search.
+
+    Every Claude model since Opus 4.5 / Sonnet 4.5 / Haiku 4.5 supports the
+    search tool, so gating denylists the closed pre-4.5 set and new model
+    releases take the native path without a code change.
+    """
     canonical_provider = provider.strip().lower().replace("-", "_")
     if canonical_provider not in _NATIVE_TOOL_SEARCH_PROVIDERS:
         return False
-    return model_id.startswith(NATIVE_TOOL_SEARCH_MODEL_ID_PREFIXES)
+    return not model_id.startswith(TOOL_SEARCH_UNSUPPORTED_MODEL_ID_PREFIXES)
 
 
 def _prompt_cache_control(*, extended_cache_time: bool = False) -> dict[str, str]:
@@ -215,7 +220,11 @@ def _request_kwargs_with_deferred_tool_search(
     for tool in tools:
         tool_dict = _as_dict(tool)
         if tool_dict is not None and tool_dict.get("name") in deferred_tool_names:
-            deferred_tools.append({**tool_dict, "defer_loading": True})
+            deferred_tool = {**tool_dict, "defer_loading": True}
+            # A deferred tool may not carry cache_control (the API returns a
+            # 400), so drop any marker Agno added (e.g. via cache_tools).
+            deferred_tool.pop("cache_control", None)
+            deferred_tools.append(deferred_tool)
         else:
             non_deferred_tools.append(tool)
     if not deferred_tools:

--- a/src/mindroom/claude_prompt_cache.py
+++ b/src/mindroom/claude_prompt_cache.py
@@ -177,12 +177,18 @@ def _mark_last_tool(tools: object, cache_control: dict[str, str]) -> tuple[objec
 
     Deferred tools may not carry ``cache_control`` (the API returns a 400) and
     sort after all non-deferred tools, so the marker position is byte-stable.
+    The injected search tool is never marked either (whether the API accepts a
+    marker on that server-tool type is unverified), so an all-deferred tool
+    surface sends no tools marker; the tools prefix still caches under the
+    system-prompt breakpoint because tools render ahead of system.
     """
     if not isinstance(tools, list) or not tools:
         return tools, 0
     for tool_index in range(len(tools) - 1, -1, -1):
         tool_dict = _as_dict(tools[tool_index])
-        if tool_dict is not None and tool_dict.get("defer_loading") is True:
+        if tool_dict is not None and (
+            tool_dict.get("defer_loading") is True or tool_dict.get("type") == _TOOL_SEARCH_TOOL_TYPE
+        ):
             continue
         if tool_dict is None or _block_has_cache_marker(tool_dict):
             return tools, 0

--- a/src/mindroom/claude_prompt_cache.py
+++ b/src/mindroom/claude_prompt_cache.py
@@ -29,6 +29,15 @@ from scratch on every request, so markers placed on Agno ``Message`` objects
 can never reach tool results. String-vs-block content shape is irrelevant at
 this layer: ``format_messages`` normalizes user strings into text blocks, and
 the API hashes both shapes identically.
+
+The same wire hook also carries Anthropic's server-side tool search for
+MindRoom's deferred tools: :func:`install_claude_deferred_tool_search` records
+the wire tool names that should stay out of the rendered prompt prefix, and
+``_prepared`` tags them with ``defer_loading: true``, injects the regex search
+tool, and orders the tools array deterministically (non-deferred first, then
+deferred sorted by name). Deferred tools may not carry ``cache_control`` (the
+API rejects the request), which is why the ladder's tools marker targets the
+last non-deferred tool.
 """
 
 from __future__ import annotations
@@ -37,12 +46,27 @@ from typing import Any, cast
 
 from agno.models.anthropic import Claude as AnthropicClaude
 
+from mindroom.model_defaults import NATIVE_TOOL_SEARCH_MODEL_ID_PREFIXES
+
 _PROMPT_CACHE_HOOK_ATTR = "_mindroom_claude_prompt_cache_hook_installed"
+_DEFERRED_TOOL_NAMES_ATTR = "_mindroom_claude_deferred_tool_names"
 # The Anthropic API allows at most four cache_control markers per request.
 _MAX_CACHE_MARKERS = 4
 # Newest cacheable block plus one fallback boundary in an earlier message.
 _MESSAGE_RUNG_COUNT = 2
 _MARKABLE_BLOCK_TYPES = frozenset({"text", "tool_result", "document", "image"})
+
+_TOOL_SEARCH_TOOL_TYPE = "tool_search_tool_regex_20251119"
+_TOOL_SEARCH_TOOL_NAME = "tool_search_tool_regex"
+_NATIVE_TOOL_SEARCH_PROVIDERS = frozenset({"anthropic", "vertexai_claude"})
+
+
+def native_tool_search_supported(provider: str, model_id: str) -> bool:
+    """Return whether one authored provider/model pair supports server-side tool search."""
+    canonical_provider = provider.strip().lower().replace("-", "_")
+    if canonical_provider not in _NATIVE_TOOL_SEARCH_PROVIDERS:
+        return False
+    return model_id.startswith(NATIVE_TOOL_SEARCH_MODEL_ID_PREFIXES)
 
 
 def _prompt_cache_control(*, extended_cache_time: bool = False) -> dict[str, str]:
@@ -144,17 +168,66 @@ def _mark_message_cache_rungs(
 
 
 def _mark_last_tool(tools: object, cache_control: dict[str, str]) -> tuple[object, int]:
-    """Mark the last tool definition so the tools prefix caches independently."""
+    """Mark the last non-deferred tool so the tools prefix caches independently.
+
+    Deferred tools may not carry ``cache_control`` (the API returns a 400) and
+    sort after all non-deferred tools, so the marker position is byte-stable.
+    """
     if not isinstance(tools, list) or not tools:
         return tools, 0
-    last_tool = _as_dict(tools[-1])
-    if last_tool is None or _block_has_cache_marker(last_tool):
-        return tools, 0
-    marked_tools = list(tools)
-    marked_tool = dict(last_tool)
-    marked_tool["cache_control"] = dict(cache_control)
-    marked_tools[-1] = marked_tool
-    return marked_tools, 1
+    for tool_index in range(len(tools) - 1, -1, -1):
+        tool_dict = _as_dict(tools[tool_index])
+        if tool_dict is not None and tool_dict.get("defer_loading") is True:
+            continue
+        if tool_dict is None or _block_has_cache_marker(tool_dict):
+            return tools, 0
+        marked_tools = list(tools)
+        marked_tool = dict(tool_dict)
+        marked_tool["cache_control"] = dict(cache_control)
+        marked_tools[tool_index] = marked_tool
+        return marked_tools, 1
+    return tools, 0
+
+
+def _model_deferred_tool_names(model: AnthropicClaude) -> frozenset[str]:
+    """Return the wire tool names registered for deferred loading on one model."""
+    deferred_tool_names = vars(model).get(_DEFERRED_TOOL_NAMES_ATTR)
+    return deferred_tool_names if isinstance(deferred_tool_names, frozenset) else frozenset()
+
+
+def _request_kwargs_with_deferred_tool_search(
+    request_kwargs: dict[str, Any],
+    deferred_tool_names: frozenset[str],
+) -> dict[str, Any]:
+    """Tag deferred tools with defer_loading and inject the server-side search tool.
+
+    Every deferred tool's full definition still ships on every request; the API
+    keeps deferred schemas out of the rendered prompt prefix and expands them
+    inline when the model searches. The tools array is ordered deterministically
+    (search tool, then the remaining non-deferred tools, then deferred tools
+    sorted by name) so the cached prefix stays byte-stable across requests.
+    """
+    tools = request_kwargs.get("tools")
+    if not deferred_tool_names or not isinstance(tools, list):
+        return request_kwargs
+    non_deferred_tools: list[Any] = []
+    deferred_tools: list[dict[str, Any]] = []
+    for tool in tools:
+        tool_dict = _as_dict(tool)
+        if tool_dict is not None and tool_dict.get("name") in deferred_tool_names:
+            deferred_tools.append({**tool_dict, "defer_loading": True})
+        else:
+            non_deferred_tools.append(tool)
+    if not deferred_tools:
+        return request_kwargs
+    deferred_tools.sort(key=lambda tool: str(tool.get("name")))
+    prepared_kwargs = dict(request_kwargs)
+    prepared_kwargs["tools"] = [
+        {"type": _TOOL_SEARCH_TOOL_TYPE, "name": _TOOL_SEARCH_TOOL_NAME},
+        *non_deferred_tools,
+        *deferred_tools,
+    ]
+    return prepared_kwargs
 
 
 def _request_kwargs_with_prompt_cache_ladder(
@@ -190,8 +263,14 @@ class _PromptCacheMessagesProxy:
         self._model = model
 
     def _prepared(self, request_kwargs: dict[str, Any]) -> dict[str, Any]:
+        prepared_kwargs = _request_kwargs_with_deferred_tool_search(
+            request_kwargs,
+            _model_deferred_tool_names(self._model),
+        )
+        if not self._model.cache_system_prompt:
+            return prepared_kwargs
         cache_control = _prompt_cache_control(extended_cache_time=self._model.extended_cache_time is True)
-        return _request_kwargs_with_prompt_cache_ladder(request_kwargs, cache_control)
+        return _request_kwargs_with_prompt_cache_ladder(prepared_kwargs, cache_control)
 
     def create(self, **request_kwargs: object) -> object:
         return self._messages_namespace.create(**self._prepared(request_kwargs))
@@ -262,7 +341,9 @@ def install_claude_prompt_cache_hook(model: object) -> None:
     Bedrock all share the SDK client shape). The ladder is skipped per request
     while ``cache_system_prompt`` is falsy, so callers that deliberately
     disable caching (for example one-off summary calls) stay unmarked even
-    when they reuse a hooked model instance.
+    when they reuse a hooked model instance. The proxy still engages for such
+    models once deferred tool names are registered, because defer_loading
+    tagging is independent of the cache ladder.
     """
     if not isinstance(model, AnthropicClaude):
         return
@@ -275,15 +356,29 @@ def install_claude_prompt_cache_hook(model: object) -> None:
 
     def _get_client_with_prompt_cache() -> object:
         client = original_get_client()
-        if not model.cache_system_prompt:
+        if not model.cache_system_prompt and not _model_deferred_tool_names(model):
             return client
         return _PromptCacheClientProxy(client, model)
 
     def _get_async_client_with_prompt_cache() -> object:
         client = original_get_async_client()
-        if not model.cache_system_prompt:
+        if not model.cache_system_prompt and not _model_deferred_tool_names(model):
             return client
         return _PromptCacheClientProxy(client, model)
 
     model_dict["get_client"] = _get_client_with_prompt_cache
     model_dict["get_async_client"] = _get_async_client_with_prompt_cache
+
+
+def install_claude_deferred_tool_search(model: object, *, deferred_tool_names: frozenset[str]) -> None:
+    """Register wire tool names for Anthropic server-side tool search on one model.
+
+    Every request through the hooked client sends the named tools with
+    ``defer_loading: true`` plus the regex tool-search entry, so their schemas
+    stay out of the rendered prompt prefix and tool discovery never invalidates
+    the prompt cache. No-op for non-Claude models and empty name sets.
+    """
+    if not isinstance(model, AnthropicClaude) or not deferred_tool_names:
+        return
+    install_claude_prompt_cache_hook(model)
+    vars(model)[_DEFERRED_TOOL_NAMES_ATTR] = frozenset(deferred_tool_names)

--- a/src/mindroom/model_defaults.py
+++ b/src/mindroom/model_defaults.py
@@ -31,6 +31,7 @@ __all__ = (
     "LOCAL_QWEN_CONTEXT_WINDOW",
     "LOCAL_QWEN_PRESET_NAME",
     "MEMORY_OLLAMA_LLM",
+    "NATIVE_TOOL_SEARCH_MODEL_ID_PREFIXES",
     "OLLAMA_GEMMA",
     "OLLAMA_HOST_DEFAULT",
     "OLLAMA_QWEN",
@@ -71,6 +72,20 @@ class ModelPreset:
 _ANTHROPIC_OPUS = "claude-opus-4-8"
 _ANTHROPIC_SONNET = "claude-sonnet-5"
 _ANTHROPIC_HAIKU = "claude-haiku-4-5"
+# Claude families that accept tool_search_tool_regex_20251119; prefix match so
+# dated snapshots (both `-YYYYMMDD` and Vertex `@YYYYMMDD` suffixes) qualify.
+NATIVE_TOOL_SEARCH_MODEL_ID_PREFIXES = (
+    "claude-fable-5",
+    "claude-haiku-4-5",
+    "claude-mythos-5",
+    "claude-opus-4-5",
+    "claude-opus-4-6",
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+    "claude-sonnet-4-5",
+    "claude-sonnet-4-6",
+    "claude-sonnet-5",
+)
 AWS_BEDROCK_CLAUDE_OPUS = "anthropic.claude-opus-4-8"
 _AWS_BEDROCK_CLAUDE_SONNET = "global.anthropic.claude-sonnet-5"
 _AWS_BEDROCK_CLAUDE_HAIKU = "global.anthropic.claude-haiku-4-5"

--- a/src/mindroom/model_defaults.py
+++ b/src/mindroom/model_defaults.py
@@ -31,7 +31,6 @@ __all__ = (
     "LOCAL_QWEN_CONTEXT_WINDOW",
     "LOCAL_QWEN_PRESET_NAME",
     "MEMORY_OLLAMA_LLM",
-    "NATIVE_TOOL_SEARCH_MODEL_ID_PREFIXES",
     "OLLAMA_GEMMA",
     "OLLAMA_HOST_DEFAULT",
     "OLLAMA_QWEN",
@@ -48,6 +47,7 @@ __all__ = (
     "OPENAI_TTS",
     "SAAS_MODEL_PRESETS",
     "SENTENCE_TRANSFORMERS_DEFAULT",
+    "TOOL_SEARCH_UNSUPPORTED_MODEL_ID_PREFIXES",
     "ModelPreset",
     "llama_cpp_server_command",
 )
@@ -72,19 +72,20 @@ class ModelPreset:
 _ANTHROPIC_OPUS = "claude-opus-4-8"
 _ANTHROPIC_SONNET = "claude-sonnet-5"
 _ANTHROPIC_HAIKU = "claude-haiku-4-5"
-# Claude families that accept tool_search_tool_regex_20251119; prefix match so
-# dated snapshots (both `-YYYYMMDD` and Vertex `@YYYYMMDD` suffixes) qualify.
-NATIVE_TOOL_SEARCH_MODEL_ID_PREFIXES = (
-    "claude-fable-5",
-    "claude-haiku-4-5",
-    "claude-mythos-5",
-    "claude-opus-4-5",
-    "claude-opus-4-6",
-    "claude-opus-4-7",
-    "claude-opus-4-8",
-    "claude-sonnet-4-5",
-    "claude-sonnet-4-6",
-    "claude-sonnet-5",
+# Claude models that predate tool_search_tool_regex_20251119 (Opus 4.1 and
+# earlier — a closed set, so new releases take the native tool-search path
+# without a list update). Prefixes cover the aliases plus the dated
+# `-YYYYMMDD` and Vertex `@YYYYMMDD` snapshot spellings.
+TOOL_SEARCH_UNSUPPORTED_MODEL_ID_PREFIXES = (
+    "claude-2",
+    "claude-3",
+    "claude-opus-4-0",
+    "claude-opus-4-1",
+    "claude-opus-4-20250514",
+    "claude-opus-4@",
+    "claude-sonnet-4-0",
+    "claude-sonnet-4-20250514",
+    "claude-sonnet-4@",
 )
 AWS_BEDROCK_CLAUDE_OPUS = "anthropic.claude-opus-4-8"
 _AWS_BEDROCK_CLAUDE_SONNET = "global.anthropic.claude-sonnet-5"

--- a/tach.toml
+++ b/tach.toml
@@ -121,6 +121,7 @@ depends_on = [
     "mindroom.agent_knowledge_descriptions",
     "mindroom.agent_descriptions",
     "mindroom.agent_storage",
+    "mindroom.claude_prompt_cache",
     "mindroom.constants",
     "mindroom.credentials",
     "mindroom.custom_tools.delegate",
@@ -228,7 +229,7 @@ depends_on = [
     "mindroom.llm_request_logging",
     "mindroom.logging_config",
     "mindroom.tool_system.dependencies",
-    "mindroom.vertex_claude_prompt_cache",
+    "mindroom.claude_prompt_cache",
 ]
 visibility = [
     "mindroom.ai",

--- a/tests/test_dynamic_toolkits.py
+++ b/tests/test_dynamic_toolkits.py
@@ -13,8 +13,10 @@ from mindroom.agents import (
     _build_dynamic_tooling_instruction_block,
     _build_dynamic_tooling_state_suffix,
     build_agent_toolkit,
+    create_agent,
     get_agent_toolkit_names,
 )
+from mindroom.claude_prompt_cache import _DEFERRED_TOOL_NAMES_ATTR
 from mindroom.config.main import Config
 from mindroom.config.models import EffectiveToolConfig, ToolConfigEntry
 from mindroom.constants import RuntimePaths, resolve_runtime_paths
@@ -809,6 +811,58 @@ def test_openclaw_compat_implies_matrix_messaging_tool(tmp_path: Path) -> None:
     config = _validated_config(tmp_path, raw)
 
     assert _agent_has_matrix_messaging_tool(config, "code", None)
+
+
+def test_native_tool_search_attaches_deferred_toolkits_and_skips_homegrown_machinery(tmp_path: Path) -> None:
+    """Claude-native tool search attaches all deferred toolkits and drops the manager machinery."""
+    raw = _base_config_data()
+    raw["models"]["claude"] = {"provider": "anthropic", "id": "claude-opus-4-8"}  # type: ignore[index]
+    raw["agents"]["code"]["model"] = "claude"  # type: ignore[index]
+    raw["agents"]["code"]["tools"] = [  # type: ignore[index]
+        {"sleep": {"defer": True}},
+        {"calculator": {"defer": True, "initial": True}},
+    ]
+    config = _validated_config(tmp_path, raw)
+
+    agent = create_agent("code", config, _runtime_paths(tmp_path), execution_identity=None, session_id="thread-a")
+
+    function_names = {name for toolkit in agent.tools for name in toolkit.get_functions()}
+    assert "sleep" in function_names
+    assert "add" in function_names
+    assert "load_tool" not in function_names
+    # Only defer&&!initial tools go on the wire deferred; initial stays plain.
+    assert vars(agent.model)[_DEFERRED_TOOL_NAMES_ATTR] == frozenset({"sleep"})
+    assert not any(block.startswith("## Dynamic Tools") for block in agent.instructions)
+    assert not any("Dynamic tools currently loaded" in block for block in agent.instructions)
+    assert ("code", "thread-a") not in dynamic_toolkits_module._loaded_tools
+
+
+@pytest.mark.parametrize(
+    ("provider", "model_id"),
+    [
+        ("openai", "gpt-4o-mini"),
+        ("anthropic", "claude-opus-4-1"),
+    ],
+)
+def test_unsupported_models_keep_homegrown_dynamic_tools_path(tmp_path: Path, provider: str, model_id: str) -> None:
+    """Non-Claude providers and unsupported Claude models keep the load_tool machinery."""
+    raw = _base_config_data()
+    raw["models"]["default"] = {"provider": provider, "id": model_id}  # type: ignore[index]
+    raw["agents"]["code"]["tools"] = [  # type: ignore[index]
+        {"sleep": {"defer": True}},
+        {"calculator": {"defer": True, "initial": True}},
+    ]
+    config = _validated_config(tmp_path, raw)
+
+    agent = create_agent("code", config, _runtime_paths(tmp_path), execution_identity=None, session_id="thread-a")
+
+    function_names = {name for toolkit in agent.tools for name in toolkit.get_functions()}
+    assert "load_tool" in function_names
+    assert "sleep" not in function_names
+    assert "add" in function_names
+    assert _DEFERRED_TOOL_NAMES_ATTR not in vars(agent.model)
+    assert any(block.startswith("## Dynamic Tools") for block in agent.instructions)
+    assert any("Dynamic tools currently loaded" in block for block in agent.instructions)
 
 
 def test_dynamic_prompt_splits_static_catalog_from_volatile_loaded_state(tmp_path: Path) -> None:

--- a/tests/test_extra_kwargs.py
+++ b/tests/test_extra_kwargs.py
@@ -940,13 +940,19 @@ def _wire_tool(name: str) -> dict[str, object]:
         ("anthropic", "claude-sonnet-5", True),
         ("Anthropic", "claude-sonnet-4-5-20250929", True),
         ("vertexai_claude", "claude-haiku-4-5@20251001", True),
+        # Unreleased Claude models default to the native path (denylist gating).
+        ("anthropic", "claude-opus-4-9", True),
+        ("anthropic", "claude-fable-6", True),
         ("anthropic", "claude-opus-4-1", False),
+        ("anthropic", "claude-opus-4-20250514", False),
+        ("anthropic", "claude-3-5-sonnet-20241022", False),
+        ("vertexai_claude", "claude-sonnet-4@20250514", False),
         ("openai", "gpt-5.5", False),
         ("bedrock_claude", "anthropic.claude-opus-4-8", False),
     ],
 )
 def test_native_tool_search_supported_gating(provider: str, model_id: str, *, expected: bool) -> None:
-    """Only Claude-family providers with tool-search-capable model ids qualify."""
+    """Claude-family providers qualify unless the model predates tool search."""
     assert native_tool_search_supported(provider, model_id) is expected
 
 
@@ -954,7 +960,13 @@ def test_deferred_tool_search_tags_tools_and_injects_search_tool() -> None:
     """Deferred tools ship tagged and name-sorted after the search tool and non-deferred tools."""
     model = Claude(id="claude-opus-4-8", api_key="test-key", cache_system_prompt=True)
     captured_kwargs = _install_fake_sync_client(model)
-    tools = [_wire_tool("always_tool"), _wire_tool("zeta_tool"), _wire_tool("alpha_tool")]
+    # zeta_tool arrives pre-marked (as Agno's cache_tools flag would): the
+    # marker must be stripped because deferred tools may not carry one.
+    tools = [
+        _wire_tool("always_tool"),
+        {**_wire_tool("zeta_tool"), "cache_control": {"type": "ephemeral"}},
+        _wire_tool("alpha_tool"),
+    ]
     vars(model)["_prepare_request_kwargs"] = lambda *_args, **_kwargs: {"tools": [dict(tool) for tool in tools]}
     install_claude_deferred_tool_search(model, deferred_tool_names=frozenset({"zeta_tool", "alpha_tool"}))
 

--- a/tests/test_extra_kwargs.py
+++ b/tests/test_extra_kwargs.py
@@ -12,17 +12,22 @@ from agno.models.aws.claude import Claude as AwsBedrockClaude
 from agno.models.azure import AzureOpenAI
 from agno.models.llama_cpp import LlamaCpp
 from agno.models.message import Message
+from agno.models.openai import OpenAIChat
 from agno.models.response import ModelResponse
 from agno.models.vertexai.claude import Claude as VertexAIClaude
 from agno.utils.models.claude import format_messages
+from anthropic.types import Message as AnthropicMessage
 
 from mindroom.claude_prompt_cache import (
+    _DEFERRED_TOOL_NAMES_ATTR,
     _MAX_CACHE_MARKERS,
     _count_cache_markers,
     _prompt_cache_control,
     _PromptCacheClientProxy,
     _request_kwargs_with_prompt_cache_ladder,
+    install_claude_deferred_tool_search,
     install_claude_prompt_cache_hook,
+    native_tool_search_supported,
 )
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
@@ -922,6 +927,190 @@ async def test_prompt_cache_hook_wraps_async_client() -> None:
     assert captured_kwargs[0]["messages"][-1]["content"] == [
         {"type": "text", "text": "Current turn", "cache_control": {"type": "ephemeral", "ttl": "1h"}},
     ]
+
+
+def _wire_tool(name: str) -> dict[str, object]:
+    return {"name": name, "description": f"{name} description", "input_schema": {"type": "object"}}
+
+
+@pytest.mark.parametrize(
+    ("provider", "model_id", "expected"),
+    [
+        ("anthropic", "claude-opus-4-8", True),
+        ("anthropic", "claude-sonnet-5", True),
+        ("Anthropic", "claude-sonnet-4-5-20250929", True),
+        ("vertexai_claude", "claude-haiku-4-5@20251001", True),
+        ("anthropic", "claude-opus-4-1", False),
+        ("openai", "gpt-5.5", False),
+        ("bedrock_claude", "anthropic.claude-opus-4-8", False),
+    ],
+)
+def test_native_tool_search_supported_gating(provider: str, model_id: str, *, expected: bool) -> None:
+    """Only Claude-family providers with tool-search-capable model ids qualify."""
+    assert native_tool_search_supported(provider, model_id) is expected
+
+
+def test_deferred_tool_search_tags_tools_and_injects_search_tool() -> None:
+    """Deferred tools ship tagged and name-sorted after the search tool and non-deferred tools."""
+    model = Claude(id="claude-opus-4-8", api_key="test-key", cache_system_prompt=True)
+    captured_kwargs = _install_fake_sync_client(model)
+    tools = [_wire_tool("always_tool"), _wire_tool("zeta_tool"), _wire_tool("alpha_tool")]
+    vars(model)["_prepare_request_kwargs"] = lambda *_args, **_kwargs: {"tools": [dict(tool) for tool in tools]}
+    install_claude_deferred_tool_search(model, deferred_tool_names=frozenset({"zeta_tool", "alpha_tool"}))
+
+    model.response(messages=[Message(role="user", content="hi")], compression_manager=None)
+
+    wire_tools = captured_kwargs[0]["tools"]
+    assert [tool.get("name") for tool in wire_tools] == [
+        "tool_search_tool_regex",
+        "always_tool",
+        "alpha_tool",
+        "zeta_tool",
+    ]
+    assert wire_tools[0] == {"type": "tool_search_tool_regex_20251119", "name": "tool_search_tool_regex"}
+    # The cache-ladder marker must land on the last non-deferred tool: deferred
+    # tools may not carry cache_control (the API rejects the request).
+    assert wire_tools[1]["cache_control"] == {"type": "ephemeral"}
+    for deferred_tool in wire_tools[2:]:
+        assert deferred_tool["defer_loading"] is True
+        assert "cache_control" not in deferred_tool
+
+
+def test_deferred_tool_search_marker_lands_on_search_tool_when_all_tools_deferred() -> None:
+    """With every authored tool deferred, the search tool is the only markable prefix tail."""
+    model = Claude(id="claude-opus-4-8", api_key="test-key", cache_system_prompt=True)
+    captured_kwargs = _install_fake_sync_client(model)
+    vars(model)["_prepare_request_kwargs"] = lambda *_args, **_kwargs: {"tools": [_wire_tool("alpha_tool")]}
+    install_claude_deferred_tool_search(model, deferred_tool_names=frozenset({"alpha_tool"}))
+
+    model.response(messages=[Message(role="user", content="hi")], compression_manager=None)
+
+    wire_tools = captured_kwargs[0]["tools"]
+    assert wire_tools[0]["name"] == "tool_search_tool_regex"
+    assert wire_tools[0]["cache_control"] == {"type": "ephemeral"}
+    assert wire_tools[1]["defer_loading"] is True
+    assert "cache_control" not in wire_tools[1]
+
+
+def test_deferred_tool_search_applies_without_cache_ladder_when_cache_disabled() -> None:
+    """Deferred tagging is independent of the cache ladder gate."""
+    model = Claude(id="claude-opus-4-8", api_key="test-key", cache_system_prompt=False)
+    captured_kwargs = _install_fake_sync_client(model)
+    vars(model)["_prepare_request_kwargs"] = lambda *_args, **_kwargs: {"tools": [_wire_tool("alpha_tool")]}
+    install_claude_deferred_tool_search(model, deferred_tool_names=frozenset({"alpha_tool"}))
+
+    model.response(messages=[Message(role="user", content="hi")], compression_manager=None)
+
+    request = captured_kwargs[0]
+    wire_tools = request["tools"]
+    assert wire_tools[0]["name"] == "tool_search_tool_regex"
+    assert wire_tools[1]["defer_loading"] is True
+    assert _count_cache_markers({"tools": list(wire_tools), "messages": list(request["messages"])}) == 0
+
+
+def test_deferred_tool_search_leaves_requests_without_matching_tools_unchanged() -> None:
+    """The search tool is injected only when a deferred tool is present in the request."""
+    model = Claude(id="claude-opus-4-8", api_key="test-key", cache_system_prompt=True)
+    captured_kwargs = _install_fake_sync_client(model)
+    vars(model)["_prepare_request_kwargs"] = lambda *_args, **_kwargs: {"tools": [_wire_tool("always_tool")]}
+    install_claude_deferred_tool_search(model, deferred_tool_names=frozenset({"other_tool"}))
+
+    model.response(messages=[Message(role="user", content="hi")], compression_manager=None)
+
+    assert [tool["name"] for tool in captured_kwargs[0]["tools"]] == ["always_tool"]
+
+
+def test_install_claude_deferred_tool_search_ignores_non_claude_and_empty_sets() -> None:
+    """The installer is a no-op for non-Claude models and empty name sets."""
+    llama = LlamaCpp(id="gemma", api_key="test-key", base_url="http://llama.local/v1")
+    install_claude_deferred_tool_search(llama, deferred_tool_names=frozenset({"alpha_tool"}))
+    assert _DEFERRED_TOOL_NAMES_ATTR not in vars(llama)
+
+    claude = Claude(id="claude-opus-4-8", api_key="test-key", cache_system_prompt=False)
+    install_claude_deferred_tool_search(claude, deferred_tool_names=frozenset())
+    assert _DEFERRED_TOOL_NAMES_ATTR not in vars(claude)
+
+
+_SERVER_TOOL_USE_BLOCK = {
+    "type": "server_tool_use",
+    "id": "srvtoolu_01ABC",
+    "name": "tool_search_tool_regex",
+    "input": {"pattern": "weather"},
+}
+_TOOL_SEARCH_RESULT_BLOCK = {
+    "type": "tool_search_tool_result",
+    "tool_use_id": "srvtoolu_01ABC",
+    "content": {
+        "type": "tool_search_tool_search_result",
+        "tool_references": [{"type": "tool_reference", "tool_name": "get_weather"}],
+    },
+}
+
+
+def _anthropic_response(content: list[dict[str, object]]) -> AnthropicMessage:
+    return AnthropicMessage.model_validate(
+        {
+            "id": "msg_test",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-opus-4-8",
+            "content": content,
+            "stop_reason": "end_turn",
+            "stop_sequence": None,
+            "usage": {"input_tokens": 1, "output_tokens": 1},
+        },
+    )
+
+
+def test_server_tool_search_blocks_round_trip_in_assistant_history() -> None:
+    """server_tool_use and tool_search_tool_result replay verbatim, in order, exactly once."""
+    model = Claude(id="claude-opus-4-8", api_key="test-key", cache_system_prompt=False)
+    first_response = _anthropic_response(
+        [
+            {"type": "text", "text": "I'll search for a weather tool."},
+            _SERVER_TOOL_USE_BLOCK,
+            _TOOL_SEARCH_RESULT_BLOCK,
+        ],
+    )
+    responses = iter([first_response, _anthropic_response([{"type": "text", "text": "Done."}])])
+    captured_kwargs: list[dict[str, object]] = []
+
+    class _FakeMessagesAPI:
+        def create(self, **kwargs: object) -> object:
+            captured_kwargs.append(kwargs)
+            return next(responses)
+
+    class _FakeClient:
+        def __init__(self) -> None:
+            self.messages = _FakeMessagesAPI()
+
+    vars(model)["get_client"] = lambda: _FakeClient()
+
+    messages = [Message(role="user", content="What is the weather?")]
+    model.response(messages=messages, compression_manager=None)
+    model.response(messages=messages, compression_manager=None)
+
+    assistant_wires = [message for message in captured_kwargs[1]["messages"] if message["role"] == "assistant"]
+    assert len(assistant_wires) == 1
+    replayed_dict_blocks = [block for block in assistant_wires[0]["content"] if isinstance(block, dict)]
+    assert replayed_dict_blocks == [
+        first_response.content[1].model_dump(),
+        first_response.content[2].model_dump(),
+    ]
+
+
+def test_server_tool_blocks_replay_to_non_anthropic_provider_without_crashing() -> None:
+    """History stored on the native path must stay replayable after a `!model` provider switch."""
+    assistant = Message(
+        role="assistant",
+        content="I'll search for a weather tool.",
+        provider_data={"server_tool_blocks": [dict(_SERVER_TOOL_USE_BLOCK), dict(_TOOL_SEARCH_RESULT_BLOCK)]},
+    )
+
+    formatted = OpenAIChat(id="gpt-5.5", api_key="test-key")._format_message(assistant)
+
+    assert formatted["role"] == "assistant"
+    assert formatted["content"] == "I'll search for a weather tool."
 
 
 def test_vertexai_claude_loads_runtime_google_application_credentials(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_extra_kwargs.py
+++ b/tests/test_extra_kwargs.py
@@ -988,8 +988,13 @@ def test_deferred_tool_search_tags_tools_and_injects_search_tool() -> None:
         assert "cache_control" not in deferred_tool
 
 
-def test_deferred_tool_search_marker_lands_on_search_tool_when_all_tools_deferred() -> None:
-    """With every authored tool deferred, the search tool is the only markable prefix tail."""
+def test_deferred_tool_search_skips_tools_marker_when_all_tools_deferred() -> None:
+    """With every authored tool deferred, no tools marker is emitted at all.
+
+    Whether the API accepts cache_control on the search-tool type is
+    unverified, and deferred tools may never carry one, so the ladder leaves
+    the tools array unmarked and relies on the system-prompt breakpoint.
+    """
     model = Claude(id="claude-opus-4-8", api_key="test-key", cache_system_prompt=True)
     captured_kwargs = _install_fake_sync_client(model)
     vars(model)["_prepare_request_kwargs"] = lambda *_args, **_kwargs: {"tools": [_wire_tool("alpha_tool")]}
@@ -999,9 +1004,8 @@ def test_deferred_tool_search_marker_lands_on_search_tool_when_all_tools_deferre
 
     wire_tools = captured_kwargs[0]["tools"]
     assert wire_tools[0]["name"] == "tool_search_tool_regex"
-    assert wire_tools[0]["cache_control"] == {"type": "ephemeral"}
     assert wire_tools[1]["defer_loading"] is True
-    assert "cache_control" not in wire_tools[1]
+    assert _count_cache_markers({"tools": list(wire_tools)}) == 0
 
 
 def test_deferred_tool_search_applies_without_cache_ladder_when_cache_disabled() -> None:


### PR DESCRIPTION
## What this does

On Claude models served via the `anthropic` and `vertexai_claude` providers, authored `defer: true` tools are now handled by Anthropic's server-side tool search instead of MindRoom's homegrown dynamic-tool loading. Every request sends each deferred tool's full definition with `defer_loading: true` plus a `{"type": "tool_search_tool_regex_20251119", "name": "tool_search_tool_regex"}` entry in `tools`.

## Cache mechanics

Anthropic prompt caching is a byte-prefix match over `tools -> system -> messages`, so the homegrown path's load-a-tool-then-rebuild-the-agent flow invalidated the entire cached prefix on every tool discovery (the tools array and the loaded-state instruction suffix both changed). With `defer_loading`, the API keeps deferred schemas out of the rendered prompt prefix and expands discovered `tool_reference` blocks inline in the message stream, so discovery never touches the prefix. Because a deferred tool may not carry `cache_control` (400), the breakpoint-ladder's tools marker from #1411 now targets the last **non-deferred** tool, and the tools array is ordered deterministically (search tool, then non-deferred, then deferred sorted by name) so the marker position and the cached prefix stay byte-stable across requests.

## What the native path replaces

- `DynamicToolsToolkit` (`load_tool`/`unload_tool`/`list_tools`/`tool_search`) is not attached.
- The dynamic-tooling catalog instruction block and the volatile loaded-state prompt suffix are not emitted.
- Session loaded-tool state is neither read nor written; all authored deferred toolkits are built and attached at agent create (through the same builders as the loaded-tool path, including optional-dependency installs), so discovered calls execute directly.
- `defer: true, initial: true` tools map to plain non-deferred tools (they were always loaded anyway); `hidden_tool_names` filtering applies before tagging.
- The load->rebuild-agent->continue-turn machinery never triggers on this path (no `load_tool` calls exist to trigger it).

## Gating

Automatic, per agent, on the agent's resolved runtime model (`active_model_name` -> agent model -> default, so `!model` thread overrides and team members gate on their own model): provider in {`anthropic`, `vertexai_claude`} and model id **not** in the closed pre-4.5 denylist (claude-2/3 families, Opus 4.0/4.1, Sonnet 4.0, incl. dated `-YYYYMMDD` and Vertex `@YYYYMMDD` snapshot spellings). Every Claude model since Opus 4.5 / Sonnet 4.5 / Haiku 4.5 supports tool search and the unsupported set will never grow, so new model releases take the native path without a code change; a wrong denylist entry can only cause a graceful fallback to the homegrown path. Everything else — including `bedrock_claude` — keeps the homegrown path unchanged. No new config surface.

Also fixes the stale `mindroom.vertex_claude_prompt_cache` reference in `tach.toml` (renamed to `mindroom.claude_prompt_cache`) and declares the new `agents -> claude_prompt_cache` dependency.

## Verified

- `uv run pytest -q --no-cov`: 9192 passed, 61 skipped, 0 failed.
- `uv run pre-commit run --all-files`: all hooks pass.
- `uv run tach check --dependencies --interfaces`: clean.
- New tests (fake-SDK-client capture pattern): defer_loading tagging + search-tool injection + deterministic ordering; ladder marker lands on the last non-deferred tool, never on a deferred tool or the search-tool entry (an all-deferred surface sends no tools marker; the tools prefix still caches under the system-prompt breakpoint); tagging works with `cache_system_prompt` off; gating matrix (unsupported model / other provider -> homegrown toolkit + catalog block + no tagging); native path attaches deferred toolkits, keeps `initial: true` plain, skips catalog/state-suffix/DynamicToolsToolkit, and leaves session state untouched.
- VERIFY item from the task: a round-trip test drives Agno's real `_parse_provider_response`/`format_messages` with a fake SDK client returning `server_tool_use` + `tool_search_tool_result` blocks and asserts the next request's assistant message replays both verbatim, in order, exactly once (Agno 2.6.12 captures them in `provider_data["server_tool_blocks"]` and dedupes via `_anthropic_block_identity` — no Agno changes needed). A companion test confirms stored server-tool blocks replay to a non-Anthropic provider (OpenAI formatting) without crashing — the blocks are dropped, the text survives — covering the `!model` mid-session provider-switch gotcha.

## Not live-verified

No `ANTHROPIC_API_KEY` was available in this environment, so the live probe (one request with a deferred tool -> model discovers and calls it -> `cache_read_input_tokens > 0` on the follow-up turn) was **not** run. All verification above is against fakes; the wire format follows the tool-search doc (GA, no beta header) and the pinned anthropic SDK 0.97.0 types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for native deferred tool search on compatible Claude models, improving how deferred tools are surfaced and loaded.
  * Expanded Claude tool handling to better preserve tool ordering and search behavior.

* **Bug Fixes**
  * Improved fallback behavior for unsupported models so existing dynamic tool handling continues to work.
  * Fixed replay of stored server tool events when switching between model providers.

* **Tests**
  * Added coverage for deferred tool search, model support detection, and message history replay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

