### PR TITLE
Make Agent Vault names human-readable

### DIFF
--- a/cluster/k8s/runtime/values.yaml
+++ b/cluster/k8s/runtime/values.yaml
@@ -379,7 +379,7 @@ workers:
       # grants also keep this owner admin on each worker vault so the init
       # container can attach the proxy-role agent even for user-created vaults.
       ownerEmail: ""
-      # Prefix for the per-worker vault name (worker_id_for_key); the
+      # Prefix for the per-worker vault name (descriptive_worker_id_for_key); the
       # agent_vault_access tool must use the same prefix
       # (MINDROOM_AGENT_VAULT_ACCESS_VAULT_NAME_PREFIX) so the UI manages the
       # same vault the worker reads.

--- a/docs/deployment/sandbox-proxy.md
+++ b/docs/deployment/sandbox-proxy.md
@@ -377,7 +377,7 @@ There are two supported shapes:
 ### Per-worker Agent Vault egress (Kubernetes backend)
 
 For per-user/per-agent isolation, the Kubernetes worker backend gives each dedicated worker its own Agent Vault identity against a single shared Agent Vault server — no per-worker bridge pod, Service, or NetworkPolicy.
-When enabled, each worker pod gets an init container that logs in with the instance owner credential (read from the bootstrap Secret's `AGENT_VAULT_OWNER_PASSWORD` key, mounted only on the init container), creates the worker's vault if missing (`worker_id_for_key(worker_key, prefix=vaultNamePrefix)`), then creates — or rotates — a proxy-role Agent Vault agent for that vault and writes its token to an in-pod `emptyDir`.
+When enabled, each worker pod gets an init container that logs in with the instance owner credential (read from the bootstrap Secret's `AGENT_VAULT_OWNER_PASSWORD` key, mounted only on the init container), creates the worker's vault if missing (`descriptive_worker_id_for_key(worker_key, prefix=vaultNamePrefix)`, a readable scope slug plus a short digest), then creates — or rotates — a proxy-role Agent Vault agent for that vault and writes its token to an in-pod `emptyDir`.
 The sandbox runner reads that token at execution time and composes `http://<token>:@<proxy host>` for python/shell only (Agent Vault accepts the token as the proxy basic-auth username), so credentials are injected in transit.
 
 ```bash
@@ -412,7 +412,7 @@ For non-Kubernetes deployments, point worker egress at a shared proxy you run yo
 ### Self-service vault access
 
 The `agent_vault_access` tool lets a user ask their own agent for a link to manage that agent's vault.
-It resolves the caller's worker target to that worker's vault (`worker_id_for_key(worker_key, prefix)`, matching `agentVault.vaultNamePrefix`), grants the caller's Agent Vault account admin access to that vault through the API, and returns the gated UI link.
+It resolves the caller's worker target to that worker's vault (`descriptive_worker_id_for_key(worker_key, prefix)`, matching `agentVault.vaultNamePrefix`), grants the caller's Agent Vault account admin access to that vault through the API, and returns the gated UI link.
 It only self-grants for requester-isolated worker scopes (`user` or `user_agent`).
 For shared worker scopes it returns the vault name and UI link without granting anything (`"access": "operator_managed"`): the link alone grants nothing because the UI enforces vault membership, and it is how the operator-designated admin discovers which vault backs the agent.
 Configure it per deployment:

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -16181,7 +16181,7 @@ There are two supported shapes:
 ### Per-worker Agent Vault egress (Kubernetes backend)
 
 For per-user/per-agent isolation, the Kubernetes worker backend gives each dedicated worker its own Agent Vault identity against a single shared Agent Vault server — no per-worker bridge pod, Service, or NetworkPolicy.
-When enabled, each worker pod gets an init container that logs in with the instance owner credential (read from the bootstrap Secret's `AGENT_VAULT_OWNER_PASSWORD` key, mounted only on the init container), creates the worker's vault if missing (`worker_id_for_key(worker_key, prefix=vaultNamePrefix)`), then creates — or rotates — a proxy-role Agent Vault agent for that vault and writes its token to an in-pod `emptyDir`.
+When enabled, each worker pod gets an init container that logs in with the instance owner credential (read from the bootstrap Secret's `AGENT_VAULT_OWNER_PASSWORD` key, mounted only on the init container), creates the worker's vault if missing (`descriptive_worker_id_for_key(worker_key, prefix=vaultNamePrefix)`, a readable scope slug plus a short digest), then creates — or rotates — a proxy-role Agent Vault agent for that vault and writes its token to an in-pod `emptyDir`.
 The sandbox runner reads that token at execution time and composes `http://<token>:@<proxy host>` for python/shell only (Agent Vault accepts the token as the proxy basic-auth username), so credentials are injected in transit.
 
 ```bash
@@ -16216,7 +16216,7 @@ For non-Kubernetes deployments, point worker egress at a shared proxy you run yo
 ### Self-service vault access
 
 The `agent_vault_access` tool lets a user ask their own agent for a link to manage that agent's vault.
-It resolves the caller's worker target to that worker's vault (`worker_id_for_key(worker_key, prefix)`, matching `agentVault.vaultNamePrefix`), grants the caller's Agent Vault account admin access to that vault through the API, and returns the gated UI link.
+It resolves the caller's worker target to that worker's vault (`descriptive_worker_id_for_key(worker_key, prefix)`, matching `agentVault.vaultNamePrefix`), grants the caller's Agent Vault account admin access to that vault through the API, and returns the gated UI link.
 It only self-grants for requester-isolated worker scopes (`user` or `user_agent`).
 For shared worker scopes it returns the vault name and UI link without granting anything (`"access": "operator_managed"`): the link alone grants nothing because the UI enforces vault membership, and it is how the operator-designated admin discovers which vault backs the agent.
 Configure it per deployment:

--- a/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
+++ b/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
@@ -373,7 +373,7 @@ There are two supported shapes:
 ### Per-worker Agent Vault egress (Kubernetes backend)
 
 For per-user/per-agent isolation, the Kubernetes worker backend gives each dedicated worker its own Agent Vault identity against a single shared Agent Vault server — no per-worker bridge pod, Service, or NetworkPolicy.
-When enabled, each worker pod gets an init container that logs in with the instance owner credential (read from the bootstrap Secret's `AGENT_VAULT_OWNER_PASSWORD` key, mounted only on the init container), creates the worker's vault if missing (`worker_id_for_key(worker_key, prefix=vaultNamePrefix)`), then creates — or rotates — a proxy-role Agent Vault agent for that vault and writes its token to an in-pod `emptyDir`.
+When enabled, each worker pod gets an init container that logs in with the instance owner credential (read from the bootstrap Secret's `AGENT_VAULT_OWNER_PASSWORD` key, mounted only on the init container), creates the worker's vault if missing (`descriptive_worker_id_for_key(worker_key, prefix=vaultNamePrefix)`, a readable scope slug plus a short digest), then creates — or rotates — a proxy-role Agent Vault agent for that vault and writes its token to an in-pod `emptyDir`.
 The sandbox runner reads that token at execution time and composes `http://<token>:@<proxy host>` for python/shell only (Agent Vault accepts the token as the proxy basic-auth username), so credentials are injected in transit.
 
 ```bash
@@ -408,7 +408,7 @@ For non-Kubernetes deployments, point worker egress at a shared proxy you run yo
 ### Self-service vault access
 
 The `agent_vault_access` tool lets a user ask their own agent for a link to manage that agent's vault.
-It resolves the caller's worker target to that worker's vault (`worker_id_for_key(worker_key, prefix)`, matching `agentVault.vaultNamePrefix`), grants the caller's Agent Vault account admin access to that vault through the API, and returns the gated UI link.
+It resolves the caller's worker target to that worker's vault (`descriptive_worker_id_for_key(worker_key, prefix)`, matching `agentVault.vaultNamePrefix`), grants the caller's Agent Vault account admin access to that vault through the API, and returns the gated UI link.
 It only self-grants for requester-isolated worker scopes (`user` or `user_agent`).
 For shared worker scopes it returns the vault name and UI link without granting anything (`"access": "operator_managed"`): the link alone grants nothing because the UI enforces vault membership, and it is how the operator-designated admin discovers which vault backs the agent.
 Configure it per deployment:

--- a/src/mindroom/agent_vault_access_grants.py
+++ b/src/mindroom/agent_vault_access_grants.py
@@ -23,8 +23,8 @@ import yaml
 from mindroom.tool_system.worker_routing import (
     ToolExecutionIdentity,
     WorkerScope,
+    descriptive_worker_id_for_key,
     resolve_worker_target,
-    worker_id_for_key,
 )
 
 _DEFAULT_VAULT_NAME_PREFIX = "agent-vault"
@@ -312,7 +312,7 @@ def _resolve_grant_target(
     return ResolvedAgentVaultAccessGrantTarget(
         grant=grant,
         worker_key=target.worker_key,
-        vault=worker_id_for_key(target.worker_key, prefix=config.vault_name_prefix),
+        vault=descriptive_worker_id_for_key(target.worker_key, prefix=config.vault_name_prefix),
     )
 
 

--- a/src/mindroom/custom_tools/agent_vault_access.py
+++ b/src/mindroom/custom_tools/agent_vault_access.py
@@ -23,7 +23,7 @@ import httpx
 from agno.tools import Toolkit
 
 from mindroom.runtime_env_policy import AGENT_VAULT_ACCESS_ENV_BY_KEY
-from mindroom.tool_system.worker_routing import worker_id_for_key
+from mindroom.tool_system.worker_routing import descriptive_worker_id_for_key
 
 if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths
@@ -100,7 +100,7 @@ class AgentVaultAccessTools(Toolkit):
                 "no worker identity is available for this agent, so it has no dedicated vault. "
                 "Agent Vault access requires a worker-scoped agent.",
             )
-        vault = worker_id_for_key(target.worker_key, prefix=self._vault_name_prefix)
+        vault = descriptive_worker_id_for_key(target.worker_key, prefix=self._vault_name_prefix)
         if target.worker_scope not in _REQUESTER_ISOLATED_SCOPES:
             # One shared vault backs this agent for every user, so self-service
             # admin grants would hand its credentials to any requester. Still

--- a/src/mindroom/tool_system/worker_routing.py
+++ b/src/mindroom/tool_system/worker_routing.py
@@ -23,6 +23,9 @@ _ExecutionChannel = Literal["matrix", "openai_compat"]
 
 _WORKER_DIRNAME_MAX_PREFIX_LENGTH = 80
 _DEFAULT_WORKER_NAME_PREFIX = "mindroom-worker"
+_DNS_LABEL_MAX_LENGTH = 63
+_WORKER_ID_DIGEST_LENGTH = 24
+_DESCRIPTIVE_WORKER_ID_DIGEST_LENGTH = 10
 _AGENT_WORKSPACE_DIRNAME = "workspace"
 _PRIVATE_INSTANCE_ROOT_DIRNAME = "private_instances"
 _SHARED_ONLY_INTEGRATION_NAMES = frozenset(
@@ -228,15 +231,61 @@ def normalize_worker_key_part(value: str) -> str:
     return normalized or "default"
 
 
-def worker_id_for_key(worker_key: str, *, prefix: str) -> str:
-    """Return a DNS-safe resource name for one worker key (63-char label limit)."""
-    digest = hashlib.sha256(worker_key.encode("utf-8")).hexdigest()[:24]
+def _digest_and_safe_prefix(worker_key: str, prefix: str, *, digest_length: int) -> tuple[str, str]:
+    """Return the worker-key digest and a prefix normalized to fit a DNS label beside it."""
+    digest = hashlib.sha256(worker_key.encode("utf-8")).hexdigest()[:digest_length]
     normalized_prefix = prefix.strip().lower().strip("-") or _DEFAULT_WORKER_NAME_PREFIX
-    max_prefix_length = 63 - len(digest) - 1
+    max_prefix_length = _DNS_LABEL_MAX_LENGTH - len(digest) - 1
     safe_prefix = normalized_prefix[:max_prefix_length].rstrip("-")
     if not safe_prefix:
         safe_prefix = _DEFAULT_WORKER_NAME_PREFIX[:max_prefix_length].rstrip("-") or "worker"
+    return digest, safe_prefix
+
+
+def worker_id_for_key(worker_key: str, *, prefix: str) -> str:
+    """Return a DNS-safe resource name for one worker key (63-char label limit)."""
+    digest, safe_prefix = _digest_and_safe_prefix(worker_key, prefix, digest_length=_WORKER_ID_DIGEST_LENGTH)
     return f"{safe_prefix}-{digest}"
+
+
+def descriptive_worker_id_for_key(worker_key: str, *, prefix: str) -> str:
+    """Return a DNS-safe resource name that keeps the worker key's scope readable.
+
+    Embeds the key's tenant/scope/requester/agent parts as a lowercase slug
+    (dropping the `v1` version tag and the `default` tenant, and reducing
+    Matrix requesters to their localpart) so listings stay human-readable,
+    with a short digest for uniqueness after truncation.
+    """
+    digest, safe_prefix = _digest_and_safe_prefix(
+        worker_key,
+        prefix,
+        digest_length=_DESCRIPTIVE_WORKER_ID_DIGEST_LENGTH,
+    )
+    max_slug_length = max(0, _DNS_LABEL_MAX_LENGTH - len(safe_prefix) - len(digest) - 2)
+    slug = _worker_key_slug(worker_key, max_length=max_slug_length)
+    if not slug:
+        return f"{safe_prefix}-{digest}"
+    return f"{safe_prefix}-{slug}-{digest}"
+
+
+def _worker_key_slug(worker_key: str, *, max_length: int) -> str:
+    parts = worker_key.split(":")
+    if len(parts) >= 4 and parts[0] == "v1":
+        tenant, scope, rest = parts[1], parts[2], parts[3:]
+        if scope == "user":
+            rest = [_requester_localpart(":".join(rest))]
+        elif scope == "user_agent" and len(rest) >= 2:
+            rest = [_requester_localpart(":".join(rest[:-1])), rest[-1]]
+        parts = ([] if tenant == "default" else [tenant]) + [scope, *rest]
+    slug = re.sub(r"[^a-z0-9]+", "-", ":".join(parts).lower()).strip("-")
+    return slug[:max_length].rstrip("-")
+
+
+def _requester_localpart(requester: str) -> str:
+    """Return the localpart of a Matrix-style requester; other requesters pass through."""
+    if requester.startswith("@"):
+        return requester[1:].split(":", 1)[0]
+    return requester
 
 
 def _normalize_worker_requester_part(value: str) -> str:

--- a/src/mindroom/tool_system/worker_routing.py
+++ b/src/mindroom/tool_system/worker_routing.py
@@ -232,9 +232,9 @@ def normalize_worker_key_part(value: str) -> str:
 
 
 def _digest_and_safe_prefix(worker_key: str, prefix: str, *, digest_length: int) -> tuple[str, str]:
-    """Return the worker-key digest and a prefix normalized to fit a DNS label beside it."""
+    """Return the worker-key digest and a prefix normalized to a DNS-label-safe slug beside it."""
     digest = hashlib.sha256(worker_key.encode("utf-8")).hexdigest()[:digest_length]
-    normalized_prefix = prefix.strip().lower().strip("-") or _DEFAULT_WORKER_NAME_PREFIX
+    normalized_prefix = re.sub(r"[^a-z0-9-]+", "-", prefix.lower()).strip("-") or _DEFAULT_WORKER_NAME_PREFIX
     max_prefix_length = _DNS_LABEL_MAX_LENGTH - len(digest) - 1
     safe_prefix = normalized_prefix[:max_prefix_length].rstrip("-")
     if not safe_prefix:

--- a/src/mindroom/workers/backends/kubernetes_resources.py
+++ b/src/mindroom/workers/backends/kubernetes_resources.py
@@ -42,7 +42,7 @@ from mindroom.runtime_env_policy import (
     credentials_encryption_key_value,
     worker_extra_env,
 )
-from mindroom.tool_system.worker_routing import worker_id_for_key
+from mindroom.tool_system.worker_routing import descriptive_worker_id_for_key
 from mindroom.workers.backend import WorkerBackendError
 from mindroom.workers.backends._dedicated_worker_common import (
     plan_scoped_visible_state_roots,
@@ -641,7 +641,7 @@ class KubernetesResourceManager:
         cfg = self.config.agent_vault
         if cfg is None:
             return None
-        return worker_id_for_key(worker_key, prefix=cfg.vault_name_prefix)
+        return descriptive_worker_id_for_key(worker_key, prefix=cfg.vault_name_prefix)
 
     def _agent_vault_init_container(self, *, worker_key: str) -> dict[str, object]:
         cfg: KubernetesAgentVaultConfig | None = self.config.agent_vault

--- a/tests/test_agent_vault_access_grants.py
+++ b/tests/test_agent_vault_access_grants.py
@@ -17,7 +17,11 @@ from mindroom.agent_vault_access_grants import (
     resolve_agent_vault_access_grant_targets,
     wait_for_agent_vault_ready,
 )
-from mindroom.tool_system.worker_routing import ToolExecutionIdentity, resolve_worker_target, worker_id_for_key
+from mindroom.tool_system.worker_routing import (
+    ToolExecutionIdentity,
+    descriptive_worker_id_for_key,
+    resolve_worker_target,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -100,7 +104,7 @@ def test_resolves_shared_grant_to_runtime_worker_vault(tmp_path: Path) -> None:
     )
 
     assert target.worker_key == expected_worker_target.worker_key
-    assert target.vault == worker_id_for_key(expected_worker_target.worker_key, prefix="agent-vault")
+    assert target.vault == descriptive_worker_id_for_key(expected_worker_target.worker_key, prefix="agent-vault")
 
 
 def test_resolves_user_agent_grant_to_runtime_worker_vault(tmp_path: Path) -> None:
@@ -141,7 +145,7 @@ def test_resolves_user_agent_grant_to_runtime_worker_vault(tmp_path: Path) -> No
     )
 
     assert target.worker_key == expected_worker_target.worker_key
-    assert target.vault == worker_id_for_key(expected_worker_target.worker_key, prefix="agent-vault")
+    assert target.vault == descriptive_worker_id_for_key(expected_worker_target.worker_key, prefix="agent-vault")
 
 
 @pytest.mark.asyncio

--- a/tests/test_agent_vault_access_tool.py
+++ b/tests/test_agent_vault_access_tool.py
@@ -13,8 +13,8 @@ from mindroom.custom_tools.agent_vault_access import AgentVaultAccessTools, _Age
 from mindroom.tool_system.metadata import get_tool_by_name
 from mindroom.tool_system.worker_routing import (
     ToolExecutionIdentity,
+    descriptive_worker_id_for_key,
     resolve_worker_target,
-    worker_id_for_key,
 )
 
 if TYPE_CHECKING:
@@ -119,7 +119,7 @@ async def test_request_vault_access_grants_and_returns_link(
 ) -> None:
     """A first request resolves the vault, grants admin access, and returns the link."""
     target = _worker_target()
-    expected_vault = worker_id_for_key(target.worker_key, prefix="agent-vault")
+    expected_vault = descriptive_worker_id_for_key(target.worker_key, prefix="agent-vault")
     api = _FakeVaultAPI({"/v1/vaults": 201, "/join": 409, "/users": 201})
     _patch_client(monkeypatch, api)
 
@@ -150,7 +150,7 @@ async def test_request_vault_access_names_shared_vault_without_granting(
     _patch_client(monkeypatch, api)
 
     target = _worker_target(worker_scope="shared")
-    expected_vault = worker_id_for_key(target.worker_key, prefix="agent-vault")
+    expected_vault = descriptive_worker_id_for_key(target.worker_key, prefix="agent-vault")
     tool = AgentVaultAccessTools(runtime_paths=_runtime_paths(tmp_path), worker_target=target)
     payload = json.loads(await tool.request_vault_access())
 
@@ -168,7 +168,7 @@ async def test_shared_scope_tool_needs_only_ui_base_url(tmp_path: Path) -> None:
     """A shared-scope instance never reaches the grant API, so only the UI base URL is required."""
     env = {"MINDROOM_AGENT_VAULT_ACCESS_UI_BASE_URL": "https://example.test/agent-vault"}
     target = _worker_target(worker_scope="shared")
-    expected_vault = worker_id_for_key(target.worker_key, prefix="agent-vault")
+    expected_vault = descriptive_worker_id_for_key(target.worker_key, prefix="agent-vault")
 
     tool = AgentVaultAccessTools(runtime_paths=_runtime_paths(tmp_path, env=env), worker_target=target)
     payload = json.loads(await tool.request_vault_access())
@@ -247,7 +247,7 @@ async def test_request_vault_access_joins_worker_created_vault(
     the owner actor vault-admin) before POSTing the member grant.
     """
     target = _worker_target()
-    expected_vault = worker_id_for_key(target.worker_key, prefix="agent-vault")
+    expected_vault = descriptive_worker_id_for_key(target.worker_key, prefix="agent-vault")
     # Pre-existing vault (409 on create), not yet joined (200 on join).
     api = _FakeVaultAPI({"/v1/vaults": 409, "/join": 200, "/users": 201})
     _patch_client(monkeypatch, api)

--- a/tests/test_kubernetes_worker_backend.py
+++ b/tests/test_kubernetes_worker_backend.py
@@ -27,10 +27,10 @@ from mindroom.runtime_env_policy import CREDENTIALS_ENCRYPTION_KEY_ENV
 from mindroom.tool_system.worker_routing import (
     ToolExecutionIdentity,
     _private_instance_state_root_path,
+    descriptive_worker_id_for_key,
     resolve_unscoped_worker_key,
     resolve_worker_key,
     worker_dir_name,
-    worker_id_for_key,
 )
 from mindroom.workers.backend import WorkerBackendError
 from mindroom.workers.backends import kubernetes as kubernetes_backend_module
@@ -3118,7 +3118,7 @@ def test_kubernetes_backend_adds_agent_vault_mint_init_container(tmp_path: Path)
     assert 'export HOME="/agent-vault"' not in mint_script
     mint_env = {e["name"]: e["value"] for e in mint["env"]}
     # The vault name is the worker's own deterministic vault, owner email is configured.
-    assert mint_env["AGENT_VAULT_VAULT"] == worker_id_for_key(worker_key, prefix="agent-vault")
+    assert mint_env["AGENT_VAULT_VAULT"] == descriptive_worker_id_for_key(worker_key, prefix="agent-vault")
     assert mint_env["AGENT_VAULT_OWNER_EMAIL"] == "vault-owner@example.test"
     # The owner password (bootstrap secret) is mounted only on the init container.
     assert any(m["name"] == "agent-vault-bootstrap" for m in mint["volumeMounts"])
@@ -3127,7 +3127,7 @@ def test_kubernetes_backend_adds_agent_vault_mint_init_container(tmp_path: Path)
     assert all(m["name"] != "agent-vault-bootstrap" for m in main["volumeMounts"])
     assert any(m["name"] == "agent-vault-token" and m.get("readOnly") for m in main["volumeMounts"])
     main_env = {e["name"]: e.get("value") for e in main["env"]}
-    expected_vault = worker_id_for_key(worker_key, prefix="agent-vault")
+    expected_vault = descriptive_worker_id_for_key(worker_key, prefix="agent-vault")
     assert main_env["MINDROOM_WORKER_EGRESS_PROXY_URL"] == "http://agent-vault:14322"
     assert main_env["MINDROOM_WORKER_EGRESS_PROXY_TOKEN_FILE"] == "/agent-vault/token"  # noqa: S105
     assert main_env["MINDROOM_WORKER_EGRESS_PROXY_VAULT"] == expected_vault

--- a/tests/test_resolve_tool_worker_target.py
+++ b/tests/test_resolve_tool_worker_target.py
@@ -109,8 +109,20 @@ def test_router_dispatch_raises_a_purposeful_error(tmp_path: Path) -> None:
 def test_descriptive_worker_id_keeps_scope_readable() -> None:
     """Descriptive worker ids embed scope, requester localpart, and agent, dropping v1 and the default tenant."""
     name = descriptive_worker_id_for_key("v1:default:user_agent:@alice.doe:example.test:code", prefix="agent-vault")
-    assert name.startswith("agent-vault-user-agent-alice-doe-code-")
+    assert re.fullmatch(r"agent-vault-user-agent-alice-doe-code-[0-9a-f]{10}", name)
     assert len(name) <= 63
+
+
+def test_descriptive_worker_id_shared_scope_with_default_tenant() -> None:
+    """The most common shape, a default-tenant shared agent, reads as shared-<agent>."""
+    name = descriptive_worker_id_for_key("v1:default:shared:research", prefix="agent-vault")
+    assert name.startswith("agent-vault-shared-research-")
+
+
+def test_descriptive_worker_id_slugifies_non_dns_prefix_characters() -> None:
+    """Underscores or dots in a configured prefix are normalized to a DNS-safe slug."""
+    name = descriptive_worker_id_for_key("v1:default:shared:research", prefix="agent_vault.v2")
+    assert name.startswith("agent-vault-v2-shared-research-")
     assert re.fullmatch(r"[a-z0-9-]+", name)
 
 

--- a/tests/test_resolve_tool_worker_target.py
+++ b/tests/test_resolve_tool_worker_target.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock
 
@@ -10,6 +11,7 @@ import pytest
 from mindroom.config.main import Config
 from mindroom.constants import ROUTER_AGENT_NAME, resolve_primary_runtime_paths
 from mindroom.tool_system.runtime_context import ToolRuntimeContext
+from mindroom.tool_system.worker_routing import descriptive_worker_id_for_key
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -102,3 +104,43 @@ def test_router_dispatch_raises_a_purposeful_error(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="requires an agent dispatch"):
         context.resolve_worker_target()
+
+
+def test_descriptive_worker_id_keeps_scope_readable() -> None:
+    """Descriptive worker ids embed scope, requester localpart, and agent, dropping v1 and the default tenant."""
+    name = descriptive_worker_id_for_key("v1:default:user_agent:@alice.doe:example.test:code", prefix="agent-vault")
+    assert name.startswith("agent-vault-user-agent-alice-doe-code-")
+    assert len(name) <= 63
+    assert re.fullmatch(r"[a-z0-9-]+", name)
+
+
+def test_descriptive_worker_id_user_scope_uses_requester_localpart() -> None:
+    """A user-scoped key keeps only the requester's Matrix localpart, not the homeserver."""
+    name = descriptive_worker_id_for_key("v1:default:user:@alice.doe:example.test", prefix="agent-vault")
+    assert name.startswith("agent-vault-user-alice-doe-")
+
+
+def test_descriptive_worker_id_keeps_non_default_tenant() -> None:
+    """A non-default tenant stays visible in the descriptive name."""
+    name = descriptive_worker_id_for_key("v1:acme:shared:code", prefix="agent-vault")
+    assert name.startswith("agent-vault-acme-shared-code-")
+
+
+def test_descriptive_worker_id_is_stable_and_unique_after_truncation() -> None:
+    """Two keys sharing a long slug prefix still get distinct, stable, DNS-safe names."""
+    long_requester = "@" + "a" * 80 + ":example.org"
+    first = descriptive_worker_id_for_key(f"v1:default:user_agent:{long_requester}:alpha", prefix="agent-vault")
+    second = descriptive_worker_id_for_key(f"v1:default:user_agent:{long_requester}:beta", prefix="agent-vault")
+    assert first != second
+    assert len(first) <= 63
+    assert len(second) <= 63
+    assert first == descriptive_worker_id_for_key(f"v1:default:user_agent:{long_requester}:alpha", prefix="agent-vault")
+
+
+def test_descriptive_worker_id_long_prefix_leaves_no_slug_room() -> None:
+    """A prefix consuming the whole label budget falls back to prefix-digest within 63 chars."""
+    long_prefix = "a" * 80
+    name = descriptive_worker_id_for_key("v1:default:user_agent:@alice.doe:example.test:code", prefix=long_prefix)
+    assert len(name) <= 63
+    assert re.fullmatch(r"[a-z0-9-]+", name)
+    assert name.startswith("a" * 52)


### PR DESCRIPTION
## Summary

Agent Vault vault names were an opaque hash of the worker key (`agent-vault-6b86b273ff34fce19d6b804e`), which made the vault admin listing impossible to scan. Vault names are now derived with a new `descriptive_worker_id_for_key` helper that keeps the worker key's readable parts — tenant (when non-default), scope, requester Matrix localpart, agent — as a lowercase DNS-safe slug plus a 10-hex digest for uniqueness after truncation, still within the 63-char label limit:

```
agent-vault-6b86b273ff34fce19d6b804e  ->  agent-vault-user-agent-alice-mind-6b86b273ff
agent-vault-d4735e3a265e16eee03f5971  ->  agent-vault-shared-research-d4735e3a26
```

All three vault-name derivation sites share the helper: the worker mint init container (`kubernetes_resources.py`), the `agent_vault_access` self-service tool, and the declarative access grants. Kubernetes worker resource names intentionally keep the old hashed scheme — renaming live worker Deployments/Secrets/PVC subpaths is a separate blast radius.

The requester keeps only its Matrix localpart (second commit) because full homeservers consume the 63-char budget and truncate away the agent name; the digest still disambiguates same-localpart requesters on different homeservers.

## Migration notes

Names are derived deterministically, so existing vaults keep their old hashed names and workers mint fresh vaults under new names after this deploys. Vaults are identified internally by UUID, so `agent-vault vault rename <old> <new>` migrates a populated vault losslessly (credentials and memberships survive; the mint script adopts the renamed vault on the next worker start). If a worker already auto-minted the empty new-name vault, delete it first — rename refuses to overwrite an existing name.

Lockstep dependency: any deployment automation that derives vault names by importing `worker_id_for_key` (e.g. an access-grants job) must switch to `descriptive_worker_id_for_key` in the same change that bumps the image.

## Testing

- New unit tests for slug derivation, localpart handling, non-default tenant, stability/uniqueness under truncation, and the zero-slug-budget fallback
- Updated vault-name expectations in the access tool, access grants, and kubernetes backend tests
- `pre-commit` and `tach check --dependencies --interfaces` pass

## Summary by Sourcery

Introduce human-readable Agent Vault names derived from worker keys while preserving DNS label constraints and deterministic uniqueness.

Enhancements:
- Add descriptive_worker_id_for_key to derive readable, slug-based worker identifiers alongside the existing hashed worker_id_for_key.
- Update Agent Vault minting, access grants, and self-service tooling to use descriptive vault names that encode tenant, scope, requester localpart, and agent where available.
- Refine worker ID derivation logic to share digest/prefix handling and support graceful fallback when no slug budget is available.

Documentation:
- Document the new descriptive vault naming scheme and its use in Kubernetes Agent Vault egress and the self-service access tool.
- Clarify configuration comments for Agent Vault vaultNamePrefix to reference the descriptive ID helper.

Tests:
- Add unit tests covering descriptive worker ID slug derivation, requester localpart handling, tenant visibility, truncation behavior, and fallback when the prefix exhausts the DNS label budget.
- Adjust Agent Vault access, access grants, and Kubernetes backend tests to expect the new descriptive vault naming behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more readable worker/vault identifiers in several workflows, making per-worker names easier to recognize while staying DNS-safe.
  * Self-service vault access and Kubernetes-backed vault setup now use the updated naming format consistently.

* **Documentation**
  * Updated deployment and reference docs to match the new worker/vault naming format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

