### PR TITLE
Log provider-reported cache usage; report actuals in the prompt-cache review tool

### DIFF
--- a/scripts/testing/prompt_cache_review.py
+++ b/scripts/testing/prompt_cache_review.py
@@ -10,7 +10,7 @@ import sqlite3
 import sys
 from collections import Counter, defaultdict
 from contextlib import suppress
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from itertools import pairwise
 from pathlib import Path
@@ -76,6 +76,8 @@ class RequestRow:
     preview: str
     tools_blob: str = ""
     cache_enabled: bool = False
+    request_log_id: str = ""
+    usage: dict[str, int] | None = None
 
     @property
     def total_prefix_chars(self) -> int:
@@ -352,6 +354,9 @@ def main() -> None:
             ),
         )
 
+    print()
+    print_cache_actuals(rows)
+
 
 def resolve_storage_root(explicit_root: Path | None) -> Path:
     """Resolve the storage root used for JSONL and session DB discovery."""
@@ -450,6 +455,7 @@ def load_request_rows(
     """Load request rows plus JSONL parse diagnostics from one log file."""
     decoder = json.JSONDecoder()
     rows: list[RequestRow] = []
+    usage_by_request_log_id: dict[str, dict[str, int]] = {}
     line_count = 0
     document_count = 0
     concatenated_document_count = 0
@@ -478,13 +484,19 @@ def load_request_rows(
                 parsed_documents += 1
                 document_count += 1
                 position = end_position
-                row_error = _append_request_row(rows, payload, session_id_filter)
+                row_error = _append_request_row(rows, payload, session_id_filter, usage_by_request_log_id)
                 if row_error is not None:
                     unparseable_row_count += 1
                     unparseable_row_errors.append(row_error)
             if parsed_documents > 1:
                 concatenated_document_count += parsed_documents - 1
 
+    rows = [
+        replace(row, usage=usage_by_request_log_id[row.request_log_id])
+        if row.request_log_id in usage_by_request_log_id
+        else row
+        for row in rows
+    ]
     rows.sort(key=lambda row: row.timestamp)
     return rows, JsonlParseStats(
         line_count=line_count,
@@ -496,8 +508,17 @@ def load_request_rows(
     )
 
 
-def _append_request_row(rows: list[RequestRow], payload: object, session_id_filter: str | None) -> str | None:
+def _append_request_row(
+    rows: list[RequestRow],
+    payload: object,
+    session_id_filter: str | None,
+    usage_by_request_log_id: dict[str, dict[str, int]],
+) -> str | None:
     """Parse one logged payload into ``rows``; return an error summary when it cannot be rebuilt.
+
+    Response records (compact usage lines written after each provider call) are
+    collected into ``usage_by_request_log_id`` before any session filtering:
+    they carry no session id and are joined to request rows by request_log_id.
 
     Corrupt logged rows can fail anywhere in the provider-format rebuild (JSON
     decoding, pydantic validation, Agno's message formatting), and one bad row
@@ -505,6 +526,11 @@ def _append_request_row(rows: list[RequestRow], payload: object, session_id_filt
     and reports the failure instead.
     """
     payload_dict = object_dict(payload)
+    usage_record = parse_response_usage_record(payload_dict)
+    if usage_record is not None:
+        request_log_id, usage = usage_record
+        usage_by_request_log_id[request_log_id] = usage
+        return None
     if session_id_filter is not None and (payload_dict is None or payload_dict.get("session_id") != session_id_filter):
         return None
     try:
@@ -516,10 +542,21 @@ def _append_request_row(rows: list[RequestRow], payload: object, session_id_filt
     return None
 
 
+def parse_response_usage_record(payload_dict: JsonDict | None) -> tuple[str, dict[str, int]] | None:
+    """Parse one response record into its (request_log_id, usage) pair, or None."""
+    if payload_dict is None or payload_dict.get("record") != "response":
+        return None
+    request_log_id = payload_dict.get("request_log_id")
+    usage = object_dict(payload_dict.get("usage"))
+    if not isinstance(request_log_id, str) or not request_log_id or usage is None:
+        return None
+    return request_log_id, {key: value for key, value in usage.items() if isinstance(value, int)}
+
+
 def parse_request_row(payload: object) -> RequestRow | None:
     """Parse one logged request payload into a normalized request row."""
     payload_dict = object_dict(payload)
-    if payload_dict is None:
+    if payload_dict is None or payload_dict.get("record") == "response":
         return None
     timestamp_raw = payload_dict.get("timestamp")
     if not isinstance(timestamp_raw, str):
@@ -547,6 +584,7 @@ def parse_request_row(payload: object) -> RequestRow | None:
     # The request logger writes "agent_id"; accept "agent_name" for older logs.
     agent_name_raw = payload_dict.get("agent_id") or payload_dict.get("agent_name")
     tools_raw = payload_dict.get("tools")
+    request_log_id_raw = payload_dict.get("request_log_id")
     model_params_dict = object_dict(model_params)
     return RequestRow(
         timestamp=timestamp,
@@ -561,6 +599,7 @@ def parse_request_row(payload: object) -> RequestRow | None:
         preview=preview or "<no preview>",
         tools_blob=stable_json(tools_raw) if isinstance(tools_raw, list) and tools_raw else "",
         cache_enabled=model_params_dict is not None and model_params_dict.get("cache_system_prompt") is True,
+        request_log_id=request_log_id_raw if isinstance(request_log_id_raw, str) else "",
     )
 
 
@@ -913,6 +952,52 @@ def simulate_prompt_cache(  # noqa: C901, PLR0912, PLR0915
 
     outcomes.sort(key=lambda outcome: outcome.row.timestamp)
     return CacheSimulationReport(ttl_seconds=ttl_seconds, lookback_blocks=lookback_blocks, outcomes=tuple(outcomes))
+
+
+def print_cache_actuals(rows: list[RequestRow]) -> None:
+    """Print provider-reported cache usage joined from logged response records.
+
+    Unlike the simulation, these are the provider's own numbers: what each
+    request actually read from and wrote to the prompt cache. Token counts are
+    real tokens, so they are comparable across requests and against billing.
+    """
+    measured = [row for row in rows if row.usage is not None and is_claude_request(row.model_id)]
+    if not measured:
+        print("ACTUAL CACHE USAGE: no Claude response usage records found (older logs predate response logging).")
+        return
+
+    def token_totals(selected: list[RequestRow]) -> tuple[int, int, int]:
+        usages = [row.usage or {} for row in selected]
+        read = sum(usage.get("cache_read_tokens", 0) for usage in usages)
+        write = sum(usage.get("cache_write_tokens", 0) for usage in usages)
+        uncached = sum(usage.get("input_tokens", 0) for usage in usages)
+        return read, write, uncached
+
+    read, write, uncached = token_totals(measured)
+    prompt_total = read + write + uncached
+    print(f"ACTUAL CACHE USAGE (provider-reported, {len(measured)} of {len(rows)} requests measured)")
+    print(f"  prompt tokens: cache_read={read:,} cache_write={write:,} uncached={uncached:,}")
+    if prompt_total:
+        print(f"  actual prefix reuse: {read / prompt_total * 100:.1f}% of prompt tokens")
+    cold_misses = [row for row in measured if row.cache_enabled and (row.usage or {}).get("cache_read_tokens", 0) == 0]
+    if cold_misses:
+        print(f"  cache-enabled requests that read nothing: {len(cold_misses)}")
+
+    by_stream: dict[tuple[str, str], list[RequestRow]] = defaultdict(list)
+    for row in measured:
+        by_stream[(row.agent_name, row.model_id)].append(row)
+    ranked = sorted(
+        by_stream.items(),
+        key=lambda item: -sum((row.usage or {}).get("cache_read_tokens", 0) for row in item[1]),
+    )
+    for (agent_name, model_id), stream_rows in ranked[:5]:
+        stream_read, stream_write, stream_uncached = token_totals(stream_rows)
+        stream_total = stream_read + stream_write + stream_uncached
+        reuse = f"{stream_read / stream_total * 100:.1f}%" if stream_total else "n/a"
+        print(
+            f"    agent={agent_name} model={model_id} requests={len(stream_rows)} "
+            f"reuse={reuse} read={stream_read:,} write={stream_write:,} uncached={stream_uncached:,}",
+        )
 
 
 def print_cache_simulation(report: CacheSimulationReport) -> None:

--- a/src/mindroom/llm_request_logging.py
+++ b/src/mindroom/llm_request_logging.py
@@ -7,7 +7,7 @@ import base64
 import json
 from contextlib import contextmanager
 from contextvars import ContextVar
-from dataclasses import asdict, fields, is_dataclass
+from dataclasses import asdict, dataclass, fields, is_dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
@@ -260,14 +260,26 @@ def stream_with_llm_request_log_context[StreamEventT](
     )
 
 
+@dataclass(frozen=True)
+class _RequestLogRef:
+    """Join key and destination file of one written request record.
+
+    The response record reuses ``log_path`` so a request/response pair always
+    lands in the same daily file, even when the response arrives after
+    midnight — the offline review tool reads one file at a time.
+    """
+
+    request_log_id: str
+    log_path: Path
+
+
 async def _write_llm_request_log(
     *,
     model: Model,
     agent_name: str,
     messages: Sequence[Message],
     tools: list[dict[str, _JSONValue]] | None,
-    log_dir: str | None,
-    default_log_dir: Path,
+    log_path: Path,
     request_context: dict[str, _JSONValue] | None = None,
     request_log_id: str,
 ) -> None:
@@ -276,7 +288,7 @@ async def _write_llm_request_log(
     resolved_request_context = request_context if request_context is not None else _snapshot_request_log_context()
     await asyncio.to_thread(
         _write_jsonl_line,
-        _daily_log_path(log_dir, default_log_dir, now),
+        log_path,
         {
             "timestamp": now.isoformat(),
             "request_log_id": request_log_id,
@@ -307,24 +319,22 @@ async def _write_llm_response_log(
     *,
     model: Model,
     agent_name: str,
-    request_log_id: str | None,
+    request_log_ref: _RequestLogRef | None,
     usage: MessageMetrics | None,
-    log_dir: str | None,
-    default_log_dir: Path,
     request_context: dict[str, _JSONValue],
 ) -> None:
     """Persist one compact response record with the provider-reported usage.
 
-    No-op when the request record was never written (no request_log_id to join
-    on) or when the provider reported no usage metrics.
+    No-op when the request record was never written (nothing to join on) or
+    when the provider reported no usage metrics.
     """
-    if request_log_id is None or usage is None:
+    if request_log_ref is None or usage is None:
         return
     now = datetime.now().astimezone()
     payload: dict[str, _JSONValue] = {
         "timestamp": now.isoformat(),
         "record": "response",
-        "request_log_id": request_log_id,
+        "request_log_id": request_log_ref.request_log_id,
         "agent_id": agent_name,
         "model_id": model.id,
         "usage": _usage_payload(usage),
@@ -332,7 +342,7 @@ async def _write_llm_response_log(
     correlation_id = request_context.get("correlation_id")
     if correlation_id is not None:
         payload["correlation_id"] = correlation_id
-    await asyncio.to_thread(_write_jsonl_line, _daily_log_path(log_dir, default_log_dir, now), payload)
+    await asyncio.to_thread(_write_jsonl_line, request_log_ref.log_path, payload)
 
 
 async def _write_llm_request_log_if_present(
@@ -343,27 +353,29 @@ async def _write_llm_request_log_if_present(
     log_dir: str | None,
     default_log_dir: Path,
     request_context: dict[str, _JSONValue],
-) -> str | None:
+) -> _RequestLogRef | None:
     """Write one request log entry when provider kwargs include API request messages.
 
-    Returns the generated request_log_id when a record was written, so the
-    matching response record can be joined to it later.
+    Returns the written record's join key and file so the matching response
+    record can be joined to it later, in the same daily file.
     """
     messages = _request_messages(kwargs.get("messages"))
     if messages is None:
         return None
-    request_log_id = uuid4().hex
+    request_log_ref = _RequestLogRef(
+        request_log_id=uuid4().hex,
+        log_path=_daily_log_path(log_dir, default_log_dir, datetime.now().astimezone()),
+    )
     await _write_llm_request_log(
         model=model,
         agent_name=agent_name,
         messages=messages,
         tools=_request_tools(kwargs.get("tools")),
-        log_dir=log_dir,
-        default_log_dir=default_log_dir,
+        log_path=request_log_ref.log_path,
         request_context=request_context,
-        request_log_id=request_log_id,
+        request_log_id=request_log_ref.request_log_id,
     )
-    return request_log_id
+    return request_log_ref
 
 
 def install_llm_request_logging(
@@ -387,7 +399,7 @@ def install_llm_request_logging(
         request_context = _snapshot_request_log_context()
 
         async def _invoke() -> ModelResponse:
-            request_log_id = await _write_llm_request_log_if_present(
+            request_log_ref = await _write_llm_request_log_if_present(
                 model=model,
                 agent_name=agent_name,
                 kwargs=kwargs,
@@ -399,10 +411,8 @@ def install_llm_request_logging(
             await _write_llm_response_log(
                 model=model,
                 agent_name=agent_name,
-                request_log_id=request_log_id,
+                request_log_ref=request_log_ref,
                 usage=response.response_usage,
-                log_dir=debug_config.llm_request_log_dir,
-                default_log_dir=default_log_dir,
                 request_context=request_context,
             )
             return response
@@ -413,7 +423,7 @@ def install_llm_request_logging(
         request_context = _snapshot_request_log_context()
 
         async def _stream() -> AsyncIterator[ModelResponse]:
-            request_log_id = await _write_llm_request_log_if_present(
+            request_log_ref = await _write_llm_request_log_if_present(
                 model=model,
                 agent_name=agent_name,
                 kwargs=kwargs,
@@ -422,19 +432,22 @@ def install_llm_request_logging(
                 request_context=request_context,
             )
             last_usage: MessageMetrics | None = None
-            async for chunk in original_ainvoke_stream(*args, **kwargs):
-                if chunk.response_usage is not None:
-                    last_usage = chunk.response_usage
-                yield chunk
-            await _write_llm_response_log(
-                model=model,
-                agent_name=agent_name,
-                request_log_id=request_log_id,
-                usage=last_usage,
-                log_dir=debug_config.llm_request_log_dir,
-                default_log_dir=default_log_dir,
-                request_context=request_context,
-            )
+            # finally: an abandoned stream (consumer break -> aclose()) must
+            # still record any usage already reported; awaiting during aclose()
+            # is allowed for async generators as long as nothing is yielded.
+            try:
+                async for chunk in original_ainvoke_stream(*args, **kwargs):
+                    if chunk.response_usage is not None:
+                        last_usage = chunk.response_usage
+                    yield chunk
+            finally:
+                await _write_llm_response_log(
+                    model=model,
+                    agent_name=agent_name,
+                    request_log_ref=request_log_ref,
+                    usage=last_usage,
+                    request_context=request_context,
+                )
 
         return _stream()
 

--- a/src/mindroom/llm_request_logging.py
+++ b/src/mindroom/llm_request_logging.py
@@ -11,6 +11,7 @@ from dataclasses import asdict, fields, is_dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
+from uuid import uuid4
 
 from agno.models.message import Message
 from pydantic import BaseModel
@@ -23,6 +24,7 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Coroutine, Iterator, Sequence
 
     from agno.models.base import Model
+    from agno.models.message import MessageMetrics
     from agno.models.response import ModelResponse
 
     from mindroom.config.models import DebugConfig
@@ -267,6 +269,7 @@ async def _write_llm_request_log(
     log_dir: str | None,
     default_log_dir: Path,
     request_context: dict[str, _JSONValue] | None = None,
+    request_log_id: str,
 ) -> None:
     """Persist one request record for an LLM invocation."""
     now = datetime.now().astimezone()
@@ -276,6 +279,7 @@ async def _write_llm_request_log(
         _daily_log_path(log_dir, default_log_dir, now),
         {
             "timestamp": now.isoformat(),
+            "request_log_id": request_log_id,
             "agent_id": agent_name,
             **resolved_request_context,
             "model_id": model.id,
@@ -289,6 +293,48 @@ async def _write_llm_request_log(
     )
 
 
+def _usage_payload(usage: MessageMetrics) -> dict[str, _JSONValue]:
+    """Return the token counts of one provider response as a JSON payload."""
+    return {
+        "input_tokens": usage.input_tokens,
+        "output_tokens": usage.output_tokens,
+        "cache_read_tokens": usage.cache_read_tokens,
+        "cache_write_tokens": usage.cache_write_tokens,
+    }
+
+
+async def _write_llm_response_log(
+    *,
+    model: Model,
+    agent_name: str,
+    request_log_id: str | None,
+    usage: MessageMetrics | None,
+    log_dir: str | None,
+    default_log_dir: Path,
+    request_context: dict[str, _JSONValue],
+) -> None:
+    """Persist one compact response record with the provider-reported usage.
+
+    No-op when the request record was never written (no request_log_id to join
+    on) or when the provider reported no usage metrics.
+    """
+    if request_log_id is None or usage is None:
+        return
+    now = datetime.now().astimezone()
+    payload: dict[str, _JSONValue] = {
+        "timestamp": now.isoformat(),
+        "record": "response",
+        "request_log_id": request_log_id,
+        "agent_id": agent_name,
+        "model_id": model.id,
+        "usage": _usage_payload(usage),
+    }
+    correlation_id = request_context.get("correlation_id")
+    if correlation_id is not None:
+        payload["correlation_id"] = correlation_id
+    await asyncio.to_thread(_write_jsonl_line, _daily_log_path(log_dir, default_log_dir, now), payload)
+
+
 async def _write_llm_request_log_if_present(
     *,
     model: Model,
@@ -297,11 +343,16 @@ async def _write_llm_request_log_if_present(
     log_dir: str | None,
     default_log_dir: Path,
     request_context: dict[str, _JSONValue],
-) -> None:
-    """Write one request log entry when provider kwargs include API request messages."""
+) -> str | None:
+    """Write one request log entry when provider kwargs include API request messages.
+
+    Returns the generated request_log_id when a record was written, so the
+    matching response record can be joined to it later.
+    """
     messages = _request_messages(kwargs.get("messages"))
     if messages is None:
-        return
+        return None
+    request_log_id = uuid4().hex
     await _write_llm_request_log(
         model=model,
         agent_name=agent_name,
@@ -310,7 +361,9 @@ async def _write_llm_request_log_if_present(
         log_dir=log_dir,
         default_log_dir=default_log_dir,
         request_context=request_context,
+        request_log_id=request_log_id,
     )
+    return request_log_id
 
 
 def install_llm_request_logging(
@@ -334,7 +387,7 @@ def install_llm_request_logging(
         request_context = _snapshot_request_log_context()
 
         async def _invoke() -> ModelResponse:
-            await _write_llm_request_log_if_present(
+            request_log_id = await _write_llm_request_log_if_present(
                 model=model,
                 agent_name=agent_name,
                 kwargs=kwargs,
@@ -342,7 +395,17 @@ def install_llm_request_logging(
                 default_log_dir=default_log_dir,
                 request_context=request_context,
             )
-            return await original_ainvoke(*args, **kwargs)
+            response = await original_ainvoke(*args, **kwargs)
+            await _write_llm_response_log(
+                model=model,
+                agent_name=agent_name,
+                request_log_id=request_log_id,
+                usage=response.response_usage,
+                log_dir=debug_config.llm_request_log_dir,
+                default_log_dir=default_log_dir,
+                request_context=request_context,
+            )
+            return response
 
         return _invoke()
 
@@ -350,7 +413,7 @@ def install_llm_request_logging(
         request_context = _snapshot_request_log_context()
 
         async def _stream() -> AsyncIterator[ModelResponse]:
-            await _write_llm_request_log_if_present(
+            request_log_id = await _write_llm_request_log_if_present(
                 model=model,
                 agent_name=agent_name,
                 kwargs=kwargs,
@@ -358,8 +421,20 @@ def install_llm_request_logging(
                 default_log_dir=default_log_dir,
                 request_context=request_context,
             )
+            last_usage: MessageMetrics | None = None
             async for chunk in original_ainvoke_stream(*args, **kwargs):
+                if chunk.response_usage is not None:
+                    last_usage = chunk.response_usage
                 yield chunk
+            await _write_llm_response_log(
+                model=model,
+                agent_name=agent_name,
+                request_log_id=request_log_id,
+                usage=last_usage,
+                log_dir=debug_config.llm_request_log_dir,
+                default_log_dir=default_log_dir,
+                request_context=request_context,
+            )
 
         return _stream()
 

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -13,7 +13,7 @@ from agno.media import File
 from agno.models.message import Message
 from agno.models.metrics import Metrics
 from agno.models.openai import OpenAIChat
-from agno.models.response import ToolExecution
+from agno.models.response import ModelResponse, ToolExecution
 from agno.models.vertexai.claude import Claude as VertexAIClaude
 from agno.run.agent import (
     ModelRequestCompletedEvent,
@@ -1915,15 +1915,15 @@ class TestUserIdPassthrough:
                 self.client = None
                 self.async_client = None
 
-            async def ainvoke(self, *_args: object, **_kwargs: object) -> dict[str, str]:
-                return {"status": "ok"}
+            async def ainvoke(self, *_args: object, **_kwargs: object) -> ModelResponse:
+                return ModelResponse(content="ok")
 
             async def ainvoke_stream(
                 self,
                 *_args: object,
                 **_kwargs: object,
-            ) -> AsyncIterator[dict[str, str]]:
-                yield {"status": "ok"}
+            ) -> AsyncIterator[ModelResponse]:
+                yield ModelResponse(content="ok")
 
         class _DeferredLoggingAgent:
             def __init__(self, model: _DeferredLoggingModel) -> None:

--- a/tests/test_issue_154_logging_integration.py
+++ b/tests/test_issue_154_logging_integration.py
@@ -16,6 +16,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import structlog
 from agno.models.message import Message
+from agno.models.response import ModelResponse
 from agno.run.agent import ModelRequestCompletedEvent, RunCompletedEvent, RunContentEvent
 from agno.run.base import RunStatus
 
@@ -70,15 +71,15 @@ class _LoggingModel:
     client: object | None = None
     async_client: object | None = None
 
-    async def ainvoke(self, *_args: object, **_kwargs: object) -> dict[str, str]:
-        return {"status": "ok"}
+    async def ainvoke(self, *_args: object, **_kwargs: object) -> ModelResponse:
+        return ModelResponse(content="ok")
 
     async def ainvoke_stream(
         self,
         *_args: object,
         **_kwargs: object,
-    ) -> AsyncIterator[dict[str, str]]:
-        yield {"status": "ok"}
+    ) -> AsyncIterator[ModelResponse]:
+        yield ModelResponse(content="ok")
 
 
 class _InvokeAgent:

--- a/tests/test_llm_request_logging.py
+++ b/tests/test_llm_request_logging.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 from agno.models.message import Message, MessageMetrics
+from agno.models.response import ModelResponse
 
 from mindroom.config.main import Config
 from mindroom.config.models import DebugConfig
@@ -31,11 +32,14 @@ class _FakeModel:
     client: object | None = None
     async_client: object | None = None
 
-    async def ainvoke(self, *_args: object, **_kwargs: object) -> dict[str, str]:
-        return {"status": "ok"}
+    response_usage: MessageMetrics | None = None
 
-    async def ainvoke_stream(self, *_args: object, **_kwargs: object) -> AsyncIterator[dict[str, str]]:
-        yield {"status": "ok"}
+    async def ainvoke(self, *_args: object, **_kwargs: object) -> ModelResponse:
+        return ModelResponse(content="ok", response_usage=self.response_usage)
+
+    async def ainvoke_stream(self, *_args: object, **_kwargs: object) -> AsyncIterator[ModelResponse]:
+        yield ModelResponse(content="ok")
+        yield ModelResponse(content="!", response_usage=self.response_usage)
 
 
 class _PlainAsyncIterator:
@@ -116,7 +120,7 @@ async def test_llm_request_logging_writes_jsonl(tmp_path: Path) -> None:  # noqa
             assistant_message=assistant_message,
             tools=[{"name": "search"}],
         )
-    assert result == {"status": "ok"}
+    assert result.content == "ok"
 
     with bind_llm_request_log_context(
         agent_id="assistant",
@@ -138,7 +142,7 @@ async def test_llm_request_logging_writes_jsonl(tmp_path: Path) -> None:  # noqa
             tools=[],
         )
     streamed = [chunk async for chunk in stream]
-    assert streamed == [{"status": "ok"}]
+    assert [chunk.content for chunk in streamed] == ["ok", "!"]
 
     entries = _read_log_entries(tmp_path)
     assert len(entries) == 2
@@ -298,3 +302,86 @@ async def test_llm_request_logging_disabled_creates_no_file(tmp_path: Path) -> N
         tools=[],
     )
     assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_llm_response_usage_record_written_and_linked(tmp_path: Path) -> None:
+    """A provider response with usage should append a response record joined by request_log_id."""
+    model = _FakeModel(
+        response_usage=MessageMetrics(input_tokens=5, output_tokens=7, cache_read_tokens=100, cache_write_tokens=20),
+    )
+    install_llm_request_logging(
+        model,
+        agent_name="default",
+        debug_config=DebugConfig(log_llm_requests=True, llm_request_log_dir=str(tmp_path)),
+        default_log_dir=tmp_path / "unused",
+    )
+
+    with bind_llm_request_log_context(agent_id="assistant", session_id="session-1", correlation_id="corr-9"):
+        await model.ainvoke(
+            messages=[Message(role="user", content="hello")],
+            assistant_message=Message(role="assistant"),
+            tools=[],
+        )
+
+    request_entry, response_entry = _read_log_entries(tmp_path)
+    assert request_entry["request_log_id"]
+    assert "record" not in request_entry
+    assert response_entry["record"] == "response"
+    assert response_entry["request_log_id"] == request_entry["request_log_id"]
+    assert response_entry["agent_id"] == "default"
+    assert response_entry["model_id"] == "test-model"
+    assert response_entry["correlation_id"] == "corr-9"
+    assert response_entry["usage"] == {
+        "input_tokens": 5,
+        "output_tokens": 7,
+        "cache_read_tokens": 100,
+        "cache_write_tokens": 20,
+    }
+
+
+@pytest.mark.asyncio
+async def test_llm_response_usage_record_uses_final_stream_chunk(tmp_path: Path) -> None:
+    """Streaming should record the usage carried by the last usage-bearing chunk."""
+    model = _FakeModel(response_usage=MessageMetrics(input_tokens=3, cache_read_tokens=42))
+    install_llm_request_logging(
+        model,
+        agent_name="default",
+        debug_config=DebugConfig(log_llm_requests=True, llm_request_log_dir=str(tmp_path)),
+        default_log_dir=tmp_path / "unused",
+    )
+
+    stream = model.ainvoke_stream(
+        messages=[Message(role="user", content="hello")],
+        assistant_message=Message(role="assistant"),
+        tools=[],
+    )
+    assert [chunk.content async for chunk in stream] == ["ok", "!"]
+
+    request_entry, response_entry = _read_log_entries(tmp_path)
+    assert response_entry["record"] == "response"
+    assert response_entry["request_log_id"] == request_entry["request_log_id"]
+    assert response_entry["usage"]["cache_read_tokens"] == 42
+    assert response_entry["usage"]["output_tokens"] == 0
+
+
+@pytest.mark.asyncio
+async def test_llm_response_record_skipped_without_usage(tmp_path: Path) -> None:
+    """Responses without usage metrics should not produce response records."""
+    model = _FakeModel()
+    install_llm_request_logging(
+        model,
+        agent_name="default",
+        debug_config=DebugConfig(log_llm_requests=True, llm_request_log_dir=str(tmp_path)),
+        default_log_dir=tmp_path / "unused",
+    )
+
+    await model.ainvoke(
+        messages=[Message(role="user", content="hello")],
+        assistant_message=Message(role="assistant"),
+        tools=[],
+    )
+
+    entries = _read_log_entries(tmp_path)
+    assert len(entries) == 1
+    assert "record" not in entries[0]

--- a/tests/test_llm_request_logging.py
+++ b/tests/test_llm_request_logging.py
@@ -13,6 +13,8 @@ from agno.models.response import ModelResponse
 from mindroom.config.main import Config
 from mindroom.config.models import DebugConfig
 from mindroom.llm_request_logging import (
+    _RequestLogRef,
+    _write_llm_response_log,
     bind_llm_request_log_context,
     current_llm_request_log_context,
     install_llm_request_logging,
@@ -385,3 +387,53 @@ async def test_llm_response_record_skipped_without_usage(tmp_path: Path) -> None
     entries = _read_log_entries(tmp_path)
     assert len(entries) == 1
     assert "record" not in entries[0]
+
+
+@pytest.mark.asyncio
+async def test_llm_response_usage_recorded_when_stream_is_abandoned(tmp_path: Path) -> None:
+    """Usage seen before an early aclose() must still produce a response record."""
+
+    @dataclass
+    class _EarlyUsageModel(_FakeModel):
+        async def ainvoke_stream(self, *_args: object, **_kwargs: object) -> AsyncIterator[ModelResponse]:
+            yield ModelResponse(content="ok", response_usage=MessageMetrics(input_tokens=3, cache_read_tokens=42))
+            yield ModelResponse(content="never consumed")
+
+    model = _EarlyUsageModel()
+    install_llm_request_logging(
+        model,
+        agent_name="default",
+        debug_config=DebugConfig(log_llm_requests=True, llm_request_log_dir=str(tmp_path)),
+        default_log_dir=tmp_path / "unused",
+    )
+
+    stream = model.ainvoke_stream(
+        messages=[Message(role="user", content="hello")],
+        assistant_message=Message(role="assistant"),
+        tools=[],
+    )
+    first_chunk = await anext(stream)
+    assert first_chunk.content == "ok"
+    await stream.aclose()
+
+    request_entry, response_entry = _read_log_entries(tmp_path)
+    assert response_entry["record"] == "response"
+    assert response_entry["request_log_id"] == request_entry["request_log_id"]
+    assert response_entry["usage"]["cache_read_tokens"] == 42
+
+
+@pytest.mark.asyncio
+async def test_llm_response_record_reuses_the_request_records_file(tmp_path: Path) -> None:
+    """The response record must land in the request record's daily file, not the current day's."""
+    request_day_file = tmp_path / "llm-requests-2026-01-01.jsonl"
+    await _write_llm_response_log(
+        model=_FakeModel(),
+        agent_name="default",
+        request_log_ref=_RequestLogRef(request_log_id="req-1", log_path=request_day_file),
+        usage=MessageMetrics(input_tokens=1, cache_read_tokens=5),
+        request_context={},
+    )
+
+    entries = [json.loads(line) for line in request_day_file.read_text(encoding="utf-8").splitlines()]
+    assert entries[0]["record"] == "response"
+    assert entries[0]["request_log_id"] == "req-1"

--- a/tests/test_prompt_cache_review.py
+++ b/tests/test_prompt_cache_review.py
@@ -391,3 +391,91 @@ def test_bootstrap_probe_environment_resolves_relative_adc_path(
     assert os.environ["GOOGLE_APPLICATION_CREDENTIALS"] == str(adc_path)
     assert os.environ["ANTHROPIC_VERTEX_PROJECT_ID"] == "mindroom-test"
     assert os.environ["CLOUD_ML_REGION"] == "us-central1"
+
+
+def test_load_request_rows_joins_response_usage_records(tmp_path: Path) -> None:
+    """Response records should attach provider usage to their request rows by request_log_id."""
+    module = _load_prompt_cache_review_module()
+    jsonl_path = tmp_path / "requests.jsonl"
+    jsonl_path.write_text(
+        '{"timestamp":"2026-04-11T11:00:00-07:00","request_log_id":"req-1","agent_id":"opus",'
+        '"model_id":"claude-opus-4-8","system_prompt":"S","messages":[{"role":"user","content":"a"}]}\n'
+        '{"timestamp":"2026-04-11T11:00:02-07:00","record":"response","request_log_id":"req-1",'
+        '"agent_id":"opus","model_id":"claude-opus-4-8","usage":{"input_tokens":10,"output_tokens":4,'
+        '"cache_read_tokens":900,"cache_write_tokens":25}}\n'
+        '{"timestamp":"2026-04-11T11:00:03-07:00","request_log_id":"req-2","agent_id":"opus",'
+        '"model_id":"claude-opus-4-8","system_prompt":"S","messages":[{"role":"user","content":"b"}]}\n',
+        encoding="utf-8",
+    )
+
+    rows, stats = module.load_request_rows(jsonl_path)
+
+    assert stats.unparseable_row_count == 0
+    assert [row.request_log_id for row in rows] == ["req-1", "req-2"]
+    assert rows[0].usage == {"input_tokens": 10, "output_tokens": 4, "cache_read_tokens": 900, "cache_write_tokens": 25}
+    assert rows[1].usage is None
+
+
+def test_response_records_are_not_parsed_as_request_rows() -> None:
+    """A response record must never masquerade as a request row."""
+    module = _load_prompt_cache_review_module()
+    payload = {
+        "timestamp": "2026-04-11T11:00:02-07:00",
+        "record": "response",
+        "request_log_id": "req-1",
+        "agent_id": "opus",
+        "model_id": "claude-opus-4-8",
+        "usage": {"cache_read_tokens": 1},
+    }
+    assert module.parse_request_row(payload) is None
+
+
+def test_print_cache_actuals_reports_reuse_and_cold_requests(capsys: pytest.CaptureFixture[str]) -> None:
+    """The actuals section should aggregate provider-reported cache usage."""
+    module = _load_prompt_cache_review_module()
+    measured = module.RequestRow(
+        timestamp=datetime.fromisoformat("2026-04-11T11:00:00-07:00"),
+        session_id=None,
+        room_id=None,
+        agent_name="opus",
+        model_id="claude-opus-4-8",
+        system_prompt="S",
+        message_count=1,
+        message_blobs=("{}",),
+        normalized_message_blobs=("{}",),
+        preview="a",
+        cache_enabled=True,
+        request_log_id="req-1",
+        usage={"input_tokens": 100, "output_tokens": 5, "cache_read_tokens": 900, "cache_write_tokens": 0},
+    )
+    cold = module.RequestRow(
+        timestamp=datetime.fromisoformat("2026-04-11T11:00:05-07:00"),
+        session_id=None,
+        room_id=None,
+        agent_name="opus",
+        model_id="claude-opus-4-8",
+        system_prompt="S",
+        message_count=1,
+        message_blobs=("{}",),
+        normalized_message_blobs=("{}",),
+        preview="b",
+        cache_enabled=True,
+        request_log_id="req-2",
+        usage={"input_tokens": 1000, "output_tokens": 5, "cache_read_tokens": 0, "cache_write_tokens": 0},
+    )
+
+    module.print_cache_actuals([measured, cold])
+
+    output = capsys.readouterr().out
+    assert "ACTUAL CACHE USAGE (provider-reported, 2 of 2 requests measured)" in output
+    assert "cache_read=900" in output
+    assert "actual prefix reuse: 45.0% of prompt tokens" in output
+    assert "cache-enabled requests that read nothing: 1" in output
+    assert "agent=opus model=claude-opus-4-8 requests=2" in output
+
+
+def test_print_cache_actuals_without_usage_records(capsys: pytest.CaptureFixture[str]) -> None:
+    """Logs predating response logging should produce a clear placeholder line."""
+    module = _load_prompt_cache_review_module()
+    module.print_cache_actuals([])
+    assert "no Claude response usage records found" in capsys.readouterr().out


### PR DESCRIPTION
## Why

The request log records only requests, so `prompt_cache_review.py` can only **simulate** provider cache behavior (added in #1411). The #1412/#1414 live probe proved defer_loading caching works once, but production has no ongoing visibility: a change that silently breaks the cached prefix (a new volatile system section, tool reordering) would only show up on the bill.

## What

**`llm_request_logging.py`:** every logged request now carries a `request_log_id`; after the provider call, a compact response record (`"record": "response"`) with the provider-reported usage (`input`/`output`/`cache_read`/`cache_write` tokens) is appended — from `response_usage` on the blocking path, from the last usage-bearing chunk on the streaming path. Responses without usage (or requests that were never logged) write nothing. The request line is still written **before** invocation, so hang/crash debugging is unaffected.

**`prompt_cache_review.py`:** response records are joined onto request rows by `request_log_id` (before session filtering — they carry no session id) and a new **ACTUAL CACHE USAGE** section reports provider-reported prefix reuse, cache-enabled requests that read nothing, and top streams by cache-read volume — actuals next to the existing simulation.

**Tests:** fakes returning bare dicts from `ainvoke`/`ainvoke_stream` upgraded to typed `ModelResponse` objects (test_llm_request_logging, test_issue_154_logging_integration, test_ai_user_id), per the no-dynamic-fallbacks rule. New tests: request/response record linkage, final-stream-chunk usage, no record without usage, response-record join in the review tool, actuals section output.

## Verified

- Targeted suites: 129 passed (logging, review tool, issue-154 integration, ai_user_id).
- `uv run pre-commit run` on all touched files: clean. `tach check`: clean.
- Full suite: 9238 passed; the single failure is `test_default_model_strings_are_not_redeclared_in_source`, which is **pre-existing on main** (introduced by #1414's merge) and fixed separately in #1419 — merge that first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added linked request/response logging so LLM runs can now capture usage metrics alongside the original request.
  * Added a cache review summary that shows actual token reuse and top streams by cache-read activity.

* **Bug Fixes**
  * Improved handling of streamed responses so usage data is captured from the final available chunk.
  * Requests without matching usage data are now preserved instead of being dropped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
