### PR TITLE
Preserve subprocess isolation for shell background handles via a worker-local supervisor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,8 @@ Matrix sync callback
 | `commands/config_confirmation.py` | Interactive config confirmation workflows |
 | `voice_handler.py` | Voice message download, transcription, and command recognition |
 | `tool_system/sandbox_proxy.py` | Container sandbox proxy for isolating shell/python tools |
+| `shell_execution.py` | Shell command execution core: spawning, output buffering, background handle registry |
+| `shell_supervisor.py` | Worker-local shell supervisor process owning background shell handles across sandbox request subprocesses |
 | `streaming.py` | Streaming state machine: placeholder, progressive edits, tool traces, cancellation |
 | `prompts.py` | Built-in prompt defaults and prompt override registry |
 | `attachments.py` | Attachment persistence, registration, and context-scoped resolution |

--- a/docs/deployment/sandbox-proxy.md
+++ b/docs/deployment/sandbox-proxy.md
@@ -332,7 +332,7 @@ If you deploy that mode without Helm, see [Kubernetes Deployment](kubernetes.md)
 | `MINDROOM_STORAGE_PATH` | Writable directory for tool registry init and worker-local caches (e.g., `/app/workspace/.mindroom`) | `mindroom_data` next to config _(will fail if not writable)_ |
 | `MINDROOM_CONFIG_PATH` | Path to config.yaml (for plugin tool registration) | _(optional)_ |
 
-`subprocess` runs every non-shell tool call in a fresh `python -m mindroom.api.sandbox_runner` child that re-imports the runtime on each call.
+`subprocess` runs every tool call in a fresh `python -m mindroom.api.sandbox_runner` child that re-imports the runtime on each call.
 `forkserver` keeps one warm template process per interpreter that imports the runtime once and forks a fresh child per call, preserving per-call process isolation while removing the per-call import cost.
 Dedicated Docker and Kubernetes workers default to `forkserver`.
 If the warm template fails to start, dispatch falls back to spawn-per-call and retries the template after a cooldown.
@@ -444,8 +444,9 @@ It also proves garbage and missing proxy session tokens are refused.
 
 Shell commands that exceed their timeout return a background handle.
 Use `check_shell_command(handle)` to poll and `kill_shell_command(handle)` to stop the process.
-These handles are process-local to the sandbox runner: they survive multiple requests to the same runner process, but not runner restarts.
-To make that work, shell background-handle requests stay owned by the long-lived runner process even when `MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE` is `subprocess` or `forkserver`.
+Handles are owned by a small worker-local shell supervisor process that the runner spawns on first shell use: they survive multiple requests to the same runner, but not runner or worker restarts.
+Shell requests run in per-request subprocesses like every other execution tool; the request process computes the shell env and cwd, then relays run/check/kill to the supervisor over a unix socket advertised via `MINDROOM_SANDBOX_SHELL_SUPERVISOR_SOCKET`.
+When the supervisor exits (runner shutdown, worker restart, or orphaning), it kills any still-running supervised process groups, so handles are invalidated without leaking processes.
 
 ## Workspace home contract
 

--- a/docs/tools/execution-and-coding.md
+++ b/docs/tools/execution-and-coding.md
@@ -195,7 +195,7 @@ kill_shell_command("shell:abcd1234")
   MindRoom forwards no committed runtime `.env` values by default; matched values pass through except credential seed declarations, Kubernetes worker backend config env names, runner control names including `MINDROOM_CREDENTIALS_ENCRYPTION_KEY`, and names starting with `MINDROOM_SANDBOX_`.
 - Use explicit argv lists for commands that need exact argument boundaries.
 - In authored YAML, `extra_env_passthrough` and `shell_path_prepend` can be written as lists, and MindRoom normalizes them to the tool's comma-or-newline form.
-- Background handles survive multiple requests to the same long-lived runner process, but they do not survive runner restarts.
+- Background handles live in a worker-local shell supervisor process: they survive multiple requests to the same runner, but not runner or worker restarts.
 - `shell_path_prepend` deduplicates PATH entries and only changes subprocess PATH, not the main MindRoom process PATH.
 - For per-workspace env that an agent can edit on the fly (PATH prefixes, `NPM_CONFIG_PREFIX`, `NPM_CONFIG_CACHE`, `PIP_INDEX_URL`, etc.), drop a `.mindroom/worker-env.sh` script in the workspace and `export` the values you want — see "Workspace env hook" in `docs/deployment/sandbox-proxy.md`.
 - MindRoom-owned env names are reasserted after the hook and cannot be redirected from `.mindroom/worker-env.sh`: `HOME`, `MINDROOM_AGENT_WORKSPACE`, `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `XDG_STATE_HOME`, `XDG_CACHE_HOME`, `PIP_CACHE_DIR`, `UV_CACHE_DIR`, `PYTHONPYCACHEPREFIX`, and `VIRTUAL_ENV`.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -16136,7 +16136,7 @@ If you deploy that mode without Helm, see [Kubernetes Deployment](https://docs.m
 | `MINDROOM_STORAGE_PATH` | Writable directory for tool registry init and worker-local caches (e.g., `/app/workspace/.mindroom`) | `mindroom_data` next to config _(will fail if not writable)_ |
 | `MINDROOM_CONFIG_PATH` | Path to config.yaml (for plugin tool registration) | _(optional)_ |
 
-`subprocess` runs every non-shell tool call in a fresh `python -m mindroom.api.sandbox_runner` child that re-imports the runtime on each call.
+`subprocess` runs every tool call in a fresh `python -m mindroom.api.sandbox_runner` child that re-imports the runtime on each call.
 `forkserver` keeps one warm template process per interpreter that imports the runtime once and forks a fresh child per call, preserving per-call process isolation while removing the per-call import cost.
 Dedicated Docker and Kubernetes workers default to `forkserver`.
 If the warm template fails to start, dispatch falls back to spawn-per-call and retries the template after a cooldown.
@@ -16248,8 +16248,9 @@ It also proves garbage and missing proxy session tokens are refused.
 
 Shell commands that exceed their timeout return a background handle.
 Use `check_shell_command(handle)` to poll and `kill_shell_command(handle)` to stop the process.
-These handles are process-local to the sandbox runner: they survive multiple requests to the same runner process, but not runner restarts.
-To make that work, shell background-handle requests stay owned by the long-lived runner process even when `MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE` is `subprocess` or `forkserver`.
+Handles are owned by a small worker-local shell supervisor process that the runner spawns on first shell use: they survive multiple requests to the same runner, but not runner or worker restarts.
+Shell requests run in per-request subprocesses like every other execution tool; the request process computes the shell env and cwd, then relays run/check/kill to the supervisor over a unix socket advertised via `MINDROOM_SANDBOX_SHELL_SUPERVISOR_SOCKET`.
+When the supervisor exits (runner shutdown, worker restart, or orphaning), it kills any still-running supervised process groups, so handles are invalidated without leaking processes.
 
 ## Workspace home contract
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -3197,7 +3197,7 @@ kill_shell_command("shell:abcd1234")
   MindRoom forwards no committed runtime `.env` values by default; matched values pass through except credential seed declarations, Kubernetes worker backend config env names, runner control names including `MINDROOM_CREDENTIALS_ENCRYPTION_KEY`, and names starting with `MINDROOM_SANDBOX_`.
 - Use explicit argv lists for commands that need exact argument boundaries.
 - In authored YAML, `extra_env_passthrough` and `shell_path_prepend` can be written as lists, and MindRoom normalizes them to the tool's comma-or-newline form.
-- Background handles survive multiple requests to the same long-lived runner process, but they do not survive runner restarts.
+- Background handles live in a worker-local shell supervisor process: they survive multiple requests to the same runner, but not runner or worker restarts.
 - `shell_path_prepend` deduplicates PATH entries and only changes subprocess PATH, not the main MindRoom process PATH.
 - For per-workspace env that an agent can edit on the fly (PATH prefixes, `NPM_CONFIG_PREFIX`, `NPM_CONFIG_CACHE`, `PIP_INDEX_URL`, etc.), drop a `.mindroom/worker-env.sh` script in the workspace and `export` the values you want — see "Workspace env hook" in `docs/deployment/sandbox-proxy.md`.
 - MindRoom-owned env names are reasserted after the hook and cannot be redirected from `.mindroom/worker-env.sh`: `HOME`, `MINDROOM_AGENT_WORKSPACE`, `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `XDG_STATE_HOME`, `XDG_CACHE_HOME`, `PIP_CACHE_DIR`, `UV_CACHE_DIR`, `PYTHONPYCACHEPREFIX`, and `VIRTUAL_ENV`.

