### PR TITLE
Recognize Z.ai media rejection errors in the inline-media fallback

### DIFF
--- a/src/mindroom/media_fallback.py
+++ b/src/mindroom/media_fallback.py
@@ -45,6 +45,17 @@ _OPENAI_AUDIO_FORMAT_VALUE_PATTERN = re.compile(
     r"invalid value: ['\"][^'\"]+['\"].*supported values are: ['\"]wav['\"] and ['\"]mp3['\"]",
 )
 _OPENAI_OUTPUT_FORMAT_PATTERN = re.compile(r"\boutput_format\b")
+# Z.ai text-only models reject any non-text content part without naming a media
+# kind ("messages.content.type is invalid, allowed values: ['text']"), so every
+# present kind is unsupported for the route.
+_TEXT_ONLY_CONTENT_TYPE_PATTERN = re.compile(
+    r"content(?:\[\d+\])?\.type is invalid, allowed values: \['text'\]",
+)
+# Z.ai reports content part types it cannot parse at all (e.g. OpenAI-style
+# "file" parts) as a bare type error on the message path.
+_CONTENT_PART_TYPE_ERROR_PATTERN = re.compile(
+    r"messages(?:\[\d+\])?\.content(?:\[\d+\])?\.type type error",
+)
 _MEDIA_KIND_PATTERN = r"audio|image|video|file|document"
 _INLINE_MEDIA_UNSUPPORTED_PATTERNS = (
     re.compile(rf"(?P<kind>{_MEDIA_KIND_PATTERN}) input is not supported"),
@@ -139,10 +150,11 @@ def retry_media_inputs_after_failure(
     """Decide whether and how one media-bearing request should retry.
 
     Explicit "kind is not supported" errors teach the route cache so later
-    requests pre-drop that kind; validation and ambiguous media errors retry
-    once without poisoning the cache. A kind can only be learned when it was
-    actually present in ``media_inputs`` or ``extra_present_kinds`` (media
-    pinned to thread-history messages in the run input).
+    requests pre-drop that kind; text-only content errors teach every present
+    kind; validation and ambiguous media errors retry once without poisoning
+    the cache. A kind can only be learned when it was actually present in
+    ``media_inputs`` or ``extra_present_kinds`` (media pinned to
+    thread-history messages in the run input).
     """
     present_kinds = media_inputs.kinds() | extra_present_kinds
     if not present_kinds:
@@ -154,6 +166,14 @@ def retry_media_inputs_after_failure(
         return _media_retry_decision_for_kinds(
             media_inputs,
             unsupported_kinds,
+            present_kinds=present_kinds,
+            cache_route=route,
+        )
+
+    if _TEXT_ONLY_CONTENT_TYPE_PATTERN.search(error_text.lower()):
+        return _media_retry_decision_for_kinds(
+            media_inputs,
+            present_kinds,
             present_kinds=present_kinds,
             cache_route=route,
         )
@@ -245,7 +265,11 @@ def _media_validation_kinds_from_error(error_text: str) -> frozenset[MediaKind]:
 
 
 def _is_ambiguous_media_error(error_text: str) -> bool:
-    return bool(_INLINE_MEDIA_GENERIC_UNSUPPORTED_PATTERN.search(error_text.lower()))
+    lowered_error_text = error_text.lower()
+    return bool(
+        _INLINE_MEDIA_GENERIC_UNSUPPORTED_PATTERN.search(lowered_error_text)
+        or _CONTENT_PART_TYPE_ERROR_PATTERN.search(lowered_error_text),
+    )
 
 
 def _canonical_media_kind(provider_kind: str) -> MediaKind | None:

--- a/tests/test_media_fallback.py
+++ b/tests/test_media_fallback.py
@@ -131,6 +131,66 @@ def test_generic_media_error_retries_without_caching() -> None:
     assert filtered.media_inputs == media
 
 
+def test_text_only_content_error_teaches_all_present_kinds() -> None:
+    """Z.ai text-only models reject every non-text part; all present kinds are learned."""
+    reset_model_media_capability_cache()
+    media = _media_inputs()
+    route = _route()
+
+    decision = retry_media_inputs_after_failure(
+        route,
+        "Error code: 400 - messages.content.type is invalid, allowed values: ['text']",
+        media,
+    )
+
+    assert decision.should_retry is True
+    assert decision.removed_kinds == frozenset({"audio", "image", "file", "video"})
+    assert decision.media_inputs == MediaInputs()
+
+    filtered = filter_media_inputs_for_route(route, media)
+    assert filtered.removed_kinds == frozenset({"audio", "image", "file", "video"})
+    assert filtered.media_inputs == MediaInputs()
+    reset_model_media_capability_cache()
+
+
+def test_text_only_content_error_teaches_only_present_kinds() -> None:
+    """Text-only errors must not disable media kinds that were never sent."""
+    reset_model_media_capability_cache()
+    media = MediaInputs(images=(MagicMock(name="image"),))
+    route = _route()
+
+    decision = retry_media_inputs_after_failure(
+        route,
+        "messages.content.type is invalid, allowed values: ['text']",
+        media,
+    )
+
+    assert decision.should_retry is True
+    assert decision.removed_kinds == frozenset({"image"})
+    assert unsupported_media_kinds_for_route(route) == frozenset({"image"})
+    reset_model_media_capability_cache()
+
+
+def test_content_part_type_error_retries_without_caching() -> None:
+    """Z.ai bare content-part type errors drop media for the retry only."""
+    reset_model_media_capability_cache()
+    media = _media_inputs()
+    route = _route()
+
+    decision = retry_media_inputs_after_failure(
+        route,
+        "Error code: 400 - messages[12].content[0].type type error",
+        media,
+    )
+
+    assert decision.should_retry is True
+    assert decision.removed_kinds == frozenset({"audio", "image", "file", "video"})
+    assert decision.media_inputs == MediaInputs()
+
+    filtered = filter_media_inputs_for_route(route, media)
+    assert filtered.media_inputs == media
+
+
 def test_openai_invalid_audio_format_error_retries_without_caching() -> None:
     """OpenAI audio format validation errors should drop audio for the retry only."""
     reset_model_media_capability_cache()


### PR DESCRIPTION
## Problem

Posting an image or PDF to an agent on the new native Z.ai provider (#1418) surfaced raw provider 400s in the room:

- image: `⚠️ Error: messages.content.type is invalid, allowed values: ['text']`
- PDF: `⚠️ Error: messages[12].content[0].type type error`

GLM-5.2 is text-only per Z.ai's docs. The `zai` provider is agno `OpenAILike`, so images go out as `image_url` content parts (rejected: only `text` allowed) and PDFs as OpenAI-style `file` parts (a type Z.ai cannot parse at all).

MindRoom already handles text-only models via the learned inline-media fallback (`media_fallback.py`): parse the provider error, drop the offending media kinds, retry with the fallback prompt. But neither Z.ai phrasing matched the error vocabulary, so `retry_media_inputs_after_failure` returned no-retry and the raw error reached the user.

## Fix

- `content.type is invalid, allowed values: ['text']` is treated as an explicit text-only signal: every present media kind is dropped and taught to the route capability cache, so later uploads are pre-dropped without a wasted API call.
- `messages[N].content[K].type type error` is treated as an ambiguous media validation error: retry once without media, without poisoning the cache (existing policy for vague errors).

## Testing

- `uv run pytest tests/test_media_fallback.py tests/test_team_media_fallback.py -x -n 0 --no-cov` — 94 passed
- `uv run pre-commit run --files src/mindroom/media_fallback.py tests/test_media_fallback.py` — clean

Observed live on mindroom-chat (agent `mindz`, model `glm-5.2`), log `mindroom_20260708_052146.log` lines 1218/1271.