### PR TITLE
Generalize the inline-media fallback to an evidence-based retry

### DIFF
--- a/docs/images.md
+++ b/docs/images.md
@@ -82,10 +82,14 @@ The retried prompt includes `[Inline media unavailable for this model]` to infor
 Agents can still reference the files via attachment IDs and tools.
 
 This fallback is transparent — no user action is required.
-It detects provider-specific error patterns such as unsupported media type, base64 field validation failures, and capability rejections.
+When the provider names the rejected media kind (for example "audio input is not supported"), only that kind is dropped and the model route immediately learns that it is unsupported.
+Any other invalid-request rejection (HTTP 400/413/415/422, or generic markers like `Error code: 400` in the error text) triggers one retry without media, so new providers degrade gracefully without MindRoom knowing their error wording.
+When such a retry succeeds, the model route learns that the dropped media kinds are unsupported, and later requests omit them up front instead of paying a failed API call.
+This learned capability state is process-local and resets on restart.
+Payload-size and context-overflow rejections still retry without media but never teach the capability state, since dropping media can shrink an oversized request for reasons unrelated to media support.
 
 ## Limitations
 
 - **Routing with multiple eligible responders** -- without an `@mention`, the router uses the image caption to select among candidates only when room configuration and reply permissions leave multiple eligible agents or teams.
 - **Bridge mention detection** uses `m.mentions` in the event, falling back to parsing HTML pills from `formatted_body` when `m.mentions` is absent (e.g., mautrix-telegram). Bridges that set neither may not trigger agent responses.
