### PR TITLE
Consolidate Matrix event-cache semantics

### DIFF
--- a/src/mindroom/matrix/cache/__init__.py
+++ b/src/mindroom/matrix/cache/__init__.py
@@ -3,6 +3,9 @@
 Developer note:
 - `event_cache.py` owns the storage-agnostic durable cache protocol.
 - `event_normalization.py` owns storage-agnostic event payload shaping before backend writes.
+- `event_cache_events.py` owns backend-neutral serialized event values, indexes, and redaction decisions.
+- `thread_cache_state.py` owns backend-neutral durable state values and comparison rules.
+- `agent_message_snapshot_semantics.py` owns backend-neutral latest-message selection rules.
 - `sqlite_event_cache.py` owns the SQLite implementation, runtime, locking, and schema lifecycle.
 - `postgres_event_cache.py` owns the PostgreSQL implementation, runtime, advisory locking, and schema lifecycle.
 - `sqlite_event_cache_events.py` owns SQLite lookup/index rows, edits, and redaction tombstones.

--- a/src/mindroom/matrix/cache/agent_message_snapshot_semantics.py
+++ b/src/mindroom/matrix/cache/agent_message_snapshot_semantics.py
@@ -1,0 +1,89 @@
+"""Pure selection semantics for cached agent-message snapshots."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from mindroom.matrix.event_info import EventInfo
+from mindroom.matrix.visible_body import visible_content_from_content
+
+from .agent_message_snapshot import AgentMessageSnapshot, AgentMessageSnapshotUnavailable
+from .thread_cache_helpers import thread_cache_rejection_reason
+
+if TYPE_CHECKING:
+    from .event_cache import ThreadCacheState
+    from .event_cache_events import CachedEventRow
+
+_THREAD_CACHE_REJECTION_NONE_REASONS = frozenset({"no_cache_state", "cache_never_validated"})
+
+
+@dataclass(frozen=True, slots=True)
+class SnapshotLookupResult:
+    """Outcome for one matching scope event during latest-message lookup."""
+
+    snapshot: AgentMessageSnapshot | None
+    stop_scanning: bool = False
+
+
+def thread_cache_has_no_snapshot(cache_state: ThreadCacheState | None) -> bool:
+    """Return whether a thread has no snapshot, raising when cached state is unsafe."""
+    rejection_reason = thread_cache_rejection_reason(cache_state)
+    if rejection_reason in _THREAD_CACHE_REJECTION_NONE_REASONS:
+        return True
+    if rejection_reason is not None:
+        msg = f"Thread cache snapshot is not usable: {rejection_reason}"
+        raise AgentMessageSnapshotUnavailable(msg)
+    return False
+
+
+def event_matches_snapshot_scope(
+    event: dict[str, Any],
+    *,
+    thread_id: str | None,
+    sender: str,
+) -> bool:
+    """Return whether one event is a visible message candidate for a snapshot scope."""
+    if event.get("type") != "m.room.message" or event.get("sender") != sender:
+        return False
+    relation_type = EventInfo.from_event(event).relation_type
+    if relation_type == "m.replace":
+        return False
+    return not (thread_id is None and relation_type == "m.thread")
+
+
+def snapshot_event_id(event: dict[str, Any]) -> str | None:
+    """Return one event's usable ID for snapshot edit lookup."""
+    event_id = event.get("event_id")
+    return event_id if isinstance(event_id, str) and event_id else None
+
+
+def snapshot_lookup_result(
+    event: dict[str, Any],
+    *,
+    latest_edit: CachedEventRow | None,
+    thread_id: str | None,
+    cached_at: float | None,
+    runtime_started_at: float | None,
+) -> SnapshotLookupResult:
+    """Resolve one cached event and optional edit into a visible snapshot outcome."""
+    latest_event = latest_edit.event if latest_edit is not None else event
+    visible_cached_at = latest_edit.cached_at if latest_edit is not None else cached_at
+    if (
+        thread_id is None
+        and runtime_started_at is not None
+        and (visible_cached_at is None or visible_cached_at < runtime_started_at)
+    ):
+        return SnapshotLookupResult(snapshot=None, stop_scanning=True)
+
+    timestamp = latest_event.get("origin_server_ts")
+    if not isinstance(timestamp, int) or isinstance(timestamp, bool):
+        return SnapshotLookupResult(snapshot=None)
+    content = latest_event.get("content")
+    visible_content = visible_content_from_content(content) if isinstance(content, dict) else {}
+    return SnapshotLookupResult(
+        snapshot=AgentMessageSnapshot(
+            content=visible_content,
+            origin_server_ts=timestamp,
+        ),
+    )

--- a/src/mindroom/matrix/cache/event_cache.py
+++ b/src/mindroom/matrix/cache/event_cache.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from .agent_message_snapshot import AgentMessageSnapshot
@@ -24,6 +24,7 @@ class EventCacheBackendUnavailableError(RuntimeError):
     """Raised when cache storage is temporarily unreachable but not logically corrupt."""
 
 
+@runtime_checkable
 class ConversationEventCache(Protocol):
     """Storage-agnostic cache API for Matrix event and thread lookups."""
 

--- a/src/mindroom/matrix/cache/event_cache_events.py
+++ b/src/mindroom/matrix/cache/event_cache_events.py
@@ -1,0 +1,188 @@
+"""Backend-neutral event values and index decisions for durable Matrix caches."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from mindroom.matrix.event_info import EventInfo
+
+_EDITABLE_EVENT_TYPES = frozenset({"m.room.message", "io.mindroom.tool_approval"})
+
+type _CachedEventValue = tuple[str, dict[str, Any]]
+
+
+@dataclass(frozen=True, slots=True)
+class SerializedCachedEvent:
+    """One normalized cached event plus its serialized storage values."""
+
+    event_id: str
+    origin_server_ts: int
+    event_json: str
+    event: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class CachedEventRow:
+    """One cached event payload plus the time its visible row was written."""
+
+    event: dict[str, Any]
+    cached_at: float | None
+
+
+@dataclass(frozen=True, slots=True)
+class _EventThreadRow:
+    """One backend-neutral event-to-thread index row."""
+
+    room_id: str
+    event_id: str
+    thread_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class _EventEditRow:
+    """One backend-neutral event-edit index row."""
+
+    edit_event_id: str
+    room_id: str
+    original_event_id: str
+    origin_server_ts: int
+
+
+def event_id_for_cache(event: dict[str, Any]) -> str:
+    """Return the required event ID from one normalized cached event."""
+    event_id = event.get("event_id")
+    if isinstance(event_id, str) and event_id:
+        return event_id
+    msg = "Cached Matrix event is missing event_id"
+    raise ValueError(msg)
+
+
+def _event_timestamp_for_cache(event: dict[str, Any]) -> int:
+    """Return the required origin-server timestamp from one normalized cached event."""
+    timestamp = event.get("origin_server_ts")
+    if isinstance(timestamp, int) and not isinstance(timestamp, bool):
+        return timestamp
+    msg = f"Cached Matrix event {event_id_for_cache(event)} is missing origin_server_ts"
+    raise ValueError(msg)
+
+
+def serialize_cached_event(event_id: str, event: dict[str, Any]) -> SerializedCachedEvent:
+    """Return the storage values for one normalized cached event."""
+    return SerializedCachedEvent(
+        event_id=event_id,
+        origin_server_ts=_event_timestamp_for_cache(event),
+        event_json=json.dumps(event, separators=(",", ":")),
+        event=event,
+    )
+
+
+def serialize_cacheable_events(cacheable_events: list[_CachedEventValue]) -> list[SerializedCachedEvent]:
+    """Return serialized storage values for normalized cacheable events."""
+    return [serialize_cached_event(event_id, event) for event_id, event in cacheable_events]
+
+
+def event_redaction_candidate_ids(event_id: str, event: dict[str, Any]) -> frozenset[str]:
+    """Return IDs whose tombstones would prevent caching one event."""
+    candidate_ids = {event_id}
+    event_info = EventInfo.from_event(event)
+    if event_info.is_edit and isinstance(event_info.original_event_id, str):
+        candidate_ids.add(event_info.original_event_id)
+    return frozenset(candidate_ids)
+
+
+def batch_redaction_candidate_ids(events: list[_CachedEventValue]) -> frozenset[str]:
+    """Return IDs whose tombstones would prevent caching any event in a batch."""
+    return frozenset(
+        candidate_id for event_id, event in events for candidate_id in event_redaction_candidate_ids(event_id, event)
+    )
+
+
+def filter_redacted_events(
+    events: list[_CachedEventValue],
+    *,
+    redacted_event_ids: frozenset[str],
+) -> list[_CachedEventValue]:
+    """Drop events that are tombstoned or edit a tombstoned original."""
+    if not redacted_event_ids:
+        return events
+    return [
+        (event_id, event)
+        for event_id, event in events
+        if event_redaction_candidate_ids(event_id, event).isdisjoint(redacted_event_ids)
+    ]
+
+
+def redaction_removal_event_ids(event_id: str, dependent_edit_ids: list[str]) -> list[str]:
+    """Return the deduplicated event IDs removed by one redaction."""
+    return list(dict.fromkeys([event_id, *dependent_edit_ids]))
+
+
+def cache_rows_were_deleted(*row_counts: int) -> bool:
+    """Return whether a redaction deleted at least one cached row."""
+    return any(row_count > 0 for row_count in row_counts)
+
+
+def _event_thread_row(room_id: str, event: dict[str, Any]) -> _EventThreadRow | None:
+    """Return an event-to-thread row when thread membership is explicit."""
+    event_id = event.get("event_id")
+    if not isinstance(event_id, str) or not event_id:
+        return None
+    event_info = EventInfo.from_event(event)
+    thread_id = event_info.thread_id
+    if not isinstance(thread_id, str):
+        thread_id = event_info.thread_id_from_edit
+    if not isinstance(thread_id, str) or not thread_id:
+        return None
+    return _EventThreadRow(room_id=room_id, event_id=event_id, thread_id=thread_id)
+
+
+def _with_thread_root_self_rows(thread_rows: list[_EventThreadRow]) -> list[_EventThreadRow]:
+    """Ensure learned thread membership also records each root's own row."""
+    return list(
+        dict.fromkeys(
+            [
+                *thread_rows,
+                *(
+                    _EventThreadRow(room_id=row.room_id, event_id=row.thread_id, thread_id=row.thread_id)
+                    for row in thread_rows
+                ),
+            ],
+        ),
+    )
+
+
+def _event_edit_row(room_id: str, event: dict[str, Any]) -> _EventEditRow | None:
+    """Return an edit-index row when one cached event is an editable replacement."""
+    if event.get("type") not in _EDITABLE_EVENT_TYPES:
+        return None
+    event_info = EventInfo.from_event(event)
+    if not event_info.is_edit or not isinstance(event_info.original_event_id, str):
+        return None
+    return _EventEditRow(
+        edit_event_id=event_id_for_cache(event),
+        room_id=room_id,
+        original_event_id=event_info.original_event_id,
+        origin_server_ts=_event_timestamp_for_cache(event),
+    )
+
+
+def event_edit_rows(room_id: str, events: list[SerializedCachedEvent]) -> list[_EventEditRow]:
+    """Return the edit-index rows derived from serialized events."""
+    return [row for event in events if (row := _event_edit_row(room_id, event.event)) is not None]
+
+
+def event_thread_rows(
+    room_id: str,
+    events: list[SerializedCachedEvent],
+    *,
+    thread_id: str | None,
+) -> list[_EventThreadRow]:
+    """Return root-complete event-to-thread rows derived from serialized events."""
+    rows = (
+        [_EventThreadRow(room_id=room_id, event_id=event.event_id, thread_id=thread_id) for event in events]
+        if thread_id is not None
+        else [row for event in events if (row := _event_thread_row(room_id, event.event)) is not None]
+    )
+    return _with_thread_root_self_rows(rows)

