### PR TITLE
fix(calls): retry keys after Olm bootstrap

### DIFF
--- a/src/mindroom/matrix_rtc/call_session.py
+++ b/src/mindroom/matrix_rtc/call_session.py
@@ -133,6 +133,7 @@ class CallSession:
     _members: list[CallMember] = field(default_factory=list, init=False)
     _key_distribution_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
     _key_distribution_retry_scheduled: bool = field(default=False, init=False)
+    _key_distribution_wakeup_scheduled: bool = field(default=False, init=False)
     _key_retry_attempt: int = field(default=0, init=False)
 
     def __post_init__(self) -> None:
@@ -218,7 +219,31 @@ class CallSession:
             participant=inbound.participant_identity,
             key_index=inbound.key_index,
         )
+        # Decrypting this Olm event proves that a usable bidirectional session
+        # now exists with the sender. Wake outbound key distribution
+        # immediately instead of waiting for the old bounded retry timer (or a
+        # future membership change after that retry budget was exhausted).
+        if self.e2ee_enabled and self._created_ts is not None:
+            self._wake_key_distribution_after_inbound_key()
         return True
+
+    def _wake_key_distribution_after_inbound_key(self) -> None:
+        """Coalesce immediate outbound retries after authenticated key intake."""
+        if self._stopped or self._key_distribution_wakeup_scheduled:
+            return
+        self._key_distribution_wakeup_scheduled = True
+        self._spawn(self._redistribute_after_inbound_key())
+
+    async def _redistribute_after_inbound_key(self) -> None:
+        """Retry our key now that inbound Olm traffic established a session."""
+        try:
+            self._key_retry_attempt = 0
+            await self._distribute_keys()
+        except _MATRIX_NETWORK_ERRORS as error:
+            logger.warning("call_key_distribution_error", room_id=self.room_id, error=str(error))
+            self._schedule_key_distribution_retry()
+        finally:
+            self._key_distribution_wakeup_scheduled = False
 
     async def stop(self) -> None:
         """Leave the call through one cancellation-safe shared cleanup task."""

--- a/tests/test_matrix_rtc_call_manager.py
+++ b/tests/test_matrix_rtc_call_manager.py
@@ -118,6 +118,35 @@ class FakeKeyTransport:
         return targets
 
 
+class RecoveringKeyTransport(FakeKeyTransport):
+    """Starts unable to send and becomes usable after inbound Olm traffic."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.available = False
+        self.delivered = asyncio.Event()
+
+    async def send_key(
+        self,
+        *,
+        room_id: str,
+        key_base64: str,
+        key_index: int,
+        targets: list[CallMember],
+    ) -> list[CallMember]:
+        """Deliver only after the test models an established Olm session."""
+        await super().send_key(
+            room_id=room_id,
+            key_base64=key_base64,
+            key_index=key_index,
+            targets=targets,
+        )
+        if not self.available:
+            return []
+        self.delivered.set()
+        return targets
+
+
 def _client() -> AsyncMock:
     client = AsyncMock(spec=nio.AsyncClient)
     client.user_id = BOT_USER
@@ -1063,6 +1092,36 @@ async def test_session_installs_inbound_keys_on_bridge() -> None:
 
     assert accepted is True
     assert bridge.frame_keys == [("@alice:example.org:ALICEDEV", b"A" * 16, 2)]
+    await session.stop()
+
+
+@pytest.mark.asyncio
+async def test_inbound_key_immediately_retries_undelivered_outbound_key() -> None:
+    """Inbound Olm traffic wakes outbound sharing after its retry budget ended."""
+    transport = RecoveringKeyTransport()
+    session = _session(_client(), FakeBridge(), transport, [1_000])
+    alice = _member("@alice:example.org", "ALICEDEV")
+    # Model a call whose bounded retry budget was already exhausted before the
+    # peer's first Olm-encrypted key established the bidirectional session.
+    session._key_retry_attempt = 3
+    await session.start([alice])
+    assert len(transport.sent) == 1
+
+    transport.available = True
+    accepted = session.on_key_received(
+        ReceivedFrameKey(
+            user_id=alice.user_id,
+            claimed_device_id=alice.device_id,
+            key_base64="QUFBQUFBQUFBQUFBQUFBQQ==",
+            key_index=2,
+            received_at_ms=1_500,
+        ),
+    )
+    await asyncio.wait_for(transport.delivered.wait(), timeout=1)
+
+    assert accepted is True
+    assert len(transport.sent) == 2
+    assert transport.sent[1]["targets"] == [alice]
     await session.stop()
 
 


### PR DESCRIPTION
## What changed

- Wake outbound MatrixRTC frame-key distribution immediately after accepting an authenticated inbound frame key.
- Coalesce concurrent wakeups and retain the existing per-call lock, bounded backoff, lifecycle cancellation, and network-error handling.
- Add a regression test for recovery after the original outbound retry budget has already been exhausted.

## Why

Encrypted calls require an Olm session in both directions. Cinny can establish the first usable session by sending its frame key to the agent. The Python backend already installs that inbound key, but previously did not use the newly proven bidirectional Olm session as an immediate opportunity to retry its own undelivered frame key. It could therefore wait for an old 30-second timer or, after exhausting the 1/5/30-second budget, wait indefinitely for another membership change.

This complements the Cinny-side empty-batch retry in mindroom-cinny#130 and closes the reverse key-delivery recovery path without disabling E2EE.

## Validation

- 127 MatrixRTC/call tests pass, including the real-Olm encrypted frame-key round trip
- `uv run ty check` on touched code/tests
- Ruff lint and format checks on touched code/tests
- `git diff --check`

The repository-wide pytest command additionally requires unrelated optional tool extras and PostgreSQL that are not installed in this focused checkout; its failures were missing-dependency/service errors outside the call path.
