### PR TITLE
Add namespace-exempt connections to the local provisioning service

### DIFF
--- a/scripts/local_mindroom_provisioning_service.py
+++ b/scripts/local_mindroom_provisioning_service.py
@@ -13,6 +13,16 @@ This service is designed for hosted Matrix + chat deployments where users run
 MindRoom locally. Browser users authenticate with their Matrix access token.
 Paired local MindRoom installs receive client credentials that can request
 registration tokens for agent account creation.
+
+Namespace exemption: pairing always assigns each new connection a random
+namespace, and register-agent only accepts usernames shaped like
+``mindroom_<entity>_<namespace>``. Legacy/operator installs that predate
+namespaces use plain ``mindroom_<entity>`` usernames. To exempt such a trusted
+connection, an operator stops the service, sets ``"namespace": ""`` on that
+connection in the persisted state file (``MINDROOM_PROVISIONING_STATE_PATH``,
+default ``/var/lib/mindroom-local-provisioning/state.json``), and starts the
+service again. An exempt connection skips the namespace suffix check but may
+still only register valid Matrix localparts starting with ``mindroom_``.
 """
 
 from __future__ import annotations
@@ -22,6 +32,7 @@ import hashlib
 import hmac
 import json
 import os
+import re
 import secrets
 import time
 from contextlib import asynccontextmanager
@@ -53,6 +64,7 @@ RATE_LIMIT_STALE_SECONDS = 3600
 NAMESPACE_ALPHABET = "abcdefghjkmnpqrstuvwxyz23456789"
 NAMESPACE_LENGTH = 8
 MANAGED_AGENT_USERNAME_PREFIX = "mindroom_"
+MATRIX_LOCALPART_RE = re.compile(r"\A[a-z0-9._=/+-]+\Z")
 PAIR_STATUS_SESSION_HEADER = "X-Local-MindRoom-Pair-Session-Id"
 
 
@@ -406,11 +418,10 @@ def _load_state_from_disk_unlocked(state: ProvisioningState, state_path: Path) -
 
     for item in payload.get("connections", []):
         connection_id = item["id"]
+        # An explicitly empty namespace is a namespace-exempt connection
+        # (operator-set, see module docstring) and must survive restarts.
         namespace = item.get("namespace")
-        if isinstance(namespace, str):
-            namespace = namespace.strip().lower()
-        if not isinstance(namespace, str) or not namespace:
-            namespace = _derive_namespace(connection_id)
+        namespace = namespace.strip().lower() if isinstance(namespace, str) else _derive_namespace(connection_id)
         connection = LocalConnection(
             id=connection_id,
             user_id=item["user_id"],
@@ -459,6 +470,22 @@ def _is_managed_agent_username_for_namespace(username: str, namespace: str) -> b
         and username.endswith(suffix)
         and len(username) > len(MANAGED_AGENT_USERNAME_PREFIX) + len(suffix)
     )
+
+
+def _is_username_permitted_for_connection(username: str, namespace: str) -> bool:
+    """Return whether a connection may register the requested agent username.
+
+    An empty namespace marks a namespace-exempt connection (operator-set, see
+    module docstring): the namespace suffix check is skipped, but the username
+    must still be a valid Matrix localpart with the managed agent prefix.
+    """
+    if not namespace:
+        return (
+            username.startswith(MANAGED_AGENT_USERNAME_PREFIX)
+            and len(username) > len(MANAGED_AGENT_USERNAME_PREFIX)
+            and MATRIX_LOCALPART_RE.match(username) is not None
+        )
+    return _is_managed_agent_username_for_namespace(username, namespace)
 
 
 def _expire_if_needed(session: PairSession, now: datetime) -> None:
@@ -817,7 +844,7 @@ async def register_agent(
     async with state.lock:
         connection = _require_local_client(state, x_local_mindroom_client_id, x_local_mindroom_client_secret)
         _enforce_rate_limit_unlocked(state, key=f"register:agent:{connection.id}", limit=60, window_seconds=60)
-        if not _is_managed_agent_username_for_namespace(payload.username, connection.namespace):
+        if not _is_username_permitted_for_connection(payload.username, connection.namespace):
             raise HTTPException(
                 status_code=403,
                 detail="Requested username is outside this local connection namespace",

--- a/scripts/local_mindroom_provisioning_service.py
+++ b/scripts/local_mindroom_provisioning_service.py
@@ -64,7 +64,7 @@ RATE_LIMIT_STALE_SECONDS = 3600
 NAMESPACE_ALPHABET = "abcdefghjkmnpqrstuvwxyz23456789"
 NAMESPACE_LENGTH = 8
 MANAGED_AGENT_USERNAME_PREFIX = "mindroom_"
-MATRIX_LOCALPART_RE = re.compile(r"\A[a-z0-9._=/+-]+\Z")
+MATRIX_LOCALPART_RE = re.compile(r"\A[-a-z0-9._=/+]+\Z")
 PAIR_STATUS_SESSION_HEADER = "X-Local-MindRoom-Pair-Session-Id"
 
 
@@ -475,15 +475,16 @@ def _is_managed_agent_username_for_namespace(username: str, namespace: str) -> b
 def _is_username_permitted_for_connection(username: str, namespace: str) -> bool:
     """Return whether a connection may register the requested agent username.
 
