### PR TITLE
Matrix E2EE Phase 2: room enablement, decrypt-failure feedback, store recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ Plain replies that never reach threaded context still stay plain replies.
 - `!config <operation>` - Manage configuration
 - `!model [name|list|reset]` - Show or switch the model used in the current thread
 - `!thread_mode [room|thread|reset|show]` - Show or switch the thread mode used in the current room (room admin only)
+- `!encrypt [confirm]` - Enable end-to-end encryption for this room (irreversible, room admin only)
+- `!e2ee` - Show encryption diagnostics for this room
 - `!hi` - Show welcome message
 
 <!-- OUTPUT:END -->


### PR DESCRIPTION
## Summary

Phase 2 of the [Matrix E2EE full-flow UX design](https://github.com/mindroom-ai/mindroom/blob/e2ee-phase2-ux/docs/superpowers/specs/2026-07-07-matrix-e2ee-user-experience-design.md) — the mindroom-repo half of the user experience. **Stacked on #1423** (retarget to `main` after that merges). Cross-signing bootstrap (Phase 3, mindroom-nio fork) comes separately.

### Room enablement (D3)

- `rooms.<key>.encrypted: true` and `matrix_room_access.encrypt_managed_rooms: true` create managed rooms with `m.room.encryption` in `initial_state`.
- Existing managed rooms are reconciled to encrypted on startup and config hot reload (enable-only — encryption is irreversible and MindRoom never disables it).
- New `!encrypt` command: bare invocation reviews the irreversibility consequences; `!encrypt confirm` enables, gated to Matrix room admins. (Dashboard toggle deferred.)

### Decrypt-failure feedback (D4)

- Undecryptable events now produce one visible `m.notice` per (room, megolm session): *"I couldn't decrypt your last message. I've requested the key; if this keeps happening, please send a new message."*
- Single-responder election prevents notice storms: the router speaks for rooms it occupies; otherwise only a sole managed bot speaks; multi-bot rooms without a router stay silent.
- A disk-backed ledger (`tracking/e2ee_decrypt_notices.json`) makes the dedup survive restarts.
- New `!e2ee` command reports room encryption state, responding bot + device, store status, and failure counters.
- `/api/health` now includes `"e2ee": {decrypt_failures, key_requests_sent, notices_sent}`.

### Store-loss recovery (D5)

- If a persisted device's olm store is missing at startup, login falls back to a **fresh device** instead of restoring a wedged crypto identity (re-using a device ID with new olm keys permanently breaks the account's crypto).
- `mindroom doctor` gains an encryption-store check that warns per-agent about missing stores.

## Live verification (local Synapse, encrypted nio test client)

- `vault` room created **encrypted from config**; encrypted round-trip with threaded streaming reply verified.
- Existing unencrypted `lobby` flipped to encrypted via config **hot reload** (`matrix_room_encryption_enabled` + server state confirmed).
- `!encrypt` review and `!encrypt confirm` admin gate verified live (non-admin got "❌ Room admin only.").
- `!e2ee` returned full diagnostics inside the encrypted room.
- Injected undecryptable event: exactly **one** notice posted (by the elected router, despite two bots seeing the event), counters `decrypt_failures: 2, key_requests_sent: 2, notices_sent: 1` visible on `/api/health`.
- Store-loss drill: deleted the assistant's `encryption_keys` store → `doctor` warned → restart logged `matrix_olm_store_missing_fresh_device_login` → fresh device (`LKXYHMRYPX` → `AIUNYXMOMY`) → encrypted conversation continued.

## Test plan

- [x] 25 new/updated unit tests (`test_e2ee_phase2.py`, `test_decrypt_failure.py`): creation state, enable-only reconcile, config precedence, command flows, notice dedup + election + restart persistence, store-loss fallback, parsing
- [x] Full suite: 9282 passed; only failures are 2 environmental (`test_knowledge_manager` git-commit signing — pass with a live SSH agent socket) and pre-existing untracked WIP
- [x] `tach check --dependencies --interfaces` clean; new modules have explicit Tach entries, visibility, and interface exposure (split-client boundary test passes)
- [x] pre-commit hooks all pass
- [x] Docs: chat-commands, configuration, architecture, index updated