### PR TITLE
Improve recovery from sustained model overloads

### DIFF
--- a/src/mindroom/claude_stream_retry.py
+++ b/src/mindroom/claude_stream_retry.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, cast
 from agno.exceptions import ContextWindowExceededError, ModelProviderError
 
 from mindroom.claude_prompt_cache import as_anthropic_claude
+from mindroom.error_handling import TRANSIENT_PROVIDER_STATUS_CODES
 from mindroom.logging_config import get_logger
 
 if TYPE_CHECKING:
@@ -47,18 +48,12 @@ _STREAM_RETRY_HOOK_ATTR = "_mindroom_claude_stream_retry_hook_installed"
 _MAX_TRANSIENT_RETRIES = 4
 _RETRY_BASE_DELAY_SECONDS = 1.0
 
-# Statuses that indicate a transient provider fault. 200 is the mid-stream SSE
-# ``error`` event case (the HTTP response was already committed when the server
-# failed). 502 is also Agno's default when it wraps connection errors and
-# unexpected SDK exceptions, which are equally worth one more attempt.
-_RETRYABLE_STATUS_CODES = frozenset({200, 408, 409, 429, 500, 502, 503, 504, 529})
-
 
 def _is_transient_model_error(error: BaseException) -> bool:
     """Return whether one model-call failure is worth re-issuing the request."""
     if isinstance(error, ContextWindowExceededError):
         return False
-    return isinstance(error, ModelProviderError) and error.status_code in _RETRYABLE_STATUS_CODES
+    return isinstance(error, ModelProviderError) and error.status_code in TRANSIENT_PROVIDER_STATUS_CODES
 
 
 def _has_meaningful_output(response: ModelResponse) -> bool:

--- a/src/mindroom/claude_stream_retry.py
+++ b/src/mindroom/claude_stream_retry.py
@@ -41,8 +41,10 @@ logger = get_logger(__name__)
 
 _STREAM_RETRY_HOOK_ATTR = "_mindroom_claude_stream_retry_hook_installed"
 
-# One initial attempt plus this many re-issued requests.
-_MAX_TRANSIENT_RETRIES = 2
+# One initial attempt plus this many re-issued requests. Provider overloads can
+# outlive the SDK's short HTTP retry window, especially when they arrive as
+# mid-stream SSE error events after the response has already started with 200.
+_MAX_TRANSIENT_RETRIES = 4
 _RETRY_BASE_DELAY_SECONDS = 1.0
 
 # Statuses that indicate a transient provider fault. 200 is the mid-stream SSE

--- a/src/mindroom/error_handling.py
+++ b/src/mindroom/error_handling.py
@@ -7,6 +7,11 @@ from mindroom.redaction import redact_sensitive_text
 
 logger = get_logger(__name__)
 
+_TRANSIENT_PROVIDER_ERROR_MARKERS = (
+    "overloaded_error",
+    "model overloaded",
+)
+
 
 class AvatarGenerationError(RuntimeError):
     """Raised when managed avatar generation cannot produce required assets."""
@@ -25,6 +30,13 @@ def _extract_provider_from_error(error: Exception) -> str | None:
     if top_module in known_providers:
         return top_module
     return None
+
+
+def _is_transient_provider_error(error_str: str) -> bool:
+    """Recognize provider failures that already exhausted automatic retries."""
+    if any(marker in error_str for marker in _TRANSIENT_PROVIDER_ERROR_MARKERS):
+        return True
+    return "api_error" in error_str and "internal server error" in error_str
 
 
 def get_user_friendly_error_message(error: Exception, agent_name: str | None = None) -> str:
