### PR TITLE
feat(shell): tell agents where shell commands actually run

### DIFF
--- a/src/mindroom/tools/shell.py
+++ b/src/mindroom/tools/shell.py
@@ -80,6 +80,12 @@ _SHELL_ARGS_ERROR = (
     '\'args\' must be a shell command string or a flat list of strings. Send args like "ls -la" or ["git", "status"].'
 )
 _SHELL_COMMAND_LINE_CHARS = frozenset("$|&;<>*?~`!(){}[]\n\r")
+_WORKSPACE_CWD_NOTE = (
+    "The command runs in your agent workspace as its working directory "
+    "(echoed as a `[cwd: ...]` first line in the result). Always use relative paths or "
+    "`$MINDROOM_AGENT_WORKSPACE` for workspace files instead of `~`: worker-routed execution maps `~` "
+    "to the workspace, while local execution maps it to the host home."
+)
 
 # Module-level process registry shared across all MindRoomShellTools instances.
 # This ensures handles survive toolkit re-creation for local execution; when a
@@ -180,20 +186,6 @@ def _shell_subprocess_env(
         env["PATH"] = path_value
     env.update(vendor_telemetry_env_values())
     return env
-
-
-def _workspace_cwd_note(base_process_env: dict[str, str]) -> str:
-    """One mode-true sentence about where shell commands run, appended to the tool description."""
-    if _workspace_home_contract_env_from_process_env(base_process_env):
-        return (
-            "The command runs in your agent workspace as its working directory "
-            "(echoed as a `[cwd: ...]` first line in the result); `~` and `$HOME` point at the workspace too."
-        )
-    return (
-        "The command runs in your agent workspace as its working directory "
-        "(echoed as a `[cwd: ...]` first line in the result), but `~` and `$HOME` point at the host home, "
-        "not your workspace. For workspace files use relative paths or `$MINDROOM_AGENT_WORKSPACE`, never `~`."
-    )
 
 
 def _login_bash_command_index(args: list[str]) -> int | None:
@@ -378,7 +370,7 @@ def shell_tools() -> type[Toolkit]:  # noqa: C901
             self._base_process_env = dict(runtime_paths.process_env)
             if run_shell_command_function is not None and self.base_dir is not None:
                 run_shell_command_function.description = (
-                    f"{run_shell_command_function.description or ''}\n\n{_workspace_cwd_note(self._base_process_env)}"
+                    f"{run_shell_command_function.description or ''}\n\n{_WORKSPACE_CWD_NOTE}"
                 ).strip()
             self._handle_namespace = _handle_namespace(runtime_paths=runtime_paths, base_dir=self.base_dir)
             self._shell_path_prepend = shell_path_prepend

--- a/src/mindroom/tools/shell.py
+++ b/src/mindroom/tools/shell.py
@@ -182,6 +182,20 @@ def _shell_subprocess_env(
     return env
 
 
+def _workspace_cwd_note(base_process_env: dict[str, str]) -> str:
+    """One mode-true sentence about where shell commands run, appended to the tool description."""
+    if _workspace_home_contract_env_from_process_env(base_process_env):
+        return (
+            "The command runs in your agent workspace as its working directory "
+            "(echoed as a `[cwd: ...]` first line in the result); `~` and `$HOME` point at the workspace too."
+        )
+    return (
+        "The command runs in your agent workspace as its working directory "
+        "(echoed as a `[cwd: ...]` first line in the result), but `~` and `$HOME` point at the host home, "
+        "not your workspace. For workspace files use relative paths or `$MINDROOM_AGENT_WORKSPACE`, never `~`."
+    )
+
+
 def _login_bash_command_index(args: list[str]) -> int | None:
     """Return the command index for `bash -lc ...` style invocations."""
     if not args or Path(args[0]).name != "bash":
@@ -362,6 +376,10 @@ def shell_tools() -> type[Toolkit]:  # noqa: C901
                 ),
             )
             self._base_process_env = dict(runtime_paths.process_env)
