### PR TITLE
Retry transient Claude streaming errors before any output

### DIFF
--- a/src/mindroom/claude_stream_retry.py
+++ b/src/mindroom/claude_stream_retry.py
@@ -20,6 +20,7 @@ consumers streamed to the user, so those errors propagate unchanged.
 from __future__ import annotations
 
 import asyncio
+import random
 import time
 from functools import partial
 from typing import TYPE_CHECKING, cast
@@ -30,7 +31,7 @@ from agno.models.anthropic import Claude as AnthropicClaude
 from mindroom.logging_config import get_logger
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Callable, Iterator
+    from collections.abc import AsyncGenerator, AsyncIterator, Callable, Generator, Iterator
     from typing import Any
 
     from agno.models.response import ModelResponse
@@ -58,13 +59,30 @@ def _is_transient_model_error(error: BaseException) -> bool:
 
 
 def _has_meaningful_output(response: ModelResponse) -> bool:
-    """Return whether one streamed delta already reached downstream consumers."""
+    """Return whether one streamed delta already reached downstream consumers.
+
+    Anything beyond role/event bookkeeping counts: downstream consumers
+    accumulate these fields (Agno extends provider-data lists, MindRoom's
+    collector appends content), so replaying an attempt that set any of them
+    would duplicate state.
+    """
     return bool(
         response.content
+        or response.parsed
+        or response.audio
+        or response.images
+        or response.videos
+        or response.audios
+        or response.files
+        or response.tool_calls
+        or response.tool_executions
+        or response.provider_data
         or response.reasoning_content
         or response.redacted_reasoning_content
-        or response.tool_calls
-        or response.tool_executions,
+        or response.citations
+        or response.response_usage
+        or response.extra
+        or response.updated_session_state,
     )
 
 
