### PR TITLE
Add a live probe for Anthropic server-side tool search (defer_loading)

### DIFF
--- a/scripts/testing/tool_search_live_probe.py
+++ b/scripts/testing/tool_search_live_probe.py
@@ -90,6 +90,14 @@ def install_probe_hooks(model: Claude) -> None:
     install_claude_deferred_tool_search(model, deferred_tool_names=frozenset({DEFERRED_TOOL_NAME}))
 
 
+class _DryRunStop(BaseException):
+    """Raised by the dry-run fake client once the wire request has been captured.
+
+    Derives from BaseException so Agno's invoke error handling (which wraps any
+    Exception in ModelProviderError and retries) lets it propagate untouched.
+    """
+
+
 def run_dry_run(model_id: str) -> int:
     """Print the prepared wire request via a capturing fake client; no network."""
     captured: list[dict[str, Any]] = []
@@ -97,8 +105,7 @@ def run_dry_run(model_id: str) -> int:
     class _FakeMessagesAPI:
         def create(self, **kwargs: Any) -> Any:  # noqa: ANN401
             captured.append(kwargs)
-            message = "dry-run: no live response"
-            raise SystemExit(message)
+            raise _DryRunStop
 
     class _FakeClient:
         def __init__(self) -> None:
@@ -109,9 +116,12 @@ def run_dry_run(model_id: str) -> int:
     install_probe_hooks(model)
 
     messages = [Message(role="system", content=_SYSTEM_PROMPT), Message(role="user", content="probe")]
-    with contextlib.suppress(SystemExit):
+    with contextlib.suppress(_DryRunStop):
         model.response(messages=messages, tools=_PROBE_TOOLS, compression_manager=None)
 
