### PR TITLE
Enable auto_resume_after_restart by default

### DIFF
--- a/src/mindroom/config/models.py
+++ b/src/mindroom/config/models.py
@@ -319,7 +319,7 @@ class DefaultsConfig(BaseModel):
     )
     show_stop_button: bool = Field(default=True, description="Whether to automatically show stop button on messages")
     auto_resume_after_restart: bool = Field(
-        default=False,
+        default=True,
         description="Whether restart cleanup should post a real system message to resume interrupted threaded conversations",
     )
     learning: bool = Field(default=True, description="Default Agno Learning setting")

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -1766,8 +1766,9 @@ async def test_cleanup_scans_past_lookback_page_for_old_terminal_interruption(tm
 
 @pytest.mark.asyncio
 async def test_cleanup_stops_at_lookback_page_when_auto_resume_disabled(tmp_path: Path) -> None:
-    """Default startup cleanup must not full-scan busy rooms when no resume relay will be queued."""
+    """Opted-out startup cleanup must not full-scan busy rooms when no resume relay will be queued."""
     config = _make_config(tmp_path)
+    config.defaults.auto_resume_after_restart = False
     client = _make_client()
     client.rooms = _joined_room_cache()
     client.room_messages = AsyncMock(


### PR DESCRIPTION
## Summary
- Flip `defaults.auto_resume_after_restart` from `False` to `True`, so restart cleanup posts the resume system message for interrupted threaded conversations out of the box.
- Update `test_cleanup_stops_at_lookback_page_when_auto_resume_disabled` to opt out explicitly, since disabled is no longer the default.

## Testing
- `uv run pytest tests/test_stale_stream_cleanup.py tests/test_sync_task_cancellation.py tests/test_config_manager_consolidated.py tests/test_config_validation_helpers.py` — 187 passed, 1 skipped.
- Full suite: only pre-existing environment failures (CLI rich-markup and git-identity tests) that also fail on the base branch without this change.
- `pre-commit` hooks pass on the changed files.

## Summary by Sourcery

Enable automatic resumption of interrupted threaded conversations after restart by default.

New Features:
- Turn on auto_resume_after_restart by default in configuration so restart cleanup posts resume system messages automatically.

Tests:
- Update cleanup lookback-page test to explicitly opt out of auto resume behavior when needed.