@@ -74,7 +92,9 @@ def _should_reraise(error: ModelProviderError, *, yielded_meaningful_output: boo
 
 
 def _retry_delay_seconds(attempt: int) -> float:
-    return _RETRY_BASE_DELAY_SECONDS * (2**attempt)
+    # Jitter spreads retries from agents that failed on the same provider
+    # incident, instead of re-hitting it in synchronized pulses.
+    return _RETRY_BASE_DELAY_SECONDS * (2**attempt) * (1.0 + random.uniform(0.0, 0.25))  # noqa: S311
 
 
 def _log_retry(model: AnthropicClaude, error: ModelProviderError, *, attempt: int, delay: float) -> None:
@@ -91,15 +111,16 @@ def _log_retry(model: AnthropicClaude, error: ModelProviderError, *, attempt: in
 
 def _invoke_stream_with_retry(
     model: AnthropicClaude,
-    original_invoke_stream: Callable[..., Iterator[ModelResponse]],
+    original_invoke_stream: Callable[..., Generator[ModelResponse, None, None]],
     *args: object,
     **kwargs: object,
 ) -> Iterator[ModelResponse]:
     """Replay one synchronous stream request after transient pre-output errors."""
     for attempt in range(_MAX_TRANSIENT_RETRIES + 1):
         yielded_meaningful_output = False
+        stream = original_invoke_stream(*args, **kwargs)
         try:
-            for response in original_invoke_stream(*args, **kwargs):
+            for response in stream:
                 yielded_meaningful_output = yielded_meaningful_output or _has_meaningful_output(response)
                 yield response
         except ModelProviderError as error:
@@ -110,19 +131,24 @@ def _invoke_stream_with_retry(
             time.sleep(delay)
         else:
             return
+        finally:
+            # If the consumer closes us mid-stream (GeneratorExit at the yield
+            # above), close the underlying request instead of leaving it to GC.
+            stream.close()
 
 
 async def _ainvoke_stream_with_retry(
     model: AnthropicClaude,
-    original_ainvoke_stream: Callable[..., AsyncIterator[ModelResponse]],
+    original_ainvoke_stream: Callable[..., AsyncGenerator[ModelResponse, None]],
     *args: object,
     **kwargs: object,
 ) -> AsyncIterator[ModelResponse]:
     """Replay one asynchronous stream request after transient pre-output errors."""
     for attempt in range(_MAX_TRANSIENT_RETRIES + 1):
         yielded_meaningful_output = False
+        stream = original_ainvoke_stream(*args, **kwargs)
         try:
-            async for response in original_ainvoke_stream(*args, **kwargs):
+            async for response in stream:
                 yielded_meaningful_output = yielded_meaningful_output or _has_meaningful_output(response)
                 yield response
         except ModelProviderError as error:
@@ -133,6 +159,11 @@ async def _ainvoke_stream_with_retry(
             await asyncio.sleep(delay)
         else:
             return
+        finally:
+            # Async generators abandoned mid-stream are only finalized by the
+            # GC hook; close the underlying request deterministically when the
+            # consumer cancels or closes us at the yield above.
+            await stream.aclose()
 
 
 def install_claude_stream_retry_hook(model: object) -> None:

--- a/src/mindroom/claude_stream_retry.py
+++ b/src/mindroom/claude_stream_retry.py
@@ -1,0 +1,154 @@
+"""Transient-error retry for Claude streaming model requests.
+
+The Anthropic SDK retries HTTP-level failures (429/5xx, connection errors)
+before a stream is established, but once the response is committed as 200 the
+API reports server faults as an SSE ``error`` event instead. The SDK raises
+that event as an ``APIStatusError`` with status code 200 and never retries it,
+Agno converts it into a generic ``ModelProviderError``, and without this hook
+the whole agent run fails on a documented-retryable fault (observed in
+production as ``{'type': 'api_error', 'message': 'Internal server error'}``
+from Vertex).
+
+This hook wraps ``invoke_stream``/``ainvoke_stream`` on Anthropic-family Claude
+models (direct API, Vertex, and Bedrock share the Agno model class) and
+re-issues the request when an attempt fails with a transient error before
+producing any meaningful output. Attempts that already yielded content, tool
+calls, or reasoning cannot be replayed without duplicating what downstream
+consumers streamed to the user, so those errors propagate unchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from functools import partial
+from typing import TYPE_CHECKING, cast
+
+from agno.exceptions import ContextWindowExceededError, ModelProviderError
+from agno.models.anthropic import Claude as AnthropicClaude
+
+from mindroom.logging_config import get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Callable, Iterator
+    from typing import Any
+
+    from agno.models.response import ModelResponse
+
+logger = get_logger(__name__)
+
+_STREAM_RETRY_HOOK_ATTR = "_mindroom_claude_stream_retry_hook_installed"
+
+# One initial attempt plus this many re-issued requests.
+_MAX_TRANSIENT_RETRIES = 2
+_RETRY_BASE_DELAY_SECONDS = 1.0
+
+# Statuses that indicate a transient provider fault. 200 is the mid-stream SSE
+# ``error`` event case (the HTTP response was already committed when the server
+# failed). 502 is also Agno's default when it wraps connection errors and
+# unexpected SDK exceptions, which are equally worth one more attempt.
+_RETRYABLE_STATUS_CODES = frozenset({200, 408, 409, 429, 500, 502, 503, 504, 529})
+
+
+def _is_transient_model_error(error: BaseException) -> bool:
+    """Return whether one model-call failure is worth re-issuing the request."""
+    if isinstance(error, ContextWindowExceededError):
+        return False
+    return isinstance(error, ModelProviderError) and error.status_code in _RETRYABLE_STATUS_CODES
+
+
+def _has_meaningful_output(response: ModelResponse) -> bool:
+    """Return whether one streamed delta already reached downstream consumers."""
+    return bool(
+        response.content
+        or response.reasoning_content
+        or response.redacted_reasoning_content
+        or response.tool_calls
+        or response.tool_executions,
+    )
+
+
+def _should_reraise(error: ModelProviderError, *, yielded_meaningful_output: bool, attempt: int) -> bool:
+    """Return whether one failed attempt must propagate instead of retrying."""
+    return yielded_meaningful_output or attempt >= _MAX_TRANSIENT_RETRIES or not _is_transient_model_error(error)
+
+
+def _retry_delay_seconds(attempt: int) -> float:
+    return _RETRY_BASE_DELAY_SECONDS * (2**attempt)
+
+
+def _log_retry(model: AnthropicClaude, error: ModelProviderError, *, attempt: int, delay: float) -> None:
+    logger.warning(
+        "Retrying Claude stream after transient model error",
+        model_id=model.id,
+        status_code=error.status_code,
+        error=str(error.message),
+        attempt=attempt + 1,
+        max_retries=_MAX_TRANSIENT_RETRIES,
+        delay_seconds=delay,
+    )
+
+
+def _invoke_stream_with_retry(
+    model: AnthropicClaude,
+    original_invoke_stream: Callable[..., Iterator[ModelResponse]],
+    *args: object,
+    **kwargs: object,
+) -> Iterator[ModelResponse]:
+    """Replay one synchronous stream request after transient pre-output errors."""
+    for attempt in range(_MAX_TRANSIENT_RETRIES + 1):
+        yielded_meaningful_output = False
+        try:
+            for response in original_invoke_stream(*args, **kwargs):
+                yielded_meaningful_output = yielded_meaningful_output or _has_meaningful_output(response)
+                yield response
+        except ModelProviderError as error:
+            if _should_reraise(error, yielded_meaningful_output=yielded_meaningful_output, attempt=attempt):
+                raise
+            delay = _retry_delay_seconds(attempt)
+            _log_retry(model, error, attempt=attempt, delay=delay)
+            time.sleep(delay)
+        else:
+            return
+
+
+async def _ainvoke_stream_with_retry(
+    model: AnthropicClaude,
+    original_ainvoke_stream: Callable[..., AsyncIterator[ModelResponse]],
+    *args: object,
+    **kwargs: object,
+) -> AsyncIterator[ModelResponse]:
+    """Replay one asynchronous stream request after transient pre-output errors."""
+    for attempt in range(_MAX_TRANSIENT_RETRIES + 1):
+        yielded_meaningful_output = False
+        try:
+            async for response in original_ainvoke_stream(*args, **kwargs):
+                yielded_meaningful_output = yielded_meaningful_output or _has_meaningful_output(response)
+                yield response
+        except ModelProviderError as error:
+            if _should_reraise(error, yielded_meaningful_output=yielded_meaningful_output, attempt=attempt):
+                raise
+            delay = _retry_delay_seconds(attempt)
+            _log_retry(model, error, attempt=attempt, delay=delay)
+            await asyncio.sleep(delay)
+        else:
+            return
+
+
+def install_claude_stream_retry_hook(model: object) -> None:
+    """Wrap a Claude model's stream invocations with transient-error retries.
+
+    Idempotent per model instance. Only attempts that have not yet yielded
+    meaningful output are retried; anything else re-raises immediately so
+    partially streamed responses are never duplicated.
+    """
+    if not isinstance(model, AnthropicClaude):
+        return
+    model_dict = vars(model)
+    if model_dict.get(_STREAM_RETRY_HOOK_ATTR) is True:
+        return
+    original_invoke_stream = model.invoke_stream
+    original_ainvoke_stream = model.ainvoke_stream
+    model_dict[_STREAM_RETRY_HOOK_ATTR] = True
+    model_dict["invoke_stream"] = partial(_invoke_stream_with_retry, model, original_invoke_stream)
+    model_dict["ainvoke_stream"] = cast("Any", partial(_ainvoke_stream_with_retry, model, original_ainvoke_stream))

--- a/src/mindroom/model_loading.py
+++ b/src/mindroom/model_loading.py
@@ -18,6 +18,7 @@ from agno.models.openai.like import OpenAILike
 from agno.models.openrouter import OpenRouter
 
 from mindroom.claude_prompt_cache import install_claude_prompt_cache_hook
+from mindroom.claude_stream_retry import install_claude_stream_retry_hook
 from mindroom.codex_model import CodexResponses, derive_codex_prompt_cache_key, normalize_codex_model_id
 from mindroom.constants import PROVIDER_ENV_KEYS, RuntimePaths, runtime_env_path
 from mindroom.credentials import get_runtime_shared_credentials_manager
@@ -317,4 +318,5 @@ def get_model_instance(
             default_log_dir=runtime_paths.storage_root / "logs" / "llm_requests",
         )
     install_claude_prompt_cache_hook(model)
+    install_claude_stream_retry_hook(model)
     return model

--- a/tests/test_claude_stream_retry.py
+++ b/tests/test_claude_stream_retry.py
@@ -124,6 +124,22 @@ async def test_does_not_retry_after_meaningful_output() -> None:
 
 
 @pytest.mark.asyncio
+async def test_does_not_retry_after_provider_data_delta() -> None:
+    """Provider-data deltas (e.g. thinking signatures) count as meaningful output."""
+    model, calls = _hooked_model_with_async_attempts(
+        [
+            [ModelResponse(provider_data={"signature": "sig"}), _mid_stream_api_error()],
+            [ModelResponse(content="never reached")],
+        ],
+    )
+
+    with pytest.raises(ModelProviderError):
+        await _collect(model.ainvoke_stream([], object()))
+
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
 async def test_does_not_retry_non_transient_error() -> None:
     """Client errors such as HTTP 400 are not retried."""
     model, calls = _hooked_model_with_async_attempts(
@@ -180,19 +196,68 @@ def test_sync_stream_retries_transient_error() -> None:
 
 
 def test_install_is_idempotent() -> None:
-    """Installing the hook twice wraps the stream only once."""
-    model, calls = _hooked_model_with_sync_attempts(
-        [
-            [_mid_stream_api_error()],
-            [ModelResponse(content="recovered")],
-        ],
-    )
+    """A second install must not stack another retry layer on top of the first.
+
+    The script exhausts the retry budget and only then offers a success: a
+    single hook raises after the final retry, while a stacked double hook
+    would keep going and reach the success attempt.
+    """
+    attempts: list[list[ModelResponse | Exception]] = [
+        [_mid_stream_api_error()] for _ in range(claude_stream_retry._MAX_TRANSIENT_RETRIES + 1)
+    ]
+    attempts.append([ModelResponse(content="only reachable when double-wrapped")])
+    model, calls = _hooked_model_with_sync_attempts(attempts)
     install_claude_stream_retry_hook(model)
 
-    responses = list(model.invoke_stream([], object()))
+    with pytest.raises(ModelProviderError):
+        list(model.invoke_stream([], object()))
 
-    assert [response.content for response in responses] == ["recovered"]
-    assert len(calls) == 2
+    assert len(calls) == claude_stream_retry._MAX_TRANSIENT_RETRIES + 1
+
+
+def test_early_close_closes_underlying_sync_stream() -> None:
+    """Closing the wrapper mid-stream closes the in-flight request too."""
+    model = Claude(id="claude-sonnet-5")
+    finalized: list[bool] = []
+
+    def fake_invoke_stream(*_args: object, **_kwargs: object) -> Iterator[ModelResponse]:
+        try:
+            yield ModelResponse(content="first")
+            yield ModelResponse(content="second")
+        finally:
+            finalized.append(True)
+
+    vars(model)["invoke_stream"] = fake_invoke_stream
+    install_claude_stream_retry_hook(model)
+
+    stream = model.invoke_stream([], object())
+    assert next(stream).content == "first"
+    stream.close()
+
+    assert finalized == [True]
+
+
+@pytest.mark.asyncio
+async def test_early_aclose_closes_underlying_async_stream() -> None:
+    """Aclosing the wrapper mid-stream finalizes the in-flight request too."""
+    model = Claude(id="claude-sonnet-5")
+    finalized: list[bool] = []
+
+    async def fake_ainvoke_stream(*_args: object, **_kwargs: object) -> AsyncIterator[ModelResponse]:
+        try:
+            yield ModelResponse(content="first")
+            yield ModelResponse(content="second")
+        finally:
+            finalized.append(True)
+
+    vars(model)["ainvoke_stream"] = fake_ainvoke_stream
+    install_claude_stream_retry_hook(model)
+
+    stream = model.ainvoke_stream([], object())
+    assert (await anext(stream)).content == "first"
+    await stream.aclose()
+
+    assert finalized == [True]
 
 
 def test_install_skips_non_claude_models() -> None:

--- a/tests/test_claude_stream_retry.py
+++ b/tests/test_claude_stream_retry.py
@@ -1,0 +1,201 @@
+"""Transient-error retry behavior for Claude streaming invocations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from agno.exceptions import ContextWindowExceededError, ModelProviderError, ModelRateLimitError
+from agno.models.anthropic import Claude
+from agno.models.response import ModelResponse
+
+from mindroom import claude_stream_retry
+from mindroom.claude_stream_retry import install_claude_stream_retry_hook
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
+
+
+@pytest.fixture(autouse=True)
+def _no_retry_delay(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(claude_stream_retry, "_RETRY_BASE_DELAY_SECONDS", 0.0)
+
+
+def _hooked_model_with_async_attempts(attempts: list[list[ModelResponse | Exception]]) -> tuple[Claude, list[int]]:
+    """Return a hooked model whose ainvoke_stream replays scripted attempts."""
+    model = Claude(id="claude-sonnet-5")
+    calls: list[int] = []
+
+    async def fake_ainvoke_stream(*_args: object, **_kwargs: object) -> AsyncIterator[ModelResponse]:
+        calls.append(len(calls))
+        for item in attempts[len(calls) - 1]:
+            if isinstance(item, Exception):
+                raise item
+            yield item
+
+    vars(model)["ainvoke_stream"] = fake_ainvoke_stream
+    install_claude_stream_retry_hook(model)
+    return model, calls
+
+
+def _hooked_model_with_sync_attempts(attempts: list[list[ModelResponse | Exception]]) -> tuple[Claude, list[int]]:
+    model = Claude(id="claude-sonnet-5")
+    calls: list[int] = []
+
+    def fake_invoke_stream(*_args: object, **_kwargs: object) -> Iterator[ModelResponse]:
+        calls.append(len(calls))
+        for item in attempts[len(calls) - 1]:
+            if isinstance(item, Exception):
+                raise item
+            yield item
+
+    vars(model)["invoke_stream"] = fake_invoke_stream
+    install_claude_stream_retry_hook(model)
+    return model, calls
+
+
+def _mid_stream_api_error() -> ModelProviderError:
+    return ModelProviderError(
+        message="{'type': 'error', 'error': {'type': 'api_error', 'message': 'Internal server error'}}",
+        status_code=200,
+        model_id="claude-sonnet-5",
+    )
+
+
+async def _collect(stream: AsyncIterator[ModelResponse]) -> list[ModelResponse]:
+    return [response async for response in stream]
+
+
+async def _collect_into(stream: AsyncIterator[ModelResponse], collected: list[ModelResponse]) -> None:
+    # Append as we go: the stream is expected to raise mid-iteration and the
+    # partially collected responses are the assertion target.
+    async for response in stream:
+        collected.append(response)  # noqa: PERF401
+
+
+@pytest.mark.asyncio
+async def test_retries_mid_stream_api_error_before_output() -> None:
+    """A mid-stream api_error before any output re-issues the request."""
+    model, calls = _hooked_model_with_async_attempts(
+        [
+            [_mid_stream_api_error()],
+            [ModelResponse(content="hello"), ModelResponse(content=" world")],
+        ],
+    )
+
+    responses = await _collect(model.ainvoke_stream([], object()))
+
+    assert [response.content for response in responses] == ["hello", " world"]
+    assert len(calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_retries_after_bookkeeping_only_responses() -> None:
+    """Role-only bookkeeping deltas do not block a retry."""
+    model, calls = _hooked_model_with_async_attempts(
+        [
+            [ModelResponse(role="assistant"), _mid_stream_api_error()],
+            [ModelResponse(content="recovered")],
+        ],
+    )
+
+    responses = await _collect(model.ainvoke_stream([], object()))
+
+    assert responses[-1].content == "recovered"
+    assert len(calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_does_not_retry_after_meaningful_output() -> None:
+    """Errors after streamed content propagate so text is never duplicated."""
+    model, calls = _hooked_model_with_async_attempts(
+        [
+            [ModelResponse(content="partial"), _mid_stream_api_error()],
+            [ModelResponse(content="never reached")],
+        ],
+    )
+
+    collected: list[ModelResponse] = []
+    with pytest.raises(ModelProviderError):
+        await _collect_into(model.ainvoke_stream([], object()), collected)
+
+    assert [response.content for response in collected] == ["partial"]
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_does_not_retry_non_transient_error() -> None:
+    """Client errors such as HTTP 400 are not retried."""
+    model, calls = _hooked_model_with_async_attempts(
+        [[ModelProviderError(message="invalid request", status_code=400)]],
+    )
+
+    with pytest.raises(ModelProviderError):
+        await _collect(model.ainvoke_stream([], object()))
+
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_does_not_retry_context_window_error() -> None:
+    """Context-window overflows are permanent and never retried."""
+    model, calls = _hooked_model_with_async_attempts(
+        [[ContextWindowExceededError(message="prompt is too long")]],
+    )
+
+    with pytest.raises(ContextWindowExceededError):
+        await _collect(model.ainvoke_stream([], object()))
+
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_retries_rate_limit_then_gives_up() -> None:
+    """Rate limits retry up to the cap, then the last error propagates."""
+    attempts: list[list[ModelResponse | Exception]] = [
+        [ModelRateLimitError(message="overloaded_error", status_code=529)]
+        for _ in range(claude_stream_retry._MAX_TRANSIENT_RETRIES + 1)
+    ]
+    model, calls = _hooked_model_with_async_attempts(attempts)
+
+    with pytest.raises(ModelRateLimitError):
+        await _collect(model.ainvoke_stream([], object()))
+
+    assert len(calls) == claude_stream_retry._MAX_TRANSIENT_RETRIES + 1
+
+
+def test_sync_stream_retries_transient_error() -> None:
+    """The synchronous stream path retries transient errors too."""
+    model, calls = _hooked_model_with_sync_attempts(
+        [
+            [_mid_stream_api_error()],
+            [ModelResponse(content="recovered")],
+        ],
+    )
+
+    responses = list(model.invoke_stream([], object()))
+
+    assert [response.content for response in responses] == ["recovered"]
+    assert len(calls) == 2
+
+
+def test_install_is_idempotent() -> None:
+    """Installing the hook twice wraps the stream only once."""
+    model, calls = _hooked_model_with_sync_attempts(
+        [
+            [_mid_stream_api_error()],
+            [ModelResponse(content="recovered")],
+        ],
+    )
+    install_claude_stream_retry_hook(model)
+
+    responses = list(model.invoke_stream([], object()))
+
+    assert [response.content for response in responses] == ["recovered"]
+    assert len(calls) == 2
+
+
+def test_install_skips_non_claude_models() -> None:
+    """Non-Claude models are left untouched."""
+    sentinel = object()
+    install_claude_stream_retry_hook(sentinel)


### PR DESCRIPTION
## Problem

On 2026-07-08 18:58Z a production saguaro turn died with:

```
[saguaro] ⚠️ Error: {'type': 'error', 'error': {'details': None, 'type': 'api_error', 'message': 'Internal server error'}, 'request_id': 'req_vrtx_011Ccq6sZHptdKq8FGHuRzmb'}
```

The control-plane log shows `Claude API error (status 200)`: the Vertex request was already committed as HTTP 200 when the server failed, so the fault arrived as an SSE `error` event mid-stream. Anthropic documents these as retryable, but nothing in the stack retries them:

1. The Anthropic SDK only auto-retries pre-stream HTTP failures (429/5xx, connection errors). Once streaming has started it raises `APIStatusError` with the original 200 status.
2. Agno's `_handle_api_error` converts it to a generic `ModelProviderError`; only 529/overloaded gets special treatment.
3. MindRoom builds agents without Agno retries (`retries` defaults to 0), so the run aborts and the raw error dict is posted to the room.

This is the second such mid-stream failure in a week (previous: 2026-07-02 21:13Z), and every occurrence costs the user their whole turn, including completed tool-call work.

## Why not Agno's `retries`

Agno retries re-run the entire attempt: completed tool calls execute again (side effects) and already-yielded stream content is re-emitted, which MindRoom's stream collector would append twice. Retrying at the model-request level keeps tool results intact and needs no dedup.

## Change

New `install_claude_stream_retry_hook`, installed in `model_loading.get_model_instance` next to the prompt-cache hook (same instance-dict wrapping pattern, covers direct API, Vertex, and Bedrock Claude). It wraps `invoke_stream`/`ainvoke_stream` and re-issues the request up to 2 times with exponential backoff (1s, 2s) when an attempt fails with a transient status (200 mid-stream event, 408/409/429/5xx/529) **before yielding any content, tool-call, or reasoning delta**.

Attempts that already produced meaningful output re-raise unchanged, so partially streamed text is never duplicated and completed tool calls are never re-executed. Context-window errors and 4xx client errors are never retried. Bookkeeping-only deltas (e.g. role-only `message_start`) do not block a retry.

The observed incident falls in the retryable window: the error event was the first thing the continuation request produced after the tool result.

## Testing

- New `tests/test_claude_stream_retry.py` (12 tests): retry on mid-stream api_error, retry after bookkeeping-only deltas, no retry after meaningful output (content or provider_data), no retry on 400/context-window, rate-limit retries then gives up, sync path, stacked-install detection, early close/aclose tears down the inner stream, non-Claude models untouched.
- `tests/test_model_loading.py`, `tests/test_ai_stream_collection.py`, `tests/test_ai_error_message_display.py`, `tests/test_prompt_cache_review.py` all pass.
- Full pre-commit (ruff, ty, vulture, tach) passes.
