### PR TITLE
Improve macOS menubar app first-launch experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -254,3 +254,6 @@ mindroom-test-storage/
 .claude/reports/
 REVIEW-*.md
 .codex-worktrees/
+
+# Swift Package Manager build artifacts (macOS menubar app)
+macos/MindRoom/.build/

--- a/docs/installation/macos-app.md
+++ b/docs/installation/macos-app.md
@@ -22,14 +22,27 @@ Open **MindRoom** from `/Applications` or Spotlight.
 
 ## First Launch
 
-Use **Install MindRoom Runtime** to install the CLI runtime with bundled `uv`.
-Use **Initialize Hosted Config** for the default `chat.mindroom.chat` profile.
-Open `https://chat.mindroom.chat`, click the Local MindRoom icon on the left to generate a local MindRoom pair code, and use **Pair Hosted MindRoom...** in the menu.
-Use **Install/Ensure Service** to run `mindroom service install --no-confirm`.
-Use **Open Dashboard** to open `http://localhost:8765`.
+The menu lists the setup steps in order under **Set Up Hosted MindRoom**.
+Each step shows a dialog when it finishes, confirming what happened and what to do next.
+
+1. **Install MindRoom Runtime** installs the `mindroom` CLI with the bundled `uv`.
+2. **Initialize Hosted Config** writes `config.yaml` and `.env` to `~/.mindroom`, preconfigured for the hosted `chat.mindroom.chat` Matrix server. Re-running this step keeps existing files unchanged.
+3. **Open chat.mindroom.chat** opens the hosted MindRoom chat in your browser. Sign in to create your hosted account, then click the Local MindRoom icon in the left sidebar to generate a pair code.
+4. **Pair Hosted MindRoom...** links this Mac to your hosted account using the pair code.
+5. **Install/Ensure Service** installs and starts the MindRoom background service via launchd.
+
+Then use **Open Dashboard** to open the local dashboard at `http://localhost:8765`.
+
+### Why sign in to chat.mindroom.chat?
+
+`chat.mindroom.chat` is MindRoom's hosted Matrix service.
+Signing in with Apple, Google, or GitHub creates a hosted Matrix account for you on the `mindroom.chat` homeserver, so you do not need to run or configure a homeserver yourself.
+Pairing connects the MindRoom runtime on your Mac to that account: your agents run locally, and the hosted server only relays your Matrix messages.
+If you want to use your own Matrix homeserver instead, use **Initialize Self-Hosted Config** under **Other Setup**.
 
 ## Other Setup Modes
 
+The **Other Setup** submenu holds the non-hosted flows.
 Use **Initialize Self-Hosted Config** when you want to connect to your own Matrix homeserver.
 Use **Run Local Stack Setup** when you want the local Matrix stack flow.
 These actions still write to `~/.mindroom`.
@@ -40,6 +53,20 @@ The menu exposes **Start Service**, **Stop Service**, **Restart Service**, and *
 The service is managed by launchd, so MindRoom keeps running after the menu bar app quits.
 Logs are available through **Open Logs Folder** at `~/Library/Logs/mindroom`.
 Configuration is available through **Open Config Folder** at `~/.mindroom`.
+
+## Troubleshooting
+
+**The dashboard at `http://localhost:8765` does not respond.**
+The dashboard is served by the MindRoom service, so check the status line at the top of the menu.
+If the service is stopped or not installed, **Open Dashboard** offers the matching fix (for example **Start Service**).
+If the service is running but the dashboard still fails, check **Open Logs Folder** for startup errors.
+A common cause is a missing model provider credential in `~/.mindroom/.env` (for example `ANTHROPIC_API_KEY` or `OPENAI_API_KEY`).
+
+**A setup step failed.**
+The failure dialog shows the command output, and **Copy Last Output** in the menu copies the full output for a bug report.
+
+**Pairing fails or the pair code expired.**
+Generate a fresh pair code in `chat.mindroom.chat` (Local MindRoom icon in the left sidebar) and run **Pair Hosted MindRoom...** again.
 
 ## Updates
 

--- a/docs/installation/macos-app.md
+++ b/docs/installation/macos-app.md
@@ -26,8 +26,10 @@ The menu lists the setup steps in order under **Set Up Hosted MindRoom**.
 Each step shows a dialog when it finishes, confirming what happened and what to do next.
 
 1. **Install MindRoom Runtime** installs the `mindroom` CLI with the bundled `uv`.
-2. **Initialize Hosted Config** writes `config.yaml` and `.env` to `~/.mindroom`, preconfigured for the hosted `chat.mindroom.chat` Matrix server. Re-running this step keeps existing files unchanged and recreates any missing ones.
-3. **Open chat.mindroom.chat** opens the hosted MindRoom chat in your browser. Sign in to create your hosted account, then click the Local MindRoom icon in the left sidebar to generate a pair code.
+2. **Initialize Hosted Config** writes `config.yaml` and `.env` to `~/.mindroom`, preconfigured for the hosted `chat.mindroom.chat` Matrix server.
+   Re-running this step keeps existing files unchanged and recreates any missing ones.
+3. **Open chat.mindroom.chat** opens the hosted MindRoom chat in your browser.
+   Sign in to create your hosted account, then click the Local MindRoom icon in the left sidebar to generate a pair code.
 4. **Pair Hosted MindRoom...** links this Mac to your hosted account using the pair code.
 5. **Install/Ensure Service** installs and starts the MindRoom background service via launchd.
 

--- a/docs/installation/macos-app.md
+++ b/docs/installation/macos-app.md
@@ -26,7 +26,7 @@ The menu lists the setup steps in order under **Set Up Hosted MindRoom**.
 Each step shows a dialog when it finishes, confirming what happened and what to do next.
 
 1. **Install MindRoom Runtime** installs the `mindroom` CLI with the bundled `uv`.
-2. **Initialize Hosted Config** writes `config.yaml` and `.env` to `~/.mindroom`, preconfigured for the hosted `chat.mindroom.chat` Matrix server. Re-running this step keeps existing files unchanged.
+2. **Initialize Hosted Config** writes `config.yaml` and `.env` to `~/.mindroom`, preconfigured for the hosted `chat.mindroom.chat` Matrix server. Re-running this step keeps existing files unchanged and recreates any missing ones.
 3. **Open chat.mindroom.chat** opens the hosted MindRoom chat in your browser. Sign in to create your hosted account, then click the Local MindRoom icon in the left sidebar to generate a pair code.
 4. **Pair Hosted MindRoom...** links this Mac to your hosted account using the pair code.
 5. **Install/Ensure Service** installs and starts the MindRoom background service via launchd.

