### PR TITLE
Serialize config, plugin, and MCP update flows

### DIFF
--- a/src/mindroom/orchestration/config_lifecycle.py
+++ b/src/mindroom/orchestration/config_lifecycle.py
@@ -107,6 +107,9 @@ class ConfigReloadLifecycle:
     in_flight_response_count: Callable[[], int]
     load_initial_config: Callable[[Config], Awaitable[bool]]
     apply_update_plan: Callable[[Config, ConfigUpdatePlan, tuple[str, ...]], Awaitable[bool]]
+    # Shared with manual plugin reloads and MCP catalog-change handling so no
+    # two publication flows can interleave their read-plan-apply sequences.
+    config_update_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     _reload_task: asyncio.Task | None = field(default=None, init=False)
     _requested_at: float | None = field(default=None, init=False)
     # Source files of the last reload attempt that failed to load, so the
@@ -138,25 +141,26 @@ class ConfigReloadLifecycle:
 
     async def update_config(self) -> bool:
         """Reload configuration from disk and dispatch the resulting update plan."""
-        # Config validation executes plugin modules and walks the filesystem;
-        # keep it off the event loop (#1260).
-        new_config = await asyncio.to_thread(load_config, self.runtime_paths, tolerate_plugin_load_errors=True)
-        current_config = self.current_config()
-        if current_config is None:
-            return await self.load_initial_config(new_config)
+        async with self.config_update_lock:
+            # Config validation executes plugin modules and walks the filesystem;
+            # keep it off the event loop (#1260).
+            new_config = await asyncio.to_thread(load_config, self.runtime_paths, tolerate_plugin_load_errors=True)
+            current_config = self.current_config()
+            if current_config is None:
+                return await self.load_initial_config(new_config)
 
