### PR TITLE
Prevent presence failures from splitting bot config state

### DIFF
--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -1127,13 +1127,21 @@ class _MultiAgentOrchestrator:
 
     async def _update_unchanged_bots(self, plan: ConfigUpdatePlan) -> None:
         """Apply the new config to bots that do not require restart."""
-        for entity_name, bot in self.agent_bots.items():
-            if entity_name in plan.entities_to_restart:
-                continue
+        unchanged_bots = [
+            (entity_name, bot)
+            for entity_name, bot in self.agent_bots.items()
+            if entity_name not in plan.entities_to_restart
+        ]
+        for _, bot in unchanged_bots:
             bot.config = plan.new_config
             bot.enable_streaming = plan.new_config.defaults.enable_streaming
             bot.hook_registry = self.hook_registry
-            await bot._set_presence_with_model_info()
+
+        for entity_name, bot in unchanged_bots:
+            try:
+                await bot._set_presence_with_model_info()
+            except Exception:
+                logger.exception("bot_presence_update_failed", agent=entity_name)
             logger.debug("bot_config_updated", agent=entity_name)
 
     async def _emit_config_reloaded(

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -2313,6 +2313,55 @@ class TestMultiAgentOrchestrator:
         reset_runtime_state()
 
     @pytest.mark.asyncio
+    async def test_update_unchanged_bots_binds_all_before_best_effort_presence(self, tmp_path: Path) -> None:
+        """Presence failures must not expose mixed config or block later unchanged bots."""
+        old_config = Config(defaults={"enable_streaming": True})
+        new_config = Config(defaults={"enable_streaming": False})
+        orchestrator = _MultiAgentOrchestrator(runtime_paths=TestAgentBot._runtime_paths(tmp_path))
+        new_hook_registry = HookRegistry.empty()
+        orchestrator.hook_registry = new_hook_registry
+        first_bot = _mock_managed_bot(old_config)
+        second_bot = _mock_managed_bot(old_config)
+        orchestrator.agent_bots = {"first": first_bot, "second": second_bot}
+        second_bot_state_at_first_await: list[tuple[bool, bool, bool]] = []
+
+        async def fail_first_presence_update() -> None:
+            second_bot_state_at_first_await.append(
+                (
+                    second_bot.config is new_config,
+                    second_bot.enable_streaming is False,
+                    second_bot.hook_registry is new_hook_registry,
+                ),
+            )
+            msg = "presence unavailable"
+            raise RuntimeError(msg)
+
+        first_bot._set_presence_with_model_info.side_effect = fail_first_presence_update
+        plan = ConfigUpdatePlan(
+            new_config=new_config,
+            changed_mcp_servers=set(),
+            configured_entities={"first", "second"},
+            entities_to_restart=set(),
+            new_entities=set(),
+            removed_entities=set(),
+            mindroom_user_changed=False,
+            matrix_room_access_changed=False,
+            matrix_space_changed=False,
+            authorization_changed=False,
+        )
+
+        with patch("mindroom.orchestrator.logger.exception") as mock_log_exception:
+            await orchestrator._update_unchanged_bots(plan)
+
+        assert first_bot.config is new_config
+        assert first_bot.enable_streaming is False
+        assert first_bot.hook_registry is new_hook_registry
+        assert second_bot_state_at_first_await == [(True, True, True)]
+        first_bot._set_presence_with_model_info.assert_awaited_once_with()
+        second_bot._set_presence_with_model_info.assert_awaited_once_with()
+        mock_log_exception.assert_called_once_with("bot_presence_update_failed", agent="first")
+
+    @pytest.mark.asyncio
     async def test_update_config_syncs_runtime_services_when_running(self, tmp_path: Path) -> None:
         """Hot reload should sync runtime services without global knowledge refresh work."""
         orchestrator = _MultiAgentOrchestrator(runtime_paths=TestAgentBot._runtime_paths(tmp_path))


### PR DESCRIPTION
## Summary

- bind the new config, streaming flag, and hook registry to every unchanged bot before the first presence await
- treat presence refresh as best-effort per bot, so one Matrix failure cannot leave later bots on the old config or fail an already-committed update

## Scope

This is one pre-existing bug extracted from #1480. It does not change publication ordering, plugin reloads, locking, MCP state, API snapshots, or rollback behavior.

## Validation

- focused orchestrator/config reload tests: 12 passed
- Ruff: passed
- ty: passed
- commit hooks, including Vulture, Tach, and module privacy: passed
- independent exact-head review: approved

## Summary by Sourcery

Prevent presence update failures from leaving bots on mixed configuration state by applying new config to all unchanged bots before performing best-effort presence refreshes.

Bug Fixes:
- Ensure all unchanged bots are bound to the new config, streaming flag, and hook registry before any presence update is awaited.
- Handle presence refresh per bot as best-effort so a failure on one bot does not block presence updates or config application for other bots.

Tests:
- Add an orchestrator runtime test verifying unchanged bots receive the new config and registry before presence updates and that presence failures are logged without blocking other bots.