### PR TITLE
Keep URL redaction escape-safe; make the cache review skip corrupt log rows

### DIFF
--- a/scripts/testing/prompt_cache_review.py
+++ b/scripts/testing/prompt_cache_review.py
@@ -57,6 +57,7 @@ class JsonlParseStats:
     concatenated_document_count: int
     decode_error_count: int
     unparseable_row_count: int = 0
+    unparseable_row_errors: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -454,6 +455,7 @@ def load_request_rows(
     concatenated_document_count = 0
     decode_error_count = 0
     unparseable_row_count = 0
+    unparseable_row_errors: list[str] = []
 
     with jsonl_path.open(encoding="utf-8", errors="replace") as handle:
         for _line_count, raw_line in enumerate(handle, start=1):
@@ -476,8 +478,10 @@ def load_request_rows(
                 parsed_documents += 1
                 document_count += 1
                 position = end_position
-                if not _append_request_row(rows, payload, session_id_filter):
+                row_error = _append_request_row(rows, payload, session_id_filter)
+                if row_error is not None:
                     unparseable_row_count += 1
+                    unparseable_row_errors.append(row_error)
             if parsed_documents > 1:
                 concatenated_document_count += parsed_documents - 1
 
@@ -488,21 +492,28 @@ def load_request_rows(
         concatenated_document_count=concatenated_document_count,
         decode_error_count=decode_error_count,
         unparseable_row_count=unparseable_row_count,
+        unparseable_row_errors=tuple(dict.fromkeys(unparseable_row_errors))[:3],
     )
 
 
-def _append_request_row(rows: list[RequestRow], payload: object, session_id_filter: str | None) -> bool:
-    """Parse one logged payload into ``rows``; return False when it cannot be rebuilt."""
+def _append_request_row(rows: list[RequestRow], payload: object, session_id_filter: str | None) -> str | None:
+    """Parse one logged payload into ``rows``; return an error summary when it cannot be rebuilt.
+
+    Corrupt logged rows can fail anywhere in the provider-format rebuild (JSON
+    decoding, pydantic validation, Agno's message formatting), and one bad row
+    must never kill an offline review, so this deliberately catches everything
+    and reports the failure instead.
+    """
     payload_dict = object_dict(payload)
     if session_id_filter is not None and (payload_dict is None or payload_dict.get("session_id") != session_id_filter):
-        return True
+        return None
     try:
-        row = parse_request_row(payload_dict if payload_dict is not None else payload)
-    except Exception:
-        return False
+        row = parse_request_row(payload)
+    except Exception as error:
+        return f"{type(error).__name__}: {error}"
     if row is not None:
         rows.append(row)
-    return True
+    return None
 
 
 def parse_request_row(payload: object) -> RequestRow | None:
@@ -1360,6 +1371,8 @@ def print_overview(
     )
     if parse_stats.unparseable_row_count:
         print(f"Skipped {parse_stats.unparseable_row_count} rows whose logged payload could not be rebuilt.")
+        for row_error in parse_stats.unparseable_row_errors:
+            print(f"  {shorten_text(row_error, 140)}")
     print(f"Rows with session_id: {len(rows) - missing_session_rows}; rows without session_id: {missing_session_rows}")
     print("Comparisons ignore moving `cache_control` markers and focus on the reusable content prefix.")
 

--- a/scripts/testing/prompt_cache_review.py
+++ b/scripts/testing/prompt_cache_review.py
@@ -56,6 +56,7 @@ class JsonlParseStats:
     document_count: int
     concatenated_document_count: int
     decode_error_count: int
+    unparseable_row_count: int = 0
 
 
 @dataclass(frozen=True)
@@ -452,6 +453,7 @@ def load_request_rows(
     document_count = 0
     concatenated_document_count = 0
     decode_error_count = 0
+    unparseable_row_count = 0
 
     with jsonl_path.open(encoding="utf-8", errors="replace") as handle:
         for _line_count, raw_line in enumerate(handle, start=1):
@@ -474,14 +476,8 @@ def load_request_rows(
                 parsed_documents += 1
                 document_count += 1
                 position = end_position
-                payload_dict = object_dict(payload)
-                if session_id_filter is not None and (
-                    payload_dict is None or payload_dict.get("session_id") != session_id_filter
-                ):
-                    continue
-                row = parse_request_row(payload_dict if payload_dict is not None else payload)
-                if row is not None:
-                    rows.append(row)
+                if not _append_request_row(rows, payload, session_id_filter):
+                    unparseable_row_count += 1
             if parsed_documents > 1:
                 concatenated_document_count += parsed_documents - 1
 
@@ -491,7 +487,22 @@ def load_request_rows(
         document_count=document_count,
         concatenated_document_count=concatenated_document_count,
         decode_error_count=decode_error_count,
+        unparseable_row_count=unparseable_row_count,
     )
+
+
+def _append_request_row(rows: list[RequestRow], payload: object, session_id_filter: str | None) -> bool:
+    """Parse one logged payload into ``rows``; return False when it cannot be rebuilt."""
+    payload_dict = object_dict(payload)
+    if session_id_filter is not None and (payload_dict is None or payload_dict.get("session_id") != session_id_filter):
+        return True
+    try:
+        row = parse_request_row(payload_dict if payload_dict is not None else payload)
+    except Exception:
+        return False
+    if row is not None:
+        rows.append(row)
+    return True
 
 
 def parse_request_row(payload: object) -> RequestRow | None:
@@ -1347,6 +1358,8 @@ def print_overview(
         f"{parse_stats.document_count} JSON documents from {parse_stats.line_count} lines "
         f"(concatenated docs: {parse_stats.concatenated_document_count}, decode errors: {parse_stats.decode_error_count}).",
     )
+    if parse_stats.unparseable_row_count:
+        print(f"Skipped {parse_stats.unparseable_row_count} rows whose logged payload could not be rebuilt.")
     print(f"Rows with session_id: {len(rows) - missing_session_rows}; rows without session_id: {missing_session_rows}")
     print("Comparisons ignore moving `cache_control` markers and focus on the reusable content prefix.")
 

--- a/src/mindroom/redaction.py
+++ b/src/mindroom/redaction.py
@@ -325,10 +325,24 @@ def _bounded_redaction_input(value: str, *, max_length: int | None) -> str:
     return value[:scan_length]
 
 
+def _redact_url_match(match: re.Match[str]) -> str:
+    r"""Redact one matched URL, leaving trailing backslashes untouched.
+
+    In logged shell commands and JSON-encoded strings, a backslash right after
+    the URL is escaping the next character (for example ``\\"``), not URL
+    content. Absorbing it into the query re-encodes it to ``%5C`` and strips
+    the escape, which corrupts the surrounding encoding.
+    """
+    matched_url = match.group(0)
+    url = matched_url.rstrip("\\")
+    trailing_backslashes = matched_url[len(url) :]
+    return _redact_url(url) + trailing_backslashes
+
+
 def redact_sensitive_text(value: str, *, max_length: int | None = None) -> str:
     """Redact common credential and bearer-token patterns from free-form text."""
     bounded_value = _bounded_redaction_input(value, max_length=max_length)
-    redacted = _URL_PATTERN.sub(lambda match: _redact_url(match.group(0)), bounded_value)
+    redacted = _URL_PATTERN.sub(_redact_url_match, bounded_value)
     redacted = _BEARER_TOKEN_PATTERN.sub(_redact_matched_token, redacted)
     redacted = _API_KEY_MESSAGE_PATTERN.sub(_redact_matched_token, redacted)
     redacted = _TOKEN_LIKE_PATTERN.sub(_redact_matched_token, redacted)

--- a/tests/test_prompt_cache_review.py
+++ b/tests/test_prompt_cache_review.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import os
 import sys
 from datetime import datetime
@@ -43,6 +44,45 @@ def test_load_request_rows_handles_concatenated_json_objects(tmp_path: Path) -> 
     assert len(rows) == 2
     assert stats.document_count == 2
     assert stats.concatenated_document_count == 1
+    assert stats.decode_error_count == 0
+
+
+def test_load_request_rows_skips_rows_with_corrupt_tool_call_arguments(tmp_path: Path) -> None:
+    """One logged row with invalid tool_call arguments must not kill the review."""
+    module = _load_prompt_cache_review_module()
+    jsonl_path = tmp_path / "requests.jsonl"
+    corrupt_arguments = '{"args": "curl \\\\"https://example.test?x=1%5C" | head"}'
+    corrupt_row = {
+        "timestamp": "2026-04-11T11:00:00-07:00",
+        "agent_name": "opus",
+        "model_id": "claude-opus-4-8",
+        "system_prompt": "S",
+        "messages": [
+            {
+                "role": "assistant",
+                "tool_calls": [{"id": "t1", "function": {"name": "run_shell_command", "arguments": corrupt_arguments}}],
+            },
+        ],
+        "message_count": 1,
+    }
+    healthy_row = {
+        "timestamp": "2026-04-11T11:00:01-07:00",
+        "agent_name": "opus",
+        "model_id": "claude-opus-4-8",
+        "system_prompt": "S",
+        "messages": [{"role": "user", "content": "hello"}],
+        "message_count": 1,
+    }
+    jsonl_path.write_text(
+        json.dumps(corrupt_row) + "\n" + json.dumps(healthy_row) + "\n",
+        encoding="utf-8",
+    )
+
+    rows, stats = module.load_request_rows(jsonl_path)
+
+    assert len(rows) == 1
+    assert rows[0].preview == "hello"
+    assert stats.unparseable_row_count == 1
     assert stats.decode_error_count == 0
 
 

--- a/tests/test_prompt_cache_review.py
+++ b/tests/test_prompt_cache_review.py
@@ -84,6 +84,8 @@ def test_load_request_rows_skips_rows_with_corrupt_tool_call_arguments(tmp_path:
     assert rows[0].preview == "hello"
     assert stats.unparseable_row_count == 1
     assert stats.decode_error_count == 0
+    assert len(stats.unparseable_row_errors) == 1
+    assert "JSONDecodeError" in stats.unparseable_row_errors[0]
 
 
 def test_build_session_reviews_detects_prefix_extension_with_two_appended_messages() -> None:

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 from mindroom.redaction import REDACTED, redact_sensitive_data
 
 
@@ -67,6 +69,30 @@ def test_redact_sensitive_data_redacts_oauth_callback_query_values_in_urls() -> 
         "url": "https://example.test/api/oauth/google/callback?code=***redacted***&state=***redacted***&keep=1",
         "query_params": {"code": REDACTED, "state": REDACTED, "keep": "1"},
     }
+
+
+def test_redact_url_in_escaped_shell_command_keeps_json_arguments_valid() -> None:
+    """URL redaction must not eat the backslash escaping the quote after the URL.
+
+    Logged tool-call arguments are JSON-encoded strings; absorbing the trailing
+    backslash of an escaped quote into the URL query re-encodes it to %5C and
+    leaves a bare quote behind, corrupting the inner JSON.
+    """
+    command = 'curl -s \\"https://example.test/repos/demo/pulls?state=open&sort=updated&per_page=10\\" | head'
+    arguments = json.dumps({"args": command})
+    payload = {
+        "messages": [
+            {"role": "assistant", "tool_calls": [{"function": {"name": "run_shell_command", "arguments": arguments}}]},
+        ],
+    }
+
+    redacted = redact_sensitive_data(payload)
+
+    redacted_arguments = redacted["messages"][0]["tool_calls"][0]["function"]["arguments"]
+    assert REDACTED in redacted_arguments
+    parsed = json.loads(redacted_arguments)
+    assert parsed["args"].startswith('curl -s \\"https://example.test/repos/demo/pulls?state=***redacted***')
+    assert '\\" | head' in parsed["args"]
 
 
 def test_redact_sensitive_data_redacts_bare_query_fragments_under_query_keys() -> None:


### PR DESCRIPTION
## Problem

The URL matcher in `redact_sensitive_text` (`https?://[^\s'\"<>]+`) does not stop at backslashes. In logged shell commands the URL is often wrapped in escaped quotes (`curl \"https://...?state=open&per_page=10\"`), so the match swallows the backslash that escapes the closing quote. `_redact_url` then round-trips the query through `parse_qsl`/`urlencode`, re-encoding that backslash to `%5C` and leaving a bare `"` behind. When this happens inside a JSON-encoded field (tool-call `arguments` in the request log), the field is no longer valid JSON.

Downstream, `prompt_cache_review.py` crashed on such rows because Agno's `format_messages` re-parses tool-call arguments with `json.loads`. Observed on real request logs: one shell command with a `state=` query parameter made the whole review unusable.

## Change

- `redaction.py`: URL matches no longer include trailing backslashes; they are always artifacts of the surrounding escaping (bash quoting or JSON string encoding), never URL content. Backslashes *inside* the match still round-trip safely (`%5C` substitution never splits an escape pair, since `"` and whitespace already terminate the match). Redaction coverage is unchanged, including `state`/`code` values behind bash-escaped `\&` separators.
- `prompt_cache_review.py`: rows whose logged payload cannot be rebuilt are skipped and counted (`Skipped N rows whose logged payload could not be rebuilt.`) instead of aborting the review, so pre-fix logs remain analyzable.

## Validation

- New regression tests: the escaped-curl case keeps tool-call `arguments` valid JSON while still redacting the `state` value; a corrupt logged row no longer kills `load_request_rows` and is counted while healthy rows load.
- Verified against the real log file that previously crashed the review: it now completes and reports the corrupted rows as skipped.
- Full redaction + review test suites and pre-commit pass.