### PR TITLE
fix: export $MINDROOM_AGENT_WORKSPACE on local shell path + clearer mindroom_output_path error

### DIFF
--- a/docs/attachments.md
+++ b/docs/attachments.md
@@ -93,7 +93,7 @@ agents:
 When `mindroom_output_path` is omitted, `get_attachment()` returns the attachment metadata response, including the runtime-local `local_path`.
 For worker-routed agents, prefer `get_attachment("att_...", mindroom_output_path="incoming/file.ext")` before processing an attachment with `file`, `coding`, `python`, or `shell`, because the runtime-local path may not exist inside the worker workspace.
 `mindroom_output_path` must be a file path relative to the agent workspace.
-It must not be empty, absolute, point at the workspace root, contain `..` or NUL bytes, or use environment or user expansion.
+It must not be empty, absolute, point at the workspace root, contain `..` or NUL bytes, start with `~`, or contain `$` or `%` characters.
 When the save succeeds, the response includes `mindroom_tool_output` with `status: "saved_to_file"`, `path`, byte count, `format: "binary"`, and `sha256`.
 In shell tools, that workspace is exposed as `$MINDROOM_AGENT_WORKSPACE`; in worker-routed shell and python tools it is also `~` and `$HOME`, so `incoming/file.ext` and `~/incoming/file.ext` refer to the same saved file.
 

