### PR TITLE
agent_vault_access: return the shared vault name and link instead of a bare refusal

### DIFF
--- a/docs/deployment/sandbox-proxy.md
+++ b/docs/deployment/sandbox-proxy.md
@@ -408,7 +408,8 @@ For non-Kubernetes deployments, point worker egress at a shared proxy you run yo
 
 The `agent_vault_access` tool lets a user ask their own agent for a link to manage that agent's vault.
 It resolves the caller's worker target to that worker's vault (`worker_id_for_key(worker_key, prefix)`, matching `agentVault.vaultNamePrefix`), grants the caller's Agent Vault account admin access to that vault through the API, and returns the gated UI link.
-It only self-grants for requester-isolated worker scopes (`user` or `user_agent`); shared worker vaults require operator-managed credentials.
+It only self-grants for requester-isolated worker scopes (`user` or `user_agent`).
+For shared worker scopes it returns the vault name and UI link without granting anything (`"access": "operator_managed"`): the link alone grants nothing because the UI enforces vault membership, and it is how the operator-designated admin discovers which vault backs the agent.
 Configure it per deployment:
 
 ```bash

--- a/docs/deployment/sandbox-proxy.md
+++ b/docs/deployment/sandbox-proxy.md
@@ -420,6 +420,8 @@ MINDROOM_AGENT_VAULT_ACCESS_EMAIL_DOMAIN=example.com
 MINDROOM_AGENT_VAULT_ACCESS_VAULT_NAME_PREFIX=agent-vault  # must match workers.kubernetes.agentVault.vaultNamePrefix
 ```
 
+Agents on a shared worker scope never reach the grant API, so for them only `MINDROOM_AGENT_VAULT_ACCESS_UI_BASE_URL` (plus the matching vault name prefix) is required; the API URL, admin token, and email domain stay required for requester-isolated scopes.
+
 The tool maps a requester's Matrix localpart to `localpart@EMAIL_DOMAIN` for the account grant.
 That mapping only decides *UI management access*; it never changes which worker reaches which vault, so the runtime secret boundary stays the per-worker vault scope plus the in-pod proxy-role token.
 The grant is idempotent and requires the user to have already registered and verified an Agent Vault account.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -16212,7 +16212,8 @@ For non-Kubernetes deployments, point worker egress at a shared proxy you run yo
 
 The `agent_vault_access` tool lets a user ask their own agent for a link to manage that agent's vault.
 It resolves the caller's worker target to that worker's vault (`worker_id_for_key(worker_key, prefix)`, matching `agentVault.vaultNamePrefix`), grants the caller's Agent Vault account admin access to that vault through the API, and returns the gated UI link.
-It only self-grants for requester-isolated worker scopes (`user` or `user_agent`); shared worker vaults require operator-managed credentials.
+It only self-grants for requester-isolated worker scopes (`user` or `user_agent`).
+For shared worker scopes it returns the vault name and UI link without granting anything (`"access": "operator_managed"`): the link alone grants nothing because the UI enforces vault membership, and it is how the operator-designated admin discovers which vault backs the agent.
 Configure it per deployment:
 
 ```bash

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -16224,6 +16224,8 @@ MINDROOM_AGENT_VAULT_ACCESS_EMAIL_DOMAIN=example.com
 MINDROOM_AGENT_VAULT_ACCESS_VAULT_NAME_PREFIX=agent-vault  # must match workers.kubernetes.agentVault.vaultNamePrefix
 ```
 
+Agents on a shared worker scope never reach the grant API, so for them only `MINDROOM_AGENT_VAULT_ACCESS_UI_BASE_URL` (plus the matching vault name prefix) is required; the API URL, admin token, and email domain stay required for requester-isolated scopes.
+
 The tool maps a requester's Matrix localpart to `localpart@EMAIL_DOMAIN` for the account grant.
 That mapping only decides *UI management access*; it never changes which worker reaches which vault, so the runtime secret boundary stays the per-worker vault scope plus the in-pod proxy-role token.
 The grant is idempotent and requires the user to have already registered and verified an Agent Vault account.

