### PR TITLE
Skip superseded sync-restart retries

### DIFF
--- a/src/mindroom/response_lifecycle.py
+++ b/src/mindroom/response_lifecycle.py
@@ -227,9 +227,10 @@ class ResponseLifecycleCoordinator:
         queued_signal: _QueuedMessageState,
         response_envelope: MessageEnvelope,
         queued_notice_reservation: QueuedHumanNoticeReservation | None,
+        signal_queued_message: bool,
     ) -> str | None:
         existing_turn = queued_signal.begin_response_turn()
-        if queued_notice_reservation is not None:
+        if not signal_queued_message or queued_notice_reservation is not None:
             return None
         if not (existing_turn or lifecycle_lock.locked()):
             return None
@@ -257,6 +258,7 @@ class ResponseLifecycleCoordinator:
         queued_notice_reservation: QueuedHumanNoticeReservation | None,
         pipeline_timing: DispatchPipelineTiming | None,
         locked_operation: Callable[[MessageTarget], Awaitable[_LockedResponseResult]],
+        signal_queued_message: bool = True,
     ) -> _LockedResponseResult:
         """Run one locked response operation with shared queued-message bookkeeping."""
         self._assert_target_matches_envelope(target, response_envelope)
@@ -267,6 +269,7 @@ class ResponseLifecycleCoordinator:
             queued_signal=queued_signal,
             response_envelope=response_envelope,
             queued_notice_reservation=queued_notice_reservation,
+            signal_queued_message=signal_queued_message,
         )
         lock_acquired = False
         reservation_consumed = False

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -56,6 +56,7 @@ from mindroom.streaming import (
     clean_partial_reply_text,
     strip_visible_tool_markers,
 )
+from mindroom.sync_restart_retry import interrupted_source_needs_retry
 from mindroom.teams import TeamMode, select_model_for_team, team_response, team_response_stream
 from mindroom.thread_summary import thread_summary_message_count_hint
 from mindroom.timing import DispatchPipelineTiming, timed
@@ -267,6 +268,7 @@ class ResponseRequest:
     pipeline_timing: DispatchPipelineTiming | None = None
     queued_notice_reservation: QueuedHumanNoticeReservation | None = None
     on_sync_restart_cancelled: Callable[[], None] | None = None
+    sync_restart_retry_source_event_id: str | None = None
     on_deferred_outcome_handled: Callable[[str], None] | None = None
 
     @property
@@ -935,15 +937,80 @@ class ResponseRunner:
         request: ResponseRequest,
         *,
         resolved_target: MessageTarget,
-    ) -> ResponseRequest:
+        history_scope: HistoryScope,
+        execution_identity: ToolExecutionIdentity,
+    ) -> ResponseRequest | None:
         """Run the shared post-lock request preparation for one locked turn."""
         if request.on_lifecycle_lock_acquired is not None:
             request.on_lifecycle_lock_acquired()
+        request = self._request_with_locked_target(request, resolved_target)
+        if not self._sync_restart_retry_is_current(
+            request,
+            history_scope=history_scope,
+            execution_identity=execution_identity,
+        ):
+            return None
         request = await self._prepare_request_after_lock(request)
         request = self._request_with_locked_target(request, resolved_target)
         if request.pipeline_timing is not None:
             request.pipeline_timing.mark("thread_refresh_ready")
         return request
+
+    def _sync_restart_retry_is_current(
+        self,
+        request: ResponseRequest,
+        *,
+        history_scope: HistoryScope,
+        execution_identity: ToolExecutionIdentity,
+    ) -> bool:
+        """Fail closed unless persisted history still ends in this retry's interrupted source."""
+        source_event_id = request.sync_restart_retry_source_event_id
+        if source_event_id is None:
+            return True
+
+        storage = None
+        should_retry = False
+        reason = "history_not_pending"
+        try:
+            storage = self.deps.state_writer.create_storage(execution_identity, scope=history_scope)
+            session = storage.get_session(
+                request.response_envelope.target.session_id,
+                self.deps.state_writer.session_type_for_scope(history_scope),
+            )
+            if isinstance(session, AgentSession | TeamSession):
+                should_retry = interrupted_source_needs_retry(
+                    session.runs or (),
+                    scope=history_scope,
+                    source_event_id=source_event_id,
+                )
+            else:
+                reason = "history_missing_or_degraded"
+        except Exception as error:
+            reason = "history_lookup_failed"
+            self.deps.logger.warning(
+                "sync_restart_retry_history_check_failed",
+                source_event_id=source_event_id,
+                session_id=request.response_envelope.target.session_id,
+                scope=history_scope.key,
+                exception_type=error.__class__.__name__,
+            )
+        finally:
+            if storage is not None:
+                try:
+                    storage.close()
+                except Exception:
+                    should_retry = False
+                    reason = "history_storage_close_failed"
+
+        if not should_retry:
+            self.deps.logger.info(
+                "sync_restart_retry_skipped",
+                source_event_id=source_event_id,
+                session_id=request.response_envelope.target.session_id,
+                scope=history_scope.key,
+                reason=reason,
+            )
+        return should_retry
 
     async def _finalize_pre_delivery_terminal(
         self,
@@ -1188,12 +1255,24 @@ class ResponseRunner:
         *,
         resolved_target: MessageTarget,
         response_kind: str,
+        history_scope: HistoryScope | None = None,
+        execution_identity: ToolExecutionIdentity | None = None,
     ) -> str | None:
         """Finalize one empty prompt through the canonical response lifecycle."""
