### PR TITLE
Lift agno OpenRouter 1024 max_tokens default

### DIFF
--- a/src/mindroom/model_loading.py
+++ b/src/mindroom/model_loading.py
@@ -206,6 +206,10 @@ def _create_model_for_provider(  # noqa: C901, PLR0911, PLR0912, PLR0915
             api_key = get_api_key_for_provider(canonical_provider, runtime_paths=runtime_paths)
         if not api_key:
             logger.warning("No OpenRouter API key found in environment or CredentialsManager")
+        # Agno's OpenRouter dataclass defaults max_tokens to 1024, which silently
+        # truncates long replies mid-sentence; None keeps the cap out of the
+        # request so the provider's own model limit applies.
+        extra_kwargs.setdefault("max_tokens", None)
         return OpenRouter(id=model_id, api_key=api_key, **extra_kwargs)
 
     if canonical_provider == "zai":

--- a/tests/test_extra_kwargs.py
+++ b/tests/test_extra_kwargs.py
@@ -185,6 +185,31 @@ def test_get_model_instance_with_extra_kwargs() -> None:
     assert model.temperature == 0.8
 
 
+def test_openrouter_provider_defaults_to_uncapped_max_tokens() -> None:
+    """Agno's OpenRouter class caps output at 1024 tokens; the loader must lift that default."""
+    config_data = {
+        "models": {
+            "uncapped": {
+                "provider": "openrouter",
+                "id": "deepseek/deepseek-v4-pro",
+                "extra_kwargs": {"api_key": "test-key"},
+            },
+            "capped": {
+                "provider": "openrouter",
+                "id": "deepseek/deepseek-v4-pro",
+                "extra_kwargs": {"api_key": "test-key", "max_tokens": 4096},
+            },
+        },
+        "router": {"model": "uncapped"},
+        "agents": {},
+    }
+
+    config, runtime_paths = _config_with_runtime_paths(config_data)
+
+    assert get_model_instance(config, runtime_paths, "uncapped").max_tokens is None
+    assert get_model_instance(config, runtime_paths, "capped").max_tokens == 4096
+
+
 def test_get_model_instance_supports_llama_cpp_provider() -> None:
     """llama.cpp should use Agno's OpenAI-compatible local provider class."""
     config_data = {


### PR DESCRIPTION
## Problem

Agent replies on OpenRouter-backed models were silently truncated mid-sentence (reported on the mindroom-mom LXC: long Dutch replies from the `mind` agent on `deepseek/deepseek-v4-pro` kept stopping mid-story).

Root cause: agno's `OpenRouter` dataclass defaults `max_tokens` to **1024**, and `model_loading.py` constructed it without an override, so every OpenRouter response was hard-capped at 1024 output tokens (`finish_reason=length`). On reasoning models the reasoning tokens count against the same budget, which also explains observed `model_returned_empty_response` warnings with `output_tokens=1024` — the whole budget went to reasoning, leaving no visible text.

## Fix

Default `max_tokens` to `None` in the openrouter branch. Agno filters `None` params out of the request, so no cap is sent and the provider's own model limit applies. An explicit `extra_kwargs.max_tokens` in config still wins via `setdefault`.

## Testing

- New test `test_openrouter_provider_defaults_to_uncapped_max_tokens` covers both the lifted default and an explicit config cap.
- `tests/test_extra_kwargs.py`: 56 passed.
- Pre-commit hooks pass on changed files.

Config-level mitigation (`extra_kwargs: {max_tokens: null}`) has been applied on the affected mindroom-mom host until this merges.