### PR TITLE
Preserve interrupted replay metadata and status

### DIFF
--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -420,6 +420,7 @@ def _build_agent_turn_callbacks(
             interrupted_tools=snapshot.interrupted_tools,
             run_metadata=snapshot.run_metadata,
             is_team=False,
+            original_status=snapshot.original_status,
         )
 
     return _AgentTurnCallbacks(
@@ -1891,6 +1892,35 @@ async def stream_agent_response(  # noqa: C901, PLR0915
         state = _StreamingAttemptState()
         pending_retry_decision: MediaRetryDecision | None = None
 
+        def _build_interrupted_metadata(
+            status: RunStatus,
+            event_run_id: str | None,
+            event_session_id: str | None,
+        ) -> dict[str, Any] | None:
+            if run_metadata_collector is None:
+                return None
+            fallback_metrics = build_model_request_metrics_fallback(
+                state.request_metric_totals,
+                state.first_token_latency,
+                state.observed_request_metric_fields,
+            )
+            return build_ai_run_metadata_content(
+                config=config,
+                model_name=prepared_run.runtime_model_name,
+                run_id=event_run_id,
+                session_id=event_session_id or session_id,
+                status=status,
+                model=state.latest_model_id,
+                model_provider=state.latest_model_provider,
+                metrics=fallback_metrics,
+                context_input_tokens=prepared_context_input_tokens,
+                context_raw_input_tokens=state.latest_request_input_tokens,
+                context_cache_read_tokens=state.latest_request_cache_read_tokens,
+                context_cache_write_tokens=state.latest_request_cache_write_tokens,
+                tool_count=state.observed_tool_calls,
+                prepared_history=prepared_run.prepared_history,
+            )
+
         for retried_after_media_fallback in (False, True):
             state = _StreamingAttemptState()
             holder.state = state
@@ -1939,29 +1969,11 @@ async def stream_agent_response(  # noqa: C901, PLR0915
                 return
 
             if state.cancelled_run_event is not None:
-                cancelled_metadata: dict[str, Any] | None = None
-                if run_metadata_collector is not None:
-                    fallback_metrics = build_model_request_metrics_fallback(
-                        state.request_metric_totals,
-                        state.first_token_latency,
-                        state.observed_request_metric_fields,
-                    )
-                    cancelled_metadata = build_ai_run_metadata_content(
-                        config=config,
-                        model_name=prepared_run.runtime_model_name,
-                        run_id=state.cancelled_run_event.run_id,
-                        session_id=state.cancelled_run_event.session_id or session_id,
-                        status=RunStatus.cancelled,
-                        model=state.latest_model_id,
-                        model_provider=state.latest_model_provider,
-                        metrics=fallback_metrics,
-                        context_input_tokens=prepared_context_input_tokens,
-                        context_raw_input_tokens=state.latest_request_input_tokens,
-                        context_cache_read_tokens=state.latest_request_cache_read_tokens,
-                        context_cache_write_tokens=state.latest_request_cache_write_tokens,
-                        tool_count=state.observed_tool_calls,
-                        prepared_history=prepared_run.prepared_history,
-                    )
+                cancelled_metadata = _build_interrupted_metadata(
+                    RunStatus.cancelled,
+                    state.cancelled_run_event.run_id,
+                    state.cancelled_run_event.session_id,
+                )
                 yield AttemptResolved(
                     ExcludedAttempt(
                         reason=state.cancelled_run_event.reason,
@@ -1976,16 +1988,21 @@ async def stream_agent_response(  # noqa: C901, PLR0915
                 return
 
             if state.paused_run_event is not None:
-                paused_content = str(state.paused_run_event.content or "")
+                paused_metadata = _build_interrupted_metadata(
+                    RunStatus.paused,
+                    state.paused_run_event.run_id,
+                    state.paused_run_event.session_id,
+                )
                 yield AttemptResolved(
                     ExcludedAttempt(
                         original_status=RunStatus.paused,
-                        response_text=paused_content,
-                        partial_text=state.assistant_text or paused_content,
+                        response_text=str(state.paused_run_event.content or ""),
+                        partial_text=state.assistant_text or str(state.paused_run_event.content or ""),
                         completed_tools=tuple(state.completed_tools),
                         interrupted_tools=tuple(pending.trace_entry for pending in state.pending_tools),
                         session_id=state.paused_run_event.session_id,
                         run_id=state.paused_run_event.run_id or attempt.attempt_run_id,
+                        metadata_content=paused_metadata,
                     ),
                 )
                 return

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -1893,6 +1893,7 @@ async def stream_agent_response(  # noqa: C901, PLR0915
         pending_retry_decision: MediaRetryDecision | None = None
 
         def _build_interrupted_metadata(
+            attempt_state: _StreamingAttemptState,
             status: RunStatus,
             event_run_id: str | None,
             event_session_id: str | None,
@@ -1900,9 +1901,9 @@ async def stream_agent_response(  # noqa: C901, PLR0915
             if run_metadata_collector is None:
                 return None
             fallback_metrics = build_model_request_metrics_fallback(
-                state.request_metric_totals,
-                state.first_token_latency,
-                state.observed_request_metric_fields,
+                attempt_state.request_metric_totals,
+                attempt_state.first_token_latency,
+                attempt_state.observed_request_metric_fields,
             )
             return build_ai_run_metadata_content(
                 config=config,
@@ -1910,14 +1911,14 @@ async def stream_agent_response(  # noqa: C901, PLR0915
                 run_id=event_run_id,
                 session_id=event_session_id or session_id,
                 status=status,
-                model=state.latest_model_id,
-                model_provider=state.latest_model_provider,
+                model=attempt_state.latest_model_id,
+                model_provider=attempt_state.latest_model_provider,
                 metrics=fallback_metrics,
                 context_input_tokens=prepared_context_input_tokens,
-                context_raw_input_tokens=state.latest_request_input_tokens,
-                context_cache_read_tokens=state.latest_request_cache_read_tokens,
-                context_cache_write_tokens=state.latest_request_cache_write_tokens,
-                tool_count=state.observed_tool_calls,
+                context_raw_input_tokens=attempt_state.latest_request_input_tokens,
+                context_cache_read_tokens=attempt_state.latest_request_cache_read_tokens,
+                context_cache_write_tokens=attempt_state.latest_request_cache_write_tokens,
+                tool_count=attempt_state.observed_tool_calls,
                 prepared_history=prepared_run.prepared_history,
             )
 
@@ -1970,6 +1971,7 @@ async def stream_agent_response(  # noqa: C901, PLR0915
 
             if state.cancelled_run_event is not None:
                 cancelled_metadata = _build_interrupted_metadata(
+                    state,
                     RunStatus.cancelled,
                     state.cancelled_run_event.run_id,
                     state.cancelled_run_event.session_id,
@@ -1989,6 +1991,7 @@ async def stream_agent_response(  # noqa: C901, PLR0915
 
             if state.paused_run_event is not None:
                 paused_metadata = _build_interrupted_metadata(
+                    state,
                     RunStatus.paused,
                     state.paused_run_event.run_id,
                     state.paused_run_event.session_id,

--- a/src/mindroom/response_turn.py
+++ b/src/mindroom/response_turn.py
@@ -391,7 +391,12 @@ def _reset_turn_state_for_dynamic_continuation(
     return turn_state
 
 
-def _fallback_matrix_run_metadata(ctx: ResponseTurnContext, run: TurnRunState) -> dict[str, Any] | None:
+def _fallback_matrix_run_metadata(
+    ctx: ResponseTurnContext,
+    run: TurnRunState,
+    *,
+    extra_metadata: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
     """Build run metadata for interruptions that fire before prepare finished."""
     return build_matrix_run_metadata(
         ctx.reply_to_event_id,
@@ -400,7 +405,7 @@ def _fallback_matrix_run_metadata(ctx: ResponseTurnContext, run: TurnRunState) -
         thread_id=ctx.thread_id,
         requester_id=ctx.requester_id,
         correlation_id=ctx.correlation_id,
-        extra_metadata=deepcopy(ctx.matrix_run_metadata),
+        extra_metadata=deepcopy(ctx.matrix_run_metadata if extra_metadata is None else extra_metadata),
     )
 
 
@@ -413,7 +418,11 @@ def _interrupted_run_metadata(
     if run.run_metadata is not None:
         return run.run_metadata
     if sinks.turn_recorder is not None and sinks.turn_recorder.run_metadata is not None:
-        return sinks.turn_recorder.run_metadata
+        return _fallback_matrix_run_metadata(
+            ctx,
+            run,
+            extra_metadata=sinks.turn_recorder.run_metadata,
+        )
     return _fallback_matrix_run_metadata(ctx, run)
 
 

--- a/src/mindroom/response_turn.py
+++ b/src/mindroom/response_turn.py
@@ -404,11 +404,25 @@ def _fallback_matrix_run_metadata(ctx: ResponseTurnContext, run: TurnRunState) -
     )
 
 
+def _interrupted_run_metadata(
+    ctx: ResponseTurnContext,
+    sinks: TurnSinks,
+    run: TurnRunState,
+) -> dict[str, Any] | None:
+    """Keep the best Matrix metadata available when an attempt is interrupted."""
+    if run.run_metadata is not None:
+        return run.run_metadata
+    if sinks.turn_recorder is not None and sinks.turn_recorder.run_metadata is not None:
+        return sinks.turn_recorder.run_metadata
+    return _fallback_matrix_run_metadata(ctx, run)
+
+
 def _persist_excluded_attempt_replay(
     ctx: ResponseTurnContext,
     persist: Callable[[ScopeSessionContext | None, StandaloneReplaySnapshot], None],
     run: TurnRunState,
     resolution: ExcludedAttempt,
+    run_metadata: dict[str, Any] | None,
 ) -> None:
     persist(
         run.scope_context,
@@ -418,7 +432,7 @@ def _persist_excluded_attempt_replay(
             partial_text=resolution.partial_text,
             completed_tools=run.turn_state.completed_tools_for(resolution.completed_tools),
             interrupted_tools=list(resolution.interrupted_tools),
-            run_metadata=run.run_metadata,
+            run_metadata=run_metadata,
             original_status=resolution.original_status,
         ),
     )
@@ -439,11 +453,7 @@ def _record_turn_excluded_fallback(
     if recorder is not None:
         if recorder.outcome == "completed":
             return
-        run_metadata = (
-            run.run_metadata
-            if run.run_metadata is not None
-            else recorder.run_metadata or _fallback_matrix_run_metadata(ctx, run)
-        )
+        run_metadata = _interrupted_run_metadata(ctx, sinks, run)
         if use_recorder_state:
             run.turn_state.record_interrupted_from_recorder(
                 recorder,
@@ -470,7 +480,7 @@ def _record_turn_excluded_fallback(
             partial_text=snapshot.assistant_text,
             completed_tools=run.turn_state.completed_tools_for(snapshot.completed_tools),
             interrupted_tools=list(snapshot.interrupted_tools),
-            run_metadata=run.run_metadata if run.run_metadata is not None else _fallback_matrix_run_metadata(ctx, run),
+            run_metadata=_interrupted_run_metadata(ctx, sinks, run),
             original_status=original_status,
         ),
     )
@@ -612,16 +622,23 @@ def _settle_blocking_attempt(
     # continuation attempt's payload must not ride out on a later resolution.
     if isinstance(resolution, ExcludedAttempt):
         _publish_run_metadata(sinks, resolution.metadata_content)
+        run_metadata = _interrupted_run_metadata(ctx, sinks, run)
         run.turn_state.record_interrupted(
             sinks.turn_recorder,
-            run_metadata=run.run_metadata,
+            run_metadata=run_metadata,
             assistant_text=resolution.partial_text,
             completed_tools=list(resolution.completed_tools),
             interrupted_tools=list(resolution.interrupted_tools),
             original_status=resolution.original_status,
         )
         if sinks.turn_recorder is None and adapter.persist_standalone_replay is not None:
-            _persist_excluded_attempt_replay(ctx, adapter.persist_standalone_replay, run, resolution)
+            _persist_excluded_attempt_replay(
+                ctx,
+                adapter.persist_standalone_replay,
+                run,
+                resolution,
+                run_metadata,
+            )
         if resolution.original_status is RunStatus.cancelled:
             raise build_cancelled_error(resolution.reason)
         return resolution.response_text
@@ -791,9 +808,10 @@ async def stream_response_turn[ChunkT](  # noqa: C901, PLR0912, PLR0915
                         )
                         return
                     if isinstance(resolution, ExcludedAttempt):
+                        run_metadata = _interrupted_run_metadata(ctx, sinks, run)
                         run.turn_state.record_interrupted(
                             sinks.turn_recorder,
-                            run_metadata=run.run_metadata,
+                            run_metadata=run_metadata,
                             assistant_text=resolution.partial_text,
                             completed_tools=list(resolution.completed_tools),
                             interrupted_tools=list(resolution.interrupted_tools),
@@ -806,6 +824,7 @@ async def stream_response_turn[ChunkT](  # noqa: C901, PLR0912, PLR0915
                                 adapter.persist_standalone_replay,
                                 run,
                                 resolution,
+                                run_metadata,
                             )
                         if resolution.original_status is RunStatus.cancelled:
                             raise build_cancelled_error(resolution.reason)

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -22,6 +22,7 @@ from agno.run.agent import (
     RunContentEvent,
     RunErrorEvent,
     RunOutput,
+    RunPausedEvent,
     ToolCallCompletedEvent,
     ToolCallStartedEvent,
 )
@@ -1149,6 +1150,45 @@ class TestUserIdPassthrough:
                 "Half done\n\n(turn stopped before completion; 1 tool call(s) had completed: run_shell_command)",
             ),
         ]
+
+    @pytest.mark.asyncio
+    async def test_ai_response_persists_paused_replay_status(self, tmp_path: Path) -> None:
+        """Recorder-less paused runs keep paused semantics in replay history."""
+        storage = _SessionStorage()
+        mock_agent = MagicMock()
+        paused_run = RunOutput(
+            run_id="run-paused",
+            agent_id="general",
+            session_id="session1",
+            content="Approval required",
+            messages=[Message(role="assistant", content="Approval required")],
+            status=RunStatus.paused,
+        )
+
+        with (
+            patch(
+                "mindroom.ai.open_resolved_scope_session_context",
+                new=lambda **_: _open_agent_scope_context(storage),
+            ),
+            patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare,
+            patch("mindroom.ai_runtime.cached_agent_run", new_callable=AsyncMock, return_value=paused_run),
+        ):
+            mock_prepare.return_value = _prepared_prompt_result(mock_agent)
+            response = await ai_response(
+                make_turn_context("general", session_id="session1", reply_to_event_id="$source"),
+                prompt="Run the action",
+                runtime_paths=_runtime_paths(tmp_path),
+                config=_config(),
+            )
+
+        assert response == "Approval required"
+        persisted_session = cast("AgentSession", storage.session)
+        assert persisted_session.runs is not None
+        persisted_run = cast("RunOutput", persisted_session.runs[0])
+        assert persisted_run.metadata is not None
+        assert persisted_run.metadata["mindroom_original_status"] == "paused"
+        assert persisted_run.messages is not None
+        assert "turn paused before completion" in str(persisted_run.messages[-1].content)
 
     @pytest.mark.asyncio
     async def test_ai_response_cancelled_run_uses_only_latest_assistant_partial_text(
@@ -3404,6 +3444,55 @@ class TestUserIdPassthrough:
         assert payload["usage"]["input_tokens"] == 100
         assert payload["usage"]["output_tokens"] == 25
         assert payload["usage"]["total_tokens"] == 125
+
+    @pytest.mark.asyncio
+    async def test_stream_agent_response_persists_paused_replay_status_and_metadata(self, tmp_path: Path) -> None:
+        """Recorder-less paused streams keep replay semantics and publish run metadata."""
+        storage = _SessionStorage()
+        mock_agent = MagicMock()
+        mock_agent.model = MagicMock()
+        mock_agent.model.__class__.__name__ = "OpenAIChat"
+        mock_agent.model.id = "test-model"
+        mock_agent.name = "GeneralAgent"
+        mock_agent.add_history_to_context = False
+
+        async def fake_arun_stream(*_args: object, **_kwargs: object) -> AsyncIterator[object]:
+            yield RunPausedEvent(
+                run_id="run-paused",
+                session_id="session1",
+                content="Approval required",
+            )
+
+        mock_agent.arun = MagicMock(return_value=fake_arun_stream())
+        run_metadata: dict[str, object] = {}
+        with (
+            patch(
+                "mindroom.ai.open_resolved_scope_session_context",
+                new=lambda **_: _open_agent_scope_context(storage),
+            ),
+            patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare,
+        ):
+            mock_prepare.return_value = _prepared_prompt_result(mock_agent)
+            chunks = [
+                chunk
+                async for chunk in stream_agent_response(
+                    make_turn_context("general", session_id="session1", reply_to_event_id="$source"),
+                    prompt="Run the action",
+                    runtime_paths=_runtime_paths(tmp_path),
+                    config=_config(),
+                    run_metadata_collector=run_metadata,
+                )
+            ]
+
+        assert [chunk.content for chunk in chunks] == ["Approval required"]
+        persisted_session = cast("AgentSession", storage.session)
+        assert persisted_session.runs is not None
+        persisted_run = cast("RunOutput", persisted_session.runs[0])
+        assert persisted_run.metadata is not None
+        assert persisted_run.metadata["mindroom_original_status"] == "paused"
+        payload = cast("dict[str, object]", run_metadata[AI_RUN_METADATA_KEY])
+        assert payload["run_id"] == "run-paused"
+        assert payload["status"] == "paused"
 
     @pytest.mark.asyncio
     async def test_stream_agent_response_persists_hidden_interrupted_tool_state(self, tmp_path: Path) -> None:

--- a/tests/test_response_turn.py
+++ b/tests/test_response_turn.py
@@ -308,6 +308,28 @@ def test_blocking_errored_attempt_returns_user_text() -> None:
     assert result == "friendly error"
 
 
+def test_blocking_errored_attempt_preserves_seeded_recorder_metadata() -> None:
+    """A pre-prepare failure keeps Matrix source metadata seeded on the recorder."""
+    log = _AdapterLog()
+    seeded_metadata = {"matrix_source_event_ids": ["$source"], "matrix_seen_event_ids": ["$source"]}
+    recorder = _FakeTurnRecorder(run_metadata=seeded_metadata)
+
+    async def _attempt(_run: TurnRunState, _c: DynamicContinuationRunState) -> ExcludedAttempt:
+        return ExcludedAttempt(RunStatus.error, "friendly error")
+
+    result = asyncio.run(
+        run_blocking_response_turn(
+            _ctx(),
+            _blocking_adapter(log, _attempt),
+            TurnSinks(turn_recorder=cast("Any", recorder)),
+            continuation=_continuation(),
+        ),
+    )
+
+    assert result == "friendly error"
+    assert recorder.interrupted_calls[-1]["run_metadata"] == seeded_metadata
+
+
 def test_blocking_cancelled_attempt_records_persists_and_raises() -> None:
     """A cancelled attempt without recorder persists one standalone replay and raises."""
     log = _AdapterLog()

--- a/tests/test_response_turn.py
+++ b/tests/test_response_turn.py
@@ -327,7 +327,18 @@ def test_blocking_errored_attempt_preserves_seeded_recorder_metadata() -> None:
     )
 
     assert result == "friendly error"
-    assert recorder.interrupted_calls[-1]["run_metadata"] == seeded_metadata
+    assert recorder.interrupted_calls[-1]["run_metadata"] == {
+        "matrix_source_event_ids": ["$source"],
+        "matrix_seen_event_ids": ["$reply", "$source"],
+        "room_id": "!room",
+        "thread_id": "$thread",
+        "reply_to_event_id": "$reply",
+        "requester_id": "@user:hs",
+        "correlation_id": "corr-1",
+        "tools_schema": [],
+        "model_params": {},
+        "matrix_event_id": "$reply",
+    }
 
 
 def test_blocking_cancelled_attempt_records_persists_and_raises() -> None:


### PR DESCRIPTION
## Summary

- Preserve seeded Matrix source and seen-event metadata while rebuilding room, thread, requester, and correlation fields for pre-prepare failures.
- Preserve paused status in recorder-less blocking and streaming replay history.
- Publish paused streaming run metadata through the same builder used for cancellations.

## Context

This is a narrow follow-up from the differential audit of #1458 against its replacement PRs.
It does not restore the broader restart or snapshot machinery.

## Tests

- `uv run pytest --no-cov -q tests/test_ai_user_id.py` (105 passed)
- `uv run pre-commit run --all-files`
- GitHub Actions full pytest, build, smoke, security, and Tach checks

## Live test

Not run because no local Matrix or model stack was active, and a synthetic provider would not validate real pause semantics better than the direct blocking and streaming seam tests.