### PR TITLE
Scope metadata-less redactions to the cache-known thread instead of nuking the room

### DIFF
--- a/src/mindroom/matrix/thread_bookkeeping.py
+++ b/src/mindroom/matrix/thread_bookkeeping.py
@@ -37,6 +37,11 @@ Who may mutate thread state, and how:
 
 5. Redactions of reactions are always ROOM_LEVEL: removing an annotation cannot change any cached
    thread's visible messages.
+
+6. Redactions whose target metadata is gone fall back to the cache's own event->thread index before
+   failing closed: the homeserver strips a redacted event's content, so old redaction targets are
+   often unresolvable through event metadata even though the durable cache still knows exactly which
+   thread holds the event. Only when the index has no entry either does the impact stay UNKNOWN.
 """
 
 from __future__ import annotations
@@ -263,7 +268,11 @@ class ThreadMutationResolver:
                     resolution_context=resolution_context,
                 )
             except ThreadMembershipLookupError:
-                return MutationThreadImpact.unknown()
+                return await self._redaction_impact_from_thread_index(
+                    room_id,
+                    redacted_event_id,
+                    resolution_context=resolution_context,
+                )
             if not _redaction_can_affect_thread_cache(target_event_info):
                 return MutationThreadImpact.room_level()
             resolution = await resolve_related_event_thread_membership(
@@ -284,6 +293,44 @@ class ThreadMutationResolver:
                 error=str(exc),
             )
             return MutationThreadImpact.unknown()
+
+    async def _redaction_impact_from_thread_index(
+        self,
+        room_id: str,
+        redacted_event_id: str,
+        *,
+        resolution_context: MutationResolutionContext | None,
+    ) -> MutationThreadImpact:
+        """Scope one metadata-less redaction to the thread the cache index already knows.
+
+        The homeserver strips a redacted event's content, so old redaction targets often cannot be
+        resolved through event metadata. When the durable cache holds the event, its event->thread
+        index names the only cached thread the redaction can affect; invalidating just that thread
+        preserves the fail-closed guarantee without discarding every other cached thread in the room.
+        """
+        try:
+            thread_id = await self._lookup_thread_id_for_mutation_context(
+                room_id,
+                redacted_event_id,
+                resolution_context=resolution_context,
+            )
+        except Exception as exc:
+            self.logger.warning(
+                "Redaction thread-index fallback failed; failing closed",
+                room_id=room_id,
+                redacted_event_id=redacted_event_id,
+                error=str(exc),
+            )
+            return MutationThreadImpact.unknown()
+        if thread_id is None:
+            return MutationThreadImpact.unknown()
+        self.logger.info(
+            "Scoped metadata-less redaction to its cached thread",
+            room_id=room_id,
+            redacted_event_id=redacted_event_id,
+            thread_id=thread_id,
+        )
+        return MutationThreadImpact.threaded(thread_id)
 
     async def resolve_thread_impact_for_mutation(
         self,

--- a/src/mindroom/matrix/thread_bookkeeping.py
+++ b/src/mindroom/matrix/thread_bookkeeping.py
@@ -271,6 +271,7 @@ class ThreadMutationResolver:
                 return await self._redaction_impact_from_thread_index(
                     room_id,
                     redacted_event_id,
+                    event_id=event_id,
                     resolution_context=resolution_context,
                 )
             if not _redaction_can_affect_thread_cache(target_event_info):
@@ -299,6 +300,7 @@ class ThreadMutationResolver:
         room_id: str,
         redacted_event_id: str,
         *,
+        event_id: str | None,
         resolution_context: MutationResolutionContext | None,
     ) -> MutationThreadImpact:
         """Scope one metadata-less redaction to the thread the cache index already knows.
@@ -318,6 +320,7 @@ class ThreadMutationResolver:
             self.logger.warning(
                 "Redaction thread-index fallback failed; failing closed",
                 room_id=room_id,
+                event_id=event_id,
                 redacted_event_id=redacted_event_id,
                 error=str(exc),
             )
@@ -327,6 +330,7 @@ class ThreadMutationResolver:
         self.logger.info(
             "Scoped metadata-less redaction to its cached thread",
             room_id=room_id,
+            event_id=event_id,
             redacted_event_id=redacted_event_id,
             thread_id=thread_id,
         )

--- a/tests/test_matrix_thread_domain.py
+++ b/tests/test_matrix_thread_domain.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
-from unittest.mock import AsyncMock
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
 
 import nio
 import pytest
@@ -18,6 +19,7 @@ from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.thread_bookkeeping import (
     MutationThreadImpact,
     MutationThreadImpactState,
+    ThreadMutationResolver,
     resolve_event_thread_impact_for_client,
     resolve_redaction_thread_impact_for_client,
 )
@@ -399,6 +401,70 @@ async def test_resolve_redaction_thread_impact_for_client_returns_room_level_for
     )
 
     assert impact == MutationThreadImpact.room_level()
