### PR TITLE
Unify response terminal settlement

### DIFF
--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -44,6 +44,7 @@ from mindroom.post_response_effects import PostResponseEffectsSupport, ResponseO
 from mindroom.response_attempt import ResponseAttemptDeps, ResponseAttemptRequest, ResponseAttemptRunner
 from mindroom.response_terminal import (
     PendingVisibleResponse,
+    TerminalFailureStatus,
     build_terminal_stream_transport_outcome,
 )
 from mindroom.runtime_shutdown import GENERIC_SHUTDOWN, RuntimeShutdownIntent
@@ -295,7 +296,7 @@ class _DeliveryProgress:
     stage_started: bool = False
     failure_reason: str | None = None
     cancelled: bool = False
-    deferred_error: BaseException | None = None
+    delivery_outcome: FinalDeliveryOutcome | None = None
 
     def note_delivery_started(self, event_id: str | None) -> None:
         """Mark visible delivery as begun, tracking the event carrying it."""
@@ -311,6 +312,13 @@ class _DeliveryProgress:
         """Remember the latest Matrix event a terminal note could edit."""
         if event_id:
             self.tracked_event_id = event_id
+
+    def settle(self, delivery_outcome: FinalDeliveryOutcome) -> None:
+        """Record the turn's one canonical terminal delivery outcome."""
+        if self.delivery_outcome is not None:
+            msg = "Response delivery already settled"
+            raise RuntimeError(msg)
+        self.delivery_outcome = delivery_outcome
 
 
 @dataclass(frozen=True)
@@ -949,7 +957,7 @@ class ResponseRunner:
         identity: ResponseIdentity,
         progress: _DeliveryProgress,
         run_message_id: str | None,