-        if request.on_lifecycle_lock_acquired is not None:
-            request.on_lifecycle_lock_acquired()
-        request = await self._prepare_request_after_lock(request)
-        request = self._request_with_locked_target(request, resolved_target)
+        resolved_history_scope = history_scope or self.deps.state_writer.history_scope()
+        resolved_execution_identity = execution_identity or self.deps.tool_runtime.build_execution_identity(
+            target=resolved_target,
+            user_id=request.user_id,
+        )
+        prepared_request = await self._begin_locked_turn(
+            request,
+            resolved_target=resolved_target,
+            history_scope=resolved_history_scope,
+            execution_identity=resolved_execution_identity,
+        )
+        if prepared_request is None:
+            return None
+        request = prepared_request
         lifecycle = self._build_lifecycle(
             identity=self._response_identity(request, response_kind=response_kind),
             request=request,
@@ -1255,13 +1334,31 @@ class ResponseRunner:
     ) -> str | None:
         """Generate a team response once the per-thread lifecycle lock is held."""
         request = team_request.request
+        retry_execution_identity = self.deps.tool_runtime.build_execution_identity(
+            target=resolved_target,
+            user_id=request.user_id,
+        )
+        session_scope = self.deps.state_writer.team_history_scope(
+            list(team_request.team_agents),
+            requester_user_id=retry_execution_identity.requester_id,
+        )
         if not request.prompt.strip():
             return await self._finalize_empty_prompt_locked(
                 request,
                 resolved_target=resolved_target,
                 response_kind="team",
+                history_scope=session_scope,
+                execution_identity=retry_execution_identity,
             )
-        request = await self._begin_locked_turn(request, resolved_target=resolved_target)
+        prepared_request = await self._begin_locked_turn(
+            request,
+            resolved_target=resolved_target,
+            history_scope=session_scope,
+            execution_identity=retry_execution_identity,
+        )
+        if prepared_request is None:
+            return None
+        request = prepared_request
         team_request = replace(team_request, request=request)
         requester_user_id = request.user_id or ""
         _memory_prompt, _memory_thread_history, prepared_prompt, model_thread_history = (
@@ -1339,10 +1436,6 @@ class ResponseRunner:
         self.deps.runtime.config.assert_team_agents_supported(
             [agent_name for agent_name in agent_names if agent_name != ROUTER_AGENT_NAME],
             allow_direct_private_agents=allow_direct_private_agents,
-        )
-        session_scope = self.deps.state_writer.team_history_scope(
-            list(team_request.team_agents),
-            requester_user_id=execution_identity.requester_id,
         )
         session_type = self.deps.state_writer.session_type_for_scope(session_scope)
 
@@ -2388,13 +2481,28 @@ class ResponseRunner:
         resolved_target: MessageTarget,
     ) -> str | None:
         """Generate one agent response after acquiring the per-thread lock."""
+        history_scope = self.deps.state_writer.history_scope()
+        execution_identity = self.deps.tool_runtime.build_execution_identity(
+            target=resolved_target,
+            user_id=request.user_id,
+        )
         if not request.prompt.strip():
             return await self._finalize_empty_prompt_locked(
                 request,
                 resolved_target=resolved_target,
                 response_kind="ai",
+                history_scope=history_scope,
+                execution_identity=execution_identity,
             )
