### PR TITLE
Stop the primary runtime from importing every provider SDK

### DIFF
--- a/src/mindroom/claude_prompt_cache.py
+++ b/src/mindroom/claude_prompt_cache.py
@@ -49,10 +49,10 @@ model with no deferred tools can still replay poisoned history.
 
 from __future__ import annotations
 
-import sys
 from typing import TYPE_CHECKING, Any, cast
 
 from mindroom.model_defaults import TOOL_SEARCH_UNSUPPORTED_MODEL_ID_PREFIXES
+from mindroom.model_instance_checks import isinstance_of_loaded
 
 if TYPE_CHECKING:
     from agno.models.anthropic import Claude as AnthropicClaude
@@ -89,15 +89,17 @@ def native_tool_search_supported(provider: str, model_id: str) -> bool:
     return not model_id.startswith(TOOL_SEARCH_UNSUPPORTED_MODEL_ID_PREFIXES)
 
 
+_ANTHROPIC_CLAUDE_CLASS = ("agno.models.anthropic.claude", "Claude")
+
+
 def as_anthropic_claude(model: object) -> AnthropicClaude | None:
     """Narrow one model to Agno's Claude without importing the anthropic SDK.
 
-    A Claude instance can only exist once ``agno.models.anthropic`` is
-    imported, so probing ``sys.modules`` keeps non-Claude runtimes from paying
+    A Claude instance can only exist once ``agno.models.anthropic.claude`` is
+    imported, so the loaded-class check keeps non-Claude runtimes from paying
     the anthropic import just to no-op these hooks (#1436).
     """
-    module = sys.modules.get("agno.models.anthropic")
-    if module is None or not isinstance(model, module.Claude):
+    if not isinstance_of_loaded(model, _ANTHROPIC_CLAUDE_CLASS):
         return None
     return cast("AnthropicClaude", model)
 

--- a/src/mindroom/embedding_factory.py
+++ b/src/mindroom/embedding_factory.py
@@ -4,10 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from agno.knowledge.embedder.ollama import OllamaEmbedder
-
 from mindroom.credentials_sync import get_api_key_for_provider, get_ollama_host
-from mindroom.embeddings import MindRoomOpenAIEmbedder, create_sentence_transformers_embedder
+from mindroom.embeddings import create_sentence_transformers_embedder
 from mindroom.model_defaults import OLLAMA_HOST_DEFAULT
 
 if TYPE_CHECKING:
@@ -23,6 +21,10 @@ def create_configured_embedder(config: Config, runtime_paths: RuntimePaths) -> E
     embedder_config = config.memory.embedder.config
 
     if provider == "openai":
+        # Imported at first construction so only the configured embedder
+        # provider's SDK loads (#1436).
+        from mindroom.openai_embedder import MindRoomOpenAIEmbedder  # noqa: PLC0415
+
         return MindRoomOpenAIEmbedder(
             id=embedder_config.model,
             api_key=get_api_key_for_provider("openai", runtime_paths=runtime_paths),
@@ -31,6 +33,8 @@ def create_configured_embedder(config: Config, runtime_paths: RuntimePaths) -> E
         )
 
     if provider == "ollama":
+        from agno.knowledge.embedder.ollama import OllamaEmbedder  # noqa: PLC0415
+
         host = get_ollama_host(runtime_paths=runtime_paths) or embedder_config.host or OLLAMA_HOST_DEFAULT
         return OllamaEmbedder(id=embedder_config.model, host=host)
 

--- a/src/mindroom/embeddings.py
+++ b/src/mindroom/embeddings.py
@@ -3,18 +3,13 @@
 from __future__ import annotations
 
 import importlib
-from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, cast
-
-from agno.knowledge.embedder.openai import OpenAIEmbedder
-from agno.utils.log import log_info, log_warning
 
 from mindroom.model_defaults import OPENAI_EMBEDDING_DIMENSIONS, SENTENCE_TRANSFORMERS_DEFAULT
 from mindroom.tool_system.dependencies import ensure_optional_deps
 
 if TYPE_CHECKING:
     from agno.knowledge.embedder.base import Embedder
-    from openai.types.create_embedding_response import CreateEmbeddingResponse
 
     from mindroom.constants import RuntimePaths
 