--- a/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
+++ b/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
@@ -416,6 +416,8 @@ MINDROOM_AGENT_VAULT_ACCESS_EMAIL_DOMAIN=example.com
 MINDROOM_AGENT_VAULT_ACCESS_VAULT_NAME_PREFIX=agent-vault  # must match workers.kubernetes.agentVault.vaultNamePrefix
 ```
 
+Agents on a shared worker scope never reach the grant API, so for them only `MINDROOM_AGENT_VAULT_ACCESS_UI_BASE_URL` (plus the matching vault name prefix) is required; the API URL, admin token, and email domain stay required for requester-isolated scopes.
+
 The tool maps a requester's Matrix localpart to `localpart@EMAIL_DOMAIN` for the account grant.
 That mapping only decides *UI management access*; it never changes which worker reaches which vault, so the runtime secret boundary stays the per-worker vault scope plus the in-pod proxy-role token.
 The grant is idempotent and requires the user to have already registered and verified an Agent Vault account.

--- a/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
+++ b/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
@@ -404,7 +404,8 @@ For non-Kubernetes deployments, point worker egress at a shared proxy you run yo
 
 The `agent_vault_access` tool lets a user ask their own agent for a link to manage that agent's vault.
 It resolves the caller's worker target to that worker's vault (`worker_id_for_key(worker_key, prefix)`, matching `agentVault.vaultNamePrefix`), grants the caller's Agent Vault account admin access to that vault through the API, and returns the gated UI link.
-It only self-grants for requester-isolated worker scopes (`user` or `user_agent`); shared worker vaults require operator-managed credentials.
+It only self-grants for requester-isolated worker scopes (`user` or `user_agent`).
+For shared worker scopes it returns the vault name and UI link without granting anything (`"access": "operator_managed"`): the link alone grants nothing because the UI enforces vault membership, and it is how the operator-designated admin discovers which vault backs the agent.
 Configure it per deployment:
 
 ```bash

--- a/src/mindroom/custom_tools/agent_vault_access.py
+++ b/src/mindroom/custom_tools/agent_vault_access.py
@@ -33,6 +33,16 @@ _DEFAULT_VAULT_NAME_PREFIX = "agent-vault"
 _HTTP_TIMEOUT_SECONDS = 15.0
 
 
+def _requires_grant_config(target: ResolvedWorkerTarget | None) -> bool:
+    """Whether this tool instance can ever reach the grant API.
+
+    Shared-scope targets return the vault name and link before any API call, so
+    they only need the UI base URL. Requester-isolated scopes self-grant and
+    need the full API configuration; unknown targets stay strict.
+    """
+    return target is None or not target.worker_key or target.worker_scope in {"user", "user_agent"}
+
+
 class _AgentVaultAccessError(RuntimeError):
     """Raised when the tool cannot be constructed from the runtime configuration."""
 
@@ -56,16 +66,16 @@ class AgentVaultAccessTools(Toolkit):
             runtime_paths.env_value(env["vault_name_prefix"]) or _DEFAULT_VAULT_NAME_PREFIX
         ).strip()
         self._owner_email = (runtime_paths.env_value(env["owner_email"]) or "").strip()