-        agent_bots = self.agent_bots()
-        plugin_changes = plugin_change_paths(current_config, new_config)
-        plan = build_config_update_plan(
-            current_config=current_config,
-            new_config=new_config,
-            configured_entities=set(configured_entity_names(new_config)),
-            existing_entities=set(agent_bots.keys()),
-            agent_bots=agent_bots,
-        )
-        if plugin_changes:
-            plan = replace(plan, entities_to_restart=plan.entities_to_restart | set(agent_bots))
-        return await self.apply_update_plan(current_config, plan, plugin_changes)
+            agent_bots = self.agent_bots()
+            plugin_changes = plugin_change_paths(current_config, new_config)
+            plan = build_config_update_plan(
+                current_config=current_config,
+                new_config=new_config,
+                configured_entities=set(configured_entity_names(new_config)),
+                existing_entities=set(agent_bots.keys()),
+                agent_bots=agent_bots,
+            )
+            if plugin_changes:
+                plan = replace(plan, entities_to_restart=plan.entities_to_restart | set(agent_bots))
+            return await self.apply_update_plan(current_config, plan, plugin_changes)
 
     async def _wait_for_reload_debounce(
         self,

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -216,8 +216,7 @@ class _MultiAgentOrchestrator:
     _memory_auto_flush_task: asyncio.Task | None = field(default=None, init=False)
     config_reload: ConfigReloadLifecycle = field(init=False)
     _mcp_manager: MCPServerManager | None = field(default=None, init=False)
-    _mcp_catalog_change_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
-    _plugin_reload_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
+    _config_update_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
     _runtime_support: OwnedRuntimeSupport = field(init=False)
     _event_cache_write_task_owner: object = field(default_factory=object, init=False)
     plugin_watch: PluginWatchState = field(init=False)
@@ -253,6 +252,7 @@ class _MultiAgentOrchestrator:
             in_flight_response_count=self.in_flight_response_count,
             load_initial_config=self._load_initial_config,
             apply_update_plan=self._apply_config_update_plan,
+            config_update_lock=self._config_update_lock,
         )
         self._approval_transport = ApprovalMatrixTransport(
             runtime_paths=self.runtime_paths,
@@ -750,7 +750,7 @@ class _MultiAgentOrchestrator:
         if not self.running:
             msg = "Plugin reload unavailable until startup finishes."
             raise RuntimeError(msg)
-        async with self._plugin_reload_lock:
+        async with self._config_update_lock:
             config = self._require_config()
             logger.info(
                 "Reloading plugins",
@@ -788,30 +788,29 @@ class _MultiAgentOrchestrator:
         changed_server_ids: set[str],
     ) -> set[str]:
         """Stage and commit plugin changes without interleaving live reloads."""
-        async with self._plugin_reload_lock:
-            prepared_plugin_roots, prepared_plugin_root_snapshots = self.plugin_watch.capture(new_config)
-            prepared_plugin_reload = prepare_plugin_reload(
-                new_config,
-                self.runtime_paths,
-                skip_broken_plugins=True,
-            )
-            pre_stopped_mcp_entities = await self._stop_entities_before_mcp_sync(
-                current_config,
-                new_config,
-                changed_server_ids,
-            )
-            self.config = new_config
-            new_hook_registry = apply_prepared_plugin_reload(
-                prepared_plugin_reload,
-                cancel_existing_tasks=True,
-            ).hook_registry
-            self.plugin_watch.replace_snapshots(
-                prepared_plugin_roots,
-                prepared_plugin_root_snapshots,
-            )
-            self._activate_hook_registry(new_hook_registry)
-            clear_worker_validation_snapshot_cache()
-            return pre_stopped_mcp_entities
+        prepared_plugin_roots, prepared_plugin_root_snapshots = self.plugin_watch.capture(new_config)
+        prepared_plugin_reload = prepare_plugin_reload(
+            new_config,
+            self.runtime_paths,
+            skip_broken_plugins=True,
+        )
+        pre_stopped_mcp_entities = await self._stop_entities_before_mcp_sync(
+            current_config,
+            new_config,
+            changed_server_ids,
+        )
+        self.config = new_config
+        new_hook_registry = apply_prepared_plugin_reload(
+            prepared_plugin_reload,
+            cancel_existing_tasks=True,
+        ).hook_registry
+        self.plugin_watch.replace_snapshots(
+            prepared_plugin_roots,
+            prepared_plugin_root_snapshots,
+        )
+        self._activate_hook_registry(new_hook_registry)
+        clear_worker_validation_snapshot_cache()
+        return pre_stopped_mcp_entities
 
     async def _start_entities_once(
         self,
@@ -1247,7 +1246,7 @@ class _MultiAgentOrchestrator:
 
     async def _handle_mcp_catalog_change(self, server_id: str) -> None:
         """Restart entities that reference one changed MCP catalog."""
-        async with self._mcp_catalog_change_lock:
+        async with self._config_update_lock:
             if not self.running or self.config is None:
                 return
             clear_worker_validation_snapshot_cache()

--- a/tests/test_config_lifecycle.py
+++ b/tests/test_config_lifecycle.py
@@ -489,3 +489,26 @@ async def test_update_config_loads_config_off_event_loop(
     gate.set()
     assert await update_task is True
     lifecycle.load_initial_config.assert_awaited_once_with(loaded_config)
+
+
+@pytest.mark.asyncio
+async def test_update_config_waits_for_lock_before_loading(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Config loading must not start until the shared update lock is available."""
+    lock = asyncio.Lock()
+    config = Config()
+    load_config_mock = MagicMock(return_value=config)
+    monkeypatch.setattr(lifecycle_module, "load_config", load_config_mock)
+    lifecycle = _make_lifecycle(tmp_path, current_config=config)
+    lifecycle.config_update_lock = lock
+
+    await lock.acquire()
+    update_task = asyncio.create_task(lifecycle.update_config())
+    await asyncio.sleep(0)
+    load_config_mock.assert_not_called()
+
+    lock.release()
+    assert await update_task is True
+    lifecycle.apply_update_plan.assert_awaited_once()

--- a/tests/test_config_lifecycle.py
+++ b/tests/test_config_lifecycle.py
@@ -499,6 +499,14 @@ async def test_update_config_waits_for_lock_before_loading(
     """Config loading must not start until the shared update lock is available."""
     lock = asyncio.Lock()
     config = Config()
+    to_thread_started = asyncio.Event()
+    real_to_thread = asyncio.to_thread
+
+    async def observed_to_thread(*args: object, **kwargs: object) -> object:
+        to_thread_started.set()
+        return await real_to_thread(*args, **kwargs)
+
+    monkeypatch.setattr(lifecycle_module.asyncio, "to_thread", observed_to_thread)
     load_config_mock = MagicMock(return_value=config)
     monkeypatch.setattr(lifecycle_module, "load_config", load_config_mock)
     lifecycle = _make_lifecycle(tmp_path, current_config=config)
@@ -507,8 +515,10 @@ async def test_update_config_waits_for_lock_before_loading(
     await lock.acquire()
     update_task = asyncio.create_task(lifecycle.update_config())
     await asyncio.sleep(0)
-    load_config_mock.assert_not_called()
+    assert not to_thread_started.is_set()
 
     lock.release()
+    await asyncio.wait_for(to_thread_started.wait(), timeout=1.0)
     assert await update_task is True
+    load_config_mock.assert_called_once()
     lifecycle.apply_update_plan.assert_awaited_once()

--- a/tests/test_config_reload.py
+++ b/tests/test_config_reload.py
@@ -1355,6 +1355,51 @@ async def test_update_config_serializes_live_plugin_reload_against_staged_plugin
 
 
 @pytest.mark.asyncio
+async def test_config_update_serializes_manual_plugin_reload_and_mcp_catalog_change(
+    tmp_path: Path,
+) -> None:
+    """Manual plugin reloads and MCP restarts must wait for config application."""
+    config = _runtime_bound_config(Config(), tmp_path)
+    orchestrator = _MultiAgentOrchestrator(runtime_paths_for(config))
+    orchestrator.config = config
+    orchestrator.running = True
+    apply_started = asyncio.Event()
+    finish_apply = asyncio.Event()
+
+    async def apply_update_plan(
+        _current_config: Config,
+        _plan: ConfigUpdatePlan,
+        _plugin_changes: tuple[str, ...],
+    ) -> bool:
+        apply_started.set()
+        await finish_apply.wait()
+        return False
+
+    reload_result = PluginReloadResult(HookRegistry.empty(), (), 0)
+    with (
+        patch("mindroom.orchestration.config_lifecycle.load_config", return_value=config),
+        patch.object(orchestrator.config_reload, "apply_update_plan", new=apply_update_plan),
+        patch("mindroom.orchestrator.reload_plugins", return_value=reload_result) as reload_plugins_mock,
+    ):
+        config_task = asyncio.create_task(orchestrator.config_reload.update_config())
+        await asyncio.wait_for(apply_started.wait(), timeout=1)
+        plugin_task = asyncio.create_task(orchestrator.reload_plugins_now(source="test"))
+        mcp_task = asyncio.create_task(orchestrator._handle_mcp_catalog_change("demo"))
+        await asyncio.sleep(0)
+
+        assert not plugin_task.done()
+        assert not mcp_task.done()
+        reload_plugins_mock.assert_not_called()
+
+        finish_apply.set()
+        assert await config_task is False
+        assert await plugin_task is reload_result
+        await mcp_task
+
+    reload_plugins_mock.assert_called_once_with(config, orchestrator.runtime_paths)
+
+
+@pytest.mark.asyncio
 async def test_queued_config_reload_waits_for_in_flight_response_without_event_id(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary

- use one orchestrator-owned lock for file-watcher config reloads, manual plugin reloads, and MCP catalog-change restarts
- hold the lock across config load, planning, and application so publication flows cannot derive and apply state concurrently
- remove the superseded private plugin and MCP locks

## Scope

This extracts only the pre-existing locking bug from #1480. It does not change config publication order, rollback, plugin staging, API snapshots, watcher revision behavior, or bot state distribution.

## Validation

- focused config lifecycle/reload tests: 22 passed
- Ruff and ty: passed
- Tach dependency/interface check: passed
- full pre-commit suite: passed
- independent exact-head review: approved