+
+
+def _mutation_resolver_with_index(
+    *,
+    fetch_event_info: AsyncMock,
+    get_thread_id_for_event: AsyncMock,
+) -> ThreadMutationResolver:
+    """Build one mutation resolver over a stub runtime exposing only the event->thread index."""
+    return ThreadMutationResolver(
+        logger_getter=Mock,
+        runtime=SimpleNamespace(event_cache=SimpleNamespace(get_thread_id_for_event=get_thread_id_for_event)),
+        fetch_event_info_for_thread_resolution=fetch_event_info,
+    )
+
+
+@pytest.mark.asyncio
+async def test_metadata_less_redaction_scopes_to_cached_thread_index() -> None:
+    """A redaction whose target metadata is gone should invalidate only the cache-known thread."""
+    resolver = _mutation_resolver_with_index(
+        fetch_event_info=AsyncMock(return_value=None),
+        get_thread_id_for_event=AsyncMock(return_value="$thread-root:localhost"),
+    )
+
+    impact = await resolver.resolve_redaction_thread_impact(
+        "!room:localhost",
+        "$old-target:localhost",
+        failure_message="Failed to apply sync redaction to cache",
+    )
+
+    assert impact == MutationThreadImpact.threaded("$thread-root:localhost")
+
+
+@pytest.mark.asyncio
+async def test_metadata_less_redaction_stays_unknown_without_index_entry() -> None:
+    """A redaction target absent from the cache index must keep failing closed."""
+    resolver = _mutation_resolver_with_index(
+        fetch_event_info=AsyncMock(return_value=None),
+        get_thread_id_for_event=AsyncMock(return_value=None),
+    )
+
+    impact = await resolver.resolve_redaction_thread_impact(
+        "!room:localhost",
+        "$untracked-target:localhost",
+        failure_message="Failed to apply sync redaction to cache",
+    )
+
+    assert impact == MutationThreadImpact.unknown()
+
+
+@pytest.mark.asyncio
+async def test_metadata_less_redaction_stays_unknown_when_index_lookup_fails() -> None:
+    """An index lookup error must not weaken the fail-closed redaction path."""
+    resolver = _mutation_resolver_with_index(
+        fetch_event_info=AsyncMock(return_value=None),
+        get_thread_id_for_event=AsyncMock(side_effect=RuntimeError("cache unavailable")),
+    )
+
+    impact = await resolver.resolve_redaction_thread_impact(
+        "!room:localhost",
+        "$old-target:localhost",
+        failure_message="Failed to apply sync redaction to cache",
+    )
+
+    assert impact == MutationThreadImpact.unknown()
 
 
 @pytest.mark.asyncio

--- a/tests/test_matrix_thread_domain.py
+++ b/tests/test_matrix_thread_domain.py
@@ -407,10 +407,12 @@ def _mutation_resolver_with_index(
     *,
     fetch_event_info: AsyncMock,
     get_thread_id_for_event: AsyncMock,
+    logger: Mock | None = None,
 ) -> ThreadMutationResolver:
     """Build one mutation resolver over a stub runtime exposing only the event->thread index."""
+    resolved_logger = logger if logger is not None else Mock()
     return ThreadMutationResolver(
-        logger_getter=Mock,
+        logger_getter=lambda: resolved_logger,
         runtime=SimpleNamespace(event_cache=SimpleNamespace(get_thread_id_for_event=get_thread_id_for_event)),
         fetch_event_info_for_thread_resolution=fetch_event_info,
     )