-        terminal_status: Literal["cancelled", "error"],
+        terminal_status: TerminalFailureStatus,
         failure_reason: str,
     ) -> FinalDeliveryOutcome:
         """Finalize one turn that terminated before a delivery outcome settled.
@@ -996,6 +1004,38 @@ class ResponseRunner:
             ),
         )
 
+    async def _settle_missing_delivery_outcome(
+        self,
+        *,
+        target: MessageTarget,
+        request: ResponseRequest,
+        identity: ResponseIdentity,
+        progress: _DeliveryProgress,
+        run_message_id: str | None,
+        terminal_status: TerminalFailureStatus,
+        failure_reason: str,
+    ) -> None:
+        """Settle a missing outcome without touching content after delivery starts."""
+        if progress.delivery_outcome is not None:
+            return
+        if progress.stage_started:
+            delivery_outcome = FinalDeliveryOutcome(
+                terminal_status=terminal_status,
+                event_id=None,
+                failure_reason=failure_reason,
+            )
+        else:
+            delivery_outcome = await self._finalize_pre_delivery_terminal(
+                target=target,
+                request=request,
+                identity=identity,
+                progress=progress,
+                run_message_id=run_message_id,
+                terminal_status=terminal_status,
+                failure_reason=failure_reason,
+            )
+        progress.settle(delivery_outcome)
+
     async def _finalize_locked_outcome(
         self,
         lifecycle: ResponseLifecycle,
@@ -1028,6 +1068,108 @@ class ResponseRunner:
                 post_response_deps=post_response_deps,
             )
             raise
+
+    async def _run_and_settle_locked_response(
+        self,
+        request: ResponseRequest,
+        *,
+        target: MessageTarget,
+        lifecycle: ResponseLifecycle,
+        progress: _DeliveryProgress,
+        response_function: Callable[[str | None], Coroutine[Any, Any, None]],
+        thinking_message: str | None,
+        user_id: str | None,
+        run_id: str,
+        build_post_response_outcome: Callable[[FinalDeliveryOutcome], ResponseOutcome],
+        post_response_deps: PostResponseEffectsDeps | Callable[[], PostResponseEffectsDeps],
+        streaming_delivery_error_handler: Callable[
+            [StreamingDeliveryError],
+            Awaitable[FinalDeliveryOutcome],
+        ]
+        | None = None,
+    ) -> str | None:
+        """Run generation and settle its terminal lifecycle exactly once."""
+        run_message_id: str | None = None
+        deferred_error: BaseException | None = None
+        try:
+            run_message_id = await self.run_cancellable_response(
+                target=target,
+                response_function=response_function,
+                thinking_message=thinking_message,
+                existing_event_id=request.existing_event_id,
+                user_id=user_id,
+                run_id=run_id,
+                pipeline_timing=request.pipeline_timing,
+                on_cancelled=progress.note_task_cancelled,
+            )
+            if progress.tracked_event_id is None:
+                progress.track_event(run_message_id)
+        except asyncio.CancelledError as error:
+            progress.note_task_cancelled(cancel_failure_reason(classify_cancel_source(error)))
+            await self._settle_missing_delivery_outcome(
+                target=target,
+                request=request,
+                identity=lifecycle.identity,
+                progress=progress,
+                run_message_id=run_message_id,
+                terminal_status="cancelled",
+                failure_reason=progress.failure_reason or "interrupted",
+            )
+            deferred_error = error
+        except Exception as error:
+            if isinstance(error, StreamingDeliveryError) and streaming_delivery_error_handler is not None:
+                progress.settle(await streaming_delivery_error_handler(error))
+            elif progress.stage_started or progress.delivery_outcome is not None:
+                # Do not touch a tracked event after delivery starts: an adopted
+                # thinking-message stream can already hold the full reply.
+                self._log_delivery_failure(response_kind=lifecycle.identity.response_kind, error=error)
+                if progress.delivery_outcome is None:
+                    progress.failure_reason = progress.failure_reason or str(error) or "late_delivery_failure"
+            else:
+                progress.failure_reason = str(error) or "delivery_failed_before_start"
+                progress.settle(
+                    await self._finalize_pre_delivery_terminal(
+                        target=target,
+                        request=request,
+                        identity=lifecycle.identity,
+                        progress=progress,
+                        run_message_id=run_message_id,
+                        terminal_status="error",
+                        failure_reason=progress.failure_reason,
+                    ),
+                )
+                deferred_error = error
+
+        if progress.delivery_outcome is None and (progress.cancelled or progress.failure_reason is not None):
+            await self._settle_missing_delivery_outcome(
+                target=target,
+                request=request,
+                identity=lifecycle.identity,
+                progress=progress,
+                run_message_id=run_message_id,
+                terminal_status="cancelled" if progress.cancelled else "error",
+                failure_reason=progress.failure_reason or "interrupted",
+            )
+
+        final_delivery_outcome = progress.delivery_outcome
+        if final_delivery_outcome is None:
+            msg = "Response generation did not settle a delivery outcome"
+            raise RuntimeError(msg)
+        final_outcome = await self._finalize_locked_outcome(
+            lifecycle,
+            final_delivery_outcome,
+            post_response_outcome=build_post_response_outcome(final_delivery_outcome),
+            post_response_deps=post_response_deps,
+        )
+        self._notify_sync_restart_cancelled(
+            request,
+            final_outcome,
+            delivery_cancelled=progress.cancelled,
+            delivery_failure_reason=progress.failure_reason,
+        )
+        if deferred_error is not None:
+            raise deferred_error
+        return final_outcome.final_visible_event_id if final_outcome.mark_handled else None
 
     def _build_lifecycle(
         self,
@@ -1110,7 +1252,7 @@ class ResponseRunner:
             ),
         )
 
-    async def generate_team_response_helper_locked(  # noqa: C901, PLR0912, PLR0915
+    async def generate_team_response_helper_locked(  # noqa: C901, PLR0915
         self,
         team_request: _TeamResponseRequest,
         *,
@@ -1227,7 +1369,6 @@ class ResponseRunner:
             msg = "Orchestrator is not set"
             raise RuntimeError(msg)
         response_run_id = str(uuid4())
-        final_delivery_outcome: FinalDeliveryOutcome | None = None
         team_run_metadata_content: dict[str, Any] = {}
         progress = _DeliveryProgress(tracked_event_id=request.existing_event_id)
         matrix_run_metadata = _materialize_matrix_run_metadata(request.matrix_run_metadata)
@@ -1260,7 +1401,6 @@ class ResponseRunner:
         )
 
         async def generate_team_response(message_id: str | None) -> None:  # noqa: C901, PLR0912, PLR0915
-            nonlocal final_delivery_outcome
             delivery_request = self._request_for_delivery(delivery_request_base, message_id=message_id)
             if message_id is not None:
                 progress.track_event(message_id)
@@ -1383,8 +1523,8 @@ class ResponseRunner:
                     existing_event_id=request.existing_event_id,
                     existing_event_is_placeholder=request.existing_event_is_placeholder,
                 )
-                final_delivery_outcome = await self.deps.delivery_gateway.finalize_streamed_response(
-                    finalize_request,
+                progress.settle(
+                    await self.deps.delivery_gateway.finalize_streamed_response(finalize_request),
                 )
                 if request.pipeline_timing is not None:
                     request.pipeline_timing.mark_first_visible_reply("final")
@@ -1449,38 +1589,44 @@ class ResponseRunner:
                     )
                     if message_id:
                         cancel_source = classify_cancel_source(exc)
-                        final_delivery_outcome = await self.deps.delivery_gateway.deliver_cancelled_visible_note(
-                            CancelledVisibleNoteRequest(
-                                target=delivery_target,
-                                event_id=message_id,
-                                existing_event_is_placeholder=delivery_request.existing_event_is_placeholder,
-                                cancel_source=cancel_source,
-                                identity=response_identity,
+                        progress.settle(
+                            await self.deps.delivery_gateway.deliver_cancelled_visible_note(
+                                CancelledVisibleNoteRequest(
+                                    target=delivery_target,
+                                    event_id=message_id,
+                                    existing_event_is_placeholder=delivery_request.existing_event_is_placeholder,
+                                    cancel_source=cancel_source,
+                                    identity=response_identity,
+                                ),
                             ),
                         )
                     else:
                         failure_reason = cancel_failure_reason(classify_cancel_source(exc))
-                        final_delivery_outcome = FinalDeliveryOutcome(
-                            terminal_status="cancelled",
-                            event_id=None,
-                            failure_reason=failure_reason,
+                        progress.settle(
+                            FinalDeliveryOutcome(
+                                terminal_status="cancelled",
+                                event_id=None,
+                                failure_reason=failure_reason,
+                            ),
                         )
                     return
 
                 progress.note_delivery_started(None)
                 try:
-                    final_delivery_outcome = await self.deps.delivery_gateway.deliver_final(
-                        FinalDeliveryRequest(
-                            target=delivery_target,
-                            existing_event_id=message_id,
-                            existing_event_is_placeholder=delivery_request.existing_event_is_placeholder,
-                            response_text=response_text,
-                            identity=response_identity,
-                            tool_trace=None,
-                            extra_content=_merge_response_extra_content(
-                                team_run_metadata_content
-                                or ai_run_extra_content_from_metadata(team_turn_recorder.run_metadata),
-                                request.attachment_ids,
+                    progress.settle(
+                        await self.deps.delivery_gateway.deliver_final(
+                            FinalDeliveryRequest(
+                                target=delivery_target,
+                                existing_event_id=message_id,
+                                existing_event_is_placeholder=delivery_request.existing_event_is_placeholder,
+                                response_text=response_text,
+                                identity=response_identity,
+                                tool_trace=None,
+                                extra_content=_merge_response_extra_content(
+                                    team_run_metadata_content
+                                    or ai_run_extra_content_from_metadata(team_turn_recorder.run_metadata),
+                                    request.attachment_ids,
+                                ),
                             ),
                         ),
                     )
@@ -1499,36 +1645,12 @@ class ResponseRunner:
                     request.pipeline_timing.mark_first_visible_reply("final")
                     request.pipeline_timing.mark("response_complete")
 
-        thinking_msg = None
-        if not request.existing_event_id and not self._has_queued_forced_compaction(
-            session_id=session_id,
-            scope=session_scope,
-            execution_identity=tool_dispatch.execution_identity,
-        ):
-            thinking_msg = "🤝 Team Response: Thinking..."
-
-        run_message_id: str | None = None
-        stream_transport_outcome: StreamTransportOutcome | None = None
-
-        try:
-            run_message_id = await self.run_cancellable_response(
-                target=delivery_target,
-                response_function=generate_team_response,
-                thinking_message=thinking_msg,
-                existing_event_id=request.existing_event_id,
-                user_id=requester_user_id,
-                run_id=response_run_id,
-                pipeline_timing=request.pipeline_timing,
-                on_cancelled=progress.note_task_cancelled,
-            )
-            if progress.tracked_event_id is None:
-                progress.track_event(run_message_id)
-        except StreamingDeliveryError as error:
-            stream_transport_outcome = error.transport_outcome
-            if stream_transport_outcome.terminal_status == "cancelled":
+        async def settle_team_streaming_delivery_error(error: StreamingDeliveryError) -> FinalDeliveryOutcome:
+            transport_outcome = error.transport_outcome
+            if transport_outcome.terminal_status == "cancelled":
                 log_cancelled_response_source(
                     self.deps.logger,
-                    cancel_source=cancel_source_from_failure_reason(stream_transport_outcome.failure_reason),
+                    cancel_source=cancel_source_from_failure_reason(transport_outcome.failure_reason),
                     message_id=error.event_id,
                     restart_message="Team streaming response interrupted by sync restart",
                     user_stop_message="Team streaming response cancelled by user",
@@ -1552,10 +1674,10 @@ class ResponseRunner:
                     is_team=True,
                     response_event_id=progress.tracked_event_id,
                 )
-            final_delivery_outcome = await self.deps.delivery_gateway.finalize_streamed_response(
+            return await self.deps.delivery_gateway.finalize_streamed_response(
                 FinalizeStreamedResponseRequest(
                     target=delivery_target,
-                    stream_transport_outcome=stream_transport_outcome,
+                    stream_transport_outcome=transport_outcome,
                     initial_delivery_kind="edited" if request.existing_event_id else "sent",
                     identity=response_identity,
                     tool_trace=error.tool_trace if show_tool_calls else None,
@@ -1568,98 +1690,48 @@ class ResponseRunner:
                     existing_event_is_placeholder=request.existing_event_is_placeholder,
                 ),
             )
-        except asyncio.CancelledError as error:
-            if progress.stage_started:
-                raise
-            # Pre-delivery cancels previously propagated raw, leaving the
-            # placeholder dangling and skipping lifecycle finalization.
-            progress.note_task_cancelled(cancel_failure_reason(classify_cancel_source(error)))
-            final_delivery_outcome = await self._finalize_pre_delivery_terminal(
-                target=delivery_target,
-                request=request,
-                identity=response_identity,
-                progress=progress,
-                run_message_id=run_message_id,
-                terminal_status="cancelled",
-                failure_reason=progress.failure_reason or "interrupted",
-            )
-            progress.deferred_error = error
-        except Exception as error:
-            if progress.stage_started:
-                # A failure after delivery started settles through the late
-                # fallback below instead of tripping the outcome assertion. Only
-                # record the reason when no outcome exists yet, so a settled
-                # sync-restart cancellation still registers its retry.
-                self._log_delivery_failure(response_kind="team", error=error)
-                if final_delivery_outcome is None:
-                    progress.failure_reason = progress.failure_reason or str(error) or "late_delivery_failure"
-            else:
-                progress.failure_reason = str(error) or "delivery_failed_before_start"
-                final_delivery_outcome = await self._finalize_pre_delivery_terminal(
-                    target=delivery_target,
-                    request=request,
-                    identity=response_identity,
-                    progress=progress,
-                    run_message_id=run_message_id,
-                    terminal_status="error",
-                    failure_reason=progress.failure_reason,
-                )
-                progress.deferred_error = error
-        if final_delivery_outcome is None and (progress.cancelled or progress.failure_reason is not None):
-            if progress.stage_started:
-                # Delivery began but never settled an outcome. Do not touch the
-                # tracked event: with an adopted thinking-message stream it can
-                # already hold the full streamed reply, and the placeholder-only
-                # cleanup in finalize_streamed_response would redact it.
-                final_delivery_outcome = FinalDeliveryOutcome(
-                    terminal_status="cancelled" if progress.cancelled else "error",
-                    event_id=None,
-                    failure_reason=progress.failure_reason or "interrupted",
-                )
-            else:
-                final_delivery_outcome = await self._finalize_pre_delivery_terminal(
-                    target=delivery_target,
-                    request=request,
-                    identity=response_identity,
-                    progress=progress,
-                    run_message_id=run_message_id,
-                    terminal_status="cancelled" if progress.cancelled else "error",
-                    failure_reason=progress.failure_reason or "interrupted",
-                )
-        assert final_delivery_outcome is not None
-        team_post_response_outcome = ResponseOutcome(
-            response_run_id=team_turn_recorder.run_id or response_run_id,
+
+        thinking_msg = None
+        if not request.existing_event_id and not self._has_queued_forced_compaction(
             session_id=session_id,
-            session_type=SessionType.TEAM,
+            scope=session_scope,
             execution_identity=tool_dispatch.execution_identity,
-            run_succeeded=team_turn_recorder.outcome == "completed",
-            interactive_target=resolved_target,
-            thread_summary_room_id=(request.room_id if resolved_target.resolved_thread_id is not None else None),
-            thread_summary_thread_id=resolved_target.resolved_thread_id,
-            thread_summary_message_count_hint=thread_summary_message_count_hint(request.thread_history),
-            thread_summary_entity_name=self.deps.agent_name,
-            memory_prompt=_memory_prompt,
-            memory_thread_history=_memory_thread_history,
-        )
-        final_outcome = await self._finalize_locked_outcome(
-            lifecycle,
-            final_delivery_outcome,
-            post_response_outcome=team_post_response_outcome,
+        ):
+            thinking_msg = "🤝 Team Response: Thinking..."
+
+        def build_team_post_response_outcome(_delivery_outcome: FinalDeliveryOutcome) -> ResponseOutcome:
+            return ResponseOutcome(
+                response_run_id=team_turn_recorder.run_id or response_run_id,
+                session_id=session_id,
+                session_type=SessionType.TEAM,
+                execution_identity=tool_dispatch.execution_identity,
+                run_succeeded=team_turn_recorder.outcome == "completed",
+                interactive_target=resolved_target,
+                thread_summary_room_id=(request.room_id if resolved_target.resolved_thread_id is not None else None),
+                thread_summary_thread_id=resolved_target.resolved_thread_id,
+                thread_summary_message_count_hint=thread_summary_message_count_hint(request.thread_history),
+                thread_summary_entity_name=self.deps.agent_name,
+                memory_prompt=_memory_prompt,
+                memory_thread_history=_memory_thread_history,
+            )
+
+        return await self._run_and_settle_locked_response(
+            request,
+            target=delivery_target,
+            lifecycle=lifecycle,
+            progress=progress,
+            response_function=generate_team_response,
+            thinking_message=thinking_msg,
+            user_id=requester_user_id,
+            run_id=response_run_id,
+            build_post_response_outcome=build_team_post_response_outcome,
             post_response_deps=lambda: self.deps.post_response_effects.build_deps(
                 room_id=request.room_id,
                 interactive_agent_name=self.deps.agent_name,
                 persist_response_event_id=persist_response_event_id,
             ),
+            streaming_delivery_error_handler=settle_team_streaming_delivery_error,
         )
-        if progress.deferred_error is not None:
-            raise progress.deferred_error
-        self._notify_sync_restart_cancelled(
-            request,
-            final_outcome,
-            delivery_cancelled=progress.cancelled,
-            delivery_failure_reason=progress.failure_reason,
-        )
-        return final_outcome.final_visible_event_id if final_outcome.mark_handled else None
 
     async def run_cancellable_response(
         self,
@@ -2316,7 +2388,7 @@ class ResponseRunner:
             ),
         )
 
-    async def generate_response_locked(  # noqa: C901, PLR0912, PLR0915
+    async def generate_response_locked(
         self,
         request: ResponseRequest,
         *,
@@ -2368,7 +2440,6 @@ class ResponseRunner:
             enable_streaming=self.deps.runtime.enable_streaming,
         )
         self._note_pipeline_metadata(request, response_kind="agent", used_streaming=use_streaming)
-        final_delivery_outcome: FinalDeliveryOutcome | None = None
         generation: _ResponseGenerationOutcome | None = None
         attempt_run_ids: list[str] = []
         response_run_id = str(uuid4())
@@ -2411,7 +2482,7 @@ class ResponseRunner:
         )
 
         async def generate(message_id: str | None) -> None:
-            nonlocal final_delivery_outcome, generation
+            nonlocal generation
             progress.track_event(message_id)
             delivery_request = self._request_for_delivery(normalized_request, message_id=message_id)
             if use_streaming:
@@ -2428,7 +2499,7 @@ class ResponseRunner:
                     on_delivery_started=progress.note_delivery_started,
                     attempt_run_id_collector=attempt_run_ids,
                 )
-            final_delivery_outcome = generation.delivery
+            progress.settle(generation.delivery)
 
         thinking_msg = None
         if not request.existing_event_id and not self._has_queued_forced_compaction(
@@ -2438,115 +2509,42 @@ class ResponseRunner:
         ):
             thinking_msg = "Thinking..."
 
-        run_message_id: str | None = None
-        try:
-            run_message_id = await self.run_cancellable_response(
-                target=resolved_target,
-                response_function=generate,
-                thinking_message=thinking_msg,
-                existing_event_id=request.existing_event_id,
-                user_id=request.user_id,
-                run_id=response_run_id,
-                pipeline_timing=request.pipeline_timing,
-                on_cancelled=progress.note_task_cancelled,
+        def build_post_response_outcome(final_delivery_outcome: FinalDeliveryOutcome) -> ResponseOutcome:
+            return ResponseOutcome(
+                # The live collector list also covers raising exit paths, where the
+                # returned generation outcome never materialized.
+                response_run_id=attempt_run_ids[-1] if attempt_run_ids else response_run_id,
+                session_id=session_id,
+                session_type=self.deps.state_writer.session_type_for_scope(self.deps.state_writer.history_scope()),
+                execution_identity=execution_identity,
+                run_succeeded=(
+                    generation.run_succeeded
+                    if generation is not None
+                    else final_delivery_outcome.terminal_status == "completed"
+                ),
+                interactive_target=resolved_target,
+                thread_summary_room_id=(request.room_id if resolved_target.resolved_thread_id is not None else None),
+                thread_summary_thread_id=resolved_target.resolved_thread_id,
+                thread_summary_message_count_hint=thread_summary_message_count_hint(request.thread_history),
+                thread_summary_entity_name=self.deps.agent_name,
+                memory_prompt=memory_prompt,
+                memory_thread_history=memory_thread_history,
             )
-            if progress.tracked_event_id is None:
-                progress.track_event(run_message_id)
-        except asyncio.CancelledError as error:
-            if progress.stage_started:
-                raise
-            progress.note_task_cancelled(cancel_failure_reason(classify_cancel_source(error)))
-            final_delivery_outcome = await self._finalize_pre_delivery_terminal(
-                target=resolved_target,
-                request=request,
-                identity=response_identity,
-                progress=progress,
-                run_message_id=run_message_id,
-                terminal_status="cancelled",
-                failure_reason=progress.failure_reason or "interrupted",
-            )
-            progress.deferred_error = error
-        except Exception as error:
-            if progress.stage_started:
-                # A failure after delivery started settles through the late
-                # fallback below instead of tripping the outcome assertion. Only
-                # record the reason when no outcome exists yet, so a settled
-                # sync-restart cancellation still registers its retry.
-                self._log_delivery_failure(response_kind="ai", error=error)
-                if final_delivery_outcome is None:
-                    progress.failure_reason = progress.failure_reason or str(error) or "late_delivery_failure"
-            else:
-                progress.failure_reason = str(error) or "delivery_failed_before_start"
-                final_delivery_outcome = await self._finalize_pre_delivery_terminal(
-                    target=resolved_target,
-                    request=request,
-                    identity=response_identity,
-                    progress=progress,
-                    run_message_id=run_message_id,
-                    terminal_status="error",
-                    failure_reason=progress.failure_reason,
-                )
-                progress.deferred_error = error
-        if final_delivery_outcome is None and (progress.cancelled or progress.failure_reason is not None):
-            if progress.stage_started:
-                # Delivery began but never settled an outcome. Do not touch the
-                # tracked event: with an adopted thinking-message stream it can
-                # already hold the full streamed reply, and the placeholder-only
-                # cleanup in finalize_streamed_response would redact it.
-                final_delivery_outcome = FinalDeliveryOutcome(
-                    terminal_status="cancelled" if progress.cancelled else "error",
-                    event_id=None,
-                    failure_reason=progress.failure_reason or "interrupted",
-                )
-            else:
-                final_delivery_outcome = await self._finalize_pre_delivery_terminal(
-                    target=resolved_target,
-                    request=request,
-                    identity=response_identity,
-                    progress=progress,
-                    run_message_id=run_message_id,
-                    terminal_status="cancelled" if progress.cancelled else "error",
-                    failure_reason=progress.failure_reason or "interrupted",
-                )
-        assert final_delivery_outcome is not None
-        post_response_outcome = ResponseOutcome(
-            # The live collector list also covers raising exit paths, where the
-            # returned generation outcome never materialized.
-            response_run_id=attempt_run_ids[-1] if attempt_run_ids else response_run_id,
-            session_id=session_id,
-            session_type=self.deps.state_writer.session_type_for_scope(self.deps.state_writer.history_scope()),
-            execution_identity=execution_identity,
-            run_succeeded=(
-                generation.run_succeeded
-                if generation is not None
-                else final_delivery_outcome.terminal_status == "completed"
-            ),
-            interactive_target=resolved_target,
-            thread_summary_room_id=(request.room_id if resolved_target.resolved_thread_id is not None else None),
-            thread_summary_thread_id=resolved_target.resolved_thread_id,
-            thread_summary_message_count_hint=thread_summary_message_count_hint(request.thread_history),
-            thread_summary_entity_name=self.deps.agent_name,
-            memory_prompt=memory_prompt,
-            memory_thread_history=memory_thread_history,
-        )
-        post_response_deps = self.deps.post_response_effects.build_deps(
-            room_id=request.room_id,
-            interactive_agent_name=self.deps.agent_name,
-            queue_memory_persistence=queue_memory_persistence,
-            persist_response_event_id=persist_response_event_id,
-        )
-        final_outcome = await self._finalize_locked_outcome(
-            lifecycle,
-            final_delivery_outcome,
-            post_response_outcome=post_response_outcome,
-            post_response_deps=post_response_deps,
-        )
-        if progress.deferred_error is not None:
-            raise progress.deferred_error
-        self._notify_sync_restart_cancelled(
+
+        return await self._run_and_settle_locked_response(
             request,
-            final_outcome,
-            delivery_cancelled=progress.cancelled,
-            delivery_failure_reason=progress.failure_reason,
+            target=resolved_target,
+            lifecycle=lifecycle,
+            progress=progress,
+            response_function=generate,
+            thinking_message=thinking_msg,
+            user_id=request.user_id,
+            run_id=response_run_id,
+            build_post_response_outcome=build_post_response_outcome,
+            post_response_deps=lambda: self.deps.post_response_effects.build_deps(
+                room_id=request.room_id,
+                interactive_agent_name=self.deps.agent_name,
+                queue_memory_persistence=queue_memory_persistence,
+                persist_response_event_id=persist_response_event_id,
+            ),
         )
-        return final_outcome.final_visible_event_id if final_outcome.mark_handled else None

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -267,6 +267,7 @@ class ResponseRequest:
     pipeline_timing: DispatchPipelineTiming | None = None
     queued_notice_reservation: QueuedHumanNoticeReservation | None = None
     on_sync_restart_cancelled: Callable[[], None] | None = None
+    on_deferred_outcome_handled: Callable[[str], None] | None = None
 
     @property
     def room_id(self) -> str:
@@ -912,9 +913,6 @@ class ResponseRunner:
         self,
         request: ResponseRequest,
         final_outcome: FinalDeliveryOutcome,
-        *,
-        delivery_cancelled: bool,
-        delivery_failure_reason: str | None,
     ) -> None:
         """Tell the dispatcher when stall recovery interrupted a marked-handled turn.
 
