### PR TITLE
Doctor: actionable messages for Vertex Claude availability failures

### DIFF
--- a/src/mindroom/cli/doctor.py
+++ b/src/mindroom/cli/doctor.py
@@ -302,12 +302,34 @@ def _classify_vertexai_claude_error(
 ) -> tuple[bool | None, str]:
     """Classify one Vertex AI Claude validation failure for doctor output."""
     if isinstance(exc, APIStatusError):
-        return False, f"HTTP {exc.status_code}"
+        return False, _vertexai_claude_api_error_detail(exc)
     if isinstance(exc, DefaultCredentialsError):
         return None, str(exc)
     if isinstance(exc, RefreshError):
         return False, str(exc)
     return None, str(exc)
+
+
+def _vertexai_claude_api_error_detail(exc: APIStatusError) -> str:
+    """Turn a Vertex Claude API error into an actionable doctor message.
+
+    Model availability on Vertex is per project and region: a project can have
+    the Vertex AI API enabled yet still 404 on a Claude model when Anthropic
+    models are not enabled in its Model Garden or when the model id form is
+    wrong for Vertex (current-generation ids are bare, e.g. the anthropic
+    default; older ones are dated snapshots with an @ separator).
+    """
+    if exc.status_code == httpx.codes.NOT_FOUND:
+        return (
+            "HTTP 404: model not available in this project/region — verify the Vertex model id form "
+            "(bare current-generation id or dated @ snapshot) and that Anthropic models are enabled "
+            f"in the project's Model Garden ({exc.message})"
+        )
+    if exc.status_code == httpx.codes.FORBIDDEN:
+        if "SERVICE_DISABLED" in exc.message:
+            return "HTTP 403: the Vertex AI API (aiplatform.googleapis.com) is not enabled in this project"
+        return "HTTP 403: permission denied — check the credentials' IAM access to Vertex AI in this project"
+    return f"HTTP {exc.status_code}"
 
 
 def _validate_vertexai_claude_connection(

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -1,0 +1,60 @@
+"""Tests for doctor's Vertex AI Claude failure classification."""
+
+from __future__ import annotations
+
+import httpx
+from anthropic import APIStatusError
+from google.auth.exceptions import DefaultCredentialsError
+
+from mindroom.cli.doctor import _classify_vertexai_claude_error
+
+
+def _api_status_error(status_code: int, message: str) -> APIStatusError:
+    request = httpx.Request("POST", "https://example.test/v1/messages")
+    response = httpx.Response(status_code, request=request)
+    return APIStatusError(message, response=response, body=None)
+
+
+def test_publisher_model_not_found_explains_model_garden() -> None:
+    """A 404 should point at per-project/region model availability, not just the code."""
+    original_message = "Publisher model `claude-x` was not found or your project does not have access to it."
+    valid, detail = _classify_vertexai_claude_error(_api_status_error(404, original_message))
+
+    assert valid is False
+    assert detail.startswith("HTTP 404: model not available in this project/region")
+    assert "Model Garden" in detail
+    assert original_message in detail
+
+
+def test_service_disabled_explains_api_enablement() -> None:
+    """A SERVICE_DISABLED 403 should name the API that needs enabling."""
+    valid, detail = _classify_vertexai_claude_error(
+        _api_status_error(403, "Agent Platform API has not been used... reason: SERVICE_DISABLED"),
+    )
+
+    assert valid is False
+    assert detail == "HTTP 403: the Vertex AI API (aiplatform.googleapis.com) is not enabled in this project"
+
+
+def test_plain_permission_denied_points_at_iam() -> None:
+    """A non-SERVICE_DISABLED 403 should point at IAM access."""
+    valid, detail = _classify_vertexai_claude_error(_api_status_error(403, "Permission denied on resource."))
+
+    assert valid is False
+    assert detail == "HTTP 403: permission denied — check the credentials' IAM access to Vertex AI in this project"
+
+
+def test_other_status_codes_stay_compact() -> None:
+    """Unclassified statuses keep the previous compact HTTP detail."""
+    valid, detail = _classify_vertexai_claude_error(_api_status_error(500, "boom"))
+
+    assert valid is False
+    assert detail == "HTTP 500"
+
+
+def test_missing_credentials_stay_inconclusive() -> None:
+    """Missing ADC credentials remain a warning, not a failure."""
+    valid, detail = _classify_vertexai_claude_error(DefaultCredentialsError("no ADC"))
+
+    assert valid is None
+    assert detail == "no ADC"


### PR DESCRIPTION
## Why

`mindroom doctor` already validates every configured `vertexai_claude` model with a real 1-token request, but any failure collapsed to a bare `HTTP <code>`. The #1414 live probe hit both real-world failure modes and showed how undiagnosable that is: a project without the Vertex AI API enabled (403 `SERVICE_DISABLED`), and a project whose Model Garden doesn't have Anthropic models enabled — or a wrong id form, since Vertex model availability is **per project and region** and current-generation ids are bare while older ones are dated `@` snapshots (404).

## What

`_classify_vertexai_claude_error` now routes `APIStatusError` through a small detail helper:
- **404** → "model not available in this project/region — verify the Vertex model id form … and that Anthropic models are enabled in the project's Model Garden" (original provider message appended)
- **403 with `SERVICE_DISABLED`** → "the Vertex AI API (aiplatform.googleapis.com) is not enabled in this project"
- **other 403** → IAM-access hint
- anything else keeps the compact `HTTP <code>`

New `tests/test_cli_doctor.py` covers all four classes plus the missing-ADC warning path (pure-function tests, no network).

## Verified

- `tests/test_cli_doctor.py`: 5/5 pass; pre-commit clean on touched files.
- Note: `test_default_model_strings_are_not_redeclared_in_source` fails on this branch's base — pre-existing main breakage from #1414's merge, fixed in #1419 (merge that first).