--- a/src/mindroom/matrix/cache/postgres_agent_message_snapshot.py
+++ b/src/mindroom/matrix/cache/postgres_agent_message_snapshot.py
@@ -3,52 +3,22 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import psycopg
 
-from mindroom.matrix.event_info import EventInfo
-from mindroom.matrix.visible_body import visible_content_from_content
-
 from . import postgres_event_cache_events, postgres_event_cache_threads
 from .agent_message_snapshot import AgentMessageSnapshot, AgentMessageSnapshotUnavailable
-from .thread_cache_helpers import thread_cache_rejection_reason
+from .agent_message_snapshot_semantics import (
+    SnapshotLookupResult,
+    event_matches_snapshot_scope,
+    snapshot_event_id,
+    snapshot_lookup_result,
+    thread_cache_has_no_snapshot,
+)
 
 if TYPE_CHECKING:
     from psycopg import AsyncConnection, AsyncCursor
-
-
-@dataclass(frozen=True, slots=True)
-class _SnapshotLookupResult:
-    """Outcome for one matching scope event during latest-message lookup."""
-
-    snapshot: AgentMessageSnapshot | None
-    stop_scanning: bool = False
-
-
-_THREAD_CACHE_REJECTION_NONE_REASONS = frozenset({"no_cache_state", "cache_never_validated"})
-
-
-def _visible_content(event: dict[str, Any]) -> dict[str, Any]:
-    content = event.get("content")
-    if not isinstance(content, dict):
-        return {}
-    return visible_content_from_content(content)
-
-
-def _event_matches_scope(
-    event: dict[str, Any],
-    *,
-    thread_id: str | None,
-    sender: str,
-) -> bool:
-    if event.get("type") != "m.room.message" or event.get("sender") != sender:
-        return False
-    relation_type = EventInfo.from_event(event).relation_type
-    if relation_type == "m.replace":
-        return False
-    return not (thread_id is None and relation_type == "m.thread")
 
 
 async def _thread_scope_has_no_snapshot(
@@ -61,7 +31,7 @@ async def _thread_scope_has_no_snapshot(
     if thread_id is None:
         return False
 
-    rejection_reason = thread_cache_rejection_reason(
+    return thread_cache_has_no_snapshot(
         await postgres_event_cache_threads.load_thread_cache_state(
             db,
             namespace=namespace,
@@ -69,12 +39,6 @@ async def _thread_scope_has_no_snapshot(
             thread_id=thread_id,
         ),
     )
-    if rejection_reason in _THREAD_CACHE_REJECTION_NONE_REASONS:
-        return True
-    if rejection_reason is not None:
-        msg = f"Thread cache snapshot is not usable: {rejection_reason}"
-        raise AgentMessageSnapshotUnavailable(msg)
-    return False
 
 
 async def _snapshot_from_event(
@@ -86,10 +50,10 @@ async def _snapshot_from_event(
     event: dict[str, Any],
     cached_at: float | None,
     runtime_started_at: float | None,
-) -> _SnapshotLookupResult:
-    event_id = event.get("event_id")
-    if not isinstance(event_id, str) or not event_id:
-        return _SnapshotLookupResult(snapshot=None)
+) -> SnapshotLookupResult:
+    event_id = snapshot_event_id(event)
+    if event_id is None:
+        return SnapshotLookupResult(snapshot=None)
 
     latest_edit = await postgres_event_cache_events.load_latest_edit_row(
         db,
@@ -97,24 +61,12 @@ async def _snapshot_from_event(
         room_id=room_id,
         original_event_id=event_id,
     )
-    latest_event = latest_edit.event if latest_edit is not None else event
-    visible_cached_at = latest_edit.cached_at if latest_edit is not None else cached_at
-    if (
-        thread_id is None
-        and runtime_started_at is not None
-        and (visible_cached_at is None or visible_cached_at < runtime_started_at)
-    ):
-        return _SnapshotLookupResult(snapshot=None, stop_scanning=True)
-
-    timestamp = latest_event.get("origin_server_ts")
-    if not isinstance(timestamp, int) or isinstance(timestamp, bool):
-        return _SnapshotLookupResult(snapshot=None)
-
-    return _SnapshotLookupResult(
-        snapshot=AgentMessageSnapshot(
-            content=_visible_content(latest_event),
-            origin_server_ts=timestamp,
-        ),
+    return snapshot_lookup_result(
+        event,
+        latest_edit=latest_edit,
+        thread_id=thread_id,
+        cached_at=cached_at,
+        runtime_started_at=runtime_started_at,
     )
 
 
@@ -167,7 +119,7 @@ async def _load_scope_snapshot(
             if row is None:
                 return None
             event = json.loads(row[0])
-            if not _event_matches_scope(
+            if not event_matches_snapshot_scope(
                 event,
                 thread_id=thread_id,
                 sender=sender,

--- a/src/mindroom/matrix/cache/postgres_agent_message_snapshot.py
+++ b/src/mindroom/matrix/cache/postgres_agent_message_snapshot.py
@@ -47,6 +47,7 @@ async def _snapshot_from_event(
     namespace: str,
     room_id: str,
     thread_id: str | None,
+    sender: str,
     event: dict[str, Any],
     cached_at: float | None,
     runtime_started_at: float | None,
@@ -60,6 +61,7 @@ async def _snapshot_from_event(
         namespace=namespace,
         room_id=room_id,
         original_event_id=event_id,
+        sender=sender,
     )
     return snapshot_lookup_result(
         event,
@@ -130,6 +132,7 @@ async def _load_scope_snapshot(
                 namespace=namespace,
                 room_id=room_id,
                 thread_id=thread_id,
+                sender=sender,
                 event=event,
                 cached_at=None if row[1] is None else float(row[1]),
                 runtime_started_at=runtime_started_at,

--- a/src/mindroom/matrix/cache/postgres_event_cache.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache.py
@@ -20,6 +20,7 @@ from .event_cache import EventCacheBackendUnavailableError
 from .event_normalization import normalize_event_source_for_cache
 from .postgres_agent_message_snapshot import load_postgres_agent_message_snapshot
 from .postgres_redaction import redact_postgres_connection_info
+from .thread_cache_state import replacement_validated_at
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Awaitable, Callable
@@ -1016,7 +1017,10 @@ class PostgresEventCache:
         validated_at: float | None = None,
     ) -> bool:
         """Replace one cached thread snapshot only when nothing newer touched it after fetch start."""
-        replacement_validated_at = fetch_started_at if validated_at is None else min(validated_at, fetch_started_at)
+        replacement_timestamp = replacement_validated_at(
+            fetch_started_at=fetch_started_at,
+            validated_at=validated_at,
+        )
 
         async def replace_if_still_safe(db: psycopg.AsyncConnection) -> bool:
             return await postgres_event_cache_threads.replace_thread_locked_if_not_newer(
@@ -1026,7 +1030,7 @@ class PostgresEventCache:
                 thread_id=thread_id,
                 events=events,
                 fetch_started_at=fetch_started_at,
-                validated_at=replacement_validated_at,
+                validated_at=replacement_timestamp,
             )
 
         return bool(

--- a/src/mindroom/matrix/cache/postgres_event_cache_events.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache_events.py
@@ -125,6 +125,7 @@ async def load_latest_edit_row(
     namespace: str,
     room_id: str,
     original_event_id: str,
+    sender: str,
 ) -> CachedEventRow | None:
     """Return the latest cached edit event plus its lookup-row write time."""
     row = await fetchone(
@@ -138,10 +139,11 @@ async def load_latest_edit_row(
         WHERE mindroom_event_cache_event_edits.namespace = %s
             AND mindroom_event_cache_event_edits.room_id = %s
             AND mindroom_event_cache_event_edits.original_event_id = %s
+            AND mindroom_event_cache_events.event_json::jsonb ->> 'sender' = %s
         ORDER BY mindroom_event_cache_event_edits.origin_server_ts DESC, mindroom_event_cache_events.write_seq DESC
         LIMIT 1
         """,
-        (namespace, room_id, original_event_id),
+        (namespace, room_id, original_event_id, sender),
     )
     if row is None:
         return None

--- a/src/mindroom/matrix/cache/postgres_event_cache_events.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache_events.py
@@ -3,71 +3,24 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from mindroom.matrix.event_info import EventInfo
-
+from .event_cache_events import (
+    CachedEventRow,
+    SerializedCachedEvent,
+    batch_redaction_candidate_ids,
+    cache_rows_were_deleted,
+    event_edit_rows,
+    event_redaction_candidate_ids,
+    event_thread_rows,
+    filter_redacted_events,
+    redaction_removal_event_ids,
+    serialize_cacheable_events,
+)
 from .postgres_cursor import fetchall, fetchone, rowcount
 
 if TYPE_CHECKING:
     from psycopg import AsyncConnection
-
-
-_EDITABLE_EVENT_TYPES = frozenset({"m.room.message", "io.mindroom.tool_approval"})
-
-
-@dataclass(frozen=True, slots=True)
-class _SerializedCachedEvent:
-    """One normalized cached event plus its serialized storage row."""
-
-    event_id: str
-    origin_server_ts: int
-    event_json: str
-    event: dict[str, Any]
-
-
-@dataclass(frozen=True, slots=True)
-class _CachedEventRow:
-    """One cached event payload plus the time its visible row was written."""
-
-    event: dict[str, Any]
-    cached_at: float | None
-
-
-def event_id_for_cache(event: dict[str, Any]) -> str:
-    """Return the required event ID from one normalized cached event."""
-    event_id = event.get("event_id")
-    if isinstance(event_id, str) and event_id:
-        return event_id
-    msg = "Cached Matrix event is missing event_id"
-    raise ValueError(msg)
-
-
-def _event_timestamp_for_cache(event: dict[str, Any]) -> int:
-    """Return the required origin-server timestamp from one normalized cached event."""
-    timestamp = event.get("origin_server_ts")
-    if isinstance(timestamp, int) and not isinstance(timestamp, bool):
-        return timestamp
-    msg = f"Cached Matrix event {event_id_for_cache(event)} is missing origin_server_ts"
-    raise ValueError(msg)
-
-
-def serialize_cached_event(event_id: str, event: dict[str, Any]) -> _SerializedCachedEvent:
-    """Serialize one normalized cached event for PostgreSQL writes."""
-    return _SerializedCachedEvent(
-        event_id=event_id,
-        origin_server_ts=_event_timestamp_for_cache(event),
-        event_json=json.dumps(event, separators=(",", ":")),
-        event=event,
-    )
-
-
-def serialize_cacheable_events(
-    cacheable_events: list[tuple[str, dict[str, Any]]],
-) -> list[_SerializedCachedEvent]:
-    """Serialize one batch of normalized cacheable events."""
-    return [serialize_cached_event(event_id, event) for event_id, event in cacheable_events]
 
 
 async def load_event(
@@ -172,7 +125,7 @@ async def load_latest_edit_row(
     namespace: str,
     room_id: str,
     original_event_id: str,
-) -> _CachedEventRow | None:
+) -> CachedEventRow | None:
     """Return the latest cached edit event plus its lookup-row write time."""
     row = await fetchone(
         db,
@@ -192,7 +145,7 @@ async def load_latest_edit_row(
     )
     if row is None:
         return None
-    return _CachedEventRow(
+    return CachedEventRow(
         event=json.loads(row[0]),
         cached_at=None if row[1] is None else float(row[1]),
     )
@@ -293,7 +246,7 @@ async def redact_event_locked(
         room_id,
         original_event_id=event_id,
     )
-    removed_event_ids = list(dict.fromkeys([event_id, *dependent_edit_ids]))
+    removed_event_ids = redaction_removal_event_ids(event_id, dependent_edit_ids)
     deleted_thread_rows = await _delete_room_thread_events(
         db,
         namespace,
@@ -320,7 +273,12 @@ async def redact_event_locked(
         room_id,
         event_ids=removed_event_ids,
     )
-    return deleted_thread_rows > 0 or deleted_event_rows > 0 or deleted_edit_rows > 0 or deleted_thread_index_rows > 0
+    return cache_rows_were_deleted(
+        deleted_thread_rows,
+        deleted_event_rows,
+        deleted_edit_rows,
+        deleted_thread_index_rows,
+    )
 
 
 async def event_or_original_is_redacted(
@@ -332,16 +290,12 @@ async def event_or_original_is_redacted(
     event: dict[str, Any],
 ) -> bool:
     """Return whether this event or its edited original was durably redacted."""
-    event_info = EventInfo.from_event(event)
-    candidate_ids = {event_id}
-    if event_info.is_edit and isinstance(event_info.original_event_id, str):
-        candidate_ids.add(event_info.original_event_id)
     return bool(
         await _redacted_event_ids_for_candidates(
             db,
             namespace,
             room_id,
-            event_ids=candidate_ids,
+            event_ids=event_redaction_candidate_ids(event_id, event),
         ),
     )
 
@@ -353,31 +307,13 @@ async def filter_cacheable_events(
     room_events: list[tuple[str, dict[str, Any]]],
 ) -> list[tuple[str, dict[str, Any]]]:
     """Drop events that target durable redaction tombstones before persisting them."""
-    candidate_ids: set[str] = set()
-    for event_id, event_data in room_events:
-        candidate_ids.add(event_id)
-        event_info = EventInfo.from_event(event_data)
-        if event_info.is_edit and isinstance(event_info.original_event_id, str):
-            candidate_ids.add(event_info.original_event_id)
     redacted_event_ids = await _redacted_event_ids_for_candidates(
         db,
         namespace,
         room_id,
-        event_ids=candidate_ids,
+        event_ids=batch_redaction_candidate_ids(room_events),
     )
-    if not redacted_event_ids:
-        return room_events
-
-    cacheable_events: list[tuple[str, dict[str, Any]]] = []
-    for event_id, event_data in room_events:
-        event_info = EventInfo.from_event(event_data)
-        original_event_id = event_info.original_event_id if event_info.is_edit else None
-        if event_id in redacted_event_ids:
-            continue
-        if isinstance(original_event_id, str) and original_event_id in redacted_event_ids:
-            continue
-        cacheable_events.append((event_id, event_data))
-    return cacheable_events
+    return filter_redacted_events(room_events, redacted_event_ids=redacted_event_ids)
 
 
 async def write_lookup_index_rows(
@@ -385,7 +321,7 @@ async def write_lookup_index_rows(
     *,
     namespace: str,
     room_id: str,
-    serialized_events: list[_SerializedCachedEvent],
+    serialized_events: list[SerializedCachedEvent],
     cached_at: float,
     thread_id: str | None = None,
 ) -> None:
@@ -414,11 +350,7 @@ async def write_lookup_index_rows(
             ),
         )
 
-    edit_rows = [
-        row
-        for row in (_edit_cache_row(namespace, room_id, event.event) for event in serialized_events)
-        if row is not None
-    ]
+    edit_rows = event_edit_rows(room_id, serialized_events)
     for row in edit_rows:
         await db.execute(
             """
@@ -429,20 +361,12 @@ async def write_lookup_index_rows(
                 original_event_id = excluded.original_event_id,
                 origin_server_ts = excluded.origin_server_ts
             """,
-            row,
+            (namespace, row.edit_event_id, row.room_id, row.original_event_id, row.origin_server_ts),
         )
 
-    thread_rows = (
-        [(namespace, room_id, event.event_id, thread_id) for event in serialized_events]
-        if thread_id is not None
-        else [
-            row
-            for row in (_event_thread_row(namespace, room_id, event.event) for event in serialized_events)
-            if row is not None
-        ]
-    )
+    thread_rows = event_thread_rows(room_id, serialized_events, thread_id=thread_id)
     if thread_rows:
-        for row in _with_thread_root_self_rows(thread_rows):
+        for row in thread_rows:
             await db.execute(
                 """
                 INSERT INTO mindroom_event_cache_event_threads(namespace, room_id, event_id, thread_id)
@@ -450,7 +374,7 @@ async def write_lookup_index_rows(
                 ON CONFLICT(namespace, room_id, event_id) DO UPDATE SET
                     thread_id = excluded.thread_id
                 """,
-                row,
+                (namespace, row.room_id, row.event_id, row.thread_id),
             )
 
 
@@ -544,61 +468,6 @@ async def delete_event_edit_rows(
     return deleted_rows
 
 
-def _event_thread_row(
-    namespace: str,
-    room_id: str,
-    event: dict[str, Any],
-) -> tuple[str, str, str, str] | None:
-    """Return one durable event-to-thread mapping row when thread membership is explicit."""
-    event_id = event.get("event_id")
-    if not isinstance(event_id, str) or not event_id:
-        return None
-    event_info = EventInfo.from_event(event)
-    thread_id = event_info.thread_id
-    if not isinstance(thread_id, str):
-        thread_id = event_info.thread_id_from_edit
-    if not isinstance(thread_id, str) or not thread_id:
-        return None
-    return namespace, room_id, event_id, thread_id
-
-
-def _with_thread_root_self_rows(
-    thread_rows: list[tuple[str, str, str, str]],
-) -> list[tuple[str, str, str, str]]:
-    """Ensure any learned thread membership also records the root's own lookup row."""
-    if not thread_rows:
-        return thread_rows
-    return list(
-        dict.fromkeys(
-            [
-                *thread_rows,
-                *(
-                    (namespace, room_id, thread_id, thread_id)
-                    for namespace, room_id, _event_id, thread_id in thread_rows
-                ),
-            ],
-        ),
-    )
-
-
-def _edit_cache_row(namespace: str, room_id: str, event: dict[str, Any]) -> tuple[str, str, str, str, int] | None:
-    """Return one edit-index row for a cached event when it is an edit."""
-    if event.get("type") not in _EDITABLE_EVENT_TYPES:
-        return None
-
-    event_info = EventInfo.from_event(event)
-    if not event_info.is_edit or not isinstance(event_info.original_event_id, str):
-        return None
-
-    return (
-        namespace,
-        event_id_for_cache(event),
-        room_id,
-        event_info.original_event_id,
-        _event_timestamp_for_cache(event),
-    )
-
-
 async def _delete_room_thread_events(
     db: AsyncConnection,
     namespace: str,
@@ -643,7 +512,7 @@ async def _redacted_event_ids_for_candidates(
     namespace: str,
     room_id: str,
     *,
-    event_ids: set[str],
+    event_ids: frozenset[str],
 ) -> frozenset[str]:
     """Return the subset of candidate event IDs that are durably tombstoned."""
     if not event_ids:

--- a/src/mindroom/matrix/cache/postgres_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache_threads.py
@@ -6,32 +6,28 @@ import json
 import time
 from typing import TYPE_CHECKING, Any
 
-from .event_cache import ThreadCacheState
+from .event_cache_events import event_id_for_cache, serialize_cacheable_events, serialize_cached_event
 from .event_normalization import normalize_event_source_for_cache
 from .postgres_cursor import fetchall, fetchone
 from .postgres_event_cache_events import (
     delete_cached_events,
     delete_event_edit_rows,
     delete_event_thread_rows,
-    event_id_for_cache,
     event_or_original_is_redacted,
     filter_cacheable_events,
-    serialize_cacheable_events,
-    serialize_cached_event,
     write_lookup_index_rows,
+)
+from .thread_cache_state import (
+    ThreadCacheStateRow,
+    can_revalidate_after_incremental_update,
+    thread_cache_state_changed_after,
+    thread_cache_state_row,
 )
 
 if TYPE_CHECKING:
     from psycopg import AsyncConnection
 
-
-_INCREMENTAL_THREAD_REVALIDATION_REASONS = frozenset(
-    {
-        "live_thread_mutation",
-        "sync_thread_mutation",
-        "outbound_thread_mutation",
-    },
-)
+    from .event_cache import ThreadCacheState
 
 
 async def load_thread_events(
@@ -86,7 +82,7 @@ async def _load_thread_cache_state_row(
     namespace: str,
     room_id: str,
     thread_id: str,
-) -> tuple[float | None, float | None, str | None, float | None, str | None] | None:
+) -> ThreadCacheStateRow | None:
     """Return one raw thread-cache-state row joined with room invalidation state."""
     row = await fetchone(
         db,
@@ -108,15 +104,7 @@ async def _load_thread_cache_state_row(
         """,
         (namespace, room_id, thread_id),
     )
-    if row is None or all(value is None for value in row):
-        return None
-    return (
-        None if row[0] is None else float(row[0]),
-        None if row[1] is None else float(row[1]),
-        row[2] if isinstance(row[2], str) else None,
-        None if row[3] is None else float(row[3]),
-        row[4] if isinstance(row[4], str) else None,
-    )
+    return thread_cache_state_row(row)
 
 
 async def load_thread_cache_state(
@@ -135,13 +123,7 @@ async def load_thread_cache_state(
     )
     if row is None:
         return None
-    return ThreadCacheState(
-        validated_at=row[0],
-        invalidated_at=row[1],
-        invalidation_reason=row[2],
-        room_invalidated_at=row[3],
-        room_invalidation_reason=row[4],
-    )
+    return row.as_public_state()
 
 
 async def _store_thread_events_locked(
@@ -257,21 +239,6 @@ async def _replace_thread_locked(
     )
 
 
-def _thread_cache_state_changed_after(
-    cache_state_row: tuple[float | None, float | None, str | None, float | None, str | None] | None,
-    *,
-    fetch_started_at: float,
-) -> bool:
-    """Return whether this thread or room cache state changed after one fetch began."""
-    if cache_state_row is None:
-        return False
-    validated_at, invalidated_at, _invalidation_reason, room_invalidated_at, _room_invalidation_reason = cache_state_row
-    return any(
-        timestamp is not None and timestamp > fetch_started_at
-        for timestamp in (validated_at, invalidated_at, room_invalidated_at)
-    )
-
-
 async def replace_thread_locked_if_not_newer(
     db: AsyncConnection,
     *,
@@ -289,7 +256,7 @@ async def replace_thread_locked_if_not_newer(
         room_id=room_id,
         thread_id=thread_id,
     )
-    if _thread_cache_state_changed_after(cache_state_row, fetch_started_at=fetch_started_at):
+    if thread_cache_state_changed_after(cache_state_row, fetch_started_at=fetch_started_at):
         return False
     await _replace_thread_locked(
         db,
@@ -447,16 +414,7 @@ async def revalidate_thread_after_incremental_update_locked(
         room_id=room_id,
         thread_id=thread_id,
     )
-    if row is None:
-        return False
-    validated_at, invalidated_at, invalidation_reason, room_invalidated_at, _room_invalidation_reason = row
-    can_revalidate = (
-        validated_at is not None
-        and invalidated_at is not None
-        and invalidation_reason in _INCREMENTAL_THREAD_REVALIDATION_REASONS
-        and not (room_invalidated_at is not None and room_invalidated_at >= validated_at)
-    )
-    if not can_revalidate:
+    if not can_revalidate_after_incremental_update(row):
         return False
     await db.execute(
         """

--- a/src/mindroom/matrix/cache/sqlite_agent_message_snapshot.py
+++ b/src/mindroom/matrix/cache/sqlite_agent_message_snapshot.py
@@ -4,50 +4,20 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
-
-from mindroom.matrix.event_info import EventInfo
-from mindroom.matrix.visible_body import visible_content_from_content
 
 from . import sqlite_event_cache_events, sqlite_event_cache_threads
 from .agent_message_snapshot import AgentMessageSnapshot, AgentMessageSnapshotUnavailable
-from .thread_cache_helpers import thread_cache_rejection_reason
+from .agent_message_snapshot_semantics import (
+    SnapshotLookupResult,
+    event_matches_snapshot_scope,
+    snapshot_event_id,
+    snapshot_lookup_result,
+    thread_cache_has_no_snapshot,
+)
 
 if TYPE_CHECKING:
     import aiosqlite
-
-
-@dataclass(frozen=True, slots=True)
-class _SnapshotLookupResult:
-    """Outcome for one matching scope event during latest-message lookup."""
-
-    snapshot: AgentMessageSnapshot | None
-    stop_scanning: bool = False
-
-
-_THREAD_CACHE_REJECTION_NONE_REASONS = frozenset({"no_cache_state", "cache_never_validated"})
-
-
-def _visible_content(event: dict[str, Any]) -> dict[str, Any]:
-    content = event.get("content")
-    if not isinstance(content, dict):
-        return {}
-    return visible_content_from_content(content)
-
-
-def _event_matches_scope(
-    event: dict[str, Any],
-    *,
-    thread_id: str | None,
-    sender: str,
-) -> bool:
-    if event.get("type") != "m.room.message" or event.get("sender") != sender:
-        return False
-    relation_type = EventInfo.from_event(event).relation_type
-    if relation_type == "m.replace":
-        return False
-    return not (thread_id is None and relation_type == "m.thread")
 
 
 async def _thread_scope_has_no_snapshot(
@@ -59,19 +29,13 @@ async def _thread_scope_has_no_snapshot(
     if thread_id is None:
         return False
 
-    rejection_reason = thread_cache_rejection_reason(
+    return thread_cache_has_no_snapshot(
         await sqlite_event_cache_threads.load_thread_cache_state(
             db,
             room_id=room_id,
             thread_id=thread_id,
         ),
     )
-    if rejection_reason in _THREAD_CACHE_REJECTION_NONE_REASONS:
-        return True
-    if rejection_reason is not None:
-        msg = f"Thread cache snapshot is not usable: {rejection_reason}"
-        raise AgentMessageSnapshotUnavailable(msg)
-    return False
 
 
 async def _snapshot_from_event(
@@ -82,34 +46,22 @@ async def _snapshot_from_event(
     event: dict[str, Any],
     cached_at: float | None,
     runtime_started_at: float | None,
-) -> _SnapshotLookupResult:
-    event_id = event.get("event_id")
-    if not isinstance(event_id, str) or not event_id:
-        return _SnapshotLookupResult(snapshot=None)
+) -> SnapshotLookupResult:
+    event_id = snapshot_event_id(event)
+    if event_id is None:
+        return SnapshotLookupResult(snapshot=None)
 
     latest_edit = await sqlite_event_cache_events.load_latest_edit_row(
         db,
         room_id=room_id,
         original_event_id=event_id,
     )
-    latest_event = latest_edit.event if latest_edit is not None else event
-    visible_cached_at = latest_edit.cached_at if latest_edit is not None else cached_at
-    if (
-        thread_id is None
-        and runtime_started_at is not None
-        and (visible_cached_at is None or visible_cached_at < runtime_started_at)
-    ):
-        return _SnapshotLookupResult(snapshot=None, stop_scanning=True)
-
-    timestamp = latest_event.get("origin_server_ts")
-    if not isinstance(timestamp, int) or isinstance(timestamp, bool):
-        return _SnapshotLookupResult(snapshot=None)
-
-    return _SnapshotLookupResult(
-        snapshot=AgentMessageSnapshot(
-            content=_visible_content(latest_event),
-            origin_server_ts=timestamp,
-        ),
+    return snapshot_lookup_result(
+        event,
+        latest_edit=latest_edit,
+        thread_id=thread_id,
+        cached_at=cached_at,
+        runtime_started_at=runtime_started_at,
     )
 
 
@@ -159,7 +111,7 @@ async def _load_scope_snapshot(
             if row is None:
                 return None
             event = json.loads(row[0])
-            if not _event_matches_scope(
+            if not event_matches_snapshot_scope(
                 event,
                 thread_id=thread_id,
                 sender=sender,

--- a/src/mindroom/matrix/cache/sqlite_agent_message_snapshot.py
+++ b/src/mindroom/matrix/cache/sqlite_agent_message_snapshot.py
@@ -43,6 +43,7 @@ async def _snapshot_from_event(
     *,
     room_id: str,
     thread_id: str | None,
+    sender: str,
     event: dict[str, Any],
     cached_at: float | None,
     runtime_started_at: float | None,
@@ -55,6 +56,7 @@ async def _snapshot_from_event(
         db,
         room_id=room_id,
         original_event_id=event_id,
+        sender=sender,
     )
     return snapshot_lookup_result(
         event,
@@ -121,6 +123,7 @@ async def _load_scope_snapshot(
                 db,
                 room_id=room_id,
                 thread_id=thread_id,
+                sender=sender,
                 event=event,
                 cached_at=None if row[1] is None else float(row[1]),
                 runtime_started_at=runtime_started_at,

--- a/src/mindroom/matrix/cache/sqlite_event_cache.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache.py
@@ -18,6 +18,7 @@ from . import sqlite_event_cache_events, sqlite_event_cache_threads
 from .event_batching import group_lookup_events_by_room
 from .event_normalization import normalize_event_source_for_cache
 from .sqlite_agent_message_snapshot import load_sqlite_agent_message_snapshot
+from .thread_cache_state import replacement_validated_at
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Awaitable, Callable
@@ -637,7 +638,10 @@ class SqliteEventCache:
         validated_at: float | None = None,
     ) -> bool:
         """Replace one cached thread snapshot only when nothing newer touched it after fetch start."""
-        replacement_validated_at = fetch_started_at if validated_at is None else min(validated_at, fetch_started_at)
+        replacement_timestamp = replacement_validated_at(
+            fetch_started_at=fetch_started_at,
+            validated_at=validated_at,
+        )
 
         async def replace_if_still_safe(db: aiosqlite.Connection) -> bool:
             return await sqlite_event_cache_threads.replace_thread_locked_if_not_newer(
@@ -646,7 +650,7 @@ class SqliteEventCache:
                 thread_id=thread_id,
                 events=events,
                 fetch_started_at=fetch_started_at,
-                validated_at=replacement_validated_at,
+                validated_at=replacement_timestamp,
             )
 
         return bool(

--- a/src/mindroom/matrix/cache/sqlite_event_cache_events.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache_events.py
@@ -3,68 +3,23 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from mindroom.matrix.event_info import EventInfo
+from .event_cache_events import (
+    CachedEventRow,
+    SerializedCachedEvent,
+    batch_redaction_candidate_ids,
+    cache_rows_were_deleted,
+    event_edit_rows,
+    event_redaction_candidate_ids,
+    event_thread_rows,
+    filter_redacted_events,
+    redaction_removal_event_ids,
+    serialize_cacheable_events,
+)
 
 if TYPE_CHECKING:
     import aiosqlite
-
-_EDITABLE_EVENT_TYPES = frozenset({"m.room.message", "io.mindroom.tool_approval"})
-
-
-@dataclass(frozen=True, slots=True)
-class _SerializedCachedEvent:
-    """One normalized cached event plus its serialized storage row."""
-
-    event_id: str
-    origin_server_ts: int
-    event_json: str
-    event: dict[str, Any]
-
-
-@dataclass(frozen=True, slots=True)
-class _CachedEventRow:
-    """One cached event payload plus the time its visible row was written."""
-
-    event: dict[str, Any]
-    cached_at: float | None
-
-
-def event_id_for_cache(event: dict[str, Any]) -> str:
-    """Return the required event ID from one normalized cached event."""
-    event_id = event.get("event_id")
-    if isinstance(event_id, str) and event_id:
-        return event_id
-    msg = "Cached Matrix event is missing event_id"
-    raise ValueError(msg)
-
-
-def _event_timestamp_for_cache(event: dict[str, Any]) -> int:
-    """Return the required origin-server timestamp from one normalized cached event."""
-    timestamp = event.get("origin_server_ts")
-    if isinstance(timestamp, int) and not isinstance(timestamp, bool):
-        return timestamp
-    msg = f"Cached Matrix event {event_id_for_cache(event)} is missing origin_server_ts"
-    raise ValueError(msg)
-
-
-def serialize_cached_event(event_id: str, event: dict[str, Any]) -> _SerializedCachedEvent:
-    """Serialize one normalized cached event for SQLite writes."""
-    return _SerializedCachedEvent(
-        event_id=event_id,
-        origin_server_ts=_event_timestamp_for_cache(event),
-        event_json=json.dumps(event, separators=(",", ":")),
-        event=event,
-    )
-
-
-def serialize_cacheable_events(
-    cacheable_events: list[tuple[str, dict[str, Any]]],
-) -> list[_SerializedCachedEvent]:
-    """Serialize one batch of normalized cacheable events."""
-    return [serialize_cached_event(event_id, event) for event_id, event in cacheable_events]
 
 
 async def load_event(
@@ -161,7 +116,7 @@ async def load_latest_edit_row(
     *,
     room_id: str,
     original_event_id: str,
-) -> _CachedEventRow | None:
+) -> CachedEventRow | None:
     """Return the latest cached edit event plus its lookup-row write time."""
     cursor = await db.execute(
         """
@@ -178,7 +133,7 @@ async def load_latest_edit_row(
     await cursor.close()
     if row is None:
         return None
-    return _CachedEventRow(
+    return CachedEventRow(
         event=json.loads(row[0]),
         cached_at=None if row[1] is None else float(row[1]),
     )
@@ -267,7 +222,7 @@ async def redact_event_locked(
 ) -> bool:
     """Delete one cached event after a redaction within an existing transaction."""
     dependent_edit_ids = await _dependent_edit_event_ids(db, room_id, original_event_id=event_id)
-    removed_event_ids = list(dict.fromkeys([event_id, *dependent_edit_ids]))
+    removed_event_ids = redaction_removal_event_ids(event_id, dependent_edit_ids)
     deleted_thread_rows = await _delete_room_thread_events(db, room_id, event_ids=removed_event_ids)
     deleted_event_rows = await delete_cached_events(db, event_ids=removed_event_ids)
     deleted_edit_rows = await delete_event_edit_rows(
@@ -286,7 +241,12 @@ async def redact_event_locked(
         room_id,
         event_ids=removed_event_ids,
     )
-    return deleted_thread_rows > 0 or deleted_event_rows > 0 or deleted_edit_rows > 0 or deleted_thread_index_rows > 0
+    return cache_rows_were_deleted(
+        deleted_thread_rows,
+        deleted_event_rows,
+        deleted_edit_rows,
+        deleted_thread_index_rows,
+    )
 
 
 async def event_or_original_is_redacted(
@@ -297,15 +257,11 @@ async def event_or_original_is_redacted(
     event: dict[str, Any],
 ) -> bool:
     """Return whether this event or its edited original was durably redacted."""
-    event_info = EventInfo.from_event(event)
-    candidate_ids = {event_id}
-    if event_info.is_edit and isinstance(event_info.original_event_id, str):
-        candidate_ids.add(event_info.original_event_id)
     return bool(
         await _redacted_event_ids_for_candidates(
             db,
             room_id,
-            event_ids=candidate_ids,
+            event_ids=event_redaction_candidate_ids(event_id, event),
         ),
     )
 
@@ -316,37 +272,19 @@ async def filter_cacheable_events(
     room_events: list[tuple[str, dict[str, Any]]],
 ) -> list[tuple[str, dict[str, Any]]]:
     """Drop events that target durable redaction tombstones before persisting them."""
-    candidate_ids: set[str] = set()
-    for event_id, event_data in room_events:
-        candidate_ids.add(event_id)
-        event_info = EventInfo.from_event(event_data)
-        if event_info.is_edit and isinstance(event_info.original_event_id, str):
-            candidate_ids.add(event_info.original_event_id)
     redacted_event_ids = await _redacted_event_ids_for_candidates(
         db,
         room_id,
-        event_ids=candidate_ids,
+        event_ids=batch_redaction_candidate_ids(room_events),
     )
-    if not redacted_event_ids:
-        return room_events
-
-    cacheable_events: list[tuple[str, dict[str, Any]]] = []
-    for event_id, event_data in room_events:
-        event_info = EventInfo.from_event(event_data)
-        original_event_id = event_info.original_event_id if event_info.is_edit else None
-        if event_id in redacted_event_ids:
-            continue
-        if isinstance(original_event_id, str) and original_event_id in redacted_event_ids:
-            continue
-        cacheable_events.append((event_id, event_data))
-    return cacheable_events
+    return filter_redacted_events(room_events, redacted_event_ids=redacted_event_ids)
 
 
 async def write_lookup_index_rows(
     db: aiosqlite.Connection,
     *,
     room_id: str,
-    serialized_events: list[_SerializedCachedEvent],
+    serialized_events: list[SerializedCachedEvent],
     cached_at: float,
     thread_id: str | None = None,
 ) -> None:
@@ -374,32 +312,23 @@ async def write_lookup_index_rows(
             for event in serialized_events
         ],
     )
-    edit_rows = [
-        row for row in (_edit_cache_row(room_id, event.event) for event in serialized_events) if row is not None
-    ]
+    edit_rows = event_edit_rows(room_id, serialized_events)
     if edit_rows:
         await db.executemany(
             """
             INSERT OR REPLACE INTO event_edits(edit_event_id, room_id, original_event_id, origin_server_ts)
             VALUES (?, ?, ?, ?)
             """,
-            edit_rows,
+            [(row.edit_event_id, row.room_id, row.original_event_id, row.origin_server_ts) for row in edit_rows],
         )
-    thread_rows = (
-        [(room_id, event.event_id, thread_id) for event in serialized_events]
-        if thread_id is not None
-        else [
-            row for row in (_event_thread_row(room_id, event.event) for event in serialized_events) if row is not None
-        ]
-    )
+    thread_rows = event_thread_rows(room_id, serialized_events, thread_id=thread_id)
     if thread_rows:
-        thread_rows = _with_thread_root_self_rows(thread_rows)
         await db.executemany(
             """
             INSERT OR REPLACE INTO event_threads(room_id, event_id, thread_id)
             VALUES (?, ?, ?)
             """,
-            thread_rows,
+            [(row.room_id, row.event_id, row.thread_id) for row in thread_rows],
         )
 
 
@@ -492,53 +421,6 @@ async def delete_event_edit_rows(
     return deleted_rows
 
 
-def _event_thread_row(room_id: str, event: dict[str, Any]) -> tuple[str, str, str] | None:
-    """Return one durable event-to-thread mapping row when thread membership is explicit."""
-    event_id = event.get("event_id")
-    if not isinstance(event_id, str) or not event_id:
-        return None
-    event_info = EventInfo.from_event(event)
-    thread_id = event_info.thread_id
-    if not isinstance(thread_id, str):
-        thread_id = event_info.thread_id_from_edit
-    if not isinstance(thread_id, str) or not thread_id:
-        return None
-    return room_id, event_id, thread_id
-
-
-def _with_thread_root_self_rows(
-    thread_rows: list[tuple[str, str, str]],
-) -> list[tuple[str, str, str]]:
-    """Ensure any learned thread membership also records the root's own lookup row."""
-    if not thread_rows:
-        return thread_rows
-    return list(
-        dict.fromkeys(
-            [
-                *thread_rows,
-                *((room_id, thread_id, thread_id) for room_id, _event_id, thread_id in thread_rows),
-            ],
-        ),
-    )
-
-
-def _edit_cache_row(room_id: str, event: dict[str, Any]) -> tuple[str, str, str, int] | None:
-    """Return one edit-index row for a cached event when it is an edit."""
-    if event.get("type") not in _EDITABLE_EVENT_TYPES:
-        return None
-
-    event_info = EventInfo.from_event(event)
-    if not event_info.is_edit or not isinstance(event_info.original_event_id, str):
-        return None
-
-    return (
-        event_id_for_cache(event),
-        room_id,
-        event_info.original_event_id,
-        _event_timestamp_for_cache(event),
-    )
-
-
 async def _delete_room_thread_events(
     db: aiosqlite.Connection,
     room_id: str,
@@ -580,7 +462,7 @@ async def _redacted_event_ids_for_candidates(
     db: aiosqlite.Connection,
     room_id: str,
     *,
-    event_ids: set[str],
+    event_ids: frozenset[str],
 ) -> frozenset[str]:
     """Return the subset of candidate event IDs that are durably tombstoned."""
     if not event_ids:

--- a/src/mindroom/matrix/cache/sqlite_event_cache_events.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache_events.py
@@ -116,6 +116,7 @@ async def load_latest_edit_row(
     *,
     room_id: str,
     original_event_id: str,
+    sender: str,
 ) -> CachedEventRow | None:
     """Return the latest cached edit event plus its lookup-row write time."""
     cursor = await db.execute(
@@ -123,11 +124,13 @@ async def load_latest_edit_row(
         SELECT events.event_json, events.cached_at
         FROM event_edits
         JOIN events ON events.event_id = event_edits.edit_event_id
-        WHERE event_edits.room_id = ? AND event_edits.original_event_id = ?
+        WHERE event_edits.room_id = ?
+            AND event_edits.original_event_id = ?
+            AND json_extract(events.event_json, '$.sender') = ?
         ORDER BY event_edits.origin_server_ts DESC, events.rowid DESC
         LIMIT 1
         """,
-        (room_id, original_event_id),
+        (room_id, original_event_id, sender),
     )
     row = await cursor.fetchone()
     await cursor.close()

--- a/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
@@ -26,31 +26,27 @@ import json
 import time
 from typing import TYPE_CHECKING, Any
 
-from .event_cache import ThreadCacheState
+from .event_cache_events import event_id_for_cache, serialize_cacheable_events, serialize_cached_event
 from .event_normalization import normalize_event_source_for_cache
 from .sqlite_event_cache_events import (
     delete_cached_events,
     delete_event_edit_rows,
     delete_event_thread_rows,
-    event_id_for_cache,
     event_or_original_is_redacted,
     filter_cacheable_events,
-    serialize_cacheable_events,
-    serialize_cached_event,
     write_lookup_index_rows,
+)
+from .thread_cache_state import (
+    ThreadCacheStateRow,
+    can_revalidate_after_incremental_update,
+    thread_cache_state_changed_after,
+    thread_cache_state_row,
 )
 
 if TYPE_CHECKING:
     import aiosqlite
 
-
-_INCREMENTAL_THREAD_REVALIDATION_REASONS = frozenset(
-    {
-        "live_thread_mutation",
-        "sync_thread_mutation",
-        "outbound_thread_mutation",
-    },
-)
+    from .event_cache import ThreadCacheState
 
 
 async def load_thread_events(
@@ -104,7 +100,7 @@ async def _load_thread_cache_state_row(
     *,
     room_id: str,
     thread_id: str,
-) -> tuple[float | None, float | None, str | None, float | None, str | None] | None:
+) -> ThreadCacheStateRow | None:
     """Return one raw thread-cache-state row joined with room invalidation state."""
     cursor = await db.execute(
         """
@@ -125,15 +121,7 @@ async def _load_thread_cache_state_row(
     )
     row = await cursor.fetchone()
     await cursor.close()
-    if row is None or all(value is None for value in row):
-        return None
-    return (
-        None if row[0] is None else float(row[0]),
-        None if row[1] is None else float(row[1]),
-        row[2] if isinstance(row[2], str) else None,
-        None if row[3] is None else float(row[3]),
-        row[4] if isinstance(row[4], str) else None,
-    )
+    return thread_cache_state_row(row)
 
 
 async def load_thread_cache_state(
@@ -150,13 +138,7 @@ async def load_thread_cache_state(
     )
     if row is None:
         return None
-    return ThreadCacheState(
-        validated_at=row[0],
-        invalidated_at=row[1],
-        invalidation_reason=row[2],
-        room_invalidated_at=row[3],
-        room_invalidation_reason=row[4],
-    )
+    return row.as_public_state()
 
 
 async def _store_thread_events_locked(
@@ -277,21 +259,6 @@ async def _replace_thread_locked(
     )
 
 
-def _thread_cache_state_changed_after(
-    cache_state_row: tuple[float | None, float | None, str | None, float | None, str | None] | None,
-    *,
-    fetch_started_at: float,
-) -> bool:
-    """Return whether this thread or room cache state changed after one fetch began."""
-    if cache_state_row is None:
-        return False
-    validated_at, invalidated_at, _invalidation_reason, room_invalidated_at, _room_invalidation_reason = cache_state_row
-    return any(
-        timestamp is not None and timestamp > fetch_started_at
-        for timestamp in (validated_at, invalidated_at, room_invalidated_at)
-    )
-
-
 async def replace_thread_locked_if_not_newer(
     db: aiosqlite.Connection,
     *,
@@ -307,7 +274,7 @@ async def replace_thread_locked_if_not_newer(
         room_id=room_id,
         thread_id=thread_id,
     )
-    if _thread_cache_state_changed_after(cache_state_row, fetch_started_at=fetch_started_at):
+    if thread_cache_state_changed_after(cache_state_row, fetch_started_at=fetch_started_at):
         return False
     await _replace_thread_locked(
         db,
@@ -447,16 +414,7 @@ async def revalidate_thread_after_incremental_update_locked(
         room_id=room_id,
         thread_id=thread_id,
     )
-    if row is None:
-        return False
-    validated_at, invalidated_at, invalidation_reason, room_invalidated_at, _room_invalidation_reason = row
-    can_revalidate = (
-        validated_at is not None
-        and invalidated_at is not None
-        and invalidation_reason in _INCREMENTAL_THREAD_REVALIDATION_REASONS
-        and not (room_invalidated_at is not None and room_invalidated_at >= validated_at)
-    )
-    if not can_revalidate:
+    if not can_revalidate_after_incremental_update(row):
         return False
     await db.execute(
         """

--- a/src/mindroom/matrix/cache/thread_cache_state.py
+++ b/src/mindroom/matrix/cache/thread_cache_state.py
@@ -1,0 +1,86 @@
+"""Backend-neutral durable thread-cache state values and decisions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from .event_cache import ThreadCacheState
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+_INCREMENTAL_THREAD_REVALIDATION_REASONS = frozenset(
+    {
+        "live_thread_mutation",
+        "sync_thread_mutation",
+        "outbound_thread_mutation",
+    },
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ThreadCacheStateRow:
+    """Backend-neutral values loaded from thread and room cache-state rows."""
+
+    validated_at: float | None
+    invalidated_at: float | None
+    invalidation_reason: str | None
+    room_invalidated_at: float | None
+    room_invalidation_reason: str | None
+
+    def as_public_state(self) -> ThreadCacheState:
+        """Return the public cache-state value."""
+        return ThreadCacheState(
+            validated_at=self.validated_at,
+            invalidated_at=self.invalidated_at,
+            invalidation_reason=self.invalidation_reason,
+            room_invalidated_at=self.room_invalidated_at,
+            room_invalidation_reason=self.room_invalidation_reason,
+        )
+
+
+def thread_cache_state_row(values: Sequence[float | str | None] | None) -> ThreadCacheStateRow | None:
+    """Normalize one backend storage row into backend-neutral cache-state values."""
+    if values is None or all(value is None for value in values):
+        return None
+    return ThreadCacheStateRow(
+        validated_at=None if values[0] is None else float(values[0]),
+        invalidated_at=None if values[1] is None else float(values[1]),
+        invalidation_reason=values[2] if isinstance(values[2], str) else None,
+        room_invalidated_at=None if values[3] is None else float(values[3]),
+        room_invalidation_reason=values[4] if isinstance(values[4], str) else None,
+    )
+
+
+def thread_cache_state_changed_after(
+    cache_state: ThreadCacheStateRow | None,
+    *,
+    fetch_started_at: float,
+) -> bool:
+    """Return whether thread or room cache state changed after one fetch began."""
+    if cache_state is None:
+        return False
+    return any(
+        timestamp is not None and timestamp > fetch_started_at
+        for timestamp in (cache_state.validated_at, cache_state.invalidated_at, cache_state.room_invalidated_at)
+    )
+
+
+def can_revalidate_after_incremental_update(cache_state: ThreadCacheStateRow | None) -> bool:
+    """Return whether an incremental update may clear one thread invalidation."""
+    if cache_state is None:
+        return False
+    return (
+        cache_state.validated_at is not None
+        and cache_state.invalidated_at is not None
+        and cache_state.invalidation_reason in _INCREMENTAL_THREAD_REVALIDATION_REASONS
+        and not (
+            cache_state.room_invalidated_at is not None and cache_state.room_invalidated_at >= cache_state.validated_at
+        )
+    )
+
+
+def replacement_validated_at(*, fetch_started_at: float, validated_at: float | None) -> float:
+    """Clamp replacement validation to the instant its fetch began."""
+    return fetch_started_at if validated_at is None else min(validated_at, fetch_started_at)

--- a/src/mindroom/matrix/cache/thread_cache_state.py
+++ b/src/mindroom/matrix/cache/thread_cache_state.py
@@ -42,7 +42,12 @@ class ThreadCacheStateRow:
 
 def thread_cache_state_row(values: Sequence[float | str | None] | None) -> ThreadCacheStateRow | None:
     """Normalize one backend storage row into backend-neutral cache-state values."""
-    if values is None or all(value is None for value in values):
+    if values is None:
+        return None
+    if len(values) != 5:
+        msg = f"Thread cache-state row must contain exactly 5 values, got {len(values)}"
+        raise ValueError(msg)
+    if all(value is None for value in values):
         return None
     return ThreadCacheStateRow(
         validated_at=None if values[0] is None else float(values[0]),

--- a/tach.toml
+++ b/tach.toml
@@ -1576,14 +1576,25 @@ path = "mindroom.matrix.cache.agent_message_snapshot"
 depends_on = []
 
 [[modules]]
-path = "mindroom.matrix.cache.sqlite_agent_message_snapshot"
+path = "mindroom.matrix.cache.agent_message_snapshot_semantics"
 depends_on = [
     "mindroom.matrix.cache.agent_message_snapshot",
-    "mindroom.matrix.cache.sqlite_event_cache_events",
-    "mindroom.matrix.cache.sqlite_event_cache_threads",
     "mindroom.matrix.cache.thread_cache_helpers",
     "mindroom.matrix.event_info",
     "mindroom.matrix.visible_body",
+]
+visibility = [
+    "mindroom.matrix.cache.postgres_agent_message_snapshot",
+    "mindroom.matrix.cache.sqlite_agent_message_snapshot",
+]
+
+[[modules]]
+path = "mindroom.matrix.cache.sqlite_agent_message_snapshot"
+depends_on = [
+    "mindroom.matrix.cache.agent_message_snapshot",
+    "mindroom.matrix.cache.agent_message_snapshot_semantics",
+    "mindroom.matrix.cache.sqlite_event_cache_events",
+    "mindroom.matrix.cache.sqlite_event_cache_threads",
 ]
 visibility = ["mindroom.matrix.cache.sqlite_event_cache"]
 
@@ -1591,34 +1602,44 @@ visibility = ["mindroom.matrix.cache.sqlite_event_cache"]
 path = "mindroom.matrix.cache.postgres_agent_message_snapshot"
 depends_on = [
     "mindroom.matrix.cache.agent_message_snapshot",
+    "mindroom.matrix.cache.agent_message_snapshot_semantics",
     "mindroom.matrix.cache.postgres_event_cache_events",
     "mindroom.matrix.cache.postgres_event_cache_threads",
-    "mindroom.matrix.cache.thread_cache_helpers",
-    "mindroom.matrix.event_info",
-    "mindroom.matrix.visible_body",
 ]
 visibility = ["mindroom.matrix.cache.postgres_event_cache"]
 
 [[modules]]
 path = "mindroom.matrix.cache.sqlite_event_cache_threads"
 depends_on = [
-    "mindroom.matrix.cache.event_cache",
+    "mindroom.matrix.cache.event_cache_events",
     "mindroom.matrix.cache.event_normalization",
     "mindroom.matrix.cache.sqlite_event_cache_events",
+    "mindroom.matrix.cache.thread_cache_state",
 ]
 
 [[modules]]
 path = "mindroom.matrix.cache.postgres_event_cache_threads"
 depends_on = [
-    "mindroom.matrix.cache.event_cache",
+    "mindroom.matrix.cache.event_cache_events",
     "mindroom.matrix.cache.event_normalization",
     "mindroom.matrix.cache.postgres_cursor",
     "mindroom.matrix.cache.postgres_event_cache_events",
+    "mindroom.matrix.cache.thread_cache_state",
 ]
 
 [[modules]]
 path = "mindroom.matrix.cache.event_cache"
 depends_on = []
+
+[[modules]]
+path = "mindroom.matrix.cache.event_cache_events"
+depends_on = ["mindroom.matrix.event_info"]
+visibility = [
+    "mindroom.matrix.cache.postgres_event_cache_events",
+    "mindroom.matrix.cache.postgres_event_cache_threads",
+    "mindroom.matrix.cache.sqlite_event_cache_events",
+    "mindroom.matrix.cache.sqlite_event_cache_threads",
+]
 
 [[modules]]
 path = "mindroom.matrix.cache.event_normalization"
@@ -1644,6 +1665,16 @@ path = "mindroom.matrix.cache.thread_cache_helpers"
 depends_on = []
 
 [[modules]]
+path = "mindroom.matrix.cache.thread_cache_state"
+depends_on = ["mindroom.matrix.cache.event_cache"]
+visibility = [
+    "mindroom.matrix.cache.postgres_event_cache",
+    "mindroom.matrix.cache.postgres_event_cache_threads",
+    "mindroom.matrix.cache.sqlite_event_cache",
+    "mindroom.matrix.cache.sqlite_event_cache_threads",
+]
+
+[[modules]]
 path = "mindroom.matrix.cache.thread_history_result"
 depends_on = []
 
@@ -1656,15 +1687,13 @@ depends_on = [
 
 [[modules]]
 path = "mindroom.matrix.cache.sqlite_event_cache_events"
-depends_on = [
-    "mindroom.matrix.event_info",
-]
+depends_on = ["mindroom.matrix.cache.event_cache_events"]
 
 [[modules]]
 path = "mindroom.matrix.cache.postgres_event_cache_events"
 depends_on = [
+    "mindroom.matrix.cache.event_cache_events",
     "mindroom.matrix.cache.postgres_cursor",
-    "mindroom.matrix.event_info",
 ]
 
 [[modules]]
@@ -1684,6 +1713,7 @@ path = "mindroom.matrix.cache.sqlite_event_cache"
 depends_on = [
     "mindroom.matrix.cache.event_batching",
     "mindroom.matrix.cache.event_normalization",
+    "mindroom.matrix.cache.thread_cache_state",
     "mindroom.logging_config",
     "mindroom.matrix.cache.sqlite_agent_message_snapshot",
     "mindroom.matrix.cache.sqlite_event_cache_events",
@@ -1697,6 +1727,7 @@ depends_on = [
     "mindroom.matrix.cache.event_batching",
     "mindroom.matrix.cache.event_cache",
     "mindroom.matrix.cache.event_normalization",
+    "mindroom.matrix.cache.thread_cache_state",
     "mindroom.logging_config",
     "mindroom.matrix.cache.postgres_agent_message_snapshot",
     "mindroom.matrix.cache.postgres_event_cache_events",
@@ -1937,8 +1968,7 @@ visibility = [
     "mindroom.approval_inbound",
     "mindroom.approval_events",
     "mindroom.bot",
-    "mindroom.matrix.cache.postgres_agent_message_snapshot",
-    "mindroom.matrix.cache.sqlite_agent_message_snapshot",
+    "mindroom.matrix.cache.agent_message_snapshot_semantics",
     "mindroom.matrix.client_visible_messages",
     "mindroom.matrix.client_thread_history",
     "mindroom.matrix.conversation_cache",

--- a/tests/test_event_cache_contract.py
+++ b/tests/test_event_cache_contract.py
@@ -1,0 +1,210 @@
+"""Behavioral contract shared by every durable Matrix event-cache backend."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mindroom.matrix.cache import ConversationEventCache
+from tests.event_cache_test_support import replace_thread_unconditionally
+
+
+def _message_event(
+    event_id: str,
+    timestamp: int,
+    *,
+    body: str | None = None,
+    sender: str = "@user:localhost",
+    thread_id: str | None = None,
+    edit_of: str | None = None,
+) -> dict[str, Any]:
+    content: dict[str, Any] = {
+        "body": event_id if body is None else body,
+        "msgtype": "m.text",
+    }
+    if thread_id is not None:
+        content["m.relates_to"] = {"rel_type": "m.thread", "event_id": thread_id}
+    if edit_of is not None:
+        content["m.new_content"] = {"body": content["body"], "msgtype": "m.text"}
+        content["m.relates_to"] = {"rel_type": "m.replace", "event_id": edit_of}
+    return {
+        "event_id": event_id,
+        "sender": sender,
+        "origin_server_ts": timestamp,
+        "type": "m.room.message",
+        "content": content,
+    }
+
+
+class TestConversationEventCacheContract:
+    """Run the public cache contract against each configured durable backend."""
+
+    @pytest.mark.asyncio
+    async def test_public_protocol_and_disabled_fail_open(self, event_cache: ConversationEventCache) -> None:
+        """Implementations expose one protocol and disabled caches return advisory misses."""
+        assert isinstance(event_cache, ConversationEventCache)
+        assert event_cache.is_initialized is True
+        assert event_cache.durable_writes_available is True
+        assert isinstance(event_cache.runtime_diagnostics()["cache_backend"], str)
+        assert isinstance(event_cache.pending_durable_write_room_ids(), tuple)
+
+        event_cache.disable("contract_test")
+
+        assert event_cache.durable_writes_available is False
+        assert await event_cache.get_event("!room:localhost", "$missing") is None
+        assert (
+            await event_cache.get_recent_room_events(
+                "!room:localhost",
+                event_type="m.room.message",
+                since_ts_ms=0,
+            )
+            == []
+        )
+        assert (
+            await event_cache.append_event(
+                "!room:localhost",
+                "$thread:localhost",
+                _message_event("$reply:localhost", 2),
+            )
+            is False
+        )
+        assert await event_cache.redact_event("!room:localhost", "$missing") is False
+
+    @pytest.mark.asyncio
+    async def test_lookup_normalization_ordering_and_edit_selection(
+        self,
+        event_cache: ConversationEventCache,
+    ) -> None:
+        """Lookup rows normalize payloads and apply the same ordering and edit rules."""
+        runtime_marker = {"resolution_ms": 12}
+        original = _message_event("$original:localhost", 1, body="original")
+        original["com.mindroom.dispatch_pipeline_timing"] = runtime_marker
+        other_sender_edit = _message_event(
+            "$other-edit:localhost",
+            2,
+            body="other edit",
+            sender="@other:localhost",
+            edit_of="$original:localhost",
+        )
+        latest_edit = _message_event(
+            "$latest-edit:localhost",
+            3,
+            body="latest edit",
+            edit_of="$original:localhost",
+        )
+        await event_cache.store_events_batch(
+            [
+                ("$original:localhost", "!room:localhost", original),
+                ("$other-edit:localhost", "!room:localhost", other_sender_edit),
+                ("$latest-edit:localhost", "!room:localhost", latest_edit),
+            ],
+        )
+
+        cached_original = await event_cache.get_event("!room:localhost", "$original:localhost")
+        recent = await event_cache.get_recent_room_events(
+            "!room:localhost",
+            event_type="m.room.message",
+            since_ts_ms=1,
+            limit=2,
+        )
+
+        assert cached_original is not None
+        assert "com.mindroom.dispatch_pipeline_timing" not in cached_original
+        assert [event["event_id"] for event in recent] == ["$latest-edit:localhost", "$other-edit:localhost"]
+        assert await event_cache.get_latest_edit("!room:localhost", "$original:localhost") == latest_edit
+        assert (
+            await event_cache.get_latest_edit(
+                "!room:localhost",
+                "$original:localhost",
+                sender="@other:localhost",
+            )
+            == other_sender_edit
+        )
+
+    @pytest.mark.asyncio
+    async def test_invalid_event_timestamp_is_rejected_consistently(
+        self,
+        event_cache: ConversationEventCache,
+    ) -> None:
+        """Every backend rejects booleans and missing values as Matrix timestamps."""
+        for event_id, invalid_timestamp in (("$boolean:localhost", True), ("$missing:localhost", None)):
+            event = _message_event(event_id, 1)
+            if invalid_timestamp is None:
+                del event["origin_server_ts"]
+            else:
+                event["origin_server_ts"] = invalid_timestamp
+
+            with pytest.raises(ValueError, match="missing origin_server_ts"):
+                await event_cache.store_event(event_id, "!room:localhost", event)
+
+            assert await event_cache.get_event("!room:localhost", event_id) is None
+
+    @pytest.mark.asyncio
+    async def test_thread_snapshot_append_state_and_race_guard(self, event_cache: ConversationEventCache) -> None:
+        """Thread snapshots share ordering, index, incremental-update, and replacement-guard semantics."""
+        room_id = "!room:localhost"
+        thread_id = "$thread:localhost"
+        root = _message_event(thread_id, 1)
+        reply = _message_event("$reply:localhost", 2, thread_id=thread_id)
+        await replace_thread_unconditionally(event_cache, room_id, thread_id, [reply, root], validated_at=10.0)
+
+        appended = await event_cache.append_event(
+            room_id,
+            thread_id,
+            _message_event("$appended:localhost", 3, thread_id=thread_id),
+        )
+        await event_cache.mark_thread_stale(room_id, thread_id, reason="live_thread_mutation")
+        revalidated = await event_cache.revalidate_thread_after_incremental_update(room_id, thread_id)
+        guarded_replacement = await event_cache.replace_thread_if_not_newer(
+            room_id,
+            thread_id,
+            [root],
+            fetch_started_at=0.0,
+        )
+        cached_events = await event_cache.get_thread_events(room_id, thread_id)
+
+        assert appended is True
+        assert revalidated is True
+        assert guarded_replacement is False
+        assert cached_events is not None
+        assert [event["event_id"] for event in cached_events] == [
+            "$thread:localhost",
+            "$reply:localhost",
+            "$appended:localhost",
+        ]
+        assert await event_cache.get_thread_id_for_event(room_id, "$appended:localhost") == thread_id
+
+    @pytest.mark.asyncio
+    async def test_redaction_tombstones_original_edits_and_late_replays(
+        self,
+        event_cache: ConversationEventCache,
+    ) -> None:
+        """Redactions remove derived rows and prevent late original or edit resurrection."""
+        room_id = "!room:localhost"
+        original_id = "$original:localhost"
+        edit_id = "$edit:localhost"
+        original = _message_event(original_id, 1)
+        edit = _message_event(edit_id, 2, edit_of=original_id)
+        await event_cache.store_events_batch(
+            [
+                (original_id, room_id, original),
+                (edit_id, room_id, edit),
+            ],
+        )
+
+        assert await event_cache.redact_event(room_id, original_id) is True
+        assert await event_cache.get_event(room_id, original_id) is None
+        assert await event_cache.get_event(room_id, edit_id) is None
+        assert await event_cache.get_latest_edit(room_id, original_id) is None
+
+        await event_cache.store_events_batch(
+            [
+                (original_id, room_id, original),
+                (edit_id, room_id, edit),
+            ],
+        )
+
+        assert await event_cache.get_event(room_id, original_id) is None
+        assert await event_cache.get_event(room_id, edit_id) is None
+        assert await event_cache.redact_event(room_id, original_id) is False

--- a/tests/test_event_cache_semantics.py
+++ b/tests/test_event_cache_semantics.py
@@ -1,0 +1,34 @@
+"""Focused tests for backend-neutral Matrix event-cache semantics."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mindroom.matrix.cache.thread_cache_state import thread_cache_state_row
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        (),
+        (1.0,),
+        (1.0, 2.0, "reason", 3.0),
+        (1.0, 2.0, "reason", 3.0, "room_reason", 4.0),
+    ],
+)
+def test_thread_cache_state_row_rejects_malformed_storage_width(
+    values: Sequence[float | str | None],
+) -> None:
+    """Storage rows must match the five-column query contract exactly."""
+    with pytest.raises(ValueError, match=r"must contain exactly 5 values, got \d+"):
+        thread_cache_state_row(values)
+
+
+def test_thread_cache_state_row_treats_full_null_row_as_absent() -> None:
+    """A complete outer-join miss remains an absent cache-state row."""
+    assert thread_cache_state_row((None, None, None, None, None)) is None

--- a/tests/test_matrix_cache_agent_message_snapshot.py
+++ b/tests/test_matrix_cache_agent_message_snapshot.py
@@ -175,6 +175,67 @@ async def test_get_latest_agent_message_snapshot_returns_streaming_status_for_th
 
 
 @pytest.mark.asyncio
+async def test_get_latest_agent_message_snapshot_ignores_foreign_sender_edits(
+    event_cache_factory: Callable[[], ConversationEventCache],
+) -> None:
+    """Snapshot edits must come from the same sender as the original message."""
+    cache = event_cache_factory()
+    await cache.initialize()
+    try:
+        await _replace_thread(
+            cache,
+            "!room:localhost",
+            "$thread-root",
+            [
+                _message_event(
+                    event_id="$thread-root",
+                    sender="@user:localhost",
+                    body="Question",
+                    origin_server_ts=1000,
+                ),
+                _message_event(
+                    event_id="$reply",
+                    sender="@agent:localhost",
+                    body="Working...",
+                    origin_server_ts=2000,
+                    relates_to={"rel_type": "m.thread", "event_id": "$thread-root"},
+                ),
+                _message_event(
+                    event_id="$reply-edit",
+                    sender="@agent:localhost",
+                    body="* Working...",
+                    origin_server_ts=3000,
+                    relates_to={"rel_type": "m.replace", "event_id": "$reply"},
+                    new_content={"body": "Finished"},
+                ),
+                _message_event(
+                    event_id="$forged-edit",
+                    sender="@attacker:localhost",
+                    body="* Working...",
+                    origin_server_ts=4000,
+                    relates_to={"rel_type": "m.replace", "event_id": "$reply"},
+                    new_content={"body": "Forged"},
+                ),
+            ],
+        )
+    finally:
+        await cache.close()
+
+    snapshot = await _read_snapshot(
+        event_cache_factory,
+        room_id="!room:localhost",
+        thread_id="$thread-root",
+        sender="@agent:localhost",
+        runtime_started_at=0.0,
+    )
+
+    assert snapshot == AgentMessageSnapshot(
+        content={"body": "Finished", "msgtype": "m.text"},
+        origin_server_ts=3000,
+    )
+
+
+@pytest.mark.asyncio
 async def test_get_latest_agent_message_snapshot_returns_room_level_message_when_thread_id_none(
     event_cache_factory: Callable[[], ConversationEventCache],
 ) -> None:


### PR DESCRIPTION
## Invariant

Both durable `ConversationEventCache` backends now implement one behavioral contract and consume the same pure event, state, redaction, row-derivation, and snapshot-selection semantics.
Backend mechanics remain explicit in the SQLite and PostgreSQL implementations.

## What changed

- Extracted backend-neutral validation, serialization, edit/thread row derivation, redaction decisions, thread cache-state comparison, and agent-message snapshot selection into focused leaf modules.
- Removed the duplicated pure helpers from the SQLite and PostgreSQL backend modules.
- Marked the existing public cache protocol runtime-checkable and added a parameterized behavioral contract covering both durable implementations through the existing fixtures.
- Updated Tach dependency and visibility boundaries for the new leaf modules.

## Production LOC

The Matrix cache subsystem at `src/mindroom/matrix/cache/*.py` changed from 8,169 to 8,115 raw Python lines.
That is a net reduction of 54 production lines while adding the shared semantic source of truth.

## Validation

- `uv sync --all-extras`
- `uv run pytest tests/test_event_cache_contract.py -n 0 --no-cov -q` — 10 passed.
- `uv run pytest tests/test_event_cache.py tests/test_event_cache_backends.py tests/test_matrix_cache_agent_message_snapshot.py tests/test_event_cache_contract.py -n 0 --no-cov -q` — 149 passed.
- `PUPPETEER_SKIP_DOWNLOAD=true uv run pytest -n 4` — 9,338 passed, 155 skipped, 89% coverage.
- `uv run tach check --dependencies --interfaces`
- `uv run pre-commit run --all-files`

## Deliberate non-generalizations

- No ORM, query builder, generic SQL executor, inheritance hierarchy, or additional backend abstraction was introduced.
- SQL text, connection and transaction behavior, retries and failure recovery, namespaces, and locking remain backend-specific.
- TurnStore, response lifecycle, and the general Matrix client layout were left untouched.
