### PR TITLE
Preserve failed turns in model history

### DIFF
--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -1984,6 +1984,8 @@ async def stream_agent_response(  # noqa: C901, PLR0915
                         partial_text=state.assistant_text or paused_content,
                         completed_tools=tuple(state.completed_tools),
                         interrupted_tools=tuple(pending.trace_entry for pending in state.pending_tools),
+                        session_id=state.paused_run_event.session_id,
+                        run_id=state.paused_run_event.run_id or attempt.attempt_run_id,
                     ),
                 )
                 return

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -7,7 +7,6 @@ from collections.abc import Mapping
 from contextlib import aclosing
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, cast
-from uuid import uuid4
 
 from agno.db.base import SessionType
 from agno.models.message import Message
@@ -19,6 +18,7 @@ from agno.run.agent import (
     RunContentEvent,
     RunErrorEvent,
     RunOutput,
+    RunPausedEvent,
     ToolCallCompletedEvent,
     ToolCallStartedEvent,
 )
@@ -71,10 +71,9 @@ from mindroom.response_turn import (
     AttemptResolved,
     BlockingAttemptResolution,
     BlockingTurnAdapter,
-    CancelledAttempt,
     CompletedAttempt,
     DynamicContinuationRunState,
-    ErroredAttempt,
+    ExcludedAttempt,
     HandledAttempt,
     ResponseTurnContext,
     StreamingTurnAdapter,
@@ -312,6 +311,7 @@ class _StreamingAttemptState:
     latest_request_cache_read_tokens: int | None = None
     latest_request_cache_write_tokens: int | None = None
     cancelled_run_event: RunCancelledEvent | None = None
+    paused_run_event: RunPausedEvent | None = None
     completed_run_event: RunCompletedEvent | None = None
     canonical_final_body_candidate: str | None = None
     completed_tool_executions: list[ToolExecution] = field(default_factory=list)
@@ -1265,7 +1265,7 @@ async def _prepare_agent_run_context(
     )
 
 
-async def ai_response(
+async def ai_response(  # noqa: C901
     ctx: ResponseTurnContext,
     prompt: str,
     runtime_paths: RuntimePaths,
@@ -1421,7 +1421,7 @@ async def ai_response(
             )
         except Exception as e:
             logger.exception("Error preparing agent", agent=agent_name)
-            return ErroredAttempt(get_user_friendly_error_message(e, agent_name))
+            return ExcludedAttempt(RunStatus.error, get_user_friendly_error_message(e, agent_name))
         prepared_run = run_context.prepared_run
         holder.agent = prepared_run.agent
         run.unseen_event_ids = prepared_run.unseen_event_ids
@@ -1444,7 +1444,8 @@ async def ai_response(
             pipeline_timing=pipeline_timing,
         )
         if attempt_result.user_error is not None:
-            return ErroredAttempt(get_user_friendly_error_message(attempt_result.user_error, agent_name))
+            error_text = get_user_friendly_error_message(attempt_result.user_error, agent_name)
+            return ExcludedAttempt(RunStatus.error, error_text)
         response = cast("RunOutput", attempt_result.response)
 
         response_tool_trace = _extract_tool_trace(response)
@@ -1466,27 +1467,29 @@ async def ai_response(
                 prepared_history=prepared_run.prepared_history,
             )
 
-        if response.status == RunStatus.cancelled:
+        if response.status in (RunStatus.cancelled, RunStatus.error, RunStatus.paused):
             partial_text = _extract_interrupted_partial_text(
                 response.content,
                 messages=response.messages,
             )
             completed_tools, interrupted_tools = _extract_cancelled_tool_trace(response)
-            return CancelledAttempt(
+            response_text = ""
+            if response.status is RunStatus.error:
+                response_text = get_user_friendly_error_message(
+                    Exception(str(response.content or "Unknown agent error")),
+                    agent_name,
+                )
+            elif response.status is RunStatus.paused:
+                response_text = _extract_response_content(response, show_tool_calls=show_tool_calls)
+            return ExcludedAttempt(
+                original_status=response.status,
+                response_text=response_text,
                 reason=response.content,
                 partial_text=partial_text,
                 completed_tools=tuple(completed_tools),
                 interrupted_tools=tuple(interrupted_tools),
                 session_id=response.session_id,
                 run_id=response.run_id or attempt.attempt_run_id,
-                metadata_content=metadata_content,
-            )
-        if response.status == RunStatus.error:
-            return ErroredAttempt(
-                get_user_friendly_error_message(
-                    Exception(str(response.content or "Unknown agent error")),
-                    agent_name,
-                ),
                 metadata_content=metadata_content,
             )
         return CompletedAttempt(
@@ -1616,6 +1619,12 @@ async def _process_stream_events(  # noqa: C901, PLR0912, PLR0915
 
             if isinstance(event, RunCancelledEvent):
                 state.cancelled_run_event = event
+                if state_updated is not None:
+                    state_updated()
+                return
+
+            if isinstance(event, RunPausedEvent):
+                state.paused_run_event = event
                 if state_updated is not None:
                     state_updated()
                 return
@@ -1831,7 +1840,7 @@ async def stream_agent_response(  # noqa: C901, PLR0915
             entity_name=agent_name,
         )
 
-    async def _run_streaming_attempt(  # noqa: C901, PLR0915
+    async def _run_streaming_attempt(  # noqa: C901
         run: TurnRunState,
         continuation_state: DynamicContinuationRunState,
     ) -> AsyncGenerator[AIStreamChunk | AttemptResolved, None]:
@@ -1925,29 +1934,6 @@ async def stream_agent_response(  # noqa: C901, PLR0915
 
             run_error = state.user_error or state.stream_exception
             if run_error is not None:
-                if state.assistant_text or state.completed_tools or state.pending_tools:
-                    interrupted_tools = [pending.trace_entry for pending in state.pending_tools]
-                    if turn_recorder is not None:
-                        turn_state.record_interrupted(
-                            turn_recorder,
-                            run_metadata=run.run_metadata,
-                            assistant_text=state.assistant_text,
-                            completed_tools=state.completed_tools,
-                            interrupted_tools=interrupted_tools,
-                        )
-                    elif not run.standalone_replay_persisted:
-                        persist_interrupted_replay(
-                            scope_context=run.scope_context,
-                            session_id=session_id,
-                            run_id=attempt.attempt_run_id or str(uuid4()),
-                            user_message=prompt,
-                            partial_text=state.assistant_text,
-                            completed_tools=turn_state.completed_tools_for(state.completed_tools),
-                            interrupted_tools=interrupted_tools,
-                            run_metadata=run.run_metadata,
-                            is_team=False,
-                        )
-                        run.standalone_replay_persisted = True
                 yield get_user_friendly_error_message(run_error, agent_name)
                 yield AttemptResolved(HandledAttempt())
                 return
@@ -1977,7 +1963,7 @@ async def stream_agent_response(  # noqa: C901, PLR0915
                         prepared_history=prepared_run.prepared_history,
                     )
                 yield AttemptResolved(
-                    CancelledAttempt(
+                    ExcludedAttempt(
                         reason=state.cancelled_run_event.reason,
                         partial_text=state.assistant_text,
                         completed_tools=tuple(state.completed_tools),
@@ -1985,6 +1971,19 @@ async def stream_agent_response(  # noqa: C901, PLR0915
                         session_id=state.cancelled_run_event.session_id,
                         run_id=state.cancelled_run_event.run_id or attempt.attempt_run_id,
                         metadata_content=cancelled_metadata,
+                    ),
+                )
+                return
+
+            if state.paused_run_event is not None:
+                paused_content = str(state.paused_run_event.content or "")
+                yield AttemptResolved(
+                    ExcludedAttempt(
+                        original_status=RunStatus.paused,
+                        response_text=paused_content,
+                        partial_text=state.assistant_text or paused_content,
+                        completed_tools=tuple(state.completed_tools),
+                        interrupted_tools=tuple(pending.trace_entry for pending in state.pending_tools),
                     ),
                 )
                 return

--- a/src/mindroom/ai_turn_state.py
+++ b/src/mindroom/ai_turn_state.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from agno.run.base import RunStatus
+
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
 
@@ -75,6 +77,7 @@ class AITurnState:
         assistant_text: str,
         completed_tools: Sequence[ToolTraceEntry],
         interrupted_tools: Sequence[ToolTraceEntry],
+        original_status: RunStatus = RunStatus.cancelled,
     ) -> None:
         """Record an interrupted top-level turn when a recorder is present."""
         self.assistant_text = assistant_text
@@ -87,6 +90,7 @@ class AITurnState:
             assistant_text=self.assistant_text,
             completed_tools=self.completed_tools,
             interrupted_tools=self.interrupted_tools,
+            original_status=original_status,
         )
 
     def record_interrupted_from_recorder(
@@ -94,6 +98,7 @@ class AITurnState:
         recorder: TurnRecorder,
         *,
         run_metadata: Mapping[str, Any] | None,
+        original_status: RunStatus = RunStatus.cancelled,
     ) -> None:
         """Mark the recorder interrupted using its already-canonical live state."""
         self.assistant_text = recorder.assistant_text
@@ -104,4 +109,5 @@ class AITurnState:
             assistant_text=self.assistant_text,
             completed_tools=self.completed_tools,
             interrupted_tools=self.interrupted_tools,
+            original_status=original_status,
         )

--- a/src/mindroom/history/interrupted_replay.py
+++ b/src/mindroom/history/interrupted_replay.py
@@ -44,6 +44,7 @@ class InterruptedReplaySnapshot:
     completed_tools: tuple[ToolTraceEntry, ...]
     interrupted_tools: tuple[ToolTraceEntry, ...]
     run_metadata: dict[str, Any] = field(default_factory=dict)
+    original_status: RunStatus = RunStatus.cancelled
 
 
 def tool_execution_call_id(tool: ToolExecution | None) -> str | None:
@@ -95,7 +96,14 @@ def _render_interruption_summary(snapshot: InterruptedReplaySnapshot) -> str:
     if snapshot.interrupted_tools:
         names = ", ".join(entry.tool_name for entry in snapshot.interrupted_tools)
         details.append(f"{len(snapshot.interrupted_tools)} tool call(s) were still running: {names}")
-    summary = "(turn interrupted by the user before completion"
+    if snapshot.original_status is RunStatus.error:
+        summary = "(turn failed before completion"
+    elif snapshot.original_status is RunStatus.paused:
+        summary = "(turn paused before completion"
+    elif snapshot.original_status is RunStatus.cancelled:
+        summary = "(turn stopped before completion"
+    else:
+        summary = "(turn ended without a model-visible completion"
     if details:
         summary += "; " + "; ".join(details)
     return summary + ")"
@@ -114,7 +122,7 @@ def _interrupted_replay_metadata(snapshot: InterruptedReplaySnapshot) -> dict[st
     metadata = dict(snapshot.run_metadata)
     metadata.update(
         {
-            _ORIGINAL_STATUS_KEY: "cancelled",
+            _ORIGINAL_STATUS_KEY: snapshot.original_status.name,
             _INTERRUPTED_REPLAY_STATE_KEY: _INTERRUPTED_REPLAY_STATE,
         },
     )
@@ -165,6 +173,7 @@ def build_interrupted_replay_snapshot(
     interrupted_tools: Sequence[ToolTraceEntry],
     run_metadata: Mapping[str, object] | None,
     response_event_id: str | None = None,
+    original_status: RunStatus = RunStatus.cancelled,
 ) -> InterruptedReplaySnapshot:
     """Build one canonical interrupted replay snapshot from trusted runtime state."""
     metadata = dict(run_metadata) if isinstance(run_metadata, Mapping) else {}
@@ -179,6 +188,7 @@ def build_interrupted_replay_snapshot(
         completed_tools=tuple(completed_tools),
         interrupted_tools=tuple(interrupted_tools),
         run_metadata=metadata,
+        original_status=original_status,
     )
 
 
@@ -235,6 +245,7 @@ def persist_interrupted_replay(
     interrupted_tools: Sequence[ToolTraceEntry],
     run_metadata: Mapping[str, object] | None,
     is_team: bool,
+    original_status: RunStatus = RunStatus.cancelled,
 ) -> None:
     """Persist one interrupted top-level turn from trusted runtime state."""
     if scope_context is None:
@@ -252,6 +263,7 @@ def persist_interrupted_replay(
             interrupted_tools=interrupted_tools,
             run_metadata=run_metadata,
             response_event_id=None,
+            original_status=original_status,
         ),
         is_team=is_team,
     )

--- a/src/mindroom/history/turn_recorder.py
+++ b/src/mindroom/history/turn_recorder.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from agno.run.base import RunStatus
+
 from mindroom.history.interrupted_replay import InterruptedReplaySnapshot, build_interrupted_replay_snapshot
 
 if TYPE_CHECKING:
@@ -25,6 +27,7 @@ class TurnRecorder:
     completed_tools: list[ToolTraceEntry] = field(default_factory=list)
     interrupted_tools: list[ToolTraceEntry] = field(default_factory=list)
     outcome: str = "pending"
+    original_status: RunStatus | None = None
     interrupted_persisted: bool = False
 
     def set_run_metadata(self, metadata: dict[str, Any] | None) -> None:
@@ -86,21 +89,23 @@ class TurnRecorder:
         assistant_text: str,
         completed_tools: Sequence[ToolTraceEntry],
         interrupted_tools: Sequence[ToolTraceEntry],
+        original_status: RunStatus = RunStatus.cancelled,
     ) -> None:
         """Record one interrupted top-level turn."""
         self.set_run_metadata(dict(run_metadata) if run_metadata is not None else None)
         self.set_assistant_text(assistant_text)
         self.set_completed_tools(list(completed_tools))
         self.set_interrupted_tools(list(interrupted_tools))
-        self.mark_interrupted()
+        self.mark_interrupted(original_status)
 
     def mark_completed(self) -> None:
         """Record successful completion."""
         self.outcome = "completed"
 
-    def mark_interrupted(self) -> None:
+    def mark_interrupted(self, original_status: RunStatus = RunStatus.cancelled) -> None:
         """Record interruption."""
         self.outcome = "interrupted"
+        self.original_status = original_status
 
     def interrupted_snapshot(self) -> InterruptedReplaySnapshot:
         """Build one canonical interrupted snapshot from the recorded facts."""
@@ -111,6 +116,7 @@ class TurnRecorder:
             interrupted_tools=self.interrupted_tools,
             run_metadata=self.run_metadata,
             response_event_id=self.response_event_id,
+            original_status=self.original_status or RunStatus.cancelled,
         )
 
     def claim_interrupted_persistence(self) -> bool:

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -616,8 +616,8 @@ class ResponseRunner:
         tool_trace: Sequence[ToolTraceEntry],
     ) -> bool:
         """Capture canonical interrupted replay state from one failed stream delivery."""
-        if recorder.outcome == "completed":
-            return False
+        if recorder.outcome != "pending":
+            return recorder.outcome == "interrupted"
         partial_text = clean_partial_reply_text(strip_visible_tool_markers(accumulated_text))
         completed_tools, interrupted_tools = _split_delivery_tool_trace(tool_trace)
         if not partial_text:
@@ -626,8 +626,6 @@ class ResponseRunner:
             completed_tools = list(recorder.completed_tools)
         if not interrupted_tools:
             interrupted_tools = list(recorder.interrupted_tools)
-        if not partial_text and not completed_tools and not interrupted_tools:
-            return False
         recorder.record_interrupted(
             run_metadata=recorder.run_metadata,
             assistant_text=partial_text,
@@ -1467,6 +1465,21 @@ class ResponseRunner:
             matrix_run_metadata=matrix_run_metadata,
         )
 
+        async def persist_failed_team_turn() -> None:
+            if team_turn_recorder.outcome == "completed" or team_turn_recorder.original_status is RunStatus.cancelled:
+                return
+            if team_turn_recorder.outcome == "pending":
+                team_turn_recorder.mark_interrupted(RunStatus.error)
+            await self._persist_interrupted_recorder_off_loop(
+                recorder=team_turn_recorder,
+                session_scope=session_scope,
+                session_id=session_id,
+                execution_identity=tool_dispatch.execution_identity,
+                run_id=response_run_id,
+                is_team=True,
+                response_event_id=progress.tracked_event_id,
+            )
+
         persist_response_event_id = self._build_persist_response_event_id_effect(
             session_id=session_id,
             session_type=session_type,
@@ -1571,16 +1584,7 @@ class ResponseRunner:
                         await lifecycle.emit_session_started(session_started_watch)
                 if request.pipeline_timing is not None:
                     request.pipeline_timing.mark("streaming_complete")
-                if team_turn_recorder.outcome == "interrupted":
-                    await self._persist_interrupted_recorder_off_loop(
-                        recorder=team_turn_recorder,
-                        session_scope=session_scope,
-                        session_id=session_id,
-                        execution_identity=tool_dispatch.execution_identity,
-                        run_id=response_run_id,
-                        is_team=True,
-                        response_event_id=progress.tracked_event_id,
-                    )
+                await persist_failed_team_turn()
                 delivery_kind: Literal["sent", "edited"] = "edited" if message_id else "sent"
                 finalize_request = FinalizeStreamedResponseRequest(
                     target=delivery_target,
@@ -1651,6 +1655,7 @@ class ResponseRunner:
                                 raise
                     finally:
                         await lifecycle.emit_session_started(session_started_watch)
+                        await persist_failed_team_turn()
                 except asyncio.CancelledError as exc:
                     log_cancelled_response(
                         self.deps.logger,

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Literal, TypeVar
 from uuid import uuid4
 
 from agno.db.base import SessionType
+from agno.run.base import RunStatus
 from agno.session.agent import AgentSession
 from agno.session.team import TeamSession
 
@@ -546,7 +547,7 @@ class ResponseRunner:
 
     def _ensure_recorder_interrupted(self, recorder: TurnRecorder) -> None:
         """Mark one recorder interrupted unless lower layers already captured richer state."""
-        if recorder.outcome != "interrupted":
+        if recorder.outcome == "pending":
             recorder.mark_interrupted()
 
     def _persist_interrupted_recorder(
@@ -615,6 +616,8 @@ class ResponseRunner:
         tool_trace: Sequence[ToolTraceEntry],
     ) -> bool:
         """Capture canonical interrupted replay state from one failed stream delivery."""
+        if recorder.outcome == "completed":
+            return False
         partial_text = clean_partial_reply_text(strip_visible_tool_markers(accumulated_text))
         completed_tools, interrupted_tools = _split_delivery_tool_trace(tool_trace)
         if not partial_text:
@@ -630,6 +633,7 @@ class ResponseRunner:
             assistant_text=partial_text,
             completed_tools=completed_tools,
             interrupted_tools=interrupted_tools,
+            original_status=RunStatus.error,
         )
         return True
 
@@ -2197,6 +2201,18 @@ class ResponseRunner:
                 )
             finally:
                 await lifecycle.emit_session_started(session_started_watch)
+                if turn_recorder.outcome != "completed" and turn_recorder.original_status is not RunStatus.cancelled:
+                    if turn_recorder.outcome == "pending":
+                        turn_recorder.mark_interrupted(RunStatus.error)
+                    await self._persist_interrupted_recorder_off_loop(
+                        recorder=turn_recorder,
+                        session_scope=session_scope,
+                        session_id=runtime.session_id,
+                        execution_identity=runtime.tool_dispatch.execution_identity,
+                        run_id=run_id,
+                        is_team=False,
+                        response_event_id=request.existing_event_id,
+                    )
         except asyncio.CancelledError as exc:
             cancel_source = classify_cancel_source(exc)
             log_cancelled_response(

--- a/src/mindroom/response_turn.py
+++ b/src/mindroom/response_turn.py
@@ -24,6 +24,8 @@ from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, NoReturn
 from uuid import uuid4
 
+from agno.run.base import RunStatus
+
 from mindroom import ai_runtime
 from mindroom.ai_turn_state import AITurnState
 from mindroom.cancellation import build_cancelled_error
@@ -54,11 +56,10 @@ __all__ = [
     "AttemptResolved",
     "BlockingAttemptResolution",
     "BlockingTurnAdapter",
-    "CancelledAttempt",
     "CompletedAttempt",
     "DynamicContinuationRunState",
     "EmptyRunDiscard",
-    "ErroredAttempt",
+    "ExcludedAttempt",
     "HandledAttempt",
     "ResponseTurnContext",
     "StandaloneReplaySnapshot",
@@ -268,9 +269,9 @@ class CompletedAttempt:
 
 
 @dataclass(frozen=True)
-class CancelledAttempt:
-    """One attempt whose provider run reported cancellation."""
-
+class ExcludedAttempt:  # noqa: D101
+    original_status: RunStatus = RunStatus.cancelled
+    response_text: str = ""
     reason: str | None = None
     partial_text: str = ""
     completed_tools: tuple[ToolTraceEntry, ...] = ()
@@ -281,20 +282,12 @@ class CancelledAttempt:
 
 
 @dataclass(frozen=True)
-class ErroredAttempt:
-    """One attempt that resolved to user-facing error text (blocking only)."""
-
-    user_message_text: str
-    metadata_content: dict[str, Any] | None = None
-
-
-@dataclass(frozen=True)
 class HandledAttempt:
-    """One streaming attempt that already emitted and recorded its own terminal output."""
+    """One streaming error whose user-facing text was already emitted."""
 
 
-BlockingAttemptResolution = CompletedAttempt | CancelledAttempt | ErroredAttempt
-StreamAttemptResolution = CompletedAttempt | CancelledAttempt | HandledAttempt
+BlockingAttemptResolution = CompletedAttempt | ExcludedAttempt
+StreamAttemptResolution = CompletedAttempt | ExcludedAttempt | HandledAttempt
 
 
 @dataclass(frozen=True)
@@ -323,6 +316,7 @@ class StandaloneReplaySnapshot:
     completed_tools: list[ToolTraceEntry]
     interrupted_tools: list[ToolTraceEntry]
     run_metadata: dict[str, Any] | None
+    original_status: RunStatus
 
 
 @dataclass(frozen=True)
@@ -408,13 +402,12 @@ def _fallback_matrix_run_metadata(ctx: ResponseTurnContext, run: TurnRunState) -
     )
 
 
-def _persist_attempt_cancelled_replay(
+def _persist_excluded_attempt_replay(
     ctx: ResponseTurnContext,
     persist: Callable[[ScopeSessionContext | None, StandaloneReplaySnapshot], None],
     run: TurnRunState,
-    resolution: CancelledAttempt,
+    resolution: ExcludedAttempt,
 ) -> None:
-    """Persist the standalone interrupted replay for one cancelled attempt."""
     persist(
         run.scope_context,
         StandaloneReplaySnapshot(
@@ -424,30 +417,37 @@ def _persist_attempt_cancelled_replay(
             completed_tools=run.turn_state.completed_tools_for(resolution.completed_tools),
             interrupted_tools=list(resolution.interrupted_tools),
             run_metadata=run.run_metadata,
+            original_status=resolution.original_status,
         ),
     )
     run.standalone_replay_persisted = True
 
 
-def _record_turn_cancelled_fallback(
+def _record_turn_excluded_fallback(
     ctx: ResponseTurnContext,
     persist: Callable[[ScopeSessionContext | None, StandaloneReplaySnapshot], None] | None,
     sinks: TurnSinks,
     run: TurnRunState,
     snapshot: TurnPartialSnapshot,
     *,
+    original_status: RunStatus,
     use_recorder_state: bool,
 ) -> None:
-    """Record an externally cancelled turn on the recorder or as a standalone replay."""
     recorder = sinks.turn_recorder
     if recorder is not None:
+        if recorder.outcome == "completed":
+            return
         run_metadata = (
             run.run_metadata
             if run.run_metadata is not None
             else recorder.run_metadata or _fallback_matrix_run_metadata(ctx, run)
         )
         if use_recorder_state:
-            run.turn_state.record_interrupted_from_recorder(recorder, run_metadata=run_metadata)
+            run.turn_state.record_interrupted_from_recorder(
+                recorder,
+                run_metadata=run_metadata,
+                original_status=original_status,
+            )
         else:
             run.turn_state.record_interrupted(
                 recorder,
@@ -455,6 +455,7 @@ def _record_turn_cancelled_fallback(
                 assistant_text=snapshot.assistant_text,
                 completed_tools=list(snapshot.completed_tools),
                 interrupted_tools=list(snapshot.interrupted_tools),
+                original_status=original_status,
             )
         return
     if run.standalone_replay_persisted or persist is None:
@@ -468,8 +469,10 @@ def _record_turn_cancelled_fallback(
             completed_tools=run.turn_state.completed_tools_for(snapshot.completed_tools),
             interrupted_tools=list(snapshot.interrupted_tools),
             run_metadata=run.run_metadata if run.run_metadata is not None else _fallback_matrix_run_metadata(ctx, run),
+            original_status=original_status,
         ),
     )
+    run.standalone_replay_persisted = True
 
 
 def _settle_empty_run(
@@ -563,16 +566,26 @@ async def run_blocking_response_turn(
         # The blocking envelope re-records from the recorder's canonical state so
         # an in-attempt cancellation (recorded above with attempt-local partials)
         # and an external task cancel converge on the same interrupted turn.
-        _record_turn_cancelled_fallback(
+        _record_turn_excluded_fallback(
             ctx,
             adapter.persist_standalone_replay,
             sinks,
             run,
             adapter.snapshot_partial(),
+            original_status=RunStatus.cancelled,
             use_recorder_state=True,
         )
         raise
     except Exception as e:
+        _record_turn_excluded_fallback(
+            ctx,
+            adapter.persist_standalone_replay,
+            sinks,
+            run,
+            adapter.snapshot_partial(),
+            original_status=RunStatus.error,
+            use_recorder_state=False,
+        )
         if adapter.unexpected_error_text is None:
             raise
         logger.exception("Response turn failed", entity=ctx.entity_label)
@@ -595,7 +608,7 @@ def _settle_blocking_attempt(
     # The blocking envelope publishes run metadata before recording, and only
     # for attempts that end the turn: a discarded empty run's or a superseded
     # continuation attempt's payload must not ride out on a later resolution.
-    if isinstance(resolution, CancelledAttempt):
+    if isinstance(resolution, ExcludedAttempt):
         _publish_run_metadata(sinks, resolution.metadata_content)
         run.turn_state.record_interrupted(
             sinks.turn_recorder,
@@ -603,13 +616,13 @@ def _settle_blocking_attempt(
             assistant_text=resolution.partial_text,
             completed_tools=list(resolution.completed_tools),
             interrupted_tools=list(resolution.interrupted_tools),
+            original_status=resolution.original_status,
         )
         if sinks.turn_recorder is None and adapter.persist_standalone_replay is not None:
-            _persist_attempt_cancelled_replay(ctx, adapter.persist_standalone_replay, run, resolution)
-        raise build_cancelled_error(resolution.reason)
-    if isinstance(resolution, ErroredAttempt):
-        _publish_run_metadata(sinks, resolution.metadata_content)
-        return resolution.user_message_text
+            _persist_excluded_attempt_replay(ctx, adapter.persist_standalone_replay, run, resolution)
+        if resolution.original_status is RunStatus.cancelled:
+            raise build_cancelled_error(resolution.reason)
+        return resolution.response_text
     settle = _settle_completed_attempt(
         ctx,
         sinks,
@@ -736,7 +749,7 @@ def _settle_completed_attempt(
     )
 
 
-async def stream_response_turn[ChunkT](  # noqa: C901, PLR0912
+async def stream_response_turn[ChunkT](  # noqa: C901, PLR0912, PLR0915
     ctx: ResponseTurnContext,
     adapter: StreamingTurnAdapter[ChunkT],
     sinks: TurnSinks,
@@ -765,26 +778,38 @@ async def stream_response_turn[ChunkT](  # noqa: C901, PLR0912
                     if resolution is None:
                         _raise_missing_stream_resolution(ctx.entity_label)
                     if isinstance(resolution, HandledAttempt):
+                        _record_turn_excluded_fallback(
+                            ctx,
+                            adapter.persist_standalone_replay,
+                            sinks,
+                            run,
+                            adapter.snapshot_partial(),
+                            original_status=RunStatus.error,
+                            use_recorder_state=False,
+                        )
                         return
-                    if isinstance(resolution, CancelledAttempt):
-                        # The streaming envelope records the interruption before
-                        # publishing cancelled run metadata to the collector.
+                    if isinstance(resolution, ExcludedAttempt):
                         run.turn_state.record_interrupted(
                             sinks.turn_recorder,
                             run_metadata=run.run_metadata,
                             assistant_text=resolution.partial_text,
                             completed_tools=list(resolution.completed_tools),
                             interrupted_tools=list(resolution.interrupted_tools),
+                            original_status=resolution.original_status,
                         )
                         _publish_run_metadata(sinks, resolution.metadata_content)
                         if sinks.turn_recorder is None and adapter.persist_standalone_replay is not None:
-                            _persist_attempt_cancelled_replay(
+                            _persist_excluded_attempt_replay(
                                 ctx,
                                 adapter.persist_standalone_replay,
                                 run,
                                 resolution,
                             )
-                        raise build_cancelled_error(resolution.reason)
+                        if resolution.original_status is RunStatus.cancelled:
+                            raise build_cancelled_error(resolution.reason)
+                        if resolution.response_text:
+                            yield adapter.make_text_chunk(resolution.response_text)
+                        return
                     settle = _settle_completed_attempt(
                         ctx,
                         sinks,
@@ -814,16 +839,26 @@ async def stream_response_turn[ChunkT](  # noqa: C901, PLR0912
                     return
             _raise_continuation_budget_exhausted()
     except asyncio.CancelledError:
-        _record_turn_cancelled_fallback(
+        _record_turn_excluded_fallback(
             ctx,
             adapter.persist_standalone_replay,
             sinks,
             run,
             adapter.snapshot_partial(),
+            original_status=RunStatus.cancelled,
             use_recorder_state=False,
         )
         raise
     except Exception as e:
+        _record_turn_excluded_fallback(
+            ctx,
+            adapter.persist_standalone_replay,
+            sinks,
+            run,
+            adapter.snapshot_partial(),
+            original_status=RunStatus.error,
+            use_recorder_state=False,
+        )
         if adapter.unexpected_error_text is None:
             raise
         logger.exception("Response turn failed", entity=ctx.entity_label)

--- a/src/mindroom/response_turn.py
+++ b/src/mindroom/response_turn.py
@@ -269,7 +269,9 @@ class CompletedAttempt:
 
 
 @dataclass(frozen=True)
-class ExcludedAttempt:  # noqa: D101
+class ExcludedAttempt:
+    """One attempt whose provider result is excluded from model history."""
+
     original_status: RunStatus = RunStatus.cancelled
     response_text: str = ""
     reason: str | None = None
@@ -490,6 +492,8 @@ def _settle_empty_run(
     iteration budget stays authoritative; a granted retry closes the spent
     entity's runtime state exactly like the continuation handoff.
     """
+    if run.empty_response_retried or continuation_count >= DYNAMIC_TOOL_CONTINUATION_LIMIT:
+        return False
     discard_empty_run(
         run.scope_context,
         EmptyRunDiscard(
@@ -498,11 +502,9 @@ def _settle_empty_run(
             output_tokens=resolution.output_tokens,
         ),
     )
-    if not run.empty_response_retried and continuation_count < DYNAMIC_TOOL_CONTINUATION_LIMIT:
-        run.empty_response_retried = True
-        release_attempt_entity(run.scope_context)
-        return True
-    return False
+    run.empty_response_retried = True
+    release_attempt_entity(run.scope_context)
+    return True
 
 
 def _advance_turn_continuation(

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -22,6 +22,7 @@ from agno.run.team import RunCancelledEvent as TeamRunCancelledEvent
 from agno.run.team import RunCompletedEvent as TeamRunCompletedEvent
 from agno.run.team import RunContentEvent as TeamRunContentEvent
 from agno.run.team import RunErrorEvent as TeamRunErrorEvent
+from agno.run.team import RunPausedEvent as TeamRunPausedEvent
 from agno.run.team import TeamRunOutput
 from agno.run.team import ToolCallCompletedEvent as TeamToolCallCompletedEvent
 from agno.run.team import ToolCallStartedEvent as TeamToolCallStartedEvent
@@ -83,10 +84,9 @@ from mindroom.response_turn import (
     AttemptResolved,
     BlockingAttemptResolution,
     BlockingTurnAdapter,
-    CancelledAttempt,
     CompletedAttempt,
     DynamicContinuationRunState,
-    ErroredAttempt,
+    ExcludedAttempt,
     HandledAttempt,
     ResponseTurnContext,
     StreamingTurnAdapter,
@@ -308,6 +308,10 @@ def is_cancelled_run_output(response: TeamRunOutput | RunOutput) -> bool:
     """Return whether a team or agent fallback run ended in a cancelled state."""
     status = response.status.value if isinstance(response.status, RunStatus) else response.status
     return str(status).lower() == "cancelled"
+
+
+def _is_bound_team_output(response: TeamRunOutput | RunOutput, *, team_id: str) -> bool:
+    return isinstance(response, TeamRunOutput) and response.team_id in (None, "", team_id)
 
 
 def _team_response_text(response: TeamRunOutput | RunOutput) -> str:
@@ -2107,7 +2111,8 @@ async def team_response(  # noqa: C901, PLR0915
                     continue
 
                 logger.exception("team_response_failed", agents=agent_list)
-                return ErroredAttempt(get_user_friendly_error_message(e, team_name))
+                error_text = get_user_friendly_error_message(e, team_name)
+                return ExcludedAttempt(RunStatus.error, error_text, run_id=attempt_run_id)
 
             if isinstance(response, (TeamRunOutput, RunOutput)):
                 holder.last_response = response
@@ -2161,24 +2166,36 @@ async def team_response(  # noqa: C901, PLR0915
                 session_id=ctx.session_id,
                 tool_count=len(run_tool_executions),
             )
-        if isinstance(response, (TeamRunOutput, RunOutput)) and is_cancelled_run_output(response):
+        if isinstance(response, (TeamRunOutput, RunOutput)) and (
+            response.status in (RunStatus.cancelled, RunStatus.error, RunStatus.paused)
+            or not _is_bound_team_output(
+                response,
+                team_id=run.scope_context.scope.scope_id if run.scope_context is not None else team.id or "",
+            )
+        ):
+            original_status = response.status if isinstance(response.status, RunStatus) else RunStatus.error
             partial_text = _extract_interrupted_team_partial_text(response)
             completed_tools, interrupted_tools = _extract_cancelled_team_tool_trace(response)
-            return CancelledAttempt(
+            response_text = ""
+            if original_status is RunStatus.error:
+                response_text = get_user_friendly_error_message(
+                    Exception(str(response.content or "Unknown team error")),
+                    team_name,
+                )
+            elif original_status is not RunStatus.cancelled:
+                response_text = _format_terminal_team_response(
+                    response,
+                    team_display_names=team_members.display_names,
+                )
+            return ExcludedAttempt(
+                original_status=original_status,
+                response_text=response_text,
                 reason=response.content,
                 partial_text=partial_text,
                 completed_tools=tuple(completed_tools),
                 interrupted_tools=tuple(interrupted_tools),
                 session_id=response.session_id,
                 run_id=response.run_id or attempt_run_id,
-                metadata_content=metadata_content,
-            )
-        if isinstance(response, (TeamRunOutput, RunOutput)) and is_errored_run_output(response):
-            return ErroredAttempt(
-                get_user_friendly_error_message(
-                    Exception(str(response.content or "Unknown team error")),
-                    team_name,
-                ),
                 metadata_content=metadata_content,
             )
         if pending_retry_decision is not None:
@@ -2438,7 +2455,7 @@ async def team_response_stream(  # noqa: C901, PLR0915
     config = orchestrator.config
     holder = _TeamTurnHolder(team_members=team_members)
 
-    async def _run_team_stream_attempt(  # noqa: C901, PLR0912, PLR0915
+    async def _run_team_stream_attempt(  # noqa: C901, PLR0911, PLR0912, PLR0915
         run: TurnRunState,
         continuation_state: DynamicContinuationRunState,
     ) -> AsyncGenerator[_TeamStreamChunk | AttemptResolved, None]:
@@ -2583,10 +2600,8 @@ async def team_response_stream(  # noqa: C901, PLR0915
             )
 
         def _record_interrupted_team_turn() -> None:
-            """Mark partial team work interrupted on an errored run, mirroring the agent path."""
+            """Sync partial team work before the shared driver records the error outcome."""
             _sync_live_turn_recorder()
-            if turn_recorder.assistant_text or turn_recorder.completed_tools or turn_recorder.interrupted_tools:
-                run.turn_state.record_interrupted_from_recorder(turn_recorder, run_metadata=run_metadata)
 
         async def _capture_stream_interrupt(stream: AsyncIterator[Any]) -> AsyncGenerator[Any, None]:
             """Record partial work interrupted when the model stream itself raises.
@@ -2753,8 +2768,12 @@ async def team_response_stream(  # noqa: C901, PLR0915
                     ),
                 ),
             )
+            bound_team_id = run.scope_context.scope.scope_id if run.scope_context is not None else team.id or ""
             async for event in raw_stream:
                 if isinstance(event, (TeamRunOutput, RunOutput)):
+                    if isinstance(event, TeamRunOutput) and not _is_bound_team_output(event, team_id=bound_team_id):
+                        logger.debug("Ignoring non-bound team run output", run_id=event.run_id)
+                        continue
                     _cleanup_team_notice_state(
                         run_output=event,
                         scope_context=run.scope_context,
@@ -2776,13 +2795,11 @@ async def team_response_stream(  # noqa: C901, PLR0915
                         partial_text = _extract_interrupted_team_partial_text(event)
                         completed_tool_trace, interrupted_tool_trace = _extract_cancelled_team_tool_trace(event)
                         yield AttemptResolved(
-                            CancelledAttempt(
+                            ExcludedAttempt(
                                 reason=event.content,
                                 partial_text=partial_text,
                                 completed_tools=tuple(completed_tool_trace),
                                 interrupted_tools=tuple(interrupted_tool_trace),
-                                session_id=event.session_id,
-                                run_id=event.run_id or attempt_run_id,
                                 metadata_content=event_metadata_content,
                             ),
                         )
@@ -2820,13 +2837,30 @@ async def team_response_stream(  # noqa: C901, PLR0915
                             pending_retry_decision = retry_decision
                             media_fallback_retry_requested = True
                             break
-                        # The attempt handles its own delivery, so publish the
-                        # errored run's usage directly before ending the turn.
                         if run_metadata_collector is not None and event_metadata_content is not None:
                             run_metadata_collector.update(event_metadata_content)
                         _record_interrupted_team_turn()
                         yield get_user_friendly_error_message(Exception(error_text), team_label)
                         yield AttemptResolved(HandledAttempt())
+                        return
+
+                    if event.status == RunStatus.paused:
+                        completed_tool_trace, interrupted_tool_trace = _extract_cancelled_team_tool_trace(event)
+                        yield AttemptResolved(
+                            ExcludedAttempt(
+                                original_status=RunStatus.paused,
+                                response_text=_format_terminal_team_response(
+                                    event,
+                                    team_display_names=team_members.display_names,
+                                ),
+                                partial_text=_extract_interrupted_team_partial_text(event),
+                                completed_tools=tuple(completed_tool_trace),
+                                interrupted_tools=tuple(interrupted_tool_trace),
+                                session_id=event.session_id,
+                                run_id=event.run_id or attempt_run_id,
+                                metadata_content=event_metadata_content,
+                            ),
+                        )
                         return
 
                     if pending_retry_decision is not None:
@@ -2842,6 +2876,16 @@ async def team_response_stream(  # noqa: C901, PLR0915
                         team_display_names=team_members.display_names,
                     )
                     event_has_visible = _has_visible_team_output(event)
+                    if isinstance(event, RunOutput):
+                        yield AttemptResolved(
+                            ExcludedAttempt(
+                                original_status=RunStatus.completed,
+                                response_text=response_text,
+                                partial_text=response_text if event_has_visible else "",
+                                metadata_content=event_metadata_content,
+                            ),
+                        )
+                        return
                     # The driver emits response_text only after settling the
                     # attempt: a pre-settle yield would leak the fallback
                     # placeholder before an empty-run retry, or stale
@@ -2868,6 +2912,8 @@ async def team_response_stream(  # noqa: C901, PLR0915
                     return
 
                 if isinstance(event, TeamRunErrorEvent):
+                    if event.team_id and event.team_id != bound_team_id:
+                        continue
                     error_text = event.content or "Unknown team error"
                     retry_decision = retry_media_inputs_after_failure(
                         media_route,
@@ -2899,9 +2945,6 @@ async def team_response_stream(  # noqa: C901, PLR0915
                         pending_retry_decision = retry_decision
                         media_fallback_retry_requested = True
                         break
-                    # The attempt handles its own delivery, so publish the
-                    # errored run's observed usage directly before ending the
-                    # turn; the driver never sees a resolution to publish from.
                     if run_metadata_collector is not None:
                         run_metadata_collector.update(
                             _build_streamed_team_run_metadata_content(
@@ -2921,6 +2964,8 @@ async def team_response_stream(  # noqa: C901, PLR0915
                     return
 
                 if isinstance(event, TeamRunCancelledEvent):
+                    if event.team_id and event.team_id != bound_team_id:
+                        continue
                     cancelled_metadata_content: dict[str, Any] | None = None
                     if run_metadata_collector is not None:
                         cancelled_metadata_content = _build_streamed_team_run_metadata_content(
@@ -2934,14 +2979,28 @@ async def team_response_stream(  # noqa: C901, PLR0915
                             tool_count=len(completed_tool_executions),
                         )
                     yield AttemptResolved(
-                        CancelledAttempt(
+                        ExcludedAttempt(
                             reason=event.reason,
                             partial_text=_current_canonical_partial_text(),
                             completed_tools=tuple(completed_tools),
                             interrupted_tools=tuple(pending.trace_entry for pending in pending_tools),
+                            metadata_content=cancelled_metadata_content,
+                        ),
+                    )
+                    return
+
+                if isinstance(event, TeamRunPausedEvent):
+                    if event.team_id and event.team_id != bound_team_id:
+                        continue
+                    yield AttemptResolved(
+                        ExcludedAttempt(
+                            original_status=RunStatus.paused,
+                            response_text=str(event.content or ""),
+                            partial_text=_current_canonical_partial_text() or str(event.content or ""),
+                            completed_tools=tuple(completed_tools),
+                            interrupted_tools=tuple(pending.trace_entry for pending in pending_tools),
                             session_id=event.session_id,
                             run_id=event.run_id or attempt_run_id,
-                            metadata_content=cancelled_metadata_content,
                         ),
                     )
                     return
@@ -3014,7 +3073,8 @@ async def team_response_stream(  # noqa: C901, PLR0915
                 elif isinstance(event, TeamRunCompletedEvent):
                     # Real Agno team streams never yield a terminal run output;
                     # this event is the stream's usage/identity source instead.
-                    completed_run_event = event
+                    if event.team_id in (None, "", bound_team_id):
+                        completed_run_event = event
                     continue
                 elif isinstance(event, TeamModelRequestCompletedEvent):
                     usage.track(event)
@@ -3045,6 +3105,17 @@ async def team_response_stream(  # noqa: C901, PLR0915
                     session_id=ctx.session_id,
                     event_ids=[ctx.reply_to_event_id, *unseen_event_ids],
                 )
+            canonical_text = _current_canonical_partial_text()
+            if not emitted_output and not completed_tool_executions and run.empty_response_retried:
+                yield AttemptResolved(
+                    ExcludedAttempt(
+                        original_status=RunStatus.error,
+                        response_text=ai_runtime.EMPTY_RESPONSE_NOTICE,
+                        partial_text=canonical_text,
+                        completed_tools=tuple(completed_tools),
+                    ),
+                )
+                return
             # Real Agno team streams end without a terminal run output, so this
             # is the resolution point where the empty-run guard must fire.
             end_metadata_content: dict[str, Any] | None = None
@@ -3060,7 +3131,6 @@ async def team_response_stream(  # noqa: C901, PLR0915
                     status=RunStatus.completed,
                     tool_count=len(completed_tool_executions),
                 )
-            canonical_text = _current_canonical_partial_text()
             yield AttemptResolved(
                 CompletedAttempt(
                     replayable_text=(

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -3106,16 +3106,6 @@ async def team_response_stream(  # noqa: C901, PLR0915
                     event_ids=[ctx.reply_to_event_id, *unseen_event_ids],
                 )
             canonical_text = _current_canonical_partial_text()
-            if not emitted_output and not completed_tool_executions and run.empty_response_retried:
-                yield AttemptResolved(
-                    ExcludedAttempt(
-                        original_status=RunStatus.error,
-                        response_text=ai_runtime.EMPTY_RESPONSE_NOTICE,
-                        partial_text=canonical_text,
-                        completed_tools=tuple(completed_tools),
-                    ),
-                )
-                return
             # Real Agno team streams end without a terminal run output, so this
             # is the resolution point where the empty-run guard must fire.
             end_metadata_content: dict[str, Any] | None = None

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -1146,8 +1146,7 @@ class TestUserIdPassthrough:
             ("user", "test"),
             (
                 "assistant",
-                "Half done\n\n(turn interrupted by the user before completion; "
-                "1 tool call(s) had completed: run_shell_command)",
+                "Half done\n\n(turn stopped before completion; 1 tool call(s) had completed: run_shell_command)",
             ),
         ]
 
@@ -1199,7 +1198,7 @@ class TestUserIdPassthrough:
         assert persisted_run.messages is not None
         assert [(message.role, message.content) for message in persisted_run.messages] == [
             ("user", "test"),
-            ("assistant", "Half done\n\n(turn interrupted by the user before completion)"),
+            ("assistant", "Half done\n\n(turn stopped before completion)"),
         ]
 
     @pytest.mark.asyncio
@@ -1253,8 +1252,7 @@ class TestUserIdPassthrough:
             ("user", "test"),
             (
                 "assistant",
-                "Half done\n\n(turn interrupted by the user before completion; "
-                "1 tool call(s) were still running: run_shell_command)",
+                "Half done\n\n(turn stopped before completion; 1 tool call(s) were still running: run_shell_command)",
             ),
         ]
 
@@ -1316,6 +1314,7 @@ class TestUserIdPassthrough:
         mock_agent = MagicMock()
         mock_run_output = MagicMock()
         mock_run_output.content = "validation failed in agno"
+        mock_run_output.run_id = mock_run_output.session_id = "run-error"
         mock_run_output.status = RunStatus.error
         mock_run_output.tools = None
 
@@ -3473,7 +3472,7 @@ class TestUserIdPassthrough:
             ("user", "test"),
             (
                 "assistant",
-                "Half done\n\n(turn interrupted by the user before completion; "
+                "Half done\n\n(turn stopped before completion; "
                 "1 tool call(s) had completed: run_shell_command; "
                 "1 tool call(s) were still running: save_file)",
             ),
@@ -3551,7 +3550,7 @@ class TestUserIdPassthrough:
             ("user", "test"),
             (
                 "assistant",
-                "Half done\n\n(turn interrupted by the user before completion; "
+                "Half done\n\n(turn stopped before completion; "
                 "1 tool call(s) had completed: run_shell_command; "
                 "1 tool call(s) were still running: run_shell_command)",
             ),
@@ -3610,7 +3609,7 @@ class TestUserIdPassthrough:
         assert persisted_run.messages is not None
         assert [(message.role, message.content) for message in persisted_run.messages] == [
             ("user", "test"),
-            ("assistant", "Half done\n\n(turn interrupted by the user before completion)"),
+            ("assistant", "Half done\n\n(turn stopped before completion)"),
         ]
 
     @pytest.mark.asyncio

--- a/tests/test_interrupted_replay.py
+++ b/tests/test_interrupted_replay.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
 from agno.models.message import Message
 from agno.models.response import ToolExecution
 from agno.run.agent import RunOutput
@@ -122,7 +123,7 @@ def test_build_interrupted_replay_run_creates_completed_agent_run_with_summary_a
         (
             "assistant",
             "Half done\n\n"
-            "(turn interrupted by the user before completion; "
+            "(turn stopped before completion; "
             "1 tool call(s) had completed: run_shell_command; "
             "1 tool call(s) were still running: save_file)",
         ),
@@ -160,11 +161,12 @@ def test_interrupted_replay_content_contains_no_raw_tool_trace() -> None:
     assert "[interrupted]" not in content
     assert '{"attachment"' not in content
     assert content.startswith("Half done")
-    assert "turn interrupted by the user before completion" in content
+    assert "turn stopped before completion" in content
     assert "get_attachment" in content
 
 
-def test_build_interrupted_replay_run_tracks_replay_and_seen_event_metadata() -> None:
+@pytest.mark.parametrize("original_status", [RunStatus.cancelled, RunStatus.error, RunStatus.paused])
+def test_build_interrupted_replay_run_tracks_replay_and_seen_event_metadata(original_status: RunStatus) -> None:
     """Interrupted replay runs should preserve the event-consumption metadata used by prompt prep."""
     snapshot = InterruptedReplaySnapshot(
         user_message="Please continue",
@@ -176,6 +178,7 @@ def test_build_interrupted_replay_run_tracks_replay_and_seen_event_metadata() ->
             "matrix_response_event_id": "$reply",
             "matrix_seen_event_ids": ["e1", "e2"],
         },
+        original_status=original_status,
     )
 
     run = _build_interrupted_replay_run(
@@ -190,9 +193,11 @@ def test_build_interrupted_replay_run_tracks_replay_and_seen_event_metadata() ->
         "matrix_event_id": "e1",
         "matrix_response_event_id": "$reply",
         "matrix_seen_event_ids": ["e1", "e2"],
-        "mindroom_original_status": "cancelled",
+        "mindroom_original_status": original_status.name,
         "mindroom_replay_state": "interrupted",
     }
+    summary = {RunStatus.cancelled: "stopped", RunStatus.error: "failed", RunStatus.paused: "paused"}[original_status]
+    assert summary in _assistant_text(run)
 
 
 def test_build_interrupted_replay_run_preserves_coalesced_source_metadata() -> None:
@@ -395,6 +400,6 @@ def test_persist_interrupted_replay_snapshot_keeps_minimal_interrupted_turn(tmp_
         assert persisted is not None
         assert persisted.runs is not None
         assert len(persisted.runs) == 1
-        assert _assistant_text(persisted.runs[0]) == "(turn interrupted by the user before completion)"
+        assert _assistant_text(persisted.runs[0]) == "(turn stopped before completion)"
     finally:
         storage.close()

--- a/tests/test_partial_reply_context.py
+++ b/tests/test_partial_reply_context.py
@@ -333,7 +333,7 @@ class TestCleanPartialReplyBody:
         ]
 
         assert rendered[0] == rendered[1] == rendered[2]
-        assert rendered[0] == b"Partial answer\n\n(turn interrupted by the user before completion)"
+        assert rendered[0] == b"Partial answer\n\n(turn stopped before completion)"
 
 
 class TestUnseenMessagesPartialReplies:

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -547,7 +547,7 @@ def test_same_target_batch_reservation_consumes_all_pending_messages(tmp_path: P
 
 @contextmanager
 def _open_scope(storage: _FakeStorage) -> object:
-    yield SimpleNamespace(storage=storage, session=storage.session)
+    yield SimpleNamespace(storage=storage, session=storage.session, scope=HistoryScope("agent", "general"))
 
 
 class _PrelockBarrierLock:

--- a/tests/test_response_runner_session_lifecycle.py
+++ b/tests/test_response_runner_session_lifecycle.py
@@ -240,7 +240,7 @@ async def test_process_and_respond_propagates_before_response_cancellation_to_ru
                 run_id="run-1",
             )
 
-    coordinator._persist_interrupted_recorder.assert_called_once()
+    coordinator._persist_interrupted_recorder.assert_called()
     coordinator.deps.delivery_gateway.deps.redact_message_event.assert_awaited_once()
 
 
@@ -891,7 +891,7 @@ async def test_process_and_respond_streaming_persists_interrupted_history_when_d
     assert persisted_run.messages is not None
     assert [(message.role, message.content) for message in persisted_run.messages] == [
         ("user", "Hello"),
-        ("assistant", "Partial answer\n\n(turn interrupted by the user before completion)"),
+        ("assistant", "Partial answer\n\n(turn failed before completion)"),
     ]
 
 
@@ -963,8 +963,7 @@ async def test_process_and_respond_streaming_persists_interrupted_history_when_m
         ("user", "Hello"),
         (
             "assistant",
-            "Partial answer\n\n(turn interrupted by the user before completion; "
-            "1 tool call(s) had completed: run_shell_command)",
+            "Partial answer\n\n(turn failed before completion; 1 tool call(s) had completed: run_shell_command)",
         ),
     ]
 
@@ -1049,8 +1048,7 @@ async def test_process_and_respond_streaming_delivery_failure_with_visible_tools
     assert "🔧 `run_shell_command` [1]" not in assistant_text
     assert assistant_text.count("run_shell_command") == 1
     assert assistant_text == (
-        "Partial answer\n\n(turn interrupted by the user before completion; "
-        "1 tool call(s) had completed: run_shell_command)"
+        "Partial answer\n\n(turn failed before completion; 1 tool call(s) had completed: run_shell_command)"
     )
 
 
@@ -1276,7 +1274,7 @@ async def test_generate_response_locked_persists_minimal_interrupted_history_aft
     assert persisted_run.messages[0].role == "user"
     assert "Hello" in cast("str", persisted_run.messages[0].content)
     assert [(message.role, message.content) for message in persisted_run.messages[-1:]] == [
-        ("assistant", "(turn interrupted by the user before completion)"),
+        ("assistant", "(turn stopped before completion)"),
     ]
 
 

--- a/tests/test_response_runner_team_streaming.py
+++ b/tests/test_response_runner_team_streaming.py
@@ -321,6 +321,7 @@ async def test_generate_team_response_preserves_retry_model_prompt(tmp_path: Pat
 
     async def fake_team_response(*_args: object, **kwargs: object) -> str:
         model_message = cast("str", kwargs["message"])
+        cast("TurnRecorder", kwargs["turn_recorder"]).mark_completed()
         run_id = cast("str | None", kwargs["ctx"].run_id)
         seen_run_ids.append(run_id)
         run_id_callback = cast("Callable[[str], None]", kwargs["run_id_callback"])
@@ -894,9 +895,10 @@ async def test_generate_team_response_helper_preserves_visible_stream_when_final
             AsyncMock(side_effect=consume_stream),
         )
 
-        def fake_team_response_stream(*_args: object, **_kwargs: object) -> AsyncIterator[str]:
+        def fake_team_response_stream(*_args: object, **kwargs: object) -> AsyncIterator[str]:
             async def fake_stream() -> AsyncIterator[str]:
                 yield "Team hello"
+                cast("TurnRecorder", kwargs["turn_recorder"]).mark_completed()
 
             return fake_stream()
 
@@ -1146,6 +1148,23 @@ def test_record_stream_delivery_error_preserves_hidden_tool_state_when_visible_t
     assert snapshot.partial_text == "Partial answer"
     assert [tool.tool_name for tool in snapshot.completed_tools] == ["run_shell_command"]
     assert [tool.tool_name for tool in snapshot.interrupted_tools] == ["save_file"]
+
+    paused_recorder = TurnRecorder(user_message="Hello")
+    paused_recorder.mark_interrupted(RunStatus.paused)
+    assert coordinator._record_stream_delivery_error(
+        recorder=paused_recorder,
+        accumulated_text="delivery failed",
+        tool_trace=[],
+    )
+    assert paused_recorder.original_status is RunStatus.paused
+
+    empty_recorder = TurnRecorder(user_message="Hello")
+    assert coordinator._record_stream_delivery_error(
+        recorder=empty_recorder,
+        accumulated_text="",
+        tool_trace=[],
+    )
+    assert empty_recorder.original_status is RunStatus.error
 
 
 @pytest.mark.asyncio
@@ -1454,6 +1473,7 @@ async def test_generate_team_response_helper_uses_persisted_team_scope_for_sessi
         async def fake_team_response(*_args: object, **kwargs: object) -> str:
             session_id = kwargs["ctx"].session_id
             assert isinstance(session_id, str)
+            cast("TurnRecorder", kwargs["turn_recorder"]).mark_interrupted(RunStatus.error)
             storage.session = TeamSession(
                 session_id=session_id,
                 team_id="team_general",
@@ -1471,6 +1491,7 @@ async def test_generate_team_response_helper_uses_persisted_team_scope_for_sessi
         )
 
     assert sequence == ["started:team:team_general:team_general"]
+    assert len(cast("TeamSession", storage.session).runs or []) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_response_runner_team_streaming.py
+++ b/tests/test_response_runner_team_streaming.py
@@ -619,7 +619,7 @@ async def test_generate_team_response_helper_persists_interrupted_history_when_s
     assert persisted_run.messages is not None
     assert [(message.role, message.content) for message in persisted_run.messages] == [
         ("user", "Hello"),
-        ("assistant", "Team hello\n\n(turn interrupted by the user before completion)"),
+        ("assistant", "Team hello\n\n(turn failed before completion)"),
     ]
 
 
@@ -706,7 +706,7 @@ async def test_generate_team_response_helper_stream_delivery_failure_with_visibl
     assert assistant_text.count("run_shell_command") == 1
     assert assistant_text == (
         "🤝 **Team Response** (General):\n\nTeam hello\n\n"
-        "(turn interrupted by the user before completion; "
+        "(turn failed before completion; "
         "1 tool call(s) had completed: run_shell_command)"
     )
 
@@ -785,7 +785,7 @@ async def test_generate_team_response_helper_persists_minimal_interrupted_histor
     assert persisted_run.messages[0].role == "user"
     assert "Hello" in cast("str", persisted_run.messages[0].content)
     assert [(message.role, message.content) for message in persisted_run.messages[-1:]] == [
-        ("assistant", "(turn interrupted by the user before completion)"),
+        ("assistant", "(turn stopped before completion)"),
     ]
 
 
@@ -793,7 +793,7 @@ async def test_generate_team_response_helper_persists_minimal_interrupted_histor
 async def test_generate_team_response_helper_persists_interrupted_history_when_final_delivery_is_cancelled(
     tmp_path: Path,
 ) -> None:
-    """Delivery-stage cancellation after a completed team run should still persist replay."""
+    """Delivery cancellation after a completed provider run must not create replay."""
     runtime_paths = _runtime_paths(tmp_path)
     config = bind_runtime_paths(_config_with_team(), runtime_paths)
     bot = _make_bot(tmp_path, config=config, runtime_paths=runtime_paths, agent_name="ultimate")
@@ -839,16 +839,7 @@ async def test_generate_team_response_helper_persists_interrupted_history_when_f
         )
 
     assert resolution is None
-    persisted_session = cast("TeamSession", storage.session)
-    assert persisted_session is not None
-    assert persisted_session.runs is not None
-    persisted_run = cast("TeamRunOutput", persisted_session.runs[0])
-    assert persisted_run.run_id == "team-run-delivery-cancel"
-    assert persisted_run.messages is not None
-    assert [(message.role, message.content) for message in persisted_run.messages] == [
-        ("user", "Hello"),
-        ("assistant", "🤝 Team Response:\n\nTeam hello\n\n(turn interrupted by the user before completion)"),
-    ]
+    assert storage.session is None
 
 
 @pytest.mark.asyncio
@@ -979,7 +970,7 @@ async def test_generate_team_response_helper_preserves_structured_stream_cancel_
     assert persisted_run.messages is not None
     assert [(message.role, message.content) for message in persisted_run.messages] == [
         ("user", "Hello"),
-        ("assistant", "Team hello\n\n(turn interrupted by the user before completion)"),
+        ("assistant", "Team hello\n\n(turn failed before completion)"),
     ]
 
 
@@ -1235,7 +1226,7 @@ async def test_generate_team_response_helper_persists_original_user_message_for_
     assert persisted_run.messages is not None
     assert [(message.role, message.content) for message in persisted_run.messages] == [
         ("user", "Hello"),
-        ("assistant", "(turn interrupted by the user before completion)"),
+        ("assistant", "(turn stopped before completion)"),
     ]
 
 
@@ -1650,6 +1641,7 @@ async def test_generate_team_response_helper_persists_interrupted_history_after_
                     assistant_text="Team partial",
                     completed_tools=[],
                     interrupted_tools=[],
+                    original_status=RunStatus.error,
                 )
 
             return fake_stream()
@@ -1669,7 +1661,7 @@ async def test_generate_team_response_helper_persists_interrupted_history_after_
     assert persisted_run.messages is not None
     assert [(message.role, message.content) for message in persisted_run.messages] == [
         ("user", "Hello"),
-        ("assistant", "Team partial\n\n(turn interrupted by the user before completion)"),
+        ("assistant", "Team partial\n\n(turn failed before completion)"),
     ]
 
 

--- a/tests/test_response_turn.py
+++ b/tests/test_response_turn.py
@@ -513,7 +513,7 @@ def test_blocking_empty_run_grants_one_retry_then_notice() -> None:
 
     assert result == EMPTY_RESPONSE_NOTICE
     assert attempts == 2
-    assert [discard.run_id for discard in log.discards] == ["run-1", "run-2"]
+    assert [discard.run_id for discard in log.discards] == ["run-1"]
     assert log.released == 1
     assert recorder.completed_calls == [
         {"run_metadata": None, "assistant_text": "", "completed_tools": []},
@@ -900,7 +900,7 @@ def test_streaming_empty_run_retries_then_yields_notice_and_records() -> None:
 
     assert chunks == [f"notice:{EMPTY_RESPONSE_NOTICE}"]
     assert attempts == 2
-    assert [discard.run_id for discard in log.discards] == ["run-1", "run-2"]
+    assert [discard.run_id for discard in log.discards] == ["run-1"]
     # The notice-only turn still records an empty completion.
     assert recorder.completed_calls[-1]["assistant_text"] == ""
 

--- a/tests/test_response_turn.py
+++ b/tests/test_response_turn.py
@@ -10,16 +10,16 @@ from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 from agno.models.response import ToolExecution
+from agno.run.base import RunStatus
 
 from mindroom.ai_runtime import EMPTY_RESPONSE_NOTICE
 from mindroom.response_turn import (
     AttemptResolved,
     BlockingTurnAdapter,
-    CancelledAttempt,
     CompletedAttempt,
     DynamicContinuationRunState,
     EmptyRunDiscard,
-    ErroredAttempt,
+    ExcludedAttempt,
     HandledAttempt,
     ResponseTurnContext,
     StandaloneReplaySnapshot,
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
 class _FakeTurnRecorder:
     """Minimal TurnRecorder double tracking recorded outcomes."""
 
+    outcome: str = "pending"
     run_metadata: dict[str, Any] | None = None
     assistant_text: str = ""
     completed_tools: list[ToolTraceEntry] = field(default_factory=list)
@@ -79,6 +80,7 @@ class _FakeTurnRecorder:
         assistant_text: str,
         completed_tools: Sequence[ToolTraceEntry],
     ) -> None:
+        self.outcome = "completed"
         self.completed_calls.append(
             {
                 "run_metadata": run_metadata,
@@ -94,7 +96,9 @@ class _FakeTurnRecorder:
         assistant_text: str,
         completed_tools: Sequence[ToolTraceEntry],
         interrupted_tools: Sequence[ToolTraceEntry],
+        original_status: RunStatus = RunStatus.cancelled,  # noqa: ARG002
     ) -> None:
+        self.outcome = "interrupted"
         self.interrupted_calls.append(
             {
                 "run_metadata": run_metadata,
@@ -289,8 +293,8 @@ def test_blocking_errored_attempt_returns_user_text() -> None:
     """An errored attempt short-circuits to its user-facing text."""
     log = _AdapterLog()
 
-    async def _attempt(_run: TurnRunState, _c: DynamicContinuationRunState) -> ErroredAttempt:
-        return ErroredAttempt("friendly error")
+    async def _attempt(_run: TurnRunState, _c: DynamicContinuationRunState) -> ExcludedAttempt:
+        return ExcludedAttempt(RunStatus.error, "friendly error")
 
     result = asyncio.run(
         run_blocking_response_turn(
@@ -308,9 +312,9 @@ def test_blocking_cancelled_attempt_records_persists_and_raises() -> None:
     """A cancelled attempt without recorder persists one standalone replay and raises."""
     log = _AdapterLog()
 
-    async def _attempt(run: TurnRunState, _c: DynamicContinuationRunState) -> CancelledAttempt:
+    async def _attempt(run: TurnRunState, _c: DynamicContinuationRunState) -> ExcludedAttempt:
         run.run_metadata = {"room_id": "!room"}
-        return CancelledAttempt(
+        return ExcludedAttempt(
             reason="user stop",
             partial_text="partial",
             completed_tools=(_trace("search"),),
@@ -345,9 +349,9 @@ def test_blocking_cancelled_attempt_with_recorder_records_twice() -> None:
     log = _AdapterLog()
     recorder = _FakeTurnRecorder()
 
-    async def _attempt(run: TurnRunState, _c: DynamicContinuationRunState) -> CancelledAttempt:
+    async def _attempt(run: TurnRunState, _c: DynamicContinuationRunState) -> ExcludedAttempt:
         run.run_metadata = {"room_id": "!room"}
-        return CancelledAttempt(reason="stop", partial_text="partial")
+        return ExcludedAttempt(RunStatus.cancelled, reason="stop", partial_text="partial")
 
     async def _run() -> None:
         await run_blocking_response_turn(
@@ -401,9 +405,9 @@ def test_blocking_external_cancel_skips_persist_after_inline_persist() -> None:
     """The standalone replay is not persisted twice for one cancelled turn."""
     log = _AdapterLog()
 
-    async def _attempt(run: TurnRunState, _c: DynamicContinuationRunState) -> CancelledAttempt:
+    async def _attempt(run: TurnRunState, _c: DynamicContinuationRunState) -> ExcludedAttempt:
         run.run_metadata = {"room_id": "!room"}
-        return CancelledAttempt(reason="stop")
+        return ExcludedAttempt(RunStatus.cancelled, reason="stop")
 
     async def _run() -> None:
         await run_blocking_response_turn(
@@ -561,7 +565,7 @@ def test_blocking_discarded_empty_run_metadata_stays_out_of_collector() -> None:
     async def _attempt(
         _run: TurnRunState,
         _c: DynamicContinuationRunState,
-    ) -> CompletedAttempt | ErroredAttempt:
+    ) -> CompletedAttempt | ExcludedAttempt:
         nonlocal attempts
         attempts += 1
         if attempts == 1:
@@ -570,7 +574,7 @@ def test_blocking_discarded_empty_run_metadata_stays_out_of_collector() -> None:
                 run_id="run-empty",
                 metadata_content={"io.mindroom.ai_run": {"run_id": "run-empty", "status": "completed"}},
             )
-        return ErroredAttempt("friendly error")
+        return ExcludedAttempt(RunStatus.error, "friendly error")
 
     result = asyncio.run(
         run_blocking_response_turn(
@@ -694,8 +698,8 @@ def test_streaming_turn_yields_chunks_and_filters_sentinel() -> None:
     assert log.finalized == 1
 
 
-def test_streaming_handled_attempt_ends_turn_without_recording() -> None:
-    """A handled attempt (self-reported error) ends the turn without recording."""
+def test_streaming_excluded_attempt_records_even_without_partial_output() -> None:
+    """An excluded attempt records even when no partial output exists."""
     log = _AdapterLog()
     recorder = _FakeTurnRecorder()
 
@@ -719,6 +723,7 @@ def test_streaming_handled_attempt_ends_turn_without_recording() -> None:
 
     assert chunks == ["friendly error"]
     assert recorder.completed_calls == []
+    assert len(recorder.interrupted_calls) == 1
     assert log.finalized == 1
 
 
@@ -734,7 +739,7 @@ def test_streaming_cancelled_attempt_records_updates_collector_and_raises() -> N
         run.run_metadata = {"room_id": "!room"}
         yield "partial"
         yield AttemptResolved(
-            CancelledAttempt(
+            ExcludedAttempt(
                 reason="stop",
                 partial_text="partial",
                 metadata_content={"io.mindroom.ai_run": {"status": "cancelled"}},
@@ -775,7 +780,9 @@ def test_streaming_cancelled_attempt_with_recorder_records_twice() -> None:
     ) -> AsyncGenerator[str | AttemptResolved, None]:
         run.run_metadata = {"room_id": "!room"}
         yield "partial"
-        yield AttemptResolved(CancelledAttempt(reason="stop", partial_text="attempt partial"))
+        yield AttemptResolved(
+            ExcludedAttempt(RunStatus.cancelled, reason="stop", partial_text="attempt partial"),
+        )
 
     async def _run() -> None:
         async for _chunk in stream_response_turn(

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -94,7 +94,7 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterator
 
 IN_PROGRESS_MARKER = " ⋯"
-_INTERRUPTION_SUMMARY = "(turn interrupted by the user before completion)"
+_INTERRUPTION_SUMMARY = "(turn stopped before completion)"
 
 
 async def _aiter(*events: object) -> AsyncIterator[object]:

--- a/tests/test_team_empty_response_and_replay.py
+++ b/tests/test_team_empty_response_and_replay.py
@@ -180,8 +180,7 @@ async def test_team_response_stream_empty_event_stream_retries_then_notices() ->
     assert mock_team.arun.call_count == 2
     rendered = "".join(chunk.content if hasattr(chunk, "content") else str(chunk) for chunk in chunks)
     assert ai_runtime.EMPTY_RESPONSE_NOTICE in rendered
-    # The notice-only turn records an empty completion, not the placeholder document.
-    assert recorder.outcome == "completed"
+    assert recorder.outcome == "interrupted"
     assert recorder.assistant_text == ""
 
 
@@ -393,8 +392,8 @@ async def test_team_response_stream_records_interrupted_turn_on_errored_run_outp
 
 
 @pytest.mark.asyncio
-async def test_team_response_stream_leaves_recorder_pending_when_error_has_no_partial() -> None:
-    """A team error with no partial work records nothing for replay."""
+async def test_team_response_stream_records_error_without_partial_output() -> None:
+    """A team error with no partial work still records one replay carrier."""
     orchestrator, config = _make_orchestrator()
 
     async def stream() -> AsyncIterator[object]:
@@ -419,7 +418,7 @@ async def test_team_response_stream_leaves_recorder_pending_when_error_has_no_pa
             )
         ]
 
-    assert recorder.outcome == "pending"
+    assert recorder.outcome == "interrupted"
 
 
 @pytest.mark.asyncio

--- a/tests/test_team_empty_response_and_replay.py
+++ b/tests/test_team_empty_response_and_replay.py
@@ -180,7 +180,7 @@ async def test_team_response_stream_empty_event_stream_retries_then_notices() ->
     assert mock_team.arun.call_count == 2
     rendered = "".join(chunk.content if hasattr(chunk, "content") else str(chunk) for chunk in chunks)
     assert ai_runtime.EMPTY_RESPONSE_NOTICE in rendered
-    assert recorder.outcome == "interrupted"
+    assert recorder.outcome == "completed"
     assert recorder.assistant_text == ""
 
 

--- a/tests/test_team_media_fallback.py
+++ b/tests/test_team_media_fallback.py
@@ -1598,7 +1598,7 @@ async def test_team_response_records_interrupted_snapshot_for_cancelled_runs() -
     assert _render_interrupted_replay_content(snapshot) == (
         "**GeneralAgent**: Half done\n\n\n"
         "*No team consensus - showing individual responses only*\n\n"
-        "(turn interrupted by the user before completion; "
+        "(turn stopped before completion; "
         "1 tool call(s) had completed: run_shell_command)"
     )
 
@@ -1666,7 +1666,7 @@ async def test_team_response_records_incomplete_cancelled_tools_as_interrupted()
     assert _render_interrupted_replay_content(snapshot) == (
         "**GeneralAgent**: Half done\n\n\n"
         "*No team consensus - showing individual responses only*\n\n"
-        "(turn interrupted by the user before completion; "
+        "(turn stopped before completion; "
         "1 tool call(s) were still running: run_shell_command)"
     )
 
@@ -2090,7 +2090,7 @@ async def test_team_response_stream_records_hidden_interrupted_tool_state() -> N
     assert _render_interrupted_replay_content(snapshot) == (
         "**GeneralAgent**: Half done\n\n\n"
         "*No team consensus - showing individual responses only*\n\n"
-        "(turn interrupted by the user before completion; "
+        "(turn stopped before completion; "
         "1 tool call(s) had completed: run_shell_command)"
     )
 
@@ -2326,7 +2326,7 @@ async def test_team_response_stream_records_interrupted_snapshot_after_external_
     assert snapshot.user_message == "Analyze this."
     assert _render_interrupted_replay_content(snapshot) == (
         "**GeneralAgent**: Half done\n\n\n*No team consensus - showing individual responses only*\n\n"
-        "(turn interrupted by the user before completion)"
+        "(turn stopped before completion)"
     )
 
 
@@ -2515,7 +2515,7 @@ async def test_team_response_stream_preserves_pending_tool_identity_within_membe
     assert _render_interrupted_replay_content(snapshot) == (
         "**GeneralAgent**: General started\n\n\n"
         "*No team consensus - showing individual responses only*\n\n"
-        "(turn interrupted by the user before completion; "
+        "(turn stopped before completion; "
         "1 tool call(s) had completed: run_shell_command; "
         "1 tool call(s) were still running: run_shell_command)"
     )


### PR DESCRIPTION
## Summary

- Classify cancelled, errored, paused, and pre-provider failures at the shared response-turn seam.
- Persist exactly one completed synthetic replay with original-status metadata, including zero-output failures, while completed provider runs remain authoritative through delivery failures.
- Accept a normal team history carrier only from the bound top-level team scope.

## Tests

- `pytest -n8` (9,483 passed, 64 skipped)
- `pre-commit run --all-files`
- `tach check --dependencies --interfaces`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Paused, failed, and cancelled runs now produce consistent “excluded” outcomes across streaming and non-streaming responses, including replay persistence.
* **Bug Fixes**
  * Interrupted/replay history now records the original run status (cancelled/paused/error) and renders the matching “turn stopped/failed” wording.
  * Improved handling of provider errors and delivery interruptions, including cases with no partial output.
  * Prevented unrelated/unbound team outputs from appearing in the current response.
  * More reliable settlement for empty responses and retries.
* **Style**
  * Updated user-facing interruption phrasing to “turn stopped before completion” / “turn failed before completion.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->