### PR TITLE
Make built-in tool registration one-way

### DIFF
--- a/.claude/agents/configfield-generator.md
+++ b/.claude/agents/configfield-generator.md
@@ -65,7 +65,8 @@ Your expertise includes:
 - **IMPORTS ONLY**: Only modify `src/mindroom/tools/__init__.py` to add imports
 - Follow the EXACT pattern from `src/mindroom/tools/github.py`
 - Use `@register_tool_with_metadata` decorator
-- Import path: `from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata`
+- Declaration import: `from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus`
+- Registration import: `from mindroom.tool_system.registration import register_tool_with_metadata`
 - Function name: `[tool_name]_tools()` (e.g., `calculator_tools()`, `file_tools()`)
 - NO BaseTool class - use the decorator pattern like GitHub tool
 - Use the docs_url from `https://docs.agno.com/llms.txt` but WITHOUT the .md extension

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,9 @@ Matrix sync callback
 | `custom_tools/` | Built-in custom tool implementations (gmail, calendar, scheduler, etc.) |
 | `background_tasks.py` | Background task management for non-blocking operations |
 | `tool_system/events.py` | Tool-event formatting and metadata for Matrix messages |
-| `tool_system/metadata.py` | Tool registry metadata and registration decorators |
+| `tool_system/declarations.py` | Leaf tool metadata enums and dataclasses shared by implementations and the runtime catalog |
+| `tool_system/registration.py` | Leaf built-in and plugin tool registration surface |
+| `tool_system/metadata.py` | Runtime tool lookup, validation, plugin resolution, and instance construction |
 | `tool_system/runtime_context.py` | Shared runtime ContextVar for tool calls (including attachment scope) |
 | `constants.py` | Shared constants, paths, and environment variable defaults |
 | `error_handling.py` | User-friendly error message extraction |

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -229,12 +229,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import (
+from mindroom.tool_system.declarations import (
     SetupType,
     ToolCategory,
     ToolStatus,
-    register_tool_with_metadata,
 )
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools import Toolkit
@@ -343,13 +343,13 @@ Each `ConfigField` describes one constructor parameter that can be configured th
 Example — a tool that requires an API key:
 
 ```python
-from mindroom.tool_system.metadata import (
+from mindroom.tool_system.declarations import (
     ConfigField,
     SetupType,
     ToolCategory,
     ToolStatus,
-    register_tool_with_metadata,
 )
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 @register_tool_with_metadata(
     name="weather",
@@ -392,7 +392,8 @@ Example:
 
 ```python
 from agno.tools import Toolkit
-from mindroom.tool_system.metadata import ToolCategory, ToolManagedInitArg, register_tool_with_metadata
+from mindroom.tool_system.declarations import ToolCategory, ToolManagedInitArg
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 
 @register_tool_with_metadata(
@@ -433,12 +434,12 @@ This plugin pattern is still useful when you want a custom wrapper around Agno `
 
 ```python
 from agno.tools.mcp import MCPTools
-from mindroom.tool_system.metadata import (
+from mindroom.tool_system.declarations import (
     SetupType,
     ToolCategory,
     ToolStatus,
-    register_tool_with_metadata,
 )
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 
 class FilesystemMCPTools(MCPTools):

--- a/scripts/testing/tool_auto_install_smoke.py
+++ b/scripts/testing/tool_auto_install_smoke.py
@@ -21,14 +21,9 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
+from mindroom.tool_system.catalog import TOOL_METADATA, ToolStatus, ensure_tool_registry_loaded, get_tool_by_name
 from mindroom.tool_system.dependencies import _pip_name_to_import, check_deps_installed
-from mindroom.tool_system.metadata import (
-    TOOL_METADATA,
-    TOOL_REGISTRY,
-    ToolStatus,
-    ensure_tool_registry_loaded,
-    get_tool_by_name,
-)
+from mindroom.tool_system.registry_state import TOOL_REGISTRY
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = Path(__file__).resolve()

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -10659,12 +10659,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import (
+from mindroom.tool_system.declarations import (
     SetupType,
     ToolCategory,
     ToolStatus,
-    register_tool_with_metadata,
 )
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools import Toolkit
@@ -10773,13 +10773,13 @@ Each `ConfigField` describes one constructor parameter that can be configured th
 Example — a tool that requires an API key:
 
 ```python
-from mindroom.tool_system.metadata import (
+from mindroom.tool_system.declarations import (
     ConfigField,
     SetupType,
     ToolCategory,
     ToolStatus,
-    register_tool_with_metadata,
 )
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 @register_tool_with_metadata(
     name="weather",
@@ -10822,7 +10822,8 @@ Example:
 
 ```python
 from agno.tools import Toolkit
-from mindroom.tool_system.metadata import ToolCategory, ToolManagedInitArg, register_tool_with_metadata
+from mindroom.tool_system.declarations import ToolCategory, ToolManagedInitArg
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 
 @register_tool_with_metadata(
@@ -10863,12 +10864,12 @@ This plugin pattern is still useful when you want a custom wrapper around Agno `
 
 ```python
 from agno.tools.mcp import MCPTools
-from mindroom.tool_system.metadata import (
+from mindroom.tool_system.declarations import (
     SetupType,
     ToolCategory,
     ToolStatus,
-    register_tool_with_metadata,
 )
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 
 class FilesystemMCPTools(MCPTools):

--- a/skills/mindroom-docs/references/page__plugins__index.md
+++ b/skills/mindroom-docs/references/page__plugins__index.md
@@ -225,12 +225,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import (
+from mindroom.tool_system.declarations import (
     SetupType,
     ToolCategory,
     ToolStatus,
-    register_tool_with_metadata,
 )
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools import Toolkit
@@ -339,13 +339,13 @@ Each `ConfigField` describes one constructor parameter that can be configured th
 Example — a tool that requires an API key:
 
 ```python
-from mindroom.tool_system.metadata import (
+from mindroom.tool_system.declarations import (
     ConfigField,
     SetupType,
     ToolCategory,
     ToolStatus,
-    register_tool_with_metadata,
 )
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 @register_tool_with_metadata(
     name="weather",
@@ -388,7 +388,8 @@ Example:
 
 ```python
 from agno.tools import Toolkit
-from mindroom.tool_system.metadata import ToolCategory, ToolManagedInitArg, register_tool_with_metadata
+from mindroom.tool_system.declarations import ToolCategory, ToolManagedInitArg
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 
 @register_tool_with_metadata(
@@ -429,12 +430,12 @@ This plugin pattern is still useful when you want a custom wrapper around Agno `
 
 ```python
 from agno.tools.mcp import MCPTools
-from mindroom.tool_system.metadata import (
+from mindroom.tool_system.declarations import (
     SetupType,
     ToolCategory,
     ToolStatus,
-    register_tool_with_metadata,
 )
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 
 class FilesystemMCPTools(MCPTools):

--- a/src/mindroom/oauth/registry.py
+++ b/src/mindroom/oauth/registry.py
@@ -16,7 +16,7 @@ from mindroom.oauth.google_gmail import google_gmail_oauth_provider
 from mindroom.oauth.google_sheets import google_sheets_oauth_provider
 from mindroom.oauth.providers import OAuthProvider
 from mindroom.tool_system import plugin_imports
-from mindroom.tool_system.metadata import TOOL_METADATA
+from mindroom.tool_system.catalog import TOOL_METADATA
 from mindroom.tool_system.plugins import load_plugin_module
 
 if TYPE_CHECKING:

--- a/src/mindroom/tool_system/bootstrap.py
+++ b/src/mindroom/tool_system/bootstrap.py
@@ -16,7 +16,7 @@ def ensure_tool_registry_loaded(
     load_plugin_tools: bool = True,
 ) -> None:
     """Load core tools, then sync MCP and optional plugin tools when config is provided."""
-    import mindroom.tools  # noqa: F401, PLC0415  # import here to avoid tools_metadata cycle
+    import mindroom.tools  # noqa: F401, PLC0415  # Explicit built-in manifest loads on demand.
 
     if config is None:
         return

--- a/src/mindroom/tool_system/catalog.py
+++ b/src/mindroom/tool_system/catalog.py
@@ -3,19 +3,21 @@
 from __future__ import annotations
 
 from mindroom.tool_system.bootstrap import ensure_tool_registry_loaded
-from mindroom.tool_system.metadata import (
-    TOOL_METADATA,
+from mindroom.tool_system.declarations import (
     ConfigField,
     SetupType,
     ToolAuthoredOverrideValidator,
     ToolCategory,
-    ToolConfigOverrideError,
-    ToolInitOverrideError,
     ToolManagedInitArg,
     ToolMetadata,
-    ToolMetadataValidationError,
     ToolStatus,
     ToolValidationInfo,
+)
+from mindroom.tool_system.metadata import (
+    TOOL_METADATA,
+    ToolConfigOverrideError,
+    ToolInitOverrideError,
+    ToolMetadataValidationError,
     apply_authored_overrides,
     authored_tool_overrides_to_runtime,
     clear_resolved_tool_state_cache,

--- a/src/mindroom/tool_system/declarations.py
+++ b/src/mindroom/tool_system/declarations.py
@@ -1,0 +1,121 @@
+"""Leaf declarations shared by tool implementations and the runtime catalog."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class ToolAuthoredOverrideValidator(str, Enum):
+    """Explicit authored-override validation modes for a tool."""
+
+    DEFAULT = "default"
+    MCP = "mcp"
+
+
+class ToolCategory(str, Enum):
+    """Tool categories for organization."""
+
+    EMAIL = "email"
+    ENTERTAINMENT = "entertainment"
+    SOCIAL = "social"
+    DEVELOPMENT = "development"
+    RESEARCH = "research"
+    INFORMATION = "information"
+    PRODUCTIVITY = "productivity"
+    COMMUNICATION = "communication"
+    INTEGRATIONS = "integrations"
+    SMART_HOME = "smart_home"
+
+
+class ToolStatus(str, Enum):
+    """Tool availability status."""
+
+    AVAILABLE = "available"
+    REQUIRES_CONFIG = "requires_config"
+
+
+class SetupType(str, Enum):
+    """Tool setup type."""
+
+    NONE = "none"
+    API_KEY = "api_key"
+    OAUTH = "oauth"
+    SPECIAL = "special"
+
+
+class ToolExecutionTarget(str, Enum):
+    """Default runtime location for one tool."""
+
+    PRIMARY = "primary"
+    WORKER = "worker"
+
+
+class ToolManagedInitArg(str, Enum):
+    """Explicit MindRoom-managed constructor inputs."""
+
+    RUNTIME_PATHS = "runtime_paths"
+    CREDENTIALS_MANAGER = "credentials_manager"
+    WORKER_TARGET = "worker_target"
+    TOOL_OUTPUT_WORKSPACE_ROOT = "tool_output_workspace_root"
+    WORKER_TOOLS_OVERRIDE = "worker_tools_override"
+
+
+@dataclass
+class ConfigField:
+    """Definition of a configuration field."""
+
+    name: str
+    label: str
+    type: Literal["boolean", "number", "password", "text", "url", "select", "string[]"] = "text"
+    required: bool = True
+    default: Any = None
+    placeholder: str | None = None
+    description: str | None = None
+    options: list[dict[str, str]] | None = None
+    validation: dict[str, Any] | None = None
+    authored_override: bool = True
+
+
+@dataclass(frozen=True)
+class ToolValidationInfo:
+    """Validation-only metadata for authored tool references."""
+
+    name: str
+    config_fields: tuple[ConfigField, ...] = ()
+    agent_override_fields: tuple[ConfigField, ...] = ()
+    authored_override_validator: ToolAuthoredOverrideValidator = ToolAuthoredOverrideValidator.DEFAULT
+    requires_room_context: bool = False
+    runtime_loadable: bool = True
+    unavailable_due_to_plugin_load_error: bool = False
+
+
+@dataclass
+class ToolMetadata:
+    """Complete metadata for a tool."""
+
+    name: str
+    display_name: str
+    description: str
+    category: ToolCategory
+    status: ToolStatus = ToolStatus.AVAILABLE
+    setup_type: SetupType = SetupType.NONE
+    default_execution_target: ToolExecutionTarget = ToolExecutionTarget.PRIMARY
+    consumes_workspace_paths: bool = False
+    requires_room_context: bool = False
+    icon: str | None = None
+    icon_color: str | None = None
+    config_fields: list[ConfigField] | None = None
+    agent_override_fields: list[ConfigField] | None = None
+    authored_override_validator: ToolAuthoredOverrideValidator = ToolAuthoredOverrideValidator.DEFAULT
+    dependencies: list[str] | None = None
+    auth_provider: str | None = None
+    docs_url: str | None = None
+    helper_text: str | None = None
+    function_names: tuple[str, ...] = ()
+    managed_init_args: tuple[ToolManagedInitArg, ...] = ()
+    factory: Callable[[], type] | None = None

--- a/src/mindroom/tool_system/metadata.py
+++ b/src/mindroom/tool_system/metadata.py
@@ -1,4 +1,4 @@
-"""Tool metadata and enhanced registration system."""
+"""Runtime tool catalog resolution, validation, and instance construction."""
 
 from __future__ import annotations
 
@@ -10,25 +10,29 @@ import sys
 import threading
 import weakref
 from dataclasses import asdict, dataclass
-from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import mindroom.tool_system.plugin_imports as plugin_module
 from mindroom.constants import DEFAULT_TOOL_OUTPUT_AUTO_SAVE_THRESHOLD_BYTES
 from mindroom.credentials import get_runtime_credentials_manager, load_scoped_credentials
 from mindroom.logging_config import get_logger
+from mindroom.tool_system.declarations import (
+    ConfigField,
+    ToolAuthoredOverrideValidator,
+    ToolCategory,
+    ToolExecutionTarget,
+    ToolManagedInitArg,
+    ToolMetadata,
+    ToolValidationInfo,
+)
 from mindroom.tool_system.dependencies import auto_install_optional_extra_for_import_retry, ensure_tool_deps
 from mindroom.tool_system.registry_state import (
     BUILTIN_TOOL_METADATA,
     BUILTIN_TOOL_REGISTRY,
-    PLUGIN_MODULE_PREFIX,
-    PLUGIN_REGISTRATION_SCOPE,
     TOOL_METADATA,
     TOOL_REGISTRY,
     ToolMetadataValidationError,
-    register_builtin_tool_metadata,
-    register_plugin_tool_metadata,
     resolved_tool_state,
     scoped_plugin_registration_owner,
     scoped_plugin_registration_store,
@@ -65,13 +69,6 @@ class ToolInitOverrideError(ValueError):
 
 class ToolConfigOverrideError(ValueError):
     """Raised when authored tool config overrides are invalid."""
-
-
-class ToolAuthoredOverrideValidator(str, Enum):
-    """Explicit authored-override validation modes for a tool."""
-
-    DEFAULT = "default"
-    MCP = "mcp"
 
 
 def _is_authored_override_inherit(value: object) -> bool:
@@ -683,110 +680,6 @@ def get_tool_by_name(
             raise second_error from first_error
 
 
-class ToolCategory(str, Enum):
-    """Tool categories for organization."""
-
-    EMAIL = "email"
-    ENTERTAINMENT = "entertainment"
-    SOCIAL = "social"
-    DEVELOPMENT = "development"
-    RESEARCH = "research"
-    INFORMATION = "information"
-    PRODUCTIVITY = "productivity"
-    COMMUNICATION = "communication"
-    INTEGRATIONS = "integrations"
-    SMART_HOME = "smart_home"
-
-
-class ToolStatus(str, Enum):
-    """Tool availability status."""
-
-    AVAILABLE = "available"
-    REQUIRES_CONFIG = "requires_config"
-
-
-class SetupType(str, Enum):
-    """Tool setup type."""
-
-    NONE = "none"  # No setup required
-    API_KEY = "api_key"  # Requires API key
-    OAUTH = "oauth"  # OAuth flow
-    SPECIAL = "special"  # Special setup (e.g., for Google)
-
-
-class ToolExecutionTarget(str, Enum):
-    """Default runtime location for one tool."""
-
-    PRIMARY = "primary"
-    WORKER = "worker"
-
-
-class ToolManagedInitArg(str, Enum):
-    """Explicit MindRoom-managed constructor inputs."""
-
-    RUNTIME_PATHS = "runtime_paths"
-    CREDENTIALS_MANAGER = "credentials_manager"
-    WORKER_TARGET = "worker_target"
-    TOOL_OUTPUT_WORKSPACE_ROOT = "tool_output_workspace_root"
-    WORKER_TOOLS_OVERRIDE = "worker_tools_override"
-
-
-@dataclass
-class ConfigField:
-    """Definition of a configuration field."""
-
-    name: str  # Environment variable name (e.g., "SMTP_HOST")
-    label: str  # Display label (e.g., "SMTP Host")
-    type: Literal["boolean", "number", "password", "text", "url", "select", "string[]"] = "text"
-    required: bool = True
-    default: Any = None
-    placeholder: str | None = None
-    description: str | None = None
-    options: list[dict[str, str]] | None = None  # For select type
-    validation: dict[str, Any] | None = None  # min, max, pattern, etc.
-    authored_override: bool = True
-
-
-@dataclass(frozen=True)
-class ToolValidationInfo:
-    """Validation-only metadata for authored tool references."""
-
-    name: str
-    config_fields: tuple[ConfigField, ...] = ()
-    agent_override_fields: tuple[ConfigField, ...] = ()
-    authored_override_validator: ToolAuthoredOverrideValidator = ToolAuthoredOverrideValidator.DEFAULT
-    requires_room_context: bool = False
-    runtime_loadable: bool = True
-    unavailable_due_to_plugin_load_error: bool = False
-
-
-@dataclass
-class ToolMetadata:
-    """Complete metadata for a tool."""
-
-    name: str  # Internal tool name (e.g., "gmail")
-    display_name: str  # Display name (e.g., "Gmail")
-    description: str  # Description for UI
-    category: ToolCategory
-    status: ToolStatus = ToolStatus.AVAILABLE
-    setup_type: SetupType = SetupType.NONE
-    default_execution_target: ToolExecutionTarget = ToolExecutionTarget.PRIMARY
-    consumes_workspace_paths: bool = False
-    requires_room_context: bool = False
-    icon: str | None = None  # Icon identifier for frontend
-    icon_color: str | None = None  # Tailwind color class like "text-blue-500"
-    config_fields: list[ConfigField] | None = None  # Detailed field definitions
-    agent_override_fields: list[ConfigField] | None = None  # Safe per-agent override field definitions
-    authored_override_validator: ToolAuthoredOverrideValidator = ToolAuthoredOverrideValidator.DEFAULT
-    dependencies: list[str] | None = None  # Required pip packages
-    auth_provider: str | None = None  # Name of integration that provides auth (e.g., "google")
-    docs_url: str | None = None  # Documentation URL
-    helper_text: str | None = None  # Additional help text for setup
-    function_names: tuple[str, ...] = ()  # Optional explicit callable names for dispatch/error matching
-    managed_init_args: tuple[ToolManagedInitArg, ...] = ()  # Explicit MindRoom-managed constructor kwargs
-    factory: Callable | None = None  # Factory function to create tool instance
-
-
 @dataclass(frozen=True)
 class _ResolvedToolState:
     """Runtime-visible tool state plus validation-only skipped-plugin metadata."""
@@ -794,107 +687,6 @@ class _ResolvedToolState:
     tool_registry: dict[str, Callable[[], type[Toolkit]]]
     tool_metadata: dict[str, ToolMetadata]
     unavailable_tool_metadata: dict[str, ToolMetadata]
-
-
-def register_tool_with_metadata(
-    *,
-    name: str,
-    display_name: str,
-    description: str,
-    category: ToolCategory,
-    status: ToolStatus = ToolStatus.AVAILABLE,
-    setup_type: SetupType = SetupType.NONE,
-    default_execution_target: ToolExecutionTarget = ToolExecutionTarget.PRIMARY,
-    consumes_workspace_paths: bool = False,
-    requires_room_context: bool = False,
-    icon: str | None = None,
-    icon_color: str | None = None,
-    config_fields: list[ConfigField] | None = None,
-    agent_override_fields: list[ConfigField] | None = None,
-    authored_override_validator: ToolAuthoredOverrideValidator = ToolAuthoredOverrideValidator.DEFAULT,
-    dependencies: list[str] | None = None,
-    auth_provider: str | None = None,
-    docs_url: str | None = None,
-    helper_text: str | None = None,
-    function_names: tuple[str, ...] = (),
-    managed_init_args: tuple[ToolManagedInitArg, ...] = (),
-) -> Callable[[Callable[[], type]], Callable[[], type]]:
-    """Decorator to register a tool with metadata.
-
-    This decorator stores comprehensive metadata about tools that can be used
-    by the frontend and other components.
-
-    Args:
-        name: Tool identifier used in registry
-        display_name: Human-readable name for UI
-        description: Brief description of what the tool does
-        category: Tool category for organization
-        status: Availability status of the tool
-        setup_type: Type of setup required
-        default_execution_target: Default runtime location for the tool
-        consumes_workspace_paths: Whether tool functions can consume files saved into the execution workspace
-        requires_room_context: Whether tool functions require a live Matrix room context
-        icon: Icon identifier for frontend
-        icon_color: CSS color class for the icon
-        config_fields: List of configuration fields
-        agent_override_fields: Safe per-agent override fields serialized via config.yaml
-        authored_override_validator: Explicit authored-override validation mode for the tool
-        dependencies: Required Python packages
-        auth_provider: Name of integration that provides authentication
-        docs_url: Link to documentation
-        helper_text: Additional setup instructions
-        function_names: Optional explicit callable names exposed by the toolkit
-        managed_init_args: Explicit MindRoom-managed constructor kwargs
-
-    Returns:
-        Decorator function
-
-    """
-
-    def decorator(func: Callable) -> Callable:
-        # Create metadata object
-        metadata = ToolMetadata(
-            name=name,
-            display_name=display_name,
-            description=description,
-            category=category,
-            status=status,
-            setup_type=setup_type,
-            default_execution_target=default_execution_target,
-            consumes_workspace_paths=consumes_workspace_paths,
-            requires_room_context=requires_room_context,
-            icon=icon,
-            icon_color=icon_color,
-            config_fields=config_fields,
-            agent_override_fields=agent_override_fields,
-            authored_override_validator=authored_override_validator,
-            dependencies=dependencies,
-            auth_provider=auth_provider,
-            docs_url=docs_url,
-            helper_text=helper_text,
-            function_names=function_names,
-            managed_init_args=managed_init_args,
-            factory=func,
-        )
-
-        validation_owner_module_name = getattr(
-            PLUGIN_REGISTRATION_SCOPE,
-            "owner_module_name",
-            None,
-        )
-        if validation_owner_module_name is not None:
-            register_plugin_tool_metadata(validation_owner_module_name, metadata)
-            return func
-
-        if func.__module__.startswith(PLUGIN_MODULE_PREFIX):
-            register_plugin_tool_metadata(func.__module__, metadata)
-            return func
-
-        register_builtin_tool_metadata(metadata)
-
-        return func
-
-    return decorator
 
 
 @functools.lru_cache(maxsize=8192)

--- a/src/mindroom/tool_system/plugins.py
+++ b/src/mindroom/tool_system/plugins.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
     from mindroom.hooks import HookCallback
-    from mindroom.tool_system.metadata import ToolMetadata
+    from mindroom.tool_system.declarations import ToolMetadata
 
 logger = get_logger(__name__)
 

--- a/src/mindroom/tool_system/registration.py
+++ b/src/mindroom/tool_system/registration.py
@@ -1,0 +1,94 @@
+"""Leaf registration surface for tool implementations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from mindroom.tool_system.declarations import (
+    ConfigField,
+    SetupType,
+    ToolAuthoredOverrideValidator,
+    ToolCategory,
+    ToolExecutionTarget,
+    ToolManagedInitArg,
+    ToolMetadata,
+    ToolStatus,
+)
+from mindroom.tool_system.registry_state import (
+    PLUGIN_MODULE_PREFIX,
+    PLUGIN_REGISTRATION_SCOPE,
+    register_builtin_tool_metadata,
+    register_plugin_tool_metadata,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def register_tool_with_metadata(
+    *,
+    name: str,
+    display_name: str,
+    description: str,
+    category: ToolCategory,
+    status: ToolStatus = ToolStatus.AVAILABLE,
+    setup_type: SetupType = SetupType.NONE,
+    default_execution_target: ToolExecutionTarget = ToolExecutionTarget.PRIMARY,
+    consumes_workspace_paths: bool = False,
+    requires_room_context: bool = False,
+    icon: str | None = None,
+    icon_color: str | None = None,
+    config_fields: list[ConfigField] | None = None,
+    agent_override_fields: list[ConfigField] | None = None,
+    authored_override_validator: ToolAuthoredOverrideValidator = ToolAuthoredOverrideValidator.DEFAULT,
+    dependencies: list[str] | None = None,
+    auth_provider: str | None = None,
+    docs_url: str | None = None,
+    helper_text: str | None = None,
+    function_names: tuple[str, ...] = (),
+    managed_init_args: tuple[ToolManagedInitArg, ...] = (),
+) -> Callable[[Callable[[], type]], Callable[[], type]]:
+    """Register a tool factory and its declarative metadata."""
+
+    def decorator(factory: Callable[[], type]) -> Callable[[], type]:
+        metadata = ToolMetadata(
+            name=name,
+            display_name=display_name,
+            description=description,
+            category=category,
+            status=status,
+            setup_type=setup_type,
+            default_execution_target=default_execution_target,
+            consumes_workspace_paths=consumes_workspace_paths,
+            requires_room_context=requires_room_context,
+            icon=icon,
+            icon_color=icon_color,
+            config_fields=config_fields,
+            agent_override_fields=agent_override_fields,
+            authored_override_validator=authored_override_validator,
+            dependencies=dependencies,
+            auth_provider=auth_provider,
+            docs_url=docs_url,
+            helper_text=helper_text,
+            function_names=function_names,
+            managed_init_args=managed_init_args,
+            factory=factory,
+        )
+
+        validation_owner_module_name = getattr(
+            PLUGIN_REGISTRATION_SCOPE,
+            "owner_module_name",
+            None,
+        )
+        if validation_owner_module_name is not None:
+            register_plugin_tool_metadata(validation_owner_module_name, metadata)
+        elif factory.__module__.startswith(PLUGIN_MODULE_PREFIX):
+            register_plugin_tool_metadata(factory.__module__, metadata)
+        else:
+            register_builtin_tool_metadata(metadata)
+        return factory
+
+    return decorator
+
+
+__all__ = ["register_builtin_tool_metadata", "register_tool_with_metadata"]

--- a/src/mindroom/tool_system/registry_state.py
+++ b/src/mindroom/tool_system/registry_state.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
     from agno.tools import Toolkit
 
-    from mindroom.tool_system.metadata import ToolMetadata
+    from mindroom.tool_system.declarations import ToolMetadata
 
 TOOL_METADATA: dict[str, ToolMetadata] = {}
 TOOL_REGISTRY: dict[str, Callable[[], type[Toolkit]]] = {}

--- a/src/mindroom/tools/__init__.py
+++ b/src/mindroom/tools/__init__.py
@@ -8,14 +8,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import (
+from mindroom.tool_system.declarations import (
     ConfigField,
     SetupType,
     ToolCategory,
     ToolManagedInitArg,
     ToolStatus,
-    register_tool_with_metadata,
 )
+from mindroom.tool_system.registration import register_tool_with_metadata
 from mindroom.tools import (
     compact_context,  # noqa: F401
     delegate,  # noqa: F401

--- a/src/mindroom/tools/agentql.py
+++ b/src/mindroom/tools/agentql.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import importlib
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from types import ModuleType

--- a/src/mindroom/tools/airflow.py
+++ b/src/mindroom/tools/airflow.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.airflow import AirflowTools

--- a/src/mindroom/tools/apify.py
+++ b/src/mindroom/tools/apify.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.apify import ApifyTools

--- a/src/mindroom/tools/approved_egress.py
+++ b/src/mindroom/tools/approved_egress.py
@@ -25,7 +25,8 @@ from mindroom.egress.policy import (
     resolve_worker_egress_policy,
 )
 from mindroom.tool_system.approval_exemptions import register_tool_approval_exemption
-from mindroom.tool_system.metadata import SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 from mindroom.tool_system.runtime_context import (
     build_execution_identity_from_runtime_context,
     get_tool_runtime_context,

--- a/src/mindroom/tools/arxiv.py
+++ b/src/mindroom/tools/arxiv.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.arxiv import ArxivTools

--- a/src/mindroom/tools/attachments.py
+++ b/src/mindroom/tools/attachments.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import (
+from mindroom.tool_system.declarations import (
     SetupType,
     ToolCategory,
     ToolManagedInitArg,
     ToolStatus,
-    register_tool_with_metadata,
 )
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from mindroom.custom_tools.attachments import AttachmentTools

--- a/src/mindroom/tools/aws_lambda.py
+++ b/src/mindroom/tools/aws_lambda.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.aws_lambda import AWSLambdaTools

--- a/src/mindroom/tools/aws_ses.py
+++ b/src/mindroom/tools/aws_ses.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.aws_ses import AWSSESTool

--- a/src/mindroom/tools/baidusearch.py
+++ b/src/mindroom/tools/baidusearch.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.baidusearch import BaiduSearchTools

--- a/src/mindroom/tools/bitbucket.py
+++ b/src/mindroom/tools/bitbucket.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.bitbucket import BitbucketTools

--- a/src/mindroom/tools/brandfetch.py
+++ b/src/mindroom/tools/brandfetch.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.brandfetch import BrandfetchTools

--- a/src/mindroom/tools/brightdata.py
+++ b/src/mindroom/tools/brightdata.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.brightdata import BrightDataTools

--- a/src/mindroom/tools/browser.py
+++ b/src/mindroom/tools/browser.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import (
+from mindroom.tool_system.declarations import (
     ConfigField,
     SetupType,
     ToolCategory,
     ToolManagedInitArg,
     ToolStatus,
-    register_tool_with_metadata,
 )
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from mindroom.custom_tools.browser import BrowserTools

--- a/src/mindroom/tools/browserbase.py
+++ b/src/mindroom/tools/browserbase.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.browserbase import BrowserbaseTools

--- a/src/mindroom/tools/cal_com.py
+++ b/src/mindroom/tools/cal_com.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.calcom import CalComTools

--- a/src/mindroom/tools/calculator.py
+++ b/src/mindroom/tools/calculator.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.calculator import CalculatorTools

--- a/src/mindroom/tools/cartesia.py
+++ b/src/mindroom/tools/cartesia.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.cartesia import CartesiaTools

--- a/src/mindroom/tools/claude_agent.py
+++ b/src/mindroom/tools/claude_agent.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from mindroom.custom_tools.claude_agent import ClaudeAgentTools

--- a/src/mindroom/tools/clickup.py
+++ b/src/mindroom/tools/clickup.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.clickup import ClickUpTools

--- a/src/mindroom/tools/coding.py
+++ b/src/mindroom/tools/coding.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import (
+from mindroom.tool_system.declarations import (
     ConfigField,
     SetupType,
     ToolCategory,
     ToolExecutionTarget,
     ToolStatus,
-    register_tool_with_metadata,
 )
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from mindroom.custom_tools.coding import CodingTools

--- a/src/mindroom/tools/compact_context.py
+++ b/src/mindroom/tools/compact_context.py
@@ -6,13 +6,13 @@ requires agent context and is instantiated directly in ``create_agent()``, so it
 is NOT added to ``TOOL_REGISTRY`` (no generic factory).
 """
 
-from mindroom.tool_system.metadata import (
+from mindroom.tool_system.declarations import (
     SetupType,
     ToolCategory,
     ToolMetadata,
     ToolStatus,
-    register_builtin_tool_metadata,
 )
+from mindroom.tool_system.registration import register_builtin_tool_metadata
 
 register_builtin_tool_metadata(
     ToolMetadata(

--- a/src/mindroom/tools/composio.py
+++ b/src/mindroom/tools/composio.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 from mindroom.vendor_telemetry import disable_vendor_telemetry
 
 if TYPE_CHECKING:

--- a/src/mindroom/tools/config_manager.py
+++ b/src/mindroom/tools/config_manager.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import (
+from mindroom.tool_system.declarations import (
     SetupType,
     ToolCategory,
     ToolManagedInitArg,
     ToolStatus,
-    register_tool_with_metadata,
 )
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from mindroom.custom_tools.config_manager import ConfigManagerTools

--- a/src/mindroom/tools/confluence.py
+++ b/src/mindroom/tools/confluence.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.confluence import ConfluenceTools

--- a/src/mindroom/tools/crawl4ai.py
+++ b/src/mindroom/tools/crawl4ai.py
@@ -6,7 +6,8 @@ from typing import TYPE_CHECKING
 
 from mindroom.browser_fetch_guard import continue_or_abort_browser_fetch
 from mindroom.server_fetch_url import validate_server_fetch_url
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.crawl4ai import Crawl4aiTools

--- a/src/mindroom/tools/csv.py
+++ b/src/mindroom/tools/csv.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.csv_toolkit import CsvTools

--- a/src/mindroom/tools/custom_api.py
+++ b/src/mindroom/tools/custom_api.py
@@ -9,7 +9,8 @@ import httpx
 
 from mindroom.redaction import redact_sensitive_data
 from mindroom.server_fetch_url import ServerFetchHTTPTransport, validate_server_fetch_url
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.api import CustomApiTools

--- a/src/mindroom/tools/dalle.py
+++ b/src/mindroom/tools/dalle.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from mindroom.model_defaults import OPENAI_DALLE
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.dalle import DalleTools

--- a/src/mindroom/tools/daytona.py
+++ b/src/mindroom/tools/daytona.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.daytona import DaytonaTools

--- a/src/mindroom/tools/delegate.py
+++ b/src/mindroom/tools/delegate.py
@@ -6,13 +6,13 @@ agent context and is instantiated directly in ``create_agent()``, so it
 is NOT added to ``TOOL_REGISTRY`` (no generic factory).
 """
 
-from mindroom.tool_system.metadata import (
+from mindroom.tool_system.declarations import (
     SetupType,
     ToolCategory,
     ToolMetadata,
     ToolStatus,
-    register_builtin_tool_metadata,
 )
+from mindroom.tool_system.registration import register_builtin_tool_metadata
 
 register_builtin_tool_metadata(
     ToolMetadata(

--- a/src/mindroom/tools/desi_vocal.py
+++ b/src/mindroom/tools/desi_vocal.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.desi_vocal import DesiVocalTools

--- a/src/mindroom/tools/discord.py
+++ b/src/mindroom/tools/discord.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.discord import DiscordTools

--- a/src/mindroom/tools/docker.py
+++ b/src/mindroom/tools/docker.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import (
+from mindroom.tool_system.declarations import (
     ConfigField,
     SetupType,
     ToolCategory,
     ToolExecutionTarget,
     ToolStatus,
-    register_tool_with_metadata,
 )
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.docker import DockerTools

--- a/src/mindroom/tools/duckdb.py
+++ b/src/mindroom/tools/duckdb.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.duckdb import DuckDbTools

--- a/src/mindroom/tools/duckduckgo.py
+++ b/src/mindroom/tools/duckduckgo.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.duckduckgo import DuckDuckGoTools

--- a/src/mindroom/tools/dynamic_tools.py
+++ b/src/mindroom/tools/dynamic_tools.py
@@ -5,13 +5,13 @@ The actual toolkit requires agent and session context and is instantiated
 directly in ``create_agent()``, so it is NOT added to ``TOOL_REGISTRY``.
 """
 
-from mindroom.tool_system.metadata import (
+from mindroom.tool_system.declarations import (
     SetupType,
     ToolCategory,
     ToolMetadata,
     ToolStatus,
-    register_builtin_tool_metadata,
 )
+from mindroom.tool_system.registration import register_builtin_tool_metadata
 
 register_builtin_tool_metadata(
     ToolMetadata(

--- a/src/mindroom/tools/dynamic_workflow.py
+++ b/src/mindroom/tools/dynamic_workflow.py
@@ -1,13 +1,13 @@
 """Dynamic Workflow tool metadata registration."""
 
-from mindroom.tool_system.metadata import (
+from mindroom.tool_system.declarations import (
     ConfigField,
     SetupType,
     ToolCategory,
     ToolMetadata,
     ToolStatus,
-    register_builtin_tool_metadata,
 )
+from mindroom.tool_system.registration import register_builtin_tool_metadata
 
 register_builtin_tool_metadata(
     ToolMetadata(

--- a/src/mindroom/tools/e2b.py
+++ b/src/mindroom/tools/e2b.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.e2b import E2BTools

--- a/src/mindroom/tools/eleven_labs.py
+++ b/src/mindroom/tools/eleven_labs.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.eleven_labs import ElevenLabsTools

--- a/src/mindroom/tools/email.py
+++ b/src/mindroom/tools/email.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.email import EmailTools

--- a/src/mindroom/tools/exa.py
+++ b/src/mindroom/tools/exa.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.exa import ExaTools

--- a/src/mindroom/tools/external_trigger_manager.py
+++ b/src/mindroom/tools/external_trigger_manager.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from mindroom.custom_tools.external_trigger_manager import ExternalTriggerManagerTools

--- a/src/mindroom/tools/fal.py
+++ b/src/mindroom/tools/fal.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.fal import FalTools

--- a/src/mindroom/tools/file.py
+++ b/src/mindroom/tools/file.py
@@ -9,14 +9,14 @@ from typing import Any, cast
 from agno.tools.file import FileTools as AgnoFileTools
 from agno.tools.file import log_debug, log_error
 
-from mindroom.tool_system.metadata import (
+from mindroom.tool_system.declarations import (
     ConfigField,
     SetupType,
     ToolCategory,
     ToolExecutionTarget,
     ToolStatus,
-    register_tool_with_metadata,
 )
+from mindroom.tool_system.registration import register_tool_with_metadata
 from mindroom.tools.path_safety import (
     blocked_file_action_message,
     format_path_for_output,

--- a/src/mindroom/tools/file_generation.py
+++ b/src/mindroom/tools/file_generation.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.file_generation import FileGenerationTools

--- a/src/mindroom/tools/financial_datasets_api.py
+++ b/src/mindroom/tools/financial_datasets_api.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.financial_datasets import FinancialDatasetsTools

--- a/src/mindroom/tools/firecrawl.py
+++ b/src/mindroom/tools/firecrawl.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.firecrawl import FirecrawlTools

--- a/src/mindroom/tools/gemini.py
+++ b/src/mindroom/tools/gemini.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from mindroom.model_defaults import GOOGLE_IMAGEN, GOOGLE_VEO
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.models.gemini import GeminiTools

--- a/src/mindroom/tools/giphy.py
+++ b/src/mindroom/tools/giphy.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.giphy import GiphyTools

--- a/src/mindroom/tools/github.py
+++ b/src/mindroom/tools/github.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.github import GithubTools

--- a/src/mindroom/tools/gmail.py
+++ b/src/mindroom/tools/gmail.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import (
+from mindroom.tool_system.declarations import (
     ConfigField,
     SetupType,
     ToolCategory,
     ToolManagedInitArg,
     ToolStatus,
-    register_tool_with_metadata,
 )
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from mindroom.custom_tools.gmail import GmailTools

--- a/src/mindroom/tools/google_bigquery.py
+++ b/src/mindroom/tools/google_bigquery.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.google.bigquery import GoogleBigQueryTools

--- a/src/mindroom/tools/google_calendar.py
+++ b/src/mindroom/tools/google_calendar.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import (
+from mindroom.tool_system.declarations import (
     ConfigField,
     SetupType,
     ToolCategory,
     ToolManagedInitArg,
     ToolStatus,
-    register_tool_with_metadata,
 )
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from mindroom.custom_tools.google_calendar import GoogleCalendarTools

--- a/src/mindroom/tools/google_drive.py
+++ b/src/mindroom/tools/google_drive.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import (
+from mindroom.tool_system.declarations import (
     ConfigField,
     SetupType,
     ToolCategory,
     ToolManagedInitArg,
     ToolStatus,
-    register_tool_with_metadata,
 )
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from mindroom.custom_tools.google_drive import GoogleDriveTools

--- a/src/mindroom/tools/google_maps.py
+++ b/src/mindroom/tools/google_maps.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.google.maps import GoogleMapTools

--- a/src/mindroom/tools/google_scholar.py
+++ b/src/mindroom/tools/google_scholar.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from mindroom.custom_tools.google_scholar import GoogleScholarTools

--- a/src/mindroom/tools/google_sheets.py
+++ b/src/mindroom/tools/google_sheets.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import (
+from mindroom.tool_system.declarations import (
     ConfigField,
     SetupType,
     ToolCategory,
     ToolManagedInitArg,
     ToolStatus,
-    register_tool_with_metadata,
 )
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from mindroom.custom_tools.google_sheets import GoogleSheetsTools

--- a/src/mindroom/tools/googlesearch.py
+++ b/src/mindroom/tools/googlesearch.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.websearch import WebSearchTools

--- a/src/mindroom/tools/groq.py
+++ b/src/mindroom/tools/groq.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from mindroom.model_defaults import GROQ_TRANSCRIPTION, GROQ_TTS
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.models.groq import GroqTools

--- a/src/mindroom/tools/hackernews.py
+++ b/src/mindroom/tools/hackernews.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.hackernews import HackerNewsTools

--- a/src/mindroom/tools/jina.py
+++ b/src/mindroom/tools/jina.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.jina import JinaReaderTools

--- a/src/mindroom/tools/jira.py
+++ b/src/mindroom/tools/jira.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.jira import JiraTools

--- a/src/mindroom/tools/linear.py
+++ b/src/mindroom/tools/linear.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.linear import LinearTools

--- a/src/mindroom/tools/linkup.py
+++ b/src/mindroom/tools/linkup.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.linkup import LinkupTools

--- a/src/mindroom/tools/lumalabs.py
+++ b/src/mindroom/tools/lumalabs.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.lumalab import LumaLabTools

--- a/src/mindroom/tools/matrix_api.py
+++ b/src/mindroom/tools/matrix_api.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from mindroom.custom_tools.matrix_api import MatrixApiTools

--- a/src/mindroom/tools/matrix_message.py
+++ b/src/mindroom/tools/matrix_message.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import (
+from mindroom.tool_system.declarations import (
     SetupType,
     ToolCategory,
     ToolManagedInitArg,
     ToolStatus,
-    register_tool_with_metadata,
 )
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from mindroom.custom_tools.matrix_message import MatrixMessageTools

--- a/src/mindroom/tools/matrix_room.py
+++ b/src/mindroom/tools/matrix_room.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from mindroom.custom_tools.matrix_room import MatrixRoomTools

--- a/src/mindroom/tools/matrix_voice_message.py
+++ b/src/mindroom/tools/matrix_voice_message.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from mindroom.model_defaults import OPENAI_TTS
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from mindroom.custom_tools.matrix_voice_message import MatrixVoiceMessageTools

--- a/src/mindroom/tools/mem0.py
+++ b/src/mindroom/tools/mem0.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.mem0 import Mem0Tools

--- a/src/mindroom/tools/memory.py
+++ b/src/mindroom/tools/memory.py
@@ -6,13 +6,13 @@ agent context and is instantiated directly in ``create_agent()``, so it
 is NOT added to ``TOOL_REGISTRY`` (no generic factory).
 """
 
-from mindroom.tool_system.metadata import (
+from mindroom.tool_system.declarations import (
     SetupType,
     ToolCategory,
     ToolMetadata,
     ToolStatus,
-    register_builtin_tool_metadata,
 )
+from mindroom.tool_system.registration import register_builtin_tool_metadata
 
 register_builtin_tool_metadata(
     ToolMetadata(

--- a/src/mindroom/tools/modelslabs.py
+++ b/src/mindroom/tools/modelslabs.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.models_labs import ModelsLabTools

--- a/src/mindroom/tools/moviepy_video_tools.py
+++ b/src/mindroom/tools/moviepy_video_tools.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.moviepy_video import MoviePyVideoTools

--- a/src/mindroom/tools/neo4j.py
+++ b/src/mindroom/tools/neo4j.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.neo4j import Neo4jTools

--- a/src/mindroom/tools/newspaper4k.py
+++ b/src/mindroom/tools/newspaper4k.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.newspaper4k import Newspaper4kTools

--- a/src/mindroom/tools/notion.py
+++ b/src/mindroom/tools/notion.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.notion import NotionTools

--- a/src/mindroom/tools/openai.py
+++ b/src/mindroom/tools/openai.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from mindroom.model_defaults import OPENAI_IMAGE, OPENAI_TRANSCRIPTION, OPENAI_TTS
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.openai import OpenAITools

--- a/src/mindroom/tools/openbb.py
+++ b/src/mindroom/tools/openbb.py
@@ -6,7 +6,8 @@ import importlib
 import os
 from typing import TYPE_CHECKING, cast
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.openbb import OpenBBTools

--- a/src/mindroom/tools/openweather.py
+++ b/src/mindroom/tools/openweather.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.openweather import OpenWeatherTools

--- a/src/mindroom/tools/oxylabs.py
+++ b/src/mindroom/tools/oxylabs.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.oxylabs import OxylabsTools

--- a/src/mindroom/tools/pandas.py
+++ b/src/mindroom/tools/pandas.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.pandas import PandasTools

--- a/src/mindroom/tools/postgres.py
+++ b/src/mindroom/tools/postgres.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.postgres import PostgresTools

--- a/src/mindroom/tools/pubmed.py
+++ b/src/mindroom/tools/pubmed.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.pubmed import PubmedTools

--- a/src/mindroom/tools/python.py
+++ b/src/mindroom/tools/python.py
@@ -6,15 +6,15 @@ import subprocess
 from typing import TYPE_CHECKING, Any
 
 from mindroom.logging_config import get_logger
-from mindroom.tool_system.dependencies import install_command_for_current_python
-from mindroom.tool_system.metadata import (
+from mindroom.tool_system.declarations import (
     ConfigField,
     SetupType,
     ToolCategory,
     ToolExecutionTarget,
     ToolStatus,
-    register_tool_with_metadata,
 )
+from mindroom.tool_system.dependencies import install_command_for_current_python
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     import logging

--- a/src/mindroom/tools/reasoning.py
+++ b/src/mindroom/tools/reasoning.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.reasoning import ReasoningTools

--- a/src/mindroom/tools/reddit.py
+++ b/src/mindroom/tools/reddit.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.reddit import RedditTools

--- a/src/mindroom/tools/redshift.py
+++ b/src/mindroom/tools/redshift.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.redshift import RedshiftTools

--- a/src/mindroom/tools/replicate.py
+++ b/src/mindroom/tools/replicate.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.replicate import ReplicateTools

--- a/src/mindroom/tools/report_publishing.py
+++ b/src/mindroom/tools/report_publishing.py
@@ -1,12 +1,12 @@
 """Report Publishing tool metadata registration."""
 
-from mindroom.tool_system.metadata import (
+from mindroom.tool_system.declarations import (
     SetupType,
     ToolCategory,
     ToolMetadata,
     ToolStatus,
-    register_builtin_tool_metadata,
 )
+from mindroom.tool_system.registration import register_builtin_tool_metadata
 
 register_builtin_tool_metadata(
     ToolMetadata(

--- a/src/mindroom/tools/resend.py
+++ b/src/mindroom/tools/resend.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.resend import ResendTools

--- a/src/mindroom/tools/scheduler.py
+++ b/src/mindroom/tools/scheduler.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from mindroom.custom_tools.scheduler import SchedulerTools

--- a/src/mindroom/tools/scrapegraph.py
+++ b/src/mindroom/tools/scrapegraph.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.scrapegraph import ScrapeGraphTools

--- a/src/mindroom/tools/searxng.py
+++ b/src/mindroom/tools/searxng.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.searxng import Searxng

--- a/src/mindroom/tools/self_config.py
+++ b/src/mindroom/tools/self_config.py
@@ -6,13 +6,13 @@ requires ``agent_name`` at instantiation and is injected directly in
 ``create_agent()``, so it is NOT added to ``TOOL_REGISTRY``.
 """
 
-from mindroom.tool_system.metadata import (
+from mindroom.tool_system.declarations import (
     SetupType,
     ToolCategory,
     ToolMetadata,
     ToolStatus,
-    register_builtin_tool_metadata,
 )
+from mindroom.tool_system.registration import register_builtin_tool_metadata
 
 register_builtin_tool_metadata(
     ToolMetadata(

--- a/src/mindroom/tools/serpapi.py
+++ b/src/mindroom/tools/serpapi.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.serpapi import SerpApiTools

--- a/src/mindroom/tools/serper.py
+++ b/src/mindroom/tools/serper.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.serper import SerperTools

--- a/src/mindroom/tools/shell.py
+++ b/src/mindroom/tools/shell.py
@@ -31,15 +31,15 @@ from mindroom.shell_supervisor import (
     kill_command_via_supervisor,
     run_command_via_supervisor,
 )
-from mindroom.tool_system.metadata import (
+from mindroom.tool_system.declarations import (
     ConfigField,
     SetupType,
     ToolCategory,
     ToolExecutionTarget,
     ToolManagedInitArg,
     ToolStatus,
-    register_tool_with_metadata,
 )
+from mindroom.tool_system.registration import register_tool_with_metadata
 from mindroom.vendor_telemetry import vendor_telemetry_env_values
 
 _LOCAL_SHELL_PASSTHROUGH_ENV_KEYS = frozenset(

--- a/src/mindroom/tools/shopify.py
+++ b/src/mindroom/tools/shopify.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.shopify import ShopifyTools

--- a/src/mindroom/tools/slack.py
+++ b/src/mindroom/tools/slack.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.slack import SlackTools

--- a/src/mindroom/tools/sleep.py
+++ b/src/mindroom/tools/sleep.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.sleep import SleepTools

--- a/src/mindroom/tools/spider.py
+++ b/src/mindroom/tools/spider.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.spider import SpiderTools

--- a/src/mindroom/tools/spotify.py
+++ b/src/mindroom/tools/spotify.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.spotify import SpotifyTools

--- a/src/mindroom/tools/sql.py
+++ b/src/mindroom/tools/sql.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.sql import SQLTools

--- a/src/mindroom/tools/subagents.py
+++ b/src/mindroom/tools/subagents.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from mindroom.custom_tools.subagents import SubAgentsTools

--- a/src/mindroom/tools/tavily.py
+++ b/src/mindroom/tools/tavily.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.tavily import TavilyTools

--- a/src/mindroom/tools/telegram.py
+++ b/src/mindroom/tools/telegram.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.telegram import TelegramTools

--- a/src/mindroom/tools/thread_model.py
+++ b/src/mindroom/tools/thread_model.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from mindroom.custom_tools.thread_model import ThreadModelTools

--- a/src/mindroom/tools/thread_summary.py
+++ b/src/mindroom/tools/thread_summary.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from mindroom.custom_tools.thread_summary import ThreadSummaryTools

--- a/src/mindroom/tools/thread_tags.py
+++ b/src/mindroom/tools/thread_tags.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from mindroom.custom_tools.thread_tags import ThreadTagsTools

--- a/src/mindroom/tools/todo.py
+++ b/src/mindroom/tools/todo.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import (
+from mindroom.tool_system.declarations import (
     SetupType,
     ToolCategory,
     ToolStatus,
-    register_tool_with_metadata,
 )
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from mindroom.custom_tools.todo import TodoTools

--- a/src/mindroom/tools/todoist.py
+++ b/src/mindroom/tools/todoist.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.todoist import TodoistTools

--- a/src/mindroom/tools/trafilatura.py
+++ b/src/mindroom/tools/trafilatura.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.trafilatura import TrafilaturaTools

--- a/src/mindroom/tools/trello.py
+++ b/src/mindroom/tools/trello.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.trello import TrelloTools

--- a/src/mindroom/tools/twilio.py
+++ b/src/mindroom/tools/twilio.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.twilio import TwilioTools

--- a/src/mindroom/tools/unsplash.py
+++ b/src/mindroom/tools/unsplash.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.unsplash import UnsplashTools

--- a/src/mindroom/tools/visualization.py
+++ b/src/mindroom/tools/visualization.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.visualization import VisualizationTools

--- a/src/mindroom/tools/web_browser_tools.py
+++ b/src/mindroom/tools/web_browser_tools.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.webbrowser import WebBrowserTools

--- a/src/mindroom/tools/webex.py
+++ b/src/mindroom/tools/webex.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.webex import WebexTools

--- a/src/mindroom/tools/website.py
+++ b/src/mindroom/tools/website.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from mindroom.custom_tools.website import WebsiteTools

--- a/src/mindroom/tools/whatsapp.py
+++ b/src/mindroom/tools/whatsapp.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.whatsapp import WhatsAppTools

--- a/src/mindroom/tools/wikipedia.py
+++ b/src/mindroom/tools/wikipedia.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.wikipedia import WikipediaTools

--- a/src/mindroom/tools/x.py
+++ b/src/mindroom/tools/x.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.x import XTools

--- a/src/mindroom/tools/yfinance.py
+++ b/src/mindroom/tools/yfinance.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.yfinance import YFinanceTools

--- a/src/mindroom/tools/youtube.py
+++ b/src/mindroom/tools/youtube.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.youtube import YouTubeTools

--- a/src/mindroom/tools/zendesk.py
+++ b/src/mindroom/tools/zendesk.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.zendesk import ZendeskTools

--- a/src/mindroom/tools/zep.py
+++ b/src/mindroom/tools/zep.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.zep import ZepTools

--- a/src/mindroom/tools/zoom.py
+++ b/src/mindroom/tools/zoom.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
     from agno.tools.zoom import ZoomTools

--- a/tach.toml
+++ b/tach.toml
@@ -2386,6 +2386,7 @@ path = "mindroom.tool_system.metadata"
 depends_on = [
     "mindroom.constants",
     "mindroom.mcp.registry",
+    "mindroom.tool_system.declarations",
     "mindroom.tool_system.dependencies",
     "mindroom.tool_system.output_files",
     "mindroom.tool_system.plugin_imports",
@@ -2398,7 +2399,19 @@ depends_on = [
 path = "mindroom.tool_system.catalog"
 depends_on = [
     "mindroom.tool_system.bootstrap",
+    "mindroom.tool_system.declarations",
     "mindroom.tool_system.metadata",
+]
+
+[[modules]]
+path = "mindroom.tool_system.declarations"
+depends_on = []
+
+[[modules]]
+path = "mindroom.tool_system.registration"
+depends_on = [
+    "mindroom.tool_system.declarations",
+    "mindroom.tool_system.registry_state",
 ]
 
 [[modules]]
@@ -3290,18 +3303,31 @@ from = ["mindroom.runtime_support"]
 
 [[interfaces]]
 expose = [
-    "TOOL_METADATA",
     "ConfigField",
     "SetupType",
     "ToolAuthoredOverrideValidator",
     "ToolCategory",
-    "ToolConfigOverrideError",
-    "ToolInitOverrideError",
+    "ToolExecutionTarget",
     "ToolManagedInitArg",
     "ToolMetadata",
-    "ToolMetadataValidationError",
     "ToolStatus",
     "ToolValidationInfo",
+]
+from = ["mindroom.tool_system.declarations"]
+
+[[interfaces]]
+expose = [
+    "register_builtin_tool_metadata",
+    "register_tool_with_metadata",
+]
+from = ["mindroom.tool_system.registration"]
+
+[[interfaces]]
+expose = [
+    "TOOL_METADATA",
+    "ToolConfigOverrideError",
+    "ToolInitOverrideError",
+    "ToolMetadataValidationError",
     "apply_authored_overrides",
     "authored_tool_overrides_to_runtime",
     "default_worker_routed_tools",
@@ -3387,6 +3413,7 @@ visibility = [
     "mindroom.mcp.registry",
     "mindroom.tool_system.metadata",
     "mindroom.tool_system.plugins",
+    "mindroom.tool_system.registration",
 ]
 exclusive = true
 

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -30,6 +30,7 @@ import mindroom.api.sandbox_runner_app as sandbox_runner_app_module
 import mindroom.api.sandbox_worker_prep as sandbox_worker_prep_module
 import mindroom.constants as constants_module
 import mindroom.tool_system.metadata as metadata_module
+import mindroom.tool_system.registration as registration_module
 from mindroom import runtime_env_policy
 from mindroom.api.sandbox_runner_app import app as sandbox_runner_app
 from mindroom.config.main import Config, ConfigRuntimeValidationError
@@ -48,13 +49,9 @@ from mindroom.credentials import (
 from mindroom.oauth.providers import OAuthConnectionRequired
 from mindroom.runtime_env_policy import SHARED_CREDENTIALS_PATH_ENV
 from mindroom.tool_system.bootstrap import ensure_tool_registry_loaded
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolMetadata, ToolStatus
 from mindroom.tool_system.metadata import (
     TOOL_METADATA,
-    ConfigField,
-    SetupType,
-    ToolCategory,
-    ToolMetadata,
-    ToolStatus,
     get_tool_by_name,
     resolved_tool_validation_snapshot_for_runtime,
     serialize_tool_validation_snapshot,
@@ -2368,7 +2365,7 @@ def test_resolve_entrypoint_loads_persisted_tool_credentials(
     )
     monkeypatch.setenv("MINDROOM_CONFIG_PATH", str(config_path))
     monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(shared_storage))
-    metadata_module.register_builtin_tool_metadata(
+    registration_module.register_builtin_tool_metadata(
         ToolMetadata(
             name=tool_name,
             display_name="Dummy",
@@ -2431,7 +2428,7 @@ def test_get_tool_by_name_loads_persisted_tool_credentials_without_explicit_mana
     original_builtin_metadata = metadata_module.BUILTIN_TOOL_METADATA.copy()
     storage_root = tmp_path / "runtime-storage"
     monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(storage_root))
-    metadata_module.register_builtin_tool_metadata(
+    registration_module.register_builtin_tool_metadata(
         ToolMetadata(
             name=tool_name,
             display_name="Dummy",
@@ -2807,7 +2804,7 @@ def test_sandbox_runner_execute_refreshes_plugin_metadata_before_override_valida
     )
     (plugin_root / "tools.py").write_text(
         "from agno.tools import Toolkit\n"
-        "from mindroom.tool_system.metadata import ConfigField, ToolCategory, register_tool_with_metadata\n"
+        "from mindroom.tool_system.declarations import ConfigField, ToolCategory\nfrom mindroom.tool_system.registration import register_tool_with_metadata\n"
         "\n"
         "class DemoPluginTool(Toolkit):\n"
         "    def __init__(self, label: str | None = None) -> None:\n"
@@ -2871,7 +2868,7 @@ def test_sandbox_runner_execute_refreshes_plugin_metadata_before_tool_init_overr
     )
     (plugin_root / "tools.py").write_text(
         "from agno.tools import Toolkit\n"
-        "from mindroom.tool_system.metadata import ConfigField, ToolCategory, register_tool_with_metadata\n"
+        "from mindroom.tool_system.declarations import ConfigField, ToolCategory\nfrom mindroom.tool_system.registration import register_tool_with_metadata\n"
         "\n"
         "class DemoPluginInitTool(Toolkit):\n"
         "    def __init__(self, base_dir: str | None = None) -> None:\n"
@@ -3391,7 +3388,7 @@ def test_sandbox_runner_auto_saves_large_result_for_routed_agent_workspace(
     original_metadata = TOOL_METADATA.copy()
     original_builtin_registry = metadata_module.BUILTIN_TOOL_REGISTRY.copy()
     original_builtin_metadata = metadata_module.BUILTIN_TOOL_METADATA.copy()
-    metadata_module.register_builtin_tool_metadata(
+    registration_module.register_builtin_tool_metadata(
         ToolMetadata(
             name=tool_name,
             display_name="Runner Auto Save",

--- a/tests/test_config_manager_consolidated.py
+++ b/tests/test_config_manager_consolidated.py
@@ -73,7 +73,7 @@ def _plugin_tool_config_path(tmp_path: Path, *, tool_name: str = "config_manager
     )
     (plugin_root / "tools.py").write_text(
         "from agno.tools import Toolkit\n"
-        "from mindroom.tool_system.metadata import ToolCategory, register_tool_with_metadata\n"
+        "from mindroom.tool_system.declarations import ToolCategory\nfrom mindroom.tool_system.registration import register_tool_with_metadata\n"
         "\n"
         "class DemoTool(Toolkit):\n"
         "    def __init__(self) -> None:\n"

--- a/tests/test_import_graph.py
+++ b/tests/test_import_graph.py
@@ -91,8 +91,10 @@ _TOOLS_ROOTS = _REGISTRY_ROOTS | frozenset(
 _ALLOWED_THIRD_PARTY_ROOTS: dict[str, frozenset[str]] = {
     "mindroom.config.main": _CONFIG_LAYER_ROOTS,
     "mindroom.model_loading": _CONFIG_LAYER_ROOTS | frozenset({"agno"}),
+    "mindroom.tool_system.declarations": frozenset({"dotenv"}),
     "mindroom.tool_system.metadata": _REGISTRY_ROOTS,
     "mindroom.tool_system.catalog": _REGISTRY_ROOTS,
+    "mindroom.tool_system.registration": _CONFIG_LAYER_ROOTS,
     "mindroom.tools": _TOOLS_ROOTS,
     # The sandbox runner is the API server for worker tool execution: fastapi
     # and its dependency tree on top of the full registry footprint.
@@ -169,8 +171,10 @@ def _assert_probe_clean(module: str, roots: tuple[str, ...]) -> None:
     [
         "mindroom.config.main",
         "mindroom.model_loading",
+        "mindroom.tool_system.declarations",
         "mindroom.tool_system.metadata",
         "mindroom.tool_system.catalog",
+        "mindroom.tool_system.registration",
         "mindroom.tools",
         "mindroom.api.sandbox_runner",
     ],
@@ -183,6 +187,14 @@ def test_slim_entry_points_do_not_import_provider_sdks(module: str) -> None:
 def test_primary_runtime_does_not_import_provider_sdks() -> None:
     """The orchestrator import (mindroom run) loads no provider SDK; only configured ones load later."""
     _assert_probe_clean("mindroom.orchestrator", _PROVIDER_SDK_ROOTS)
+
+
+def test_builtin_tool_manifest_does_not_import_runtime_catalog() -> None:
+    """Built-in registration may write registry state without loading catalog behavior."""
+    _assert_probe_clean(
+        "mindroom.tools",
+        ("mindroom.tool_system.catalog", "mindroom.tool_system.metadata"),
+    )
 
 
 @pytest.mark.parametrize("module", sorted(_ALLOWED_THIRD_PARTY_ROOTS))

--- a/tests/test_import_graph.py
+++ b/tests/test_import_graph.py
@@ -197,6 +197,15 @@ def test_builtin_tool_manifest_does_not_import_runtime_catalog() -> None:
     )
 
 
+def test_tool_auto_install_smoke_entrypoint_imports() -> None:
+    """The repository smoke entry point must use the post-split tool-system surfaces."""
+    subprocess.run(
+        [sys.executable, "-c", "import scripts.testing.tool_auto_install_smoke"],
+        check=True,
+        timeout=120,
+    )
+
+
 @pytest.mark.parametrize("module", sorted(_ALLOWED_THIRD_PARTY_ROOTS))
 def test_slim_entry_points_only_load_allowlisted_packages(module: str) -> None:
     """A new third-party package in a slim import graph must be a conscious decision.

--- a/tests/test_mcp_registry.py
+++ b/tests/test_mcp_registry.py
@@ -22,12 +22,10 @@ from mindroom.mcp.registry import (
 )
 from mindroom.mcp.toolkit import bind_mcp_server_manager
 from mindroom.mcp.types import MCPServerState
+from mindroom.tool_system.declarations import SetupType, ToolManagedInitArg, ToolStatus
 from mindroom.tool_system.metadata import (
     TOOL_METADATA,
     TOOL_REGISTRY,
-    SetupType,
-    ToolManagedInitArg,
-    ToolStatus,
     get_tool_by_name,
 )
 from mindroom.tool_system.worker_routing import (
@@ -258,7 +256,7 @@ def test_config_validation_rejects_runtime_mcp_name_collisions(tmp_path: Path) -
     )
     (plugin_root / "tools.py").write_text(
         "from agno.tools import Toolkit\n"
-        "from mindroom.tool_system.metadata import ToolCategory, register_tool_with_metadata\n"
+        "from mindroom.tool_system.declarations import ToolCategory\nfrom mindroom.tool_system.registration import register_tool_with_metadata\n"
         "\n"
         "class DemoTool(Toolkit):\n"
         "    def __init__(self) -> None:\n"
@@ -307,7 +305,7 @@ def test_config_validation_allows_non_mcp_prefixed_plugin_tools_on_isolating_sco
     )
     (plugin_root / "tools.py").write_text(
         "from agno.tools import Toolkit\n"
-        "from mindroom.tool_system.metadata import ToolCategory, register_tool_with_metadata\n"
+        "from mindroom.tool_system.declarations import ToolCategory\nfrom mindroom.tool_system.registration import register_tool_with_metadata\n"
         "\n"
         "class DemoTool(Toolkit):\n"
         "    def __init__(self) -> None:\n"

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -2817,7 +2817,7 @@ class TestMultiAgentOrchestrator:
         )
         (plugin_root / "tools.py").write_text(
             "from agno.tools import Toolkit\n"
-            "from mindroom.tool_system.metadata import ToolCategory, register_tool_with_metadata\n"
+            "from mindroom.tool_system.declarations import ToolCategory\nfrom mindroom.tool_system.registration import register_tool_with_metadata\n"
             "\n"
             "class UpdatedTool(Toolkit):\n"
             "    def __init__(self) -> None:\n"

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -63,7 +63,7 @@ def _write_broken_tool_plugin(plugin_root: Path, tool_name: str = "broken_plugin
     )
     (plugin_root / "tools.py").write_text(
         "from agno.tools import Toolkit\n"
-        "from mindroom.tool_system.metadata import ToolCategory, register_tool_with_metadata\n"
+        "from mindroom.tool_system.declarations import ToolCategory\nfrom mindroom.tool_system.registration import register_tool_with_metadata\n"
         "\n"
         "class BrokenTool(Toolkit):\n"
         "    def __init__(self) -> None:\n"
@@ -92,7 +92,7 @@ def _write_pre_registration_broken_tool_plugin(plugin_root: Path, tool_name: str
     (plugin_root / "tools.py").write_text(
         "from definitely_missing_plugin_dependency import broken\n"
         "from agno.tools import Toolkit\n"
-        "from mindroom.tool_system.metadata import ToolCategory, register_tool_with_metadata\n"
+        "from mindroom.tool_system.declarations import ToolCategory\nfrom mindroom.tool_system.registration import register_tool_with_metadata\n"
         "\n"
         "class BrokenTool(Toolkit):\n"
         "    def __init__(self) -> None:\n"
@@ -118,7 +118,7 @@ def _write_mid_registration_broken_tool_plugin(plugin_root: Path) -> None:
     )
     (plugin_root / "tools.py").write_text(
         "from agno.tools import Toolkit\n"
-        "from mindroom.tool_system.metadata import ToolCategory, register_tool_with_metadata\n"
+        "from mindroom.tool_system.declarations import ToolCategory\nfrom mindroom.tool_system.registration import register_tool_with_metadata\n"
         "\n"
         "class BrokenTool(Toolkit):\n"
         "    def __init__(self) -> None:\n"
@@ -155,7 +155,7 @@ def _write_working_tool_plugin(plugin_root: Path, *, plugin_name: str, tool_name
     )
     (plugin_root / "tools.py").write_text(
         "from agno.tools import Toolkit\n"
-        "from mindroom.tool_system.metadata import ToolCategory, register_tool_with_metadata\n"
+        "from mindroom.tool_system.declarations import ToolCategory\nfrom mindroom.tool_system.registration import register_tool_with_metadata\n"
         "\n"
         "class WorkingTool(Toolkit):\n"
         "    def __init__(self) -> None:\n"
@@ -264,7 +264,7 @@ def test_load_plugins_registers_tools_and_skills(tmp_path: Path) -> None:
     tools_path = plugin_root / "tools.py"
     tools_path.write_text(
         "from agno.tools import Toolkit\n"
-        "from mindroom.tool_system.metadata import ToolCategory, register_tool_with_metadata\n"
+        "from mindroom.tool_system.declarations import ToolCategory\nfrom mindroom.tool_system.registration import register_tool_with_metadata\n"
         "\n"
         "class DemoTool(Toolkit):\n"
         "    def __init__(self) -> None:\n"
@@ -327,7 +327,7 @@ def test_resolved_tool_metadata_for_runtime_does_not_mutate_live_registry(tmp_pa
     )
     (plugin_root / "tools.py").write_text(
         "from agno.tools import Toolkit\n"
-        "from mindroom.tool_system.metadata import ToolCategory, register_tool_with_metadata\n"
+        "from mindroom.tool_system.declarations import ToolCategory\nfrom mindroom.tool_system.registration import register_tool_with_metadata\n"
         "\n"
         "class DemoTool(Toolkit):\n"
         "    def __init__(self) -> None:\n"
@@ -393,7 +393,7 @@ def test_load_plugins_from_python_package(tmp_path: Path, monkeypatch: pytest.Mo
     tools_path = plugin_root / "tools.py"
     tools_path.write_text(
         "from agno.tools import Toolkit\n"
-        "from mindroom.tool_system.metadata import ToolCategory, register_tool_with_metadata\n"
+        "from mindroom.tool_system.declarations import ToolCategory\nfrom mindroom.tool_system.registration import register_tool_with_metadata\n"
         "\n"
         "class DemoTool(Toolkit):\n"
         "    def __init__(self) -> None:\n"
@@ -924,7 +924,7 @@ def test_validate_with_runtime_does_not_leak_plugin_tools_after_failure(tmp_path
     )
     (plugin_root / "tools.py").write_text(
         "from agno.tools import Toolkit\n"
-        "from mindroom.tool_system.metadata import ToolCategory, register_tool_with_metadata\n"
+        "from mindroom.tool_system.declarations import ToolCategory\nfrom mindroom.tool_system.registration import register_tool_with_metadata\n"
         "\n"
         "class DemoTool(Toolkit):\n"
         "    def __init__(self) -> None:\n"
@@ -999,7 +999,7 @@ def test_validate_with_runtime_does_not_mutate_live_tool_registry_on_success(tmp
     )
     (plugin_root / "tools.py").write_text(
         "from agno.tools import Toolkit\n"
-        "from mindroom.tool_system.metadata import ToolCategory, register_tool_with_metadata\n"
+        "from mindroom.tool_system.declarations import ToolCategory\nfrom mindroom.tool_system.registration import register_tool_with_metadata\n"
         "\n"
         "class DemoTool(Toolkit):\n"
         "    def __init__(self) -> None:\n"
@@ -1114,7 +1114,7 @@ def test_validate_with_runtime_does_not_mutate_live_registry_for_package_helper_
     )
     (plugin_root / "helpers.py").write_text(
         "from agno.tools import Toolkit\n"
-        "from mindroom.tool_system.metadata import ToolCategory, register_tool_with_metadata\n"
+        "from mindroom.tool_system.declarations import ToolCategory\nfrom mindroom.tool_system.registration import register_tool_with_metadata\n"
         "\n"
         "class HelperTool(Toolkit):\n"
         "    def __init__(self) -> None:\n"
@@ -1190,7 +1190,7 @@ def test_load_plugins_removes_tools_for_successfully_removed_plugins(tmp_path: P
     )
     (plugin_root / "tools.py").write_text(
         "from agno.tools import Toolkit\n"
-        "from mindroom.tool_system.metadata import ToolCategory, register_tool_with_metadata\n"
+        "from mindroom.tool_system.declarations import ToolCategory\nfrom mindroom.tool_system.registration import register_tool_with_metadata\n"
         "\n"
         "class DemoTool(Toolkit):\n"
         "    def __init__(self) -> None:\n"
@@ -1267,7 +1267,7 @@ def test_load_plugins_re_registers_tools_when_plugin_is_re_enabled(tmp_path: Pat
     )
     (plugin_root / "tools.py").write_text(
         "from agno.tools import Toolkit\n"
-        "from mindroom.tool_system.metadata import ToolCategory, register_tool_with_metadata\n"
+        "from mindroom.tool_system.declarations import ToolCategory\nfrom mindroom.tool_system.registration import register_tool_with_metadata\n"
         "\n"
         "class DemoTool(Toolkit):\n"
         "    def __init__(self) -> None:\n"
@@ -1376,7 +1376,7 @@ def test_load_plugins_removes_stale_tools_when_enabled_plugin_changes_exports(tm
     tools_path = plugin_root / "tools.py"
     tools_path.write_text(
         "from agno.tools import Toolkit\n"
-        "from mindroom.tool_system.metadata import ToolCategory, register_tool_with_metadata\n"
+        "from mindroom.tool_system.declarations import ToolCategory\nfrom mindroom.tool_system.registration import register_tool_with_metadata\n"
         "\n"
         "class DemoTool(Toolkit):\n"
         "    def __init__(self) -> None:\n"
@@ -1409,7 +1409,7 @@ def test_load_plugins_removes_stale_tools_when_enabled_plugin_changes_exports(tm
 
         tools_path.write_text(
             "from agno.tools import Toolkit\n"
-            "from mindroom.tool_system.metadata import ToolCategory, register_tool_with_metadata\n"
+            "from mindroom.tool_system.declarations import ToolCategory\nfrom mindroom.tool_system.registration import register_tool_with_metadata\n"
             "\n"
             "class DemoTool(Toolkit):\n"
             "    def __init__(self) -> None:\n"
@@ -1454,7 +1454,7 @@ def test_load_plugins_rejects_built_in_tool_name_collisions(tmp_path: Path) -> N
     )
     (plugin_root / "tools.py").write_text(
         "from agno.tools import Toolkit\n"
-        "from mindroom.tool_system.metadata import ToolCategory, register_tool_with_metadata\n"
+        "from mindroom.tool_system.declarations import ToolCategory\nfrom mindroom.tool_system.registration import register_tool_with_metadata\n"
         "\n"
         "class DemoTool(Toolkit):\n"
         "    def __init__(self) -> None:\n"
@@ -1495,7 +1495,7 @@ def test_load_plugins_rejects_plugin_tool_name_collisions(tmp_path: Path) -> Non
     for root, display_name in ((first_root, "First Tool"), (second_root, "Second Tool")):
         (root / "tools.py").write_text(
             "from agno.tools import Toolkit\n"
-            "from mindroom.tool_system.metadata import ToolCategory, register_tool_with_metadata\n"
+            "from mindroom.tool_system.declarations import ToolCategory\nfrom mindroom.tool_system.registration import register_tool_with_metadata\n"
             "\n"
             "class DemoTool(Toolkit):\n"
             "    def __init__(self) -> None:\n"
@@ -1532,7 +1532,7 @@ def test_load_plugins_rejects_duplicate_tool_names_within_one_plugin(tmp_path: P
     )
     (plugin_root / "tools.py").write_text(
         "from agno.tools import Toolkit\n"
-        "from mindroom.tool_system.metadata import ToolCategory, register_tool_with_metadata\n"
+        "from mindroom.tool_system.declarations import ToolCategory\nfrom mindroom.tool_system.registration import register_tool_with_metadata\n"
         "\n"
         "class FirstTool(Toolkit):\n"
         "    def __init__(self) -> None:\n"
@@ -1583,7 +1583,7 @@ def test_load_plugins_preserves_tools_when_manifest_name_changes(tmp_path: Path)
     )
     (plugin_root / "tools.py").write_text(
         "from agno.tools import Toolkit\n"
-        "from mindroom.tool_system.metadata import ToolCategory, register_tool_with_metadata\n"
+        "from mindroom.tool_system.declarations import ToolCategory\nfrom mindroom.tool_system.registration import register_tool_with_metadata\n"
         "\n"
         "class DemoTool(Toolkit):\n"
         "    def __init__(self) -> None:\n"
@@ -1671,7 +1671,7 @@ def test_load_config_tolerates_missing_and_broken_plugins_on_startup(
     )
     (good_root / "tools.py").write_text(
         "from agno.tools import Toolkit\n"
-        "from mindroom.tool_system.metadata import ToolCategory, register_tool_with_metadata\n"
+        "from mindroom.tool_system.declarations import ToolCategory\nfrom mindroom.tool_system.registration import register_tool_with_metadata\n"
         "\n"
         "class DemoTool(Toolkit):\n"
         "    def __init__(self) -> None:\n"
@@ -2183,7 +2183,7 @@ def test_load_plugins_skips_later_broken_plugin_and_keeps_earlier_tools(
     )
     (good_root / "tools.py").write_text(
         "from agno.tools import Toolkit\n"
-        "from mindroom.tool_system.metadata import ToolCategory, register_tool_with_metadata\n"
+        "from mindroom.tool_system.declarations import ToolCategory\nfrom mindroom.tool_system.registration import register_tool_with_metadata\n"
         "\n"
         "class DemoTool(Toolkit):\n"
         "    def __init__(self) -> None:\n"
@@ -2822,7 +2822,7 @@ def test_failed_strict_tool_plugin_reload_preserves_previous_live_registry(tmp_p
     tools_path = plugin_root / "tools.py"
     tools_path.write_text(
         "from agno.tools import Toolkit\n"
-        "from mindroom.tool_system.metadata import ToolCategory, register_tool_with_metadata\n"
+        "from mindroom.tool_system.declarations import ToolCategory\nfrom mindroom.tool_system.registration import register_tool_with_metadata\n"
         "\n"
         "class ReloadTool(Toolkit):\n"
         "    def __init__(self) -> None:\n"

--- a/tests/test_sandbox_proxy.py
+++ b/tests/test_sandbox_proxy.py
@@ -55,11 +55,11 @@ from mindroom.tool_system.metadata import (
     ToolMetadata,
     ToolValidationInfo,
     get_tool_by_name,
-    register_tool_with_metadata,
     resolved_tool_validation_snapshot_for_runtime,
     serialize_tool_validation_snapshot,
 )
 from mindroom.tool_system.output_files import OUTPUT_PATH_ARGUMENT
+from mindroom.tool_system.registration import register_tool_with_metadata
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, tool_runtime_context, worker_progress_pump_scope
 from mindroom.tool_system.tool_hooks import build_tool_hook_bridge, prepend_tool_hook_bridge
 from mindroom.tool_system.worker_proxy_client import WorkerProxyClientConfig, execute_worker_proxy_request

--- a/tests/test_self_config.py
+++ b/tests/test_self_config.py
@@ -98,7 +98,7 @@ def _plugin_tool_config_path(tmp_path: Path, *, tool_name: str = "self_config_pl
     )
     (plugin_root / "tools.py").write_text(
         "from agno.tools import Toolkit\n"
-        "from mindroom.tool_system.metadata import ToolCategory, register_tool_with_metadata\n"
+        "from mindroom.tool_system.declarations import ToolCategory\nfrom mindroom.tool_system.registration import register_tool_with_metadata\n"
         "\n"
         "class DemoTool(Toolkit):\n"
         "    def __init__(self) -> None:\n"

--- a/tests/test_tool_dependencies.py
+++ b/tests/test_tool_dependencies.py
@@ -14,6 +14,7 @@ import pytest
 from agno.tools import Toolkit
 
 from mindroom.constants import resolve_runtime_paths
+from mindroom.tool_system.declarations import SetupType, ToolCategory, ToolMetadata, ToolStatus
 from mindroom.tool_system.dependencies import (
     _PIP_TO_IMPORT,
     _auto_install_optional_extra,
@@ -28,10 +29,6 @@ from mindroom.tool_system.dependencies import (
 from mindroom.tool_system.metadata import (
     TOOL_METADATA,
     TOOL_REGISTRY,
-    SetupType,
-    ToolCategory,
-    ToolMetadata,
-    ToolStatus,
     get_tool_by_name,
 )
 from mindroom.tools.openbb import openbb_tools

--- a/tests/test_tool_hooks.py
+++ b/tests/test_tool_hooks.py
@@ -52,7 +52,8 @@ from mindroom.orchestrator import _MultiAgentOrchestrator
 from mindroom.sync_bridge_state import is_loop_blocked_by_sync_tool_bridge
 from mindroom.tool_approval import ToolCallWorkflowOrigin, _shutdown_approval_store
 from mindroom.tool_system import tool_hooks
-from mindroom.tool_system.metadata import TOOL_METADATA, TOOL_REGISTRY, ToolCategory, register_tool_with_metadata
+from mindroom.tool_system.metadata import TOOL_METADATA, TOOL_REGISTRY, ToolCategory
+from mindroom.tool_system.registration import register_tool_with_metadata
 from mindroom.tool_system.runtime_context import (
     ToolDispatchContext,
     ToolRuntimeContext,

--- a/tests/test_tool_system_facade_boundaries.py
+++ b/tests/test_tool_system_facade_boundaries.py
@@ -19,6 +19,13 @@ PRIVATE_REGISTRY_STATE_INTERFACE_VISIBILITY = {
     "mindroom.mcp.registry",
     "mindroom.tool_system.metadata",
     "mindroom.tool_system.plugins",
+    "mindroom.tool_system.registration",
+}
+FORBIDDEN_BUILTIN_TOOL_DEPENDENCIES = {
+    "mindroom.tool_system.bootstrap",
+    "mindroom.tool_system.catalog",
+    "mindroom.tool_system.metadata",
+    "mindroom.tool_system.registry_state",
 }
 ALLOWED_PUBLIC_CATALOG_REEXPORTS = {
     "TOOL_METADATA",
@@ -220,6 +227,50 @@ def _function_local_imports(py_path: Path) -> set[str]:
     return local_imports
 
 
+def _builtin_tool_forbidden_importers() -> dict[str, set[str]]:
+    importers: dict[str, set[str]] = {}
+    for py_path in (SOURCE_ROOT / "tools").glob("*.py"):
+        importer_module = f"mindroom.tools.{py_path.stem}"
+        imported_modules = {
+            module_name
+            for node in ast.walk(ast.parse(py_path.read_text()))
+            for module_name in _imported_module_names(node)
+            if module_name in FORBIDDEN_BUILTIN_TOOL_DEPENDENCIES
+        }
+        if imported_modules:
+            importers[importer_module] = imported_modules
+    return importers
+
+
+def _builtin_registration_modules() -> list[str]:
+    modules: list[str] = []
+    for py_path in (SOURCE_ROOT / "tools").glob("*.py"):
+        if py_path.name == "__init__.py":
+            continue
+        imported_modules = {
+            module_name
+            for node in ast.walk(ast.parse(py_path.read_text()))
+            for module_name in _imported_module_names(node)
+        }
+        if "mindroom.tool_system.registration" in imported_modules:
+            modules.append(f"mindroom.tools.{py_path.stem}")
+    return sorted(modules)
+
+
+def _manifest_modules() -> list[str]:
+    tree = ast.parse((SOURCE_ROOT / "tools" / "__init__.py").read_text())
+    modules: list[str] = []
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            modules.extend(alias.name for alias in node.names if alias.name.startswith("mindroom.tools."))
+        elif isinstance(node, ast.ImportFrom):
+            if node.module == "mindroom.tools":
+                modules.extend(f"mindroom.tools.{alias.name}" for alias in node.names)
+            elif node.module and node.module.startswith("mindroom.tools."):
+                modules.append(node.module)
+    return modules
+
+
 def test_tool_system_runtime_and_extensions_modules_are_removed() -> None:
     """The runtime and extensions facade modules should no longer exist."""
     assert not (SOURCE_ROOT / "tool_system" / "runtime.py").exists()
@@ -270,6 +321,18 @@ def test_catalog_private_registry_helpers_have_no_importers() -> None:
     assert not _catalog_private_importers()
 
 
+def test_builtin_tools_depend_only_on_declaration_and_registration_leaves() -> None:
+    """Built-in tool modules must never import the runtime catalog or its private state."""
+    assert not _builtin_tool_forbidden_importers()
+
+
+def test_builtin_tool_manifest_explicitly_imports_every_registration_module() -> None:
+    """The deterministic manifest should list every built-in registration module exactly once."""
+    manifest_modules = _manifest_modules()
+    assert len(manifest_modules) == len(set(manifest_modules))
+    assert sorted(manifest_modules) == _builtin_registration_modules()
+
+
 def test_tach_does_not_expose_catalog_private_registry_helpers() -> None:
     """Tach should not publish catalog private registry helpers as public interfaces."""
     forbidden_catalog_exports = _private_registry_state_exports()
@@ -313,15 +376,27 @@ def test_tach_breaks_metadata_plugins_cycle_with_private_split_modules() -> None
     plugins_deps = _tach_module_depends_on("mindroom.tool_system.plugins")
     catalog_deps = _tach_module_depends_on("mindroom.tool_system.catalog")
     bootstrap_deps = _tach_module_depends_on("mindroom.tool_system.bootstrap")
+    declarations_deps = _tach_module_depends_on("mindroom.tool_system.declarations")
+    registration_deps = _tach_module_depends_on("mindroom.tool_system.registration")
 
     assert "mindroom.tool_system.plugins" not in metadata_deps
     assert "mindroom.tool_system.metadata" not in plugins_deps
+    assert "mindroom.tool_system.declarations" in metadata_deps
     assert "mindroom.tool_system.registry_state" in metadata_deps
     assert "mindroom.tool_system.plugin_imports" in metadata_deps
     assert "mindroom.tool_system.registry_state" in plugins_deps
     assert "mindroom.tool_system.plugin_imports" in plugins_deps
-    assert catalog_deps == {"mindroom.tool_system.bootstrap", "mindroom.tool_system.metadata"}
+    assert catalog_deps == {
+        "mindroom.tool_system.bootstrap",
+        "mindroom.tool_system.declarations",
+        "mindroom.tool_system.metadata",
+    }
     assert bootstrap_deps == {"mindroom.mcp.registry", "mindroom.tool_system.plugins"}
+    assert declarations_deps == set()
+    assert registration_deps == {
+        "mindroom.tool_system.declarations",
+        "mindroom.tool_system.registry_state",
+    }
 
 
 def test_selected_modules_do_not_hide_tool_system_imports_inside_functions() -> None:

--- a/tests/test_tools_metadata.py
+++ b/tests/test_tools_metadata.py
@@ -36,10 +36,10 @@ from mindroom.tool_system.metadata import (
     deserialize_tool_validation_snapshot,
     export_tools_metadata,
     get_tool_by_name,
-    register_tool_with_metadata,
     resolved_tool_validation_snapshot_for_runtime,
     serialize_tool_validation_snapshot,
 )
+from mindroom.tool_system.registration import register_tool_with_metadata
 from mindroom.tool_system.registry_state import (
     BUILTIN_TOOL_METADATA,
     BUILTIN_TOOL_REGISTRY,


### PR DESCRIPTION
## Summary

- split declarative tool metadata into `tool_system.declarations` and registration into `tool_system.registration`
- migrate every built-in registration module and plugin example to the leaf surfaces
- keep runtime lookup, validation, plugin resolution, credential handling, sandbox wrapping, and construction in the catalog/metadata layer
- add import-graph, manifest-completeness, and Tach boundary regressions for the new direction

## New invariant

Tool implementations may depend on the declaration and registration leaves.
The runtime catalog may load the explicit built-in manifest.
Tool implementations never depend on the runtime catalog or its private registry state.

## Production LOC

The touched tool registration/catalog subsystem (`src/mindroom/tool_system` plus `src/mindroom/tools`) changes from 21,548 to 21,663 production lines (+115), including the mechanical split-import migration across all built-in modules.

## Validation

- `uv sync --all-extras`
- focused tool catalog, plugin, sandbox, MCP, dependency, and import-boundary suites (550 tests; final focused boundary rerun: 32 passed)
- full pytest suite at reduced parallelism with optional Docker integrations unavailable: 9,286 passed, 204 skipped
- representative Docker-backed Postgres cache test passed independently
- `uv run pre-commit run --all-files`
- `uv run tach check --dependencies --interfaces`

The first maximum-parallel full-suite attempt hit one unrelated 40 ms event-loop timing assertion under load.
That test passed in isolation, and the complete lower-parallelism rerun passed.

## Deliberate non-generalizations

- no filesystem auto-discovery; `mindroom.tools` remains the explicit deterministic built-in manifest
- no Config resolution or runtime entity behavior changes
- no compatibility wrappers or new umbrella facade
- no refactor of runtime catalog responsibilities beyond removing declarations and registration writes from `metadata.py`
