### PR TITLE
Prevent stale plugin watcher reloads

### DIFF
--- a/src/mindroom/orchestration/plugin_watch.py
+++ b/src/mindroom/orchestration/plugin_watch.py
@@ -78,8 +78,9 @@ class _PluginWatcherRuntime(Protocol):
         *,
         source: str,
         changed_paths: tuple[Path, ...] = (),
-    ) -> PluginReloadResult:
-        """Rebuild and atomically swap the live plugin registry snapshot."""
+        expected_revision: int,
+    ) -> PluginReloadResult | None:
+        """Reload only if no newer publication consumed the watcher's edits."""
 
 
 async def watch_plugins_task(orchestrator: _PluginWatcherRuntime) -> None:
@@ -110,6 +111,11 @@ async def watch_plugins_task(orchestrator: _PluginWatcherRuntime) -> None:
                 watch_state_revision = watch_state.revision
             pending_changes = _filter_pending_plugin_changes(pending_changes, configured_roots)
             changed_paths = await _collect_plugin_root_changes(configured_roots, watch_state.last_snapshot_by_root)
+            if watch_state_revision != watch_state.revision:
+                pending_changes.clear()
+                last_change_at = None
+                watch_state_revision = watch_state.revision
+                continue
 
             if changed_paths:
                 pending_changes.update(changed_paths)
@@ -127,6 +133,7 @@ async def watch_plugins_task(orchestrator: _PluginWatcherRuntime) -> None:
                 await orchestrator.reload_plugins_now(
                     source="watcher",
                     changed_paths=changed_paths,
+                    expected_revision=watch_state_revision,
                 )
         except Exception:
             logger.exception("Exception during plugin watcher callback - continuing to watch")

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -9,7 +9,7 @@ from collections.abc import Awaitable, Callable
 from contextlib import suppress
 from dataclasses import dataclass, field, replace
 from functools import partial
-from typing import TYPE_CHECKING, NoReturn, cast
+from typing import TYPE_CHECKING, NoReturn, cast, overload
 from uuid import uuid4
 
 import uvicorn
@@ -740,23 +740,49 @@ class _MultiAgentOrchestrator:
         for bot in self.agent_bots.values():
             bot.hook_registry = hook_registry
 
+    @overload
     async def reload_plugins_now(
         self,
         *,
         source: str,
         changed_paths: tuple[Path, ...] = (),
-    ) -> PluginReloadResult:
+    ) -> PluginReloadResult: ...
+
+    @overload
+    async def reload_plugins_now(
+        self,
+        *,
+        source: str,
+        changed_paths: tuple[Path, ...] = (),
+        expected_revision: int,
+    ) -> PluginReloadResult | None: ...
+
+    async def reload_plugins_now(
+        self,
+        *,
+        source: str,
+        changed_paths: tuple[Path, ...] = (),
+        expected_revision: int | None = None,
+    ) -> PluginReloadResult | None:
         """Rebuild and atomically swap the live plugin registry snapshot."""
         if not self.running:
             msg = "Plugin reload unavailable until startup finishes."
             raise RuntimeError(msg)
         async with self._plugin_reload_lock:
+            if expected_revision is not None and self.plugin_watch.revision != expected_revision:
+                logger.info(
+                    "Skipping stale watcher plugin reload",
+                    expected_revision=expected_revision,
+                    current_revision=self.plugin_watch.revision,
+                )
+                return None
             config = self._require_config()
             logger.info(
                 "Reloading plugins",
                 source=source,
                 changed_paths=[str(path) for path in changed_paths],
             )
+            watch_roots, watch_root_snapshots = self.plugin_watch.capture(config)
             try:
                 result = reload_plugins(config, self.runtime_paths)
             except Exception:
@@ -766,12 +792,12 @@ class _MultiAgentOrchestrator:
                 )
                 self._activate_hook_registry(recovery_result.hook_registry)
                 clear_worker_validation_snapshot_cache()
-                self.plugin_watch.refresh(config)
+                self.plugin_watch.replace_snapshots(watch_roots, watch_root_snapshots)
                 logger.warning(warning_message, source=source, **warning_kwargs)
                 raise
             self._activate_hook_registry(result.hook_registry)
             clear_worker_validation_snapshot_cache()