@@ -419,18 +421,28 @@ def _mutation_resolver_with_index(
 @pytest.mark.asyncio
 async def test_metadata_less_redaction_scopes_to_cached_thread_index() -> None:
     """A redaction whose target metadata is gone should invalidate only the cache-known thread."""
+    logger = Mock()
     resolver = _mutation_resolver_with_index(
         fetch_event_info=AsyncMock(return_value=None),
         get_thread_id_for_event=AsyncMock(return_value="$thread-root:localhost"),
+        logger=logger,
     )
 
     impact = await resolver.resolve_redaction_thread_impact(
         "!room:localhost",
         "$old-target:localhost",
         failure_message="Failed to apply sync redaction to cache",
+        event_id="$redaction:localhost",
     )
 
     assert impact == MutationThreadImpact.threaded("$thread-root:localhost")
+    logger.info.assert_called_once_with(
+        "Scoped metadata-less redaction to its cached thread",
+        room_id="!room:localhost",
+        event_id="$redaction:localhost",
+        redacted_event_id="$old-target:localhost",
+        thread_id="$thread-root:localhost",
+    )
 
 
 @pytest.mark.asyncio
@@ -453,18 +465,28 @@ async def test_metadata_less_redaction_stays_unknown_without_index_entry() -> No
 @pytest.mark.asyncio
 async def test_metadata_less_redaction_stays_unknown_when_index_lookup_fails() -> None:
     """An index lookup error must not weaken the fail-closed redaction path."""
+    logger = Mock()
     resolver = _mutation_resolver_with_index(
         fetch_event_info=AsyncMock(return_value=None),
         get_thread_id_for_event=AsyncMock(side_effect=RuntimeError("cache unavailable")),
+        logger=logger,
     )
 
     impact = await resolver.resolve_redaction_thread_impact(
         "!room:localhost",
         "$old-target:localhost",
         failure_message="Failed to apply sync redaction to cache",
+        event_id="$redaction:localhost",
     )
 
     assert impact == MutationThreadImpact.unknown()
+    logger.warning.assert_called_once_with(
+        "Redaction thread-index fallback failed; failing closed",
+        room_id="!room:localhost",
+        event_id="$redaction:localhost",
+        redacted_event_id="$old-target:localhost",
+        error="cache unavailable",
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem, with production evidence

While backfilling thread exports on the mindroom-chat instance, the cache-first read path showed an unexpectedly low hit rate. Measured over one 30-minute window: 124 cache hits vs 51 homeserver refetches, and 47 of the 51 misses were rejected with `room_invalidated_after_validation`. In the dormant-thread tail the ratio was 0 hits / 19 misses per 15 minutes, with each miss costing a backward room scan of up to 58 pages / 5800 events (~25s, `homeserver_fetch_ms=25185`).

The stored markers tell the story. Production log line (room id redacted here):

```json
{"room_id": "!l3DX...", "thread_id": "$DeX9...",
 "cache_reject_reason": "room_invalidated_after_validation",
 "cache_validated_at": 1777216467.82,        // 2026-04-26
 "room_cache_invalidated_at": 1780036243.44, // 2026-05-29
 "room_cache_invalidation_reason": "sync_redaction_lookup_unavailable"}
```

One redaction on May 29 put every thread validated before it behind a room-wide marker. Active threads re-validate quickly because dispatch re-reads them; dormant threads stay rejected forever, because only a read re-validates. Any later bulk reader (thread export, compaction over old threads) pays the entire accumulated refetch bill.

## Root cause

When a redaction arrives via sync for an old event, the homeserver has already stripped the target's content, so `_event_info_for_mutation_context` cannot classify it and raises `ThreadMembershipLookupError`. `resolve_redaction_thread_impact` then returned UNKNOWN, and `invalidate_after_redaction` invalidated the whole room's cached threads.

The contradiction: that room-wide invalidation only fires when `redacted=True`, i.e. `redact_event` actually changed a cached row (`thread_write_cache_ops.py:202`). If the cache changed a row, the cache holds the event, and its event->thread index (`event_threads`, `get_thread_id_for_event`) knows exactly which thread the redaction affects. We were discarding every cached thread in the room while holding the precise answer.

## Fix

`resolve_redaction_thread_impact` now falls back to the cache's own event->thread index when the target's metadata is unavailable:

- index hit: THREADED impact. The row is redacted and only that thread gets a stale marker.
- index miss: UNKNOWN, exactly as before.
- index lookup error: UNKNOWN, exactly as before.

## Why this preserves the fail-closed guarantees

- The marker's purpose is to stop a cached snapshot from serving redacted content. An event belongs to exactly one thread, so only the index-named thread's snapshot can contain it; no other thread's snapshot is affected.
- The thread-scoped stale marker is written at the same barrier point as the room-wide marker was, so the store-race guard from PR #716 (`replace_thread_if_not_newer` vs marker timestamps) applies unchanged to the affected thread.
- Targets the cache never held keep today's behavior: `redacted=False` means no marker is written at all (nothing cached can resurrect the content).
- An inconsistent state where rows contain the event but the index does not still fails closed to the room-wide marker.
- Reaction redactions with intact metadata keep their existing ROOM_LEVEL no-op path.

## Evidence the fix addresses the observed problem

All 47 `room_invalidated_after_validation` rejects in the measured window traced to `sync_redaction_lookup_unavailable` markers, which this path wrote. With the fix, the same May 29 redaction would have stale-marked one thread; the other cached threads in that room (validated April 26) would have stayed trusted, and the backfill's 25-second deep scans would have been cache reads.

## Testing

- Three new tests at the resolver seam: index hit scopes to the thread, index miss stays UNKNOWN, index lookup failure stays UNKNOWN.
- `tests/test_matrix_thread_domain.py` and `tests/test_thread_read_guards.py` pass; pre-commit clean.
- Module docstring rule added (`thread_bookkeeping.py` rule 6) documenting the fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redaction impact resolution when the target event’s thread metadata can’t be determined.
  * Redactions now fall back to cached event-to-thread information to associate impacts with the correct thread when available.
  * When fallback lookup fails or has no cached mapping, the impact now consistently resolves to an unknown state.
* **Tests**
  * Added coverage for cached-thread success and failure scenarios during redaction impact resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->