-        missing = [
-            name
-            for name, value in (
-                (env["api_url"], self._api_url),
-                (env["ui_base_url"], self._ui_base_url),
-                (env["email_domain"], self._email_domain),
+        required = [(env["ui_base_url"], self._ui_base_url)]
+        if _requires_grant_config(worker_target):
+            required.extend(
+                (
+                    (env["api_url"], self._api_url),
+                    (env["email_domain"], self._email_domain),
+                ),
             )
-            if not value
-        ]
-        if not self._admin_token and not self._admin_token_file:
+        missing = [name for name, value in required if not value]
+        if _requires_grant_config(worker_target) and not self._admin_token and not self._admin_token_file:
             missing.append(f"{env['admin_token']} or {env['admin_token_file']}")
         if missing:
             msg = f"AgentVaultAccessTools requires these environment values: {', '.join(sorted(missing))}"

--- a/src/mindroom/custom_tools/agent_vault_access.py
+++ b/src/mindroom/custom_tools/agent_vault_access.py
@@ -31,16 +31,17 @@ if TYPE_CHECKING:
 
 _DEFAULT_VAULT_NAME_PREFIX = "agent-vault"
 _HTTP_TIMEOUT_SECONDS = 15.0
+_REQUESTER_ISOLATED_SCOPES = frozenset({"user", "user_agent"})
 
 
 def _requires_grant_config(target: ResolvedWorkerTarget | None) -> bool:
-    """Whether this tool instance can ever reach the grant API.
+    """Whether construction must require the grant API configuration.
 
     Shared-scope targets return the vault name and link before any API call, so
     they only need the UI base URL. Requester-isolated scopes self-grant and
     need the full API configuration; unknown targets stay strict.
     """
-    return target is None or not target.worker_key or target.worker_scope in {"user", "user_agent"}
+    return target is None or not target.worker_key or target.worker_scope in _REQUESTER_ISOLATED_SCOPES
 
 
 class _AgentVaultAccessError(RuntimeError):
@@ -66,8 +67,9 @@ class AgentVaultAccessTools(Toolkit):
             runtime_paths.env_value(env["vault_name_prefix"]) or _DEFAULT_VAULT_NAME_PREFIX
         ).strip()
         self._owner_email = (runtime_paths.env_value(env["owner_email"]) or "").strip()
+        requires_grant_config = _requires_grant_config(worker_target)
         required = [(env["ui_base_url"], self._ui_base_url)]
-        if _requires_grant_config(worker_target):
+        if requires_grant_config:
             required.extend(
                 (
                     (env["api_url"], self._api_url),
@@ -75,7 +77,7 @@ class AgentVaultAccessTools(Toolkit):
                 ),
             )
         missing = [name for name, value in required if not value]
-        if _requires_grant_config(worker_target) and not self._admin_token and not self._admin_token_file:
+        if requires_grant_config and not self._admin_token and not self._admin_token_file:
             missing.append(f"{env['admin_token']} or {env['admin_token_file']}")
         if missing:
             msg = f"AgentVaultAccessTools requires these environment values: {', '.join(sorted(missing))}"
@@ -99,7 +101,7 @@ class AgentVaultAccessTools(Toolkit):
                 "Agent Vault access requires a worker-scoped agent.",
             )
         vault = worker_id_for_key(target.worker_key, prefix=self._vault_name_prefix)
-        if target.worker_scope not in {"user", "user_agent"}:
+        if target.worker_scope not in _REQUESTER_ISOLATED_SCOPES:
             # One shared vault backs this agent for every user, so self-service
             # admin grants would hand its credentials to any requester. Still
             # name the vault: the link grants nothing (the UI enforces vault
@@ -120,6 +122,10 @@ class AgentVaultAccessTools(Toolkit):
                 },
                 sort_keys=True,
             )
+        return await self._self_grant_and_link(target, vault)
+
+    async def _self_grant_and_link(self, target: ResolvedWorkerTarget, vault: str) -> str:
+        """Grant the requester admin access on their requester-isolated vault and return the link payload."""
         identity = target.execution_identity
         requester_id = identity.requester_id if identity is not None else None
         if not requester_id:
@@ -152,9 +158,10 @@ class AgentVaultAccessTools(Toolkit):
                     ),
                 )
             granted = await self._grant_admin(vault, email, token)
-        except (_AgentVaultAccessError, httpx.HTTPError) as exc:
-            detail = f"Agent Vault API request failed: {exc}" if isinstance(exc, httpx.HTTPError) else str(exc)
-            return self._error(detail)
+        except _AgentVaultAccessError as exc:
+            return self._error(str(exc))
+        except httpx.HTTPError as exc:
+            return self._error(f"Agent Vault API request failed: {exc}")
 
         status = "granted" if granted else "already had access"
         return json.dumps(

--- a/src/mindroom/custom_tools/agent_vault_access.py
+++ b/src/mindroom/custom_tools/agent_vault_access.py
@@ -79,13 +79,37 @@ class AgentVaultAccessTools(Toolkit):
         Resolves the vault that backs your worker identity for this agent,
         grants your Agent Vault account admin access, and returns the UI link
         where you can add or update the secrets this agent's tools will use.
+        For shared-worker agents it returns the vault name and link without
+        granting anything; an operator manages access to shared vaults.
         """
         target = self._worker_target
-        if target_error := self._target_error(target):
-            return self._error(target_error)
-        assert target is not None  # Narrowed by _target_error.
-        worker_key = target.worker_key
-        assert worker_key is not None  # Narrowed by _target_error.
+        if target is None or not target.worker_key:
+            return self._error(
+                "no worker identity is available for this agent, so it has no dedicated vault. "
+                "Agent Vault access requires a worker-scoped agent.",
+            )
+        vault = worker_id_for_key(target.worker_key, prefix=self._vault_name_prefix)
+        if target.worker_scope not in {"user", "user_agent"}:
+            # One shared vault backs this agent for every user, so self-service
+            # admin grants would hand its credentials to any requester. Still
+            # name the vault: the link grants nothing (the UI enforces vault
+            # membership) and is how the designated admin finds their vault.
+            return json.dumps(
+                {
+                    "tool": "agent_vault_access",
+                    "status": "ok",
+                    "vault": vault,
+                    "access": "operator_managed",
+                    "url": self._vault_link(vault),
+                    "note": (
+                        "This agent uses a shared worker scope, so one vault backs it for all users and "
+                        "self-service admin grants are disabled. An operator grants access to this vault "
+                        "instead: pass them this vault name and link, or open the link if you already "
+                        "have access."
+                    ),
+                },
+                sort_keys=True,
+            )
         identity = target.execution_identity
         requester_id = identity.requester_id if identity is not None else None
         if not requester_id:
@@ -98,7 +122,6 @@ class AgentVaultAccessTools(Toolkit):
                 "expected a Matrix ID whose localpart maps to the configured email domain.",
             )
 
