### PR TITLE
Fix orphaned Claude tool-search replay

### DIFF
--- a/src/mindroom/claude_prompt_cache.py
+++ b/src/mindroom/claude_prompt_cache.py
@@ -39,12 +39,12 @@ deferred sorted by name). Deferred tools may not carry ``cache_control`` (the
 API rejects the request), which is why the ladder's tools marker targets the
 last non-deferred tool.
 
-The hook's third job is history repair: replayed tool-search result blocks
-are stripped down to the request schema on every request, because Agno
-persists the response-shape block verbatim and the API rejects its extra
-fields as a 400. This is why the client proxy is installed unconditionally —
-the ladder and defer tagging gate themselves per request, but a cache-disabled
-model with no deferred tools can still replay poisoned history.
+The hook's third job is history repair: replayed tool-search results are
+stripped down to the request schema, and search uses missing their result are
+removed. Both response shapes otherwise produce a 400 on the next request.
+This is why the client proxy is installed unconditionally — the ladder and
+defer tagging gate themselves per request, but a cache-disabled model with no
+deferred tools can still replay poisoned history.
 """
 
 from __future__ import annotations
@@ -69,6 +69,7 @@ _TOOL_SEARCH_TOOL_TYPE = "tool_search_tool_regex_20251119"
 _TOOL_SEARCH_TOOL_NAME = "tool_search_tool_regex"
 _NATIVE_TOOL_SEARCH_PROVIDERS = frozenset({"anthropic", "vertexai_claude"})
 
+_SERVER_TOOL_USE_BLOCK_TYPE = "server_tool_use"
 _TOOL_SEARCH_RESULT_BLOCK_TYPE = "tool_search_tool_result"
 # The request schema for replayed tool-search results accepts only these keys
 # (ToolSearchToolResultBlockParam); response blocks additionally carry
@@ -237,7 +238,7 @@ def _model_deferred_tool_names(model: AnthropicClaude) -> frozenset[str]:
 
 
 def _request_kwargs_with_replay_safe_tool_search_results(request_kwargs: dict[str, Any]) -> dict[str, Any]:
-    """Strip response-only fields from replayed tool-search result blocks.
+    """Repair replayed tool-search blocks before sending assistant history.
 
     Agno replays captured server-tool blocks verbatim in assistant history,
     and the SDK response block carries fields (``citations``, ``parsed_output``,
@@ -245,7 +246,13 @@ def _request_kwargs_with_replay_safe_tool_search_results(request_kwargs: dict[st
     not permitted"). Once such a block is persisted, every later turn of that
     conversation replays it, so the thread stays broken until the block is
     sanitized here. Keys used for history identity (``type``, ``tool_use_id``)
-    are preserved. The input structure is never mutated.
+    are preserved.
+
+    Anthropic can also return a ``server_tool_use`` without its matching
+    ``tool_search_tool_result`` when native search and client tools are called
+    together. Replaying that orphan produces another 400. Drop only unmatched
+    regex-search uses; valid pairs and other server-tool types remain intact.
+    The input structure is never mutated.
     """
     messages = request_kwargs.get("messages")
     if not isinstance(messages, list):
