### PR TITLE
Support OpenRouter voice models in matrix_voice_message

### DIFF
--- a/src/mindroom/custom_tools/matrix_voice_message.py
+++ b/src/mindroom/custom_tools/matrix_voice_message.py
@@ -7,6 +7,7 @@ from collections import defaultdict, deque
 from dataclasses import dataclass
 from threading import Lock
 from typing import ClassVar, Literal, cast, get_args
+from urllib.parse import urlparse
 
 from agno.tools import Toolkit
 from openai import APIStatusError, OpenAI
@@ -30,6 +31,9 @@ _OPUS_FILENAME = "voice-message.opus"
 _DEFAULT_RESPONSE_FORMAT = "opus"
 _SpeechResponseFormat = Literal["aac", "flac", "mp3", "opus", "wav"]
 _ALLOWED_RESPONSE_FORMATS = frozenset(get_args(_SpeechResponseFormat))
+_OPENROUTER_TTS_BASE_URL = "https://openrouter.ai/api/v1"
+# OpenRouter's /audio/speech endpoint only returns mp3 or pcm; mp3 is the one we can turn into a Matrix voice message.
+_OPENROUTER_RESPONSE_FORMAT = "mp3"
 logger = get_logger(__name__)
 
 
@@ -41,6 +45,7 @@ class _VoiceMessagePreflight:
     room_id: str
     api_key: str
     base_url: str | None
+    response_format: str
 
 
 def _normalize_openai_base_url(base_url: str | None) -> str | None:
@@ -52,6 +57,17 @@ def _normalize_openai_base_url(base_url: str | None) -> str | None:
     if normalized.endswith("/v1"):
         return normalized
     return f"{normalized}/v1"
+
+
+def _is_openrouter_base_url(base_url: str | None) -> bool:
+    if base_url is None:
+        return False
+    return urlparse(base_url).hostname == "openrouter.ai"
+
+
+def _is_openrouter_model(model: str) -> bool:
+    """OpenRouter voice models are provider-prefixed, e.g. ``openai/gpt-4o-mini-tts``."""
+    return "/" in model
 
 
 def _input_validation_error(
@@ -127,18 +143,36 @@ class MatrixVoiceMessageTools(Toolkit):
         )
 
     def _base_url_for_context(self, context: ToolRuntimeContext) -> str | None:
-        return self._base_url or _normalize_openai_base_url(get_secret_from_env("TTS_URL", context.runtime_paths))
+        explicit = self._base_url or _normalize_openai_base_url(get_secret_from_env("TTS_URL", context.runtime_paths))
+        if explicit is not None:
+            return explicit
+        if _is_openrouter_model(self._model):
+            return _OPENROUTER_TTS_BASE_URL
+        return None
 
     def _api_key_for_context(self, context: ToolRuntimeContext, *, base_url: str | None) -> str | None:
         if self._api_key:
             return self._api_key
+        if _is_openrouter_base_url(base_url):
+            return get_secret_from_env("OPENROUTER_API_KEY", context.runtime_paths)
         if base_url is not None:
             return LOCAL_OPENAI_API_KEY_DEFAULT
         return get_secret_from_env("OPENAI_API_KEY", context.runtime_paths)
 
-    def _generate_speech_bytes(self, *, api_key: str, base_url: str | None, text: str) -> bytes:
+    def _response_format_for_target(self, base_url: str | None) -> str:
+        if _is_openrouter_base_url(base_url) and self._response_format != _OPENROUTER_RESPONSE_FORMAT:
+            logger.info(
+                "matrix_voice_response_format_coerced",
+                configured_format=self._response_format,
+                effective_format=_OPENROUTER_RESPONSE_FORMAT,
+                reason="openrouter_speech_supports_mp3_only",
+            )
+            return _OPENROUTER_RESPONSE_FORMAT
+        return self._response_format
+
+    def _generate_speech_bytes(self, *, api_key: str, base_url: str | None, text: str, response_format: str) -> bytes:
         client = OpenAI(api_key=api_key) if base_url is None else OpenAI(api_key=api_key, base_url=base_url)