--- a/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
+++ b/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
@@ -328,7 +328,7 @@ If you deploy that mode without Helm, see [Kubernetes Deployment](https://docs.m
 | `MINDROOM_STORAGE_PATH` | Writable directory for tool registry init and worker-local caches (e.g., `/app/workspace/.mindroom`) | `mindroom_data` next to config _(will fail if not writable)_ |
 | `MINDROOM_CONFIG_PATH` | Path to config.yaml (for plugin tool registration) | _(optional)_ |
 
-`subprocess` runs every non-shell tool call in a fresh `python -m mindroom.api.sandbox_runner` child that re-imports the runtime on each call.
+`subprocess` runs every tool call in a fresh `python -m mindroom.api.sandbox_runner` child that re-imports the runtime on each call.
 `forkserver` keeps one warm template process per interpreter that imports the runtime once and forks a fresh child per call, preserving per-call process isolation while removing the per-call import cost.
 Dedicated Docker and Kubernetes workers default to `forkserver`.
 If the warm template fails to start, dispatch falls back to spawn-per-call and retries the template after a cooldown.
@@ -440,8 +440,9 @@ It also proves garbage and missing proxy session tokens are refused.
 
 Shell commands that exceed their timeout return a background handle.
 Use `check_shell_command(handle)` to poll and `kill_shell_command(handle)` to stop the process.
-These handles are process-local to the sandbox runner: they survive multiple requests to the same runner process, but not runner restarts.
-To make that work, shell background-handle requests stay owned by the long-lived runner process even when `MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE` is `subprocess` or `forkserver`.
+Handles are owned by a small worker-local shell supervisor process that the runner spawns on first shell use: they survive multiple requests to the same runner, but not runner or worker restarts.
+Shell requests run in per-request subprocesses like every other execution tool; the request process computes the shell env and cwd, then relays run/check/kill to the supervisor over a unix socket advertised via `MINDROOM_SANDBOX_SHELL_SUPERVISOR_SOCKET`.
+When the supervisor exits (runner shutdown, worker restart, or orphaning), it kills any still-running supervised process groups, so handles are invalidated without leaking processes.
 
 ## Workspace home contract
 

--- a/skills/mindroom-docs/references/page__tools__execution-and-coding__index.md
+++ b/skills/mindroom-docs/references/page__tools__execution-and-coding__index.md
@@ -191,7 +191,7 @@ kill_shell_command("shell:abcd1234")
   MindRoom forwards no committed runtime `.env` values by default; matched values pass through except credential seed declarations, Kubernetes worker backend config env names, runner control names including `MINDROOM_CREDENTIALS_ENCRYPTION_KEY`, and names starting with `MINDROOM_SANDBOX_`.
 - Use explicit argv lists for commands that need exact argument boundaries.
 - In authored YAML, `extra_env_passthrough` and `shell_path_prepend` can be written as lists, and MindRoom normalizes them to the tool's comma-or-newline form.
-- Background handles survive multiple requests to the same long-lived runner process, but they do not survive runner restarts.
+- Background handles live in a worker-local shell supervisor process: they survive multiple requests to the same runner, but not runner or worker restarts.
 - `shell_path_prepend` deduplicates PATH entries and only changes subprocess PATH, not the main MindRoom process PATH.
 - For per-workspace env that an agent can edit on the fly (PATH prefixes, `NPM_CONFIG_PREFIX`, `NPM_CONFIG_CACHE`, `PIP_INDEX_URL`, etc.), drop a `.mindroom/worker-env.sh` script in the workspace and `export` the values you want — see "Workspace env hook" in `docs/deployment/sandbox-proxy.md`.
 - MindRoom-owned env names are reasserted after the hook and cannot be redirected from `.mindroom/worker-env.sh`: `HOME`, `MINDROOM_AGENT_WORKSPACE`, `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `XDG_STATE_HOME`, `XDG_CACHE_HOME`, `PIP_CACHE_DIR`, `UV_CACHE_DIR`, `PYTHONPYCACHEPREFIX`, and `VIRTUAL_ENV`.

--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Annotated, Any, Literal, cast
 from fastapi import APIRouter, Depends, FastAPI, Header, HTTPException, Request
 from pydantic import BaseModel, Field, ValidationError
 
-from mindroom import constants
+from mindroom import constants, shell_supervisor
 from mindroom.api import sandbox_env_assembly, sandbox_exec, sandbox_forkserver, sandbox_protocol, sandbox_worker_prep
 from mindroom.api.worker_responses import (
     SandboxWorkerCleanupResponse,
@@ -41,6 +41,7 @@ from mindroom.runtime_env_policy import (
     sandbox_runner_startup_process_env,
 )
 from mindroom.runtime_resolution import resolve_agent_runtime
+from mindroom.shell_execution import DEFAULT_RUN_TIMEOUT_SECONDS
 from mindroom.tool_system.catalog import (
     TOOL_METADATA,
     ToolConfigOverrideError,
@@ -83,6 +84,7 @@ logger = get_logger(__name__)
 
 _SUBPROCESS_WORKER_ARG = "--sandbox-subprocess-worker"
 _WORKSPACE_ENV_HOOK_TOOL_NAMES = frozenset({"shell", "python"})
+_SHELL_DISPATCH_TIMEOUT_GRACE_SECONDS = 30.0
 _STARTUP_RUNTIME_PATHS_JSON_ENV = "MINDROOM_RUNTIME_PATHS_JSON"
 
 
@@ -1198,6 +1200,39 @@ def _execute_request_forkserver(
     return _parse_subprocess_response(request, runtime_paths, completed)
 
 
+def _shell_run_timeout_seconds(prepared: PreparedSandboxRunnerExecuteRequest) -> float:
+    """Return the foreground wait requested by one run_shell_command call."""
+    if prepared.function_name != "run_shell_command":
+        return 0.0
+    raw_timeout = prepared.kwargs.get("timeout", DEFAULT_RUN_TIMEOUT_SECONDS)
+    try:
+        return max(0.0, float(raw_timeout))
+    except (TypeError, ValueError):
+        return float(DEFAULT_RUN_TIMEOUT_SECONDS)
+
+
+def _shell_subprocess_dispatch_context(
+    prepared: PreparedSandboxRunnerExecuteRequest,
+    subprocess_context: _PreparedSandboxSubprocessContext,
+    timeout_seconds: float,
+) -> tuple[_PreparedSandboxSubprocessContext, float]:
+    """Attach the shell supervisor socket and cover the shell timeout in the budget.
+
+    Background shell handles live in the runner's long-lived supervisor
+    process, so the per-request subprocess only relays the call. Its budget
+    must outlast the shell command's own foreground timeout or the runner
+    would kill the relay (and with it the supervised command) mid-wait.
+    """
+    socket_path = shell_supervisor.ensure_shell_supervisor()
+    subprocess_env = dict(subprocess_context.subprocess_env or {})
+    subprocess_env[shell_supervisor.SHELL_SUPERVISOR_SOCKET_ENV] = socket_path
+    timeout_seconds = max(
+        timeout_seconds,
+        _shell_run_timeout_seconds(prepared) + _SHELL_DISPATCH_TIMEOUT_GRACE_SECONDS,
+    )
+    return replace(subprocess_context, subprocess_env=subprocess_env), timeout_seconds
+
+
 def _execute_request_subprocess_sync(
     request: SandboxRunnerExecuteRequest,
     runtime_paths: RuntimePaths,
@@ -1225,6 +1260,15 @@ def _execute_request_subprocess_sync(
         runtime_paths=constants.serialize_runtime_paths(prepared_request.runtime_paths),
     )
     timeout_seconds = sandbox_exec.runner_subprocess_timeout_seconds(runtime_paths)
+    if prepared_request.request.tool_name == "shell":
+        try:
+            subprocess_context, timeout_seconds = _shell_subprocess_dispatch_context(
+                prepared_request.request,
+                subprocess_context,
+                timeout_seconds,
+            )
+        except shell_supervisor.ShellSupervisorStartupError as exc:
+            return _subprocess_failure_response(request, str(exc), runtime_paths)
 
     if sandbox_exec.runner_uses_forkserver(runtime_paths) and sandbox_forkserver.forkserver_supported():
         forkserver_response = _execute_request_forkserver(
@@ -1558,10 +1602,7 @@ async def execute_tool_call(
             if exc.failure_kind == "worker":
                 return SandboxRunnerExecuteResponse(ok=False, error=str(exc), failure_kind="worker")
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-    # Shell background handles live in the long-lived runner process, so shell
-    # must stay on the in-process path even when the runner defaults to
-    # per-request subprocess execution.
-    if payload.tool_name != "shell" and sandbox_exec.runner_uses_subprocess(runtime_paths):
+    if sandbox_exec.runner_uses_subprocess(runtime_paths):
         return await _execute_request_subprocess(
             payload,
             runtime_paths,
@@ -1582,7 +1623,7 @@ async def execute_tool_call(
     # Worker-routed execution stays on the subprocess path so the per-worker
     # virtualenv and worker-specific process environment remain authoritative,
     # even when this pod is itself a dedicated worker runtime.
-    if payload.tool_name != "shell" and payload.worker_key is not None:
+    if payload.worker_key is not None:
         return await _execute_request_subprocess(
             payload,
             runtime_paths,

--- a/src/mindroom/shell_execution.py
+++ b/src/mindroom/shell_execution.py
@@ -112,6 +112,19 @@ class ProcessRecord:
     _monitor_task: asyncio.Task[None] | None = field(default=None, repr=False)
 
 
+@dataclass(frozen=True)
+class _RunResult:
+    """Outcome of one run_command call.
+
+    ``handle`` is set only when the command timed out and was registered as a
+    background record, so callers that could not deliver the message can roll
+    the registration back with ``discard_background_record``.
+    """
+
+    message: str
+    handle: str | None = None
+
+
 async def run_command(
     registry: dict[str, ProcessRecord],
     *,
@@ -121,7 +134,7 @@ async def run_command(
     cwd: str | None,
     tail: int,
     timeout: float,  # noqa: ASYNC109
-) -> str:
+) -> _RunResult:
     """Run one shell command; return output, an error message, or a background handle.
 
     When the command completes within ``timeout`` seconds the last ``tail``
@@ -142,7 +155,7 @@ async def run_command(
             start_new_session=True,
         )
     except Exception as exc:
-        return f"Error: {exc}"
+        return _RunResult(message=f"Error: {exc}")
 
     stdout_buf = _OutputBuffer()
     stderr_buf = _OutputBuffer()
@@ -161,9 +174,11 @@ async def run_command(
                 with contextlib.suppress(ProcessLookupError, PermissionError):
                     os.killpg(process.pid, signal.SIGKILL)
                 await _cancel_pending_tasks(stdout_reader, stderr_reader)
-                return (
-                    f"Error: Too many backgrounded processes ({active}/{_MAX_BACKGROUNDED}). "
-                    "Kill or wait for existing ones before running more."
+                return _RunResult(
+                    message=(
+                        f"Error: Too many backgrounded processes ({active}/{_MAX_BACKGROUNDED}). "
+                        "Kill or wait for existing ones before running more."
+                    ),
                 )
             handle = f"shell:{uuid.uuid4().hex[:8]}"
             record = ProcessRecord(
@@ -183,11 +198,14 @@ async def run_command(
             background_handle = handle
             background_monitor_task = record._monitor_task
             await asyncio.sleep(0)
-            return (
-                f"Command timed out after {timeout}s. Still running (PID {process.pid}).\n"
-                f"Handle: {handle}\n"
-                f"Use check_shell_command('{handle}') to poll or "
-                f"kill_shell_command('{handle}') to stop."
+            return _RunResult(
+                message=(
+                    f"Command timed out after {timeout}s. Still running (PID {process.pid}).\n"
+                    f"Handle: {handle}\n"
+                    f"Use check_shell_command('{handle}') to poll or "
+                    f"kill_shell_command('{handle}') to stop."
+                ),
+                handle=handle,
             )
 
         await _await_reader_tasks_with_grace(
@@ -209,8 +227,8 @@ async def run_command(
         raise
 
     if process.returncode != 0:
-        return f"Error: {stderr_buf.render()}"
-    return stdout_buf.render(tail=tail)
+        return _RunResult(message=f"Error: {stderr_buf.render()}")
+    return _RunResult(message=stdout_buf.render(tail=tail))
 
 
 def check_command(registry: dict[str, ProcessRecord], *, namespace: str, handle: str) -> str:
@@ -260,12 +278,23 @@ def kill_command(registry: dict[str, ProcessRecord], *, namespace: str, handle: 
 def kill_all_records(registry: dict[str, ProcessRecord]) -> None:
     """Kill every unfinished process group in *registry* and clear it."""
     for record in registry.values():
-        if record._monitor_task is not None:
-            record._monitor_task.cancel()
-        if not record.finished:
-            with contextlib.suppress(ProcessLookupError, PermissionError):
-                os.killpg(record.pid, signal.SIGKILL)
+        _kill_record(record)
     registry.clear()
+
+
+def discard_background_record(registry: dict[str, ProcessRecord], handle: str) -> None:
+    """Kill and drop one just-registered background record whose handle is undeliverable."""
+    record = registry.pop(handle, None)
+    if record is not None:
+        _kill_record(record)
+
+
+def _kill_record(record: ProcessRecord) -> None:
+    if record._monitor_task is not None:
+        record._monitor_task.cancel()
+    if not record.finished:
+        with contextlib.suppress(ProcessLookupError, PermissionError):
+            os.killpg(record.pid, signal.SIGKILL)
 
 
 def _sweep_stale_records(registry: dict[str, ProcessRecord]) -> None:
@@ -380,7 +409,7 @@ async def _terminate_process_group(
     if process.returncode is None:
         with contextlib.suppress(ProcessLookupError, PermissionError):
             os.killpg(process.pid, signal.SIGKILL)
-        with contextlib.suppress(asyncio.TimeoutError):
+        with contextlib.suppress(TimeoutError):
             await asyncio.wait_for(process.wait(), timeout=grace_period)
 
 

--- a/src/mindroom/shell_execution.py
+++ b/src/mindroom/shell_execution.py
@@ -1,0 +1,404 @@
+"""Shell command execution core with timeout-to-handle background support.
+
+This module owns the process spawning, output buffering, and background
+handle registry shared by the shell toolkit (local execution) and the
+worker-local shell supervisor process. It must stay importable without the
+heavy `mindroom.tools` package so the supervisor process starts fast.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import codecs
+import contextlib
+import os
+import signal
+import time
+import uuid
+from collections import deque
+from dataclasses import dataclass, field
+
+DEFAULT_RUN_TIMEOUT_SECONDS = 120
+
+_STALE_RECORD_SECONDS = 600  # 10 minutes
+_MAX_BACKGROUNDED = 16
+_MAX_OUTPUT_LINES = 10_000
+_MAX_OUTPUT_BYTES = 50 * 1024
+_STREAM_READ_CHUNK_BYTES = 8192
+_PROCESS_EXIT_POLL_INTERVAL_SECONDS = 0.05
+_POST_EXIT_READER_GRACE_SECONDS = 0.5
+
+
+@dataclass
+class _OutputBuffer:
+    """Bound shell output by both line count and encoded byte size."""
+
+    max_lines: int = _MAX_OUTPUT_LINES
+    max_bytes: int = _MAX_OUTPUT_BYTES
+    chunks: deque[str] = field(default_factory=deque)
+    byte_count: int = 0
+    truncated: bool = False
+
+    def append(self, text: str) -> None:
+        if not text:
+            return
+
+        encoded = text.encode("utf-8", errors="replace")
+        if len(encoded) > self.max_bytes:
+            text = encoded[-self.max_bytes :].decode("utf-8", errors="ignore")
+            encoded = text.encode("utf-8", errors="replace")
+            self.truncated = True
+
+        self.chunks.append(text)
+        self.byte_count += len(encoded)
+
+        while self.chunks and self.byte_count > self.max_bytes:
+            removed = self.chunks.popleft()
+            self.byte_count -= len(removed.encode("utf-8", errors="replace"))
+            self.truncated = True
+
+        self._trim_to_max_lines()
+
+    def render(self, *, tail: int | None = None) -> str:
+        output = self._rendered_text()
+        output_lines = output.split("\n") if output else []
+        if tail is not None:
+            output_lines = output_lines[-tail:]
+        output = "\n".join(output_lines)
+        if not self.truncated:
+            return output
+
+        notice = (
+            f"[Output truncated to the last {self.max_bytes} bytes. "
+            "Redirect command output to a file for complete results.]"
+        )
+        return f"{notice}\n{output}" if output else notice
+
+    def __len__(self) -> int:
+        output = self._rendered_text()
+        return len(output.split("\n")) if output else 0
+
+    def _rendered_text(self) -> str:
+        return "".join(self.chunks).rstrip("\n")
+
+    def _trim_to_max_lines(self) -> None:
+        output = self._rendered_text()
+        lines = output.split("\n")
+        if len(lines) <= self.max_lines:
+            return
+
+        output = "\n".join(lines[-self.max_lines :])
+        self.chunks = deque([output])
+        self.byte_count = len(output.encode("utf-8", errors="replace"))
+        self.truncated = True
+
+
+@dataclass
+class ProcessRecord:
+    """Tracks a backgrounded shell process."""
+
+    namespace: str
+    handle: str
+    pid: int
+    args: list[str]
+    process: asyncio.subprocess.Process
+    stdout_buf: _OutputBuffer = field(default_factory=_OutputBuffer)
+    stderr_buf: _OutputBuffer = field(default_factory=_OutputBuffer)
+    started_at: float = field(default_factory=time.monotonic)
+    tail: int = 100
+    finished: bool = False
+    finished_at: float | None = None
+    return_code: int | None = None
+    _monitor_task: asyncio.Task[None] | None = field(default=None, repr=False)
+
+
+async def run_command(
+    registry: dict[str, ProcessRecord],
+    *,
+    namespace: str,
+    argv: list[str],
+    env: dict[str, str],
+    cwd: str | None,
+    tail: int,
+    timeout: float,  # noqa: ASYNC109
+) -> str:
+    """Run one shell command; return output, an error message, or a background handle.
+
+    When the command completes within ``timeout`` seconds the last ``tail``
+    lines of stdout are returned (or the stderr on non-zero exit). When the
+    timeout is exceeded the process keeps running under *registry* and a
+    handle string is returned for ``check_command``/``kill_command``.
+    Cancellation terminates the process group and drops any registered handle.
+    """
+    _sweep_stale_records(registry)
+
+    try:
+        process = await asyncio.create_subprocess_exec(
+            *argv,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=cwd,
+            env=env,
+            start_new_session=True,
+        )
+    except Exception as exc:
+        return f"Error: {exc}"
+
+    stdout_buf = _OutputBuffer()
+    stderr_buf = _OutputBuffer()
+    background_handle: str | None = None
+    background_monitor_task: asyncio.Task[None] | None = None
+
+    stdout_reader = asyncio.create_task(_read_stream(process.stdout, stdout_buf))
+    stderr_reader = asyncio.create_task(_read_stream(process.stderr, stderr_buf))
+
+    try:
+        try:
+            await _await_foreground_process_exit(process, timeout_seconds=timeout)
+        except TimeoutError:
+            active = sum(1 for r in registry.values() if not r.finished)
+            if active >= _MAX_BACKGROUNDED:
+                with contextlib.suppress(ProcessLookupError, PermissionError):
+                    os.killpg(process.pid, signal.SIGKILL)
+                await _cancel_pending_tasks(stdout_reader, stderr_reader)
+                return (
+                    f"Error: Too many backgrounded processes ({active}/{_MAX_BACKGROUNDED}). "
+                    "Kill or wait for existing ones before running more."
+                )
+            handle = f"shell:{uuid.uuid4().hex[:8]}"
+            record = ProcessRecord(
+                namespace=namespace,
+                handle=handle,
+                pid=process.pid,
+                args=argv,
+                process=process,
+                stdout_buf=stdout_buf,
+                stderr_buf=stderr_buf,
+                tail=tail,
+            )
+            record._monitor_task = asyncio.create_task(
+                _monitor_process(registry, handle, process, stdout_reader, stderr_reader),
+            )
+            registry[handle] = record
+            background_handle = handle
+            background_monitor_task = record._monitor_task
+            await asyncio.sleep(0)
+            return (
+                f"Command timed out after {timeout}s. Still running (PID {process.pid}).\n"
+                f"Handle: {handle}\n"
+                f"Use check_shell_command('{handle}') to poll or "
+                f"kill_shell_command('{handle}') to stop."
+            )
+
+        await _await_reader_tasks_with_grace(
+            stdout_reader,
+            stderr_reader,
+            grace_seconds=_POST_EXIT_READER_GRACE_SECONDS,
+        )
+    except asyncio.CancelledError:
+        if background_handle is not None:
+            registry.pop(background_handle, None)
+        if background_monitor_task is not None:
+            background_monitor_task.cancel()
+        if process.returncode is None:
+            await _terminate_process_group(process)
+        await _cancel_pending_tasks(stdout_reader, stderr_reader)
+        if background_monitor_task is not None:
+            with contextlib.suppress(asyncio.CancelledError):
+                await background_monitor_task
+        raise
+
+    if process.returncode != 0:
+        return f"Error: {stderr_buf.render()}"
+    return stdout_buf.render(tail=tail)
+
+
+def check_command(registry: dict[str, ProcessRecord], *, namespace: str, handle: str) -> str:
+    """Poll the status of a backgrounded shell command in *registry*."""
+    record = registry.get(handle)
+    if record is None or record.namespace != namespace:
+        return f"Error: Unknown handle '{handle}'"
+
+    elapsed = time.monotonic() - record.started_at
+
+    if record.finished:
+        output = record.stdout_buf.render(tail=record.tail)
+        errors = record.stderr_buf.render()
+        result = f"Status: FINISHED (exit code {record.return_code}, ran for {elapsed:.1f}s)\n"
+        if record.return_code != 0 and errors:
+            result += f"Stderr:\n{errors}\n"
+        result += f"Output:\n{output}"
+        return result
+
+    partial = record.stdout_buf.render(tail=50)
+    return (
+        f"Status: RUNNING (PID {record.pid}, elapsed {elapsed:.1f}s)\n"
+        f"Partial output ({len(record.stdout_buf)} lines buffered):\n{partial}"
+    )
+
+
+def kill_command(registry: dict[str, ProcessRecord], *, namespace: str, handle: str, force: bool = False) -> str:
+    """Kill a backgrounded shell command tracked in *registry*."""
+    record = registry.get(handle)
+    if record is None or record.namespace != namespace:
+        return f"Error: Unknown handle '{handle}'"
+
+    if record.finished:
+        return f"Process already finished (exit code {record.return_code})"
+
+    sig = signal.SIGKILL if force else signal.SIGTERM
+    sig_name = "SIGKILL" if force else "SIGTERM"
+    try:
+        os.killpg(record.pid, sig)
+    except (ProcessLookupError, PermissionError):
+        return f"Process {record.pid} already exited"
+
+    action = "Force-killed" if force else "Terminated"
+    return f"{action} process {record.pid} ({sig_name} sent). Use check_shell_command('{handle}') to confirm exit."
+
+
+def kill_all_records(registry: dict[str, ProcessRecord]) -> None:
+    """Kill every unfinished process group in *registry* and clear it."""
+    for record in registry.values():
+        if record._monitor_task is not None:
+            record._monitor_task.cancel()
+        if not record.finished:
+            with contextlib.suppress(ProcessLookupError, PermissionError):
+                os.killpg(record.pid, signal.SIGKILL)
+    registry.clear()
+
+
+def _sweep_stale_records(registry: dict[str, ProcessRecord]) -> None:
+    """Remove records that finished more than 10 minutes ago."""
+    now = time.monotonic()
+    stale = [
+        h
+        for h, r in registry.items()
+        if r.finished and r.finished_at is not None and (now - r.finished_at) > _STALE_RECORD_SECONDS
+    ]
+    for h in stale:
+        registry.pop(h, None)
+
+
+async def _read_stream(stream: asyncio.StreamReader | None, buf: _OutputBuffer) -> None:
+    """Read bounded chunks from an async stream into *buf* until EOF."""
+    if stream is None:
+        return
+
+    decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+    while True:
+        chunk = await stream.read(_STREAM_READ_CHUNK_BYTES)
+        if not chunk:
+            break
+        buf.append(decoder.decode(chunk))
+
+    buf.append(decoder.decode(b"", final=True))
+
+
+async def _cancel_pending_tasks(*tasks: asyncio.Task[None]) -> None:
+    """Cancel any pending tasks and wait for them to finish."""
+    pending_tasks = [task for task in tasks if not task.done()]
+    for task in pending_tasks:
+        task.cancel()
+    for task in pending_tasks:
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
+async def _await_foreground_process_exit(
+    process: asyncio.subprocess.Process,
+    *,
+    timeout_seconds: float,
+) -> None:
+    """Wait for the foreground process to exit without depending on pipe EOF."""
+    if process.returncode is not None:
+        return
+    if timeout_seconds <= 0:
+        raise TimeoutError
+
+    wait_task = asyncio.create_task(process.wait())
+    deadline = asyncio.get_running_loop().time() + timeout_seconds
+    try:
+        while process.returncode is None:
+            remaining = deadline - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                raise TimeoutError
+            done_tasks, _pending_tasks = await asyncio.wait(
+                (wait_task,),
+                timeout=min(_PROCESS_EXIT_POLL_INTERVAL_SECONDS, remaining),
+            )
+            if wait_task in done_tasks:
+                await wait_task
+                return
+    finally:
+        if not wait_task.done():
+            wait_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await wait_task
+
+
+async def _await_reader_tasks_with_grace(
+    stdout_reader: asyncio.Task[None],
+    stderr_reader: asyncio.Task[None],
+    *,
+    grace_seconds: float,
+) -> None:
+    """Drain reader tasks briefly after foreground exit, then stop waiting for EOF."""
+    reader_tasks = (stdout_reader, stderr_reader)
+    done_tasks, pending_tasks = await asyncio.wait(reader_tasks, timeout=grace_seconds)
+
+    try:
+        for task in done_tasks:
+            await task
+    finally:
+        for task in pending_tasks:
+            task.cancel()
+        for task in pending_tasks:
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+
+async def _terminate_process_group(
+    process: asyncio.subprocess.Process,
+    *,
+    grace_period: float = 0.5,
+) -> None:
+    """Terminate a subprocess process group, escalating to SIGKILL if needed."""
+    if process.returncode is not None:
+        return
+
+    with contextlib.suppress(ProcessLookupError, PermissionError):
+        os.killpg(process.pid, signal.SIGTERM)
+
+    try:
+        await asyncio.wait_for(process.wait(), timeout=grace_period)
+    except TimeoutError:
+        pass
+    else:
+        return
+
+    if process.returncode is None:
+        with contextlib.suppress(ProcessLookupError, PermissionError):
+            os.killpg(process.pid, signal.SIGKILL)
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(process.wait(), timeout=grace_period)
+
+
+async def _monitor_process(
+    registry: dict[str, ProcessRecord],
+    handle: str,
+    process: asyncio.subprocess.Process,
+    stdout_reader: asyncio.Task[None],
+    stderr_reader: asyncio.Task[None],
+) -> None:
+    """Wait for a backgrounded process to exit and update its record."""
+    try:
+        await process.wait()
+    finally:
+        await asyncio.wait([stdout_reader, stderr_reader], timeout=2.0)
+        await _cancel_pending_tasks(stdout_reader, stderr_reader)
+        record = registry.get(handle)
+        if record is not None:
+            record.finished = True
+            record.finished_at = time.monotonic()
+            record.return_code = process.returncode

--- a/src/mindroom/shell_supervisor.py
+++ b/src/mindroom/shell_supervisor.py
@@ -42,7 +42,14 @@ from functools import partial
 from pathlib import Path
 
 from mindroom.logging_config import get_logger
-from mindroom.shell_execution import ProcessRecord, check_command, kill_all_records, kill_command, run_command
+from mindroom.shell_execution import (
+    ProcessRecord,
+    check_command,
+    discard_background_record,
+    kill_all_records,
+    kill_command,
+    run_command,
+)
 
 logger = get_logger(__name__)
 
@@ -94,15 +101,23 @@ async def _handle_run(
     # cancelled local run instead of lingering with an undelivered handle.
     eof_task = asyncio.create_task(reader.read())
     done, _pending = await asyncio.wait({run_task, eof_task}, return_when=asyncio.FIRST_COMPLETED)
-    if run_task in done:
-        eof_task.cancel()
-        with suppress(asyncio.CancelledError):
-            await eof_task
-        return await run_task
-    run_task.cancel()
+    if eof_task in done:
+        # The client is gone even if the run finished in the same loop cycle:
+        # a handle registered by that run is undeliverable, so discard it
+        # instead of leaving the command running with no owner.
+        if run_task.done():
+            result = await run_task
+            if result.handle is not None:
+                discard_background_record(registry, result.handle)
+        else:
+            run_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await run_task
+        return None
+    eof_task.cancel()
     with suppress(asyncio.CancelledError):
-        await run_task
-    return None
+        await eof_task
+    return (await run_task).message
 
 
 async def _handle_connection(
@@ -251,6 +266,8 @@ def _sync_supervisor_request(socket_path: str, request: dict[str, object]) -> st
 def _recv_line(conn: socket.socket) -> bytes:
     buffer = bytearray()
     while b"\n" not in buffer:
+        if len(buffer) >= _REQUEST_LIMIT_BYTES:
+            break
         chunk = conn.recv(65536)
         if not chunk:
             break

--- a/src/mindroom/shell_supervisor.py
+++ b/src/mindroom/shell_supervisor.py
@@ -1,0 +1,402 @@
+"""Worker-local shell supervisor process for background shell handles.
+
+The sandbox runner isolates tool calls in per-request subprocesses (spawn or
+forkserver children), which cannot own background shell handles: the handle
+registry and the ``check``/``kill`` follow-ups arrive in different processes.
+This module keeps one small long-lived *supervisor* process per runner that
+owns the shell child processes and the in-memory handle registry, so shell
+requests get the same subprocess isolation as every other execution tool.
+
+Flow:
+
+- The runner spawns ``python -m mindroom.shell_supervisor <socket>`` once and
+  advertises the socket to shell tool subprocesses via
+  ``MINDROOM_SANDBOX_SHELL_SUPERVISOR_SOCKET`` (the ``MINDROOM_SANDBOX_``
+  prefix keeps it out of shell env passthrough).
+- The shell toolkit computes argv, env, and cwd exactly as for local
+  execution, then sends the run/check/kill request over the unix socket.
+- The supervisor spawns and monitors the command with the shared
+  :mod:`mindroom.shell_execution` core. A client that disconnects mid-run
+  cancels the run, mirroring local cancellation semantics.
+- The supervisor exits when its parent runner dies or terminates it, killing
+  unfinished process groups, so restarting the worker invalidates handles.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import atexit
+import json
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from contextlib import suppress
+from dataclasses import dataclass
+from functools import partial
+from pathlib import Path
+
+from mindroom.logging_config import get_logger
+from mindroom.shell_execution import ProcessRecord, check_command, kill_all_records, kill_command, run_command
+
+logger = get_logger(__name__)
+
+SHELL_SUPERVISOR_SOCKET_ENV = "MINDROOM_SANDBOX_SHELL_SUPERVISOR_SOCKET"
+
+_REQUEST_LIMIT_BYTES = 4 * 1024 * 1024
+_PARENT_POLL_INTERVAL_SECONDS = 1.0
+_READY_PROBE_INTERVAL_SECONDS = 0.05
+_STARTUP_TIMEOUT_SECONDS = 30.0
+_SUPERVISOR_TERMINATE_WAIT_SECONDS = 5.0
+_SYNC_REQUEST_TIMEOUT_SECONDS = 10.0
+_RUN_RESPONSE_GRACE_SECONDS = 30.0
+_STDERR_TAIL_BYTES = 4096
+
+
+class ShellSupervisorStartupError(RuntimeError):
+    """The shell supervisor process failed to start or become ready."""
+
+
+# ---------------------------------------------------------------------------
+# Server (runs inside `python -m mindroom.shell_supervisor <socket>`)
+# ---------------------------------------------------------------------------
+
+
+async def _handle_run(
+    registry: dict[str, ProcessRecord],
+    payload: dict[str, object],
+    reader: asyncio.StreamReader,
+) -> str | None:
+    """Run one command, cancelling it if the client disconnects mid-wait."""
+    argv_payload = payload["argv"]
+    env_payload = payload["env"]
+    if not isinstance(argv_payload, list) or not isinstance(env_payload, dict):
+        msg = "run request requires an 'argv' list and an 'env' object"
+        raise TypeError(msg)
+    run_task = asyncio.create_task(
+        run_command(
+            registry,
+            namespace=str(payload["namespace"]),
+            argv=[str(item) for item in argv_payload],
+            env={str(key): str(value) for key, value in env_payload.items()},
+            cwd=str(payload["cwd"]) if payload.get("cwd") is not None else None,
+            tail=int(payload["tail"]),  # ty: ignore[invalid-argument-type]
+            timeout=float(payload["timeout"]),  # ty: ignore[invalid-argument-type]
+        ),
+    )
+    # EOF before the run response means the client (a per-request tool
+    # subprocess) died; cancel the run so the command is killed exactly like a
+    # cancelled local run instead of lingering with an undelivered handle.
+    eof_task = asyncio.create_task(reader.read())
+    done, _pending = await asyncio.wait({run_task, eof_task}, return_when=asyncio.FIRST_COMPLETED)
+    if run_task in done:
+        eof_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await eof_task
+        return await run_task
+    run_task.cancel()
+    with suppress(asyncio.CancelledError):
+        await run_task
+    return None
+
+
+async def _handle_connection(
+    registry: dict[str, ProcessRecord],
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+) -> None:
+    try:
+        line = await reader.readline()
+        if not line.strip():
+            return  # Ready-probe connections close without sending a request.
+        payload = json.loads(line)
+        op = payload.get("op")
+        if op == "run":
+            message = await _handle_run(registry, payload, reader)
+            if message is None:
+                return
+        elif op == "check":
+            message = check_command(registry, namespace=str(payload["namespace"]), handle=str(payload["handle"]))
+        elif op == "kill":
+            message = kill_command(
+                registry,
+                namespace=str(payload["namespace"]),
+                handle=str(payload["handle"]),
+                force=bool(payload.get("force", False)),
+            )
+        else:
+            message = f"Error: Unknown shell supervisor operation '{op}'."
+        writer.write(json.dumps({"message": message}).encode("utf-8") + b"\n")
+        await writer.drain()
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+        with suppress(OSError):
+            writer.write(json.dumps({"message": f"Error: Invalid shell supervisor request: {exc}"}).encode() + b"\n")
+            await writer.drain()
+    except OSError:
+        logger.warning("shell_supervisor_connection_failed", exc_info=True)
+    finally:
+        writer.close()
+        with suppress(OSError):
+            await writer.wait_closed()
+
+
+async def _serve(socket_path: str) -> int:
+    registry: dict[str, ProcessRecord] = {}
+    parent_pid = os.getppid()
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    loop.add_signal_handler(signal.SIGTERM, stop_event.set)
+    server = await asyncio.start_unix_server(
+        partial(_handle_connection, registry),
+        path=socket_path,
+        limit=_REQUEST_LIMIT_BYTES,
+    )
+    orphaned = False
+    async with server:
+        while not stop_event.is_set():
+            if os.getppid() != parent_pid:
+                orphaned = True
+                break
+            with suppress(TimeoutError):
+                await asyncio.wait_for(stop_event.wait(), timeout=_PARENT_POLL_INTERVAL_SECONDS)
+    # Handles cannot outlive the supervisor; kill their process groups so a
+    # runner or worker restart invalidates handles without leaking processes.
+    kill_all_records(registry)
+    if orphaned:
+        # The runner died without running its cleanup (e.g. SIGKILL), so
+        # remove our runtime dir ourselves.
+        shutil.rmtree(Path(socket_path).parent, ignore_errors=True)
+    return 0
+
+
+def _main(argv: list[str]) -> int:
+    """Supervisor process entry point: serve shell requests on a unix socket."""
+    return asyncio.run(_serve(argv[1]))
+
+
+# ---------------------------------------------------------------------------
+# Clients (run inside per-request tool subprocesses)
+# ---------------------------------------------------------------------------
+
+
+async def run_command_via_supervisor(
+    socket_path: str,
+    *,
+    namespace: str,
+    argv: list[str],
+    env: dict[str, str],
+    cwd: str | None,
+    tail: int,
+    timeout: float,  # noqa: ASYNC109
+) -> str:
+    """Run one shell command through the supervisor and return its message."""
+    request = {
+        "op": "run",
+        "namespace": namespace,
+        "argv": argv,
+        "env": env,
+        "cwd": cwd,
+        "tail": tail,
+        "timeout": timeout,
+    }
+    try:
+        reader, writer = await asyncio.open_unix_connection(socket_path, limit=_REQUEST_LIMIT_BYTES)
+    except OSError as exc:
+        return f"Error: Shell supervisor is unavailable: {exc}"
+    try:
+        writer.write(json.dumps(request).encode("utf-8") + b"\n")
+        await writer.drain()
+        line = await asyncio.wait_for(reader.readline(), timeout=timeout + _RUN_RESPONSE_GRACE_SECONDS)
+    except TimeoutError:
+        return "Error: Shell supervisor did not respond in time."
+    except OSError as exc:
+        return f"Error: Shell supervisor request failed: {exc}"
+    finally:
+        writer.close()
+        with suppress(OSError):
+            await writer.wait_closed()
+    return _parse_supervisor_response(line)
+
+
+def check_command_via_supervisor(socket_path: str, *, namespace: str, handle: str) -> str:
+    """Poll a background handle through the supervisor."""
+    return _sync_supervisor_request(socket_path, {"op": "check", "namespace": namespace, "handle": handle})
+
+
+def kill_command_via_supervisor(socket_path: str, *, namespace: str, handle: str, force: bool = False) -> str:
+    """Kill a background handle through the supervisor."""
+    return _sync_supervisor_request(
+        socket_path,
+        {"op": "kill", "namespace": namespace, "handle": handle, "force": force},
+    )
+
+
+def _sync_supervisor_request(socket_path: str, request: dict[str, object]) -> str:
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as conn:
+            conn.settimeout(_SYNC_REQUEST_TIMEOUT_SECONDS)
+            conn.connect(socket_path)
+            conn.sendall(json.dumps(request).encode("utf-8") + b"\n")
+            line = _recv_line(conn)
+    except OSError as exc:
+        return f"Error: Shell supervisor is unavailable: {exc}"
+    return _parse_supervisor_response(line)
+
+
+def _recv_line(conn: socket.socket) -> bytes:
+    buffer = bytearray()
+    while b"\n" not in buffer:
+        chunk = conn.recv(65536)
+        if not chunk:
+            break
+        buffer.extend(chunk)
+    return bytes(buffer)
+
+
+def _parse_supervisor_response(line: bytes) -> str:
+    if not line.strip():
+        return "Error: Shell supervisor closed the connection unexpectedly."
+    try:
+        payload = json.loads(line)
+        return str(payload["message"])
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        return f"Error: Invalid shell supervisor response: {exc}"
+
+
+# ---------------------------------------------------------------------------
+# Manager (runs inside the long-lived sandbox runner process)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _SupervisorProcess:
+    process: subprocess.Popen[bytes]
+    socket_path: str
+    stderr_path: Path
+    runtime_dir: Path
+
+
+def _stderr_tail(stderr_path: Path) -> str:
+    try:
+        raw = stderr_path.read_bytes()
+    except OSError:
+        return ""
+    return raw[-_STDERR_TAIL_BYTES:].decode("utf-8", errors="replace").strip()
+
+
+def _terminate_supervisor(supervisor: _SupervisorProcess) -> None:
+    process = supervisor.process
+    if process.poll() is None:
+        process.terminate()
+        try:
+            process.wait(timeout=_SUPERVISOR_TERMINATE_WAIT_SECONDS)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
+    shutil.rmtree(supervisor.runtime_dir, ignore_errors=True)
+
+
+class _ShellSupervisorManager:
+    """Owns the one shell supervisor process for this runner instance."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._supervisor: _SupervisorProcess | None = None
+
+    def ensure(self) -> str:
+        """Return the socket path of a live supervisor, spawning one if needed."""
+        with self._lock:
+            supervisor = self._supervisor
+            if supervisor is not None and supervisor.process.poll() is not None:
+                logger.warning("shell_supervisor_died", stderr_tail=_stderr_tail(supervisor.stderr_path))
+                shutil.rmtree(supervisor.runtime_dir, ignore_errors=True)
+                self._supervisor = None
+                supervisor = None
+            if supervisor is None:
+                supervisor = self._spawn()
+                try:
+                    _wait_supervisor_ready(supervisor)
+                except ShellSupervisorStartupError:
+                    _terminate_supervisor(supervisor)
+                    raise
+                self._supervisor = supervisor
+            return supervisor.socket_path
+
+    def shutdown(self) -> None:
+        """Terminate the supervisor process and clear cached state."""
+        with self._lock:
+            supervisor = self._supervisor
+            self._supervisor = None
+        if supervisor is not None:
+            _terminate_supervisor(supervisor)
+
+    def _spawn(self) -> _SupervisorProcess:
+        runtime_dir = Path(tempfile.mkdtemp(prefix="mindroom-shell-"))
+        socket_path = str(runtime_dir / "supervisor.sock")
+        stderr_path = runtime_dir / "supervisor.err"
+        logger.info("shell_supervisor_spawning", socket_path=socket_path)
+        try:
+            with stderr_path.open("wb") as stderr_file:
+                process = subprocess.Popen(
+                    [sys.executable, "-m", "mindroom.shell_supervisor", socket_path],
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
+                    stderr=stderr_file,
+                )
+        except OSError as exc:
+            shutil.rmtree(runtime_dir, ignore_errors=True)
+            msg = f"Failed to start the shell supervisor: {exc}"
+            raise ShellSupervisorStartupError(msg) from exc
+        return _SupervisorProcess(
+            process=process,
+            socket_path=socket_path,
+            stderr_path=stderr_path,
+            runtime_dir=runtime_dir,
+        )
+
+
+def _wait_supervisor_ready(supervisor: _SupervisorProcess) -> None:
+    deadline = time.monotonic() + _STARTUP_TIMEOUT_SECONDS
+    while True:
+        if supervisor.process.poll() is not None:
+            msg = (
+                f"Shell supervisor exited during startup "
+                f"(code {supervisor.process.returncode}): {_stderr_tail(supervisor.stderr_path)}"
+            )
+            raise ShellSupervisorStartupError(msg)
+        if time.monotonic() >= deadline:
+            msg = "Shell supervisor did not become ready in time."
+            raise ShellSupervisorStartupError(msg)
+        try:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as probe:
+                probe.settimeout(1.0)
+                probe.connect(supervisor.socket_path)
+        except OSError:
+            time.sleep(_READY_PROBE_INTERVAL_SECONDS)
+        else:
+            logger.info("shell_supervisor_ready", supervisor_pid=supervisor.process.pid)
+            return
+
+
+_manager: _ShellSupervisorManager | None = None
+_manager_lock = threading.Lock()
+
+
+def ensure_shell_supervisor() -> str:
+    """Return the runner-wide shell supervisor socket, spawning it on first use."""
+    global _manager
+    with _manager_lock:
+        if _manager is None:
+            _manager = _ShellSupervisorManager()
+            atexit.register(_manager.shutdown)
+        manager = _manager
+    return manager.ensure()
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main(sys.argv))

--- a/src/mindroom/tools/shell.py
+++ b/src/mindroom/tools/shell.py
@@ -2,18 +2,10 @@
 
 from __future__ import annotations
 
-import asyncio
-import codecs
-import contextlib
 import json
 import os
 import re
 import shlex
-import signal
-import time
-import uuid
-from collections import deque
-from dataclasses import dataclass, field
 from pathlib import Path
 from typing import cast
 
@@ -25,6 +17,19 @@ from mindroom.constants import (
     shell_execution_runtime_env_values,
     subprocess_path_with_prepends,
     workspace_home_identity_env,
+)
+from mindroom.shell_execution import (
+    DEFAULT_RUN_TIMEOUT_SECONDS,
+    ProcessRecord,
+    check_command,
+    kill_command,
+    run_command,
+)
+from mindroom.shell_supervisor import (
+    SHELL_SUPERVISOR_SOCKET_ENV,
+    check_command_via_supervisor,
+    kill_command_via_supervisor,
+    run_command_via_supervisor,
 )
 from mindroom.tool_system.metadata import (
     ConfigField,
@@ -71,22 +76,15 @@ _LOCAL_SHELL_PASSTHROUGH_ENV_KEYS = frozenset(
         "no_proxy",
     },
 )
-_STALE_RECORD_SECONDS = 600  # 10 minutes
-_MAX_BACKGROUNDED = 16
-_MAX_OUTPUT_LINES = 10_000
-_MAX_OUTPUT_BYTES = 50 * 1024
-_STREAM_READ_CHUNK_BYTES = 8192
-_PROCESS_EXIT_POLL_INTERVAL_SECONDS = 0.05
-_POST_EXIT_READER_GRACE_SECONDS = 0.5
 _SHELL_ARGS_ERROR = (
     '\'args\' must be a shell command string or a flat list of strings. Send args like "ls -la" or ["git", "status"].'
 )
 _SHELL_COMMAND_LINE_CHARS = frozenset("$|&;<>*?~`!(){}[]\n\r")
 
 # Module-level process registry shared across all MindRoomShellTools instances.
-# This ensures handles survive toolkit re-creation (e.g. in sandbox runner mode
-# where _resolve_entrypoint builds a fresh toolkit per request).
-_process_registry: dict[str, _ProcessRecord] = {}
+# This ensures handles survive toolkit re-creation for local execution; when a
+# supervisor socket is advertised, the supervisor owns the registry instead.
+_process_registry: dict[str, ProcessRecord] = {}
 
 
 def _normalize_shell_command_line(command: str) -> list[str]:
@@ -237,89 +235,6 @@ def _handle_namespace(*, runtime_paths: RuntimePaths, base_dir: Path | None) -> 
     return f"{storage_root}::{resolved_base_dir}"
 
 
-@dataclass
-class _OutputBuffer:
-    """Bound shell output by both line count and encoded byte size."""
-
-    max_lines: int = _MAX_OUTPUT_LINES
-    max_bytes: int = _MAX_OUTPUT_BYTES
-    chunks: deque[str] = field(default_factory=deque)
-    byte_count: int = 0
-    truncated: bool = False
-
-    def append(self, text: str) -> None:
-        if not text:
-            return
-
-        encoded = text.encode("utf-8", errors="replace")
-        if len(encoded) > self.max_bytes:
-            text = encoded[-self.max_bytes :].decode("utf-8", errors="ignore")
-            encoded = text.encode("utf-8", errors="replace")
-            self.truncated = True
-
-        self.chunks.append(text)
-        self.byte_count += len(encoded)
-
-        while self.chunks and self.byte_count > self.max_bytes:
-            removed = self.chunks.popleft()
-            self.byte_count -= len(removed.encode("utf-8", errors="replace"))
-            self.truncated = True
-
-        self._trim_to_max_lines()
-
-    def render(self, *, tail: int | None = None) -> str:
-        output = self._rendered_text()
-        output_lines = output.split("\n") if output else []
-        if tail is not None:
-            output_lines = output_lines[-tail:]
-        output = "\n".join(output_lines)
-        if not self.truncated:
-            return output
-
-        notice = (
-            f"[Output truncated to the last {self.max_bytes} bytes. "
-            "Redirect command output to a file for complete results.]"
-        )
-        return f"{notice}\n{output}" if output else notice
-
-    def __len__(self) -> int:
-        output = self._rendered_text()
-        return len(output.split("\n")) if output else 0
-
-    def _rendered_text(self) -> str:
-        return "".join(self.chunks).rstrip("\n")
-
-    def _trim_to_max_lines(self) -> None:
-        output = self._rendered_text()
-        lines = output.split("\n")
-        if len(lines) <= self.max_lines:
-            return
-
-        output = "\n".join(lines[-self.max_lines :])
-        self.chunks = deque([output])
-        self.byte_count = len(output.encode("utf-8", errors="replace"))
-        self.truncated = True
-
-
-@dataclass
-class _ProcessRecord:
-    """Tracks a backgrounded shell process."""
-
-    namespace: str
-    handle: str
-    pid: int
-    args: list[str]
-    process: asyncio.subprocess.Process
-    stdout_buf: _OutputBuffer = field(default_factory=_OutputBuffer)
-    stderr_buf: _OutputBuffer = field(default_factory=_OutputBuffer)
-    started_at: float = field(default_factory=time.monotonic)
-    tail: int = 100
-    finished: bool = False
-    finished_at: float | None = None
-    return_code: int | None = None
-    _monitor_task: asyncio.Task[None] | None = field(default=None, repr=False)
-
-
 @register_tool_with_metadata(
     name="shell",
     display_name="Shell Commands",
@@ -440,15 +355,18 @@ def shell_tools() -> type[Toolkit]:  # noqa: C901
                 ),
             )
             self._base_process_env = dict(runtime_paths.process_env)
