### PR TITLE
Pin slim entry points to a third-party import allowlist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,6 +334,7 @@ Teams (`src/mindroom/teams.py`) let multiple agents work together:
 - **Documentation Line Style**: In Markdown docs, write one sentence per line, and never split a single sentence across multiple lines.
 - Do not wrap things in try-excepts unless it's necessary. Avoid wrapping things that should not fail.
 - NEVER put imports in the function, unless it is to avoid circular imports or to keep a heavy import (for example a provider SDK) out of module import time. Prefer an explicit function-level `from x import Y` with `# noqa: PLC0415` over dynamic `import_module` indirection. Imports should be at the top of the file.
+- `tests/test_import_graph.py` pins which third-party packages the slim entry points (config, tool registry, sandbox runner) may import and bans provider SDKs from the primary runtime. If it fails on your change, defer the new import to first use; extend the allowlist only when the dependency is genuinely needed at import time.
 - Do not use `getattr()` or `hasattr()` to weaken a typed interface or probe for fields that the declared type should guarantee.
 - If mocks or tests break, fix them to use proper typed objects or stricter mocks instead of adding dynamic attribute fallbacks in production code.
 - **Merge and forget**: Code you touch should be polished enough to never revisit. Fix rough edges in code you're already changing.

--- a/tests/test_import_graph.py
+++ b/tests/test_import_graph.py
@@ -1,9 +1,18 @@
 """Import-graph regression tests for slim entry points (#1436).
 
-Importing the tool registry, config layer, sandbox runner, or the primary
-runtime must not import any provider SDK; those load on first model or tool
-construction. Slim entry points additionally must not import the nio matrix
-client or the mcp SDK, which the primary runtime genuinely needs at boot.
+Two guards keep import-time regressions from creeping back:
+
+1. A provider-SDK ban: importing the tool registry, config layer, sandbox
+   runner, or the primary runtime must not import any provider SDK; those load
+   on first model or tool construction. Slim entry points additionally must
+   not import the nio matrix client or the mcp SDK, which the primary runtime
+   genuinely needs at boot.
+2. A third-party allowlist: each slim entry point may only load the
+   third-party packages it loads today. Any new package in the graph fails
+   loudly — either defer the import (see the CLAUDE.md import rule) or extend
+   the allowlist as a conscious, reviewed decision. The orchestrator is
+   exempt: its dependency set is large and legitimately grows.
+
 Each probe runs in a subprocess so the assertion sees exactly what the import
 graph pulls in.
 """
@@ -27,7 +36,88 @@ _PROVIDER_SDK_ROOTS = (
 )
 _SLIM_ONLY_ROOTS = ("mcp", "nio")
 
-_PROBE_TEMPLATE = """
+# Small, stable third-party footprints shared by the config layer and the
+# registry chain: pydantic and yaml for config, structlog/rich for logging,
+# cryptography for credentials, dotenv for runtime env files.
+_CONFIG_LAYER_ROOTS = frozenset(
+    {
+        "annotated_types",
+        "attr",
+        "colorama",
+        "cryptography",
+        "cython_runtime",
+        "dotenv",
+        "greenlet",
+        "pydantic",
+        "pydantic_core",
+        "pygments",
+        "rich",
+        "structlog",
+        "typing_extensions",
+        "typing_inspection",
+        "yaml",
+    },
+)
+# The registry additionally carries httpx (sandbox proxy transport) and click
+# (tool CLI plumbing).
+_REGISTRY_ROOTS = _CONFIG_LAYER_ROOTS | frozenset({"brotli", "click", "httpx", "idna", "zstandard"})
+# The full tool-module sweep adds the agno toolkit runtime (redis-backed run
+# cancellation, opentelemetry via redis) and the httpx dependency tree.
+_TOOLS_ROOTS = _REGISTRY_ROOTS | frozenset(
+    {
+        "agno",
+        "anyio",
+        "attrs",
+        "certifi",
+        "docstring_parser",
+        "h11",
+        "h2",
+        "hpack",
+        "httpcore",
+        "hyperframe",
+        "importlib_metadata",
+        "opentelemetry",
+        "outcome",
+        "packaging",
+        "psutil",
+        "redis",
+        "sniffio",
+        "sortedcontainers",
+        "trio",
+        "xxhash",
+        "zipp",
+    },
+)
+_ALLOWED_THIRD_PARTY_ROOTS: dict[str, frozenset[str]] = {
+    "mindroom.config.main": _CONFIG_LAYER_ROOTS,
+    "mindroom.model_loading": _CONFIG_LAYER_ROOTS | frozenset({"agno"}),
+    "mindroom.tool_system.metadata": _REGISTRY_ROOTS,
+    "mindroom.tool_system.catalog": _REGISTRY_ROOTS,
+    "mindroom.tools": _TOOLS_ROOTS,
+    # The sandbox runner is the API server for worker tool execution: fastapi
+    # and its dependency tree on top of the full registry footprint.
+    "mindroom.api.sandbox_runner": _TOOLS_ROOTS
+    | frozenset(
+        {
+            "annotated_doc",
+            "authlib",
+            "bcrypt",
+            "chardet",
+            "charset_normalizer",
+            "email_validator",
+            "fastapi",
+            "joserfc",
+            "orjson",
+            "python_multipart",
+            "requests",
+            "socks",
+            "starlette",
+            "urllib3",
+        },
+    ),
+}
+
+_BAN_PROBE_TEMPLATE = """
 import importlib, json, sys
 
 importlib.import_module({module!r})