--- a/docs/attachments.md
+++ b/docs/attachments.md
@@ -95,7 +95,7 @@ For worker-routed agents, prefer `get_attachment("att_...", mindroom_output_path
 `mindroom_output_path` must be a file path relative to the agent workspace.
 It must not be empty, absolute, point at the workspace root, contain `..` or NUL bytes, or use environment or user expansion.
 When the save succeeds, the response includes `mindroom_tool_output` with `status: "saved_to_file"`, `path`, byte count, `format: "binary"`, and `sha256`.
-In worker-routed shell and python tools, that workspace is also exposed as `~`, `$HOME`, and `$MINDROOM_AGENT_WORKSPACE`, so `incoming/file.ext` and `~/incoming/file.ext` refer to the same saved file.
+In shell tools, that workspace is exposed as `$MINDROOM_AGENT_WORKSPACE`; in worker-routed shell and python tools it is also `~` and `$HOME`, so `incoming/file.ext` and `~/incoming/file.ext` refer to the same saved file.
 
 `attachment_ids` accepts only context attachment IDs (`att_*`).
 `attachment_file_paths` accepts local file paths and auto-registers them in the current context before sending.

--- a/docs/tools/matrix-and-attachments.md
+++ b/docs/tools/matrix-and-attachments.md
@@ -321,7 +321,7 @@ matrix_api(
 `get_attachment(attachment_id, mindroom_output_path="relative/path")` saves the attachment bytes into the agent workspace and returns a `mindroom_tool_output` save receipt with the saved path, byte count, binary format, and SHA256 digest.
 Use `mindroom_output_path` before handing attachments to worker-routed workspace tools such as `file`, `coding`, `python`, or `shell`, because the runtime-local path may not exist inside the worker workspace.
 In shell tools, the agent workspace is exposed as `$MINDROOM_AGENT_WORKSPACE`; in worker-routed shell and python tools it is also `~` and `$HOME`, so a saved path like `incoming/file.txt` can also be read as `~/incoming/file.txt`.
-The path must be relative to the workspace and must not be empty, absolute, point at the workspace root, contain `..` or NUL bytes, or use environment or user expansion.
+The path must be relative to the workspace and must not be empty, absolute, point at the workspace root, contain `..` or NUL bytes, start with `~`, or contain `$` or `%` characters.
 `register_attachment()` turns a local file path into a new context-scoped `att_*` ID and appends that ID to the current runtime context so later tool calls in the same run can reuse it.
 Relative `register_attachment()` paths resolve from the agent workspace when one is available, and they must stay inside that workspace.
 Attachment records include kind, filename, MIME type, room ID, thread ID, sender, creation time, and an `available` flag that reports whether the local file still exists.

--- a/docs/tools/matrix-and-attachments.md
+++ b/docs/tools/matrix-and-attachments.md
@@ -320,7 +320,7 @@ matrix_api(
 `get_attachment()` returns a single attachment record, including the runtime-local path, when called with only an attachment ID.
 `get_attachment(attachment_id, mindroom_output_path="relative/path")` saves the attachment bytes into the agent workspace and returns a `mindroom_tool_output` save receipt with the saved path, byte count, binary format, and SHA256 digest.
 Use `mindroom_output_path` before handing attachments to worker-routed workspace tools such as `file`, `coding`, `python`, or `shell`, because the runtime-local path may not exist inside the worker workspace.
-In worker-routed shell and python tools, the agent workspace is also `~`, `$HOME`, and `$MINDROOM_AGENT_WORKSPACE`, so a saved path like `incoming/file.txt` can also be read as `~/incoming/file.txt`.
+In shell tools, the agent workspace is exposed as `$MINDROOM_AGENT_WORKSPACE`; in worker-routed shell and python tools it is also `~` and `$HOME`, so a saved path like `incoming/file.txt` can also be read as `~/incoming/file.txt`.
 The path must be relative to the workspace and must not be empty, absolute, point at the workspace root, contain `..` or NUL bytes, or use environment or user expansion.
 `register_attachment()` turns a local file path into a new context-scoped `att_*` ID and appends that ID to the current runtime context so later tool calls in the same run can reuse it.
 Relative `register_attachment()` paths resolve from the agent workspace when one is available, and they must stay inside that workspace.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -6965,7 +6965,7 @@ matrix_api(
 `get_attachment()` returns a single attachment record, including the runtime-local path, when called with only an attachment ID.
 `get_attachment(attachment_id, mindroom_output_path="relative/path")` saves the attachment bytes into the agent workspace and returns a `mindroom_tool_output` save receipt with the saved path, byte count, binary format, and SHA256 digest.
 Use `mindroom_output_path` before handing attachments to worker-routed workspace tools such as `file`, `coding`, `python`, or `shell`, because the runtime-local path may not exist inside the worker workspace.
-In worker-routed shell and python tools, the agent workspace is also `~`, `$HOME`, and `$MINDROOM_AGENT_WORKSPACE`, so a saved path like `incoming/file.txt` can also be read as `~/incoming/file.txt`.
+In shell tools, the agent workspace is exposed as `$MINDROOM_AGENT_WORKSPACE`; in worker-routed shell and python tools it is also `~` and `$HOME`, so a saved path like `incoming/file.txt` can also be read as `~/incoming/file.txt`.
 The path must be relative to the workspace and must not be empty, absolute, point at the workspace root, contain `..` or NUL bytes, or use environment or user expansion.
 `register_attachment()` turns a local file path into a new context-scoped `att_*` ID and appends that ID to the current runtime context so later tool calls in the same run can reuse it.
 Relative `register_attachment()` paths resolve from the agent workspace when one is available, and they must stay inside that workspace.
@@ -13245,7 +13245,7 @@ For worker-routed agents, prefer `get_attachment("att_...", mindroom_output_path
 `mindroom_output_path` must be a file path relative to the agent workspace.
 It must not be empty, absolute, point at the workspace root, contain `..` or NUL bytes, or use environment or user expansion.
 When the save succeeds, the response includes `mindroom_tool_output` with `status: "saved_to_file"`, `path`, byte count, `format: "binary"`, and `sha256`.
-In worker-routed shell and python tools, that workspace is also exposed as `~`, `$HOME`, and `$MINDROOM_AGENT_WORKSPACE`, so `incoming/file.ext` and `~/incoming/file.ext` refer to the same saved file.
+In shell tools, that workspace is exposed as `$MINDROOM_AGENT_WORKSPACE`; in worker-routed shell and python tools it is also `~` and `$HOME`, so `incoming/file.ext` and `~/incoming/file.ext` refer to the same saved file.
 
 `attachment_ids` accepts only context attachment IDs (`att_*`).
 `attachment_file_paths` accepts local file paths and auto-registers them in the current context before sending.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -6966,7 +6966,7 @@ matrix_api(
 `get_attachment(attachment_id, mindroom_output_path="relative/path")` saves the attachment bytes into the agent workspace and returns a `mindroom_tool_output` save receipt with the saved path, byte count, binary format, and SHA256 digest.
 Use `mindroom_output_path` before handing attachments to worker-routed workspace tools such as `file`, `coding`, `python`, or `shell`, because the runtime-local path may not exist inside the worker workspace.
 In shell tools, the agent workspace is exposed as `$MINDROOM_AGENT_WORKSPACE`; in worker-routed shell and python tools it is also `~` and `$HOME`, so a saved path like `incoming/file.txt` can also be read as `~/incoming/file.txt`.
-The path must be relative to the workspace and must not be empty, absolute, point at the workspace root, contain `..` or NUL bytes, or use environment or user expansion.
+The path must be relative to the workspace and must not be empty, absolute, point at the workspace root, contain `..` or NUL bytes, start with `~`, or contain `$` or `%` characters.
 `register_attachment()` turns a local file path into a new context-scoped `att_*` ID and appends that ID to the current runtime context so later tool calls in the same run can reuse it.
 Relative `register_attachment()` paths resolve from the agent workspace when one is available, and they must stay inside that workspace.
 Attachment records include kind, filename, MIME type, room ID, thread ID, sender, creation time, and an `available` flag that reports whether the local file still exists.
@@ -13243,7 +13243,7 @@ agents:
 When `mindroom_output_path` is omitted, `get_attachment()` returns the attachment metadata response, including the runtime-local `local_path`.
 For worker-routed agents, prefer `get_attachment("att_...", mindroom_output_path="incoming/file.ext")` before processing an attachment with `file`, `coding`, `python`, or `shell`, because the runtime-local path may not exist inside the worker workspace.
 `mindroom_output_path` must be a file path relative to the agent workspace.
-It must not be empty, absolute, point at the workspace root, contain `..` or NUL bytes, or use environment or user expansion.
+It must not be empty, absolute, point at the workspace root, contain `..` or NUL bytes, start with `~`, or contain `$` or `%` characters.
 When the save succeeds, the response includes `mindroom_tool_output` with `status: "saved_to_file"`, `path`, byte count, `format: "binary"`, and `sha256`.
 In shell tools, that workspace is exposed as `$MINDROOM_AGENT_WORKSPACE`; in worker-routed shell and python tools it is also `~` and `$HOME`, so `incoming/file.ext` and `~/incoming/file.ext` refer to the same saved file.
 

--- a/skills/mindroom-docs/references/page__attachments__index.md
+++ b/skills/mindroom-docs/references/page__attachments__index.md
@@ -89,7 +89,7 @@ agents:
 When `mindroom_output_path` is omitted, `get_attachment()` returns the attachment metadata response, including the runtime-local `local_path`.
 For worker-routed agents, prefer `get_attachment("att_...", mindroom_output_path="incoming/file.ext")` before processing an attachment with `file`, `coding`, `python`, or `shell`, because the runtime-local path may not exist inside the worker workspace.
 `mindroom_output_path` must be a file path relative to the agent workspace.
-It must not be empty, absolute, point at the workspace root, contain `..` or NUL bytes, or use environment or user expansion.
+It must not be empty, absolute, point at the workspace root, contain `..` or NUL bytes, start with `~`, or contain `$` or `%` characters.
 When the save succeeds, the response includes `mindroom_tool_output` with `status: "saved_to_file"`, `path`, byte count, `format: "binary"`, and `sha256`.
 In shell tools, that workspace is exposed as `$MINDROOM_AGENT_WORKSPACE`; in worker-routed shell and python tools it is also `~` and `$HOME`, so `incoming/file.ext` and `~/incoming/file.ext` refer to the same saved file.
 

--- a/skills/mindroom-docs/references/page__attachments__index.md
+++ b/skills/mindroom-docs/references/page__attachments__index.md
@@ -91,7 +91,7 @@ For worker-routed agents, prefer `get_attachment("att_...", mindroom_output_path
 `mindroom_output_path` must be a file path relative to the agent workspace.
 It must not be empty, absolute, point at the workspace root, contain `..` or NUL bytes, or use environment or user expansion.
 When the save succeeds, the response includes `mindroom_tool_output` with `status: "saved_to_file"`, `path`, byte count, `format: "binary"`, and `sha256`.
-In worker-routed shell and python tools, that workspace is also exposed as `~`, `$HOME`, and `$MINDROOM_AGENT_WORKSPACE`, so `incoming/file.ext` and `~/incoming/file.ext` refer to the same saved file.
+In shell tools, that workspace is exposed as `$MINDROOM_AGENT_WORKSPACE`; in worker-routed shell and python tools it is also `~` and `$HOME`, so `incoming/file.ext` and `~/incoming/file.ext` refer to the same saved file.
 
 `attachment_ids` accepts only context attachment IDs (`att_*`).
 `attachment_file_paths` accepts local file paths and auto-registers them in the current context before sending.

--- a/skills/mindroom-docs/references/page__tools__matrix-and-attachments__index.md
+++ b/skills/mindroom-docs/references/page__tools__matrix-and-attachments__index.md
@@ -317,7 +317,7 @@ matrix_api(
 `get_attachment(attachment_id, mindroom_output_path="relative/path")` saves the attachment bytes into the agent workspace and returns a `mindroom_tool_output` save receipt with the saved path, byte count, binary format, and SHA256 digest.
 Use `mindroom_output_path` before handing attachments to worker-routed workspace tools such as `file`, `coding`, `python`, or `shell`, because the runtime-local path may not exist inside the worker workspace.
 In shell tools, the agent workspace is exposed as `$MINDROOM_AGENT_WORKSPACE`; in worker-routed shell and python tools it is also `~` and `$HOME`, so a saved path like `incoming/file.txt` can also be read as `~/incoming/file.txt`.
-The path must be relative to the workspace and must not be empty, absolute, point at the workspace root, contain `..` or NUL bytes, or use environment or user expansion.
+The path must be relative to the workspace and must not be empty, absolute, point at the workspace root, contain `..` or NUL bytes, start with `~`, or contain `$` or `%` characters.
 `register_attachment()` turns a local file path into a new context-scoped `att_*` ID and appends that ID to the current runtime context so later tool calls in the same run can reuse it.
 Relative `register_attachment()` paths resolve from the agent workspace when one is available, and they must stay inside that workspace.
 Attachment records include kind, filename, MIME type, room ID, thread ID, sender, creation time, and an `available` flag that reports whether the local file still exists.

--- a/skills/mindroom-docs/references/page__tools__matrix-and-attachments__index.md
+++ b/skills/mindroom-docs/references/page__tools__matrix-and-attachments__index.md
@@ -316,7 +316,7 @@ matrix_api(
 `get_attachment()` returns a single attachment record, including the runtime-local path, when called with only an attachment ID.
 `get_attachment(attachment_id, mindroom_output_path="relative/path")` saves the attachment bytes into the agent workspace and returns a `mindroom_tool_output` save receipt with the saved path, byte count, binary format, and SHA256 digest.
 Use `mindroom_output_path` before handing attachments to worker-routed workspace tools such as `file`, `coding`, `python`, or `shell`, because the runtime-local path may not exist inside the worker workspace.
-In worker-routed shell and python tools, the agent workspace is also `~`, `$HOME`, and `$MINDROOM_AGENT_WORKSPACE`, so a saved path like `incoming/file.txt` can also be read as `~/incoming/file.txt`.
+In shell tools, the agent workspace is exposed as `$MINDROOM_AGENT_WORKSPACE`; in worker-routed shell and python tools it is also `~` and `$HOME`, so a saved path like `incoming/file.txt` can also be read as `~/incoming/file.txt`.
 The path must be relative to the workspace and must not be empty, absolute, point at the workspace root, contain `..` or NUL bytes, or use environment or user expansion.
 `register_attachment()` turns a local file path into a new context-scoped `att_*` ID and appends that ID to the current runtime context so later tool calls in the same run can reuse it.
 Relative `register_attachment()` paths resolve from the agent workspace when one is available, and they must stay inside that workspace.

--- a/src/mindroom/prompts.py
+++ b/src/mindroom/prompts.py
@@ -150,7 +150,8 @@ Simply present your findings naturally, as if you already knew the information.
 OUTPUT_REDIRECT_PROMPT = (
     "To save a tool's full supported output to a file in your workspace instead of returning it, pass "
     "`mindroom_output_path: <relative-path>` and then inspect the saved file with file, coding, python, or shell tools. "
-    "In worker-routed shell and python tools, `~`, `$HOME`, and `$MINDROOM_AGENT_WORKSPACE` point at that workspace."
+    "In shell tools, `$MINDROOM_AGENT_WORKSPACE` points at that workspace; in worker-routed shell and python tools, "
+    "`~` and `$HOME` point there too."
 )
 
 DATETIME_CONTEXT_TEMPLATE = """## Current Date and Time

--- a/src/mindroom/tool_system/output_files.py
+++ b/src/mindroom/tool_system/output_files.py
@@ -298,7 +298,7 @@ def _validate_raw_output_path(raw_path: object) -> tuple[str, Path] | str:
     elif _path_has_environment_expansion(raw_path):
         error = (
             f"mindroom_output_path must be a plain path relative to the agent workspace, but got {raw_path!r}. "
-            "`~`, `$VAR`, and `%VAR%` are not expanded; pass a workspace-relative path like 'output.json', "
+            "Paths must not start with `~` or contain `$` or `%`; pass a workspace-relative path like 'output.json', "
             "then copy the file elsewhere with shell tools if needed."
         )
     else:

--- a/src/mindroom/tool_system/output_files.py
+++ b/src/mindroom/tool_system/output_files.py
@@ -296,7 +296,11 @@ def _validate_raw_output_path(raw_path: object) -> tuple[str, Path] | str:
     elif "\x00" in raw_path:
         error = "mindroom_output_path must not contain NUL bytes."
     elif _path_has_environment_expansion(raw_path):
-        error = "mindroom_output_path must not use environment or user expansion."
+        error = (
+            f"mindroom_output_path must be a plain path relative to the agent workspace, but got {raw_path!r}. "
+            "`~`, `$VAR`, and `%VAR%` are not expanded; pass a workspace-relative path like 'output.json', "
+            "then copy the file elsewhere with shell tools if needed."
+        )
     else:
         relative_path = Path(raw_path)
         if relative_path.is_absolute():

--- a/src/mindroom/tools/shell.py
+++ b/src/mindroom/tools/shell.py
@@ -161,9 +161,11 @@ def _shell_subprocess_env(
     if base_process_env is not None:
         env.update({key: value for key, value in base_process_env.items() if key in _LOCAL_SHELL_PASSTHROUGH_ENV_KEYS})
     env.update(runtime_env)
-    if base_process_env is not None:
-        env.update(_workspace_home_contract_env_from_process_env(base_process_env))
-    if workspace_dir is not None and not env.get("MINDROOM_AGENT_WORKSPACE"):
+    workspace_home_contract = (
+        _workspace_home_contract_env_from_process_env(base_process_env) if base_process_env is not None else {}
+    )
+    env.update(workspace_home_contract)
+    if workspace_dir is not None and not workspace_home_contract:
         # Local (non-worker) execution keeps the host HOME, but the workspace
         # env var is still promised to agents, so export it from base_dir.
         env["MINDROOM_AGENT_WORKSPACE"] = str(workspace_dir.expanduser().resolve())

--- a/src/mindroom/tools/shell.py
+++ b/src/mindroom/tools/shell.py
@@ -154,6 +154,7 @@ def _shell_subprocess_env(
     *,
     base_process_env: dict[str, str] | None = None,
     shell_path_prepend: str | None = None,
+    workspace_dir: Path | None = None,
 ) -> dict[str, str]:
     """Build the env passed to shell subprocesses."""
     env = {key: value for key, value in os.environ.items() if key in _LOCAL_SHELL_PASSTHROUGH_ENV_KEYS}
@@ -162,6 +163,10 @@ def _shell_subprocess_env(
     env.update(runtime_env)
     if base_process_env is not None:
         env.update(_workspace_home_contract_env_from_process_env(base_process_env))
+    if workspace_dir is not None and not env.get("MINDROOM_AGENT_WORKSPACE"):
+        # Local (non-worker) execution keeps the host HOME, but the workspace
+        # env var is still promised to agents, so export it from base_dir.
+        env["MINDROOM_AGENT_WORKSPACE"] = str(workspace_dir.expanduser().resolve())
 
     path_value = subprocess_path_with_prepends(
         env.get("PATH"),
@@ -393,6 +398,7 @@ def shell_tools() -> type[Toolkit]:  # noqa: C901
                 self._runtime_env,
                 base_process_env=self._base_process_env,
                 shell_path_prepend=self._shell_path_prepend,
+                workspace_dir=self.base_dir,
             )
             argv = _shell_subprocess_args(command_args, subprocess_env)
             cwd = str(self.base_dir) if self.base_dir else None

--- a/tests/test_shell_async.py
+++ b/tests/test_shell_async.py
@@ -846,7 +846,7 @@ async def test_local_shell_replaces_stale_agent_workspace_env(tmp_path: Path) ->
     entrypoint = tool.async_functions["run_shell_command"].entrypoint
     assert entrypoint is not None
 
-    result = await entrypoint(["/bin/sh", "-c", 'printf %s "$MINDROOM_AGENT_WORKSPACE"'])
+    result = await entrypoint('printf %s "$MINDROOM_AGENT_WORKSPACE"')
     assert result == str(workspace.resolve())
 
 

--- a/tests/test_shell_async.py
+++ b/tests/test_shell_async.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths
 
 
-def _make_runtime_paths(tmp_path: Path) -> RuntimePaths:
+def _make_runtime_paths(tmp_path: Path, *, process_env: dict[str, str] | None = None) -> RuntimePaths:
     config_path = tmp_path / "config.yaml"
     config_path.write_text(
         "models:\n  default:\n    provider: openai\n    id: gpt-5.4\nagents: {}\nrouter:\n  model: default\n",
@@ -42,7 +42,7 @@ def _make_runtime_paths(tmp_path: Path) -> RuntimePaths:
     return resolve_runtime_paths(
         config_path=config_path,
         storage_path=tmp_path / "storage",
-        process_env={},
+        process_env={} if process_env is None else process_env,
     )
 
 
@@ -787,6 +787,25 @@ def test_shell_subprocess_env_exports_workspace_from_base_dir_without_home_contr
     assert env["HOME"] == "/home/host-user"
 
 
+def test_shell_subprocess_env_replaces_incomplete_workspace_contract(tmp_path: Path) -> None:
+    """An unvalidated process workspace must not override the local agent workspace."""
+    workspace = tmp_path / "workspace"
+    stale_workspace = tmp_path / "stale-workspace"
+    base_env = {
+        "HOME": "/home/host-user",
+        "MINDROOM_AGENT_WORKSPACE": str(stale_workspace),
+    }
+
+    env = _shell_subprocess_env(
+        {"MINDROOM_AGENT_WORKSPACE": str(stale_workspace)},
+        base_process_env=base_env,
+        workspace_dir=workspace,
+    )
+
+    assert env["MINDROOM_AGENT_WORKSPACE"] == str(workspace.resolve())
+    assert env["HOME"] == "/home/host-user"
+
+
 def test_shell_subprocess_env_prefers_worker_home_contract_over_base_dir(tmp_path: Path) -> None:
     """The worker workspace HOME contract stays authoritative over the base_dir fallback."""
     contract_workspace = tmp_path / "contract-workspace"
@@ -806,11 +825,17 @@ def test_shell_subprocess_env_prefers_worker_home_contract_over_base_dir(tmp_pat
 
 
 @pytest.mark.asyncio
-async def test_local_shell_exports_agent_workspace_env(tmp_path: Path) -> None:
-    """Locally-executed shell commands should see MINDROOM_AGENT_WORKSPACE from base_dir."""
+async def test_local_shell_replaces_stale_agent_workspace_env(tmp_path: Path) -> None:
+    """Local shell execution should replace a stale process workspace with base_dir."""
     workspace = tmp_path / "agent-workspace"
     workspace.mkdir()
-    runtime_paths = _make_runtime_paths(tmp_path)
+    runtime_paths = _make_runtime_paths(
+        tmp_path,
+        process_env={
+            "HOME": str(tmp_path / "host-home"),
+            "MINDROOM_AGENT_WORKSPACE": str(tmp_path / "stale-workspace"),
+        },
+    )
     tool = get_tool_by_name(
         "shell",
         runtime_paths,
@@ -821,7 +846,7 @@ async def test_local_shell_exports_agent_workspace_env(tmp_path: Path) -> None:
     entrypoint = tool.async_functions["run_shell_command"].entrypoint
     assert entrypoint is not None
 
-    result = await entrypoint(["bash", "-lc", 'printf %s "$MINDROOM_AGENT_WORKSPACE"'])
+    result = await entrypoint(["/bin/sh", "-c", 'printf %s "$MINDROOM_AGENT_WORKSPACE"'])
     assert result == str(workspace.resolve())
 
 

--- a/tests/test_shell_async.py
+++ b/tests/test_shell_async.py
@@ -18,6 +18,7 @@ from mindroom.shell_execution import _MAX_OUTPUT_BYTES
 from mindroom.tool_system.metadata import get_tool_by_name
 from mindroom.tools.shell import (
     _process_registry,
+    _shell_subprocess_env,
     _workspace_home_contract_env_from_process_env,
     shell_tools,
 )
@@ -774,6 +775,54 @@ def test_workspace_home_contract_env_requires_full_identity_fragment(tmp_path: P
     mismatched_env = dict(base_env)
     mismatched_env["XDG_DATA_HOME"] = str(tmp_path / "other-data")
     assert _workspace_home_contract_env_from_process_env(mismatched_env) == {}
+
+
+def test_shell_subprocess_env_exports_workspace_from_base_dir_without_home_contract(tmp_path: Path) -> None:
+    """Local execution keeps the host HOME but still exports the workspace env var."""
+    workspace = tmp_path / "workspace"
+
+    env = _shell_subprocess_env({}, base_process_env={"HOME": "/home/host-user"}, workspace_dir=workspace)
+
+    assert env["MINDROOM_AGENT_WORKSPACE"] == str(workspace.resolve())
+    assert env["HOME"] == "/home/host-user"
+
+
+def test_shell_subprocess_env_prefers_worker_home_contract_over_base_dir(tmp_path: Path) -> None:
+    """The worker workspace HOME contract stays authoritative over the base_dir fallback."""
+    contract_workspace = tmp_path / "contract-workspace"
+    base_env = {
+        **workspace_home_identity_env(contract_workspace),
+        "XDG_CACHE_HOME": str(tmp_path / "cache"),
+        "PIP_CACHE_DIR": str(tmp_path / "cache" / "pip"),
+        "UV_CACHE_DIR": str(tmp_path / "cache" / "uv"),
+        "PYTHONPYCACHEPREFIX": str(tmp_path / "cache" / "pycache"),
+        "VIRTUAL_ENV": str(tmp_path / "venv"),
+    }
+
+    env = _shell_subprocess_env({}, base_process_env=base_env, workspace_dir=tmp_path / "other-base-dir")
+
+    assert env["MINDROOM_AGENT_WORKSPACE"] == str(contract_workspace)
+    assert env["HOME"] == str(contract_workspace)
+
+
+@pytest.mark.asyncio
+async def test_local_shell_exports_agent_workspace_env(tmp_path: Path) -> None:
+    """Locally-executed shell commands should see MINDROOM_AGENT_WORKSPACE from base_dir."""
+    workspace = tmp_path / "agent-workspace"
+    workspace.mkdir()
+    runtime_paths = _make_runtime_paths(tmp_path)
+    tool = get_tool_by_name(
+        "shell",
+        runtime_paths,
+        disable_sandbox_proxy=True,
+        worker_target=None,
+        tool_init_overrides={"base_dir": str(workspace)},
+    )
+    entrypoint = tool.async_functions["run_shell_command"].entrypoint
+    assert entrypoint is not None
+
+    result = await entrypoint(["bash", "-lc", 'printf %s "$MINDROOM_AGENT_WORKSPACE"'])
+    assert result == str(workspace.resolve())
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_output_files.py
+++ b/tests/test_tool_output_files.py
@@ -34,6 +34,7 @@ from mindroom.tool_system.output_files import (
     _wrap_function_for_output_files,
     ensure_output_path_schema_optional,
     saved_tool_output_receipt,
+    validate_output_path_syntax,
     wrap_toolkit_for_output_files,
 )
 from mindroom.tool_system.tool_hooks import build_tool_hook_bridge, prepend_tool_hook_bridge
@@ -542,6 +543,16 @@ def test_invalid_output_paths_rejected_without_calling_tool(tmp_path: Path, bad_
 
     assert seen == []
     assert _receipt(result.result)["status"] == "error"
+
+
+@pytest.mark.parametrize("expanded_path", ["~/ride-trace.json", "$HOME/ride-trace.json", "%USERPROFILE%\\out.json"])
+def test_expansion_rejected_with_actionable_workspace_relative_message(expanded_path: str) -> None:
+    error = validate_output_path_syntax(expanded_path)
+
+    assert error is not None
+    assert repr(expanded_path) in error
+    assert "relative to the agent workspace" in error
+    assert "workspace-relative path" in error
 
 
 def test_existing_directory_rejected_without_calling_tool(tmp_path: Path) -> None:

--- a/tests/test_tool_output_files.py
+++ b/tests/test_tool_output_files.py
@@ -545,13 +545,24 @@ def test_invalid_output_paths_rejected_without_calling_tool(tmp_path: Path, bad_
     assert _receipt(result.result)["status"] == "error"
 
 
-@pytest.mark.parametrize("expanded_path", ["~/ride-trace.json", "$HOME/ride-trace.json", "%USERPROFILE%\\out.json"])
-def test_expansion_rejected_with_actionable_workspace_relative_message(expanded_path: str) -> None:
-    error = validate_output_path_syntax(expanded_path)
+@pytest.mark.parametrize(
+    "rejected_path",
+    [
+        "~/ride-trace.json",
+        "$HOME/ride-trace.json",
+        "%USERPROFILE%\\out.json",
+        "reports/100%/out.json",
+        "price$5/output.json",
+        "~literal/output.json",
+    ],
+)
+def test_expansion_characters_rejected_with_actionable_workspace_relative_message(rejected_path: str) -> None:
+    error = validate_output_path_syntax(rejected_path)
 
     assert error is not None
-    assert repr(expanded_path) in error
+    assert repr(rejected_path) in error
     assert "relative to the agent workspace" in error
+    assert "must not start with `~` or contain `$` or `%`" in error
     assert "workspace-relative path" in error
 
 


### PR DESCRIPTION
## Summary

- Export `MINDROOM_AGENT_WORKSPACE` from the agent workspace for locally executed shell tools.
- Keep a complete worker HOME contract authoritative while replacing stale or incomplete primary-process workspace values.
- Clarify that local shell tools expose the workspace through `MINDROOM_AGENT_WORKSPACE`, while worker-routed shell and Python tools also use the workspace as `HOME`.
- Make `mindroom_output_path` validation errors actionable and document the exact `~`, `$`, and `%` restrictions.
- Add unit and toolkit-seam regressions for local execution, worker-contract precedence, stale environment values, and rejected output paths.

## Root cause

Agents whose shell tool bypassed worker routing executed on the primary host.
That path kept the host `HOME` but did not derive `MINDROOM_AGENT_WORKSPACE` from the tool `base_dir`, despite the system prompt promising the variable.
The initial fallback also trusted any pre-existing non-empty variable, even when it was not part of a valid worker HOME contract.

The shell environment builder now preserves `MINDROOM_AGENT_WORKSPACE` only when it comes from a validated worker contract.
Otherwise, a configured shell `base_dir` is the authoritative local agent workspace.

## Validation

- `uv run pytest tests/test_shell_async.py tests/test_tool_output_files.py -x -n 0 --no-cov -q`
- `PUPPETEER_SKIP_DOWNLOAD=true uv run pytest -x -n 0 --no-cov -q`
- `PUPPETEER_SKIP_DOWNLOAD=true uv run pre-commit run --all-files`

All commands pass.
The local shell behavior was exercised through the real toolkit entrypoint; a Matrix live test was not needed for this subprocess-environment change.

## Scope

Local in-process Python execution still does not receive a per-agent `MINDROOM_AGENT_WORKSPACE`, because setting it would require mutating shared process environment state.
Worker-routed Python already receives the complete workspace HOME contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified valid and invalid paths when saving attachments to the workspace.
  * Documented workspace path environment variables for shell and Python tools.

* **Bug Fixes**
  * Improved workspace environment handling for local shell commands.
  * Added clearer validation errors for unsupported path formats, including `~`, `$`, and `%`.

* **Tests**
  * Added coverage for workspace environment resolution and attachment path validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->