+    if not captured:
+        print("FAIL: the hooked client was never invoked; the request never reached the fake SDK client.")
+        return 1
     wire = captured[0]
     tool_summary = [
         {
@@ -125,13 +135,25 @@ def run_dry_run(model_id: str) -> int:
     print("Prepared wire request (dry run):")
     print(json.dumps(tool_summary, indent=2))
     system_blocks = wire.get("system") or []
-    print(f"system markers: {sum(1 for block in system_blocks if block.get('cache_control'))}")
+    system_markers = sum(1 for block in system_blocks if block.get("cache_control"))
+    print(f"system markers: {system_markers}")
+    tool_names = [tool.get("name") for tool in wire["tools"]]
     deferred = [tool["name"] for tool in wire["tools"] if tool.get("defer_loading") is True]
-    ok = (
-        wire["tools"][0].get("type") == "tool_search_tool_regex_20251119"
-        and deferred == [DEFERRED_TOOL_NAME]
-        and not any(tool.get("cache_control") for tool in wire["tools"] if tool.get("defer_loading"))
-    )
+    checks = {
+        "tool order (search tool, non-deferred, deferred)": tool_names
+        == ["tool_search_tool_regex", "echo", DEFERRED_TOOL_NAME],
+        "search tool type": wire["tools"][0].get("type") == "tool_search_tool_regex_20251119",
+        "only get_weather deferred": deferred == [DEFERRED_TOOL_NAME],
+        "no marker on deferred tools": not any(
+            tool.get("cache_control") for tool in wire["tools"] if tool.get("defer_loading")
+        ),
+        "ladder marker on last non-deferred tool": wire["tools"][1].get("cache_control") is not None,
+        "exactly one system marker": system_markers == 1,
+    }
+    for check_name, check_ok in checks.items():
+        if not check_ok:
+            print(f"UNEXPECTED: {check_name}")
+    ok = all(checks.values())
     print(f"dry-run wire shape: {'OK' if ok else 'UNEXPECTED'}")
     return 0 if ok else 1
 
@@ -191,7 +213,7 @@ def run_live(model_id: str, api_key: str) -> int:
 def main() -> int:
     """Parse arguments and run the requested probe mode."""
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--model-id", default="claude-sonnet-4-6", help="Claude model id to probe.")
+    parser.add_argument("--model-id", default="claude-sonnet-5", help="Claude model id to probe.")
     parser.add_argument("--dry-run", action="store_true", help="Print the prepared wire request without any API call.")
     args = parser.parse_args()
 

--- a/scripts/testing/tool_search_live_probe.py
+++ b/scripts/testing/tool_search_live_probe.py
@@ -11,9 +11,13 @@ hooks installed — against the live API and checks that:
 
 Usage:
     ANTHROPIC_API_KEY=... uv run python scripts/testing/tool_search_live_probe.py
-    uv run python scripts/testing/tool_search_live_probe.py --dry-run  # no key needed
+    uv run python scripts/testing/tool_search_live_probe.py --provider vertexai --project-id <gcp-project>
+    uv run python scripts/testing/tool_search_live_probe.py --dry-run  # no credentials needed
 
-Exit codes: 0 = pass, 1 = fail, 2 = no API key.
+The vertexai provider authenticates via GCP application-default credentials and
+requires the project to have Anthropic models enabled in Model Garden.
+
+Exit codes: 0 = pass, 1 = fail, 2 = missing credentials/arguments.
 """
 
 from __future__ import annotations

--- a/scripts/testing/tool_search_live_probe.py
+++ b/scripts/testing/tool_search_live_probe.py
@@ -1,0 +1,209 @@
+"""Live probe for Anthropic server-side tool search (defer_loading) on the MindRoom hook path.
+
+Closes the verification gap left by PR #1412: all defer_loading behavior was tested
+against fakes because no API key was available. This probe drives the real merged
+code path — an Agno Claude model with the MindRoom prompt-cache and deferred-tool
+hooks installed — against the live API and checks that:
+
+1. the request with ``defer_loading`` tools plus the regex search tool is accepted;
+2. the model discovers the deferred tool via ``tool_search_tool_result`` and calls it;
+3. the follow-up turn reads the cached prefix (``cache_read_tokens > 0``).
+
+Usage:
+    ANTHROPIC_API_KEY=... uv run python scripts/testing/tool_search_live_probe.py
+    uv run python scripts/testing/tool_search_live_probe.py --dry-run  # no key needed
+
+Exit codes: 0 = pass, 1 = fail, 2 = no API key.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from agno.models.anthropic import Claude
+from agno.models.message import Message
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from mindroom.claude_prompt_cache import install_claude_deferred_tool_search  # noqa: E402
+
+DEFERRED_TOOL_NAME = "get_weather"
+# Deterministic padding so the system prompt clears every model's minimum
+# cacheable prefix (4096 tokens on Opus-tier models).
+_SYSTEM_PROMPT = "You are a MindRoom tool-search live probe agent. " + (
+    "This sentence is deterministic cache padding for the probe system prompt. " * 700
+)
+
+_PROBE_TOOLS: list[dict[str, Any]] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "echo",
+            "description": "Echo the provided text back to the user.",
+            "parameters": {
+                "type": "object",
+                "properties": {"text": {"type": "string", "description": "Text to echo."}},
+                "required": ["text"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": DEFERRED_TOOL_NAME,
+            "description": "Get the current weather for a location.",
+            "parameters": {
+                "type": "object",
+                "properties": {"location": {"type": "string", "description": "City name."}},
+                "required": ["location"],
+            },
+        },
+    },
+]
+
+
+def build_probe_model(model_id: str, api_key: str) -> Claude:
+    """Build a Claude model mirroring the production Anthropic settings, hooks not yet installed."""
+    return Claude(
+        id=model_id,
+        api_key=api_key,
+        cache_system_prompt=True,
+        extended_cache_time=True,
+    )
+
+
+def install_probe_hooks(model: Claude) -> None:
+    """Install the production deferred-tool-search (and prompt-cache) hooks.
+
+    Must run after any fake client is planted on the model: the hook wraps the
+    current ``get_client``, so installing first would let a later fake bypass it.
+    """
+    install_claude_deferred_tool_search(model, deferred_tool_names=frozenset({DEFERRED_TOOL_NAME}))
+
+
+def run_dry_run(model_id: str) -> int:
+    """Print the prepared wire request via a capturing fake client; no network."""
+    captured: list[dict[str, Any]] = []
+
+    class _FakeMessagesAPI:
+        def create(self, **kwargs: Any) -> Any:  # noqa: ANN401
+            captured.append(kwargs)
+            message = "dry-run: no live response"
+            raise SystemExit(message)
+
+    class _FakeClient:
+        def __init__(self) -> None:
+            self.messages = _FakeMessagesAPI()
+
+    model = build_probe_model(model_id, api_key="dry-run-key")
+    vars(model)["get_client"] = lambda: _FakeClient()
+    install_probe_hooks(model)
+
+    messages = [Message(role="system", content=_SYSTEM_PROMPT), Message(role="user", content="probe")]
+    with contextlib.suppress(SystemExit):
+        model.response(messages=messages, tools=_PROBE_TOOLS, compression_manager=None)
+
+    wire = captured[0]
+    tool_summary = [
+        {
+            "name": tool.get("name"),
+            "type": tool.get("type"),
+            "defer_loading": tool.get("defer_loading"),
+            "cache_control": tool.get("cache_control"),
+        }
+        for tool in wire["tools"]
+    ]
+    print("Prepared wire request (dry run):")
+    print(json.dumps(tool_summary, indent=2))
+    system_blocks = wire.get("system") or []
+    print(f"system markers: {sum(1 for block in system_blocks if block.get('cache_control'))}")
+    deferred = [tool["name"] for tool in wire["tools"] if tool.get("defer_loading") is True]
+    ok = (
+        wire["tools"][0].get("type") == "tool_search_tool_regex_20251119"
+        and deferred == [DEFERRED_TOOL_NAME]
+        and not any(tool.get("cache_control") for tool in wire["tools"] if tool.get("defer_loading"))
+    )
+    print(f"dry-run wire shape: {'OK' if ok else 'UNEXPECTED'}")
+    return 0 if ok else 1
+
+
+def run_live(model_id: str, api_key: str) -> int:
+    """Run the two-turn live probe and report discovery and cache reuse."""
+    model = build_probe_model(model_id, api_key)
+    install_probe_hooks(model)
+    messages = [
+        Message(role="system", content=_SYSTEM_PROMPT),
+        Message(
+            role="user",
+            content="What is the weather in Paris right now? Use your available tools; search for one if needed.",
+        ),
+    ]
+
+    first = model.response(messages=messages, tools=_PROBE_TOOLS, compression_manager=None)
+    server_blocks = (first.provider_data or {}).get("server_tool_blocks", [])
+    block_types = [block.get("type") for block in server_blocks]
+    discovered = "tool_search_tool_result" in block_types
+    tool_calls = first.tool_executions or []
+    called_deferred = any(execution.tool_name == DEFERRED_TOOL_NAME for execution in tool_calls)
+    usage_first = first.response_usage
+    print(f"turn 1: server blocks={block_types} tool calls={[execution.tool_name for execution in tool_calls]}")
+    if usage_first is not None:
+        print(f"turn 1 usage: cache_write={usage_first.cache_write_tokens} cache_read={usage_first.cache_read_tokens}")
+
+    if not called_deferred:
+        print(f"FAIL: model did not call the deferred tool '{DEFERRED_TOOL_NAME}'.")
+        return 1
+
+    messages.extend(
+        Message(
+            role="tool",
+            tool_call_id=execution.tool_call_id,
+            tool_name=execution.tool_name,
+            content="22 degrees Celsius and sunny.",
+        )
+        for execution in tool_calls
+    )
+    second = model.response(messages=messages, tools=_PROBE_TOOLS, compression_manager=None)
+    usage_second = second.response_usage
+    cache_read = usage_second.cache_read_tokens if usage_second is not None else 0
+    print(
+        f"turn 2 usage: cache_write={usage_second.cache_write_tokens if usage_second else '?'} cache_read={cache_read}",
+    )
+
+    passed = discovered and called_deferred and cache_read > 0
+    print(
+        "PASS: deferred tool discovered, called, and the follow-up turn read the cached prefix."
+        if passed
+        else f"FAIL: discovered={discovered} called_deferred={called_deferred} cache_read={cache_read}",
+    )
+    return 0 if passed else 1
+
+
+def main() -> int:
+    """Parse arguments and run the requested probe mode."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model-id", default="claude-sonnet-4-6", help="Claude model id to probe.")
+    parser.add_argument("--dry-run", action="store_true", help="Print the prepared wire request without any API call.")
+    args = parser.parse_args()
+
+    if args.dry_run:
+        return run_dry_run(args.model_id)
+
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    if not api_key:
+        print("No ANTHROPIC_API_KEY set; nothing probed. Use --dry-run to inspect the wire request offline.")
+        return 2
+    return run_live(args.model_id, api_key)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/testing/tool_search_live_probe.py
+++ b/scripts/testing/tool_search_live_probe.py
@@ -35,6 +35,7 @@ if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
 
 from mindroom.claude_prompt_cache import install_claude_deferred_tool_search  # noqa: E402
+from mindroom.vertex_claude_compat import MindroomVertexAIClaude  # noqa: E402
 
 DEFERRED_TOOL_NAME = "get_weather"
 # Deterministic padding so the system prompt clears every model's minimum
@@ -71,11 +72,24 @@ _PROBE_TOOLS: list[dict[str, Any]] = [
 ]
 
 
-def build_probe_model(model_id: str, api_key: str) -> Claude:
-    """Build a Claude model mirroring the production Anthropic settings, hooks not yet installed."""
+def build_probe_model(args: argparse.Namespace) -> Claude:
+    """Build a Claude model mirroring the production settings, hooks not yet installed.
+
+    ``--provider vertexai`` builds the same ``MindroomVertexAIClaude`` class the
+    production model loader uses, authenticated via GCP application-default
+    credentials — no ``ANTHROPIC_API_KEY`` needed.
+    """
+    if args.provider == "vertexai":
+        return MindroomVertexAIClaude(
+            id=args.model_id,
+            project_id=args.project_id,
+            region=args.region,
+            cache_system_prompt=True,
+            extended_cache_time=True,
+        )
     return Claude(
-        id=model_id,
-        api_key=api_key,
+        id=args.model_id,
+        api_key=os.environ.get("ANTHROPIC_API_KEY", "dry-run-key"),
         cache_system_prompt=True,
         extended_cache_time=True,
     )
@@ -98,7 +112,7 @@ class _DryRunStop(BaseException):
     """
 
 
-def run_dry_run(model_id: str) -> int:
+def run_dry_run(args: argparse.Namespace) -> int:
     """Print the prepared wire request via a capturing fake client; no network."""
     captured: list[dict[str, Any]] = []
 
@@ -111,7 +125,7 @@ def run_dry_run(model_id: str) -> int:
         def __init__(self) -> None:
             self.messages = _FakeMessagesAPI()
 
-    model = build_probe_model(model_id, api_key="dry-run-key")
+    model = build_probe_model(args)
     vars(model)["get_client"] = lambda: _FakeClient()
     install_probe_hooks(model)
 
@@ -158,9 +172,9 @@ def run_dry_run(model_id: str) -> int:
     return 0 if ok else 1
 
 
-def run_live(model_id: str, api_key: str) -> int:
+def run_live(args: argparse.Namespace) -> int:
     """Run the two-turn live probe and report discovery and cache reuse."""
-    model = build_probe_model(model_id, api_key)
+    model = build_probe_model(args)
     install_probe_hooks(model)
     messages = [
         Message(role="system", content=_SYSTEM_PROMPT),
@@ -214,17 +228,28 @@ def main() -> int:
     """Parse arguments and run the requested probe mode."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--model-id", default="claude-sonnet-5", help="Claude model id to probe.")
+    parser.add_argument(
+        "--provider",
+        choices=("anthropic", "vertexai"),
+        default="anthropic",
+        help="anthropic uses ANTHROPIC_API_KEY; vertexai uses GCP application-default credentials.",
+    )
+    parser.add_argument("--project-id", default="", help="GCP project id (vertexai provider).")
+    parser.add_argument("--region", default="global", help="Vertex AI region (vertexai provider). Default: global")
     parser.add_argument("--dry-run", action="store_true", help="Print the prepared wire request without any API call.")
     args = parser.parse_args()
 
     if args.dry_run:
-        return run_dry_run(args.model_id)
+        return run_dry_run(args)
 
-    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
-    if not api_key:
-        print("No ANTHROPIC_API_KEY set; nothing probed. Use --dry-run to inspect the wire request offline.")
+    if args.provider == "vertexai":
+        if not args.project_id:
+            print("Missing --project-id for the vertexai provider; nothing probed.")
+            return 2
+    elif not os.environ.get("ANTHROPIC_API_KEY"):
+        print("No ANTHROPIC_API_KEY set; nothing probed. Use --dry-run or --provider vertexai (GCP ADC).")
         return 2
-    return run_live(args.model_id, api_key)
+    return run_live(args)
 
 
 if __name__ == "__main__":

--- a/scripts/testing/tool_search_live_probe.py
+++ b/scripts/testing/tool_search_live_probe.py
@@ -28,6 +28,7 @@ from typing import Any
 
 from agno.models.anthropic import Claude
 from agno.models.message import Message
+from agno.tools.function import Function
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SRC_ROOT = REPO_ROOT / "src"
@@ -44,32 +45,30 @@ _SYSTEM_PROMPT = "You are a MindRoom tool-search live probe agent. " + (
     "This sentence is deterministic cache padding for the probe system prompt. " * 700
 )
 
-_PROBE_TOOLS: list[dict[str, Any]] = [
-    {
-        "type": "function",
-        "function": {
-            "name": "echo",
-            "description": "Echo the provided text back to the user.",
-            "parameters": {
-                "type": "object",
-                "properties": {"text": {"type": "string", "description": "Text to echo."}},
-                "required": ["text"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": DEFERRED_TOOL_NAME,
-            "description": "Get the current weather for a location.",
-            "parameters": {
-                "type": "object",
-                "properties": {"location": {"type": "string", "description": "City name."}},
-                "required": ["location"],
-            },
-        },
-    },
-]
+
+def echo(text: str) -> str:
+    """Echo the provided text back to the user.
+
+    Args:
+        text: Text to echo.
+
+    """
+    return text
+
+
+def get_weather(location: str) -> str:
+    """Get the current weather for a location.
+
+    Args:
+        location: City name.
+
+    """
+    return f"The weather in {location} is 22 degrees Celsius and sunny."
+
+
+def build_probe_tools() -> list[Function]:
+    """Build executable probe tools so Agno's response loop can run them for real."""
+    return [Function.from_callable(echo), Function.from_callable(get_weather)]
 
 
 def build_probe_model(args: argparse.Namespace) -> Claude:
@@ -131,7 +130,7 @@ def run_dry_run(args: argparse.Namespace) -> int:
 
     messages = [Message(role="system", content=_SYSTEM_PROMPT), Message(role="user", content="probe")]
     with contextlib.suppress(_DryRunStop):
-        model.response(messages=messages, tools=_PROBE_TOOLS, compression_manager=None)
+        model.response(messages=messages, tools=build_probe_tools(), compression_manager=None)
 
     if not captured:
         print("FAIL: the hooked client was never invoked; the request never reached the fake SDK client.")
@@ -184,9 +183,17 @@ def run_live(args: argparse.Namespace) -> int:
         ),
     ]
 
