### PR TITLE
Speed up parallel pytest infrastructure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -442,7 +442,6 @@ dev = [
   "pytest-asyncio>=1.1",
   "pytest-cov>=6.2.1",
   "pytest-mock>=3.14.1",
-  "pytest-sugar>=1",
   "pytest-timeout>=2.4",
   "pytest-xdist>=3.8",
   "requests>=2.32.4",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,6 +95,7 @@ if TYPE_CHECKING:
     from agno.db.base import BaseDb
     from agno.session.agent import AgentSession
     from agno.session.team import TeamSession
+    from xdist.workermanage import WorkerController
 
     from mindroom.config.models import CompactionConfig
     from mindroom.dispatch_handoff import DispatchEvent
@@ -103,6 +104,8 @@ if TYPE_CHECKING:
 
 
 _STRUCTLOG_CONFIGURE = structlog.configure
+_POSTGRES_CONTAINER_NAME_STASH_KEY = pytest.StashKey[str]()
+_POSTGRES_CONTAINER_PREFIX = "mindroom-postgres-cache-test-"
 
 
 def _configure_quiet_structlog() -> None:
@@ -438,21 +441,75 @@ def _wait_for_postgres_container(database_url: str) -> None:
     raise RuntimeError(msg) from last_error
 
 
-def _postgres_url_from_container_port(docker: str, container_name: str) -> str:
-    result = subprocess.run(
-        [docker, "port", container_name, "5432/tcp"],
-        check=True,
+def _create_postgres_worker_database(database_url: str, worker_id: str) -> str:
+    """Create an isolated database for one worker on the shared Postgres server."""
+    import psycopg  # noqa: PLC0415
+    from psycopg import sql  # noqa: PLC0415
+
+    database_name = f"mindroom_{worker_id}"
+    with psycopg.connect(database_url, autocommit=True) as db:
+        db.execute(sql.SQL("CREATE DATABASE {}").format(sql.Identifier(database_name)))
+    return f"{database_url.rsplit('/', 1)[0]}/{database_name}"
+
+
+def _wait_for_postgres_container_port(docker: str, container_name: str) -> str:
+    """Wait for Docker to publish a shared container's random host port."""
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        result = subprocess.run(
+            [docker, "port", container_name, "5432/tcp"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            mapped_port = result.stdout.strip().splitlines()[-1]
+            host, port = mapped_port.rsplit(":", 1)
+            clean_host = host.removeprefix("[").removesuffix("]")
+            return f"postgresql://cache:test@{clean_host}:{port}/mindroom"
+        time.sleep(0.05)
+    msg = "Postgres test container did not publish a port"
+    raise RuntimeError(msg)
+
+
+def _postgres_container_name(run_id: str) -> str:
+    """Return the deterministic disposable Postgres container name for one test run."""
+    return f"{_POSTGRES_CONTAINER_PREFIX}{run_id}"
+
+
+def _remove_postgres_container(docker: str, container_name: str) -> None:
+    """Remove one disposable Postgres container if it exists."""
+    subprocess.run(
+        [docker, "rm", "-f", container_name],
+        check=False,
         capture_output=True,
         text=True,
     )
-    mapped_port = result.stdout.strip().splitlines()[-1]
-    host, port = mapped_port.rsplit(":", 1)
-    return f"postgresql://cache:test@{host.removeprefix('[').removesuffix(']')}:{port}/mindroom"
+
+
+def pytest_configure_node(node: "WorkerController") -> None:
+    """Remember the shared Postgres container name in the xdist controller."""
+    node.config.stash[_POSTGRES_CONTAINER_NAME_STASH_KEY] = _postgres_container_name(
+        node.workerinput["testrunuid"],
+    )
+
+
+def pytest_sessionfinish(session: pytest.Session) -> None:
+    """Remove the shared Postgres container after every xdist worker has finished."""
+    if hasattr(session.config, "workerinput"):
+        return
+    container_name = session.config.stash.get(_POSTGRES_CONTAINER_NAME_STASH_KEY, None)
+    docker = shutil.which("docker")
+    if container_name is not None and docker is not None:
+        _remove_postgres_container(docker, container_name)
 
 
 @pytest.fixture(scope="session")
-def postgres_event_cache_url() -> Iterator[str]:
-    """Start a disposable Postgres server when Docker is available."""
+def postgres_event_cache_url(
+    worker_id: str,
+    testrun_uid: str,
+) -> Iterator[str]:
+    """Start or reuse one disposable Postgres server for the current test run."""
     docker = shutil.which("docker")
     if docker is None:
         pytest.skip("Docker is required for Postgres event-cache integration tests")
@@ -466,7 +523,9 @@ def postgres_event_cache_url() -> Iterator[str]:
     if info_result.returncode != 0:
         pytest.skip("Docker daemon is unavailable for Postgres event-cache integration tests")
 
-    container_name = f"mindroom-postgres-cache-test-{uuid.uuid4().hex}"
+    shared_across_workers = worker_id != "master"
+    run_id = testrun_uid if shared_across_workers else uuid.uuid4().hex
+    container_name = _postgres_container_name(run_id)
     run_result = subprocess.run(
         [
             docker,
@@ -475,6 +534,8 @@ def postgres_event_cache_url() -> Iterator[str]:
             "-d",
             "--name",
             container_name,
+            "--label",
+            f"mindroom.pytest.run={run_id}",
             "-e",
             "POSTGRES_USER=cache",
             "-e",
@@ -490,19 +551,24 @@ def postgres_event_cache_url() -> Iterator[str]:
         text=True,
     )
     if run_result.returncode != 0:
-        pytest.skip(f"Could not start Postgres test container: {run_result.stderr.strip()}")
-
-    try:
-        database_url = _postgres_url_from_container_port(docker, container_name)
-        _wait_for_postgres_container(database_url)
-        yield database_url
-    finally:
-        subprocess.run(
-            [docker, "rm", "-f", container_name],
+        inspect_result = subprocess.run(
+            [docker, "inspect", container_name],
             check=False,
             capture_output=True,
             text=True,
         )
+        if not shared_across_workers or inspect_result.returncode != 0:
+            pytest.skip(f"Could not start Postgres test container: {run_result.stderr.strip()}")
+
+    try:
+        database_url = _wait_for_postgres_container_port(docker, container_name)
+        _wait_for_postgres_container(database_url)
+        if shared_across_workers:
+            database_url = _create_postgres_worker_database(database_url, worker_id)
+        yield database_url
+    finally:
+        if not shared_across_workers:
+            _remove_postgres_container(docker, container_name)
 
 
 @pytest.fixture(params=("sqlite", "postgres"), ids=("sqlite", "postgres"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import time
 import uuid
+import warnings
 from collections.abc import (
     AsyncGenerator,
     AsyncIterator,
@@ -106,6 +107,7 @@ if TYPE_CHECKING:
 _STRUCTLOG_CONFIGURE = structlog.configure
 _POSTGRES_CONTAINER_NAME_STASH_KEY = pytest.StashKey[str]()
 _POSTGRES_CONTAINER_PREFIX = "mindroom-postgres-cache-test-"
+_POSTGRES_STARTUP_TIMEOUT_SECONDS = 30
 
 
 def _configure_quiet_structlog() -> None:
@@ -428,7 +430,7 @@ async def drain_coalescing(*bots: RuntimeBot) -> None:
 def _wait_for_postgres_container(database_url: str) -> None:
     import psycopg  # noqa: PLC0415
 
-    deadline = time.monotonic() + 30
+    deadline = time.monotonic() + _POSTGRES_STARTUP_TIMEOUT_SECONDS
     last_error: Exception | None = None
     while time.monotonic() < deadline:
         try:
@@ -454,7 +456,8 @@ def _create_postgres_worker_database(database_url: str, worker_id: str) -> str:
 
 def _wait_for_postgres_container_port(docker: str, container_name: str) -> str:
     """Wait for Docker to publish a shared container's random host port."""
-    deadline = time.monotonic() + 5
+    deadline = time.monotonic() + _POSTGRES_STARTUP_TIMEOUT_SECONDS
+    last_error = ""
     while time.monotonic() < deadline:
         result = subprocess.run(
             [docker, "port", container_name, "5432/tcp"],
@@ -464,11 +467,11 @@ def _wait_for_postgres_container_port(docker: str, container_name: str) -> str:
         )
         if result.returncode == 0 and result.stdout.strip():
             mapped_port = result.stdout.strip().splitlines()[-1]
-            host, port = mapped_port.rsplit(":", 1)
-            clean_host = host.removeprefix("[").removesuffix("]")
-            return f"postgresql://cache:test@{clean_host}:{port}/mindroom"
+            _, port = mapped_port.rsplit(":", 1)
+            return f"postgresql://cache:test@127.0.0.1:{port}/mindroom"
+        last_error = result.stderr.strip()
         time.sleep(0.05)
-    msg = "Postgres test container did not publish a port"
+    msg = f"Postgres test container did not publish a port: {last_error}"
     raise RuntimeError(msg)
 
 
@@ -479,12 +482,16 @@ def _postgres_container_name(run_id: str) -> str:
 
 def _remove_postgres_container(docker: str, container_name: str) -> None:
     """Remove one disposable Postgres container if it exists."""
-    subprocess.run(
+    result = subprocess.run(
         [docker, "rm", "-f", container_name],
         check=False,
         capture_output=True,
         text=True,
     )
+    if result.returncode == 0 or "No such container" in result.stderr:
+        return
+    msg = f"Could not remove Postgres test container {container_name}: {result.stderr.strip()}"
+    raise RuntimeError(msg)
 
 
 def pytest_configure_node(node: "WorkerController") -> None:
@@ -501,7 +508,11 @@ def pytest_sessionfinish(session: pytest.Session) -> None:
     container_name = session.config.stash.get(_POSTGRES_CONTAINER_NAME_STASH_KEY, None)
     docker = shutil.which("docker")
     if container_name is not None and docker is not None:
-        _remove_postgres_container(docker, container_name)
+        try:
+            _remove_postgres_container(docker, container_name)
+        except RuntimeError as exc:
+            warnings.warn(pytest.PytestWarning(str(exc)), stacklevel=1)
+            session.exitstatus = pytest.ExitCode.TESTS_FAILED
 
 
 @pytest.fixture(scope="session")
@@ -552,13 +563,16 @@ def postgres_event_cache_url(
     )
     if run_result.returncode != 0:
         inspect_result = subprocess.run(
-            [docker, "inspect", container_name],
+            [docker, "inspect", "--format", "{{.State.Status}}", container_name],
             check=False,
             capture_output=True,
             text=True,
         )
         if not shared_across_workers or inspect_result.returncode != 0:
             pytest.skip(f"Could not start Postgres test container: {run_result.stderr.strip()}")
+        if inspect_result.stdout.strip() in {"dead", "exited"}:
+            msg = f"Shared Postgres test container is {inspect_result.stdout.strip()}"
+            raise RuntimeError(msg)
 
     try:
         database_url = _wait_for_postgres_container_port(docker, container_name)

--- a/tests/test_pytest_postgres_harness.py
+++ b/tests/test_pytest_postgres_harness.py
@@ -1,0 +1,59 @@
+"""Tests for the disposable Postgres pytest harness."""
+
+import subprocess
+
+import pytest
+from pytest_mock import MockerFixture
+
+from tests import conftest
+
+
+def test_postgres_port_url_uses_explicit_loopback_binding(mocker: MockerFixture) -> None:
+    """Docker's reported host must not override the explicit IPv4 binding."""
+    mocker.patch.object(
+        conftest.subprocess,
+        "run",
+        return_value=subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="[::1]:54321\n",
+            stderr="",
+        ),
+    )
+
+    database_url = conftest._wait_for_postgres_container_port("docker", "postgres-test")
+
+    assert database_url == "postgresql://cache:test@127.0.0.1:54321/mindroom"
+
+
+def test_remove_postgres_container_accepts_missing_container(mocker: MockerFixture) -> None:
+    """Docker auto-removal racing controller cleanup is expected."""
+    mocker.patch.object(
+        conftest.subprocess,
+        "run",
+        return_value=subprocess.CompletedProcess(
+            args=[],
+            returncode=1,
+            stdout="",
+            stderr="Error response from daemon: No such container: postgres-test",
+        ),
+    )
+
+    conftest._remove_postgres_container("docker", "postgres-test")
+
+
+def test_remove_postgres_container_rejects_cleanup_failure(mocker: MockerFixture) -> None:
+    """Unexpected cleanup failures must not silently leak containers."""
+    mocker.patch.object(
+        conftest.subprocess,
+        "run",
+        return_value=subprocess.CompletedProcess(
+            args=[],
+            returncode=1,
+            stdout="",
+            stderr="permission denied",
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="permission denied"):
+        conftest._remove_postgres_container("docker", "postgres-test")

--- a/uv.lock
+++ b/uv.lock
@@ -4344,7 +4344,6 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
-    { name = "pytest-sugar" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "requests" },
@@ -4536,7 +4535,6 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=1.1" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pytest-mock", specifier = ">=3.14.1" },
-    { name = "pytest-sugar", specifier = ">=1" },
     { name = "pytest-timeout", specifier = ">=2.4" },
     { name = "pytest-xdist", specifier = ">=3.8" },
     { name = "requests", specifier = ">=2.32.4" },
@@ -7254,19 +7252,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pytest-sugar"
-version = "1.1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pytest" },
-    { name = "termcolor" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/4e/60fed105549297ba1a700e1ea7b828044842ea27d72c898990510b79b0e2/pytest-sugar-1.1.1.tar.gz", hash = "sha256:73b8b65163ebf10f9f671efab9eed3d56f20d2ca68bda83fa64740a92c08f65d", size = 16533, upload-time = "2025-08-23T12:19:35.737Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/d5/81d38a91c1fdafb6711f053f5a9b92ff788013b19821257c2c38c1e132df/pytest_sugar-1.1.1-py3-none-any.whl", hash = "sha256:2f8319b907548d5b9d03a171515c1d43d2e38e32bd8182a1781eb20b43344cc8", size = 11440, upload-time = "2025-08-23T12:19:34.894Z" },
-]
-
-[[package]]
 name = "pytest-timeout"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -8720,15 +8705,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
-]
-
-[[package]]
-name = "termcolor"
-version = "3.3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/46/79/cf31d7a93a8fdc6aa0fbb665be84426a8c5a557d9240b6239e9e11e35fc5/termcolor-3.3.0.tar.gz", hash = "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5", size = 14434, upload-time = "2025-12-29T12:55:21.882Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl", hash = "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5", size = 7734, upload-time = "2025-12-29T12:55:20.718Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Reuse one disposable Postgres container per xdist run while keeping a separate database per worker.
- Let the xdist controller remove the shared container only after all workers finish and surface genuine cleanup failures.
- Remove pytest-sugar so interactive and captured runs use the same compact, stable pytest output.

## Performance

- tests/test_event_cache_backends.py with four workers: 12.03s to 6.91s wall time on exact origin/main versus this branch (43% faster).
- Warm full-suite A/B: 54.28s on origin/main versus 54.61s on this branch, so there is no measurable whole-suite wall-time improvement; the critical path is elsewhere.
- The shared run created one container and left zero containers behind.
- A full latest-main run produced 19 KB across 214 lines; the pytest-sugar PTY benchmark generated roughly 304K raw tool tokens and was truncated by the agent tool.

Warnings remain visible because several project-owned deprecations are actionable; this does not blanket-suppress them.

## Testing

- uv run pytest: 9,652 passed, 57 skipped
- uv run pytest -n 4 tests/test_event_cache_backends.py: 29 passed
- uv run pytest -n 0 tests/test_pytest_postgres_harness.py: 3 passed
- uv run pre-commit run --all-files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of parallel test runs that use PostgreSQL-backed event caching.
  * Added better isolation between parallel workers and streamlined test resource cleanup.

* **Chores**
  * Removed an unused development testing dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
