### PR TITLE
Document unconditional client proxying and pin it with a wire test

### DIFF
--- a/src/mindroom/claude_prompt_cache.py
+++ b/src/mindroom/claude_prompt_cache.py
@@ -38,6 +38,13 @@ tool, and orders the tools array deterministically (non-deferred first, then
 deferred sorted by name). Deferred tools may not carry ``cache_control`` (the
 API rejects the request), which is why the ladder's tools marker targets the
 last non-deferred tool.
+
+The hook's third job is history repair: replayed tool-search result blocks
+are stripped down to the request schema on every request, because Agno
+persists the response-shape block verbatim and the API rejects its extra
+fields as a 400. This is why the client proxy is installed unconditionally —
+the ladder and defer tagging gate themselves per request, but a cache-disabled
+model with no deferred tools can still replay poisoned history.
 """
 
 from __future__ import annotations
@@ -405,12 +412,14 @@ def install_claude_prompt_cache_hook(model: object) -> None:
     """Route an Agno Claude model's SDK clients through the prompt-cache ladder.
 
     Applies to every Anthropic-family Claude model (direct API, Vertex, and
-    Bedrock all share the SDK client shape). The ladder is skipped per request
-    while ``cache_system_prompt`` is falsy, so callers that deliberately
-    disable caching (for example one-off summary calls) stay unmarked even
-    when they reuse a hooked model instance. The proxy still engages for such
-    models once deferred tool names are registered, because defer_loading
-    tagging is independent of the cache ladder.
+    Bedrock all share the SDK client shape). Every request goes through the
+    client proxy; the ladder and defer_loading tagging gate themselves per
+    request inside ``_prepared``, so callers that deliberately disable caching
+    (for example one-off summary calls) stay unmarked even when they reuse a
+    hooked model instance. The proxy is never skipped outright because
+    replayed tool-search result blocks must be sanitized on every request —
+    a cache-disabled model with no deferred tools still replays poisoned
+    history.
     """
     if not isinstance(model, AnthropicClaude):
         return
@@ -421,9 +430,6 @@ def install_claude_prompt_cache_hook(model: object) -> None:
     original_get_async_client = model.get_async_client
     model_dict[_PROMPT_CACHE_HOOK_ATTR] = True
 
-    # Always proxy: the ladder and deferred-tool tagging gate themselves inside
-    # _prepared, but replayed tool-search result blocks must be sanitized on
-    # every request, including cache-disabled models replaying history.
     def _get_client_with_prompt_cache() -> object:
         client = original_get_client()
         return _PromptCacheClientProxy(client, model)

--- a/tests/test_extra_kwargs.py
+++ b/tests/test_extra_kwargs.py
@@ -1162,13 +1162,9 @@ def test_replay_safe_tool_search_results_strips_response_only_fields() -> None:
     assert _request_kwargs_with_replay_safe_tool_search_results(prepared) is prepared
 
 
-def test_prompt_cache_hook_sanitizes_replayed_tool_search_results() -> None:
-    """A persisted tool-search result with response-only fields must not reach the wire."""
-    model = _vertex_claude_model()
-    captured_kwargs = _install_fake_sync_client(model)
-    install_claude_prompt_cache_hook(model)
-
-    messages = [
+def _dirty_replay_messages() -> list[Message]:
+    """A conversation whose assistant turn replays a persisted dirty tool-search block."""
+    return [
         Message(role="system", content="System prompt"),
         Message(role="user", content="Find me a tool."),
         Message(
@@ -1180,16 +1176,45 @@ def test_prompt_cache_hook_sanitizes_replayed_tool_search_results() -> None:
         ),
         Message(role="user", content="Thanks, what did you find?"),
     ]
-    model.response(messages=messages, compression_manager=None)
 
-    wire_messages = captured_kwargs[0]["messages"]
-    search_results = [
+
+def _wire_tool_search_results(wire_messages: list[dict[str, object]]) -> list[object]:
+    return [
         block
         for message in wire_messages
         for block in (message.get("content") or [])
         if isinstance(block, dict) and block.get("type") == "tool_search_tool_result"
     ]
-    assert search_results == [_TOOL_SEARCH_RESULT_BLOCK]
+
+
+def test_prompt_cache_hook_sanitizes_replayed_tool_search_results() -> None:
+    """A persisted tool-search result with response-only fields must not reach the wire."""
+    model = _vertex_claude_model()
+    captured_kwargs = _install_fake_sync_client(model)
+    install_claude_prompt_cache_hook(model)
+
+    model.response(messages=_dirty_replay_messages(), compression_manager=None)
+
+    assert _wire_tool_search_results(captured_kwargs[0]["messages"]) == [_TOOL_SEARCH_RESULT_BLOCK]
+
+
+def test_prompt_cache_hook_sanitizes_replay_with_cache_disabled_and_no_deferred_tools() -> None:
+    """Sanitization must engage even when neither the ladder nor defer tagging does.
+
+    Pins the unconditional client proxying: a thread poisoned under a
+    tool-search model and continued via `!model` on a cache-disabled Claude
+    model with no deferred tools must still send schema-clean history, while
+    the disabled ladder stays inert.
+    """
+    model = Claude(id="claude-opus-4-8", api_key="test-key", cache_system_prompt=False)
+    captured_kwargs = _install_fake_sync_client(model)
+    install_claude_prompt_cache_hook(model)
+
+    model.response(messages=_dirty_replay_messages(), compression_manager=None)
+
+    wire_messages = captured_kwargs[0]["messages"]
+    assert _wire_tool_search_results(wire_messages) == [_TOOL_SEARCH_RESULT_BLOCK]
+    assert _count_cache_markers({"messages": list(wire_messages)}) == 0
 
 
 def test_vertexai_claude_loads_runtime_google_application_credentials(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Follow-up to #1426, addressing the two blockers from its post-merge review.

## Stale docstring contradicted the gate removal

`install_claude_prompt_cache_hook`'s docstring still ended with "The proxy still engages for such models once deferred tool names are registered" — describing the exact early-return that #1426 deleted, directly above an inline comment saying the opposite.
A reader would conclude that a cache-disabled, no-deferred-tools model bypasses the proxy, which is the pre-#1426 behavior.
The docstring now states that every request goes through the client proxy, that the ladder and defer tagging gate themselves per request inside `_prepared`, and why the proxy is never skipped outright (replay sanitization must run on every request).
The module header gains a paragraph naming the hook's third responsibility (history repair of replayed tool-search result blocks), and the inline comment is dropped since the docstring in the same function now covers it.

## The gate removal had no pinning test

Reintroducing the removed early-return (`if not model.cache_system_prompt and not _model_deferred_tool_names(model): return client`) broke **zero** tests — the existing wire test used a cache-enabled Vertex model that went through the proxy even under the old gate.
That regression would silently break the real scenario #1426's gate removal covers: a thread poisoned under a tool-search model, then continued via `!model` on a Claude model with caching off and no deferred tools.

Added `test_prompt_cache_hook_sanitizes_replay_with_cache_disabled_and_no_deferred_tools`: `Claude(cache_system_prompt=False)`, no deferred names, hook installed, dirty block in `provider_data` → asserts the sanitized block on the wire and zero cache markers.
The dirty-replay message fixture and wire-extraction comprehension are factored into helpers shared with the existing wire test.

**Verified the pin works**: with the old gate temporarily reintroduced, exactly this one test fails (the dirty block reaches the wire) and all 54 others in the file still pass.

## Testing

- `pytest tests/test_extra_kwargs.py tests/test_dynamic_toolkits.py -n 0 --no-cov` → 99 passed
- `pre-commit run --files src/mindroom/claude_prompt_cache.py tests/test_extra_kwargs.py` → all hooks pass (ruff, ty, vulture, tach)