### PR TITLE
fix: resolve attachment context in interactive-selection callback turns

### DIFF
--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -63,6 +63,7 @@ from mindroom.error_handling import get_user_friendly_error_message
 from mindroom.handled_turns import TurnRecord
 from mindroom.hooks import MessageEnvelope, build_hook_matrix_admin, hook_ingress_policy
 from mindroom.inbound_turn_normalizer import (
+    DispatchPayloadWithAttachmentsRequest,
     InboundTurnNormalizer,
     TextNormalizationRequest,
     VoiceNormalizationRequest,
@@ -1292,6 +1293,20 @@ class TurnController:
                 source_event_id=selection.question_event_id,
             )
             return
+        # The selection is a synthetic turn with no Matrix message of its own, so
+        # the attachment context that ingress normally resolves per message must
+        # be rebuilt here from the conversation that asked the question.
+        selection_payload = await self.deps.normalizer.build_dispatch_payload_with_attachments(
+            DispatchPayloadWithAttachmentsRequest(
+                room_id=room.room_id,
+                prompt=interactive.build_selection_prompt(selection),
+                current_attachment_ids=[],
+                thread_id=selection.thread_id,
+                media_thread_id=response_target.resolved_thread_id,
+                thread_history=thread_history,
+            ),
+        )
+        selection_attachment_ids = tuple(selection_payload.attachment_ids or ())
         selection_handled_turn = self.deps.turn_store.attach_response_context(
             TurnRecord.create(
                 [selection.question_event_id],
@@ -1308,7 +1323,7 @@ class TurnController:
             source_event_id=source_event_id,
             target=response_target,
             body=f"The user selected: {selection.selected_value}",
-            attachment_ids=(),
+            attachment_ids=selection_attachment_ids,
             mentioned_agents=(),
             agent_name=self.deps.agent_name,
             origin=classify_turn_origin(
@@ -1324,11 +1339,13 @@ class TurnController:
 
         response_event_id = await self.deps.response_runner.generate_response(
             ResponseRequest(
-                prompt=interactive.build_selection_prompt(selection),
+                prompt=selection_payload.prompt,
+                model_prompt=selection_payload.model_prompt,
                 thread_history=thread_history,
                 existing_event_id=ack_event_id,
                 existing_event_is_placeholder=True,
                 user_id=user_id,
+                attachment_ids=selection_attachment_ids or None,
                 response_envelope=response_envelope,
                 matrix_run_metadata=selection_matrix_run_metadata,
             ),

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -36,7 +36,7 @@ from mindroom.constants import (
     VOICE_TRANSCRIPT_KEY,
     RuntimePaths,
 )
-from mindroom.delivery_gateway import SendTextRequest
+from mindroom.delivery_gateway import EditTextRequest, SendTextRequest
 from mindroom.dispatch_handoff import (
     DispatchEvent,
     DispatchHandoff,
@@ -1293,20 +1293,6 @@ class TurnController:
                 source_event_id=selection.question_event_id,
             )
             return
-        # The selection is a synthetic turn with no Matrix message of its own, so
-        # the attachment context that ingress normally resolves per message must
-        # be rebuilt here from the conversation that asked the question.
-        selection_payload = await self.deps.normalizer.build_dispatch_payload_with_attachments(
-            DispatchPayloadWithAttachmentsRequest(
-                room_id=room.room_id,
-                prompt=interactive.build_selection_prompt(selection),
-                current_attachment_ids=[],
-                thread_id=selection.thread_id,
-                media_thread_id=response_target.resolved_thread_id,
-                thread_history=thread_history,
-            ),
-        )
-        selection_attachment_ids = tuple(selection_payload.attachment_ids or ())
         selection_handled_turn = self.deps.turn_store.attach_response_context(
             TurnRecord.create(
                 [selection.question_event_id],
@@ -1317,6 +1303,32 @@ class TurnController:
             history_scope=self.deps.turn_store.response_history_scope(ResponseAction(kind="individual")),
             conversation_target=response_target,
         )
+        # The selection is a synthetic turn with no Matrix message of its own, so
+        # the attachment context that ingress normally resolves per message must
+        # be rebuilt here from the conversation that asked the question.
+        try:
+            selection_payload = await self.deps.normalizer.build_dispatch_payload_with_attachments(
+                DispatchPayloadWithAttachmentsRequest(
+                    room_id=room.room_id,
+                    prompt=interactive.build_selection_prompt(selection),
+                    current_attachment_ids=[],
+                    thread_id=selection.thread_id,
+                    media_thread_id=response_target.resolved_thread_id,
+                    thread_history=thread_history,
+                ),
+            )
+        except Exception as error:
+            response_event_id = await self._finalize_dispatch_failure(
+                target=ack_target,
+                error=error,
+                existing_event_id=ack_event_id,
+            )
+            if response_event_id is not None:
+                self._mark_source_events_responded(
+                    replace(selection_handled_turn, response_event_id=response_event_id),
+                )
+            return
+        selection_attachment_ids = tuple(selection_payload.attachment_ids or ())
         selection_matrix_run_metadata = self.deps.turn_store.build_run_metadata(selection_handled_turn)
         registry = entity_identity_registry(self.deps.runtime.config, self.deps.runtime_paths)
         response_envelope = MessageEnvelope(
@@ -1529,10 +1541,22 @@ class TurnController:
         *,
         target: MessageTarget,
         error: Exception,
+        existing_event_id: str | None = None,
     ) -> str | None:
         """Convert dispatch setup failures into a visible terminal message."""
         error_text = get_user_friendly_error_message(error, self.deps.agent_name)
         terminal_extra_content = {STREAM_STATUS_KEY: STREAM_STATUS_COMPLETED}
+        if existing_event_id is not None:
+            edited = await self.deps.delivery_gateway.edit_text(
+                EditTextRequest(
+                    target=target,
+                    event_id=existing_event_id,
+                    new_text=error_text,
+                    extra_content=terminal_extra_content,
+                ),
+            )
+            if edited:
+                return existing_event_id
         return await self.deps.delivery_gateway.send_text(
             SendTextRequest(
                 target=target,

--- a/tests/test_turn_controller_focused.py
+++ b/tests/test_turn_controller_focused.py
@@ -60,7 +60,7 @@ if TYPE_CHECKING:
     from unittest.mock import AsyncMock
 
     from mindroom.coalescing_batch import CoalescedBatch
-    from mindroom.delivery_gateway import DeliveryGateway, SendTextRequest
+    from mindroom.delivery_gateway import DeliveryGateway, EditTextRequest, SendTextRequest
     from mindroom.hooks import MessageEnvelope
     from mindroom.matrix.cache import ThreadHistoryResult
     from mindroom.matrix.event_info import EventInfo
@@ -150,10 +150,16 @@ class _RecordingDeliveryGateway:
     """Typed DeliveryGateway stand-in that records visible sends."""
 
     sent: list[SendTextRequest] = field(default_factory=list)
+    edited: list[EditTextRequest] = field(default_factory=list)
+    edit_succeeds: bool = True
 
     async def send_text(self, request: SendTextRequest) -> str | None:
         self.sent.append(request)
         return f"$sent-{len(self.sent)}:localhost"
+
+    async def edit_text(self, request: EditTextRequest) -> bool:
+        self.edited.append(request)
+        return self.edit_succeeds
 
 
 @dataclass
@@ -759,6 +765,63 @@ async def test_interactive_selection_rehydrates_attachment_context_from_thread(
     request = harness.runner.requests[0]
     assert request.attachment_ids == (record.attachment_id,)
     assert request.response_envelope.attachment_ids == (record.attachment_id,)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("edit_succeeds", "expected_send_count"), [(True, 1), (False, 2)])
+async def test_interactive_selection_attachment_setup_failure_finalizes_ack(
+    config: Config,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    edit_succeeds: bool,
+    expected_send_count: int,
+) -> None:
+    """An attachment-resolution failure visibly terminates the processing acknowledgment."""
+    harness = _build_harness(config, tmp_path)
+    harness.gateway.edit_succeeds = edit_succeeds
+
+    async def fail_attachment_resolution(
+        _normalizer: InboundTurnNormalizer,
+        _request: object,
+    ) -> object:
+        msg = "attachment lookup failed"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(
+        InboundTurnNormalizer,
+        "build_dispatch_payload_with_attachments",
+        fail_attachment_resolution,
+    )
+    room = nio.MatrixRoom(_ROOM_ID, _entity_user_id(config, "general"))
+    selection = interactive.InteractiveSelection(
+        question_event_id="$question:localhost",
+        question_text="Process the attached report?",
+        selection_key="1",
+        selected_label="Yes",
+        selected_value="Yes",
+        thread_id="$thread-root:localhost",
+    )
+
+    await harness.controller.handle_interactive_selection(
+        room,
+        selection=selection,
+        user_id=_SENDER,
+        source_event_id="$selection:localhost",
+    )
+
+    assert harness.runner.requests == []
+    assert len(harness.gateway.sent) == expected_send_count
+    assert len(harness.gateway.edited) == 1
+    edit_request = harness.gateway.edited[0]
+    assert edit_request.event_id == "$sent-1:localhost"
+    assert edit_request.new_text == "[general] ⚠️ Error: attachment lookup failed"
+    assert edit_request.extra_content == {constants.STREAM_STATUS_KEY: constants.STREAM_STATUS_COMPLETED}
+    if not edit_succeeds:
+        fallback_request = harness.gateway.sent[1]
+        assert fallback_request.response_text == edit_request.new_text
+        assert fallback_request.extra_content == edit_request.extra_content
+    assert harness.turn_store.is_handled(selection.question_event_id) is True
+    assert harness.turn_store.is_handled("$selection:localhost") is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_turn_controller_focused.py
+++ b/tests/test_turn_controller_focused.py
@@ -23,6 +23,7 @@ import nio
 import pytest
 
 from mindroom import constants, interactive
+from mindroom.attachments import register_local_attachment
 from mindroom.bot_runtime_view import BotRuntimeState
 from mindroom.coalescing import CoalescingGate
 from mindroom.config.agent import AgentConfig
@@ -695,6 +696,69 @@ async def test_interactive_selection_acks_generates_and_records_once(config: Con
 
     assert harness.turn_store.is_handled(selection.question_event_id) is True
     assert harness.turn_store.is_handled("$selection:localhost") is True
+
+
+@pytest.mark.asyncio
+async def test_interactive_selection_rehydrates_attachment_context_from_thread(
+    config: Config,
+    tmp_path: Path,
+) -> None:
+    """A selection callback turn reaches the attachments of the conversation that asked the question.
+
+    The selection is a synthetic turn with no Matrix message of its own, so it
+    must rebuild the attachment context from the originating thread; before the
+    fix the callback request carried no attachment IDs and ``get_attachment``
+    rejected IDs that were available when the question was asked.
+    """
+    harness = _build_harness(config, tmp_path)
+    media_path = tmp_path / "incoming_media" / "report.pdf"
+    media_path.parent.mkdir(parents=True, exist_ok=True)
+    media_path.write_bytes(b"%PDF-1.4 fake report")
+    record = register_local_attachment(
+        tmp_path,
+        media_path,
+        kind="file",
+        filename="report.pdf",
+        room_id=_ROOM_ID,
+        thread_id="$thread-root:localhost",
+        sender=_SENDER,
+    )
+    assert record is not None
+    triggering_message = make_visible_message(
+        sender=_SENDER,
+        body="here is the report",
+        content={
+            "msgtype": "m.text",
+            "body": "here is the report",
+            constants.ATTACHMENT_IDS_KEY: [record.attachment_id],
+        },
+        thread_id="$thread-root:localhost",
+    )
+    harness.conversation_cache.get_strict_thread_history.return_value = thread_history_result(
+        [triggering_message],
+        is_full_history=True,
+    )
+    room = nio.MatrixRoom(_ROOM_ID, _entity_user_id(config, "general"))
+    selection = interactive.InteractiveSelection(
+        question_event_id="$question:localhost",
+        question_text="Process the attached report?",
+        selection_key="1",
+        selected_label="Yes",
+        selected_value="Yes",
+        thread_id="$thread-root:localhost",
+    )
+
+    await harness.controller.handle_interactive_selection(
+        room,
+        selection=selection,
+        user_id=_SENDER,
+        source_event_id="$selection:localhost",
+    )
+
+    assert len(harness.runner.requests) == 1
+    request = harness.runner.requests[0]
+    assert request.attachment_ids == (record.attachment_id,)
+    assert request.response_envelope.attachment_ids == (record.attachment_id,)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Interactive-selection callback turns now recover the attachment context of their originating Matrix thread.
This allows attachment tools such as `list_attachments` and `get_attachment` to use files that were available when the interactive question was asked.

## Root cause

Normal inbound turns rebuild their attachment context from the current message, thread root, and thread history before response generation.
Interactive selections use a synthetic callback turn that bypassed that preparation and therefore created a `ToolRuntimeContext` with no attachment IDs.

## Implementation

- Rebuild the synthetic selection payload through `InboundTurnNormalizer.build_dispatch_payload_with_attachments` using the already-fetched thread history and canonical room/thread scope.
- Pass the resolved attachment IDs into both the callback `MessageEnvelope` and `ResponseRequest`.
- Keep the immediate “Processing your response...” acknowledgment while treating attachment-resolution errors as terminal dispatch-setup failures.
- Edit the acknowledgment into a user-facing terminal error when setup fails, fall back to a new terminal message if the edit fails, and record the turn only after visible terminal delivery succeeds.
- Reuse the existing `TurnController._finalize_dispatch_failure` policy for both normal dispatch and synthetic selection setup failures.

The selection has no current-turn attachments or fallback images, so the rebuilt payload's media collection is empty by construction; earlier attachment bytes remain represented by thread history while attachment IDs are exposed to tools.

## Tests

- Added a regression test proving thread-scoped attachment IDs reach the selection response request and envelope.
- Added failure-path coverage for successful acknowledgment editing and fallback terminal delivery.
- `uv run pytest tests/test_turn_controller_focused.py tests/test_turn_controller.py tests/test_attachments.py tests/test_attachments_tool.py -n 0 --no-cov -q`
- `PUPPETEER_SKIP_DOWNLOAD=true uv run pytest -n auto --no-cov -q`
- `uv run pre-commit run --all-files`

All checks pass.
Live Matrix end-to-end testing was not run for this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Interactive selections now retain and apply the attachment context from the originating conversation thread.
  * Response generation for interactive selections now correctly includes related attachment identifiers.
  * If interactive payload setup fails, the prior acknowledgement is updated in the chat instead of only showing a new terminal message.
* **Tests**
  * Added/expanded unit coverage for interactive-selection attachment handling and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->