-            self._processes = _process_registry
             self._handle_namespace = _handle_namespace(runtime_paths=runtime_paths, base_dir=self.base_dir)
             self._shell_path_prepend = shell_path_prepend
+            # Sandbox tool subprocesses delegate execution to the runner's
+            # long-lived shell supervisor so background handles survive the
+            # per-request process.
+            self._supervisor_socket = os.environ.get(SHELL_SUPERVISOR_SOCKET_ENV) or None
 
         async def run_shell_command(
             self,
             args: list[str] | str,
             tail: int = 100,
-            timeout: int = 120,  # noqa: ASYNC109
+            timeout: int = DEFAULT_RUN_TIMEOUT_SECONDS,  # noqa: ASYNC109
         ) -> str:
             """Runs a shell command and returns the output or error.
 
@@ -467,93 +385,36 @@ def shell_tools() -> type[Toolkit]:  # noqa: C901
                 The command output, an error message, or a background handle.
 
             """
-            self._sweep_stale_records()
-
             try:
                 command_args = _normalize_shell_args(args)
-                subprocess_env = _shell_subprocess_env(
-                    self._runtime_env,
-                    base_process_env=self._base_process_env,
-                    shell_path_prepend=self._shell_path_prepend,
-                )
-                process = await asyncio.create_subprocess_exec(
-                    *_shell_subprocess_args(command_args, subprocess_env),
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                    cwd=str(self.base_dir) if self.base_dir else None,
-                    env=subprocess_env,
-                    start_new_session=True,
-                )
-            except Exception as exc:
+            except ValueError as exc:
                 return f"Error: {exc}"