-            self.plugin_watch.refresh(config)
+            self.plugin_watch.replace_snapshots(watch_roots, watch_root_snapshots)
             logger.info(
                 "Plugin reload complete",
                 source=source,

--- a/tests/test_config_reload.py
+++ b/tests/test_config_reload.py
@@ -28,7 +28,11 @@ from mindroom.matrix.state import MatrixState
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
 from mindroom.orchestration.config_updates import ConfigUpdatePlan, _get_changed_agents, build_config_update_plan
-from mindroom.orchestration.plugin_watch import _drop_unconfigured_plugin_root_snapshots, watch_plugins_task
+from mindroom.orchestration.plugin_watch import (
+    _collect_plugin_root_changes,
+    _drop_unconfigured_plugin_root_snapshots,
+    watch_plugins_task,
+)
 from mindroom.orchestration.runtime import log_startup_phase_finished, log_startup_phase_started
 from mindroom.orchestrator import _MultiAgentOrchestrator, _watch_skills_task
 from mindroom.startup_errors import PermanentStartupError
@@ -326,7 +330,7 @@ async def test_plugin_watcher_debounces_changes_and_ignores_unconfigured_roots(
     reload_calls: list[tuple[str, tuple[Path, ...]]] = []
     reload_seen = asyncio.Event()
 
-    async def record_reload(*, source: str, changed_paths: tuple[Path, ...] = ()) -> PluginReloadResult:
+    async def record_reload(*, source: str, changed_paths: tuple[Path, ...] = (), **_: int) -> PluginReloadResult:
         reload_calls.append((source, changed_paths))
         reload_seen.set()
         return PluginReloadResult(HookRegistry.empty(), (), 0)
@@ -397,7 +401,7 @@ async def test_plugin_watcher_tracks_configured_absolute_root_outside_config_dir
     reload_calls: list[tuple[str, tuple[Path, ...]]] = []
     reload_seen = asyncio.Event()
 
-    async def record_reload(*, source: str, changed_paths: tuple[Path, ...] = ()) -> PluginReloadResult:
+    async def record_reload(*, source: str, changed_paths: tuple[Path, ...] = (), **_: int) -> PluginReloadResult:
         reload_calls.append((source, changed_paths))
         reload_seen.set()
         return PluginReloadResult(HookRegistry.empty(), (), 0)
@@ -445,7 +449,7 @@ async def test_plugin_watcher_catches_first_save_after_startup(
     reload_calls: list[tuple[str, tuple[Path, ...]]] = []
     reload_seen = asyncio.Event()
 
-    async def record_reload(*, source: str, changed_paths: tuple[Path, ...] = ()) -> PluginReloadResult:
+    async def record_reload(*, source: str, changed_paths: tuple[Path, ...] = (), **_: int) -> PluginReloadResult:
         reload_calls.append((source, changed_paths))
         reload_seen.set()
         return PluginReloadResult(HookRegistry.empty(), (), 0)
@@ -499,7 +503,7 @@ async def test_plugin_watcher_catches_first_save_after_config_switch(
     reload_calls: list[tuple[str, tuple[Path, ...]]] = []
     reload_seen = asyncio.Event()
 
-    async def record_reload(*, source: str, changed_paths: tuple[Path, ...] = ()) -> PluginReloadResult:
+    async def record_reload(*, source: str, changed_paths: tuple[Path, ...] = (), **_: int) -> PluginReloadResult:
         reload_calls.append((source, changed_paths))
         reload_seen.set()
         return PluginReloadResult(HookRegistry.empty(), (), 0)
@@ -558,7 +562,7 @@ async def test_plugin_watcher_does_not_reload_on_config_switch_without_plugin_ed
 
     reload_calls: list[tuple[str, tuple[Path, ...]]] = []
 
-    async def record_reload(*, source: str, changed_paths: tuple[Path, ...] = ()) -> PluginReloadResult:
+    async def record_reload(*, source: str, changed_paths: tuple[Path, ...] = (), **_: int) -> PluginReloadResult:
         reload_calls.append((source, changed_paths))
         return PluginReloadResult(HookRegistry.empty(), (), 0)
 
@@ -603,7 +607,7 @@ async def test_plugin_watcher_ignores_cache_artifacts_created_during_reload(
     reload_calls: list[tuple[str, tuple[Path, ...]]] = []
     reload_seen = asyncio.Event()
 
-    async def record_reload(*, source: str, changed_paths: tuple[Path, ...] = ()) -> PluginReloadResult:
+    async def record_reload(*, source: str, changed_paths: tuple[Path, ...] = (), **_: int) -> PluginReloadResult:
         reload_calls.append((source, changed_paths))
         if len(reload_calls) == 1:
             pycache_dir = plugin_root / "__pycache__"
@@ -690,6 +694,101 @@ async def test_manual_plugin_reload_consumes_pending_watcher_changes(
     assert reload_call_count == 1
 
 
+def _plugin_watcher_race_runtime(tmp_path: Path) -> tuple[_MultiAgentOrchestrator, Config, Path, Path]:
+    plugin_root = tmp_path / "plugin"
+    plugin_root.mkdir()
+    (plugin_root / "mindroom.plugin.json").write_text('{"name":"demo","skills":[]}', encoding="utf-8")
+    hooks_path = plugin_root / "hooks.py"
+    hooks_path.write_text("VALUE = 1\n", encoding="utf-8")
+    config = _runtime_bound_config(Config(plugins=[str(plugin_root)]), tmp_path)
+    orchestrator = _MultiAgentOrchestrator(runtime_paths_for(config))
+    orchestrator.config = config
+    orchestrator.running = True
+    return orchestrator, config, plugin_root, hooks_path
+
+
+@pytest.mark.asyncio
+async def test_plugin_watcher_drops_pending_changes_when_reload_commits_during_scan(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A reload committing mid-scan should consume pending edits."""
+    monkeypatch.setattr("mindroom.file_watcher._WATCH_SCAN_INTERVAL_SECONDS", 0.0)
+    monkeypatch.setattr("mindroom.file_watcher._WATCH_TREE_DEBOUNCE_SECONDS", 0.0)
+    orchestrator, config, plugin_root, hooks_path = _plugin_watcher_race_runtime(tmp_path)
+    second_scan_started = asyncio.Event()
+    release_second_scan = asyncio.Event()
+    collect_count = 0
+
+    async def collect(roots: tuple[Path, ...], _snapshots: dict[Path, dict[Path, int]]) -> set[Path]:
+        nonlocal collect_count
+        assert roots == (plugin_root,)
+        collect_count += 1
+        if collect_count == 1:
+            return {hooks_path}
+        second_scan_started.set()
+        await release_second_scan.wait()
+        return set()
+
+    monkeypatch.setattr("mindroom.orchestration.plugin_watch._collect_plugin_root_changes", collect)
+    reload_mock = AsyncMock()
+    orchestrator.reload_plugins_now = reload_mock
+    task = asyncio.create_task(watch_plugins_task(orchestrator))
+    try:
+        await asyncio.wait_for(second_scan_started.wait(), timeout=1)
+        orchestrator.plugin_watch.refresh(config)
+        orchestrator.running = False
+        release_second_scan.set()
+        await task
+    finally:
+        task.cancel()
+        release_second_scan.set()
+    reload_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_manual_plugin_reload_keeps_edit_landing_while_source_loads(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """An edit during source loading should remain visible to the watcher."""
+    orchestrator, _, plugin_root, hooks_path = _plugin_watcher_race_runtime(tmp_path)
+    source_loaded = False
+
+    def snapshot(_root: Path) -> dict[Path, int]:
+        return {hooks_path: 2 if source_loaded else 1}
+
+    def load_source(_config: Config, _runtime_paths: object) -> PluginReloadResult:
+        nonlocal source_loaded
+        source_loaded = True
+        return PluginReloadResult(HookRegistry.empty(), ("demo",), 0)
+
+    monkeypatch.setattr("mindroom.orchestration.plugin_watch.file_watcher._tree_snapshot", snapshot)
+    with patch("mindroom.orchestrator.reload_plugins", side_effect=load_source):
+        await orchestrator.reload_plugins_now(source="command")
+    changed_paths = await _collect_plugin_root_changes((plugin_root,), orchestrator.plugin_watch.last_snapshot_by_root)
+    assert changed_paths == {hooks_path}
+
+
+@pytest.mark.asyncio
+async def test_watcher_reload_drops_stale_revision_after_waiting_for_plugin_lock(tmp_path: Path) -> None:
+    """A newer publication while lock-blocked should consume watcher work."""
+    orchestrator, config, _, hooks_path = _plugin_watcher_race_runtime(tmp_path)
+    orchestrator.plugin_watch.sync_roots(config)
+    await orchestrator._plugin_reload_lock.acquire()
+    task = asyncio.create_task(
+        orchestrator.reload_plugins_now(
+            source="watcher",
+            changed_paths=(hooks_path,),
+            expected_revision=orchestrator.plugin_watch.revision,
+        ),
+    )
+    await asyncio.sleep(0)
+    orchestrator.plugin_watch.refresh(config)
+    orchestrator._plugin_reload_lock.release()
+    assert await task is None
+
+
 def test_plugin_tree_snapshot_ignores_git_metadata(tmp_path: Path) -> None:
     """Plugin tree snapshots should ignore Git metadata files inside watched repos."""
     plugin_root = tmp_path / "plugins" / "demo"
@@ -739,7 +838,7 @@ async def test_plugin_watcher_does_not_retry_failed_reload_without_new_change(
     second_reload_seen = asyncio.Event()
     error_message = "broken plugin"
 
-    async def record_reload(*, source: str, changed_paths: tuple[Path, ...] = ()) -> PluginReloadResult:
+    async def record_reload(*, source: str, changed_paths: tuple[Path, ...] = (), **_: int) -> PluginReloadResult:
         reload_calls.append((source, changed_paths))
         if len(reload_calls) == 1:
             first_reload_seen.set()


### PR DESCRIPTION
## Summary

- discard pending watcher edits when a manual reload commits new baselines while a tree scan is off-loop
- capture reload baselines before loading plugin source, so edits landing during a manual reload remain detectable
- re-check the watcher revision after acquiring the shared config-update lock, dropping work already consumed by a newer publication

## Scope

This extracts only the pre-existing watcher races from #1480.
It does not change publication ordering, rollback, MCP state, API snapshots, bot config distribution, or task ownership.

## Validation

- post-merge focused independent run: 63 passed, 1 skipped
- full pre-commit: passed
- diff check: passed
- PR diff remains 3 files, +146 / -14
- independent exact-head review: approved
- GitHub CI: passed, including pytest, smoke stacks, container builds, Tach, security scans, CodeRabbit, and Greptile

## Merge note

Current `main`, including #1487 and #1488, is merged into this branch without rewriting history.
The only conflict was the expected overlap at the plugin reload call site: the stale-revision guard now runs after acquiring #1488's shared `_config_update_lock`.