+            if run_shell_command_function is not None and self.base_dir is not None:
+                run_shell_command_function.description = (
+                    f"{run_shell_command_function.description or ''}\n\n{_workspace_cwd_note(self._base_process_env)}"
+                ).strip()
             self._handle_namespace = _handle_namespace(runtime_paths=runtime_paths, base_dir=self.base_dir)
             self._shell_path_prepend = shell_path_prepend
             # Sandbox tool subprocesses delegate execution to the runner's
@@ -405,7 +423,7 @@ def shell_tools() -> type[Toolkit]:  # noqa: C901
             argv = _shell_subprocess_args(command_args, subprocess_env)
             cwd = str(self.base_dir) if self.base_dir else None
             if self._supervisor_socket is not None:
-                return await run_command_via_supervisor(
+                message = await run_command_via_supervisor(
                     self._supervisor_socket,
                     namespace=self._handle_namespace,
                     argv=argv,
@@ -414,16 +432,20 @@ def shell_tools() -> type[Toolkit]:  # noqa: C901
                     tail=tail,
                     timeout=timeout,
                 )
-            result = await run_command(
-                _process_registry,
-                namespace=self._handle_namespace,
-                argv=argv,
-                env=subprocess_env,
-                cwd=cwd,
-                tail=tail,
-                timeout=timeout,
-            )
-            return result.message
+            else:
+                result = await run_command(
+                    _process_registry,
+                    namespace=self._handle_namespace,
+                    argv=argv,
+                    env=subprocess_env,
+                    cwd=cwd,
+                    tail=tail,
+                    timeout=timeout,
+                )
+                message = result.message
+            if cwd is None:
+                return message
+            return f"[cwd: {cwd}]\n{message}"
 
         def check_shell_command(self, handle: str) -> str:
             """Poll the status of a backgrounded shell command.

--- a/src/mindroom/tools/shell.py
+++ b/src/mindroom/tools/shell.py
@@ -447,7 +447,7 @@ def shell_tools() -> type[Toolkit]:  # noqa: C901
             a running process.
 
             Args:
-                handle: The handle string returned by ``run_shell_command``.
+                handle: The ``shell:...`` identifier from the ``Handle:`` line returned by ``run_shell_command``.
 
             Returns:
                 Output if the command finished, or a status summary if still running.
@@ -465,7 +465,7 @@ def shell_tools() -> type[Toolkit]:  # noqa: C901
             """Kill a backgrounded shell command.
 
             Args:
-                handle: The handle string returned by ``run_shell_command``.
+                handle: The ``shell:...`` identifier from the ``Handle:`` line returned by ``run_shell_command``.
                 force: If True send SIGKILL immediately instead of SIGTERM.
 
             Returns:

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -121,6 +121,14 @@ def _set_sandbox_token(monkeypatch: pytest.MonkeyPatch) -> None:
     _refresh_runner_app_from_env()
 
 
+def _shell_command_output(result: object, *, cwd: Path) -> str:
+    """Assert and remove the workspace cwd line from a shell command result."""
+    assert isinstance(result, str)
+    prefix = f"[cwd: {cwd.resolve()}]\n"
+    assert result.startswith(prefix)
+    return result.removeprefix(prefix)
+
+
 def _set_worker_tool_validation_snapshot(*tool_names: str) -> None:
     """Set the upstream-authored validation snapshot visible to one worker runtime."""
     runtime_paths = resolve_primary_runtime_paths(process_env=dict(os.environ))
@@ -1324,7 +1332,7 @@ async def test_inprocess_execution_tool_uses_encrypted_persisted_config_after_ke
     )
 
     assert response.ok is True, response
