### PR TITLE
Make avatar generation robust to truncated prompts and no-image responses

### DIFF
--- a/src/mindroom/avatar_generation.py
+++ b/src/mindroom/avatar_generation.py
@@ -38,6 +38,14 @@ logger = get_logger(__name__)
 _PROMPT_MODEL = GOOGLE_AVATAR_PROMPT
 _IMAGE_MODEL = GOOGLE_AVATAR_IMAGE
 _ROOT_SPACE_AVATAR_NAME = "root_space"
+# Team prompts include per-member breakdowns; a low cap truncates them
+# mid-sentence and the mangled prompt makes the image model answer with
+# text instead of an image.
+_PROMPT_MAX_OUTPUT_TOKENS = 400
+# The image model occasionally returns no image for a valid prompt; each
+# retry regenerates the prompt (sampled at temperature), so attempts are
+# not identical.
+_MAX_IMAGE_ATTEMPTS = 3
 
 _ROOM_PURPOSES = {
     "lobby": "Central meeting space, entrance and welcome area",
@@ -153,7 +161,7 @@ async def _generate_prompt(
         config=types.GenerateContentConfig(
             system_instruction=system_prompt,
             temperature=0.7,
-            max_output_tokens=150,
+            max_output_tokens=_PROMPT_MAX_OUTPUT_TOKENS,
         ),
     )
     if not response.text:
@@ -208,22 +216,37 @@ async def _generate_avatar(
     if target.team_members:
         console.print(f"   [dim]Team members: {', '.join(member.name for member in target.team_members)}[/dim]")
 
-    prompt = await _generate_prompt(client, target, config)
-    response = await client.aio.models.generate_content(
-        model=_IMAGE_MODEL,
-        contents=prompt,
-        config=types.GenerateContentConfig(
-            response_modalities=["IMAGE"],
-            image_config=types.ImageConfig(
-                aspect_ratio="1:1",
-                image_size="1K",
+    image_bytes: bytes | None = None
+    for attempt in range(1, _MAX_IMAGE_ATTEMPTS + 1):
+        prompt = await _generate_prompt(client, target, config)
+        response = await client.aio.models.generate_content(
+            model=_IMAGE_MODEL,
+            contents=prompt,
+            config=types.GenerateContentConfig(
+                response_modalities=["IMAGE"],
+                image_config=types.ImageConfig(
+                    aspect_ratio="1:1",
+                    image_size="1K",
+                ),
             ),
-        ),
-    )
+        )
+        image_bytes = _extract_image_bytes(response)
+        if image_bytes:
+            break
+        logger.warning(
+            "Image model returned no image for avatar target",
+            entity_type=target.entity_type,
+            entity_name=target.entity_name,
+            attempt=attempt,
+            max_attempts=_MAX_IMAGE_ATTEMPTS,
+        )
+        console.print(
+            f"[yellow]⟳ No image returned for {target.entity_type}/{target.entity_name} "
+            f"(attempt {attempt}/{_MAX_IMAGE_ATTEMPTS}); regenerating prompt[/yellow]",
+        )
 
-    image_bytes = _extract_image_bytes(response)
     if not image_bytes:
-        msg = f"No image data found for {target.entity_type}/{target.entity_name}"
+        msg = f"No image data found for {target.entity_type}/{target.entity_name} after {_MAX_IMAGE_ATTEMPTS} attempts"
         raise ValueError(msg)
 
     avatar_path.write_bytes(image_bytes)

--- a/src/mindroom/avatar_generation.py
+++ b/src/mindroom/avatar_generation.py
@@ -186,6 +186,16 @@ async def _generate_prompt(
     return final_prompt
 
 
+def _no_image_diagnostic(response: types.GenerateContentResponse) -> str:
+    """Summarize a no-image response for logs without dumping the payload."""
+    finish_reasons = [
+        str(candidate.finish_reason) for candidate in response.candidates or [] if candidate.finish_reason
+    ]
+    texts = [text for part in response.parts or [] if isinstance(text := getattr(part, "text", None), str)]
+    snippet = " ".join(texts).strip()[:200]
+    return f"finish_reasons={finish_reasons or None} text={snippet!r}"
+
+
 def _extract_image_bytes(response: types.GenerateContentResponse) -> bytes | None:
     """Return the first generated image bytes from a Gemini response."""
     for part in response.parts or []:
@@ -239,11 +249,13 @@ async def _generate_avatar(
             entity_name=target.entity_name,
             attempt=attempt,
             max_attempts=_MAX_IMAGE_ATTEMPTS,
+            response_diagnostic=_no_image_diagnostic(response),
         )
-        console.print(
-            f"[yellow]⟳ No image returned for {target.entity_type}/{target.entity_name} "
-            f"(attempt {attempt}/{_MAX_IMAGE_ATTEMPTS}); regenerating prompt[/yellow]",
-        )
+        if attempt < _MAX_IMAGE_ATTEMPTS:
+            console.print(
+                f"[yellow]⟳ No image returned for {target.entity_type}/{target.entity_name} "
+                f"(attempt {attempt}/{_MAX_IMAGE_ATTEMPTS}); regenerating prompt[/yellow]",
+            )
 
     if not image_bytes:
         msg = f"No image data found for {target.entity_type}/{target.entity_name} after {_MAX_IMAGE_ATTEMPTS} attempts"

--- a/tests/test_avatar_generation.py
+++ b/tests/test_avatar_generation.py
@@ -1091,3 +1091,80 @@ async def test_set_room_avatars_in_matrix_wraps_router_login_failures(
         match="Failed to log in as router for avatar sync",
     ):
         await generate_avatars.set_room_avatars_in_matrix(_runtime_paths(tmp_path))
+
+
+def _image_response(data: bytes) -> SimpleNamespace:
+    return SimpleNamespace(parts=[SimpleNamespace(inline_data=SimpleNamespace(data=data))])
+
+
+def _no_image_response() -> SimpleNamespace:
+    return SimpleNamespace(parts=[SimpleNamespace(inline_data=None, text="cannot draw that")])
+
+
+def _client_with_image_responses(responses: list[SimpleNamespace]) -> SimpleNamespace:
+    return SimpleNamespace(
+        aio=SimpleNamespace(models=SimpleNamespace(generate_content=AsyncMock(side_effect=responses))),
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_avatar_retries_with_fresh_prompt_when_no_image_returned(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_avatar_dir: Path,
+    tmp_path: Path,
+) -> None:
+    """A no-image response regenerates the prompt and retries the image call."""
+    prompt_mock = AsyncMock(side_effect=["prompt one", "prompt two"])
+    monkeypatch.setattr(generate_avatars, "_generate_prompt", prompt_mock)
+    client = _client_with_image_responses([_no_image_response(), _image_response(b"png-bytes")])
+    target = generate_avatars._AvatarTarget(entity_type="teams", entity_name="incident", role="incident response")
+
+    await generate_avatars._generate_avatar(
+        client,  # type: ignore[arg-type]
+        target,
+        _runtime_paths(tmp_path),
+        _config_with_runtime_paths(
+            {
+                "models": {"default": {"provider": "anthropic", "id": "claude-sonnet-4-6"}},
+                "router": {"model": "default"},
+                "agents": {"a": {"display_name": "A", "model": "default"}},
+            },
+            tmp_path,
+        ),
+    )
+
+    assert (workspace_avatar_dir / "teams" / "incident.png").read_bytes() == b"png-bytes"
+    assert prompt_mock.await_count == 2
+    assert client.aio.models.generate_content.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_generate_avatar_raises_after_exhausting_image_attempts(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_avatar_dir: Path,
+    tmp_path: Path,
+) -> None:
+    """Persistent no-image responses fail with an attempt-count error."""
+    monkeypatch.setattr(generate_avatars, "_generate_prompt", AsyncMock(return_value="prompt"))
+    client = _client_with_image_responses(
+        [_no_image_response() for _ in range(generate_avatars._MAX_IMAGE_ATTEMPTS)],
+    )
+    target = generate_avatars._AvatarTarget(entity_type="agents", entity_name="general", role="general work")
+
+    with pytest.raises(ValueError, match=f"after {generate_avatars._MAX_IMAGE_ATTEMPTS} attempts"):
+        await generate_avatars._generate_avatar(
+            client,  # type: ignore[arg-type]
+            target,
+            _runtime_paths(tmp_path),
+            _config_with_runtime_paths(
+                {
+                    "models": {"default": {"provider": "anthropic", "id": "claude-sonnet-4-6"}},
+                    "router": {"model": "default"},
+                    "agents": {"a": {"display_name": "A", "model": "default"}},
+                },
+                tmp_path,
+            ),
+        )
+
+    assert not (workspace_avatar_dir / "agents" / "general.png").exists()
+    assert client.aio.models.generate_content.await_count == generate_avatars._MAX_IMAGE_ATTEMPTS

--- a/tests/test_avatar_generation.py
+++ b/tests/test_avatar_generation.py
@@ -1094,11 +1094,14 @@ async def test_set_room_avatars_in_matrix_wraps_router_login_failures(
 
 
 def _image_response(data: bytes) -> SimpleNamespace:
-    return SimpleNamespace(parts=[SimpleNamespace(inline_data=SimpleNamespace(data=data))])
+    return SimpleNamespace(candidates=None, parts=[SimpleNamespace(inline_data=SimpleNamespace(data=data))])
 
 
 def _no_image_response() -> SimpleNamespace:
-    return SimpleNamespace(parts=[SimpleNamespace(inline_data=None, text="cannot draw that")])
+    return SimpleNamespace(
+        candidates=[SimpleNamespace(finish_reason="STOP")],
+        parts=[SimpleNamespace(inline_data=None, text="cannot draw that")],
+    )
 
 
 def _client_with_image_responses(responses: list[SimpleNamespace]) -> SimpleNamespace:
@@ -1120,7 +1123,7 @@ async def test_generate_avatar_retries_with_fresh_prompt_when_no_image_returned(
     target = generate_avatars._AvatarTarget(entity_type="teams", entity_name="incident", role="incident response")
 
     await generate_avatars._generate_avatar(
-        client,  # type: ignore[arg-type]
+        client,
         target,
         _runtime_paths(tmp_path),
         _config_with_runtime_paths(
@@ -1153,7 +1156,7 @@ async def test_generate_avatar_raises_after_exhausting_image_attempts(
 
     with pytest.raises(ValueError, match=f"after {generate_avatars._MAX_IMAGE_ATTEMPTS} attempts"):
         await generate_avatars._generate_avatar(
-            client,  # type: ignore[arg-type]
+            client,
             target,
             _runtime_paths(tmp_path),
             _config_with_runtime_paths(


### PR DESCRIPTION
## Problem

`mindroom avatars generate` intermittently fails with `No image data found for teams/<name>` even when the API key and models are fine. Two compounding causes:

1. `_generate_prompt` caps the prompt model at `max_output_tokens=150`. Team prompts include per-member visual breakdowns and routinely exceed that, so the visual-elements text gets cut off mid-word (observed: a prompt ending in `... symmetry, brushed-slate texture\"\n*`). 
2. `_generate_avatar` makes exactly one image call. The image model occasionally responds to such mangled markdown-fragment prompts with text instead of an image (verified live: the same target failed twice, then produced an image on a later attempt with a freshly sampled prompt), and that single miss fails the entire generation run.

## Change

- Raise the prompt budget to 400 tokens (`_PROMPT_MAX_OUTPUT_TOKENS`).
- Retry the image call up to 3 attempts (`_MAX_IMAGE_ATTEMPTS`), regenerating the prompt on each attempt — the prompt is sampled at temperature 0.7, so retries are not identical — with a console note and a structured warning per miss. The final failure message now includes the attempt count.

## Testing

- New: retry succeeds on the second attempt with a fresh prompt (asserts both the prompt model and image model were called twice and the file content is the retried image).
- New: persistent no-image responses raise after exactly `_MAX_IMAGE_ATTEMPTS` calls and write nothing.
- Full `tests/test_avatar_generation.py` suite passes (31 tests); pre-commit clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved avatar creation reliability by retrying image generation when no image is returned.
  * Added clearer feedback when avatar generation fails after multiple attempts.
  * Limited prompt output length to keep generation more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->