### PR TITLE
Always retry media-bearing model failures without inline media

### DIFF
--- a/docs/images.md
+++ b/docs/images.md
@@ -82,11 +82,12 @@ The retried prompt includes `[Inline media unavailable for this model]` to infor
 Agents can still reference the files via attachment IDs and tools.
 
 This fallback is transparent — no user action is required.
+Any failure of a media-bearing request triggers one retry without media — no error wording decides whether to retry, so unknown provider prose degrades gracefully instead of surfacing a raw provider error.
 When the provider names the rejected media kind (for example "audio input is not supported"), only that kind is dropped and the model route immediately learns that it is unsupported.
-Any other invalid-request rejection (HTTP 400/413/415/422, or generic markers like `Error code: 400` in the error text) triggers one retry without media, so new providers degrade gracefully without MindRoom knowing their error wording.
-When such a retry succeeds, the model route learns that the dropped media kinds are unsupported, and later requests omit them up front instead of paying a failed API call.
+When a retry succeeds after an invalid-request rejection (HTTP 400/413/415/422, or generic markers like `Error code: 400` in the error text), the model route learns that the dropped media kinds are unsupported, and later requests omit them up front instead of paying a failed API call.
+Transient failures (rate limits, server errors) also retry without media, but never teach the capability state, since their retry can succeed for reasons unrelated to media support.
 This learned capability state is process-local and resets on restart.
-Payload-size and context-overflow rejections still retry without media but never teach the capability state, since dropping media can shrink an oversized request for reasons unrelated to media support.
+Payload-size and context-overflow rejections likewise never teach the capability state, since dropping media can shrink an oversized request for reasons unrelated to media support.
 
 ## Limitations
 

--- a/docs/images.md
+++ b/docs/images.md
@@ -83,11 +83,9 @@ Agents can still reference the files via attachment IDs and tools.
 
 This fallback is transparent — no user action is required.
 Any failure of a media-bearing request triggers one retry without media — no error wording decides whether to retry, so unknown provider prose degrades gracefully instead of surfacing a raw provider error.
-When the provider names the rejected media kind (for example "audio input is not supported"), only that kind is dropped and the model route immediately learns that it is unsupported.
-When a retry succeeds after an invalid-request rejection (HTTP 400/413/415/422, or generic markers like `Error code: 400` in the error text), the model route learns that the dropped media kinds are unsupported, and later requests omit them up front instead of paying a failed API call.
-Transient failures (rate limits, server errors) also retry without media, but never teach the capability state, since their retry can succeed for reasons unrelated to media support.
+When the retry succeeds, the model route learns that the dropped media kinds are unsupported, and later requests omit them up front instead of paying a failed API call.
 This learned capability state is process-local and resets on restart.
-Payload-size and context-overflow rejections likewise never teach the capability state, since dropping media can shrink an oversized request for reasons unrelated to media support.
+Payload-size and context-overflow rejections never teach the capability state, since dropping media can shrink an oversized request for reasons unrelated to media support.
 
 ## Limitations
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -12888,11 +12888,9 @@ Agents can still reference the files via attachment IDs and tools.
 
 This fallback is transparent — no user action is required.
 Any failure of a media-bearing request triggers one retry without media — no error wording decides whether to retry, so unknown provider prose degrades gracefully instead of surfacing a raw provider error.
-When the provider names the rejected media kind (for example "audio input is not supported"), only that kind is dropped and the model route immediately learns that it is unsupported.
-When a retry succeeds after an invalid-request rejection (HTTP 400/413/415/422, or generic markers like `Error code: 400` in the error text), the model route learns that the dropped media kinds are unsupported, and later requests omit them up front instead of paying a failed API call.
-Transient failures (rate limits, server errors) also retry without media, but never teach the capability state, since their retry can succeed for reasons unrelated to media support.
+When the retry succeeds, the model route learns that the dropped media kinds are unsupported, and later requests omit them up front instead of paying a failed API call.
 This learned capability state is process-local and resets on restart.
-Payload-size and context-overflow rejections likewise never teach the capability state, since dropping media can shrink an oversized request for reasons unrelated to media support.
+Payload-size and context-overflow rejections never teach the capability state, since dropping media can shrink an oversized request for reasons unrelated to media support.
 
 ## Limitations
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -12887,11 +12887,12 @@ The retried prompt includes `[Inline media unavailable for this model]` to infor
 Agents can still reference the files via attachment IDs and tools.
 
 This fallback is transparent — no user action is required.
+Any failure of a media-bearing request triggers one retry without media — no error wording decides whether to retry, so unknown provider prose degrades gracefully instead of surfacing a raw provider error.
 When the provider names the rejected media kind (for example "audio input is not supported"), only that kind is dropped and the model route immediately learns that it is unsupported.
-Any other invalid-request rejection (HTTP 400/413/415/422, or generic markers like `Error code: 400` in the error text) triggers one retry without media, so new providers degrade gracefully without MindRoom knowing their error wording.
-When such a retry succeeds, the model route learns that the dropped media kinds are unsupported, and later requests omit them up front instead of paying a failed API call.
+When a retry succeeds after an invalid-request rejection (HTTP 400/413/415/422, or generic markers like `Error code: 400` in the error text), the model route learns that the dropped media kinds are unsupported, and later requests omit them up front instead of paying a failed API call.
+Transient failures (rate limits, server errors) also retry without media, but never teach the capability state, since their retry can succeed for reasons unrelated to media support.
 This learned capability state is process-local and resets on restart.
-Payload-size and context-overflow rejections still retry without media but never teach the capability state, since dropping media can shrink an oversized request for reasons unrelated to media support.
+Payload-size and context-overflow rejections likewise never teach the capability state, since dropping media can shrink an oversized request for reasons unrelated to media support.
 
 ## Limitations
 

--- a/skills/mindroom-docs/references/page__images__index.md
+++ b/skills/mindroom-docs/references/page__images__index.md
@@ -79,11 +79,9 @@ Agents can still reference the files via attachment IDs and tools.
 
 This fallback is transparent — no user action is required.
 Any failure of a media-bearing request triggers one retry without media — no error wording decides whether to retry, so unknown provider prose degrades gracefully instead of surfacing a raw provider error.
-When the provider names the rejected media kind (for example "audio input is not supported"), only that kind is dropped and the model route immediately learns that it is unsupported.
-When a retry succeeds after an invalid-request rejection (HTTP 400/413/415/422, or generic markers like `Error code: 400` in the error text), the model route learns that the dropped media kinds are unsupported, and later requests omit them up front instead of paying a failed API call.
-Transient failures (rate limits, server errors) also retry without media, but never teach the capability state, since their retry can succeed for reasons unrelated to media support.
+When the retry succeeds, the model route learns that the dropped media kinds are unsupported, and later requests omit them up front instead of paying a failed API call.
 This learned capability state is process-local and resets on restart.
-Payload-size and context-overflow rejections likewise never teach the capability state, since dropping media can shrink an oversized request for reasons unrelated to media support.
+Payload-size and context-overflow rejections never teach the capability state, since dropping media can shrink an oversized request for reasons unrelated to media support.
 
 ## Limitations
 