-        request = await self._begin_locked_turn(request, resolved_target=resolved_target)
+        prepared_request = await self._begin_locked_turn(
+            request,
+            resolved_target=resolved_target,
+            history_scope=history_scope,
+            execution_identity=execution_identity,
+        )
+        if prepared_request is None:
+            return None
+        request = prepared_request
         memory_prompt, memory_thread_history, model_prompt_text, model_thread_history = (
             prepare_memory_and_model_context(
                 request.prompt,
@@ -2413,10 +2521,6 @@ class ResponseRunner:
         )
 
         session_id = resolved_target.session_id
-        execution_identity = self.deps.tool_runtime.build_execution_identity(
-            target=resolved_target,
-            user_id=request.user_id,
-        )
         reprioritize_auto_flush_sessions(
             self.deps.storage_path,
             self.deps.runtime.config,
@@ -2469,7 +2573,7 @@ class ResponseRunner:
 
         persist_response_event_id = self._build_persist_response_event_id_effect(
             session_id=session_id,
-            session_type=self.deps.state_writer.session_type_for_scope(self.deps.state_writer.history_scope()),
+            session_type=self.deps.state_writer.session_type_for_scope(history_scope),
             create_storage=lambda: self.deps.state_writer.create_storage(execution_identity),
         )
 

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -22,7 +22,6 @@ from mindroom.final_delivery import FinalDeliveryOutcome, StreamTransportOutcome
 from mindroom.history.interrupted_replay import persist_interrupted_replay_snapshot
 from mindroom.history.storage import has_pending_force_compaction_scope, read_scope_state
 from mindroom.history.turn_recorder import TurnRecorder
-from mindroom.history.types import HistoryScope
 from mindroom.matrix.client_visible_messages import replace_visible_message
 from mindroom.matrix.presence import should_use_streaming
 from mindroom.matrix.typing import typing_indicator
@@ -710,6 +709,7 @@ class ResponseRunner:
             queued_notice_reservation=request.queued_notice_reservation,
             pipeline_timing=request.pipeline_timing,
             locked_operation=locked_operation,
+            signal_queued_message=request.sync_restart_retry_source_event_id is None,
         )
 
     def _request_with_locked_target(
@@ -968,48 +968,30 @@ class ResponseRunner:
         if source_event_id is None:
             return True
 
-        storage = None
-        should_retry = False
-        reason = "history_not_pending"
         try:
             storage = self.deps.state_writer.create_storage(execution_identity, scope=history_scope)
-            session = storage.get_session(
-                request.response_envelope.target.session_id,
-                self.deps.state_writer.session_type_for_scope(history_scope),
-            )
-            if isinstance(session, AgentSession | TeamSession):
-                should_retry = interrupted_source_needs_retry(
+            try:
+                session = storage.get_session(
+                    request.response_envelope.target.session_id,
+                    self.deps.state_writer.session_type_for_scope(history_scope),
+                )
+                should_retry = isinstance(session, AgentSession | TeamSession) and interrupted_source_needs_retry(
                     session.runs or (),
                     scope=history_scope,
                     source_event_id=source_event_id,
                 )
-            else:
-                reason = "history_missing_or_degraded"
+            finally:
+                storage.close()
         except Exception as error:
-            reason = "history_lookup_failed"
             self.deps.logger.warning(
                 "sync_restart_retry_history_check_failed",
                 source_event_id=source_event_id,
-                session_id=request.response_envelope.target.session_id,
                 scope=history_scope.key,
                 exception_type=error.__class__.__name__,
             )
-        finally:
-            if storage is not None:
-                try:
-                    storage.close()
-                except Exception:
-                    should_retry = False
-                    reason = "history_storage_close_failed"
-
+            return False
         if not should_retry:
-            self.deps.logger.info(
-                "sync_restart_retry_skipped",
-                source_event_id=source_event_id,
-                session_id=request.response_envelope.target.session_id,
-                scope=history_scope.key,
-                reason=reason,
-            )
+            self.deps.logger.info("sync_restart_retry_skipped", source_event_id=source_event_id)
         return should_retry
 
     async def _finalize_pre_delivery_terminal(

--- a/src/mindroom/sync_restart_retry.py
+++ b/src/mindroom/sync_restart_retry.py
@@ -40,14 +40,21 @@ def _run_matches_scope(run: RunOutput | TeamRunOutput, scope: HistoryScope) -> b
     return isinstance(run, RunOutput) and run.agent_id == scope.scope_id
 
 
-def _run_matches_source(run: RunOutput | TeamRunOutput, source_event_id: str) -> bool:
+def _run_source_event_ids(run: RunOutput | TeamRunOutput) -> set[str] | None:
     metadata = run.metadata
     if not isinstance(metadata, dict):
-        return False
+        return None
+    source_event_id = metadata.get(MATRIX_EVENT_ID_METADATA_KEY)
     source_event_ids = metadata.get(MATRIX_SOURCE_EVENT_IDS_METADATA_KEY)
-    return metadata.get(MATRIX_EVENT_ID_METADATA_KEY) == source_event_id or (
-        isinstance(source_event_ids, list) and source_event_id in source_event_ids
-    )
+    if source_event_id is not None and (not isinstance(source_event_id, str) or not source_event_id):
+        return None
+    if source_event_ids is not None and (
+        not isinstance(source_event_ids, list)
+        or any(not isinstance(value, str) or not value for value in source_event_ids)
+    ):
+        return None
+    event_ids = [source_event_id, *(source_event_ids or ())]
+    return {event_id for event_id in event_ids if event_id} or None
 
 
 def interrupted_source_needs_retry(
@@ -63,8 +70,14 @@ def interrupted_source_needs_retry(
             run.parent_run_id is not None
             or run.status in _MODEL_INVISIBLE_RUN_STATUSES
             or not _run_matches_scope(run, scope)
-            or not _run_matches_source(run, source_event_id)
         ):
+            continue
+        run_source_event_ids = _run_source_event_ids(run)
+        if run_source_event_ids is None:
+            if interrupted_replay_found:
+                return False
+            continue
+        if source_event_id not in run_source_event_ids:
             continue
         if interrupted_replay_found:
             return False

--- a/src/mindroom/sync_restart_retry.py
+++ b/src/mindroom/sync_restart_retry.py
@@ -34,12 +34,14 @@ _INTERRUPTED_REPLAY_STATE = "interrupted"
 
 
 def _run_matches_scope(run: RunOutput | TeamRunOutput, scope: HistoryScope) -> bool:
+    """Return whether one stored run belongs to the requested history scope."""
     if scope.kind == "team":
         return isinstance(run, TeamRunOutput) and run.team_id == scope.scope_id
     return isinstance(run, RunOutput) and run.agent_id == scope.scope_id
 
 
 def _run_source_event_ids(run: RunOutput | TeamRunOutput) -> set[str] | None:
+    """Return valid source event IDs, or None when provenance is absent or malformed."""
     metadata = run.metadata
     if not isinstance(metadata, dict):
         return None

--- a/src/mindroom/sync_restart_retry.py
+++ b/src/mindroom/sync_restart_retry.py
@@ -15,10 +15,10 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from agno.run.agent import RunOutput
-from agno.run.base import RunStatus
 from agno.run.team import TeamRunOutput
 
 from mindroom.constants import MATRIX_EVENT_ID_METADATA_KEY, MATRIX_SOURCE_EVENT_IDS_METADATA_KEY
+from mindroom.history.storage import is_model_history_visible_run
 from mindroom.logging_config import get_logger
 
 if TYPE_CHECKING:
@@ -31,7 +31,6 @@ logger = get_logger(__name__)
 _MAX_ATTEMPTED_KEYS = 512
 _INTERRUPTED_REPLAY_STATE_KEY = "mindroom_replay_state"
 _INTERRUPTED_REPLAY_STATE = "interrupted"
-_MODEL_INVISIBLE_RUN_STATUSES = {RunStatus.paused, RunStatus.cancelled, RunStatus.error}
 
 
 def _run_matches_scope(run: RunOutput | TeamRunOutput, scope: HistoryScope) -> bool:
@@ -66,11 +65,7 @@ def interrupted_source_needs_retry(
     """Return whether stored run order ends in this source's interrupted replay."""
     interrupted_replay_found = False
     for run in runs:
-        if (
-            run.parent_run_id is not None
-            or run.status in _MODEL_INVISIBLE_RUN_STATUSES
-            or not _run_matches_scope(run, scope)
-        ):
+        if not is_model_history_visible_run(run) or not _run_matches_scope(run, scope):
             continue
         run_source_event_ids = _run_source_event_ids(run)
         if run_source_event_ids is None:

--- a/src/mindroom/sync_restart_retry.py
+++ b/src/mindroom/sync_restart_retry.py
@@ -14,14 +14,64 @@ import asyncio
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from agno.run.agent import RunOutput
+from agno.run.base import RunStatus
+from agno.run.team import TeamRunOutput
+
+from mindroom.constants import MATRIX_EVENT_ID_METADATA_KEY, MATRIX_SOURCE_EVENT_IDS_METADATA_KEY
 from mindroom.logging_config import get_logger
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
+    from collections.abc import Awaitable, Callable, Sequence
+
+    from mindroom.history.types import HistoryScope
 
 logger = get_logger(__name__)
 
 _MAX_ATTEMPTED_KEYS = 512
+_INTERRUPTED_REPLAY_STATE_KEY = "mindroom_replay_state"
+_INTERRUPTED_REPLAY_STATE = "interrupted"
+_MODEL_INVISIBLE_RUN_STATUSES = {RunStatus.paused, RunStatus.cancelled, RunStatus.error}
+
+
+def _run_matches_scope(run: RunOutput | TeamRunOutput, scope: HistoryScope) -> bool:
+    if scope.kind == "team":
+        return isinstance(run, TeamRunOutput) and run.team_id == scope.scope_id
+    return isinstance(run, RunOutput) and run.agent_id == scope.scope_id
+
+
+def _run_matches_source(run: RunOutput | TeamRunOutput, source_event_id: str) -> bool:
+    metadata = run.metadata
+    if not isinstance(metadata, dict):
+        return False
+    source_event_ids = metadata.get(MATRIX_SOURCE_EVENT_IDS_METADATA_KEY)
+    return metadata.get(MATRIX_EVENT_ID_METADATA_KEY) == source_event_id or (
+        isinstance(source_event_ids, list) and source_event_id in source_event_ids
+    )
+
+
+def interrupted_source_needs_retry(
+    runs: Sequence[RunOutput | TeamRunOutput],
+    *,
+    scope: HistoryScope,
+    source_event_id: str,
+) -> bool:
+    """Return whether stored run order ends in this source's interrupted replay."""
+    interrupted_replay_found = False
+    for run in runs:
+        if (
+            run.parent_run_id is not None
+            or run.status in _MODEL_INVISIBLE_RUN_STATUSES
+            or not _run_matches_scope(run, scope)
+            or not _run_matches_source(run, source_event_id)
+        ):
+            continue
+        if interrupted_replay_found:
+            return False
+        metadata = run.metadata
+        assert isinstance(metadata, dict)
+        interrupted_replay_found = metadata.get(_INTERRUPTED_REPLAY_STATE_KEY) == _INTERRUPTED_REPLAY_STATE
+    return interrupted_replay_found
 
 
 @dataclass

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -90,7 +90,7 @@ from mindroom.response_payload_preparation import (
 )
 from mindroom.response_runner import PostLockRequestPreparationError, ResponseRequest
 from mindroom.routing import suggest_responder_for_message
-from mindroom.teams import TeamIntent, select_ad_hoc_team_mode
+from mindroom.teams import TeamIntent, TeamMode, select_ad_hoc_team_mode
 from mindroom.text_ingress_dispatch import dispatch_text_message
 from mindroom.thread_utils import (
     check_agent_mentioned,
@@ -1534,6 +1534,7 @@ class TurnController:
         *,
         handled_turn: TurnRecord,
         matrix_run_metadata: dict[str, Any] | None,
+        retry_team_mode: TeamMode | None,
     ) -> tuple[Callable[[], None], Callable[[str], None]]:
         """Build callbacks for sync-restart retry and deferred handled recording."""
 
@@ -1549,6 +1550,8 @@ class TurnController:
                     dispatch_started_at=time.monotonic(),
                     handled_turn=handled_turn,
                     matrix_run_metadata=matrix_run_metadata,
+                    retry_team_mode=retry_team_mode,
+                    sync_restart_retry_source_event_id=event.event_id,
                 )
 
             self.deps.restart_retry.register(event.event_id, retry)
@@ -1558,7 +1561,7 @@ class TurnController:
 
         return register_sync_restart_retry, record_deferred_outcome
 
-    async def _execute_response_action(  # noqa: C901, PLR0912
+    async def _execute_response_action(  # noqa: C901, PLR0912, PLR0915
         self,
         room: nio.MatrixRoom,
         event: DispatchEvent,
@@ -1572,6 +1575,8 @@ class TurnController:
         matrix_run_metadata: dict[str, Any] | None = None,
         queued_notice_reservation: QueuedHumanNoticeReservation | None = None,
         on_lifecycle_lock_acquired: Callable[[], None] | None = None,
+        retry_team_mode: TeamMode | None = None,
+        sync_restart_retry_source_event_id: str | None = None,
     ) -> None:
         """Execute one final response path for a prepared dispatch action."""
         if room.room_id != dispatch.target.room_id:
@@ -1636,6 +1641,19 @@ class TurnController:
                 context_ready_monotonic=context_ready_monotonic,
             )
 
+            team_mode: TeamMode | None = None
+            if action.kind == "team":
+                assert action.form_team is not None
+                assert action.form_team.mode is not None
+                team_mode = retry_team_mode or action.form_team.mode
+                if retry_team_mode is None and action.form_team.intent is not TeamIntent.CONFIGURED_TEAM and event.body:
+                    team_mode = await select_ad_hoc_team_mode(
+                        event.body,
+                        action.form_team.eligible_members,
+                        self.deps.runtime.config,
+                        self.deps.runtime_paths,
+                    )
+
             register_sync_restart_retry, record_deferred_outcome = self._build_response_settlement_callbacks(
                 room,
                 event,
@@ -1644,19 +1662,12 @@ class TurnController:
                 payload_inputs,
                 handled_turn=handled_turn,
                 matrix_run_metadata=matrix_run_metadata,
+                retry_team_mode=team_mode,
             )
             try:
                 if action.kind == "team":
                     assert action.form_team is not None
-                    assert action.form_team.mode is not None
-                    team_mode = action.form_team.mode
-                    if action.form_team.intent is not TeamIntent.CONFIGURED_TEAM and event.body:
-                        team_mode = await select_ad_hoc_team_mode(
-                            event.body,
-                            action.form_team.eligible_members,
-                            self.deps.runtime.config,
-                            self.deps.runtime_paths,
-                        )
+                    assert team_mode is not None
                     response_event_id = await self.deps.response_runner.generate_team_response_helper(
                         ResponseRequest(
                             thread_history=dispatch.context.thread_history,
@@ -1673,6 +1684,7 @@ class TurnController:
                             queued_notice_reservation=queued_notice_reservation,
                             on_lifecycle_lock_acquired=on_lifecycle_lock_acquired,
                             on_sync_restart_cancelled=register_sync_restart_retry,
+                            sync_restart_retry_source_event_id=sync_restart_retry_source_event_id,
                             on_deferred_outcome_handled=record_deferred_outcome,
                         ),
                         team_agents=action.form_team.eligible_members,
@@ -1695,6 +1707,7 @@ class TurnController:
                             queued_notice_reservation=queued_notice_reservation,
                             on_lifecycle_lock_acquired=on_lifecycle_lock_acquired,
                             on_sync_restart_cancelled=register_sync_restart_retry,
+                            sync_restart_retry_source_event_id=sync_restart_retry_source_event_id,
                             on_deferred_outcome_handled=record_deferred_outcome,
                         ),
                     )

--- a/tach.toml
+++ b/tach.toml
@@ -1827,6 +1827,7 @@ depends_on = []
 path = "mindroom.sync_restart_retry"
 depends_on = [
     "mindroom.constants",
+    "mindroom.history.storage",
     "mindroom.history.types",
     "mindroom.logging_config",
 ]

--- a/tach.toml
+++ b/tach.toml
@@ -1216,6 +1216,7 @@ depends_on = [
     "mindroom.response_lifecycle",
     "mindroom.response_terminal",
     "mindroom.streaming",
+    "mindroom.sync_restart_retry",
     "mindroom.teams",
     "mindroom.thread_summary",
     "mindroom.tool_system.dynamic_toolkits",
@@ -1824,8 +1825,15 @@ depends_on = []
 
 [[modules]]
 path = "mindroom.sync_restart_retry"
-depends_on = ["mindroom.logging_config"]
-visibility = ["mindroom.bot"]
+depends_on = [
+    "mindroom.constants",
+    "mindroom.history.types",
+    "mindroom.logging_config",
+]
+visibility = [
+    "mindroom.bot",
+    "mindroom.response_runner",
+]
 
 [[modules]]
 path = "mindroom.sync_bridge_state"

--- a/tests/test_sync_restart_retry.py
+++ b/tests/test_sync_restart_retry.py
@@ -3,19 +3,153 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import replace
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from agno.run.agent import RunOutput
+from agno.run.base import RunStatus
+from agno.run.team import TeamRunOutput
+from agno.session.agent import AgentSession
+from agno.session.team import TeamSession
 from structlog.testing import capture_logs
 
+from mindroom.constants import MATRIX_EVENT_ID_METADATA_KEY
 from mindroom.final_delivery import FinalDeliveryOutcome
-from mindroom.response_runner import ResponseRequest, ResponseRunner
-from mindroom.sync_restart_retry import SyncRestartRetryQueue
-from tests.conftest import request_envelope
+from mindroom.history.types import HistoryScope
+from mindroom.response_runner import PostLockRequestPreparationError, ResponseRequest, ResponseRunner
+from mindroom.sync_restart_retry import SyncRestartRetryQueue, interrupted_source_needs_retry
+from tests.conftest import request_envelope, unwrap_extracted_collaborator
+from tests.response_runner_helpers import _bot, _plain_request, _target
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
+    from pathlib import Path
+
+
+def _stored_run(
+    scope: HistoryScope,
+    run_id: str,
+    *,
+    source_event_id: str = "$source",
+    interrupted: bool = False,
+) -> RunOutput | TeamRunOutput:
+    metadata = {MATRIX_EVENT_ID_METADATA_KEY: source_event_id}
+    if interrupted:
+        metadata["mindroom_replay_state"] = "interrupted"
+    run_kwargs = {
+        "run_id": run_id,
+        "status": RunStatus.completed,
+        "content": "answer",
+        "metadata": metadata,
+    }
+    if scope.kind == "team":
+        return TeamRunOutput(team_id=scope.scope_id, **run_kwargs)
+    return RunOutput(agent_id=scope.scope_id, **run_kwargs)
+
+
+def test_retry_history_uses_latest_matching_visible_run() -> None:
+    """Only latest model-visible run for same source and scope decides retry eligibility."""
+    scope = HistoryScope(kind="agent", scope_id="general")
+    interrupted = _stored_run(scope, "interrupted", interrupted=True)
+
+    assert interrupted_source_needs_retry([interrupted], scope=scope, source_event_id="$source") is True
+    assert interrupted_source_needs_retry([], scope=scope, source_event_id="$source") is False
+    for later in (
+        _stored_run(scope, "completed"),
+        _stored_run(scope, "failed-replay", interrupted=True),
+    ):
+        assert interrupted_source_needs_retry([interrupted, later], scope=scope, source_event_id="$source") is False
+    unrelated_runs = [
+        _stored_run(scope, "interrupted", interrupted=True),
+        _stored_run(scope, "other-source", source_event_id="$other"),
+        _stored_run(HistoryScope(kind="team", scope_id="team"), "other-scope"),
+    ]
+    assert interrupted_source_needs_retry(unrelated_runs, scope=scope, source_event_id="$source") is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("is_team", [False, True])
+@pytest.mark.parametrize("history_case", ["current", "superseded", "missing", "degraded", "error"])
+async def test_locked_retry_guard_precedes_payload_and_fails_closed(
+    tmp_path: Path,
+    *,
+    is_team: bool,
+    history_case: str,
+) -> None:
+    """Agent and team retries check history after lock and before payload work."""
+    bot = _bot(tmp_path)
+    runner = unwrap_extracted_collaborator(bot._response_runner)
+    target = _target(reply_to_event_id="$source")
+    execution_identity = runner.deps.tool_runtime.build_execution_identity(
+        target=target,
+        user_id="@user:localhost",
+    )
+    history_scope = (
+        runner.deps.state_writer.team_history_scope(
+            [bot.matrix_id],
+            requester_user_id=execution_identity.requester_id,
+        )
+        if is_team
+        else runner.deps.state_writer.history_scope()
+    )
+    runs = [_stored_run(history_scope, "interrupted", interrupted=True)]
+    if history_case == "superseded":
+        runs.append(_stored_run(history_scope, "completed"))
+    session = (
+        TeamSession(session_id=target.session_id, team_id=history_scope.scope_id, runs=runs)
+        if is_team
+        else AgentSession(session_id=target.session_id, agent_id=history_scope.scope_id, runs=runs)
+    )
+    storage = MagicMock()
+    if history_case == "error":
+        storage.get_session.side_effect = RuntimeError("history unavailable")
+    elif history_case == "missing":
+        storage.get_session.return_value = None
+    elif history_case == "degraded":
+        storage.get_session.return_value = object()
+    else:
+        storage.get_session.return_value = session
+
+    events: list[str] = []
+
+    def create_storage(*_args: object, **_kwargs: object) -> MagicMock:
+        events.append("history")
+        return storage
+
+    async def prepare_payload(_request: ResponseRequest) -> ResponseRequest:
+        events.append("prepare")
+        message = "payload preparation reached"
+        raise RuntimeError(message)
+
+    request = replace(
+        _plain_request(target, source_event_id="$source"),
+        payload_preparation=MagicMock(),
+        sync_restart_retry_source_event_id="$source",
+        on_lifecycle_lock_acquired=lambda: events.append("lock"),
+    )
+    with (
+        patch.object(runner.deps.state_writer, "create_storage", side_effect=create_storage),
+        patch.object(runner.deps.request_preparer, "prepare", new=AsyncMock(side_effect=prepare_payload)),
+    ):
+        response = (
+            runner.generate_team_response_helper(
+                request,
+                team_agents=[bot.matrix_id],
+                team_mode="coordinate",
+            )
+            if is_team
+            else runner.generate_response(request)
+        )
+        if history_case == "current":
+            with pytest.raises(PostLockRequestPreparationError):
+                await response
+        else:
+            assert await response is None
+
+    assert events == (["lock", "history", "prepare"] if history_case == "current" else ["lock", "history"])
+    bot.client.room_send.assert_not_awaited()
 
 
 def _request(on_sync_restart_cancelled: Callable[[], None] | None = None) -> ResponseRequest:

--- a/tests/test_sync_restart_retry.py
+++ b/tests/test_sync_restart_retry.py
@@ -32,10 +32,10 @@ def _stored_run(
     scope: HistoryScope,
     run_id: str,
     *,
-    source_event_id: str = "$source",
+    source_event_id: str | None = "$source",
     interrupted: bool = False,
 ) -> RunOutput | TeamRunOutput:
-    metadata = {MATRIX_EVENT_ID_METADATA_KEY: source_event_id}
+    metadata = {} if source_event_id is None else {MATRIX_EVENT_ID_METADATA_KEY: source_event_id}
     if interrupted:
         metadata["mindroom_replay_state"] = "interrupted"
     run_kwargs = {
@@ -56,17 +56,16 @@ def test_retry_history_uses_latest_matching_visible_run() -> None:
 
     assert interrupted_source_needs_retry([interrupted], scope=scope, source_event_id="$source") is True
     assert interrupted_source_needs_retry([], scope=scope, source_event_id="$source") is False
-    for later in (
-        _stored_run(scope, "completed"),
-        _stored_run(scope, "failed-replay", interrupted=True),
-    ):
+    for later in (_stored_run(scope, "completed"), _stored_run(scope, "failed-replay", interrupted=True)):
         assert interrupted_source_needs_retry([interrupted, later], scope=scope, source_event_id="$source") is False
     unrelated_runs = [
-        _stored_run(scope, "interrupted", interrupted=True),
+        interrupted,
         _stored_run(scope, "other-source", source_event_id="$other"),
         _stored_run(HistoryScope(kind="team", scope_id="team"), "other-scope"),
     ]
     assert interrupted_source_needs_retry(unrelated_runs, scope=scope, source_event_id="$source") is True
+    ambiguous_runs = [interrupted, _stored_run(scope, "ambiguous", source_event_id=None)]
+    assert interrupted_source_needs_retry(ambiguous_runs, scope=scope, source_event_id="$source") is False
 
 
 @pytest.mark.asyncio
@@ -82,15 +81,9 @@ async def test_locked_retry_guard_precedes_payload_and_fails_closed(
     bot = _bot(tmp_path)
     runner = unwrap_extracted_collaborator(bot._response_runner)
     target = _target(reply_to_event_id="$source")
-    execution_identity = runner.deps.tool_runtime.build_execution_identity(
-        target=target,
-        user_id="@user:localhost",
-    )
+    execution_identity = runner.deps.tool_runtime.build_execution_identity(target=target, user_id="@user:localhost")
     history_scope = (
-        runner.deps.state_writer.team_history_scope(
-            [bot.matrix_id],
-            requester_user_id=execution_identity.requester_id,
-        )
+        runner.deps.state_writer.team_history_scope([bot.matrix_id], requester_user_id=execution_identity.requester_id)
         if is_team
         else runner.deps.state_writer.history_scope()
     )
@@ -103,14 +96,9 @@ async def test_locked_retry_guard_precedes_payload_and_fails_closed(
         else AgentSession(session_id=target.session_id, agent_id=history_scope.scope_id, runs=runs)
     )
     storage = MagicMock()
+    storage.get_session.return_value = {"missing": None, "degraded": object()}.get(history_case, session)
     if history_case == "error":
         storage.get_session.side_effect = RuntimeError("history unavailable")
-    elif history_case == "missing":
-        storage.get_session.return_value = None
-    elif history_case == "degraded":
-        storage.get_session.return_value = object()
-    else:
-        storage.get_session.return_value = session
 
     events: list[str] = []
 
@@ -134,19 +122,27 @@ async def test_locked_retry_guard_precedes_payload_and_fails_closed(
         patch.object(runner.deps.request_preparer, "prepare", new=AsyncMock(side_effect=prepare_payload)),
     ):
         response = (
-            runner.generate_team_response_helper(
-                request,
-                team_agents=[bot.matrix_id],
-                team_mode="coordinate",
-            )
+            runner.generate_team_response_helper(request, team_agents=[bot.matrix_id], team_mode="coordinate")
             if is_team
             else runner.generate_response(request)
         )
+        lifecycle = runner._lifecycle_coordinator
+        lock = lifecycle._response_lifecycle_lock(target)
+        queued_signal = lifecycle._get_or_create_queued_signal(target)
+        await lock.acquire()
+        queued_signal.begin_response_turn()
+        task = asyncio.create_task(response)
+        try:
+            await asyncio.sleep(0)
+            assert queued_signal.pending_human_messages == 0
+        finally:
+            lock.release()
+            queued_signal.finish_response_turn()
         if history_case == "current":
             with pytest.raises(PostLockRequestPreparationError):
-                await response
+                await task
         else:
-            assert await response is None
+            assert await task is None
 
     assert events == (["lock", "history", "prepare"] if history_case == "current" else ["lock", "history"])
     bot.client.room_send.assert_not_awaited()

--- a/tests/test_turn_controller_focused.py
+++ b/tests/test_turn_controller_focused.py
@@ -574,10 +574,15 @@ async def test_deferred_sync_restart_records_handled_outcome_before_rethrow(conf
         await harness.deliver(room, event)
 
     assert harness.restart_retry.has_pending
+    assert harness.runner.requests[0].sync_restart_retry_source_event_id is None
     assert harness.turn_store.is_handled(event.event_id) is True
     record = harness.turn_store.get_turn_record(event.event_id)
     assert record is not None
     assert record.response_event_id == "$response:localhost"
+
+    harness.runner.deferred_sync_restart_error = None
+    await harness.restart_retry.flush()
+    assert harness.runner.requests[1].sync_restart_retry_source_event_id == event.event_id
 
 
 @pytest.mark.asyncio

--- a/tests/test_turn_dispatch_pipeline.py
+++ b/tests/test_turn_dispatch_pipeline.py
@@ -1802,7 +1802,16 @@ class TestAgentBot(AgentBotTestBase):
             ),
         )
 
-        mock_generate_team_response = AsyncMock(return_value="$team-response")
+        team_requests: list[ResponseRequest] = []
+
+        async def generate_team_response(request: ResponseRequest, **_kwargs: object) -> str:
+            team_requests.append(request)
+            if len(team_requests) == 1:
+                assert request.on_sync_restart_cancelled is not None
+                request.on_sync_restart_cancelled()
+            return "$team-response"
+
+        mock_generate_team_response = AsyncMock(side_effect=generate_team_response)
         install_send_response_mock(bot, AsyncMock())
         bot._response_runner.generate_team_response_helper = mock_generate_team_response
         _replace_turn_policy_deps(
@@ -1826,6 +1835,7 @@ class TestAgentBot(AgentBotTestBase):
                 dispatch_started_at=0.0,
                 handled_turn=TurnRecord.create([event.event_id]),
             )
+            await bot._restart_retry_queue.flush()
 
         assert action.form_team is not None
         mock_select_team_mode.assert_awaited_once_with(
@@ -1834,6 +1844,8 @@ class TestAgentBot(AgentBotTestBase):
             bot._turn_controller.deps.runtime.config,
             bot._turn_controller.deps.runtime_paths,
         )
+        assert [request.sync_restart_retry_source_event_id for request in team_requests] == [None, event.event_id]
+        assert mock_generate_team_response.await_count == 2
         assert mock_generate_team_response.await_args.kwargs["team_mode"] == "coordinate"
         assert mock_generate_team_response.await_args.kwargs["team_agents"] == action.form_team.eligible_members
 


### PR DESCRIPTION
## Summary

- carry the interrupted source event ID on sync-restart retry requests
- validate persisted run order under the canonical lifecycle lock before payload or provider work
- fail closed for missing, degraded, ambiguous, or superseded history across agent and team paths
- reuse the selected ad-hoc team mode so stale retries make no pre-lock provider call
- reuse the canonical model-history visibility policy from src/mindroom/history/storage.py

## Tests

- uv run pytest tests/test_sync_restart_retry.py -x -n 0 --no-cov -q (20 passed)
- uv run pytest (9492 passed, 64 skipped)
- uv run pre-commit run --all-files
- uv run tach check --dependencies --interfaces

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery after interrupted sync restarts by retrying only the appropriate response based on persisted history scope and source-event eligibility.
  * Added an option to suppress queued-message notices for locked response turns when needed.
  * Ensured retry execution uses the correct history scope, execution identity, and team mode for team responses.
* **Tests**
  * Expanded coverage for retry eligibility, locked-turn guard ordering (history lookup before payload prep), ambiguity/outdated/history-unavailable cases, and team-response retry handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->