### PR TITLE
Skip stale restart auto-resume prompts

### DIFF
--- a/src/mindroom/matrix/stale_stream_cleanup.py
+++ b/src/mindroom/matrix/stale_stream_cleanup.py
@@ -224,41 +224,36 @@ async def auto_resume_interrupted_threads(
     if not interrupted or (max_resumes is not None and max_resumes <= 0):
         return 0
 
-    unique_threads = _select_threads_to_resume(interrupted, max_resumes=None)
-    resumable_threads = [
-        interrupted_thread
-        for interrupted_thread in unique_threads
-        if await _interrupted_target_remains_latest_human_work(
+    candidate_threads = _ordered_auto_resume_candidates(interrupted, max_resumes=max_resumes)
+    resumed_count = 0
+    delay_due = False
+    for interrupted_thread in candidate_threads:
+        if max_resumes is not None and resumed_count >= max_resumes:
+            break
+        if not await _interrupted_target_remains_latest_human_work(
             interrupted_thread,
             config=config,
             runtime_paths=runtime_paths,
             conversation_cache=conversation_cache,
-        )
-    ]
-    if not resumable_threads:
-        return 0
-
-    selected_threads = resumable_threads
-    if max_resumes is not None and max_resumes < len(resumable_threads):
-        selected_threads = [
-            *resumable_threads[-max_resumes:],
-            *reversed(resumable_threads[:-max_resumes]),
-        ]
-
-    resumed_count = 0
-    send_attempts = 0
-    for interrupted_thread in selected_threads:
-        if max_resumes is not None and resumed_count >= max_resumes:
-            break
+        ):
+            continue
         try:
             content = _build_auto_resume_content(
                 interrupted_thread,
                 config=config,
                 runtime_paths=runtime_paths,
             )
-            if send_attempts:
+            if delay_due:
                 await asyncio.sleep(delay)
-            send_attempts += 1
+                delay_due = False
+                if not await _interrupted_target_remains_latest_human_work(
+                    interrupted_thread,
+                    config=config,
+                    runtime_paths=runtime_paths,
+                    conversation_cache=conversation_cache,
+                ):
+                    continue
+            delay_due = True
             delivered = await send_message_result(client, interrupted_thread.room_id, content)
             if delivered is not None:
                 if conversation_cache is not None:
@@ -343,11 +338,10 @@ def _authoritative_history_after_target(
 ) -> Sequence[ResolvedVisibleMessage]:
     """Return history entries after an exact target or raise when history is unusable."""
     history_source = history.diagnostics.get(THREAD_HISTORY_SOURCE_DIAGNOSTIC)
-    if (
-        not history.is_full_history
-        or is_thread_history_degraded(history)
-        or history_source not in {THREAD_HISTORY_SOURCE_CACHE, THREAD_HISTORY_SOURCE_HOMESERVER}
-    ):
+    if not history.is_full_history or is_thread_history_degraded(history):
+        msg = "Thread history is incomplete or degraded"
+        raise ValueError(msg)
+    if history_source not in {THREAD_HISTORY_SOURCE_CACHE, THREAD_HISTORY_SOURCE_HOMESERVER}:
         msg = f"Non-authoritative thread history source: {history_source!r}"
         raise ValueError(msg)
 
@@ -1536,12 +1530,12 @@ def _truncate_partial_text(text: str, *, limit: int = _INTERRUPTED_PARTIAL_TEXT_
     return f"{stripped_text[: limit - 1]}…"
 
 
-def _select_threads_to_resume(
+def _ordered_auto_resume_candidates(
     interrupted: list[InterruptedThread],
     *,
     max_resumes: int | None,
 ) -> list[InterruptedThread]:
-    """Return the newest unique threaded interruptions, optionally capped."""
+    """Return newest unique capped candidates first, then older delivery fallbacks."""
     latest_by_key: dict[tuple[str, str, str], InterruptedThread] = {}
 
     for interrupted_thread in interrupted:
@@ -1563,7 +1557,7 @@ def _select_threads_to_resume(
     )
     if max_resumes is None or max_resumes >= len(unique_threads):
         return unique_threads
-    return unique_threads[-max_resumes:]
+    return [*unique_threads[-max_resumes:], *reversed(unique_threads[:-max_resumes])]
 
 
 def _has_restart_interrupted_note(body: str) -> bool:

--- a/src/mindroom/matrix/stale_stream_cleanup.py
+++ b/src/mindroom/matrix/stale_stream_cleanup.py
@@ -37,6 +37,12 @@ from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.mentions import format_message_with_mentions
 from mindroom.matrix.message_builder import build_message_content, markdown_to_html
 from mindroom.matrix.message_content import extract_and_resolve_message, extract_edit_body
+from mindroom.matrix.thread_diagnostics import (
+    THREAD_HISTORY_SOURCE_CACHE,
+    THREAD_HISTORY_SOURCE_DIAGNOSTIC,
+    THREAD_HISTORY_SOURCE_HOMESERVER,
+    is_thread_history_degraded,
+)
 from mindroom.matrix.thread_projection import (
     SupportsVisibleThreadMessage,
     latest_visible_thread_event_id_by_thread,
@@ -51,11 +57,11 @@ from mindroom.streaming import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Iterable
+    from collections.abc import AsyncIterator, Iterable, Sequence
 
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
-    from mindroom.matrix.conversation_cache import ConversationCacheProtocol
+    from mindroom.matrix.conversation_cache import ConversationCacheProtocol, ThreadReadResult
 
 logger = get_logger(__name__)
 
@@ -218,18 +224,41 @@ async def auto_resume_interrupted_threads(
     if not interrupted or (max_resumes is not None and max_resumes <= 0):
         return 0
 
-    selected_threads = _select_threads_to_resume(interrupted, max_resumes=max_resumes)
-    if not selected_threads:
+    unique_threads = _select_threads_to_resume(interrupted, max_resumes=None)
+    resumable_threads = [
+        interrupted_thread
+        for interrupted_thread in unique_threads
+        if await _interrupted_target_remains_latest_human_work(
+            interrupted_thread,
+            config=config,
+            runtime_paths=runtime_paths,
+            conversation_cache=conversation_cache,
+        )
+    ]
+    if not resumable_threads:
         return 0
 
+    selected_threads = resumable_threads
+    if max_resumes is not None and max_resumes < len(resumable_threads):
+        selected_threads = [
+            *resumable_threads[-max_resumes:],
+            *reversed(resumable_threads[:-max_resumes]),
+        ]
+
     resumed_count = 0
-    for index, interrupted_thread in enumerate(selected_threads):
+    send_attempts = 0
+    for interrupted_thread in selected_threads:
+        if max_resumes is not None and resumed_count >= max_resumes:
+            break
         try:
             content = _build_auto_resume_content(
                 interrupted_thread,
                 config=config,
                 runtime_paths=runtime_paths,
             )
+            if send_attempts:
+                await asyncio.sleep(delay)
+            send_attempts += 1
             delivered = await send_message_result(client, interrupted_thread.room_id, content)
             if delivered is not None:
                 if conversation_cache is not None:
@@ -261,10 +290,103 @@ async def auto_resume_interrupted_threads(
                 target_event_id=interrupted_thread.target_event_id,
                 error=str(exc),
             )
-        if index < len(selected_threads) - 1:
-            await asyncio.sleep(delay)
 
     return resumed_count
+
+
+async def _interrupted_target_remains_latest_human_work(
+    interrupted_thread: InterruptedThread,
+    *,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    conversation_cache: ConversationCacheProtocol | None,
+) -> bool:
+    """Return whether authoritative history has no newer effective human activity."""
+    if conversation_cache is None or interrupted_thread.thread_id is None:
+        return False
+
+    try:
+        history = await conversation_cache.get_strict_thread_history(
+            interrupted_thread.room_id,
+            interrupted_thread.thread_id,
+            caller_label="startup_auto_resume_freshness",
+        )
+        later_messages = _authoritative_history_after_target(
+            history,
+            target_event_id=interrupted_thread.target_event_id,
+        )
+        remains_latest = _later_thread_activity_is_internal(
+            later_messages,
+            config=config,
+            runtime_paths=runtime_paths,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Skipping auto-resume because authoritative freshness check failed",
+            target_event_id=interrupted_thread.target_event_id,
+            error=str(exc),
+        )
+        return False
+
+    if not remains_latest:
+        logger.info(
+            "Skipping stale auto-resume after newer human activity",
+            target_event_id=interrupted_thread.target_event_id,
+        )
+    return remains_latest
+
+
+def _authoritative_history_after_target(
+    history: ThreadReadResult,
+    *,
+    target_event_id: str,
+) -> Sequence[ResolvedVisibleMessage]:
+    """Return history entries after an exact target or raise when history is unusable."""
+    history_source = history.diagnostics.get(THREAD_HISTORY_SOURCE_DIAGNOSTIC)
+    if (
+        not history.is_full_history
+        or is_thread_history_degraded(history)
+        or history_source not in {THREAD_HISTORY_SOURCE_CACHE, THREAD_HISTORY_SOURCE_HOMESERVER}
+    ):
+        msg = f"Non-authoritative thread history source: {history_source!r}"
+        raise ValueError(msg)
+
+    target_index = next(
+        (index for index, message in enumerate(history) if message.event_id == target_event_id),
+        None,
+    )
+    if target_index is None:
+        msg = f"Interrupted target absent from thread history: {target_event_id}"
+        raise ValueError(msg)
+    return history[target_index + 1 :]
+
+
+def _later_thread_activity_is_internal(
+    messages: Sequence[ResolvedVisibleMessage],
+    *,
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> bool:
+    """Return whether every later event is from an effective internal requester."""
+    if not messages:
+        return True
+
+    internal_sender_ids = current_internal_sender_ids(config, runtime_paths)
+    for message in messages:
+        if not message.sender:
+            msg = "Thread history contains a message without a trustworthy sender"
+            raise ValueError(msg)
+        effective_requester = _effective_requester_for_message(
+            message,
+            config=config,
+            runtime_paths=runtime_paths,
+        )
+        if not effective_requester:
+            msg = "Thread history sender classification returned no requester"
+            raise ValueError(msg)
+        if effective_requester not in internal_sender_ids:
+            return False
+    return True
 
 
 async def _cleanup_room_stale_streaming_messages(

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -251,16 +251,14 @@ def _authoritative_history(*messages: ResolvedVisibleMessage) -> ThreadHistoryRe
 
 
 def _auto_resume_conversation_cache(interrupted: list[InterruptedThread]) -> AsyncMock:
-    messages_by_thread: dict[tuple[str, str], list[ResolvedVisibleMessage]] = {}
-    for item in interrupted:
-        if item.thread_id is not None:
-            messages_by_thread.setdefault((item.room_id, item.thread_id), []).append(
-                _history_message(item.target_event_id, timestamp=item.timestamp_ms),
-            )
     conversation_cache = AsyncMock()
     conversation_cache.get_strict_thread_history = AsyncMock(
         side_effect=lambda room_id, thread_id, **_: _authoritative_history(
-            *messages_by_thread[(room_id, thread_id)],
+            *[
+                _history_message(item.target_event_id, timestamp=item.timestamp_ms)
+                for item in interrupted
+                if (item.room_id, item.thread_id) == (room_id, thread_id)
+            ],
         ),
     )
     conversation_cache.notify_outbound_message = Mock()
@@ -844,24 +842,26 @@ async def test_auto_resume_fails_closed_without_authoritative_target_history(
 
 
 @pytest.mark.asyncio
-async def test_auto_resume_skipped_newest_does_not_consume_cap_or_delay(tmp_path: Path) -> None:
-    """Freshness skips should leave send capacity and should not add rate-limit sleeps."""
+async def test_auto_resume_rechecks_after_delay_and_bounds_history_reads(tmp_path: Path) -> None:
+    """Resume should recheck after delay and stop reading history when successful-send cap is full."""
     config = _make_config(tmp_path)
     client = AsyncMock(spec=nio.AsyncClient)
     interrupted = [
         InterruptedThread(ROOM_ID, f"$thread-{index}", f"$target-{index}", "partial", "test_agent", timestamp_ms=index)
-        for index in range(3)
+        for index in range(5)
     ]
     conversation_cache = _auto_resume_conversation_cache(interrupted)
-    histories = {
-        "$thread-0": _authoritative_history(_history_message("$target-0")),
-        "$thread-1": _authoritative_history(_history_message("$target-1")),
-        "$thread-2": _authoritative_history(
-            _history_message("$target-2"),
-            _history_message("$human-later", sender=USER_ID),
-        ),
-    }
-    conversation_cache.get_strict_thread_history.side_effect = lambda _, thread_id, **__: histories[thread_id]
+    history_calls: dict[str, int] = {}
+
+    def history_for_call(_: str, thread_id: str, **__: object) -> ThreadHistoryResult:
+        history_calls[thread_id] = history_calls.get(thread_id, 0) + 1
+        index = thread_id.removeprefix("$thread-")
+        messages = [_history_message(f"$target-{index}")]
+        if index == "4" or (index == "2" and history_calls[thread_id] == 2):
+            messages.append(_history_message("$human-later", sender=USER_ID))
+        return _authoritative_history(*messages)
+
+    conversation_cache.get_strict_thread_history.side_effect = history_for_call
 
     with (
         patch(
@@ -881,9 +881,10 @@ async def test_auto_resume_skipped_newest_does_not_consume_cap_or_delay(tmp_path
 
     assert resumed_count == 2
     assert [call.args[2]["m.relates_to"]["event_id"] for call in mock_send.await_args_list] == [
-        "$thread-0",
+        "$thread-3",
         "$thread-1",
     ]
+    assert history_calls == {"$thread-3": 1, "$thread-4": 1, "$thread-2": 2, "$thread-1": 1}
     mock_sleep.assert_awaited_once_with(2.0)
 
 
@@ -928,8 +929,8 @@ async def test_auto_resume_target_mention_ignores_unprepared_unrelated_entity(tm
     assert content["m.mentions"] == {"user_ids": [BOT_USER_ID]}
 
 
-def test_select_threads_to_resume_returns_all_unique_threads_when_unlimited() -> None:
-    """Selector should return every unique threaded interruption when uncapped."""
+def test_ordered_auto_resume_candidates_returns_all_unique_threads_when_unlimited() -> None:
+    """Candidate ordering should return every unique threaded interruption when uncapped."""
     interrupted = [
         InterruptedThread(
             room_id=ROOM_ID,
@@ -965,7 +966,7 @@ def test_select_threads_to_resume_returns_all_unique_threads_when_unlimited() ->
         ),
     ]
 
-    selected = stale_stream_cleanup_module._select_threads_to_resume(
+    selected = stale_stream_cleanup_module._ordered_auto_resume_candidates(
         interrupted,
         max_resumes=None,
     )

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -24,6 +24,7 @@ from mindroom.constants import (
 from mindroom.dispatch_source import TRUSTED_INTERNAL_RELAY_SOURCE_KIND
 from mindroom.entity_resolution import MissingManagedEntityAccountError, entity_identity_registry
 from mindroom.matrix import stale_stream_cleanup as stale_stream_cleanup_module
+from mindroom.matrix.cache import ThreadHistoryResult, thread_history_result
 from mindroom.matrix.client import ResolvedVisibleMessage
 from mindroom.matrix.identity import managed_account_key
 from mindroom.matrix.stale_stream_cleanup import (
@@ -223,6 +224,47 @@ async def _run_cleanup(
             runtime_paths=runtime_paths_for(config),
             startup_cutoff_ms=startup_cutoff_ms,
         )
+
+
+def _history_message(
+    event_id: str,
+    *,
+    sender: str = BOT_USER_ID,
+    timestamp: int = 0,
+    content: dict[str, object] | None = None,
+) -> ResolvedVisibleMessage:
+    return ResolvedVisibleMessage.synthetic(
+        sender=sender,
+        body=event_id,
+        event_id=event_id,
+        timestamp=timestamp,
+        content=content,
+    )
+
+
+def _authoritative_history(*messages: ResolvedVisibleMessage) -> ThreadHistoryResult:
+    return thread_history_result(
+        list(messages),
+        is_full_history=True,
+        diagnostics={"thread_read_source": "cache"},
+    )
+
+
+def _auto_resume_conversation_cache(interrupted: list[InterruptedThread]) -> AsyncMock:
+    messages_by_thread: dict[tuple[str, str], list[ResolvedVisibleMessage]] = {}
+    for item in interrupted:
+        if item.thread_id is not None:
+            messages_by_thread.setdefault((item.room_id, item.thread_id), []).append(
+                _history_message(item.target_event_id, timestamp=item.timestamp_ms),
+            )
+    conversation_cache = AsyncMock()
+    conversation_cache.get_strict_thread_history = AsyncMock(
+        side_effect=lambda room_id, thread_id, **_: _authoritative_history(
+            *messages_by_thread[(room_id, thread_id)],
+        ),
+    )
+    conversation_cache.notify_outbound_message = Mock()
+    return conversation_cache
 
 
 def _assert_preserved_edit_payload(content: dict[str, object], expected_keys: dict[str, object]) -> None:
@@ -681,6 +723,7 @@ async def test_auto_resume_sends_correctly_threaded_messages(tmp_path: Path) -> 
             interrupted,
             config=config,
             runtime_paths=runtime_paths_for(config),
+            conversation_cache=_auto_resume_conversation_cache(interrupted),
         )
 
     assert resumed_count == 2
@@ -698,6 +741,149 @@ async def test_auto_resume_sends_correctly_threaded_messages(tmp_path: Path) -> 
     assert second_content["body"] == f"@Test Agent {AUTO_RESUME_MESSAGE}"
     assert second_content["m.relates_to"]["event_id"] == "$thread-two"
     assert second_content[ORIGINAL_SENDER_KEY] == USER_ID
+    mock_sleep.assert_awaited_once_with(2.0)
+
+
+@pytest.mark.parametrize(
+    ("newer_sender", "newer_content", "expected_resumes"),
+    [
+        (USER_ID, None, 0),
+        (
+            OTHER_BOT_USER_ID,
+            {
+                SOURCE_KIND_KEY: TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
+                ORIGINAL_SENDER_KEY: USER_ID,
+            },
+            0,
+        ),
+        (OTHER_BOT_USER_ID, None, 1),
+    ],
+)
+@pytest.mark.asyncio
+async def test_auto_resume_classifies_later_activity_by_effective_sender_and_history_order(
+    tmp_path: Path,
+    newer_sender: str,
+    newer_content: dict[str, object] | None,
+    expected_resumes: int,
+) -> None:
+    """Later direct or relayed humans suppress resume; internal bot events do not."""
+    config = _make_config(tmp_path)
+    client = AsyncMock(spec=nio.AsyncClient)
+    interrupted = [
+        InterruptedThread(ROOM_ID, "$thread", "$target", "partial", "test_agent", timestamp_ms=100),
+    ]
+    conversation_cache = _auto_resume_conversation_cache(interrupted)
+    conversation_cache.get_strict_thread_history.side_effect = None
+    conversation_cache.get_strict_thread_history.return_value = _authoritative_history(
+        _history_message("$target", timestamp=100),
+        _history_message("$newer", sender=newer_sender, timestamp=100, content=newer_content),
+    )
+
+    with patch(
+        "mindroom.matrix.stale_stream_cleanup.send_message_result",
+        new=AsyncMock(side_effect=delivered_matrix_side_effect("$resume")),
+    ) as mock_send:
+        resumed_count = await auto_resume_interrupted_threads(
+            client,
+            interrupted,
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            conversation_cache=conversation_cache,
+        )
+
+    assert resumed_count == expected_resumes
+    assert mock_send.await_count == expected_resumes
+
+
+@pytest.mark.parametrize("history_case", ["missing", "failed", "degraded", "missing_target", "untrusted_sender"])
+@pytest.mark.asyncio
+async def test_auto_resume_fails_closed_without_authoritative_target_history(
+    tmp_path: Path,
+    history_case: str,
+) -> None:
+    """Unusable history or untrusted sender classification should suppress auto-resume."""
+    config = _make_config(tmp_path)
+    client = AsyncMock(spec=nio.AsyncClient)
+    interrupted = [InterruptedThread(ROOM_ID, "$thread", "$target", "partial", "test_agent")]
+    conversation_cache = None if history_case == "missing" else _auto_resume_conversation_cache(interrupted)
+    if conversation_cache is not None and history_case == "failed":
+        conversation_cache.get_strict_thread_history.side_effect = RuntimeError("history failed")
+    elif conversation_cache is not None and history_case == "degraded":
+        conversation_cache.get_strict_thread_history.side_effect = None
+        conversation_cache.get_strict_thread_history.return_value = thread_history_result(
+            [_history_message("$target")],
+            is_full_history=False,
+            diagnostics={"thread_read_source": "degraded", "thread_read_degraded": True},
+        )
+    elif conversation_cache is not None and history_case == "missing_target":
+        conversation_cache.get_strict_thread_history.side_effect = None
+        conversation_cache.get_strict_thread_history.return_value = _authoritative_history(
+            _history_message("$other"),
+        )
+    elif conversation_cache is not None and history_case == "untrusted_sender":
+        state = MatrixState.load(runtime_paths_for(config))
+        state.accounts.pop(managed_account_key("other"))
+        state.save(runtime_paths_for(config))
+        conversation_cache.get_strict_thread_history.side_effect = None
+        conversation_cache.get_strict_thread_history.return_value = _authoritative_history(
+            _history_message("$target"),
+            _history_message("$later", sender=OTHER_BOT_USER_ID),
+        )
+
+    with patch("mindroom.matrix.stale_stream_cleanup.send_message_result", new=AsyncMock()) as mock_send:
+        resumed_count = await auto_resume_interrupted_threads(
+            client,
+            interrupted,
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            conversation_cache=conversation_cache,
+        )
+
+    assert resumed_count == 0
+    mock_send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_auto_resume_skipped_newest_does_not_consume_cap_or_delay(tmp_path: Path) -> None:
+    """Freshness skips should leave send capacity and should not add rate-limit sleeps."""
+    config = _make_config(tmp_path)
+    client = AsyncMock(spec=nio.AsyncClient)
+    interrupted = [
+        InterruptedThread(ROOM_ID, f"$thread-{index}", f"$target-{index}", "partial", "test_agent", timestamp_ms=index)
+        for index in range(3)
+    ]
+    conversation_cache = _auto_resume_conversation_cache(interrupted)
+    histories = {
+        "$thread-0": _authoritative_history(_history_message("$target-0")),
+        "$thread-1": _authoritative_history(_history_message("$target-1")),
+        "$thread-2": _authoritative_history(
+            _history_message("$target-2"),
+            _history_message("$human-later", sender=USER_ID),
+        ),
+    }
+    conversation_cache.get_strict_thread_history.side_effect = lambda _, thread_id, **__: histories[thread_id]
+
+    with (
+        patch(
+            "mindroom.matrix.stale_stream_cleanup.send_message_result",
+            new=AsyncMock(side_effect=delivered_matrix_side_effect("$resume")),
+        ) as mock_send,
+        patch("mindroom.matrix.stale_stream_cleanup.asyncio.sleep", new=AsyncMock()) as mock_sleep,
+    ):
+        resumed_count = await auto_resume_interrupted_threads(
+            client,
+            interrupted,
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            conversation_cache=conversation_cache,
+            max_resumes=2,
+        )
+
+    assert resumed_count == 2
+    assert [call.args[2]["m.relates_to"]["event_id"] for call in mock_send.await_args_list] == [
+        "$thread-0",
+        "$thread-1",
+    ]
     mock_sleep.assert_awaited_once_with(2.0)
 
 
@@ -733,6 +919,7 @@ async def test_auto_resume_target_mention_ignores_unprepared_unrelated_entity(tm
             interrupted,
             config=config,
             runtime_paths=runtime_paths,
+            conversation_cache=_auto_resume_conversation_cache(interrupted),
         )
 
     assert resumed_count == 1
@@ -818,6 +1005,7 @@ async def test_auto_resume_skips_thread_id_none(tmp_path: Path) -> None:
             interrupted,
             config=config,
             runtime_paths=runtime_paths_for(config),
+            conversation_cache=_auto_resume_conversation_cache(interrupted),
         )
 
     assert resumed_count == 1
@@ -831,8 +1019,6 @@ async def test_auto_resume_records_outbound_message_when_send_succeeds(tmp_path:
     """Auto-resume should write successful threaded sends through the conversation cache."""
     config = _make_config(tmp_path)
     client = AsyncMock(spec=nio.AsyncClient)
-    conversation_cache = AsyncMock()
-    conversation_cache.notify_outbound_message = Mock()
     interrupted = [
         InterruptedThread(
             room_id=ROOM_ID,
@@ -842,6 +1028,7 @@ async def test_auto_resume_records_outbound_message_when_send_succeeds(tmp_path:
             agent_name="test_agent",
         ),
     ]
+    conversation_cache = _auto_resume_conversation_cache(interrupted)
 
     with patch(
         "mindroom.matrix.stale_stream_cleanup.send_message_result",
@@ -2354,6 +2541,7 @@ async def test_auto_resume_dedupes_same_agent_and_thread_using_newest_target(tmp
             interrupted,
             config=config,
             runtime_paths=runtime_paths_for(config),
+            conversation_cache=_auto_resume_conversation_cache(interrupted),
         )
 
     assert resumed_count == 1
@@ -2410,6 +2598,7 @@ async def test_auto_resume_honors_cap_after_replacing_older_duplicate_targets(tm
             interrupted,
             config=config,
             runtime_paths=runtime_paths_for(config),
+            conversation_cache=_auto_resume_conversation_cache(interrupted),
             max_resumes=2,
         )
 
@@ -2456,6 +2645,7 @@ async def test_auto_resume_cap_uses_timestamps_not_room_iteration_order(tmp_path
             interrupted,
             config=config,
             runtime_paths=runtime_paths_for(config),
+            conversation_cache=_auto_resume_conversation_cache(interrupted),
             max_resumes=1,
         )
 
@@ -2648,6 +2838,7 @@ async def test_auto_resume_continues_after_send_exception(tmp_path: Path) -> Non
             interrupted,
             config=config,
             runtime_paths=runtime_paths_for(config),
+            conversation_cache=_auto_resume_conversation_cache(interrupted),
         )
 
     assert resumed_count == 2


### PR DESCRIPTION
## Summary

- validate unique startup auto-resume candidates against strict full thread history
- skip candidates when newer effective human activity exists, including trusted relays, and fail closed when history or sender trust is unavailable
- preserve newest-candidate priority while capping successful sends and delaying only between actual send attempts

## Tests

- `pytest tests/test_stale_stream_cleanup.py -x -n 0 --no-cov -q`
- `pytest -n 8`
- `pre-commit run --all-files`
- `tach check --dependencies --interfaces`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic resumption of interrupted conversations by confirming that the interrupted message is still the latest human activity.
  * Prevented resumes when conversation history is incomplete, unavailable, or cannot be trusted.
  * Rechecked conversation freshness after delays to avoid sending outdated resume prompts.
  * Improved selection and ordering when multiple interrupted conversations are eligible for resumption.
  * Added spacing between resumed messages to support more reliable processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->