### PR TITLE
Compile bytecode into the runtime images at build time

### DIFF
--- a/local/instances/deploy/Dockerfile.mindroom
+++ b/local/instances/deploy/Dockerfile.mindroom
@@ -12,6 +12,10 @@ COPY --from=bun /usr/local/bin/bunx /usr/local/bin/bunx
 
 WORKDIR /app
 
+# Compile bytecode at install time so pod boots skip the first-import .pyc
+# compilation of the whole dependency tree (several seconds on small pods).
+ENV UV_COMPILE_BYTECODE=1
+
 # Copy project files
 COPY pyproject.toml uv.lock README.md hatch_build.py /app/
 
@@ -35,8 +39,11 @@ ENV PUPPETEER_SKIP_DOWNLOAD=true
 # Set pretend version for setuptools-scm (no .git in container)
 ARG VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}
+# mindroom itself installs editable (its modules import from /app/src), so
+# UV_COMPILE_BYTECODE only covers site-packages; compile the src tree too.
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked --no-dev --all-extras --no-extra sentence_transformers --reinstall-package mindroom \
+    && /app/.venv/bin/python -m compileall -q /app/src \
     && rm -rf frontend/node_modules
 
 # Final production stage
@@ -82,6 +89,8 @@ RUN chmod +x /app/run-sandbox-runner.sh \
 # Set environment variable to indicate Docker mode
 ENV DOCKER_CONTAINER=1
 ENV PATH="/app/.venv/bin:${PATH}"
+# Runtime tool-dependency auto-installs also compile bytecode on install.
+ENV UV_COMPILE_BYTECODE=1
 
 # Run as non-root user
 USER 1000:1000

--- a/local/instances/deploy/Dockerfile.mindroom-minimal
+++ b/local/instances/deploy/Dockerfile.mindroom-minimal
@@ -14,6 +14,10 @@ COPY --from=bun /usr/local/bin/bunx /usr/local/bin/bunx
 
 WORKDIR /app
 
+# Compile bytecode at install time so pod boots skip the first-import .pyc
+# compilation of the whole dependency tree (several seconds on small pods).
+ENV UV_COMPILE_BYTECODE=1
+
 # Copy project files
 COPY pyproject.toml uv.lock README.md hatch_build.py /app/
 
@@ -35,8 +39,11 @@ ENV PUPPETEER_SKIP_DOWNLOAD=true
 # Set pretend version for setuptools-scm (no .git in container)
 ARG VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}
+# mindroom itself installs editable (its modules import from /app/src), so
+# UV_COMPILE_BYTECODE only covers site-packages; compile the src tree too.
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked --no-dev --reinstall-package mindroom \
+    && /app/.venv/bin/python -m compileall -q /app/src \
     && rm -rf frontend/node_modules
 
 # Final production stage
@@ -80,6 +87,8 @@ RUN chmod +x /app/run-sandbox-runner.sh \
 # Set environment variable to indicate Docker mode
 ENV DOCKER_CONTAINER=1
 ENV PATH="/app/.venv/bin:${PATH}"
+# Runtime tool-dependency auto-installs also compile bytecode on install.
+ENV UV_COMPILE_BYTECODE=1
 
 # Run as non-root user
 USER 1000:1000


### PR DESCRIPTION
Follow-up to #1442, closing out the cold-boot remainder of #1436.

## Problem

uv does not precompile bytecode on install, so every container start paid first-import `.pyc` compilation of the entire dependency tree. Profiling on #1442 showed this is the whole difference between cold and warm imports: `mindroom.api.sandbox_runner` cold 1.5 s vs warm ~0.6 s locally (M1), scaling ~3-4× on a 2-CPU pod — paid again on every pod boot, template warm-up after restart, and cooldown retry.

## Change

Both runtime Dockerfiles (`Dockerfile.mindroom`, `Dockerfile.mindroom-minimal`):

- `ENV UV_COMPILE_BYTECODE=1` in the builder stage, so `uv sync` writes `.pyc` for all of site-packages at image-build time (the venv is copied into the final stage, pycache included).
- `python -m compileall -q /app/src` after the project install — mindroom itself installs editable, so its modules import from `/app/src`, which `UV_COMPILE_BYTECODE` does not cover.
- `ENV UV_COMPILE_BYTECODE=1` in the final stage too, so runtime tool-dependency auto-installs (`tool_system/dependencies.py` uses `uv pip install` in the running container) also compile what they install.

Build time and image size go up slightly (one-time compile, `.pyc` files in layers); every subsequent container start skips the compile.

## Verification

Built the minimal image locally and timed first import inside fresh containers of the *same image*, with and without the baked pycache:

| | `import mindroom.api.sandbox_runner` (first import) |
|---|---|
| pycache stripped (old behavior) | 1.35 s |
| bytecode baked (this PR) | 0.71 s |

The full image (all extras, much larger site-packages) and 2-CPU pods gain proportionally more.