### PR TITLE
Speed up Kubernetes worker hot path

### DIFF
--- a/src/mindroom/workers/backends/kubernetes.py
+++ b/src/mindroom/workers/backends/kubernetes.py
@@ -46,7 +46,6 @@ _COLD_START_GRACE_SECONDS = 1.5
 _WAITING_PROGRESS_INTERVAL_SECONDS = 5.0
 _PROGRESS_REPORTER_JOIN_TIMEOUT_SECONDS = 1.0
 _READY_WORKER_REVALIDATE_SECONDS = 300.0
-_MAX_LAST_USED_PERSIST_INTERVAL_SECONDS = 60.0
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +63,6 @@ class _ReadyWorkerCacheEntry:
     spec: WorkerSpec
     handle: WorkerHandle
     validated_at: float
-    persisted_last_used_at: float
     credentials_encryption_key_hash: str | None
 
 
@@ -489,7 +487,7 @@ class KubernetesWorkerBackend:
                     **final_annotations,
                 }
                 handle = self._handle_from_deployment(deployment, now=timestamp)
-                self._store_ready_worker(spec, handle, validated_at=timestamp, persisted_last_used_at=timestamp)
+                self._store_ready_worker(spec, handle, validated_at=timestamp)
                 return handle
         finally:
             if progress_sink is not None:
@@ -524,12 +522,7 @@ class KubernetesWorkerBackend:
         """List workers known to this backend."""
         timestamp = time.time() if now is None else now
         handles = [
-            self._handle_with_cached_usage(
-                self._handle_from_deployment(deployment, now=timestamp),
-                running=int(deployment.spec.replicas or 0) > 0,
-                now=timestamp,
-            )
-            for deployment in self._resources.list_deployments()
+            self._handle_from_deployment(deployment, now=timestamp) for deployment in self._resources.list_deployments()
         ]
         return filter_and_sort_worker_handles(handles, include_idle)
 
@@ -538,42 +531,21 @@ class KubernetesWorkerBackend:
         timestamp = time.time() if now is None else now
         cleaned: list[WorkerHandle] = []
         for deployment in self._resources.list_deployments():
-            handle = self._handle_with_cached_usage(
-                self._handle_from_deployment(deployment, now=timestamp),
-                running=int(deployment.spec.replicas or 0) > 0,
-                now=timestamp,
-            )
+            handle = self._handle_from_deployment(deployment, now=timestamp)
             if handle.status != "idle" or int(deployment.spec.replicas or 0) == 0:
                 continue
-            worker_lock = self._worker_lock(handle.worker_key)
-            if not worker_lock.acquire(blocking=False):
-                continue
-            try:
-                live = self._resources.read_deployment(handle.worker_id)
-                if live is None:
-                    self._invalidate_ready_worker(handle.worker_key)
-                    continue
-                live_handle = self._handle_with_cached_usage(
-                    self._handle_from_deployment(live, now=timestamp),
-                    running=int(live.spec.replicas or 0) > 0,
-                    now=timestamp,
-                )
-                if live_handle.status != "idle" or int(live.spec.replicas or 0) == 0:
-                    continue
-                annotations = dict(live.metadata.annotations or {})
-                resources.apply_lifecycle_annotations(
-                    annotations,
-                    mark_worker_idle(resources.lifecycle_from_annotations(annotations, now=timestamp)),
-                )
-                self._resources.patch_deployment(live_handle.worker_id, replicas=0, annotations=annotations)
-                self._resources.delete_service(live_handle.worker_id)
-                self._resources.delete_secret(live_handle.worker_id)
-                self._invalidate_ready_worker(live_handle.worker_key)
-                live.spec.replicas = 0
-                live.metadata.annotations = annotations
-                cleaned.append(self._handle_from_deployment(live, now=timestamp))
-            finally:
-                worker_lock.release()
+            annotations = dict(deployment.metadata.annotations or {})
+            resources.apply_lifecycle_annotations(
+                annotations,
+                mark_worker_idle(resources.lifecycle_from_annotations(annotations, now=timestamp)),
+            )
+            self._resources.patch_deployment(handle.worker_id, replicas=0, annotations=annotations)
+            self._resources.delete_service(handle.worker_id)
+            self._resources.delete_secret(handle.worker_id)
+            self._invalidate_ready_worker(handle.worker_key)
+            deployment.spec.replicas = 0
+            deployment.metadata.annotations = annotations
+            cleaned.append(self._handle_from_deployment(deployment, now=timestamp))
         return cleaned
 
     def reconcile_drifted_workers(self, *, now: float | None = None) -> list[WorkerHandle]:
@@ -718,14 +690,19 @@ class KubernetesWorkerBackend:
         )
 
     def _reuse_cached_ready_worker(self, spec: WorkerSpec, *, now: float) -> WorkerHandle | None:
-        handle = self._cached_ready_worker(spec, now=now)
-        if handle is None:
+        entry = self._cached_ready_worker(spec.worker_key, spec=spec, now=now)
+        if entry is None:
             return None
         try:
+            handle = self._patch_cached_worker_usage(entry, now=now)
+            if handle is None:
+                return None
             self._sync_shared_credentials(spec.worker_key)
         except WorkerBackendError:
+            self._invalidate_ready_worker(spec.worker_key)
             raise
         except Exception as exc:
+            self._invalidate_ready_worker(spec.worker_key)
             raise WorkerBackendError(str(exc)) from exc
         return handle
 
@@ -741,13 +718,11 @@ class KubernetesWorkerBackend:
         handle: WorkerHandle,
         *,
         validated_at: float,
-        persisted_last_used_at: float,
     ) -> None:
         entry = _ReadyWorkerCacheEntry(
             spec=spec,
             handle=handle,
             validated_at=validated_at,
-            persisted_last_used_at=persisted_last_used_at,
             credentials_encryption_key_hash=self._current_credentials_encryption_key_hash(),
         )
         with self._ready_workers_lock:
