### PR TITLE
Resolve !include tags when dedicated workers load the runtime config

### DIFF
--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -18,7 +18,6 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Annotated, Any, Literal, cast
 
-import yaml
 from fastapi import APIRouter, Depends, FastAPI, Header, HTTPException, Request
 from pydantic import BaseModel, Field, ValidationError
 
@@ -31,6 +30,7 @@ from mindroom.api.worker_responses import (
 )
 from mindroom.attachments import normalize_attachment_id
 from mindroom.config.main import Config, load_config, normalized_config_data
+from mindroom.config.yaml_includes import load_yaml_config_source
 from mindroom.credentials import CredentialsManager, get_runtime_credentials_manager, load_scoped_credentials
 from mindroom.logging_config import get_logger
 from mindroom.oauth.providers import OAuthConnectionRequired, oauth_connection_required_payload
@@ -231,8 +231,9 @@ def _runtime_config_or_empty(runtime_paths: RuntimePaths) -> Config:
 
 def _dedicated_worker_runtime_config_or_empty(runtime_paths: RuntimePaths) -> Config:
     """Return dedicated-worker config, tolerating plugins unavailable in that worker image."""
-    with runtime_paths.config_path.open() as f:
-        data = yaml.safe_load(f) or {}
+    # The authored config may be split across !include files; a plain
+    # yaml.safe_load crashes the worker on the include tags.
+    data, _config_source_files = load_yaml_config_source(runtime_paths.config_path)
 
     tool_validation_snapshot = _upstream_tool_validation_snapshot(runtime_paths)
     if not tool_validation_snapshot:

--- a/tach.toml
+++ b/tach.toml
@@ -669,6 +669,7 @@ depends_on = [
     "mindroom.api.sandbox_worker_prep",
     "mindroom.api.worker_responses",
     "mindroom.config.main",
+    "mindroom.config.yaml_includes",
     "mindroom.constants",
     "mindroom.credentials",
     "mindroom.logging_config",

--- a/tests/test_sandbox_proxy.py
+++ b/tests/test_sandbox_proxy.py
@@ -2350,6 +2350,36 @@ async def test_proxy_shell_path_prepend_survives_sandbox_runner_rebuild(
     assert result.endswith("/usr/local/bin:/usr/bin:/bin")
 
 
+def test_dedicated_worker_runtime_config_resolves_include_tags(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Dedicated workers must load configs split across !include files."""
+    (tmp_path / "models.yaml").write_text(
+        "default:\n  provider: openai\n  id: gpt-5.4\n",
+        encoding="utf-8",
+    )
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "models: !include models.yaml\nagents: {}\nrouter:\n  model: default\n",
+        encoding="utf-8",
+    )
+    runtime_paths = resolve_runtime_paths(
+        config_path=config_path,
+        storage_path=config_path.parent / "storage",
+        process_env={},
+    )
+    monkeypatch.setattr(
+        sandbox_runner_module,
+        "_upstream_tool_validation_snapshot",
+        lambda _runtime_paths: {"shell": object()},
+    )
+
+    config = sandbox_runner_module._dedicated_worker_runtime_config_or_empty(runtime_paths)
+
+    assert config.models["default"].id == "gpt-5.4"
+
+
 @pytest.mark.asyncio
 async def test_inprocess_runner_shell_uses_request_scoped_extra_env_snapshot(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Problem

`_dedicated_worker_runtime_config_or_empty` (sandbox_runner.py) reads the runtime config with a plain `yaml.safe_load`. Since #1408 the authored config may be split across `!include` files, which the main loader resolves via `config/yaml_includes.py`, but the dedicated-worker path does not. The result: with a split config, every dedicated worker crash-loops at startup (`yaml.constructor.ConstructorError: could not determine a constructor for the tag '!include'`) while the control plane runs fine, so worker provisioning times out on every sandboxed tool call once existing workers are recreated. Observed in a real deployment immediately after combining a split config with a runtime image bump (which forces worker recreation).

## Change

Parse the config through `load_yaml_config_source`, which resolves the include tree, keeps the empty-file `{}` behavior, and fails loudly on invalid include targets like the main loader. Declares the `mindroom.config.yaml_includes` dependency for `mindroom.api.sandbox_runner` in tach.toml.

## Validation

- New regression test: a dedicated worker (tool-validation snapshot present) loading a config whose `models:` section lives behind `!include` — fails with the ConstructorError before this change, passes after.
- Full `tests/test_sandbox_proxy.py` (150 passed), `tach check --dependencies --interfaces`, and pre-commit on the touched files.
- The same include-resolved config content was verified against a live crash-looping worker: replacing the split file with resolved content recovered the worker immediately, confirming the parse step is the only failure.