@@ -924,13 +922,11 @@ class ResponseRunner:
         turns are recovered by that replay instead; retrying them too would
         answer twice.
         """
-        delivery_cancelled = delivery_cancelled or final_outcome.terminal_status == "cancelled"
-        delivery_failure_reason = delivery_failure_reason or final_outcome.failure_reason
-        if request.on_sync_restart_cancelled is None or not delivery_cancelled:
+        if request.on_sync_restart_cancelled is None or final_outcome.terminal_status != "cancelled":
             return
         if not final_outcome.mark_handled:
             return
-        if cancel_source_from_failure_reason(delivery_failure_reason) != "sync_restart":
+        if cancel_source_from_failure_reason(final_outcome.failure_reason) != "sync_restart":
             return
         request.on_sync_restart_cancelled()
 
@@ -1069,7 +1065,7 @@ class ResponseRunner:
             )
             raise
 
-    async def _run_and_settle_locked_response(
+    async def _run_and_settle_locked_response(  # noqa: C901
         self,
         request: ResponseRequest,
         *,
@@ -1161,13 +1157,12 @@ class ResponseRunner:
             post_response_outcome=build_post_response_outcome(final_delivery_outcome),
             post_response_deps=post_response_deps,
         )
-        self._notify_sync_restart_cancelled(
-            request,
-            final_outcome,
-            delivery_cancelled=progress.cancelled,
-            delivery_failure_reason=progress.failure_reason,
-        )
+        self._notify_sync_restart_cancelled(request, final_outcome)
         if deferred_error is not None:
+            if final_outcome.mark_handled and request.on_deferred_outcome_handled is not None:
+                response_event_id = final_outcome.final_visible_event_id
+                assert response_event_id is not None
+                request.on_deferred_outcome_handled(response_event_id)
             raise deferred_error
         return final_outcome.final_visible_event_id if final_outcome.mark_handled else None
 

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -1545,7 +1545,7 @@ class TurnController:
             ),
         )
 
-    def _build_sync_restart_retry_registrar(
+    def _build_response_settlement_callbacks(
         self,
         room: nio.MatrixRoom,
         event: DispatchEvent,
@@ -1555,8 +1555,8 @@ class TurnController:
         *,
         handled_turn: HandledTurnState,
         matrix_run_metadata: dict[str, Any] | None,
-    ) -> Callable[[], None]:
-        """Build the callback that queues a one-shot re-dispatch after stall recovery."""
+    ) -> tuple[Callable[[], None], Callable[[str], None]]:
+        """Build callbacks for sync-restart retry and deferred handled recording."""
 
         def register_sync_restart_retry() -> None:
             async def retry() -> None:
@@ -1574,7 +1574,10 @@ class TurnController:
 
             self.deps.restart_retry.register(event.event_id, retry)
 
-        return register_sync_restart_retry
+        def record_deferred_outcome(response_event_id: str) -> None:
+            self._mark_source_events_responded(handled_turn.with_response_event_id(response_event_id))
+
+        return register_sync_restart_retry, record_deferred_outcome
 
     async def _execute_response_action(  # noqa: C901, PLR0912
         self,
@@ -1654,7 +1657,7 @@ class TurnController:
                 context_ready_monotonic=context_ready_monotonic,
             )
 
-            register_sync_restart_retry = self._build_sync_restart_retry_registrar(
+            register_sync_restart_retry, record_deferred_outcome = self._build_response_settlement_callbacks(
                 room,
                 event,
                 dispatch,
@@ -1691,6 +1694,7 @@ class TurnController:
                             queued_notice_reservation=queued_notice_reservation,
                             on_lifecycle_lock_acquired=on_lifecycle_lock_acquired,
                             on_sync_restart_cancelled=register_sync_restart_retry,
+                            on_deferred_outcome_handled=record_deferred_outcome,
                         ),
                         team_agents=action.form_team.eligible_members,
                         team_mode=team_mode.value,
@@ -1712,6 +1716,7 @@ class TurnController:
                             queued_notice_reservation=queued_notice_reservation,
                             on_lifecycle_lock_acquired=on_lifecycle_lock_acquired,
                             on_sync_restart_cancelled=register_sync_restart_retry,
+                            on_deferred_outcome_handled=record_deferred_outcome,
                         ),
                     )
             except PostLockRequestPreparationError as error:

--- a/tests/test_response_runner_focused.py
+++ b/tests/test_response_runner_focused.py
@@ -852,6 +852,181 @@ async def test_duplicate_queued_request_without_reservation_registers_one_notice
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "delivery_outcome",
+    [
+        _completed_outcome(),
+        FinalDeliveryOutcome(
+            terminal_status="cancelled",
+            event_id="$response",
+            is_visible_response=True,
+            failure_reason="cancelled_by_user",
+        ),
+        FinalDeliveryOutcome(
+            terminal_status="error",
+            event_id="$response",
+            is_visible_response=True,
+            failure_reason="delivery_failed",
+        ),
+    ],
+    ids=["completed", "cancelled", "error"],
+)
+async def test_terminal_settlement_finalizes_and_runs_post_effects_once(
+    tmp_path: Path,
+    delivery_outcome: FinalDeliveryOutcome,
+) -> None:
+    """Every canonical terminal status should cross finalization and post-effects exactly once."""
+    bot = _bot(tmp_path)
+    coordinator = unwrap_extracted_collaborator(bot._response_runner)
+    request = _plain_request(_target())
+    progress = response_runner._DeliveryProgress()
+    post_effects = AsyncMock()
+    build_post_outcome = MagicMock(return_value=ResponseOutcome())
+
+    async def generate(_message_id: str | None) -> None:
+        progress.settle(delivery_outcome)
+
+    async def run_cancellable_response(**kwargs: object) -> str:
+        response_function = kwargs["response_function"]
+        await response_function("$response")  # type: ignore[operator]
+        return "$response"
+
+    lifecycle = coordinator._build_lifecycle(
+        identity=coordinator._response_identity(request, response_kind="ai"),
+        request=request,
+    )
+    finalize = AsyncMock(wraps=lifecycle.finalize)
+    with (
+        patch.object(
+            coordinator,
+            "run_cancellable_response",
+            new=AsyncMock(side_effect=run_cancellable_response),
+        ),
+        patch.object(lifecycle, "finalize", new=finalize),
+        patch_response_runner_module(apply_post_response_effects=post_effects),
+    ):
+        result = await coordinator._run_and_settle_locked_response(
+            request,
+            target=request.response_envelope.target,
+            lifecycle=lifecycle,
+            progress=progress,
+            response_function=generate,
+            thinking_message=None,
+            user_id=request.user_id,
+            run_id="run-1",
+            build_post_response_outcome=build_post_outcome,
+            post_response_deps=PostResponseEffectsDeps(logger=get_logger("tests.post_response")),
+        )
+
+    assert result == "$response"
+    assert progress.delivery_outcome is delivery_outcome
+    build_post_outcome.assert_called_once_with(delivery_outcome)
+    finalize.assert_awaited_once()
+    post_effects.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_terminal_settlement_registers_retry_before_rethrowing_cancel(tmp_path: Path) -> None:
+    """A deferred sync-restart cancel should finalize once, register its retry, then re-raise."""
+    bot = _bot(tmp_path)
+    coordinator = unwrap_extracted_collaborator(bot._response_runner)
+    order: list[str] = []
+    request = replace(
+        _plain_request(_target()),
+        on_sync_restart_cancelled=lambda: order.append("retry"),
+    )
+    delivery_outcome = FinalDeliveryOutcome(
+        terminal_status="cancelled",
+        event_id="$response",
+        is_visible_response=True,
+        failure_reason="sync_restart_cancelled",
+    )
+    progress = response_runner._DeliveryProgress()
+    progress.note_delivery_started("$response")
+    progress.settle(delivery_outcome)
+    post_effects = AsyncMock(side_effect=lambda *_args: order.append("post_effects"))
+    lifecycle = coordinator._build_lifecycle(
+        identity=coordinator._response_identity(request, response_kind="ai"),
+        request=request,
+    )
+    finalize = AsyncMock(wraps=lifecycle.finalize)
+
+    with (
+        patch.object(
+            coordinator,
+            "run_cancellable_response",
+            new=AsyncMock(side_effect=asyncio.CancelledError("sync_restart")),
+        ),
+        patch.object(lifecycle, "finalize", new=finalize),
+        patch_response_runner_module(apply_post_response_effects=post_effects),
+        pytest.raises(asyncio.CancelledError, match="sync_restart"),
+    ):
+        await coordinator._run_and_settle_locked_response(
+            request,
+            target=request.response_envelope.target,
+            lifecycle=lifecycle,
+            progress=progress,
+            response_function=AsyncMock(),
+            thinking_message=None,
+            user_id=request.user_id,
+            run_id="run-1",
+            build_post_response_outcome=lambda _outcome: ResponseOutcome(),
+            post_response_deps=PostResponseEffectsDeps(logger=get_logger("tests.post_response")),
+        )
+
+    assert order == ["post_effects", "retry"]
+    assert progress.delivery_outcome is delivery_outcome
+    finalize.assert_awaited_once()
+    post_effects.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_terminal_settlement_rethrows_generation_error_after_post_effects(tmp_path: Path) -> None:
+    """A pre-delivery generation error should settle, finalize once, run effects, then re-raise."""
+    bot = _bot(tmp_path)
+    coordinator = unwrap_extracted_collaborator(bot._response_runner)
+    request = _plain_request(_target())
+    progress = response_runner._DeliveryProgress()
+    post_effects = AsyncMock()
+    build_post_outcome = MagicMock(return_value=ResponseOutcome())
+    lifecycle = coordinator._build_lifecycle(
+        identity=coordinator._response_identity(request, response_kind="ai"),
+        request=request,
+    )
+    finalize = AsyncMock(wraps=lifecycle.finalize)
+
+    with (
+        patch.object(
+            coordinator,
+            "run_cancellable_response",
+            new=AsyncMock(side_effect=RuntimeError("generation failed")),
+        ),
+        patch.object(lifecycle, "finalize", new=finalize),
+        patch_response_runner_module(apply_post_response_effects=post_effects),
+        pytest.raises(RuntimeError, match="generation failed"),
+    ):
+        await coordinator._run_and_settle_locked_response(
+            request,
+            target=request.response_envelope.target,
+            lifecycle=lifecycle,
+            progress=progress,
+            response_function=AsyncMock(),
+            thinking_message=None,
+            user_id=request.user_id,
+            run_id="run-1",
+            build_post_response_outcome=build_post_outcome,
+            post_response_deps=PostResponseEffectsDeps(logger=get_logger("tests.post_response")),
+        )
+
+    assert progress.delivery_outcome is not None
+    assert progress.delivery_outcome.terminal_status == "error"
+    assert progress.delivery_outcome.failure_reason == "generation failed"
+    build_post_outcome.assert_called_once_with(progress.delivery_outcome)
+    finalize.assert_awaited_once()
+    post_effects.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_success_runs_post_response_effects_after_delivery(tmp_path: Path) -> None:
     """A successful turn applies post-response effects only after visible delivery completed."""
     bot = _bot(tmp_path)

--- a/tests/test_response_runner_focused.py
+++ b/tests/test_response_runner_focused.py
@@ -934,6 +934,7 @@ async def test_terminal_settlement_registers_retry_before_rethrowing_cancel(tmp_
     request = replace(
         _plain_request(_target()),
         on_sync_restart_cancelled=lambda: order.append("retry"),
+        on_deferred_outcome_handled=lambda event_id: order.append(f"handled:{event_id}"),
     )
     delivery_outcome = FinalDeliveryOutcome(
         terminal_status="cancelled",
@@ -974,7 +975,73 @@ async def test_terminal_settlement_registers_retry_before_rethrowing_cancel(tmp_
             post_response_deps=PostResponseEffectsDeps(logger=get_logger("tests.post_response")),
         )
 
-    assert order == ["post_effects", "retry"]
+    assert order == ["post_effects", "retry", "handled:$response"]
+    assert progress.delivery_outcome is delivery_outcome
+    finalize.assert_awaited_once()
+    post_effects.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "delivery_outcome",
+    [
+        _completed_outcome(),
+        FinalDeliveryOutcome(
+            terminal_status="error",
+            event_id="$response",
+            is_visible_response=True,
+            failure_reason="delivery_failed",
+        ),
+    ],
+    ids=["completed", "error"],
+)
+async def test_terminal_settlement_late_cancel_keeps_settled_outcome_canonical(
+    tmp_path: Path,
+    delivery_outcome: FinalDeliveryOutcome,
+) -> None:
+    """A late cancel records an existing terminal outcome without queueing a duplicate retry."""
+    bot = _bot(tmp_path)
+    coordinator = unwrap_extracted_collaborator(bot._response_runner)
+    order: list[str] = []
+    request = replace(
+        _plain_request(_target()),
+        on_sync_restart_cancelled=lambda: order.append("retry"),
+        on_deferred_outcome_handled=lambda event_id: order.append(f"handled:{event_id}"),
+    )
+    progress = response_runner._DeliveryProgress()
+    progress.note_delivery_started("$response")
+    progress.settle(delivery_outcome)
+    post_effects = AsyncMock(side_effect=lambda *_args: order.append("post_effects"))
+    lifecycle = coordinator._build_lifecycle(
+        identity=coordinator._response_identity(request, response_kind="ai"),
+        request=request,
+    )
+    finalize = AsyncMock(wraps=lifecycle.finalize)
+
+    with (
+        patch.object(
+            coordinator,
+            "run_cancellable_response",
+            new=AsyncMock(side_effect=asyncio.CancelledError("sync_restart")),
+        ),
+        patch.object(lifecycle, "finalize", new=finalize),
+        patch_response_runner_module(apply_post_response_effects=post_effects),
+        pytest.raises(asyncio.CancelledError, match="sync_restart"),
+    ):
+        await coordinator._run_and_settle_locked_response(
+            request,
+            target=request.response_envelope.target,
+            lifecycle=lifecycle,
+            progress=progress,
+            response_function=AsyncMock(),
+            thinking_message=None,
+            user_id=request.user_id,
+            run_id="run-1",
+            build_post_response_outcome=lambda _outcome: ResponseOutcome(),
+            post_response_deps=PostResponseEffectsDeps(logger=get_logger("tests.post_response")),
+        )
+
+    assert order == ["post_effects", "handled:$response"]
     assert progress.delivery_outcome is delivery_outcome
     finalize.assert_awaited_once()
     post_effects.assert_awaited_once()

--- a/tests/test_sync_restart_retry.py
+++ b/tests/test_sync_restart_retry.py
@@ -40,15 +40,8 @@ def _notify(
     runner: ResponseRunner,
     request: ResponseRequest,
     outcome: FinalDeliveryOutcome,
-    *,
-    delivery_cancelled: bool = True,
 ) -> None:
-    runner._notify_sync_restart_cancelled(
-        request,
-        outcome,
-        delivery_cancelled=delivery_cancelled,
-        delivery_failure_reason=outcome.failure_reason,
-    )
+    runner._notify_sync_restart_cancelled(request, outcome)
 
 
 def test_notify_fires_for_marked_handled_sync_restart_cancellation() -> None:
@@ -74,16 +67,20 @@ def test_notify_ignores_user_stop_and_unmarked_turns() -> None:
     assert calls == []
 
 
-def test_notify_uses_final_delivery_outcome_when_cancel_flag_is_missing() -> None:
-    """Streaming cancellations can surface only through the final delivery outcome."""
+def test_notify_uses_only_the_canonical_final_delivery_outcome() -> None:
+    """Transient cancellation state must not retry a turn whose final outcome completed."""
     calls: list[str] = []
     _notify(
         ResponseRunner(deps=MagicMock()),
         _request(on_sync_restart_cancelled=lambda: calls.append("retry")),
-        _cancelled_outcome(failure_reason="sync_restart_cancelled"),
-        delivery_cancelled=False,
+        FinalDeliveryOutcome(
+            terminal_status="completed",
+            event_id="$response",
+            is_visible_response=True,
+            failure_reason=None,
+        ),
     )
-    assert calls == ["retry"]
+    assert calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_turn_controller_focused.py
+++ b/tests/test_turn_controller_focused.py
@@ -88,6 +88,7 @@ class _RecordingResponseRunner:
     """
 
     response_event_id: str | None = "$response:localhost"