-        vault = worker_id_for_key(worker_key, prefix=self._vault_name_prefix)
         try:
             # One token read per request: both API calls must use the same
             # token, or a rotation between them could 401 the second call.
@@ -119,12 +142,10 @@ class AgentVaultAccessTools(Toolkit):
                     ),
                 )
             granted = await self._grant_admin(vault, email, token)
-        except _AgentVaultAccessError as exc:
-            return self._error(str(exc))
-        except httpx.HTTPError as exc:
-            return self._error(f"Agent Vault API request failed: {exc}")
+        except (_AgentVaultAccessError, httpx.HTTPError) as exc:
+            detail = f"Agent Vault API request failed: {exc}" if isinstance(exc, httpx.HTTPError) else str(exc)
+            return self._error(detail)
 
-        link = urljoin(self._ui_base_url.rstrip("/") + "/", f"vaults/{quote(vault, safe='')}")
         status = "granted" if granted else "already had access"
         return json.dumps(
             {
@@ -133,7 +154,7 @@ class AgentVaultAccessTools(Toolkit):
                 "vault": vault,
                 "email": email,
                 "access": status,
-                "url": link,
+                "url": self._vault_link(vault),
                 "note": (
                     "Open the link, log in through the usual SSO gate, and manage this agent's secrets there. "
                     "Anyone you grant can read those secrets, so only add what this agent needs."
@@ -142,19 +163,8 @@ class AgentVaultAccessTools(Toolkit):
             sort_keys=True,
         )
 
-    def _target_error(self, target: ResolvedWorkerTarget | None) -> str | None:
-        if target is None or not target.worker_key:
-            return (
-                "no worker identity is available for this agent, so it has no dedicated vault. "
-                "Agent Vault access requires a worker-scoped agent."
-            )
-        if target.worker_scope not in {"user", "user_agent"}:
-            return (
-                "Agent Vault self-service admin access requires a requester-isolated worker vault "
-                "(worker_scope=user or worker_scope=user_agent). This agent uses a shared worker scope, "
-                "so ask an operator to configure shared credentials or give the agent a private worker scope."
-            )
-        return None
+    def _vault_link(self, vault: str) -> str:
+        return urljoin(self._ui_base_url.rstrip("/") + "/", f"vaults/{quote(vault, safe='')}")
 
     def _requester_email(self, requester_id: str) -> str | None:
         # Matrix IDs look like @localpart:server; map localpart to the configured domain.

--- a/tests/test_agent_vault_access_tool.py
+++ b/tests/test_agent_vault_access_tool.py
@@ -137,23 +137,40 @@ async def test_request_vault_access_grants_and_returns_link(
 
 
 @pytest.mark.asyncio
-async def test_request_vault_access_rejects_shared_scope_admin_grant(
+async def test_request_vault_access_names_shared_vault_without_granting(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Shared worker vaults are not requester-owned, so the tool must not grant admin."""
+    """Shared worker vaults are not requester-owned: name the vault, never grant admin.
+
+    The link alone grants nothing (the UI enforces vault membership), and it is
+    how the operator-designated admin discovers which vault backs this agent.
+    """
     api = _FakeVaultAPI({"/v1/vaults": 201, "/join": 409, "/users": 201})
     _patch_client(monkeypatch, api)
 
-    tool = AgentVaultAccessTools(
-        runtime_paths=_runtime_paths(tmp_path),
-        worker_target=_worker_target(worker_scope="shared"),
-    )
+    target = _worker_target(worker_scope="shared")
+    expected_vault = worker_id_for_key(target.worker_key, prefix="agent-vault")
+    tool = AgentVaultAccessTools(runtime_paths=_runtime_paths(tmp_path), worker_target=target)
     payload = json.loads(await tool.request_vault_access())
 
-    assert payload["status"] == "error"
-    assert "requester-isolated" in payload["error"]
+    assert payload["status"] == "ok"
+    assert payload["access"] == "operator_managed"
+    assert payload["vault"] == expected_vault
+    assert payload["url"] == f"https://example.test/agent-vault/vaults/{expected_vault}"
+    assert "operator" in payload["note"]
+    assert "email" not in payload
     assert api.calls == []
+
+
+@pytest.mark.asyncio
+async def test_shared_vault_link_needs_no_requester(tmp_path: Path) -> None:
+    """The shared-vault link is requester-independent, so a missing requester is fine."""
+    target = _worker_target(requester=None, worker_scope="shared")
+    tool = AgentVaultAccessTools(runtime_paths=_runtime_paths(tmp_path), worker_target=target)
+    payload = json.loads(await tool.request_vault_access())
+    assert payload["status"] == "ok"
+    assert payload["access"] == "operator_managed"
 
 
 @pytest.mark.asyncio

--- a/tests/test_agent_vault_access_tool.py
+++ b/tests/test_agent_vault_access_tool.py
@@ -164,6 +164,35 @@ async def test_request_vault_access_names_shared_vault_without_granting(
 
 
 @pytest.mark.asyncio
+async def test_shared_scope_tool_needs_only_ui_base_url(tmp_path: Path) -> None:
+    """A shared-scope instance never reaches the grant API, so only the UI base URL is required."""
+    env = {"MINDROOM_AGENT_VAULT_ACCESS_UI_BASE_URL": "https://example.test/agent-vault"}
+    target = _worker_target(worker_scope="shared")
+    expected_vault = worker_id_for_key(target.worker_key, prefix="agent-vault")
+
+    tool = AgentVaultAccessTools(runtime_paths=_runtime_paths(tmp_path, env=env), worker_target=target)
+    payload = json.loads(await tool.request_vault_access())
+
+    assert payload["status"] == "ok"
+    assert payload["access"] == "operator_managed"
+    assert payload["url"] == f"https://example.test/agent-vault/vaults/{expected_vault}"
+
+
+def test_isolated_scope_still_requires_grant_config(tmp_path: Path) -> None:
+    """Requester-isolated scopes self-grant, so the full API configuration stays required."""
+    env = {"MINDROOM_AGENT_VAULT_ACCESS_UI_BASE_URL": "https://example.test/agent-vault"}
+    with pytest.raises(_AgentVaultAccessError, match="API_URL"):
+        AgentVaultAccessTools(runtime_paths=_runtime_paths(tmp_path, env=env), worker_target=_worker_target())
+
+
+def test_unknown_target_still_requires_grant_config(tmp_path: Path) -> None:
+    """Without a worker target the reachable paths are unknown, so validation stays strict."""
+    env = {"MINDROOM_AGENT_VAULT_ACCESS_UI_BASE_URL": "https://example.test/agent-vault"}
+    with pytest.raises(_AgentVaultAccessError, match="API_URL"):
+        AgentVaultAccessTools(runtime_paths=_runtime_paths(tmp_path, env=env), worker_target=None)
+
+
+@pytest.mark.asyncio
 async def test_shared_vault_link_needs_no_requester(tmp_path: Path) -> None:
     """The shared-vault link is requester-independent, so a missing requester is fine."""
     target = _worker_target(requester=None, worker_scope="shared")


### PR DESCRIPTION
## Problem

For agents on a shared worker scope, `request_vault_access` returns only an error. That is correct about not granting (self-service admin on a shared vault would hand the agent's credentials to any requester), but it also withholds the vault name and UI link. Per-worker vault names are opaque hashes (`agent-vault-<hash>`), so the human who *is* supposed to administer the shared vault has no way to find out which vault backs the agent, short of an operator resolving `worker_id_for_key` by hand.

## Change

When `worker_scope` is not requester-isolated (`user`/`user_agent`), the tool now skips all grant API calls and returns a structured response with the resolved vault name and gated UI link:

```json
{"status": "ok", "access": "operator_managed", "vault": "agent-vault-…", "url": "…/vaults/agent-vault-…", "note": "…"}
```

Revealing the link is safe: the UI still enforces SSO plus vault membership, so the link alone grants nothing. Self-grant behavior for `user`/`user_agent` scopes is unchanged.

Since the shared-vault link is requester-independent, the shared branch no longer requires a resolvable requester email.

**Scope-aware constructor validation**: because a shared-scope instance never reaches the grant API, its construction now requires only `MINDROOM_AGENT_VAULT_ACCESS_UI_BASE_URL` (previously a hard construction failure without the full API config). Requester-isolated scopes and unknown targets still require the API URL, admin token, and email domain.

Also:
- extracted `_vault_link()` (used by both branches), inlined the former `_target_error()` into the method flow, and moved the self-grant flow into `_self_grant_and_link()`
- one `_REQUESTER_ISOLATED_SCOPES` constant backs both the constructor validation and the runtime branch
- docs: updated the self-service vault access section in `docs/deployment/sandbox-proxy.md`, including the relaxed shared-scope config requirements (plus regenerated skill references)

## Tests

- `test_request_vault_access_names_shared_vault_without_granting`: shared scope returns vault + URL, `access=operator_managed`, and makes zero vault API calls
- `test_shared_vault_link_needs_no_requester`: shared branch works without a requester identity
- `test_shared_scope_tool_needs_only_ui_base_url`: shared-scope construction succeeds with only the UI base URL
- `test_isolated_scope_still_requires_grant_config` / `test_unknown_target_still_requires_grant_config`: strict validation is preserved where the grant API is (or may be) reachable
- full `tests/test_agent_vault_access_tool.py` suite passes (22 passed); ruff, format, and pre-commit clean