-    An empty namespace marks a namespace-exempt connection (operator-set, see
-    module docstring): the namespace suffix check is skipped, but the username
-    must still be a valid Matrix localpart with the managed agent prefix.
+    Every username must be a valid Matrix localpart. An empty namespace marks
+    a namespace-exempt connection (operator-set, see module docstring): the
+    namespace suffix check is skipped, but the managed agent prefix is still
+    required.
     """
+    if MATRIX_LOCALPART_RE.match(username) is None:
+        return False
     if not namespace:
-        return (
-            username.startswith(MANAGED_AGENT_USERNAME_PREFIX)
-            and len(username) > len(MANAGED_AGENT_USERNAME_PREFIX)
-            and MATRIX_LOCALPART_RE.match(username) is not None
+        return username.startswith(MANAGED_AGENT_USERNAME_PREFIX) and len(username) > len(
+            MANAGED_AGENT_USERNAME_PREFIX,
         )
     return _is_managed_agent_username_for_namespace(username, namespace)
 

--- a/scripts/local_mindroom_provisioning_service.py
+++ b/scripts/local_mindroom_provisioning_service.py
@@ -21,8 +21,13 @@ namespaces use plain ``mindroom_<entity>`` usernames. To exempt such a trusted
 connection, an operator stops the service, sets ``"namespace": ""`` on that
 connection in the persisted state file (``MINDROOM_PROVISIONING_STATE_PATH``,
 default ``/var/lib/mindroom-local-provisioning/state.json``), and starts the
-service again. An exempt connection skips the namespace suffix check but may
-still only register valid Matrix localparts starting with ``mindroom_``.
+service again. The value must be exactly ``""``: ``null``, a removed key, or a
+whitespace-only string fails closed to a derived namespace that will not match
+the connection's original pairing namespace. An exempt connection skips only
+the namespace suffix check — usernames must still be valid Matrix localparts
+starting with ``mindroom_``. Exemption trusts that connection with the entire
+``mindroom_*`` username space, including usernames shaped like other
+connections' namespaced agents, so exempt only installs you fully control.
 """
 
 from __future__ import annotations
@@ -418,10 +423,17 @@ def _load_state_from_disk_unlocked(state: ProvisioningState, state_path: Path) -
 
     for item in payload.get("connections", []):
         connection_id = item["id"]
