### PR TITLE
Speed up the full test suite

### DIFF
--- a/docs/dev/TESTING.md
+++ b/docs/dev/TESTING.md
@@ -144,9 +144,9 @@ The 20 slowest tests are reported at the end of every run (`--durations 20`).
 Normal test runs skip coverage instrumentation so the fast feedback path stays fast.
 Run `just test-backend-coverage` for core backend coverage or `just test-saas-backend-coverage` for SaaS backend coverage.
 
-## Running All Tests
+## Running Standard Test Suites
 
-Use the convenience script to run the core Python, core frontend, SaaS backend, SaaS frontend, and SaaS frontend API-command suites:
+Use `just test-standard` or the convenience script to run the core Python, core frontend, SaaS backend, SaaS frontend, and SaaS frontend API-command suites:
 
 ```bash
 ./run-tests.sh

--- a/docs/dev/TESTING.md
+++ b/docs/dev/TESTING.md
@@ -139,14 +139,14 @@ To run serially for debugging, pass `-n0`: `python -m pytest tests/ -n0`.
 Each test has a 60-second timeout (`--timeout 60` in `addopts`).
 The 20 slowest tests are reported at the end of every run (`--durations 20`).
 
-### Automatic Coverage
+### Coverage
 
-Coverage runs automatically with every test invocation (`--cov=mindroom` in `addopts`).
-Reports are generated in three formats: terminal summary, HTML (`htmlcov/`), and XML (`coverage.xml`).
+Normal test runs skip coverage instrumentation so the fast feedback path stays fast.
+Run `just test-backend-coverage` for core backend coverage or `just test-saas-backend-coverage` for SaaS backend coverage.
 
 ## Running All Tests
 
-Use the convenience script to run both frontend and backend tests:
+Use the convenience script to run the core Python, core frontend, SaaS backend, SaaS frontend, and SaaS frontend API-command suites:
 
 ```bash
 ./run-tests.sh

