### PR TITLE
Document OpenRouter provider routing via extra_kwargs.extra_body

### DIFF
--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -155,6 +155,30 @@ Live testing against the Codex subscription endpoint reported `cached_tokens` on
 Repeated long requests then reported cache hits, while requests without those headers stayed at `cached_tokens: 0`, and `prompt_cache_retention` was rejected.
 Treat Codex prompt caching as best-effort rather than guaranteed.
 
+## OpenRouter Provider Routing
+
+Use `provider: openrouter` to reach many hosted models through a single API key.
+OpenRouter routes each request to one of several upstream providers serving that model, often including quantized (fp8/fp4) third-party deployments.
+Upstream quality varies: we have seen a third-party upstream leak raw model tool-call markup (DeepSeek `<|DSML|>` tokens) into visible replies when a tool call contained heavily nested quoting, and quantized hosts can degrade tool-calling reliability in general.
+Pin routing to trusted upstreams with OpenRouter [provider preferences](https://openrouter.ai/docs/features/provider-routing), passed through `extra_kwargs.extra_body`:
+
+```yaml
+models:
+  deepseek:
+    provider: openrouter
+    id: deepseek/deepseek-v4-pro
+    context_window: 1048576
+    extra_kwargs:
+      extra_body:
+        provider:
+          order: [deepseek]        # upstreams to try, in order
+          allow_fallbacks: false   # fail instead of routing to unlisted upstreams
+```
+
+Provider slugs are listed on each model's Providers tab on openrouter.ai, or in the `tag` field of `https://openrouter.ai/api/v1/models/<model-id>/endpoints`.
+With `allow_fallbacks: false`, requests fail when every listed upstream is down or rate-limited, instead of silently degrading to an unvetted host; for agents doing heavy tool calling we recommend this trade-off.
+A softer alternative is `require_parameters: true`, which keeps fallbacks but only routes to upstreams that support every request parameter, including tools.
+
 ## Azure OpenAI
 
 Use `provider: azure` when your model is deployed through Azure OpenAI.
@@ -230,6 +254,7 @@ The `extra_kwargs` field passes additional parameters directly to the underlying
 - `base_url` - Custom API endpoint (useful for OpenAI-compatible servers)
 - `temperature` - Sampling temperature
 - `max_tokens` - Maximum tokens in response
+- `extra_body` - Extra JSON body fields for OpenAI-compatible providers (e.g., OpenRouter provider routing above)
 
 ## Environment Variables
 

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -157,10 +157,8 @@ Treat Codex prompt caching as best-effort rather than guaranteed.
 
 ## OpenRouter Provider Routing
 
-Use `provider: openrouter` to reach many hosted models through a single API key.
-OpenRouter routes each request to one of several upstream providers serving that model, often including quantized (fp8/fp4) third-party deployments.
-Upstream quality varies: we have seen a third-party upstream leak raw model tool-call markup (DeepSeek `<|DSML|>` tokens) into visible replies when a tool call contained heavily nested quoting, and quantized hosts can degrade tool-calling reliability in general.
-Pin routing to trusted upstreams with OpenRouter [provider preferences](https://openrouter.ai/docs/features/provider-routing), passed through `extra_kwargs.extra_body`:
+OpenRouter routes each request to one of several upstream providers serving the model, and upstream quality varies (we have seen a third-party host leak raw tool-call markup into a visible reply).
+Control routing by passing OpenRouter [provider preferences](https://openrouter.ai/docs/features/provider-routing) through `extra_kwargs.extra_body`:
 
 ```yaml
 models:
@@ -171,31 +169,14 @@ models:
     extra_kwargs:
       extra_body:
         provider:
-          order: [fireworks, together]  # upstreams to try, in order
-          allow_fallbacks: false        # fail instead of routing to unlisted upstreams
+          sort: price                     # cheapest available endpoint
+          # order: [fireworks, together]  # or pin specific upstreams, in order
+          # allow_fallbacks: false        # fail instead of using unlisted upstreams
 ```
 
-Provider slugs are listed on each model's Providers tab on openrouter.ai, or in the `tag` field of `https://openrouter.ai/api/v1/models/<model-id>/endpoints`.
-With `allow_fallbacks: false`, requests fail when every listed upstream is down or rate-limited, instead of silently degrading to an unvetted host; for agents doing heavy tool calling we recommend this trade-off.
-A softer alternative is `require_parameters: true`, which keeps fallbacks but only routes to upstreams that support every request parameter, including tools.
-When cost matters more than picking specific upstreams, use `sort: price` instead of `order` to always route to the cheapest endpoint your account can reach, optionally with an `ignore:` list to exclude upstreams that have misbehaved:
-
-```yaml
-    extra_kwargs:
-      extra_body:
-        provider:
-          sort: price
-```
-
-Account-level OpenRouter settings (ignored providers and data-policy filters) are applied on top of request preferences and cannot be overridden per request, so a pinned upstream that your account excludes yields `No endpoints found` errors when `allow_fallbacks` is `false`.
-Always verify a new pin with a direct test request and confirm the `provider` field in the response before relying on it:
-
-```bash
-curl -s https://openrouter.ai/api/v1/chat/completions \
-  -H "Authorization: Bearer $OPENROUTER_API_KEY" -H "Content-Type: application/json" \
-  -d '{"model": "deepseek/deepseek-v4-pro", "messages": [{"role": "user", "content": "Say OK"}],
-       "max_tokens": 5, "provider": {"order": ["fireworks", "together"], "allow_fallbacks": false}}'
-```
+Provider slugs are in the `tag` field of `https://openrouter.ai/api/v1/models/<model-id>/endpoints`.
+Account-level OpenRouter settings (ignored providers, data-policy filters) still apply and cannot be overridden per request, so pinning an upstream your account excludes fails with `No endpoints found`.
+Verify a new pin with a direct API test request and check the `provider` field in the response.
 
 ## Azure OpenAI
 

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -171,13 +171,31 @@ models:
     extra_kwargs:
       extra_body:
         provider:
-          order: [deepseek]        # upstreams to try, in order
-          allow_fallbacks: false   # fail instead of routing to unlisted upstreams
+          order: [fireworks, together]  # upstreams to try, in order
+          allow_fallbacks: false        # fail instead of routing to unlisted upstreams
 ```
 
 Provider slugs are listed on each model's Providers tab on openrouter.ai, or in the `tag` field of `https://openrouter.ai/api/v1/models/<model-id>/endpoints`.
 With `allow_fallbacks: false`, requests fail when every listed upstream is down or rate-limited, instead of silently degrading to an unvetted host; for agents doing heavy tool calling we recommend this trade-off.
 A softer alternative is `require_parameters: true`, which keeps fallbacks but only routes to upstreams that support every request parameter, including tools.
+When cost matters more than picking specific upstreams, use `sort: price` instead of `order` to always route to the cheapest endpoint your account can reach, optionally with an `ignore:` list to exclude upstreams that have misbehaved:
+
+```yaml
+    extra_kwargs:
+      extra_body:
+        provider:
+          sort: price
+```
+
+Account-level OpenRouter settings (ignored providers and data-policy filters) are applied on top of request preferences and cannot be overridden per request, so a pinned upstream that your account excludes yields `No endpoints found` errors when `allow_fallbacks` is `false`.
+Always verify a new pin with a direct test request and confirm the `provider` field in the response before relying on it:
+
+```bash
+curl -s https://openrouter.ai/api/v1/chat/completions \
+  -H "Authorization: Bearer $OPENROUTER_API_KEY" -H "Content-Type: application/json" \
+  -d '{"model": "deepseek/deepseek-v4-pro", "messages": [{"role": "user", "content": "Say OK"}],
+       "max_tokens": 5, "provider": {"order": ["fireworks", "together"], "allow_fallbacks": false}}'
+```
 
 ## Azure OpenAI
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -2384,6 +2384,30 @@ Live testing against the Codex subscription endpoint reported `cached_tokens` on
 Repeated long requests then reported cache hits, while requests without those headers stayed at `cached_tokens: 0`, and `prompt_cache_retention` was rejected.
 Treat Codex prompt caching as best-effort rather than guaranteed.
 
+## OpenRouter Provider Routing
+
+Use `provider: openrouter` to reach many hosted models through a single API key.
+OpenRouter routes each request to one of several upstream providers serving that model, often including quantized (fp8/fp4) third-party deployments.
+Upstream quality varies: we have seen a third-party upstream leak raw model tool-call markup (DeepSeek `<|DSML|>` tokens) into visible replies when a tool call contained heavily nested quoting, and quantized hosts can degrade tool-calling reliability in general.
+Pin routing to trusted upstreams with OpenRouter [provider preferences](https://openrouter.ai/docs/features/provider-routing), passed through `extra_kwargs.extra_body`:
+
+```yaml
+models:
+  deepseek:
+    provider: openrouter
+    id: deepseek/deepseek-v4-pro
+    context_window: 1048576
+    extra_kwargs:
+      extra_body:
+        provider:
+          order: [deepseek]        # upstreams to try, in order
+          allow_fallbacks: false   # fail instead of routing to unlisted upstreams
+```
+
+Provider slugs are listed on each model's Providers tab on openrouter.ai, or in the `tag` field of `https://openrouter.ai/api/v1/models/<model-id>/endpoints`.
+With `allow_fallbacks: false`, requests fail when every listed upstream is down or rate-limited, instead of silently degrading to an unvetted host; for agents doing heavy tool calling we recommend this trade-off.
+A softer alternative is `require_parameters: true`, which keeps fallbacks but only routes to upstreams that support every request parameter, including tools.
+
 ## Azure OpenAI
 
 Use `provider: azure` when your model is deployed through Azure OpenAI.
@@ -2459,6 +2483,7 @@ The `extra_kwargs` field passes additional parameters directly to the underlying
 - `base_url` - Custom API endpoint (useful for OpenAI-compatible servers)
 - `temperature` - Sampling temperature
 - `max_tokens` - Maximum tokens in response
+- `extra_body` - Extra JSON body fields for OpenAI-compatible providers (e.g., OpenRouter provider routing above)
 
 ## Environment Variables
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -2400,13 +2400,31 @@ models:
     extra_kwargs:
       extra_body:
         provider:
-          order: [deepseek]        # upstreams to try, in order
-          allow_fallbacks: false   # fail instead of routing to unlisted upstreams
+          order: [fireworks, together]  # upstreams to try, in order
+          allow_fallbacks: false        # fail instead of routing to unlisted upstreams
 ```
 
 Provider slugs are listed on each model's Providers tab on openrouter.ai, or in the `tag` field of `https://openrouter.ai/api/v1/models/<model-id>/endpoints`.
 With `allow_fallbacks: false`, requests fail when every listed upstream is down or rate-limited, instead of silently degrading to an unvetted host; for agents doing heavy tool calling we recommend this trade-off.
 A softer alternative is `require_parameters: true`, which keeps fallbacks but only routes to upstreams that support every request parameter, including tools.
+When cost matters more than picking specific upstreams, use `sort: price` instead of `order` to always route to the cheapest endpoint your account can reach, optionally with an `ignore:` list to exclude upstreams that have misbehaved:
+
+```yaml
+    extra_kwargs:
+      extra_body:
+        provider:
+          sort: price
+```
+
+Account-level OpenRouter settings (ignored providers and data-policy filters) are applied on top of request preferences and cannot be overridden per request, so a pinned upstream that your account excludes yields `No endpoints found` errors when `allow_fallbacks` is `false`.
+Always verify a new pin with a direct test request and confirm the `provider` field in the response before relying on it:
+
+```bash
+curl -s https://openrouter.ai/api/v1/chat/completions \
+  -H "Authorization: Bearer $OPENROUTER_API_KEY" -H "Content-Type: application/json" \
+  -d '{"model": "deepseek/deepseek-v4-pro", "messages": [{"role": "user", "content": "Say OK"}],
+       "max_tokens": 5, "provider": {"order": ["fireworks", "together"], "allow_fallbacks": false}}'
+```
 
 ## Azure OpenAI
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -2386,10 +2386,8 @@ Treat Codex prompt caching as best-effort rather than guaranteed.
 
 ## OpenRouter Provider Routing
 
-Use `provider: openrouter` to reach many hosted models through a single API key.
-OpenRouter routes each request to one of several upstream providers serving that model, often including quantized (fp8/fp4) third-party deployments.
-Upstream quality varies: we have seen a third-party upstream leak raw model tool-call markup (DeepSeek `<|DSML|>` tokens) into visible replies when a tool call contained heavily nested quoting, and quantized hosts can degrade tool-calling reliability in general.
-Pin routing to trusted upstreams with OpenRouter [provider preferences](https://openrouter.ai/docs/features/provider-routing), passed through `extra_kwargs.extra_body`:
+OpenRouter routes each request to one of several upstream providers serving the model, and upstream quality varies (we have seen a third-party host leak raw tool-call markup into a visible reply).
+Control routing by passing OpenRouter [provider preferences](https://openrouter.ai/docs/features/provider-routing) through `extra_kwargs.extra_body`:
 
 ```yaml
 models:
@@ -2400,31 +2398,14 @@ models:
     extra_kwargs:
       extra_body:
         provider:
-          order: [fireworks, together]  # upstreams to try, in order
-          allow_fallbacks: false        # fail instead of routing to unlisted upstreams
+          sort: price                     # cheapest available endpoint
+          # order: [fireworks, together]  # or pin specific upstreams, in order
+          # allow_fallbacks: false        # fail instead of using unlisted upstreams
 ```
 
-Provider slugs are listed on each model's Providers tab on openrouter.ai, or in the `tag` field of `https://openrouter.ai/api/v1/models/<model-id>/endpoints`.
-With `allow_fallbacks: false`, requests fail when every listed upstream is down or rate-limited, instead of silently degrading to an unvetted host; for agents doing heavy tool calling we recommend this trade-off.
-A softer alternative is `require_parameters: true`, which keeps fallbacks but only routes to upstreams that support every request parameter, including tools.
-When cost matters more than picking specific upstreams, use `sort: price` instead of `order` to always route to the cheapest endpoint your account can reach, optionally with an `ignore:` list to exclude upstreams that have misbehaved:
-
-```yaml
-    extra_kwargs:
-      extra_body:
-        provider:
-          sort: price
-```
-
-Account-level OpenRouter settings (ignored providers and data-policy filters) are applied on top of request preferences and cannot be overridden per request, so a pinned upstream that your account excludes yields `No endpoints found` errors when `allow_fallbacks` is `false`.
-Always verify a new pin with a direct test request and confirm the `provider` field in the response before relying on it:
-
-```bash
-curl -s https://openrouter.ai/api/v1/chat/completions \
-  -H "Authorization: Bearer $OPENROUTER_API_KEY" -H "Content-Type: application/json" \
-  -d '{"model": "deepseek/deepseek-v4-pro", "messages": [{"role": "user", "content": "Say OK"}],
-       "max_tokens": 5, "provider": {"order": ["fireworks", "together"], "allow_fallbacks": false}}'
-```
+Provider slugs are in the `tag` field of `https://openrouter.ai/api/v1/models/<model-id>/endpoints`.
+Account-level OpenRouter settings (ignored providers, data-policy filters) still apply and cannot be overridden per request, so pinning an upstream your account excludes fails with `No endpoints found`.
+Verify a new pin with a direct API test request and check the `provider` field in the response.
 
 ## Azure OpenAI
 

--- a/skills/mindroom-docs/references/page__configuration__models__index.md
+++ b/skills/mindroom-docs/references/page__configuration__models__index.md
@@ -153,10 +153,8 @@ Treat Codex prompt caching as best-effort rather than guaranteed.
 
 ## OpenRouter Provider Routing
 
-Use `provider: openrouter` to reach many hosted models through a single API key.
-OpenRouter routes each request to one of several upstream providers serving that model, often including quantized (fp8/fp4) third-party deployments.
-Upstream quality varies: we have seen a third-party upstream leak raw model tool-call markup (DeepSeek `<|DSML|>` tokens) into visible replies when a tool call contained heavily nested quoting, and quantized hosts can degrade tool-calling reliability in general.
-Pin routing to trusted upstreams with OpenRouter [provider preferences](https://openrouter.ai/docs/features/provider-routing), passed through `extra_kwargs.extra_body`:
+OpenRouter routes each request to one of several upstream providers serving the model, and upstream quality varies (we have seen a third-party host leak raw tool-call markup into a visible reply).
+Control routing by passing OpenRouter [provider preferences](https://openrouter.ai/docs/features/provider-routing) through `extra_kwargs.extra_body`:
 
 ```yaml
 models:
@@ -167,31 +165,14 @@ models:
     extra_kwargs:
       extra_body:
         provider:
-          order: [fireworks, together]  # upstreams to try, in order
-          allow_fallbacks: false        # fail instead of routing to unlisted upstreams
+          sort: price                     # cheapest available endpoint
+          # order: [fireworks, together]  # or pin specific upstreams, in order
+          # allow_fallbacks: false        # fail instead of using unlisted upstreams
 ```
 
-Provider slugs are listed on each model's Providers tab on openrouter.ai, or in the `tag` field of `https://openrouter.ai/api/v1/models/<model-id>/endpoints`.
-With `allow_fallbacks: false`, requests fail when every listed upstream is down or rate-limited, instead of silently degrading to an unvetted host; for agents doing heavy tool calling we recommend this trade-off.
-A softer alternative is `require_parameters: true`, which keeps fallbacks but only routes to upstreams that support every request parameter, including tools.
-When cost matters more than picking specific upstreams, use `sort: price` instead of `order` to always route to the cheapest endpoint your account can reach, optionally with an `ignore:` list to exclude upstreams that have misbehaved:
-
-```yaml
-    extra_kwargs:
-      extra_body:
-        provider:
-          sort: price
-```
-
-Account-level OpenRouter settings (ignored providers and data-policy filters) are applied on top of request preferences and cannot be overridden per request, so a pinned upstream that your account excludes yields `No endpoints found` errors when `allow_fallbacks` is `false`.
-Always verify a new pin with a direct test request and confirm the `provider` field in the response before relying on it:
-
-```bash
-curl -s https://openrouter.ai/api/v1/chat/completions \
-  -H "Authorization: Bearer $OPENROUTER_API_KEY" -H "Content-Type: application/json" \
-  -d '{"model": "deepseek/deepseek-v4-pro", "messages": [{"role": "user", "content": "Say OK"}],
-       "max_tokens": 5, "provider": {"order": ["fireworks", "together"], "allow_fallbacks": false}}'
-```
+Provider slugs are in the `tag` field of `https://openrouter.ai/api/v1/models/<model-id>/endpoints`.
+Account-level OpenRouter settings (ignored providers, data-policy filters) still apply and cannot be overridden per request, so pinning an upstream your account excludes fails with `No endpoints found`.
+Verify a new pin with a direct API test request and check the `provider` field in the response.
 
 ## Azure OpenAI
 

--- a/skills/mindroom-docs/references/page__configuration__models__index.md
+++ b/skills/mindroom-docs/references/page__configuration__models__index.md
@@ -151,6 +151,30 @@ Live testing against the Codex subscription endpoint reported `cached_tokens` on
 Repeated long requests then reported cache hits, while requests without those headers stayed at `cached_tokens: 0`, and `prompt_cache_retention` was rejected.
 Treat Codex prompt caching as best-effort rather than guaranteed.
 
+## OpenRouter Provider Routing
+
+Use `provider: openrouter` to reach many hosted models through a single API key.
+OpenRouter routes each request to one of several upstream providers serving that model, often including quantized (fp8/fp4) third-party deployments.
+Upstream quality varies: we have seen a third-party upstream leak raw model tool-call markup (DeepSeek `<|DSML|>` tokens) into visible replies when a tool call contained heavily nested quoting, and quantized hosts can degrade tool-calling reliability in general.
+Pin routing to trusted upstreams with OpenRouter [provider preferences](https://openrouter.ai/docs/features/provider-routing), passed through `extra_kwargs.extra_body`:
+
+```yaml
+models:
+  deepseek:
+    provider: openrouter
+    id: deepseek/deepseek-v4-pro
+    context_window: 1048576
+    extra_kwargs:
+      extra_body:
+        provider:
+          order: [deepseek]        # upstreams to try, in order
+          allow_fallbacks: false   # fail instead of routing to unlisted upstreams
+```
+
+Provider slugs are listed on each model's Providers tab on openrouter.ai, or in the `tag` field of `https://openrouter.ai/api/v1/models/<model-id>/endpoints`.
+With `allow_fallbacks: false`, requests fail when every listed upstream is down or rate-limited, instead of silently degrading to an unvetted host; for agents doing heavy tool calling we recommend this trade-off.
+A softer alternative is `require_parameters: true`, which keeps fallbacks but only routes to upstreams that support every request parameter, including tools.
+
 ## Azure OpenAI
 
 Use `provider: azure` when your model is deployed through Azure OpenAI.
@@ -226,6 +250,7 @@ The `extra_kwargs` field passes additional parameters directly to the underlying
 - `base_url` - Custom API endpoint (useful for OpenAI-compatible servers)
 - `temperature` - Sampling temperature
 - `max_tokens` - Maximum tokens in response
+- `extra_body` - Extra JSON body fields for OpenAI-compatible providers (e.g., OpenRouter provider routing above)
 
 ## Environment Variables
 

--- a/skills/mindroom-docs/references/page__configuration__models__index.md
+++ b/skills/mindroom-docs/references/page__configuration__models__index.md
@@ -167,13 +167,31 @@ models:
     extra_kwargs:
       extra_body:
         provider:
-          order: [deepseek]        # upstreams to try, in order
-          allow_fallbacks: false   # fail instead of routing to unlisted upstreams
+          order: [fireworks, together]  # upstreams to try, in order
+          allow_fallbacks: false        # fail instead of routing to unlisted upstreams
 ```
 
 Provider slugs are listed on each model's Providers tab on openrouter.ai, or in the `tag` field of `https://openrouter.ai/api/v1/models/<model-id>/endpoints`.
 With `allow_fallbacks: false`, requests fail when every listed upstream is down or rate-limited, instead of silently degrading to an unvetted host; for agents doing heavy tool calling we recommend this trade-off.
 A softer alternative is `require_parameters: true`, which keeps fallbacks but only routes to upstreams that support every request parameter, including tools.
+When cost matters more than picking specific upstreams, use `sort: price` instead of `order` to always route to the cheapest endpoint your account can reach, optionally with an `ignore:` list to exclude upstreams that have misbehaved:
+
+```yaml
+    extra_kwargs:
+      extra_body:
+        provider:
+          sort: price
+```
+
+Account-level OpenRouter settings (ignored providers and data-policy filters) are applied on top of request preferences and cannot be overridden per request, so a pinned upstream that your account excludes yields `No endpoints found` errors when `allow_fallbacks` is `false`.
+Always verify a new pin with a direct test request and confirm the `provider` field in the response before relying on it:
+
+```bash
+curl -s https://openrouter.ai/api/v1/chat/completions \
+  -H "Authorization: Bearer $OPENROUTER_API_KEY" -H "Content-Type: application/json" \
+  -d '{"model": "deepseek/deepseek-v4-pro", "messages": [{"role": "user", "content": "Say OK"}],
+       "max_tokens": 5, "provider": {"order": ["fireworks", "together"], "allow_fallbacks": false}}'
+```
 
 ## Azure OpenAI
 


### PR DESCRIPTION
## Summary

- Add an **OpenRouter Provider Routing** section to `docs/configuration/models.md` explaining how to pin OpenRouter requests to trusted upstreams via `extra_kwargs.extra_body.provider` (`order`, `allow_fallbacks`, `require_parameters`).
- Mention `extra_body` in the Extra Kwargs option list.
- Includes the regenerated mindroom-docs skill references (pre-commit hook).

## Motivation

OpenRouter routes each request to one of many upstreams, often quantized third-party hosts. On a live instance running `deepseek/deepseek-v4-pro`, one such upstream failed to convert the model's native DSML tool-call markup into structured tool calls when a `run_shell_command` call contained heavily nested quoting, and leaked raw `<|DSML|>` token snapshots into the visible streamed reply (agno also logged `Unable to decode function arguments` for the mangled call). Pinning `provider.order: [deepseek]` with `allow_fallbacks: false` avoids this class of failure; this PR documents the technique.

Plumbing is already supported: agno's `OpenRouter` inherits `OpenAIChat.extra_body`, which MindRoom passes through `extra_kwargs` (verified on a live instance).

No code changes, docs only.