### PR TITLE
config init: write defaults.worker_tools: [] in the starter template

### DIFF
--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -1010,6 +1010,12 @@ authorization:
       - {constants.OWNER_MATRIX_USER_ID_PLACEHOLDER}
 
 defaults:
+  # Execution tools (shell, file, python, coding, docker) run directly in the
+  # MindRoom process. For isolation, run them in a sandboxed worker instead:
+  # deploy the sandbox runner (Docker Compose or Kubernetes) and remove this
+  # line — or replace [] with the tools to route, e.g. [shell, file, python].
+  # See https://docs.mindroom.chat/deployment/sandbox-proxy/
+  worker_tools: []
   tools:
     - scheduler
   markdown: true


### PR DESCRIPTION
## Problem

A fresh native install — `mindroom config init` + `mindroom run` on a bare host, no docker-compose sandbox stack, no k8s — fails closed on the agent's first `shell`/`file`/`coding` call:

```
MINDROOM_SANDBOX_PROXY_URL must be set when sandbox proxying is enabled.
```

Cause: the starter template doesn't write `worker_tools`, so `resolve_runtime_worker_tools()` falls back to the implicit metadata default (every tool with `default_execution_target: worker` — `shell`, `file`, `python`, `coding`, `docker`). The sandbox gate treats any non-None `worker_tools` as an explicit routing request, which takes precedence over `MINDROOM_SANDBOX_EXECUTION_MODE=off`, and the default `static_runner` backend without a proxy URL then fails closed.

This contradicts the docs in two places: the env-var table says the `MINDROOM_SANDBOX_PROXY_URL` default is "_none — plain static-runner installs execute locally_", and `EXECUTION_MODE=off` promises "execution tools may run in the primary runtime". Neither holds with the implicit fallback in play. (Hit in production on two single-user LXC companion deployments.)

## Change

`config init` now writes an explicit `worker_tools: []` under `defaults:` with a comment explaining that deploying the sandbox runner (Docker Compose / Kubernetes) enables isolated execution — remove the line or list the tools to route — linking https://docs.mindroom.chat/deployment/sandbox-proxy/

Out-of-the-box configs now match the documented static-runner behavior; sandbox-stack users get a visible, documented knob instead of a silent implicit list.

## Testing

- `tests/test_cli_config.py::TestConfigInit` — 52 passed
- `tests/test_cli_config.py` + `tests/test_config_commands.py` full run: failure set identical to the `origin/main` baseline (pre-existing terminal-width/bun flakes only, verified by diffing failing-test IDs)
- Verified rendered output via `mindroom config init --print`

## Note

This fixes the out-of-the-box experience, but the underlying precedence question remains: arguably only *explicitly configured* `worker_tools` should override the `MINDROOM_SANDBOX_EXECUTION_MODE=off` kill-switch, not the implicit metadata fallback. Happy to follow up separately if there's appetite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the starter configuration template to include a new `worker_tools` setting under defaults.
  * Added guidance in the generated config about running execution tools in an isolated sandboxed worker.
  * The rendered YAML now includes `worker_tools: []` by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->