### PR TITLE
feat: support voice calls in authorized invited rooms

### DIFF
--- a/docs/voice-calls.md
+++ b/docs/voice-calls.md
@@ -43,6 +43,7 @@ The realtime backend requires an `OPENAI_API_KEY` in your credentials and otherw
 MindRoom enforces at most one calls-enabled agent per room.
 Calls only join rooms configured for that agent and only while the sole caller passes the normal room and per-agent reply permissions.
 Calls-enabled agents also join calls in ad-hoc rooms they accepted through their normal authorized-invite policy. This lets Matrix clients create a private, temporary voice room and invite one agent without adding that room to `config.yaml` first.
+Calls-enabled agents advertise `📞 Voice calls` in their Matrix presence status so clients can show the call action only where it will be answered.
 Requester-private agents are not currently supported for calls.
 
 ## Cascaded cloud example

--- a/docs/voice-calls.md
+++ b/docs/voice-calls.md
@@ -42,6 +42,7 @@ Voice calls require the `matrix_calls` extra (`pip install "mindroom[matrix_call
 The realtime backend requires an `OPENAI_API_KEY` in your credentials and otherwise behaves as before.
 MindRoom enforces at most one calls-enabled agent per room.
 Calls only join rooms configured for that agent and only while the sole caller passes the normal room and per-agent reply permissions.
+Calls-enabled agents also join calls in ad-hoc rooms they accepted through their normal authorized-invite policy. This lets Matrix clients create a private, temporary voice room and invite one agent without adding that room to `config.yaml` first.
 Requester-private agents are not currently supported for calls.
 
 ## Cascaded cloud example

--- a/docs/voice-calls.md
+++ b/docs/voice-calls.md
@@ -43,7 +43,7 @@ The realtime backend requires an `OPENAI_API_KEY` in your credentials and otherw
 MindRoom enforces at most one calls-enabled agent per room.
 Calls only join rooms configured for that agent and only while the sole caller passes the normal room and per-agent reply permissions.
 Calls-enabled agents also join calls in ad-hoc rooms they accepted through their normal authorized-invite policy. This lets Matrix clients create a private, temporary voice room and invite one agent without adding that room to `config.yaml` first.
-Calls-enabled agents advertise `📞 Voice calls` in their Matrix presence status so clients can show the call action only where it will be answered.
+Calls-enabled agents advertise `📞 Voice calls` in their Matrix presence status only when their MatrixRTC runtime is available, so clients can show the call action only where it will be answered.
 Requester-private agents are not currently supported for calls.
 
 ## Cascaded cloud example

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -12938,7 +12938,7 @@ The realtime backend requires an `OPENAI_API_KEY` in your credentials and otherw
 MindRoom enforces at most one calls-enabled agent per room.
 Calls only join rooms configured for that agent and only while the sole caller passes the normal room and per-agent reply permissions.
 Calls-enabled agents also join calls in ad-hoc rooms they accepted through their normal authorized-invite policy. This lets Matrix clients create a private, temporary voice room and invite one agent without adding that room to `config.yaml` first.
-Calls-enabled agents advertise `📞 Voice calls` in their Matrix presence status so clients can show the call action only where it will be answered.
+Calls-enabled agents advertise `📞 Voice calls` in their Matrix presence status only when their MatrixRTC runtime is available, so clients can show the call action only where it will be answered.
 Requester-private agents are not currently supported for calls.
 
 ## Cascaded cloud example

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -12937,6 +12937,8 @@ Voice calls require the `matrix_calls` extra (`pip install "mindroom[matrix_call
 The realtime backend requires an `OPENAI_API_KEY` in your credentials and otherwise behaves as before.
 MindRoom enforces at most one calls-enabled agent per room.
 Calls only join rooms configured for that agent and only while the sole caller passes the normal room and per-agent reply permissions.
+Calls-enabled agents also join calls in ad-hoc rooms they accepted through their normal authorized-invite policy. This lets Matrix clients create a private, temporary voice room and invite one agent without adding that room to `config.yaml` first.
+Calls-enabled agents advertise `📞 Voice calls` in their Matrix presence status so clients can show the call action only where it will be answered.
 Requester-private agents are not currently supported for calls.
 
 ## Cascaded cloud example

--- a/skills/mindroom-docs/references/page__voice-calls__index.md
+++ b/skills/mindroom-docs/references/page__voice-calls__index.md
@@ -42,6 +42,8 @@ Voice calls require the `matrix_calls` extra (`pip install "mindroom[matrix_call
 The realtime backend requires an `OPENAI_API_KEY` in your credentials and otherwise behaves as before.
 MindRoom enforces at most one calls-enabled agent per room.
 Calls only join rooms configured for that agent and only while the sole caller passes the normal room and per-agent reply permissions.
+Calls-enabled agents also join calls in ad-hoc rooms they accepted through their normal authorized-invite policy. This lets Matrix clients create a private, temporary voice room and invite one agent without adding that room to `config.yaml` first.
+Calls-enabled agents advertise `📞 Voice calls` in their Matrix presence status so clients can show the call action only where it will be answered.
 Requester-private agents are not currently supported for calls.
 
 ## Cascaded cloud example

--- a/skills/mindroom-docs/references/page__voice-calls__index.md
+++ b/skills/mindroom-docs/references/page__voice-calls__index.md
@@ -43,7 +43,7 @@ The realtime backend requires an `OPENAI_API_KEY` in your credentials and otherw
 MindRoom enforces at most one calls-enabled agent per room.
 Calls only join rooms configured for that agent and only while the sole caller passes the normal room and per-agent reply permissions.
 Calls-enabled agents also join calls in ad-hoc rooms they accepted through their normal authorized-invite policy. This lets Matrix clients create a private, temporary voice room and invite one agent without adding that room to `config.yaml` first.
-Calls-enabled agents advertise `📞 Voice calls` in their Matrix presence status so clients can show the call action only where it will be answered.
+Calls-enabled agents advertise `📞 Voice calls` in their Matrix presence status only when their MatrixRTC runtime is available, so clients can show the call action only where it will be answered.
 Requester-private agents are not currently supported for calls.
 
 ## Cascaded cloud example

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -986,7 +986,11 @@ class AgentBot:
         if self.client is None:
             return
 
-        status_msg = build_agent_status_message(self.agent_name, self.config)
+        status_msg = build_agent_status_message(
+            self.agent_name,
+            self.config,
+            voice_calls_available=self._call_manager is not None,
+        )
         await set_presence_status(self.client, status_msg)
 
     def mark_sync_loop_started(self) -> None:
@@ -1332,6 +1336,14 @@ class AgentBot:
             ssl_verify=constants.runtime_matrix_ssl_verify(self.runtime_paths),
             tool_support=self._tool_runtime_support,
         )
+        client.add_event_callback(
+            _create_task_wrapper(
+                self._on_call_room_membership_event,
+                owner=self._runtime_view,
+                on_error=self._mark_callback_failed,
+            ),
+            nio.RoomMemberEvent,
+        )
         if self._call_manager is None:
             return
         client.add_event_callback(
@@ -1341,14 +1353,6 @@ class AgentBot:
                 on_error=self._mark_callback_failed,
             ),
             nio.UnknownEvent,
-        )
-        client.add_event_callback(
-            _create_task_wrapper(
-                self._on_call_room_membership_event,
-                owner=self._runtime_view,
-                on_error=self._mark_callback_failed,
-            ),
-            nio.RoomMemberEvent,
         )
         client.add_to_device_callback(
             _create_task_wrapper(  # ty: ignore[invalid-argument-type]  # matrix-nio callback types are too strict here
@@ -1388,7 +1392,6 @@ class AgentBot:
             self._runtime_view.mark_runtime_started()
             self._restore_saved_sync_token()
             await self._set_avatar_if_available()
-            await self._set_presence_with_model_info()
             # Both load tracking state under advisory file locks; keep that
             # off the event loop so per-bot startup never stalls dispatch.
             await asyncio.to_thread(self._turn_store.warm)
@@ -1440,6 +1443,7 @@ class AgentBot:
                 nio.MegolmEvent,
             )
             self._register_call_manager_callbacks(client)
+            await self._set_presence_with_model_info()
             client.add_response_callback(self._on_sync_response, nio.SyncResponse)  # ty: ignore[invalid-argument-type]  # matrix-nio callback types are too strict here
             client.add_response_callback(self._on_sync_error, nio.SyncError)  # ty: ignore[invalid-argument-type]
 

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -17,7 +17,11 @@ from mindroom.approval_inbound import (
     maybe_handle_tool_approval_reply,
     parse_approval_response_event,
 )
-from mindroom.bot_room_lifecycle import BotRoomLifecycle, BotRoomLifecycleDeps, own_room_departures_from_sync
+from mindroom.bot_room_lifecycle import (
+    BotRoomLifecycle,
+    BotRoomLifecycleDeps,
+    own_room_membership_events_from_sync,
+)
 from mindroom.bot_runtime_view import BotRuntimeState
 from mindroom.entity_resolution import entity_identity_registry
 from mindroom.hooks import (
@@ -1234,7 +1238,7 @@ class AgentBot:
         if isinstance(_response, nio.SyncResponse):
             client = self.client
             assert client is not None
-            for room, event in own_room_departures_from_sync(
+            for room, event in own_room_membership_events_from_sync(
                 _response,
                 own_user_id=self.agent_user.user_id,
                 rooms=client.rooms,

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -17,7 +17,7 @@ from mindroom.approval_inbound import (
     maybe_handle_tool_approval_reply,
     parse_approval_response_event,
 )
-from mindroom.bot_room_lifecycle import BotRoomLifecycle, BotRoomLifecycleDeps
+from mindroom.bot_room_lifecycle import BotRoomLifecycle, BotRoomLifecycleDeps, own_room_departures_from_sync
 from mindroom.bot_runtime_view import BotRuntimeState
 from mindroom.entity_resolution import entity_identity_registry
 from mindroom.hooks import (
@@ -1232,6 +1232,14 @@ class AgentBot:
             )
 
         if isinstance(_response, nio.SyncResponse):
+            client = self.client
+            assert client is not None
+            for room, event in own_room_departures_from_sync(
+                _response,
+                own_user_id=self.agent_user.user_id,
+                rooms=client.rooms,
+            ):
+                await self._on_call_room_membership_event(room, event)
             restored_token_first_sync_response = (
                 first_sync_response and self._sync_trust_state is SyncTrustState.PENDING
             )

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -1344,7 +1344,7 @@ class AgentBot:
         )
         client.add_event_callback(
             _create_task_wrapper(
-                self._call_manager.on_room_membership_event,
+                self._on_call_room_membership_event,
                 owner=self._runtime_view,
                 on_error=self._mark_callback_failed,
             ),
@@ -1358,6 +1358,17 @@ class AgentBot:
             ),
             AuthenticatedToDeviceEvent,
         )
+
+    async def _on_call_room_membership_event(
+        self,
+        room: nio.MatrixRoom,
+        event: nio.RoomMemberEvent,
+    ) -> None:
+        """Apply call teardown before dropping persisted ad-hoc room ownership."""
+        call_manager = self._call_manager
+        if call_manager is not None:
+            await call_manager.on_room_membership_event(room, event)
+        self._room_lifecycle.forget_invited_room_after_own_leave(room, event)
 
     async def start(self) -> None:
         """Start the agent bot with user account setup (but don't join rooms yet)."""

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -1364,11 +1364,11 @@ class AgentBot:
         room: nio.MatrixRoom,
         event: nio.RoomMemberEvent,
     ) -> None:
-        """Apply call teardown before dropping persisted ad-hoc room ownership."""
+        """Drop ad-hoc ownership and then apply serialized call teardown."""
+        self._room_lifecycle.forget_invited_room_after_own_leave(room, event)
         call_manager = self._call_manager
         if call_manager is not None:
             await call_manager.on_room_membership_event(room, event)
-        self._room_lifecycle.forget_invited_room_after_own_leave(room, event)
 
     async def start(self) -> None:
         """Start the agent bot with user account setup (but don't join rooms yet)."""

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -17,11 +17,7 @@ from mindroom.approval_inbound import (
     maybe_handle_tool_approval_reply,
     parse_approval_response_event,
 )
-from mindroom.bot_room_lifecycle import (
-    BotRoomLifecycle,
-    BotRoomLifecycleDeps,
-    own_room_membership_events_from_sync,
-)
+from mindroom.bot_room_lifecycle import BotRoomLifecycle, BotRoomLifecycleDeps
 from mindroom.bot_runtime_view import BotRuntimeState
 from mindroom.entity_resolution import entity_identity_registry
 from mindroom.hooks import (
@@ -1236,14 +1232,7 @@ class AgentBot:
             )
 
         if isinstance(_response, nio.SyncResponse):
-            client = self.client
-            assert client is not None
-            for room, event in own_room_membership_events_from_sync(
-                _response,
-                own_user_id=self.agent_user.user_id,
-                rooms=client.rooms,
-            ):
-                await self._on_call_room_membership_event(room, event)
+            await self._apply_own_room_membership_from_sync(_response)
             restored_token_first_sync_response = (
                 first_sync_response and self._sync_trust_state is SyncTrustState.PENDING
             )
@@ -1347,10 +1336,11 @@ class AgentBot:
             runtime_paths=self.runtime_paths,
             ssl_verify=constants.runtime_matrix_ssl_verify(self.runtime_paths),
             tool_support=self._tool_runtime_support,
+            get_invited_rooms_by_agent=self._invited_call_rooms_by_agent,
         )
         client.add_event_callback(
             _create_task_wrapper(
-                self._on_call_room_membership_event,
+                self._on_room_membership_event,
                 owner=self._runtime_view,
                 on_error=self._mark_callback_failed,
             ),
@@ -1375,13 +1365,42 @@ class AgentBot:
             AuthenticatedToDeviceEvent,
         )
 
-    async def _on_call_room_membership_event(
+    async def _apply_own_room_membership_from_sync(self, response: nio.SyncResponse) -> None:
+        """Apply this bot's authoritative joined/left room sections before other sync work."""
+        joined_room_ids = set(response.rooms.join)
+        left_room_ids = set(response.rooms.leave)
+        for room_id in left_room_ids:
+            self._room_lifecycle.forget_invited_room(room_id)
+        call_manager = self._call_manager
+        if call_manager is not None:
+            await call_manager.on_sync_room_membership(
+                joined_room_ids=joined_room_ids,
+                left_room_ids=left_room_ids,
+            )
+
+    def _invited_call_rooms_by_agent(self) -> dict[str, frozenset[str]]:
+        """Return live accepted-invite state for the configured call agents."""
+        orchestrator = self.orchestrator
+        agent_bots_value = orchestrator.agent_bots if orchestrator is not None else None
+        if not isinstance(agent_bots_value, dict):
+            return {self.agent_name: frozenset(self._room_lifecycle.invited_rooms)}
+        agent_bots = cast("dict[str, object]", agent_bots_value)
+
+        invited_rooms: dict[str, frozenset[str]] = {}
+        for agent_name in self.config.calls.agents:
+            bot = agent_bots.get(agent_name)
+            if isinstance(bot, AgentBot):
+                invited_rooms[agent_name] = frozenset(bot._room_lifecycle.invited_rooms)
+        return invited_rooms
+
+    async def _on_room_membership_event(
         self,
         room: nio.MatrixRoom,
         event: nio.RoomMemberEvent,
     ) -> None:
-        """Drop ad-hoc ownership and then apply serialized call teardown."""
-        self._room_lifecycle.forget_invited_room_after_own_leave(room, event)
+        """Apply invited-room cleanup before optional call reconciliation."""
+        if event.state_key == self.agent_user.user_id and event.membership in {"leave", "ban"}:
+            self._room_lifecycle.forget_invited_room(room.room_id)
         call_manager = self._call_manager
         if call_manager is not None:
             await call_manager.on_room_membership_event(room, event)

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -989,7 +989,7 @@ class AgentBot:
         status_msg = build_agent_status_message(
             self.agent_name,
             self.config,
-            voice_calls_available=self._call_manager is not None,
+            voice_calls_available=(self._call_manager is not None and self._call_manager.voice_backend_available),
         )
         await set_presence_status(self.client, status_msg)
 

--- a/src/mindroom/bot_room_lifecycle.py
+++ b/src/mindroom/bot_room_lifecycle.py
@@ -50,14 +50,14 @@ class _SendRoomResponse(Protocol):
         ...
 
 
-def own_room_departures_from_sync(
+def own_room_membership_events_from_sync(
     response: nio.SyncResponse,
     *,
     own_user_id: str,
     rooms: Mapping[str, nio.MatrixRoom],
 ) -> tuple[tuple[nio.MatrixRoom, nio.RoomMemberEvent], ...]:
-    """Return this bot's leave/ban events from Matrix sync leave sections."""
-    departures: list[tuple[nio.MatrixRoom, nio.RoomMemberEvent]] = []
+    """Return own membership events that matrix-nio does not dispatch to callbacks."""
+    membership_events: list[tuple[nio.MatrixRoom, nio.RoomMemberEvent]] = []
     for room_id, room_info in response.rooms.leave.items():
         room = rooms.get(room_id) or nio.MatrixRoom(room_id=room_id, own_user_id=own_user_id)
         events = (*room_info.timeline.events, *room_info.state)
@@ -72,8 +72,29 @@ def own_room_departures_from_sync(
             None,
         )
         if departure is not None:
-            departures.append((room, departure))
-    return tuple(departures)
+            membership_events.append((room, departure))
+
+    for room_id, room_info in response.rooms.join.items():
+        timeline_has_own_join = any(
+            isinstance(event, nio.RoomMemberEvent) and event.state_key == own_user_id and event.membership == "join"
+            for event in room_info.timeline.events
+        )
+        if timeline_has_own_join:
+            continue
+        joined = next(
+            (
+                event
+                for event in room_info.state
+                if isinstance(event, nio.RoomMemberEvent)
+                and event.state_key == own_user_id
+                and event.membership == "join"
+            ),
+            None,
+        )
+        if joined is not None:
+            room = rooms.get(room_id) or nio.MatrixRoom(room_id=room_id, own_user_id=own_user_id)
+            membership_events.append((room, joined))
+    return tuple(membership_events)
 
 
 @dataclass(frozen=True)

--- a/src/mindroom/bot_room_lifecycle.py
+++ b/src/mindroom/bot_room_lifecycle.py
@@ -50,6 +50,32 @@ class _SendRoomResponse(Protocol):
         ...
 
 
+def own_room_departures_from_sync(
+    response: nio.SyncResponse,
+    *,
+    own_user_id: str,
+    rooms: Mapping[str, nio.MatrixRoom],
+) -> tuple[tuple[nio.MatrixRoom, nio.RoomMemberEvent], ...]:
+    """Return this bot's leave/ban events from Matrix sync leave sections."""
+    departures: list[tuple[nio.MatrixRoom, nio.RoomMemberEvent]] = []
+    for room_id, room_info in response.rooms.leave.items():
+        room = rooms.get(room_id) or nio.MatrixRoom(room_id=room_id, own_user_id=own_user_id)
+        events = (*room_info.timeline.events, *room_info.state)
+        departure = next(
+            (
+                event
+                for event in events
+                if isinstance(event, nio.RoomMemberEvent)
+                and event.state_key == own_user_id
+                and event.membership in {"leave", "ban"}
+            ),
+            None,
+        )
+        if departure is not None:
+            departures.append((room, departure))
+    return tuple(departures)
+
+
 @dataclass(frozen=True)
 class BotRoomLifecycleDeps:
     """Dependencies required for room membership and invite handling."""

--- a/src/mindroom/bot_room_lifecycle.py
+++ b/src/mindroom/bot_room_lifecycle.py
@@ -50,53 +50,6 @@ class _SendRoomResponse(Protocol):
         ...
 
 
-def own_room_membership_events_from_sync(
-    response: nio.SyncResponse,
-    *,
-    own_user_id: str,
-    rooms: Mapping[str, nio.MatrixRoom],
-) -> tuple[tuple[nio.MatrixRoom, nio.RoomMemberEvent], ...]:
-    """Return own membership events that matrix-nio does not dispatch to callbacks."""
-    membership_events: list[tuple[nio.MatrixRoom, nio.RoomMemberEvent]] = []
-    for room_id, room_info in response.rooms.leave.items():
-        room = rooms.get(room_id) or nio.MatrixRoom(room_id=room_id, own_user_id=own_user_id)
-        events = (*room_info.timeline.events, *room_info.state)
-        departure = next(
-            (
-                event
-                for event in events
-                if isinstance(event, nio.RoomMemberEvent)
-                and event.state_key == own_user_id
-                and event.membership in {"leave", "ban"}
-            ),
-            None,
-        )
-        if departure is not None:
-            membership_events.append((room, departure))
-
-    for room_id, room_info in response.rooms.join.items():
-        timeline_has_own_join = any(
-            isinstance(event, nio.RoomMemberEvent) and event.state_key == own_user_id and event.membership == "join"
-            for event in room_info.timeline.events
-        )
-        if timeline_has_own_join:
-            continue
-        joined = next(
-            (
-                event
-                for event in room_info.state
-                if isinstance(event, nio.RoomMemberEvent)
-                and event.state_key == own_user_id
-                and event.membership == "join"
-            ),
-            None,
-        )
-        if joined is not None:
-            room = rooms.get(room_id) or nio.MatrixRoom(room_id=room_id, own_user_id=own_user_id)
-            membership_events.append((room, joined))
-    return tuple(membership_events)
-
-
 @dataclass(frozen=True)
 class BotRoomLifecycleDeps:
     """Dependencies required for room membership and invite handling."""
@@ -183,13 +136,11 @@ class BotRoomLifecycle:
             return
         save_invited_rooms(self.invited_rooms_file_path(), self.invited_rooms)
 
-    def forget_invited_room_after_own_leave(self, room: nio.MatrixRoom, event: nio.RoomMemberEvent) -> None:
-        """Stop preserving an ad-hoc room after this bot was kicked, banned, or left."""
-        if event.state_key != self.deps.agent_user.user_id or event.membership not in {"leave", "ban"}:
+    def forget_invited_room(self, room_id: str) -> None:
+        """Stop preserving an ad-hoc room after this bot leaves it."""
+        if room_id not in self.invited_rooms:
             return
-        if room.room_id not in self.invited_rooms:
-            return
-        self.invited_rooms.remove(room.room_id)
+        self.invited_rooms.remove(room_id)
         self.save_invited_rooms()
 
     async def join_configured_rooms(self) -> None:

--- a/src/mindroom/bot_room_lifecycle.py
+++ b/src/mindroom/bot_room_lifecycle.py
@@ -136,6 +136,15 @@ class BotRoomLifecycle:
             return
         save_invited_rooms(self.invited_rooms_file_path(), self.invited_rooms)
 
+    def forget_invited_room_after_own_leave(self, room: nio.MatrixRoom, event: nio.RoomMemberEvent) -> None:
+        """Stop preserving an ad-hoc room after this bot was kicked, banned, or left."""
+        if event.state_key != self.deps.agent_user.user_id or event.membership not in {"leave", "ban"}:
+            return
+        if room.room_id not in self.invited_rooms:
+            return
+        self.invited_rooms.remove(room.room_id)
+        self.save_invited_rooms()
+
     async def join_configured_rooms(self) -> None:
         """Join all rooms this bot should preserve across restarts."""
         client = self._client()

--- a/src/mindroom/entity_resolution.py
+++ b/src/mindroom/entity_resolution.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Literal
 from mindroom.constants import ROUTER_AGENT_NAME, runtime_matrix_homeserver
 from mindroom.matrix import state as matrix_state
 from mindroom.matrix.identity import MatrixID, managed_account_key, managed_account_user_id
+from mindroom.matrix.invited_rooms_store import invited_rooms_path, load_invited_rooms
 from mindroom.matrix_identifiers import (
     extract_server_name_from_homeserver,
     room_alias_identifier_candidates,
@@ -70,7 +71,12 @@ def configured_call_agent_name_for_room(
         runtime_paths,
         room_aliases=room_aliases,
     )
-    call_agents = sorted(set(routable_names).intersection(config.calls.agents))
+    call_agents = set(routable_names).intersection(config.calls.agents)
+    for agent_name in config.calls.agents:
+        invited_path = invited_rooms_path(runtime_paths.storage_root, agent_name)
+        if room_id in load_invited_rooms(invited_path):
+            call_agents.add(agent_name)
+    call_agents = sorted(call_agents)
     if len(call_agents) > 1:
         msg = f"calls.agents resolves multiple agents for live room {room_id}: {', '.join(call_agents)}"
         raise ValueError(msg)

--- a/src/mindroom/entity_resolution.py
+++ b/src/mindroom/entity_resolution.py
@@ -8,7 +8,11 @@ from typing import TYPE_CHECKING, Literal
 from mindroom.constants import ROUTER_AGENT_NAME, runtime_matrix_homeserver
 from mindroom.matrix import state as matrix_state
 from mindroom.matrix.identity import MatrixID, managed_account_key, managed_account_user_id
-from mindroom.matrix.invited_rooms_store import invited_rooms_path, load_invited_rooms
+from mindroom.matrix.invited_rooms_store import (
+    invited_rooms_path,
+    load_cached_invited_rooms,
+    should_persist_invited_rooms,
+)
 from mindroom.matrix_identifiers import (
     extract_server_name_from_homeserver,
     room_alias_identifier_candidates,
@@ -73,8 +77,10 @@ def configured_call_agent_name_for_room(
     )
     call_agents = set(routable_names).intersection(config.calls.agents)
     for agent_name in config.calls.agents:
+        if not should_persist_invited_rooms(config, agent_name):
+            continue
         invited_path = invited_rooms_path(runtime_paths.storage_root, agent_name)
-        if room_id in load_invited_rooms(invited_path):
+        if room_id in load_cached_invited_rooms(invited_path):
             call_agents.add(agent_name)
     call_agents = sorted(call_agents)
     if len(call_agents) > 1:

--- a/src/mindroom/entity_resolution.py
+++ b/src/mindroom/entity_resolution.py
@@ -8,11 +8,7 @@ from typing import TYPE_CHECKING, Literal
 from mindroom.constants import ROUTER_AGENT_NAME, runtime_matrix_homeserver
 from mindroom.matrix import state as matrix_state
 from mindroom.matrix.identity import MatrixID, managed_account_key, managed_account_user_id
-from mindroom.matrix.invited_rooms_store import (
-    invited_rooms_path,
-    load_cached_invited_rooms,
-    should_persist_invited_rooms,
-)
+from mindroom.matrix.invited_rooms_store import should_persist_invited_rooms
 from mindroom.matrix_identifiers import (
     extract_server_name_from_homeserver,
     room_alias_identifier_candidates,
@@ -20,6 +16,7 @@ from mindroom.matrix_identifiers import (
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
+    from collections.abc import Set as AbstractSet
 
     from mindroom.config.agent import AgentConfig, TeamConfig
     from mindroom.config.main import Config
@@ -67,6 +64,7 @@ def configured_call_agent_name_for_room(
     runtime_paths: RuntimePaths,
     *,
     room_aliases: Iterable[str] = (),
+    invited_rooms_by_agent: Mapping[str, AbstractSet[str]],
 ) -> str | None:
     """Return the sole calls-enabled agent for a live room, failing on ambiguity."""
     routable_names = configured_routable_entity_names_for_room(
@@ -79,8 +77,7 @@ def configured_call_agent_name_for_room(
     for agent_name in config.calls.agents:
         if not should_persist_invited_rooms(config, agent_name):
             continue
-        invited_path = invited_rooms_path(runtime_paths.storage_root, agent_name)
-        if room_id in load_cached_invited_rooms(invited_path):
+        if room_id in invited_rooms_by_agent.get(agent_name, ()):
             call_agents.add(agent_name)
     call_agents = sorted(call_agents)
     if len(call_agents) > 1:

--- a/src/mindroom/matrix/invited_rooms_store.py
+++ b/src/mindroom/matrix/invited_rooms_store.py
@@ -17,8 +17,6 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-_cached_invited_rooms: dict[Path, frozenset[str]] = {}
-
 
 def invited_rooms_path(storage_root: Path, agent_name: str) -> Path:
     """Return the storage path for one agent's persisted invited rooms."""
@@ -48,15 +46,6 @@ def load_invited_rooms(path: Path) -> set[str]:
     return set(room_ids)
 
 
-def load_cached_invited_rooms(path: Path) -> set[str]:
-    """Load invited rooms once, returning a mutable snapshot of cached internal state."""
-    cached = _cached_invited_rooms.get(path)
-    if cached is None:
-        cached = frozenset(load_invited_rooms(path))
-        _cached_invited_rooms[path] = cached
-    return set(cached)
-
-
 def save_invited_rooms(path: Path, room_ids: set[str]) -> None:
     """Persist invited rooms atomically for one eligible entity."""
     temp_path = path.with_name(f"{path.name}.{uuid4().hex}.tmp")
@@ -67,7 +56,6 @@ def save_invited_rooms(path: Path, room_ids: set[str]) -> None:
             encoding="utf-8",
         )
         safe_replace(temp_path, path)
-        _cached_invited_rooms[path] = frozenset(room_ids)
     except OSError:
         logger.exception("failed_to_save_invited_rooms", path=str(path))
     finally:

--- a/src/mindroom/matrix/invited_rooms_store.py
+++ b/src/mindroom/matrix/invited_rooms_store.py
@@ -17,6 +17,8 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+_cached_invited_rooms: dict[Path, frozenset[str]] = {}
+
 
 def invited_rooms_path(storage_root: Path, agent_name: str) -> Path:
     """Return the storage path for one agent's persisted invited rooms."""
@@ -46,6 +48,15 @@ def load_invited_rooms(path: Path) -> set[str]:
     return set(room_ids)
 
 
+def load_cached_invited_rooms(path: Path) -> set[str]:
+    """Load invited rooms once, returning a mutable snapshot of cached internal state."""
+    cached = _cached_invited_rooms.get(path)
+    if cached is None:
+        cached = frozenset(load_invited_rooms(path))
+        _cached_invited_rooms[path] = cached
+    return set(cached)
+
+
 def save_invited_rooms(path: Path, room_ids: set[str]) -> None:
     """Persist invited rooms atomically for one eligible entity."""
     temp_path = path.with_name(f"{path.name}.{uuid4().hex}.tmp")
@@ -56,6 +67,7 @@ def save_invited_rooms(path: Path, room_ids: set[str]) -> None:
             encoding="utf-8",
         )
         safe_replace(temp_path, path)
+        _cached_invited_rooms[path] = frozenset(room_ids)
     except OSError:
         logger.exception("failed_to_save_invited_rooms", path=str(path))
     finally:

--- a/src/mindroom/matrix/presence.py
+++ b/src/mindroom/matrix/presence.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+_VOICE_CALLS_STATUS = "📞 Voice calls"
+
 
 async def set_presence_status(
     client: nio.AsyncClient,
@@ -91,6 +93,8 @@ def build_agent_status_message(
         effective_tools = entity_view.available_tools
         if effective_tools:
             status_parts.append(f"🔧 {len(effective_tools)} tools available")
+        if config.calls.enabled and agent_name in config.calls.agents:
+            status_parts.append(_VOICE_CALLS_STATUS)
 
     # Join all parts with separators
     return " | ".join(status_parts)

--- a/src/mindroom/matrix/presence.py
+++ b/src/mindroom/matrix/presence.py
@@ -52,12 +52,15 @@ async def set_presence_status(
 def build_agent_status_message(
     agent_name: str,
     config: Config,
+    *,
+    voice_calls_available: bool = False,
 ) -> str:
     """Build status message with model and role information for an agent.
 
     Args:
         agent_name: Name of the agent
         config: Application configuration
+        voice_calls_available: Whether this bot has a usable MatrixRTC call manager
 
     Returns:
         Status message string, limited to 250 characters
@@ -93,7 +96,7 @@ def build_agent_status_message(
         effective_tools = entity_view.available_tools
         if effective_tools:
             status_parts.append(f"🔧 {len(effective_tools)} tools available")
-        if config.calls.enabled and agent_name in config.calls.agents:
+        if voice_calls_available:
             status_parts.append(_VOICE_CALLS_STATUS)
 
     # Join all parts with separators

--- a/src/mindroom/matrix_rtc/call_manager.py
+++ b/src/mindroom/matrix_rtc/call_manager.py
@@ -767,14 +767,20 @@ class CallManager:
     @property
     def voice_backend_available(self) -> bool:
         """Return whether the configured voice backend has its runtime credentials."""
-        return self._resolve_voice_backend(room_id=None) is not None
+        return self._resolve_voice_backend(room_id=None, warn_if_unavailable=False) is not None
 
-    def _resolve_voice_backend(self, room_id: str | None) -> _ResolvedVoiceBackend | None:
+    def _resolve_voice_backend(
+        self,
+        room_id: str | None,
+        *,
+        warn_if_unavailable: bool = True,
+    ) -> _ResolvedVoiceBackend | None:
         """Resolve backend-specific credentials without affecting call lifecycle."""
         if self._config.calls.backend == "realtime":
             api_key = get_api_key_for_provider("openai", self._runtime_paths)
             if not api_key:
-                logger.warning("call_join_skipped_no_openai_key", room_id=room_id, agent=self._agent_name)
+                if warn_if_unavailable:
+                    logger.warning("call_join_skipped_no_openai_key", room_id=room_id, agent=self._agent_name)
                 return None
             return _ResolvedVoiceBackend(realtime_api_key=api_key)
 
@@ -783,8 +789,18 @@ class CallManager:
         if stt_config is None or tts_config is None:
             msg = "Cascaded call configuration requires STT and TTS"
             raise ValueError(msg)
-        stt = self._resolve_speech_service(stt_config, component="stt", room_id=room_id)
-        tts = self._resolve_speech_service(tts_config, component="tts", room_id=room_id)
+        stt = self._resolve_speech_service(
+            stt_config,
+            component="stt",
+            room_id=room_id,
+            warn_if_unavailable=warn_if_unavailable,
+        )
+        tts = self._resolve_speech_service(
+            tts_config,
+            component="tts",
+            room_id=room_id,
+            warn_if_unavailable=warn_if_unavailable,
+        )
         if stt is None or tts is None:
             return None
         return _ResolvedVoiceBackend(stt=stt, tts=tts)
@@ -838,6 +854,7 @@ class CallManager:
         *,
         component: str,
         room_id: str | None,
+        warn_if_unavailable: bool = True,
     ) -> SpeechServiceOptions | None:
         """Resolve one independently credentialed cloud or local speech service."""
         base_url = normalize_speech_base_url(service.host)
@@ -848,7 +865,7 @@ class CallManager:
             api_key = LOCAL_OPENAI_API_KEY_DEFAULT
         if api_key is None:
             api_key = get_api_key_for_provider(service.provider, self._runtime_paths)
-        if not api_key:
+        if not api_key and warn_if_unavailable:
             logger.warning(
                 "call_join_skipped_no_speech_key",
                 room_id=room_id,
@@ -856,6 +873,7 @@ class CallManager:
                 component=component,
                 provider=service.provider,
             )
+        if not api_key:
             return None
         return SpeechServiceOptions(
             provider=service.provider,

--- a/src/mindroom/matrix_rtc/call_manager.py
+++ b/src/mindroom/matrix_rtc/call_manager.py
@@ -174,6 +174,7 @@ class CallManager:
         self._sessions: dict[str, CallSession] = {}
         self._pending_keys: dict[str, dict[tuple[str, str, int], ReceivedFrameKey]] = {}
         self._observed_rooms: dict[str, nio.MatrixRoom] = {}
+        self._departed_rooms: set[str] = set()
         self._locks: dict[str, asyncio.Lock] = {}
         self._retry_tasks: dict[str, asyncio.Task[None]] = {}
         self._retry_attempts: dict[str, int] = {}
@@ -189,13 +190,16 @@ class CallManager:
         self._observed_rooms[room.room_id] = room
         await self._reconcile(room)
 
-    async def on_room_membership_event(self, room: nio.MatrixRoom, _event: nio.RoomMemberEvent) -> None:
+    async def on_room_membership_event(self, room: nio.MatrixRoom, event: nio.RoomMemberEvent) -> None:
         """Reconcile calls when a user's underlying room membership changes."""
         if self._shutting_down:
             return
-        if _event.state_key == self._client.user_id and _event.membership in {"leave", "ban"}:
+        if event.state_key == self._client.user_id and event.membership in {"leave", "ban"}:
+            self._departed_rooms.add(room.room_id)
             await self._handle_own_room_leave(room.room_id)
             return
+        if event.state_key == self._client.user_id and event.membership == "join":
+            self._departed_rooms.discard(room.room_id)
         if not self._is_configured_call_room(room):
             return
         self._observed_rooms[room.room_id] = room
@@ -203,15 +207,17 @@ class CallManager:
 
     async def _handle_own_room_leave(self, room_id: str) -> None:
         """Tear down call state immediately when the bot no longer belongs to the room."""
-        self._observed_rooms.pop(room_id, None)
-        self._pending_keys.pop(room_id, None)
-        self._clear_logical_call(room_id)
-        expiry = self._expiry_handles.pop(room_id, None)
-        if expiry is not None:
-            expiry.cancel()
-        session = self._sessions.pop(room_id, None)
-        if session is not None:
-            await self._stop_session(session)
+        lock = self._locks.setdefault(room_id, asyncio.Lock())
+        async with lock:
+            self._observed_rooms.pop(room_id, None)
+            self._pending_keys.pop(room_id, None)
+            self._clear_logical_call(room_id)
+            expiry = self._expiry_handles.pop(room_id, None)
+            if expiry is not None:
+                expiry.cancel()
+            session = self._sessions.pop(room_id, None)
+            if session is not None:
+                await self._stop_session(session)
 
     async def on_to_device_event(self, event: nio.ToDeviceEvent) -> None:
         """Sync callback for decrypted call frame-key to-device events."""
@@ -269,13 +275,13 @@ class CallManager:
             await self._stop_session(session, event="call_session_shutdown_failed")
 
     async def _reconcile(self, room: nio.MatrixRoom, *, retrying: bool = False) -> None:
-        if not self._is_configured_call_room(room):
+        if room.room_id in self._departed_rooms or not self._is_configured_call_room(room):
             return
         self._observed_rooms[room.room_id] = room
         room_id = room.room_id
         lock = self._locks.setdefault(room_id, asyncio.Lock())
         async with lock:
-            if self._shutting_down:
+            if self._shutting_down or room_id in self._departed_rooms:
                 return
             members = await self._fetch_remote_members(room_id)
             if members is None:

--- a/src/mindroom/matrix_rtc/call_manager.py
+++ b/src/mindroom/matrix_rtc/call_manager.py
@@ -14,6 +14,7 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 from uuid import uuid4
+from weakref import WeakValueDictionary
 
 import aiohttp
 import httpx
@@ -175,7 +176,7 @@ class CallManager:
         self._pending_keys: dict[str, dict[tuple[str, str, int], ReceivedFrameKey]] = {}
         self._observed_rooms: dict[str, nio.MatrixRoom] = {}
         self._departed_rooms: set[str] = set()
-        self._locks: dict[str, asyncio.Lock] = {}
+        self._locks: WeakValueDictionary[str, asyncio.Lock] = WeakValueDictionary()
         self._retry_tasks: dict[str, asyncio.Task[None]] = {}
         self._retry_attempts: dict[str, int] = {}
         self._logical_calls: dict[str, _LogicalCallState] = {}
@@ -195,8 +196,10 @@ class CallManager:
         if self._shutting_down:
             return
         if event.state_key == self._client.user_id and event.membership in {"leave", "ban"}:
-            self._departed_rooms.add(room.room_id)
-            await self._handle_own_room_leave(room.room_id)
+            if self._is_configured_call_room(room):
+                self._departed_rooms.add(room.room_id)
+            if self._has_tracked_call_state(room.room_id):
+                await self._handle_own_room_leave(room.room_id)
             return
         if event.state_key == self._client.user_id and event.membership == "join":
             self._departed_rooms.discard(room.room_id)
@@ -232,9 +235,13 @@ class CallManager:
         if parsed is None:
             return
         room_id, received = parsed
-        if not self._is_configured_call_room_id(room_id) or not self._is_authorized_call_member(
-            received.user_id,
-            room_id,
+        if (
+            room_id in self._departed_rooms
+            or not self._is_configured_call_room_id(room_id)
+            or not self._is_authorized_call_member(
+                received.user_id,
+                room_id,
+            )
         ):
             return
         session = self._sessions.get(room_id)
@@ -262,6 +269,9 @@ class CallManager:
         self._background_tasks.clear()
         self._retry_attempts.clear()
         self._logical_calls.clear()
+        self._observed_rooms.clear()
+        self._departed_rooms.clear()
+        self._locks.clear()
         for handle in self._expiry_handles.values():
             handle.cancel()
         self._expiry_handles.clear()
@@ -391,6 +401,21 @@ class CallManager:
         """Return whether this agent is configured to join calls in ``room_id``."""
         room = self._observed_rooms.get(room_id) or self._client.rooms.get(room_id)
         return room is not None and self._is_configured_call_room(room)
+
+    def _has_tracked_call_state(self, room_id: str) -> bool:
+        """Return whether this manager has call state to tear down for ``room_id``."""
+        return any(
+            room_id in state
+            for state in (
+                self._observed_rooms,
+                self._sessions,
+                self._pending_keys,
+                self._retry_tasks,
+                self._retry_attempts,
+                self._logical_calls,
+                self._expiry_handles,
+            )
+        )
 
     def _queue_pending_key(self, room_id: str, received: ReceivedFrameKey) -> None:
         """Retain a bounded, deduplicated key set while a session is starting."""
@@ -739,7 +764,12 @@ class CallManager:
         self._logical_calls.pop(room_id, None)
         self._clear_reconcile_retry(room_id)
 
-    def _resolve_voice_backend(self, room_id: str) -> _ResolvedVoiceBackend | None:
+    @property
+    def voice_backend_available(self) -> bool:
+        """Return whether the configured voice backend has its runtime credentials."""
+        return self._resolve_voice_backend(room_id=None) is not None
+
+    def _resolve_voice_backend(self, room_id: str | None) -> _ResolvedVoiceBackend | None:
         """Resolve backend-specific credentials without affecting call lifecycle."""
         if self._config.calls.backend == "realtime":
             api_key = get_api_key_for_provider("openai", self._runtime_paths)
@@ -807,7 +837,7 @@ class CallManager:
         service: SpeechServiceConfig,
         *,
         component: str,
-        room_id: str,
+        room_id: str | None,
     ) -> SpeechServiceOptions | None:
         """Resolve one independently credentialed cloud or local speech service."""
         base_url = normalize_speech_base_url(service.host)

--- a/src/mindroom/matrix_rtc/call_manager.py
+++ b/src/mindroom/matrix_rtc/call_manager.py
@@ -191,10 +191,27 @@ class CallManager:
 
     async def on_room_membership_event(self, room: nio.MatrixRoom, _event: nio.RoomMemberEvent) -> None:
         """Reconcile calls when a user's underlying room membership changes."""
-        if self._shutting_down or not self._is_configured_call_room(room):
+        if self._shutting_down:
+            return
+        if _event.state_key == self._client.user_id and _event.membership in {"leave", "ban"}:
+            await self._handle_own_room_leave(room.room_id)
+            return
+        if not self._is_configured_call_room(room):
             return
         self._observed_rooms[room.room_id] = room
         await self._reconcile(room)
+
+    async def _handle_own_room_leave(self, room_id: str) -> None:
+        """Tear down call state immediately when the bot no longer belongs to the room."""
+        self._observed_rooms.pop(room_id, None)
+        self._pending_keys.pop(room_id, None)
+        self._clear_logical_call(room_id)
+        expiry = self._expiry_handles.pop(room_id, None)
+        if expiry is not None:
+            expiry.cancel()
+        session = self._sessions.pop(room_id, None)
+        if session is not None:
+            await self._stop_session(session)
 
     async def on_to_device_event(self, event: nio.ToDeviceEvent) -> None:
         """Sync callback for decrypted call frame-key to-device events."""

--- a/src/mindroom/matrix_rtc/call_manager.py
+++ b/src/mindroom/matrix_rtc/call_manager.py
@@ -52,7 +52,8 @@ from mindroom.model_defaults import LOCAL_OPENAI_API_KEY_DEFAULT
 from mindroom.session_ids import create_session_id
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Mapping
+    from collections.abc import Set as AbstractSet
 
     from mindroom.config.main import Config
     from mindroom.config.voice import SpeechServiceConfig
@@ -123,6 +124,7 @@ def maybe_build_call_manager(
     runtime_paths: RuntimePaths,
     ssl_verify: bool,
     tool_support: ToolRuntimeSupport,
+    get_invited_rooms_by_agent: Callable[[], Mapping[str, AbstractSet[str]]],
 ) -> CallManager | None:
     """Build a call manager when this agent is configured for voice calls."""
     if not config.calls.enabled or agent_name not in config.calls.agents:
@@ -143,6 +145,7 @@ def maybe_build_call_manager(
         runtime_paths=runtime_paths,
         ssl_verify=ssl_verify,
         tool_support=tool_support,
+        get_invited_rooms_by_agent=get_invited_rooms_by_agent,
     )
 
 
@@ -159,6 +162,7 @@ class CallManager:
         ssl_verify: bool,
         bridge_factory: Callable[[str, bool], VoiceBridgeLike] | None = None,
         tool_support: ToolRuntimeSupport,
+        get_invited_rooms_by_agent: Callable[[], Mapping[str, AbstractSet[str]]],
         clock_ms: Callable[[], int] = lambda: int(time.time() * 1000),
     ) -> None:
         self._agent_name = agent_name
@@ -170,6 +174,7 @@ class CallManager:
             _default_cascaded_bridge_factory if config.calls.backend == "cascaded" else _default_bridge_factory
         )
         self._tool_support = tool_support
+        self._get_invited_rooms_by_agent = get_invited_rooms_by_agent
         self._clock_ms = clock_ms
         self._key_transport = ToDeviceFrameKeyTransport(client)
         self._sessions: dict[str, CallSession] = {}
@@ -207,6 +212,23 @@ class CallManager:
             return
         self._observed_rooms[room.room_id] = room
         await self._reconcile(room)
+
+    async def on_sync_room_membership(
+        self,
+        *,
+        joined_room_ids: AbstractSet[str],
+        left_room_ids: AbstractSet[str],
+    ) -> None:
+        """Apply the bot's authoritative joined/left room sections from sync."""
+        if self._shutting_down:
+            return
+        self._departed_rooms.difference_update(joined_room_ids)
+        for room_id in left_room_ids:
+            room = self._observed_rooms.get(room_id) or self._client.rooms.get(room_id)
+            if room is not None and self._is_configured_call_room(room):
+                self._departed_rooms.add(room_id)
+            if self._has_tracked_call_state(room_id):
+                await self._handle_own_room_leave(room_id)
 
     async def _handle_own_room_leave(self, room_id: str) -> None:
         """Tear down call state immediately when the bot no longer belongs to the room."""
@@ -391,6 +413,7 @@ class CallManager:
                 room.room_id,
                 self._runtime_paths,
                 room_aliases=room_aliases,
+                invited_rooms_by_agent=self._get_invited_rooms_by_agent(),
             )
         except ValueError as error:
             logger.warning("call_room_ownership_ambiguous", room_id=room.room_id, error=str(error))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,6 +101,7 @@ if TYPE_CHECKING:
     from mindroom.config.models import CompactionConfig
     from mindroom.dispatch_handoff import DispatchEvent
     from mindroom.matrix.cache import ConversationEventCache
+    from mindroom.matrix_rtc.call_manager import CallManager
     from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
 
@@ -160,6 +161,7 @@ __all__ = [
     "drain_coalescing",
     "event_cache",
     "event_cache_factory",
+    "install_call_manager_mock",
     "install_edit_message_mock",
     "install_generate_response_mock",
     "install_runtime_cache_support",
@@ -839,6 +841,11 @@ def install_runtime_cache_support(bot: RuntimeBot) -> RuntimeBot:
         bot.startup_thread_prewarm_registry = StartupThreadPrewarmRegistry()
     sync_bot_runtime_state(bot)
     return bot
+
+
+def install_call_manager_mock(bot: RuntimeBot, call_manager: object | None) -> None:
+    """Install a call-manager fake through the shared test seam."""
+    bot._call_manager = cast("CallManager | None", call_manager)
 
 
 def normalize_console_output(text: str) -> str:

--- a/tests/manual/scratch/live_agent_speaking_test.py
+++ b/tests/manual/scratch/live_agent_speaking_test.py
@@ -586,6 +586,7 @@ async def main() -> int:  # noqa: C901, PLR0915
                 runtime_paths=paths,
                 ssl_verify=True,
                 tool_support=LiveToolSupport(),  # type: ignore[arg-type]
+                get_invited_rooms_by_agent=dict,
             )
 
             room_obj = nio.MatrixRoom(room_id=room_id, own_user_id=bot.user_id)

--- a/tests/test_bot_ready_hook.py
+++ b/tests/test_bot_ready_hook.py
@@ -184,10 +184,23 @@ def test_call_manager_registers_call_and_room_membership_callbacks(tmp_path: Pat
 
     assert bot._call_manager is call_manager
     assert [call.args[1] for call in client.add_event_callback.call_args_list] == [
-        nio.UnknownEvent,
         nio.RoomMemberEvent,
+        nio.UnknownEvent,
     ]
     client.add_to_device_callback.assert_called_once_with(ANY, AuthenticatedToDeviceEvent)
+
+
+def test_room_membership_cleanup_registers_without_call_runtime(tmp_path: Path) -> None:
+    """Persisted ad-hoc ownership is cleaned even when voice dependencies are absent."""
+    bot = _agent_bot(tmp_path)
+    client = MagicMock(spec=nio.AsyncClient)
+
+    with patch("mindroom.bot.maybe_build_call_manager", return_value=None):
+        bot._register_call_manager_callbacks(client)
+
+    assert bot._call_manager is None
+    client.add_event_callback.assert_called_once_with(ANY, nio.RoomMemberEvent)
+    client.add_to_device_callback.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_bot_ready_hook.py
+++ b/tests/test_bot_ready_hook.py
@@ -14,6 +14,7 @@ import pytest
 from mindroom.background_tasks import wait_for_background_tasks
 from mindroom.bot import AgentBot
 from mindroom.config.agent import AgentConfig
+from mindroom.config.calls import CallsConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
 from mindroom.config.plugin import PluginEntryConfig
@@ -115,26 +116,17 @@ def _thread_root_event(
     return event
 
 
-def _sync_response_with_own_room_membership(
+def _sync_response_with_room_membership_section(
     room_id: str,
-    user_id: str,
     *,
     membership: str,
 ) -> nio.SyncResponse:
     room_section = "join" if membership == "join" else "leave"
-    event = {
-        "type": "m.room.member",
-        "event_id": f"$own-{membership}",
-        "sender": "@owner:localhost",
-        "origin_server_ts": 1,
-        "state_key": user_id,
-        "content": {"membership": membership},
-    }
     room_info = {
-        "state": {"events": [event] if membership == "join" else []},
+        "state": {"events": []},
         "timeline": {
-            "events": [] if membership == "join" else [event],
-            "limited": membership == "join",
+            "events": [],
+            "limited": False,
             "prev_batch": "s-before-membership",
         },
     }
@@ -240,6 +232,22 @@ def test_room_membership_cleanup_registers_without_call_runtime(tmp_path: Path) 
     client.add_to_device_callback.assert_not_called()
 
 
+def test_call_admission_reads_live_invites_from_managed_agents(tmp_path: Path) -> None:
+    """Call admission gets one live snapshot from each managed calls-enabled agent."""
+    bot = _agent_bot(tmp_path)
+    other = _agent_bot(tmp_path, agent_name="other")
+    bot.config.agents["other"] = AgentConfig(display_name="Other")
+    bot.config.calls = CallsConfig(enabled=True, agents=["code", "other"])
+    bot.orchestrator = MagicMock(agent_bots={"code": bot, "other": other})
+    bot._room_lifecycle.invited_rooms.add("!code-call:localhost")
+    other._room_lifecycle.invited_rooms.add("!other-call:localhost")
+
+    assert bot._invited_call_rooms_by_agent() == {
+        "code": frozenset({"!code-call:localhost"}),
+        "other": frozenset({"!other-call:localhost"}),
+    }
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("backend_available", [False, True])
 async def test_presence_uses_voice_backend_availability(
@@ -274,17 +282,15 @@ async def test_sync_leave_section_forgets_invited_room_before_call_teardown(
     bot = _agent_bot(tmp_path)
     client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
     room_id = "!agent-call:localhost"
-    room = nio.MatrixRoom(room_id=room_id, own_user_id=bot.agent_user.user_id)
-    client.rooms[room_id] = room
     bot.client = client
     bot._room_lifecycle.invited_rooms = {room_id}
     bot._room_lifecycle.save_invited_rooms()
     call_manager = MagicMock()
 
-    async def assert_invite_was_forgotten(_room: nio.MatrixRoom, _event: nio.RoomMemberEvent) -> None:
+    async def assert_invite_was_forgotten(**_kwargs: object) -> None:
         assert bot._room_lifecycle.invited_rooms == set()
 
-    call_manager.on_room_membership_event = AsyncMock(side_effect=assert_invite_was_forgotten)
+    call_manager.on_sync_room_membership = AsyncMock(side_effect=assert_invite_was_forgotten)
     install_call_manager_mock(bot, call_manager)
     monkeypatch.setattr(
         bot,
@@ -293,34 +299,31 @@ async def test_sync_leave_section_forgets_invited_room_before_call_teardown(
     )
 
     await bot._on_sync_response(
-        _sync_response_with_own_room_membership(
+        _sync_response_with_room_membership_section(
             room_id,
-            bot.agent_user.user_id,
             membership="leave",
         ),
     )
 
     assert bot._room_lifecycle.invited_rooms == set()
-    call_manager.on_room_membership_event.assert_awaited_once()
-    handled_room, handled_event = call_manager.on_room_membership_event.await_args.args
-    assert handled_room is room
-    assert handled_event.event_id == "$own-leave"
+    call_manager.on_sync_room_membership.assert_awaited_once_with(
+        joined_room_ids=set(),
+        left_room_ids={room_id},
+    )
 
 
 @pytest.mark.asyncio
-async def test_sync_join_state_reaches_call_manager(
+async def test_sync_join_section_reaches_call_manager(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Own joins present only in sync state can clear departed call state."""
+    """A room in the sync join section can clear departed call state."""
     bot = _agent_bot(tmp_path)
     client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
     room_id = "!configured-call:localhost"
-    room = nio.MatrixRoom(room_id=room_id, own_user_id=bot.agent_user.user_id)
-    client.rooms[room_id] = room
     bot.client = client
     call_manager = MagicMock()
-    call_manager.on_room_membership_event = AsyncMock()
+    call_manager.on_sync_room_membership = AsyncMock()
     install_call_manager_mock(bot, call_manager)
     monkeypatch.setattr(
         bot,
@@ -329,17 +332,16 @@ async def test_sync_join_state_reaches_call_manager(
     )
 
     await bot._on_sync_response(
-        _sync_response_with_own_room_membership(
+        _sync_response_with_room_membership_section(
             room_id,
-            bot.agent_user.user_id,
             membership="join",
         ),
     )
 
-    call_manager.on_room_membership_event.assert_awaited_once()
-    handled_room, handled_event = call_manager.on_room_membership_event.await_args.args
-    assert handled_room is room
-    assert handled_event.event_id == "$own-join"
+    call_manager.on_sync_room_membership.assert_awaited_once_with(
+        joined_room_ids={room_id},
+        left_room_ids=set(),
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_bot_ready_hook.py
+++ b/tests/test_bot_ready_hook.py
@@ -204,6 +204,31 @@ def test_room_membership_cleanup_registers_without_call_runtime(tmp_path: Path) 
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("backend_available", [False, True])
+async def test_presence_uses_voice_backend_availability(
+    tmp_path: Path,
+    backend_available: bool,
+) -> None:
+    """Presence advertises calls only when the constructed manager can answer them."""
+    bot = _agent_bot(tmp_path)
+    bot.client = AsyncMock()
+    bot._call_manager = MagicMock(voice_backend_available=backend_available)
+
+    with (
+        patch("mindroom.bot.build_agent_status_message", return_value="status") as build_status,
+        patch("mindroom.bot.set_presence_status", new_callable=AsyncMock) as set_presence,
+    ):
+        await bot._set_presence_with_model_info()
+
+    build_status.assert_called_once_with(
+        bot.agent_name,
+        bot.config,
+        voice_calls_available=backend_available,
+    )
+    set_presence.assert_awaited_once_with(bot.client, "status")
+
+
+@pytest.mark.asyncio
 async def test_call_membership_callback_forgets_invited_room_before_teardown(tmp_path: Path) -> None:
     """A kick closes ad-hoc admission before serialized media teardown."""
     bot = _agent_bot(tmp_path)

--- a/tests/test_bot_ready_hook.py
+++ b/tests/test_bot_ready_hook.py
@@ -27,6 +27,7 @@ from mindroom.hooks import (
     hook,
 )
 from mindroom.matrix.cache import ThreadHistoryResult, thread_history_result
+from mindroom.matrix.sync_certification import SyncCacheWriteResult
 from mindroom.matrix.to_device import AuthenticatedToDeviceEvent
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.orchestrator import _MultiAgentOrchestrator
@@ -111,6 +112,42 @@ def _thread_root_event(
     )
     assert isinstance(event, nio.RoomMessageText)
     return event
+
+
+def _sync_response_with_own_room_departure(
+    room_id: str,
+    user_id: str,
+) -> nio.SyncResponse:
+    response = nio.SyncResponse.from_dict(
+        {
+            "next_batch": "s-after-leave",
+            "rooms": {
+                "join": {},
+                "invite": {},
+                "leave": {
+                    room_id: {
+                        "state": {"events": []},
+                        "timeline": {
+                            "events": [
+                                {
+                                    "type": "m.room.member",
+                                    "event_id": "$own-leave",
+                                    "sender": "@owner:localhost",
+                                    "origin_server_ts": 1,
+                                    "state_key": user_id,
+                                    "content": {"membership": "leave"},
+                                },
+                            ],
+                            "limited": False,
+                            "prev_batch": "s-before-leave",
+                        },
+                    },
+                },
+            },
+        },
+    )
+    assert isinstance(response, nio.SyncResponse)
+    return response
 
 
 def _plugin(name: str, callbacks: list[object]) -> object:
@@ -245,6 +282,40 @@ async def test_call_membership_callback_forgets_invited_room_before_teardown(tmp
     await bot._on_call_room_membership_event(room, event)
 
     assert order == ["lifecycle", "call"]
+
+
+@pytest.mark.asyncio
+async def test_sync_leave_section_forgets_invited_room_before_call_teardown(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Own departures delivered under rooms.leave reach the lifecycle cleanup path."""
+    bot = _agent_bot(tmp_path)
+    client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
+    room_id = "!agent-call:localhost"
+    room = nio.MatrixRoom(room_id=room_id, own_user_id=bot.agent_user.user_id)
+    client.rooms[room_id] = room
+    bot.client = client
+    bot._room_lifecycle.invited_rooms = {room_id}
+    bot._room_lifecycle.save_invited_rooms()
+    call_manager = MagicMock()
+    call_manager.on_room_membership_event = AsyncMock()
+    bot._call_manager = call_manager
+    monkeypatch.setattr(
+        bot,
+        "_sync_cache_result_for_certification",
+        AsyncMock(return_value=SyncCacheWriteResult(complete=True)),
+    )
+
+    await bot._on_sync_response(
+        _sync_response_with_own_room_departure(room_id, bot.agent_user.user_id),
+    )
+
+    assert bot._room_lifecycle.invited_rooms == set()
+    call_manager.on_room_membership_event.assert_awaited_once()
+    handled_room, handled_event = call_manager.on_room_membership_event.await_args.args
+    assert handled_room is room
+    assert handled_event.event_id == "$own-leave"
 
 
 @pytest.mark.asyncio

--- a/tests/test_bot_ready_hook.py
+++ b/tests/test_bot_ready_hook.py
@@ -36,6 +36,7 @@ from tests.conftest import (
     TEST_PASSWORD,
     bind_runtime_paths,
     delivered_matrix_event,
+    install_call_manager_mock,
     install_runtime_cache_support,
     make_matrix_client_mock,
     orchestrator_runtime_paths,
@@ -114,36 +115,35 @@ def _thread_root_event(
     return event
 
 
-def _sync_response_with_own_room_departure(
+def _sync_response_with_own_room_membership(
     room_id: str,
     user_id: str,
+    *,
+    membership: str,
 ) -> nio.SyncResponse:
+    room_section = "join" if membership == "join" else "leave"
+    event = {
+        "type": "m.room.member",
+        "event_id": f"$own-{membership}",
+        "sender": "@owner:localhost",
+        "origin_server_ts": 1,
+        "state_key": user_id,
+        "content": {"membership": membership},
+    }
+    room_info = {
+        "state": {"events": [event] if membership == "join" else []},
+        "timeline": {
+            "events": [] if membership == "join" else [event],
+            "limited": membership == "join",
+            "prev_batch": "s-before-membership",
+        },
+    }
+    rooms: dict[str, object] = {"join": {}, "invite": {}, "leave": {}}
+    rooms[room_section] = {room_id: room_info}
     response = nio.SyncResponse.from_dict(
         {
-            "next_batch": "s-after-leave",
-            "rooms": {
-                "join": {},
-                "invite": {},
-                "leave": {
-                    room_id: {
-                        "state": {"events": []},
-                        "timeline": {
-                            "events": [
-                                {
-                                    "type": "m.room.member",
-                                    "event_id": "$own-leave",
-                                    "sender": "@owner:localhost",
-                                    "origin_server_ts": 1,
-                                    "state_key": user_id,
-                                    "content": {"membership": "leave"},
-                                },
-                            ],
-                            "limited": False,
-                            "prev_batch": "s-before-leave",
-                        },
-                    },
-                },
-            },
+            "next_batch": f"s-after-{membership}",
+            "rooms": rooms,
         },
     )
     assert isinstance(response, nio.SyncResponse)
@@ -190,7 +190,7 @@ async def test_call_reconciliation_runs_once_per_sync_loop(tmp_path: Path) -> No
     bot.client = AsyncMock()
     call_manager = MagicMock()
     call_manager.reconcile_joined_rooms = AsyncMock()
-    bot._call_manager = call_manager
+    install_call_manager_mock(bot, call_manager)
 
     with (
         patch("mindroom.bot.mark_matrix_sync_success", return_value=datetime.now(UTC)),
@@ -249,7 +249,7 @@ async def test_presence_uses_voice_backend_availability(
     """Presence advertises calls only when the constructed manager can answer them."""
     bot = _agent_bot(tmp_path)
     bot.client = AsyncMock()
-    bot._call_manager = MagicMock(voice_backend_available=backend_available)
+    install_call_manager_mock(bot, MagicMock(voice_backend_available=backend_available))
 
     with (
         patch("mindroom.bot.build_agent_status_message", return_value="status") as build_status,
@@ -263,25 +263,6 @@ async def test_presence_uses_voice_backend_availability(
         voice_calls_available=backend_available,
     )
     set_presence.assert_awaited_once_with(bot.client, "status")
-
-
-@pytest.mark.asyncio
-async def test_call_membership_callback_forgets_invited_room_before_teardown(tmp_path: Path) -> None:
-    """A kick closes ad-hoc admission before serialized media teardown."""
-    bot = _agent_bot(tmp_path)
-    order: list[str] = []
-    call_manager = MagicMock()
-    call_manager.on_room_membership_event = AsyncMock(side_effect=lambda *_args: order.append("call"))
-    bot._call_manager = call_manager
-    bot._room_lifecycle.forget_invited_room_after_own_leave = MagicMock(
-        side_effect=lambda *_args: order.append("lifecycle"),
-    )
-    room = MagicMock(spec=nio.MatrixRoom)
-    event = MagicMock(spec=nio.RoomMemberEvent)
-
-    await bot._on_call_room_membership_event(room, event)
-
-    assert order == ["lifecycle", "call"]
 
 
 @pytest.mark.asyncio
@@ -299,8 +280,12 @@ async def test_sync_leave_section_forgets_invited_room_before_call_teardown(
     bot._room_lifecycle.invited_rooms = {room_id}
     bot._room_lifecycle.save_invited_rooms()
     call_manager = MagicMock()
-    call_manager.on_room_membership_event = AsyncMock()
-    bot._call_manager = call_manager
+
+    async def assert_invite_was_forgotten(_room: nio.MatrixRoom, _event: nio.RoomMemberEvent) -> None:
+        assert bot._room_lifecycle.invited_rooms == set()
+
+    call_manager.on_room_membership_event = AsyncMock(side_effect=assert_invite_was_forgotten)
+    install_call_manager_mock(bot, call_manager)
     monkeypatch.setattr(
         bot,
         "_sync_cache_result_for_certification",
@@ -308,7 +293,11 @@ async def test_sync_leave_section_forgets_invited_room_before_call_teardown(
     )
 
     await bot._on_sync_response(
-        _sync_response_with_own_room_departure(room_id, bot.agent_user.user_id),
+        _sync_response_with_own_room_membership(
+            room_id,
+            bot.agent_user.user_id,
+            membership="leave",
+        ),
     )
 
     assert bot._room_lifecycle.invited_rooms == set()
@@ -316,6 +305,41 @@ async def test_sync_leave_section_forgets_invited_room_before_call_teardown(
     handled_room, handled_event = call_manager.on_room_membership_event.await_args.args
     assert handled_room is room
     assert handled_event.event_id == "$own-leave"
+
+
+@pytest.mark.asyncio
+async def test_sync_join_state_reaches_call_manager(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Own joins present only in sync state can clear departed call state."""
+    bot = _agent_bot(tmp_path)
+    client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
+    room_id = "!configured-call:localhost"
+    room = nio.MatrixRoom(room_id=room_id, own_user_id=bot.agent_user.user_id)
+    client.rooms[room_id] = room
+    bot.client = client
+    call_manager = MagicMock()
+    call_manager.on_room_membership_event = AsyncMock()
+    install_call_manager_mock(bot, call_manager)
+    monkeypatch.setattr(
+        bot,
+        "_sync_cache_result_for_certification",
+        AsyncMock(return_value=SyncCacheWriteResult(complete=True)),
+    )
+
+    await bot._on_sync_response(
+        _sync_response_with_own_room_membership(
+            room_id,
+            bot.agent_user.user_id,
+            membership="join",
+        ),
+    )
+
+    call_manager.on_room_membership_event.assert_awaited_once()
+    handled_room, handled_event = call_manager.on_room_membership_event.await_args.args
+    assert handled_room is room
+    assert handled_event.event_id == "$own-join"
 
 
 @pytest.mark.asyncio

--- a/tests/test_bot_ready_hook.py
+++ b/tests/test_bot_ready_hook.py
@@ -191,6 +191,25 @@ def test_call_manager_registers_call_and_room_membership_callbacks(tmp_path: Pat
 
 
 @pytest.mark.asyncio
+async def test_call_membership_callback_tears_down_before_forgetting_invited_room(tmp_path: Path) -> None:
+    """A kick closes the media session before removing ad-hoc room ownership."""
+    bot = _agent_bot(tmp_path)
+    order: list[str] = []
+    call_manager = MagicMock()
+    call_manager.on_room_membership_event = AsyncMock(side_effect=lambda *_args: order.append("call"))
+    bot._call_manager = call_manager
+    bot._room_lifecycle.forget_invited_room_after_own_leave = MagicMock(
+        side_effect=lambda *_args: order.append("lifecycle"),
+    )
+    room = MagicMock(spec=nio.MatrixRoom)
+    event = MagicMock(spec=nio.RoomMemberEvent)
+
+    await bot._on_call_room_membership_event(room, event)
+
+    assert order == ["call", "lifecycle"]
+
+
+@pytest.mark.asyncio
 async def test_installed_runtime_cache_support_runs_fire_and_forget_sync_cache_writes(tmp_path: Path) -> None:
     """The shared test runtime helper must preserve the coordinator's synchronous queue contract."""
     bot = _agent_bot(tmp_path)

--- a/tests/test_bot_ready_hook.py
+++ b/tests/test_bot_ready_hook.py
@@ -191,8 +191,8 @@ def test_call_manager_registers_call_and_room_membership_callbacks(tmp_path: Pat
 
 
 @pytest.mark.asyncio
-async def test_call_membership_callback_tears_down_before_forgetting_invited_room(tmp_path: Path) -> None:
-    """A kick closes the media session before removing ad-hoc room ownership."""
+async def test_call_membership_callback_forgets_invited_room_before_teardown(tmp_path: Path) -> None:
+    """A kick closes ad-hoc admission before serialized media teardown."""
     bot = _agent_bot(tmp_path)
     order: list[str] = []
     call_manager = MagicMock()
@@ -206,7 +206,7 @@ async def test_call_membership_callback_tears_down_before_forgetting_invited_roo
 
     await bot._on_call_room_membership_event(room, event)
 
-    assert order == ["call", "lifecycle"]
+    assert order == ["lifecycle", "call"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_entity_resolution.py
+++ b/tests/test_entity_resolution.py
@@ -7,14 +7,17 @@ from typing import TYPE_CHECKING
 import pytest
 
 from mindroom.config.agent import AgentConfig, TeamConfig
+from mindroom.config.calls import CallsConfig
 from mindroom.config.main import Config
 from mindroom.constants import ROUTER_AGENT_NAME, resolve_runtime_paths
 from mindroom.entity_resolution import (
     DuplicateManagedEntityIdentityError,
     MissingManagedEntityAccountError,
     configured_bot_user_ids_for_room,
+    configured_call_agent_name_for_room,
     entity_identity_registry,
 )
+from mindroom.matrix.invited_rooms_store import invited_rooms_path, save_invited_rooms
 from mindroom.matrix.state import MatrixState
 from tests.conftest import bind_runtime_paths, runtime_paths_for
 
@@ -98,6 +101,65 @@ def test_configured_bot_user_ids_for_room_uses_persisted_current_user_ids(tmp_pa
         "@actual_general:matrix.example",
         "@actual_team:matrix.example",
     }
+
+
+def test_configured_call_agent_includes_authorized_ad_hoc_invited_room(tmp_path: Path) -> None:
+    """A calls-enabled agent may answer in a room accepted through its invite policy."""
+    config = bind_runtime_paths(
+        Config(
+            agents={
+                "general": AgentConfig(display_name="General", role="General agent"),
+                "other": AgentConfig(display_name="Other", role="Other agent"),
+            },
+            calls=CallsConfig(enabled=True, agents=["general", "other"]),
+        ),
+        runtime_paths=resolve_runtime_paths(
+            config_path=tmp_path / "config.yaml",
+            storage_path=tmp_path / "mindroom_data",
+            process_env={},
+        ),
+    )
+    runtime_paths = runtime_paths_for(config)
+    save_invited_rooms(
+        invited_rooms_path(runtime_paths.storage_root, "general"),
+        {"!agent-call:server"},
+    )
+
+    assert (
+        configured_call_agent_name_for_room(
+            config,
+            "!agent-call:server",
+            runtime_paths,
+        )
+        == "general"
+    )
+
+
+def test_configured_call_agent_rejects_ambiguous_invited_room(tmp_path: Path) -> None:
+    """One ad-hoc room cannot silently select between two calls-enabled invitees."""
+    config = bind_runtime_paths(
+        Config(
+            agents={
+                "general": AgentConfig(display_name="General", role="General agent"),
+                "other": AgentConfig(display_name="Other", role="Other agent"),
+            },
+            calls=CallsConfig(enabled=True, agents=["general", "other"]),
+        ),
+        runtime_paths=resolve_runtime_paths(
+            config_path=tmp_path / "config.yaml",
+            storage_path=tmp_path / "mindroom_data",
+            process_env={},
+        ),
+    )
+    runtime_paths = runtime_paths_for(config)
+    for agent_name in ("general", "other"):
+        save_invited_rooms(
+            invited_rooms_path(runtime_paths.storage_root, agent_name),
+            {"!agent-call:server"},
+        )
+
+    with pytest.raises(ValueError, match="general, other"):
+        configured_call_agent_name_for_room(config, "!agent-call:server", runtime_paths)
 
 
 def test_entity_identity_registry_uses_only_persisted_current_ids(tmp_path: Path) -> None:

--- a/tests/test_entity_resolution.py
+++ b/tests/test_entity_resolution.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from unittest.mock import patch
 
 import pytest
 
@@ -18,12 +17,29 @@ from mindroom.entity_resolution import (
     configured_call_agent_name_for_room,
     entity_identity_registry,
 )
-from mindroom.matrix.invited_rooms_store import invited_rooms_path, load_invited_rooms, save_invited_rooms
 from mindroom.matrix.state import MatrixState
 from tests.conftest import bind_runtime_paths, runtime_paths_for
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+def _call_config(tmp_path: Path, **accept_invites_by_agent: bool) -> Config:
+    runtime_paths = resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path / "mindroom_data",
+        process_env={},
+    )
+    return bind_runtime_paths(
+        Config(
+            agents={
+                name: AgentConfig(display_name=name.title(), accept_invites=accept_invites)
+                for name, accept_invites in accept_invites_by_agent.items()
+            },
+            calls=CallsConfig(enabled=True, agents=list(accept_invites_by_agent)),
+        ),
+        runtime_paths=runtime_paths,
+    )
 
 
 def test_configured_bot_user_ids_for_room_includes_agents_teams_and_router(tmp_path: Path) -> None:
@@ -106,31 +122,14 @@ def test_configured_bot_user_ids_for_room_uses_persisted_current_user_ids(tmp_pa
 
 def test_configured_call_agent_includes_authorized_ad_hoc_invited_room(tmp_path: Path) -> None:
     """A calls-enabled agent may answer in a room accepted through its invite policy."""
-    config = bind_runtime_paths(
-        Config(
-            agents={
-                "general": AgentConfig(display_name="General", role="General agent", accept_invites=True),
-                "other": AgentConfig(display_name="Other", role="Other agent"),
-            },
-            calls=CallsConfig(enabled=True, agents=["general", "other"]),
-        ),
-        runtime_paths=resolve_runtime_paths(
-            config_path=tmp_path / "config.yaml",
-            storage_path=tmp_path / "mindroom_data",
-            process_env={},
-        ),
-    )
+    config = _call_config(tmp_path, general=True, other=False)
     runtime_paths = runtime_paths_for(config)
-    save_invited_rooms(
-        invited_rooms_path(runtime_paths.storage_root, "general"),
-        {"!agent-call:server"},
-    )
-
     assert (
         configured_call_agent_name_for_room(
             config,
             "!agent-call:server",
             runtime_paths,
+            invited_rooms_by_agent={"general": {"!agent-call:server"}},
         )
         == "general"
     )
@@ -138,91 +137,63 @@ def test_configured_call_agent_includes_authorized_ad_hoc_invited_room(tmp_path:
 
 def test_configured_call_agent_rejects_ambiguous_invited_room(tmp_path: Path) -> None:
     """One ad-hoc room cannot silently select between two calls-enabled invitees."""
-    config = bind_runtime_paths(
-        Config(
-            agents={
-                "general": AgentConfig(display_name="General", role="General agent", accept_invites=True),
-                "other": AgentConfig(display_name="Other", role="Other agent", accept_invites=True),
-            },
-            calls=CallsConfig(enabled=True, agents=["general", "other"]),
-        ),
-        runtime_paths=resolve_runtime_paths(
-            config_path=tmp_path / "config.yaml",
-            storage_path=tmp_path / "mindroom_data",
-            process_env={},
-        ),
-    )
+    config = _call_config(tmp_path, general=True, other=True)
     runtime_paths = runtime_paths_for(config)
-    for agent_name in ("general", "other"):
-        save_invited_rooms(
-            invited_rooms_path(runtime_paths.storage_root, agent_name),
-            {"!agent-call:server"},
-        )
-
     with pytest.raises(ValueError, match="general, other"):
-        configured_call_agent_name_for_room(config, "!agent-call:server", runtime_paths)
+        configured_call_agent_name_for_room(
+            config,
+            "!agent-call:server",
+            runtime_paths,
+            invited_rooms_by_agent={
+                "general": {"!agent-call:server"},
+                "other": {"!agent-call:server"},
+            },
+        )
 
 
 def test_configured_call_agent_ignores_stale_invites_when_acceptance_is_disabled(tmp_path: Path) -> None:
     """Disabling invite acceptance revokes persisted ad-hoc call-room ownership."""
-    config = bind_runtime_paths(
-        Config(
-            agents={
-                "general": AgentConfig(
-                    display_name="General",
-                    role="General agent",
-                    accept_invites=False,
-                ),
-            },
-            calls=CallsConfig(enabled=True, agents=["general"]),
-        ),
-        runtime_paths=resolve_runtime_paths(
-            config_path=tmp_path / "config.yaml",
-            storage_path=tmp_path / "mindroom_data",
-            process_env={},
-        ),
-    )
+    config = _call_config(tmp_path, general=False)
     runtime_paths = runtime_paths_for(config)
-    save_invited_rooms(
-        invited_rooms_path(runtime_paths.storage_root, "general"),
-        {"!agent-call:server"},
+    assert (
+        configured_call_agent_name_for_room(
+            config,
+            "!agent-call:server",
+            runtime_paths,
+            invited_rooms_by_agent={"general": {"!agent-call:server"}},
+        )
+        is None
     )
 
-    assert configured_call_agent_name_for_room(config, "!agent-call:server", runtime_paths) is None
 
-
-def test_configured_call_agent_caches_internal_invited_room_state(tmp_path: Path) -> None:
-    """Repeated live-room resolution does not reread unchanged internal state."""
-    config = bind_runtime_paths(
-        Config(
-            agents={
-                "general": AgentConfig(
-                    display_name="General",
-                    role="General agent",
-                    accept_invites=True,
-                ),
-            },
-            calls=CallsConfig(enabled=True, agents=["general"]),
-        ),
-        runtime_paths=resolve_runtime_paths(
-            config_path=tmp_path / "config.yaml",
-            storage_path=tmp_path / "mindroom_data",
-            process_env={},
-        ),
-    )
+def test_configured_call_agent_uses_live_invited_room_state(tmp_path: Path) -> None:
+    """Call ownership follows the invite lifecycle's current in-memory state."""
+    config = _call_config(tmp_path, general=True)
     runtime_paths = runtime_paths_for(config)
-    path = invited_rooms_path(runtime_paths.storage_root, "general")
-    path.parent.mkdir(parents=True)
-    path.write_text('["!agent-call:server"]\n', encoding="utf-8")
+    invited_rooms: set[str] = set()
+    invited_rooms_by_agent = {"general": invited_rooms}
 
-    with patch(
-        "mindroom.matrix.invited_rooms_store.load_invited_rooms",
-        wraps=load_invited_rooms,
-    ) as load:
-        for _ in range(2):
-            assert configured_call_agent_name_for_room(config, "!agent-call:server", runtime_paths) == "general"
+    assert (
+        configured_call_agent_name_for_room(
+            config,
+            "!agent-call:server",
+            runtime_paths,
+            invited_rooms_by_agent=invited_rooms_by_agent,
+        )
+        is None
+    )
 
-    load.assert_called_once_with(path)
+    invited_rooms.add("!agent-call:server")
+
+    assert (
+        configured_call_agent_name_for_room(
+            config,
+            "!agent-call:server",
+            runtime_paths,
+            invited_rooms_by_agent=invited_rooms_by_agent,
+        )
+        == "general"
+    )
 
 
 def test_entity_identity_registry_uses_only_persisted_current_ids(tmp_path: Path) -> None:

--- a/tests/test_entity_resolution.py
+++ b/tests/test_entity_resolution.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import pytest
 
@@ -17,7 +18,7 @@ from mindroom.entity_resolution import (
     configured_call_agent_name_for_room,
     entity_identity_registry,
 )
-from mindroom.matrix.invited_rooms_store import invited_rooms_path, save_invited_rooms
+from mindroom.matrix.invited_rooms_store import invited_rooms_path, load_invited_rooms, save_invited_rooms
 from mindroom.matrix.state import MatrixState
 from tests.conftest import bind_runtime_paths, runtime_paths_for
 
@@ -108,7 +109,7 @@ def test_configured_call_agent_includes_authorized_ad_hoc_invited_room(tmp_path:
     config = bind_runtime_paths(
         Config(
             agents={
-                "general": AgentConfig(display_name="General", role="General agent"),
+                "general": AgentConfig(display_name="General", role="General agent", accept_invites=True),
                 "other": AgentConfig(display_name="Other", role="Other agent"),
             },
             calls=CallsConfig(enabled=True, agents=["general", "other"]),
@@ -140,8 +141,8 @@ def test_configured_call_agent_rejects_ambiguous_invited_room(tmp_path: Path) ->
     config = bind_runtime_paths(
         Config(
             agents={
-                "general": AgentConfig(display_name="General", role="General agent"),
-                "other": AgentConfig(display_name="Other", role="Other agent"),
+                "general": AgentConfig(display_name="General", role="General agent", accept_invites=True),
+                "other": AgentConfig(display_name="Other", role="Other agent", accept_invites=True),
             },
             calls=CallsConfig(enabled=True, agents=["general", "other"]),
         ),
@@ -160,6 +161,68 @@ def test_configured_call_agent_rejects_ambiguous_invited_room(tmp_path: Path) ->
 
     with pytest.raises(ValueError, match="general, other"):
         configured_call_agent_name_for_room(config, "!agent-call:server", runtime_paths)
+
+
+def test_configured_call_agent_ignores_stale_invites_when_acceptance_is_disabled(tmp_path: Path) -> None:
+    """Disabling invite acceptance revokes persisted ad-hoc call-room ownership."""
+    config = bind_runtime_paths(
+        Config(
+            agents={
+                "general": AgentConfig(
+                    display_name="General",
+                    role="General agent",
+                    accept_invites=False,
+                ),
+            },
+            calls=CallsConfig(enabled=True, agents=["general"]),
+        ),
+        runtime_paths=resolve_runtime_paths(
+            config_path=tmp_path / "config.yaml",
+            storage_path=tmp_path / "mindroom_data",
+            process_env={},
+        ),
+    )
+    runtime_paths = runtime_paths_for(config)
+    save_invited_rooms(
+        invited_rooms_path(runtime_paths.storage_root, "general"),
+        {"!agent-call:server"},
+    )
+
+    assert configured_call_agent_name_for_room(config, "!agent-call:server", runtime_paths) is None
+
+
+def test_configured_call_agent_caches_internal_invited_room_state(tmp_path: Path) -> None:
+    """Repeated live-room resolution does not reread unchanged internal state."""
+    config = bind_runtime_paths(
+        Config(
+            agents={
+                "general": AgentConfig(
+                    display_name="General",
+                    role="General agent",
+                    accept_invites=True,
+                ),
+            },
+            calls=CallsConfig(enabled=True, agents=["general"]),
+        ),
+        runtime_paths=resolve_runtime_paths(
+            config_path=tmp_path / "config.yaml",
+            storage_path=tmp_path / "mindroom_data",
+            process_env={},
+        ),
+    )
+    runtime_paths = runtime_paths_for(config)
+    path = invited_rooms_path(runtime_paths.storage_root, "general")
+    path.parent.mkdir(parents=True)
+    path.write_text('["!agent-call:server"]\n', encoding="utf-8")
+
+    with patch(
+        "mindroom.matrix.invited_rooms_store.load_invited_rooms",
+        wraps=load_invited_rooms,
+    ) as load:
+        for _ in range(2):
+            assert configured_call_agent_name_for_room(config, "!agent-call:server", runtime_paths) == "general"
+
+    load.assert_called_once_with(path)
 
 
 def test_entity_identity_registry_uses_only_persisted_current_ids(tmp_path: Path) -> None:

--- a/tests/test_matrix_rtc_call_manager.py
+++ b/tests/test_matrix_rtc_call_manager.py
@@ -20,7 +20,6 @@ from mindroom.config.main import Config
 from mindroom.config.memory import MemoryConfig
 from mindroom.config.models import ModelConfig
 from mindroom.config.voice import SpeechServiceConfig
-from mindroom.matrix.invited_rooms_store import invited_rooms_path, save_invited_rooms
 from mindroom.matrix.state import MatrixState
 from mindroom.matrix.to_device import AuthenticatedToDeviceEvent
 from mindroom.matrix_rtc.call_manager import (
@@ -236,6 +235,7 @@ def _manager(
     config: Config | None = None,
     tool_support: object = object(),
     clock_ms: Callable[[], int] = lambda: int(time.time() * 1000),
+    invited_rooms_by_agent: dict[str, set[str]] | None = None,
 ) -> CallManager:
     return CallManager(
         agent_name="helper",
@@ -245,6 +245,7 @@ def _manager(
         ssl_verify=True,
         bridge_factory=lambda _identity, _e2ee: bridge,
         tool_support=tool_support,  # type: ignore[arg-type]
+        get_invited_rooms_by_agent=lambda: invited_rooms_by_agent or {},
         clock_ms=clock_ms,
     )
 
@@ -340,12 +341,13 @@ async def test_manager_joins_call_in_authorized_ad_hoc_invited_room(tmp_path: Pa
     bridge = FakeBridge()
     config = _config()
     config.agents["helper"].rooms = []
-    runtime_paths = test_runtime_paths(tmp_path)
-    save_invited_rooms(
-        invited_rooms_path(runtime_paths.storage_root, "helper"),
-        {ROOM_ID},
+    manager = _manager(
+        client,
+        bridge,
+        tmp_path,
+        config,
+        invited_rooms_by_agent={"helper": {ROOM_ID}},
     )
-    manager = _manager(client, bridge, tmp_path, config)
 
     await manager.on_room_event(_room(), _member_unknown_event())
 
@@ -361,19 +363,8 @@ async def test_manager_stops_call_when_agent_is_kicked_from_ephemeral_room(tmp_p
     manager = _manager(client, bridge, tmp_path)
     room = _room()
     await manager.on_room_event(room, _member_unknown_event())
-    event = nio.RoomMemberEvent.from_dict(
-        {
-            "event_id": "$leave",
-            "sender": "@alice:example.org",
-            "origin_server_ts": int(time.time() * 1000),
-            "type": "m.room.member",
-            "state_key": BOT_USER,
-            "content": {"membership": "leave"},
-        },
-    )
-    assert isinstance(event, nio.RoomMemberEvent)
 
-    await manager.on_room_membership_event(room, event)
+    await manager.on_sync_room_membership(joined_room_ids=set(), left_room_ids={ROOM_ID})
 
     assert bridge.closed is True
     assert manager._sessions == {}
@@ -413,13 +404,17 @@ async def test_manager_does_not_retain_departed_ad_hoc_room(tmp_path: Path) -> N
     client = _client()
     config = _config()
     config.agents["helper"].rooms = []
-    runtime_paths = test_runtime_paths(tmp_path)
-    path = invited_rooms_path(runtime_paths.storage_root, "helper")
-    save_invited_rooms(path, {ROOM_ID})
-    manager = _manager(client, FakeBridge(), tmp_path, config)
+    invited_rooms = {ROOM_ID}
+    manager = _manager(
+        client,
+        FakeBridge(),
+        tmp_path,
+        config,
+        invited_rooms_by_agent={"helper": invited_rooms},
+    )
     room = _room()
     manager._observed_rooms[ROOM_ID] = room
-    save_invited_rooms(path, set())
+    invited_rooms.clear()
     event = nio.RoomMemberEvent.from_dict(
         {
             "event_id": "$leave",
@@ -468,25 +463,12 @@ async def test_manager_ignores_frame_keys_after_departing_configured_room(tmp_pa
 async def test_manager_clears_departure_guard_on_own_rejoin(tmp_path: Path) -> None:
     """A forwarded own join makes a configured call room eligible again."""
     client = _client()
-    client.room_get_state.return_value = nio.RoomGetStateResponse([], ROOM_ID)
     manager = _manager(client, FakeBridge(), tmp_path)
     manager._departed_rooms.add(ROOM_ID)
-    event = nio.RoomMemberEvent.from_dict(
-        {
-            "event_id": "$join",
-            "sender": BOT_USER,
-            "origin_server_ts": int(time.time() * 1000),
-            "type": "m.room.member",
-            "state_key": BOT_USER,
-            "content": {"membership": "join"},
-        },
-    )
-    assert isinstance(event, nio.RoomMemberEvent)
 
-    await manager.on_room_membership_event(_room(), event)
+    await manager.on_sync_room_membership(joined_room_ids={ROOM_ID}, left_room_ids=set())
 
     assert ROOM_ID not in manager._departed_rooms
-    client.room_get_state.assert_awaited_once_with(ROOM_ID)
 
 
 @pytest.mark.asyncio
@@ -647,6 +629,7 @@ def test_default_bridge_factory_tracks_configured_backend(tmp_path: Path) -> Non
         runtime_paths=test_runtime_paths(tmp_path),
         ssl_verify=True,
         tool_support=object(),  # type: ignore[arg-type]
+        get_invited_rooms_by_agent=dict,
     )
 
     bridge = manager._bridge_factory("@helper:example.org:BOTDEV", False)
@@ -858,6 +841,7 @@ async def test_manager_restarts_when_sole_requester_changes(
         ssl_verify=True,
         bridge_factory=lambda _identity, _e2ee: next(bridges),
         tool_support=object(),  # type: ignore[arg-type]
+        get_invited_rooms_by_agent=dict,
     )
     client.room_get_state.return_value = _state_response(_remote_member_event())
     await manager.on_room_event(_room(), _member_unknown_event())
@@ -1018,6 +1002,7 @@ def test_maybe_build_call_manager_respects_configuration(tmp_path: Path) -> None
         runtime_paths=runtime_paths,
         ssl_verify=True,
         tool_support=object(),
+        get_invited_rooms_by_agent=dict,
     )
     assert disabled is None
     not_listed = maybe_build_call_manager(
@@ -1027,6 +1012,7 @@ def test_maybe_build_call_manager_respects_configuration(tmp_path: Path) -> None
         runtime_paths=runtime_paths,
         ssl_verify=True,
         tool_support=object(),
+        get_invited_rooms_by_agent=dict,
     )
     assert not_listed is None
     enabled = maybe_build_call_manager(
@@ -1036,6 +1022,7 @@ def test_maybe_build_call_manager_respects_configuration(tmp_path: Path) -> None
         runtime_paths=runtime_paths,
         ssl_verify=True,
         tool_support=object(),
+        get_invited_rooms_by_agent=dict,
     )
     assert isinstance(enabled, CallManager)
 
@@ -1058,6 +1045,7 @@ def test_maybe_build_call_manager_survives_missing_livekit_package(
         runtime_paths=test_runtime_paths(tmp_path),
         ssl_verify=True,
         tool_support=object(),
+        get_invited_rooms_by_agent=dict,
     )
     assert manager is None
 

--- a/tests/test_matrix_rtc_call_manager.py
+++ b/tests/test_matrix_rtc_call_manager.py
@@ -379,6 +379,89 @@ async def test_manager_stops_call_when_agent_is_kicked_from_ephemeral_room(tmp_p
     assert manager._sessions == {}
     assert manager._logical_calls == {}
     assert ROOM_ID in manager._departed_rooms
+    assert ROOM_ID not in manager._observed_rooms
+    assert ROOM_ID not in manager._locks
+
+
+@pytest.mark.asyncio
+async def test_manager_ignores_own_departure_from_unmanaged_room(tmp_path: Path) -> None:
+    """Ordinary room churn cannot create call-manager departure or lock state."""
+    client = _client()
+    manager = _manager(client, FakeBridge(), tmp_path)
+    room = _room(room_id="!text:example.org")
+    event = nio.RoomMemberEvent.from_dict(
+        {
+            "event_id": "$leave",
+            "sender": "@alice:example.org",
+            "origin_server_ts": int(time.time() * 1000),
+            "type": "m.room.member",
+            "state_key": BOT_USER,
+            "content": {"membership": "leave"},
+        },
+    )
+    assert isinstance(event, nio.RoomMemberEvent)
+
+    await manager.on_room_membership_event(room, event)
+
+    assert manager._departed_rooms == set()
+    assert dict(manager._locks) == {}
+
+
+@pytest.mark.asyncio
+async def test_manager_does_not_retain_departed_ad_hoc_room(tmp_path: Path) -> None:
+    """Forgotten invite ownership permits teardown without retaining the room ID."""
+    client = _client()
+    config = _config()
+    config.agents["helper"].rooms = []
+    runtime_paths = test_runtime_paths(tmp_path)
+    path = invited_rooms_path(runtime_paths.storage_root, "helper")
+    save_invited_rooms(path, {ROOM_ID})
+    manager = _manager(client, FakeBridge(), tmp_path, config)
+    room = _room()
+    manager._observed_rooms[ROOM_ID] = room
+    save_invited_rooms(path, set())
+    event = nio.RoomMemberEvent.from_dict(
+        {
+            "event_id": "$leave",
+            "sender": "@alice:example.org",
+            "origin_server_ts": int(time.time() * 1000),
+            "type": "m.room.member",
+            "state_key": BOT_USER,
+            "content": {"membership": "leave"},
+        },
+    )
+    assert isinstance(event, nio.RoomMemberEvent)
+
+    await manager.on_room_membership_event(room, event)
+
+    assert manager._observed_rooms == {}
+    assert manager._departed_rooms == set()
+    assert dict(manager._locks) == {}
+
+
+@pytest.mark.asyncio
+async def test_manager_ignores_frame_keys_after_departing_configured_room(tmp_path: Path) -> None:
+    """Late to-device keys cannot repopulate state after the bot leaves."""
+    client = _client()
+    client.rooms = {ROOM_ID: _room(encrypted=True)}
+    manager = _manager(client, FakeBridge(), tmp_path)
+    event = nio.RoomMemberEvent.from_dict(
+        {
+            "event_id": "$leave",
+            "sender": "@alice:example.org",
+            "origin_server_ts": int(time.time() * 1000),
+            "type": "m.room.member",
+            "state_key": BOT_USER,
+            "content": {"membership": "leave"},
+        },
+    )
+    assert isinstance(event, nio.RoomMemberEvent)
+    await manager.on_room_membership_event(client.rooms[ROOM_ID], event)
+
+    await manager.on_to_device_event(_frame_key_event())
+
+    assert manager._pending_keys == {}
+    client.room_get_state.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -952,6 +1035,20 @@ def test_maybe_build_call_manager_survives_missing_livekit_package(
         tool_support=object(),
     )
     assert manager is None
+
+
+def test_voice_backend_availability_requires_runtime_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Presence readiness is false when the realtime backend cannot authenticate."""
+    monkeypatch.setattr(
+        "mindroom.matrix_rtc.call_manager.get_api_key_for_provider",
+        lambda _provider, _paths: None,
+    )
+    manager = _manager(_client(), FakeBridge(), tmp_path)
+
+    assert manager.voice_backend_available is False
 
 
 def test_build_call_instructions_appends_voice_guidance() -> None:

--- a/tests/test_matrix_rtc_call_manager.py
+++ b/tests/test_matrix_rtc_call_manager.py
@@ -378,6 +378,7 @@ async def test_manager_stops_call_when_agent_is_kicked_from_ephemeral_room(tmp_p
     assert bridge.closed is True
     assert manager._sessions == {}
     assert manager._logical_calls == {}
+    assert ROOM_ID in manager._departed_rooms
 
 
 @pytest.mark.asyncio

--- a/tests/test_matrix_rtc_call_manager.py
+++ b/tests/test_matrix_rtc_call_manager.py
@@ -20,6 +20,7 @@ from mindroom.config.main import Config
 from mindroom.config.memory import MemoryConfig
 from mindroom.config.models import ModelConfig
 from mindroom.config.voice import SpeechServiceConfig
+from mindroom.matrix.invited_rooms_store import invited_rooms_path, save_invited_rooms
 from mindroom.matrix.state import MatrixState
 from mindroom.matrix.to_device import AuthenticatedToDeviceEvent
 from mindroom.matrix_rtc.call_manager import (
@@ -329,6 +330,54 @@ async def test_manager_joins_call_when_remote_member_appears(tmp_path: Path) -> 
     assert args[1] == CALL_MEMBER_EVENT_TYPE
     assert args[2]["device_id"] == BOT_DEVICE
     assert kwargs["state_key"] == membership_state_key(BOT_USER, BOT_DEVICE)
+
+
+@pytest.mark.asyncio
+async def test_manager_joins_call_in_authorized_ad_hoc_invited_room(tmp_path: Path) -> None:
+    """An accepted invite is sufficient room ownership for a calls-enabled agent."""
+    client = _client()
+    client.room_get_state.return_value = _state_response(_remote_member_event())
+    bridge = FakeBridge()
+    config = _config()
+    config.agents["helper"].rooms = []
+    runtime_paths = test_runtime_paths(tmp_path)
+    save_invited_rooms(
+        invited_rooms_path(runtime_paths.storage_root, "helper"),
+        {ROOM_ID},
+    )
+    manager = _manager(client, bridge, tmp_path, config)
+
+    await manager.on_room_event(_room(), _member_unknown_event())
+
+    assert bridge.connected_grant == GRANT
+
+
+@pytest.mark.asyncio
+async def test_manager_stops_call_when_agent_is_kicked_from_ephemeral_room(tmp_path: Path) -> None:
+    """Own membership removal tears down media without waiting for another call event."""
+    client = _client()
+    client.room_get_state.return_value = _state_response(_remote_member_event())
+    bridge = FakeBridge()
+    manager = _manager(client, bridge, tmp_path)
+    room = _room()
+    await manager.on_room_event(room, _member_unknown_event())
+    event = nio.RoomMemberEvent.from_dict(
+        {
+            "event_id": "$leave",
+            "sender": "@alice:example.org",
+            "origin_server_ts": int(time.time() * 1000),
+            "type": "m.room.member",
+            "state_key": BOT_USER,
+            "content": {"membership": "leave"},
+        },
+    )
+    assert isinstance(event, nio.RoomMemberEvent)
+
+    await manager.on_room_membership_event(room, event)
+
+    assert bridge.closed is True
+    assert manager._sessions == {}
+    assert manager._logical_calls == {}
 
 
 @pytest.mark.asyncio

--- a/tests/test_matrix_rtc_call_manager.py
+++ b/tests/test_matrix_rtc_call_manager.py
@@ -6,7 +6,7 @@ import asyncio
 import base64
 import time
 from typing import TYPE_CHECKING, cast
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
 import httpx
@@ -462,6 +462,31 @@ async def test_manager_ignores_frame_keys_after_departing_configured_room(tmp_pa
 
     assert manager._pending_keys == {}
     client.room_get_state.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_manager_clears_departure_guard_on_own_rejoin(tmp_path: Path) -> None:
+    """A forwarded own join makes a configured call room eligible again."""
+    client = _client()
+    client.room_get_state.return_value = nio.RoomGetStateResponse([], ROOM_ID)
+    manager = _manager(client, FakeBridge(), tmp_path)
+    manager._departed_rooms.add(ROOM_ID)
+    event = nio.RoomMemberEvent.from_dict(
+        {
+            "event_id": "$join",
+            "sender": BOT_USER,
+            "origin_server_ts": int(time.time() * 1000),
+            "type": "m.room.member",
+            "state_key": BOT_USER,
+            "content": {"membership": "join"},
+        },
+    )
+    assert isinstance(event, nio.RoomMemberEvent)
+
+    await manager.on_room_membership_event(_room(), event)
+
+    assert ROOM_ID not in manager._departed_rooms
+    client.room_get_state.assert_awaited_once_with(ROOM_ID)
 
 
 @pytest.mark.asyncio
@@ -1048,7 +1073,16 @@ def test_voice_backend_availability_requires_runtime_credentials(
     )
     manager = _manager(_client(), FakeBridge(), tmp_path)
 
-    assert manager.voice_backend_available is False
+    with patch("mindroom.matrix_rtc.call_manager.logger.warning") as warning:
+        assert manager.voice_backend_available is False
+        warning.assert_not_called()
+
+        assert manager._resolve_voice_backend(ROOM_ID) is None
+        warning.assert_called_once_with(
+            "call_join_skipped_no_openai_key",
+            room_id=ROOM_ID,
+            agent="helper",
+        )
 
 
 def test_build_call_instructions_appends_voice_guidance() -> None:

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -186,7 +186,7 @@ class TestAgentBot(AgentBotTestBase):
         assert mock_login.called
         mock_init_persistence.assert_called_once_with(runtime_paths_for(config).storage_root)
         assert (
-            mock_client.add_event_callback.call_count == 14
+            mock_client.add_event_callback.call_count == 15
         )  # invite, message, redaction, reaction, audio, image/file/video, unknown-event, megolm callbacks
         registered_event_types = [call.args[1] for call in mock_client.add_event_callback.call_args_list]
         assert nio.MegolmEvent in registered_event_types  # undecryptable events must not vanish silently
@@ -287,7 +287,7 @@ class TestAgentBot(AgentBotTestBase):
         assert bot._turn_policy.deps.matrix_id.full_id == actual_user_id
         assert bot._turn_controller.deps.matrix_id.full_id == actual_user_id
         mock_init_persistence.assert_called_once_with(runtime_paths_for(config).storage_root)
-        assert mock_client.add_event_callback.call_count == 14
+        assert mock_client.add_event_callback.call_count == 15
 
     @pytest.mark.asyncio
     @patch("mindroom.constants.runtime_matrix_homeserver", new=lambda *_args, **_kwargs: "http://localhost:8008")

--- a/tests/test_presence.py
+++ b/tests/test_presence.py
@@ -9,6 +9,7 @@ import nio
 import pytest
 
 from mindroom.config.agent import AgentConfig, TeamConfig
+from mindroom.config.calls import CallsConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
 from mindroom.constants import ROUTER_AGENT_NAME
@@ -101,6 +102,19 @@ class TestBuildAgentStatusMessage:
         assert "🤖 Model: ollama/llama3" in status
         assert "💼 General purpose assistant" in status
         assert "🔧" not in status  # No tools section
+
+    def test_only_calls_enabled_agents_advertise_voice_calls(self) -> None:
+        """Presence gives clients an exact per-agent voice-call capability signal."""
+        config = Config(
+            agents={
+                "voice": AgentConfig(display_name="Voice"),
+                "text": AgentConfig(display_name="Text"),
+            },
+            calls=CallsConfig(enabled=True, agents=["voice"]),
+        )
+
+        assert "📞 Voice calls" in build_agent_status_message("voice", config).split(" | ")
+        assert "📞 Voice calls" not in build_agent_status_message("text", config).split(" | ")
 
     def test_team_agent_status(self) -> None:
         """Test building status message for team agent."""

--- a/tests/test_presence.py
+++ b/tests/test_presence.py
@@ -103,8 +103,8 @@ class TestBuildAgentStatusMessage:
         assert "💼 General purpose assistant" in status
         assert "🔧" not in status  # No tools section
 
-    def test_only_calls_enabled_agents_advertise_voice_calls(self) -> None:
-        """Presence gives clients an exact per-agent voice-call capability signal."""
+    def test_only_runtime_ready_calls_agents_advertise_voice_calls(self) -> None:
+        """Presence gives clients an exact runtime-ready voice-call capability signal."""
         config = Config(
             agents={
                 "voice": AgentConfig(display_name="Voice"),
@@ -113,7 +113,12 @@ class TestBuildAgentStatusMessage:
             calls=CallsConfig(enabled=True, agents=["voice"]),
         )
 
-        assert "📞 Voice calls" in build_agent_status_message("voice", config).split(" | ")
+        assert "📞 Voice calls" in build_agent_status_message(
+            "voice",
+            config,
+            voice_calls_available=True,
+        ).split(" | ")
+        assert "📞 Voice calls" not in build_agent_status_message("voice", config).split(" | ")
         assert "📞 Voice calls" not in build_agent_status_message("text", config).split(" | ")
 
     def test_team_agent_status(self) -> None:

--- a/tests/test_room_invites.py
+++ b/tests/test_room_invites.py
@@ -362,20 +362,7 @@ def test_agent_forgets_persisted_invited_room_after_being_kicked(
     room_id = "!agent-call:localhost"
     bot._room_lifecycle.invited_rooms = {room_id}
     bot._room_lifecycle.save_invited_rooms()
-    room = nio.MatrixRoom(room_id=room_id, own_user_id="@mindroom_agent1:localhost")
-    event = nio.RoomMemberEvent.from_dict(
-        {
-            "event_id": "$leave",
-            "sender": "@alice:localhost",
-            "origin_server_ts": 1,
-            "type": "m.room.member",
-            "state_key": "@mindroom_agent1:localhost",
-            "content": {"membership": "leave"},
-        },
-    )
-    assert isinstance(event, nio.RoomMemberEvent)
-
-    bot._room_lifecycle.forget_invited_room_after_own_leave(room, event)
+    bot._room_lifecycle.forget_invited_room(room_id)
 
     assert bot._room_lifecycle.invited_rooms == set()
     assert _invited_rooms_path(config, "agent1").read_text(encoding="utf-8") == "[]\n"

--- a/tests/test_room_invites.py
+++ b/tests/test_room_invites.py
@@ -332,6 +332,55 @@ async def test_router_deduplicates_concurrent_invite_callbacks(
     assert bot._room_lifecycle.invited_rooms == {"!router-invited:localhost"}
 
 
+def test_agent_forgets_persisted_invited_room_after_being_kicked(
+    tmp_path: Path,
+) -> None:
+    """An ephemeral call room cannot be rejoined after its creator removes the agent."""
+    config = bind_runtime_paths(
+        Config(
+            agents={
+                "agent1": AgentConfig(
+                    display_name="Agent 1",
+                    role="Test agent",
+                    accept_invites=True,
+                ),
+            },
+        ),
+        test_runtime_paths(tmp_path),
+    )
+    bot = AgentBot(
+        agent_user=AgentMatrixUser(
+            agent_name="agent1",
+            user_id="@mindroom_agent1:localhost",
+            display_name="Agent 1",
+            password=TEST_PASSWORD,
+        ),
+        storage_path=tmp_path,
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+    )
+    room_id = "!agent-call:localhost"
+    bot._room_lifecycle.invited_rooms = {room_id}
+    bot._room_lifecycle.save_invited_rooms()
+    room = nio.MatrixRoom(room_id=room_id, own_user_id="@mindroom_agent1:localhost")
+    event = nio.RoomMemberEvent.from_dict(
+        {
+            "event_id": "$leave",
+            "sender": "@alice:localhost",
+            "origin_server_ts": 1,
+            "type": "m.room.member",
+            "state_key": "@mindroom_agent1:localhost",
+            "content": {"membership": "leave"},
+        },
+    )
+    assert isinstance(event, nio.RoomMemberEvent)
+
+    bot._room_lifecycle.forget_invited_room_after_own_leave(room, event)
+
+    assert bot._room_lifecycle.invited_rooms == set()
+    assert _invited_rooms_path(config, "agent1").read_text(encoding="utf-8") == "[]\n"
+
+
 @pytest.mark.asyncio
 async def test_router_duplicate_invite_retries_failed_welcome_delivery(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_room_member_hooks.py
+++ b/tests/test_room_member_hooks.py
@@ -93,12 +93,14 @@ def _sync_response_with_state(
     response.__class__ = nio.SyncResponse
     response.next_batch = "s_next"
     response.rooms = SimpleNamespace(
+        invite={},
         join={
             room_id: SimpleNamespace(
                 state=events,
                 timeline=SimpleNamespace(events=timeline_events or [], limited=False),
             ),
         },
+        leave={},
     )
     return cast("nio.SyncResponse", response)
 


### PR DESCRIPTION
## What changed

- Treat rooms accepted through a calls-enabled agent's authorized invite policy as valid MatrixRTC call rooms.
- Advertise `📞 Voice calls` in presence only for agents selected in `calls.agents` with an available MatrixRTC runtime, giving clients an exact usable-capability signal.
- Fail closed if an ad-hoc room resolves to more than one calls-enabled agent.
- Remove departed rooms from persisted invite ownership before serialized media teardown, preventing an in-flight reconciliation from restarting a kicked call.
- Document the ad-hoc voice-room behavior and regenerate the MindRoom docs skill references.

## Why

Cinny needs to create a private, temporary voice room and invite one MindRoom agent without first adding every generated room ID to `config.yaml`.
Previously, the agent accepted the room invite but the call manager ignored it because it only considered statically configured room references.

## User and operator impact

Calls-enabled agents can now join calls in private rooms created on demand by authorized users.
Text-only agents and agents without a usable call runtime do not advertise the capability, existing static-room call behavior is unchanged, and normal invite authorization plus per-agent call authorization still applies.

## Validation

- `PUPPETEER_SKIP_DOWNLOAD=true uv run pytest -q` — full suite passed.
- `uv run pre-commit run --all-files` — all hooks passed, including Ruff, ty, vulture, Tach, module privacy, generated docs, Prettier, ESLint, and TypeScript checks.
- Focused entity-resolution, invite-lifecycle, MatrixRTC-manager, ready-hook, and presence suites passed.
- `git diff --check` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Calls-enabled agents can join authorized ad-hoc rooms without prior room configuration.
  * Presence now advertises “📞 Voice calls” only when voice calling is actually available.
* **Bug Fixes**
  * Call sessions and related state shut down immediately when the agent leaves/kicked from ephemeral voice rooms.
  * Departure handling avoids reprocessing, ignores late frame keys, and clears invited-room tracking when appropriate.
* **Documentation**
  * Updated voice-call docs and configuration notes for ad-hoc rooms and conditional presence.
* **Refactor**
  * Consolidated call admission around the existing live invited-room lifecycle state and direct sync membership sections.
* **Tests**
  * Expanded integration and unit coverage for callback wiring, presence logic, invite ownership cleanup, and teardown timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