@@ -757,48 +732,37 @@ class KubernetesWorkerBackend:
         with self._ready_workers_lock:
             self._ready_workers.pop(worker_key, None)
 
-    def _cached_ready_worker(self, spec: WorkerSpec, *, now: float) -> WorkerHandle | None:
-        with self._ready_workers_lock:
-            entry = self._ready_workers.get(spec.worker_key)
-            if entry is None:
-                return None
-            cache_invalid = (
-                entry.spec != spec
-                or entry.credentials_encryption_key_hash != self._current_credentials_encryption_key_hash()
-                or now - entry.validated_at >= _READY_WORKER_REVALIDATE_SECONDS
-                or now - entry.handle.last_used_at >= self.idle_timeout_seconds
-            )
-            if cache_invalid:
-                self._ready_workers.pop(spec.worker_key, None)
-                return None
-            handle = replace(entry.handle, last_used_at=now)
-            self._ready_workers[spec.worker_key] = replace(entry, handle=handle)
-            return handle
-
-    def _touch_cached_worker(self, worker_key: str, *, now: float) -> WorkerHandle | None:
+    def _cached_ready_worker(
+        self,
+        worker_key: str,
+        *,
+        spec: WorkerSpec | None = None,
+        now: float,
+    ) -> _ReadyWorkerCacheEntry | None:
         with self._ready_workers_lock:
             entry = self._ready_workers.get(worker_key)
             if entry is None:
                 return None
             cache_invalid = (
-                entry.credentials_encryption_key_hash != self._current_credentials_encryption_key_hash()
+                (spec is not None and entry.spec != spec)
+                or entry.credentials_encryption_key_hash != self._current_credentials_encryption_key_hash()
                 or now - entry.validated_at >= _READY_WORKER_REVALIDATE_SECONDS
                 or now - entry.handle.last_used_at >= self.idle_timeout_seconds
             )
             if cache_invalid:
                 self._ready_workers.pop(worker_key, None)
                 return None
-            handle = replace(entry.handle, last_used_at=now, status="ready", failure_reason=None)
-            flush_interval = min(
-                _MAX_LAST_USED_PERSIST_INTERVAL_SECONDS,
-                self.idle_timeout_seconds / 4,
-            )
-            if now - entry.persisted_last_used_at < flush_interval:
-                self._ready_workers[worker_key] = replace(entry, handle=handle)
-                return handle
-            self._ready_workers.pop(worker_key, None)
+            return entry
 
