### PR TITLE
Surface real provisioning error details instead of always claiming revoked credentials

### DIFF
--- a/scripts/local_mindroom_provisioning_service.py
+++ b/scripts/local_mindroom_provisioning_service.py
@@ -53,6 +53,10 @@ RATE_LIMIT_STALE_SECONDS = 3600
 NAMESPACE_ALPHABET = "abcdefghjkmnpqrstuvwxyz23456789"
 NAMESPACE_LENGTH = 8
 MANAGED_AGENT_USERNAME_PREFIX = "mindroom_"
+# The local MindRoom client (src/mindroom/matrix/provisioning.py) classifies
+# errors by these exact strings; a contract test keeps the two sides in sync.
+CONNECTION_REVOKED_DETAIL = "Connection revoked"
+NAMESPACE_MISMATCH_DETAIL = "Requested username is outside this local connection namespace"
 PAIR_STATUS_SESSION_HEADER = "X-Local-MindRoom-Pair-Session-Id"
 
 
@@ -513,7 +517,7 @@ def _require_local_client(
     if not hmac.compare_digest(expected_hash, provided_hash):
         raise HTTPException(status_code=401, detail="Invalid local client credentials")
     if connection.revoked_at:
-        raise HTTPException(status_code=403, detail="Connection revoked")
+        raise HTTPException(status_code=403, detail=CONNECTION_REVOKED_DETAIL)
     return connection
 
 
@@ -820,7 +824,7 @@ async def register_agent(
         if not _is_managed_agent_username_for_namespace(payload.username, connection.namespace):
             raise HTTPException(
                 status_code=403,
-                detail="Requested username is outside this local connection namespace",
+                detail=NAMESPACE_MISMATCH_DETAIL,
             )
         connection.last_seen_at = now
         _persist_state_unlocked(state, config.state_path)

--- a/src/mindroom/cli/connect.py
+++ b/src/mindroom/cli/connect.py
@@ -11,6 +11,7 @@ import yaml
 from mindroom.cli.owner import parse_owner_matrix_user_id, replace_owner_placeholders_in_text
 from mindroom.config.yaml_includes import load_yaml_config_source
 from mindroom.constants import OWNER_MATRIX_USER_ID_ENV
+from mindroom.http_error_detail import error_detail_from_response
 
 from .env_file import env_path_for_config, upsert_env_values
 
@@ -68,7 +69,7 @@ def complete_local_pairing(
         raise ValueError(msg) from exc
 
     if not response.is_success:
-        detail = _extract_error_detail(response)
+        detail = error_detail_from_response(response)
         msg = f"Pairing failed ({response.status_code}): {detail}"
         raise ValueError(msg)
 
@@ -173,20 +174,3 @@ def _parse_namespace(raw_value: object) -> str | None:
     if _NAMESPACE_RE.fullmatch(namespace):
         return namespace
     return None
-
-
-def _extract_error_detail(response: httpx.Response) -> str:
-    """Extract a compact error detail from JSON or plaintext responses."""
-    try:
-        body = response.json()
-    except ValueError:
-        text = response.text.strip()
-        return text or "unknown error"
-
-    if isinstance(body, dict):
-        detail = body.get("detail")
-        if isinstance(detail, str):
-            return detail
-        if detail is not None:
-            return str(detail)
-    return "unknown error"

--- a/src/mindroom/http_error_detail.py
+++ b/src/mindroom/http_error_detail.py
@@ -1,0 +1,54 @@
+"""Safe error-detail extraction from HTTP error responses."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+_MAX_LENGTH = 300
+
+
+class _ErrorResponse(Protocol):
+    """The error-body surface of an httpx.Response (a protocol so importers can lazy-import httpx)."""
+
+    text: str
+
+    def json(self) -> object: ...
+
+
+def error_detail_from_response(response: _ErrorResponse) -> str:
+    """Extract a compact, safe error detail from a JSON or plaintext error response.
+
+    FastAPI validation errors carry ``detail`` as a list whose items echo the
+    submitted request body under ``input``; only ``loc``/``msg`` are kept so
+    secrets in the request body never reach error messages or logs. The raw
+    body text is used only when the body is not JSON at all.
+    """
+    try:
+        raw = response.json()
+    except ValueError:
+        return response.text.strip()[:_MAX_LENGTH] or "unknown error"
+    body = _json_object(raw)
+    detail = body.get("detail") if body is not None else None
+    if isinstance(detail, str) and detail.strip():
+        return detail.strip()[:_MAX_LENGTH]
+    if isinstance(detail, list):
+        parts = [part for part in map(_validation_error_part, detail) if part is not None]
+        if parts:
+            return "; ".join(parts)[:_MAX_LENGTH]
+    return "unknown error"
+
+
+def _json_object(value: object) -> dict[str, object] | None:
+    if not isinstance(value, dict):
+        return None
+    return {str(key): item for key, item in value.items()}
+
+
+def _validation_error_part(item: object) -> str | None:
+    entry = _json_object(item)
+    if entry is None:
+        return None
+    loc = entry.get("loc")
+    msg = entry.get("msg")
+    field = ".".join(str(part) for part in loc) if isinstance(loc, list) and loc else "request"
+    return f"{field}: {msg}" if isinstance(msg, str) else field

--- a/src/mindroom/matrix/provisioning.py
+++ b/src/mindroom/matrix/provisioning.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, NoReturn
 
 import httpx
 
@@ -86,6 +86,54 @@ class _ProvisioningRegisterResult:
     user_id: str
 
 
+# Detail strings raised by scripts/local_mindroom_provisioning_service.py when the
+# client credentials themselves are the problem. Only these justify the "re-pair"
+# advice; other 403 details (e.g. namespace enforcement) describe a different failure.
+_CLIENT_AUTH_FAILURE_DETAILS = frozenset(
+    {
+        "Missing local client credentials",
+        "Invalid local client credentials",
+        "Connection revoked",
+    },
+)
+_NAMESPACE_MISMATCH_DETAIL = "Requested username is outside this local connection namespace"
+_ERROR_DETAIL_MAX_LENGTH = 300
+
+
+def _provisioning_error_detail(response: httpx.Response) -> str:
+    """Extract the server-supplied error detail from a provisioning error response."""
+    try:
+        body = response.json()
+    except ValueError:
+        body = None
+    if isinstance(body, dict):
+        detail = body.get("detail")
+        if isinstance(detail, str) and detail.strip():
+            return detail.strip()[:_ERROR_DETAIL_MAX_LENGTH]
+    return response.text.strip()[:_ERROR_DETAIL_MAX_LENGTH] or "unknown error"
+
+
+def _raise_for_register_agent_error(response: httpx.Response, *, username: str) -> NoReturn:
+    """Raise the appropriate error for a failed register-agent response."""
+    detail = _provisioning_error_detail(response)
+    if response.status_code == 401 or (response.status_code == 403 and detail in _CLIENT_AUTH_FAILURE_DETAILS):
+        msg = "Provisioning credentials are invalid or revoked. Run `mindroom connect --pair-code ...` again."
+        raise matrix_startup_error(msg, permanent=True)
+    if response.status_code == 403:
+        msg = f"Provisioning service refused to register agent user {username!r}: {detail}"
+        if detail == _NAMESPACE_MISMATCH_DETAIL:
+            msg += (
+                " Usernames must match mindroom_<entity>_<namespace> for this connection, "
+                "so this connection's namespace does not allow this username."
+            )
+        raise matrix_startup_error(msg, permanent=True)
+    if response.status_code == 404:
+        msg = "Provisioning service does not support /register-agent yet. Deploy the latest local provisioning service."
+        raise matrix_startup_error(msg, permanent=True)
+    msg = f"Provisioning service returned HTTP {response.status_code}: {detail}"
+    raise ValueError(msg)
+
+
 async def register_user_via_provisioning_service(
     *,
     provisioning_url: str,
@@ -120,18 +168,7 @@ async def register_user_via_provisioning_service(
         raise ValueError(msg) from exc
 
     if not response.is_success:
-        detail = response.text.strip() or "unknown error"
-        if response.status_code in {401, 403}:
-            msg = "Provisioning credentials are invalid or revoked. Run `mindroom connect --pair-code ...` again."
-            raise matrix_startup_error(msg, permanent=True)
-        if response.status_code == 404:
-            msg = (
-                "Provisioning service does not support /register-agent yet. "
-                "Deploy the latest local provisioning service."
-            )
-            raise matrix_startup_error(msg, permanent=True)
-        msg = f"Provisioning service returned HTTP {response.status_code}: {detail}"
-        raise ValueError(msg)
+        _raise_for_register_agent_error(response, username=username)
 
     try:
         body = response.json()

--- a/src/mindroom/matrix/provisioning.py
+++ b/src/mindroom/matrix/provisioning.py
@@ -8,6 +8,7 @@ from typing import Literal, NoReturn
 import httpx
 
 from mindroom.constants import RuntimePaths, runtime_env_path, runtime_matrix_ssl_verify
+from mindroom.http_error_detail import error_detail_from_response
 from mindroom.matrix.client_session import matrix_startup_error
 from mindroom.matrix.identity import parse_current_matrix_user_id
 
@@ -86,49 +87,42 @@ class _ProvisioningRegisterResult:
     user_id: str
 
 
-# Detail strings raised by scripts/local_mindroom_provisioning_service.py when the
-# client credentials themselves are the problem. Only these justify the "re-pair"
-# advice; other 403 details (e.g. namespace enforcement) describe a different failure.
-_CLIENT_AUTH_FAILURE_DETAILS = frozenset(
-    {
-        "Missing local client credentials",
-        "Invalid local client credentials",
-        "Connection revoked",
-    },
-)
+# Kept in sync with scripts/local_mindroom_provisioning_service.py by a contract
+# test. The service's other credential failures ("Missing/Invalid local client
+# credentials") always use HTTP 401, so only the revoked detail matters for 403.
+_CONNECTION_REVOKED_DETAIL = "Connection revoked"
 _NAMESPACE_MISMATCH_DETAIL = "Requested username is outside this local connection namespace"
-_ERROR_DETAIL_MAX_LENGTH = 300
-
-
-def _provisioning_error_detail(response: httpx.Response) -> str:
-    """Extract the server-supplied error detail from a provisioning error response."""
-    try:
-        body = response.json()
-    except ValueError:
-        body = None
-    if isinstance(body, dict):
-        detail = body.get("detail")
-        if isinstance(detail, str) and detail.strip():
-            return detail.strip()[:_ERROR_DETAIL_MAX_LENGTH]
-    return response.text.strip()[:_ERROR_DETAIL_MAX_LENGTH] or "unknown error"
 
 
 def _raise_for_register_agent_error(response: httpx.Response, *, username: str) -> NoReturn:
     """Raise the appropriate error for a failed register-agent response."""
-    detail = _provisioning_error_detail(response)
-    if response.status_code == 401 or (response.status_code == 403 and detail in _CLIENT_AUTH_FAILURE_DETAILS):
-        msg = "Provisioning credentials are invalid or revoked. Run `mindroom connect --pair-code ...` again."
+    detail = error_detail_from_response(response)
+    if response.status_code == 401 or (response.status_code == 403 and detail == _CONNECTION_REVOKED_DETAIL):
+        msg = (
+            f"Provisioning credentials are invalid or revoked (server said: {detail}). "
+            "Run `mindroom connect --pair-code ...` again."
+        )
         raise matrix_startup_error(msg, permanent=True)
     if response.status_code == 403:
         msg = f"Provisioning service refused to register agent user {username!r}: {detail}"
         if detail == _NAMESPACE_MISMATCH_DETAIL:
             msg += (
-                " Usernames must match mindroom_<entity>_<namespace> for this connection, "
-                "so this connection's namespace does not allow this username."
+                ". Usernames must match mindroom_<entity>_<namespace>; check that MINDROOM_NAMESPACE "
+                "matches this connection's namespace or re-run `mindroom connect --pair-code ...`."
             )
         raise matrix_startup_error(msg, permanent=True)
     if response.status_code == 404:
         msg = "Provisioning service does not support /register-agent yet. Deploy the latest local provisioning service."
+        raise matrix_startup_error(msg, permanent=True)
+    if response.status_code in {400, 422}:
+        msg = f"Provisioning service rejected the register-agent request (HTTP {response.status_code}): {detail}"
+        raise matrix_startup_error(msg, permanent=True)
+    if 300 <= response.status_code < 400:
+        location = response.headers.get("location", "unknown")
+        msg = (
+            f"Provisioning service URL redirects (HTTP {response.status_code} to {location}). "
+            "Update MINDROOM_PROVISIONING_URL to the final URL."
+        )
         raise matrix_startup_error(msg, permanent=True)
     msg = f"Provisioning service returned HTTP {response.status_code}: {detail}"
     raise ValueError(msg)

--- a/tach.toml
+++ b/tach.toml
@@ -40,6 +40,14 @@ path = "mindroom.path_globs"
 depends_on = []
 
 [[modules]]
+path = "mindroom.http_error_detail"
+depends_on = []
+visibility = [
+    "mindroom.cli.connect",
+    "mindroom.matrix.provisioning",
+]
+
+[[modules]]
 path = "mindroom.tool_schema_cache"
 depends_on = []
 visibility = [
@@ -1053,7 +1061,11 @@ depends_on = [
 
 [[modules]]
 path = "mindroom.matrix.provisioning"
-depends_on = ["mindroom.matrix.client_session", "mindroom.constants"]
+depends_on = [
+    "mindroom.constants",
+    "mindroom.http_error_detail",
+    "mindroom.matrix.client_session",
+]
 
 [[modules]]
 path = "mindroom.matrix.room_cleanup"
@@ -2078,6 +2090,7 @@ depends_on = [
     "mindroom.cli.owner",
     "mindroom.config.yaml_includes",
     "mindroom.constants",
+    "mindroom.http_error_detail",
 ]
 
 [[modules]]

--- a/tests/test_local_mindroom_provisioning_service.py
+++ b/tests/test_local_mindroom_provisioning_service.py
@@ -9,6 +9,7 @@ from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 import scripts.local_mindroom_provisioning_service as provisioning
+from mindroom.matrix import provisioning as matrix_provisioning
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -447,3 +448,9 @@ async def test_register_agent_user_in_use_respects_matrix_server_name_override(
     result = await provisioning._register_agent_with_matrix(config, payload)
     assert result.status == "user_in_use"
     assert result.user_id == "@mindroom_code:mindroom.chat"
+
+
+def test_client_error_detail_constants_match_service() -> None:
+    """The runtime client classifies register-agent 403s by these exact strings."""
+    assert matrix_provisioning._CONNECTION_REVOKED_DETAIL == provisioning.CONNECTION_REVOKED_DETAIL
+    assert matrix_provisioning._NAMESPACE_MISMATCH_DETAIL == provisioning.NAMESPACE_MISMATCH_DETAIL

--- a/tests/test_matrix_agent_manager.py
+++ b/tests/test_matrix_agent_manager.py
@@ -859,48 +859,78 @@ class TestMatrixRegistration:
                 runtime_paths=runtime_paths,
             )
 
-    @pytest.mark.asyncio
-    async def test_register_user_via_provisioning_service_invalid_credentials_is_permanent(
-        self,
+    @staticmethod
+    async def _register_via_provisioning_with_response(
         tmp_path: Path,
+        response: httpx.Response,
     ) -> None:
-        """Credential revocation from the provisioning service should stop startup retries."""
-        client_secret = "secret-123"  # noqa: S105
-        password = "test_pass"  # noqa: S105
-
-        class _FakeResponse:
-            is_success = False
-            status_code = 403
-            text = "forbidden"
-
-        class _FakeAsyncClient:
-            def __init__(self, *_: object, **__: object) -> None:
-                pass
-
-            async def __aenter__(self) -> Self:
-                return self
-
-            async def __aexit__(self, *_: object) -> None:
-                return None
-
-            async def post(self, *_: object, **__: object) -> _FakeResponse:
-                return _FakeResponse()
-
         runtime_paths = constants_mod.resolve_runtime_paths(config_path=tmp_path / "config.yaml", process_env={})
-        with (
-            patch.object(provisioning.httpx, "AsyncClient", _FakeAsyncClient),
-            pytest.raises(PermanentMatrixStartupError, match="invalid or revoked"),
-        ):
+        with patch.object(provisioning.httpx, "AsyncClient", _recording_httpx_async_client([], response)):
             await provisioning.register_user_via_provisioning_service(
                 provisioning_url="https://provisioning.example",
                 client_id="client-123",
-                client_secret=client_secret,
+                client_secret="secret-123",  # noqa: S106
                 homeserver="http://localhost:8008",
-                username="test_user",
-                password=password,
+                username="mindroom_test_user_otherns",
+                password="test_pass",  # noqa: S106
                 display_name="Test User",
                 runtime_paths=runtime_paths,
             )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("status_code", "detail"),
+        [
+            (401, "Invalid local client credentials"),
+            (403, "Connection revoked"),
+        ],
+    )
+    async def test_register_user_via_provisioning_service_client_auth_failure_is_permanent(
+        self,
+        tmp_path: Path,
+        status_code: int,
+        detail: str,
+    ) -> None:
+        """Only genuine client-auth failures should claim the credentials are invalid or revoked."""
+        with pytest.raises(PermanentMatrixStartupError, match="invalid or revoked"):
+            await self._register_via_provisioning_with_response(
+                tmp_path,
+                httpx.Response(status_code, json={"detail": detail}),
+            )
+
+    @pytest.mark.asyncio
+    async def test_register_user_via_provisioning_service_namespace_mismatch_surfaces_detail(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A namespace-enforcement 403 must surface the server detail, not blame the credentials."""
+        detail = "Requested username is outside this local connection namespace"
+        with pytest.raises(PermanentMatrixStartupError) as excinfo:
+            await self._register_via_provisioning_with_response(
+                tmp_path,
+                httpx.Response(403, json={"detail": detail}),
+            )
+
+        message = str(excinfo.value)
+        assert detail in message
+        assert "mindroom_<entity>_<namespace>" in message
+        assert "invalid or revoked" not in message
+        assert "secret-123" not in message
+        assert "test_pass" not in message
+
+    @pytest.mark.asyncio
+    async def test_register_user_via_provisioning_service_malformed_error_body_surfaces_text(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A 403 with a non-JSON body should surface the raw text instead of the re-pair advice."""
+        with pytest.raises(PermanentMatrixStartupError, match="policy says no") as excinfo:
+            await self._register_via_provisioning_with_response(
+                tmp_path,
+                httpx.Response(403, content=b"policy says no"),
+            )
+
+        assert "invalid or revoked" not in str(excinfo.value)
 
     @pytest.mark.asyncio
     async def test_register_user_via_provisioning_service_invalid_json_is_permanent(self, tmp_path: Path) -> None:

--- a/tests/test_matrix_agent_manager.py
+++ b/tests/test_matrix_agent_manager.py
@@ -879,24 +879,30 @@ class TestMatrixRegistration:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        ("status_code", "detail"),
+        "response",
         [
-            (401, "Invalid local client credentials"),
-            (403, "Connection revoked"),
+            pytest.param(
+                httpx.Response(401, json={"detail": "Invalid local client credentials"}),
+                id="invalid-credentials-401",
+            ),
+            pytest.param(
+                httpx.Response(401, content=b"<html>authentication required</html>"),
+                id="proxy-401-unrelated-body",
+            ),
+            pytest.param(
+                httpx.Response(403, json={"detail": "Connection revoked"}),
+                id="connection-revoked-403",
+            ),
         ],
     )
     async def test_register_user_via_provisioning_service_client_auth_failure_is_permanent(
         self,
         tmp_path: Path,
-        status_code: int,
-        detail: str,
+        response: httpx.Response,
     ) -> None:
-        """Only genuine client-auth failures should claim the credentials are invalid or revoked."""
+        """Any 401, and a revoked-connection 403, should ask the user to re-pair."""
         with pytest.raises(PermanentMatrixStartupError, match="invalid or revoked"):
-            await self._register_via_provisioning_with_response(
-                tmp_path,
-                httpx.Response(status_code, json={"detail": detail}),
-            )
+            await self._register_via_provisioning_with_response(tmp_path, response)
 
     @pytest.mark.asyncio
     async def test_register_user_via_provisioning_service_namespace_mismatch_surfaces_detail(
@@ -914,9 +920,8 @@ class TestMatrixRegistration:
         message = str(excinfo.value)
         assert detail in message
         assert "mindroom_<entity>_<namespace>" in message
+        assert "MINDROOM_NAMESPACE" in message
         assert "invalid or revoked" not in message
-        assert "secret-123" not in message
-        assert "test_pass" not in message
 
     @pytest.mark.asyncio
     async def test_register_user_via_provisioning_service_malformed_error_body_surfaces_text(
@@ -933,45 +938,62 @@ class TestMatrixRegistration:
         assert "invalid or revoked" not in str(excinfo.value)
 
     @pytest.mark.asyncio
+    async def test_register_user_via_provisioning_service_validation_error_redacts_request_body(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """FastAPI 422 bodies echo the request under 'input'; the password must never reach the error."""
+        body = {
+            "detail": [
+                {
+                    "type": "missing",
+                    "loc": ["body", "display_name"],
+                    "msg": "Field required",
+                    "input": {
+                        "homeserver": "http://localhost:8008",
+                        "username": "mindroom_test_user_otherns",
+                        "password": "test_pass",
+                    },
+                },
+            ],
+        }
+        with pytest.raises(PermanentMatrixStartupError) as excinfo:
+            await self._register_via_provisioning_with_response(tmp_path, httpx.Response(422, json=body))
+
+        message = str(excinfo.value)
+        assert "test_pass" not in message
+        assert "body.display_name: Field required" in message
+
+    @pytest.mark.asyncio
+    async def test_register_user_via_provisioning_service_homeserver_mismatch_is_permanent(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A deterministic 400 (homeserver mismatch) must stop startup retries and surface the detail."""
+        detail = "Invalid homeserver for this provisioning service. Expected https://a, got https://b."
+        with pytest.raises(PermanentMatrixStartupError, match="Expected https://a"):
+            await self._register_via_provisioning_with_response(
+                tmp_path,
+                httpx.Response(400, json={"detail": detail}),
+            )
+
+    @pytest.mark.asyncio
+    async def test_register_user_via_provisioning_service_redirect_is_permanent(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A redirecting provisioning URL is a config error, not something to retry forever."""
+        response = httpx.Response(308, headers={"location": "https://mindroom.chat/v1/local-mindroom"})
+        with pytest.raises(PermanentMatrixStartupError, match="MINDROOM_PROVISIONING_URL"):
+            await self._register_via_provisioning_with_response(tmp_path, response)
+
+    @pytest.mark.asyncio
     async def test_register_user_via_provisioning_service_invalid_json_is_permanent(self, tmp_path: Path) -> None:
         """Invalid provisioning responses should not trigger endless retries."""
-        client_secret = "secret-123"  # noqa: S105
-        password = "test_pass"  # noqa: S105
-
-        class _FakeResponse:
-            is_success = True
-
-            def json(self) -> object:
-                msg = "bad json"
-                raise ValueError(msg)
-
-        class _FakeAsyncClient:
-            def __init__(self, *_: object, **__: object) -> None:
-                pass
-
-            async def __aenter__(self) -> Self:
-                return self
-
-            async def __aexit__(self, *_: object) -> None:
-                return None
-
-            async def post(self, *_: object, **__: object) -> _FakeResponse:
-                return _FakeResponse()
-
-        runtime_paths = constants_mod.resolve_runtime_paths(config_path=tmp_path / "config.yaml", process_env={})
-        with (
-            patch.object(provisioning.httpx, "AsyncClient", _FakeAsyncClient),
-            pytest.raises(PermanentMatrixStartupError, match="invalid JSON"),
-        ):
-            await provisioning.register_user_via_provisioning_service(
-                provisioning_url="https://provisioning.example",
-                client_id="client-123",
-                client_secret=client_secret,
-                homeserver="http://localhost:8008",
-                username="test_user",
-                password=password,
-                display_name="Test User",
-                runtime_paths=runtime_paths,
+        with pytest.raises(PermanentMatrixStartupError, match="invalid JSON"):
+            await self._register_via_provisioning_with_response(
+                tmp_path,
+                httpx.Response(200, content=b"not json"),
             )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

`register_user_via_provisioning_service()` collapsed **every** 401/403 from `POST /v1/local-mindroom/register-agent` into:

> Provisioning credentials are invalid or revoked. Run `mindroom connect --pair-code ...` again.

But the server returns distinct 403s — notably the namespace enforcement added in #1038 (`{"detail": "Requested username is outside this local connection namespace"}`). Real-world debugging of that case wasted hours because the client claimed valid credentials were revoked.

## Changes

- Parse the JSON error body and extract `detail` when present, falling back to `response.text` truncated to 300 chars.
- Keep the "invalid or revoked / re-pair" message **only** for genuine client-auth failures: any 401, or a 403 whose detail matches the known auth strings from `scripts/local_mindroom_provisioning_service.py` (`Missing local client credentials`, `Invalid local client credentials`, `Connection revoked`).
- Other 403s raise a permanent startup error that includes the server's detail verbatim. The namespace-mismatch case additionally gets a hint that usernames must match `mindroom_<entity>_<namespace>` for this connection.
- The client secret and password never appear in any error text (asserted in tests).
- 404 and non-4xx branches keep their existing messages (the generic branch now benefits from JSON `detail` extraction instead of raw body text).
- The error branching moved into a `_raise_for_register_agent_error()` helper to keep the main function under the complexity limit.

## Tests

Extended `tests/test_matrix_agent_manager.py` with: 401 invalid client, 403 connection revoked, 403 namespace mismatch (asserts the detail and hint are surfaced and no secrets leak), and a 403 with a malformed (non-JSON) body that surfaces the raw text. The old fake-response 403 test was replaced by these, using real `httpx.Response` objects.

`uv run pytest tests/test_matrix_agent_manager.py -n 0 --no-cov`: 40 passed. `pre-commit` on both files: all hooks pass.