-
-            stdout_buf = _OutputBuffer()
-            stderr_buf = _OutputBuffer()
-            background_handle: str | None = None
-            background_monitor_task: asyncio.Task[None] | None = None
-
-            stdout_reader = asyncio.create_task(_read_stream(process.stdout, stdout_buf))
-            stderr_reader = asyncio.create_task(_read_stream(process.stderr, stderr_buf))
-
-            try:
-                try:
-                    await _await_foreground_process_exit(process, timeout_seconds=timeout)
-                except TimeoutError:
-                    active = sum(1 for r in self._processes.values() if not r.finished)
-                    if active >= _MAX_BACKGROUNDED:
-                        with contextlib.suppress(ProcessLookupError, PermissionError):
-                            os.killpg(process.pid, signal.SIGKILL)
-                        await _cancel_pending_tasks(stdout_reader, stderr_reader)
-                        return (
-                            f"Error: Too many backgrounded processes ({active}/{_MAX_BACKGROUNDED}). "
-                            "Kill or wait for existing ones before running more."
-                        )
-                    handle = f"shell:{uuid.uuid4().hex[:8]}"
-                    record = _ProcessRecord(
-                        namespace=self._handle_namespace,
-                        handle=handle,
-                        pid=process.pid,
-                        args=command_args,
-                        process=process,
-                        stdout_buf=stdout_buf,
-                        stderr_buf=stderr_buf,
-                        tail=tail,
-                    )
-                    record._monitor_task = asyncio.create_task(
-                        _monitor_process(self._processes, handle, process, stdout_reader, stderr_reader),
-                    )
-                    self._processes[handle] = record
-                    background_handle = handle
-                    background_monitor_task = record._monitor_task
-                    await asyncio.sleep(0)
-                    return (
-                        f"Command timed out after {timeout}s. Still running (PID {process.pid}).\n"
-                        f"Handle: {handle}\n"
-                        f"Use check_shell_command('{handle}') to poll or "
-                        f"kill_shell_command('{handle}') to stop."
-                    )
-
-                await _await_reader_tasks_with_grace(
-                    stdout_reader,
-                    stderr_reader,
-                    grace_seconds=_POST_EXIT_READER_GRACE_SECONDS,
+            subprocess_env = _shell_subprocess_env(
+                self._runtime_env,
+                base_process_env=self._base_process_env,
+                shell_path_prepend=self._shell_path_prepend,
+            )
+            argv = _shell_subprocess_args(command_args, subprocess_env)
+            cwd = str(self.base_dir) if self.base_dir else None
+            if self._supervisor_socket is not None:
+                return await run_command_via_supervisor(
+                    self._supervisor_socket,
+                    namespace=self._handle_namespace,
+                    argv=argv,
+                    env=subprocess_env,
+                    cwd=cwd,
+                    tail=tail,
+                    timeout=timeout,
                 )
-            except asyncio.CancelledError:
-                if background_handle is not None:
-                    self._processes.pop(background_handle, None)
-                if background_monitor_task is not None:
-                    background_monitor_task.cancel()
-                if process.returncode is None:
-                    await _terminate_process_group(process)
-                await _cancel_pending_tasks(stdout_reader, stderr_reader)
-                if background_monitor_task is not None:
-                    with contextlib.suppress(asyncio.CancelledError):
-                        await background_monitor_task
-                raise
-
-            if process.returncode != 0:
-                return f"Error: {stderr_buf.render()}"
-            return stdout_buf.render(tail=tail)
+            return await run_command(
+                _process_registry,
+                namespace=self._handle_namespace,
+                argv=argv,
+                env=subprocess_env,
+                cwd=cwd,
+                tail=tail,
+                timeout=timeout,
+            )
 
         def check_shell_command(self, handle: str) -> str:
             """Poll the status of a backgrounded shell command.
@@ -569,26 +430,13 @@ def shell_tools() -> type[Toolkit]:  # noqa: C901
                 Output if the command finished, or a status summary if still running.
 
             """
-            record = self._processes.get(handle)
-            if record is None or record.namespace != self._handle_namespace:
-                return f"Error: Unknown handle '{handle}'"
-
-            elapsed = time.monotonic() - record.started_at
-
-            if record.finished:
-                output = record.stdout_buf.render(tail=record.tail)
-                errors = record.stderr_buf.render()
-                result = f"Status: FINISHED (exit code {record.return_code}, ran for {elapsed:.1f}s)\n"
-                if record.return_code != 0 and errors:
-                    result += f"Stderr:\n{errors}\n"
-                result += f"Output:\n{output}"
-                return result
-
-            partial = record.stdout_buf.render(tail=50)
-            return (
-                f"Status: RUNNING (PID {record.pid}, elapsed {elapsed:.1f}s)\n"
-                f"Partial output ({len(record.stdout_buf)} lines buffered):\n{partial}"
-            )
+            if self._supervisor_socket is not None:
+                return check_command_via_supervisor(
+                    self._supervisor_socket,
+                    namespace=self._handle_namespace,
+                    handle=handle,
+                )
+            return check_command(_process_registry, namespace=self._handle_namespace, handle=handle)
 
         def kill_shell_command(self, handle: str, force: bool = False) -> str:
             """Kill a backgrounded shell command.
@@ -601,158 +449,13 @@ def shell_tools() -> type[Toolkit]:  # noqa: C901
                 Confirmation message or error.
 
             """
-            record = self._processes.get(handle)
-            if record is None or record.namespace != self._handle_namespace:
-                return f"Error: Unknown handle '{handle}'"
-
-            if record.finished:
-                return f"Process already finished (exit code {record.return_code})"
-
-            sig = signal.SIGKILL if force else signal.SIGTERM
-            sig_name = "SIGKILL" if force else "SIGTERM"
-            try:
-                os.killpg(record.pid, sig)
-            except (ProcessLookupError, PermissionError):
-                return f"Process {record.pid} already exited"
-
-            action = "Force-killed" if force else "Terminated"
-            return (
-                f"{action} process {record.pid} ({sig_name} sent). Use check_shell_command('{handle}') to confirm exit."
-            )
-
-        def _sweep_stale_records(self) -> None:
-            """Remove records that finished more than 10 minutes ago."""
-            now = time.monotonic()
-            stale = [
-                h
-                for h, r in self._processes.items()
-                if r.finished and r.finished_at is not None and (now - r.finished_at) > _STALE_RECORD_SECONDS
-            ]
-            for h in stale:
-                self._processes.pop(h, None)
+            if self._supervisor_socket is not None:
+                return kill_command_via_supervisor(
+                    self._supervisor_socket,
+                    namespace=self._handle_namespace,
+                    handle=handle,
+                    force=force,
+                )
+            return kill_command(_process_registry, namespace=self._handle_namespace, handle=handle, force=force)
 
     return MindRoomShellTools
-
-
-async def _read_stream(stream: asyncio.StreamReader | None, buf: _OutputBuffer) -> None:
-    """Read bounded chunks from an async stream into *buf* until EOF."""
-    if stream is None:
-        return
-
-    decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
-    while True:
-        chunk = await stream.read(_STREAM_READ_CHUNK_BYTES)
-        if not chunk:
-            break
-        buf.append(decoder.decode(chunk))
-
-    buf.append(decoder.decode(b"", final=True))
-
-
-async def _cancel_pending_tasks(*tasks: asyncio.Task[None]) -> None:
-    """Cancel any pending tasks and wait for them to finish."""
-    pending_tasks = [task for task in tasks if not task.done()]
-    for task in pending_tasks:
-        task.cancel()
-    for task in pending_tasks:
-        with contextlib.suppress(asyncio.CancelledError):
-            await task
-
-
-async def _await_foreground_process_exit(
-    process: asyncio.subprocess.Process,
-    *,
-    timeout_seconds: float,
-) -> None:
-    """Wait for the foreground process to exit without depending on pipe EOF."""
-    if process.returncode is not None:
-        return
-    if timeout_seconds <= 0:
-        raise TimeoutError
-
-    wait_task = asyncio.create_task(process.wait())
-    deadline = asyncio.get_running_loop().time() + timeout_seconds
-    try:
-        while process.returncode is None:
-            remaining = deadline - asyncio.get_running_loop().time()
-            if remaining <= 0:
-                raise TimeoutError
-            done_tasks, _pending_tasks = await asyncio.wait(
-                (wait_task,),
-                timeout=min(_PROCESS_EXIT_POLL_INTERVAL_SECONDS, remaining),
-            )
-            if wait_task in done_tasks:
-                await wait_task
-                return
-    finally:
-        if not wait_task.done():
-            wait_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await wait_task
-
-
-async def _await_reader_tasks_with_grace(
-    stdout_reader: asyncio.Task[None],
-    stderr_reader: asyncio.Task[None],
-    *,
-    grace_seconds: float,
-) -> None:
-    """Drain reader tasks briefly after foreground exit, then stop waiting for EOF."""
-    reader_tasks = (stdout_reader, stderr_reader)
-    done_tasks, pending_tasks = await asyncio.wait(reader_tasks, timeout=grace_seconds)
-
-    try:
-        for task in done_tasks:
-            await task
-    finally:
-        for task in pending_tasks:
-            task.cancel()
-        for task in pending_tasks:
-            with contextlib.suppress(asyncio.CancelledError):
-                await task
-
-
-async def _terminate_process_group(
-    process: asyncio.subprocess.Process,
-    *,
-    grace_period: float = 0.5,
-) -> None:
-    """Terminate a subprocess process group, escalating to SIGKILL if needed."""
-    if process.returncode is not None:
-        return
-
-    with contextlib.suppress(ProcessLookupError, PermissionError):
-        os.killpg(process.pid, signal.SIGTERM)
-
-    try:
-        await asyncio.wait_for(process.wait(), timeout=grace_period)
-    except TimeoutError:
-        pass
-    else:
-        return
-
-    if process.returncode is None:
-        with contextlib.suppress(ProcessLookupError, PermissionError):
-            os.killpg(process.pid, signal.SIGKILL)
-        with contextlib.suppress(asyncio.TimeoutError):
-            await asyncio.wait_for(process.wait(), timeout=grace_period)
-
-
-async def _monitor_process(
-    registry: dict[str, _ProcessRecord],
-    handle: str,
-    process: asyncio.subprocess.Process,
-    stdout_reader: asyncio.Task[None],
-    stderr_reader: asyncio.Task[None],
-) -> None:
-    """Wait for a backgrounded process to exit and update its record."""
-    try:
-        await process.wait()
-    finally:
-        await asyncio.wait([stdout_reader, stderr_reader], timeout=2.0)
-        await _cancel_pending_tasks(stdout_reader, stderr_reader)
-        record = registry.get(handle)
-        if record is not None:
-            record.finished = True
-            record.finished_at = time.monotonic()
-            record.return_code = process.returncode

--- a/src/mindroom/tools/shell.py
+++ b/src/mindroom/tools/shell.py
@@ -406,7 +406,7 @@ def shell_tools() -> type[Toolkit]:  # noqa: C901
                     tail=tail,
                     timeout=timeout,
                 )