-        self._resources.patch_deployment_annotations(
+    def _touch_cached_worker(self, worker_key: str, *, now: float) -> WorkerHandle | None:
+        entry = self._cached_ready_worker(worker_key, now=now)
+        if entry is None:
+            return None
+        return self._patch_cached_worker_usage(entry, now=now)
+
+    def _patch_cached_worker_usage(self, entry: _ReadyWorkerCacheEntry, *, now: float) -> WorkerHandle | None:
+        handle = replace(entry.handle, last_used_at=now, status="ready", failure_reason=None)
+        exists = self._resources.patch_deployment_annotations(
             handle.worker_id,
             annotations={
                 resources.ANNOTATION_LAST_USED_AT: str(now),
@@ -806,28 +770,15 @@ class KubernetesWorkerBackend:
                 resources.ANNOTATION_FAILURE_REASON: "",
             },
         )
+        if not exists:
+            self._invalidate_ready_worker(entry.spec.worker_key)
+            return None
         self._store_ready_worker(
             entry.spec,
             handle,
             validated_at=entry.validated_at,
-            persisted_last_used_at=now,
         )
         return handle
-
-    def _handle_with_cached_usage(self, handle: WorkerHandle, *, running: bool, now: float) -> WorkerHandle:
-        if not running or handle.status == "failed":
-            return handle
-        with self._ready_workers_lock:
-            entry = self._ready_workers.get(handle.worker_key)
-        if entry is None or entry.handle.last_used_at <= handle.last_used_at:
-            return handle
-        status = effective_idle_status("ready", entry.handle.last_used_at, self.idle_timeout_seconds, now)
-        return replace(
-            handle,
-            last_used_at=entry.handle.last_used_at,
-            status=status,
-            failure_reason=None,
-        )
 
     def _record_startup_failure_or_cleanup_secret(
         self,

--- a/src/mindroom/workers/backends/kubernetes.py
+++ b/src/mindroom/workers/backends/kubernetes.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import logging
 import threading
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING
 
 from mindroom.credential_policy import credential_service_policy
 from mindroom.credentials import get_runtime_credentials_manager, sync_shared_credentials_to_worker
+from mindroom.runtime_env_policy import CREDENTIALS_ENCRYPTION_KEY_ENV, credentials_encryption_key_value
 from mindroom.tool_system.worker_routing import resolved_worker_key_scope, worker_dir_name, worker_id_for_key
 from mindroom.workers.backend import WorkerBackendError, effective_idle_status, filter_and_sort_worker_handles
 from mindroom.workers.backends._lifecycle import mark_worker_failed, mark_worker_idle, touch_worker_lifecycle
@@ -23,7 +24,11 @@ from mindroom.workers.models import (
 )
 
 from . import kubernetes_resources as resources
-from .kubernetes_config import KubernetesWorkerBackendConfig, kubernetes_backend_config_signature
+from .kubernetes_config import (
+    KubernetesWorkerBackendConfig,
+    credentials_encryption_key_hash,
+    kubernetes_backend_config_signature,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -40,6 +45,8 @@ __all__ = [
 _COLD_START_GRACE_SECONDS = 1.5
 _WAITING_PROGRESS_INTERVAL_SECONDS = 5.0
 _PROGRESS_REPORTER_JOIN_TIMEOUT_SECONDS = 1.0
+_READY_WORKER_REVALIDATE_SECONDS = 300.0
+_MAX_LAST_USED_PERSIST_INTERVAL_SECONDS = 60.0
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +57,15 @@ class _ProgressReporterState:
     cold_start_emitted: bool = False
     next_waiting_elapsed: float = _WAITING_PROGRESS_INTERVAL_SECONDS
     reporter_done: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class _ReadyWorkerCacheEntry:
+    spec: WorkerSpec
+    handle: WorkerHandle
+    validated_at: float
+    persisted_last_used_at: float
+    credentials_encryption_key_hash: str | None
 
 
 def _noop_finalize_progress(_phase: WorkerReadyPhase, _error: str | None) -> None:
@@ -294,6 +310,8 @@ class KubernetesWorkerBackend:
         self._progress_sinks: dict[str, list[ProgressSink]] = {}
         self._progress_snapshots: dict[str, WorkerReadyProgress | None] = {}
         self._progress_sinks_lock = threading.Lock()
+        self._ready_workers: dict[str, _ReadyWorkerCacheEntry] = {}
+        self._ready_workers_lock = threading.Lock()
 
     @classmethod
     def from_runtime(
@@ -317,7 +335,8 @@ class KubernetesWorkerBackend:
 
     def shutdown(self) -> None:
         """Kubernetes workers are persistent; manager replacement leaves them running."""
-        return
+        with self._ready_workers_lock:
+            self._ready_workers.clear()
 
     def _register_progress_sink(self, worker_key: str, progress_sink: ProgressSink) -> None:
         with self._progress_sinks_lock:
@@ -362,6 +381,9 @@ class KubernetesWorkerBackend:
         try:
             with self._worker_lock(worker_key):
                 timestamp = time.time() if now is None else now
+                cached_handle = self._reuse_cached_ready_worker(spec, now=timestamp)
+                if cached_handle is not None:
+                    return cached_handle
                 worker_id = self._worker_id(worker_key)
                 state_subpath = self._state_subpath(worker_key)
                 existing = self._resources.read_deployment(worker_id)
@@ -433,11 +455,7 @@ class KubernetesWorkerBackend:
                             status="starting",
                         )
                         self._resources.patch_deployment(worker_id, annotations=annotations)
-                    sync_shared_credentials_to_worker(
-                        worker_key,
-                        allowed_services=self.worker_grantable_credentials,
-                        credentials_manager=get_runtime_credentials_manager(self.runtime_paths),
-                    )
+                    self._sync_shared_credentials(worker_key)
                     self._resources.apply_service(worker_id)
                     deployment = self._resources.wait_for_ready(
                         worker_id,
@@ -470,7 +488,9 @@ class KubernetesWorkerBackend:
                     **dict(deployment.metadata.annotations or {}),
                     **final_annotations,
                 }
-                return self._handle_from_deployment(deployment, now=timestamp)
+                handle = self._handle_from_deployment(deployment, now=timestamp)
+                self._store_ready_worker(spec, handle, validated_at=timestamp, persisted_last_used_at=timestamp)
+                return handle
         finally:
             if progress_sink is not None:
                 self._unregister_progress_sink(worker_key, progress_sink)
@@ -478,25 +498,38 @@ class KubernetesWorkerBackend:
     def touch_worker(self, worker_key: str, *, now: float | None = None) -> WorkerHandle | None:
         """Refresh last-used metadata for one existing worker."""
         timestamp = time.time() if now is None else now
-        worker_id = self._worker_id(worker_key)
-        deployment = self._resources.read_deployment(worker_id)
-        if deployment is None:
-            return None
+        with self._worker_lock(worker_key):
+            cached_handle = self._touch_cached_worker(worker_key, now=timestamp)
+            if cached_handle is not None:
+                return cached_handle
 
-        annotations = dict(deployment.metadata.annotations or {})
-        resources.apply_lifecycle_annotations(
-            annotations,
-            touch_worker_lifecycle(resources.lifecycle_from_annotations(annotations, now=timestamp), now=timestamp),
-        )
-        self._resources.patch_deployment(worker_id, annotations=annotations)
-        deployment.metadata.annotations = annotations
-        return self._handle_from_deployment(deployment, now=timestamp)
+            worker_id = self._worker_id(worker_key)
+            deployment = self._resources.read_deployment(worker_id)
+            if deployment is None:
+                return None
+
+            annotations = dict(deployment.metadata.annotations or {})
+            resources.apply_lifecycle_annotations(
+                annotations,
+                touch_worker_lifecycle(
+                    resources.lifecycle_from_annotations(annotations, now=timestamp),
+                    now=timestamp,
+                ),
+            )
+            self._resources.patch_deployment(worker_id, annotations=annotations)
+            deployment.metadata.annotations = annotations
+            return self._handle_from_deployment(deployment, now=timestamp)
 
     def list_workers(self, *, include_idle: bool = True, now: float | None = None) -> list[WorkerHandle]:
         """List workers known to this backend."""
         timestamp = time.time() if now is None else now
         handles = [
-            self._handle_from_deployment(deployment, now=timestamp) for deployment in self._resources.list_deployments()
+            self._handle_with_cached_usage(
+                self._handle_from_deployment(deployment, now=timestamp),
+                running=int(deployment.spec.replicas or 0) > 0,
+                now=timestamp,
+            )
+            for deployment in self._resources.list_deployments()
         ]
         return filter_and_sort_worker_handles(handles, include_idle)
 
@@ -505,20 +538,42 @@ class KubernetesWorkerBackend:
         timestamp = time.time() if now is None else now
         cleaned: list[WorkerHandle] = []
         for deployment in self._resources.list_deployments():
-            handle = self._handle_from_deployment(deployment, now=timestamp)
+            handle = self._handle_with_cached_usage(
+                self._handle_from_deployment(deployment, now=timestamp),
+                running=int(deployment.spec.replicas or 0) > 0,
+                now=timestamp,
+            )
             if handle.status != "idle" or int(deployment.spec.replicas or 0) == 0:
                 continue
-            annotations = dict(deployment.metadata.annotations or {})
-            resources.apply_lifecycle_annotations(
-                annotations,
-                mark_worker_idle(resources.lifecycle_from_annotations(annotations, now=timestamp)),
-            )
-            self._resources.patch_deployment(handle.worker_id, replicas=0, annotations=annotations)
-            self._resources.delete_service(handle.worker_id)
-            self._resources.delete_secret(handle.worker_id)
-            deployment.spec.replicas = 0
-            deployment.metadata.annotations = annotations
-            cleaned.append(self._handle_from_deployment(deployment, now=timestamp))
+            worker_lock = self._worker_lock(handle.worker_key)
+            if not worker_lock.acquire(blocking=False):
+                continue
+            try:
+                live = self._resources.read_deployment(handle.worker_id)
+                if live is None:
+                    self._invalidate_ready_worker(handle.worker_key)
+                    continue
+                live_handle = self._handle_with_cached_usage(
+                    self._handle_from_deployment(live, now=timestamp),
+                    running=int(live.spec.replicas or 0) > 0,
+                    now=timestamp,
+                )
+                if live_handle.status != "idle" or int(live.spec.replicas or 0) == 0:
+                    continue
+                annotations = dict(live.metadata.annotations or {})
+                resources.apply_lifecycle_annotations(
+                    annotations,
+                    mark_worker_idle(resources.lifecycle_from_annotations(annotations, now=timestamp)),
+                )
+                self._resources.patch_deployment(live_handle.worker_id, replicas=0, annotations=annotations)
+                self._resources.delete_service(live_handle.worker_id)
+                self._resources.delete_secret(live_handle.worker_id)
+                self._invalidate_ready_worker(live_handle.worker_key)
+                live.spec.replicas = 0
+                live.metadata.annotations = annotations
+                cleaned.append(self._handle_from_deployment(live, now=timestamp))
+            finally:
+                worker_lock.release()
         return cleaned
 
     def reconcile_drifted_workers(self, *, now: float | None = None) -> list[WorkerHandle]:
@@ -613,6 +668,24 @@ class KubernetesWorkerBackend:
     ) -> WorkerHandle:
         """Persist a failed worker startup or execution state."""
         timestamp = time.time() if now is None else now
+        with self._worker_lock(worker_key):
+            return self._record_failure_locked(
+                worker_key,
+                failure_reason,
+                now=timestamp,
+                annotations_override=annotations_override,
+            )
+
+    def _record_failure_locked(
+        self,
+        worker_key: str,
+        failure_reason: str,
+        *,
+        now: float,
+        annotations_override: dict[str, str] | None = None,
+    ) -> WorkerHandle:
+        """Persist failure state while holding the worker provisioning lock."""
+        self._invalidate_ready_worker(worker_key)
         worker_id = self._worker_id(worker_key)
         deployment = self._resources.read_deployment(worker_id)
         if deployment is None:
@@ -625,8 +698,8 @@ class KubernetesWorkerBackend:
         resources.apply_lifecycle_annotations(
             annotations,
             mark_worker_failed(
-                resources.lifecycle_from_annotations(annotations, now=timestamp),
-                now=timestamp,
+                resources.lifecycle_from_annotations(annotations, now=now),
+                now=now,
                 failure_reason=failure_reason,
             ),
         )
@@ -635,7 +708,126 @@ class KubernetesWorkerBackend:
         self._resources.delete_secret(worker_id)
         deployment.spec.replicas = 0
         deployment.metadata.annotations = annotations
-        return self._handle_from_deployment(deployment, now=timestamp)
+        return self._handle_from_deployment(deployment, now=now)
+
+    def _sync_shared_credentials(self, worker_key: str) -> None:
+        sync_shared_credentials_to_worker(
+            worker_key,
+            allowed_services=self.worker_grantable_credentials,
+            credentials_manager=get_runtime_credentials_manager(self.runtime_paths),
+        )
+
+    def _reuse_cached_ready_worker(self, spec: WorkerSpec, *, now: float) -> WorkerHandle | None:
+        handle = self._cached_ready_worker(spec, now=now)
+        if handle is None:
+            return None
+        try:
+            self._sync_shared_credentials(spec.worker_key)
+        except WorkerBackendError:
+            raise
+        except Exception as exc:
+            raise WorkerBackendError(str(exc)) from exc
+        return handle
+
+    def _current_credentials_encryption_key_hash(self) -> str | None:
+        encryption_key = credentials_encryption_key_value(
+            self.runtime_paths.env_value(CREDENTIALS_ENCRYPTION_KEY_ENV),
+        )
+        return credentials_encryption_key_hash(encryption_key)
+
+    def _store_ready_worker(
+        self,
+        spec: WorkerSpec,
+        handle: WorkerHandle,
+        *,
+        validated_at: float,
+        persisted_last_used_at: float,
+    ) -> None:
+        entry = _ReadyWorkerCacheEntry(
+            spec=spec,
+            handle=handle,
+            validated_at=validated_at,
+            persisted_last_used_at=persisted_last_used_at,
+            credentials_encryption_key_hash=self._current_credentials_encryption_key_hash(),
+        )
+        with self._ready_workers_lock:
+            self._ready_workers[spec.worker_key] = entry
+
+    def _invalidate_ready_worker(self, worker_key: str) -> None:
+        with self._ready_workers_lock:
+            self._ready_workers.pop(worker_key, None)
+
+    def _cached_ready_worker(self, spec: WorkerSpec, *, now: float) -> WorkerHandle | None:
+        with self._ready_workers_lock:
+            entry = self._ready_workers.get(spec.worker_key)
+            if entry is None:
+                return None
+            cache_invalid = (
+                entry.spec != spec
+                or entry.credentials_encryption_key_hash != self._current_credentials_encryption_key_hash()
+                or now - entry.validated_at >= _READY_WORKER_REVALIDATE_SECONDS
+                or now - entry.handle.last_used_at >= self.idle_timeout_seconds
+            )
+            if cache_invalid:
+                self._ready_workers.pop(spec.worker_key, None)
+                return None
+            handle = replace(entry.handle, last_used_at=now)
+            self._ready_workers[spec.worker_key] = replace(entry, handle=handle)
+            return handle
+
+    def _touch_cached_worker(self, worker_key: str, *, now: float) -> WorkerHandle | None:
+        with self._ready_workers_lock:
+            entry = self._ready_workers.get(worker_key)
+            if entry is None:
+                return None
+            cache_invalid = (
+                entry.credentials_encryption_key_hash != self._current_credentials_encryption_key_hash()
+                or now - entry.validated_at >= _READY_WORKER_REVALIDATE_SECONDS
+                or now - entry.handle.last_used_at >= self.idle_timeout_seconds
+            )
+            if cache_invalid:
+                self._ready_workers.pop(worker_key, None)
+                return None
+            handle = replace(entry.handle, last_used_at=now, status="ready", failure_reason=None)
+            flush_interval = min(
+                _MAX_LAST_USED_PERSIST_INTERVAL_SECONDS,
+                self.idle_timeout_seconds / 4,
+            )
+            if now - entry.persisted_last_used_at < flush_interval:
+                self._ready_workers[worker_key] = replace(entry, handle=handle)
+                return handle
+            self._ready_workers.pop(worker_key, None)
+
+        self._resources.patch_deployment_annotations(
+            handle.worker_id,
+            annotations={
+                resources.ANNOTATION_LAST_USED_AT: str(now),
+                resources.ANNOTATION_WORKER_STATUS: "ready",
+                resources.ANNOTATION_FAILURE_REASON: "",
+            },
+        )
+        self._store_ready_worker(
+            entry.spec,
+            handle,
+            validated_at=entry.validated_at,
+            persisted_last_used_at=now,
+        )
+        return handle
+
+    def _handle_with_cached_usage(self, handle: WorkerHandle, *, running: bool, now: float) -> WorkerHandle:
+        if not running or handle.status == "failed":
+            return handle
+        with self._ready_workers_lock:
+            entry = self._ready_workers.get(handle.worker_key)
+        if entry is None or entry.handle.last_used_at <= handle.last_used_at:
+            return handle
+        status = effective_idle_status("ready", entry.handle.last_used_at, self.idle_timeout_seconds, now)
+        return replace(
+            handle,
+            last_used_at=entry.handle.last_used_at,
+            status=status,
+            failure_reason=None,
+        )
 
     def _record_startup_failure_or_cleanup_secret(
         self,
@@ -651,7 +843,7 @@ class KubernetesWorkerBackend:
         deployment_after_failure = self._resources.read_deployment(worker_id)
         if deployment_after_failure is not None:
             if destructive_failure_allowed:
-                self.record_failure(
+                self._record_failure_locked(
                     worker_key,
                     failure_reason,
                     now=timestamp,

--- a/src/mindroom/workers/backends/kubernetes_resources.py
+++ b/src/mindroom/workers/backends/kubernetes_resources.py
@@ -609,6 +609,14 @@ class KubernetesResourceManager:
             body["spec"] = {"replicas": replicas}
         self._apps.patch_namespaced_deployment(deployment_name, self.config.namespace, body)
 
+    def patch_deployment_annotations(self, deployment_name: str, *, annotations: dict[str, str]) -> None:
+        """Merge selected Deployment annotations without a preceding read."""
+        self._apps.patch_namespaced_deployment(
+            deployment_name,
+            self.config.namespace,
+            {"metadata": {"annotations": annotations}},
+        )
+
     def delete_deployment(self, deployment_name: str) -> None:
         """Delete one worker Deployment, ignoring 404s."""
         self._delete_object(self._apps.delete_namespaced_deployment, deployment_name)

--- a/src/mindroom/workers/backends/kubernetes_resources.py
+++ b/src/mindroom/workers/backends/kubernetes_resources.py
@@ -609,13 +609,19 @@ class KubernetesResourceManager:
             body["spec"] = {"replicas": replicas}
         self._apps.patch_namespaced_deployment(deployment_name, self.config.namespace, body)
 
-    def patch_deployment_annotations(self, deployment_name: str, *, annotations: dict[str, str]) -> None:
-        """Merge selected Deployment annotations without a preceding read."""
-        self._apps.patch_namespaced_deployment(
-            deployment_name,
-            self.config.namespace,
-            {"metadata": {"annotations": annotations}},
-        )
+    def patch_deployment_annotations(self, deployment_name: str, *, annotations: dict[str, str]) -> bool:
+        """Merge selected Deployment annotations, returning false when it disappeared."""
+        try:
+            self._apps.patch_namespaced_deployment(
+                deployment_name,
+                self.config.namespace,
+                {"metadata": {"annotations": annotations}},
+            )
+        except self._api_exception as exc:
+            if exc.status == 404:
+                return False
+            raise
+        return True
 
     def delete_deployment(self, deployment_name: str) -> None:
         """Delete one worker Deployment, ignoring 404s."""

--- a/tests/test_kubernetes_worker_backend.py
+++ b/tests/test_kubernetes_worker_backend.py
@@ -210,7 +210,9 @@ class _FakeAppsApi:
     def patch_namespaced_deployment(self, name: str, namespace: str, body: dict[str, object]) -> object:
         _ = namespace
         self.patched_bodies.append((name, body))
-        deployment = self.read_namespaced_deployment(name, namespace)
+        deployment = self.deployments.get(name)
+        if deployment is None:
+            raise _FakeApiError(404)
         metadata = body.get("metadata")
         if isinstance(metadata, dict):
             annotations = metadata.get("annotations")
@@ -2074,8 +2076,8 @@ def _kubernetes_api_call_counts(apps_api: _FakeAppsApi, core_api: _FakeCoreApi) 
     )
 
 
-def test_kubernetes_backend_reuses_recent_ready_worker_without_cluster_calls() -> None:
-    """A recently validated ready worker should stay on the local hot path."""
+def test_kubernetes_backend_reuses_recent_ready_worker_with_one_metadata_patch() -> None:
+    """A recently validated ready worker should skip cluster reconciliation."""
     backend, apps_api, core_api = _backend()
     first = backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=10.0)
     calls_after_first_ensure = _kubernetes_api_call_counts(apps_api, core_api)
@@ -2084,7 +2086,34 @@ def test_kubernetes_backend_reuses_recent_ready_worker_without_cluster_calls() -
 
     assert second.worker_id == first.worker_id
     assert second.last_used_at == 20.0
-    assert _kubernetes_api_call_counts(apps_api, core_api) == calls_after_first_ensure
+    calls_after_second_ensure = _kubernetes_api_call_counts(apps_api, core_api)
+    assert tuple(
+        after - before for before, after in zip(calls_after_first_ensure, calls_after_second_ensure, strict=True)
+    ) == (
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    )
+    assert apps_api.deployments[first.worker_id].metadata.annotations["mindroom.ai/last-used-at"] == "20.0"
+
+
+def test_kubernetes_backend_reconciles_when_cached_worker_disappears() -> None:
+    """A missing cached Deployment should fall back to full reconciliation."""
+    backend, apps_api, _core_api = _backend()
+    first = backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=10.0)
+    apps_api.deployments.pop(first.worker_id)
+
+    recreated = backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=20.0)
+
+    assert recreated.status == "ready"
+    assert len(apps_api.created_bodies) == 2
 
 
 def test_kubernetes_backend_periodically_revalidates_cached_ready_worker() -> None:
@@ -2094,17 +2123,24 @@ def test_kubernetes_backend_periodically_revalidates_cached_ready_worker() -> No
     calls_after_first_ensure = _kubernetes_api_call_counts(apps_api, core_api)
 
     backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=309.0)
-    assert _kubernetes_api_call_counts(apps_api, core_api) == calls_after_first_ensure
+    calls_before_revalidation = _kubernetes_api_call_counts(apps_api, core_api)
+    assert calls_before_revalidation[0] == calls_after_first_ensure[0]
+    assert calls_before_revalidation[2] == calls_after_first_ensure[2] + 1
+    assert calls_before_revalidation[4:] == calls_after_first_ensure[4:]
 
     backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=310.0)