@@ -57,6 +69,10 @@ def get_user_friendly_error_message(error: Exception, agent_name: str | None = N
         return f"{agent_prefix}❌ Authentication failed{provider_hint}: {safe_error}"
     if any(x in error_str for x in ["rate", "429", "quota"]):
         return f"{agent_prefix}⏱️ Rate limited. Please wait a moment and try again."
+    if _is_transient_provider_error(error_str):
+        return (
+            f"{agent_prefix}⚠️ Model provider temporarily unavailable after automatic retries. Please try again shortly."
+        )
     if "timeout" in error_str:
         return f"{agent_prefix}⏰ Request timed out. Please try again."
     # Generic error with the actual error message for transparency

--- a/src/mindroom/error_handling.py
+++ b/src/mindroom/error_handling.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
+import ast
+import json
+
+from agno.exceptions import ModelProviderError
+
 from mindroom.logging_config import get_logger
 from mindroom.redaction import redact_sensitive_text
 
 logger = get_logger(__name__)
 
-_TRANSIENT_PROVIDER_ERROR_MARKERS = (
-    "overloaded_error",
-    "model overloaded",
-)
+_TRANSIENT_PROVIDER_STATUS_CODES = frozenset({200, 408, 409, 429, 500, 502, 503, 504, 529})
 
 
 class AvatarGenerationError(RuntimeError):
@@ -32,11 +34,47 @@ def _extract_provider_from_error(error: Exception) -> str | None:
     return None
 
 
-def _is_transient_provider_error(error_str: str) -> bool:
+def _structured_provider_error(error_str: str) -> tuple[str, str] | None:
+    """Extract ``(type, message)`` from one JSON or Python-repr provider payload."""
+    start = error_str.find("{")
+    end = error_str.rfind("}")
+    if start < 0 or end <= start:
+        return None
+    candidate = error_str[start : end + 1]
+    try:
+        payload = json.loads(candidate)
+    except (TypeError, ValueError):
+        try:
+            payload = ast.literal_eval(candidate)
+        except (SyntaxError, ValueError):
+            return None
+    if not isinstance(payload, dict) or payload.get("type") != "error":
+        return None
+    provider_error = payload.get("error")
+    if not isinstance(provider_error, dict):
+        return None
+    error_type = provider_error.get("type")
+    message = provider_error.get("message")
+    if not isinstance(error_type, str) or not isinstance(message, str):
+        return None
+    return error_type.casefold(), message.casefold()
+
+
+def _is_transient_provider_error(error: Exception) -> bool:
     """Recognize provider failures that already exhausted automatic retries."""
-    if any(marker in error_str for marker in _TRANSIENT_PROVIDER_ERROR_MARKERS):
+    status_code = getattr(error, "status_code", None)
+    if isinstance(error, ModelProviderError) and status_code in _TRANSIENT_PROVIDER_STATUS_CODES:
         return True
-    return "api_error" in error_str and "internal server error" in error_str
+    if _extract_provider_from_error(error) is not None and status_code in _TRANSIENT_PROVIDER_STATUS_CODES:
+        return True
+
+    structured_error = _structured_provider_error(str(error))
+    if structured_error is None:
+        return False
+    error_type, message = structured_error
+    return error_type in {"overloaded", "overloaded_error"} or (
+        error_type == "api_error" and "internal server error" in message
+    )
 
 
 def get_user_friendly_error_message(error: Exception, agent_name: str | None = None) -> str:
@@ -69,7 +107,7 @@ def get_user_friendly_error_message(error: Exception, agent_name: str | None = N
         return f"{agent_prefix}❌ Authentication failed{provider_hint}: {safe_error}"
     if any(x in error_str for x in ["rate", "429", "quota"]):
         return f"{agent_prefix}⏱️ Rate limited. Please wait a moment and try again."
-    if _is_transient_provider_error(error_str):
+    if _is_transient_provider_error(error):
         return (
             f"{agent_prefix}⚠️ Model provider temporarily unavailable after automatic retries. Please try again shortly."
         )

--- a/src/mindroom/error_handling.py
+++ b/src/mindroom/error_handling.py
@@ -12,7 +12,10 @@ from mindroom.redaction import redact_sensitive_text
 
 logger = get_logger(__name__)
 
-_TRANSIENT_PROVIDER_STATUS_CODES = frozenset({200, 408, 409, 429, 500, 502, 503, 504, 529})
+# Shared by provider retry policy and final user-message routing. Status 200 is
+# the Claude mid-stream SSE error case: the HTTP response was already committed
+# before the provider emitted an error event.
+TRANSIENT_PROVIDER_STATUS_CODES = frozenset({200, 408, 409, 429, 500, 502, 503, 504, 529})
 
 
 class AvatarGenerationError(RuntimeError):
@@ -60,12 +63,19 @@ def _structured_provider_error(error_str: str) -> tuple[str, str] | None:
     return error_type.casefold(), message.casefold()
 
 
+def _has_provider_status(error: Exception, status_code: int) -> bool:
+    """Return whether a typed provider exception has the given status."""
+    if getattr(error, "status_code", None) != status_code:
+        return False
+    return isinstance(error, ModelProviderError) or _extract_provider_from_error(error) is not None
+
+
 def _is_transient_provider_error(error: Exception) -> bool:
     """Recognize provider failures that already exhausted automatic retries."""
     status_code = getattr(error, "status_code", None)
-    if isinstance(error, ModelProviderError) and status_code in _TRANSIENT_PROVIDER_STATUS_CODES:
+    if isinstance(error, ModelProviderError) and status_code in TRANSIENT_PROVIDER_STATUS_CODES:
         return True
-    if _extract_provider_from_error(error) is not None and status_code in _TRANSIENT_PROVIDER_STATUS_CODES:
+    if _extract_provider_from_error(error) is not None and status_code in TRANSIENT_PROVIDER_STATUS_CODES:
         return True
 
     structured_error = _structured_provider_error(str(error))
@@ -105,7 +115,7 @@ def get_user_friendly_error_message(error: Exception, agent_name: str | None = N
         provider = _extract_provider_from_error(error)
         provider_hint = f" ({provider})" if provider else ""
         return f"{agent_prefix}❌ Authentication failed{provider_hint}: {safe_error}"
-    if any(x in error_str for x in ["rate", "429", "quota"]):
+    if any(x in error_str for x in ["rate", "429", "quota"]) or _has_provider_status(error, 429):
         return f"{agent_prefix}⏱️ Rate limited. Please wait a moment and try again."
     if _is_transient_provider_error(error):
         return (

--- a/tests/test_claude_stream_retry.py
+++ b/tests/test_claude_stream_retry.py
@@ -180,6 +180,25 @@ async def test_retries_rate_limit_then_gives_up() -> None:
     assert len(calls) == claude_stream_retry._MAX_TRANSIENT_RETRIES + 1
 
 
+@pytest.mark.asyncio
+async def test_retries_sustained_overload_before_success() -> None:
+    """A provider overload lasting beyond the old retry window can recover."""
+    model, calls = _hooked_model_with_async_attempts(
+        [
+            [ModelRateLimitError(message="overloaded_error", status_code=529)],
+            [ModelRateLimitError(message="overloaded_error", status_code=529)],
+            [ModelRateLimitError(message="overloaded_error", status_code=529)],
+            [ModelRateLimitError(message="overloaded_error", status_code=529)],
+            [ModelResponse(content="recovered")],
+        ],
+    )
+
+    responses = await _collect(model.ainvoke_stream([], object()))
+
+    assert [response.content for response in responses] == ["recovered"]
+    assert len(calls) == 5
+
+
 def test_sync_stream_retries_transient_error() -> None:
     """The synchronous stream path retries transient errors too."""
     model, calls = _hooked_model_with_sync_attempts(

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -65,6 +65,16 @@ def test_rate_limit_error() -> None:
     assert "Rate limited" in message
 
 
+def test_typed_rate_limit_error_uses_status_code() -> None:
+    """Typed 429 errors remain rate limits even when their message is generic."""
+    error = ModelProviderError(message="upstream unavailable", status_code=429)
+
+    message = get_user_friendly_error_message(error)
+
+    assert "Rate limited" in message
+    assert "temporarily unavailable" not in message
+
+
 def test_overloaded_provider_error_is_user_friendly() -> None:
     """An exhausted provider overload must not dump its raw payload to Matrix."""
     error = Exception(

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,6 +1,7 @@
 """Tests for error handling module."""
 
 import httpx
+from agno.exceptions import ModelProviderError
 from anthropic import AuthenticationError as AnthropicAuthError
 from openai import AuthenticationError as OpenAIAuthError
 
@@ -89,6 +90,45 @@ def test_internal_provider_error_is_user_friendly() -> None:
 
     assert "Model provider temporarily unavailable after automatic retries" in message
     assert "req_secret" not in message
+
+
+def test_json_provider_error_is_case_insensitive() -> None:
+    """Structured JSON provider payloads normalize error type and message casing."""
+    error = Exception(
+        '{"type":"error","error":{"type":"API_ERROR","message":"Internal Server Error"},"request_id":"req_secret"}',
+    )
+
+    message = get_user_friendly_error_message(error)
+
+    assert "Model provider temporarily unavailable after automatic retries" in message
+    assert "req_secret" not in message
+
+
+def test_typed_model_provider_error_is_user_friendly() -> None:
+    """Typed provider errors use their status instead of message substrings."""
+    error = ModelProviderError(message="upstream unavailable", status_code=503)
+
+    message = get_user_friendly_error_message(error)
+
+    assert "Model provider temporarily unavailable after automatic retries" in message
+
+
+def test_unstructured_overloaded_text_is_not_misclassified() -> None:
+    """Arbitrary application errors containing overloaded retain useful details."""
+    error = Exception("Local model overloaded while loading workspace state")
+
+    message = get_user_friendly_error_message(error)
+
+    assert message == "⚠️ Error: Local model overloaded while loading workspace state"
+
+
+def test_unstructured_api_error_text_is_not_misclassified() -> None:
+    """Provider-like words alone do not suppress an arbitrary application error."""
+    error = Exception("api_error: Internal Server Error while reading local cache")
+
+    message = get_user_friendly_error_message(error)
+
+    assert message == "⚠️ Error: api_error: Internal Server Error while reading local cache"
 
 
 def test_timeout_error() -> None:

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -64,6 +64,33 @@ def test_rate_limit_error() -> None:
     assert "Rate limited" in message
 
 
+def test_overloaded_provider_error_is_user_friendly() -> None:
+    """An exhausted provider overload must not dump its raw payload to Matrix."""
+    error = Exception(
+        "{'type': 'error', 'error': {'type': 'overloaded_error', 'message': 'Overloaded'}, 'request_id': 'req_secret'}",
+    )
+
+    message = get_user_friendly_error_message(error, "assistant")
+
+    assert message == (
+        "[assistant] ⚠️ Model provider temporarily unavailable after automatic retries. Please try again shortly."
+    )
+    assert "req_secret" not in message
+
+
+def test_internal_provider_error_is_user_friendly() -> None:
+    """A transient provider api_error gets the same bounded-retry message."""
+    error = Exception(
+        "{'type': 'error', 'error': {'type': 'api_error', 'message': 'Internal server error'}, "
+        "'request_id': 'req_secret'}",
+    )
+
+    message = get_user_friendly_error_message(error)
+
+    assert "Model provider temporarily unavailable after automatic retries" in message
+    assert "req_secret" not in message
+
+
 def test_timeout_error() -> None:
     """Test timeout error message."""
     error = TimeoutError("Request timeout")


### PR DESCRIPTION
## Summary

- expand the pre-output Claude transient retry budget from two to four retries
- replace exhausted overload/internal-provider payload dumps with a stable user-facing message
- preserve the existing no-replay guard once content, reasoning, or tool state has streamed

## Why

Transient SSE provider failures can outlive the current three-request window. When that window is exhausted, serialized provider payloads and request IDs currently become chat-visible error text.

## Tests

- `uv run pytest -q tests/test_claude_stream_retry.py tests/test_error_handling.py`
- `uv run pytest -m "not requires_matrix"` (`9655 passed, 44 skipped`)
- `uv run ruff check ...`
- `uv run ruff format --check ...`
- `uv run ty check`
- full pre-commit suite