### PR TITLE
feat(config): add thread_summary tool to mind starter template

### DIFF
--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -956,6 +956,7 @@ agents:
       - subagents
       - matrix_message
       - thread_tags
+      - thread_summary
     skills:
       - mindroom-docs
     instructions:

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -241,6 +241,7 @@ class TestConfigInit:
             "subagents",
             "matrix_message",
             "thread_tags",
+            "thread_summary",
         ]
         assert mind["skills"] == ["mindroom-docs"]
         assert "knowledge_bases" not in config


### PR DESCRIPTION
## Summary

Adds `thread_summary` to the Mind agent's tools in the `mindroom config init` starter template.

## Why

Mind's starter toolset includes `matrix_message` and `thread_tags` but not `thread_summary`. Thread titles are stored as separate `io.mindroom.thread_summary` notices, so an agent without the tool cannot change them. In practice, when asked to fix broken thread summaries (in this case, error text like "Insufficient balance or no resource package. Please recharge." persisted as summaries by a failed summary-model provider), Mind fell back to editing thread messages with `matrix_message`, which has no effect on the rendered titles.

With `set_thread_summary` available, the agent can update summaries directly for the current or any specified thread.

## Changes

- `src/mindroom/cli/config.py`: add `thread_summary` to the Mind template tools list
- `tests/test_cli_config.py`: update the fresh-init assertion; migration fixtures are intentionally untouched since `config migrate` does not add new tools to existing configs

## Testing

- `uv run pytest tests/test_cli_config.py -n 0 --no-cov`: 153 passed

## Summary by Sourcery

Add the thread_summary tool to the default Mind agent starter template and update tests accordingly.

New Features:
- Include the thread_summary tool in the Mind starter template tool list.

Tests:
- Update CLI config initialization test expectations to cover the new thread_summary tool in the template.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The generated configuration for the Mind agent now includes the `thread_summary` tool by default.
  * Mind agent context settings now recognize `thread_summary`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->