### PR TITLE
Eliminate the ~11 s per-call import cost for worker-routed sandbox tools with a warm forkserver template

### DIFF
--- a/docs/deployment/sandbox-proxy.md
+++ b/docs/deployment/sandbox-proxy.md
@@ -327,10 +327,15 @@ If you deploy that mode without Helm, see [Kubernetes Deployment](kubernetes.md)
 | `MINDROOM_SANDBOX_RUNNER_PORT` | Port the sandbox runner listens on | `8766` |
 | `MINDROOM_SANDBOX_RUNNER_MODE` | Set to `true` to indicate runner mode | `false` |
 | `MINDROOM_SANDBOX_PROXY_TOKEN` | Runner bearer token. Static runners use the shared primary token; Kubernetes dedicated workers receive a per-worker derived token. | _(required)_ |
-| `MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE` | `inprocess` or `subprocess` | `inprocess` |
-| `MINDROOM_SANDBOX_RUNNER_SUBPROCESS_TIMEOUT_SECONDS` | Subprocess timeout | `120` |
+| `MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE` | `inprocess`, `subprocess`, or `forkserver` | `inprocess` |
+| `MINDROOM_SANDBOX_RUNNER_SUBPROCESS_TIMEOUT_SECONDS` | Per-call timeout for `subprocess` and `forkserver` execution | `120` |
 | `MINDROOM_STORAGE_PATH` | Writable directory for tool registry init and worker-local caches (e.g., `/app/workspace/.mindroom`) | `mindroom_data` next to config _(will fail if not writable)_ |
 | `MINDROOM_CONFIG_PATH` | Path to config.yaml (for plugin tool registration) | _(optional)_ |
+
+`subprocess` runs every non-shell tool call in a fresh `python -m mindroom.api.sandbox_runner` child that re-imports the runtime on each call.
+`forkserver` keeps one warm template process per interpreter that imports the runtime once and forks a fresh child per call, preserving per-call process isolation while removing the per-call import cost.
+Dedicated Docker and Kubernetes workers default to `forkserver`.
+If the warm template fails to start, dispatch falls back to spawn-per-call and retries the template after a cooldown.
 
 ## Execution modes
 
@@ -437,7 +442,7 @@ It also proves garbage and missing proxy session tokens are refused.
 Shell commands that exceed their timeout return a background handle.
 Use `check_shell_command(handle)` to poll and `kill_shell_command(handle)` to stop the process.
 These handles are process-local to the sandbox runner: they survive multiple requests to the same runner process, but not runner restarts.
-To make that work, shell background-handle requests stay owned by the long-lived runner process even when `MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE=subprocess`.
+To make that work, shell background-handle requests stay owned by the long-lived runner process even when `MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE` is `subprocess` or `forkserver`.
 
 ## Workspace home contract
 

