### PR TITLE
test: cherry-pick rebased test expectation fixes

### DIFF
--- a/tests/test_multi_agent_e2e.py
+++ b/tests/test_multi_agent_e2e.py
@@ -556,6 +556,7 @@ async def test_agent_responds_in_threads_based_on_participation(  # noqa: PLR091
             assert ai_kwargs["media"] == MediaInputs()
             assert ai_ctx.reply_to_event_id == f"$test_event2:{domain}"
             assert ai_kwargs["show_tool_calls"] is True
+            assert ai_kwargs["collect_streamed_response"] is True
             assert ai_kwargs["tool_trace_collector"] == []
             assert ai_kwargs["run_metadata_collector"] == {}
 

--- a/tests/test_tools_metadata.py
+++ b/tests/test_tools_metadata.py
@@ -57,7 +57,7 @@ from mindroom.tools.custom_api import custom_api_tools
 _BASE_TOOL_REGISTRY = TOOL_REGISTRY.copy()
 _BASE_TOOL_METADATA = TOOL_METADATA.copy()
 _SKIP_PARALLEL_FACTORY_IMPORTS = {"daytona", "openbb"}
-_OPTIONAL_TOOL_IMPORTS = frozenset({"telegram"})
+_OPTIONAL_TOOL_IMPORTS = frozenset({"scrapegraph", "telegram"})
 
 
 def _restore_builtin_tool_metadata_state() -> None:


### PR DESCRIPTION
Cherry-picks two test-only commits from `e2ee-live-test-fixes`:

- 9b5abdf44 — test: update rebased thread summary expectations
- 1ef89f844 — test(matrix): assert offline responses collect stream output

The second commit keeps e2e coverage aligned with the `collect_streamed_response` contract for offline/non-streaming responses with visible tool calls, preventing a regression where completed tool markers could reappear at the end of the final message body.

Verified: `pytest tests/test_tools_metadata.py tests/test_multi_agent_e2e.py` — 34 passed, 1 skipped.

## Summary by Sourcery

Align test expectations with updated tool metadata and multi-agent offline response behavior.

Tests:
- Mark the scrapegraph tool import as optional in tools metadata tests.
- Ensure multi-agent e2e tests assert collect_streamed_response is enabled for offline responses with visible tool calls.