-    assert _kubernetes_api_call_counts(apps_api, core_api) != calls_after_first_ensure
+    calls_after_revalidation = _kubernetes_api_call_counts(apps_api, core_api)
+    assert calls_after_revalidation[0] > calls_before_revalidation[0]
+    assert calls_after_revalidation[4] > calls_before_revalidation[4]
+    assert calls_after_revalidation[6] > calls_before_revalidation[6]
 
 
-def test_kubernetes_backend_coalesces_recent_last_used_patches() -> None:
-    """Frequent worker touches should retain fresh local state without patching Kubernetes each time."""
+def test_kubernetes_backend_cached_touch_uses_one_metadata_patch() -> None:
+    """A cached touch should persist usage without reading or reconciling cluster objects."""
     backend, apps_api, _core_api = _backend()
     handle = backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=10.0)
     patch_count_after_ensure = len(apps_api.patched_bodies)
+    read_count_after_ensure = len(apps_api.read_names)
 
     first_touch = backend.touch_worker(_TEST_SCOPED_WORKER_KEY_A, now=11.0)
     second_touch = backend.touch_worker(_TEST_SCOPED_WORKER_KEY_A, now=12.0)
@@ -2112,32 +2148,13 @@ def test_kubernetes_backend_coalesces_recent_last_used_patches() -> None:
     assert first_touch is not None
     assert second_touch is not None
     assert second_touch.last_used_at == 12.0
