### PR TITLE
Write thread summaries in the thread's language

### DIFF
--- a/src/mindroom/prompts.py
+++ b/src/mindroom/prompts.py
@@ -267,6 +267,7 @@ It must remain accurate whether the thread has 5 messages or 50+.
 
 RULES:
 - One line only, plain text only.
+- Write the summary in the thread's language: use the dominant language of the messages, and fall back to English only when no single language dominates.
 - Under 160 characters is preferred.
 - Hard max 300 characters after normalization.
 - Prefer stable noun phrases such as "Fixing X", "Review of Y", "Discussion of Z", "Live test of A", or "Investigation of B".


### PR DESCRIPTION
## Summary

Automatic thread summaries were always generated in English, even for threads conducted in another language. This adds a rule to `THREAD_SUMMARY_INSTRUCTIONS` telling the summarizer to write the summary in the dominant language of the thread messages, falling back to English only when no single language dominates.

## Changes

- `src/mindroom/prompts.py`: one new rule in the `RULES` section of `THREAD_SUMMARY_INSTRUCTIONS`.

## Testing

- `uv run pytest tests/test_thread_summary.py` — 79 passed.
- `uv run pre-commit` hooks pass on the changed file.

## Summary by Sourcery

Enhancements:
- Add a rule to thread summary instructions to select the thread’s dominant language, falling back to English only when no single language dominates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Thread summaries now match the dominant language used in the conversation, with English used only when no single language stands out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->