### PR TITLE
Constrain the README setup-video thumbnail to 480px

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ See [macOS app guide](docs/installation/macos-app.md) for setup, updates, and un
 Use this path if you want to run MindRoom locally while using hosted chat + Matrix on `mindroom.chat`.
 Watch the 2-minute setup video:
 
-[![MindRoom: installing and talking to my first AI agent in 2 minutes](https://img.youtube.com/vi/jR3xLUxyWhg/maxresdefault.jpg)](https://youtu.be/jR3xLUxyWhg)
+<a href="https://youtu.be/jR3xLUxyWhg"><img src="https://img.youtube.com/vi/jR3xLUxyWhg/maxresdefault.jpg" alt="MindRoom: installing and talking to my first AI agent in 2 minutes" width="480"></a>
 
 ```bash
 # Create ~/.mindroom/config.yaml and ~/.mindroom/.env with hosted defaults


### PR DESCRIPTION
Follow-up to #1446: the bare Markdown image rendered the maxres YouTube thumbnail at its full 1280px width, dominating the README Quick Start section. This replaces it with an HTML `<img width="480">` inside the video link so it stays a modest clickable thumbnail. The docs pages keep the plain Markdown image since MkDocs constrains content width there.

## Test plan

- [x] `uv run pre-commit run --files README.md` passes