### PR TITLE
Count only model-visible runs as seen

### DIFF
--- a/src/mindroom/history/compaction.py
+++ b/src/mindroom/history/compaction.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING, cast
 from uuid import uuid4
 
 from agno.run.agent import RunOutput
-from agno.run.base import RunStatus
 from agno.run.team import TeamRunOutput
 from agno.session.summary import SessionSummary
 from agno.utils.message import filter_tool_calls
@@ -21,6 +20,7 @@ from pydantic import BaseModel
 from mindroom.constants import MINDROOM_COMPACTION_CHUNK_TIMEOUT_SECONDS, prompt_roles_for_history_storage
 from mindroom.history.storage import (
     compacted_run_ids_with,
+    is_model_history_visible_run,
     record_compaction_chunk,
     remove_runs_by_id,
     seen_event_ids_for_runs,
@@ -1043,29 +1043,19 @@ def _history_skip_roles(history_settings: ResolvedHistorySettings) -> list[str]:
     return sorted(prompt_roles_for_history_storage(history_settings.system_message_role))
 
 
-def _completed_top_level_runs(session: AgentSession | TeamSession) -> list[RunOutput | TeamRunOutput]:
-    """Return completed top-level runs that can contribute to persisted replay."""
-    skip_statuses = {RunStatus.paused, RunStatus.cancelled, RunStatus.error}
-    return [
-        run
-        for run in session.runs or []
-        if isinstance(run, (RunOutput, TeamRunOutput)) and run.parent_run_id is None and run.status not in skip_statuses
-    ]
-
-
 def scope_visible_runs(
     session: AgentSession | TeamSession,
     scope: HistoryScope,
 ) -> list[RunOutput | TeamRunOutput]:
-    """Return this scope's completed top-level runs in stored order."""
-    return _runs_for_scope(_completed_top_level_runs(session), scope)
+    """Return this scope's model-history-visible runs in stored order."""
+    return _runs_for_scope([run for run in session.runs or [] if is_model_history_visible_run(run)], scope)
 
 
 def _runs_for_scope(
     runs: Sequence[RunOutput | TeamRunOutput],
     scope: HistoryScope,
 ) -> list[RunOutput | TeamRunOutput]:
-    """Filter completed top-level runs down to one persisted history scope."""
+    """Filter model-history-visible runs down to one persisted history scope."""
     if scope.kind == "team":
         return [run for run in runs if isinstance(run, TeamRunOutput) and run.team_id == scope.scope_id]
     return [run for run in runs if isinstance(run, RunOutput) and run.agent_id == scope.scope_id]

--- a/src/mindroom/history/storage.py
+++ b/src/mindroom/history/storage.py
@@ -29,10 +29,11 @@ from __future__ import annotations
 from copy import deepcopy
 from dataclasses import replace
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeGuard
 
 from agno.db.base import SessionType
 from agno.run.agent import RunOutput
+from agno.run.base import RunStatus
 from agno.run.team import TeamRunOutput
 from agno.session.agent import AgentSession
 from agno.session.team import TeamSession
@@ -55,6 +56,15 @@ _COMPACTION_METADATA_VERSION = 2
 _MATRIX_HISTORY_METADATA_VERSION = 1
 _PENDING_COMPACTION_SCOPE_KEYS_SESSION_STATE_KEY = "mindroom_pending_compaction_scope_keys"
 _COMPACTED_RUN_ID_RETENTION_LIMIT = 1_024
+
+
+def is_model_history_visible_run(run: object) -> TypeGuard[RunOutput | TeamRunOutput]:
+    """Return whether one run is represented in Agno model history."""
+    return (
+        isinstance(run, (RunOutput, TeamRunOutput))
+        and run.parent_run_id is None
+        and run.status not in {RunStatus.paused, RunStatus.cancelled, RunStatus.error}
+    )
 
 
 def new_scope_session(*, session_id: str, scope_id: str, is_team: bool) -> AgentSession | TeamSession:
@@ -227,7 +237,7 @@ def read_scope_seen_event_ids(session: AgentSession | TeamSession, scope: Histor
     """Return the consumed Matrix event ids for one session scope."""
     seen_event_ids = _read_preserved_scope_seen_event_ids(session, scope)
     for run in session.runs or []:
-        if not isinstance(run, (RunOutput, TeamRunOutput)):
+        if not is_model_history_visible_run(run):
             continue
         if _scope_for_run(run) != scope:
             continue
@@ -239,6 +249,8 @@ def seen_event_ids_for_runs(runs: Iterable[RunOutput | TeamRunOutput]) -> set[st
     """Return Matrix event ids already represented by run metadata."""
     seen_event_ids: set[str] = set()
     for run in runs:
+        if not is_model_history_visible_run(run):
+            continue
         seen_event_ids.update(_run_seen_event_ids(run))
     return seen_event_ids
 

--- a/src/mindroom/history/storage.py
+++ b/src/mindroom/history/storage.py
@@ -246,7 +246,7 @@ def read_scope_seen_event_ids(session: AgentSession | TeamSession, scope: Histor
 
 
 def seen_event_ids_for_runs(runs: Iterable[RunOutput | TeamRunOutput]) -> set[str]:
-    """Return Matrix event ids already represented by run metadata."""
+    """Return Matrix event ids represented by model-history-visible runs."""
     seen_event_ids: set[str] = set()
     for run in runs:
         if not is_model_history_visible_run(run):

--- a/tests/test_history_scope_state.py
+++ b/tests/test_history_scope_state.py
@@ -11,17 +11,21 @@ import pytest
 from agno.run.agent import RunOutput
 from agno.run.base import RunStatus
 from agno.run.team import TeamRunOutput
+from agno.session.agent import AgentSession
 from agno.session.summary import SessionSummary
+from agno.session.team import TeamSession
 
 from mindroom.agent_storage import create_session_storage, get_agent_session
 from mindroom.config.models import CompactionOverrideConfig
 from mindroom.constants import (
     MINDROOM_COMPACTION_METADATA_KEY,
 )
+from mindroom.history.compaction import scope_visible_runs
 from mindroom.history.storage import (
     read_scope_seen_event_ids,
     read_scope_state,
     record_compaction_chunk,
+    seen_event_ids_for_runs,
     set_force_compaction_state,
     update_scope_seen_event_ids,
     write_scope_state,
@@ -93,6 +97,48 @@ def test_scope_seen_event_ids_include_persisted_response_event_ids(tmp_path: Pat
     session = _session("session-1", runs=[run])
 
     assert read_scope_seen_event_ids(session, scope) == {"question-1", "answer-1"}
+
+
+@pytest.mark.parametrize("is_team", [False, True], ids=["agent", "team"])
+def test_seen_event_ids_match_model_history_visibility(is_team: bool) -> None:
+    entity_id = "team-123" if is_team else "test_agent"
+    scope = HistoryScope(kind="team" if is_team else "agent", scope_id=entity_id)
+
+    def make_run(run_id: str, status: RunStatus, *, parent_run_id: str | None = None) -> RunOutput | TeamRunOutput:
+        metadata = {"matrix_seen_event_ids": [f"{run_id}-event"]}
+        if is_team:
+            return TeamRunOutput(
+                run_id=run_id,
+                team_id=entity_id,
+                status=status,
+                parent_run_id=parent_run_id,
+                metadata=metadata,
+            )
+        return RunOutput(
+            run_id=run_id,
+            agent_id=entity_id,
+            status=status,
+            parent_run_id=parent_run_id,
+            metadata=metadata,
+        )
+
+    runs = [
+        make_run("completed", RunStatus.completed),
+        make_run("paused", RunStatus.paused),
+        make_run("cancelled", RunStatus.cancelled),
+        make_run("error", RunStatus.error),
+        make_run("child", RunStatus.completed, parent_run_id="completed"),
+    ]
+    session: AgentSession | TeamSession
+    if is_team:
+        session = TeamSession(session_id="session-1", team_id=entity_id, runs=runs, created_at=1, updated_at=1)
+    else:
+        session = AgentSession(session_id="session-1", agent_id=entity_id, runs=runs, created_at=1, updated_at=1)
+    update_scope_seen_event_ids(session, scope, ["preserved-event"])
+
+    assert read_scope_seen_event_ids(session, scope) == {"completed-event", "preserved-event"}
+    assert seen_event_ids_for_runs(runs) == {"completed-event"}
+    assert [run.run_id for run in scope_visible_runs(session, scope)] == ["completed"]
 
 
 def test_scope_states_do_not_bleed_between_scopes(tmp_path: Path) -> None:

--- a/tests/test_history_scope_state.py
+++ b/tests/test_history_scope_state.py
@@ -124,6 +124,7 @@ def test_seen_event_ids_match_model_history_visibility(is_team: bool) -> None:
 
     runs = [
         make_run("completed", RunStatus.completed),
+        make_run("running", RunStatus.running),
         make_run("paused", RunStatus.paused),
         make_run("cancelled", RunStatus.cancelled),
         make_run("error", RunStatus.error),
@@ -136,9 +137,9 @@ def test_seen_event_ids_match_model_history_visibility(is_team: bool) -> None:
         session = AgentSession(session_id="session-1", agent_id=entity_id, runs=runs, created_at=1, updated_at=1)
     update_scope_seen_event_ids(session, scope, ["preserved-event"])
 
-    assert read_scope_seen_event_ids(session, scope) == {"completed-event", "preserved-event"}
-    assert seen_event_ids_for_runs(runs) == {"completed-event"}
-    assert [run.run_id for run in scope_visible_runs(session, scope)] == ["completed"]
+    assert read_scope_seen_event_ids(session, scope) == {"completed-event", "preserved-event", "running-event"}
+    assert seen_event_ids_for_runs(runs) == {"completed-event", "running-event"}
+    assert [run.run_id for run in scope_visible_runs(session, scope)] == ["completed", "running"]
 
 
 def test_scope_states_do_not_bleed_between_scopes(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Centralize Agno model-history run visibility for top-level agent and team runs.
- Apply that rule to seen-event reads and compaction preservation writes.
- Reuse the same predicate for compaction run selection.
- Cover completed, paused, cancelled, error, child, and preserved event IDs for agent and team sessions.

## Testing

- `uv run pytest tests/test_history_scope_state.py tests/test_history_compaction_rewrite.py tests/test_history_prompt_tokens.py tests/test_compaction_invariants.py -q -n 0 --no-cov`
- `uv run pytest` (9457 passed, 64 skipped)
- `uv run pre-commit run --all-files`