@@ -91,94 +86,3 @@ def create_sentence_transformers_embedder(
     if dimensions is None:
         return cast("Embedder", embedder_class(id=model))
     return cast("Embedder", embedder_class(id=model, dimensions=dimensions))
-
-
-@dataclass
-class MindRoomOpenAIEmbedder(OpenAIEmbedder):
-    """Avoid forcing OpenAI defaults onto arbitrary OpenAI-compatible hosts."""
-
-    _dimensions_explicit: bool = field(init=False, default=False, repr=False)
-
-    def __post_init__(self) -> None:
-        """Track whether dimensions came from explicit config."""
-        self._dimensions_explicit = self.dimensions is not None
-        if self.dimensions is None:
-            self.dimensions = _default_dimensions(self.id)
-
-    def _should_send_dimensions(self) -> bool:
-        return self.dimensions is not None and (self._dimensions_explicit or self.id in _OPENAI_EMBEDDING_DIMENSIONS)
-
-    def _request_params(self, input_value: str | list[str]) -> dict[str, Any]:
-        request: dict[str, Any] = {
-            "input": input_value,
-            "model": self.id,
-            "encoding_format": self.encoding_format,
-        }
-        if self.user is not None:
-            request["user"] = self.user
-        if self._should_send_dimensions():
-            request["dimensions"] = self.dimensions
-        if self.request_params:
-            request.update(self.request_params)
-        return request
-
-    # NOTE: These overrides intentionally mirror agno's async/embedder methods
-    # because upstream inlines request construction instead of calling a shared helper.
-    # Keep them aligned with agno when upgrading that dependency.
-    def response(self, text: str) -> CreateEmbeddingResponse:
-        """Request a single embedding synchronously."""
-        return self.client.embeddings.create(**self._request_params(text))
-
-    async def async_get_embedding(self, text: str) -> list[float]:
-        """Request a single embedding asynchronously."""
-        try:
-            response: CreateEmbeddingResponse = await self.aclient.embeddings.create(**self._request_params(text))
-            return response.data[0].embedding
-        except Exception as e:
-            log_warning(e)
-            return []
-
-    async def async_get_embedding_and_usage(self, text: str) -> tuple[list[float], dict[str, Any] | None]:
-        """Request one embedding and its usage payload asynchronously."""
-        try:
-            response = await self.aclient.embeddings.create(**self._request_params(text))
-            embedding = response.data[0].embedding
-            usage = response.usage
-            return embedding, usage.model_dump() if usage else None
-        except Exception as e:
-            log_warning(f"Error getting embedding: {e}")
-            return [], None
-
-    async def async_get_embeddings_batch_and_usage(
-        self,
-        texts: list[str],
-    ) -> tuple[list[list[float]], list[dict[str, Any] | None]]:
-        """Request embeddings for a batch of texts and return per-item usage."""
-        all_embeddings: list[list[float]] = []
-        all_usage: list[dict[str, Any] | None] = []
-        log_info(f"Getting embeddings and usage for {len(texts)} texts in batches of {self.batch_size} (async)")
-
-        for i in range(0, len(texts), self.batch_size):
-            batch_texts = texts[i : i + self.batch_size]
-            try:
-                response: CreateEmbeddingResponse = await self.aclient.embeddings.create(
-                    **self._request_params(batch_texts),
-                )
-                batch_embeddings = [data.embedding for data in response.data]
-                all_embeddings.extend(batch_embeddings)
-
-                usage_dict = response.usage.model_dump() if response.usage else None
-                all_usage.extend([usage_dict] * len(batch_embeddings))
-            except Exception as e:
-                log_warning(f"Error in async batch embedding: {e}")
-                for text in batch_texts:
-                    try:
-                        embedding, usage = await self.async_get_embedding_and_usage(text)
-                        all_embeddings.append(embedding)
-                        all_usage.append(usage)
-                    except Exception as inner:
-                        log_warning(f"Error in individual async embedding fallback: {inner}")
-                        all_embeddings.append([])
-                        all_usage.append(None)
-
-        return all_embeddings, all_usage

--- a/src/mindroom/embeddings.py
+++ b/src/mindroom/embeddings.py
@@ -13,15 +13,13 @@ if TYPE_CHECKING:
 
     from mindroom.constants import RuntimePaths
 
-_OPENAI_EMBEDDING_DIMENSIONS = OPENAI_EMBEDDING_DIMENSIONS
-_DEFAULT_SENTENCE_TRANSFORMERS_MODEL = SENTENCE_TRANSFORMERS_DEFAULT
 _SENTENCE_TRANSFORMERS_DEPENDENCIES = ["sentence-transformers"]
 _SENTENCE_TRANSFORMERS_EXTRA = "sentence_transformers"
 
 
 def _default_dimensions(model: str) -> int | None:
     """Return the default dimensions for models that support the parameter."""
-    return _OPENAI_EMBEDDING_DIMENSIONS.get(model)
+    return OPENAI_EMBEDDING_DIMENSIONS.get(model)
 
 
 def effective_knowledge_embedder_signature(
@@ -75,7 +73,7 @@ def ensure_sentence_transformers_dependencies(runtime_paths: RuntimePaths) -> No
 
 def create_sentence_transformers_embedder(
     runtime_paths: RuntimePaths,
-    model: str = _DEFAULT_SENTENCE_TRANSFORMERS_MODEL,
+    model: str = SENTENCE_TRANSFORMERS_DEFAULT,
     *,
     dimensions: int | None = None,
 ) -> Embedder:

--- a/src/mindroom/history/summary_call.py
+++ b/src/mindroom/history/summary_call.py
@@ -35,25 +35,22 @@ import asyncio
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from functools import partial
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from agno.models.message import Message
 from agno.session.summary import SessionSummary
 
 from mindroom.cancellation import request_task_cancel
+from mindroom.claude_prompt_cache import as_anthropic_claude
 from mindroom.constants import MINDROOM_COMPACTION_CHUNK_TIMEOUT_SECONDS
 from mindroom.logging_config import get_logger
-from mindroom.model_instance_checks import isinstance_of_loaded
 from mindroom.timing import timed
 
 if TYPE_CHECKING:
-    from agno.models.anthropic import Claude
     from agno.models.base import Model
     from agno.models.response import ModelResponse
 
 logger = get_logger(__name__)
-
-_ANTHROPIC_CLAUDE_CLASS = ("agno.models.anthropic.claude", "Claude")
 
 _COMPACTION_CANCEL_DRAIN_TIMEOUT_SECONDS = 1.0
 
@@ -119,14 +116,14 @@ def configure_summary_model(model: Model, *, timeout_seconds: float | None = Non
     Mutating the instance is safe: ``get_model_instance`` builds a fresh model per
     call and compaction loads its own instance per run.
     """
-    if not isinstance_of_loaded(model, _ANTHROPIC_CLAUDE_CLASS):
+    claude_model = as_anthropic_claude(model)
+    if claude_model is None:
         logger.debug(
             "Compaction summary model tuning skipped",
             model_type=type(model).__name__,
             reason="provider_specific_tuning_only_defined_for_claude",
         )
         return model
-    claude_model = cast("Claude", model)
     resolved_timeout = MINDROOM_COMPACTION_CHUNK_TIMEOUT_SECONDS if timeout_seconds is None else timeout_seconds
     claude_model.cache_system_prompt = False
     claude_model.extended_cache_time = False
@@ -282,9 +279,8 @@ def _normalize_compaction_summary_text(raw_text: str) -> str:
 
 
 def _summary_output_token_limit(model: Model) -> int | None:
-    if isinstance_of_loaded(model, _ANTHROPIC_CLAUDE_CLASS):
-        return cast("Claude", model).max_tokens
-    return None
+    claude_model = as_anthropic_claude(model)
+    return claude_model.max_tokens if claude_model is not None else None
 
 
 def _summary_response_likely_truncated(response: ModelResponse, *, output_token_limit: int | None) -> bool:

--- a/src/mindroom/history/summary_call.py
+++ b/src/mindroom/history/summary_call.py
@@ -35,22 +35,25 @@ import asyncio
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from functools import partial
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
-from agno.models.anthropic import Claude
 from agno.models.message import Message
 from agno.session.summary import SessionSummary
 
 from mindroom.cancellation import request_task_cancel
 from mindroom.constants import MINDROOM_COMPACTION_CHUNK_TIMEOUT_SECONDS
 from mindroom.logging_config import get_logger
+from mindroom.model_instance_checks import isinstance_of_loaded
 from mindroom.timing import timed
 
 if TYPE_CHECKING:
+    from agno.models.anthropic import Claude
     from agno.models.base import Model
     from agno.models.response import ModelResponse
 
 logger = get_logger(__name__)
+
+_ANTHROPIC_CLAUDE_CLASS = ("agno.models.anthropic.claude", "Claude")
 
 _COMPACTION_CANCEL_DRAIN_TIMEOUT_SECONDS = 1.0
 
@@ -116,21 +119,22 @@ def configure_summary_model(model: Model, *, timeout_seconds: float | None = Non
     Mutating the instance is safe: ``get_model_instance`` builds a fresh model per
     call and compaction loads its own instance per run.
     """
-    if not isinstance(model, Claude):
+    if not isinstance_of_loaded(model, _ANTHROPIC_CLAUDE_CLASS):
         logger.debug(
             "Compaction summary model tuning skipped",
             model_type=type(model).__name__,
             reason="provider_specific_tuning_only_defined_for_claude",
         )
         return model
+    claude_model = cast("Claude", model)
     resolved_timeout = MINDROOM_COMPACTION_CHUNK_TIMEOUT_SECONDS if timeout_seconds is None else timeout_seconds
-    model.cache_system_prompt = False
-    model.extended_cache_time = False
-    model.thinking = None
-    model.timeout = min(model.timeout, resolved_timeout) if model.timeout else resolved_timeout
-    client_params = dict(model.client_params or {})
+    claude_model.cache_system_prompt = False
+    claude_model.extended_cache_time = False
+    claude_model.thinking = None
+    claude_model.timeout = min(claude_model.timeout, resolved_timeout) if claude_model.timeout else resolved_timeout
+    client_params = dict(claude_model.client_params or {})
     client_params["max_retries"] = 0
-    model.client_params = client_params
+    claude_model.client_params = client_params
     return model
 
 
@@ -278,8 +282,8 @@ def _normalize_compaction_summary_text(raw_text: str) -> str:
 
 
 def _summary_output_token_limit(model: Model) -> int | None:
-    if isinstance(model, Claude):
-        return model.max_tokens
+    if isinstance_of_loaded(model, _ANTHROPIC_CLAUDE_CLASS):
+        return cast("Claude", model).max_tokens
     return None
 
 

--- a/src/mindroom/media_fallback.py
+++ b/src/mindroom/media_fallback.py
@@ -4,26 +4,47 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from agno.exceptions import ContextWindowExceededError, ModelProviderError
-from agno.models.anthropic import Claude
-from agno.models.azure.openai_chat import AzureOpenAI
-from agno.models.cerebras import Cerebras
-from agno.models.deepseek import DeepSeek
-from agno.models.google import Gemini
-from agno.models.groq import Groq
-from agno.models.ollama import Ollama
-from agno.models.openai import OpenAIChat, OpenAIResponses
-from agno.models.openrouter import OpenRouter
-from agno.models.vertexai.claude import Claude as VertexAIClaude
 
 from mindroom.media_inputs import MediaInputs, MediaKind
+from mindroom.model_instance_checks import isinstance_of_loaded
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
+    from agno.models.anthropic import Claude
+    from agno.models.azure.openai_chat import AzureOpenAI
     from agno.models.base import Model
+    from agno.models.cerebras.cerebras import Cerebras
+    from agno.models.deepseek.deepseek import DeepSeek
+    from agno.models.google import Gemini
+    from agno.models.groq.groq import Groq
+    from agno.models.ollama import Ollama
+    from agno.models.openai import OpenAIChat, OpenAIResponses
+    from agno.models.openrouter.openrouter import OpenRouter
+    from agno.models.vertexai.claude import Claude as VertexAIClaude
+
+# Route dispatch checks model classes without importing them (a model instance
+# can only exist once its provider module is imported), so this module never
+# pulls provider SDKs into the runtime import graph (#1436). Paths name each
+# class's concrete defining module.
+_AZURE_OPENAI_CLASS = ("agno.models.azure.openai_chat", "AzureOpenAI")
+_OLLAMA_CLASS = ("agno.models.ollama.chat", "Ollama")
+_BASE_URL_MODEL_CLASSES = (
+    ("agno.models.vertexai.claude", "Claude"),
+    ("agno.models.cerebras.cerebras", "Cerebras"),
+    ("agno.models.deepseek.deepseek", "DeepSeek"),
+    ("agno.models.groq.groq", "Groq"),
+    ("agno.models.openai.chat", "OpenAIChat"),
+    ("agno.models.openai.responses", "OpenAIResponses"),
+    ("agno.models.openrouter.openrouter", "OpenRouter"),
+)
+_CLIENT_PARAMS_MODEL_CLASSES = (
+    ("agno.models.anthropic.claude", "Claude"),
+    ("agno.models.google.gemini", "Gemini"),
+)
 
 __all__ = [
     "MediaRetryDecision",
@@ -337,37 +358,33 @@ def _without_media_kinds(media_inputs: MediaInputs, kinds: frozenset[MediaKind])
 
 
 def _route_endpoint(model: Model) -> str | None:
-    if isinstance(model, AzureOpenAI):
+    if isinstance_of_loaded(model, _AZURE_OPENAI_CLASS):
+        azure_model = cast("AzureOpenAI", model)
         return _route_endpoint_text(
-            model.azure_endpoint,
-            model.base_url,
-            _client_params_endpoint(model.client_params),
+            azure_model.azure_endpoint,
+            azure_model.base_url,
+            _client_params_endpoint(azure_model.client_params),
         )
-    if isinstance(model, Ollama):
+    if isinstance_of_loaded(model, _OLLAMA_CLASS):
+        ollama_model = cast("Ollama", model)
         return _route_endpoint_text(
-            model.host,
-            _client_params_endpoint(model.client_params),
+            ollama_model.host,
+            _client_params_endpoint(ollama_model.client_params),
         )
     # VertexAIClaude subclasses the Anthropic Claude model but exposes a base_url,
     # so it must be matched here, before the Claude/Gemini branch below.
-    if isinstance(
-        model,
-        (
-            VertexAIClaude,
-            Cerebras,
-            DeepSeek,
-            Groq,
-            OpenAIChat,
-            OpenAIResponses,
-            OpenRouter,
-        ),
-    ):
-        return _route_endpoint_text(
-            str(model.base_url) if model.base_url is not None else None,
-            _client_params_endpoint(model.client_params),
+    if isinstance_of_loaded(model, *_BASE_URL_MODEL_CLASSES):
+        base_url_model = cast(
+            "VertexAIClaude | Cerebras | DeepSeek | Groq | OpenAIChat | OpenAIResponses | OpenRouter",
+            model,
         )
-    if isinstance(model, (Claude, Gemini)):
-        return _client_params_endpoint(model.client_params)
+        return _route_endpoint_text(
+            str(base_url_model.base_url) if base_url_model.base_url is not None else None,
+            _client_params_endpoint(base_url_model.client_params),
+        )
+    if isinstance_of_loaded(model, *_CLIENT_PARAMS_MODEL_CLASSES):
+        claude_or_gemini = cast("Claude | Gemini", model)
+        return _client_params_endpoint(claude_or_gemini.client_params)
     return None
 
 

--- a/src/mindroom/media_fallback.py
+++ b/src/mindroom/media_fallback.py
@@ -4,47 +4,16 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from agno.exceptions import ContextWindowExceededError, ModelProviderError
 
 from mindroom.media_inputs import MediaInputs, MediaKind
-from mindroom.model_instance_checks import isinstance_of_loaded
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-    from agno.models.anthropic import Claude
-    from agno.models.azure.openai_chat import AzureOpenAI
     from agno.models.base import Model
-    from agno.models.cerebras.cerebras import Cerebras
-    from agno.models.deepseek.deepseek import DeepSeek
-    from agno.models.google import Gemini
-    from agno.models.groq.groq import Groq
-    from agno.models.ollama import Ollama
-    from agno.models.openai import OpenAIChat, OpenAIResponses
-    from agno.models.openrouter.openrouter import OpenRouter
-    from agno.models.vertexai.claude import Claude as VertexAIClaude
-
-# Route dispatch checks model classes without importing them (a model instance
-# can only exist once its provider module is imported), so this module never
-# pulls provider SDKs into the runtime import graph (#1436). Paths name each
-# class's concrete defining module.
-_AZURE_OPENAI_CLASS = ("agno.models.azure.openai_chat", "AzureOpenAI")
-_OLLAMA_CLASS = ("agno.models.ollama.chat", "Ollama")
-_BASE_URL_MODEL_CLASSES = (
-    ("agno.models.vertexai.claude", "Claude"),
-    ("agno.models.cerebras.cerebras", "Cerebras"),
-    ("agno.models.deepseek.deepseek", "DeepSeek"),
-    ("agno.models.groq.groq", "Groq"),
-    ("agno.models.openai.chat", "OpenAIChat"),
-    ("agno.models.openai.responses", "OpenAIResponses"),
-    ("agno.models.openrouter.openrouter", "OpenRouter"),
-)
-_CLIENT_PARAMS_MODEL_CLASSES = (
-    ("agno.models.anthropic.claude", "Claude"),
-    ("agno.models.google.gemini", "Gemini"),
-)
 
 __all__ = [
     "MediaRetryDecision",
@@ -357,34 +326,55 @@ def _without_media_kinds(media_inputs: MediaInputs, kinds: frozenset[MediaKind])
     )
 
 
+# The effective endpoint is dispatched on which endpoint attribute the model
+# exposes, not on its class, so this module never imports provider model
+# classes (and through them provider SDKs) just to route media errors (#1436).
+# Azure models keep the endpoint in azure_endpoint, Ollama in host, most
+# OpenAI-compatible providers in base_url, and Claude/Gemini only carry
+# client_params.
+@runtime_checkable
+class _HasAzureEndpoint(Protocol):
+    azure_endpoint: str | None
+    base_url: object
+    client_params: Mapping[str, object] | None
+
+
+@runtime_checkable
+class _HasHost(Protocol):
+    host: str | None
+    client_params: Mapping[str, object] | None
+
+
+@runtime_checkable
+class _HasBaseUrl(Protocol):
+    base_url: object
+    client_params: Mapping[str, object] | None
+
+
+@runtime_checkable
+class _HasClientParams(Protocol):
+    client_params: Mapping[str, object] | None
+
+
 def _route_endpoint(model: Model) -> str | None:
-    if isinstance_of_loaded(model, _AZURE_OPENAI_CLASS):
-        azure_model = cast("AzureOpenAI", model)
+    if isinstance(model, _HasAzureEndpoint):
         return _route_endpoint_text(
-            azure_model.azure_endpoint,
-            azure_model.base_url,
-            _client_params_endpoint(azure_model.client_params),
+            model.azure_endpoint,
+            str(model.base_url) if model.base_url is not None else None,
+            _client_params_endpoint(model.client_params),
         )
-    if isinstance_of_loaded(model, _OLLAMA_CLASS):
-        ollama_model = cast("Ollama", model)
+    if isinstance(model, _HasHost):
         return _route_endpoint_text(
-            ollama_model.host,
-            _client_params_endpoint(ollama_model.client_params),
+            model.host,
+            _client_params_endpoint(model.client_params),
         )
-    # VertexAIClaude subclasses the Anthropic Claude model but exposes a base_url,
-    # so it must be matched here, before the Claude/Gemini branch below.
-    if isinstance_of_loaded(model, *_BASE_URL_MODEL_CLASSES):
-        base_url_model = cast(
-            "VertexAIClaude | Cerebras | DeepSeek | Groq | OpenAIChat | OpenAIResponses | OpenRouter",
-            model,
-        )
+    if isinstance(model, _HasBaseUrl):
         return _route_endpoint_text(
-            str(base_url_model.base_url) if base_url_model.base_url is not None else None,
-            _client_params_endpoint(base_url_model.client_params),
+            str(model.base_url) if model.base_url is not None else None,
+            _client_params_endpoint(model.client_params),
         )
-    if isinstance_of_loaded(model, *_CLIENT_PARAMS_MODEL_CLASSES):
-        claude_or_gemini = cast("Claude | Gemini", model)
-        return _client_params_endpoint(claude_or_gemini.client_params)
+    if isinstance(model, _HasClientParams):
+        return _client_params_endpoint(model.client_params)
     return None
 
 

--- a/src/mindroom/model_instance_checks.py
+++ b/src/mindroom/model_instance_checks.py
@@ -1,0 +1,24 @@
+"""Leaf isinstance checks against provider model classes without importing them.
+
+An instance of a provider model class can only exist once the class's defining
+module is imported, so probing ``sys.modules`` is semantically identical to
+importing the class for an ``isinstance`` check — subclasses included — while
+keeping provider SDKs out of import graphs that merely dispatch on model type
+(#1436). Callers pass the class's concrete defining module (for example
+``agno.models.azure.openai_chat``), not a package init that may re-export a
+try/except stub.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def isinstance_of_loaded(instance: object, *class_paths: tuple[str, str]) -> bool:
+    """Return isinstance against the named classes, treating unloaded modules as no-match."""
+    for module_name, class_name in class_paths:
+        module = sys.modules.get(module_name)
+        loaded_class = getattr(module, class_name, None) if module is not None else None
+        if loaded_class is not None and isinstance(instance, loaded_class):
+            return True
+    return False

--- a/src/mindroom/openai_embedder.py
+++ b/src/mindroom/openai_embedder.py
@@ -1,0 +1,110 @@
+"""OpenAI-compatible embedder used for semantic indexes.
+
+Lives apart from the light helpers in ``mindroom.embeddings`` because
+subclassing agno's ``OpenAIEmbedder`` imports the openai SDK; the embedding
+factory imports this module only when the openai provider is configured
+(#1436).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from agno.knowledge.embedder.openai import OpenAIEmbedder
+from agno.utils.log import log_info, log_warning
+
+from mindroom.model_defaults import OPENAI_EMBEDDING_DIMENSIONS
+
+if TYPE_CHECKING:
+    from openai.types.create_embedding_response import CreateEmbeddingResponse
+
+
+@dataclass
+class MindRoomOpenAIEmbedder(OpenAIEmbedder):
+    """Avoid forcing OpenAI defaults onto arbitrary OpenAI-compatible hosts."""
+
+    _dimensions_explicit: bool = field(init=False, default=False, repr=False)
+
+    def __post_init__(self) -> None:
+        """Track whether dimensions came from explicit config."""
+        self._dimensions_explicit = self.dimensions is not None
+        if self.dimensions is None:
+            self.dimensions = OPENAI_EMBEDDING_DIMENSIONS.get(self.id)
+
+    def _should_send_dimensions(self) -> bool:
+        return self.dimensions is not None and (self._dimensions_explicit or self.id in OPENAI_EMBEDDING_DIMENSIONS)
+
+    def _request_params(self, input_value: str | list[str]) -> dict[str, Any]:
+        request: dict[str, Any] = {
+            "input": input_value,
+            "model": self.id,
+            "encoding_format": self.encoding_format,
+        }
+        if self.user is not None:
+            request["user"] = self.user
+        if self._should_send_dimensions():
+            request["dimensions"] = self.dimensions
+        if self.request_params:
+            request.update(self.request_params)
+        return request
+
+    # NOTE: These overrides intentionally mirror agno's async/embedder methods
+    # because upstream inlines request construction instead of calling a shared helper.
+    # Keep them aligned with agno when upgrading that dependency.
+    def response(self, text: str) -> CreateEmbeddingResponse:
+        """Request a single embedding synchronously."""
+        return self.client.embeddings.create(**self._request_params(text))
+
+    async def async_get_embedding(self, text: str) -> list[float]:
+        """Request a single embedding asynchronously."""
+        try:
+            response: CreateEmbeddingResponse = await self.aclient.embeddings.create(**self._request_params(text))
+            return response.data[0].embedding
+        except Exception as e:
+            log_warning(e)
+            return []
+
+    async def async_get_embedding_and_usage(self, text: str) -> tuple[list[float], dict[str, Any] | None]:
+        """Request one embedding and its usage payload asynchronously."""
+        try:
+            response = await self.aclient.embeddings.create(**self._request_params(text))
+            embedding = response.data[0].embedding
+            usage = response.usage
+            return embedding, usage.model_dump() if usage else None
+        except Exception as e:
+            log_warning(f"Error getting embedding: {e}")
+            return [], None
+
+    async def async_get_embeddings_batch_and_usage(
+        self,
+        texts: list[str],
+    ) -> tuple[list[list[float]], list[dict[str, Any] | None]]:
+        """Request embeddings for a batch of texts and return per-item usage."""
+        all_embeddings: list[list[float]] = []
+        all_usage: list[dict[str, Any] | None] = []
+        log_info(f"Getting embeddings and usage for {len(texts)} texts in batches of {self.batch_size} (async)")
+
+        for i in range(0, len(texts), self.batch_size):
+            batch_texts = texts[i : i + self.batch_size]
+            try:
+                response: CreateEmbeddingResponse = await self.aclient.embeddings.create(
+                    **self._request_params(batch_texts),
+                )
+                batch_embeddings = [data.embedding for data in response.data]
+                all_embeddings.extend(batch_embeddings)
+                usage_dict = response.usage.model_dump() if response.usage else None
+                all_usage.extend([usage_dict] * len(batch_embeddings))
+            except Exception as e:
+                log_warning(f"Error in async batch embedding: {e}")
+                for text in batch_texts:
+                    try:
+                        embedding, usage = await self.async_get_embedding_and_usage(text)
+                        all_embeddings.append(embedding)
+                        all_usage.append(usage)
+                    except Exception as inner:
+                        log_warning(f"Error in individual async embedding fallback: {inner}")
+                        all_embeddings.append([])
+                        all_usage.append(None)
+
+        return all_embeddings, all_usage

--- a/src/mindroom/openai_tool_search.py
+++ b/src/mindroom/openai_tool_search.py
@@ -26,15 +26,17 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any, cast
 
-from agno.models.openai import OpenAIResponses
-
 from mindroom.model_defaults import OPENAI_TOOL_SEARCH_MIN_GPT_VERSION
+from mindroom.model_instance_checks import isinstance_of_loaded
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
 
     from agno.models.message import Message
+    from agno.models.openai import OpenAIResponses
     from agno.models.response import ModelResponse
+
+_OPENAI_RESPONSES_CLASS = ("agno.models.openai.responses", "OpenAIResponses")
 
 _DEFERRED_TOOL_NAMES_ATTR = "_mindroom_openai_deferred_tool_names"
 _TOOL_SEARCH_ITEMS_KEY = "tool_search_items"
@@ -74,7 +76,7 @@ def install_openai_deferred_tool_search(model: object, *, deferred_tool_names: f
     and tool discovery never invalidates the prompt cache. No-op for
     non-Responses models and empty name sets.
     """
-    if not isinstance(model, OpenAIResponses) or not deferred_tool_names:
+    if not isinstance_of_loaded(model, _OPENAI_RESPONSES_CLASS) or not deferred_tool_names:
         return
     vars(model)[_DEFERRED_TOOL_NAMES_ATTR] = frozenset(deferred_tool_names)
 

--- a/src/mindroom/thread_summary.py
+++ b/src/mindroom/thread_summary.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 import nio
 from agno.agent import Agent
-from agno.models.base import Model
 from pydantic import BaseModel, Field
 
 from mindroom import model_loading
@@ -21,6 +20,7 @@ from mindroom.entity_resolution import resolve_room_scoped_model_override
 from mindroom.logging_config import get_logger
 from mindroom.matrix.client_delivery import send_message_result
 from mindroom.matrix.message_builder import build_message_content
+from mindroom.model_instance_checks import isinstance_of_loaded
 from mindroom.timing import timed
 
 if TYPE_CHECKING:
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from mindroom.matrix.conversation_cache import ConversationCacheProtocol
 
 logger = get_logger(__name__)
-_VERTEXAI_PROVIDER = "VertexAI"
+_VERTEXAI_CLAUDE_CLASS = ("agno.models.vertexai.claude", "Claude")
 THREAD_SUMMARY_MAX_LENGTH = 300
 _MARKDOWN_LINK_RE = re.compile(r"!\[([^\]]*)\]\([^)]+\)|\[([^\]]+)\]\([^)]+\)")
 _MARKDOWN_CODE_BLOCK_RE = re.compile(r"```(?:[^\n`]*)\n?(.*?)```", re.DOTALL)
@@ -88,7 +88,7 @@ def _configure_summary_model_temperature(
 ) -> None:
     """Prepare the summary model's temperature setting for one request."""
     if isinstance(model, _SupportsTemperature):
-        if isinstance(model, Model) and model.provider == _VERTEXAI_PROVIDER:
+        if isinstance_of_loaded(model, _VERTEXAI_CLAUDE_CLASS):
             # Vertex Claude's rawPredict helper rejects a temperature field entirely.
             model.temperature = None
         else:

--- a/src/mindroom/thread_summary.py
+++ b/src/mindroom/thread_summary.py
@@ -8,10 +8,11 @@ import re
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Protocol, cast, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 import nio
 from agno.agent import Agent
+from agno.models.base import Model
 from pydantic import BaseModel, Field
 
 from mindroom import model_loading
@@ -20,7 +21,6 @@ from mindroom.entity_resolution import resolve_room_scoped_model_override
 from mindroom.logging_config import get_logger
 from mindroom.matrix.client_delivery import send_message_result
 from mindroom.matrix.message_builder import build_message_content
-from mindroom.model_instance_checks import isinstance_of_loaded
 from mindroom.timing import timed
 
 if TYPE_CHECKING:
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from mindroom.matrix.conversation_cache import ConversationCacheProtocol
 
 logger = get_logger(__name__)
-_VERTEXAI_CLAUDE_CLASS = ("agno.models.vertexai.claude", "Claude")
+_VERTEXAI_PROVIDER = "VertexAI"
 THREAD_SUMMARY_MAX_LENGTH = 300
 _MARKDOWN_LINK_RE = re.compile(r"!\[([^\]]*)\]\([^)]+\)|\[([^\]]+)\]\([^)]+\)")
 _MARKDOWN_CODE_BLOCK_RE = re.compile(r"```(?:[^\n`]*)\n?(.*?)```", re.DOTALL)
@@ -87,12 +87,12 @@ def _configure_summary_model_temperature(
     model_name: str,
 ) -> None:
     """Prepare the summary model's temperature setting for one request."""
-    if isinstance_of_loaded(model, _VERTEXAI_CLAUDE_CLASS):
-        # Vertex Claude's rawPredict helper rejects a temperature field entirely.
-        cast("_SupportsTemperature", model).temperature = None
-        return
     if isinstance(model, _SupportsTemperature):
-        model.temperature = summary_temperature
+        if isinstance(model, Model) and model.provider == _VERTEXAI_PROVIDER:
+            # Vertex Claude's rawPredict helper rejects a temperature field entirely.
+            model.temperature = None
+        else:
+            model.temperature = summary_temperature
         return
     if summary_temperature is None:
         return

--- a/src/mindroom/thread_summary.py
+++ b/src/mindroom/thread_summary.py
@@ -8,11 +8,10 @@ import re
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, cast, runtime_checkable
 
 import nio
 from agno.agent import Agent
-from agno.models.vertexai.claude import Claude as VertexAIClaude
 from pydantic import BaseModel, Field
 
 from mindroom import model_loading
@@ -21,6 +20,7 @@ from mindroom.entity_resolution import resolve_room_scoped_model_override
 from mindroom.logging_config import get_logger
 from mindroom.matrix.client_delivery import send_message_result
 from mindroom.matrix.message_builder import build_message_content
+from mindroom.model_instance_checks import isinstance_of_loaded
 from mindroom.timing import timed
 
 if TYPE_CHECKING:
@@ -86,9 +86,9 @@ def _configure_summary_model_temperature(
     model_name: str,
 ) -> None:
     """Prepare the summary model's temperature setting for one request."""
-    if isinstance(model, VertexAIClaude):
+    if isinstance_of_loaded(model, ("agno.models.vertexai.claude", "Claude")):
         # Vertex Claude's rawPredict helper rejects a temperature field entirely.
-        model.temperature = None
+        cast("_SupportsTemperature", model).temperature = None
         return
     if isinstance(model, _SupportsTemperature):
         model.temperature = summary_temperature

--- a/src/mindroom/thread_summary.py
+++ b/src/mindroom/thread_summary.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     from mindroom.matrix.conversation_cache import ConversationCacheProtocol
 
 logger = get_logger(__name__)
+_VERTEXAI_CLAUDE_CLASS = ("agno.models.vertexai.claude", "Claude")
 THREAD_SUMMARY_MAX_LENGTH = 300
 _MARKDOWN_LINK_RE = re.compile(r"!\[([^\]]*)\]\([^)]+\)|\[([^\]]+)\]\([^)]+\)")
 _MARKDOWN_CODE_BLOCK_RE = re.compile(r"```(?:[^\n`]*)\n?(.*?)```", re.DOTALL)
@@ -86,7 +87,7 @@ def _configure_summary_model_temperature(
     model_name: str,
 ) -> None:
     """Prepare the summary model's temperature setting for one request."""
-    if isinstance_of_loaded(model, ("agno.models.vertexai.claude", "Claude")):
+    if isinstance_of_loaded(model, _VERTEXAI_CLAUDE_CLASS):
         # Vertex Claude's rawPredict helper rejects a temperature field entirely.
         cast("_SupportsTemperature", model).temperature = None
         return

--- a/tach.toml
+++ b/tach.toml
@@ -2492,6 +2492,7 @@ depends_on = [
     "mindroom.ai_runtime",
     "mindroom.entity_resolution",
     "mindroom.matrix.client_delivery",
+    "mindroom.model_instance_checks",
     "mindroom.model_loading",
 ]
 

--- a/tach.toml
+++ b/tach.toml
@@ -33,7 +33,16 @@ depends_on = [
     "mindroom.credentials_sync",
     "mindroom.embeddings",
     "mindroom.model_defaults",
+    "mindroom.openai_embedder",
 ]
+
+[[modules]]
+path = "mindroom.model_instance_checks"
+depends_on = []
+
+[[modules]]
+path = "mindroom.openai_embedder"
+depends_on = ["mindroom.model_defaults"]
 
 [[modules]]
 path = "mindroom.path_globs"
@@ -950,6 +959,7 @@ depends_on = [
 path = "mindroom.history.summary_call"
 depends_on = [
     "mindroom.cancellation",
+    "mindroom.claude_prompt_cache",
     "mindroom.constants",
     "mindroom.logging_config",
     "mindroom.timing",
@@ -2482,6 +2492,7 @@ depends_on = [
     "mindroom.ai_runtime",
     "mindroom.entity_resolution",
     "mindroom.matrix.client_delivery",
+    "mindroom.model_instance_checks",
     "mindroom.model_loading",
 ]
 

--- a/tach.toml
+++ b/tach.toml
@@ -2492,7 +2492,6 @@ depends_on = [
     "mindroom.ai_runtime",
     "mindroom.entity_resolution",
     "mindroom.matrix.client_delivery",
-    "mindroom.model_instance_checks",
     "mindroom.model_loading",
 ]
 

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -10,12 +10,12 @@ import pytest
 
 from mindroom.constants import resolve_primary_runtime_paths
 from mindroom.embeddings import (
-    MindRoomOpenAIEmbedder,
     create_sentence_transformers_embedder,
     effective_knowledge_embedder_signature,
     effective_mem0_embedder_signature,
 )
 from mindroom.model_defaults import OPENAI_EMBEDDING_LARGE, SENTENCE_TRANSFORMERS_DEFAULT
+from mindroom.openai_embedder import MindRoomOpenAIEmbedder
 
 TEST_RUNTIME_PATHS = resolve_primary_runtime_paths(config_path=Path("config.yaml"))
 

--- a/tests/test_import_graph.py
+++ b/tests/test_import_graph.py
@@ -1,9 +1,11 @@
 """Import-graph regression tests for slim entry points (#1436).
 
-Importing the tool registry, config layer, or sandbox runner must not import
-any provider SDK (or the nio matrix client); those load on first model or tool
-construction. Each probe runs in a subprocess so the assertion sees exactly
-what the import graph pulls in.
+Importing the tool registry, config layer, sandbox runner, or the primary
+runtime must not import any provider SDK; those load on first model or tool
+construction. Slim entry points additionally must not import the nio matrix
+client or the mcp SDK, which the primary runtime genuinely needs at boot.
+Each probe runs in a subprocess so the assertion sees exactly what the import
+graph pulls in.
 """
 
 from __future__ import annotations
@@ -14,17 +16,16 @@ import sys
 
 import pytest
 
-_BANNED_IMPORT_ROOTS = (
+_PROVIDER_SDK_ROOTS = (
     "anthropic",
     "boto3",
     "cerebras",
     "google.genai",
     "groq",
-    "mcp",
-    "nio",
     "ollama",
     "openai",
 )
+_SLIM_ONLY_ROOTS = ("mcp", "nio")
 
 _PROBE_TEMPLATE = """
 import importlib, json, sys
@@ -40,6 +41,19 @@ print(json.dumps(loaded))
 """
 
 
+def _assert_probe_clean(module: str, roots: tuple[str, ...]) -> None:
+    probe = _PROBE_TEMPLATE.format(module=module, roots=roots)
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=120,
+    )
+    loaded = json.loads(result.stdout)
+    assert loaded == [], f"importing {module} pulled in banned modules: {loaded}"
+
+
 @pytest.mark.parametrize(
     "module",
     [
@@ -53,13 +67,9 @@ print(json.dumps(loaded))
 )
 def test_slim_entry_points_do_not_import_provider_sdks(module: str) -> None:
     """Slim entry points must keep provider SDKs and the matrix client unimported."""
-    probe = _PROBE_TEMPLATE.format(module=module, roots=_BANNED_IMPORT_ROOTS)
-    result = subprocess.run(
-        [sys.executable, "-c", probe],
-        capture_output=True,
-        text=True,
-        check=True,
-        timeout=120,
-    )
-    loaded = json.loads(result.stdout)
-    assert loaded == [], f"importing {module} pulled in banned modules: {loaded}"
+    _assert_probe_clean(module, _PROVIDER_SDK_ROOTS + _SLIM_ONLY_ROOTS)
+
+
+def test_primary_runtime_does_not_import_provider_sdks() -> None:
+    """The orchestrator import (mindroom run) loads no provider SDK; only configured ones load later."""
+    _assert_probe_clean("mindroom.orchestrator", _PROVIDER_SDK_ROOTS)

--- a/tests/test_model_instance_checks.py
+++ b/tests/test_model_instance_checks.py
@@ -17,11 +17,13 @@ import pytest
 from mindroom.claude_prompt_cache import _ANTHROPIC_CLAUDE_CLASS
 from mindroom.model_instance_checks import isinstance_of_loaded
 from mindroom.openai_tool_search import _OPENAI_RESPONSES_CLASS
+from mindroom.thread_summary import _VERTEXAI_CLAUDE_CLASS
 
 _ALL_DECLARED_CLASS_PATHS = sorted(
     {
         _ANTHROPIC_CLAUDE_CLASS,
         _OPENAI_RESPONSES_CLASS,
+        _VERTEXAI_CLAUDE_CLASS,
     },
 )
 

--- a/tests/test_model_instance_checks.py
+++ b/tests/test_model_instance_checks.py
@@ -1,0 +1,75 @@
+"""Tests for sys.modules-gated model class checks (#1436).
+
+The declared ``(module, class)`` tuples are load-bearing strings: a typo or an
+agno relocation would make ``isinstance_of_loaded`` silently return False
+forever instead of failing at import like a real import would. The resolution
+test walks every declared tuple and asserts it names the class's actual
+defining module, converting that silent failure mode back into a loud one.
+"""
+
+from __future__ import annotations
+
+import decimal
+from importlib import import_module
+
+import pytest
+
+from mindroom.claude_prompt_cache import _ANTHROPIC_CLAUDE_CLASS
+from mindroom.media_fallback import (
+    _AZURE_OPENAI_CLASS,
+    _BASE_URL_MODEL_CLASSES,
+    _CLIENT_PARAMS_MODEL_CLASSES,
+    _OLLAMA_CLASS,
+)
+from mindroom.model_instance_checks import isinstance_of_loaded
+from mindroom.openai_tool_search import _OPENAI_RESPONSES_CLASS
+from mindroom.thread_summary import _VERTEXAI_CLAUDE_CLASS
+
+_ALL_DECLARED_CLASS_PATHS = sorted(
+    {
+        _ANTHROPIC_CLAUDE_CLASS,
+        _AZURE_OPENAI_CLASS,
+        _OLLAMA_CLASS,
+        _OPENAI_RESPONSES_CLASS,
+        _VERTEXAI_CLAUDE_CLASS,
+        *_BASE_URL_MODEL_CLASSES,
+        *_CLIENT_PARAMS_MODEL_CLASSES,
+    },
+)
+
+
+@pytest.mark.parametrize(("module_name", "class_name"), _ALL_DECLARED_CLASS_PATHS)
+def test_declared_class_paths_name_the_defining_module(module_name: str, class_name: str) -> None:
+    """Every declared tuple must resolve, and to the class's defining module.
+
+    Resolving through a package init that merely re-exports the class would
+    pass ``getattr`` but leave ``isinstance_of_loaded`` blind whenever only
+    the concrete module is imported, so the defining module is asserted too.
+    """
+    loaded_class = getattr(import_module(module_name), class_name)
+    assert loaded_class.__module__ == module_name
+
+
+def test_isinstance_of_loaded_matches_loaded_class_and_subclass() -> None:
+    """Loaded classes match exact instances and subclass instances."""
+
+    class _SubDecimal(decimal.Decimal):
+        pass
+
+    assert isinstance_of_loaded(decimal.Decimal(1), ("decimal", "Decimal"))
+    assert isinstance_of_loaded(_SubDecimal("1"), ("decimal", "Decimal"))
+    assert not isinstance_of_loaded("not a decimal", ("decimal", "Decimal"))
+
+
+def test_isinstance_of_loaded_treats_unloaded_module_as_no_match() -> None:
+    """Unloaded or nonexistent modules never match and never import."""
+    assert not isinstance_of_loaded(object(), ("module_that_is_never_imported", "Anything"))
+
+
+def test_isinstance_of_loaded_checks_paths_in_order_until_first_match() -> None:
+    """Any matching path in the tuple list is sufficient."""
+    assert isinstance_of_loaded(
+        decimal.Decimal(1),
+        ("module_that_is_never_imported", "Anything"),
+        ("decimal", "Decimal"),
+    )

--- a/tests/test_model_instance_checks.py
+++ b/tests/test_model_instance_checks.py
@@ -15,25 +15,13 @@ from importlib import import_module
 import pytest
 
 from mindroom.claude_prompt_cache import _ANTHROPIC_CLAUDE_CLASS
-from mindroom.media_fallback import (
-    _AZURE_OPENAI_CLASS,
-    _BASE_URL_MODEL_CLASSES,
-    _CLIENT_PARAMS_MODEL_CLASSES,
-    _OLLAMA_CLASS,
-)
 from mindroom.model_instance_checks import isinstance_of_loaded
 from mindroom.openai_tool_search import _OPENAI_RESPONSES_CLASS
-from mindroom.thread_summary import _VERTEXAI_CLAUDE_CLASS
 
 _ALL_DECLARED_CLASS_PATHS = sorted(
     {
         _ANTHROPIC_CLAUDE_CLASS,
-        _AZURE_OPENAI_CLASS,
-        _OLLAMA_CLASS,
         _OPENAI_RESPONSES_CLASS,
-        _VERTEXAI_CLAUDE_CLASS,
-        *_BASE_URL_MODEL_CLASSES,
-        *_CLIENT_PARAMS_MODEL_CLASSES,
     },
 )
 


### PR DESCRIPTION
Extends #1442 (#1436) to the `mindroom run` startup path.

## Problem

#1442 fixed the slim entry points (registry, config, sandbox runner), but `import mindroom.orchestrator` — the bulk of `mindroom run` startup — still loaded **every** provider SDK (anthropic, google.genai, openai, ollama, groq, cerebras, deepseek) regardless of which providers the config uses. Four modules imported agno model classes at module top purely for `isinstance` dispatch, and the embedder factory imported both embedder SDKs eagerly:

| Module | Eager imports | Why they existed |
|---|---|---|
| `media_fallback.py` | 11 model classes | endpoint-attribute dispatch in `_route_endpoint` |
| `openai_tool_search.py` | `OpenAIResponses` | one `isinstance` gate |
| `thread_summary.py` | `VertexAIClaude` | one `isinstance` gate |
| `history/summary_call.py` | `Claude` | compaction model tuning gates |
| `embedding_factory.py` / `embeddings.py` | `OllamaEmbedder`, openai SDK | embedder construction + `MindRoomOpenAIEmbedder` subclassing agno's `OpenAIEmbedder` at class-definition time |

## Change

- New leaf helper `model_instance_checks.isinstance_of_loaded(instance, *(module, class))`: probes `sys.modules` for the class's concrete defining module and runs `isinstance` only against loaded classes. This is semantically identical to importing the class — an instance (including subclasses like `MindroomVertexAIClaude` or `CodexResponses`) can only exist once its module is imported — the same invariant #1442 established for `claude_prompt_cache.as_anthropic_claude`. Plain string dispatch on class names would break exactly those subclass cases, which is why `isinstance` stays.
- The four dispatch modules switch to it, with `TYPE_CHECKING` imports + casts keeping the narrowed attribute access typed.
- `MindRoomOpenAIEmbedder` moves to its own module (`openai_embedder.py`); `embeddings.py` keeps the light signature helpers its other importers (memory config, knowledge indexing) actually need; the embedder factory imports each provider's embedder inside its branch.
- The import-graph regression test grows a `mindroom.orchestrator` probe (provider SDKs only — `nio` and `mcp` are genuine runtime-boot dependencies: the MCP manager syncs unconditionally at startup).

## Measurements (warm `-X importtime`, M1-class Mac, best of 3)

| | main | PR |
|---|---|---|
| `import mindroom.orchestrator` | 2.60 s, loads 7 provider SDKs | **1.90 s, loads none** |

The configured provider's SDK still loads at first model construction during startup (correct), so a single-provider config now pays for one SDK instead of seven. Remaining known weight, deliberately left: `mem0` eagerly imports `qdrant_client` (~0.32 s) upstream even though we use chroma, and mem0 loads at startup whenever memory is enabled; `nio`/`mcp`/`chromadb`/agno core are genuine runtime dependencies.

## Testing

- Full suite: 9361 passed, 61 skipped.
- `uv run pre-commit run --all-files` clean; `tach check --dependencies --interfaces` clean.
- New probe fails on main, passes here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for OpenAI-compatible embedding providers with configurable dimensions and robust single/batch embedding + usage handling.

* **Bug Fixes**
  * Improved provider/model-type detection for summary configuration, media routing, and tool-search so the right provider-specific behavior is applied.
  * Reduced unnecessary provider SDK loading via deferred and import-safe runtime checks.

* **Tests**
  * Strengthened import-safety regression coverage and added tests for “loaded-only” class detection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->