### PR TITLE
Never teach media capability from transient failures (5xx, 429)

### DIFF
--- a/docs/images.md
+++ b/docs/images.md
@@ -86,6 +86,7 @@ Any failure of a media-bearing request triggers one retry without media — no e
 When the retry succeeds, the model route learns that the dropped media kinds are unsupported, and later requests omit them up front instead of paying a failed API call.
 This learned capability state is process-local and resets on restart.
 Payload-size and context-overflow rejections never teach the capability state, since dropping media can shrink an oversized request for reasons unrelated to media support.
+Transient failures (HTTP 5xx and 429 status codes on the provider exception) also never teach, since their retry can succeed simply because the outage or rate limit passed.
 
 ## Limitations
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -12946,6 +12946,7 @@ Any failure of a media-bearing request triggers one retry without media — no e
 When the retry succeeds, the model route learns that the dropped media kinds are unsupported, and later requests omit them up front instead of paying a failed API call.
 This learned capability state is process-local and resets on restart.
 Payload-size and context-overflow rejections never teach the capability state, since dropping media can shrink an oversized request for reasons unrelated to media support.
+Transient failures (HTTP 5xx and 429 status codes on the provider exception) also never teach, since their retry can succeed simply because the outage or rate limit passed.
 
 ## Limitations
 

--- a/skills/mindroom-docs/references/page__images__index.md
+++ b/skills/mindroom-docs/references/page__images__index.md
@@ -82,6 +82,7 @@ Any failure of a media-bearing request triggers one retry without media — no e
 When the retry succeeds, the model route learns that the dropped media kinds are unsupported, and later requests omit them up front instead of paying a failed API call.
 This learned capability state is process-local and resets on restart.
 Payload-size and context-overflow rejections never teach the capability state, since dropping media can shrink an oversized request for reasons unrelated to media support.
+Transient failures (HTTP 5xx and 429 status codes on the provider exception) also never teach, since their retry can succeed simply because the outage or rate limit passed.
 
 ## Limitations
 

--- a/src/mindroom/media_fallback.py
+++ b/src/mindroom/media_fallback.py
@@ -37,6 +37,8 @@ __all__ = [
 
 _INLINE_MEDIA_FALLBACK_MARKER = "[Inline media unavailable for this model]"
 _PAYLOAD_TOO_LARGE_STATUS = 413
+_RATE_LIMIT_STATUS = 429
+_SERVER_ERROR_STATUS = 500
 
 
 @dataclass(frozen=True, slots=True)
@@ -179,11 +181,18 @@ def _capability_teaching_blocked(error: Exception | str, lowered_error_text: str
     """Report when a retry success would not prove the media kinds unsupported.
 
     Payload-size and context-overflow rejections shrink below the limit once
-    media is dropped, so a successful retry says nothing about capability.
+    media is dropped, and transient failures (5xx outages, 429 rate limits)
+    can pass on the retry because the blip passed — in both cases a
+    successful retry says nothing about media capability. Status codes come
+    from the exception object, never from provider error prose; streamed run
+    errors arrive as bare text without a status and stay eligible to teach.
     """
     if isinstance(error, ContextWindowExceededError):
         return True
-    if isinstance(error, ModelProviderError) and error.status_code == _PAYLOAD_TOO_LARGE_STATUS:
+    if isinstance(error, ModelProviderError) and (
+        error.status_code in (_PAYLOAD_TOO_LARGE_STATUS, _RATE_LIMIT_STATUS)
+        or error.status_code >= _SERVER_ERROR_STATUS
+    ):
         return True
     if f"error code: {_PAYLOAD_TOO_LARGE_STATUS}" in lowered_error_text:
         return True

--- a/tests/test_media_fallback.py
+++ b/tests/test_media_fallback.py
@@ -55,7 +55,6 @@ def test_model_route_includes_provider_model_and_base_url() -> None:
         "Rate limit exceeded",
         "Error code: 400 - invalid api key provided",
         ModelProviderError(message="Some brand new provider wording about content", status_code=400),
-        ModelProviderError(message="upstream connect error", status_code=502),
     ],
 )
 def test_any_failure_retries_without_media_and_teaches_on_success(error: Exception | str) -> None:
@@ -101,10 +100,15 @@ def test_no_media_present_never_retries() -> None:
         ContextWindowExceededError(message="prompt is too long: 250000 tokens > 200000 maximum"),
         "Error code: 400 - maximum context length is 128000 tokens",
         ModelProviderError(message="Request Entity Too Large", status_code=413),
+        # Transient failures can pass on the retry because the blip passed, so
+        # a lucky retry success must not disable media for the route.
+        ModelProviderError(message="upstream connect error", status_code=502),
+        ModelProviderError(message="model overloaded", status_code=503),
+        ModelProviderError(message="Too Many Requests", status_code=429),
     ],
 )
-def test_size_and_context_overflow_retries_but_never_teaches(error: Exception | str) -> None:
-    """Dropping media can shrink an oversized request, so success must not teach capability."""
+def test_size_context_and_transient_failures_retry_but_never_teach(error: Exception | str) -> None:
+    """Oversized requests and transient failures must not teach capability on retry success."""
     reset_model_media_capability_cache()
     media = _media_inputs()
     route = _route()


### PR DESCRIPTION
Follow-up to #1444, addressing the legitimate half of the Greptile 3/5 review.

## Problem

A transient server error (502 proxy blip, 503 overload) or a 429 rate limit on a media-bearing request retries without media; if that retry succeeds simply because the blip passed, `record_retry_success()` would wrongly mark all media kinds unsupported for the route until the process restarts — silently dropping e.g. images from a vision model.

## Fix

`_capability_teaching_blocked` now also blocks teaching when the provider exception carries status 429 or ≥ 500. The guard is string-free: status codes come from agno's `ModelProviderError`, never from provider error prose, so this does not reintroduce the pattern-matching #1444 removed. Streamed run errors (bare text, no status) remain eligible to teach, which is desired for genuine invalid-request rejections like Z.ai's code 1214.

The retry behavior itself is unchanged — transient failures still retry once without media before surfacing.

The second Greptile finding (named-kind rejections drop all kinds instead of just the named one) is left as-is: restoring selective attribution would require the per-provider wording patterns #1444 deliberately deleted, and the cost is one conservative retry, not a correctness issue.

## Testing

- 502/503/429 `ModelProviderError` cases moved into the never-teaches parametrized test; `record_retry_success()` verified to leave the cache empty.
- `tests/test_media_fallback.py`, `tests/test_team_media_fallback.py`, `tests/test_ai_user_id.py`: 202 passed. Pre-commit green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined media fallback behavior so transient provider failures, including rate limits and server errors, no longer update learned capability state after retries.
  * This helps avoid incorrectly treating temporary outages as unsupported media.

* **Documentation**
  * Updated the images/media fallback guidance and related reference docs to clarify when capability learning is skipped for transient failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->