### PR TITLE
Add --config/--storage-path options to mindroom doctor

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -505,7 +505,12 @@ Runs a series of checks in one pass:
  so you can fix everything before running `mindroom run`.
 
 ╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ --help  -h        Show this message and exit.                                          │
+│ --config        -c      PATH  Use this config file path. Defaults the storage location │
+│                               to the selected config directory unless --storage-path   │
+│                               is set.                                                  │
+│ --storage-path  -s      PATH  Base directory for persistent MindRoom data (state,      │
+│                               sessions, tracking)                                      │
+│ --help          -h            Show this message and exit.                              │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -17443,7 +17443,12 @@ Runs a series of checks in one pass:
  so you can fix everything before running `mindroom run`.
 
 ╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ --help  -h        Show this message and exit.                                          │
+│ --config        -c      PATH  Use this config file path. Defaults the storage location │
+│                               to the selected config directory unless --storage-path   │
+│                               is set.                                                  │
+│ --storage-path  -s      PATH  Base directory for persistent MindRoom data (state,      │
+│                               sessions, tracking)                                      │
+│ --help          -h            Show this message and exit.                              │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 
 

--- a/skills/mindroom-docs/references/page__cli__index.md
+++ b/skills/mindroom-docs/references/page__cli__index.md
@@ -501,7 +501,12 @@ Runs a series of checks in one pass:
  so you can fix everything before running `mindroom run`.
 
 ╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ --help  -h        Show this message and exit.                                          │
+│ --config        -c      PATH  Use this config file path. Defaults the storage location │
+│                               to the selected config directory unless --storage-path   │
+│                               is set.                                                  │
+│ --storage-path  -s      PATH  Base directory for persistent MindRoom data (state,      │
+│                               sessions, tracking)                                      │
+│ --help          -h            Show this message and exit.                              │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 
 

--- a/src/mindroom/cli/doctor.py
+++ b/src/mindroom/cli/doctor.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 from mindroom.config.main import CONFIG_LOAD_USER_ERROR_TYPES, Config, iter_config_validation_messages
 
 
-def doctor() -> None:
+def doctor(config_path: Path | None = None, storage_path: Path | None = None) -> None:
     """Check your environment for common issues.
 
     Runs connectivity, configuration, and credential checks in a single pass
@@ -46,8 +46,9 @@ def doctor() -> None:
     failed = 0
     warnings = 0
 
-    runtime_paths = activate_cli_runtime()
+    runtime_paths = activate_cli_runtime(path=config_path, storage_path=storage_path)
     config_path = runtime_paths.config_path
+    console.print(f"[dim]Config directory: {config_path.parent}[/dim]")
 
     # 1. Config file exists
     p, f, w = _run_doctor_step("Checking config file...", lambda: _check_config_exists(config_path))

--- a/src/mindroom/cli/doctor.py
+++ b/src/mindroom/cli/doctor.py
@@ -48,7 +48,7 @@ def doctor(config_path: Path | None = None, storage_path: Path | None = None) ->
 
     runtime_paths = activate_cli_runtime(path=config_path, storage_path=storage_path)
     config_path = runtime_paths.config_path
-    console.print(f"[dim]Config directory: {config_path.parent}[/dim]")
+    console.print(f"[dim]Config directory: {runtime_paths.config_dir}[/dim]")
 
     # 1. Config file exists
     p, f, w = _run_doctor_step("Checking config file...", lambda: _check_config_exists(config_path))
@@ -57,7 +57,7 @@ def doctor(config_path: Path | None = None, storage_path: Path | None = None) ->
     warnings += w
 
     # 2+. Config validity + provider API key validation (skip if file missing)
-    if config_path.exists():
+    if config_path.is_file():
         config, p, f, w = _run_doctor_step(
             "Validating configuration...",
             lambda: _check_config_valid(runtime_paths),
@@ -113,9 +113,12 @@ def _run_doctor_step[T](message: str, check: Callable[[], T]) -> T:
 
 def _check_config_exists(config_path: Path) -> tuple[int, int, int]:
     """Check config file exists. Returns (passed, failed, warnings)."""
-    if config_path.exists():
+    if config_path.is_file():
         console.print(f"[green]✓[/green] Config file: {config_path}")
         return 1, 0, 0
+    if config_path.exists():
+        console.print(f"[red]✗[/red] Config path is not a file: {config_path}")
+        return 0, 1, 0
     console.print(f"[red]✗[/red] Config file not found: {config_path}")
     return 0, 1, 0
 

--- a/src/mindroom/cli/main.py
+++ b/src/mindroom/cli/main.py
@@ -227,7 +227,20 @@ async def _run(
 
 
 @app.command()
-def doctor() -> None:
+def doctor(
+    config_path: Path | None = typer.Option(  # noqa: B008
+        None,
+        "--config",
+        "-c",
+        help="Use this config file path. Defaults the storage location to the selected config directory unless --storage-path is set.",
+    ),
+    storage_path: Path | None = typer.Option(  # noqa: B008
+        None,
+        "--storage-path",
+        "-s",
+        help="Base directory for persistent MindRoom data (state, sessions, tracking)",
+    ),
+) -> None:
     """Check your environment for common issues.
 
     Runs connectivity, configuration, and credential checks in a single pass
@@ -235,7 +248,7 @@ def doctor() -> None:
     """
     from .doctor import doctor as doctor_command  # noqa: PLC0415
 
-    doctor_command()
+    doctor_command(config_path=config_path, storage_path=storage_path)
 
 
 @avatars_app.command("generate")


### PR DESCRIPTION
## Summary
- `mindroom doctor` now accepts `--config`/`-c` and `--storage-path`/`-s`, matching `mindroom run`, so you can point it at any config instead of relying on cwd auto-detection.
- Doctor now prints the active config directory at the top of its output, making it obvious which install is being checked (e.g. `/srv/mindroom` vs `~/.mindroom`).
- Regenerated auto-generated CLI docs (`docs/cli.md`, mindroom-docs skill references) via `docs/run_markdown_code_runner.py`.

## Test plan
- `uv run pytest tests/test_cli_doctor.py -x -n 0 --no-cov` passes.
- Manually verified `mindroom doctor -c /tmp/mrdoc/config.yaml` prints the config directory, reports the missing config, and defaults storage next to the selected config.
- `uv run pre-commit run --all-files` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The `doctor` command now supports `--config` (`-c`) and `--storage-path` (`-s`) to select the config file and persistent data directory.
  * The command now displays the resolved config location before running its checks.

* **Documentation**
  * Updated `doctor` CLI help output to document the new options.

* **Bug Fixes**
  * Improved validation so config paths must point to an existing file (not just an existing path), with clearer error messaging when validation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->