### PR TITLE
Sanitize replayed tool-search result blocks to the request schema

### DIFF
--- a/src/mindroom/claude_prompt_cache.py
+++ b/src/mindroom/claude_prompt_cache.py
@@ -60,6 +60,12 @@ _TOOL_SEARCH_TOOL_TYPE = "tool_search_tool_regex_20251119"
 _TOOL_SEARCH_TOOL_NAME = "tool_search_tool_regex"
 _NATIVE_TOOL_SEARCH_PROVIDERS = frozenset({"anthropic", "vertexai_claude"})
 
+_TOOL_SEARCH_RESULT_BLOCK_TYPE = "tool_search_tool_result"
+# The request schema for replayed tool-search results accepts only these keys
+# (ToolSearchToolResultBlockParam); response blocks additionally carry
+# citations/parsed_output/text, which the API rejects as extra inputs.
+_TOOL_SEARCH_RESULT_INPUT_KEYS = frozenset({"type", "tool_use_id", "content", "cache_control"})
+
 
 def native_tool_search_supported(provider: str, model_id: str) -> bool:
     """Return whether one authored provider/model pair supports server-side tool search.
@@ -206,6 +212,51 @@ def _model_deferred_tool_names(model: AnthropicClaude) -> frozenset[str]:
     return deferred_tool_names if isinstance(deferred_tool_names, frozenset) else frozenset()
 
 
+def _request_kwargs_with_replay_safe_tool_search_results(request_kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Strip response-only fields from replayed tool-search result blocks.
+
+    Agno replays captured server-tool blocks verbatim in assistant history,
+    and the SDK response block carries fields (``citations``, ``parsed_output``,
+    ``text``) that the request schema rejects with a 400 ("Extra inputs are
+    not permitted"). Once such a block is persisted, every later turn of that
+    conversation replays it, so the thread stays broken until the block is
+    sanitized here. Keys used for history identity (``type``, ``tool_use_id``)
+    are preserved. The input structure is never mutated.
+    """
+    messages = request_kwargs.get("messages")
+    if not isinstance(messages, list):
+        return request_kwargs
+    sanitized_messages = list(messages)
+    changed = False
+    for message_index, message in enumerate(sanitized_messages):
+        message_dict = _as_dict(message)
+        content = message_dict.get("content") if message_dict is not None else None
+        if message_dict is None or not isinstance(content, list):
+            continue
+        sanitized_content = list(content)
+        content_changed = False
+        for block_index, block in enumerate(sanitized_content):
+            block_dict = _as_dict(block)
+            if block_dict is None or block_dict.get("type") != _TOOL_SEARCH_RESULT_BLOCK_TYPE:
+                continue
+            if set(block_dict) <= _TOOL_SEARCH_RESULT_INPUT_KEYS:
+                continue
+            sanitized_content[block_index] = {
+                key: value for key, value in block_dict.items() if key in _TOOL_SEARCH_RESULT_INPUT_KEYS
+            }
+            content_changed = True
+        if content_changed:
+            sanitized_message = dict(message_dict)
+            sanitized_message["content"] = sanitized_content
+            sanitized_messages[message_index] = sanitized_message
+            changed = True
+    if not changed:
+        return request_kwargs
+    prepared_kwargs = dict(request_kwargs)
+    prepared_kwargs["messages"] = sanitized_messages
+    return prepared_kwargs
+
+
 def _request_kwargs_with_deferred_tool_search(
     request_kwargs: dict[str, Any],
     deferred_tool_names: frozenset[str],
@@ -278,8 +329,9 @@ class _PromptCacheMessagesProxy:
         self._model = model
 
     def _prepared(self, request_kwargs: dict[str, Any]) -> dict[str, Any]:
+        prepared_kwargs = _request_kwargs_with_replay_safe_tool_search_results(request_kwargs)
         prepared_kwargs = _request_kwargs_with_deferred_tool_search(
-            request_kwargs,
+            prepared_kwargs,
             _model_deferred_tool_names(self._model),
         )
         if not self._model.cache_system_prompt:
@@ -369,16 +421,15 @@ def install_claude_prompt_cache_hook(model: object) -> None:
     original_get_async_client = model.get_async_client
     model_dict[_PROMPT_CACHE_HOOK_ATTR] = True
 
+    # Always proxy: the ladder and deferred-tool tagging gate themselves inside
+    # _prepared, but replayed tool-search result blocks must be sanitized on
+    # every request, including cache-disabled models replaying history.
     def _get_client_with_prompt_cache() -> object:
         client = original_get_client()
-        if not model.cache_system_prompt and not _model_deferred_tool_names(model):
-            return client
         return _PromptCacheClientProxy(client, model)
 
     def _get_async_client_with_prompt_cache() -> object:
         client = original_get_async_client()
-        if not model.cache_system_prompt and not _model_deferred_tool_names(model):
-            return client
         return _PromptCacheClientProxy(client, model)
 
     model_dict["get_client"] = _get_client_with_prompt_cache

--- a/tests/test_extra_kwargs.py
+++ b/tests/test_extra_kwargs.py
@@ -26,6 +26,7 @@ from mindroom.claude_prompt_cache import (
     _prompt_cache_control,
     _PromptCacheClientProxy,
     _request_kwargs_with_prompt_cache_ladder,
+    _request_kwargs_with_replay_safe_tool_search_results,
     install_claude_deferred_tool_search,
     install_claude_prompt_cache_hook,
     native_tool_search_supported,
@@ -1065,6 +1066,15 @@ _TOOL_SEARCH_RESULT_BLOCK = {
         "tool_references": [{"type": "tool_reference", "tool_name": "get_weather"}],
     },
 }
+# The shape the SDK response capture actually persists: response-only fields
+# (citations/parsed_output/text) ride along and the request schema rejects
+# them with "Extra inputs are not permitted".
+_DIRTY_TOOL_SEARCH_RESULT_BLOCK = {
+    **_TOOL_SEARCH_RESULT_BLOCK,
+    "citations": None,
+    "parsed_output": None,
+    "text": "Found 1 tool",
+}
 
 
 def _anthropic_response(content: list[dict[str, object]]) -> AnthropicMessage:
@@ -1131,6 +1141,55 @@ def test_server_tool_blocks_replay_to_non_anthropic_provider_without_crashing() 
 
     assert formatted["role"] == "assistant"
     assert formatted["content"] == "I'll search for a weather tool."
+
+
+def test_replay_safe_tool_search_results_strips_response_only_fields() -> None:
+    """Replayed tool-search results must carry only request-schema fields."""
+    request_kwargs = {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": [dict(_DIRTY_TOOL_SEARCH_RESULT_BLOCK), {"type": "text", "text": "found it"}],
+            },
+        ],
+    }
+
+    prepared = _request_kwargs_with_replay_safe_tool_search_results(request_kwargs)
+
+    assert prepared["messages"][0]["content"][0] == _TOOL_SEARCH_RESULT_BLOCK
+    assert prepared["messages"][0]["content"][1] == {"type": "text", "text": "found it"}
+    assert "citations" in request_kwargs["messages"][0]["content"][0]
+    assert _request_kwargs_with_replay_safe_tool_search_results(prepared) is prepared
+
+
+def test_prompt_cache_hook_sanitizes_replayed_tool_search_results() -> None:
+    """A persisted tool-search result with response-only fields must not reach the wire."""
+    model = _vertex_claude_model()
+    captured_kwargs = _install_fake_sync_client(model)
+    install_claude_prompt_cache_hook(model)
+
+    messages = [
+        Message(role="system", content="System prompt"),
+        Message(role="user", content="Find me a tool."),
+        Message(
+            role="assistant",
+            content="I'll search for a weather tool.",
+            provider_data={
+                "server_tool_blocks": [dict(_SERVER_TOOL_USE_BLOCK), dict(_DIRTY_TOOL_SEARCH_RESULT_BLOCK)],
+            },
+        ),
+        Message(role="user", content="Thanks, what did you find?"),
+    ]
+    model.response(messages=messages, compression_manager=None)
+
+    wire_messages = captured_kwargs[0]["messages"]
+    search_results = [
+        block
+        for message in wire_messages
+        for block in (message.get("content") or [])
+        if isinstance(block, dict) and block.get("type") == "tool_search_tool_result"
+    ]
+    assert search_results == [_TOOL_SEARCH_RESULT_BLOCK]
 
 
 def test_vertexai_claude_loads_runtime_google_application_credentials(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Problem

The SDK's `tool_search_tool_result` **response** block carries fields the **request** schema does not accept: `citations`, `parsed_output`, and `text` (`ToolSearchToolResultBlockParam` allows only `type`, `tool_use_id`, `content`, `cache_control`). Agno persists captured server-tool blocks verbatim in `provider_data["server_tool_blocks"]` and replays them into assistant history on every later turn, so as soon as one tool-search turn is stored, every subsequent request in that conversation fails:

```
400 - messages.N.content.M.tool_search_tool_result.citations: Extra inputs are not permitted
```

The thread then stays broken until compaction, because each retry replays the same block. Observed live within hours of #1412 reaching real traffic. Notably, enforcement is model-dependent: a Haiku 4.5 endpoint accepted the extra fields while Fable 5 rejects them, which is why #1412's clean-fixture round-trip tests and small-model smoke checks did not catch it.

## Change

- `_prepared()` now strips replayed `tool_search_tool_result` blocks down to the request-schema allowlist before the deferred-tagging and ladder steps. Identity keys (`type`, `tool_use_id`) and `cache_control` are preserved, so Agno's history dedup and the cache ladder are unaffected. Copy-on-write, no-op fast path when blocks are already clean.
- The client proxy is now installed unconditionally (the ladder and defer tagging still gate themselves inside `_prepared`), so sanitizing also covers cache-disabled Claude models replaying history.

Poisoned blocks already persisted in session storage need no repair: they are sanitized at request time, so affected conversations recover on the next turn once this deploys.

## Validation

- Regression tests use a dirty fixture matching the actually-persisted shape (`citations: null`, `parsed_output`, `text`): unit-level sanitization (strips extras, preserves content/identity, does not mutate input, no-op fast path) and wire-level through the hooked client from `provider_data` replay.
- Live API validation on the strict model family: the dirty block reproduces the exact 400 unhooked, and succeeds through the hooked client with the same conversation and tools.
- Full `test_extra_kwargs.py` + `test_dynamic_toolkits.py` (98 tests) and pre-commit pass.

## Residual edge (out of scope)

A replayed `tool_reference` naming a tool absent from the current request's `tools[]` is rejected by the API ("Tool reference ... not found in available tools"). That requires the agent's tool surface to shrink mid-conversation (or a mid-thread switch to an agent lacking the tool); left for a follow-up since it needs a policy decision (drop the block vs. prune the reference).