--- a/skills/mindroom-docs/references/page__images__index.md
+++ b/skills/mindroom-docs/references/page__images__index.md
@@ -78,11 +78,12 @@ The retried prompt includes `[Inline media unavailable for this model]` to infor
 Agents can still reference the files via attachment IDs and tools.
 
 This fallback is transparent — no user action is required.
+Any failure of a media-bearing request triggers one retry without media — no error wording decides whether to retry, so unknown provider prose degrades gracefully instead of surfacing a raw provider error.
 When the provider names the rejected media kind (for example "audio input is not supported"), only that kind is dropped and the model route immediately learns that it is unsupported.
-Any other invalid-request rejection (HTTP 400/413/415/422, or generic markers like `Error code: 400` in the error text) triggers one retry without media, so new providers degrade gracefully without MindRoom knowing their error wording.
-When such a retry succeeds, the model route learns that the dropped media kinds are unsupported, and later requests omit them up front instead of paying a failed API call.
+When a retry succeeds after an invalid-request rejection (HTTP 400/413/415/422, or generic markers like `Error code: 400` in the error text), the model route learns that the dropped media kinds are unsupported, and later requests omit them up front instead of paying a failed API call.
+Transient failures (rate limits, server errors) also retry without media, but never teach the capability state, since their retry can succeed for reasons unrelated to media support.
 This learned capability state is process-local and resets on restart.
-Payload-size and context-overflow rejections still retry without media but never teach the capability state, since dropping media can shrink an oversized request for reasons unrelated to media support.
+Payload-size and context-overflow rejections likewise never teach the capability state, since dropping media can shrink an oversized request for reasons unrelated to media support.
 
 ## Limitations
 

--- a/src/mindroom/media_fallback.py
+++ b/src/mindroom/media_fallback.py
@@ -65,6 +65,14 @@ _INVALID_REQUEST_TEXT_PATTERN = re.compile(
     rf"error code: (?:{'|'.join(str(code) for code in sorted(_INVALID_REQUEST_STATUS_CODES))})\b"
     r"|\bbad request\b|\binvalid_request_error\b|\binvalid_argument\b",
 )
+# Z.ai reports content part types it cannot parse at all (e.g. OpenAI-style
+# "file" parts) as a bare "messages[N].content[M].type type error" (code 1214).
+# On the streaming path agno converts the 400 into a RunErrorEvent whose text
+# is only this bare message — the status code and "Error code: 400" marker are
+# gone — so the generic invalid-request gate cannot recognize it there.
+_CONTENT_PART_TYPE_ERROR_PATTERN = re.compile(
+    r"messages(?:\[\d+\])?\.content(?:\[\d+\])?\.type type error",
+)
 # Invalid-request errors that name credentials are not media failures; retrying
 # without media would fail identically.
 _AUTH_ERROR_TEXT_PATTERN = re.compile(r"api[\s_-]?key|unauthorized|forbidden|authentication")