+    deferred_sync_restart_error: asyncio.CancelledError | None = None
     requests: list[ResponseRequest] = field(default_factory=list)
     team_requests: list[ResponseRequest] = field(default_factory=list)
     inbox_tasks: list[asyncio.Task[None]] = field(default_factory=list)
@@ -121,6 +122,13 @@ class _RecordingResponseRunner:
         self.requests.append(request)
         if request.on_lifecycle_lock_acquired is not None:
             request.on_lifecycle_lock_acquired()
+        if self.deferred_sync_restart_error is not None:
+            assert self.response_event_id is not None
+            assert request.on_sync_restart_cancelled is not None
+            assert request.on_deferred_outcome_handled is not None
+            request.on_sync_restart_cancelled()
+            request.on_deferred_outcome_handled(self.response_event_id)
+            raise self.deferred_sync_restart_error
         return self.response_event_id
 
     async def generate_team_response_helper(
@@ -205,6 +213,7 @@ class _Harness:
     runner: _RecordingResponseRunner
     gateway: _RecordingDeliveryGateway
     turn_store: TurnStore
+    restart_retry: SyncRestartRetryQueue
     gate: CoalescingGate
     gate_batches: list[CoalescedBatch]
     conversation_cache: AsyncMock
@@ -316,6 +325,7 @@ def _build_harness(
     )
     runner = _RecordingResponseRunner()
     gateway = _RecordingDeliveryGateway()
+    restart_retry = SyncRestartRetryQueue()
     controller_ref: list[TurnController] = []
     gate_batches: list[CoalescedBatch] = []
 
@@ -356,7 +366,7 @@ def _build_harness(
             coalescing_gate=gate,
             edit_regenerator=_UnusedEditRegenerator(),
             ingress=ingress_validator,
-            restart_retry=SyncRestartRetryQueue(),
+            restart_retry=restart_retry,
         ),
     )
     controller_ref.append(controller)