@@ -40,9 +130,25 @@ loaded = sorted(
 print(json.dumps(loaded))
 """
 
+# mypyc-compiled dependencies register hash-named helper modules (e.g.
+# "4ef79d...__mypyc") that vary per build, so they are excluded from the
+# footprint along with private roots and mindroom itself.
+_ALLOWLIST_PROBE_TEMPLATE = """
+import importlib, json, sys
 
-def _assert_probe_clean(module: str, roots: tuple[str, ...]) -> None:
-    probe = _PROBE_TEMPLATE.format(module=module, roots=roots)
+stdlib = set(sys.stdlib_module_names)
+baseline = {{name.split(".")[0] for name in sys.modules}}
+importlib.import_module({module!r})
+roots = sorted(
+    root
+    for root in {{name.split(".")[0] for name in sys.modules}} - stdlib - baseline
+    if not root.startswith("_") and not root.endswith("__mypyc") and not root.startswith("mindroom")
+)
+print(json.dumps(roots))
+"""
+
+
+def _run_probe(probe: str) -> list[str]:
     result = subprocess.run(
         [sys.executable, "-c", probe],
         capture_output=True,
@@ -50,7 +156,11 @@ def _assert_probe_clean(module: str, roots: tuple[str, ...]) -> None:
         check=True,
         timeout=120,
     )
-    loaded = json.loads(result.stdout)
+    return json.loads(result.stdout)
+
+
+def _assert_probe_clean(module: str, roots: tuple[str, ...]) -> None:
+    loaded = _run_probe(_BAN_PROBE_TEMPLATE.format(module=module, roots=roots))
     assert loaded == [], f"importing {module} pulled in banned modules: {loaded}"
 
 
@@ -73,3 +183,20 @@ def test_slim_entry_points_do_not_import_provider_sdks(module: str) -> None:
 def test_primary_runtime_does_not_import_provider_sdks() -> None:
     """The orchestrator import (mindroom run) loads no provider SDK; only configured ones load later."""
     _assert_probe_clean("mindroom.orchestrator", _PROVIDER_SDK_ROOTS)
+
+
+@pytest.mark.parametrize("module", sorted(_ALLOWED_THIRD_PARTY_ROOTS))
+def test_slim_entry_points_only_load_allowlisted_packages(module: str) -> None:
+    """A new third-party package in a slim import graph must be a conscious decision.
+
+    The check is subset-based (new packages fail, absent ones pass) so
+    platform-conditional dependencies do not flake. If this fails, prefer
+    deferring the import to first use over extending the allowlist.
+    """
+    loaded = frozenset(_run_probe(_ALLOWLIST_PROBE_TEMPLATE.format(module=module)))
+    unexpected = sorted(loaded - _ALLOWED_THIRD_PARTY_ROOTS[module])
+    assert not unexpected, (
+        f"importing {module} now loads third-party packages not in its allowlist: {unexpected}. "
+        "Defer the import to first use (see the CLAUDE.md function-level import rule), "
+        "or extend the allowlist here if the dependency is genuinely needed at import time."
+    )


### PR DESCRIPTION
Closes out the durability question from #1436/#1442/#1450: how do slow imports stay gone?

## Problem

The existing guard (`test_slim_entry_points_do_not_import_provider_sdks`) is a blacklist — it only catches the SDKs we already know about. Someone adding, say, `torch`, `pandas`, or a new API client at the top of a config-layer module would regress startup silently with every test green.

## Change

Each slim entry point (`config.main`, `model_loading`, `tool_system.metadata`, `tool_system.catalog`, `tools`, `api.sandbox_runner`) now pins the exact set of third-party package roots it may load, built as layered supersets (config layer → registry → tools → runner) so the lists document *why* each package is there. Any new package in an import graph fails with an actionable message:

```
importing mindroom.config.main now loads third-party packages not in its allowlist:
['brotli', 'certifi', 'chardet', 'charset_normalizer', 'idna', 'requests', 'socks', 'urllib3'].
Defer the import to first use (see the CLAUDE.md function-level import rule),
or extend the allowlist here if the dependency is genuinely needed at import time.
```

(That's the real output from the negative test: one eager `import requests` in `config.main`, and the probe names the entire transitive tree it dragged in.)

Design choices:
- **Subset assertion**, not equality: new packages fail, absent ones pass, so platform-conditional dependencies don't flake CI.
- **mypyc hash-named helper modules excluded** (`<hash>__mypyc`) — they vary per dependency build.
- **The orchestrator keeps only the provider-SDK ban**: its dependency set is large and legitimately grows, so an allowlist there would be churn without signal.
- CLAUDE.md's function-level-import rule now points at this test, so the intended fix (defer, don't allowlist) is documented where contributors and coding agents will see it.

## Testing

- All 13 import-graph tests pass; full suite 9416 passed, 61 skipped.
- Negative-tested as above; `pre-commit run --all-files` clean.