--- a/scripts/testing/benchmark_tool_call_overhead.py
+++ b/scripts/testing/benchmark_tool_call_overhead.py
@@ -145,11 +145,16 @@ def _run_sandbox_dispatch_case(mode: str, iterations: int, warmup: int) -> dict[
     # runtime import that this case exists to measure.
     from mindroom.api import sandbox_runner  # noqa: PLC0415
     from mindroom.constants import resolve_primary_runtime_paths  # noqa: PLC0415
+    from mindroom.model_defaults import CONFIG_INIT_MODEL_PRESETS  # noqa: PLC0415
 
+    default_model = CONFIG_INIT_MODEL_PRESETS["openai"]
     with tempfile.TemporaryDirectory(prefix="mindroom-dispatch-benchmark-") as tmp:
         config_path = Path(tmp) / "config.yaml"
         config_path.write_text(
-            "models:\n  default:\n    provider: openai\n    id: gpt-5.5\nagents: {}\nrouter:\n  model: default\n",
+            "models:\n  default:\n"
+            f"    provider: {default_model.provider}\n"
+            f"    id: {default_model.id}\n"
+            "agents: {}\nrouter:\n  model: default\n",
             encoding="utf-8",
         )
         runtime_paths = resolve_primary_runtime_paths(

--- a/scripts/testing/benchmark_tool_call_overhead.py
+++ b/scripts/testing/benchmark_tool_call_overhead.py
@@ -1,4 +1,4 @@
-"""Synthetic benchmark for MindRoom tool-call bridge overhead."""
+"""Synthetic benchmark for MindRoom tool-call bridge and sandbox dispatch overhead."""
 
 from __future__ import annotations
 
@@ -7,7 +7,9 @@ import asyncio
 import json
 import logging
 import math
+import tempfile
 import time
+from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
@@ -137,11 +139,67 @@ async def _run_benchmark(iterations: int, warmup: int) -> list[dict[str, object]
     ]
 
 
+def _run_sandbox_dispatch_case(mode: str, iterations: int, warmup: int) -> dict[str, object]:
+    """Benchmark one worker-routed sandbox dispatch mode with a trivial tool call."""
+    # Imported here so the lightweight hook benchmark does not pay the full
+    # runtime import that this case exists to measure.
+    from mindroom.api import sandbox_runner  # noqa: PLC0415
+    from mindroom.constants import resolve_primary_runtime_paths  # noqa: PLC0415
+
+    with tempfile.TemporaryDirectory(prefix="mindroom-dispatch-benchmark-") as tmp:
+        config_path = Path(tmp) / "config.yaml"
+        config_path.write_text(
+            "models:\n  default:\n    provider: openai\n    id: gpt-5.5\nagents: {}\nrouter:\n  model: default\n",
+            encoding="utf-8",
+        )
+        runtime_paths = resolve_primary_runtime_paths(
+            config_path=config_path,
+            storage_path=Path(tmp) / "storage",
+            process_env={"MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE": mode},
+        )
+        config = sandbox_runner._runtime_config_or_empty(runtime_paths)
+
+        def _call() -> None:
+            response = sandbox_runner._execute_request_subprocess_sync(
+                sandbox_runner.SandboxRunnerExecuteRequest(
+                    tool_name="calculator",
+                    function_name="add",
+                    args=[1, 2],
+                    kwargs={},
+                ),
+                runtime_paths,
+                config,
+            )
+            if not response.ok:
+                msg = f"sandbox dispatch failed: {response.error}"
+                raise RuntimeError(msg)
+
+        for _ in range(warmup):
+            _call()
+        samples: list[float] = []
+        for _ in range(iterations):
+            started_at = time.perf_counter()
+            _call()
+            samples.append((time.perf_counter() - started_at) * 1000)
+    return {"case": f"sandbox_dispatch_{mode}", **summarize_samples(samples)}
+
+
 def main() -> None:
     """Run the command-line benchmark and print JSON results."""
-    parser = argparse.ArgumentParser(description="Benchmark MindRoom tool-call bridge overhead.")
+    parser = argparse.ArgumentParser(description="Benchmark MindRoom tool-call bridge and sandbox dispatch overhead.")
     parser.add_argument("--iterations", type=int, default=1000)
     parser.add_argument("--warmup", type=int, default=50)
+    parser.add_argument(
+        "--sandbox-dispatch",
+        nargs="+",
+        choices=["forkserver", "subprocess"],
+        default=None,
+        help=(
+            "Benchmark worker-routed sandbox dispatch for the given execution modes "
+            "instead of the hook bridge. Each spawn-per-call iteration pays the full "
+            "runtime import, so pass a small --iterations (e.g. 5) and --warmup 1."
+        ),
+    )
     args = parser.parse_args()
     if args.iterations < 1:
         parser.error("--iterations must be >= 1")
@@ -155,7 +213,10 @@ def main() -> None:
         wrapper_class=structlog.make_filtering_bound_logger(logging.WARNING),
         cache_logger_on_first_use=False,
     )
-    results = asyncio.run(_run_benchmark(iterations=args.iterations, warmup=args.warmup))
+    if args.sandbox_dispatch:
+        results = [_run_sandbox_dispatch_case(mode, args.iterations, args.warmup) for mode in args.sandbox_dispatch]
+    else:
+        results = asyncio.run(_run_benchmark(iterations=args.iterations, warmup=args.warmup))
     print(json.dumps(results, indent=2, sort_keys=True))
 
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -16131,10 +16131,15 @@ If you deploy that mode without Helm, see [Kubernetes Deployment](https://docs.m
 | `MINDROOM_SANDBOX_RUNNER_PORT` | Port the sandbox runner listens on | `8766` |
 | `MINDROOM_SANDBOX_RUNNER_MODE` | Set to `true` to indicate runner mode | `false` |
 | `MINDROOM_SANDBOX_PROXY_TOKEN` | Runner bearer token. Static runners use the shared primary token; Kubernetes dedicated workers receive a per-worker derived token. | _(required)_ |
-| `MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE` | `inprocess` or `subprocess` | `inprocess` |
-| `MINDROOM_SANDBOX_RUNNER_SUBPROCESS_TIMEOUT_SECONDS` | Subprocess timeout | `120` |
+| `MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE` | `inprocess`, `subprocess`, or `forkserver` | `inprocess` |
+| `MINDROOM_SANDBOX_RUNNER_SUBPROCESS_TIMEOUT_SECONDS` | Per-call timeout for `subprocess` and `forkserver` execution | `120` |
 | `MINDROOM_STORAGE_PATH` | Writable directory for tool registry init and worker-local caches (e.g., `/app/workspace/.mindroom`) | `mindroom_data` next to config _(will fail if not writable)_ |
 | `MINDROOM_CONFIG_PATH` | Path to config.yaml (for plugin tool registration) | _(optional)_ |
+
+`subprocess` runs every non-shell tool call in a fresh `python -m mindroom.api.sandbox_runner` child that re-imports the runtime on each call.
+`forkserver` keeps one warm template process per interpreter that imports the runtime once and forks a fresh child per call, preserving per-call process isolation while removing the per-call import cost.
+Dedicated Docker and Kubernetes workers default to `forkserver`.
+If the warm template fails to start, dispatch falls back to spawn-per-call and retries the template after a cooldown.
 
 ## Execution modes
 
@@ -16241,7 +16246,7 @@ It also proves garbage and missing proxy session tokens are refused.
 Shell commands that exceed their timeout return a background handle.
 Use `check_shell_command(handle)` to poll and `kill_shell_command(handle)` to stop the process.
 These handles are process-local to the sandbox runner: they survive multiple requests to the same runner process, but not runner restarts.
-To make that work, shell background-handle requests stay owned by the long-lived runner process even when `MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE=subprocess`.
+To make that work, shell background-handle requests stay owned by the long-lived runner process even when `MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE` is `subprocess` or `forkserver`.
 
 ## Workspace home contract
 

--- a/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
+++ b/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
@@ -323,10 +323,15 @@ If you deploy that mode without Helm, see [Kubernetes Deployment](https://docs.m
 | `MINDROOM_SANDBOX_RUNNER_PORT` | Port the sandbox runner listens on | `8766` |
 | `MINDROOM_SANDBOX_RUNNER_MODE` | Set to `true` to indicate runner mode | `false` |
 | `MINDROOM_SANDBOX_PROXY_TOKEN` | Runner bearer token. Static runners use the shared primary token; Kubernetes dedicated workers receive a per-worker derived token. | _(required)_ |
-| `MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE` | `inprocess` or `subprocess` | `inprocess` |
-| `MINDROOM_SANDBOX_RUNNER_SUBPROCESS_TIMEOUT_SECONDS` | Subprocess timeout | `120` |
+| `MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE` | `inprocess`, `subprocess`, or `forkserver` | `inprocess` |
+| `MINDROOM_SANDBOX_RUNNER_SUBPROCESS_TIMEOUT_SECONDS` | Per-call timeout for `subprocess` and `forkserver` execution | `120` |
 | `MINDROOM_STORAGE_PATH` | Writable directory for tool registry init and worker-local caches (e.g., `/app/workspace/.mindroom`) | `mindroom_data` next to config _(will fail if not writable)_ |
 | `MINDROOM_CONFIG_PATH` | Path to config.yaml (for plugin tool registration) | _(optional)_ |
+
+`subprocess` runs every non-shell tool call in a fresh `python -m mindroom.api.sandbox_runner` child that re-imports the runtime on each call.
+`forkserver` keeps one warm template process per interpreter that imports the runtime once and forks a fresh child per call, preserving per-call process isolation while removing the per-call import cost.
+Dedicated Docker and Kubernetes workers default to `forkserver`.
+If the warm template fails to start, dispatch falls back to spawn-per-call and retries the template after a cooldown.
 
 ## Execution modes
 
@@ -433,7 +438,7 @@ It also proves garbage and missing proxy session tokens are refused.
 Shell commands that exceed their timeout return a background handle.
 Use `check_shell_command(handle)` to poll and `kill_shell_command(handle)` to stop the process.
 These handles are process-local to the sandbox runner: they survive multiple requests to the same runner process, but not runner restarts.
-To make that work, shell background-handle requests stay owned by the long-lived runner process even when `MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE=subprocess`.
+To make that work, shell background-handle requests stay owned by the long-lived runner process even when `MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE` is `subprocess` or `forkserver`.
 
 ## Workspace home contract
 

--- a/src/mindroom/api/sandbox_exec.py
+++ b/src/mindroom/api/sandbox_exec.py
@@ -55,8 +55,13 @@ def _runner_execution_mode(runtime_paths: RuntimePaths) -> str:
 
 
 def runner_uses_subprocess(runtime_paths: RuntimePaths) -> bool:
-    """Return whether the runner should dispatch through a subprocess."""
-    return _runner_execution_mode(runtime_paths) == "subprocess"
+    """Return whether the runner should dispatch through a per-request child process."""
+    return _runner_execution_mode(runtime_paths) in {"subprocess", "forkserver"}
+
+
+def runner_uses_forkserver(runtime_paths: RuntimePaths) -> bool:
+    """Return whether per-request children should fork from a warm template process."""
+    return _runner_execution_mode(runtime_paths) == "forkserver"
 
 
 def runner_subprocess_timeout_seconds(runtime_paths: RuntimePaths) -> float:

--- a/src/mindroom/api/sandbox_forkserver.py
+++ b/src/mindroom/api/sandbox_forkserver.py
@@ -326,6 +326,8 @@ class _SandboxForkserver:
             try:
                 conn.connect(template.socket_path)
                 conn.sendall(request_payload)
+            except TimeoutError as exc:
+                raise ForkserverTimeoutError from exc
             except OSError as exc:
                 self._discard(key, template)
                 msg = f"Failed to reach the sandbox forkserver template: {exc}"
@@ -334,10 +336,13 @@ class _SandboxForkserver:
             try:
                 child_pid = int(json.loads(reader.read_line())["pid"])
                 response = json.loads(reader.read_line())
+                returncode = int(response["returncode"])
+                stdout_text = str(response["stdout"])
+                stderr_text = str(response["stderr"])
             except TimeoutError as exc:
                 self._kill_child(child_pid)
                 raise ForkserverTimeoutError from exc
-            except (_ConnectionClosedError, OSError, ValueError, KeyError) as exc:
+            except (_ConnectionClosedError, OSError, ValueError, KeyError, TypeError) as exc:
                 if template.process.poll() is not None:
                     self._discard(key, template)
                 msg = "Sandbox forkserver child exited without returning a response."
@@ -346,9 +351,9 @@ class _SandboxForkserver:
             conn.close()
         return subprocess.CompletedProcess(
             args=["sandbox-forkserver", key],
-            returncode=int(response["returncode"]),
-            stdout=str(response["stdout"]),
-            stderr=str(response["stderr"]),
+            returncode=returncode,
+            stdout=stdout_text,
+            stderr=stderr_text,
         )
 
     @staticmethod
@@ -396,7 +401,13 @@ def serve_template(socket_path: str, run_payload: Callable[[str], tuple[int, str
                 if os.getppid() != parent_pid:
                     return 0
                 continue
-            child_pid = os.fork()
+            try:
+                child_pid = os.fork()
+            except OSError:
+                # Fork pressure (e.g. EAGAIN) fails this one request via EOF on
+                # the connection; the template keeps serving.
+                conn.close()
+                continue
             if child_pid == 0:
                 server.close()
                 _child_main(conn, run_payload)

--- a/src/mindroom/api/sandbox_forkserver.py
+++ b/src/mindroom/api/sandbox_forkserver.py
@@ -327,10 +327,9 @@ class _SandboxForkserver:
                 logger.warning("sandbox_forkserver_template_startup_failed", error=msg)
                 raise ForkserverStartupError(msg)
             try:
-                probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-                probe.settimeout(1.0)
-                probe.connect(template.socket_path)
-                probe.close()
+                with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as probe:
+                    probe.settimeout(1.0)
+                    probe.connect(template.socket_path)
             except OSError:
                 time.sleep(_READY_PROBE_INTERVAL_SECONDS)
             else:
@@ -400,7 +399,9 @@ class _SandboxForkserver:
 
     @staticmethod
     def _kill_child(child_pid: int | None) -> None:
-        if child_pid is None:
+        # The pid is deserialized from the child's socket message; never let a
+        # degenerate value reach os.kill, where 0 targets the process group.
+        if child_pid is None or child_pid <= 0:
             return
         with suppress(OSError):
             os.kill(child_pid, signal.SIGKILL)
@@ -467,10 +468,12 @@ def _child_main(conn: socket.socket, run_payload: Callable[[str], tuple[int, str
     exit_code = 1
     try:
         _send_json(conn, {"pid": os.getpid()})
-        conn.settimeout(_CHILD_REQUEST_READ_TIMEOUT_SECONDS)
-        reader = conn.makefile("rb")
-        request_line = reader.readline()
-        # Ready-wait probe connections close without sending a request line.
+        reader = _SocketLineReader(conn, time.monotonic() + _CHILD_REQUEST_READ_TIMEOUT_SECONDS)
+        try:
+            request_line = reader.read_line()
+        except _ConnectionClosedError:
+            # Ready-wait probe connections close without sending a request line.
+            request_line = b""
         if request_line.strip():
             exit_code = _run_child_request(conn, _parse_child_request(request_line), run_payload)
     except Exception:

--- a/src/mindroom/api/sandbox_forkserver.py
+++ b/src/mindroom/api/sandbox_forkserver.py
@@ -97,13 +97,15 @@ def _default_template_command(python_executable: str, socket_path: str) -> list[
     return [python_executable, "-m", "mindroom.api.sandbox_runner", TEMPLATE_ARG, socket_path]
 
 
-@dataclass(frozen=True)
+@dataclass
 class _Template:
     fingerprint: str
     process: subprocess.Popen[bytes]
     socket_path: str
     stderr_path: Path
     runtime_dir: Path
+    # Set once the socket accepts connections; mutated only under the key lock.
+    ready: bool = False
 
 
 @dataclass(frozen=True)
@@ -255,14 +257,19 @@ class _SandboxForkserver:
             self._discard(key, template)
             template = None
         if template is None:
-            template = self._spawn_template(
-                key=key,
-                fingerprint=fingerprint,
-                template_env=template_env,
-                deadline=deadline,
-            )
+            template = self._spawn_template(key=key, fingerprint=fingerprint, template_env=template_env)
             with self._lock:
                 self._templates[key] = template
+        try:
+            self._wait_template_ready(key=key, template=template, deadline=deadline)
+        except ForkserverStartupError as exc:
+            with self._lock:
+                if self._templates.get(key) is template:
+                    self._templates.pop(key)
+            shutil.rmtree(template.runtime_dir, ignore_errors=True)
+            self._failed_fingerprints[fingerprint] = (str(exc), time.monotonic())
+            logger.warning("sandbox_forkserver_template_startup_failed", error=str(exc))
+            raise
         return template
 
     def _discard(self, key: str, template: _Template) -> None:
@@ -277,7 +284,6 @@ class _SandboxForkserver:
         key: str,
         fingerprint: str,
         template_env: dict[str, str] | None,
-        deadline: float,
     ) -> _Template:
         runtime_dir = Path(tempfile.mkdtemp(prefix="mindroom-fs-"))
         socket_path = str(runtime_dir / "template.sock")
@@ -297,35 +303,31 @@ class _SandboxForkserver:
             msg = f"Failed to start sandbox forkserver template: {exc}"
             self._failed_fingerprints[fingerprint] = (msg, time.monotonic())
             raise ForkserverStartupError(msg) from exc
-        template = _Template(
+        return _Template(
             fingerprint=fingerprint,
             process=process,
             socket_path=socket_path,
             stderr_path=stderr_path,
             runtime_dir=runtime_dir,
         )
-        self._wait_template_ready(template=template, fingerprint=fingerprint, deadline=deadline)
-        logger.info("sandbox_forkserver_template_ready", python_executable=key, template_pid=process.pid)
-        return template
 
-    def _wait_template_ready(self, *, template: _Template, fingerprint: str, deadline: float) -> None:
+    def _wait_template_ready(self, *, key: str, template: _Template, deadline: float) -> None:
+        if template.ready:
+            return
         while True:
             if template.process.poll() is not None:
                 stderr_tail = _stderr_tail(template.stderr_path)
-                shutil.rmtree(template.runtime_dir, ignore_errors=True)
                 msg = (
                     f"Sandbox forkserver template exited during startup "
                     f"(code {template.process.returncode}): {stderr_tail}"
                 )
-                self._failed_fingerprints[fingerprint] = (msg, time.monotonic())
-                logger.warning("sandbox_forkserver_template_startup_failed", error=msg)
                 raise ForkserverStartupError(msg)
             if time.monotonic() >= deadline:
-                _terminate_template(template)
-                msg = "Timed out waiting for the sandbox forkserver template to import the runtime."
-                self._failed_fingerprints[fingerprint] = (msg, time.monotonic())
-                logger.warning("sandbox_forkserver_template_startup_failed", error=msg)
-                raise ForkserverStartupError(msg)
+                # Startup outlasting one request's budget is not a template
+                # failure: keep it importing so a later request finds it warm,
+                # and report the same timeout spawn-per-call would have hit.
+                logger.info("sandbox_forkserver_template_still_importing", python_executable=key)
+                raise ForkserverTimeoutError
             try:
                 with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as probe:
                     probe.settimeout(1.0)
@@ -333,6 +335,12 @@ class _SandboxForkserver:
             except OSError:
                 time.sleep(_READY_PROBE_INTERVAL_SECONDS)
             else:
+                template.ready = True
+                logger.info(
+                    "sandbox_forkserver_template_ready",
+                    python_executable=key,
+                    template_pid=template.process.pid,
+                )
                 return
 
     def _request(
@@ -428,6 +436,12 @@ def serve_template(socket_path: str, run_payload: Callable[[str], tuple[int, str
     after the heavy runtime import has completed. Must stay fork-safe: no
     threads, event loops, or network clients before forking.
     """
+    if (thread_count := threading.active_count()) > 1:
+        msg = (
+            f"Sandbox forkserver template must be single-threaded before forking; "
+            f"found {thread_count} threads after the runtime import."
+        )
+        raise RuntimeError(msg)
     parent_pid = os.getppid()
     # Auto-reap forked request children; each child restores SIG_DFL for its
     # own tool subprocesses immediately after fork.
@@ -476,7 +490,7 @@ def _child_main(conn: socket.socket, run_payload: Callable[[str], tuple[int, str
             request_line = b""
         if request_line.strip():
             exit_code = _run_child_request(conn, _parse_child_request(request_line), run_payload)
-    except Exception:
+    except BaseException:
         with suppress(Exception):
             _send_json(
                 conn,

--- a/src/mindroom/api/sandbox_forkserver.py
+++ b/src/mindroom/api/sandbox_forkserver.py
@@ -11,6 +11,11 @@ its own fresh process - at ~ms fork cost instead of the import cost.
 
 The template must stay fork-safe: it only imports modules and then blocks on
 ``accept()``; it never starts threads, event loops, or network clients.
+
+The template's stderr file collects raw-fd output from fork children (native
+libraries or tool subprocesses writing to fd 2); Python-level tool output is
+captured per request. The file lives for the template's lifetime and is
+removed on recycle, shutdown, or orphan exit.
 """
 
 from __future__ import annotations
@@ -18,6 +23,7 @@ from __future__ import annotations
 import atexit
 import hashlib
 import json
+import math
 import os
 import shutil
 import signal
@@ -47,6 +53,8 @@ _TEMPLATE_ACCEPT_POLL_SECONDS = 1.0
 _TEMPLATE_TERMINATE_WAIT_SECONDS = 5.0
 _CHILD_REQUEST_READ_TIMEOUT_SECONDS = 30.0
 _CHILD_RESPONSE_WRITE_TIMEOUT_SECONDS = 60.0
+_CHILD_TIMEOUT_GRACE_SECONDS = 5.0
+_STARTUP_FAILURE_COOLDOWN_SECONDS = 300.0
 _READY_PROBE_INTERVAL_SECONDS = 0.05
 _STDERR_TAIL_BYTES = 4096
 _RECV_CHUNK_BYTES = 65536
@@ -96,6 +104,16 @@ class _Template:
     socket_path: str
     stderr_path: Path
     runtime_dir: Path
+
+
+@dataclass(frozen=True)
+class _ChildRequest:
+    """One parent-to-child request line, authored by `_request`."""
+
+    env: dict[str, str] | None
+    cwd: str | None
+    envelope: str
+    timeout_seconds: float
 
 
 def _stderr_tail(stderr_path: Path) -> str:
@@ -148,12 +166,18 @@ class _SocketLineReader:
 class _SandboxForkserver:
     """Runner-side manager for warm template processes keyed by interpreter."""
 
-    def __init__(self, template_command: Callable[[str, str], list[str]] | None = None) -> None:
+    def __init__(
+        self,
+        template_command: Callable[[str, str], list[str]] | None = None,
+        *,
+        startup_failure_cooldown_seconds: float = _STARTUP_FAILURE_COOLDOWN_SECONDS,
+    ) -> None:
         self._template_command = template_command or _default_template_command
+        self._startup_failure_cooldown_seconds = startup_failure_cooldown_seconds
         self._lock = threading.Lock()
         self._key_locks: dict[str, threading.Lock] = {}
         self._templates: dict[str, _Template] = {}
-        self._failed_fingerprints: dict[str, str] = {}
+        self._failed_fingerprints: dict[str, tuple[str, float]] = {}
 
     def execute(
         self,
@@ -170,7 +194,8 @@ class _SandboxForkserver:
         key = python_executable or sys.executable
         fingerprint = _template_fingerprint(key, template_env)
         key_lock = self._key_lock(key)
-        if not key_lock.acquire(timeout=max(0.1, deadline - time.monotonic())):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0 or not key_lock.acquire(timeout=remaining):
             msg = "Timed out waiting for the sandbox forkserver template."
             raise ForkserverTimeoutError(msg)
         try:
@@ -217,14 +242,19 @@ class _SandboxForkserver:
             logger.warning("sandbox_forkserver_template_died", python_executable=key)
             self._discard(key, template)
             template = None
+        # A pinned fingerprint must bail out before the recycle check so it
+        # cannot tear down a healthy template of another fingerprint.
+        failure = self._failed_fingerprints.get(fingerprint)
+        if failure is not None:
+            message, failed_at = failure
+            if time.monotonic() - failed_at < self._startup_failure_cooldown_seconds:
+                raise ForkserverStartupError(message)
+            self._failed_fingerprints.pop(fingerprint, None)
         if template is not None and template.fingerprint != fingerprint:
             logger.info("sandbox_forkserver_template_recycled", python_executable=key)
             self._discard(key, template)
             template = None
         if template is None:
-            previous_failure = self._failed_fingerprints.get(fingerprint)
-            if previous_failure is not None:
-                raise ForkserverStartupError(previous_failure)
             template = self._spawn_template(
                 key=key,
                 fingerprint=fingerprint,
@@ -265,7 +295,7 @@ class _SandboxForkserver:
         except OSError as exc:
             shutil.rmtree(runtime_dir, ignore_errors=True)
             msg = f"Failed to start sandbox forkserver template: {exc}"
-            self._failed_fingerprints[fingerprint] = msg
+            self._failed_fingerprints[fingerprint] = (msg, time.monotonic())
             raise ForkserverStartupError(msg) from exc
         template = _Template(
             fingerprint=fingerprint,
@@ -287,13 +317,13 @@ class _SandboxForkserver:
                     f"Sandbox forkserver template exited during startup "
                     f"(code {template.process.returncode}): {stderr_tail}"
                 )
-                self._failed_fingerprints[fingerprint] = msg
+                self._failed_fingerprints[fingerprint] = (msg, time.monotonic())
                 logger.warning("sandbox_forkserver_template_startup_failed", error=msg)
                 raise ForkserverStartupError(msg)
             if time.monotonic() >= deadline:
                 _terminate_template(template)
                 msg = "Timed out waiting for the sandbox forkserver template to import the runtime."
-                self._failed_fingerprints[fingerprint] = msg
+                self._failed_fingerprints[fingerprint] = (msg, time.monotonic())
                 logger.warning("sandbox_forkserver_template_startup_failed", error=msg)
                 raise ForkserverStartupError(msg)
             try:
@@ -316,13 +346,25 @@ class _SandboxForkserver:
         envelope: str,
         deadline: float,
     ) -> subprocess.CompletedProcess[str]:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            # Never deliver a request the caller has no budget left for; a
+            # delivered request forks a child the parent may not learn about.
+            raise ForkserverTimeoutError
         request_payload = (
-            json.dumps({"env": request_env, "cwd": request_cwd, "envelope": envelope}).encode("utf-8") + b"\n"
+            json.dumps(
+                {"env": request_env, "cwd": request_cwd, "envelope": envelope, "timeout_seconds": remaining},
+            ).encode("utf-8")
+            + b"\n"
         )
         child_pid: int | None = None
-        conn = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         try:
-            conn.settimeout(max(0.1, deadline - time.monotonic()))
+            conn = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        except OSError as exc:
+            msg = f"Failed to open a sandbox forkserver connection: {exc}"
+            raise ForkserverError(msg) from exc
+        try:
+            conn.settimeout(remaining)
             try:
                 conn.connect(template.socket_path)
                 conn.sendall(request_payload)
@@ -399,6 +441,9 @@ def serve_template(socket_path: str, run_payload: Callable[[str], tuple[int, str
                 conn, _addr = server.accept()
             except TimeoutError:
                 if os.getppid() != parent_pid:
+                    # Orphaned: the runner died without running its cleanup
+                    # (e.g. SIGKILL), so remove our runtime dir ourselves.
+                    shutil.rmtree(Path(socket_path).parent, ignore_errors=True)
                     return 0
                 continue
             try:
@@ -425,9 +470,9 @@ def _child_main(conn: socket.socket, run_payload: Callable[[str], tuple[int, str
         conn.settimeout(_CHILD_REQUEST_READ_TIMEOUT_SECONDS)
         reader = conn.makefile("rb")
         request_line = reader.readline()
+        # Ready-wait probe connections close without sending a request line.
         if request_line.strip():
-            request = json.loads(request_line)
-            exit_code = _run_child_request(conn, request, run_payload)
+            exit_code = _run_child_request(conn, _parse_child_request(request_line), run_payload)
     except Exception:
         with suppress(Exception):
             _send_json(
@@ -443,19 +488,33 @@ def _child_main(conn: socket.socket, run_payload: Callable[[str], tuple[int, str
     os._exit(exit_code)
 
 
+def _parse_child_request(request_line: bytes) -> _ChildRequest:
+    payload = json.loads(request_line)
+    return _ChildRequest(
+        env=payload["env"],
+        cwd=payload["cwd"],
+        envelope=payload["envelope"],
+        timeout_seconds=payload["timeout_seconds"],
+    )
+
+
 def _run_child_request(
     conn: socket.socket,
-    request: dict[str, object],
+    request: _ChildRequest,
     run_payload: Callable[[str], tuple[int, str, str]],
 ) -> int:
-    env = request.get("env")
-    if isinstance(env, dict):
+    # Self-destruct backstop for the rare case where the runner never learned
+    # this child's pid; the grace keeps the runner-side SIGKILL primary.
+    signal.alarm(max(1, math.ceil(request.timeout_seconds + _CHILD_TIMEOUT_GRACE_SECONDS)))
+    if request.env is not None:
         os.environ.clear()
-        os.environ.update({str(name): str(value) for name, value in env.items()})
-    cwd = request.get("cwd")
-    if cwd:
-        os.chdir(str(cwd))
-    returncode, stdout_text, stderr_text = run_payload(str(request["envelope"]))
+        os.environ.update(request.env)
+    if request.cwd is not None:
+        os.chdir(request.cwd)
+    # `python -m` prepends the effective cwd to sys.path; mirror that for the
+    # request cwd (the runner template drops its own baked entry at startup).
+    sys.path.insert(0, str(Path.cwd()))
+    returncode, stdout_text, stderr_text = run_payload(request.envelope)
     conn.settimeout(_CHILD_RESPONSE_WRITE_TIMEOUT_SECONDS)
     _send_json(conn, {"returncode": returncode, "stdout": stdout_text, "stderr": stderr_text})
     return 0

--- a/src/mindroom/api/sandbox_forkserver.py
+++ b/src/mindroom/api/sandbox_forkserver.py
@@ -1,0 +1,454 @@
+"""Warm-template forkserver for sandbox subprocess dispatch.
+
+Spawning a fresh ``python -m mindroom.api.sandbox_runner`` per tool call pays
+the full runtime import (~11-17 s on a 2-CPU worker pod) on every request.
+This module keeps one long-lived *template* process per interpreter that pays
+that import once and then blocks on a unix socket. Each request forks the
+template; the fork child applies the per-request env and cwd, executes the
+already-prepared envelope, streams the response back over the socket, and
+exits. Isolation semantics match spawn-per-call - every request still runs in
+its own fresh process - at ~ms fork cost instead of the import cost.
+
+The template must stay fork-safe: it only imports modules and then blocks on
+``accept()``; it never starts threads, event loops, or network clients.
+"""
+
+from __future__ import annotations
+
+import atexit
+import hashlib
+import json
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import traceback
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, NoReturn
+
+from mindroom.logging_config import get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
+logger = get_logger(__name__)
+
+TEMPLATE_ARG = "--sandbox-forkserver-template"
+
+_TEMPLATE_LISTEN_BACKLOG = 64
+_TEMPLATE_ACCEPT_POLL_SECONDS = 1.0
+_TEMPLATE_TERMINATE_WAIT_SECONDS = 5.0
+_CHILD_REQUEST_READ_TIMEOUT_SECONDS = 30.0
+_CHILD_RESPONSE_WRITE_TIMEOUT_SECONDS = 60.0
+_READY_PROBE_INTERVAL_SECONDS = 0.05
+_STDERR_TAIL_BYTES = 4096
+_RECV_CHUNK_BYTES = 65536
+
+
+class ForkserverError(RuntimeError):
+    """One forkserver-dispatched request failed; message maps to a worker failure."""
+
+
+class ForkserverStartupError(ForkserverError):
+    """The template process failed to start; callers should fall back to spawn-per-call."""
+
+
+class ForkserverTimeoutError(ForkserverError):
+    """One forkserver-dispatched request exceeded the sandbox subprocess timeout."""
+
+
+def forkserver_supported() -> bool:
+    """Return whether warm-template fork dispatch is available on this platform."""
+    return hasattr(os, "fork") and hasattr(socket, "AF_UNIX")
+
+
+def _template_fingerprint(python_executable: str, template_env: Mapping[str, str] | None) -> str:
+    """Fingerprint the interpreter and base env that bake the template's import graph.
+
+    The interpreter stat stamp changes when a worker venv is rebuilt in place,
+    so a stale template is recycled even when the env values are unchanged.
+    """
+    try:
+        stat_result = Path(python_executable).stat()
+        interpreter_stamp = f"{stat_result.st_ino}:{stat_result.st_mtime_ns}:{stat_result.st_size}"
+    except OSError:
+        interpreter_stamp = "missing"
+    env_items = sorted(template_env.items()) if template_env is not None else None
+    payload = json.dumps([python_executable, interpreter_stamp, env_items])
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _default_template_command(python_executable: str, socket_path: str) -> list[str]:
+    return [python_executable, "-m", "mindroom.api.sandbox_runner", TEMPLATE_ARG, socket_path]
+
+
+@dataclass(frozen=True)
+class _Template:
+    fingerprint: str
+    process: subprocess.Popen[bytes]
+    socket_path: str
+    stderr_path: Path
+    runtime_dir: Path
+
+
+def _stderr_tail(stderr_path: Path) -> str:
+    try:
+        raw = stderr_path.read_bytes()
+    except OSError:
+        return ""
+    return raw[-_STDERR_TAIL_BYTES:].decode("utf-8", errors="replace").strip()
+
+
+def _terminate_template(template: _Template) -> None:
+    process = template.process
+    if process.poll() is None:
+        process.terminate()
+        try:
+            process.wait(timeout=_TEMPLATE_TERMINATE_WAIT_SECONDS)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
+    shutil.rmtree(template.runtime_dir, ignore_errors=True)
+
+
+class _ConnectionClosedError(RuntimeError):
+    """The socket closed before a full protocol line arrived."""
+
+
+class _SocketLineReader:
+    """Read newline-framed protocol lines from a socket under one deadline."""
+
+    def __init__(self, conn: socket.socket, deadline: float) -> None:
+        self._conn = conn
+        self._deadline = deadline
+        self._buffer = bytearray()
+
+    def read_line(self) -> bytes:
+        while b"\n" not in self._buffer:
+            remaining = self._deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError
+            self._conn.settimeout(remaining)
+            chunk = self._conn.recv(_RECV_CHUNK_BYTES)
+            if not chunk:
+                raise _ConnectionClosedError
+            self._buffer.extend(chunk)
+        line, _, rest = bytes(self._buffer).partition(b"\n")
+        self._buffer = bytearray(rest)
+        return line
+
+
+class _SandboxForkserver:
+    """Runner-side manager for warm template processes keyed by interpreter."""
+
+    def __init__(self, template_command: Callable[[str, str], list[str]] | None = None) -> None:
+        self._template_command = template_command or _default_template_command
+        self._lock = threading.Lock()
+        self._key_locks: dict[str, threading.Lock] = {}
+        self._templates: dict[str, _Template] = {}
+        self._failed_fingerprints: dict[str, str] = {}
+
+    def execute(
+        self,
+        *,
+        python_executable: str | None,
+        template_env: dict[str, str] | None,
+        request_env: dict[str, str] | None,
+        request_cwd: str | None,
+        envelope: str,
+        timeout_seconds: float,
+    ) -> subprocess.CompletedProcess[str]:
+        """Execute one prepared envelope in a fresh fork of the warm template."""
+        deadline = time.monotonic() + timeout_seconds
+        key = python_executable or sys.executable
+        fingerprint = _template_fingerprint(key, template_env)
+        key_lock = self._key_lock(key)
+        if not key_lock.acquire(timeout=max(0.1, deadline - time.monotonic())):
+            msg = "Timed out waiting for the sandbox forkserver template."
+            raise ForkserverTimeoutError(msg)
+        try:
+            template = self._ready_template(
+                key=key,
+                fingerprint=fingerprint,
+                template_env=template_env,
+                deadline=deadline,
+            )
+        finally:
+            key_lock.release()
+        return self._request(
+            key,
+            template,
+            request_env=request_env,
+            request_cwd=request_cwd,
+            envelope=envelope,
+            deadline=deadline,
+        )
+
+    def shutdown(self) -> None:
+        """Terminate all template processes and clear cached state."""
+        with self._lock:
+            templates = list(self._templates.values())
+            self._templates.clear()
+            self._failed_fingerprints.clear()
+        for template in templates:
+            _terminate_template(template)
+
+    def _key_lock(self, key: str) -> threading.Lock:
+        with self._lock:
+            return self._key_locks.setdefault(key, threading.Lock())
+
+    def _ready_template(
+        self,
+        *,
+        key: str,
+        fingerprint: str,
+        template_env: dict[str, str] | None,
+        deadline: float,
+    ) -> _Template:
+        template = self._templates.get(key)
+        if template is not None and template.process.poll() is not None:
+            logger.warning("sandbox_forkserver_template_died", python_executable=key)
+            self._discard(key, template)
+            template = None
+        if template is not None and template.fingerprint != fingerprint:
+            logger.info("sandbox_forkserver_template_recycled", python_executable=key)
+            self._discard(key, template)
+            template = None
+        if template is None:
+            previous_failure = self._failed_fingerprints.get(fingerprint)
+            if previous_failure is not None:
+                raise ForkserverStartupError(previous_failure)
+            template = self._spawn_template(
+                key=key,
+                fingerprint=fingerprint,
+                template_env=template_env,
+                deadline=deadline,
+            )
+            with self._lock:
+                self._templates[key] = template
+        return template
+
+    def _discard(self, key: str, template: _Template) -> None:
+        with self._lock:
+            if self._templates.get(key) is template:
+                self._templates.pop(key)
+        _terminate_template(template)
+
+    def _spawn_template(
+        self,
+        *,
+        key: str,
+        fingerprint: str,
+        template_env: dict[str, str] | None,
+        deadline: float,
+    ) -> _Template:
+        runtime_dir = Path(tempfile.mkdtemp(prefix="mindroom-fs-"))
+        socket_path = str(runtime_dir / "template.sock")
+        stderr_path = runtime_dir / "template.err"
+        logger.info("sandbox_forkserver_template_spawning", python_executable=key)
+        try:
+            with stderr_path.open("wb") as stderr_file:
+                process = subprocess.Popen(
+                    self._template_command(key, socket_path),
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
+                    stderr=stderr_file,
+                    env=template_env,
+                )
+        except OSError as exc:
+            shutil.rmtree(runtime_dir, ignore_errors=True)
+            msg = f"Failed to start sandbox forkserver template: {exc}"
+            self._failed_fingerprints[fingerprint] = msg
+            raise ForkserverStartupError(msg) from exc
+        template = _Template(
+            fingerprint=fingerprint,
+            process=process,
+            socket_path=socket_path,
+            stderr_path=stderr_path,
+            runtime_dir=runtime_dir,
+        )
+        self._wait_template_ready(template=template, fingerprint=fingerprint, deadline=deadline)
+        logger.info("sandbox_forkserver_template_ready", python_executable=key, template_pid=process.pid)
+        return template
+
+    def _wait_template_ready(self, *, template: _Template, fingerprint: str, deadline: float) -> None:
+        while True:
+            if template.process.poll() is not None:
+                stderr_tail = _stderr_tail(template.stderr_path)
+                shutil.rmtree(template.runtime_dir, ignore_errors=True)
+                msg = (
+                    f"Sandbox forkserver template exited during startup "
+                    f"(code {template.process.returncode}): {stderr_tail}"
+                )
+                self._failed_fingerprints[fingerprint] = msg
+                logger.warning("sandbox_forkserver_template_startup_failed", error=msg)
+                raise ForkserverStartupError(msg)
+            if time.monotonic() >= deadline:
+                _terminate_template(template)
+                msg = "Timed out waiting for the sandbox forkserver template to import the runtime."
+                self._failed_fingerprints[fingerprint] = msg
+                logger.warning("sandbox_forkserver_template_startup_failed", error=msg)
+                raise ForkserverStartupError(msg)
+            try:
+                probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                probe.settimeout(1.0)
+                probe.connect(template.socket_path)
+                probe.close()
+            except OSError:
+                time.sleep(_READY_PROBE_INTERVAL_SECONDS)
+            else:
+                return
+
+    def _request(
+        self,
+        key: str,
+        template: _Template,
+        *,
+        request_env: dict[str, str] | None,
+        request_cwd: str | None,
+        envelope: str,
+        deadline: float,
+    ) -> subprocess.CompletedProcess[str]:
+        request_payload = (
+            json.dumps({"env": request_env, "cwd": request_cwd, "envelope": envelope}).encode("utf-8") + b"\n"
+        )
+        child_pid: int | None = None
+        conn = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            conn.settimeout(max(0.1, deadline - time.monotonic()))
+            try:
+                conn.connect(template.socket_path)
+                conn.sendall(request_payload)
+            except OSError as exc:
+                self._discard(key, template)
+                msg = f"Failed to reach the sandbox forkserver template: {exc}"
+                raise ForkserverError(msg) from exc
+            reader = _SocketLineReader(conn, deadline)
+            try:
+                child_pid = int(json.loads(reader.read_line())["pid"])
+                response = json.loads(reader.read_line())
+            except TimeoutError as exc:
+                self._kill_child(child_pid)
+                raise ForkserverTimeoutError from exc
+            except (_ConnectionClosedError, OSError, ValueError, KeyError) as exc:
+                if template.process.poll() is not None:
+                    self._discard(key, template)
+                msg = "Sandbox forkserver child exited without returning a response."
+                raise ForkserverError(msg) from exc
+        finally:
+            conn.close()
+        return subprocess.CompletedProcess(
+            args=["sandbox-forkserver", key],
+            returncode=int(response["returncode"]),
+            stdout=str(response["stdout"]),
+            stderr=str(response["stderr"]),
+        )
+
+    @staticmethod
+    def _kill_child(child_pid: int | None) -> None:
+        if child_pid is None:
+            return
+        with suppress(OSError):
+            os.kill(child_pid, signal.SIGKILL)
+
+
+_forkserver: _SandboxForkserver | None = None
+_forkserver_lock = threading.Lock()
+
+
+def get_sandbox_forkserver() -> _SandboxForkserver:
+    """Return the process-wide forkserver manager, creating it on first use."""
+    global _forkserver
+    with _forkserver_lock:
+        if _forkserver is None:
+            _forkserver = _SandboxForkserver()
+            atexit.register(_forkserver.shutdown)
+        return _forkserver
+
+
+def serve_template(socket_path: str, run_payload: Callable[[str], tuple[int, str, str]]) -> int:
+    """Template process main loop: accept one connection per request and fork.
+
+    Runs inside ``python -m mindroom.api.sandbox_runner --sandbox-forkserver-template``
+    after the heavy runtime import has completed. Must stay fork-safe: no
+    threads, event loops, or network clients before forking.
+    """
+    parent_pid = os.getppid()
+    # Auto-reap forked request children; each child restores SIG_DFL for its
+    # own tool subprocesses immediately after fork.
+    signal.signal(signal.SIGCHLD, signal.SIG_IGN)
+    server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        server.bind(socket_path)
+        server.listen(_TEMPLATE_LISTEN_BACKLOG)
+        server.settimeout(_TEMPLATE_ACCEPT_POLL_SECONDS)
+        while True:
+            try:
+                conn, _addr = server.accept()
+            except TimeoutError:
+                if os.getppid() != parent_pid:
+                    return 0
+                continue
+            child_pid = os.fork()
+            if child_pid == 0:
+                server.close()
+                _child_main(conn, run_payload)
+            conn.close()
+    finally:
+        server.close()
+
+
+def _child_main(conn: socket.socket, run_payload: Callable[[str], tuple[int, str, str]]) -> NoReturn:
+    """Fork-child request handler; never returns to the template loop."""
+    signal.signal(signal.SIGCHLD, signal.SIG_DFL)
+    exit_code = 1
+    try:
+        _send_json(conn, {"pid": os.getpid()})
+        conn.settimeout(_CHILD_REQUEST_READ_TIMEOUT_SECONDS)
+        reader = conn.makefile("rb")
+        request_line = reader.readline()
+        if request_line.strip():
+            request = json.loads(request_line)
+            exit_code = _run_child_request(conn, request, run_payload)
+    except Exception:
+        with suppress(Exception):
+            _send_json(
+                conn,
+                {
+                    "returncode": 1,
+                    "stdout": "",
+                    "stderr": f"Sandbox forkserver child failed: {traceback.format_exc()}",
+                },
+            )
+    with suppress(Exception):
+        conn.close()
+    os._exit(exit_code)
+
+
+def _run_child_request(
+    conn: socket.socket,
+    request: dict[str, object],
+    run_payload: Callable[[str], tuple[int, str, str]],
+) -> int:
+    env = request.get("env")
+    if isinstance(env, dict):
+        os.environ.clear()
+        os.environ.update({str(name): str(value) for name, value in env.items()})
+    cwd = request.get("cwd")
+    if cwd:
+        os.chdir(str(cwd))
+    returncode, stdout_text, stderr_text = run_payload(str(request["envelope"]))
+    conn.settimeout(_CHILD_RESPONSE_WRITE_TIMEOUT_SECONDS)
+    _send_json(conn, {"returncode": returncode, "stdout": stdout_text, "stderr": stderr_text})
+    return 0
+
+
+def _send_json(conn: socket.socket, payload: dict[str, object]) -> None:
+    conn.sendall(json.dumps(payload).encode("utf-8") + b"\n")

--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -22,7 +22,7 @@ from fastapi import APIRouter, Depends, FastAPI, Header, HTTPException, Request
 from pydantic import BaseModel, Field, ValidationError
 
 from mindroom import constants
-from mindroom.api import sandbox_env_assembly, sandbox_exec, sandbox_protocol, sandbox_worker_prep
+from mindroom.api import sandbox_env_assembly, sandbox_exec, sandbox_forkserver, sandbox_protocol, sandbox_worker_prep
 from mindroom.api.worker_responses import (
     SandboxWorkerCleanupResponse,
     SandboxWorkerListResponse,
@@ -534,6 +534,7 @@ class _PreparedSandboxSubprocessContext:
     python_executable: str | None
     subprocess_env: dict[str, str] | None
     subprocess_cwd: str | None
+    template_env: dict[str, str] | None
 
 
 def _app_context(app: FastAPI) -> _SandboxRunnerContext:
@@ -1009,10 +1010,10 @@ def _prepare_execute_request(
 def _prepare_subprocess_context(
     prepared_request: _PreparedSandboxRequestContext,
 ) -> _PreparedSandboxSubprocessContext:
-    python_executable, subprocess_env, subprocess_cwd = sandbox_exec.resolve_subprocess_worker_context(
+    python_executable, template_env, subprocess_cwd = sandbox_exec.resolve_subprocess_worker_context(
         prepared_request.prepared_worker.paths if prepared_request.prepared_worker is not None else None,
     )
-    subprocess_env = sandbox_exec.subprocess_env_for_request(subprocess_env, prepared_request.execution_env)
+    subprocess_env = sandbox_exec.subprocess_env_for_request(template_env, prepared_request.execution_env)
     if workspace := prepared_request.execution_env.get("MINDROOM_AGENT_WORKSPACE"):
         workspace_path = Path(workspace).expanduser().resolve()
         if not sandbox_exec.runner_uses_dedicated_worker(prepared_request.runtime_paths):
@@ -1022,6 +1023,7 @@ def _prepare_subprocess_context(
         python_executable=python_executable,
         subprocess_env=subprocess_env,
         subprocess_cwd=subprocess_cwd,
+        template_env=template_env,
     )
 
 
@@ -1166,6 +1168,36 @@ def _parse_subprocess_response(
     return _subprocess_failure_response(request, "Sandbox subprocess returned an invalid response.", runtime_paths)
 
 
+def _execute_request_forkserver(
+    request: SandboxRunnerExecuteRequest,
+    runtime_paths: RuntimePaths,
+    *,
+    subprocess_context: _PreparedSandboxSubprocessContext,
+    envelope: str,
+    timeout_seconds: float,
+) -> SandboxRunnerExecuteResponse | None:
+    """Dispatch one prepared request via the warm template; None means fall back to spawn-per-call."""
+    try:
+        completed = sandbox_forkserver.get_sandbox_forkserver().execute(
+            python_executable=subprocess_context.python_executable,
+            template_env=subprocess_context.template_env,
+            request_env=subprocess_context.subprocess_env,
+            request_cwd=subprocess_context.subprocess_cwd,
+            envelope=envelope,
+            timeout_seconds=timeout_seconds,
+        )
+    except sandbox_forkserver.ForkserverTimeoutError:
+        return _subprocess_failure_response(request, "Sandbox subprocess timed out.", runtime_paths)
+    except sandbox_forkserver.ForkserverStartupError as exc:
+        # The warm template could not start; fall back to spawn-per-call so
+        # tool calls keep working at the old per-request import cost.
+        logger.warning("sandbox_forkserver_fallback_to_spawn", error=str(exc))
+        return None
+    except sandbox_forkserver.ForkserverError as exc:
+        return _subprocess_failure_response(request, str(exc), runtime_paths)
+    return _parse_subprocess_response(request, runtime_paths, completed)
+
+
 def _execute_request_subprocess_sync(
     request: SandboxRunnerExecuteRequest,
     runtime_paths: RuntimePaths,
@@ -1192,6 +1224,18 @@ def _execute_request_subprocess_sync(
         request=prepared_request.request.model_dump(mode="json"),
         runtime_paths=constants.serialize_runtime_paths(prepared_request.runtime_paths),
     )
+    timeout_seconds = sandbox_exec.runner_subprocess_timeout_seconds(runtime_paths)
+
+    if sandbox_exec.runner_uses_forkserver(runtime_paths) and sandbox_forkserver.forkserver_supported():
+        forkserver_response = _execute_request_forkserver(
+            request,
+            runtime_paths,
+            subprocess_context=subprocess_context,
+            envelope=envelope,
+            timeout_seconds=timeout_seconds,
+        )
+        if forkserver_response is not None:
+            return forkserver_response
 
     try:
         completed = subprocess.run(
@@ -1202,7 +1246,7 @@ def _execute_request_subprocess_sync(
             input=envelope,
             capture_output=True,
             text=True,
-            timeout=sandbox_exec.runner_subprocess_timeout_seconds(runtime_paths),
+            timeout=timeout_seconds,
             check=False,
             env=subprocess_context.subprocess_env,
             cwd=subprocess_context.subprocess_cwd,
@@ -1234,57 +1278,58 @@ async def _execute_request_subprocess(
     )
 
 
-def _run_subprocess_worker() -> int:
-    payload = sys.stdin.read()
+def _run_subprocess_worker_payload(payload: str) -> tuple[int, str, str]:
+    """Execute one serialized envelope; return (exit_code, tool_output, marked_response)."""
     if not payload.strip():
-        print(
-            sandbox_protocol.response_marker_payload(
-                SandboxRunnerExecuteResponse(
-                    ok=False,
-                    error="Sandbox subprocess received empty payload.",
-                    failure_kind="worker",
-                ).model_dump_json(),
-            ),
-            file=sys.stderr,
+        response = SandboxRunnerExecuteResponse(
+            ok=False,
+            error="Sandbox subprocess received empty payload.",
+            failure_kind="worker",
         )
-        return 1
+        return 1, "", sandbox_protocol.response_marker_payload(response.model_dump_json())
 
     try:
         envelope = sandbox_protocol.parse_subprocess_envelope(payload)
         request = PreparedSandboxRunnerExecuteRequest.model_validate(envelope.request)
     except ValidationError as exc:
-        print(
-            sandbox_protocol.response_marker_payload(
-                SandboxRunnerExecuteResponse(
-                    ok=False,
-                    error=f"Sandbox subprocess payload validation failed: {exc}",
-                    failure_kind="worker",
-                ).model_dump_json(),
-            ),
-            file=sys.stderr,
+        response = SandboxRunnerExecuteResponse(
+            ok=False,
+            error=f"Sandbox subprocess payload validation failed: {exc}",
+            failure_kind="worker",
         )
-        return 1
+        return 1, "", sandbox_protocol.response_marker_payload(response.model_dump_json())
     runtime_paths = constants.deserialize_runtime_paths(envelope.runtime_paths)
     config = _runtime_config_or_empty(runtime_paths)
 
     # Redirect stdout/stderr during tool execution so tool output doesn't
-    # interfere with the protocol marker we write to stderr afterwards.
+    # interfere with the protocol marker in the returned response text.
     captured_out = io.StringIO()
     captured_err = io.StringIO()
     with redirect_stdout(captured_out), redirect_stderr(captured_err):
         response = asyncio.run(_execute_prepared_request_inprocess(request, runtime_paths, config))
 
-    # Flush captured tool output to real stdout/stderr (informational only).
-    tool_stdout = captured_out.getvalue()
-    if tool_stdout:
-        sys.stdout.write(tool_stdout)
-    tool_stderr = captured_err.getvalue()
-    if tool_stderr:
-        sys.stdout.write(tool_stderr)
+    tool_output = captured_out.getvalue() + captured_err.getvalue()
+    return 0, tool_output, sandbox_protocol.response_marker_payload(response.model_dump_json())
 
-    # Write the response JSON to stderr after the marker.
-    print(sandbox_protocol.response_marker_payload(response.model_dump_json()), file=sys.stderr)
-    return 0
+
+def _run_subprocess_worker() -> int:
+    exit_code, tool_output, marked_response = _run_subprocess_worker_payload(sys.stdin.read())
+    # Flush captured tool output to real stdout (informational only), then
+    # write the response JSON to stderr after the marker.
+    if tool_output:
+        sys.stdout.write(tool_output)
+    print(marked_response, file=sys.stderr)
+    return exit_code
+
+
+def _run_forkserver_template() -> int:
+    """Serve warm forkserver requests from an already-imported runtime template."""
+    socket_path = sys.argv[sys.argv.index(sandbox_forkserver.TEMPLATE_ARG) + 1]
+    # Pre-warm the full tool import graph once so fork children skip it; this
+    # belongs to template startup, not to importing this module.
+    import mindroom.tools  # noqa: F401, PLC0415
+
+    return sandbox_forkserver.serve_template(socket_path, _run_subprocess_worker_payload)
 
 
 @router.post("/leases", response_model=SandboxRunnerLeaseResponse)
@@ -1551,3 +1596,5 @@ async def execute_tool_call(
 if __name__ == "__main__":
     if _SUBPROCESS_WORKER_ARG in sys.argv:
         raise SystemExit(_run_subprocess_worker())
+    if sandbox_forkserver.TEMPLATE_ARG in sys.argv:
+        raise SystemExit(_run_forkserver_template())

--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -12,7 +12,7 @@ import secrets
 import subprocess
 import sys
 from collections.abc import Mapping
-from contextlib import redirect_stderr, redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout, suppress
 from dataclasses import dataclass, replace
 from pathlib import Path
 from types import MappingProxyType
@@ -1329,6 +1329,11 @@ def _run_forkserver_template() -> int:
     # belongs to template startup, not to importing this module.
     import mindroom.tools  # noqa: F401, PLC0415
 
+    # `python -m` prepended the runner's cwd to sys.path at template startup;
+    # fork children prepend their own request cwd instead, matching what a
+    # spawn-per-call child started in that cwd would see.
+    with suppress(ValueError):
+        sys.path.remove(str(Path.cwd()))
     return sandbox_forkserver.serve_template(socket_path, _run_subprocess_worker_payload)
 
 

--- a/src/mindroom/workers/backends/_dedicated_worker_common.py
+++ b/src/mindroom/workers/backends/_dedicated_worker_common.py
@@ -193,7 +193,7 @@ def build_dedicated_worker_runtime_paths(
     process_env.update(
         {
             SANDBOX_RUNTIME_ENV_BY_KEY["runner_mode"]: "true",
-            SANDBOX_RUNTIME_ENV_BY_KEY["runner_execution_mode"]: "subprocess",
+            SANDBOX_RUNTIME_ENV_BY_KEY["runner_execution_mode"]: "forkserver",
             SANDBOX_RUNTIME_ENV_BY_KEY["runner_port"]: str(worker_port),
             "MINDROOM_CONFIG_PATH": str(config_path),
             "MINDROOM_STORAGE_PATH": str(dedicated_root),

--- a/src/mindroom/workers/backends/docker.py
+++ b/src/mindroom/workers/backends/docker.py
@@ -812,7 +812,7 @@ class DockerWorkerBackend:
         shared_storage_root = self.config.storage_mount_path
         env = {
             SANDBOX_RUNTIME_ENV_BY_KEY["runner_mode"]: "true",
-            SANDBOX_RUNTIME_ENV_BY_KEY["runner_execution_mode"]: "subprocess",
+            SANDBOX_RUNTIME_ENV_BY_KEY["runner_execution_mode"]: "forkserver",
             _RUNNER_PORT_ENV_NAME: str(self.config.worker_port),
             _STARTUP_RUNTIME_PATHS_ENV: json.dumps(
                 serialize_runtime_paths(startup_runtime_paths),

--- a/src/mindroom/workers/backends/kubernetes_resources.py
+++ b/src/mindroom/workers/backends/kubernetes_resources.py
@@ -1120,7 +1120,7 @@ class KubernetesResourceManager:
         venv_path = f"{dedicated_root}/venv"
         env: list[dict[str, object]] = [
             {"name": SANDBOX_RUNTIME_ENV_BY_KEY["runner_mode"], "value": "true"},
-            {"name": SANDBOX_RUNTIME_ENV_BY_KEY["runner_execution_mode"], "value": "subprocess"},
+            {"name": SANDBOX_RUNTIME_ENV_BY_KEY["runner_execution_mode"], "value": "forkserver"},
             {"name": SANDBOX_RUNTIME_ENV_BY_KEY["runner_port"], "value": str(self.config.worker_port)},
             {
                 "name": SANDBOX_STARTUP_MANIFEST_PATH_ENV,
@@ -1245,7 +1245,7 @@ class KubernetesResourceManager:
         process_env.update(
             {
                 SANDBOX_RUNTIME_ENV_BY_KEY["runner_mode"]: "true",
-                SANDBOX_RUNTIME_ENV_BY_KEY["runner_execution_mode"]: "subprocess",
+                SANDBOX_RUNTIME_ENV_BY_KEY["runner_execution_mode"]: "forkserver",
                 SANDBOX_RUNTIME_ENV_BY_KEY["runner_port"]: str(self.config.worker_port),
                 "MINDROOM_CONFIG_PATH": str(config_path),
                 "MINDROOM_STORAGE_PATH": str(dedicated_root),

--- a/tach.toml
+++ b/tach.toml
@@ -659,6 +659,10 @@ depends_on = [
 ]
 
 [[modules]]
+path = "mindroom.api.sandbox_forkserver"
+depends_on = ["mindroom.logging_config"]
+
+[[modules]]
 path = "mindroom.api.sandbox_protocol"
 depends_on = []
 
@@ -675,6 +679,7 @@ path = "mindroom.api.sandbox_runner"
 depends_on = [
     "mindroom.api.sandbox_env_assembly",
     "mindroom.api.sandbox_exec",
+    "mindroom.api.sandbox_forkserver",
     "mindroom.api.sandbox_protocol",
     "mindroom.api.sandbox_worker_prep",
     "mindroom.api.worker_responses",

--- a/tests/api/test_sandbox_forkserver.py
+++ b/tests/api/test_sandbox_forkserver.py
@@ -212,6 +212,28 @@ def test_template_startup_failure_pins_fingerprint() -> None:
     assert len(attempts) == 1
 
 
+def test_slow_template_warmup_survives_request_timeouts(tmp_path: Path) -> None:
+    """A ready-wait timeout must leave the template importing instead of killing and pinning it."""
+    script = tmp_path / "slow_template.py"
+    script.write_text("import time\n\ntime.sleep(2)\n\n" + _STUB_TEMPLATE, encoding="utf-8")
+    spawned: list[str] = []
+
+    def _command(python_executable: str, socket_path: str) -> list[str]:
+        spawned.append(socket_path)
+        return [python_executable, str(script), socket_path]
+
+    manager = _SandboxForkserver(template_command=_command)
+    try:
+        with pytest.raises(ForkserverTimeoutError):
+            _stub_execute(manager, timeout_seconds=0.5)
+
+        assert _stub_execute(manager, timeout_seconds=30.0).returncode == 0
+    finally:
+        manager.shutdown()
+
+    assert len(spawned) == 1
+
+
 def test_template_startup_failure_retries_after_cooldown() -> None:
     """A transient startup failure must not disable the forkserver forever."""
     attempts: list[str] = []

--- a/tests/api/test_sandbox_forkserver.py
+++ b/tests/api/test_sandbox_forkserver.py
@@ -1,0 +1,364 @@
+"""Tests for the sandbox forkserver warm-template dispatch."""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+
+import mindroom.api.sandbox_exec as sandbox_exec_module
+import mindroom.api.sandbox_forkserver as sandbox_forkserver_module
+import mindroom.api.sandbox_protocol as sandbox_protocol_module
+import mindroom.api.sandbox_runner as sandbox_runner_module
+from mindroom.api.sandbox_forkserver import (
+    ForkserverError,
+    ForkserverStartupError,
+    ForkserverTimeoutError,
+    _SandboxForkserver,
+)
+from mindroom.constants import resolve_primary_runtime_paths
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+    from mindroom.config.main import Config
+    from mindroom.constants import RuntimePaths
+
+pytestmark = pytest.mark.skipif(
+    not sandbox_forkserver_module.forkserver_supported(),
+    reason="forkserver dispatch requires os.fork and unix sockets",
+)
+
+_STUB_TEMPLATE = '''\
+"""Lightweight forkserver template used to test the manager transport."""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+from mindroom.api.sandbox_forkserver import serve_template
+
+
+def _run_payload(payload: str) -> tuple[int, str, str]:
+    if payload.startswith("sleep:"):
+        pid_file = Path(payload.removeprefix("sleep:"))
+        pid_file.write_text(str(os.getpid()), encoding="utf-8")
+        time.sleep(30)
+    marker = os.environ.get("FORKSERVER_TEST_MARKER", "")
+    return 0, f"{os.getppid()}|{os.getcwd()}|{marker}", "stderr:" + payload
+
+
+sys.exit(serve_template(sys.argv[1], _run_payload))
+'''
+
+
+@pytest.fixture
+def stub_manager(tmp_path: Path) -> Iterator[tuple[_SandboxForkserver, list[str]]]:
+    """Manager whose template runs a fast stub instead of the full runtime import."""
+    script = tmp_path / "stub_template.py"
+    script.write_text(_STUB_TEMPLATE, encoding="utf-8")
+    spawned: list[str] = []
+
+    def _command(python_executable: str, socket_path: str) -> list[str]:
+        spawned.append(socket_path)
+        return [python_executable, str(script), socket_path]
+
+    manager = _SandboxForkserver(template_command=_command)
+    yield manager, spawned
+    manager.shutdown()
+
+
+def _stub_execute(
+    manager: _SandboxForkserver,
+    *,
+    template_env: dict[str, str] | None = None,
+    request_env: dict[str, str] | None = None,
+    request_cwd: str | None = None,
+    envelope: str = "payload",
+    timeout_seconds: float = 30.0,
+) -> subprocess.CompletedProcess[str]:
+    return manager.execute(
+        python_executable=None,
+        template_env=template_env,
+        request_env=request_env,
+        request_cwd=request_cwd,
+        envelope=envelope,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def _template_pid(completed: subprocess.CompletedProcess[str]) -> int:
+    return int(completed.stdout.split("|")[0])
+
+
+def test_execute_round_trips_and_reuses_one_template(
+    stub_manager: tuple[_SandboxForkserver, list[str]],
+    tmp_path: Path,
+) -> None:
+    """Repeated calls must fork the same warm template instead of respawning it."""
+    manager, spawned = stub_manager
+    workdir = tmp_path / "request-cwd"
+    workdir.mkdir()
+
+    first = _stub_execute(
+        manager,
+        request_env={"FORKSERVER_TEST_MARKER": "marker-1"},
+        request_cwd=str(workdir),
+        envelope="payload-1",
+    )
+    second = _stub_execute(manager, request_env={"FORKSERVER_TEST_MARKER": "marker-2"}, envelope="payload-2")
+
+    assert first.returncode == 0
+    assert first.stdout.split("|")[1] == str(workdir.resolve())
+    assert first.stdout.split("|")[2] == "marker-1"
+    assert first.stderr == "stderr:payload-1"
+    assert second.stdout.split("|")[2] == "marker-2"
+    assert _template_pid(first) == _template_pid(second)
+    assert len(spawned) == 1
+
+
+def test_template_recycled_when_env_fingerprint_changes(
+    stub_manager: tuple[_SandboxForkserver, list[str]],
+) -> None:
+    """A changed template env must terminate the old template and spawn a fresh one."""
+    manager, spawned = stub_manager
+    base_env = dict(os.environ)
+
+    first = _stub_execute(manager, template_env=base_env)
+    changed = _stub_execute(manager, template_env={**base_env, "FORKSERVER_FINGERPRINT": "changed"})
+
+    assert _template_pid(first) != _template_pid(changed)
+    assert len(spawned) == 2
+    with pytest.raises(ProcessLookupError):
+        os.kill(_template_pid(first), 0)
+
+
+def test_crashed_template_respawns_transparently(
+    stub_manager: tuple[_SandboxForkserver, list[str]],
+) -> None:
+    """A killed template must be detected and replaced on the next call."""
+    manager, spawned = stub_manager
+
+    first_pid = _template_pid(_stub_execute(manager))
+    os.kill(first_pid, signal.SIGKILL)
+
+    deadline = time.monotonic() + 10.0
+    while True:
+        try:
+            completed = _stub_execute(manager)
+            break
+        except ForkserverError:
+            if time.monotonic() > deadline:
+                raise
+            time.sleep(0.05)
+
+    assert _template_pid(completed) != first_pid
+    assert len(spawned) == 2
+
+
+def test_timeout_kills_child_and_keeps_template_alive(
+    stub_manager: tuple[_SandboxForkserver, list[str]],
+    tmp_path: Path,
+) -> None:
+    """A timed-out request must SIGKILL the fork child without recycling the template."""
+    manager, spawned = stub_manager
+    pid_file = tmp_path / "child.pid"
+
+    with pytest.raises(ForkserverTimeoutError):
+        _stub_execute(manager, envelope=f"sleep:{pid_file}", timeout_seconds=2.0)
+
+    child_pid = int(pid_file.read_text(encoding="utf-8"))
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        try:
+            os.kill(child_pid, 0)
+        except ProcessLookupError:
+            break
+        time.sleep(0.05)
+    else:
+        pytest.fail("forked child survived the request timeout")
+
+    assert _stub_execute(manager).returncode == 0
+    assert len(spawned) == 1
+
+
+def test_template_startup_failure_pins_fingerprint() -> None:
+    """A template that dies during startup must not be respawned on every call."""
+    attempts: list[str] = []
+
+    def _command(python_executable: str, socket_path: str) -> list[str]:
+        attempts.append(socket_path)
+        return [python_executable, "-c", "import sys; sys.exit(3)"]
+
+    manager = _SandboxForkserver(template_command=_command)
+    try:
+        with pytest.raises(ForkserverStartupError):
+            _stub_execute(manager)
+        with pytest.raises(ForkserverStartupError):
+            _stub_execute(manager)
+    finally:
+        manager.shutdown()
+
+    assert len(attempts) == 1
+
+
+def _forkserver_runtime(tmp_path: Path) -> tuple[RuntimePaths, Config]:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "models:\n  default:\n    provider: openai\n    id: gpt-5.5\nagents: {}\nrouter:\n  model: default\n",
+        encoding="utf-8",
+    )
+    runtime_paths = resolve_primary_runtime_paths(
+        config_path=config_path,
+        storage_path=tmp_path / "storage",
+        process_env={"MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE": "forkserver"},
+    )
+    return runtime_paths, sandbox_runner_module._runtime_config_or_empty(runtime_paths)
+
+
+def test_forkserver_mode_routes_through_subprocess_dispatch(tmp_path: Path) -> None:
+    """Forkserver mode must keep the subprocess routing decision in execute_tool_call."""
+    runtime_paths, _config = _forkserver_runtime(tmp_path)
+
+    assert sandbox_exec_module.runner_uses_subprocess(runtime_paths) is True
+    assert sandbox_exec_module.runner_uses_forkserver(runtime_paths) is True
+
+
+def test_forkserver_mode_reuses_one_template_across_tool_calls(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Warm-path acceptance: repeated non-shell tool calls must not re-pay the runtime import."""
+    runtime_paths, config = _forkserver_runtime(tmp_path)
+    spawned: list[str] = []
+
+    def _command(python_executable: str, socket_path: str) -> list[str]:
+        spawned.append(socket_path)
+        return sandbox_forkserver_module._default_template_command(python_executable, socket_path)
+
+    manager = _SandboxForkserver(template_command=_command)
+    monkeypatch.setattr(sandbox_forkserver_module, "get_sandbox_forkserver", lambda: manager)
+    try:
+        for _ in range(2):
+            response = sandbox_runner_module._execute_request_subprocess_sync(
+                sandbox_runner_module.SandboxRunnerExecuteRequest(
+                    tool_name="calculator",
+                    function_name="add",
+                    args=[1, 2],
+                    kwargs={},
+                ),
+                runtime_paths,
+                config,
+            )
+            assert response.ok is True
+            assert '"result": 3' in str(response.result)
+
+        workdir = tmp_path / "files"
+        workdir.mkdir()
+        response = sandbox_runner_module._execute_request_subprocess_sync(
+            sandbox_runner_module.SandboxRunnerExecuteRequest(
+                tool_name="file",
+                function_name="save_file",
+                kwargs={"contents": "hello forkserver", "file_name": "out.txt"},
+                tool_init_overrides={"base_dir": str(workdir)},
+            ),
+            runtime_paths,
+            config,
+        )
+        assert response.ok is True
+        assert (workdir / "out.txt").read_text(encoding="utf-8") == "hello forkserver"
+
+        response = sandbox_runner_module._execute_request_subprocess_sync(
+            sandbox_runner_module.SandboxRunnerExecuteRequest(
+                tool_name="python",
+                function_name="run_python_code",
+                args=['import os\nresult = os.environ.get("TEST_EXECUTION_ENV")', "result"],
+                kwargs={},
+                execution_env={"TEST_EXECUTION_ENV": "explicit-value"},
+            ),
+            runtime_paths,
+            config,
+        )
+        assert response.ok is True
+        assert response.result == "explicit-value"
+    finally:
+        manager.shutdown()
+
+    assert len(spawned) == 1
+
+
+def test_forkserver_timeout_maps_to_worker_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Forkserver timeouts must surface the same worker failure as spawn-per-call timeouts."""
+    runtime_paths, config = _forkserver_runtime(tmp_path)
+
+    class _TimeoutForkserver:
+        def execute(self, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            raise ForkserverTimeoutError
+
+    monkeypatch.setattr(sandbox_forkserver_module, "get_sandbox_forkserver", _TimeoutForkserver)
+
+    response = sandbox_runner_module._execute_request_subprocess_sync(
+        sandbox_runner_module.SandboxRunnerExecuteRequest(
+            tool_name="calculator",
+            function_name="add",
+            args=[1, 2],
+            kwargs={},
+        ),
+        runtime_paths,
+        config,
+    )
+
+    assert response.ok is False
+    assert response.error == "Sandbox subprocess timed out."
+    assert response.failure_kind == "worker"
+
+
+def test_forkserver_startup_failure_falls_back_to_spawn_per_call(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A broken template must not break tool calls; dispatch falls back to spawn-per-call."""
+    runtime_paths, config = _forkserver_runtime(tmp_path)
+
+    class _BrokenForkserver:
+        def execute(self, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            msg = "template import crashed"
+            raise ForkserverStartupError(msg)
+
+    monkeypatch.setattr(sandbox_forkserver_module, "get_sandbox_forkserver", _BrokenForkserver)
+
+    def _fake_run(*_args: object, **run_kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert json.loads(str(run_kwargs["input"]))["request"]["tool_name"] == "calculator"
+        response = sandbox_runner_module.SandboxRunnerExecuteResponse(ok=True, result="spawned")
+        return subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="",
+            stderr=sandbox_protocol_module._RESPONSE_MARKER + response.model_dump_json(),
+        )
+
+    monkeypatch.setattr(sandbox_runner_module.subprocess, "run", _fake_run)
+
+    response = sandbox_runner_module._execute_request_subprocess_sync(
+        sandbox_runner_module.SandboxRunnerExecuteRequest(
+            tool_name="calculator",
+            function_name="add",
+            args=[1, 2],
+            kwargs={},
+        ),
+        runtime_paths,
+        config,
+    )
+
+    assert response.ok is True
+    assert response.result == "spawned"

--- a/tests/api/test_sandbox_forkserver.py
+++ b/tests/api/test_sandbox_forkserver.py
@@ -170,6 +170,9 @@ def test_timeout_kills_child_and_keeps_template_alive(
     """A timed-out request must SIGKILL the fork child without recycling the template."""
     manager, spawned = stub_manager
     pid_file = tmp_path / "child.pid"
+    # Warm the template first so the 2 s deadline below covers only the
+    # request, not stub startup on a loaded CI machine.
+    assert _stub_execute(manager).returncode == 0
 
     with pytest.raises(ForkserverTimeoutError):
         _stub_execute(manager, envelope=f"sleep:{pid_file}", timeout_seconds=2.0)
@@ -209,6 +212,60 @@ def test_template_startup_failure_pins_fingerprint() -> None:
     assert len(attempts) == 1
 
 
+def test_template_startup_failure_retries_after_cooldown() -> None:
+    """A transient startup failure must not disable the forkserver forever."""
+    attempts: list[str] = []
+
+    def _command(python_executable: str, socket_path: str) -> list[str]:
+        attempts.append(socket_path)
+        return [python_executable, "-c", "import sys; sys.exit(3)"]
+
+    manager = _SandboxForkserver(template_command=_command, startup_failure_cooldown_seconds=0.0)
+    try:
+        with pytest.raises(ForkserverStartupError):
+            _stub_execute(manager)
+        with pytest.raises(ForkserverStartupError):
+            _stub_execute(manager)
+    finally:
+        manager.shutdown()
+
+    assert len(attempts) == 2
+
+
+def test_pinned_fingerprint_leaves_healthy_template_of_other_fingerprint_alone(tmp_path: Path) -> None:
+    """A pinned fingerprint must fail fast without recycling another fingerprint's warm template."""
+    script = tmp_path / "stub_template.py"
+    script.write_text(_STUB_TEMPLATE, encoding="utf-8")
+    attempts: list[str] = []
+    broken = {"active": False}
+
+    def _command(python_executable: str, socket_path: str) -> list[str]:
+        attempts.append(socket_path)
+        if broken["active"]:
+            return [python_executable, "-c", "import sys; sys.exit(3)"]
+        return [python_executable, str(script), socket_path]
+
+    manager = _SandboxForkserver(template_command=_command)
+    healthy_env = dict(os.environ)
+    broken_env = {**healthy_env, "FORKSERVER_FINGERPRINT": "broken"}
+    try:
+        broken["active"] = True
+        with pytest.raises(ForkserverStartupError):
+            _stub_execute(manager, template_env=broken_env)
+
+        broken["active"] = False
+        healthy_pid = _template_pid(_stub_execute(manager, template_env=healthy_env))
+
+        with pytest.raises(ForkserverStartupError):
+            _stub_execute(manager, template_env=broken_env)
+
+        assert _template_pid(_stub_execute(manager, template_env=healthy_env)) == healthy_pid
+    finally:
+        manager.shutdown()
+
+    assert len(attempts) == 2
+
+
 def _forkserver_runtime(tmp_path: Path) -> tuple[RuntimePaths, Config]:
     config_path = tmp_path / "config.yaml"
     config_path.write_text(
@@ -224,7 +281,7 @@ def _forkserver_runtime(tmp_path: Path) -> tuple[RuntimePaths, Config]:
 
 
 def test_forkserver_mode_routes_through_subprocess_dispatch(tmp_path: Path) -> None:
-    """Forkserver mode must keep the subprocess routing decision in execute_tool_call."""
+    """Forkserver mode must count as a per-request child-process mode for dispatch routing."""
     runtime_paths, _config = _forkserver_runtime(tmp_path)
 
     assert sandbox_exec_module.runner_uses_subprocess(runtime_paths) is True
@@ -288,6 +345,23 @@ def test_forkserver_mode_reuses_one_template_across_tool_calls(
         )
         assert response.ok is True
         assert response.result == "explicit-value"
+
+        # Spawn-per-call parity: `python -m` puts the request cwd on sys.path,
+        # so python-tool code can import modules saved into its workspace.
+        (workdir / "helper.py").write_text('VALUE = "helper-value"\n', encoding="utf-8")
+        response = sandbox_runner_module._execute_request_subprocess_sync(
+            sandbox_runner_module.SandboxRunnerExecuteRequest(
+                tool_name="python",
+                function_name="run_python_code",
+                args=["import helper\nresult = helper.VALUE", "result"],
+                kwargs={},
+                execution_env={"MINDROOM_AGENT_WORKSPACE": str(workdir)},
+            ),
+            runtime_paths,
+            config,
+        )
+        assert response.ok is True
+        assert response.result == "helper-value"
     finally:
         manager.shutdown()
 
@@ -305,7 +379,7 @@ def test_forkserver_timeout_maps_to_worker_failure(
         def execute(self, **_kwargs: object) -> subprocess.CompletedProcess[str]:
             raise ForkserverTimeoutError
 
-    monkeypatch.setattr(sandbox_forkserver_module, "get_sandbox_forkserver", _TimeoutForkserver)
+    monkeypatch.setattr(sandbox_forkserver_module, "get_sandbox_forkserver", lambda: _TimeoutForkserver())
 
     response = sandbox_runner_module._execute_request_subprocess_sync(
         sandbox_runner_module.SandboxRunnerExecuteRequest(
@@ -335,7 +409,7 @@ def test_forkserver_startup_failure_falls_back_to_spawn_per_call(
             msg = "template import crashed"
             raise ForkserverStartupError(msg)
 
-    monkeypatch.setattr(sandbox_forkserver_module, "get_sandbox_forkserver", _BrokenForkserver)
+    monkeypatch.setattr(sandbox_forkserver_module, "get_sandbox_forkserver", lambda: _BrokenForkserver())
 
     def _fake_run(*_args: object, **run_kwargs: object) -> subprocess.CompletedProcess[str]:
         assert json.loads(str(run_kwargs["input"]))["request"]["tool_name"] == "calculator"

--- a/tests/test_docker_worker_backend.py
+++ b/tests/test_docker_worker_backend.py
@@ -1166,7 +1166,7 @@ def test_docker_backend_ensures_worker_container_and_bind_mount(
     env = run_call["environment"]
     assert isinstance(env, dict)
     assert env["MINDROOM_SANDBOX_RUNNER_MODE"] == "true"
-    assert env["MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE"] == "subprocess"
+    assert env["MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE"] == "forkserver"
     assert env["MINDROOM_SANDBOX_PROXY_TOKEN"] == _TEST_AUTH_TOKEN
     assert env["MINDROOM_SANDBOX_DEDICATED_WORKER_KEY"] == _TEST_UNSCOPED_WORKER_KEY
     assert env["MINDROOM_SANDBOX_DEDICATED_WORKER_ROOT"] == "/app/worker"

--- a/tests/test_kubernetes_worker_backend.py
+++ b/tests/test_kubernetes_worker_backend.py
@@ -559,7 +559,7 @@ def test_kubernetes_backend_ensures_worker_service_deployment_and_auth_secret(tm
     assert handle.auth_token not in json.dumps(deployment)
     assert deployment["spec"]["template"]["metadata"]["annotations"][_ANNOTATION_RUNNER_TOKEN_HASH]
     assert deployment["spec"]["template"]["metadata"]["annotations"][_ANNOTATION_RUNNER_TOKEN_HASH] != handle.auth_token
-    assert env_values["MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE"] == "subprocess"
+    assert env_values["MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE"] == "forkserver"
     assert env_values["MINDROOM_SANDBOX_RUNNER_PORT"] == "8766"
     manifest_path = env_values["MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH"]
     assert manifest_path is not None
@@ -1560,7 +1560,7 @@ def test_kubernetes_backend_omits_backend_config_env_from_worker_env_and_manifes
     assert env_values["MINDROOM_SANDBOX_RUNNER_SUBPROCESS_TIMEOUT_SECONDS"] == "45"
     assert committed_runtime.env_value("MINDROOM_SANDBOX_RUNNER_SUBPROCESS_TIMEOUT_SECONDS") == "45"
     assert committed_runtime.env_value("MINDROOM_SANDBOX_RUNNER_MODE") == "true"
-    assert committed_runtime.env_value("MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE") == "subprocess"
+    assert committed_runtime.env_value("MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE") == "forkserver"
     assert committed_runtime.env_value("MINDROOM_SANDBOX_RUNNER_PORT") == "8766"
     assert env_names.count("MINDROOM_SANDBOX_PROXY_TOKEN") == 1
     assert env_values["MINDROOM_SANDBOX_PROXY_TOKEN"] is None


### PR DESCRIPTION
## Problem

Every worker-routed sandbox tool call except `shell` spawns a fresh `python -m mindroom.api.sandbox_runner` subprocess that re-imports the entire MindRoom runtime.
Measured on a prod worker pod (2-CPU cgroup limit, 2026-07-08): `import mindroom.api.sandbox_runner` takes **11–17 s** while a bare interpreter starts in 0.03 s.
Production `tool_calls.jsonl` data from the #1336 timing instrumentation (2026-06-26 → 07-08) shows the impact: `save_file` median 14.4 s (minimum 10.7 s, flat regardless of content size), `read_file` 15.7 s, `read_file_chunk` 15.5 s, `replace_file_chunk` 14.9 s — while `run_shell_command` on the same worker and proxy path (exempted from the subprocess) has a 1.7 s median.
Over 12 days, 490 file-tool calls burned ~3 h of tool time, ≥90 min of it pure subprocess startup (~12 % of all tool time).
The cost is CPU-bound import work (`-X importtime` shows a long tail of pydantic model construction across LLM SDKs pulled in transitively by the tool registry), not NFS.

## Design: warm forkserver template

New module `mindroom.api.sandbox_forkserver` plus a new `MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE=forkserver` value:

1. On the first subprocess-mode request, the runner spawns one **template process** per interpreter (`<worker-venv>/bin/python -m mindroom.api.sandbox_runner --sandbox-forkserver-template <socket>`) with the same base env as today's spawn-per-call child. The template pays the runtime import once, pre-warms the tool import graph (`import mindroom.tools`), and then blocks on a unix socket in a private `mkdtemp` dir. It stays fork-safe: import only, no threads, event loops, or network clients — enforced by a single-thread assertion at template startup.
2. Per request, the runner connects and sends `{env, cwd, envelope, timeout_seconds}` (newline-framed JSON). The template `fork()`s per connection; the **fork child** reports its PID, applies the per-request env (`os.environ.clear()/update()`), chdirs, runs the exact same `_run_subprocess_worker` envelope logic as today (extracted as `_run_subprocess_worker_payload`), sends `{returncode, stdout, stderr}` back, and `os._exit()`s. Every call still runs in its own fresh process — isolation semantics are unchanged at ~ms fork cost.
3. The parent enforces the existing per-request timeout by SIGKILLing the reported child PID and returns the same `"Sandbox subprocess timed out."` worker failure. The `__SANDBOX_RESPONSE__` marker protocol, stdout/stderr capture, credential-lease flow (leases are still consumed in the runner HTTP handler before dispatch), `execution_env` overlay, and `failure_kind` mapping are all reused verbatim — the forkserver returns a `CompletedProcess` that feeds the existing `_parse_subprocess_response`.
4. Templates are fingerprinted over `(python executable path, executable stat stamp, base env)`, so a rebuilt worker venv or changed env recycles the template. A crashed template respawns lazily on the next call. SIGCHLD is set to SIG_IGN in the template (auto-reap of request children, no zombies) and restored to SIG_DFL in each fork child before tool code runs, so tool subprocess exit codes stay correct.
5. Concurrency is preserved: requests still run through `asyncio.to_thread`, the template forks concurrently per connection, and only template creation is serialized (per-interpreter lock), so concurrent first calls share one warm-up.

### Fallback / safety valve

- A template that fails to start deterministically (spawn error or startup crash) pins its fingerprint for a 5-minute cooldown, logs `sandbox_forkserver_fallback_to_spawn`, and affected requests fall back to today's spawn-per-call path until a retry succeeds. A template whose import merely outlasts one request's timeout keeps importing in the background: that request reports the same timeout spawn-per-call would have hit, and the next request finds the template warm. Tool calls never hard-fail because of the forkserver.
- Platforms without `os.fork`/`AF_UNIX` (Windows dev) use spawn-per-call automatically.
- `MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE=subprocess` remains the explicit spawn-per-call mode. Note that dedicated workers read the mode from their startup manifest (baked at provision time), not from ad-hoc pod env edits, so flipping a fleet back means reverting the backend constant and re-provisioning - or simply relying on the automatic fallback.

Dedicated worker backends (`_dedicated_worker_common`, docker, kubernetes) now set `forkserver` instead of `subprocess`. The primary-runtime local-worker path (`worker_key` set, mode unset) keeps spawn-per-call — the prod pain is dedicated worker pods.

## Honest behavior differences

- Interpreter import-time state (env values read at module import, PYTHONPATH-derived `sys.path` entries) comes from the template's base env instead of the final per-request env. For non-execution tools the two are identical; for `python` execution requests only the `execution_env` overlay differs, and tool code still sees the correct `os.environ` and its request cwd on `sys.path` (both covered by tests).
- Raw-fd writes from tool code (C extensions writing to fd 1/2 directly) land in the template's stderr file instead of the captured pipes. Python-level output is captured identically via `redirect_stdout/stderr`, which is what the response protocol and stored tool output actually use.
- One warm template (~RSS of the imported runtime) stays resident per worker venv instead of transient per-call spikes of the same size.

## Measurements

`scripts/testing/benchmark_tool_call_overhead.py --sandbox-dispatch forkserver subprocess --iterations 5 --warmup 1` (M-series dev machine, warm FS cache — prod pods are ~5× slower on the import):

| case | p50 | mean |
|---|---|---|
| `sandbox_dispatch_forkserver` | **22.6 ms** | 23.1 ms |
| `sandbox_dispatch_subprocess` | 2226 ms | 2200 ms |

On a prod pod where the import is 11–17 s, the same ~20–30 ms warm path applies after the one-time template warm-up, i.e. `save_file` dispatch overhead drops from ~14 s to well under 1 s.

## Adversarial review hardening (second pass, commits `3c9bfbf` + `b11d524`)

Two independent adversarial reviews on the diff surfaced real issues, all fixed and covered:

- **Workspace `sys.path` parity**: `python -m` prepends the request cwd to `sys.path`, so spawn-per-call python-tool code could import modules saved into its workspace. Fork children now mirror that exactly (template drops its baked runner-cwd entry; each child prepends its request cwd). Regression test: save `helper.py`, then `import helper` through the warm path - verified to fail without the fix.
- **Timeout-kill hole**: a request delivered with (nearly) exhausted budget could fork a child the runner never learned the PID of, leaving the tool to run (and side-effect) after the caller saw "timed out". Requests are no longer delivered past their deadline, and every fork child arms a SIGALRM self-destruct (`timeout + 5 s` grace) so no child can outlive its budget even if the runner dies.
- **Transient startup failures no longer disable the warm path forever**: fingerprint pinning now has a 5-minute cooldown (one OOM-killed or CPU-starved first import previously reverted the pod to spawn-per-call until restart). The pinned check also runs before the recycle check, so a pinned fingerprint can no longer tear down a healthy template of another fingerprint on the same interpreter.
- **Error contract**: socket-creation failure (fd exhaustion) maps to a structured worker failure instead of escaping as a raw `OSError` 500.
- **Leak**: templates orphaned by a SIGKILLed runner now remove their own runtime dir on watchdog exit.
- **Protocol shape**: the child request is a frozen `_ChildRequest` dataclass instead of a probed dict.
- **Docs**: `docs/deployment/sandbox-proxy.md` (and its generated mirrors) now document the `forkserver` mode, the dedicated-worker default, and the fallback/cooldown behavior.

## Tests

`tests/api/test_sandbox_forkserver.py`:
- transport round-trip + template reuse (one spawn across calls), request env/cwd application
- template recycled when the env fingerprint changes (old template terminated)
- crashed template respawns transparently
- timeout SIGKILLs the fork child, keeps the template alive, and the next call succeeds
- startup failure pins the fingerprint (no respawn storm) and dispatch falls back to spawn-per-call
- forkserver timeout maps to the exact existing `"Sandbox subprocess timed out."` worker failure
- real-template integration: calculator, `file.save_file` (writes to disk), and `python` with `execution_env` all through `_execute_request_subprocess_sync` in forkserver mode with a single template spawn

Full suite green with `pytest -n auto`; `tach check` and all pre-commit hooks pass.

## Out of scope (follow-up)

Trimming the child import graph with lazy provider-SDK imports in the tool registry is complementary but capped: a perfectly slim file-tool entry still costs 3–4 s (`mindroom.tools.file` alone imports 3.6 s because `tool_system/metadata.py` costs 3.2 s), which is why import-slimming alone cannot fix this. Issue #407 (restoring shell isolation) can now ride the same warm template instead of expanding the in-process exception.