-        # An explicitly empty namespace is a namespace-exempt connection
-        # (operator-set, see module docstring) and must survive restarts.
-        namespace = item.get("namespace")
-        namespace = namespace.strip().lower() if isinstance(namespace, str) else _derive_namespace(connection_id)
+        raw_namespace = item.get("namespace")
+        # Only a literal "" (the operator-set exemption sentinel, see module
+        # docstring) may stay empty. Whitespace-only, null, and missing values
+        # fail closed to a derived namespace so a connection can never become
+        # namespace-exempt by accident.
+        if raw_namespace == "":
+            namespace = ""
+        elif isinstance(raw_namespace, str) and raw_namespace.strip():
+            namespace = raw_namespace.strip().lower()
+        else:
+            namespace = _derive_namespace(connection_id)
         connection = LocalConnection(
             id=connection_id,
             user_id=item["user_id"],
@@ -475,13 +487,11 @@ def _is_managed_agent_username_for_namespace(username: str, namespace: str) -> b
 def _is_username_permitted_for_connection(username: str, namespace: str) -> bool:
     """Return whether a connection may register the requested agent username.
 
-    Every username must be a valid Matrix localpart. An empty namespace marks
-    a namespace-exempt connection (operator-set, see module docstring): the
-    namespace suffix check is skipped, but the managed agent prefix is still
-    required.
+    An empty namespace marks a namespace-exempt connection (operator-set, see
+    module docstring): the namespace suffix check is skipped, but the managed
+    agent prefix is still required. Localpart syntax is validated separately
+    in register_agent so it surfaces as 400, not 403.
     """
-    if MATRIX_LOCALPART_RE.match(username) is None:
-        return False
     if not namespace:
         return username.startswith(MANAGED_AGENT_USERNAME_PREFIX) and len(username) > len(
             MANAGED_AGENT_USERNAME_PREFIX,
@@ -841,6 +851,14 @@ async def register_agent(
             f"Expected {configured_homeserver}, got {requested_homeserver}."
         )
         raise HTTPException(status_code=400, detail=msg)
+
+    # 400, not 403: clients treat 403 as an authorization problem, but a
+    # malformed localpart can only be fixed by changing the agent name.
+    if MATRIX_LOCALPART_RE.match(payload.username) is None:
+        raise HTTPException(
+            status_code=400,
+            detail="Requested username is not a valid Matrix localpart (allowed: a-z 0-9 . _ = / + -)",
+        )
 
     async with state.lock:
         connection = _require_local_client(state, x_local_mindroom_client_id, x_local_mindroom_client_secret)

--- a/scripts/local_mindroom_provisioning_service.py
+++ b/scripts/local_mindroom_provisioning_service.py
@@ -16,12 +16,16 @@ registration tokens for agent account creation.
 
 Namespace exemption: pairing always assigns each new connection a random
 namespace, and register-agent only accepts usernames shaped like
-``mindroom_<entity>_<namespace>``. Legacy/operator installs that predate
-namespaces use plain ``mindroom_<entity>`` usernames. To exempt such a trusted
-connection, an operator stops the service, sets ``"namespace": ""`` on that
-connection in the persisted state file (``MINDROOM_PROVISIONING_STATE_PATH``,
-default ``/var/lib/mindroom-local-provisioning/state.json``), and starts the
-service again. The value must be exactly ``""``: ``null``, a removed key, or a
+``mindroom_<entity>_<namespace>``. The operator's own installs are the
+deliberate exception: they keep the plain ``mindroom_<entity>`` names. To mark
+such a trusted connection namespace-exempt, the operator stops the service,
+sets ``"namespace": ""`` on that connection in the persisted state file
+(``MINDROOM_PROVISIONING_STATE_PATH``, default
+``/var/lib/mindroom-local-provisioning/state.json``), and starts the service
+again. The paired install must also unset ``MINDROOM_NAMESPACE`` in its local
+``.env`` (``mindroom connect`` writes one during pairing) so the client builds
+plain usernames, and the exemption is per-connection, so re-pairing requires
+editing the state file again. The value must be exactly ``""``: ``null``, a removed key, or a
 whitespace-only string fails closed to a derived namespace that will not match
 the connection's original pairing namespace. An exempt connection skips only
 the namespace suffix check — usernames must still be valid Matrix localparts

--- a/tests/test_local_mindroom_provisioning_service.py
+++ b/tests/test_local_mindroom_provisioning_service.py
@@ -84,12 +84,15 @@ def _pair_local_client(client: TestClient) -> dict[str, str]:
     return complete.json()
 
 
-def _set_connection_namespace(state_path: Path, connection_id: str, namespace: str) -> None:
+def _set_connection_namespace(state_path: Path, connection_id: str, namespace: str | None) -> None:
     """Edit the persisted state file the way an operator would (service stopped)."""
     payload = json.loads(state_path.read_text(encoding="utf-8"))
     for item in payload["connections"]:
         if item["id"] == connection_id:
-            item["namespace"] = namespace
+            if namespace is None:
+                item.pop("namespace", None)
+            else:
+                item["namespace"] = namespace
     state_path.write_text(json.dumps(payload), encoding="utf-8")
 
 
@@ -301,19 +304,20 @@ def test_pair_status_rejects_missing_session_header(
 
 
 @pytest.mark.parametrize(
-    "invalid_username_case",
+    ("invalid_username_case", "expected_status"),
     [
-        "missing_entity_between_prefix_and_namespace",
-        "wrong_namespace_suffix",
-        "wrong_prefix_for_namespace",
-        "plain_username_without_namespace",
-        "invalid_localpart_for_namespace",
+        ("missing_entity_between_prefix_and_namespace", 403),
+        ("wrong_namespace_suffix", 403),
+        ("wrong_prefix_for_namespace", 403),
+        ("plain_username_without_namespace", 403),
+        ("invalid_localpart_for_namespace", 400),
     ],
 )
 def test_register_agent_rejects_username_outside_connection_namespace(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     invalid_username_case: str,
+    expected_status: int,
 ) -> None:
     """A local client must not register Matrix users outside its assigned namespace."""
     _patch_matrix_auth(monkeypatch)
@@ -362,8 +366,11 @@ def test_register_agent_rejects_username_outside_connection_namespace(
             },
         )
 
-        assert register.status_code == 403
-        assert register.json()["detail"] == "Requested username is outside this local connection namespace"
+        assert register.status_code == expected_status
+        if expected_status == 403:
+            assert register.json()["detail"] == "Requested username is outside this local connection namespace"
+        else:
+            assert "not a valid Matrix localpart" in register.json()["detail"]
         assert register_calls == []
 
 
@@ -392,17 +399,18 @@ def test_register_agent_allows_plain_username_for_namespace_exempt_connection(
 
 
 @pytest.mark.parametrize(
-    "username",
+    ("username", "expected_status"),
     [
-        "other_foo",  # missing managed prefix
-        "mindroom_",  # bare prefix without entity
-        "mindroom_Foo",  # invalid Matrix localpart (uppercase)
+        ("other_foo", 403),  # missing managed prefix
+        ("mindroom_", 403),  # bare prefix without entity
+        ("mindroom_Foo", 400),  # invalid Matrix localpart (uppercase)
     ],
 )
 def test_register_agent_namespace_exempt_connection_still_requires_managed_prefix(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     username: str,
+    expected_status: int,
 ) -> None:
     """Namespace-exempt connections still only get mindroom_-prefixed valid localparts."""
     _patch_matrix_auth(monkeypatch)
@@ -418,8 +426,44 @@ def test_register_agent_namespace_exempt_connection_still_requires_managed_prefi
     with TestClient(provisioning.create_app(_service_config(state_path))) as client:
         register = _post_register_agent(client, complete, username)
 
+        assert register.status_code == expected_status
+        assert register_calls == []
+
+
+@pytest.mark.parametrize("corrupt_namespace", [None, "null", " "], ids=["missing_key", "json_null", "whitespace"])
+def test_state_load_fails_closed_for_missing_or_blank_namespace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    corrupt_namespace: str | None,
+) -> None:
+    """Only a literal "" exempts; missing, null, or whitespace namespaces must fail closed to a derived one."""
+    _patch_matrix_auth(monkeypatch)
+    state_path = tmp_path / "state.json"
+    register_calls: list[str] = []
+    _install_fake_register(monkeypatch, register_calls)
+
+    with TestClient(provisioning.create_app(_service_config(state_path))) as client:
+        complete = _pair_local_client(client)
+
+    if corrupt_namespace == "null":
+        payload = json.loads(state_path.read_text(encoding="utf-8"))
+        payload["connections"][0]["namespace"] = None
+        state_path.write_text(json.dumps(payload), encoding="utf-8")
+    else:
+        _set_connection_namespace(state_path, complete["client_id"], corrupt_namespace)
+
+    with TestClient(provisioning.create_app(_service_config(state_path))) as client:
+        register = _post_register_agent(client, complete, "mindroom_foo")
         assert register.status_code == 403
         assert register_calls == []
+
+        listed = client.get(
+            "/v1/local-mindroom/connections",
+            headers={"Authorization": "Bearer token-alice"},
+        )
+        derived = listed.json()["connections"][0]["namespace"]
+        assert isinstance(derived, str)
+        assert derived.strip() != ""
 
 
 def test_state_round_trip_preserves_empty_namespace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_local_mindroom_provisioning_service.py
+++ b/tests/test_local_mindroom_provisioning_service.py
@@ -61,6 +61,8 @@ def _invalid_managed_agent_username(case: str, namespace: str) -> str:
         return f"other_code_{namespace}"
     if case == "plain_username_without_namespace":
         return f"{provisioning.MANAGED_AGENT_USERNAME_PREFIX}foo"
+    if case == "invalid_localpart_for_namespace":
+        return _managed_agent_username("Foo", namespace)
     msg = f"Unknown invalid username case: {case}"
     raise ValueError(msg)
 
@@ -305,6 +307,7 @@ def test_pair_status_rejects_missing_session_header(
         "wrong_namespace_suffix",
         "wrong_prefix_for_namespace",
         "plain_username_without_namespace",
+        "invalid_localpart_for_namespace",
     ],
 )
 def test_register_agent_rejects_username_outside_connection_namespace(

--- a/tests/test_local_mindroom_provisioning_service.py
+++ b/tests/test_local_mindroom_provisioning_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, Self
 
 import pytest
@@ -12,6 +13,8 @@ import scripts.local_mindroom_provisioning_service as provisioning
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    import httpx
 
 
 def _service_config(state_path: Path) -> provisioning.ServiceConfig:
@@ -56,8 +59,67 @@ def _invalid_managed_agent_username(case: str, namespace: str) -> str:
         return f"{_managed_agent_username('code', namespace)}x"
     if case == "wrong_prefix_for_namespace":
         return f"other_code_{namespace}"
+    if case == "plain_username_without_namespace":
+        return f"{provisioning.MANAGED_AGENT_USERNAME_PREFIX}foo"
     msg = f"Unknown invalid username case: {case}"
     raise ValueError(msg)
+
+
+def _pair_local_client(client: TestClient) -> dict[str, str]:
+    pair_code = client.post(
+        "/v1/local-mindroom/pair/start",
+        headers={"Authorization": "Bearer token-alice"},
+    ).json()["pair_code"]
+    complete = client.post(
+        "/v1/local-mindroom/pair/complete",
+        json={
+            "pair_code": pair_code,
+            "client_name": "alice-macbook",
+            "client_pubkey_or_fingerprint": "sha256:abc123",
+        },
+    )
+    assert complete.status_code == 200
+    return complete.json()
+
+
+def _set_connection_namespace(state_path: Path, connection_id: str, namespace: str) -> None:
+    """Edit the persisted state file the way an operator would (service stopped)."""
+    payload = json.loads(state_path.read_text(encoding="utf-8"))
+    for item in payload["connections"]:
+        if item["id"] == connection_id:
+            item["namespace"] = namespace
+    state_path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _install_fake_register(monkeypatch: pytest.MonkeyPatch, register_calls: list[str]) -> None:
+    async def _fake_register(
+        config: provisioning.ServiceConfig,
+        payload: provisioning.RegisterAgentRequest,
+    ) -> provisioning.RegisterAgentResponse:
+        del config
+        register_calls.append(payload.username)
+        return provisioning.RegisterAgentResponse(
+            status="created",
+            user_id=f"@{payload.username}:mindroom.chat",
+        )
+
+    monkeypatch.setattr(provisioning, "_register_agent_with_matrix", _fake_register)
+
+
+def _post_register_agent(client: TestClient, complete: dict[str, str], username: str) -> httpx.Response:
+    return client.post(
+        "/v1/local-mindroom/register-agent",
+        json={
+            "homeserver": "https://mindroom.chat",
+            "username": username,
+            "password": "agent-pass-123",
+            "display_name": "CodeAgent",
+        },
+        headers={
+            "X-Local-MindRoom-Client-Id": complete["client_id"],
+            "X-Local-MindRoom-Client-Secret": complete["client_secret"],
+        },
+    )
 
 
 def test_pairing_and_register_agent_flow(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -242,6 +304,7 @@ def test_pair_status_rejects_missing_session_header(
         "missing_entity_between_prefix_and_namespace",
         "wrong_namespace_suffix",
         "wrong_prefix_for_namespace",
+        "plain_username_without_namespace",
     ],
 )
 def test_register_agent_rejects_username_outside_connection_namespace(
@@ -297,7 +360,93 @@ def test_register_agent_rejects_username_outside_connection_namespace(
         )
 
         assert register.status_code == 403
+        assert register.json()["detail"] == "Requested username is outside this local connection namespace"
         assert register_calls == []
+
+
+def test_register_agent_allows_plain_username_for_namespace_exempt_connection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A connection with operator-set namespace "" may register plain mindroom_<entity> usernames."""
+    _patch_matrix_auth(monkeypatch)
+    state_path = tmp_path / "state.json"
+    register_calls: list[str] = []
+    _install_fake_register(monkeypatch, register_calls)
+
+    with TestClient(provisioning.create_app(_service_config(state_path))) as client:
+        complete = _pair_local_client(client)
+
+    _set_connection_namespace(state_path, complete["client_id"], "")
+
+    with TestClient(provisioning.create_app(_service_config(state_path))) as client:
+        register = _post_register_agent(client, complete, "mindroom_foo")
+
+        assert register.status_code == 200
+        assert register.json()["status"] == "created"
+        assert register.json()["user_id"] == "@mindroom_foo:mindroom.chat"
+        assert register_calls == ["mindroom_foo"]
+
+
+@pytest.mark.parametrize(
+    "username",
+    [
+        "other_foo",  # missing managed prefix
+        "mindroom_",  # bare prefix without entity
+        "mindroom_Foo",  # invalid Matrix localpart (uppercase)
+    ],
+)
+def test_register_agent_namespace_exempt_connection_still_requires_managed_prefix(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    username: str,
+) -> None:
+    """Namespace-exempt connections still only get mindroom_-prefixed valid localparts."""
+    _patch_matrix_auth(monkeypatch)
+    state_path = tmp_path / "state.json"
+    register_calls: list[str] = []
+    _install_fake_register(monkeypatch, register_calls)
+
+    with TestClient(provisioning.create_app(_service_config(state_path))) as client:
+        complete = _pair_local_client(client)
+
+    _set_connection_namespace(state_path, complete["client_id"], "")
+
+    with TestClient(provisioning.create_app(_service_config(state_path))) as client:
+        register = _post_register_agent(client, complete, username)
+
+        assert register.status_code == 403
+        assert register_calls == []
+
+
+def test_state_round_trip_preserves_empty_namespace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An operator-set empty namespace must survive load and re-persist cycles."""
+    _patch_matrix_auth(monkeypatch)
+    state_path = tmp_path / "state.json"
+    register_calls: list[str] = []
+    _install_fake_register(monkeypatch, register_calls)
+
+    with TestClient(provisioning.create_app(_service_config(state_path))) as client:
+        complete = _pair_local_client(client)
+
+    _set_connection_namespace(state_path, complete["client_id"], "")
+
+    with TestClient(provisioning.create_app(_service_config(state_path))) as client:
+        listed = client.get(
+            "/v1/local-mindroom/connections",
+            headers={"Authorization": "Bearer token-alice"},
+        )
+        assert listed.status_code == 200
+        assert listed.json()["connections"][0]["namespace"] == ""
+
+        # Registering updates last_seen_at and re-persists state to disk.
+        assert _post_register_agent(client, complete, "mindroom_foo").status_code == 200
+
+    persisted = json.loads(state_path.read_text(encoding="utf-8"))
+    assert [item["namespace"] for item in persisted["connections"]] == [""]
+
+    with TestClient(provisioning.create_app(_service_config(state_path))) as client:
+        assert _post_register_agent(client, complete, "mindroom_bar").status_code == 200
 
 
 def test_register_agent_validates_homeserver(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Problem

Since #1038, `/v1/local-mindroom/register-agent` enforces `_is_managed_agent_username_for_namespace(username, connection.namespace)`, requiring usernames shaped like `mindroom_<entity>_<namespace>`. Legacy/operator instances that predate namespaces use plain `mindroom_<entity>` usernames and are hard-broken: there was no way to opt a trusted connection out, and an empty namespace was regenerated on state load, so it could not even be forced by hand.

## Change

- A connection whose `namespace` is the empty string is **namespace-exempt**: the suffix check is skipped, but the username must still start with `MANAGED_AGENT_USERNAME_PREFIX` (`mindroom_`), have a non-empty entity part, and be a valid Matrix localpart (`[a-z0-9._=/+-]+`).
- State load now preserves an explicitly empty namespace instead of regenerating one, so the exemption survives restarts and re-persist cycles. A missing/non-string namespace still gets the derived fallback as before.
- Pairing is unchanged: `_generate_connection_namespace` still assigns a random namespace to every new connection, so `""` is only ever an operator-set state. The pair/complete response path needs no changes — a freshly paired connection can never be exempt.
- Operator workflow documented in the module docstring: stop the service, set `"namespace": ""` on the connection in the state file (`MINDROOM_PROVISIONING_STATE_PATH`, default `/var/lib/mindroom-local-provisioning/state.json`), start the service.

## Tests

`tests/test_local_mindroom_provisioning_service.py` (17 passed):
- Exempt connection registers plain `mindroom_foo` → 200, and the register call reaches Matrix.
- Exempt connection still rejects `other_foo`, bare `mindroom_`, and invalid localpart `mindroom_Foo` → 403.
- Namespaced connections unchanged: plain `mindroom_foo` → 403 with "outside this local connection namespace" (new parametrize case); `mindroom_<entity>_<ns>` allowed (existing happy path).
- State round-trip: `""` survives load → list → register (re-persist) → restart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened agent registration checks to reject invalid usernames earlier and return clearer errors.
  * Added support for a namespace-exempt connection mode while still enforcing required username format and prefix rules.
  * Improved saved-state handling so missing or malformed namespace settings now fall back safely instead of being accepted.

* **Tests**
  * Expanded coverage for namespace-exempt behavior, invalid username handling, and state reload/persistence scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->