-- **Model support** -- the configured model must support vision. Text-only models will ignore the image or return an error. If the model rejects the image entirely, the [media fallback](#media-fallback) retries without the inline image.
+- **Model support** -- vision input requires a model that supports it. Text-only models reject inline images, and the [media fallback](#media-fallback) retries without them so the agent still answers with a note that it cannot view the attachment.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -12883,13 +12883,17 @@ The retried prompt includes `[Inline media unavailable for this model]` to infor
 Agents can still reference the files via attachment IDs and tools.
 
 This fallback is transparent — no user action is required.
-It detects provider-specific error patterns such as unsupported media type, base64 field validation failures, and capability rejections.
+When the provider names the rejected media kind (for example "audio input is not supported"), only that kind is dropped and the model route immediately learns that it is unsupported.
+Any other invalid-request rejection (HTTP 400/413/415/422, or generic markers like `Error code: 400` in the error text) triggers one retry without media, so new providers degrade gracefully without MindRoom knowing their error wording.
+When such a retry succeeds, the model route learns that the dropped media kinds are unsupported, and later requests omit them up front instead of paying a failed API call.
+This learned capability state is process-local and resets on restart.
+Payload-size and context-overflow rejections still retry without media but never teach the capability state, since dropping media can shrink an oversized request for reasons unrelated to media support.
 
 ## Limitations
 
 - **Routing with multiple eligible responders** -- without an `@mention`, the router uses the image caption to select among candidates only when room configuration and reply permissions leave multiple eligible agents or teams.
 - **Bridge mention detection** uses `m.mentions` in the event, falling back to parsing HTML pills from `formatted_body` when `m.mentions` is absent (e.g., mautrix-telegram). Bridges that set neither may not trigger agent responses.
-- **Model support** -- the configured model must support vision. Text-only models will ignore the image or return an error. If the model rejects the image entirely, the [media fallback](#media-fallback) retries without the inline image.
+- **Model support** -- vision input requires a model that supports it. Text-only models reject inline images, and the [media fallback](#media-fallback) retries without them so the agent still answers with a note that it cannot view the attachment.
 
 # Attachments
 

--- a/skills/mindroom-docs/references/page__images__index.md
+++ b/skills/mindroom-docs/references/page__images__index.md
@@ -78,10 +78,14 @@ The retried prompt includes `[Inline media unavailable for this model]` to infor
 Agents can still reference the files via attachment IDs and tools.
 
 This fallback is transparent — no user action is required.
-It detects provider-specific error patterns such as unsupported media type, base64 field validation failures, and capability rejections.
+When the provider names the rejected media kind (for example "audio input is not supported"), only that kind is dropped and the model route immediately learns that it is unsupported.
+Any other invalid-request rejection (HTTP 400/413/415/422, or generic markers like `Error code: 400` in the error text) triggers one retry without media, so new providers degrade gracefully without MindRoom knowing their error wording.
+When such a retry succeeds, the model route learns that the dropped media kinds are unsupported, and later requests omit them up front instead of paying a failed API call.
+This learned capability state is process-local and resets on restart.
+Payload-size and context-overflow rejections still retry without media but never teach the capability state, since dropping media can shrink an oversized request for reasons unrelated to media support.
 
 ## Limitations
 
 - **Routing with multiple eligible responders** -- without an `@mention`, the router uses the image caption to select among candidates only when room configuration and reply permissions leave multiple eligible agents or teams.
 - **Bridge mention detection** uses `m.mentions` in the event, falling back to parsing HTML pills from `formatted_body` when `m.mentions` is absent (e.g., mautrix-telegram). Bridges that set neither may not trigger agent responses.
-- **Model support** -- the configured model must support vision. Text-only models will ignore the image or return an error. If the model rejects the image entirely, the [media fallback](#media-fallback) retries without the inline image.
+- **Model support** -- vision input requires a model that supports it. Text-only models reject inline images, and the [media fallback](#media-fallback) retries without them so the agent still answers with a note that it cannot view the attachment.

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -58,6 +58,7 @@ from mindroom.llm_request_logging import (
 )
 from mindroom.logging_config import get_logger
 from mindroom.media_fallback import (
+    MediaRetryDecision,
     ModelMediaRoute,
     build_model_media_route,
     filter_media_inputs_for_route,
@@ -318,9 +319,7 @@ class _StreamingAttemptState:
     request_metric_totals: dict[str, int] = field(default_factory=empty_request_metric_totals)
     first_token_latency: float | None = None
     first_token_logged: bool = False
-    media_fallback_retry_requested: bool = False
-    media_fallback_retry_inputs: MediaInputs | None = None
-    media_fallback_removed_kinds: frozenset[MediaKind] = frozenset()
+    media_fallback_retry: MediaRetryDecision | None = None
     user_error: Exception | None = None
     stream_exception: Exception | None = None
 
@@ -733,9 +732,7 @@ def _request_stream_retry(
     )
     if not retry_decision.should_retry:
         return False
-    state.media_fallback_retry_requested = True
-    state.media_fallback_retry_inputs = retry_decision.media_inputs
-    state.media_fallback_removed_kinds = retry_decision.removed_kinds
+    state.media_fallback_retry = retry_decision
     logger.warning(
         log_message,
         agent=agent_name,
@@ -942,6 +939,7 @@ async def _run_non_streaming_agent_attempts(
     """Run one non-streaming agent response sequence, including media fallback."""
     agent = run_context.prepared_run.agent
     response: RunOutput | None = None
+    pending_retry_decision: MediaRetryDecision | None = None
     try:
         for retried_after_media_fallback in (False, True):
             response = None
@@ -982,6 +980,7 @@ async def _run_non_streaming_agent_attempts(
                         error=str(e),
                         removed_media_kinds=sorted(retry_decision.removed_kinds),
                     )
+                    pending_retry_decision = retry_decision
                     attempt.retry(
                         run_context.run_input,
                         fallback_prompt=run_context.inline_media_fallback_prompt,
@@ -1009,6 +1008,7 @@ async def _run_non_streaming_agent_attempts(
                         error=error_text,
                         removed_media_kinds=sorted(retry_decision.removed_kinds),
                     )
+                    pending_retry_decision = retry_decision
                     attempt.retry(
                         run_context.run_input,
                         fallback_prompt=run_context.inline_media_fallback_prompt,
@@ -1027,6 +1027,8 @@ async def _run_non_streaming_agent_attempts(
             break
 
         assert response is not None
+        if pending_retry_decision is not None and response.status not in (RunStatus.error, RunStatus.cancelled):
+            pending_retry_decision.record_retry_success()
         return _NonStreamingAttemptResult(response=response, attempt=attempt)
     finally:
         ai_runtime.cleanup_queued_notice_state(
@@ -1830,7 +1832,7 @@ async def stream_agent_response(  # noqa: C901, PLR0915
             entity_name=agent_name,
         )
 
-    async def _run_streaming_attempt(  # noqa: C901
+    async def _run_streaming_attempt(  # noqa: C901, PLR0915
         run: TurnRunState,
         continuation_state: DynamicContinuationRunState,
     ) -> AsyncGenerator[AIStreamChunk | AttemptResolved, None]:
@@ -1879,6 +1881,7 @@ async def stream_agent_response(  # noqa: C901, PLR0915
         holder.attempt_started = True
         turn_state = run.turn_state
         state = _StreamingAttemptState()
+        pending_retry_decision: MediaRetryDecision | None = None
 
         for retried_after_media_fallback in (False, True):
             state = _StreamingAttemptState()
@@ -1910,12 +1913,13 @@ async def stream_agent_response(  # noqa: C901, PLR0915
             ):
                 yield stream_chunk
 
-            if state.media_fallback_retry_requested:
+            if state.media_fallback_retry is not None:
+                pending_retry_decision = state.media_fallback_retry
                 attempt.retry(
                     run_context.run_input,
                     fallback_prompt=run_context.inline_media_fallback_prompt,
-                    extra_removed_kinds=state.media_fallback_removed_kinds,
-                    retry_media_inputs=state.media_fallback_retry_inputs or MediaInputs(),
+                    extra_removed_kinds=pending_retry_decision.removed_kinds,
+                    retry_media_inputs=pending_retry_decision.media_inputs,
                     run_id=continuation_state.active_run_id,
                 )
                 continue
@@ -1986,6 +1990,8 @@ async def stream_agent_response(  # noqa: C901, PLR0915
                 )
                 return
 
+            if pending_retry_decision is not None:
+                pending_retry_decision.record_retry_success()
             break
 
         metadata_content: dict[str, Any] | None = None

--- a/src/mindroom/media_fallback.py
+++ b/src/mindroom/media_fallback.py
@@ -62,7 +62,8 @@ _TEXT_ONLY_CONTENT_TYPE_PATTERN = re.compile(
 _INVALID_REQUEST_STATUS_CODES = frozenset({400, 413, 415, 422})
 _PAYLOAD_TOO_LARGE_STATUS = 413
 _INVALID_REQUEST_TEXT_PATTERN = re.compile(
-    r"error code: (?:400|413|415|422)\b|\bbad request\b|\binvalid_request_error\b|\binvalid_argument\b",
+    rf"error code: (?:{'|'.join(str(code) for code in sorted(_INVALID_REQUEST_STATUS_CODES))})\b"
+    r"|\bbad request\b|\binvalid_request_error\b|\binvalid_argument\b",
 )
 # Invalid-request errors that name credentials are not media failures; retrying
 # without media would fail identically.
@@ -270,10 +271,12 @@ def _no_media_retry_decision(media_inputs: MediaInputs) -> MediaRetryDecision:
 
 
 def _is_invalid_request_error(error: Exception | str, lowered_error_text: str) -> bool:
-    if isinstance(error, ModelProviderError) and error.status_code in _INVALID_REQUEST_STATUS_CODES:
-        return True
+    # Auth-worded failures are excluded regardless of evidence source: providers
+    # such as Google reject bad API keys with HTTP 400.
     if _AUTH_ERROR_TEXT_PATTERN.search(lowered_error_text):
         return False
+    if isinstance(error, ModelProviderError) and error.status_code in _INVALID_REQUEST_STATUS_CODES:
+        return True
     return bool(_INVALID_REQUEST_TEXT_PATTERN.search(lowered_error_text))
 
 

--- a/src/mindroom/media_fallback.py
+++ b/src/mindroom/media_fallback.py
@@ -6,6 +6,7 @@ import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from agno.exceptions import ContextWindowExceededError, ModelProviderError
 from agno.models.anthropic import Claude
 from agno.models.azure.openai_chat import AzureOpenAI
 from agno.models.cerebras import Cerebras
@@ -25,6 +26,7 @@ if TYPE_CHECKING:
     from agno.models.base import Model
 
 __all__ = [
+    "MediaRetryDecision",
     "ModelMediaRoute",
     "append_inline_media_fallback_prompt",
     "build_model_media_route",
@@ -51,11 +53,20 @@ _OPENAI_OUTPUT_FORMAT_PATTERN = re.compile(r"\boutput_format\b")
 _TEXT_ONLY_CONTENT_TYPE_PATTERN = re.compile(
     r"content(?:\[\d+\])?\.type is invalid, allowed values: \['text'\]",
 )
-# Z.ai reports content part types it cannot parse at all (e.g. OpenAI-style
-# "file" parts) as a bare type error on the message path.
-_CONTENT_PART_TYPE_ERROR_PATTERN = re.compile(
-    r"messages(?:\[\d+\])?\.content(?:\[\d+\])?\.type type error",
+# Invalid-request-class evidence: the provider rejected the request itself, so
+# when the request carried media, retrying once without it degrades gracefully
+# for any provider without matching that provider's error prose. Exceptions
+# carry the status code; stringified errored-run text only keeps generic,
+# protocol-stable markers (OpenAI SDK "Error code: N" prefixes, HTTP phrasing,
+# OpenAI/Anthropic "invalid_request_error", Google "INVALID_ARGUMENT").
+_INVALID_REQUEST_STATUS_CODES = frozenset({400, 413, 415, 422})
+_PAYLOAD_TOO_LARGE_STATUS = 413
+_INVALID_REQUEST_TEXT_PATTERN = re.compile(
+    r"error code: (?:400|413|415|422)\b|\bbad request\b|\binvalid_request_error\b|\binvalid_argument\b",
 )
+# Invalid-request errors that name credentials are not media failures; retrying
+# without media would fail identically.
+_AUTH_ERROR_TEXT_PATTERN = re.compile(r"api[\s_-]?key|unauthorized|forbidden|authentication")
 _MEDIA_KIND_PATTERN = r"audio|image|video|file|document"
 _INLINE_MEDIA_UNSUPPORTED_PATTERNS = (
     re.compile(rf"(?P<kind>{_MEDIA_KIND_PATTERN}) input is not supported"),
@@ -93,12 +104,24 @@ class _MediaFilterResult:
 
 
 @dataclass(frozen=True, slots=True)
-class _MediaRetryDecision:
-    """Retry policy after one provider media failure."""
+class MediaRetryDecision:
+    """Retry policy after one provider media failure.
+
+    ``teach_route_on_success`` carries the route whose capability cache should
+    learn ``removed_kinds`` once the without-media retry actually succeeds; the
+    attempt loop reports that via :meth:`record_retry_success`.
+    """
 
     should_retry: bool
     media_inputs: MediaInputs
     removed_kinds: frozenset[MediaKind]
+    teach_route_on_success: ModelMediaRoute | None = None
+
+    def record_retry_success(self) -> None:
+        """Teach the route cache from the successful without-media experiment."""
+        if self.teach_route_on_success is None or not self.removed_kinds:
+            return
+        _UNSUPPORTED_MEDIA_KINDS_BY_ROUTE.setdefault(self.teach_route_on_success, set()).update(self.removed_kinds)
 
 
 # Intentional process-lifetime pessimism: learned negative capability state is cleared by restart.
@@ -146,15 +169,19 @@ def retry_media_inputs_after_failure(
     media_inputs: MediaInputs,
     *,
     extra_present_kinds: frozenset[MediaKind] = frozenset(),
-) -> _MediaRetryDecision:
+) -> MediaRetryDecision:
     """Decide whether and how one media-bearing request should retry.
 
     Explicit "kind is not supported" errors teach the route cache so later
     requests pre-drop that kind; text-only content errors teach every present
-    kind; validation and ambiguous media errors retry once without poisoning
-    the cache. A kind can only be learned when it was actually present in
-    ``media_inputs`` or ``extra_present_kinds`` (media pinned to
-    thread-history messages in the run input).
+    kind; kind-specific validation errors (malformed or mis-encoded media)
+    retry once without ever teaching. Any other invalid-request-class failure
+    retries once without media and teaches the cache only when that retry
+    succeeds — unless the error names a payload-size or context-overflow
+    cause, where dropping media can succeed for the wrong reason. A kind can
+    only be learned when it was actually present in ``media_inputs`` or
+    ``extra_present_kinds`` (media pinned to thread-history messages in the
+    run input).
     """
     present_kinds = media_inputs.kinds() | extra_present_kinds
     if not present_kinds:
@@ -170,7 +197,8 @@ def retry_media_inputs_after_failure(
             cache_route=route,
         )
 
-    if _TEXT_ONLY_CONTENT_TYPE_PATTERN.search(error_text.lower()):
+    lowered_error_text = error_text.lower()
+    if _TEXT_ONLY_CONTENT_TYPE_PATTERN.search(lowered_error_text):
         return _media_retry_decision_for_kinds(
             media_inputs,
             present_kinds,
@@ -182,11 +210,16 @@ def retry_media_inputs_after_failure(
     if validation_kinds:
         return _media_retry_decision_for_kinds(media_inputs, validation_kinds, present_kinds=present_kinds)
 
-    if _is_ambiguous_media_error(error_text):
-        return _MediaRetryDecision(
+    if _INLINE_MEDIA_GENERIC_UNSUPPORTED_PATTERN.search(lowered_error_text) or _is_invalid_request_error(
+        error,
+        lowered_error_text,
+    ):
+        teaching_blocked = _capability_teaching_blocked(error, lowered_error_text)
+        return MediaRetryDecision(
             should_retry=True,
             media_inputs=_without_media_kinds(media_inputs, present_kinds),
             removed_kinds=present_kinds,
+            teach_route_on_success=None if teaching_blocked else route,
         )
 
     return _no_media_retry_decision(media_inputs)
@@ -215,25 +248,48 @@ def _media_retry_decision_for_kinds(
     *,
     present_kinds: frozenset[MediaKind],
     cache_route: ModelMediaRoute | None = None,
-) -> _MediaRetryDecision:
+) -> MediaRetryDecision:
     removed_kinds = kinds & present_kinds
     if not removed_kinds:
         return _no_media_retry_decision(media_inputs)
     if cache_route is not None:
         _UNSUPPORTED_MEDIA_KINDS_BY_ROUTE.setdefault(cache_route, set()).update(removed_kinds)
-    return _MediaRetryDecision(
+    return MediaRetryDecision(
         should_retry=True,
         media_inputs=_without_media_kinds(media_inputs, removed_kinds),
         removed_kinds=removed_kinds,
     )
 
 
-def _no_media_retry_decision(media_inputs: MediaInputs) -> _MediaRetryDecision:
-    return _MediaRetryDecision(
+def _no_media_retry_decision(media_inputs: MediaInputs) -> MediaRetryDecision:
+    return MediaRetryDecision(
         should_retry=False,
         media_inputs=media_inputs,
         removed_kinds=frozenset(),
     )
+
+
+def _is_invalid_request_error(error: Exception | str, lowered_error_text: str) -> bool:
+    if isinstance(error, ModelProviderError) and error.status_code in _INVALID_REQUEST_STATUS_CODES:
+        return True
+    if _AUTH_ERROR_TEXT_PATTERN.search(lowered_error_text):
+        return False
+    return bool(_INVALID_REQUEST_TEXT_PATTERN.search(lowered_error_text))
+
+
+def _capability_teaching_blocked(error: Exception | str, lowered_error_text: str) -> bool:
+    """Report when a retry success would not prove the media kinds unsupported.
+
+    Payload-size and context-overflow rejections shrink below the limit once
+    media is dropped, so a successful retry says nothing about capability.
+    """
+    if isinstance(error, ContextWindowExceededError):
+        return True
+    if isinstance(error, ModelProviderError) and error.status_code == _PAYLOAD_TOO_LARGE_STATUS:
+        return True
+    if f"error code: {_PAYLOAD_TOO_LARGE_STATUS}" in lowered_error_text:
+        return True
+    return any(marker in lowered_error_text for marker in ModelProviderError.CONTEXT_WINDOW_PATTERNS)
 
 
 def _unsupported_media_kinds_from_error(error_text: str) -> frozenset[MediaKind]:
@@ -262,14 +318,6 @@ def _media_validation_kinds_from_error(error_text: str) -> frozenset[MediaKind]:
     ):
         kinds.add("audio")
     return frozenset(kinds)
-
-
-def _is_ambiguous_media_error(error_text: str) -> bool:
-    lowered_error_text = error_text.lower()
-    return bool(
-        _INLINE_MEDIA_GENERIC_UNSUPPORTED_PATTERN.search(lowered_error_text)
-        or _CONTENT_PART_TYPE_ERROR_PATTERN.search(lowered_error_text),
-    )
 
 
 def _canonical_media_kind(provider_kind: str) -> MediaKind | None:

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -71,6 +71,7 @@ from mindroom.llm_request_logging import (
 )
 from mindroom.logging_config import get_logger
 from mindroom.media_fallback import (
+    MediaRetryDecision,
     append_inline_media_fallback_prompt,
     build_model_media_route,
     filter_media_inputs_for_route,
@@ -2072,6 +2073,7 @@ async def team_response(  # noqa: C901, PLR0915
         )
         attempt_media_inputs = media_filter.media_inputs
         holder.attempt_started = True
+        pending_retry_decision: MediaRetryDecision | None = None
         for retried_after_media_fallback in (False, True):
             response = None
             holder.last_response = None
@@ -2101,6 +2103,7 @@ async def team_response(  # noqa: C901, PLR0915
                     attempt_media_inputs = retry_decision.media_inputs
                     attempt_run_id = ai_runtime.next_retry_run_id(continuation_state.active_run_id)
                     holder.attempt_run_id = attempt_run_id
+                    pending_retry_decision = retry_decision
                     continue
 
                 logger.exception("team_response_failed", agents=agent_list)
@@ -2139,6 +2142,7 @@ async def team_response(  # noqa: C901, PLR0915
                     attempt_media_inputs = retry_decision.media_inputs
                     attempt_run_id = ai_runtime.next_retry_run_id(continuation_state.active_run_id)
                     holder.attempt_run_id = attempt_run_id
+                    pending_retry_decision = retry_decision
                     continue
                 logger.warning("Team response returned errored run output", agents=agent_list, error=error_text)
 
@@ -2177,6 +2181,8 @@ async def team_response(  # noqa: C901, PLR0915
                 ),
                 metadata_content=metadata_content,
             )
+        if pending_retry_decision is not None:
+            pending_retry_decision.record_retry_success()
         if ctx.reply_to_event_id:
             _persist_bound_seen_event_ids(
                 scope_context=run.scope_context,
@@ -2700,6 +2706,7 @@ async def team_response_stream(  # noqa: C901, PLR0915
             )
 
         holder.attempt_started = True
+        pending_retry_decision: MediaRetryDecision | None = None
         for retried_after_media_fallback in (False, True):
             canonical_per_member = dict.fromkeys(display_names, "")
             visible_per_member = dict.fromkeys(display_names, "")
@@ -2810,6 +2817,7 @@ async def team_response_stream(  # noqa: C901, PLR0915
                             attempt_media_inputs = retry_decision.media_inputs
                             attempt_run_id = ai_runtime.next_retry_run_id(continuation_state.active_run_id)
                             holder.attempt_run_id = attempt_run_id
+                            pending_retry_decision = retry_decision
                             media_fallback_retry_requested = True
                             break
                         # The attempt handles its own delivery, so publish the
@@ -2821,6 +2829,8 @@ async def team_response_stream(  # noqa: C901, PLR0915
                         yield AttemptResolved(HandledAttempt())
                         return
 
+                    if pending_retry_decision is not None:
+                        pending_retry_decision.record_retry_success()
                     if ctx.reply_to_event_id:
                         _persist_bound_seen_event_ids(
                             scope_context=run.scope_context,
@@ -2886,6 +2896,7 @@ async def team_response_stream(  # noqa: C901, PLR0915
                         attempt_media_inputs = retry_decision.media_inputs
                         attempt_run_id = ai_runtime.next_retry_run_id(continuation_state.active_run_id)
                         holder.attempt_run_id = attempt_run_id
+                        pending_retry_decision = retry_decision
                         media_fallback_retry_requested = True
                         break
                     # The attempt handles its own delivery, so publish the
@@ -3026,6 +3037,8 @@ async def team_response_stream(  # noqa: C901, PLR0915
 
             if media_fallback_retry_requested:
                 continue
+            if pending_retry_decision is not None:
+                pending_retry_decision.record_retry_success()
             if emitted_output and ctx.reply_to_event_id:
                 _persist_bound_seen_event_ids(
                     scope_context=run.scope_context,

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -2116,8 +2116,10 @@ class TestUserIdPassthrough:
             ("Error code: 500 - audio input is not supported", True),
             ("Error code: 404 - No endpoints found that support input audio", True),
             ("[openclaw] Error: At most 0 audio(s) may be provided in one prompt.", True),
-            ("invalid_request_error: max_tokens must be <= 4096", False),
+            # Invalid-request-class evidence retries once even without media wording.
+            ("invalid_request_error: max_tokens must be <= 4096", True),
             ("Rate limit exceeded", False),
+            ("Error code: 500 - internal server error", False),
         ],
     )
     def test_retry_media_inputs_after_failure_error_matching(self, error_text: str, expected: bool) -> None:
@@ -2171,14 +2173,14 @@ class TestUserIdPassthrough:
 
     @pytest.mark.asyncio
     async def test_ai_response_does_not_retry_without_media_validation_match(self, tmp_path: Path) -> None:
-        """Non-media failures should not trigger inline-media retry even when media is present."""
+        """Failures outside the invalid-request class should not trigger inline-media retry."""
         mock_agent = MagicMock()
         mock_agent.model = MagicMock()
         mock_agent.model.__class__.__name__ = "OpenAIChat"
         mock_agent.model.id = "test-model"
         mock_agent.name = "GeneralAgent"
         mock_agent.add_history_to_context = False
-        mock_agent.arun = AsyncMock(side_effect=Exception("invalid_request_error: max_tokens must be <= 4096"))
+        mock_agent.arun = AsyncMock(side_effect=Exception("Error code: 500 - upstream connect error"))
 
         document_file = File(
             filepath=str(tmp_path / "report.pdf"),

--- a/tests/test_media_fallback.py
+++ b/tests/test_media_fallback.py
@@ -282,18 +282,26 @@ def test_payload_too_large_retries_but_never_teaches() -> None:
 
 
 def test_auth_worded_invalid_request_does_not_retry() -> None:
-    """Credential failures phrased as 400s would fail identically without media."""
+    """Credential failures phrased as 400s would fail identically without media on either path."""
     reset_model_media_capability_cache()
     media = _media_inputs()
 
-    decision = retry_media_inputs_after_failure(
+    text_decision = retry_media_inputs_after_failure(
         _route(),
         "Error code: 400 - invalid api key provided",
         media,
     )
+    # Google rejects bad API keys with HTTP 400, so the status-code path needs the same exclusion.
+    exception_decision = retry_media_inputs_after_failure(
+        _route(),
+        ModelProviderError(message="API key not valid. Please pass a valid API key.", status_code=400),
+        media,
+    )
 
-    assert decision.should_retry is False
-    assert decision.media_inputs == media
+    assert text_decision.should_retry is False
+    assert text_decision.media_inputs == media
+    assert exception_decision.should_retry is False
+    assert exception_decision.media_inputs == media
 
 
 def test_non_request_status_exception_does_not_retry() -> None:

--- a/tests/test_media_fallback.py
+++ b/tests/test_media_fallback.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+from agno.exceptions import ContextWindowExceededError, ModelProviderError
 from agno.media import Audio, Image
 from agno.models.message import Message
 from agno.models.openai import OpenAIChat
@@ -171,8 +172,8 @@ def test_text_only_content_error_teaches_only_present_kinds() -> None:
     reset_model_media_capability_cache()
 
 
-def test_content_part_type_error_retries_without_caching() -> None:
-    """Z.ai bare content-part type errors drop media for the retry only."""
+def test_content_part_type_error_retries_via_generic_gate() -> None:
+    """Z.ai bare content-part type errors carry the 400 marker the generic gate matches."""
     reset_model_media_capability_cache()
     media = _media_inputs()
     route = _route()
@@ -189,6 +190,137 @@ def test_content_part_type_error_retries_without_caching() -> None:
 
     filtered = filter_media_inputs_for_route(route, media)
     assert filtered.media_inputs == media
+    reset_model_media_capability_cache()
+
+
+def test_invalid_request_status_retries_and_teaches_only_on_success() -> None:
+    """Any 400-class provider exception retries without media; the cache learns on retry success."""
+    reset_model_media_capability_cache()
+    media = _media_inputs()
+    route = _route()
+    error = ModelProviderError(message="Some brand new provider wording about content", status_code=400)
+
+    decision = retry_media_inputs_after_failure(route, error, media)
+
+    assert decision.should_retry is True
+    assert decision.removed_kinds == frozenset({"audio", "image", "file", "video"})
+    assert decision.media_inputs == MediaInputs()
+    assert filter_media_inputs_for_route(route, media).media_inputs == media
+
+    decision.record_retry_success()
+
+    assert unsupported_media_kinds_for_route(route) == frozenset({"audio", "image", "file", "video"})
+    reset_model_media_capability_cache()
+
+
+def test_invalid_request_text_marker_retries_and_teaches_only_on_success() -> None:
+    """Errored-run text with a generic 400 marker retries even for unknown provider prose."""
+    reset_model_media_capability_cache()
+    media = _media_inputs()
+    route = _route()
+
+    decision = retry_media_inputs_after_failure(route, "Error code: 422 - unknown validation prose", media)
+
+    assert decision.should_retry is True
+    assert decision.removed_kinds == frozenset({"audio", "image", "file", "video"})
+    assert filter_media_inputs_for_route(route, media).media_inputs == media
+
+    decision.record_retry_success()
+
+    assert unsupported_media_kinds_for_route(route) == frozenset({"audio", "image", "file", "video"})
+    reset_model_media_capability_cache()
+
+
+def test_context_window_error_retries_but_never_teaches() -> None:
+    """Dropping media can shrink an overflowing prompt, so success must not teach capability."""
+    reset_model_media_capability_cache()
+    media = _media_inputs()
+    route = _route()
+    error = ContextWindowExceededError(message="prompt is too long: 250000 tokens > 200000 maximum")
+
+    decision = retry_media_inputs_after_failure(route, error, media)
+
+    assert decision.should_retry is True
+    assert decision.teach_route_on_success is None
+
+    decision.record_retry_success()
+
+    assert unsupported_media_kinds_for_route(route) == frozenset()
+
+
+def test_context_window_text_never_teaches() -> None:
+    """Context-overflow vocabulary in errored-run text blocks teaching, not the retry."""
+    reset_model_media_capability_cache()
+    media = _media_inputs()
+    route = _route()
+
+    decision = retry_media_inputs_after_failure(
+        route,
+        "Error code: 400 - maximum context length is 128000 tokens",
+        media,
+    )
+
+    assert decision.should_retry is True
+    assert decision.teach_route_on_success is None
+
+
+def test_payload_too_large_retries_but_never_teaches() -> None:
+    """Oversized-payload rejections are about size, not media capability."""
+    reset_model_media_capability_cache()
+    media = _media_inputs()
+    route = _route()
+    error = ModelProviderError(message="Request Entity Too Large", status_code=413)
+
+    decision = retry_media_inputs_after_failure(route, error, media)
+
+    assert decision.should_retry is True
+    assert decision.teach_route_on_success is None
+
+    decision.record_retry_success()
+
+    assert unsupported_media_kinds_for_route(route) == frozenset()
+
+
+def test_auth_worded_invalid_request_does_not_retry() -> None:
+    """Credential failures phrased as 400s would fail identically without media."""
+    reset_model_media_capability_cache()
+    media = _media_inputs()
+
+    decision = retry_media_inputs_after_failure(
+        _route(),
+        "Error code: 400 - invalid api key provided",
+        media,
+    )
+
+    assert decision.should_retry is False
+    assert decision.media_inputs == media
+
+
+def test_non_request_status_exception_does_not_retry() -> None:
+    """Server-side failures are not media evidence even when media was present."""
+    reset_model_media_capability_cache()
+    media = _media_inputs()
+    error = ModelProviderError(message="upstream connect error", status_code=502)
+
+    decision = retry_media_inputs_after_failure(_route(), error, media)
+
+    assert decision.should_retry is False
+
+
+def test_kind_specific_error_takes_precedence_over_generic_gate() -> None:
+    """A named kind on a 400 drops and teaches only that kind, not everything present."""
+    reset_model_media_capability_cache()
+    media = _media_inputs()
+    route = _route()
+    error = ModelProviderError(message="audio input is not supported", status_code=400)
+
+    decision = retry_media_inputs_after_failure(route, error, media)
+
+    assert decision.should_retry is True
+    assert decision.removed_kinds == frozenset({"audio"})
+    assert decision.media_inputs.images == media.images
+    assert unsupported_media_kinds_for_route(route) == frozenset({"audio"})
+    reset_model_media_capability_cache()
 
 
 def test_openai_invalid_audio_format_error_retries_without_caching() -> None:

--- a/tests/test_team_media_fallback.py
+++ b/tests/test_team_media_fallback.py
@@ -47,6 +47,11 @@ from mindroom.history.turn_recorder import TurnRecorder
 from mindroom.history.types import CompactionDecision, CompactionReplyOutcome, PreparedHistoryState
 from mindroom.hooks import EnrichmentItem
 from mindroom.knowledge.utils import _KnowledgeResolution
+from mindroom.media_fallback import (
+    build_model_media_route,
+    reset_model_media_capability_cache,
+    unsupported_media_kinds_for_route,
+)
 from mindroom.media_inputs import MediaInputs
 from mindroom.prompts import QUEUED_MESSAGE_NOTICE_TEXT
 from mindroom.team_exact_members import (
@@ -348,6 +353,91 @@ async def test_team_response_retries_errored_plain_run_output_with_fresh_run_id(
     assert second_call.kwargs["run_id"] is not None
     assert second_call.kwargs["run_id"] != "run-123"
     assert callback_run_ids == [first_call.kwargs["run_id"], second_call.kwargs["run_id"]]
+
+
+@pytest.mark.asyncio
+async def test_team_generic_invalid_request_retry_teaches_route_after_success() -> None:
+    """A successful without-media retry after an unrecognized 400 teaches the route cache."""
+    reset_model_media_capability_cache()
+    config = _build_test_config()
+    orchestrator = MagicMock()
+    orchestrator.config = config
+    orchestrator.runtime_paths = runtime_paths_for(config)
+    orchestrator.knowledge_managers = {}
+    orchestrator.agent_bots = {"general": MagicMock()}
+
+    mock_team = _make_test_team()
+    mock_team.arun = AsyncMock(
+        side_effect=[
+            Exception("Error code: 400 - completely new provider wording"),
+            TeamRunOutput(content="Recovered team response"),
+        ],
+    )
+
+    fake_agent = _make_test_agent("GeneralAgent")
+    with (
+        patch("mindroom.teams.create_agent", return_value=fake_agent),
+        patch("mindroom.teams.resolve_agent_knowledge_access", return_value=_KnowledgeResolution(knowledge=None)),
+        patch("mindroom.teams._create_team_instance", return_value=mock_team),
+    ):
+        response = await team_response(
+            agent_names=["general"],
+            mode=TeamMode.COORDINATE,
+            message="Analyze this.",
+            turn_recorder=_team_turn_recorder("Analyze this."),
+            orchestrator=orchestrator,
+            execution_identity=None,
+            ctx=make_turn_context(session_id=None),
+            media=MediaInputs(audio=[MagicMock(name="audio_input")]),
+        )
+
+    assert "Recovered team response" in response
+    assert mock_team.arun.await_count == 2
+    route = build_model_media_route(mock_team.model)
+    assert unsupported_media_kinds_for_route(route) == frozenset({"audio"})
+    reset_model_media_capability_cache()
+
+
+@pytest.mark.asyncio
+async def test_team_generic_invalid_request_retry_failure_does_not_teach() -> None:
+    """When the without-media retry fails too, the route capability cache stays untouched."""
+    reset_model_media_capability_cache()
+    config = _build_test_config()
+    orchestrator = MagicMock()
+    orchestrator.config = config
+    orchestrator.runtime_paths = runtime_paths_for(config)
+    orchestrator.knowledge_managers = {}
+    orchestrator.agent_bots = {"general": MagicMock()}
+
+    mock_team = _make_test_team()
+    mock_team.arun = AsyncMock(
+        side_effect=[
+            Exception("Error code: 400 - completely new provider wording"),
+            Exception("Error code: 400 - completely new provider wording"),
+        ],
+    )
+
+    fake_agent = _make_test_agent("GeneralAgent")
+    with (
+        patch("mindroom.teams.create_agent", return_value=fake_agent),
+        patch("mindroom.teams.resolve_agent_knowledge_access", return_value=_KnowledgeResolution(knowledge=None)),
+        patch("mindroom.teams._create_team_instance", return_value=mock_team),
+    ):
+        response = await team_response(
+            agent_names=["general"],
+            mode=TeamMode.COORDINATE,
+            message="Analyze this.",
+            turn_recorder=_team_turn_recorder("Analyze this."),
+            orchestrator=orchestrator,
+            execution_identity=None,
+            ctx=make_turn_context(session_id=None),
+            media=MediaInputs(audio=[MagicMock(name="audio_input")]),
+        )
+
+    assert mock_team.arun.await_count == 2
+    assert "Recovered" not in response
+    route = build_model_media_route(mock_team.model)
+    assert unsupported_media_kinds_for_route(route) == frozenset()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

`media_fallback.py` decided whether a failed model request was media-caused by matching regexes over provider error prose. Every new provider wording silently regressed to a raw provider error in the Matrix room until someone added a pattern — most recently Z.ai in #1428.

## Approach

The prose patterns are now the fast path for *attribution*; the load-bearing decision is generic evidence:

- **Generic invalid-request gate.** When a media-bearing request fails and no media-specific pattern matches, any invalid-request-class error triggers one retry without the media (existing fallback prompt/marker mechanics). Classification uses `status_code in {400, 413, 415, 422}` via `isinstance` on agno's `ModelProviderError` when an exception object is available. The errored-run path only has stringified text (agno converts provider exceptions to errored `RunOutput`s / `RunErrorEvent`s carrying just the message), so it uses a small set of protocol-stable markers instead: `Error code: 400/413/415/422` (OpenAI-SDK prefix, observed verbatim in the live Z.ai failures), `bad request`, `invalid_request_error`, `INVALID_ARGUMENT`. Auth-worded text (`api key`, `unauthorized`, …) never retries — dropping media cannot fix credentials.
- **Teach the cache from the experiment, not the wording.** The retry decision carries `teach_route_on_success`; the attempt loops in `ai.py` and `teams.py` (blocking and streaming) call `record_retry_success()` only when the without-media retry actually succeeds. The route capability cache then pre-drops those kinds, so the second upload to the same route skips the wasted API call.
- **Misattribution guard.** Teaching is blocked when the error names a payload-size or context-overflow cause (`ContextWindowExceededError`, status 413, or agno's `CONTEXT_WINDOW_PATTERNS` vocabulary): dropping media can shrink such a request below the limit, and the "success" would poison the cache. The retry itself still happens — it is a legitimate last resort when a huge attachment is what overflowed the window.
- **Kind-specific precedence kept.** Named-kind errors ("audio input is not supported") still drop and teach only that kind; kind-specific validation errors (mis-encoded media, wrong MIME) still retry without ever teaching; the Z.ai text-only pattern still teaches every present kind on first failure.

## Deleted

- `_CONTENT_PART_TYPE_ERROR_PATTERN` (Z.ai bare content-part type error): its observed live messages carry the `Error code: 400` marker the generic gate matches.
- `_is_ambiguous_media_error`: folded into the generic-gate branch, which also upgrades the "inline media is not supported" phrasing from retry-only to teach-on-retry-success.

## Behavior changes

- An invalid-request-class failure with media present now costs at most one extra API call even when nothing about it names media (e.g. `invalid_request_error: max_tokens must be <= 4096` now retries once without media instead of surfacing immediately). The corresponding test expectations were updated; one retry is the deliberate price of not maintaining per-provider prose.
- The streaming attempt state now stores the `MediaRetryDecision` itself instead of three parallel fields.

## Testing

- `uv run pytest tests/test_media_fallback.py tests/test_team_media_fallback.py -x -n 0 --no-cov` — 104 passed. New coverage: generic-400 retry without immediate caching (exception and text-marker paths), teach-on-retry-success through the real team attempt loop, no-teach when the retry also fails, no-teach on context-window and 413 errors, auth-worded 400 does not retry, kind-specific precedence over the generic gate.
- `uv run pytest tests/test_ai_user_id.py tests/test_dispatch_timing_instrumentation.py -n 0 --no-cov` — 109 passed.
- Full suite: 2342 passed; the only 2 failures (`tests/test_cli_config.py`) reproduce identically on unmodified `main` in this environment (ANSI escapes in captured CLI output) and are unrelated.
- `uv run pre-commit run --files <changed files>` — clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Media-related failures now retry more intelligently, including support for broader provider error patterns.
  * Successful retries can now update future fallback behavior more reliably.

* **Bug Fixes**
  * Improved handling of media uploads when requests fail due to unsupported media, invalid request errors, or text-only limitations.
  * Prevents the app from learning incorrect media support in cases like oversized payloads or context-window issues.

* **Tests**
  * Expanded coverage for media retry behavior, including success, failure, and no-retry scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->