### PR TITLE
Use OpenAI native tool search (defer_loading) for deferred tools on Codex models

### DIFF
--- a/docs/tools/dynamic-tools.md
+++ b/docs/tools/dynamic-tools.md
@@ -2,7 +2,7 @@
 
 Dynamic tools let an agent keep rarely used tools out of the provider-visible schema list until it needs them.
 The loading unit is one authored entry in the agent's `tools:` list.
-MindRoom performs the schema gating in its runtime, so the feature works across model providers.
+On providers with server-side tool search the gating happens inside the provider API; everywhere else MindRoom performs the schema gating in its runtime.
 
 ## Configuration
 
@@ -30,9 +30,17 @@ No flags means the tool is eager and appears in every request.
 `defer: true` hides the tool schema until the agent loads that authored tool for the current session.
 `defer: true, initial: true` loads the tool at session start and prevents unloading.
 
+## Native Server-Side Tool Search
+
+Claude models since Opus 4.5 / Sonnet 4.5 / Haiku 4.5 on the `anthropic` and `vertexai_claude` providers, and GPT models 5.4 or newer on the `codex` and `openai_codex` providers, use the provider's server-side tool search automatically.
+On this path every deferred tool ships in every request tagged `defer_loading: true` together with the provider's tool-search entry, so deferred schemas stay out of the model's rendered context until the model searches for them.
+Tool discovery never invalidates the prompt cache: Anthropic expands discovered tool references inline in the message stream, and OpenAI loads discovered tools at the end of the context window.
+The `dynamic_tools` manager, its prompt blocks, and session loaded-tool state are not used on this path; all deferred toolkits are attached at agent build, so discovered calls execute directly.
+`defer: true, initial: true` tools stay in the rendered schema list as plain non-deferred tools.
+
 ## Runtime Tools
 
-When an agent has at least one deferred tool and a stable session id, MindRoom injects the `dynamic_tools` manager.
+On providers without native tool search, when an agent has at least one deferred tool and a stable session id, MindRoom injects the `dynamic_tools` manager.
 The manager exposes `list_tools()`, `tool_search(query)`, `load_tool(tool_name)`, and `unload_tool(tool_name)`.
 Search is plain keyword and exact-name lookup only.
 A newly loaded tool becomes callable once it appears in the agent's available tools, never in the same parallel tool-call batch as `load_tool()`.
@@ -43,3 +51,4 @@ Team members and other embedded agents run without that continuation loop, so th
 
 Loaded state is keyed by the exact `(agent, session_id)` pair.
 Two agents in the same Matrix thread do not share loaded tools.
+Native tool-search sessions neither read nor write this state.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -2944,7 +2944,7 @@ Set `MINDROOM_NO_AUTO_INSTALL_TOOLS=1` to disable that behavior.
 
 Dynamic tools let an agent keep rarely used tools out of the provider-visible schema list until it needs them.
 The loading unit is one authored entry in the agent's `tools:` list.
-MindRoom performs the schema gating in its runtime, so the feature works across model providers.
+On providers with server-side tool search the gating happens inside the provider API; everywhere else MindRoom performs the schema gating in its runtime.
 
 ## Configuration
 
@@ -2972,9 +2972,17 @@ No flags means the tool is eager and appears in every request.
 `defer: true` hides the tool schema until the agent loads that authored tool for the current session.
 `defer: true, initial: true` loads the tool at session start and prevents unloading.
 
+## Native Server-Side Tool Search
+
+Claude models since Opus 4.5 / Sonnet 4.5 / Haiku 4.5 on the `anthropic` and `vertexai_claude` providers, and GPT models 5.4 or newer on the `codex` and `openai_codex` providers, use the provider's server-side tool search automatically.
+On this path every deferred tool ships in every request tagged `defer_loading: true` together with the provider's tool-search entry, so deferred schemas stay out of the model's rendered context until the model searches for them.
+Tool discovery never invalidates the prompt cache: Anthropic expands discovered tool references inline in the message stream, and OpenAI loads discovered tools at the end of the context window.
+The `dynamic_tools` manager, its prompt blocks, and session loaded-tool state are not used on this path; all deferred toolkits are attached at agent build, so discovered calls execute directly.
+`defer: true, initial: true` tools stay in the rendered schema list as plain non-deferred tools.
+
 ## Runtime Tools
 
-When an agent has at least one deferred tool and a stable session id, MindRoom injects the `dynamic_tools` manager.
+On providers without native tool search, when an agent has at least one deferred tool and a stable session id, MindRoom injects the `dynamic_tools` manager.
 The manager exposes `list_tools()`, `tool_search(query)`, `load_tool(tool_name)`, and `unload_tool(tool_name)`.
 Search is plain keyword and exact-name lookup only.
 A newly loaded tool becomes callable once it appears in the agent's available tools, never in the same parallel tool-call batch as `load_tool()`.
@@ -2985,6 +2993,7 @@ Team members and other embedded agents run without that continuation loop, so th
 
 Loaded state is keyed by the exact `(agent, session_id)` pair.
 Two agents in the same Matrix thread do not share loaded tools.
+Native tool-search sessions neither read nor write this state.
 
 # Execution & Coding
 

--- a/skills/mindroom-docs/references/page__tools__dynamic-tools__index.md
+++ b/skills/mindroom-docs/references/page__tools__dynamic-tools__index.md
@@ -2,7 +2,7 @@
 
 Dynamic tools let an agent keep rarely used tools out of the provider-visible schema list until it needs them.
 The loading unit is one authored entry in the agent's `tools:` list.
-MindRoom performs the schema gating in its runtime, so the feature works across model providers.
+On providers with server-side tool search the gating happens inside the provider API; everywhere else MindRoom performs the schema gating in its runtime.
 
 ## Configuration
 
@@ -30,9 +30,17 @@ No flags means the tool is eager and appears in every request.
 `defer: true` hides the tool schema until the agent loads that authored tool for the current session.
 `defer: true, initial: true` loads the tool at session start and prevents unloading.
 
+## Native Server-Side Tool Search
+
+Claude models since Opus 4.5 / Sonnet 4.5 / Haiku 4.5 on the `anthropic` and `vertexai_claude` providers, and GPT models 5.4 or newer on the `codex` and `openai_codex` providers, use the provider's server-side tool search automatically.
+On this path every deferred tool ships in every request tagged `defer_loading: true` together with the provider's tool-search entry, so deferred schemas stay out of the model's rendered context until the model searches for them.
+Tool discovery never invalidates the prompt cache: Anthropic expands discovered tool references inline in the message stream, and OpenAI loads discovered tools at the end of the context window.
+The `dynamic_tools` manager, its prompt blocks, and session loaded-tool state are not used on this path; all deferred toolkits are attached at agent build, so discovered calls execute directly.
+`defer: true, initial: true` tools stay in the rendered schema list as plain non-deferred tools.
+
 ## Runtime Tools
 