-    assert len(apps_api.patched_bodies) == patch_count_after_ensure
+    assert len(apps_api.patched_bodies) == patch_count_after_ensure + 2
+    assert len(apps_api.read_names) == read_count_after_ensure
     assert backend.list_workers(now=12.0)[0].last_used_at == 12.0
-    assert apps_api.deployments[handle.worker_id].metadata.annotations["mindroom.ai/last-used-at"] == "10.0"
-
-    persisted_touch = backend.touch_worker(_TEST_SCOPED_WORKER_KEY_A, now=25.0)
-
-    assert persisted_touch is not None
-    assert len(apps_api.patched_bodies) == patch_count_after_ensure + 1
-    assert apps_api.deployments[handle.worker_id].metadata.annotations["mindroom.ai/last-used-at"] == "25.0"
+    assert apps_api.deployments[handle.worker_id].metadata.annotations["mindroom.ai/last-used-at"] == "12.0"
     assert apps_api.deployments[handle.worker_id].metadata.annotations[ANNOTATION_WORKER_KEY] == (
         _TEST_SCOPED_WORKER_KEY_A
     )
-
-
-def test_kubernetes_backend_cleanup_honors_deferred_last_used_update() -> None:
-    """Idle cleanup should use fresher cached usage before scaling down a worker."""
-    backend, apps_api, _core_api = _backend(idle_timeout_seconds=20.0)
-    handle = backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=0.0)
-
-    touched = backend.touch_worker(_TEST_SCOPED_WORKER_KEY_A, now=2.0)
-    cleaned = backend.cleanup_idle_workers(now=21.0)
-
-    assert touched is not None
-    assert apps_api.deployments[handle.worker_id].metadata.annotations["mindroom.ai/last-used-at"] == "0.0"
-    assert cleaned == []
-    assert apps_api.deployments[handle.worker_id].spec.replicas == 1
 
 
 def test_kubernetes_backend_failure_invalidates_ready_cache() -> None:

