### PR TITLE
Source the tool-search probe's default model id from model_defaults

### DIFF
--- a/scripts/testing/tool_search_live_probe.py
+++ b/scripts/testing/tool_search_live_probe.py
@@ -40,7 +40,10 @@ if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
 
 from mindroom.claude_prompt_cache import install_claude_deferred_tool_search  # noqa: E402
+from mindroom.model_defaults import CONFIG_INIT_MODEL_PRESETS  # noqa: E402
 from mindroom.vertex_claude_compat import MindroomVertexAIClaude  # noqa: E402
+
+DEFAULT_MODEL_ID = CONFIG_INIT_MODEL_PRESETS["anthropic"].id
 
 DEFERRED_TOOL_NAME = "get_weather"
 # Deterministic padding so the system prompt clears every model's minimum
@@ -230,7 +233,7 @@ def run_live(args: argparse.Namespace) -> int:
 def main() -> int:
     """Parse arguments and run the requested probe mode."""
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--model-id", default="claude-sonnet-5", help="Claude model id to probe.")
+    parser.add_argument("--model-id", default=DEFAULT_MODEL_ID, help="Claude model id to probe.")
     parser.add_argument(
         "--provider",
         choices=("anthropic", "vertexai"),


### PR DESCRIPTION
## Summary
CI on main failed after #1414 landed: [run 28907550302](https://github.com/mindroom-ai/mindroom/actions/runs/28907550302/job/85757758973).

`test_default_model_strings_are_not_redeclared_in_source` scans `scripts/` for hardcoded default model strings, and the new live probe `scripts/testing/tool_search_live_probe.py` redeclared `claude-sonnet-5` as its `--model-id` default.

## Fix
Import the anthropic preset id from `mindroom.model_defaults` (`CONFIG_INIT_MODEL_PRESETS["anthropic"].id`) and use it as the argparse default, keeping `model_defaults` the single source of truth.

## Testing
- `uv run pytest tests/test_model_defaults.py -n 0 --no-cov` — 6 passed (previously 1 failed)
- `uv run pre-commit run --files scripts/testing/tool_search_live_probe.py` — passed

## Summary by Sourcery

Bug Fixes:
- Fix test failure by removing a hardcoded default model ID in the tool search live probe script that duplicated a value defined in model_defaults.