-When an agent has at least one deferred tool and a stable session id, MindRoom injects the `dynamic_tools` manager.
+On providers without native tool search, when an agent has at least one deferred tool and a stable session id, MindRoom injects the `dynamic_tools` manager.
 The manager exposes `list_tools()`, `tool_search(query)`, `load_tool(tool_name)`, and `unload_tool(tool_name)`.
 Search is plain keyword and exact-name lookup only.
 A newly loaded tool becomes callable once it appears in the agent's available tools, never in the same parallel tool-call batch as `load_tool()`.
@@ -43,3 +51,4 @@ Team members and other embedded agents run without that continuation loop, so th
 
 Loaded state is keyed by the exact `(agent, session_id)` pair.
 Two agents in the same Matrix thread do not share loaded tools.
+Native tool-search sessions neither read nor write this state.

--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -26,6 +26,7 @@ from mindroom.credentials import get_runtime_credentials_manager
 from mindroom.entity_resolution import entity_identity_registry
 from mindroom.hooks import HookRegistry
 from mindroom.logging_config import get_logger
+from mindroom.openai_tool_search import install_openai_deferred_tool_search, openai_native_tool_search_supported
 from mindroom.prompt_templates import build_agent_identity_context, render_prompt_template
 from mindroom.runtime_resolution import (
     ResolvedAgentRuntime,
@@ -131,7 +132,8 @@ class _AgentToolAssembly:
     hidden_toolkits: frozenset[str]
     selected_dynamic_tools: tuple[str, ...]
     # Wire-level function names to send with defer_loading on the native
-    # Anthropic tool-search path; empty on the homegrown dynamic-tools path.
+    # server-side tool-search path (Anthropic and OpenAI Responses); empty on
+    # the homegrown dynamic-tools path.
     deferred_wire_tool_names: frozenset[str]
 
 
@@ -1106,7 +1108,7 @@ def _resolve_agent_dynamic_tool_selection(
     native_deferred_tools: bool,
 ) -> VisibleToolSurface:
     if native_deferred_tools:
-        # Anthropic server-side tool search: attach every authored deferred
+        # Native server-side tool search: attach every authored deferred
         # tool so discovered calls execute, skip the dynamic-tools manager,
         # and never touch session loaded-tool state.
         return visible_tool_surface(
@@ -1422,7 +1424,7 @@ def _build_agent_instructions(
     if skills and skills.get_skill_names():
         instructions.append(config.get_prompt("SKILLS_TOOL_USAGE_PROMPT"))
 
-    # Anthropic's server-side tool search replaces the load_tool catalog and
+    # Native server-side tool search replaces the load_tool catalog and
     # loaded-state prompt blocks, so the native path emits neither.
     enable_dynamic_tools_manager = session_id is not None and not native_deferred_tools
     dynamic_tooling_block = None
@@ -1611,9 +1613,9 @@ def create_agent(
     # Gate on this agent's resolved runtime model (thread overrides and team
     # members resolve per agent), not on any surrounding team's model.
     runtime_model_config = config.models.get(active_model_name or agent_config.model or "default")
-    native_deferred_tools = runtime_model_config is not None and native_tool_search_supported(
-        runtime_model_config.provider,
-        runtime_model_config.id,
+    native_deferred_tools = runtime_model_config is not None and (
+        native_tool_search_supported(runtime_model_config.provider, runtime_model_config.id)
+        or openai_native_tool_search_supported(runtime_model_config.provider, runtime_model_config.id)
     )
 
     tool_assembly = _assemble_agent_toolkits(
@@ -1662,7 +1664,9 @@ def create_agent(
     # Create agent with defaults applied
     model = _load_agent_model_instance(config, runtime_paths, role_context.model_name, execution_identity)
     if tool_assembly.deferred_wire_tool_names:
+        # Each installer no-ops on the other provider family's model class.
         install_claude_deferred_tool_search(model, deferred_tool_names=tool_assembly.deferred_wire_tool_names)
+        install_openai_deferred_tool_search(model, deferred_tool_names=tool_assembly.deferred_wire_tool_names)
     logger.info(
         "create_agent",
         agent=agent_name,

--- a/src/mindroom/codex_model.py
+++ b/src/mindroom/codex_model.py
@@ -16,14 +16,23 @@ from agno.models.openai import OpenAIResponses
 from agno.models.response import ModelResponse
 from agno.utils.http import get_default_async_client, get_default_sync_client
 from openai import AsyncOpenAI, OpenAI
+from openai.types.responses import ResponseOutputItemDoneEvent
 
 from mindroom.file_locks import advisory_file_lock
 from mindroom.model_defaults import CODEX_GPT
+from mindroom.openai_tool_search import (
+    formatted_input_with_tool_search_items,
+    model_deferred_tool_names,
+    record_tool_search_items,
+    request_params_with_deferred_tool_search,
+)
 from mindroom.prompts import CODEX_DEFAULT_INSTRUCTIONS
 
 if TYPE_CHECKING:
     from agno.models.message import Message
     from agno.run.agent import RunOutput
+    from agno.tools.function import Function
+    from openai.types.responses import Response, ResponseStreamEvent
     from pydantic import BaseModel
 
     from mindroom.tool_system.worker_routing import ToolExecutionIdentity
@@ -309,6 +318,7 @@ class CodexResponses(OpenAIResponses):
             tools=tools,
             tool_choice=tool_choice,
         )
+        request_params = request_params_with_deferred_tool_search(request_params, model_deferred_tool_names(self))
         request_params.setdefault("instructions", self._instructions_text())
         prompt_cache_key = self._prompt_cache_key()
         if prompt_cache_key:
@@ -326,6 +336,34 @@ class CodexResponses(OpenAIResponses):
         for param_name in _CODEX_UNSUPPORTED_REQUEST_PARAMS:
             request_params.pop(param_name, None)
         return request_params
+
+    def _format_messages(
+        self,
+        messages: list[Message],
+        compress_tool_results: bool = False,
+        tools: list[Function | dict[str, Any]] | None = None,
+    ) -> list[Any]:
+        """Reinsert captured tool_search items that Agno's formatter drops from history."""
+        formatted_input = super()._format_messages(messages, compress_tool_results, tools=tools)
+        return formatted_input_with_tool_search_items(messages, formatted_input)
+
+    def _parse_provider_response(self, response: Response, **kwargs: object) -> ModelResponse:
+        """Capture tool_search output items that Agno's response parser drops."""
+        model_response = super()._parse_provider_response(response, **kwargs)
+        record_tool_search_items(model_response, response.output)
+        return model_response
+
+    def _parse_provider_response_delta(
+        self,
+        stream_event: ResponseStreamEvent,
+        assistant_message: Message,
+        tool_use: dict[str, Any],
+    ) -> tuple[ModelResponse, dict[str, Any]]:
+        """Capture streamed tool_search output items that Agno's delta parser drops."""
+        model_response, tool_use = super()._parse_provider_response_delta(stream_event, assistant_message, tool_use)
+        if isinstance(stream_event, ResponseOutputItemDoneEvent):
+            record_tool_search_items(model_response, [stream_event.item])
+        return model_response, tool_use
 
     def invoke(
         self,

--- a/src/mindroom/model_defaults.py
+++ b/src/mindroom/model_defaults.py
@@ -43,6 +43,7 @@ __all__ = (
     "OPENAI_IMAGE",
     "OPENAI_REALTIME",
     "OPENAI_REALTIME_TRANSCRIPTION",
+    "OPENAI_TOOL_SEARCH_MIN_GPT_VERSION",
     "OPENAI_TRANSCRIPTION",
     "OPENAI_TTS",
     "SAAS_MODEL_PRESETS",
@@ -92,6 +93,10 @@ _AWS_BEDROCK_CLAUDE_SONNET = "global.anthropic.claude-sonnet-5"
 _AWS_BEDROCK_CLAUDE_HAIKU = "global.anthropic.claude-haiku-4-5"
 CODEX_GPT = "gpt-5.5"
 _OPENAI_GPT = "gpt-5.5"
+# OpenAI's Responses-API tool_search tool requires gpt-5.4 or newer; gating
+# parses the gpt-N.M version from the model id so new releases take the
+# native tool-search path without a list update.
+OPENAI_TOOL_SEARCH_MIN_GPT_VERSION = (5, 4)
 OPENAI_GPT_MINI = "gpt-5.4-mini"
 OPENAI_GPT_NANO = "gpt-5.4-nano"
 AZURE_OPENAI_DEFAULT_DEPLOYMENT = "your-azure-openai-deployment"

--- a/src/mindroom/openai_tool_search.py
+++ b/src/mindroom/openai_tool_search.py
@@ -147,31 +147,34 @@ def formatted_input_with_tool_search_items(
 
     Each assistant message's items are inserted once, immediately ahead of the
     message's replayed function calls (matched by call id) or its replayed
-    content — the position they held in the original response output. Anchors
-    are searched left to right past earlier insertions, and a message whose
-    anchor is missing (for example rewritten foreign history) is skipped, so
-    items replay verbatim, in order, at most once. The input list is never
-    mutated.
+    content — the position they held in the original response output. The
+    cursor advances past every anchored assistant message, so an earlier turn
+    with identical content can never claim a later message's anchor. A message
+    whose anchor is missing (for example rewritten foreign history) is
+    skipped, so items replay verbatim, in order, at most once. The input list
+    is never mutated.
     """
     prepared_input = formatted_input
     cursor = 0
     for message in messages:
-        items = _message_tool_search_items(message)
-        if not items:
+        if message.role != "assistant":
             continue
         anchor = _anchor_index(prepared_input, cursor, message)
         if anchor is None:
             continue
-        if prepared_input is formatted_input:
-            prepared_input = list(formatted_input)
-        prepared_input[anchor:anchor] = [dict(item) for item in items]
-        cursor = anchor + len(items) + 1
+        items = _message_tool_search_items(message)
+        if items:
+            if prepared_input is formatted_input:
+                prepared_input = list(formatted_input)
+            prepared_input[anchor:anchor] = [dict(item) for item in items]
+            anchor += len(items)
+        cursor = anchor + 1
     return prepared_input
 
 
 def _message_tool_search_items(message: Message) -> list[dict[str, Any]]:
     """Return the tool_search items captured on one assistant message."""
-    if message.role != "assistant" or not isinstance(message.provider_data, dict):
+    if not isinstance(message.provider_data, dict):
         return []
     items = message.provider_data.get(_TOOL_SEARCH_ITEMS_KEY)
     if not isinstance(items, list):

--- a/src/mindroom/openai_tool_search.py
+++ b/src/mindroom/openai_tool_search.py
@@ -42,7 +42,9 @@ _TOOL_SEARCH_ITEM_TYPES = frozenset({"tool_search_call", "tool_search_output"})
 _NATIVE_TOOL_SEARCH_PROVIDERS = frozenset({"codex", "openai_codex"})
 # LLM-plugin-style `openai-codex/gpt-N.M` ids match the same way as bare or
 # `-codex`-suffixed ids, so no prefix normalization is needed before the search.
-_GPT_VERSION_PATTERN = re.compile(r"gpt-(\d+)\.(\d+)")
+# A missing minor version counts as .0, so a major-only future release gates
+# native while `gpt-5` stays homegrown.
+_GPT_VERSION_PATTERN = re.compile(r"gpt-(\d+)(?:\.(\d+))?")
 
 
 def openai_native_tool_search_supported(provider: str, model_id: str) -> bool:
@@ -59,7 +61,7 @@ def openai_native_tool_search_supported(provider: str, model_id: str) -> bool:
     version_match = _GPT_VERSION_PATTERN.search(model_id)
     if version_match is None:
         return False
-    version = (int(version_match.group(1)), int(version_match.group(2)))
+    version = (int(version_match.group(1)), int(version_match.group(2) or 0))
     return version >= OPENAI_TOOL_SEARCH_MIN_GPT_VERSION
 
 

--- a/src/mindroom/openai_tool_search.py
+++ b/src/mindroom/openai_tool_search.py
@@ -1,0 +1,205 @@
+"""OpenAI server-side tool search (defer_loading) for MindRoom deferred tools.
+
+On the Codex provider (OpenAI Responses API), authored ``defer: true`` tools
+are handled by OpenAI's server-side tool search instead of MindRoom's
+homegrown dynamic-tool loading. Every request sends each deferred tool's full
+definition with ``defer_loading: true`` plus a hosted ``tool_search`` entry,
+so deferred schemas stay out of the model's rendered context up front.
+Discovered tools load at the END of the context window (the opposite
+mechanism from Anthropic's inline tool_reference expansion, with the same
+effect), so tool discovery never invalidates the cached prompt prefix.
+
+:class:`~mindroom.codex_model.CodexResponses` owns the wire seams and calls
+into this module: :func:`request_params_with_deferred_tool_search` tags the
+registered tools and injects the search entry with a deterministic order
+(search tool, then non-deferred tools, then deferred sorted by name) so the
+cached prefix stays byte-stable; :func:`record_tool_search_items` captures the
+``tool_search_call`` / ``tool_search_output`` output items that Agno's parser
+drops into the assistant message's ``provider_data``; and
+:func:`formatted_input_with_tool_search_items` replays the captured items
+verbatim, in order, exactly once when history is resent (the Responses input
+item union accepts both types).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any, cast
+
+from agno.models.openai import OpenAIResponses
+
+from mindroom.model_defaults import OPENAI_TOOL_SEARCH_MIN_GPT_VERSION
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+    from agno.models.message import Message
+    from agno.models.response import ModelResponse
+
+_DEFERRED_TOOL_NAMES_ATTR = "_mindroom_openai_deferred_tool_names"
+_TOOL_SEARCH_ITEMS_KEY = "tool_search_items"
+_TOOL_SEARCH_ITEM_TYPES = frozenset({"tool_search_call", "tool_search_output"})
+_NATIVE_TOOL_SEARCH_PROVIDERS = frozenset({"codex", "openai_codex"})
+# LLM-plugin-style `openai-codex/gpt-N.M` ids match the same way as bare or
+# `-codex`-suffixed ids, so no prefix normalization is needed before the search.
+_GPT_VERSION_PATTERN = re.compile(r"gpt-(\d+)\.(\d+)")
+
+
+def openai_native_tool_search_supported(provider: str, model_id: str) -> bool:
+    """Return whether one authored provider/model pair supports server-side tool search.
+
+    Tool search is a Responses-API feature on gpt-5.4 and later, so the gate
+    covers the Codex provider only (the plain ``openai`` provider speaks Chat
+    Completions) and parses the ``gpt-N.M`` version from the model id instead
+    of keeping an allowlist that goes stale with each release.
+    """
+    canonical_provider = provider.strip().lower().replace("-", "_")
+    if canonical_provider not in _NATIVE_TOOL_SEARCH_PROVIDERS:
+        return False
+    version_match = _GPT_VERSION_PATTERN.search(model_id)
+    if version_match is None:
+        return False
+    version = (int(version_match.group(1)), int(version_match.group(2)))
+    return version >= OPENAI_TOOL_SEARCH_MIN_GPT_VERSION
+
+
+def install_openai_deferred_tool_search(model: object, *, deferred_tool_names: frozenset[str]) -> None:
+    """Register wire tool names for OpenAI server-side tool search on one model.
+
+    Every request built by :class:`~mindroom.codex_model.CodexResponses` sends
+    the named tools with ``defer_loading: true`` plus the hosted
+    ``tool_search`` entry, so their schemas stay out of the rendered context
+    and tool discovery never invalidates the prompt cache. No-op for
+    non-Responses models and empty name sets.
+    """
+    if not isinstance(model, OpenAIResponses) or not deferred_tool_names:
+        return
+    vars(model)[_DEFERRED_TOOL_NAMES_ATTR] = frozenset(deferred_tool_names)
+
+
+def model_deferred_tool_names(model: OpenAIResponses) -> frozenset[str]:
+    """Return the wire tool names registered for deferred loading on one model."""
+    deferred_tool_names = vars(model).get(_DEFERRED_TOOL_NAMES_ATTR)
+    return deferred_tool_names if isinstance(deferred_tool_names, frozenset) else frozenset()
+
+
+def request_params_with_deferred_tool_search(
+    request_params: dict[str, Any],
+    deferred_tool_names: frozenset[str],
+) -> dict[str, Any]:
+    """Tag deferred function tools with defer_loading and inject the search tool.
+
+    Every deferred tool's full definition still ships on every request; the
+    API keeps deferred schemas out of the rendered context and loads
+    discovered tools at the end of the context window. The tools array is
+    ordered deterministically (search tool, then the remaining non-deferred
+    tools, then deferred tools sorted by name) so the cached prefix stays
+    byte-stable across requests. The search tool is injected only when at
+    least one deferred tool is present in the request.
+    """
+    tools = request_params.get("tools")
+    if not deferred_tool_names or not isinstance(tools, list):
+        return request_params
+    non_deferred_tools: list[Any] = []
+    deferred_tools: list[dict[str, Any]] = []
+    for tool in tools:
+        tool_dict = _as_dict(tool)
+        if (
+            tool_dict is not None
+            and tool_dict.get("type") == "function"
+            and tool_dict.get("name") in deferred_tool_names
+        ):
+            deferred_tools.append({**tool_dict, "defer_loading": True})
+        else:
+            non_deferred_tools.append(tool)
+    if not deferred_tools:
+        return request_params
+    deferred_tools.sort(key=lambda tool: str(tool.get("name")))
+    prepared_params = dict(request_params)
+    prepared_params["tools"] = [{"type": "tool_search"}, *non_deferred_tools, *deferred_tools]
+    return prepared_params
+
+
+def record_tool_search_items(model_response: ModelResponse, output_items: Iterable[Any]) -> None:
+    """Store tool_search output items on one response's provider data.
+
+    Agno's Responses parser only handles message/function_call/reasoning
+    items, so the search items would otherwise be dropped and could never be
+    replayed. Both the non-streaming output list and streamed
+    ``response.output_item.done`` items land here; Agno's provider-data merge
+    extends lists, so streamed items accumulate in arrival order.
+    """
+    items = [item.model_dump(exclude_none=True) for item in output_items if item.type in _TOOL_SEARCH_ITEM_TYPES]
+    if not items:
+        return
+    if model_response.provider_data is None:
+        model_response.provider_data = {}
+    model_response.provider_data.setdefault(_TOOL_SEARCH_ITEMS_KEY, []).extend(items)
+
+
+def formatted_input_with_tool_search_items(
+    messages: Sequence[Message],
+    formatted_input: list[Any],
+) -> list[Any]:
+    """Reinsert captured tool_search items into the formatted request input.
+
+    Each assistant message's items are inserted once, immediately ahead of the
+    message's replayed function calls (matched by call id) or its replayed
+    content — the position they held in the original response output. Anchors
+    are searched left to right past earlier insertions, and a message whose
+    anchor is missing (for example rewritten foreign history) is skipped, so
+    items replay verbatim, in order, at most once. The input list is never
+    mutated.
+    """
+    prepared_input = formatted_input
+    cursor = 0
+    for message in messages:
+        items = _message_tool_search_items(message)
+        if not items:
+            continue
+        anchor = _anchor_index(prepared_input, cursor, message)
+        if anchor is None:
+            continue
+        if prepared_input is formatted_input:
+            prepared_input = list(formatted_input)
+        prepared_input[anchor:anchor] = [dict(item) for item in items]
+        cursor = anchor + len(items) + 1
+    return prepared_input
+
+
+def _message_tool_search_items(message: Message) -> list[dict[str, Any]]:
+    """Return the tool_search items captured on one assistant message."""
+    if message.role != "assistant" or not isinstance(message.provider_data, dict):
+        return []
+    items = message.provider_data.get(_TOOL_SEARCH_ITEMS_KEY)
+    if not isinstance(items, list):
+        return []
+    return [item for item in items if isinstance(item, dict)]
+
+
+def _anchor_index(formatted_input: list[Any], start: int, message: Message) -> int | None:
+    """Return the formatted-input index where one message's items belong."""
+    if message.tool_calls:
+        anchor_ids = {tool_call.get("id") for tool_call in message.tool_calls}
+        anchor_ids |= {tool_call.get("call_id") for tool_call in message.tool_calls}
+        anchor_ids.discard(None)
+        for index in range(start, len(formatted_input)):
+            item = _as_dict(formatted_input[index])
+            if (
+                item is not None
+                and item.get("type") == "function_call"
+                and (item.get("id") in anchor_ids or item.get("call_id") in anchor_ids)
+            ):
+                return index
+        return None
+    content = message.content if message.content is not None else ""
+    for index in range(start, len(formatted_input)):
+        item = _as_dict(formatted_input[index])
+        if item is not None and item.get("role") == "assistant" and item.get("content") == content:
+            return index
+    return None
+
+
+def _as_dict(value: object) -> dict[str, Any] | None:
+    """Return the value as a string-keyed dict when possible."""
+    return cast("dict[str, Any]", value) if isinstance(value, dict) else None

--- a/tach.toml
+++ b/tach.toml
@@ -131,6 +131,7 @@ depends_on = [
     "mindroom.logging_config",
     "mindroom.matrix.identity",
     "mindroom.model_loading",
+    "mindroom.openai_tool_search",
     "mindroom.prompt_templates",
     "mindroom.runtime_resolution",
     "mindroom.timing",

--- a/tests/test_codex_model.py
+++ b/tests/test_codex_model.py
@@ -631,3 +631,30 @@ def test_claude_server_tool_history_replays_to_codex_without_injection() -> None
     formatted_input = CodexResponses(id="gpt-5.5")._format_messages([assistant])
 
     assert formatted_input == [{"role": "assistant", "content": "Claude searched here."}]
+
+
+def test_codex_tool_search_replay_skips_identical_earlier_assistant_content() -> None:
+    """An earlier identical-content assistant turn cannot claim a later message's anchor."""
+    model = CodexResponses(id="gpt-5.5")
+    later = Message(
+        role="assistant",
+        content="same text",
+        provider_data={"tool_search_items": [dict(_TOOL_SEARCH_CALL_ITEM)]},
+    )
+
+    formatted_input = model._format_messages(
+        [
+            Message(role="user", content="q1"),
+            Message(role="assistant", content="same text"),
+            Message(role="user", content="q2"),
+            later,
+        ],
+    )
+
+    assert formatted_input == [
+        {"role": "user", "content": "q1"},
+        {"role": "assistant", "content": "same text"},
+        {"role": "user", "content": "q2"},
+        dict(_TOOL_SEARCH_CALL_ITEM),
+        {"role": "assistant", "content": "same text"},
+    ]

--- a/tests/test_codex_model.py
+++ b/tests/test_codex_model.py
@@ -444,8 +444,11 @@ class _FakeCodexClient:
         ("openai_codex", "openai-codex/gpt-5.5", True),
         ("codex", "gpt-5.5-codex", True),
         ("codex", "gpt-5.4-mini", True),
-        # Unreleased GPT versions default to the native path (version gating).
+        # Unreleased GPT versions default to the native path (version gating),
+        # including major-only spellings, which parse as .0.
         ("codex", "gpt-6.0", True),
+        ("codex", "gpt-6", True),
+        ("codex", "gpt-6-codex", True),
         ("codex", "gpt-5-codex", False),
         ("codex", "gpt-4.1", False),
         ("codex", "codex-mini-latest", False),

--- a/tests/test_codex_model.py
+++ b/tests/test_codex_model.py
@@ -12,9 +12,14 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
+import pytest
 from agno.metrics import MessageMetrics
+from agno.models.anthropic import Claude
 from agno.models.message import Message
+from agno.models.openai import OpenAIChat
 from agno.models.response import ModelResponse
+from agno.utils.models.claude import format_messages as claude_format_messages
+from openai.types.responses import Response, ResponseOutputItemDoneEvent, ResponseTextDeltaEvent
 
 from mindroom import codex_model
 from mindroom.codex_model import _CODEX_BASE_URL, CodexResponses, _borrow_codex_key
@@ -22,12 +27,15 @@ from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
 from mindroom.constants import resolve_runtime_paths
 from mindroom.model_loading import get_model_instance
+from mindroom.openai_tool_search import (
+    _DEFERRED_TOOL_NAMES_ATTR,
+    install_openai_deferred_tool_search,
+    openai_native_tool_search_supported,
+)
 from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
-
-    import pytest
 
 
 def _jwt_with_exp(exp: int) -> str:
@@ -381,3 +389,242 @@ def test_get_model_instance_supports_codex_provider(tmp_path: Path) -> None:
     assert model.store is False
     assert model.get_request_params()["instructions"] == "Custom Codex default instructions."
     assert str(model.base_url) == _CODEX_BASE_URL
+
+
+_TOOL_SEARCH_CALL_ITEM = {
+    "id": "ts_1",
+    "type": "tool_search_call",
+    "call_id": "tsc_1",
+    "arguments": {"queries": ["weather"]},
+    "execution": "server",
+    "status": "completed",
+}
+_TOOL_SEARCH_OUTPUT_ITEM = {
+    "id": "tso_1",
+    "type": "tool_search_output",
+    "call_id": "tsc_1",
+    "execution": "server",
+    "status": "completed",
+    "tools": [{"type": "function", "name": "get_weather", "parameters": {"type": "object"}}],
+}
+
+
+def _agno_tool(name: str) -> dict[str, object]:
+    return {
+        "type": "function",
+        "function": {"name": name, "description": f"{name} description", "parameters": {"type": "object"}},
+    }
+
+
+def _output_item_done_event(item: dict[str, object], index: int) -> ResponseOutputItemDoneEvent:
+    return ResponseOutputItemDoneEvent.model_validate(
+        {"type": "response.output_item.done", "item": item, "output_index": index, "sequence_number": index},
+    )
+
+
+class _FakeResponsesAPI:
+    def __init__(self, event_batches: list[list[object]]) -> None:
+        self._event_batches = iter(event_batches)
+        self.captured_kwargs: list[dict[str, object]] = []
+
+    def create(self, **kwargs: object) -> Iterator[object]:
+        self.captured_kwargs.append(kwargs)
+        return iter(next(self._event_batches))
+
+
+class _FakeCodexClient:
+    def __init__(self, event_batches: list[list[object]]) -> None:
+        self.responses = _FakeResponsesAPI(event_batches)
+
+
+@pytest.mark.parametrize(
+    ("provider", "model_id", "expected"),
+    [
+        ("codex", "gpt-5.5", True),
+        ("openai_codex", "openai-codex/gpt-5.5", True),
+        ("codex", "gpt-5.5-codex", True),
+        ("codex", "gpt-5.4-mini", True),
+        # Unreleased GPT versions default to the native path (version gating).
+        ("codex", "gpt-6.0", True),
+        ("codex", "gpt-5-codex", False),
+        ("codex", "gpt-4.1", False),
+        ("codex", "codex-mini-latest", False),
+        # The plain openai provider speaks Chat Completions; tool search is Responses-only.
+        ("openai", "gpt-5.5", False),
+        ("anthropic", "claude-opus-4-8", False),
+    ],
+)
+def test_openai_native_tool_search_supported_gating(provider: str, model_id: str, *, expected: bool) -> None:
+    """Codex-family providers qualify when the model id parses to gpt-5.4 or newer."""
+    assert openai_native_tool_search_supported(provider, model_id) is expected
+
+
+def test_install_openai_deferred_tool_search_ignores_non_responses_models_and_empty_sets() -> None:
+    """The installer is a no-op for non-Responses models and empty name sets."""
+    claude = Claude(id="claude-opus-4-8", api_key="test-key")
+    install_openai_deferred_tool_search(claude, deferred_tool_names=frozenset({"alpha_tool"}))
+    assert _DEFERRED_TOOL_NAMES_ATTR not in vars(claude)
+
+    codex = CodexResponses(id="gpt-5.5")
+    install_openai_deferred_tool_search(codex, deferred_tool_names=frozenset())
+    assert _DEFERRED_TOOL_NAMES_ATTR not in vars(codex)
+
+
+def test_codex_deferred_tool_search_tags_tools_and_injects_search_tool() -> None:
+    """Deferred tools ship tagged and name-sorted after the search tool and non-deferred tools."""
+    model = CodexResponses(id="gpt-5.5")
+    install_openai_deferred_tool_search(model, deferred_tool_names=frozenset({"zeta_tool", "alpha_tool"}))
+
+    request_params = model.get_request_params(
+        tools=[_agno_tool("always_tool"), _agno_tool("zeta_tool"), _agno_tool("alpha_tool")],
+    )
+
+    wire_tools = request_params["tools"]
+    assert wire_tools[0] == {"type": "tool_search"}
+    assert [tool.get("name") for tool in wire_tools] == [None, "always_tool", "alpha_tool", "zeta_tool"]
+    assert "defer_loading" not in wire_tools[1]
+    for deferred_tool in wire_tools[2:]:
+        assert deferred_tool["defer_loading"] is True
+
+
+def test_codex_deferred_tool_search_leaves_requests_without_matching_tools_unchanged() -> None:
+    """The search tool is injected only when a deferred tool is present in the request."""
+    model = CodexResponses(id="gpt-5.5")
+    install_openai_deferred_tool_search(model, deferred_tool_names=frozenset({"other_tool"}))
+
+    request_params = model.get_request_params(tools=[_agno_tool("always_tool")])
+
+    assert [tool["name"] for tool in request_params["tools"]] == ["always_tool"]
+
+
+def test_codex_tool_search_items_round_trip_through_streaming_history() -> None:
+    """tool_search_call and tool_search_output replay verbatim, in order, exactly once."""
+    text_event = ResponseTextDeltaEvent.model_validate(
+        {
+            "type": "response.output_text.delta",
+            "delta": "I found a weather tool.",
+            "content_index": 0,
+            "item_id": "msg_1",
+            "output_index": 2,
+            "sequence_number": 2,
+            "logprobs": [],
+        },
+    )
+    first_batch = [
+        _output_item_done_event(_TOOL_SEARCH_CALL_ITEM, 0),
+        _output_item_done_event(_TOOL_SEARCH_OUTPUT_ITEM, 1),
+        text_event,
+    ]
+    client = _FakeCodexClient([first_batch, []])
+    model = CodexResponses(id="gpt-5.5")
+    vars(model)["get_client"] = lambda: client
+
+    messages = [Message(role="user", content="What is the weather?")]
+    model.response(messages=messages, compression_manager=None)
+    model.response(messages=messages, compression_manager=None)
+
+    expected_items = [
+        _output_item_done_event(_TOOL_SEARCH_CALL_ITEM, 0).item.model_dump(exclude_none=True),
+        _output_item_done_event(_TOOL_SEARCH_OUTPUT_ITEM, 1).item.model_dump(exclude_none=True),
+    ]
+    assert messages[1].provider_data == {"tool_search_items": expected_items}
+    assert client.responses.captured_kwargs[1]["input"] == [
+        {"role": "user", "content": "What is the weather?"},
+        *expected_items,
+        {"role": "assistant", "content": "I found a weather tool."},
+    ]
+
+
+def test_codex_tool_search_items_replay_ahead_of_the_discovered_function_call() -> None:
+    """Captured items are reinserted immediately ahead of the message's replayed function calls."""
+    model = CodexResponses(id="gpt-5.5")
+    assistant = Message(
+        role="assistant",
+        content="",
+        tool_calls=[
+            {
+                "id": "fc_1",
+                "call_id": "call_1",
+                "type": "function",
+                "function": {"name": "get_weather", "arguments": "{}"},
+            },
+        ],
+        provider_data={"tool_search_items": [dict(_TOOL_SEARCH_CALL_ITEM), dict(_TOOL_SEARCH_OUTPUT_ITEM)]},
+    )
+    tool_result = Message(role="tool", content="sunny", tool_call_id="fc_1")
+
+    formatted_input = model._format_messages([Message(role="user", content="weather?"), assistant, tool_result])
+
+    assert formatted_input == [
+        {"role": "user", "content": "weather?"},
+        dict(_TOOL_SEARCH_CALL_ITEM),
+        dict(_TOOL_SEARCH_OUTPUT_ITEM),
+        {
+            "type": "function_call",
+            "id": "fc_1",
+            "call_id": "call_1",
+            "name": "get_weather",
+            "arguments": "{}",
+            "status": "completed",
+        },
+        {"type": "function_call_output", "call_id": "call_1", "output": "sunny"},
+    ]
+
+
+def test_codex_parse_provider_response_captures_tool_search_items() -> None:
+    """The non-streaming Response parse stores the search items Agno drops."""
+    model = CodexResponses(id="gpt-5.5")
+    response = Response.model_validate(
+        {
+            "id": "resp_1",
+            "created_at": 1,
+            "model": "gpt-5.5",
+            "object": "response",
+            "output": [dict(_TOOL_SEARCH_CALL_ITEM), dict(_TOOL_SEARCH_OUTPUT_ITEM)],
+            "parallel_tool_calls": True,
+            "tool_choice": "auto",
+            "tools": [],
+            "error": None,
+            "incomplete_details": None,
+            "instructions": None,
+            "metadata": None,
+            "temperature": None,
+            "top_p": None,
+        },
+    )
+
+    model_response = model._parse_provider_response(response)
+
+    assert model_response.provider_data["tool_search_items"] == [
+        response.output[0].model_dump(exclude_none=True),
+        response.output[1].model_dump(exclude_none=True),
+    ]
+
+
+def test_tool_search_items_replay_to_non_openai_provider_without_crashing() -> None:
+    """History stored on the native path must stay replayable after a `!model` provider switch."""
+    assistant = Message(
+        role="assistant",
+        content="I found a weather tool.",
+        provider_data={"tool_search_items": [dict(_TOOL_SEARCH_CALL_ITEM), dict(_TOOL_SEARCH_OUTPUT_ITEM)]},
+    )
+
+    chat_wire = OpenAIChat(id="gpt-5.5", api_key="test-key")._format_message(assistant)
+    assert chat_wire["role"] == "assistant"
+    assert chat_wire["content"] == "I found a weather tool."
+
+    claude_wire, _system = claude_format_messages([assistant])
+    assert claude_wire[0]["role"] == "assistant"
+
+
+def test_claude_server_tool_history_replays_to_codex_without_injection() -> None:
+    """Anthropic-native server tool blocks are ignored when a thread switches to Codex."""
+    assistant = Message(
+        role="assistant",
+        content="Claude searched here.",
+        provider_data={"server_tool_blocks": [{"type": "server_tool_use", "id": "srv_1"}]},
+    )
+
+    formatted_input = CodexResponses(id="gpt-5.5")._format_messages([assistant])
+
+    assert formatted_input == [{"role": "assistant", "content": "Claude searched here."}]

--- a/tests/test_dynamic_toolkits.py
+++ b/tests/test_dynamic_toolkits.py
@@ -22,6 +22,7 @@ from mindroom.config.models import EffectiveToolConfig, ToolConfigEntry
 from mindroom.constants import RuntimePaths, resolve_runtime_paths
 from mindroom.custom_tools.dynamic_tools import DynamicToolsToolkit
 from mindroom.mcp.toolkit import bind_mcp_server_manager
+from mindroom.openai_tool_search import _DEFERRED_TOOL_NAMES_ATTR as _OPENAI_DEFERRED_TOOL_NAMES_ATTR
 from mindroom.response_runner import _agent_has_matrix_messaging_tool
 from mindroom.tool_system import dynamic_toolkits as dynamic_toolkits_module
 from mindroom.tool_system.dynamic_toolkits import (
@@ -837,15 +838,44 @@ def test_native_tool_search_attaches_deferred_toolkits_and_skips_homegrown_machi
     assert ("code", "thread-a") not in dynamic_toolkits_module._loaded_tools
 
 
+def test_codex_native_tool_search_attaches_deferred_toolkits_and_skips_homegrown_machinery(tmp_path: Path) -> None:
+    """OpenAI-native tool search attaches all deferred toolkits and drops the manager machinery."""
+    raw = _base_config_data()
+    raw["models"]["codex_gpt"] = {"provider": "codex", "id": "gpt-5.5"}  # type: ignore[index]
+    raw["agents"]["code"]["model"] = "codex_gpt"  # type: ignore[index]
+    raw["agents"]["code"]["tools"] = [  # type: ignore[index]
+        {"sleep": {"defer": True}},
+        {"calculator": {"defer": True, "initial": True}},
+    ]
+    config = _validated_config(tmp_path, raw)
+
+    agent = create_agent("code", config, _runtime_paths(tmp_path), execution_identity=None, session_id="thread-a")
+
+    function_names = {name for toolkit in agent.tools for name in toolkit.get_functions()}
+    assert "sleep" in function_names
+    assert "add" in function_names
+    assert "load_tool" not in function_names
+    # Only defer&&!initial tools go on the wire deferred; initial stays plain.
+    assert vars(agent.model)[_OPENAI_DEFERRED_TOOL_NAMES_ATTR] == frozenset({"sleep"})
+    assert _DEFERRED_TOOL_NAMES_ATTR not in vars(agent.model)
+    assert not any(block.startswith("## Dynamic Tools") for block in agent.instructions)
+    assert not any("Dynamic tools currently loaded" in block for block in agent.instructions)
+    assert ("code", "thread-a") not in dynamic_toolkits_module._loaded_tools
+
+
 @pytest.mark.parametrize(
     ("provider", "model_id"),
     [
         ("openai", "gpt-4o-mini"),
+        # The plain openai provider speaks Chat Completions, where tool search
+        # is unavailable even on ids the Codex provider would gate native.
+        ("openai", "gpt-5.5"),
+        ("codex", "gpt-4.1"),
         ("anthropic", "claude-opus-4-1"),
     ],
 )
 def test_unsupported_models_keep_homegrown_dynamic_tools_path(tmp_path: Path, provider: str, model_id: str) -> None:
-    """Non-Claude providers and unsupported Claude models keep the load_tool machinery."""
+    """Unsupported providers and models keep the load_tool machinery."""
     raw = _base_config_data()
     raw["models"]["default"] = {"provider": provider, "id": model_id}  # type: ignore[index]
     raw["agents"]["code"]["tools"] = [  # type: ignore[index]
@@ -861,6 +891,7 @@ def test_unsupported_models_keep_homegrown_dynamic_tools_path(tmp_path: Path, pr
     assert "sleep" not in function_names
     assert "add" in function_names
     assert _DEFERRED_TOOL_NAMES_ATTR not in vars(agent.model)
+    assert _OPENAI_DEFERRED_TOOL_NAMES_ATTR not in vars(agent.model)
     assert any(block.startswith("## Dynamic Tools") for block in agent.instructions)
     assert any("Dynamic tools currently loaded" in block for block in agent.instructions)
 


### PR DESCRIPTION
## What this does

On models served via the `codex` / `openai_codex` provider (OpenAI Responses API, Agno `CodexResponses`), authored `defer: true` tools are now handled by OpenAI's server-side tool search instead of MindRoom's homegrown dynamic-tool loading. Every request sends each deferred tool's full definition with `defer_loading: true` plus a hosted `{"type": "tool_search"}` entry in `tools`. This mirrors #1412 (the Anthropic equivalent) and reuses its provider-agnostic half unchanged (`native_deferred_tools` assembly, `deferred_wire_tool_names` collection, catalog/state-suffix suppression).

## Cache mechanics

OpenAI keeps deferred schemas out of the model's rendered context and loads every discovered tool at the **end of the context window** — the opposite mechanism from Anthropic's inline `tool_reference` expansion, with the same effect: tool discovery never invalidates the cached prompt prefix, whereas the homegrown load-a-tool-then-rebuild-the-agent flow changed the tools array and the loaded-state prompt suffix on every discovery. The tools array is ordered deterministically (search tool, then non-deferred tools, then deferred sorted by name) so the prefix stays byte-stable across requests, and the mutation composes with the existing Codex prompt-cache key/headers/extra-body plumbing (it only rewrites `request_params["tools"]`).

## What the native path replaces

Same as #1412: no `DynamicToolsToolkit` (`load_tool`/`unload_tool`/`list_tools`/`tool_search`), no catalog instruction block, no volatile loaded-state suffix, no session loaded-tool state reads/writes; all authored deferred toolkits are built and attached at agent create so discovered calls execute directly; `defer: true, initial: true` maps to plain non-deferred; `hidden_tool_names` filtering applies before tagging.

## Wire round-trip (new vs #1412)

Agno's `OpenAIResponses` parser drops the `tool_search_call` / `tool_search_output` output items and never replays them, so `CodexResponses` (MindRoom-owned) now overrides `_parse_provider_response` / `_parse_provider_response_delta` to capture them into the assistant message's `provider_data`, and `_format_messages` to reinsert them verbatim, in order, exactly once — immediately ahead of the message's replayed function calls (matched by call id) or its replayed content. The Responses input-item union accepts both types (verified against the pinned openai 2.32.0 SDK). Cross-provider `!model` switches are covered both ways: stored tool-search items replay to `OpenAIChat`/Claude without crashing, and Claude's `server_tool_blocks` replay to Codex without injection.

## Gating

Automatic, per agent, on the agent's resolved runtime model: provider in {`codex`, `openai_codex`} and a `gpt-N.M` version parsed from the model id with N.M >= 5.4 (per current OpenAI docs, tool search is supported on gpt-5.4 and later, Responses API only). The version parse handles bare, `-codex`-suffixed, and `openai-codex/`-prefixed id spellings and never goes stale: new GPT releases take the native path without a code change, while `gpt-5-codex`, `gpt-4.1`, etc. fall back to the homegrown path. The plain `openai` provider (Chat Completions) keeps the homegrown path — tool search is documented for the Responses API only. The minimum version lives in `model_defaults.py`.

## Live verification (ran against the real Codex backend)

Ran a live probe via local Codex CLI OAuth: one request with a deferred `get_current_weather` tool was **accepted** (`defer_loading` + `tool_search` are honored by the Codex backend), the model **discovered** the tool (`tool_search_call` + `tool_search_output` items captured into `provider_data`) and called it; the follow-up turn **replayed** the history including the reinserted search items without any API error, answered from the tool result, and reported **cached_tokens=4096 of input_tokens=4846** — confirming the cached prefix survives discovery.

## Scope notes

- **Azure OpenAI**: out of scope — MindRoom's Azure provider is not a Responses-API surface, so it keeps the homegrown path.
- **Namespaces**: the SDK has a wire-level `NamespaceTool`, but v1 keeps flat `defer_loading` per function; grouping authored toolkits into namespaces is a possible follow-up.
- **No field stripping needed** on deferred entries (no Anthropic `cache_control`-equivalent constraint; the backend even echoes `defer_loading: true` back in `tool_search_output.tools`).

## Validation

- Full `uv run pytest -q --no-cov`: 9219 passed, 61 skipped.
- `uv run pre-commit run --all-files`: all hooks pass.
- `uv run tach check --dependencies --interfaces`: clean (new `mindroom.openai_tool_search` declared as an `agents` dependency).
- New tests: gate matrix, installer no-ops, defer tagging + search-tool injection + deterministic ordering, streaming round-trip through `model.response` (capture -> provider_data -> verbatim replay), function-call-anchored replay, non-streaming parse capture, cross-provider replay both directions, and the `create_agent` matrix in `test_dynamic_toolkits.py` (codex/gpt-5.5 native; openai gpt-5.5, codex gpt-4.1 homegrown).

## Review follow-ups

- The gate now parses major-only ids (a future \`gpt-6\` counts as 6.0 and goes native; \`gpt-5\`/\`gpt-5-codex\` stay homegrown).
- The replay cursor anchors every assistant turn, so an earlier turn with identical content can no longer claim a later message's insertion point.
- \`docs/tools/dynamic-tools.md\` now documents the native server-side tool-search path (both provider families) and scopes the \`dynamic_tools\` manager section to the remaining providers.