-            return await run_command(
+            result = await run_command(
                 _process_registry,
                 namespace=self._handle_namespace,
                 argv=argv,
@@ -415,6 +415,7 @@ def shell_tools() -> type[Toolkit]:  # noqa: C901
                 tail=tail,
                 timeout=timeout,
             )
+            return result.message
 
         def check_shell_command(self, handle: str) -> str:
             """Poll the status of a backgrounded shell command.

--- a/tests/test_shell_async.py
+++ b/tests/test_shell_async.py
@@ -14,9 +14,9 @@ from unittest.mock import patch
 import pytest
 
 from mindroom.constants import RuntimePaths, resolve_runtime_paths, workspace_home_identity_env
+from mindroom.shell_execution import _MAX_OUTPUT_BYTES
 from mindroom.tool_system.metadata import get_tool_by_name
 from mindroom.tools.shell import (
-    _MAX_OUTPUT_BYTES,
     _process_registry,
     _workspace_home_contract_env_from_process_env,
     shell_tools,
@@ -957,7 +957,7 @@ async def test_max_backgrounded_limit(tmp_path: Path) -> None:
     handles: list[str] = []
 
     # Patch to a small limit
-    with patch("mindroom.tools.shell._MAX_BACKGROUNDED", 2):
+    with patch("mindroom.shell_execution._MAX_BACKGROUNDED", 2):
         # Fill up to the limit
         for _ in range(2):
             result = await run_fn(["sleep", "300"], timeout=0)

--- a/tests/test_shell_cancel.py
+++ b/tests/test_shell_cancel.py
@@ -129,7 +129,7 @@ async def test_run_shell_command_cancellation_kills_subprocess(tmp_path: Path) -
         str(pid_file),
     ]
 
-    with patch("mindroom.tools.shell.os.killpg", wraps=os.killpg) as killpg_mock:
+    with patch("mindroom.shell_execution.os.killpg", wraps=os.killpg) as killpg_mock:
         task = asyncio.create_task(run_shell_command(command, timeout=120))
         pid = await _wait_for_pid(pid_file)
         await asyncio.sleep(0.1)
@@ -206,7 +206,7 @@ async def test_run_shell_command_cancellation_cleans_up_background_handle(tmp_pa
             return
         await real_sleep(delay)
 
-    with patch("mindroom.tools.shell.asyncio.sleep", new=controlled_sleep):
+    with patch("mindroom.shell_execution.asyncio.sleep", new=controlled_sleep):
         task = asyncio.create_task(run_shell_command(command, timeout=0))
         pid = await _wait_for_pid(pid_file)
         await background_registered.wait()
@@ -246,8 +246,8 @@ async def test_run_shell_command_cancellation_after_foreground_exit_does_not_ter
     terminate_process_group = AsyncMock()
 
     with (
-        patch("mindroom.tools.shell._await_reader_tasks_with_grace", new=blocked_reader_grace),
-        patch("mindroom.tools.shell._terminate_process_group", new=terminate_process_group),
+        patch("mindroom.shell_execution._await_reader_tasks_with_grace", new=blocked_reader_grace),
+        patch("mindroom.shell_execution._terminate_process_group", new=terminate_process_group),
     ):
         task = asyncio.create_task(run_shell_command(command, timeout=120))
         try:

--- a/tests/test_shell_supervisor.py
+++ b/tests/test_shell_supervisor.py
@@ -19,6 +19,7 @@ import pytest
 from mindroom import shell_supervisor
 from mindroom.api import sandbox_runner as sandbox_runner_module
 from mindroom.constants import resolve_runtime_paths
+from mindroom.shell_execution import run_command
 from mindroom.shell_supervisor import (
     SHELL_SUPERVISOR_SOCKET_ENV,
     _handle_connection,
@@ -204,6 +205,52 @@ async def test_client_disconnect_cancels_foreground_run() -> None:
             assert registry == {}
     finally:
         shutil.rmtree(pid_dir, ignore_errors=True)
+
+
+@pytest.mark.asyncio
+async def test_backgrounded_handle_is_discarded_when_client_died_in_same_cycle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A run that backgrounds in the same loop cycle the client dies must not leak.
+
+    When ``asyncio.wait`` reports the run and the client EOF as done together,
+    the registered handle is undeliverable and the command must be killed.
+    """
+    registry: dict[str, ProcessRecord] = {}
+    result = await run_command(
+        registry,
+        namespace="ns",
+        argv=["sleep", "300"],
+        env=_MINIMAL_ENV,
+        cwd=None,
+        tail=100,
+        timeout=0,
+    )
+    assert result.handle is not None
+    assert result.handle in registry
+    pid = registry[result.handle].pid
+
+    async def completed_run(*_args: object, **_kwargs: object) -> object:
+        return result
+
+    monkeypatch.setattr(shell_supervisor, "run_command", completed_run)
+    eof_reader = asyncio.StreamReader()
+    eof_reader.feed_eof()
+    payload = {
+        "op": "run",
+        "namespace": "ns",
+        "argv": ["sleep", "300"],
+        "env": _MINIMAL_ENV,
+        "cwd": None,
+        "tail": 100,
+        "timeout": 0,
+    }
+
+    message = await shell_supervisor._handle_run(registry, payload, eof_reader)
+
+    assert message is None
+    assert registry == {}
+    await _assert_pid_dead(pid)
 
 
 @pytest.mark.asyncio

--- a/tests/test_shell_supervisor.py
+++ b/tests/test_shell_supervisor.py
@@ -1,0 +1,478 @@
+"""Tests for the worker-local shell supervisor process and its clients."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+import shutil
+import signal
+import sys
+import tempfile
+from functools import partial
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mindroom import shell_supervisor
+from mindroom.api import sandbox_runner as sandbox_runner_module
+from mindroom.constants import resolve_runtime_paths
+from mindroom.shell_supervisor import (
+    SHELL_SUPERVISOR_SOCKET_ENV,
+    _handle_connection,
+    _ShellSupervisorManager,
+    check_command_via_supervisor,
+    kill_command_via_supervisor,
+    run_command_via_supervisor,
+)
+from mindroom.tool_system.metadata import get_tool_by_name
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
+
+    from agno.tools.toolkit import Toolkit
+
+    from mindroom.constants import RuntimePaths
+    from mindroom.shell_execution import ProcessRecord
+
+_MINIMAL_ENV = {"PATH": os.environ.get("PATH", "/usr/bin:/bin")}
+
+
+@contextlib.asynccontextmanager
+async def _running_server(registry: dict[str, ProcessRecord]) -> AsyncIterator[str]:
+    runtime_dir = Path(tempfile.mkdtemp(prefix="mindroom-shell-test-"))
+    socket_path = str(runtime_dir / "s.sock")
+    server = await asyncio.start_unix_server(partial(_handle_connection, registry), path=socket_path)
+    try:
+        yield socket_path
+    finally:
+        server.close()
+        await server.wait_closed()
+        shutil.rmtree(runtime_dir, ignore_errors=True)
+
+
+async def _run(socket_path: str, argv: list[str], *, namespace: str = "ns", timeout: float = 30) -> str:  # noqa: ASYNC109
+    return await run_command_via_supervisor(
+        socket_path,
+        namespace=namespace,
+        argv=argv,
+        env=_MINIMAL_ENV,
+        cwd=None,
+        tail=100,
+        timeout=timeout,
+    )
+
+
+def _extract_handle(message: str) -> str:
+    assert "Handle: " in message, message
+    return message.split("Handle: ")[1].split("\n", maxsplit=1)[0]
+
+
+async def _check(socket_path: str, handle: str, *, namespace: str = "ns") -> str:
+    return await asyncio.to_thread(check_command_via_supervisor, socket_path, namespace=namespace, handle=handle)
+
+
+async def _kill(socket_path: str, handle: str, *, namespace: str = "ns", force: bool = False) -> str:
+    return await asyncio.to_thread(
+        kill_command_via_supervisor,
+        socket_path,
+        namespace=namespace,
+        handle=handle,
+        force=force,
+    )
+
+
+async def _wait_for_finished(socket_path: str, handle: str) -> str:
+    for _ in range(50):
+        status = await _check(socket_path, handle)
+        if "FINISHED" in status:
+            return status
+        await asyncio.sleep(0.1)
+    message = f"Handle {handle} never finished: {status}"
+    raise AssertionError(message)
+
+
+async def _assert_pid_dead(pid: int) -> None:
+    for _ in range(40):
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return
+        await asyncio.sleep(0.05)
+    message = f"Process {pid} is still alive"
+    raise AssertionError(message)
+
+
+# ---------------------------------------------------------------------------
+# Server protocol
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_returns_output() -> None:
+    """Fast commands should return their output through the supervisor."""
+    registry: dict[str, ProcessRecord] = {}
+    async with _running_server(registry) as socket_path:
+        assert await _run(socket_path, ["echo", "hello supervisor"]) == "hello supervisor"
+
+
+@pytest.mark.asyncio
+async def test_run_nonzero_exit_returns_stderr() -> None:
+    """Non-zero exits should surface stderr as an error message."""
+    registry: dict[str, ProcessRecord] = {}
+    async with _running_server(registry) as socket_path:
+        result = await _run(socket_path, ["bash", "-c", "echo oops >&2; exit 1"])
+        assert result.startswith("Error:")
+        assert "oops" in result
+
+
+@pytest.mark.asyncio
+async def test_run_timeout_backgrounds_then_check_and_kill() -> None:
+    """The full run→check→kill handle lifecycle should work over the socket."""
+    registry: dict[str, ProcessRecord] = {}
+    async with _running_server(registry) as socket_path:
+        result = await _run(socket_path, ["bash", "-c", "echo bg-line; sleep 300"], timeout=0)
+        assert "timed out" in result.lower()
+        handle = _extract_handle(result)
+
+        await asyncio.sleep(0.3)
+        status = await _check(socket_path, handle)
+        assert "RUNNING" in status
+        assert "bg-line" in status
+
+        kill_result = await _kill(socket_path, handle, force=True)
+        assert "Force-killed" in kill_result
+
+        assert "FINISHED" in await _wait_for_finished(socket_path, handle)
+
+
+@pytest.mark.asyncio
+async def test_handles_are_namespace_scoped() -> None:
+    """Handles must not be visible to callers from another namespace."""
+    registry: dict[str, ProcessRecord] = {}
+    async with _running_server(registry) as socket_path:
+        result = await _run(socket_path, ["sleep", "300"], namespace="ns-a", timeout=0)
+        handle = _extract_handle(result)
+        try:
+            assert "Unknown handle" in await _check(socket_path, handle, namespace="ns-b")
+            assert "Unknown handle" in await _kill(socket_path, handle, namespace="ns-b", force=True)
+        finally:
+            await _kill(socket_path, handle, namespace="ns-a", force=True)
+
+
+@pytest.mark.asyncio
+async def test_client_disconnect_cancels_foreground_run() -> None:
+    """A client that dies mid-run must not leave the command running unsupervised."""
+    registry: dict[str, ProcessRecord] = {}
+    pid_dir = Path(tempfile.mkdtemp(prefix="mindroom-shell-pid-"))
+    pid_file = pid_dir / "run.pid"
+    script = (
+        "import os, pathlib, sys, time; "
+        "pathlib.Path(sys.argv[1]).write_text(str(os.getpid()), encoding='utf-8'); "
+        "time.sleep(300)"
+    )
+    try:
+        async with _running_server(registry) as socket_path:
+            _reader, writer = await asyncio.open_unix_connection(socket_path)
+            request = {
+                "op": "run",
+                "namespace": "ns",
+                "argv": [sys.executable, "-c", script, str(pid_file)],
+                "env": _MINIMAL_ENV,
+                "cwd": None,
+                "tail": 100,
+                "timeout": 300,
+            }
+            writer.write(json.dumps(request).encode() + b"\n")
+            await writer.drain()
+
+            pid: int | None = None
+            for _ in range(50):
+                if pid_file.exists() and pid_file.read_text(encoding="utf-8").strip():
+                    pid = int(pid_file.read_text(encoding="utf-8").strip())
+                    break
+                await asyncio.sleep(0.05)
+            assert pid is not None
+
+            writer.close()
+            with contextlib.suppress(OSError):
+                await writer.wait_closed()
+
+            await _assert_pid_dead(pid)
+            assert registry == {}
+    finally:
+        shutil.rmtree(pid_dir, ignore_errors=True)
+
+
+@pytest.mark.asyncio
+async def test_unknown_operation_returns_error() -> None:
+    """Unknown operations should produce an error message, not kill the server."""
+    registry: dict[str, ProcessRecord] = {}
+    async with _running_server(registry) as socket_path:
+        reader, writer = await asyncio.open_unix_connection(socket_path)
+        writer.write(json.dumps({"op": "nope"}).encode() + b"\n")
+        await writer.drain()
+        line = await reader.readline()
+        writer.close()
+        with contextlib.suppress(OSError):
+            await writer.wait_closed()
+        assert "Unknown shell supervisor operation" in json.loads(line)["message"]
+
+        # The server keeps serving after the bad request.
+        assert await _run(socket_path, ["echo", "still-alive"]) == "still-alive"
+
+
+# ---------------------------------------------------------------------------
+# Supervisor process + manager
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def manager() -> Iterator[_ShellSupervisorManager]:
+    """Provide an isolated supervisor manager that is shut down after the test."""
+    supervisor_manager = _ShellSupervisorManager()
+    yield supervisor_manager
+    supervisor_manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_manager_spawns_supervisor_and_reuses_it(manager: _ShellSupervisorManager) -> None:
+    """ensure() should spawn one real supervisor process and reuse it while alive."""
+    socket_path = manager.ensure()
+    assert await _run(socket_path, ["echo", "via-process"]) == "via-process"
+    assert manager.ensure() == socket_path
+
+
+@pytest.mark.asyncio
+async def test_supervisor_terminate_kills_children_and_invalidates_handles(
+    manager: _ShellSupervisorManager,
+) -> None:
+    """Stopping the supervisor must kill supervised processes; a respawn has no handles."""
+    socket_path = manager.ensure()
+    result = await _run(socket_path, ["sleep", "300"], timeout=0)
+    handle = _extract_handle(result)
+    assert "PID " in result
+    pid = int(result.split("PID ")[1].split(")")[0])
+
+    supervisor = manager._supervisor
+    assert supervisor is not None
+    supervisor.process.terminate()
+    supervisor.process.wait(timeout=10)
+    await _assert_pid_dead(pid)
+
+    new_socket_path = manager.ensure()
+    assert new_socket_path != socket_path
+    assert "Unknown handle" in await _check(new_socket_path, handle)
+
+
+@pytest.mark.asyncio
+async def test_orphaned_supervisor_exits_and_kills_children() -> None:
+    """A supervisor whose parent dies must clean up its children and socket dir."""
+    runtime_dir = Path(tempfile.mkdtemp(prefix="mindroom-shell-orphan-"))
+    socket_path = runtime_dir / "supervisor.sock"
+    supervisor_pid_file = runtime_dir / "supervisor.pid"
+    # Spawn the supervisor from a short-lived intermediate parent so it becomes
+    # an orphan as soon as that parent exits.
+    launcher = (
+        "import pathlib, subprocess, sys, time\n"
+        "process = subprocess.Popen([sys.executable, '-m', 'mindroom.shell_supervisor', sys.argv[1]])\n"
+        "pathlib.Path(sys.argv[2]).write_text(str(process.pid), encoding='utf-8')\n"
+        "deadline = time.monotonic() + 20\n"
+        "while not pathlib.Path(sys.argv[1]).exists() and time.monotonic() < deadline:\n"
+        "    time.sleep(0.05)\n"
+    )
+    launch = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        launcher,
+        str(socket_path),
+        str(supervisor_pid_file),
+    )
+    await launch.wait()
+    supervisor_pid = int(supervisor_pid_file.read_text(encoding="utf-8").strip())
+
+    try:
+        await _assert_pid_dead(supervisor_pid)
+        for _ in range(40):
+            if not runtime_dir.exists():
+                break
+            await asyncio.sleep(0.1)
+        assert not runtime_dir.exists()
+    finally:
+        with contextlib.suppress(ProcessLookupError, PermissionError):
+            os.kill(supervisor_pid, signal.SIGKILL)
+        shutil.rmtree(runtime_dir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Toolkit client mode
+# ---------------------------------------------------------------------------
+
+
+def _make_runtime_paths(tmp_path: Path) -> RuntimePaths:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "models:\n  default:\n    provider: openai\n    id: gpt-5.4\nagents: {}\nrouter:\n  model: default\n",
+        encoding="utf-8",
+    )
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    return resolve_runtime_paths(
+        config_path=config_path,
+        storage_path=tmp_path / "storage",
+        process_env={},
+    )
+
+
+def _get_toolkit(tmp_path: Path) -> Toolkit:
+    runtime_paths = _make_runtime_paths(tmp_path)
+    return get_tool_by_name("shell", runtime_paths, disable_sandbox_proxy=True, worker_target=None)
+
+
+@pytest.mark.asyncio
+async def test_toolkit_routes_through_supervisor_across_instances(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    manager: _ShellSupervisorManager,
+) -> None:
+    """With the socket env set, handles must work across fresh toolkit instances.
+
+    This simulates the sandbox subprocess path where every run/check/kill
+    request executes in a separate short-lived process.
+    """
+    monkeypatch.setenv(SHELL_SUPERVISOR_SOCKET_ENV, manager.ensure())
+
+    tool_run = _get_toolkit(tmp_path)
+    run_fn = tool_run.async_functions["run_shell_command"].entrypoint
+    assert run_fn is not None
+    result = await run_fn(["bash", "-c", "echo client-mode; sleep 300"], timeout=0)
+    handle = _extract_handle(result)
+
+    await asyncio.sleep(0.3)
+    tool_check = _get_toolkit(tmp_path)
+    check_fn = tool_check.functions["check_shell_command"].entrypoint
+    assert check_fn is not None
+    status = await asyncio.to_thread(check_fn, handle)
+    assert "RUNNING" in status
+    assert "client-mode" in status
+
+    tool_kill = _get_toolkit(tmp_path)
+    kill_fn = tool_kill.functions["kill_shell_command"].entrypoint
+    assert kill_fn is not None
+    kill_result = await asyncio.to_thread(kill_fn, handle, True)
+    assert "Force-killed" in kill_result
+
+
+@pytest.mark.asyncio
+async def test_toolkit_reports_unavailable_supervisor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dead supervisor socket should produce a clear error, not a crash."""
+    monkeypatch.setenv(SHELL_SUPERVISOR_SOCKET_ENV, str(tmp_path / "missing.sock"))
+    tool = _get_toolkit(tmp_path)
+    run_fn = tool.async_functions["run_shell_command"].entrypoint
+    assert run_fn is not None
+    result = await run_fn(["echo", "hi"])
+    assert result.startswith("Error: Shell supervisor is unavailable")
+
+
+# ---------------------------------------------------------------------------
+# Sandbox runner subprocess dispatch (end-to-end)
+# ---------------------------------------------------------------------------
+
+
+def test_subprocess_mode_shell_background_handle_across_requests(tmp_path: Path) -> None:
+    """Background handles must survive per-request subprocess isolation.
+
+    Each run/check/kill request executes in its own sandbox subprocess; the
+    handle lives in the runner's shell supervisor, not in any request process.
+    """
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "models:\n  default:\n    provider: openai\n    id: gpt-5.4\nagents: {}\nrouter:\n  model: default\n",
+        encoding="utf-8",
+    )
+    runtime_paths = resolve_runtime_paths(
+        config_path=config_path,
+        storage_path=tmp_path / "storage",
+        process_env={"MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE": "subprocess"},
+    )
+    config = sandbox_runner_module._runtime_config_or_empty(runtime_paths)
+
+    def execute(function_name: str, kwargs: dict[str, object]) -> str:
+        response = sandbox_runner_module._execute_request_subprocess_sync(
+            sandbox_runner_module.SandboxRunnerExecuteRequest(
+                tool_name="shell",
+                function_name=function_name,
+                kwargs=kwargs,
+            ),
+            runtime_paths,
+            config,
+        )
+        assert response.ok, response.error
+        assert isinstance(response.result, str)
+        return response.result
+
+    result = execute("run_shell_command", {"args": ["bash", "-c", "echo bg-e2e; sleep 300"], "timeout": 0})
+    handle = _extract_handle(result)
+
+    status = execute("check_shell_command", {"handle": handle})
+    assert "RUNNING" in status
+
+    kill_result = execute("kill_shell_command", {"handle": handle, "force": True})
+    assert "Force-killed" in kill_result
+
+
+# ---------------------------------------------------------------------------
+# Runner dispatch helpers
+# ---------------------------------------------------------------------------
+
+
+def test_shell_run_timeout_seconds_parses_kwargs() -> None:
+    """The dispatch budget helper should read the requested foreground timeout."""
+
+    def prepared(function_name: str, kwargs: dict[str, object]) -> object:
+        return sandbox_runner_module.PreparedSandboxRunnerExecuteRequest(
+            tool_name="shell",
+            function_name=function_name,
+            kwargs=kwargs,
+        )
+
+    helper = sandbox_runner_module._shell_run_timeout_seconds
+    assert helper(prepared("run_shell_command", {"timeout": 300})) == 300.0
+    assert helper(prepared("run_shell_command", {})) == 120.0
+    assert helper(prepared("run_shell_command", {"timeout": "nope"})) == 120.0
+    assert helper(prepared("check_shell_command", {"timeout": 300})) == 0.0
+
+
+def test_shell_subprocess_dispatch_context_injects_socket_and_budget(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Shell dispatch should advertise the supervisor socket and stretch the budget."""
+    socket_path = str(tmp_path / "test.sock")
+    monkeypatch.setattr(shell_supervisor, "ensure_shell_supervisor", lambda: socket_path)
+    prepared = sandbox_runner_module.PreparedSandboxRunnerExecuteRequest(
+        tool_name="shell",
+        function_name="run_shell_command",
+        kwargs={"timeout": 600},
+    )
+    subprocess_context = sandbox_runner_module._PreparedSandboxSubprocessContext(
+        python_executable=sys.executable,
+        subprocess_env={"PATH": "/usr/bin"},
+        subprocess_cwd=None,
+        template_env={"PATH": "/usr/bin"},
+    )
+
+    updated_context, timeout_seconds = sandbox_runner_module._shell_subprocess_dispatch_context(
+        prepared,
+        subprocess_context,
+        120.0,
+    )
+
+    assert updated_context.subprocess_env is not None
+    assert updated_context.subprocess_env[SHELL_SUPERVISOR_SOCKET_ENV] == socket_path
+    assert updated_context.template_env == {"PATH": "/usr/bin"}
+    assert timeout_seconds == 630.0


### PR DESCRIPTION
Closes #407.

## Problem

PR #394 kept shell background handles alive by exempting `shell` from sandbox subprocess isolation: shell always executed in-process in the long-lived sandbox runner because the handle registry and monitor tasks lived there. That weakened the isolation model for `shell` compared with `python` and other execution tools, and the runner dispatch carried two `tool_name != "shell"` special cases.

## Design

Shell now dispatches through the same per-request subprocess (spawn or forkserver) path as every other tool. Background handles move into a **worker-local shell supervisor**: one small long-lived process per runner instance that owns the shell child processes and the in-memory handle registry.

```text
primary runtime ──HTTP──> sandbox runner ──spawn/fork──> per-request tool subprocess
                              │                                  │ shell toolkit computes argv/env/cwd
                              │ spawns once, owns lifetime       │ relays run/check/kill over unix socket
                              └────────> shell supervisor <──────┘
                                         (owns shell children + handle registry)
```

- `mindroom/shell_execution.py` (new): the process spawning, output buffering, and handle-registry core, extracted verbatim from the shell toolkit. Importable in ~0.2 s (no `mindroom.tools` package import), so the supervisor starts near-instantly — no warm-template machinery needed.
- `mindroom/shell_supervisor.py` (new): asyncio unix-socket server around that core, plus the toolkit-side clients and the runner-side manager (`ensure_shell_supervisor()`). The runner advertises the socket via `MINDROOM_SANDBOX_SHELL_SUPERVISOR_SOCKET`; the `MINDROOM_SANDBOX_` prefix keeps it out of shell env passthrough automatically.
- `sandbox_runner.py`: the two shell in-process exceptions are deleted. Shell dispatch injects the supervisor socket into the child env and stretches the per-request subprocess budget over the requested `run_shell_command` timeout so the runner can't kill the relay mid-wait.

## Issue requirements

- `run_shell_command(timeout=...)` returns a handle for long-running commands — unchanged UX, same message formats.
- `check_shell_command` / `kill_shell_command` work across multiple requests to the same worker: each request subprocess talks to the same supervisor.
- Handle ownership stays worker-local: handles remain namespaced by `storage_root::base_dir`, enforced supervisor-side; dedicated worker pods get a per-pod supervisor.
- Restarting the worker invalidates handles: the supervisor exits on parent death, orphaning, or SIGTERM, and kills unfinished process groups on the way out (no leaked commands).
- Worker-specific `HOME`, `VIRTUAL_ENV`, `PATH`, `base_dir`, and explicit runtime env are still honored: env assembly is untouched and still happens in the request subprocess; the fully-computed env ships with each run request.
- The in-process exception is gone: shell uses the same per-request subprocess execution model as every other tool. One shell-specific block remains on that shared path (`_shell_subprocess_dispatch_context` injects the supervisor socket and stretches the timeout budget) — the special case shrank from a different execution model to an env var plus a budget adjustment; it did not vanish entirely.

Cancellation parity: a client that disconnects mid-run (e.g. the request subprocess is killed) cancels the supervised run, which terminates the process group — the same semantics as cancelling a local `run_shell_command`.

Local (non-sandbox) execution keeps the in-process registry; nothing changes for setups without workers.

## Testing

- `tests/test_shell_supervisor.py` (new): protocol round-trips, handle lifecycle, namespace isolation, client-disconnect cancellation, orphan cleanup, manager respawn-invalidates-handles, toolkit client mode across fresh instances, and an end-to-end `subprocess`-mode test proving run/check/kill work across three separate sandbox subprocesses.
- Existing shell and sandbox suites updated for the extraction (import/patch targets only); the proxy-side shell subprocess tests now exercise the supervisor end-to-end.
- Full suite: 9316 passed, 61 skipped. `tach check` and pre-commit clean.