@@ -257,18 +264,38 @@ def _request_kwargs_with_replay_safe_tool_search_results(request_kwargs: dict[st
         content = message_dict.get("content") if message_dict is not None else None
         if message_dict is None or not isinstance(content, list):
             continue
-        sanitized_content = list(content)
+        paired_result_ids = {
+            tool_use_id
+            for block in content
+            if (block_dict := _as_dict(block)) is not None
+            and block_dict.get("type") == _TOOL_SEARCH_RESULT_BLOCK_TYPE
+            and isinstance(tool_use_id := block_dict.get("tool_use_id"), str)
+        }
+        sanitized_content: list[Any] = []
         content_changed = False
-        for block_index, block in enumerate(sanitized_content):
+        for block in content:
             block_dict = _as_dict(block)
-            if block_dict is None or block_dict.get("type") != _TOOL_SEARCH_RESULT_BLOCK_TYPE:
+            if block_dict is None:
+                sanitized_content.append(block)
                 continue
-            if set(block_dict) <= _TOOL_SEARCH_RESULT_INPUT_KEYS:
+            block_id = block_dict.get("id")
+            if (
+                block_dict.get("type") == _SERVER_TOOL_USE_BLOCK_TYPE
+                and block_dict.get("name") == _TOOL_SEARCH_TOOL_NAME
+                and (not isinstance(block_id, str) or block_id not in paired_result_ids)
+            ):
+                content_changed = True
                 continue
-            sanitized_content[block_index] = {
-                key: value for key, value in block_dict.items() if key in _TOOL_SEARCH_RESULT_INPUT_KEYS
-            }
-            content_changed = True
+            if block_dict.get("type") == _TOOL_SEARCH_RESULT_BLOCK_TYPE and not (
+                set(block_dict) <= _TOOL_SEARCH_RESULT_INPUT_KEYS
+            ):
+                prepared_block = {
+                    key: value for key, value in block_dict.items() if key in _TOOL_SEARCH_RESULT_INPUT_KEYS
+                }
+                content_changed = True
+            else:
+                prepared_block = block
+            sanitized_content.append(prepared_block)
         if content_changed:
             sanitized_message = dict(message_dict)
             sanitized_message["content"] = sanitized_content
@@ -434,9 +461,8 @@ def install_claude_prompt_cache_hook(model: object) -> None:
     request inside ``_prepared``, so callers that deliberately disable caching
     (for example one-off summary calls) stay unmarked even when they reuse a
     hooked model instance. The proxy is never skipped outright because
-    replayed tool-search result blocks must be sanitized on every request —
-    a cache-disabled model with no deferred tools still replays poisoned
-    history.
+    replayed tool-search blocks must be repaired on every request — a
+    cache-disabled model with no deferred tools still replays poisoned history.
     """
     claude_model = as_anthropic_claude(model)
     if claude_model is None:

--- a/src/mindroom/claude_prompt_cache.py
+++ b/src/mindroom/claude_prompt_cache.py
@@ -237,6 +237,19 @@ def _model_deferred_tool_names(model: AnthropicClaude) -> frozenset[str]:
     return deferred_tool_names if isinstance(deferred_tool_names, frozenset) else frozenset()
 
 
+def _tool_search_result_ids(content: list[Any]) -> set[str]:
+    """Return tool-use IDs paired with search results in one message."""
+    result_ids: set[str] = set()
+    for block in content:
+        block_dict = _as_dict(block)
+        if block_dict is None or block_dict.get("type") != _TOOL_SEARCH_RESULT_BLOCK_TYPE:
+            continue
+        tool_use_id = block_dict.get("tool_use_id")
+        if isinstance(tool_use_id, str):
+            result_ids.add(tool_use_id)
+    return result_ids
+
+
 def _request_kwargs_with_replay_safe_tool_search_results(request_kwargs: dict[str, Any]) -> dict[str, Any]:
     """Repair replayed tool-search blocks before sending assistant history.
 
@@ -264,13 +277,7 @@ def _request_kwargs_with_replay_safe_tool_search_results(request_kwargs: dict[st
         content = message_dict.get("content") if message_dict is not None else None
         if message_dict is None or not isinstance(content, list):
             continue
-        paired_result_ids = {
-            tool_use_id
-            for block in content
-            if (block_dict := _as_dict(block)) is not None
-            and block_dict.get("type") == _TOOL_SEARCH_RESULT_BLOCK_TYPE
-            and isinstance(tool_use_id := block_dict.get("tool_use_id"), str)
-        }
+        paired_result_ids = _tool_search_result_ids(content)
         sanitized_content: list[Any] = []
         content_changed = False
         for block in content:
@@ -286,8 +293,9 @@ def _request_kwargs_with_replay_safe_tool_search_results(request_kwargs: dict[st
             ):
                 content_changed = True
                 continue
-            if block_dict.get("type") == _TOOL_SEARCH_RESULT_BLOCK_TYPE and not (
-                set(block_dict) <= _TOOL_SEARCH_RESULT_INPUT_KEYS
+            if (
+                block_dict.get("type") == _TOOL_SEARCH_RESULT_BLOCK_TYPE
+                and not block_dict.keys() <= _TOOL_SEARCH_RESULT_INPUT_KEYS
             ):
                 prepared_block = {
                     key: value for key, value in block_dict.items() if key in _TOOL_SEARCH_RESULT_INPUT_KEYS

--- a/tests/test_extra_kwargs.py
+++ b/tests/test_extra_kwargs.py
@@ -1224,6 +1224,7 @@ def test_replay_safe_tool_search_results_drops_only_orphaned_search_uses() -> No
     ]
     assert request_kwargs["messages"][0]["content"][0] == _ORPHAN_TOOL_SEARCH_USE_BLOCK
     assert "citations" in request_kwargs["messages"][0]["content"][3]
+    assert _request_kwargs_with_replay_safe_tool_search_results(prepared) is prepared
 
 
 @pytest.mark.asyncio

--- a/tests/test_extra_kwargs.py
+++ b/tests/test_extra_kwargs.py
@@ -1083,6 +1083,16 @@ _SERVER_TOOL_USE_BLOCK = {
     "name": "tool_search_tool_regex",
     "input": {"pattern": "weather"},
 }
+_ORPHAN_TOOL_SEARCH_USE_BLOCK = {
+    **_SERVER_TOOL_USE_BLOCK,
+    "id": "srvtoolu_01ORPHAN",
+}
+_OTHER_SERVER_TOOL_USE_BLOCK = {
+    "type": "server_tool_use",
+    "id": "srvtoolu_01OTHER",
+    "name": "web_search",
+    "input": {"query": "weather"},
+}
 _TOOL_SEARCH_RESULT_BLOCK = {
     "type": "tool_search_tool_result",
     "tool_use_id": "srvtoolu_01ABC",
@@ -1185,6 +1195,105 @@ def test_replay_safe_tool_search_results_strips_response_only_fields() -> None:
     assert prepared["messages"][0]["content"][1] == {"type": "text", "text": "found it"}
     assert "citations" in request_kwargs["messages"][0]["content"][0]
     assert _request_kwargs_with_replay_safe_tool_search_results(prepared) is prepared
+
+
+def test_replay_safe_tool_search_results_drops_only_orphaned_search_uses() -> None:
+    """Only regex-search uses missing a same-message result should be removed."""
+    request_kwargs = {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": [
+                    dict(_ORPHAN_TOOL_SEARCH_USE_BLOCK),
+                    dict(_OTHER_SERVER_TOOL_USE_BLOCK),
+                    dict(_SERVER_TOOL_USE_BLOCK),
+                    dict(_DIRTY_TOOL_SEARCH_RESULT_BLOCK),
+                    {"type": "text", "text": "found it"},
+                ],
+            },
+        ],
+    }
+
+    prepared = _request_kwargs_with_replay_safe_tool_search_results(request_kwargs)
+
+    assert prepared["messages"][0]["content"] == [
+        _OTHER_SERVER_TOOL_USE_BLOCK,
+        _SERVER_TOOL_USE_BLOCK,
+        _TOOL_SEARCH_RESULT_BLOCK,
+        {"type": "text", "text": "found it"},
+    ]
+    assert request_kwargs["messages"][0]["content"][0] == _ORPHAN_TOOL_SEARCH_USE_BLOCK
+    assert "citations" in request_kwargs["messages"][0]["content"][3]
+
+
+@pytest.mark.asyncio
+async def test_prompt_cache_hook_drops_orphaned_search_use_from_streaming_replay() -> None:
+    """Mixed client/server tool history must remain valid on the next streamed request."""
+    model = Claude(id="claude-opus-4-8", api_key="test-key", cache_system_prompt=False)
+    captured_kwargs: list[dict[str, object]] = []
+
+    class _EmptyAsyncStream:
+        async def __aenter__(self) -> object:
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+        def __aiter__(self) -> object:
+            return self
+
+        async def __anext__(self) -> object:
+            raise StopAsyncIteration
+
+    class _FakeAsyncMessagesAPI:
+        def stream(self, **kwargs: object) -> object:
+            captured_kwargs.append(kwargs)
+            return _EmptyAsyncStream()
+
+    class _FakeAsyncClient:
+        def __init__(self) -> None:
+            self.messages = _FakeAsyncMessagesAPI()
+
+    vars(model)["get_async_client"] = lambda: _FakeAsyncClient()
+    vars(model)["_prepare_request_kwargs"] = lambda *_args, **_kwargs: {}
+    vars(model)["_has_beta_features"] = lambda **_kwargs: False
+    install_claude_prompt_cache_hook(model)
+    messages = [
+        Message(role="user", content="Run the tool sweep."),
+        Message(
+            role="assistant",
+            content="Calling tools.",
+            tool_calls=[
+                {
+                    "id": "toolu_01CLIENT",
+                    "function": {"name": "demo_tool", "arguments": "{}"},
+                },
+            ],
+            provider_data={"server_tool_blocks": [dict(_ORPHAN_TOOL_SEARCH_USE_BLOCK)]},
+        ),
+        Message(role="tool", tool_call_id="toolu_01CLIENT", content="ok"),
+        Message(role="user", content="Continue."),
+    ]
+
+    responses = [
+        response
+        async for response in model.ainvoke_stream(
+            messages=messages,
+            assistant_message=Message(role="assistant"),
+        )
+    ]
+
+    assert responses == []
+    wire_messages = captured_kwargs[0]["messages"]
+    assistant_wire = next(message for message in wire_messages if message["role"] == "assistant")
+    assert not any(
+        isinstance(block, dict)
+        and block.get("type") == "server_tool_use"
+        and block.get("name") == "tool_search_tool_regex"
+        for block in assistant_wire["content"]
+    )
+    assert any(getattr(block, "type", None) == "tool_use" for block in assistant_wire["content"])
+    assert wire_messages[-1]["content"][0]["type"] == "tool_result"
 
 
 def _dirty_replay_messages() -> list[Message]:


### PR DESCRIPTION
## Summary

- repair replayed Claude tool-search history by dropping regex-search uses that have no matching result in the same assistant message
- preserve valid search pairs, unrelated server tools, client tool calls, and caller-owned request data
- add direct sanitizer coverage plus a regression test through the real async streaming wire path

## Why

Anthropic can emit client tool calls alongside server search uses without returning matching search results. Replaying those orphaned uses causes the next request to fail with a 400. Repair now runs in the existing unconditional Claude request hook before caching and deferred-tool preparation.

## Validation

- `uv run pytest` (9500 passed, 64 skipped)
- `uv run pre-commit run --all-files`
- `uv run tach check --dependencies --interfaces`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved replayed tool-search history repair by removing unmatched server tool-use entries.
  * Prevented response-only fields from being replayed in tool-search result history.
  * Preserved valid tool-use and tool-result entries while filtering only orphaned search records.
  * Fixed streaming requests to avoid emitting orphaned tool-search entries.

* **Documentation**
  * Clarified prompt-cache behavior and history repair scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->