--- a/tests/test_kubernetes_worker_backend.py
+++ b/tests/test_kubernetes_worker_backend.py
@@ -173,6 +173,7 @@ def _to_namespace(value: object, *, key: str | None = None) -> object:
 class _FakeAppsApi:
     def __init__(self) -> None:
         self.deployments: dict[str, object] = {}
+        self.read_names: list[str] = []
         self.created_bodies: list[dict[str, object]] = []
         self.patched_bodies: list[tuple[str, dict[str, object]]] = []
         self.deleted_names: list[str] = []
@@ -182,6 +183,7 @@ class _FakeAppsApi:
 
     def read_namespaced_deployment(self, name: str, namespace: str) -> object:
         _ = namespace
+        self.read_names.append(name)
         deployment = self.deployments.get(name)
         if deployment is None:
             raise _FakeApiError(404)
@@ -213,7 +215,10 @@ class _FakeAppsApi:
         if isinstance(metadata, dict):
             annotations = metadata.get("annotations")
             if isinstance(annotations, dict):
-                deployment.metadata.annotations = annotations
+                deployment.metadata.annotations = {
+                    **dict(deployment.metadata.annotations or {}),
+                    **annotations,
+                }
         spec = body.get("spec")
         if isinstance(spec, dict) and "replicas" in spec:
             deployment.spec.replicas = spec["replicas"]