-    first = model.response(messages=messages, tools=_PROBE_TOOLS, compression_manager=None)
-    server_blocks = (first.provider_data or {}).get("server_tool_blocks", [])
-    block_types = [block.get("type") for block in server_blocks]
+    tools = build_probe_tools()
+    # Agno's response() runs the full production loop: the model searches, the
+    # API expands the discovered schema, Agno executes the entrypoint, and the
+    # model finishes with the tool result.
+    first = model.response(messages=messages, tools=tools, compression_manager=None)
+    block_types = [
+        block.get("type")
+        for message in messages
+        if message.role == "assistant"
+        for block in (message.provider_data or {}).get("server_tool_blocks", [])
+    ]
     discovered = "tool_search_tool_result" in block_types
     tool_calls = first.tool_executions or []
     called_deferred = any(execution.tool_name == DEFERRED_TOOL_NAME for execution in tool_calls)
@@ -199,16 +206,8 @@ def run_live(args: argparse.Namespace) -> int:
         print(f"FAIL: model did not call the deferred tool '{DEFERRED_TOOL_NAME}'.")
         return 1
 
-    messages.extend(
-        Message(
-            role="tool",
-            tool_call_id=execution.tool_call_id,
-            tool_name=execution.tool_name,
-            content="22 degrees Celsius and sunny.",
-        )
-        for execution in tool_calls
-    )
-    second = model.response(messages=messages, tools=_PROBE_TOOLS, compression_manager=None)
+    messages.append(Message(role="user", content="Thanks — and what is the weather in London?"))
+    second = model.response(messages=messages, tools=tools, compression_manager=None)
     usage_second = second.response_usage
     cache_read = usage_second.cache_read_tokens if usage_second is not None else 0
     print(


### PR DESCRIPTION
## Why

PR #1412 shipped `defer_loading` support with all verification against fakes — no `ANTHROPIC_API_KEY` was available, so the live probe from the task spec was explicitly left owed. This adds the probe as a repeatable script instead of a one-off snippet, so anyone with a key can close (and re-check) that gap in one command.

## What

`scripts/testing/tool_search_live_probe.py` drives the real merged hook path — an Agno `Claude` model with `install_claude_deferred_tool_search` (which also installs the prompt-cache ladder) — for two turns against the live API and verifies:

1. the request with `defer_loading` tools + the regex search tool is accepted;
2. the model discovers the deferred tool (`tool_search_tool_result` in `provider_data["server_tool_blocks"]`) and calls it;
3. the follow-up turn reads the cached prefix (`cache_read_tokens > 0`).

`--dry-run` needs no key or network: a capturing fake client prints the prepared wire request and checks tool ordering (search tool first), `defer_loading` tags, and that no deferred tool carries `cache_control` while the last non-deferred tool does.

## Verified

- `--dry-run` passes locally and shows the expected wire shape: `tool_search_tool_regex_20251119` first, non-deferred `echo` carrying the 1h ladder marker, deferred `get_weather` tagged with no marker.
- No-key invocation exits 2 with a clear message.
- `uv run pre-commit run --files scripts/testing/tool_search_live_probe.py`: all hooks pass.
- **Not run**: the live mode itself — same key constraint as #1412. Run `ANTHROPIC_API_KEY=... uv run python scripts/testing/tool_search_live_probe.py` to close it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new verification script for checking tool-search behavior and cached request reuse.
  * Supports a dry-run mode for inspecting request setup and a live mode for end-to-end validation.
  * Returns clear exit codes for success, failure, and missing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