@@ -366,6 +376,7 @@ def _build_harness(
         runner=runner,
         gateway=gateway,
         turn_store=turn_store,
+        restart_retry=restart_retry,
         gate=gate,
         gate_batches=gate_batches,
         conversation_cache=conversation_cache,
@@ -549,6 +560,24 @@ async def test_policy_respond_crosses_seam_as_immutable_values(config: Config, t
     assert metadata is not None
     assert metadata[constants.MATRIX_RESPONSE_OWNER_METADATA_KEY] == "general"
     assert harness.turn_store.is_handled(event.event_id) is True
+
+
+@pytest.mark.asyncio
+async def test_deferred_sync_restart_records_handled_outcome_before_rethrow(config: Config, tmp_path: Path) -> None:
+    """A queued retry must not race normal replay of the same visibly settled source turn."""
+    harness = _build_harness(config, tmp_path)
+    harness.runner.deferred_sync_restart_error = asyncio.CancelledError("sync_restart")
+    room = _room_with_members(config, "general")
+    event = _text_event("please survive the sync restart")
+
+    with pytest.raises(asyncio.CancelledError, match="sync_restart"):
+        await harness.deliver(room, event)
+
+    assert harness.restart_retry.has_pending
+    assert harness.turn_store.is_handled(event.event_id) is True
+    record = harness.turn_store.get_turn_record(event.event_id)
+    assert record is not None
+    assert record.response_event_id == "$response:localhost"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Give agent and team locked response paths one shared terminal settlement workflow.
- Keep their generation and streaming adapters separate while making `FinalDeliveryOutcome` the canonical terminal value.
- Register sync-restart retries before deferred failures are rethrown, while recording marked outcomes first so normal replay cannot race the retry.

## New invariant

Every non-empty locked agent or team turn settles exactly one `FinalDeliveryOutcome`, finalizes and applies post-response effects exactly once, derives retry eligibility from that canonical outcome, records any marked deferred outcome, registers any sync-restart retry, and only then rethrows a deferred failure.

## Production LOC

The touched production settlement subsystem (`src/mindroom/response_runner.py` plus `src/mindroom/turn_controller.py`) changes from 4,982 to 4,980 physical lines (-2).

## Validation

- `uv sync --all-extras`
- `uv run pytest tests/test_response_runner_focused.py tests/test_response_runner_session_lifecycle.py tests/test_response_runner_team.py tests/test_response_runner_team_streaming.py tests/test_response_runner_agent.py tests/test_sync_restart_retry.py tests/test_turn_controller_focused.py -n 0 --no-cov -q` — 167 passed
- `uv run pytest -n 0 --tb=short -q` — 9,336 passed, 155 skipped
- `uv run pre-commit run --all-files`
- `uv run tach check --dependencies --interfaces`

## Deliberate non-generalizations

- Agent and team generation semantics remain separate.
- Streaming and non-streaming adapters remain separate.
- No generic pipeline or state-machine framework was introduced.
- No `MessageEnvelope`, `ToolRuntimeContext`, config architecture, or `TurnStore` schema changes.