-        response_format = cast("_SpeechResponseFormat", self._response_format)
+        response_format = cast("_SpeechResponseFormat", response_format)
         response = client.audio.speech.create(
             model=self._model,
             voice=self._voice,
@@ -211,7 +245,9 @@ class MatrixVoiceMessageTools(Toolkit):
         if not normalized_text:
             return None, self._payload("error", message="text is required and must be non-empty.")
 
-        if self._response_format not in _ALLOWED_RESPONSE_FORMATS:
+        base_url = self._base_url_for_context(context)
+        response_format = self._response_format_for_target(base_url)
+        if response_format not in _ALLOWED_RESPONSE_FORMATS:
             return None, self._payload(
                 "error",
                 message=f"response_format must be one of: {', '.join(sorted(_ALLOWED_RESPONSE_FORMATS))}.",
@@ -232,13 +268,17 @@ class MatrixVoiceMessageTools(Toolkit):
                 message=limit_error,
             )
 
-        base_url = self._base_url_for_context(context)
         api_key = self._api_key_for_context(context, base_url=base_url)
         if not api_key:
+            missing_key_message = (
+                "OPENROUTER_API_KEY is required to use an OpenRouter voice model with matrix_voice_message."
+                if _is_openrouter_base_url(base_url)
+                else "OPENAI_API_KEY or a local TTS base_url/TTS_URL is required for matrix_voice_message."
+            )
             return None, self._payload(
                 "error",
                 room_id=resolved_room_id,
-                message="OPENAI_API_KEY or a local TTS base_url/TTS_URL is required for matrix_voice_message.",
+                message=missing_key_message,
             )
 
         return _VoiceMessagePreflight(
@@ -246,6 +286,7 @@ class MatrixVoiceMessageTools(Toolkit):
             room_id=resolved_room_id,
             api_key=api_key,
             base_url=base_url,
+            response_format=response_format,
         ), None
 
     async def _latest_thread_event_id_or_error(
@@ -349,6 +390,7 @@ class MatrixVoiceMessageTools(Toolkit):
                 api_key=preflight.api_key,
                 base_url=preflight.base_url,
                 text=preflight.text,
+                response_format=preflight.response_format,
             )
         except Exception as error:
             status_code = error.status_code if isinstance(error, APIStatusError) else None
@@ -367,13 +409,13 @@ class MatrixVoiceMessageTools(Toolkit):
                 message="Failed to generate speech.",
             )
 