@@ -211,9 +219,10 @@ def retry_media_inputs_after_failure(
     if validation_kinds:
         return _media_retry_decision_for_kinds(media_inputs, validation_kinds, present_kinds=present_kinds)
 
-    if _INLINE_MEDIA_GENERIC_UNSUPPORTED_PATTERN.search(lowered_error_text) or _is_invalid_request_error(
-        error,
-        lowered_error_text,
+    if (
+        _INLINE_MEDIA_GENERIC_UNSUPPORTED_PATTERN.search(lowered_error_text)
+        or _CONTENT_PART_TYPE_ERROR_PATTERN.search(lowered_error_text)
+        or _is_invalid_request_error(error, lowered_error_text)
     ):
         teaching_blocked = _capability_teaching_blocked(error, lowered_error_text)
         return MediaRetryDecision(

--- a/src/mindroom/media_fallback.py
+++ b/src/mindroom/media_fallback.py
@@ -54,11 +54,12 @@ _TEXT_ONLY_CONTENT_TYPE_PATTERN = re.compile(
     r"content(?:\[\d+\])?\.type is invalid, allowed values: \['text'\]",
 )
 # Invalid-request-class evidence: the provider rejected the request itself, so
-# when the request carried media, retrying once without it degrades gracefully
-# for any provider without matching that provider's error prose. Exceptions
-# carry the status code; stringified errored-run text only keeps generic,
-# protocol-stable markers (OpenAI SDK "Error code: N" prefixes, HTTP phrasing,
-# OpenAI/Anthropic "invalid_request_error", Google "INVALID_ARGUMENT").
+# a successful without-media retry is proof the media caused it and the route
+# capability cache may learn from it. Retrying never depends on this evidence
+# — only teaching does. Exceptions carry the status code; stringified
+# errored-run text only keeps generic, protocol-stable markers (OpenAI SDK
+# "Error code: N" prefixes, HTTP phrasing, OpenAI/Anthropic
+# "invalid_request_error", Google "INVALID_ARGUMENT").
 _INVALID_REQUEST_STATUS_CODES = frozenset({400, 413, 415, 422})
 _PAYLOAD_TOO_LARGE_STATUS = 413
 _INVALID_REQUEST_TEXT_PATTERN = re.compile(
@@ -69,7 +70,7 @@ _INVALID_REQUEST_TEXT_PATTERN = re.compile(
 # "file" parts) as a bare "messages[N].content[M].type type error" (code 1214).
 # On the streaming path agno converts the 400 into a RunErrorEvent whose text
 # is only this bare message — the status code and "Error code: 400" marker are
-# gone — so the generic invalid-request gate cannot recognize it there.
+# gone — so this shape is teaching evidence in its own right.
 _CONTENT_PART_TYPE_ERROR_PATTERN = re.compile(
     r"messages(?:\[\d+\])?\.content(?:\[\d+\])?\.type type error",
 )
@@ -181,14 +182,21 @@ def retry_media_inputs_after_failure(
 ) -> MediaRetryDecision:
     """Decide whether and how one media-bearing request should retry.
 
-    Explicit "kind is not supported" errors teach the route cache so later
-    requests pre-drop that kind; text-only content errors teach every present
-    kind; kind-specific validation errors (malformed or mis-encoded media)
-    retry once without ever teaching. Any other invalid-request-class failure
-    retries once without media and teaches the cache only when that retry
-    succeeds — unless the error names a payload-size or context-overflow
-    cause, where dropping media can succeed for the wrong reason. A kind can
-    only be learned when it was actually present in ``media_inputs`` or
+    Every failure of a media-bearing request retries once without media —
+    no error wording decides *whether* to retry, so unknown provider prose
+    (and streamed run errors that lost their HTTP status) still degrade
+    gracefully instead of leaking a raw provider error to the user. Error
+    patterns only refine the decision: explicit "kind is not supported"
+    errors drop and teach just that kind; text-only content errors teach
+    every present kind; kind-specific validation errors (malformed or
+    mis-encoded media) drop just that kind without ever teaching. Any other
+    failure drops all media, and the route capability cache learns from the
+    retry's success only when the error carried invalid-request-class
+    evidence (4xx status or protocol-stable text markers) — a transient
+    failure whose retry happens to succeed must not teach — and never when
+    the error names a payload-size or context-overflow cause, where
+    dropping media can succeed for the wrong reason. A kind can only be
+    learned when it was actually present in ``media_inputs`` or
     ``extra_present_kinds`` (media pinned to thread-history messages in the
     run input).
     """
@@ -219,20 +227,18 @@ def retry_media_inputs_after_failure(
     if validation_kinds:
         return _media_retry_decision_for_kinds(media_inputs, validation_kinds, present_kinds=present_kinds)
 
-    if (
+    teaching_evidence = bool(
         _INLINE_MEDIA_GENERIC_UNSUPPORTED_PATTERN.search(lowered_error_text)
         or _CONTENT_PART_TYPE_ERROR_PATTERN.search(lowered_error_text)
-        or _is_invalid_request_error(error, lowered_error_text)
-    ):
-        teaching_blocked = _capability_teaching_blocked(error, lowered_error_text)
-        return MediaRetryDecision(
-            should_retry=True,
-            media_inputs=_without_media_kinds(media_inputs, present_kinds),
-            removed_kinds=present_kinds,
-            teach_route_on_success=None if teaching_blocked else route,
-        )
-
-    return _no_media_retry_decision(media_inputs)
+        or _is_invalid_request_error(error, lowered_error_text),
+    )
+    teaching_blocked = _capability_teaching_blocked(error, lowered_error_text)
+    return MediaRetryDecision(
+        should_retry=True,
+        media_inputs=_without_media_kinds(media_inputs, present_kinds),
+        removed_kinds=present_kinds,
+        teach_route_on_success=route if teaching_evidence and not teaching_blocked else None,
+    )
 
 
 def reset_model_media_capability_cache() -> None:

--- a/src/mindroom/media_fallback.py
+++ b/src/mindroom/media_fallback.py
@@ -1,8 +1,7 @@
-"""Shared inline-media fallback detection and model capability helpers."""
+"""Shared inline-media fallback and model capability helpers."""
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -37,63 +36,7 @@ __all__ = [
 ]
 
 _INLINE_MEDIA_FALLBACK_MARKER = "[Inline media unavailable for this model]"
-_INLINE_MEDIA_FIELD_PATTERN = re.compile(
-    r"(?P<kind>document|image|audio|video)\.source\.base64(?:\.media_type)?",
-)
-_INLINE_MEDIA_MIME_MISMATCH_PATTERN = re.compile(r"image was specified using the .* media type")
-_INLINE_MEDIA_GENERIC_UNSUPPORTED_PATTERN = re.compile(r"(?:inline media|media input) is not supported")
-_OPENAI_AUDIO_FORMAT_FIELD_PATTERN = re.compile(r"\binput_audio\.format\b")
-_OPENAI_AUDIO_FORMAT_VALUE_PATTERN = re.compile(
-    r"invalid value: ['\"][^'\"]+['\"].*supported values are: ['\"]wav['\"] and ['\"]mp3['\"]",
-)
-_OPENAI_OUTPUT_FORMAT_PATTERN = re.compile(r"\boutput_format\b")
-# Z.ai text-only models reject any non-text content part without naming a media
-# kind ("messages.content.type is invalid, allowed values: ['text']"), so every
-# present kind is unsupported for the route.
-_TEXT_ONLY_CONTENT_TYPE_PATTERN = re.compile(
-    r"content(?:\[\d+\])?\.type is invalid, allowed values: \['text'\]",
-)
-# Invalid-request-class evidence: the provider rejected the request itself, so
-# a successful without-media retry is proof the media caused it and the route
-# capability cache may learn from it. Retrying never depends on this evidence
-# — only teaching does. Exceptions carry the status code; stringified
-# errored-run text only keeps generic, protocol-stable markers (OpenAI SDK
-# "Error code: N" prefixes, HTTP phrasing, OpenAI/Anthropic
-# "invalid_request_error", Google "INVALID_ARGUMENT").
-_INVALID_REQUEST_STATUS_CODES = frozenset({400, 413, 415, 422})
 _PAYLOAD_TOO_LARGE_STATUS = 413
-_INVALID_REQUEST_TEXT_PATTERN = re.compile(
-    rf"error code: (?:{'|'.join(str(code) for code in sorted(_INVALID_REQUEST_STATUS_CODES))})\b"
-    r"|\bbad request\b|\binvalid_request_error\b|\binvalid_argument\b",
-)
-# Z.ai reports content part types it cannot parse at all (e.g. OpenAI-style
-# "file" parts) as a bare "messages[N].content[M].type type error" (code 1214).
-# On the streaming path agno converts the 400 into a RunErrorEvent whose text
-# is only this bare message — the status code and "Error code: 400" marker are
-# gone — so this shape is teaching evidence in its own right.
-_CONTENT_PART_TYPE_ERROR_PATTERN = re.compile(
-    r"messages(?:\[\d+\])?\.content(?:\[\d+\])?\.type type error",
-)
-# Invalid-request errors that name credentials are not media failures; retrying
-# without media would fail identically.
-_AUTH_ERROR_TEXT_PATTERN = re.compile(r"api[\s_-]?key|unauthorized|forbidden|authentication")
-_MEDIA_KIND_PATTERN = r"audio|image|video|file|document"
-_INLINE_MEDIA_UNSUPPORTED_PATTERNS = (
-    re.compile(rf"(?P<kind>{_MEDIA_KIND_PATTERN}) input is not supported"),
-    re.compile(rf"(?P<kind>{_MEDIA_KIND_PATTERN}) inputs are not supported"),
-    re.compile(rf"does not support (?P<kind>{_MEDIA_KIND_PATTERN}) input"),
-    re.compile(rf"support input (?P<kind>{_MEDIA_KIND_PATTERN})"),
-    re.compile(rf"at most 0 (?P<kind>{_MEDIA_KIND_PATTERN})\(s\) may be provided"),
-)
-
-# Provider error vocabulary -> our MediaInputs kind (providers say "document" for files).
-_PROVIDER_MEDIA_KINDS: dict[str, MediaKind] = {
-    "audio": "audio",
-    "image": "image",
-    "video": "video",
-    "file": "file",
-    "document": "file",
-}
 
 
 @dataclass(frozen=True, slots=True)
@@ -180,21 +123,15 @@ def retry_media_inputs_after_failure(
     *,
     extra_present_kinds: frozenset[MediaKind] = frozenset(),
 ) -> MediaRetryDecision:
-    """Decide whether and how one media-bearing request should retry.
+    """Decide how one media-bearing request should retry after a failure.
 
     Every failure of a media-bearing request retries once without media —
-    no error wording decides *whether* to retry, so unknown provider prose
-    (and streamed run errors that lost their HTTP status) still degrade
-    gracefully instead of leaking a raw provider error to the user. Error
-    patterns only refine the decision: explicit "kind is not supported"
-    errors drop and teach just that kind; text-only content errors teach
-    every present kind; kind-specific validation errors (malformed or
-    mis-encoded media) drop just that kind without ever teaching. Any other
-    failure drops all media, and the route capability cache learns from the
-    retry's success only when the error carried invalid-request-class
-    evidence (4xx status or protocol-stable text markers) — a transient
-    failure whose retry happens to succeed must not teach — and never when
-    the error names a payload-size or context-overflow cause, where
+    no error wording decides whether to retry, so unknown provider prose
+    (and streamed run errors that lost their HTTP status) degrade
+    gracefully instead of leaking a raw provider error to the user. The
+    route capability cache learns the dropped kinds once the retry actually
+    succeeds (via :meth:`MediaRetryDecision.record_retry_success`), except
+    when the error names a payload-size or context-overflow cause, where
     dropping media can succeed for the wrong reason. A kind can only be
     learned when it was actually present in ``media_inputs`` or
     ``extra_present_kinds`` (media pinned to thread-history messages in the
@@ -204,40 +141,12 @@ def retry_media_inputs_after_failure(
     if not present_kinds:
         return _no_media_retry_decision(media_inputs)
 
-    error_text = str(error)
-    unsupported_kinds = _unsupported_media_kinds_from_error(error_text)
-    if unsupported_kinds:
-        return _media_retry_decision_for_kinds(
-            media_inputs,
-            unsupported_kinds,
-            present_kinds=present_kinds,
-            cache_route=route,
-        )
-
-    lowered_error_text = error_text.lower()
-    if _TEXT_ONLY_CONTENT_TYPE_PATTERN.search(lowered_error_text):
-        return _media_retry_decision_for_kinds(
-            media_inputs,
-            present_kinds,
-            present_kinds=present_kinds,
-            cache_route=route,
-        )
-
-    validation_kinds = _media_validation_kinds_from_error(error_text)
-    if validation_kinds:
-        return _media_retry_decision_for_kinds(media_inputs, validation_kinds, present_kinds=present_kinds)
-
-    teaching_evidence = bool(
-        _INLINE_MEDIA_GENERIC_UNSUPPORTED_PATTERN.search(lowered_error_text)
-        or _CONTENT_PART_TYPE_ERROR_PATTERN.search(lowered_error_text)
-        or _is_invalid_request_error(error, lowered_error_text),
-    )
-    teaching_blocked = _capability_teaching_blocked(error, lowered_error_text)
+    teaching_blocked = _capability_teaching_blocked(error, str(error).lower())
     return MediaRetryDecision(
         should_retry=True,
         media_inputs=_without_media_kinds(media_inputs, present_kinds),
         removed_kinds=present_kinds,
-        teach_route_on_success=route if teaching_evidence and not teaching_blocked else None,
+        teach_route_on_success=None if teaching_blocked else route,
     )
 
 
@@ -258,41 +167,12 @@ def append_inline_media_fallback_prompt(
     return f"{full_prompt.rstrip()}\n\n{_INLINE_MEDIA_FALLBACK_MARKER}\n{fallback_prompt}"
 
 
-def _media_retry_decision_for_kinds(
-    media_inputs: MediaInputs,
-    kinds: frozenset[MediaKind],
-    *,
-    present_kinds: frozenset[MediaKind],
-    cache_route: ModelMediaRoute | None = None,
-) -> MediaRetryDecision:
-    removed_kinds = kinds & present_kinds
-    if not removed_kinds:
-        return _no_media_retry_decision(media_inputs)
-    if cache_route is not None:
-        _UNSUPPORTED_MEDIA_KINDS_BY_ROUTE.setdefault(cache_route, set()).update(removed_kinds)
-    return MediaRetryDecision(
-        should_retry=True,
-        media_inputs=_without_media_kinds(media_inputs, removed_kinds),
-        removed_kinds=removed_kinds,
-    )
-
-
 def _no_media_retry_decision(media_inputs: MediaInputs) -> MediaRetryDecision:
     return MediaRetryDecision(
         should_retry=False,
         media_inputs=media_inputs,
         removed_kinds=frozenset(),
     )
-
-
-def _is_invalid_request_error(error: Exception | str, lowered_error_text: str) -> bool:
-    # Auth-worded failures are excluded regardless of evidence source: providers
-    # such as Google reject bad API keys with HTTP 400.
-    if _AUTH_ERROR_TEXT_PATTERN.search(lowered_error_text):
-        return False
-    if isinstance(error, ModelProviderError) and error.status_code in _INVALID_REQUEST_STATUS_CODES:
-        return True
-    return bool(_INVALID_REQUEST_TEXT_PATTERN.search(lowered_error_text))
 
 
 def _capability_teaching_blocked(error: Exception | str, lowered_error_text: str) -> bool:
@@ -308,38 +188,6 @@ def _capability_teaching_blocked(error: Exception | str, lowered_error_text: str
     if f"error code: {_PAYLOAD_TOO_LARGE_STATUS}" in lowered_error_text:
         return True
     return any(marker in lowered_error_text for marker in ModelProviderError.CONTEXT_WINDOW_PATTERNS)
-
-
-def _unsupported_media_kinds_from_error(error_text: str) -> frozenset[MediaKind]:
-    lowered_error_text = error_text.lower()
-    kinds: set[MediaKind] = set()
-    for pattern in _INLINE_MEDIA_UNSUPPORTED_PATTERNS:
-        for match in pattern.finditer(lowered_error_text):
-            kind = _canonical_media_kind(match.group("kind"))
-            if kind is not None:
-                kinds.add(kind)
-    return frozenset(kinds)
-
-
-def _media_validation_kinds_from_error(error_text: str) -> frozenset[MediaKind]:
-    lowered_error_text = error_text.lower()
-    kinds = {
-        kind
-        for match in _INLINE_MEDIA_FIELD_PATTERN.finditer(lowered_error_text)
-        if (kind := _canonical_media_kind(match.group("kind"))) is not None
-    }
-    if _INLINE_MEDIA_MIME_MISMATCH_PATTERN.search(lowered_error_text):
-        kinds.add("image")
-    if _OPENAI_AUDIO_FORMAT_FIELD_PATTERN.search(lowered_error_text) or (
-        _OPENAI_AUDIO_FORMAT_VALUE_PATTERN.search(lowered_error_text)
-        and not _OPENAI_OUTPUT_FORMAT_PATTERN.search(lowered_error_text)
-    ):
-        kinds.add("audio")
-    return frozenset(kinds)
-
-
-def _canonical_media_kind(provider_kind: str) -> MediaKind | None:
-    return _PROVIDER_MEDIA_KINDS.get(provider_kind)
 
 
 def _without_media_kinds(media_inputs: MediaInputs, kinds: frozenset[MediaKind]) -> MediaInputs:

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -1493,8 +1493,8 @@ class TestUserIdPassthrough:
         assert "Inline media unavailable for this model" in str(second_prompt[-1].content)
 
     @pytest.mark.asyncio
-    async def test_ai_response_learns_audio_unsupported_for_same_model_route(self, tmp_path: Path) -> None:
-        """Audio-only capability failure should omit audio on later calls to the same concrete route."""
+    async def test_ai_response_learns_media_unsupported_for_same_model_route(self, tmp_path: Path) -> None:
+        """A successful without-media retry teaches the route to omit media on later calls."""
         reset_model_media_capability_cache()
 
         def build_agent() -> MagicMock:
@@ -1560,10 +1560,11 @@ class TestUserIdPassthrough:
         assert fallback_marker in str(cached_prompt[-1].content)
         assert first_prompt[-1].audio == [audio_input]
         assert first_prompt[-1].images == [image_input]
-        assert retry_prompt[-1].audio == ()
-        assert retry_prompt[-1].images == [image_input]
-        assert cached_prompt[-1].audio == ()
-        assert cached_prompt[-1].images == [image_input]
+        # The retry drops all media, and the successful retry teaches the route.
+        assert not retry_prompt[-1].audio
+        assert not retry_prompt[-1].images
+        assert not cached_prompt[-1].audio
+        assert not cached_prompt[-1].images
         reset_model_media_capability_cache()
 
     @pytest.mark.asyncio

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -2118,8 +2118,10 @@ class TestUserIdPassthrough:
             ("[openclaw] Error: At most 0 audio(s) may be provided in one prompt.", True),
             # Invalid-request-class evidence retries once even without media wording.
             ("invalid_request_error: max_tokens must be <= 4096", True),
-            ("Rate limit exceeded", False),
-            ("Error code: 500 - internal server error", False),
+            # Any other failure of a media-bearing request also retries once;
+            # no wording decides whether to retry, only whether the cache teaches.
+            ("Rate limit exceeded", True),
+            ("Error code: 500 - internal server error", True),
         ],
     )
     def test_retry_media_inputs_after_failure_error_matching(self, error_text: str, expected: bool) -> None:
@@ -2172,8 +2174,8 @@ class TestUserIdPassthrough:
         assert custom_user_copy == repeated_custom_user_copy
 
     @pytest.mark.asyncio
-    async def test_ai_response_does_not_retry_without_media_validation_match(self, tmp_path: Path) -> None:
-        """Failures outside the invalid-request class should not trigger inline-media retry."""
+    async def test_ai_response_retries_once_without_media_for_any_failure(self, tmp_path: Path) -> None:
+        """Failures outside the invalid-request class still retry once without inline media."""
         mock_agent = MagicMock()
         mock_agent.model = MagicMock()
         mock_agent.model.__class__.__name__ = "OpenAIChat"
@@ -2202,7 +2204,8 @@ class TestUserIdPassthrough:
             )
 
         assert response == "friendly"
-        assert mock_agent.arun.await_count == 1
+        # First attempt with media, one retry without it, then the error surfaces.
+        assert mock_agent.arun.await_count == 2
         mock_friendly_error.assert_called_once()
 
     @pytest.mark.asyncio

--- a/tests/test_media_fallback.py
+++ b/tests/test_media_fallback.py
@@ -103,15 +103,19 @@ def test_different_base_url_does_not_inherit_negative_cache() -> None:
     assert filtered.media_inputs.audio == media.audio
 
 
-def test_generic_errors_do_not_update_cache() -> None:
-    """Transient or unrelated failures should not teach media capability."""
+def test_generic_errors_retry_but_never_teach() -> None:
+    """Transient failures retry without media but must not teach capability, even on success."""
     reset_model_media_capability_cache()
     media = _media_inputs()
     route = _route()
 
     decision = retry_media_inputs_after_failure(route, "Rate limit exceeded", media)
 
-    assert decision.should_retry is False
+    assert decision.should_retry is True
+    assert decision.media_inputs == MediaInputs()
+    assert decision.teach_route_on_success is None
+
+    decision.record_retry_success()
     filtered = filter_media_inputs_for_route(route, media)
     assert filtered.media_inputs == media
 
@@ -310,8 +314,8 @@ def test_payload_too_large_retries_but_never_teaches() -> None:
     assert unsupported_media_kinds_for_route(route) == frozenset()
 
 
-def test_auth_worded_invalid_request_does_not_retry() -> None:
-    """Credential failures phrased as 400s would fail identically without media on either path."""
+def test_auth_worded_invalid_request_retries_but_never_teaches() -> None:
+    """Credential failures phrased as 400s retry (and fail again) but are not capability evidence."""
     reset_model_media_capability_cache()
     media = _media_inputs()
 
@@ -327,21 +331,22 @@ def test_auth_worded_invalid_request_does_not_retry() -> None:
         media,
     )
 
-    assert text_decision.should_retry is False
-    assert text_decision.media_inputs == media
-    assert exception_decision.should_retry is False
-    assert exception_decision.media_inputs == media
+    assert text_decision.should_retry is True
+    assert text_decision.teach_route_on_success is None
+    assert exception_decision.should_retry is True
+    assert exception_decision.teach_route_on_success is None
 
 
-def test_non_request_status_exception_does_not_retry() -> None:
-    """Server-side failures are not media evidence even when media was present."""
+def test_non_request_status_exception_retries_but_never_teaches() -> None:
+    """Server-side failures retry without media but are not capability evidence."""
     reset_model_media_capability_cache()
     media = _media_inputs()
     error = ModelProviderError(message="upstream connect error", status_code=502)
 
     decision = retry_media_inputs_after_failure(_route(), error, media)
 
-    assert decision.should_retry is False
+    assert decision.should_retry is True
+    assert decision.teach_route_on_success is None
 
 
 def test_kind_specific_error_takes_precedence_over_generic_gate() -> None:
@@ -403,8 +408,8 @@ def test_openai_invalid_audio_format_message_without_field_retries_without_cachi
     assert filter_media_inputs_for_route(route, media).media_inputs == media
 
 
-def test_openai_supported_audio_values_without_audio_field_does_not_retry() -> None:
-    """Wav/mp3 validation text alone should not be treated as an audio input failure."""
+def test_openai_supported_audio_values_without_audio_field_is_not_audio_attribution() -> None:
+    """Wav/mp3 validation text alone must not single out audio; the generic drop-all retry applies."""
     reset_model_media_capability_cache()
     media = _media_inputs()
     route = _route()
@@ -412,8 +417,9 @@ def test_openai_supported_audio_values_without_audio_field_does_not_retry() -> N
 
     decision = retry_media_inputs_after_failure(route, error, media)
 
-    assert decision.should_retry is False
-    assert decision.media_inputs == media
+    assert decision.should_retry is True
+    assert decision.removed_kinds == frozenset({"audio", "image", "file", "video"})
+    assert decision.teach_route_on_success is None
     assert filter_media_inputs_for_route(route, media).media_inputs == media
 
 

--- a/tests/test_media_fallback.py
+++ b/tests/test_media_fallback.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
 from agno.exceptions import ContextWindowExceededError, ModelProviderError
 from agno.media import Audio, Image
 from agno.models.message import Message
@@ -43,176 +44,32 @@ def test_model_route_includes_provider_model_and_base_url() -> None:
     )
 
 
-def test_audio_unsupported_error_records_audio_only() -> None:
-    """Audio unsupported errors should disable only audio for the route."""
-    reset_model_media_capability_cache()
-    media = _media_inputs()
-    route = _route()
-
-    decision = retry_media_inputs_after_failure(
-        route,
-        RuntimeError("audio input is not supported - hint: you may need to provide the mmproj"),
-        media,
-    )
-
-    assert decision.should_retry is True
-    assert decision.removed_kinds == frozenset({"audio"})
-    assert decision.media_inputs.audio == ()
-    assert decision.media_inputs.images == media.images
-    assert decision.media_inputs.files == media.files
-    assert decision.media_inputs.videos == media.videos
-
-    filtered = filter_media_inputs_for_route(route, media)
-    assert filtered.removed_kinds == frozenset({"audio"})
-    assert filtered.media_inputs.audio == ()
-    assert filtered.media_inputs.images == media.images
-
-
-def test_image_remains_enabled_when_only_audio_failed() -> None:
-    """Negative cache should track kinds independently."""
-    reset_model_media_capability_cache()
-    media = _media_inputs()
-    route = _route()
-
-    retry_media_inputs_after_failure(
-        route,
-        "Error code: 400 - at most 0 audio(s) may be provided",
-        media,
-    )
-
-    filtered = filter_media_inputs_for_route(route, media)
-    assert filtered.media_inputs.audio == ()
-    assert filtered.media_inputs.images == media.images
-
-
-def test_different_base_url_does_not_inherit_negative_cache() -> None:
-    """Effective route should include endpoint, not just provider/model."""
-    reset_model_media_capability_cache()
-    media = _media_inputs()
-    first_route = _route(base_url="http://localhost:9292/v1")
-    second_route = _route(base_url="http://localhost:9293/v1")
-
-    retry_media_inputs_after_failure(
-        first_route,
-        "audio input is not supported",
-        media,
-    )
-
-    filtered = filter_media_inputs_for_route(second_route, media)
-    assert filtered.removed_kinds == frozenset()
-    assert filtered.media_inputs.audio == media.audio
-
-
-def test_generic_errors_retry_but_never_teach() -> None:
-    """Transient failures retry without media but must not teach capability, even on success."""
-    reset_model_media_capability_cache()
-    media = _media_inputs()
-    route = _route()
-
-    decision = retry_media_inputs_after_failure(route, "Rate limit exceeded", media)
-
-    assert decision.should_retry is True
-    assert decision.media_inputs == MediaInputs()
-    assert decision.teach_route_on_success is None
-
-    decision.record_retry_success()
-    filtered = filter_media_inputs_for_route(route, media)
-    assert filtered.media_inputs == media
-
-
-def test_generic_media_error_retries_without_caching() -> None:
-    """Ambiguous media errors should preserve old drop-all retry without teaching cache."""
-    reset_model_media_capability_cache()
-    media = _media_inputs()
-    route = _route()
-
-    decision = retry_media_inputs_after_failure(route, "inline media input is not supported", media)
-
-    assert decision.should_retry is True
-    assert decision.removed_kinds == frozenset({"audio", "image", "file", "video"})
-    assert decision.media_inputs == MediaInputs()
-
-    filtered = filter_media_inputs_for_route(route, media)
-    assert filtered.media_inputs == media
-
-
-def test_text_only_content_error_teaches_all_present_kinds() -> None:
-    """Z.ai text-only models reject every non-text part; all present kinds are learned."""
-    reset_model_media_capability_cache()
-    media = _media_inputs()
-    route = _route()
-
-    decision = retry_media_inputs_after_failure(
-        route,
+@pytest.mark.parametrize(
+    "error",
+    [
+        # Z.ai code 1214 as it reaches the streamed run-error path: bare message,
+        # no exception object, no status code, no "Error code: 400" marker.
+        "messages[30].content[0].type type error",
         "Error code: 400 - messages.content.type is invalid, allowed values: ['text']",
-        media,
-    )
+        "audio input is not supported - hint: you may need to provide the mmproj",
+        "Rate limit exceeded",
+        "Error code: 400 - invalid api key provided",
+        ModelProviderError(message="Some brand new provider wording about content", status_code=400),
+        ModelProviderError(message="upstream connect error", status_code=502),
+    ],
+)
+def test_any_failure_retries_without_media_and_teaches_on_success(error: Exception | str) -> None:
+    """No error wording decides the retry: every failure drops all media once.
 
-    assert decision.should_retry is True
-    assert decision.removed_kinds == frozenset({"audio", "image", "file", "video"})
-    assert decision.media_inputs == MediaInputs()
-
-    filtered = filter_media_inputs_for_route(route, media)
-    assert filtered.removed_kinds == frozenset({"audio", "image", "file", "video"})
-    assert filtered.media_inputs == MediaInputs()
-    reset_model_media_capability_cache()
-
-
-def test_text_only_content_error_teaches_only_present_kinds() -> None:
-    """Text-only errors must not disable media kinds that were never sent."""
-    reset_model_media_capability_cache()
-    media = MediaInputs(images=(MagicMock(name="image"),))
-    route = _route()
-
-    decision = retry_media_inputs_after_failure(
-        route,
-        "messages.content.type is invalid, allowed values: ['text']",
-        media,
-    )
-
-    assert decision.should_retry is True
-    assert decision.removed_kinds == frozenset({"image"})
-    assert unsupported_media_kinds_for_route(route) == frozenset({"image"})
-    reset_model_media_capability_cache()
-
-
-def test_content_part_type_error_retries_via_generic_gate() -> None:
-    """Z.ai bare content-part type errors carry the 400 marker the generic gate matches."""
-    reset_model_media_capability_cache()
-    media = _media_inputs()
-    route = _route()
-
-    decision = retry_media_inputs_after_failure(
-        route,
-        "Error code: 400 - messages[12].content[0].type type error",
-        media,
-    )
-
-    assert decision.should_retry is True
-    assert decision.removed_kinds == frozenset({"audio", "image", "file", "video"})
-    assert decision.media_inputs == MediaInputs()
-
-    filtered = filter_media_inputs_for_route(route, media)
-    assert filtered.media_inputs == media
-    reset_model_media_capability_cache()
-
-
-def test_bare_content_part_type_error_from_streamed_run_retries() -> None:
-    """Streamed RunErrorEvents carry only Z.ai's bare 1214 message, without the 400 marker.
-
-    Agno converts the provider 400 into a RunErrorEvent whose content is just
-    str(ModelProviderError) — the status code and "Error code: 400" prefix are
-    lost — so the bare message shape must be recognized on its own.
+    The route capability cache learns the dropped kinds only when the retry
+    actually succeeds, which never happens for failures unrelated to media
+    (auth, rate limits, outages) because their retry fails identically.
     """
     reset_model_media_capability_cache()
     media = _media_inputs()
     route = _route()
 
-    decision = retry_media_inputs_after_failure(
-        route,
-        "messages[30].content[0].type type error",
-        media,
-    )
+    decision = retry_media_inputs_after_failure(route, error, media)
 
     assert decision.should_retry is True
     assert decision.removed_kinds == frozenset({"audio", "image", "file", "video"})
@@ -222,209 +79,63 @@ def test_bare_content_part_type_error_from_streamed_run_retries() -> None:
     assert filter_media_inputs_for_route(route, media).media_inputs == media
 
     decision.record_retry_success()
-    assert unsupported_media_kinds_for_route(route) == frozenset({"audio", "image", "file", "video"})
-    reset_model_media_capability_cache()
-
-
-def test_invalid_request_status_retries_and_teaches_only_on_success() -> None:
-    """Any 400-class provider exception retries without media; the cache learns on retry success."""
-    reset_model_media_capability_cache()
-    media = _media_inputs()
-    route = _route()
-    error = ModelProviderError(message="Some brand new provider wording about content", status_code=400)
-
-    decision = retry_media_inputs_after_failure(route, error, media)
-
-    assert decision.should_retry is True
-    assert decision.removed_kinds == frozenset({"audio", "image", "file", "video"})
-    assert decision.media_inputs == MediaInputs()
-    assert filter_media_inputs_for_route(route, media).media_inputs == media
-
-    decision.record_retry_success()
 
     assert unsupported_media_kinds_for_route(route) == frozenset({"audio", "image", "file", "video"})
-    reset_model_media_capability_cache()
-
-
-def test_invalid_request_text_marker_retries_and_teaches_only_on_success() -> None:
-    """Errored-run text with a generic 400 marker retries even for unknown provider prose."""
-    reset_model_media_capability_cache()
-    media = _media_inputs()
-    route = _route()
-
-    decision = retry_media_inputs_after_failure(route, "Error code: 422 - unknown validation prose", media)
-
-    assert decision.should_retry is True
-    assert decision.removed_kinds == frozenset({"audio", "image", "file", "video"})
-    assert filter_media_inputs_for_route(route, media).media_inputs == media
-
-    decision.record_retry_success()
-
-    assert unsupported_media_kinds_for_route(route) == frozenset({"audio", "image", "file", "video"})
-    reset_model_media_capability_cache()
-
-
-def test_context_window_error_retries_but_never_teaches() -> None:
-    """Dropping media can shrink an overflowing prompt, so success must not teach capability."""
-    reset_model_media_capability_cache()
-    media = _media_inputs()
-    route = _route()
-    error = ContextWindowExceededError(message="prompt is too long: 250000 tokens > 200000 maximum")
-
-    decision = retry_media_inputs_after_failure(route, error, media)
-
-    assert decision.should_retry is True
-    assert decision.teach_route_on_success is None
-
-    decision.record_retry_success()
-
-    assert unsupported_media_kinds_for_route(route) == frozenset()
-
-
-def test_context_window_text_never_teaches() -> None:
-    """Context-overflow vocabulary in errored-run text blocks teaching, not the retry."""
-    reset_model_media_capability_cache()
-    media = _media_inputs()
-    route = _route()
-
-    decision = retry_media_inputs_after_failure(
-        route,
-        "Error code: 400 - maximum context length is 128000 tokens",
-        media,
-    )
-
-    assert decision.should_retry is True
-    assert decision.teach_route_on_success is None
-
-
-def test_payload_too_large_retries_but_never_teaches() -> None:
-    """Oversized-payload rejections are about size, not media capability."""
-    reset_model_media_capability_cache()
-    media = _media_inputs()
-    route = _route()
-    error = ModelProviderError(message="Request Entity Too Large", status_code=413)
-
-    decision = retry_media_inputs_after_failure(route, error, media)
-
-    assert decision.should_retry is True
-    assert decision.teach_route_on_success is None
-
-    decision.record_retry_success()
-
-    assert unsupported_media_kinds_for_route(route) == frozenset()
-
-
-def test_auth_worded_invalid_request_retries_but_never_teaches() -> None:
-    """Credential failures phrased as 400s retry (and fail again) but are not capability evidence."""
-    reset_model_media_capability_cache()
-    media = _media_inputs()
-
-    text_decision = retry_media_inputs_after_failure(
-        _route(),
-        "Error code: 400 - invalid api key provided",
-        media,
-    )
-    # Google rejects bad API keys with HTTP 400, so the status-code path needs the same exclusion.
-    exception_decision = retry_media_inputs_after_failure(
-        _route(),
-        ModelProviderError(message="API key not valid. Please pass a valid API key.", status_code=400),
-        media,
-    )
-
-    assert text_decision.should_retry is True
-    assert text_decision.teach_route_on_success is None
-    assert exception_decision.should_retry is True
-    assert exception_decision.teach_route_on_success is None
-
-
-def test_non_request_status_exception_retries_but_never_teaches() -> None:
-    """Server-side failures retry without media but are not capability evidence."""
-    reset_model_media_capability_cache()
-    media = _media_inputs()
-    error = ModelProviderError(message="upstream connect error", status_code=502)
-
-    decision = retry_media_inputs_after_failure(_route(), error, media)
-
-    assert decision.should_retry is True
-    assert decision.teach_route_on_success is None
-
-
-def test_kind_specific_error_takes_precedence_over_generic_gate() -> None:
-    """A named kind on a 400 drops and teaches only that kind, not everything present."""
-    reset_model_media_capability_cache()
-    media = _media_inputs()
-    route = _route()
-    error = ModelProviderError(message="audio input is not supported", status_code=400)
-
-    decision = retry_media_inputs_after_failure(route, error, media)
-
-    assert decision.should_retry is True
-    assert decision.removed_kinds == frozenset({"audio"})
-    assert decision.media_inputs.images == media.images
-    assert unsupported_media_kinds_for_route(route) == frozenset({"audio"})
-    reset_model_media_capability_cache()
-
-
-def test_openai_invalid_audio_format_error_retries_without_caching() -> None:
-    """OpenAI audio format validation errors should drop audio for the retry only."""
-    reset_model_media_capability_cache()
-    media = _media_inputs()
-    route = _route()
-    error = (
-        "litellm.BadRequestError: OpenAIException - Invalid value: 'bin'. "
-        "Supported values are: 'wav' and 'mp3'.. Received Model Group=gpt-5.5 "
-        "messages[3].content[1].input_audio.format"
-    )
-
-    decision = retry_media_inputs_after_failure(route, error, media)
-
-    assert decision.should_retry is True
-    assert decision.removed_kinds == frozenset({"audio"})
-    assert decision.media_inputs.audio == ()
-    assert decision.media_inputs.images == media.images
-    assert decision.media_inputs.files == media.files
-    assert decision.media_inputs.videos == media.videos
-
     filtered = filter_media_inputs_for_route(route, media)
-    assert filtered.media_inputs == media
+    assert filtered.removed_kinds == frozenset({"audio", "image", "file", "video"})
+    assert filtered.media_inputs == MediaInputs()
+    reset_model_media_capability_cache()
 
 
-def test_openai_invalid_audio_format_message_without_field_retries_without_caching() -> None:
-    """LiteLLM can omit OpenAI's input_audio.format field from the surfaced message."""
+def test_no_media_present_never_retries() -> None:
+    """Media-shaped errors without any media sent are not retried."""
+    decision = retry_media_inputs_after_failure(_route(), "audio input is not supported", MediaInputs())
+
+    assert decision.should_retry is False
+    assert decision.removed_kinds == frozenset()
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        ContextWindowExceededError(message="prompt is too long: 250000 tokens > 200000 maximum"),
+        "Error code: 400 - maximum context length is 128000 tokens",
+        ModelProviderError(message="Request Entity Too Large", status_code=413),
+    ],
+)
+def test_size_and_context_overflow_retries_but_never_teaches(error: Exception | str) -> None:
+    """Dropping media can shrink an oversized request, so success must not teach capability."""
     reset_model_media_capability_cache()
     media = _media_inputs()
     route = _route()
-    error = (
-        "litellm.BadRequestError: OpenAIException - Invalid value: 'bin'. "
-        "Supported values are: 'wav' and 'mp3'.. Received Model Group=gpt-5.5"
-    )
 
     decision = retry_media_inputs_after_failure(route, error, media)
 
     assert decision.should_retry is True
-    assert decision.removed_kinds == frozenset({"audio"})
-    assert decision.media_inputs.audio == ()
-    assert decision.media_inputs.images == media.images
-    assert filter_media_inputs_for_route(route, media).media_inputs == media
-
-
-def test_openai_supported_audio_values_without_audio_field_is_not_audio_attribution() -> None:
-    """Wav/mp3 validation text alone must not single out audio; the generic drop-all retry applies."""
-    reset_model_media_capability_cache()
-    media = _media_inputs()
-    route = _route()
-    error = "Invalid value: 'bin'. Supported values are: 'wav' and 'mp3'. parameter=output_format"
-
-    decision = retry_media_inputs_after_failure(route, error, media)
-
-    assert decision.should_retry is True
-    assert decision.removed_kinds == frozenset({"audio", "image", "file", "video"})
     assert decision.teach_route_on_success is None
-    assert filter_media_inputs_for_route(route, media).media_inputs == media
+
+    decision.record_retry_success()
+
+    assert unsupported_media_kinds_for_route(route) == frozenset()
+
+
+def test_different_base_url_does_not_inherit_negative_cache() -> None:
+    """Effective route should include endpoint, not just provider/model."""
+    reset_model_media_capability_cache()
+    media = _media_inputs()
+    first_route = _route(base_url="http://localhost:9292/v1")
+    second_route = _route(base_url="http://localhost:9293/v1")
+
+    retry_media_inputs_after_failure(first_route, "audio input is not supported", media).record_retry_success()
+
+    filtered = filter_media_inputs_for_route(second_route, media)
+    assert filtered.removed_kinds == frozenset()
+    assert filtered.media_inputs == media
+    reset_model_media_capability_cache()
 
 
 def test_context_media_kinds_enable_retry_without_current_turn_media() -> None:
-    """Media pinned to history messages should still trigger retry and teach the cache."""
+    """Media pinned to history messages should still trigger the retry and teach on success."""
     reset_model_media_capability_cache()
     route = _route()
 
@@ -437,6 +148,9 @@ def test_context_media_kinds_enable_retry_without_current_turn_media() -> None:
 
     assert decision.should_retry is True
     assert decision.removed_kinds == frozenset({"image"})
+
+    decision.record_retry_success()
+
     assert unsupported_media_kinds_for_route(route) == frozenset({"image"})
     reset_model_media_capability_cache()
 
@@ -450,15 +164,16 @@ def test_unsupported_media_kinds_for_route_defaults_empty() -> None:
 
 def test_cache_can_be_reset() -> None:
     """Tests need explicit access to clear process-local learned state."""
+    reset_model_media_capability_cache()
     media = _media_inputs()
     route = _route()
 
-    retry_media_inputs_after_failure(route, "image input is not supported", media)
-    assert filter_media_inputs_for_route(route, media).media_inputs.images == ()
+    retry_media_inputs_after_failure(route, "image input is not supported", media).record_retry_success()
+    assert filter_media_inputs_for_route(route, media).media_inputs == MediaInputs()
 
     reset_model_media_capability_cache()
 
-    assert filter_media_inputs_for_route(route, media).media_inputs.images == media.images
+    assert filter_media_inputs_for_route(route, media).media_inputs == media
 
 
 def _route(base_url: str = "http://localhost:9292/v1") -> ModelMediaRoute:

--- a/tests/test_media_fallback.py
+++ b/tests/test_media_fallback.py
@@ -193,6 +193,35 @@ def test_content_part_type_error_retries_via_generic_gate() -> None:
     reset_model_media_capability_cache()
 
 
+def test_bare_content_part_type_error_from_streamed_run_retries() -> None:
+    """Streamed RunErrorEvents carry only Z.ai's bare 1214 message, without the 400 marker.
+
+    Agno converts the provider 400 into a RunErrorEvent whose content is just
+    str(ModelProviderError) — the status code and "Error code: 400" prefix are
+    lost — so the bare message shape must be recognized on its own.
+    """
+    reset_model_media_capability_cache()
+    media = _media_inputs()
+    route = _route()
+
+    decision = retry_media_inputs_after_failure(
+        route,
+        "messages[30].content[0].type type error",
+        media,
+    )
+
+    assert decision.should_retry is True
+    assert decision.removed_kinds == frozenset({"audio", "image", "file", "video"})
+    assert decision.media_inputs == MediaInputs()
+    assert decision.teach_route_on_success == route
+    # Nothing is taught until the without-media retry actually succeeds.
+    assert filter_media_inputs_for_route(route, media).media_inputs == media
+
+    decision.record_retry_success()
+    assert unsupported_media_kinds_for_route(route) == frozenset({"audio", "image", "file", "video"})
+    reset_model_media_capability_cache()
+
+
 def test_invalid_request_status_retries_and_teaches_only_on_success() -> None:
     """Any 400-class provider exception retries without media; the cache learns on retry success."""
     reset_model_media_capability_cache()


### PR DESCRIPTION
## Problem

Mom uploaded a PDF in `!UPwC8gOzVFLSbtKo2b:mindroom.chat` (the `mind` agent on `mindroom-mom`, GLM-5.2 via Z.ai) and got a raw provider error in the room on every turn of the thread:

```
[mind] ⚠️ Error: messages[30].content[0].type type error
```

MindRoom passes the PDF as inline agno `File` media, agno serializes it as an OpenAI `{"type": "file", ...}` content part, and Z.ai rejects it with 400 code 1214. The inline-media fallback never fired because on the **streaming** path agno converts the provider 400 into a `RunErrorEvent` whose content is only `str(ModelProviderError)` — no status code, no `Error code: 400` marker — so the evidence gate from #1430 could not match. This was the third provider-wording incident in a week (#1428, #1430, now this).

## Fix (final design)

**No error wording decides anything about retrying.** Every failure of a media-bearing request retries once without inline media (with the `[Inline media unavailable for this model]` note so the agent falls back to attachment tools). All provider error-prose patterns are deleted — `media_fallback.py` drops from 412 to 260 lines, and this class of bug is structurally impossible regardless of future provider wording.

The route capability cache learns the dropped kinds when the without-media retry succeeds, except for payload-size/context-overflow causes (agno-owned exception types and vocabulary), where dropping media can shrink the request below the limit without proving anything about media support. The cache remains process-local and resets on restart.

## Accepted trade-offs (deliberate, not oversights)

- **Non-media failures pay one doomed retry** (rate limit, auth, 5xx) before the error surfaces.
- **Named-kind rejections drop all media for the retry**, not just the named kind — selective kind attribution required per-provider wording patterns.
- **A transient failure whose retry happens to succeed can mislearn the route's media capability until restart.** This is a soft, self-healing failure: media is pre-dropped with the fallback note, agents still use attachment tools, and a restart clears the cache. If it shows up in practice, the string-free fix is to require repeated fail-then-succeed observations before teaching — not to resurrect the regexes.

The bot-review P1s flag these trade-offs; they were consciously chosen (see the final commit message).

## Testing

- Regression test with the exact bare Z.ai 1214 message observed in the mindroom-mom journal, parametrized alongside auth/rate-limit/5xx/unknown-prose cases.
- Full test job green in CI; `tests/test_media_fallback.py` consolidated to the simplified policy.
- Deployed on `mindroom-mom` (cherry-picked) and running.