@@ -254,6 +259,8 @@ class _FakeCoreApi:
         self.services: dict[str, object] = {}
         self.secrets: dict[str, object] = {}
         self.pods: dict[str, object] = {}
+        self.read_service_names: list[str] = []
+        self.read_secret_names: list[str] = []
         self.created_bodies: list[dict[str, object]] = []
         self.created_secret_bodies: list[dict[str, object]] = []
         self.patched_secret_bodies: list[tuple[str, object]] = []
@@ -262,6 +269,7 @@ class _FakeCoreApi:
 
     def read_namespaced_service(self, name: str, namespace: str) -> object:
         _ = namespace
+        self.read_service_names.append(name)
         service = self.services.get(name)
         if service is None:
             raise _FakeApiError(404)
@@ -286,6 +294,7 @@ class _FakeCoreApi:
 
     def read_namespaced_secret(self, name: str, namespace: str) -> object:
         _ = namespace
+        self.read_secret_names.append(name)
         secret = self.secrets.get(name)
         if secret is None:
             raise _FakeApiError(404)
@@ -967,7 +976,11 @@ def test_kubernetes_backend_recreate_failure_removes_orphaned_tenant_auth_secret
         storage_path=tmp_path / "mindroom-test-storage",
     )
     auth_secret_name = "mindroom-worker-auth-demo"  # noqa: S105
-    backend, apps_api, core_api = _backend(runtime_paths=runtime_paths, auth_secret_name=auth_secret_name)
+    backend, apps_api, core_api = _backend(
+        runtime_paths=runtime_paths,
+        auth_secret_name=auth_secret_name,
+        idle_timeout_seconds=600.0,
+    )
     handle = backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=10.0)
     deployment = apps_api.deployments[handle.worker_id]
     deployment.metadata.annotations[_ANNOTATION_TEMPLATE_HASH] = "stale"
@@ -981,7 +994,7 @@ def test_kubernetes_backend_recreate_failure_removes_orphaned_tenant_auth_secret
     backend._resources._recreate_deployment = recreate_with_failure  # type: ignore[method-assign]
 
     with pytest.raises(WorkerBackendError, match="deployment recreate failed"):
-        backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=20.0)
+        backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=310.0)
 
     assert handle.worker_id not in apps_api.deployments
     assert handle.worker_id not in core_api.secrets[auth_secret_name].stringData