-    assert response.result == f"{workspace}|"
+    assert _shell_command_output(response.result, cwd=workspace) == f"{workspace}|"
 
 
 def test_subprocess_execution_preloads_encrypted_persisted_config_without_runtime_key(
@@ -3969,7 +3977,7 @@ def test_dedicated_user_agent_worker_shell_uses_private_base_dir(
     assert response.status_code == 200
     data = response.json()
     assert data["ok"] is True
-    assert json.loads(data["result"]) == {
+    assert json.loads(_shell_command_output(data["result"], cwd=private_workspace)) == {
         "cwd": str(private_workspace),
         "owner": "alice",
     }
@@ -4121,8 +4129,9 @@ def test_sandbox_runner_worker_shell_uses_workspace_home_and_worker_venv(
     assert data["ok"] is True
 
     worker_root = storage_root / "workers" / worker_dir_name("worker-a")
-    expected_result = f"{worker_root / 'workspace'}|{worker_root / 'venv'}|{worker_root / 'workspace'}"
-    assert data["result"] == expected_result
+    workspace = worker_root / "workspace"
+    expected_result = f"{workspace}|{worker_root / 'venv'}|{workspace}"
+    assert _shell_command_output(data["result"], cwd=workspace) == expected_result
 
 
 @requires_linux(reason=LINUX_LOCAL_WORKER_REASON, timeout=LINUX_LOCAL_WORKER_TIMEOUT_SECONDS)
@@ -5236,7 +5245,8 @@ def test_worker_routed_shell_uses_agent_workspace_as_home(
     assert response.status_code == 200
     payload = response.json()
     assert payload["ok"] is True, payload
-    pwd, home, agent_workspace, xdg_config, xdg_cache, virtual_env = payload["result"].split("|", 5)
+    shell_output = _shell_command_output(payload["result"], cwd=workspace)
+    pwd, home, agent_workspace, xdg_config, xdg_cache, virtual_env = shell_output.split("|", 5)
     assert pwd == str(workspace.resolve())
     assert home == str(workspace.resolve())
     assert agent_workspace == str(workspace.resolve())
@@ -5302,7 +5312,8 @@ def test_worker_routed_shell_ignores_dotenv_for_workspace_home_contract(
     assert response.status_code == 200
     payload = response.json()
     assert payload["ok"] is True, payload
-    home, agent_workspace, xdg_config, xdg_cache, pip_cache, uv_cache, pycache, virtual_env = payload["result"].split(
+    shell_output = _shell_command_output(payload["result"], cwd=workspace)
+    home, agent_workspace, xdg_config, xdg_cache, pip_cache, uv_cache, pycache, virtual_env = shell_output.split(
         "|",
         7,
     )
@@ -5424,7 +5435,7 @@ def test_worker_attachment_save_can_be_read_through_shell_home(
     assert read_response.status_code == 200
     read_payload = read_response.json()
     assert read_payload["ok"] is True, read_payload
-    assert read_payload["result"] == payload_bytes.decode()
+    assert _shell_command_output(read_payload["result"], cwd=workspace) == payload_bytes.decode()
 
 
 def test_workspace_env_hook_uses_routed_agent_workspace_without_base_dir(tmp_path: Path) -> None:
@@ -5680,7 +5691,7 @@ def test_workspace_env_hook_shell_side_effects_do_not_reach_command(tmp_path: Pa
     response = sandbox_runner_module._execute_request_subprocess_sync(request, runtime_paths, config)
 
     assert response.ok is True, response
-    token, pwd = str(response.result).split("|", 1)
+    token, pwd = _shell_command_output(response.result, cwd=workspace).split("|", 1)
     assert token == "hooked"  # noqa: S105
     assert pwd == str(workspace)
 
@@ -5767,7 +5778,7 @@ def test_workspace_env_hook_overlays_shell_execution(
     assert response.status_code == 200
     payload = response.json()
     assert payload["ok"] is True, payload
-    token, path_value = payload["result"].split("|", 1)
+    token, path_value = _shell_command_output(payload["result"], cwd=workspace).split("|", 1)
     assert token == "hello-from-hook"  # noqa: S105
     assert path_value.startswith(f"{workspace.resolve()}/.local/bin:")
 
@@ -5803,7 +5814,7 @@ def test_workspace_env_hook_edits_take_effect_on_next_call(
 
         assert first.status_code == 200
         assert first.json()["ok"] is True
-        assert first.json()["result"] == "first"
+        assert _shell_command_output(first.json()["result"], cwd=workspace) == "first"
 
         _write_workspace_env_hook(workspace, "export WORKSPACE_HOOK_TOKEN=second\n")
 
@@ -5822,7 +5833,7 @@ def test_workspace_env_hook_edits_take_effect_on_next_call(
 
     assert second.status_code == 200
     assert second.json()["ok"] is True
-    assert second.json()["result"] == "second"
+    assert _shell_command_output(second.json()["result"], cwd=workspace) == "second"
 
 
 @requires_linux(reason=LINUX_LOCAL_WORKER_REASON, timeout=LINUX_LOCAL_WORKER_TIMEOUT_SECONDS)
@@ -5878,7 +5889,8 @@ def test_workspace_env_hook_keeps_user_credentials_and_filters_runner_control(
     assert response.status_code == 200
     payload = response.json()
     assert payload["ok"] is True, payload
-    api_key, stripe_secret, token, proxy_token, sandbox_value = payload["result"].split("|", 4)
+    shell_output = _shell_command_output(payload["result"], cwd=workspace)
+    api_key, stripe_secret, token, proxy_token, sandbox_value = shell_output.split("|", 4)
     assert api_key == "from-hook"
     assert stripe_secret == "from-hook"  # noqa: S105
     assert token == "from-hook"  # noqa: S105
@@ -6147,7 +6159,7 @@ def test_workspace_env_hook_unkeyed_proxy_uses_init_override_base_dir(
     assert response.status_code == 200
     payload = response.json()
     assert payload["ok"] is True, payload
-    assert payload["result"] == "visible"
+    assert _shell_command_output(payload["result"], cwd=workspace) == "visible"
 
 
 @requires_linux(reason=LINUX_LOCAL_WORKER_REASON, timeout=LINUX_LOCAL_WORKER_TIMEOUT_SECONDS)

--- a/tests/test_shell_async.py
+++ b/tests/test_shell_async.py
@@ -486,7 +486,7 @@ async def test_run_shell_command_respects_base_dir(tmp_path: Path) -> None:
     assert entrypoint is not None
 
     result = await entrypoint(["pwd"])
-    assert result.strip() == str(tmp_path)
+    assert result.splitlines() == [f"[cwd: {tmp_path}]", str(tmp_path)]
 
 
 # ---------------------------------------------------------------------------
@@ -847,7 +847,52 @@ async def test_local_shell_replaces_stale_agent_workspace_env(tmp_path: Path) ->
     assert entrypoint is not None
 
     result = await entrypoint('printf %s "$MINDROOM_AGENT_WORKSPACE"')
-    assert result == str(workspace.resolve())
+    assert result.splitlines() == [f"[cwd: {workspace}]", str(workspace.resolve())]
+
+
+def test_run_shell_command_description_notes_host_home_in_local_mode(tmp_path: Path) -> None:
+    """Local-mode tool description warns that `~` is not the workspace."""
+    workspace = tmp_path / "workspace"
+    runtime_paths = _make_runtime_paths(tmp_path, process_env={"HOME": "/home/host-user"})
+    tool = get_tool_by_name(
+        "shell",
+        runtime_paths,
+        disable_sandbox_proxy=True,
+        worker_target=None,
+        tool_init_overrides={"base_dir": str(workspace)},
+    )
+
+    description = tool.async_functions["run_shell_command"].description
+    assert description is not None
+    assert "point at the host home" in description
+    assert "$MINDROOM_AGENT_WORKSPACE" in description
+
+
+def test_run_shell_command_description_notes_workspace_home_in_worker_mode(tmp_path: Path) -> None:
+    """Worker-mode tool description says `~` points at the workspace."""
+    workspace = tmp_path / "workspace"
+    runtime_paths = _make_runtime_paths(tmp_path, process_env=dict(workspace_home_identity_env(workspace)))
+    tool = get_tool_by_name(
+        "shell",
+        runtime_paths,
+        disable_sandbox_proxy=True,
+        worker_target=None,
+        tool_init_overrides={"base_dir": str(workspace)},
+    )
+
+    description = tool.async_functions["run_shell_command"].description
+    assert description is not None
+    assert "`~` and `$HOME` point at the workspace too" in description
+    assert "host home" not in description
+
+
+def test_run_shell_command_description_has_no_workspace_note_without_base_dir(tmp_path: Path) -> None:
+    """Without a workspace there is no cwd contract to describe."""
+    tool = _get_toolkit(tmp_path)
+
+    description = tool.async_functions["run_shell_command"].description
+    assert description is not None
+    assert "[cwd:" not in description
 
 
 @pytest.mark.asyncio

--- a/tests/test_shell_async.py
+++ b/tests/test_shell_async.py
@@ -439,8 +439,15 @@ async def test_run_shell_command_truncates_oversized_single_stderr_line(tmp_path
 
 @pytest.mark.asyncio
 async def test_run_shell_command_returns_handle_on_timeout(tmp_path: Path) -> None:
-    """Command exceeding timeout should return a handle."""
-    tool = _get_toolkit(tmp_path)
+    """A workspace-prefixed timeout result should expose a usable handle identifier."""
+    runtime_paths = _make_runtime_paths(tmp_path)
+    tool = get_tool_by_name(
+        "shell",
+        runtime_paths,
+        disable_sandbox_proxy=True,
+        worker_target=None,
+        tool_init_overrides={"base_dir": str(tmp_path)},
+    )
     entrypoint = tool.async_functions["run_shell_command"].entrypoint
     check_fn = tool.functions["check_shell_command"].entrypoint
     assert entrypoint is not None
@@ -448,6 +455,7 @@ async def test_run_shell_command_returns_handle_on_timeout(tmp_path: Path) -> No
 
     result = await entrypoint(["sleep", "300"], timeout=1)
 
+    assert result.startswith(f"[cwd: {tmp_path}]\n")
     assert "timed out" in result.lower()
     assert "Handle: shell:" in result
     assert "check_shell_command" in result

--- a/tests/test_shell_async.py
+++ b/tests/test_shell_async.py
@@ -850,8 +850,8 @@ async def test_local_shell_replaces_stale_agent_workspace_env(tmp_path: Path) ->
     assert result.splitlines() == [f"[cwd: {workspace}]", str(workspace.resolve())]
 
 
-def test_run_shell_command_description_notes_host_home_in_local_mode(tmp_path: Path) -> None:
-    """Local-mode tool description warns that `~` is not the workspace."""
+def test_run_shell_command_description_uses_portable_workspace_paths(tmp_path: Path) -> None:
+    """The shell description should give workspace guidance valid in every execution mode."""
     workspace = tmp_path / "workspace"
     runtime_paths = _make_runtime_paths(tmp_path, process_env={"HOME": "/home/host-user"})
     tool = get_tool_by_name(
@@ -864,26 +864,33 @@ def test_run_shell_command_description_notes_host_home_in_local_mode(tmp_path: P
 
     description = tool.async_functions["run_shell_command"].description
     assert description is not None
-    assert "point at the host home" in description
+    assert "Always use relative paths" in description
     assert "$MINDROOM_AGENT_WORKSPACE" in description
+    assert "worker-routed execution maps `~` to the workspace" in description
+    assert "local execution maps it to the host home" in description
 
 
-def test_run_shell_command_description_notes_workspace_home_in_worker_mode(tmp_path: Path) -> None:
-    """Worker-mode tool description says `~` points at the workspace."""
+def test_proxied_run_shell_command_description_does_not_claim_host_home(tmp_path: Path) -> None:
+    """The model-facing proxy description must not misidentify worker execution as local."""
     workspace = tmp_path / "workspace"
-    runtime_paths = _make_runtime_paths(tmp_path, process_env=dict(workspace_home_identity_env(workspace)))
+    runtime_paths = _make_runtime_paths(
+        tmp_path,
+        process_env={
+            "HOME": "/home/host-user",
+            "MINDROOM_SANDBOX_EXECUTION_MODE": "all",
+        },
+    )
     tool = get_tool_by_name(
         "shell",
         runtime_paths,
-        disable_sandbox_proxy=True,
         worker_target=None,
         tool_init_overrides={"base_dir": str(workspace)},
     )
 
     description = tool.async_functions["run_shell_command"].description
     assert description is not None
-    assert "`~` and `$HOME` point at the workspace too" in description
-    assert "host home" not in description
+    assert "worker-routed execution maps `~` to the workspace" in description
+    assert "`~` and `$HOME` point at the host home" not in description
 
 
 def test_run_shell_command_description_has_no_workspace_note_without_base_dir(tmp_path: Path) -> None:

--- a/tests/test_shell_supervisor.py
+++ b/tests/test_shell_supervisor.py
@@ -378,6 +378,31 @@ def _get_toolkit(tmp_path: Path) -> Toolkit:
 
 
 @pytest.mark.asyncio
+async def test_toolkit_supervisor_result_includes_workspace_cwd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    manager: _ShellSupervisorManager,
+) -> None:
+    """Supervisor-backed shell results should expose the same cwd contract as local results."""
+    monkeypatch.setenv(SHELL_SUPERVISOR_SOCKET_ENV, manager.ensure())
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    tool = get_tool_by_name(
+        "shell",
+        _make_runtime_paths(tmp_path),
+        disable_sandbox_proxy=True,
+        worker_target=None,
+        tool_init_overrides={"base_dir": str(workspace)},
+    )
+    run_fn = tool.async_functions["run_shell_command"].entrypoint
+    assert run_fn is not None
+
+    result = await run_fn(["pwd"])
+
+    assert result.splitlines() == [f"[cwd: {workspace}]", str(workspace)]
+
+
+@pytest.mark.asyncio
 async def test_toolkit_routes_through_supervisor_across_instances(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Agents wrote files through `cd ~` assuming it was their workspace, but local shell execution keeps the host `HOME`, so those files landed outside the workspace and later attachment registration failed.

This makes the cwd contract explicit:

- `run_shell_command` results start with a `[cwd: ...]` line whenever a workspace `base_dir` is configured.
- The tool description tells agents to use relative paths or `$MINDROOM_AGENT_WORKSPACE`, which is correct for local and worker-routed execution.
- The description explains that worker-routed execution maps `~` to the workspace while local execution maps it to the host home, without trying to infer the later proxy route during toolkit construction.

Tests cover local results, supervisor-backed results, local descriptions, proxied model-facing descriptions, and the no-workspace case.

Verification: `uv run pytest tests/test_shell_async.py tests/test_shell_supervisor.py tests/test_shell_cancel.py -x -n 0 --no-cov -q` (77 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shell command output now includes a `[cwd: ...]` prefix indicating the exact working directory used for execution.
  * Shell tool guidance now explains workspace/cwd behavior, including how `~` and `$HOME` are interpreted differently across execution modes.

* **Bug Fixes**
  * Standardized working-directory formatting so local and supervisor-backed runs report consistent `[cwd: ...]` information.
  * When no workspace directory is configured, the `[cwd: ...]` guidance is omitted.

* **Tests**
  * Added coverage for the new output format and description content in both local and supervisor-backed scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->