-        prepared_audio = await prepare_voice_audio_bytes(audio_bytes, response_format=self._response_format)
+        prepared_audio = await prepare_voice_audio_bytes(audio_bytes, response_format=preflight.response_format)
         if prepared_audio is None:
             logger.error(
                 "matrix_voice_audio_preparation_failed",
                 room_id=preflight.room_id,
                 thread_id=effective_thread_id,
-                response_format=self._response_format,
+                response_format=preflight.response_format,
             )
             return self._payload(
                 "error",

--- a/src/mindroom/custom_tools/matrix_voice_message.py
+++ b/src/mindroom/custom_tools/matrix_voice_message.py
@@ -147,6 +147,11 @@ class MatrixVoiceMessageTools(Toolkit):
         if explicit is not None:
             return explicit
         if _is_openrouter_model(self._model):
+            logger.info(
+                "matrix_voice_tts_routed_to_openrouter",
+                model=self._model,
+                reason="provider_prefixed_model_without_explicit_base_url",
+            )
             return _OPENROUTER_TTS_BASE_URL
         return None
 
@@ -245,13 +250,14 @@ class MatrixVoiceMessageTools(Toolkit):
         if not normalized_text:
             return None, self._payload("error", message="text is required and must be non-empty.")
 
-        base_url = self._base_url_for_context(context)
-        response_format = self._response_format_for_target(base_url)
-        if response_format not in _ALLOWED_RESPONSE_FORMATS:
+        if self._response_format not in _ALLOWED_RESPONSE_FORMATS:
             return None, self._payload(
                 "error",
                 message=f"response_format must be one of: {', '.join(sorted(_ALLOWED_RESPONSE_FORMATS))}.",
             )
+
+        base_url = self._base_url_for_context(context)
+        response_format = self._response_format_for_target(base_url)
 
         resolved_room_id = resolve_optional_room_id(context, room_id)
         if not room_access_allowed(context, resolved_room_id):

--- a/src/mindroom/custom_tools/matrix_voice_message.py
+++ b/src/mindroom/custom_tools/matrix_voice_message.py
@@ -66,7 +66,7 @@ def _is_openrouter_base_url(base_url: str | None) -> bool:
 
 
 def _is_openrouter_model(model: str) -> bool:
-    """OpenRouter voice models are provider-prefixed, e.g. ``openai/gpt-4o-mini-tts``."""
+    """OpenRouter voice models are provider-prefixed, e.g. ``hexgrad/kokoro-82m``."""
     return "/" in model
 
 

--- a/src/mindroom/tools/matrix_voice_message.py
+++ b/src/mindroom/tools/matrix_voice_message.py
@@ -24,10 +24,11 @@ if TYPE_CHECKING:
     config_fields=[
         ConfigField(
             name="api_key",
-            label="OpenAI API Key",
+            label="TTS API Key",
             type="password",
             required=False,
             default=None,
+            description="When empty, OpenAI models use OPENAI_API_KEY and OpenRouter voice models use OPENROUTER_API_KEY.",
         ),
         ConfigField(
             name="model",
@@ -35,6 +36,7 @@ if TYPE_CHECKING:
             type="text",
             required=False,
             default=OPENAI_TTS,
+            description="Plain OpenAI model IDs use OpenAI; provider-prefixed IDs (e.g. openai/gpt-4o-mini-tts) route through OpenRouter.",
         ),
         ConfigField(
             name="base_url",
@@ -42,7 +44,7 @@ if TYPE_CHECKING:
             type="url",
             required=False,
             default=None,
-            description="OpenAI-compatible speech endpoint (e.g. a local Kokoro server); leave empty to use OpenAI.",
+            description="OpenAI-compatible speech endpoint (e.g. a local Kokoro server); leave empty to use OpenAI or OpenRouter based on the model ID.",
         ),
         ConfigField(
             name="voice",
@@ -57,7 +59,7 @@ if TYPE_CHECKING:
             type="text",
             required=False,
             default="opus",
-            description="Audio format the TTS endpoint returns: aac, flac, mp3, opus, or wav. Non-opus formats require ffmpeg and ffprobe.",
+            description="Audio format the TTS endpoint returns: aac, flac, mp3, opus, or wav. Non-opus formats require ffmpeg and ffprobe. OpenRouter voice models always use mp3.",
         ),
     ],
     dependencies=["openai"],

--- a/src/mindroom/tools/matrix_voice_message.py
+++ b/src/mindroom/tools/matrix_voice_message.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
             type="text",
             required=False,
             default=OPENAI_TTS,
-            description="Plain OpenAI model IDs use OpenAI; provider-prefixed IDs (e.g. openai/gpt-4o-mini-tts) route through OpenRouter.",
+            description="Plain OpenAI model IDs use OpenAI; provider-prefixed IDs (e.g. hexgrad/kokoro-82m) route through OpenRouter.",
         ),
         ConfigField(
             name="base_url",

--- a/src/mindroom/tools_metadata.json
+++ b/src/mindroom/tools_metadata.json
@@ -196,8 +196,8 @@
         {
           "authored_override": true,
           "default": null,
-          "description": null,
-          "label": "OpenAI API Key",
+          "description": "When empty, OpenAI models use OPENAI_API_KEY and OpenRouter voice models use OPENROUTER_API_KEY.",
+          "label": "TTS API Key",
           "name": "api_key",
           "options": null,
           "placeholder": null,
@@ -208,7 +208,7 @@
         {
           "authored_override": true,
           "default": "gpt-4o-mini-tts",
-          "description": null,
+          "description": "Plain OpenAI model IDs use OpenAI; provider-prefixed IDs (e.g. openai/gpt-4o-mini-tts) route through OpenRouter.",
           "label": "TTS Model",
           "name": "model",
           "options": null,
@@ -220,7 +220,7 @@
         {
           "authored_override": true,
           "default": null,
-          "description": "OpenAI-compatible speech endpoint (e.g. a local Kokoro server); leave empty to use OpenAI.",
+          "description": "OpenAI-compatible speech endpoint (e.g. a local Kokoro server); leave empty to use OpenAI or OpenRouter based on the model ID.",
           "label": "OpenAI-Compatible TTS Base URL",
           "name": "base_url",
           "options": null,
@@ -244,7 +244,7 @@
         {
           "authored_override": true,
           "default": "opus",
-          "description": "Audio format the TTS endpoint returns: aac, flac, mp3, opus, or wav. Non-opus formats require ffmpeg and ffprobe.",
+          "description": "Audio format the TTS endpoint returns: aac, flac, mp3, opus, or wav. Non-opus formats require ffmpeg and ffprobe. OpenRouter voice models always use mp3.",
           "label": "Audio Response Format",
           "name": "response_format",
           "options": null,

--- a/src/mindroom/tools_metadata.json
+++ b/src/mindroom/tools_metadata.json
@@ -208,7 +208,7 @@
         {
           "authored_override": true,
           "default": "gpt-4o-mini-tts",
-          "description": "Plain OpenAI model IDs use OpenAI; provider-prefixed IDs (e.g. openai/gpt-4o-mini-tts) route through OpenRouter.",
+          "description": "Plain OpenAI model IDs use OpenAI; provider-prefixed IDs (e.g. hexgrad/kokoro-82m) route through OpenRouter.",
           "label": "TTS Model",
           "name": "model",
           "options": null,

--- a/tests/test_matrix_voice_message.py
+++ b/tests/test_matrix_voice_message.py
@@ -473,13 +473,13 @@ async def test_matrix_voice_message_routes_openrouter_models_through_openrouter(
         mock_send.return_value = "$voice-event"
 
         result = await MatrixVoiceMessageTools(
-            model="openai/gpt-4o-mini-tts",
+            model="hexgrad/kokoro-82m",
             voice="alloy",
         ).matrix_voice_message("openrouter speech")
 
     mock_openai.assert_called_once_with(api_key="sk-or-test", base_url="https://openrouter.ai/api/v1")
     mock_openai.return_value.audio.speech.create.assert_called_once_with(
-        model="openai/gpt-4o-mini-tts",
+        model="hexgrad/kokoro-82m",
         voice="alloy",
         input="openrouter speech",
         response_format="mp3",
@@ -499,7 +499,7 @@ async def test_matrix_voice_message_openrouter_model_without_key_is_structured_e
         patch("mindroom.custom_tools.matrix_voice_message.get_secret_from_env", return_value=None),
         patch("mindroom.custom_tools.matrix_voice_message.OpenAI") as mock_openai,
     ):
-        result = await MatrixVoiceMessageTools(model="openai/gpt-4o-mini-tts").matrix_voice_message("hello")
+        result = await MatrixVoiceMessageTools(model="hexgrad/kokoro-82m").matrix_voice_message("hello")
 
     mock_openai.assert_not_called()
     payload = _payload(result)

--- a/tests/test_matrix_voice_message.py
+++ b/tests/test_matrix_voice_message.py
@@ -574,6 +574,30 @@ async def test_matrix_voice_message_openrouter_base_url_uses_openrouter_key(tmp_
 
 
 @pytest.mark.asyncio
+async def test_matrix_voice_message_rejects_invalid_response_format_even_for_openrouter(tmp_path: Path) -> None:
+    """Misconfigured response formats should fail preflight before OpenRouter mp3 coercion hides them."""
+    context = _context(tmp_path, thread_id=None)
+
+    def fake_secret(name: str, _runtime_paths: object) -> str | None:
+        return "sk-or-test" if name == "OPENROUTER_API_KEY" else None
+
+    with (
+        tool_runtime_context(context),
+        patch("mindroom.custom_tools.matrix_voice_message.get_secret_from_env", side_effect=fake_secret),
+        patch("mindroom.custom_tools.matrix_voice_message.OpenAI") as mock_openai,
+    ):
+        result = await MatrixVoiceMessageTools(
+            model="hexgrad/kokoro-82m",
+            response_format="ogg",
+        ).matrix_voice_message("hello")
+
+    mock_openai.assert_not_called()
+    payload = _payload(result)
+    assert payload["status"] == "error"
+    assert payload["message"] == "response_format must be one of: aac, flac, mp3, opus, wav."
+
+
+@pytest.mark.asyncio
 async def test_matrix_voice_message_rejects_unknown_response_format(tmp_path: Path) -> None:
     """Unsupported response formats should fail preflight before any TTS call."""
     context = _context(tmp_path, thread_id=None)

--- a/tests/test_matrix_voice_message.py
+++ b/tests/test_matrix_voice_message.py
@@ -451,6 +451,129 @@ async def test_matrix_voice_message_can_use_local_openai_compatible_tts(tmp_path
 
 
 @pytest.mark.asyncio
+async def test_matrix_voice_message_routes_openrouter_models_through_openrouter(tmp_path: Path) -> None:
+    """Provider-prefixed model IDs should use OpenRouter's speech endpoint with OPENROUTER_API_KEY and mp3 audio."""
+    context = _context(tmp_path, thread_id=None)
+
+    def fake_secret(name: str, _runtime_paths: object) -> str | None:
+        return "sk-or-test" if name == "OPENROUTER_API_KEY" else None
+
+    with (
+        tool_runtime_context(context),
+        patch("mindroom.custom_tools.matrix_voice_message.get_secret_from_env", side_effect=fake_secret),
+        patch("mindroom.custom_tools.matrix_voice_message.OpenAI") as mock_openai,
+        patch(
+            "mindroom.custom_tools.matrix_voice_message.prepare_voice_audio_bytes",
+            new_callable=AsyncMock,
+            return_value=_prepared_voice_audio(),
+        ) as mock_voice_payload,
+        patch("mindroom.custom_tools.matrix_voice_message.send_audio_message", new_callable=AsyncMock) as mock_send,
+    ):
+        mock_openai.return_value.audio.speech.create.return_value = SimpleNamespace(content=b"mp3-bytes")
+        mock_send.return_value = "$voice-event"
+
+        result = await MatrixVoiceMessageTools(
+            model="openai/gpt-4o-mini-tts",
+            voice="alloy",
+        ).matrix_voice_message("openrouter speech")
+
+    mock_openai.assert_called_once_with(api_key="sk-or-test", base_url="https://openrouter.ai/api/v1")
+    mock_openai.return_value.audio.speech.create.assert_called_once_with(
+        model="openai/gpt-4o-mini-tts",
+        voice="alloy",
+        input="openrouter speech",
+        response_format="mp3",
+    )
+    assert mock_voice_payload.await_args.kwargs["response_format"] == "mp3"
+    payload = _payload(result)
+    assert payload["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_matrix_voice_message_openrouter_model_without_key_is_structured_error(tmp_path: Path) -> None:
+    """OpenRouter voice models without OPENROUTER_API_KEY should fail preflight with a targeted message."""
+    context = _context(tmp_path, thread_id=None)
+
+    with (
+        tool_runtime_context(context),
+        patch("mindroom.custom_tools.matrix_voice_message.get_secret_from_env", return_value=None),
+        patch("mindroom.custom_tools.matrix_voice_message.OpenAI") as mock_openai,
+    ):
+        result = await MatrixVoiceMessageTools(model="openai/gpt-4o-mini-tts").matrix_voice_message("hello")
+
+    mock_openai.assert_not_called()
+    payload = _payload(result)
+    assert payload["status"] == "error"
+    assert (
+        payload["message"]
+        == "OPENROUTER_API_KEY is required to use an OpenRouter voice model with matrix_voice_message."
+    )
+
+
+@pytest.mark.asyncio
+async def test_matrix_voice_message_explicit_base_url_overrides_openrouter_model_routing(tmp_path: Path) -> None:
+    """An explicit base URL should win over OpenRouter model detection and keep the configured format."""
+    context = _context(tmp_path, thread_id=None)
+
+    with (
+        tool_runtime_context(context),
+        patch("mindroom.custom_tools.matrix_voice_message.OpenAI") as mock_openai,
+        patch(
+            "mindroom.custom_tools.matrix_voice_message.prepare_voice_audio_bytes",
+            new_callable=AsyncMock,
+            return_value=_prepared_voice_audio(),
+        ),
+        patch("mindroom.custom_tools.matrix_voice_message.send_audio_message", new_callable=AsyncMock) as mock_send,
+    ):
+        mock_openai.return_value.audio.speech.create.return_value = SimpleNamespace(content=b"wav-bytes")
+        mock_send.return_value = "$voice-event"
+
+        result = await MatrixVoiceMessageTools(
+            model="hexgrad/kokoro",
+            base_url="http://pc.local:10201",
+            response_format="wav",
+        ).matrix_voice_message("local speech")
+
+    mock_openai.assert_called_once_with(api_key="sk-no-key-required", base_url="http://pc.local:10201/v1")
+    assert mock_openai.return_value.audio.speech.create.call_args.kwargs["response_format"] == "wav"
+    payload = _payload(result)
+    assert payload["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_matrix_voice_message_openrouter_base_url_uses_openrouter_key(tmp_path: Path) -> None:
+    """An explicit OpenRouter base URL should use OPENROUTER_API_KEY, not the local placeholder key."""
+    context = _context(tmp_path, thread_id=None)
+
+    def fake_secret(name: str, _runtime_paths: object) -> str | None:
+        return "sk-or-test" if name == "OPENROUTER_API_KEY" else None
+
+    with (
+        tool_runtime_context(context),
+        patch("mindroom.custom_tools.matrix_voice_message.get_secret_from_env", side_effect=fake_secret),
+        patch("mindroom.custom_tools.matrix_voice_message.OpenAI") as mock_openai,
+        patch(
+            "mindroom.custom_tools.matrix_voice_message.prepare_voice_audio_bytes",
+            new_callable=AsyncMock,
+            return_value=_prepared_voice_audio(),
+        ),
+        patch("mindroom.custom_tools.matrix_voice_message.send_audio_message", new_callable=AsyncMock) as mock_send,
+    ):
+        mock_openai.return_value.audio.speech.create.return_value = SimpleNamespace(content=b"mp3-bytes")
+        mock_send.return_value = "$voice-event"
+
+        result = await MatrixVoiceMessageTools(
+            model="mistralai/voxtral-mini-tts",
+            base_url="https://openrouter.ai/api/v1",
+        ).matrix_voice_message("openrouter speech")
+
+    mock_openai.assert_called_once_with(api_key="sk-or-test", base_url="https://openrouter.ai/api/v1")
+    assert mock_openai.return_value.audio.speech.create.call_args.kwargs["response_format"] == "mp3"
+    payload = _payload(result)
+    assert payload["status"] == "ok"
+
+
+@pytest.mark.asyncio
 async def test_matrix_voice_message_rejects_unknown_response_format(tmp_path: Path) -> None:
     """Unsupported response formats should fail preflight before any TTS call."""
     context = _context(tmp_path, thread_id=None)


### PR DESCRIPTION
## Summary

`matrix_voice_message` previously only worked against OpenAI (or an explicitly configured OpenAI-compatible base URL). This adds first-class support for OpenRouter voice models:

- **Model-based routing**: provider-prefixed TTS model IDs (e.g. `hexgrad/kokoro-82m`, `mistralai/voxtral-mini-tts-2603`) are recognized as OpenRouter voice models and routed to OpenRouter's OpenAI-compatible speech endpoint (`https://openrouter.ai/api/v1/audio/speech`) when no explicit `base_url`/`TTS_URL` is set. The available catalog is `GET /api/v1/models?output_modalities=speech`.
- **Correct API key resolution**: OpenRouter targets (whether detected from the model ID or an explicit `openrouter.ai` base URL) use `OPENROUTER_API_KEY` instead of `OPENAI_API_KEY` or the local no-key placeholder, with a targeted preflight error when the key is missing.
- **Response format handling**: OpenRouter's `/audio/speech` endpoint only returns `mp3` or `pcm` ([docs](https://openrouter.ai/docs/guides/overview/multimodal/tts)), so the configured format (default `opus`) is coerced to `mp3` for OpenRouter targets; the existing ffmpeg-based pipeline converts mp3 to a Matrix opus voice message.
- An explicit `base_url` still takes precedence over model-based OpenRouter detection, preserving local/self-hosted TTS behavior.
- Updated tool config-field descriptions and regenerated `tools_metadata.json`.

## Testing

- **Live-tested against OpenRouter with a real API key**: `hexgrad/kokoro-82m` through the exact tool code path (`_generate_speech_bytes` → `prepare_voice_audio_bytes`) returned real mp3 (33 KB) and converted cleanly to a Matrix opus voice payload (`audio/ogg`, 4.45 s, 30-point waveform). The format-coercion log fired as expected (`opus` → `mp3`).
- Note: the model IDs in OpenRouter's own docs (`openai/gpt-4o-mini-tts-2025-12-15`) do **not** exist on the live API; examples in code/config now use the verified `hexgrad/kokoro-82m`.
- 4 new unit tests: OpenRouter model routing + mp3 coercion, missing-key preflight error, explicit base_url precedence, OpenRouter base URL key resolution.
- `pytest tests/test_matrix_voice_message.py tests/test_tools_metadata.py` → 58 passed; pre-commit hooks pass.