@@ -2046,6 +2059,101 @@ def _wire_fake_apis(backend: KubernetesWorkerBackend, apps_api: _FakeAppsApi, co
     backend._resources.api_exception_cls = _FakeApiError
 
 
+def _kubernetes_api_call_counts(apps_api: _FakeAppsApi, core_api: _FakeCoreApi) -> tuple[int, ...]:
+    return (
+        len(apps_api.read_names),
+        len(apps_api.created_bodies),
+        len(apps_api.patched_bodies),
+        len(apps_api.deleted_names),
+        len(core_api.read_service_names),
+        len(core_api.created_bodies),
+        len(core_api.read_secret_names),
+        len(core_api.created_secret_bodies),
+        len(core_api.patched_secret_bodies),
+        len(core_api.deleted_secret_names),
+    )
+
+
+def test_kubernetes_backend_reuses_recent_ready_worker_without_cluster_calls() -> None:
+    """A recently validated ready worker should stay on the local hot path."""
+    backend, apps_api, core_api = _backend()
+    first = backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=10.0)
+    calls_after_first_ensure = _kubernetes_api_call_counts(apps_api, core_api)
+
+    second = backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=20.0)
+
+    assert second.worker_id == first.worker_id
+    assert second.last_used_at == 20.0
+    assert _kubernetes_api_call_counts(apps_api, core_api) == calls_after_first_ensure
+
+
+def test_kubernetes_backend_periodically_revalidates_cached_ready_worker() -> None:
+    """The ready cache should bound how long external cluster drift can stay hidden."""
+    backend, apps_api, core_api = _backend(idle_timeout_seconds=600.0)
+    backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=10.0)
+    calls_after_first_ensure = _kubernetes_api_call_counts(apps_api, core_api)
+
+    backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=309.0)
+    assert _kubernetes_api_call_counts(apps_api, core_api) == calls_after_first_ensure
+
+    backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=310.0)
+    assert _kubernetes_api_call_counts(apps_api, core_api) != calls_after_first_ensure
+
+
+def test_kubernetes_backend_coalesces_recent_last_used_patches() -> None:
+    """Frequent worker touches should retain fresh local state without patching Kubernetes each time."""
+    backend, apps_api, _core_api = _backend()
+    handle = backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=10.0)
+    patch_count_after_ensure = len(apps_api.patched_bodies)
+
+    first_touch = backend.touch_worker(_TEST_SCOPED_WORKER_KEY_A, now=11.0)
+    second_touch = backend.touch_worker(_TEST_SCOPED_WORKER_KEY_A, now=12.0)
+
+    assert first_touch is not None
+    assert second_touch is not None
+    assert second_touch.last_used_at == 12.0
+    assert len(apps_api.patched_bodies) == patch_count_after_ensure
+    assert backend.list_workers(now=12.0)[0].last_used_at == 12.0
+    assert apps_api.deployments[handle.worker_id].metadata.annotations["mindroom.ai/last-used-at"] == "10.0"
+
+    persisted_touch = backend.touch_worker(_TEST_SCOPED_WORKER_KEY_A, now=25.0)
+
+    assert persisted_touch is not None
+    assert len(apps_api.patched_bodies) == patch_count_after_ensure + 1
+    assert apps_api.deployments[handle.worker_id].metadata.annotations["mindroom.ai/last-used-at"] == "25.0"
+    assert apps_api.deployments[handle.worker_id].metadata.annotations[ANNOTATION_WORKER_KEY] == (
+        _TEST_SCOPED_WORKER_KEY_A
+    )
+
+
+def test_kubernetes_backend_cleanup_honors_deferred_last_used_update() -> None:
+    """Idle cleanup should use fresher cached usage before scaling down a worker."""
+    backend, apps_api, _core_api = _backend(idle_timeout_seconds=20.0)
+    handle = backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=0.0)
+
+    touched = backend.touch_worker(_TEST_SCOPED_WORKER_KEY_A, now=2.0)
+    cleaned = backend.cleanup_idle_workers(now=21.0)
+
+    assert touched is not None
+    assert apps_api.deployments[handle.worker_id].metadata.annotations["mindroom.ai/last-used-at"] == "0.0"
+    assert cleaned == []
+    assert apps_api.deployments[handle.worker_id].spec.replicas == 1
+
+
+def test_kubernetes_backend_failure_invalidates_ready_cache() -> None:
+    """A failed worker must take the full restart path on its next ensure."""
+    backend, apps_api, core_api = _backend()
+    backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=10.0)
+    backend.record_failure(_TEST_SCOPED_WORKER_KEY_A, "worker failed", now=11.0)
+    calls_after_failure = _kubernetes_api_call_counts(apps_api, core_api)
+
+    restarted = backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=12.0)
+
+    assert restarted.status == "ready"
+    assert restarted.startup_count == 2
+    assert _kubernetes_api_call_counts(apps_api, core_api) != calls_after_failure
+
+
 def test_kubernetes_backend_reconciles_drifted_idle_worker_template(tmp_path: Path) -> None:
     """Reconciliation should recreate scaled-down workers whose pod template drifted from current config."""
     runtime_paths = resolve_primary_runtime_paths(
@@ -2748,7 +2856,7 @@ def test_kubernetes_backend_warm_reconcile_failures_are_non_destructive(
         config_path=Path("config.yaml"),
         storage_path=tmp_path / "mindroom-test-storage",
     )
-    backend, apps_api, core_api = _backend(runtime_paths=runtime_paths)
+    backend, apps_api, core_api = _backend(runtime_paths=runtime_paths, idle_timeout_seconds=600.0)
     handle = backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=10.0)
 
     if failure_target == "apply_deployment":
@@ -2771,7 +2879,7 @@ def test_kubernetes_backend_warm_reconcile_failures_are_non_destructive(
     with pytest.raises(WorkerBackendError, match=error_message):
         backend.ensure_worker(
             WorkerSpec(_TEST_SCOPED_WORKER_KEY_A),
-            now=11.0,
+            now=310.0,
             progress_sink=events.append,
         )
 
@@ -2799,7 +2907,7 @@ def test_kubernetes_backend_existing_starting_worker_failures_record_failure(
         config_path=Path("config.yaml"),
         storage_path=tmp_path / "mindroom-test-storage",
     )
-    backend, apps_api, core_api = _backend(runtime_paths=runtime_paths)
+    backend, apps_api, core_api = _backend(runtime_paths=runtime_paths, idle_timeout_seconds=600.0)
     handle = backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=10.0)
     deployment = apps_api.deployments[handle.worker_id]
     deployment.metadata.annotations["mindroom.ai/worker-status"] = "starting"
@@ -2833,7 +2941,7 @@ def test_kubernetes_backend_existing_starting_worker_failures_record_failure(
     with pytest.raises(WorkerBackendError, match=error_message):
         backend.ensure_worker(
             WorkerSpec(_TEST_SCOPED_WORKER_KEY_A),
-            now=11.0,
+            now=310.0,
             progress_sink=events.append,
         )
 


### PR DESCRIPTION
## Summary

- cache recently validated ready workers so repeated ensures skip full Kubernetes reconciliation
- persist last-used metadata on every cached ensure and touch through one metadata-only patch
- revalidate periodically and invalidate on spec changes, credential-key changes, failures, cleanup, or missing Deployments

## Tests

- `pre-commit run --all-files`
- `pytest tests/test_kubernetes_worker_backend.py tests/test_sandbox_proxy.py -q -n 0 --no-cov` (241 passed, 1 skipped)
- `pytest -q --no-cov -n 8` (9,460 passed, 64 skipped)