--- a/macos/MindRoom/Sources/MindRoom/CommandResult.swift
+++ b/macos/MindRoom/Sources/MindRoom/CommandResult.swift
@@ -8,9 +8,10 @@ struct CommandResult: Equatable {
         exitCode == 0
     }
 
-    /// Output condensed for display in an alert: no blank lines, capped length.
+    /// Output condensed for display in a failure alert: no blank lines, capped length.
+    /// Keeps the tail because CLI errors appear at the end of long output.
     var condensedOutput: String {
-        let lines = output
+        let lines = output.suffix(2000)
             .split(whereSeparator: \.isNewline)
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
@@ -18,6 +19,6 @@ struct CommandResult: Equatable {
         if joined.count <= 800 {
             return joined
         }
-        return String(joined.prefix(797)) + "..."
+        return "..." + String(joined.suffix(797))
     }
 }

--- a/macos/MindRoom/Sources/MindRoom/CommandResult.swift
+++ b/macos/MindRoom/Sources/MindRoom/CommandResult.swift
@@ -3,4 +3,21 @@ import Foundation
 struct CommandResult: Equatable {
     let exitCode: Int32
     let output: String
+
+    var isSuccess: Bool {
+        exitCode == 0
+    }
+
+    /// Output condensed for display in an alert: no blank lines, capped length.
+    var condensedOutput: String {
+        let lines = output
+            .split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        let joined = lines.joined(separator: "\n")
+        if joined.count <= 800 {
+            return joined
+        }
+        return String(joined.prefix(797)) + "..."
+    }
 }

--- a/macos/MindRoom/Sources/MindRoom/LoginItemController.swift
+++ b/macos/MindRoom/Sources/MindRoom/LoginItemController.swift
@@ -37,15 +37,11 @@ final class LoginItemController {
         }
     }
 
-    func toggle() {
-        do {
-            if isEnabled {
-                try SMAppService.mainApp.unregister()
-            } else {
-                try SMAppService.mainApp.register()
-            }
-        } catch {
-            MindRoomCommandRunner.shared.lastOutputForDisplay = error.localizedDescription
+    func toggle() throws {
+        if isEnabled {
+            try SMAppService.mainApp.unregister()
+        } else {
+            try SMAppService.mainApp.register()
         }
     }
 }

--- a/macos/MindRoom/Sources/MindRoom/MindRoomCommand.swift
+++ b/macos/MindRoom/Sources/MindRoom/MindRoomCommand.swift
@@ -52,6 +52,33 @@ enum MindRoomCommand: Equatable {
         }
     }
 
