### PR TITLE
Fix model-literal guard violation introduced by #1414

### DIFF
--- a/scripts/testing/tool_search_live_probe.py
+++ b/scripts/testing/tool_search_live_probe.py
@@ -40,8 +40,10 @@ if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
 
 from mindroom.claude_prompt_cache import install_claude_deferred_tool_search  # noqa: E402
+from mindroom.model_defaults import CONFIG_INIT_MODEL_PRESETS  # noqa: E402
 from mindroom.vertex_claude_compat import MindroomVertexAIClaude  # noqa: E402
 
+DEFAULT_PROBE_MODEL_ID = CONFIG_INIT_MODEL_PRESETS["anthropic"].id
 DEFERRED_TOOL_NAME = "get_weather"
 # Deterministic padding so the system prompt clears every model's minimum
 # cacheable prefix (4096 tokens on Opus-tier models).
@@ -230,7 +232,7 @@ def run_live(args: argparse.Namespace) -> int:
 def main() -> int:
     """Parse arguments and run the requested probe mode."""
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--model-id", default="claude-sonnet-5", help="Claude model id to probe.")
+    parser.add_argument("--model-id", default=DEFAULT_PROBE_MODEL_ID, help="Claude model id to probe.")
     parser.add_argument(
         "--provider",
         choices=("anthropic", "vertexai"),


### PR DESCRIPTION
#1414's review round changed the probe's `--model-id` default to a `claude-sonnet-5` **literal**, violating the guard test from #1412 (`test_default_model_strings_are_not_redeclared_in_source` scans `src/` and `scripts/` for model-id strings redeclared outside `model_defaults`). **main is currently red on that test.** My miss: I applied the reviewer suggestion and re-ran only the probe-targeted checks, not the guard.

Fix: import the default from `CONFIG_INIT_MODEL_PRESETS["anthropic"].id`.

Verified: `tests/test_model_defaults.py` passes (6/6), probe `--dry-run` still OK, pre-commit clean.
