### PR TITLE
Retry compaction summary once when the model returns an empty result

### DIFF
--- a/src/mindroom/history/compaction.py
+++ b/src/mindroom/history/compaction.py
@@ -553,9 +553,10 @@ async def _generate_compaction_summary_with_retry(
                     max_input_tokens=retry_budget,
                 )
                 # The policy decides whether a retry is allowed; rebuilt_runs is the
-                # feasibility gate. An empty rebuild means the shrunken budget fits no
-                # run at all, so a retry would resend the same failing input — fall
-                # through to raise instead.
+                # feasibility gate. Only a shrunken budget can rebuild empty (an
+                # unchanged budget reproduces the input that already fit), and it
+                # means no run fits — fall through to raise instead of resending
+                # the too-large input.
                 if rebuilt_runs:
                     summary_input = rebuilt_input
                     included_runs = rebuilt_runs

--- a/src/mindroom/history/summary_call.py
+++ b/src/mindroom/history/summary_call.py
@@ -14,10 +14,12 @@ It enforces the call-side half of the compaction invariants
    max_tokens as the truncation guard. Unknown providers pass through untouched
    and rely on the outer chunk timeout alone.
 
-4. Budget shrinks deterministically on provider failure.
+4. Retry on provider failure is deterministic.
    ``SummaryRetryPolicy`` decides which error classes warrant a smaller retry
    (timeouts and the named context-length fragments), the shrink schedule
    (halving), and the give-up floor — no inline string matching at call sites.
+   Empty-text success responses re-issue once at the unchanged budget instead,
+   because shrinking cannot fix a transient empty response.
 
 5. Output-capped summaries use an explicit retry signal.
    ``generate_compaction_summary`` refuses to return a likely truncated summary,
@@ -81,11 +83,12 @@ class _CompactionSummaryEmptyResultError(RuntimeError):
 
 @dataclass(frozen=True)
 class SummaryRetryPolicy:
-    """Explicit budget-shrink policy for failed compaction summary calls.
+    """Explicit retry policy for failed compaction summary calls.
 
-    The schedule is deterministic: each policy-approved failure divides the input
-    budget by ``shrink_divisor`` (clamped to ``floor_tokens``); once the budget can
-    no longer shrink, or ``max_attempts`` is reached, the error propagates.
+    The schedule is deterministic: each shrinkable failure divides the input
+    budget by ``shrink_divisor`` (clamped to ``floor_tokens``), while an empty
+    result re-issues at the unchanged budget; once the budget can no longer
+    shrink, or ``max_attempts`` is reached, the error propagates.
     """
 
     max_attempts: int = 2

--- a/src/mindroom/history/summary_call.py
+++ b/src/mindroom/history/summary_call.py
@@ -75,6 +75,10 @@ class CompactionSummaryOutputLimitError(RuntimeError):
     """Raised when the summary response reaches the configured output-token cap."""
 
 
+class _CompactionSummaryEmptyResultError(RuntimeError):
+    """Raised when the summary model returns a success response with no text."""
+
+
 @dataclass(frozen=True)
 class SummaryRetryPolicy:
     """Explicit budget-shrink policy for failed compaction summary calls.
@@ -96,8 +100,15 @@ class SummaryRetryPolicy:
         return any(fragment in message for fragment in _RETRYABLE_PROVIDER_ERROR_FRAGMENTS)
 
     def retry_budget(self, *, attempt: int, budget: int, error: Exception) -> int | None:
-        """Return the next smaller input budget, or None when the policy gives up."""
-        if attempt >= self.max_attempts or not self.should_shrink(error):
+        """Return the input budget for the next attempt, or None when the policy gives up."""
+        if attempt >= self.max_attempts:
+            return None
+        if isinstance(error, _CompactionSummaryEmptyResultError):
+            # Shrinking does not fix an empty response: the provider fault is
+            # transient (a byte-identical input has been observed to fail
+            # fast-empty and then summarize fine), so re-issue unchanged.
+            return budget
+        if not self.should_shrink(error):
             return None
         smaller_budget = max(self.floor_tokens, budget // self.shrink_divisor)
         if smaller_budget >= budget:
@@ -258,8 +269,12 @@ async def generate_compaction_summary(
     raw_text = response.content if isinstance(response.content, str) else ""
     normalized_text = _normalize_compaction_summary_text(raw_text)
     if not normalized_text:
-        msg = "summary generation returned no result"
-        raise RuntimeError(msg)
+        msg = (
+            "summary generation returned no result "
+            f"(output_tokens={_response_output_tokens(response)}, "
+            f"has_reasoning={bool(response.reasoning_content or response.redacted_reasoning_content)})"
+        )
+        raise _CompactionSummaryEmptyResultError(msg)
     if _summary_response_likely_truncated(response, output_token_limit=summary_output_limit):
         msg = "compaction summary hit configured output token limit; refusing to persist incomplete summary"
         raise CompactionSummaryOutputLimitError(msg)

--- a/tests/test_compaction_invariants.py
+++ b/tests/test_compaction_invariants.py
@@ -3,7 +3,7 @@
 1. Compacted runs never reappear (``mindroom.history.storage``).
 2. Chunk progress survives interruption (``mindroom.history.storage``).
 3. Summary calls get exactly one model configuration path (``mindroom.history.summary_call``).
-4. Budget shrinks deterministically on provider failure (``mindroom.history.summary_call``).
+4. Retry on provider failure is deterministic (``mindroom.history.summary_call``).
 
 These tests exercise the owning interfaces directly, not the bot runtime.
 """
@@ -414,7 +414,7 @@ async def test_chunk_progress_survives_interruption_and_restart(tmp_path: Path) 
 
 def test_configure_summary_model_tunes_claude_in_one_place() -> None:
     model = Claude(
-        id="claude-sonnet-4-6",
+        id="claude-sonnet-5",
         cache_system_prompt=True,
         extended_cache_time=True,
         thinking={"type": "enabled", "budget_tokens": 8192},
@@ -436,7 +436,7 @@ def test_configure_summary_model_tunes_claude_in_one_place() -> None:
 
 def test_configure_summary_model_tunes_vertexai_claude() -> None:
     model = MindroomVertexAIClaude(
-        id="claude-sonnet-4-6",
+        id="claude-sonnet-5",
         project_id="demo-project",
         region="us-central1",
         cache_system_prompt=True,
@@ -456,7 +456,7 @@ def test_configure_summary_model_tunes_vertexai_claude() -> None:
 
 
 def test_configure_summary_model_preserves_authored_output_cap() -> None:
-    model = Claude(id="claude-sonnet-4-6", max_tokens=1024, timeout=30.0)
+    model = Claude(id="claude-sonnet-5", max_tokens=1024, timeout=30.0)
 
     configure_summary_model(model)
 
@@ -476,7 +476,7 @@ def test_configure_summary_model_leaves_unknown_providers_untouched() -> None:
 @pytest.mark.asyncio
 async def test_generate_compaction_summary_applies_tuning_and_request_shape() -> None:
     model = _RecordingClaude(
-        id="claude-sonnet-4-6",
+        id="claude-sonnet-5",
         cache_system_prompt=True,
         extended_cache_time=True,
         thinking={"type": "enabled", "budget_tokens": 8192},
@@ -508,7 +508,7 @@ async def test_generate_compaction_summary_rejects_output_cap_truncation() -> No
     with pytest.raises(RuntimeError, match="output token limit"):
         await generate_compaction_summary(
             model=_RecordingClaude(
-                id="claude-sonnet-4-6",
+                id="claude-sonnet-5",
                 max_tokens=64_000,
                 response=ModelResponse(
                     content="durable summary ended cleanly.",
@@ -525,7 +525,7 @@ async def test_generate_compaction_summary_uses_configured_output_cap() -> None:
     with pytest.raises(RuntimeError, match="output token limit"):
         await generate_compaction_summary(
             model=_RecordingClaude(
-                id="claude-sonnet-4-6",
+                id="claude-sonnet-5",
                 max_tokens=1_024,
                 response=ModelResponse(content="durable summary ended cleanly.", output_tokens=1_024),
             ),
@@ -538,7 +538,7 @@ async def test_generate_compaction_summary_uses_configured_output_cap() -> None:
 async def test_generate_compaction_summary_allows_claude_summary_below_output_cap() -> None:
     summary = await generate_compaction_summary(
         model=_RecordingClaude(
-            id="claude-sonnet-4-6",
+            id="claude-sonnet-5",
             max_tokens=64_000,
             response=ModelResponse(
                 content="durable summary ended cleanly.",
@@ -556,7 +556,7 @@ async def test_generate_compaction_summary_allows_claude_summary_below_output_ca
 async def test_generate_compaction_summary_allows_full_history_summary_above_four_k() -> None:
     summary = await generate_compaction_summary(
         model=_RecordingClaude(
-            id="claude-sonnet-4-6",
+            id="claude-sonnet-5",
             max_tokens=8192,
             response=ModelResponse(
                 content="durable full-history summary ended cleanly.",
@@ -572,7 +572,7 @@ async def test_generate_compaction_summary_allows_full_history_summary_above_fou
 
 @pytest.mark.asyncio
 async def test_generate_compaction_summary_uses_claude_default_output_cap() -> None:
-    model = _RecordingClaude(id="claude-sonnet-4-6")
+    model = _RecordingClaude(id="claude-sonnet-5")
     default_output_cap = model.max_tokens
     assert default_output_cap is not None
     model.response = ModelResponse(
@@ -678,7 +678,7 @@ async def test_generate_compaction_summary_empty_result_raises_typed_error_with_
     ):
         await generate_compaction_summary(
             model=_RecordingClaude(
-                id="claude-sonnet-4-6",
+                id="claude-sonnet-5",
                 max_tokens=64_000,
                 response=ModelResponse(content="", output_tokens=0),
             ),

--- a/tests/test_compaction_invariants.py
+++ b/tests/test_compaction_invariants.py
@@ -49,6 +49,7 @@ from mindroom.history.summary_call import (
     DEFAULT_SUMMARY_RETRY_POLICY,
     CompactionSummaryOutputLimitError,
     SummaryRetryPolicy,
+    _CompactionSummaryEmptyResultError,
     build_summary_request_messages,
     configure_summary_model,
     generate_compaction_summary,
@@ -666,3 +667,82 @@ def test_retry_schedule_halves_deterministically() -> None:
         attempt += 1
 
     assert budgets == [8_000, 4_000, 2_000, 1_000]
+
+
+@pytest.mark.asyncio
+async def test_generate_compaction_summary_empty_result_raises_typed_error_with_diagnostics() -> None:
+    """An empty summary response raises the typed error carrying response diagnostics."""
+    with pytest.raises(
+        _CompactionSummaryEmptyResultError,
+        match=r"returned no result \(output_tokens=0, has_reasoning=False\)",
+    ):
+        await generate_compaction_summary(
+            model=_RecordingClaude(
+                id="claude-sonnet-4-6",
+                max_tokens=64_000,
+                response=ModelResponse(content="", output_tokens=0),
+            ),
+            summary_input="conversation payload",
+            summary_prompt="Summarize the conversation.",
+        )
+
+
+def test_retry_policy_reissues_same_budget_for_empty_result() -> None:
+    """Empty-result failures retry once at the SAME budget; shrinking would not help."""
+    error = _CompactionSummaryEmptyResultError("summary generation returned no result")
+    assert DEFAULT_SUMMARY_RETRY_POLICY.retry_budget(attempt=1, budget=16_000, error=error) == 16_000
+    assert DEFAULT_SUMMARY_RETRY_POLICY.retry_budget(attempt=2, budget=16_000, error=error) is None
+
+
+@pytest.mark.asyncio
+async def test_compaction_retries_empty_summary_result_once_at_same_budget(tmp_path: Path) -> None:
+    """One transient empty summary response recovers on the plain re-issue."""
+    config, runtime_paths = _make_config(tmp_path)
+    storage = create_session_storage("test_agent", config, runtime_paths, execution_identity=None)
+    session = _session(
+        [
+            _completed_run("run-1", marker="RUN1-MARKER", padding=16_000),
+            _completed_run("run-2", marker="RUN2-MARKER", padding=16_000),
+        ],
+    )
+    write_scope_state(session, _SCOPE, HistoryScopeState(force_compact_before_next_run=True))
+    storage.upsert_session(session)
+
+    attempts: list[str] = []
+
+    async def flaky_summary(*, summary_input: str, **_kwargs: object) -> SessionSummary:
+        attempts.append(summary_input)
+        if len(attempts) == 1:
+            msg = "summary generation returned no result (output_tokens=0, has_reasoning=False)"
+            raise _CompactionSummaryEmptyResultError(msg)
+        return SessionSummary(summary="recovered summary", updated_at=datetime.now(UTC))
+
+    with patch(
+        "mindroom.history.compaction.generate_compaction_summary",
+        new=AsyncMock(side_effect=flaky_summary),
+    ):
+        outcome = await compact_scope_history(
+            storage=storage,
+            session=session,
+            scope=_SCOPE,
+            state=read_scope_state(session, _SCOPE),
+            history_settings=_HISTORY_SETTINGS,
+            available_history_budget=None,
+            summary_input_budget=10_000,
+            summary_model=FakeModel(id="summary-model", provider="fake"),
+            summary_model_name="summary-model",
+            replay_window_tokens=64_000,
+            threshold_tokens=None,
+            summary_prompt=COMPACTION_SUMMARY_PROMPT,
+        )
+
+    assert outcome is not None
+    # Chunk 1 fails empty, is re-issued unchanged, then chunk 2 compacts run-2.
+    assert len(attempts) == 3
+    assert attempts[0] == attempts[1]
+    assert attempts[2] != attempts[1]
+    persisted = get_agent_session(storage, "session-1")
+    assert persisted is not None
+    assert persisted.summary is not None
+    assert persisted.summary.summary == "recovered summary"
+    storage.close()


### PR DESCRIPTION
## Problem

Compaction intermittently fails with `summary generation returned no result`, editing the lifecycle notice to "Compaction failed; continuing with trimmed history" and skipping compaction for the turn.

Production timing data shows the failure is a transient provider fault, not an input problem: three empty responses came back in a constant ~5.4s regardless of input size (134k-155k tokens), while a genuine summarization of the byte-identical 155k-token input that had failed earlier took ~94s and succeeded. The response is HTTP-success with empty text.

Two gaps compound it:

1. `SummaryRetryPolicy.should_shrink` only recognizes timeouts and too-large errors (by message fragment), so an empty result propagates on attempt 1 even though a plain re-issue demonstrably succeeds.
2. The bare `RuntimeError` discards the response, so logs cannot distinguish a zero-token stop from a truncated thinking-only response.

## Change

- Raise a typed `_CompactionSummaryEmptyResultError` whose message carries response diagnostics (`output_tokens`, `has_reasoning`); this text flows into the existing chunk-failure log and the room notice.
- `SummaryRetryPolicy.retry_budget` re-issues the request once at the SAME input budget for empty results (shrinking does not fix an empty response), still bounded by `max_attempts`. Timeout/too-large behavior is unchanged.

No changes needed in the compaction chunk loop: the policy returning an unchanged budget flows through the existing rebuild-and-retry path.

## Testing

- Empty response raises the typed error with diagnostics in the message.
- Policy: empty result at attempt 1 returns the same budget; attempt 2 gives up; unrelated errors still return None.
- Loop-level: a flaky first chunk (empty then success) recovers with a byte-identical re-issue and compaction completes; asserts the retried input equals the failed input.
- Full compaction/summary suites pass (`test_compaction_invariants`, `test_history_summary_call`, `test_compaction`, `test_history_compaction_rewrite`: 78 tests); pre-commit clean.