--- a/frontend/src/components/Credentials/Credentials.test.tsx
+++ b/frontend/src/components/Credentials/Credentials.test.tsx
@@ -473,7 +473,7 @@ describe("Credentials", () => {
     render(<Credentials />);
 
     await waitFor(() => {
-      expect(screen.getByText("service_b")).toBeInTheDocument();
+      expect((global.fetch as any).mock.calls).toHaveLength(4);
     });
 
     fireEvent.click(screen.getByRole("button", { name: /service_b/i }));

--- a/frontend/src/components/Credentials/Credentials.test.tsx
+++ b/frontend/src/components/Credentials/Credentials.test.tsx
@@ -472,11 +472,15 @@ describe("Credentials", () => {
 
     render(<Credentials />);
 
+    const serviceBButton = await screen.findByRole("button", {
+      name: /service_b/i,
+    });
     await waitFor(() => {
+      // The fourth request is service A's pending credential load; switch only after that stale request starts.
       expect((global.fetch as any).mock.calls).toHaveLength(4);
     });
 
-    fireEvent.click(screen.getByRole("button", { name: /service_b/i }));
+    fireEvent.click(serviceBButton);
 
     const editor = screen.getByPlaceholderText(
       '{"api_key":"..."}',

--- a/justfile
+++ b/justfile
@@ -221,8 +221,8 @@ test-backend-coverage *args:
     uv sync --all-extras
     uv run --all-extras pytest --cov=mindroom --cov-report=term-missing {{ args }}
 
-# Run every local automated test suite with dependency preflight and fail-fast behavior
-test-all:
+# Run the standard cross-platform test suites with dependency preflight and fail-fast behavior
+test-standard:
     ./run-tests.sh
 
 # Check for public symbols that should be private

--- a/justfile
+++ b/justfile
@@ -197,6 +197,10 @@ env-saas:
 test-saas-backend *args:
     cd saas-platform/platform-backend && uv run pytest {{args}}
 
+# Run SaaS platform backend tests with a terminal coverage report
+test-saas-backend-coverage *args:
+    cd saas-platform/platform-backend && uv run pytest --cov=backend --cov-report=term-missing {{ args }}
+
 # Run SaaS platform frontend tests (Jest)
 test-saas-frontend:
     cd saas-platform/platform-frontend && bun install && bun run test
@@ -211,6 +215,15 @@ test-front:
 test-backend *args:
     uv sync --all-extras
     uv run --all-extras pytest {{args}}
+
+# Run core backend tests with a terminal coverage report
+test-backend-coverage *args:
+    uv sync --all-extras
+    uv run --all-extras pytest --cov=mindroom --cov-report=term-missing {{ args }}
+
+# Run every local automated test suite with dependency preflight and fail-fast behavior
+test-all:
+    ./run-tests.sh
 
 # Check for public symbols that should be private
 check-module-privacy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -554,12 +554,8 @@ asyncio_mode = "auto"
 pythonpath = [ "src" ]
 addopts = """
     -p no:tach
-    -vvv
+    -q
     -n auto
-    --cov=mindroom
-    --cov-report term
-    --cov-report html
-    --cov-report xml
     --asyncio-mode=strict
     --timeout 60
     --durations 20

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,27 +1,117 @@
 #!/usr/bin/env bash
 
-echo "Running MindRoom Tests"
-echo "======================"
+set -euo pipefail
 
-# Frontend tests
-echo ""
-echo "Running Frontend Tests (TypeScript/React)..."
-echo "-------------------------------------------"
-cd frontend
-bun run vitest run
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+cd "$REPO_ROOT"
 
-# Backend tests
-echo ""
-echo "Running Backend Tests (Python/FastAPI)..."
-echo "----------------------------------------"
-cd ..
-uv run pytest tests/api/ -v -o addopts=""
+section() {
+    printf '\n%s\n' "$1"
+}
 
-# Bot tests
-echo ""
-echo "Running Bot Tests (Python)..."
-echo "-----------------------------"
-uv run pytest tests/ -v -o addopts="" --ignore=tests/api/
+find_command() {
+    local command_name="$1"
+    shift
 
-echo ""
-echo "Test run complete!"
+    local command_path
+    command_path="$(command -v "$command_name" 2>/dev/null || true)"
+    if [[ -n "$command_path" && -x "$command_path" ]]; then
+        printf '%s\n' "$command_path"
+        return
+    fi
+
+    for command_path in "$@"; do
+        if [[ -n "$command_path" && -x "$command_path" ]]; then
+            printf '%s\n' "$command_path"
+            return
+        fi
+    done
+
+    printf 'Missing required command: %s\n' "$command_name" >&2
+    return 127
+}
+
+find_real_node() {
+    local command_path
+    command_path="$(command -v node 2>/dev/null || true)"
+
+    for command_path in "$command_path" "$@"; do
+        if [[ -n "$command_path" && -x "$command_path" ]] && \
+            "$command_path" -e 'process.exit(process.versions.bun ? 1 : 0)' >/dev/null 2>&1; then
+            printf '%s\n' "$command_path"
+            return
+        fi
+    done
+
+    printf 'Missing required command: node (a real Node.js runtime, not the Bun compatibility layer)\n' >&2
+    return 127
+}
+
+UV_BIN="$(
+    find_command uv \
+        "${HOME:+${HOME}/.local/bin/uv}" \
+        "${HOME:+${HOME}/.cargo/bin/uv}" \
+        /opt/homebrew/bin/uv \
+        /usr/local/bin/uv
+)"
+BUN_BIN="$(
+    find_command bun \
+        "${HOME:+${HOME}/.bun/bin/bun}" \
+        /opt/homebrew/bin/bun \
+        /usr/local/bin/bun
+)"
+NODE_BIN="$(
+    find_real_node \
+        "${NVM_BIN:+${NVM_BIN}/node}" \
+        "${VOLTA_HOME:+${VOLTA_HOME}/bin/node}" \
+        "${HOME:+${HOME}/.volta/bin/node}" \
+        /opt/homebrew/bin/node \
+        /usr/local/bin/node \
+        /usr/bin/node \
+        /run/current-system/sw/bin/node
+)"
+
+# Bun follows JavaScript bin shebangs through PATH. Require real Node so
+# Vitest and Jest do not run inside Bun's Node compatibility layer.
+export PATH="$(dirname "$NODE_BIN")${PATH:+:$PATH}"
+
+section "Toolchain"
+printf 'uv: %s\n' "$UV_BIN"
+"$UV_BIN" --version
+printf 'bun: %s\n' "$BUN_BIN"
+"$BUN_BIN" --version
+printf 'node: %s\n' "$NODE_BIN"
+"$NODE_BIN" --version
+
+section "Core Python tests"
+"$UV_BIN" sync --all-extras
+"$UV_BIN" run --all-extras pytest
+
+section "Core frontend tests"
+(
+    cd frontend
+    "$BUN_BIN" install --frozen-lockfile
+    "$BUN_BIN" run test --run
+)
+
+section "SaaS backend tests"
+(
+    cd saas-platform/platform-backend
+    "$UV_BIN" sync
+    "$UV_BIN" run pytest
+)
+
+section "SaaS frontend tests"
+(
+    cd saas-platform/platform-frontend
+    "$BUN_BIN" install --frozen-lockfile
+    "$BUN_BIN" run test
+)
+
+section "SaaS frontend API command test"
+(
+    cd saas-platform/platform-frontend
+    "$BUN_BIN" run test:api-check
+)
+
+section "All automated test suites passed"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -73,7 +73,9 @@ NODE_BIN="$(
 
 # Bun follows JavaScript bin shebangs through PATH. Require real Node so
 # Vitest and Jest do not run inside Bun's Node compatibility layer.
-export PATH="$(dirname "$NODE_BIN")${PATH:+:$PATH}"
+NODE_DIR="$(dirname "$NODE_BIN")"
+PATH="$NODE_DIR${PATH:+:$PATH}"
+export PATH
 
 section "Toolchain"
 printf 'uv: %s\n' "$UV_BIN"
@@ -114,4 +116,4 @@ section "SaaS frontend API command test"
     "$BUN_BIN" run test:api-check
 )
 
-section "All automated test suites passed"
+section "All standard cross-platform test suites passed"

--- a/saas-platform/platform-backend/pyproject.toml
+++ b/saas-platform/platform-backend/pyproject.toml
@@ -53,11 +53,7 @@ extend-exclude = [ "tests/conftest.py" ]
 testpaths = [ "tests" ]
 python_files = "test_*.py"
 addopts = """
-    -vvv
-    --cov=backend
-    --cov-report term
-    --cov-report html
-    --cov-report xml
+    -q
     --asyncio-mode=strict
     --timeout 60
     --durations 20

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -639,7 +639,13 @@ def test_load_config_into_app_discards_stale_results_after_runtime_swap(tmp_path
 
     def _fake_load_result(
         runtime_paths: constants.RuntimePaths,
-    ) -> tuple[config_lifecycle.ConfigLoadResult, dict[str, Any] | None, Config | None, str | None]:
+    ) -> tuple[
+        config_lifecycle.ConfigLoadResult,
+        dict[str, Any] | None,
+        Config | None,
+        str | None,
+        frozenset[Path] | None,
+    ]:
         if runtime_paths == first_runtime:
             started.set()
             allow_finish.wait(timeout=1)
@@ -652,6 +658,7 @@ def test_load_config_into_app_discards_stale_results_after_runtime_swap(tmp_path
                 None,
                 None,
                 "stale-old-source",
+                frozenset({first_runtime.config_path}),
             )
         return original_load_result(runtime_paths)
 
@@ -669,6 +676,7 @@ def test_load_config_into_app_discards_stale_results_after_runtime_swap(tmp_path
         assert config_lifecycle.load_config_into_app(second_runtime, fresh_app) is True
         allow_finish.set()
         stale_thread.join(timeout=1)
+        assert not stale_thread.is_alive()
 
     context = main._app_context(fresh_app)
     assert context.runtime_paths == second_runtime

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -6,6 +6,7 @@ import os
 import threading
 import time
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace, TracebackType
@@ -648,7 +649,7 @@ def test_load_config_into_app_discards_stale_results_after_runtime_swap(tmp_path
     ]:
         if runtime_paths == first_runtime:
             started.set()
-            allow_finish.wait(timeout=1)
+            allow_finish.wait()
             return (
                 config_lifecycle.ConfigLoadResult(
                     success=False,
@@ -664,19 +665,20 @@ def test_load_config_into_app_discards_stale_results_after_runtime_swap(tmp_path
 
     main.initialize_api_app(fresh_app, first_runtime)
 
-    with patch.object(config_lifecycle, "_load_config_result", side_effect=_fake_load_result):
-        stale_thread = threading.Thread(
-            target=config_lifecycle.load_config_into_app,
-            args=(first_runtime, fresh_app),
-        )
-        stale_thread.start()
-        assert started.wait(timeout=1)
+    with (
+        patch.object(config_lifecycle, "_load_config_result", side_effect=_fake_load_result),
+        ThreadPoolExecutor(max_workers=1) as executor,
+    ):
+        stale_result = executor.submit(config_lifecycle.load_config_into_app, first_runtime, fresh_app)
+        try:
+            assert started.wait(timeout=1)
 
-        main.initialize_api_app(fresh_app, second_runtime)
-        assert config_lifecycle.load_config_into_app(second_runtime, fresh_app) is True
-        allow_finish.set()
-        stale_thread.join(timeout=1)
-        assert not stale_thread.is_alive()
+            main.initialize_api_app(fresh_app, second_runtime)
+            assert config_lifecycle.load_config_into_app(second_runtime, fresh_app) is True
+        finally:
+            allow_finish.set()
+
+        assert stale_result.result(timeout=1) is False
 
     context = main._app_context(fresh_app)
     assert context.runtime_paths == second_runtime

--- a/tests/api/test_file_watcher.py
+++ b/tests/api/test_file_watcher.py
@@ -1,6 +1,5 @@
 """Tests for file watching functionality."""
 
-import time
 from pathlib import Path
 
 import yaml
@@ -67,8 +66,6 @@ def test_config_format_validation(test_client: TestClient, temp_config_file: Pat
 
     with temp_config_file.open("w") as f:
         yaml.dump(valid_config, f)
-
-    time.sleep(0.5)
 
     # Should be able to load the fixed config
     response = test_client.post("/api/config/load")

--- a/tests/api/test_sandbox_forkserver.py
+++ b/tests/api/test_sandbox_forkserver.py
@@ -170,13 +170,17 @@ def test_timeout_kills_child_and_keeps_template_alive(
     """A timed-out request must SIGKILL the fork child without recycling the template."""
     manager, spawned = stub_manager
     pid_file = tmp_path / "child.pid"
-    # Warm the template first so the 2 s deadline below covers only the
+    # Warm the template first so the short deadline below covers only the
     # request, not stub startup on a loaded CI machine.
     assert _stub_execute(manager).returncode == 0
 
     with pytest.raises(ForkserverTimeoutError):
-        _stub_execute(manager, envelope=f"sleep:{pid_file}", timeout_seconds=2.0)
+        _stub_execute(manager, envelope=f"sleep:{pid_file}", timeout_seconds=0.5)
 
+    pid_deadline = time.monotonic() + 2.0
+    while not pid_file.exists() and time.monotonic() < pid_deadline:
+        time.sleep(0.01)
+    assert pid_file.exists(), "forked child did not start before the request timeout"
     child_pid = int(pid_file.read_text(encoding="utf-8"))
     deadline = time.monotonic() + 5.0
     while time.monotonic() < deadline:
@@ -215,18 +219,25 @@ def test_template_startup_failure_pins_fingerprint() -> None:
 def test_slow_template_warmup_survives_request_timeouts(tmp_path: Path) -> None:
     """A ready-wait timeout must leave the template importing instead of killing and pinning it."""
     script = tmp_path / "slow_template.py"
-    script.write_text("import time\n\ntime.sleep(2)\n\n" + _STUB_TEMPLATE, encoding="utf-8")
+    release_file = tmp_path / "release-template"
+    script.write_text(
+        "import sys\nimport time\nfrom pathlib import Path\n\n"
+        "while not Path(sys.argv[2]).exists():\n"
+        "    time.sleep(0.01)\n\n" + _STUB_TEMPLATE,
+        encoding="utf-8",
+    )
     spawned: list[str] = []
 
     def _command(python_executable: str, socket_path: str) -> list[str]:
         spawned.append(socket_path)
-        return [python_executable, str(script), socket_path]
+        return [python_executable, str(script), socket_path, str(release_file)]
 
     manager = _SandboxForkserver(template_command=_command)
     try:
         with pytest.raises(ForkserverTimeoutError):
-            _stub_execute(manager, timeout_seconds=0.5)
+            _stub_execute(manager, timeout_seconds=0.05)
 
+        release_file.touch()
         assert _stub_execute(manager, timeout_seconds=30.0).returncode == 0
     finally:
         manager.shutdown()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,6 +124,7 @@ def _configure_uncached_structlog(
     cache_logger_on_first_use: bool | None = None,
 ) -> None:
     """Prevent logging tests from leaving cached production renderers behind."""
+    # Cached proxies outlive one test, so the suite intentionally overrides this request.
     _ = cache_logger_on_first_use
     _STRUCTLOG_CONFIGURE(
         processors=processors,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from collections.abc import (
     Awaitable,
     Callable,
     Generator,
+    Iterable,
     Iterator,
     Mapping,
     MutableMapping,
@@ -29,10 +30,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import nio
 import pytest
 import pytest_asyncio
+import structlog
 import yaml
 from agno.models.base import Model
 from agno.models.response import ModelResponse
 from aioresponses import aioresponses
+from structlog.testing import ReturnLoggerFactory
+from structlog.typing import BindableLogger, Context, Processor, WrappedLogger
 
 import mindroom.bot  # noqa: F401
 from mindroom.agent_storage import get_agent_session, get_team_session
@@ -96,6 +100,42 @@ if TYPE_CHECKING:
     from mindroom.dispatch_handoff import DispatchEvent
     from mindroom.matrix.cache import ConversationEventCache
     from mindroom.tool_system.worker_routing import ToolExecutionIdentity
+
+
+_STRUCTLOG_CONFIGURE = structlog.configure
+
+
+def _configure_quiet_structlog() -> None:
+    """Keep incidental test logging cheap and silent."""
+    _STRUCTLOG_CONFIGURE(
+        processors=[],
+        context_class=dict,
+        logger_factory=ReturnLoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=False,
+    )
+
+
+def _configure_uncached_structlog(
+    processors: Iterable[Processor] | None = None,
+    wrapper_class: type[BindableLogger] | None = None,
+    context_class: type[Context] | None = None,
+    logger_factory: Callable[..., WrappedLogger] | None = None,
+    cache_logger_on_first_use: bool | None = None,
+) -> None:
+    """Prevent logging tests from leaving cached production renderers behind."""
+    _ = cache_logger_on_first_use
+    _STRUCTLOG_CONFIGURE(
+        processors=processors,
+        wrapper_class=wrapper_class,
+        context_class=context_class,
+        logger_factory=logger_factory,
+        cache_logger_on_first_use=False,
+    )
+
+
+_configure_quiet_structlog()
+
 
 __all__ = [
     "TEST_ACCESS_TOKEN",
@@ -1375,6 +1415,19 @@ async def aioresponse() -> AsyncGenerator[aioresponses, None]:
     # Based on https://github.com/matrix-nio/matrix-nio/blob/main/tests/conftest_async.py
     with aioresponses() as m:
         yield m
+
+
+@pytest.fixture(autouse=True)
+def _isolate_structlog_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+) -> Generator[None, None, None]:
+    """Silence incidental logs and prevent global logging configuration leaks."""
+    _configure_quiet_structlog()
+    if request.node.path.name != "test_logging_config.py":
+        monkeypatch.setattr(structlog, "configure", _configure_uncached_structlog)
+    yield
+    _configure_quiet_structlog()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
+import structlog
 import typer
 import yaml
 from anthropic import PermissionDeniedError
@@ -138,6 +139,22 @@ def test_format_config_search_locations_numbers_paths_and_statuses(
 
     assert lines[0] == f"  1. {missing.resolve()} ([dim]not found[/dim])"
     assert lines[1] == f"  2. {existing.resolve()} ([green]exists[/green])"
+
+
+def test_load_config_quiet_restores_unconfigured_structlog(tmp_path: Path) -> None:
+    """Quiet CLI loads must exercise and restore the unconfigured structlog path."""
+    config_path = tmp_path / "config.yaml"
+    _write_minimal_runtime_config(config_path)
+    runtime_paths = constants_module.resolve_primary_runtime_paths(config_path=config_path, process_env={})
+
+    structlog.reset_defaults()
+    assert structlog.is_configured() is False
+    with patch.object(structlog, "configure", wraps=structlog.configure) as configure:
+        loaded_config = config_cli.load_config_quiet(runtime_paths)
+
+    configure.assert_called_once()
+    assert loaded_config.agents
+    assert structlog.is_configured() is False
 
 
 def test_activate_cli_runtime_explicit_path_keeps_exported_storage_override(

--- a/tests/test_history_summary_call.py
+++ b/tests/test_history_summary_call.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 import pytest
 from agno.models.message import Message
 from agno.models.response import ModelResponse
+from structlog.testing import capture_logs
 
 import mindroom.background_tasks as background_tasks_module
 from mindroom.agent_storage import create_session_storage, get_agent_session
@@ -346,7 +347,6 @@ async def test_compaction_timeout_cleanup_detaches_after_grace_window() -> None:
 @pytest.mark.asyncio
 async def test_compaction_call_timeout_falls_back_in_runtime(
     tmp_path: Path,
-    capsys: pytest.CaptureFixture[str],
 ) -> None:
     class _SlowSummaryModel(FakeModel):
         async def aresponse(self, *_args: object, **_kwargs: object) -> ModelResponse:
@@ -378,6 +378,7 @@ async def test_compaction_call_timeout_falls_back_in_runtime(
             return_value=_SlowSummaryModel(id="summary-model", provider="fake"),
         ),
         patch("mindroom.history.summary_call.MINDROOM_COMPACTION_CHUNK_TIMEOUT_SECONDS", 0.01),
+        capture_logs() as logs,
     ):
         prepared = await prepare_history_for_run_for_test(
             agent=_agent(db=storage),
@@ -399,9 +400,9 @@ async def test_compaction_call_timeout_falls_back_in_runtime(
     assert read_scope_state(persisted, scope).force_compact_before_next_run is False
     assert prepared.compaction_outcomes == []
     assert prepared.compaction_reply_outcome == "timeout"
-    captured = capsys.readouterr()
-    assert "Compaction failed; continuing without compaction" in captured.out
-    assert "Timed-out compaction request" not in captured.out
+    events = [entry["event"] for entry in logs]
+    assert "Compaction failed; continuing without compaction" in events
+    assert "Timed-out compaction request" not in events
 
 
 def test_build_summary_input_advances_past_oversized_oldest_run() -> None:

--- a/tests/test_import_graph.py
+++ b/tests/test_import_graph.py
@@ -132,21 +132,27 @@ loaded = sorted(
 print(json.dumps(loaded))
 """
 
-# mypyc-compiled dependencies register hash-named helper modules (e.g.
-# "4ef79d...__mypyc") that vary per build, so they are excluded from the
-# footprint along with private roots and mindroom itself.
-_ALLOWLIST_PROBE_TEMPLATE = """
+_SLIM_PROBE_TEMPLATE = """
 import importlib, json, sys
 
 stdlib = set(sys.stdlib_module_names)
 baseline = {{name.split(".")[0] for name in sys.modules}}
 importlib.import_module({module!r})
-roots = sorted(
+banned_roots = {banned_roots!r}
+banned = sorted(
+    name
+    for name in sys.modules
+    if any(name == root or name.startswith(root + ".") for root in banned_roots)
+)
+# mypyc-compiled dependencies register hash-named helper modules (e.g.
+# "4ef79d...__mypyc") that vary per build, so they are excluded from the
+# footprint along with private roots and mindroom itself.
+third_party = sorted(
     root
     for root in {{name.split(".")[0] for name in sys.modules}} - stdlib - baseline
     if not root.startswith("_") and not root.endswith("__mypyc") and not root.startswith("mindroom")
 )
-print(json.dumps(roots))
+print(json.dumps({{"banned": banned, "third_party": third_party}}))
 """
 
 
@@ -161,27 +167,41 @@ def _run_probe(probe: str) -> list[str]:
     return json.loads(result.stdout)
 
 
+def _run_slim_probe(module: str) -> tuple[list[str], frozenset[str]]:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _SLIM_PROBE_TEMPLATE.format(
+                module=module,
+                banned_roots=_PROVIDER_SDK_ROOTS + _SLIM_ONLY_ROOTS,
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=120,
+    )
+    payload = json.loads(result.stdout)
+    return payload["banned"], frozenset(payload["third_party"])
+
+
 def _assert_probe_clean(module: str, roots: tuple[str, ...]) -> None:
     loaded = _run_probe(_BAN_PROBE_TEMPLATE.format(module=module, roots=roots))
     assert loaded == [], f"importing {module} pulled in banned modules: {loaded}"
 
 
-@pytest.mark.parametrize(
-    "module",
-    [
-        "mindroom.config.main",
-        "mindroom.model_loading",
-        "mindroom.tool_system.declarations",
-        "mindroom.tool_system.metadata",
-        "mindroom.tool_system.catalog",
-        "mindroom.tool_system.registration",
-        "mindroom.tools",
-        "mindroom.api.sandbox_runner",
-    ],
-)
-def test_slim_entry_points_do_not_import_provider_sdks(module: str) -> None:
-    """Slim entry points must keep provider SDKs and the matrix client unimported."""
-    _assert_probe_clean(module, _PROVIDER_SDK_ROOTS + _SLIM_ONLY_ROOTS)
+@pytest.mark.parametrize("module", sorted(_ALLOWED_THIRD_PARTY_ROOTS))
+def test_slim_entry_point_import_contract(module: str) -> None:
+    """One isolated import must satisfy both the banned-module and third-party contracts."""
+    banned, third_party = _run_slim_probe(module)
+    assert banned == [], f"importing {module} pulled in banned modules: {banned}"
+    unexpected = sorted(third_party - _ALLOWED_THIRD_PARTY_ROOTS[module])
+    assert not unexpected, (
+        f"importing {module} now loads third-party packages not in its allowlist: {unexpected}. "
+        "Defer the import to first use (see the CLAUDE.md function-level import rule), "
+        "or extend the allowlist here if the dependency is genuinely needed at import time."
+    )
 
 
 def test_primary_runtime_does_not_import_provider_sdks() -> None:
@@ -203,21 +223,4 @@ def test_tool_auto_install_smoke_entrypoint_imports() -> None:
         [sys.executable, "-c", "import scripts.testing.tool_auto_install_smoke"],
         check=True,
         timeout=120,
-    )
-
-
-@pytest.mark.parametrize("module", sorted(_ALLOWED_THIRD_PARTY_ROOTS))
-def test_slim_entry_points_only_load_allowlisted_packages(module: str) -> None:
-    """A new third-party package in a slim import graph must be a conscious decision.
-
-    The check is subset-based (new packages fail, absent ones pass) so
-    platform-conditional dependencies do not flake. If this fails, prefer
-    deferring the import to first use over extending the allowlist.
-    """
-    loaded = frozenset(_run_probe(_ALLOWLIST_PROBE_TEMPLATE.format(module=module)))
-    unexpected = sorted(loaded - _ALLOWED_THIRD_PARTY_ROOTS[module])
-    assert not unexpected, (
-        f"importing {module} now loads third-party packages not in its allowlist: {unexpected}. "
-        "Defer the import to first use (see the CLAUDE.md function-level import rule), "
-        "or extend the allowlist here if the dependency is genuinely needed at import time."
     )

--- a/tests/test_shell_async.py
+++ b/tests/test_shell_async.py
@@ -502,7 +502,7 @@ async def test_check_shell_command_running(tmp_path: Path) -> None:
     assert run_fn is not None
     assert check_fn is not None
 
-    result = await run_fn(["sleep", "300"], timeout=1)
+    result = await run_fn(["sleep", "300"], timeout=0)
     handle = result.split("Handle: ")[1].split("\n")[0]
 
     status = check_fn(handle)
@@ -523,9 +523,9 @@ async def test_check_shell_command_finished(tmp_path: Path) -> None:
     assert run_fn is not None
     assert check_fn is not None
 
-    # Use a command that sleeps longer than the timeout to guarantee backgrounding,
-    # but emits output first so we can verify it after finish.
-    result = await run_fn(["bash", "-c", "echo done-output; sleep 3"], timeout=1)
+    # Force backgrounding immediately, but let the command live long enough for
+    # the monitor path to observe its output and final status.
+    result = await run_fn(["bash", "-c", "echo done-output; sleep 0.05"], timeout=0)
     assert "Handle:" in result
     handle = result.split("Handle: ")[1].split("\n")[0]
 
@@ -534,7 +534,7 @@ async def test_check_shell_command_finished(tmp_path: Path) -> None:
         status = check_fn(handle)
         if "FINISHED" in status:
             break
-        await asyncio.sleep(0.1)
+        await asyncio.sleep(0.02)
     assert "FINISHED" in status
     assert "done-output" in status
 
@@ -562,15 +562,16 @@ async def test_check_shell_command_partial_output(tmp_path: Path) -> None:
 
     result = await run_fn(
         ["bash", "-c", "for i in 1 2 3; do echo partial-line-$i; done; sleep 300"],
-        timeout=1,
+        timeout=0,
     )
     assert "Handle:" in result
     handle = result.split("Handle: ")[1].split("\n")[0]
 
-    # Give readers a moment to consume output
-    await asyncio.sleep(0.3)
-
-    status = check_fn(handle)
+    for _ in range(50):
+        status = check_fn(handle)
+        if "partial-line" in status:
+            break
+        await asyncio.sleep(0.02)
     assert "RUNNING" in status
     assert "lines buffered" in status
     assert "lines so far" not in status
@@ -598,7 +599,7 @@ async def test_kill_shell_command(tmp_path: Path) -> None:
     assert kill_fn is not None
     assert check_fn is not None
 
-    result = await run_fn(["sleep", "300"], timeout=1)
+    result = await run_fn(["sleep", "300"], timeout=0)
     handle = result.split("Handle: ")[1].split("\n")[0]
 
     kill_result = kill_fn(handle)
@@ -609,7 +610,7 @@ async def test_kill_shell_command(tmp_path: Path) -> None:
         status = check_fn(handle)
         if "FINISHED" in status:
             break
-        await asyncio.sleep(0.1)
+        await asyncio.sleep(0.02)
 
     assert "FINISHED" in status
 
@@ -623,7 +624,7 @@ async def test_kill_shell_command_force(tmp_path: Path) -> None:
     assert run_fn is not None
     assert kill_fn is not None
 
-    result = await run_fn(["sleep", "300"], timeout=1)
+    result = await run_fn(["sleep", "300"], timeout=0)
     handle = result.split("Handle: ")[1].split("\n")[0]
 
     kill_result = kill_fn(handle, force=True)
@@ -849,7 +850,7 @@ async def test_handle_persists_across_toolkit_instances(tmp_path: Path) -> None:
     run_fn = tool1.async_functions["run_shell_command"].entrypoint
     assert run_fn is not None
 
-    result = await run_fn(["sleep", "300"], timeout=1)
+    result = await run_fn(["sleep", "300"], timeout=0)
     assert "Handle:" in result
     handle = result.split("Handle: ")[1].split("\n")[0]
 
@@ -876,17 +877,19 @@ async def test_handle_check_then_kill_across_instances(tmp_path: Path) -> None:
     run_fn = tool_run.async_functions["run_shell_command"].entrypoint
     assert run_fn is not None
 
-    result = await run_fn(["bash", "-c", "for i in 1 2 3; do echo line-$i; done; sleep 300"], timeout=1)
+    result = await run_fn(["bash", "-c", "for i in 1 2 3; do echo line-$i; done; sleep 300"], timeout=0)
     assert "Handle:" in result
     handle = result.split("Handle: ")[1].split("\n")[0]
-
-    await asyncio.sleep(0.3)
 
     # Check from a fresh instance
     tool_check = _get_toolkit(tmp_path)
     check_fn = tool_check.functions["check_shell_command"].entrypoint
     assert check_fn is not None
-    status = check_fn(handle)
+    for _ in range(50):
+        status = check_fn(handle)
+        if "line-" in status:
+            break
+        await asyncio.sleep(0.02)
     assert "RUNNING" in status
     assert "line-" in status
 
@@ -903,7 +906,7 @@ async def test_handle_check_then_kill_across_instances(tmp_path: Path) -> None:
         status = final_check(handle)
         if "FINISHED" in status:
             break
-        await asyncio.sleep(0.1)
+        await asyncio.sleep(0.02)
 
     assert "FINISHED" in status
 

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -1842,4 +1842,4 @@ async def test_single_failure_no_duplicate_cleanup_logs(
         await sync_forever_with_restart(bot, max_retries=1)
 
     cleanup_warnings = [entry for entry in logs if entry["event"] == "Suppressed error during sync iteration cleanup"]
-    assert len(cleanup_warnings) <= 1, f"Expected at most 1 cleanup warning, got {len(cleanup_warnings)}"
+    assert len(cleanup_warnings) == 1, f"Expected exactly 1 cleanup warning, got {len(cleanup_warnings)}"

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from structlog.testing import capture_logs
 
 from mindroom.bot import AgentBot
 from mindroom.bot_runtime_view import BotRuntimeState
@@ -202,6 +203,7 @@ async def test_sync_forever_with_restart_restarts_stalled_sync(monkeypatch: pyte
     monkeypatch.setattr(runtime_helpers, "MATRIX_SYNC_STARTUP_GRACE_SECONDS", 0.01)
     monkeypatch.setattr(runtime_helpers, "_MATRIX_SYNC_WATCHDOG_POLL_INTERVAL_SECONDS", 0.01)
     monkeypatch.setattr(runtime_helpers, "retry_delay_seconds", lambda *_args, **_kwargs: 0.0)
+    monkeypatch.setattr(runtime_helpers, "_stalled_restart_jitter_seconds", lambda: 0.0)
 
     await sync_forever_with_restart(bot, max_retries=2)
 
@@ -324,6 +326,7 @@ async def test_sync_forever_with_restart_retries_on_sync_restart_cancel(
 
     monkeypatch.setattr(_SyncIteration, "_watch", staticmethod(fake_watch))
     monkeypatch.setattr(runtime_helpers, "retry_delay_seconds", lambda *_args, **_kwargs: 0.0)
+    monkeypatch.setattr(runtime_helpers, "_stalled_restart_jitter_seconds", lambda: 0.0)
 
     bot.sync_forever = sync_then_stop
 
@@ -1695,6 +1698,7 @@ async def test_restart_resets_monotonic_clock(monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setattr(runtime_helpers, "MATRIX_SYNC_STARTUP_GRACE_SECONDS", 0.5)
     monkeypatch.setattr(runtime_helpers, "_MATRIX_SYNC_WATCHDOG_POLL_INTERVAL_SECONDS", 0.01)
     monkeypatch.setattr(runtime_helpers, "retry_delay_seconds", lambda *_args, **_kwargs: 0.0)
+    monkeypatch.setattr(runtime_helpers, "_stalled_restart_jitter_seconds", lambda: 0.0)
 
     await sync_forever_with_restart(bot, max_retries=3)
 
@@ -1812,7 +1816,6 @@ async def test_immediate_sync_failure_retries(monkeypatch: pytest.MonkeyPatch) -
 @pytest.mark.asyncio
 async def test_single_failure_no_duplicate_cleanup_logs(
     monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """A single sync failure should produce exactly 1 cleanup warning, not 2+.
 
@@ -1835,8 +1838,8 @@ async def test_single_failure_no_duplicate_cleanup_logs(
     monkeypatch.setattr(runtime_helpers, "_MATRIX_SYNC_WATCHDOG_POLL_INTERVAL_SECONDS", 0.01)
     monkeypatch.setattr(runtime_helpers, "retry_delay_seconds", lambda *_args, **_kwargs: 0.0)
 
-    with caplog.at_level("WARNING", logger="mindroom.orchestration.runtime"):
+    with capture_logs() as logs:
         await sync_forever_with_restart(bot, max_retries=1)
 
-    cleanup_warnings = [r for r in caplog.records if "Suppressed error during sync iteration cleanup" in r.message]
+    cleanup_warnings = [entry for entry in logs if entry["event"] == "Suppressed error during sync iteration cleanup"]
     assert len(cleanup_warnings) <= 1, f"Expected at most 1 cleanup warning, got {len(cleanup_warnings)}"

--- a/tests/test_tach_split_matrix_client_boundaries.py
+++ b/tests/test_tach_split_matrix_client_boundaries.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import functools
 import importlib
 import shutil
 import subprocess
@@ -144,8 +145,13 @@ def _walk_runtime_nodes(
         _walk_runtime_nodes(child, importer_module, target_modules, imports, in_type_checking=in_type_checking)
 
 
+@functools.cache
+def _parsed_python_module(py_path: Path) -> ast.Module:
+    return ast.parse(py_path.read_text())
+
+
 def _runtime_direct_imports(py_path: Path, importer_module: str, target_modules: set[str]) -> set[str]:
-    tree = ast.parse(py_path.read_text())
+    tree = _parsed_python_module(py_path)
     imports: set[str] = set()
     _walk_runtime_nodes(tree, importer_module, target_modules, imports)
     return imports
@@ -277,80 +283,19 @@ def test_bot_runtime_view_visibility_is_limited_to_owner_and_protocol_facade() -
     assert BOT_RUNTIME_VIEW_MODULE not in depends_on
 
 
-def test_tach_rejects_forbidden_split_matrix_client_import(tmp_path: Path) -> None:
-    """A new direct split-client import must fail Tach until tach.toml is updated."""
-    project_root = tmp_path / "project"
-    shutil.copytree(REPO_ROOT / "src", project_root / "src")
-    shutil.copy2(TACH_CONFIG, project_root / "tach.toml")
-
-    attachments_path = project_root / "src" / "mindroom" / "custom_tools" / "attachments.py"
-    original_text = attachments_path.read_text()
-    probe_import = (
-        "from mindroom.matrix.client_session import _create_matrix_client as _tach_probe_private_client_session\n"
-    )
-    attachments_path.write_text(
-        original_text.replace(
-            "from mindroom.matrix.client_delivery import send_file_message\n",
-            f"{probe_import}from mindroom.matrix.client_delivery import send_file_message\n",
-        ),
-    )
-
-    result = subprocess.run(
-        [sys.executable, "-m", "tach", "check", "--dependencies", "--interfaces"],
-        cwd=project_root,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-
-    assert result.returncode == 1, result.stdout + result.stderr
-    assert "mindroom.matrix.client_session" in (result.stdout + result.stderr)
-
-
 def test_tach_rejects_forbidden_runtime_protocol_import(tmp_path: Path) -> None:
-    """A new runtime-protocol consumer must fail Tach until allowed explicitly."""
+    """A public runtime-protocol import must fail independently of private-symbol checks."""
     project_root = tmp_path / "project"
     shutil.copytree(REPO_ROOT / "src", project_root / "src")
     shutil.copy2(TACH_CONFIG, project_root / "tach.toml")
 
     attachments_path = project_root / "src" / "mindroom" / "custom_tools" / "attachments.py"
     original_text = attachments_path.read_text()
-    probe_import = "from mindroom.runtime_protocols import SupportsConfig as _tach_probe_runtime_protocol\n"
+    runtime_protocol_probe = "from mindroom.runtime_protocols import SupportsConfig as _tach_probe_runtime_protocol\n"
     attachments_path.write_text(
         original_text.replace(
             "from __future__ import annotations\n\n",
-            f"from __future__ import annotations\n\n{probe_import}",
-        ),
-    )
-
-    result = subprocess.run(
-        [sys.executable, "-m", "tach", "check", "--dependencies", "--interfaces"],
-        cwd=project_root,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-
-    assert result.returncode == 1, result.stdout + result.stderr
-    assert RUNTIME_PROTOCOL_MODULE in (result.stdout + result.stderr)
-
-
-def test_tach_rejects_private_runtime_protocol_import(tmp_path: Path) -> None:
-    """An allowed consumer still may not import a private runtime-protocol helper."""
-    project_root = tmp_path / "project"
-    shutil.copytree(REPO_ROOT / "src", project_root / "src")
-    shutil.copy2(TACH_CONFIG, project_root / "tach.toml")
-
-    effects_path = project_root / "src" / "mindroom" / "post_response_effects.py"
-    original_text = effects_path.read_text()
-    probe_import = (
-        "from mindroom.runtime_protocols import "
-        "_check_narrow_protocols_are_subsets_of_bot_runtime_view as _tach_probe_private_runtime_protocol\n"
-    )
-    effects_path.write_text(
-        original_text.replace(
-            "from mindroom.runtime_protocols import SupportsClientConfig  # noqa: TC001\n",
-            f"from mindroom.runtime_protocols import SupportsClientConfig  # noqa: TC001\n{probe_import}",
+            f"from __future__ import annotations\n\n{runtime_protocol_probe}",
         ),
     )
 
@@ -365,22 +310,40 @@ def test_tach_rejects_private_runtime_protocol_import(tmp_path: Path) -> None:
     output = result.stdout + result.stderr
     assert result.returncode == 1, output
     assert RUNTIME_PROTOCOL_MODULE in output
-    assert RUNTIME_PROTOCOL_PRIVATE_SYMBOL in output
 
 
-def test_tach_rejects_forbidden_bot_runtime_view_import(tmp_path: Path) -> None:
-    """A direct full-runtime import must fail Tach outside the owning bot shell."""
+def test_tach_rejects_forbidden_boundary_imports(tmp_path: Path) -> None:
+    """One negative project must prove the remaining split-runtime boundaries."""
     project_root = tmp_path / "project"
     shutil.copytree(REPO_ROOT / "src", project_root / "src")
     shutil.copy2(TACH_CONFIG, project_root / "tach.toml")
 
-    effects_path = project_root / "src" / "mindroom" / "post_response_effects.py"
-    original_text = effects_path.read_text()
-    probe_import = "from mindroom.bot_runtime_view import BotRuntimeView as _tach_probe_runtime_view\n"
-    effects_path.write_text(
+    attachments_path = project_root / "src" / "mindroom" / "custom_tools" / "attachments.py"
+    original_text = attachments_path.read_text()
+    split_client_probe = (
+        "from mindroom.matrix.client_session import _create_matrix_client as _tach_probe_private_client_session\n"
+    )
+    attachments_path.write_text(
         original_text.replace(
+            "from mindroom.matrix.client_delivery import send_file_message\n",
+            f"{split_client_probe}from mindroom.matrix.client_delivery import send_file_message\n",
+        ),
+    )
+
+    effects_path = project_root / "src" / "mindroom" / "post_response_effects.py"
+    original_effects_text = effects_path.read_text()
+    private_protocol_probe = (
+        "from mindroom.runtime_protocols import "
+        "_check_narrow_protocols_are_subsets_of_bot_runtime_view as _tach_probe_private_runtime_protocol\n"
+    )
+    runtime_view_probe = "from mindroom.bot_runtime_view import BotRuntimeView as _tach_probe_runtime_view\n"
+    effects_path.write_text(
+        original_effects_text.replace(
             "from __future__ import annotations\n\n",
-            f"from __future__ import annotations\n\n{probe_import}",
+            f"from __future__ import annotations\n\n{runtime_view_probe}",
+        ).replace(
+            "from mindroom.runtime_protocols import SupportsClientConfig  # noqa: TC001\n",
+            f"from mindroom.runtime_protocols import SupportsClientConfig  # noqa: TC001\n{private_protocol_probe}",
         ),
     )
 
@@ -392,8 +355,12 @@ def test_tach_rejects_forbidden_bot_runtime_view_import(tmp_path: Path) -> None:
         text=True,
     )
 
-    assert result.returncode == 1, result.stdout + result.stderr
-    assert BOT_RUNTIME_VIEW_MODULE in (result.stdout + result.stderr)
+    output = result.stdout + result.stderr
+    assert result.returncode == 1, output
+    assert "mindroom.matrix.client_session" in output
+    assert RUNTIME_PROTOCOL_MODULE in output
+    assert RUNTIME_PROTOCOL_PRIVATE_SYMBOL in output
+    assert BOT_RUNTIME_VIEW_MODULE in output
 
 
 def test_ty_rejects_runtime_view_missing_structural_member(tmp_path: Path) -> None:

--- a/tests/test_tach_split_matrix_client_boundaries.py
+++ b/tests/test_tach_split_matrix_client_boundaries.py
@@ -147,7 +147,7 @@ def _walk_runtime_nodes(
 
 @functools.cache
 def _parsed_python_module(py_path: Path) -> ast.Module:
-    return ast.parse(py_path.read_text())
+    return ast.parse(py_path.read_text(encoding="utf-8"))
 
 
 def _runtime_direct_imports(py_path: Path, importer_module: str, target_modules: set[str]) -> set[str]:

--- a/tests/test_tool_config_sync.py
+++ b/tests/test_tool_config_sync.py
@@ -5,15 +5,17 @@ from types import UnionType
 from typing import Union, get_args, get_origin, get_type_hints
 
 import pytest
+from agno.tools import Toolkit
 from agno.tools.dalle import DalleTools
 
 # Import tools to ensure they're registered
 import mindroom.tools  # noqa: F401
 from mindroom.constants import RuntimePaths
-from mindroom.tool_system.metadata import TOOL_METADATA, TOOL_REGISTRY, ToolManagedInitArg
+from mindroom.tool_system.declarations import ToolManagedInitArg, ToolStatus
+from mindroom.tool_system.metadata import TOOL_METADATA, TOOL_REGISTRY
 from mindroom.tool_system.worker_routing import ResolvedWorkerTarget
 
-SKIP_CUSTOM = {
+SKIP_CONFIG_FIELD_VALIDATION = {
     "agent_vault_access",
     "homeassistant",
     "gmail",
@@ -22,6 +24,7 @@ SKIP_CUSTOM = {
     "google_sheets",
     "openclaw_compat",
 }
+OPTIONAL_TOOL_IMPORTS = frozenset({"scrapegraph", "telegram"})
 IGNORED_AGNO_PARAMS = {
     # Agno still exposes deprecated BigQuery aliases in its constructor, but MindRoom intentionally only surfaces canonical flags.
     "google_bigquery": {"enable_list_tables", "enable_describe_table", "enable_run_sql_query"},
@@ -46,34 +49,61 @@ def test_dalle_default_model_is_accepted_by_agno() -> None:
 
 
 @pytest.mark.parametrize("tool_name", list(TOOL_REGISTRY.keys()))
-def test_all(tool_name: str) -> None:
-    """Test that all tools have matching ConfigFields and agno parameters."""
-    if tool_name in SKIP_CUSTOM:
-        pytest.skip(f"{tool_name} is a custom tool, skipping test")
+def test_registered_tool_contract(tool_name: str) -> None:
+    """Validate one registered tool's import, managed inputs, and authored config fields."""
+    metadata = TOOL_METADATA[tool_name]
     tool_factory = TOOL_REGISTRY[tool_name]
     try:
         tool_class = tool_factory()
-    except NotImplementedError:
-        pytest.skip(f"{tool_name} tool is not implemented, skipping test")
-    except ImportError as e:
-        pytest.skip(f"{tool_name} dependency not installed: {e}")
-    except RuntimeError as e:
-        if tool_name == "openbb" and ".build.lock" in str(e):
-            pytest.skip(f"{tool_name} import is transiently locked by upstream build process: {e}")
+    except Exception as exc:
+        if isinstance(exc, ImportError) and tool_name in OPTIONAL_TOOL_IMPORTS:
+            pytest.skip(f"{tool_name} optional dependency not installed: {exc}")
+        if isinstance(exc, NotImplementedError):
+            pytest.skip(f"{tool_name} tool is not implemented: {exc}")
+        if isinstance(exc, RuntimeError) and tool_name == "openbb" and ".build.lock" in str(exc):
+            pytest.skip(f"{tool_name} import is transiently locked by upstream build process: {exc}")
         raise
-    verify_tool_configfields(tool_name, tool_class)
+
+    assert isinstance(tool_class, type)
+    if metadata.status != ToolStatus.REQUIRES_CONFIG:
+        assert issubclass(tool_class, Toolkit)
+
+    init_signature = inspect.signature(tool_class.__init__)
+    verify_managed_init_args(tool_name, init_signature)
+    if tool_name not in SKIP_CONFIG_FIELD_VALIDATION:
+        verify_tool_configfields(tool_name, tool_class, init_signature)
 
 
-def verify_tool_configfields(tool_name: str, tool_class: type) -> None:  # noqa: C901, PLR0912, PLR0915
+def verify_managed_init_args(tool_name: str, init_signature: inspect.Signature) -> None:
+    """Verify one tool explicitly declares every MindRoom-managed constructor input."""
+    metadata = TOOL_METADATA[tool_name]
+    managed_arg_names = {managed_arg.value for managed_arg in ToolManagedInitArg}
+    constructor_param_names = {name for name in init_signature.parameters if name != "self"}
+    expected_managed_args = tuple(
+        managed_arg for managed_arg in ToolManagedInitArg if managed_arg.value in constructor_param_names
+    )
+
+    assert metadata.managed_init_args == expected_managed_args, (
+        f"{tool_name} declares constructor inputs "
+        f"{sorted(constructor_param_names & managed_arg_names)} but metadata lists "
+        f"{[managed_arg.value for managed_arg in metadata.managed_init_args]}"
+    )
+
+
+def verify_tool_configfields(  # noqa: C901, PLR0912, PLR0915
+    tool_name: str,
+    tool_class: type,
+    init_signature: inspect.Signature,
+) -> None:
     """Verify tool ConfigFields match agno tool parameters.
 
     Args:
         tool_name: Name of the tool in the registry
         tool_class: The agno tool class to check against
+        init_signature: Constructor signature shared with managed-input validation
 
     """
     # Get the actual parameters from agno
-    sig = inspect.signature(tool_class.__init__)
     resolved_type_hints = get_type_hints(
         tool_class.__init__,
         globalns=tool_class.__init__.__globals__
@@ -84,7 +114,7 @@ def verify_tool_configfields(tool_name: str, tool_class: type) -> None:  # noqa:
     )
     agno_params = {}
 
-    for name, param in sig.parameters.items():
+    for name, param in init_signature.parameters.items():
         if name == "self":
             continue
         # Skip **kwargs as it's for forward compatibility

--- a/tests/test_tool_config_sync.py
+++ b/tests/test_tool_config_sync.py
@@ -56,12 +56,14 @@ def test_registered_tool_contract(tool_name: str) -> None:
     try:
         tool_class = tool_factory()
     except Exception as exc:
-        if isinstance(exc, ImportError) and tool_name in OPTIONAL_TOOL_IMPORTS:
+        if (
+            metadata.status == ToolStatus.REQUIRES_CONFIG
+            and isinstance(exc, ImportError)
+            and tool_name in OPTIONAL_TOOL_IMPORTS
+        ):
             pytest.skip(f"{tool_name} optional dependency not installed: {exc}")
-        if isinstance(exc, NotImplementedError):
+        if metadata.status == ToolStatus.REQUIRES_CONFIG and isinstance(exc, NotImplementedError):
             pytest.skip(f"{tool_name} tool is not implemented: {exc}")
-        if isinstance(exc, RuntimeError) and tool_name == "openbb" and ".build.lock" in str(exc):
-            pytest.skip(f"{tool_name} import is transiently locked by upstream build process: {exc}")
         raise
 
     assert isinstance(tool_class, type)

--- a/tests/test_tool_dependencies.py
+++ b/tests/test_tool_dependencies.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-from agno.tools import Toolkit
 
 from mindroom.constants import resolve_runtime_paths
 from mindroom.tool_system.declarations import SetupType, ToolCategory, ToolMetadata, ToolStatus
@@ -47,29 +46,6 @@ def _base_dependency_names() -> set[str]:
             name = name.split(separator, 1)[0]
         dependency_names.add(name.lower().replace("_", "-"))
     return dependency_names
-
-
-def test_all_tools_can_be_imported() -> None:
-    """Test that all registered tools can be imported from the registry."""
-    failed = []
-
-    for tool_name, factory in TOOL_REGISTRY.items():
-        metadata = TOOL_METADATA.get(tool_name)
-        requires_config = metadata and metadata.status == ToolStatus.REQUIRES_CONFIG
-
-        try:
-            tool_class = factory()
-            assert isinstance(tool_class, type)
-            assert issubclass(tool_class, Toolkit)
-        except Exception as e:
-            if not requires_config:
-                failed.append((tool_name, str(e)))
-
-    if failed:
-        error_msg = "\nThe following tools failed:\n"
-        for tool_name, error in failed:
-            error_msg += f"  - {tool_name}: {error}\n"
-        pytest.fail(error_msg)
 
 
 @pytest.mark.parametrize("existing_value", [None, "true"])

--- a/tests/test_tools_metadata.py
+++ b/tests/test_tools_metadata.py
@@ -1,7 +1,6 @@
 """Test tool metadata JSON snapshot for dashboard consumption."""
 
 import gc
-import inspect
 import json
 import sys
 from dataclasses import replace
@@ -56,8 +55,6 @@ from mindroom.tools.custom_api import custom_api_tools
 
 _BASE_TOOL_REGISTRY = TOOL_REGISTRY.copy()
 _BASE_TOOL_METADATA = TOOL_METADATA.copy()
-_SKIP_PARALLEL_FACTORY_IMPORTS = {"daytona", "openbb"}
-_OPTIONAL_TOOL_IMPORTS = frozenset({"scrapegraph", "telegram"})
 
 
 def _restore_builtin_tool_metadata_state() -> None:
@@ -452,6 +449,11 @@ def test_tool_metadata_consistency() -> None:
         assert metadata.category, f"Tool {tool_name} missing category"
         assert metadata.status, f"Tool {tool_name} missing status"
         assert metadata.setup_type, f"Tool {tool_name} missing setup_type"
+        if tool_name not in TOOL_REGISTRY:
+            assert metadata.managed_init_args == (), (
+                f"{tool_name} is metadata-only and should not declare managed init args: "
+                f"{[managed_arg.value for managed_arg in metadata.managed_init_args]}"
+            )
 
 
 def test_dynamic_tools_is_durable_metadata_only_builtin(tmp_path: Path) -> None:
@@ -486,41 +488,6 @@ def test_tool_metadata_does_not_advertise_env_var_fallbacks() -> None:
             lowered = text.lower()
             assert not any(phrase in lowered for phrase in forbidden_phrases), (
                 f"Tool metadata for {tool_name} still advertises env fallback: {text}"
-            )
-
-
-@pytest.mark.timeout(180)
-def test_registered_tools_declare_managed_init_args_for_explicit_constructor_inputs() -> None:
-    """Built-in tools must opt in explicitly instead of relying on hidden constructor inference."""
-    managed_arg_names = {managed_arg.value for managed_arg in ToolManagedInitArg}
-
-    for tool_name, tool_factory in TOOL_REGISTRY.items():
-        metadata = TOOL_METADATA[tool_name]
-        if tool_name in _SKIP_PARALLEL_FACTORY_IMPORTS:
-            continue
-        try:
-            tool_class = tool_factory()
-        except ImportError as exc:
-            if tool_name in _OPTIONAL_TOOL_IMPORTS:
-                continue
-            msg = f"Unexpected ImportError while loading tool {tool_name}: {exc}"
-            pytest.fail(msg)
-        init_signature = inspect.signature(tool_class.__init__)
-        constructor_param_names = {name for name in init_signature.parameters if name != "self"}
-        expected_managed_args = tuple(
-            managed_arg for managed_arg in ToolManagedInitArg if managed_arg.value in constructor_param_names
-        )
-        assert metadata.managed_init_args == expected_managed_args, (
-            f"{tool_name} declares constructor inputs "
-            f"{sorted(constructor_param_names & managed_arg_names)} but metadata lists "
-            f"{[managed_arg.value for managed_arg in metadata.managed_init_args]}"
-        )
-
-    for tool_name, metadata in TOOL_METADATA.items():
-        if tool_name not in TOOL_REGISTRY:
-            assert metadata.managed_init_args == (), (
-                f"{tool_name} is metadata-only and should not declare managed init args: "
-                f"{[managed_arg.value for managed_arg in metadata.managed_init_args]}"
             )
 
 

--- a/tests/test_voice_bot_threading.py
+++ b/tests/test_voice_bot_threading.py
@@ -566,9 +566,13 @@ async def test_voice_message_signals_active_turn_before_stt(mock_home_bot: Agent
     prepare_started = asyncio.Event()
     allow_prepare = asyncio.Event()
 
-    async def prepare_voice_event(*_args: object, **_kwargs: object) -> None:
+    async def prepare_voice_event(
+        *_args: object,
+        **_kwargs: object,
+    ) -> inbound_turn_normalizer._VoiceNormalizationResult:
         prepare_started.set()
         await allow_prepare.wait()
+        return _normalized_voice_result(event=voice_event, text="voice transcript")
 
     turn_active = True
     queued_signal.begin_response_turn()


### PR DESCRIPTION
## Summary

- make normal root and SaaS pytest runs quiet and remove automatic coverage instrumentation while preserving uncapped `-n auto`
- keep coverage available through explicit terminal-only Just recipes
- isolate incidental Structlog output so production logging setup cannot leak expensive renderers between tests
- replace fixed sleeps and random watchdog jitter with immediate backgrounding, polling, and event-driven synchronization
- consolidate duplicate heavyweight tool-import, import-graph, and Tach checks without dropping their contracts
- strengthen stale-runtime, cleanup-log, tool-factory, and frontend request-order regressions
- make `run-tests.sh` fail fast across the standard core Python, core frontend, SaaS backend, SaaS frontend, and API-command suites

## Performance

Measured on the same worktree and machine:

- root pytest wall time: 152.38s -> 50.21s
- pytest-reported runtime: 131.80s -> 46.82s
- wall-time reduction: 67 percent, about 3.0x faster

## Validation

- root pytest on the PR head based on current main: 9497 passed, 54 skipped
- core frontend: 491 passed, 1 skipped
- SaaS backend: 411 passed, 5 skipped
- SaaS frontend: 209 passed
- SaaS API command test: 1 passed
- nightly soak: passed
- pre-commit run --all-files: passed
- Tach dependency and interface checks: passed