+    var successMessage: String? {
+        switch self {
+        case .installRuntime:
+            return "The MindRoom runtime is installed.\n\nNext: Initialize Hosted Config."
+        case .updateRuntime:
+            return "The MindRoom runtime is up to date."
+        case .installService:
+            return "The MindRoom background service is installed and running.\n\nNext: Open Dashboard."
+        case .startService:
+            return "The MindRoom service was started."
+        case .stopService:
+            return "The MindRoom service was stopped."
+        case .restartService:
+            return "The MindRoom service was restarted."
+        case .initializeHostedConfig:
+            return "Config files are ready in ~/.mindroom.\n\nNext: use Open chat.mindroom.chat, sign in to create your hosted account, click the Local MindRoom icon in the sidebar to generate a pair code, then use Pair Hosted MindRoom..."
+        case .initializeSelfHostedConfig:
+            return "Config files are ready in ~/.mindroom.\n\nEdit config.yaml and .env to point at your Matrix homeserver and model provider, then use Install/Ensure Service."
+        case .localStackSetup:
+            return "Local stack setup finished."
+        case .pairHosted:
+            return "Paired with hosted MindRoom.\n\nNext: Install/Ensure Service, then Open Dashboard."
+        case .serviceStatus, .openDashboard, .openHostedChat, .openConfigFolder, .openLogsFolder:
+            return nil
+        }
+    }
+
     var runtimeAction: MindRoomRuntimeAction? {
         switch self {
         case .installRuntime:

--- a/macos/MindRoom/Sources/MindRoom/MindRoomCommand.swift
+++ b/macos/MindRoom/Sources/MindRoom/MindRoomCommand.swift
@@ -61,7 +61,7 @@ enum MindRoomCommand: Equatable {
         case .installService:
             return "The MindRoom background service is installed and running.\n\nNext: Open Dashboard."
         case .startService:
-            return "The MindRoom service was started."
+            return "The MindRoom service was started.\n\nNext: Open Dashboard."
         case .stopService:
             return "The MindRoom service was stopped."
         case .restartService:

--- a/macos/MindRoom/Sources/MindRoom/MindRoomCommandRunner.swift
+++ b/macos/MindRoom/Sources/MindRoom/MindRoomCommandRunner.swift
@@ -11,9 +11,13 @@ final class MindRoomCommandRunner: ObservableObject {
         state: .unknown,
         message: "MindRoom status is unknown"
     )
-    @Published private(set) var isRunningCommand = false
+    @Published private(set) var runningCommandTitle: String?
     @Published private(set) var lastOutput = ""
 
+    /// Called on the main actor when a user-initiated command finishes.
+    var onCommandFinished: ((MindRoomCommand, CommandResult) -> Void)?
+
+    private var isRefreshingStatus = false
     private let runtime: MindRoomRuntime
     private let processRunner: MindRoomProcessRunner
 
@@ -25,13 +29,24 @@ final class MindRoomCommandRunner: ObservableObject {
         self.processRunner = processRunner
     }
 
-    func refreshStatus() {
-        runRuntimeAction(.serviceStatus, updateStatusFromOutput: true)
+    var isRunningCommand: Bool {
+        runningCommandTitle != nil
     }
 
-    var lastOutputForDisplay: String {
-        get { lastOutput }
-        set { lastOutput = newValue }
+    // Status refreshes run independently of user commands so a background
+    // refresh never swallows a menu click.
+    func refreshStatus() {
+        guard !isRefreshingStatus else { return }
+        isRefreshingStatus = true
+        let invocation = runtime.command(for: .serviceStatus)
+        let processRunner = processRunner
+        DispatchQueue.global(qos: .utility).async {
+            let result = processRunner(invocation)
+            DispatchQueue.main.async {
+                self.isRefreshingStatus = false
+                self.serviceStatus = MindRoomServiceStatus.parse(result.output)
+            }
+        }
     }
 
     func run(_ command: MindRoomCommand) {
@@ -44,29 +59,26 @@ final class MindRoomCommandRunner: ObservableObject {
             NSWorkspace.shared.open(runtime.configDirectoryURL)
         case .openLogsFolder:
             NSWorkspace.shared.open(runtime.logsDirectoryURL)
+        case .serviceStatus:
+            refreshStatus()
         default:
             guard let action = command.runtimeAction else { return }
-            runRuntimeAction(action, updateStatusFromOutput: action == .serviceStatus)
+            runUserCommand(command, action: action)
         }
     }
 
-    private func runRuntimeAction(_ action: MindRoomRuntimeAction, updateStatusFromOutput: Bool = false) {
-        guard !isRunningCommand else { return }
-        isRunningCommand = true
+    private func runUserCommand(_ command: MindRoomCommand, action: MindRoomRuntimeAction) {
+        guard runningCommandTitle == nil else { return }
+        runningCommandTitle = command.title
         let invocation = runtime.command(for: action)
         let processRunner = processRunner
         DispatchQueue.global(qos: .userInitiated).async {
             let result = processRunner(invocation)
             DispatchQueue.main.async {
-                self.isRunningCommand = false
-                if updateStatusFromOutput {
-                    self.serviceStatus = MindRoomServiceStatus.parse(result.output)
-                } else {
-                    self.lastOutput = result.output
-                    if result.exitCode == 0 {
-                        self.refreshStatus()
-                    }
-                }
+                self.runningCommandTitle = nil
+                self.lastOutput = result.output
+                self.onCommandFinished?(command, result)
+                self.refreshStatus()
             }
         }
     }
@@ -76,6 +88,8 @@ final class MindRoomCommandRunner: ObservableObject {
         process.executableURL = invocation.executableURL
         process.arguments = invocation.arguments
         process.environment = invocation.environment
+        // No TTY is attached, so any CLI prompt must see EOF instead of hanging.
+        process.standardInput = FileHandle.nullDevice
 
         let pipe = Pipe()
         process.standardOutput = pipe

--- a/macos/MindRoom/Sources/MindRoom/MindRoomRuntime.swift
+++ b/macos/MindRoom/Sources/MindRoom/MindRoomRuntime.swift
@@ -76,9 +76,9 @@ struct MindRoomRuntime {
         case .serviceStatus:
             return mindroomCommand(arguments: ["service", "status", "--logs", "0"])
         case .initializeHostedConfig:
-            return mindroomCommand(arguments: ["config", "init", "--matrix-server", "mindroom.chat"])
+            return mindroomCommand(arguments: ["config", "init", "--matrix-server", "mindroom.chat", "--no-input"])
         case .initializeSelfHostedConfig:
-            return mindroomCommand(arguments: ["config", "init", "--matrix-server", "self-hosted"])
+            return mindroomCommand(arguments: ["config", "init", "--matrix-server", "self-hosted", "--no-input"])
         case .localStackSetup:
             return mindroomCommand(arguments: ["local-stack-setup"])
         case let .pairHosted(pairCode):

--- a/macos/MindRoom/Sources/MindRoom/MindRoomRuntime.swift
+++ b/macos/MindRoom/Sources/MindRoom/MindRoomRuntime.swift
@@ -76,9 +76,11 @@ struct MindRoomRuntime {
         case .serviceStatus:
             return mindroomCommand(arguments: ["service", "status", "--logs", "0"])
         case .initializeHostedConfig:
-            return mindroomCommand(arguments: ["config", "init", "--matrix-server", "mindroom.chat", "--no-input"])
+            // Pin --path so config init targets ~/.mindroom regardless of the app's
+            // working directory; without it, a CWD-local config.yaml wins the search.
+            return mindroomCommand(arguments: ["config", "init", "--path", configPathURL.path, "--matrix-server", "mindroom.chat", "--no-input"])
         case .initializeSelfHostedConfig:
-            return mindroomCommand(arguments: ["config", "init", "--matrix-server", "self-hosted", "--no-input"])
+            return mindroomCommand(arguments: ["config", "init", "--path", configPathURL.path, "--matrix-server", "self-hosted", "--no-input"])
         case .localStackSetup:
             return mindroomCommand(arguments: ["local-stack-setup"])
         case let .pairHosted(pairCode):

--- a/macos/MindRoom/Sources/MindRoom/StatusMenuController.swift
+++ b/macos/MindRoom/Sources/MindRoom/StatusMenuController.swift
@@ -215,7 +215,11 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
         alert.alertStyle = .warning
         alert.messageText = "\(command.title) Failed"
         let output = result.condensedOutput
-        alert.informativeText = output.isEmpty ? "The command exited with code \(result.exitCode)." : output
+        var informativeText = output.isEmpty ? "The command exited with code \(result.exitCode)." : output
+        if output.contains("No such option") {
+            informativeText += "\n\nThe installed MindRoom runtime is older than this app. Use Update MindRoom Runtime, then try again."
+        }
+        alert.informativeText = informativeText
         alert.addButton(withTitle: "OK")
         alert.addButton(withTitle: "Copy Output")
         if alert.runModal() == .alertSecondButtonReturn {

--- a/macos/MindRoom/Sources/MindRoom/StatusMenuController.swift
+++ b/macos/MindRoom/Sources/MindRoom/StatusMenuController.swift
@@ -287,9 +287,36 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
         runner.run(.pairHosted(pairCode: pairCode))
     }
 
+    /// Why the dashboard would not respond in this state, with the one-click fix; nil when opening is fine.
+    private func dashboardBlocker(
+        for state: MindRoomServiceState
+    ) -> (message: String, fixTitle: String, fix: MindRoomCommand)? {
+        switch state {
+        case .stopped:
+            return (
+                "The dashboard at http://localhost:8765 is served by the MindRoom service, which is installed but stopped.",
+                "Start Service",
+                .startService
+            )
+        case .notInstalled:
+            return (
+                "The dashboard at http://localhost:8765 is served by the MindRoom service, which is not installed yet. Follow the Set Up Hosted MindRoom steps in the menu.",
+                "Install Service",
+                .installService
+            )
+        case .runtimeMissing:
+            return (
+                "The dashboard at http://localhost:8765 is served by the MindRoom service, but the MindRoom runtime is not installed yet. Follow the Set Up Hosted MindRoom steps in the menu.",
+                "Install Runtime",
+                .installRuntime
+            )
+        case .running, .unknown:
+            return nil
+        }
+    }
+
     @objc private func openDashboard() {
-        let state = runner.serviceStatus.state
-        guard state == .stopped || state == .notInstalled || state == .runtimeMissing else {
+        guard let blocker = dashboardBlocker(for: runner.serviceStatus.state) else {
             runner.run(.openDashboard)
             return
         }
@@ -298,25 +325,14 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
         let alert = NSAlert()
         alert.alertStyle = .warning
         alert.messageText = "MindRoom Is Not Running"
-        let fix: (title: String, command: MindRoomCommand)
-        switch state {
-        case .stopped:
-            alert.informativeText = "The dashboard at http://localhost:8765 is served by the MindRoom service, which is installed but stopped."
-            fix = ("Start Service", .startService)
-        case .notInstalled:
-            alert.informativeText = "The dashboard at http://localhost:8765 is served by the MindRoom service, which is not installed yet. Follow the Set Up Hosted MindRoom steps in the menu."
-            fix = ("Install Service", .installService)
-        default:
-            alert.informativeText = "The dashboard at http://localhost:8765 is served by the MindRoom service, but the MindRoom runtime is not installed yet. Follow the Set Up Hosted MindRoom steps in the menu."
-            fix = ("Install Runtime", .installRuntime)
-        }
-        alert.addButton(withTitle: fix.title)
+        alert.informativeText = blocker.message
+        alert.addButton(withTitle: blocker.fixTitle)
         alert.addButton(withTitle: "Open Anyway")
         alert.addButton(withTitle: "Cancel")
 
         switch alert.runModal() {
         case .alertFirstButtonReturn:
-            runner.run(fix.command)
+            runner.run(blocker.fix)
         case .alertSecondButtonReturn:
             runner.run(.openDashboard)
         default:

--- a/macos/MindRoom/Sources/MindRoom/StatusMenuController.swift
+++ b/macos/MindRoom/Sources/MindRoom/StatusMenuController.swift
@@ -15,10 +15,14 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
     private override init() {
         super.init()
         menu.delegate = self
+        menu.autoenablesItems = false
     }
 
     func start() {
         guard statusItem == nil else { return }
+        runner.onCommandFinished = { [weak self] command, result in
+            self?.showCommandResult(command, result: result)
+        }
         let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         item.menu = menu
         statusItem = item
@@ -45,35 +49,76 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
         menu.removeAllItems()
 
         menu.addItem(disabledItem("Status: \(runner.serviceStatus.message)"))
-        if runner.isRunningCommand {
-            menu.addItem(disabledItem("Running command..."))
+        if let runningTitle = runner.runningCommandTitle {
+            menu.addItem(disabledItem("Running \(runningTitle)..."))
         }
         menu.addItem(.separator())
 
-        menu.addItem(actionItem(MindRoomCommand.installRuntime.title, symbolName: "arrow.down.circle", action: #selector(installRuntime)))
-        menu.addItem(actionItem(MindRoomCommand.updateRuntime.title, symbolName: "arrow.triangle.2.circlepath", action: #selector(updateRuntime)))
+        menu.addItem(disabledItem("Set Up Hosted MindRoom"))
+        menu.addItem(actionItem(
+            "1. \(MindRoomCommand.installRuntime.title)",
+            symbolName: "arrow.down.circle",
+            action: #selector(installRuntime),
+            toolTip: "Installs the mindroom CLI with the bundled uv."
+        ))
+        menu.addItem(actionItem(
+            "2. \(MindRoomCommand.initializeHostedConfig.title)",
+            symbolName: "person.2.wave.2",
+            action: #selector(initializeHostedConfig),
+            toolTip: "Writes config.yaml and .env to ~/.mindroom for the hosted chat.mindroom.chat Matrix server. Existing files are kept unchanged."
+        ))
+        menu.addItem(actionItem(
+            "3. \(MindRoomCommand.openHostedChat.title)",
+            symbolName: "safari",
+            action: #selector(openHostedChat),
+            toolTip: "Sign in to create your hosted account, then click the Local MindRoom icon in the sidebar to generate a pair code."
+        ))
+        menu.addItem(actionItem(
+            "4. \(MindRoomCommand.pairHosted(pairCode: "").title)",
+            symbolName: "link",
+            action: #selector(pairHosted),
+            toolTip: "Links this Mac to your hosted account using the pair code."
+        ))
+        menu.addItem(actionItem(
+            "5. \(MindRoomCommand.installService.title)",
+            symbolName: "checkmark.circle",
+            action: #selector(installService),
+            toolTip: "Installs and starts the MindRoom background service (launchd)."
+        ))
         menu.addItem(.separator())
 
-        menu.addItem(actionItem(MindRoomCommand.installService.title, symbolName: "checkmark.circle", action: #selector(installService)))
         menu.addItem(actionItem(MindRoomCommand.startService.title, symbolName: "play.circle", action: #selector(startService)))
         menu.addItem(actionItem(MindRoomCommand.stopService.title, symbolName: "stop.circle", action: #selector(stopService)))
         menu.addItem(actionItem(MindRoomCommand.restartService.title, symbolName: "arrow.clockwise.circle", action: #selector(restartService)))
         menu.addItem(actionItem(MindRoomCommand.serviceStatus.title, symbolName: "waveform.path.ecg", action: #selector(refreshStatus)))
         menu.addItem(.separator())
 
-        menu.addItem(actionItem(MindRoomCommand.initializeHostedConfig.title, symbolName: "person.2.wave.2", action: #selector(initializeHostedConfig)))
-        menu.addItem(actionItem(MindRoomCommand.initializeSelfHostedConfig.title, symbolName: "server.rack", action: #selector(initializeSelfHostedConfig)))
-        menu.addItem(actionItem(MindRoomCommand.localStackSetup.title, symbolName: "shippingbox", action: #selector(localStackSetup)))
-        menu.addItem(actionItem(MindRoomCommand.pairHosted(pairCode: "").title, symbolName: "link", action: #selector(pairHosted)))
-        menu.addItem(actionItem(MindRoomCommand.openHostedChat.title, symbolName: "safari", action: #selector(openHostedChat)))
-        menu.addItem(.separator())
-
-        menu.addItem(actionItem(MindRoomCommand.openDashboard.title, symbolName: "rectangle.3.group", action: #selector(openDashboard)))
+        menu.addItem(actionItem(
+            MindRoomCommand.openDashboard.title,
+            symbolName: "rectangle.3.group",
+            action: #selector(openDashboard),
+            toolTip: "Opens the local dashboard at http://localhost:8765, served by the MindRoom service."
+        ))
         menu.addItem(actionItem(MindRoomCommand.openConfigFolder.title, symbolName: "folder", action: #selector(openConfigFolder)))
         menu.addItem(actionItem(MindRoomCommand.openLogsFolder.title, symbolName: "doc.text.magnifyingglass", action: #selector(openLogsFolder)))
         if !runner.lastOutput.isEmpty {
             menu.addItem(actionItem("Copy Last Output", symbolName: "doc.on.doc", action: #selector(copyLastOutput)))
         }
+        menu.addItem(.separator())
+
+        let otherSetup = NSMenuItem(title: "Other Setup", action: nil, keyEquivalent: "")
+        let otherSetupMenu = NSMenu()
+        otherSetupMenu.autoenablesItems = false
+        otherSetupMenu.addItem(actionItem(
+            MindRoomCommand.initializeSelfHostedConfig.title,
+            symbolName: "server.rack",
+            action: #selector(initializeSelfHostedConfig),
+            toolTip: "Writes config.yaml and .env to ~/.mindroom for connecting to your own Matrix homeserver."
+        ))
+        otherSetupMenu.addItem(actionItem(MindRoomCommand.localStackSetup.title, symbolName: "shippingbox", action: #selector(localStackSetup)))
+        otherSetup.submenu = otherSetupMenu
+        menu.addItem(otherSetup)
+        menu.addItem(actionItem(MindRoomCommand.updateRuntime.title, symbolName: "arrow.triangle.2.circlepath", action: #selector(updateRuntime)))
         menu.addItem(.separator())
 
         let loginItem = actionItem(loginItemController.menuTitle, symbolName: loginItemController.isEnabled ? "checkmark.circle" : "circle", action: #selector(toggleStartAtLogin))
@@ -85,6 +130,28 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
         menu.addItem(updateItem)
         menu.addItem(.separator())
         menu.addItem(actionItem("Quit", symbolName: "power", action: #selector(quit)))
+
+        if runner.isRunningCommand {
+            disableRuntimeCommandItems(in: menu)
+        }
+    }
+
+    /// Only one runtime command runs at a time, so gray the triggers out while one is in flight.
+    private func disableRuntimeCommandItems(in menu: NSMenu) {
+        let runtimeSelectors: Set<Selector> = [
+            #selector(installRuntime), #selector(updateRuntime), #selector(installService),
+            #selector(startService), #selector(stopService), #selector(restartService),
+            #selector(initializeHostedConfig), #selector(initializeSelfHostedConfig),
+            #selector(localStackSetup), #selector(pairHosted),
+        ]
+        for item in menu.items {
+            if let submenu = item.submenu {
+                disableRuntimeCommandItems(in: submenu)
+            }
+            if let action = item.action, runtimeSelectors.contains(action) {
+                item.isEnabled = false
+            }
+        }
     }
 
     private func startStatusRefreshTimer() {
@@ -120,10 +187,11 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
         }
     }
 
-    private func actionItem(_ title: String, symbolName: String, action: Selector) -> NSMenuItem {
+    private func actionItem(_ title: String, symbolName: String, action: Selector, toolTip: String? = nil) -> NSMenuItem {
         let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
         item.target = self
         item.image = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)
+        item.toolTip = toolTip
         return item
     }
 
@@ -131,6 +199,28 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
         let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
         item.isEnabled = false
         return item
+    }
+
+    private func showCommandResult(_ command: MindRoomCommand, result: CommandResult) {
+        NSApp.activate(ignoringOtherApps: true)
+        let alert = NSAlert()
+        if result.isSuccess {
+            alert.alertStyle = .informational
+            alert.messageText = "\(command.title) Finished"
+            alert.informativeText = command.successMessage ?? result.condensedOutput
+            alert.addButton(withTitle: "OK")
+            alert.runModal()
+            return
+        }
+        alert.alertStyle = .warning
+        alert.messageText = "\(command.title) Failed"
+        let output = result.condensedOutput
+        alert.informativeText = output.isEmpty ? "The command exited with code \(result.exitCode)." : output
+        alert.addButton(withTitle: "OK")
+        alert.addButton(withTitle: "Copy Output")
+        if alert.runModal() == .alertSecondButtonReturn {
+            copyLastOutput()
+        }
     }
 
     @objc private func installRuntime() {
@@ -174,9 +264,10 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
     }
 
     @objc private func pairHosted() {
+        NSApp.activate(ignoringOtherApps: true)
         let alert = NSAlert()
         alert.messageText = "Pair Hosted MindRoom"
-        alert.informativeText = "Enter the pair code from chat.mindroom.chat."
+        alert.informativeText = "In chat.mindroom.chat, click the Local MindRoom icon in the left sidebar to generate a pair code, then enter it here."
         let textField = NSTextField(frame: NSRect(x: 0, y: 0, width: 220, height: 24))
         textField.placeholderString = "ABCD-EFGH"
         alert.accessoryView = textField
@@ -186,14 +277,47 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
         guard alert.runModal() == .alertFirstButtonReturn else { return }
         let pairCode = textField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !pairCode.isEmpty else {
-            runner.lastOutputForDisplay = "Pair code cannot be empty."
+            showSimpleAlert(title: "Pair Code Missing", message: "Enter the pair code from chat.mindroom.chat to pair.")
             return
         }
         runner.run(.pairHosted(pairCode: pairCode))
     }
 
     @objc private func openDashboard() {
-        runner.run(.openDashboard)
+        let state = runner.serviceStatus.state
+        guard state == .stopped || state == .notInstalled || state == .runtimeMissing else {
+            runner.run(.openDashboard)
+            return
+        }
+
+        NSApp.activate(ignoringOtherApps: true)
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "MindRoom Is Not Running"
+        let fix: (title: String, command: MindRoomCommand)
+        switch state {
+        case .stopped:
+            alert.informativeText = "The dashboard at http://localhost:8765 is served by the MindRoom service, which is installed but stopped."
+            fix = ("Start Service", .startService)
+        case .notInstalled:
+            alert.informativeText = "The dashboard at http://localhost:8765 is served by the MindRoom service, which is not installed yet. Follow the Set Up Hosted MindRoom steps in the menu."
+            fix = ("Install Service", .installService)
+        default:
+            alert.informativeText = "The dashboard at http://localhost:8765 is served by the MindRoom service, but the MindRoom runtime is not installed yet. Follow the Set Up Hosted MindRoom steps in the menu."
+            fix = ("Install Runtime", .installRuntime)
+        }
+        alert.addButton(withTitle: fix.title)
+        alert.addButton(withTitle: "Open Anyway")
+        alert.addButton(withTitle: "Cancel")
+
+        switch alert.runModal() {
+        case .alertFirstButtonReturn:
+            runner.run(fix.command)
+        case .alertSecondButtonReturn:
+            runner.run(.openDashboard)
+        default:
+            break
+        }
     }
 
     @objc private func openHostedChat() {
@@ -214,7 +338,11 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
     }
 
     @objc private func toggleStartAtLogin() {
-        loginItemController.toggle()
+        do {
+            try loginItemController.toggle()
+        } catch {
+            showSimpleAlert(title: "Start at Login Failed", message: error.localizedDescription)
+        }
         rebuildMenu()
     }
 
@@ -222,8 +350,17 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
         do {
             try appUpdater.checkForUpdates()
         } catch {
-            runner.lastOutputForDisplay = error.localizedDescription
+            showSimpleAlert(title: "App Update Check Failed", message: error.localizedDescription)
         }
+    }
+
+    private func showSimpleAlert(title: String, message: String) {
+        NSApp.activate(ignoringOtherApps: true)
+        let alert = NSAlert()
+        alert.messageText = title
+        alert.informativeText = message
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
     }
 
     @objc private func quit() {

--- a/macos/MindRoom/Tests/MindRoomTests/MindRoomRuntimeTests.swift
+++ b/macos/MindRoom/Tests/MindRoomTests/MindRoomRuntimeTests.swift
@@ -54,7 +54,7 @@ final class MindRoomRuntimeTests: XCTestCase {
         XCTAssertEqual(command.arguments, ["mindroom", "service", "install", "--no-confirm"])
     }
 
-    func testHostedConfigCommandUsesPublicProfile() {
+    func testHostedConfigCommandUsesPublicProfileWithoutPrompts() {
         let runtime = MindRoomRuntime(
             homeURL: URL(fileURLWithPath: "/Users/example", isDirectory: true),
             bundleURL: URL(fileURLWithPath: "/Applications/MindRoom.app", isDirectory: true),
@@ -62,6 +62,17 @@ final class MindRoomRuntimeTests: XCTestCase {
         )
 
         let command = runtime.command(for: .initializeHostedConfig)
-        XCTAssertEqual(command.arguments, ["mindroom", "config", "init", "--matrix-server", "mindroom.chat"])
+        XCTAssertEqual(command.arguments, ["mindroom", "config", "init", "--matrix-server", "mindroom.chat", "--no-input"])
+    }
+
+    func testSelfHostedConfigCommandRunsWithoutPrompts() {
+        let runtime = MindRoomRuntime(
+            homeURL: URL(fileURLWithPath: "/Users/example", isDirectory: true),
+            bundleURL: URL(fileURLWithPath: "/Applications/MindRoom.app", isDirectory: true),
+            environment: ["PATH": "/usr/bin:/bin"]
+        )
+
+        let command = runtime.command(for: .initializeSelfHostedConfig)
+        XCTAssertEqual(command.arguments, ["mindroom", "config", "init", "--matrix-server", "self-hosted", "--no-input"])
     }
 }

--- a/macos/MindRoom/Tests/MindRoomTests/MindRoomRuntimeTests.swift
+++ b/macos/MindRoom/Tests/MindRoomTests/MindRoomRuntimeTests.swift
@@ -62,7 +62,10 @@ final class MindRoomRuntimeTests: XCTestCase {
         )
 
         let command = runtime.command(for: .initializeHostedConfig)
-        XCTAssertEqual(command.arguments, ["mindroom", "config", "init", "--matrix-server", "mindroom.chat", "--no-input"])
+        XCTAssertEqual(
+            command.arguments,
+            ["mindroom", "config", "init", "--path", "/Users/example/.mindroom/config.yaml", "--matrix-server", "mindroom.chat", "--no-input"]
+        )
     }
 
     func testSelfHostedConfigCommandRunsWithoutPrompts() {
@@ -73,6 +76,9 @@ final class MindRoomRuntimeTests: XCTestCase {
         )
 
         let command = runtime.command(for: .initializeSelfHostedConfig)
-        XCTAssertEqual(command.arguments, ["mindroom", "config", "init", "--matrix-server", "self-hosted", "--no-input"])
+        XCTAssertEqual(
+            command.arguments,
+            ["mindroom", "config", "init", "--path", "/Users/example/.mindroom/config.yaml", "--matrix-server", "self-hosted", "--no-input"]
+        )
     }
 }

--- a/macos/MindRoom/Tests/MindRoomTests/ServiceStatusTests.swift
+++ b/macos/MindRoom/Tests/MindRoomTests/ServiceStatusTests.swift
@@ -83,10 +83,11 @@ final class CommandResultTests: XCTestCase {
         XCTAssertEqual(result.condensedOutput, "Error: bad config\nsecond line")
     }
 
-    func testCondensedOutputTruncatesLongOutput() {
-        let result = CommandResult(exitCode: 1, output: String(repeating: "x", count: 2000))
+    func testCondensedOutputKeepsTailOfLongOutput() {
+        let result = CommandResult(exitCode: 1, output: String(repeating: "x", count: 2000) + "\nError: the part that matters")
 
         XCTAssertEqual(result.condensedOutput.count, 800)
-        XCTAssertTrue(result.condensedOutput.hasSuffix("..."))
+        XCTAssertTrue(result.condensedOutput.hasPrefix("..."))
+        XCTAssertTrue(result.condensedOutput.hasSuffix("Error: the part that matters"))
     }
 }

--- a/macos/MindRoom/Tests/MindRoomTests/ServiceStatusTests.swift
+++ b/macos/MindRoom/Tests/MindRoomTests/ServiceStatusTests.swift
@@ -61,4 +61,32 @@ final class MindRoomCommandTests: XCTestCase {
         XCTAssertEqual(MindRoomCommand.openConfigFolder.title, "Open Config Folder")
         XCTAssertEqual(MindRoomCommand.openLogsFolder.title, "Open Logs Folder")
     }
+
+    func testEveryUserRunCommandExposesASuccessMessage() {
+        let commands: [MindRoomCommand] = [
+            .installRuntime, .updateRuntime, .installService, .startService, .stopService,
+            .restartService, .initializeHostedConfig, .initializeSelfHostedConfig,
+            .localStackSetup, .pairHosted(pairCode: "ABCD-EFGH"),
+        ]
+        for command in commands {
+            XCTAssertNotNil(command.successMessage, "\(command.title) has no success message")
+        }
+        XCTAssertNil(MindRoomCommand.serviceStatus.successMessage)
+        XCTAssertNil(MindRoomCommand.openDashboard.successMessage)
+    }
+}
+
+final class CommandResultTests: XCTestCase {
+    func testCondensedOutputCollapsesBlankLinesAndWhitespace() {
+        let result = CommandResult(exitCode: 1, output: "  Error: bad config  \n\n\n  second line \n")
+
+        XCTAssertEqual(result.condensedOutput, "Error: bad config\nsecond line")
+    }
+
+    func testCondensedOutputTruncatesLongOutput() {
+        let result = CommandResult(exitCode: 1, output: String(repeating: "x", count: 2000))
+
+        XCTAssertEqual(result.condensedOutput.count, 800)
+        XCTAssertTrue(result.condensedOutput.hasSuffix("..."))
+    }
 }

--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -424,12 +424,15 @@ def config_init(
     target = _resolve_config_path(path)
     env_path = target.parent / ".env"
 
+    # With --no-input an existing config.yaml is kept, but .env handling still
+    # runs so a missing .env is recreated and hosted defaults are appended.
+    keep_existing_config = False
     if target.exists() and not force and not print_config:
         console.print(f"[yellow]Config file already exists:[/yellow] {target}")
         if no_input:
-            console.print("Left existing config unchanged. Use --force to overwrite.")
-            raise typer.Exit(0)
-        if not typer.confirm("Overwrite existing config file?"):
+            console.print("Keeping existing config.yaml. Use --force to overwrite.")
+            keep_existing_config = True
+        elif not typer.confirm("Overwrite existing config file?"):
             console.print("[dim]Aborted.[/dim]")
             raise typer.Exit(0)
 
@@ -466,8 +469,9 @@ def config_init(
         console.print(_yaml_syntax(content, line_numbers=False, word_wrap=False), soft_wrap=True)
         return
 
-    target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_text(content, encoding="utf-8")
+    if not keep_existing_config:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
 
     _ensure_mind_workspace(_default_mind_workspace(storage_root), force=force)
 
@@ -479,7 +483,10 @@ def config_init(
         replace_existing=replace_env_file,
     )
 
-    console.print(f"[green]Config created:[/green] {target}")
+    if keep_existing_config:
+        console.print(f"[green]Config unchanged:[/green] {target}")
+    else:
+        console.print(f"[green]Config created:[/green] {target}")
     _print_config_init_next_steps(
         env_path,
         env_changed=env_changed,

--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -217,11 +217,15 @@ def _append_missing_env_defaults(
     return True
 
 
-def _should_replace_env_file(env_path: Path, *, force: bool) -> bool:
+def _should_replace_env_file(env_path: Path, *, force: bool, no_input: bool) -> bool:
     """Return whether config init should create or overwrite the full env template."""
     if not env_path.exists():
         return True
-    return force or typer.confirm(f"Overwrite existing .env file ({env_path})?", default=False)
+    if force:
+        return True
+    if no_input:
+        return False
+    return typer.confirm(f"Overwrite existing .env file ({env_path})?", default=False)
 
 
 def _config_init_env_hint(matrix_server: _MatrixServerPreset, selected_preset: _ProviderPreset) -> str:
@@ -407,6 +411,11 @@ def config_init(
         "--print",
         help="Print generated config YAML with syntax highlighting instead of writing files.",
     ),
+    no_input: bool = typer.Option(
+        False,
+        "--no-input",
+        help="Never prompt: keep existing files unchanged and use the default provider preset.",
+    ),
 ) -> None:
     """Create a starter config.yaml with example agents and models.
 
@@ -417,6 +426,9 @@ def config_init(
 
     if target.exists() and not force and not print_config:
         console.print(f"[yellow]Config file already exists:[/yellow] {target}")
+        if no_input:
+            console.print("Left existing config unchanged. Use --force to overwrite.")
+            raise typer.Exit(0)
         if not typer.confirm("Overwrite existing config file?"):
             console.print("[dim]Aborted.[/dim]")
             raise typer.Exit(0)
@@ -424,10 +436,10 @@ def config_init(
     selected_matrix_server, selected_preset = _resolve_config_init_selection(
         matrix_server,
         provider=provider,
-        interactive=not print_config,
+        interactive=not print_config and not no_input,
     )
 
-    replace_env_file = False if print_config else _should_replace_env_file(env_path, force=force)
+    replace_env_file = False if print_config else _should_replace_env_file(env_path, force=force, no_input=no_input)
     storage_root, use_storage_env_placeholder = _config_init_storage_plan(
         target.parent,
         env_path,

--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -414,7 +414,7 @@ def config_init(
     no_input: bool = typer.Option(
         False,
         "--no-input",
-        help="Never prompt: keep existing files unchanged and use the default provider preset.",
+        help="Never prompt: keep an existing config.yaml unchanged, create anything missing, and use the default provider preset.",
     ),
 ) -> None:
     """Create a starter config.yaml with example agents and models.
@@ -449,27 +449,27 @@ def config_init(
         replace_env_file=replace_env_file,
     )
 
-    content = _full_template(
-        selected_preset,
-        target.parent,
-        storage_root=storage_root,
-        use_storage_env_placeholder=use_storage_env_placeholder,
-        matrix_server=selected_matrix_server,
-    )
-
-    # `connect` can run before `config init`, when no config exists to patch.
-    # In that order, connect persists the owner MXID in .env so init can render
-    # authorization defaults without leaving pairing placeholders behind.
-    if owner_user_id := _config_init_owner_user_id(target):
-        from mindroom.cli.owner import replace_owner_placeholders_in_text  # noqa: PLC0415
-
-        content = replace_owner_placeholders_in_text(content, owner_user_id)
-
-    if print_config:
-        console.print(_yaml_syntax(content, line_numbers=False, word_wrap=False), soft_wrap=True)
-        return
-
     if not keep_existing_config:
+        content = _full_template(
+            selected_preset,
+            target.parent,
+            storage_root=storage_root,
+            use_storage_env_placeholder=use_storage_env_placeholder,
+            matrix_server=selected_matrix_server,
+        )
+
+        # `connect` can run before `config init`, when no config exists to patch.
+        # In that order, connect persists the owner MXID in .env so init can render
+        # authorization defaults without leaving pairing placeholders behind.
+        if owner_user_id := _config_init_owner_user_id(target):
+            from mindroom.cli.owner import replace_owner_placeholders_in_text  # noqa: PLC0415
+
+            content = replace_owner_placeholders_in_text(content, owner_user_id)
+
+        if print_config:
+            console.print(_yaml_syntax(content, line_numbers=False, word_wrap=False), soft_wrap=True)
+            return
+
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text(content, encoding="utf-8")
 

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -909,6 +909,38 @@ class TestConfigInit:
         assert content != "existing"
         assert "agents:" in content
 
+    def test_init_no_input_keeps_existing_config(self, tmp_path: Path) -> None:
+        """Config init --no-input leaves an existing config untouched and exits cleanly."""
+        target = tmp_path / "config.yaml"
+        target.write_text("existing")
+        result = runner.invoke(app, ["config", "init", "--path", str(target), "--no-input"])
+        assert result.exit_code == 0
+        assert target.read_text() == "existing"
+        assert "Left existing config unchanged" in normalize_console_output(result.output)
+
+    def test_init_no_input_keeps_existing_env_and_appends_hosted_defaults(self, tmp_path: Path) -> None:
+        """Config init --no-input preserves .env values and only appends missing hosted defaults."""
+        target = tmp_path / "config.yaml"
+        env_path = tmp_path / ".env"
+        env_path.write_text("ANTHROPIC_API_KEY=sk-existing\n")
+        result = runner.invoke(app, ["config", "init", "--path", str(target), "--no-input"])
+        assert result.exit_code == 0
+        assert target.exists()
+        env_content = env_path.read_text()
+        assert "ANTHROPIC_API_KEY=sk-existing" in env_content
+        assert "MATRIX_HOMESERVER" in env_content
+
+    def test_init_no_input_self_hosted_defaults_to_openai_without_prompting(self, tmp_path: Path) -> None:
+        """Self-hosted config init --no-input skips the provider prompt and uses OpenAI."""
+        target = tmp_path / "config.yaml"
+        result = runner.invoke(
+            app,
+            ["config", "init", "--path", str(target), "--matrix-server", "self-hosted", "--no-input"],
+        )
+        assert result.exit_code == 0
+        config = yaml.safe_load(target.read_text())
+        assert config["models"]["default"]["provider"] == "openai"
+
     def test_init_openai_preset_uses_openai_models(self, tmp_path: Path) -> None:
         """Config init --provider openai prepopulates OpenAI defaults."""
         target = tmp_path / "config.yaml"

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -909,14 +909,28 @@ class TestConfigInit:
         assert content != "existing"
         assert "agents:" in content
 
-    def test_init_no_input_keeps_existing_config(self, tmp_path: Path) -> None:
-        """Config init --no-input leaves an existing config untouched and exits cleanly."""
+    def test_init_no_input_keeps_existing_config_and_recreates_missing_env(self, tmp_path: Path) -> None:
+        """Config init --no-input keeps an existing config but still creates a missing .env."""
         target = tmp_path / "config.yaml"
         target.write_text("existing")
         result = runner.invoke(app, ["config", "init", "--path", str(target), "--no-input"])
         assert result.exit_code == 0
         assert target.read_text() == "existing"
-        assert "Left existing config unchanged" in normalize_console_output(result.output)
+        assert "Keeping existing config.yaml" in normalize_console_output(result.output)
+        env_content = (tmp_path / ".env").read_text()
+        assert "MATRIX_HOMESERVER" in env_content
+
+    def test_init_no_input_rerun_leaves_config_and_env_untouched(self, tmp_path: Path) -> None:
+        """Config init --no-input is idempotent once config.yaml and a hosted .env exist."""
+        target = tmp_path / "config.yaml"
+        first = runner.invoke(app, ["config", "init", "--path", str(target), "--no-input"])
+        assert first.exit_code == 0
+        config_before = target.read_text()
+        env_before = (tmp_path / ".env").read_text()
+        second = runner.invoke(app, ["config", "init", "--path", str(target), "--no-input"])
+        assert second.exit_code == 0
+        assert target.read_text() == config_before
+        assert (tmp_path / ".env").read_text() == env_before
 
     def test_init_no_input_keeps_existing_env_and_appends_hosted_defaults(self, tmp_path: Path) -> None:
         """Config init --no-input preserves .env values and only appends missing hosted defaults."""


### PR DESCRIPTION
Addresses the newbie-confusion feedback in #1315.

## What was actually broken

Beyond the docs gaps, the app had four real defects:

- **No feedback at all.** Command output went only to a hidden "Copy Last Output" menu item, so "Initialize Hosted Config" (and every other action) finished silently — success or failure.
- **Hidden CLI prompts aborted menu actions.** `mindroom config init` asks interactive questions (overwrite config? overwrite .env? provider preset?), and the app runs it without a TTY, so those prompts hit EOF and aborted. **Initialize Self-Hosted Config always failed silently**, and re-running Initialize Hosted Config failed silently too.
- **Dropped clicks.** The runner shared one `isRunningCommand` guard between user commands and the 5-second background status refresh, so a menu click landing during a refresh did nothing.
- **Open Dashboard opened localhost:8765 blindly**, even when the service was stopped or never installed — the exact dead-end reported in the issue.

## Changes

### CLI
- New `mindroom config init --no-input` flag: never prompts. Existing `config.yaml`/`.env` are kept unchanged (hosted Matrix defaults are still appended to `.env`), and the provider preset defaults to openai. Useful for scripting/CI too.

### macOS app
- Every command now ends in a dialog: success messages say what happened **and what the next setup step is**; failure dialogs show the command output with a Copy Output button.
- The menu leads with a numbered **Set Up Hosted MindRoom** section in docs order (install runtime → init config → open chat → pair → install service), with explanatory tooltips. Self-hosted / local-stack flows moved to an **Other Setup** submenu.
- **Open Dashboard** checks the service state first and offers the matching one-click fix (Start Service / Install Service / Install Runtime), plus Open Anyway.
- Config init runs with `--no-input`, and all subprocesses get a null-device stdin so a CLI prompt can never hang or abort a menu action again.
- Status refreshes no longer share a lock with user commands; the menu shows *which* command is running and grays out command items meanwhile.
- `menu.autoenablesItems = false` so the pre-existing `isEnabled` assignments (login item, Sparkle updates) actually take effect.
- Start-at-login and update-check errors surface as alerts instead of being written into the invisible last-output buffer.

### Docs
- First Launch rewritten as numbered steps matching the menu, noting each step confirms completion.
- New "Why sign in to chat.mindroom.chat?" section explaining the hosted-account architecture (the OAuth confusion in the issue).
- New Troubleshooting section, led by "the dashboard at localhost:8765 does not respond".

Not addressed here (hosted-platform config, not repo code): the OAuth app showing "basnijholt" instead of a MindRoom org.

## Testing
- `uv run pytest tests/test_cli_config.py` — 150 passed (3 new `--no-input` tests).
- `swift build` clean; Swift unit tests updated/added for the new invocations, success messages, and output condensing (XCTest not runnable locally — CLT-only toolchain).
- Verified live: drove `config init` exactly as the app invokes it (null stdin) — fresh init, idempotent re-run, `.env` key preservation with hosted-default append, self-hosted without prompting, and `--force` still overwriting; also reproduced the old abort behavior without the flag.

Closes #1315.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a no-prompt setup mode that preserves existing config files and uses sensible defaults.
  * Improved menu bar interactions with clearer setup steps, tooltips, and success/failure alerts.
  * Added easier recovery for dashboard, pairing, and setup issues.

* **Bug Fixes**
  * Prevented setup from overwriting existing files in no-input mode.
  * Improved command output display by trimming long logs and removing blank lines.
  * Made dashboard access safer when required services are unavailable.

* **Documentation**
  * Expanded macOS app setup instructions and added troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->