### PR TITLE
Consolidate durable JSON override stores

### DIFF
--- a/src/mindroom/durable_write.py
+++ b/src/mindroom/durable_write.py
@@ -6,8 +6,15 @@ import json
 import os
 from pathlib import Path
 from tempfile import NamedTemporaryFile
+from typing import TYPE_CHECKING, cast
 
 from mindroom.constants import safe_replace
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+type OverrideRecord = dict[str, str]
+_override_load_cache: dict[Path, tuple[int, dict[str, OverrideRecord]]] = {}
 
 
 def write_json_file_durable(
@@ -17,6 +24,7 @@ def write_json_file_durable(
     temp_dir: Path | None = None,
     indent: int | None = None,
     sort_keys: bool = False,
+    trailing_newline: bool = False,
 ) -> None:
     """Write JSON through fsynced temp file, bind-mount-safe replace, and directory fsync."""
     directory = temp_dir or path.parent
@@ -33,6 +41,8 @@ def write_json_file_durable(
         ) as temp_file:
             temp_path = directory / Path(temp_file.name).name
             json.dump(payload, temp_file, indent=indent, sort_keys=sort_keys)
+            if trailing_newline:
+                temp_file.write("\n")
             temp_file.flush()
             os.fsync(temp_file.fileno())
         safe_replace(temp_path, path)
@@ -40,6 +50,47 @@ def write_json_file_durable(
     finally:
         if temp_path is not None and temp_path.exists():
             temp_path.unlink()
+
+
+def load_cached_override_records(
+    path: Path,
+    is_valid: Callable[[str, dict[object, object]], bool],
+) -> dict[str, OverrideRecord]:
+    """Load validated override records, caching parsed data by file mtime."""
+    try:
+        mtime_ns = path.stat().st_mtime_ns
+    except OSError:
+        return {}
+    cached = _override_load_cache.get(path)
+    if cached is not None and cached[0] == mtime_ns:
+        return cached[1]
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        data = {}
+    if not isinstance(data, dict):
+        data = {}
+    records = {
+        record_id: cast("OverrideRecord", record)
+        for record_id, record in data.items()
+        if isinstance(record_id, str) and isinstance(record, dict) and is_valid(record_id, record)
+    }
+    _override_load_cache[path] = (mtime_ns, records)
+    return records
+
+
+def write_bounded_override_records(
+    path: Path,
+    records: dict[str, OverrideRecord],
+    *,
+    max_records: int,
+) -> None:
+    """Prune and durably replace one bounded override record file."""
+    if len(records) > max_records:
+        newest = sorted(records.items(), key=lambda item: item[1].get("set_at", ""), reverse=True)
+        records = dict(newest[:max_records])
+    write_json_file_durable(path, records, indent=2, sort_keys=True)
+    _override_load_cache.pop(path, None)
 
 
 def fsync_directory(directory: Path) -> None:

--- a/src/mindroom/durable_write.py
+++ b/src/mindroom/durable_write.py
@@ -28,7 +28,9 @@ def write_json_file_durable(
 ) -> None:
     """Write JSON through fsynced temp file, bind-mount-safe replace, and directory fsync."""
     directory = temp_dir or path.parent
-    directory.mkdir(parents=True, exist_ok=True)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if directory != path.parent:
+        directory.mkdir(parents=True, exist_ok=True)
     temp_path: Path | None = None
     try:
         with NamedTemporaryFile(
@@ -63,7 +65,7 @@ def load_cached_override_records(
         return {}
     cached = _override_load_cache.get(path)
     if cached is not None and cached[0] == mtime_ns:
-        return cached[1]
+        return _copy_override_records(cached[1])
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError, UnicodeDecodeError):
@@ -76,7 +78,12 @@ def load_cached_override_records(
         if isinstance(record_id, str) and isinstance(record, dict) and is_valid(record_id, record)
     }
     _override_load_cache[path] = (mtime_ns, records)
-    return records
+    return _copy_override_records(records)
+
+
+def _copy_override_records(records: dict[str, OverrideRecord]) -> dict[str, OverrideRecord]:
+    """Return mutable records without exposing the cache's nested dictionaries."""
+    return {record_id: record.copy() for record_id, record in records.items()}
 
 
 def write_bounded_override_records(

--- a/src/mindroom/dynamic_workflows/store.py
+++ b/src/mindroom/dynamic_workflows/store.py
@@ -17,6 +17,7 @@ from uuid import uuid4
 
 import yaml
 
+from mindroom.durable_write import write_json_file_durable
 from mindroom.dynamic_workflows.validation import (
     ID_RE,
     DynamicWorkflowError,
@@ -390,7 +391,7 @@ class DynamicWorkflowStore:
 
     def _write_run(self, run: DynamicWorkflowRun) -> None:
         run_path = self._workflow_dir(run.scope, run.owner_id, run.workflow_id) / "runs" / f"{run.run_id}.json"
-        _atomic_write_json(run_path, _run_to_json(run))
+        write_json_file_durable(run_path, _run_to_json(run), indent=2, sort_keys=True, trailing_newline=True)
 
     def _write_run_artifacts(
         self,
@@ -406,7 +407,7 @@ class DynamicWorkflowStore:
         step_outputs_path = artifact_dir / "step_outputs.json"
         _atomic_write_text(report_path, _render_report_html(title=title, markdown=report_markdown))
         _atomic_write_text(report_markdown_path, report_markdown)
-        _atomic_write_json(step_outputs_path, step_outputs)
+        write_json_file_durable(step_outputs_path, step_outputs, indent=2, sort_keys=True, trailing_newline=True)
         return {
             "report_markdown": _relative_artifact_path(report_markdown_path, self._storage_root),
             "report_html": _relative_artifact_path(report_path, self._storage_root),
@@ -636,10 +637,6 @@ def _load_json_mapping(path: Path) -> dict[str, object]:
 
 def _atomic_write_yaml(path: Path, data: dict[str, object]) -> None:
     _atomic_write_text(path, yaml.safe_dump(data, sort_keys=False, allow_unicode=True))
-
-
-def _atomic_write_json(path: Path, data: dict[str, object]) -> None:
-    _atomic_write_text(path, json.dumps(data, indent=2, sort_keys=True) + "\n")
 
 
 def _atomic_write_text(path: Path, text: str) -> None:

--- a/src/mindroom/report_publishing/store.py
+++ b/src/mindroom/report_publishing/store.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, cast
 from uuid import uuid4
 
+from mindroom.durable_write import write_json_file_durable
 from mindroom.report_publishing.static_site import (
     StaticSiteSnapshotError,
     resolve_static_site_asset,
@@ -103,7 +104,9 @@ class ReportPublishingStore:
             published_at=_utc_now(),
             public_url=_public_report_url(base_url, slug, artifact_kind=source.artifact_kind),
         )
-        _atomic_write_json(self._public_report_path(slug), _published_report_to_json(report))
+        report_path = self._public_report_path(slug)
+        payload = _published_report_to_json(report)
+        write_json_file_durable(report_path, payload, indent=2, sort_keys=True, trailing_newline=True)
         return report
 
     def get_public_report(self, slug: str, *, include_revoked: bool = False) -> PublishedReport:
@@ -140,7 +143,9 @@ class ReportPublishingStore:
         if report.revoked_at is not None:
             return report
         revoked = replace(report, revoked_at=_utc_now(), revoked_by=revoked_by)
-        _atomic_write_json(self._public_report_path(slug), _published_report_to_json(revoked))
+        report_path = self._public_report_path(slug)
+        payload = _published_report_to_json(revoked)
+        write_json_file_durable(report_path, payload, indent=2, sort_keys=True, trailing_newline=True)
         return revoked
 
     def _publish_artifact(self, source: PublishableReport, slug: str) -> str:
@@ -256,10 +261,3 @@ def _load_json_mapping(path: Path) -> dict[str, object]:
         msg = "Expected JSON mapping."
         raise ReportPublishingError(msg)
     return data
-
-
-def _atomic_write_json(path: Path, data: dict[str, object]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
-    tmp_path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    tmp_path.replace(path)

--- a/src/mindroom/room_thread_modes.py
+++ b/src/mindroom/room_thread_modes.py
@@ -94,7 +94,7 @@ def set_room_thread_mode_override(
 ) -> None:
     """Persist one room's thread mode override, replacing any previous one."""
     path = _store_path(runtime_paths)
-    overrides = dict(_load_overrides(path))
+    overrides = _load_overrides(path)
     overrides[room_id] = {
         "mode": mode,
         "set_by": set_by,
@@ -106,7 +106,7 @@ def set_room_thread_mode_override(
 def clear_room_thread_mode_override(runtime_paths: RuntimePaths, room_id: str) -> bool:
     """Remove one room's thread mode override; return whether one was present."""
     path = _store_path(runtime_paths)
-    overrides = dict(_load_overrides(path))
+    overrides = _load_overrides(path)
     if room_id not in overrides:
         return False
     del overrides[room_id]

--- a/src/mindroom/room_thread_modes.py
+++ b/src/mindroom/room_thread_modes.py
@@ -31,7 +31,8 @@ def _store_path(runtime_paths: RuntimePaths) -> Path:
 
 def _is_valid_override(_room_id: str, record: dict[object, object]) -> bool:
     """Return whether one persisted room-mode record has the required shape."""
-    return record.get("mode") in _VALID_ROOM_THREAD_MODES and isinstance(record.get("set_at", ""), str)
+    mode = record.get("mode")
+    return isinstance(mode, str) and mode in _VALID_ROOM_THREAD_MODES and isinstance(record.get("set_at", ""), str)
 
 
 def _load_overrides(path: Path) -> dict[str, OverrideRecord]:

--- a/src/mindroom/room_thread_modes.py
+++ b/src/mindroom/room_thread_modes.py
@@ -2,17 +2,20 @@
 
 from __future__ import annotations
 
-import json
-import tempfile
-from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from pathlib import Path
 from typing import TYPE_CHECKING, Literal, cast
 
 from mindroom.constants import tracking_dir
+from mindroom.durable_write import (
+    OverrideRecord,
+    load_cached_override_records,
+    write_bounded_override_records,
+)
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from mindroom.constants import RuntimePaths
 
 RoomThreadMode = Literal["thread", "room"]
@@ -21,55 +24,23 @@ _ROOM_THREAD_MODES_FILENAME = "room_thread_modes.json"
 _VALID_ROOM_THREAD_MODES: frozenset[str] = frozenset({"thread", "room"})
 _MAX_TRACKED_ROOMS = 1000
 
-_load_cache: dict[Path, tuple[int, dict[str, dict[str, str]]]] = {}
-
 
 def _store_path(runtime_paths: RuntimePaths) -> Path:
     return tracking_dir(runtime_paths) / _ROOM_THREAD_MODES_FILENAME
 
 
-def _load_overrides(path: Path) -> dict[str, dict[str, str]]:
+def _is_valid_override(_room_id: str, record: dict[object, object]) -> bool:
+    """Return whether one persisted room-mode record has the required shape."""
+    return record.get("mode") in _VALID_ROOM_THREAD_MODES and isinstance(record.get("set_at", ""), str)
+
+
+def _load_overrides(path: Path) -> dict[str, OverrideRecord]:
     """Load persisted room thread mode overrides, treating missing or unreadable files as empty."""
-    try:
-        mtime_ns = path.stat().st_mtime_ns
-    except OSError:
-        return {}
-    cached = _load_cache.get(path)
-    if cached is not None and cached[0] == mtime_ns:
-        return cached[1]
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
-        data = {}
-    if not isinstance(data, dict):
-        data = {}
-    overrides = {
-        room_id: record
-        for room_id, record in data.items()
-        if isinstance(room_id, str)
-        and isinstance(record, dict)
-        and record.get("mode") in _VALID_ROOM_THREAD_MODES
-        and isinstance(record.get("set_at", ""), str)
-    }
-    _load_cache[path] = (mtime_ns, overrides)
-    return overrides
+    return load_cached_override_records(path, _is_valid_override)
 
 
-def _save_overrides(path: Path, overrides: dict[str, dict[str, str]]) -> None:
-    if len(overrides) > _MAX_TRACKED_ROOMS:
-        newest = sorted(overrides.items(), key=lambda item: item[1].get("set_at", ""), reverse=True)
-        overrides = dict(newest[:_MAX_TRACKED_ROOMS])
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with tempfile.NamedTemporaryFile("w", dir=path.parent, suffix=".tmp", delete=False, encoding="utf-8") as temp_file:
-        temp_file.write(json.dumps(overrides, indent=2, sort_keys=True))
-        temp_path = Path(temp_file.name)
-    try:
-        temp_path.replace(path)
-    except OSError:
-        with suppress(OSError):
-            temp_path.unlink()
-        raise
-    _load_cache.pop(path, None)
+def _save_overrides(path: Path, overrides: dict[str, OverrideRecord]) -> None:
+    write_bounded_override_records(path, overrides, max_records=_MAX_TRACKED_ROOMS)
 
 
 def _get_room_thread_mode_override(runtime_paths: RuntimePaths, room_id: str | None) -> RoomThreadMode | None:

--- a/src/mindroom/thread_models.py
+++ b/src/mindroom/thread_models.py
@@ -2,70 +2,43 @@
 
 from __future__ import annotations
 
-import json
-import tempfile
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from mindroom.constants import tracking_dir
+from mindroom.durable_write import (
+    OverrideRecord,
+    load_cached_override_records,
+    write_bounded_override_records,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Container
+    from pathlib import Path
 
     from mindroom.constants import RuntimePaths
 
 _THREAD_MODELS_FILENAME = "thread_models.json"
 _MAX_TRACKED_THREADS = 1000
 
-# Parsed store keyed by path and invalidated by mtime, so per-turn model
-# resolution does not re-read and re-parse the file on every call.
-_load_cache: dict[Path, tuple[int, dict[str, dict[str, str]]]] = {}
-
 
 def _store_path(runtime_paths: RuntimePaths) -> Path:
     return tracking_dir(runtime_paths) / _THREAD_MODELS_FILENAME
 
 
-def _load_overrides(path: Path) -> dict[str, dict[str, str]]:
+def _is_valid_override(_thread_id: str, record: dict[object, object]) -> bool:
+    """Return whether one persisted thread-model record has the required shape."""
+    return isinstance(record.get("model"), str) and isinstance(record.get("set_at", ""), str)
+
+
+def _load_overrides(path: Path) -> dict[str, OverrideRecord]:
     """Load persisted overrides, treating a missing or unreadable file as empty."""
-    try:
-        mtime_ns = path.stat().st_mtime_ns
-    except OSError:
-        return {}
-    cached = _load_cache.get(path)
-    if cached is not None and cached[0] == mtime_ns:
-        return cached[1]
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
-        data = {}
-    if not isinstance(data, dict):
-        data = {}
-    # Records must keep the shape the store guarantees: a string model name
-    # and a string set_at so prune sorting cannot fail on mixed types.
-    overrides = {
-        thread_id: record
-        for thread_id, record in data.items()
-        if isinstance(record, dict)
-        and isinstance(record.get("model"), str)
-        and isinstance(record.get("set_at", ""), str)
-    }
-    _load_cache[path] = (mtime_ns, overrides)
-    return overrides
+    return load_cached_override_records(path, _is_valid_override)
 
 
-def _save_overrides(path: Path, overrides: dict[str, dict[str, str]]) -> None:
-    if len(overrides) > _MAX_TRACKED_THREADS:
-        newest = sorted(overrides.items(), key=lambda item: item[1].get("set_at", ""), reverse=True)
-        overrides = dict(newest[:_MAX_TRACKED_THREADS])
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with tempfile.NamedTemporaryFile("w", dir=path.parent, suffix=".tmp", delete=False, encoding="utf-8") as temp_file:
-        temp_file.write(json.dumps(overrides, indent=2, sort_keys=True))
-        temp_path = Path(temp_file.name)
-    temp_path.replace(path)
-    _load_cache.pop(path, None)
+def _save_overrides(path: Path, overrides: dict[str, OverrideRecord]) -> None:
+    write_bounded_override_records(path, overrides, max_records=_MAX_TRACKED_THREADS)
 
 
 def _get_thread_model_override(runtime_paths: RuntimePaths, thread_id: str | None) -> str | None:

--- a/src/mindroom/thread_models.py
+++ b/src/mindroom/thread_models.py
@@ -87,7 +87,7 @@ def set_thread_model_override(
 ) -> None:
     """Persist one thread's model override, replacing any previous one."""
     path = _store_path(runtime_paths)
-    overrides = dict(_load_overrides(path))
+    overrides = _load_overrides(path)
     overrides[thread_id] = {
         "model": model_name,
         "room_id": room_id,
@@ -100,7 +100,7 @@ def set_thread_model_override(
 def clear_thread_model_override(runtime_paths: RuntimePaths, thread_id: str) -> bool:
     """Remove one thread's model override; return whether one was present."""
     path = _store_path(runtime_paths)
-    overrides = dict(_load_overrides(path))
+    overrides = _load_overrides(path)
     if thread_id not in overrides:
         return False
     del overrides[thread_id]

--- a/tach.toml
+++ b/tach.toml
@@ -66,11 +66,11 @@ visibility = [
 
 [[modules]]
 path = "mindroom.dynamic_workflows"
-depends_on = []
+depends_on = ["mindroom.durable_write"]
 
 [[modules]]
 path = "mindroom.report_publishing"
-depends_on = []
+depends_on = ["mindroom.durable_write"]
 
 # Keep memory consumers explicit so imports are enforced rather than merely
 # interface-checked.
@@ -1998,12 +1998,14 @@ depends_on = [
 path = "mindroom.thread_models"
 depends_on = [
     "mindroom.constants",
+    "mindroom.durable_write",
 ]
 
 [[modules]]
 path = "mindroom.room_thread_modes"
 depends_on = [
     "mindroom.constants",
+    "mindroom.durable_write",
 ]
 
 [[modules]]

--- a/tests/test_durable_write.py
+++ b/tests/test_durable_write.py
@@ -1,0 +1,46 @@
+"""Tests for shared durable JSON and override-record helpers."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from mindroom.durable_write import load_cached_override_records, write_json_file_durable
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_durable_json_write_creates_target_parent_with_separate_temp_dir(tmp_path: Path) -> None:
+    """A separate temp directory must not bypass target-parent creation."""
+    target = tmp_path / "target" / "payload.json"
+    temp_dir = tmp_path / "temp"
+
+    write_json_file_durable(target, {"value": 1}, temp_dir=temp_dir)
+
+    assert json.loads(target.read_text(encoding="utf-8")) == {"value": 1}
+    assert not list(temp_dir.glob("*.tmp"))
+
+
+def test_cached_override_records_are_returned_as_independent_snapshots(tmp_path: Path) -> None:
+    """Callers must not be able to mutate cached record dictionaries."""
+    path = tmp_path / "overrides.json"
+    path.write_text(
+        json.dumps({"record": {"model": "default", "set_at": "2026-07-09T00:00:00+00:00"}}),
+        encoding="utf-8",
+    )
+
+    def is_valid(_record_id: str, record: dict[object, object]) -> bool:
+        return isinstance(record.get("model"), str) and isinstance(record.get("set_at"), str)
+
+    first = load_cached_override_records(path, is_valid)
+    first["record"]["model"] = "mutated"
+    first["extra"] = {"model": "extra", "set_at": "2026-07-09T00:00:01+00:00"}
+
+    second = load_cached_override_records(path, is_valid)
+    assert second == {"record": {"model": "default", "set_at": "2026-07-09T00:00:00+00:00"}}
+
+    second["record"]["model"] = "mutated-again"
+    assert load_cached_override_records(path, is_valid) == {
+        "record": {"model": "default", "set_at": "2026-07-09T00:00:00+00:00"},
+    }

--- a/tests/test_room_thread_modes.py
+++ b/tests/test_room_thread_modes.py
@@ -133,6 +133,7 @@ def test_room_thread_mode_store_drops_invalid_records(tmp_path: Path) -> None:
             {
                 ROOM_ID: {"mode": "invalid", "set_at": "2026-06-17T00:00:00+00:00"},
                 "!other:localhost": {"mode": "room", "set_at": 12345},
+                "!container:localhost": {"mode": [], "set_at": "2026-06-17T00:00:00+00:00"},
             },
         ),
         encoding="utf-8",
@@ -140,6 +141,7 @@ def test_room_thread_mode_store_drops_invalid_records(tmp_path: Path) -> None:
 
     assert _get_room_thread_mode_override(runtime_paths, ROOM_ID) is None
     assert _get_room_thread_mode_override(runtime_paths, "!other:localhost") is None
+    assert _get_room_thread_mode_override(runtime_paths, "!container:localhost") is None
 
 
 def test_room_thread_mode_store_detects_file_created_after_missing_read(tmp_path: Path) -> None:

--- a/tests/test_room_thread_modes.py
+++ b/tests/test_room_thread_modes.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
+from pathlib import Path
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
 
 import nio
@@ -17,7 +17,6 @@ from mindroom.config.agent import AgentConfig, TeamConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig, RouterConfig
 from mindroom.constants import ROUTER_AGENT_NAME, resolve_runtime_paths
-from mindroom.durable_write import _override_load_cache
 from mindroom.handled_turns import HandledTurnState
 from mindroom.message_target import MessageTarget
 from mindroom.room_thread_modes import (
@@ -28,9 +27,6 @@ from mindroom.room_thread_modes import (
     set_room_thread_mode_override,
 )
 from tests.conftest import bind_runtime_paths, make_event_cache_mock, runtime_paths_for, test_runtime_paths
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 ROOM_ID = "!room:localhost"
 
@@ -117,7 +113,6 @@ def test_room_thread_mode_store_ignores_corrupt_file(tmp_path: Path) -> None:
     path.write_text("not json", encoding="utf-8")
 
     assert _get_room_thread_mode_override(runtime_paths, ROOM_ID) is None
-    assert _override_load_cache[path] == (path.stat().st_mtime_ns, {})
 
     set_room_thread_mode_override(
         runtime_paths,
@@ -176,8 +171,18 @@ def test_room_thread_mode_store_removes_temp_file_when_replace_fails(
         mode="thread",
         set_by="@admin:localhost",
     )
+    real_read_text = Path.read_text
+    read_count = 0
+
+    def tracked_read_text(read_path: Path, *args: object, **kwargs: object) -> str:
+        nonlocal read_count
+        if read_path == path:
+            read_count += 1
+        return real_read_text(read_path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", tracked_read_text)
     assert _get_room_thread_mode_override(runtime_paths, ROOM_ID) == "thread"
-    cached = _override_load_cache[path]
+    assert read_count == 1
 
     def fail_room_mode_replace(_temp_path: Path, target: Path) -> None:
         if target == path:
@@ -195,8 +200,8 @@ def test_room_thread_mode_store_removes_temp_file_when_replace_fails(
         )
 
     assert not list(path.parent.glob("*.tmp"))
-    assert _override_load_cache[path] == cached
     assert _get_room_thread_mode_override(runtime_paths, ROOM_ID) == "thread"
+    assert read_count == 1
 
 
 def test_get_entity_thread_mode_prefers_runtime_room_override(tmp_path: Path) -> None:

--- a/tests/test_room_thread_modes.py
+++ b/tests/test_room_thread_modes.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from pathlib import Path
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
 
 import nio
@@ -17,17 +17,20 @@ from mindroom.config.agent import AgentConfig, TeamConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig, RouterConfig
 from mindroom.constants import ROUTER_AGENT_NAME, resolve_runtime_paths
+from mindroom.durable_write import _override_load_cache
 from mindroom.handled_turns import HandledTurnState
 from mindroom.message_target import MessageTarget
 from mindroom.room_thread_modes import (
     _get_room_thread_mode_override,
-    _load_cache,
     _store_path,
     clear_room_thread_mode_override,
     get_room_thread_mode_override,
     set_room_thread_mode_override,
 )
 from tests.conftest import bind_runtime_paths, make_event_cache_mock, runtime_paths_for, test_runtime_paths
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 ROOM_ID = "!room:localhost"
 
@@ -114,7 +117,7 @@ def test_room_thread_mode_store_ignores_corrupt_file(tmp_path: Path) -> None:
     path.write_text("not json", encoding="utf-8")
 
     assert _get_room_thread_mode_override(runtime_paths, ROOM_ID) is None
-    assert _load_cache[path] == (path.stat().st_mtime_ns, {})
+    assert _override_load_cache[path] == (path.stat().st_mtime_ns, {})
 
     set_room_thread_mode_override(
         runtime_paths,
@@ -164,18 +167,24 @@ def test_room_thread_mode_store_removes_temp_file_when_replace_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Failed atomic replacement should not leave orphaned .tmp files."""
+    """Failed durable replacement should preserve cache and remove its temp file."""
     runtime_paths = test_runtime_paths(tmp_path)
     path = _store_path(runtime_paths)
-    real_replace = Path.replace
+    set_room_thread_mode_override(
+        runtime_paths,
+        room_id=ROOM_ID,
+        mode="thread",
+        set_by="@admin:localhost",
+    )
+    assert _get_room_thread_mode_override(runtime_paths, ROOM_ID) == "thread"
+    cached = _override_load_cache[path]
 
-    def fail_room_mode_replace(self: Path, target: Path) -> Path:
+    def fail_room_mode_replace(_temp_path: Path, target: Path) -> None:
         if target == path:
             message = "replace failed"
             raise OSError(message)
-        return real_replace(self, target)
 
-    monkeypatch.setattr(Path, "replace", fail_room_mode_replace)
+    monkeypatch.setattr("mindroom.durable_write.safe_replace", fail_room_mode_replace)
 
     with pytest.raises(OSError, match="replace failed"):
         set_room_thread_mode_override(
@@ -186,7 +195,8 @@ def test_room_thread_mode_store_removes_temp_file_when_replace_fails(
         )
 
     assert not list(path.parent.glob("*.tmp"))
-    assert _get_room_thread_mode_override(runtime_paths, ROOM_ID) is None
+    assert _override_load_cache[path] == cached
+    assert _get_room_thread_mode_override(runtime_paths, ROOM_ID) == "thread"
 
 
 def test_get_entity_thread_mode_prefers_runtime_room_override(tmp_path: Path) -> None:

--- a/tests/test_thread_models.py
+++ b/tests/test_thread_models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import tempfile
 from pathlib import Path
 from unittest.mock import AsyncMock
@@ -18,9 +19,9 @@ from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
 from mindroom.constants import AI_RUN_METADATA_KEY
 from mindroom.custom_tools.thread_model import ThreadModelTools
+from mindroom.durable_write import _override_load_cache
 from mindroom.thread_models import (
     _get_thread_model_override,
-    _load_cache,
     _store_path,
     clear_thread_model_override,
     set_thread_model_override,
@@ -77,7 +78,7 @@ def test_store_ignores_corrupt_file(tmp_path: Path) -> None:
 
     assert _get_thread_model_override(runtime_paths, THREAD_ID) is None
     # The corrupt parse result is cached so repeat reads skip re-parsing.
-    assert _load_cache[path] == (path.stat().st_mtime_ns, {})
+    assert _override_load_cache[path] == (path.stat().st_mtime_ns, {})
 
     set_thread_model_override(
         runtime_paths,
@@ -106,6 +107,30 @@ def test_store_prunes_oldest_entries(tmp_path: Path, monkeypatch: pytest.MonkeyP
     stored = json.loads(_store_path(runtime_paths).read_text(encoding="utf-8"))
     assert len(stored) == 3
     assert _get_thread_model_override(runtime_paths, "$thread-4:localhost") == "large"
+
+
+def test_store_invalidates_cached_records_when_mtime_changes(tmp_path: Path) -> None:
+    """An external file replacement should invalidate the parsed-record cache."""
+    runtime_paths = test_runtime_paths(tmp_path)
+    path = _store_path(runtime_paths)
+    set_thread_model_override(
+        runtime_paths,
+        thread_id=THREAD_ID,
+        model_name="large",
+        room_id=ROOM_ID,
+        set_by="@user:localhost",
+    )
+    assert _get_thread_model_override(runtime_paths, THREAD_ID) == "large"
+
+    path.write_text(
+        json.dumps({THREAD_ID: {"model": "default", "set_at": "2026-07-09T00:00:00+00:00"}}),
+        encoding="utf-8",
+    )
+    stat = path.stat()
+    os.utime(path, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000))
+
+    assert _get_thread_model_override(runtime_paths, THREAD_ID) == "default"
+    assert _override_load_cache[path][0] == path.stat().st_mtime_ns
 
 
 def test_resolve_runtime_model_prefers_thread_override(tmp_path: Path) -> None:

--- a/tests/test_thread_models.py
+++ b/tests/test_thread_models.py
@@ -19,7 +19,6 @@ from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
 from mindroom.constants import AI_RUN_METADATA_KEY
 from mindroom.custom_tools.thread_model import ThreadModelTools
-from mindroom.durable_write import _override_load_cache
 from mindroom.thread_models import (
     _get_thread_model_override,
     _store_path,
@@ -69,16 +68,26 @@ def test_store_roundtrip(tmp_path: Path) -> None:
     assert clear_thread_model_override(runtime_paths, THREAD_ID) is False
 
 
-def test_store_ignores_corrupt_file(tmp_path: Path) -> None:
+def test_store_ignores_corrupt_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A corrupt store file should read as empty and be replaced on write."""
     runtime_paths = test_runtime_paths(tmp_path)
     path = _store_path(runtime_paths)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("not json", encoding="utf-8")
 
+    parse_calls = 0
+    real_loads = json.loads
+
+    def tracked_loads(payload: str) -> object:
+        nonlocal parse_calls
+        parse_calls += 1
+        return real_loads(payload)
+
+    monkeypatch.setattr("mindroom.durable_write.json.loads", tracked_loads)
+
     assert _get_thread_model_override(runtime_paths, THREAD_ID) is None
-    # The corrupt parse result is cached so repeat reads skip re-parsing.
-    assert _override_load_cache[path] == (path.stat().st_mtime_ns, {})
+    assert _get_thread_model_override(runtime_paths, THREAD_ID) is None
+    assert parse_calls == 1
 
     set_thread_model_override(
         runtime_paths,
@@ -88,6 +97,7 @@ def test_store_ignores_corrupt_file(tmp_path: Path) -> None:
         set_by="@user:localhost",
     )
     assert _get_thread_model_override(runtime_paths, THREAD_ID) == "large"
+    assert parse_calls == 2
 
 
 def test_store_prunes_oldest_entries(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -130,7 +140,6 @@ def test_store_invalidates_cached_records_when_mtime_changes(tmp_path: Path) -> 
     os.utime(path, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000))
 
     assert _get_thread_model_override(runtime_paths, THREAD_ID) == "default"
-    assert _override_load_cache[path][0] == path.stat().st_mtime_ns
 
 
 def test_resolve_runtime_model_prefers_thread_override(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Route workflow, published-report, thread-model, and room-thread-mode JSON replacement through the durable writer.
- Share bounded mtime-cache and pruning mechanics while keeping each domain validator and public API explicit.
- Preserve pretty-JSON newlines, malformed-file handling, cache invalidation, pruning, and replacement-error behavior with focused tests.
- Return isolated cached-record snapshots and support separate temporary and target directories.
- Ignore invalid container-valued room-mode records without disrupting override reads.

## Production LOC

- Before: 1,261 lines across the five touched production files.
- After: 1,259 lines.
- Net: -2 production lines.

## Validation

- uv sync --all-extras
- Focused persistence and API tests: 164 passed.
- PUPPETEER_SKIP_DOWNLOAD=true uv run pytest -n 4: 9,331 passed and 155 skipped.
- uv run pre-commit run --all-files
- uv run tach check --dependencies --interfaces
