### PR TITLE
Add bulk thread-cache backfill: one room scan warms many dormant threads

### DIFF
--- a/src/mindroom/matrix/client_thread_history.py
+++ b/src/mindroom/matrix/client_thread_history.py
@@ -33,6 +33,7 @@ Cache-trust rules (each encodes a shipped regression fix; do not weaken them):
 
 from __future__ import annotations
 
+import asyncio
 import time
 from collections.abc import Collection, Iterable, Mapping, Sequence
 from dataclasses import dataclass
@@ -1164,6 +1165,13 @@ async def _group_scanned_sources_by_thread(
     latest_edits_by_original_event_id: dict[str, tuple[nio.RoomMessageText | nio.RoomMessageNotice, str | None]],
 ) -> dict[str, list[dict[str, Any]]]:
     """Bucket one room scan's event sources per requested thread with one canonical resolution."""
+    grouped: dict[str, dict[str, dict[str, Any]]] = {
+        root_id: {root_id: scanned_message_sources[root_id]}
+        for root_id in thread_root_ids
+        if root_id in scanned_message_sources
+    }
+    if not grouped:
+        return {}
     event_infos = {
         event_id: EventInfo.from_event(event_source) for event_id, event_source in scanned_message_sources.items()
     }
@@ -1173,11 +1181,6 @@ async def _group_scanned_sources_by_thread(
         event_infos=event_infos,
         ordered_event_ids=ordered_event_ids,
     )
-    grouped: dict[str, dict[str, dict[str, Any]]] = {
-        root_id: {root_id: scanned_message_sources[root_id]}
-        for root_id in thread_root_ids
-        if root_id in scanned_message_sources
-    }
     for event_id in ordered_event_ids:
         root_id = resolved_thread_ids.get(event_id)
         if root_id is None or root_id == event_id:
@@ -1187,17 +1190,23 @@ async def _group_scanned_sources_by_thread(
             continue
         bucket[event_id] = scanned_message_sources[event_id]
 
-    thread_event_sources: dict[str, list[dict[str, Any]]] = {}
-    for root_id, bucket in grouped.items():
-        event_sources = sort_thread_event_sources_root_first(list(bucket.values()), thread_id=root_id)
-        member_event_ids = set(bucket)
-        event_sources.extend(
-            _event_source_for_cache(edit_event)
-            for original_event_id, (edit_event, edit_thread_id) in latest_edits_by_original_event_id.items()
-            if original_event_id in member_event_ids or edit_thread_id == root_id
+    edits_by_root: dict[str, list[dict[str, Any]]] = {}
+    for original_event_id, (edit_event, edit_thread_id) in latest_edits_by_original_event_id.items():
+        target_roots = {
+            root_id
+            for root_id in (original_event_id, resolved_thread_ids.get(original_event_id), edit_thread_id)
+            if root_id in grouped
+        }
+        for root_id in target_roots:
+            edits_by_root.setdefault(root_id, []).append(_event_source_for_cache(edit_event))
+
+    return {
+        root_id: sort_thread_event_sources_root_first(
+            [*bucket.values(), *edits_by_root.get(root_id, [])],
+            thread_id=root_id,
         )
-        thread_event_sources[root_id] = event_sources
-    return thread_event_sources
+        for root_id, bucket in grouped.items()
+    }
 
 
 async def _bulk_scan_thread_event_sources(
@@ -1315,12 +1324,14 @@ async def untrusted_cached_thread_ids(
     thread_ids: Collection[str],
 ) -> tuple[str, ...]:
     """Return the given threads whose durable snapshots would not be served from cache."""
-    untrusted: list[str] = []
-    for thread_id in thread_ids:
-        cache_state = await event_cache.get_thread_cache_state(room_id, thread_id)
-        if thread_cache_rejection_reason(cache_state) is not None:
-            untrusted.append(thread_id)
-    return tuple(untrusted)
+    cache_states = await asyncio.gather(
+        *(event_cache.get_thread_cache_state(room_id, thread_id) for thread_id in thread_ids),
+    )
+    return tuple(
+        thread_id
+        for thread_id, cache_state in zip(thread_ids, cache_states, strict=True)
+        if thread_cache_rejection_reason(cache_state) is not None
+    )
 
 
 async def get_room_threads_page(

--- a/src/mindroom/matrix/client_thread_history.py
+++ b/src/mindroom/matrix/client_thread_history.py
@@ -1021,118 +1021,27 @@ def _record_scanned_room_message_source(
     return event.event_id
 
 
-async def _resolve_scanned_thread_message_sources(
-    *,
-    room_id: str,
-    thread_id: str,
-    scanned_message_sources: dict[str, dict[str, Any]],
-) -> dict[str, dict[str, Any]]:
-    """Filter scanned room messages down to events that belong to one thread."""
-    event_infos = {
-        event_id: EventInfo.from_event(event_source) for event_id, event_source in scanned_message_sources.items()
-    }
-    relevant_message_sources = {
-        thread_id: scanned_message_sources[thread_id],
-    }
-    ordered_event_ids = ordered_event_ids_from_scanned_event_sources(scanned_message_sources.values())
-    resolved_thread_ids = await resolve_thread_ids_for_event_infos(
-        room_id,
-        event_infos=event_infos,
-        ordered_event_ids=ordered_event_ids,
-    )
-
-    for event_id in ordered_event_ids:
-        if event_id == thread_id or event_id in relevant_message_sources:
-            continue
-        if resolved_thread_ids.get(event_id) != thread_id:
-            continue
-        relevant_message_sources[event_id] = scanned_message_sources[event_id]
-
-    ordered_relevant_sources = sort_thread_event_sources_root_first(
-        list(relevant_message_sources.values()),
-        thread_id=thread_id,
-    )
-    return {
-        event_id: event_source
-        for event_source in ordered_relevant_sources
-        if isinstance((event_id := _event_id_from_source(event_source)), str)
-    }
-
-
 async def fetch_thread_event_sources_via_room_messages(
     client: nio.AsyncClient,
     room_id: str,
     thread_id: str,
 ) -> _ThreadEventSourceScanResult:
-    """Fetch thread event sources by scanning room history pages."""
-    latest_edits_by_original_event_id: dict[str, tuple[nio.RoomMessageText | nio.RoomMessageNotice, str | None]] = {}
-    scanned_message_sources: dict[str, dict[str, Any]] = {}
-    from_token = None
-    root_message_found = False
-    page_count = 0
-    scanned_event_count = 0
-
-    while True:
-        response = await client.room_messages(
-            room_id,
-            start=from_token,
-            limit=100,
-            message_filter={"types": list(_ROOM_HISTORY_MESSAGE_TYPES)},
-            direction=nio.MessageDirection.back,
-        )
-
-        if not isinstance(response, nio.RoomMessagesResponse):
-            msg = f"room scan failed for {thread_id}: {response}"
-            logger.error("Failed to fetch thread history", room_id=room_id, thread_id=thread_id, error=str(response))
-            raise RuntimeError(msg)  # noqa: TRY004
-
-        if not response.chunk:
-            break
-        page_count += 1
-
-        for event in response.chunk:
-            if not isinstance(event, nio.Event):
-                continue
-            scanned_event_count += 1
-            recorded_event_id = _record_scanned_room_message_source(
-                event,
-                latest_edits_by_original_event_id=latest_edits_by_original_event_id,
-                scanned_message_sources=scanned_message_sources,
-            )
-            if recorded_event_id == thread_id:
-                root_message_found = True
-
-        if root_message_found or not response.end:
-            break
-        from_token = response.end
-
-    if not root_message_found:
+    """Fetch one thread's event sources by scanning room history pages."""
+    scan_result = await _bulk_scan_thread_event_sources(client, room_id, thread_root_ids=(thread_id,))
+    if thread_id in scan_result.missing_root_ids:
         msg = f"thread root {thread_id} not found during room scan"
         logger.warning(
             "Thread room scan ended without finding root",
             room_id=room_id,
             thread_id=thread_id,
-            room_scan_pages=page_count,
-            scanned_event_count=len(scanned_message_sources),
+            room_scan_pages=scan_result.page_count,
+            scanned_event_count=scan_result.scanned_event_count,
         )
         raise ThreadRoomScanRootNotFoundError(msg)
-
-    relevant_message_sources = await _resolve_scanned_thread_message_sources(
-        room_id=room_id,
-        thread_id=thread_id,
-        scanned_message_sources=scanned_message_sources,
-    )
-    relevant_event_ids = set(relevant_message_sources)
-    event_sources = list(relevant_message_sources.values())
-    event_sources.extend(
-        _event_source_for_cache(edit_event)
-        for original_event_id, (edit_event, edit_thread_id) in latest_edits_by_original_event_id.items()
-        if original_event_id in relevant_event_ids or edit_thread_id == thread_id
-    )
     return _ThreadEventSourceScanResult(
-        event_sources=sort_thread_event_sources_root_first(event_sources, thread_id=thread_id),
-        page_count=page_count,
-        scanned_event_count=scanned_event_count,
+        event_sources=scan_result.thread_event_sources[thread_id],
+        page_count=scan_result.page_count,
+        scanned_event_count=scan_result.scanned_event_count,
     )
 
 

--- a/src/mindroom/matrix/client_thread_history.py
+++ b/src/mindroom/matrix/client_thread_history.py
@@ -999,13 +999,12 @@ async def _fetch_thread_history_via_room_messages_with_events(
 def _record_scanned_room_message_source(
     event: nio.Event,
     *,
-    thread_id: str,
     latest_edits_by_original_event_id: dict[str, tuple[nio.RoomMessageText | nio.RoomMessageNotice, str | None]],
     scanned_message_sources: dict[str, dict[str, Any]],
-) -> bool:
-    """Record one scanned room-message source and return whether the thread root was found."""
+) -> str | None:
+    """Record one scanned room-message source and return the recorded event ID."""
     if not _is_room_message_event(event):
-        return False
+        return None
 
     event_info = EventInfo.from_event(event.source)
     if isinstance(event, _VISIBLE_ROOM_MESSAGE_EVENT_TYPES) and record_latest_thread_edit(
@@ -1013,12 +1012,12 @@ def _record_scanned_room_message_source(
         event_info=event_info,
         latest_edits_by_original_event_id=latest_edits_by_original_event_id,
     ):
-        return False
+        return None
     if event_info.is_edit:
-        return False
+        return None
 
     scanned_message_sources[event.event_id] = _event_source_for_cache(event)
-    return event.event_id == thread_id
+    return event.event_id
 
 
 async def _resolve_scanned_thread_message_sources(
@@ -1094,12 +1093,12 @@ async def fetch_thread_event_sources_via_room_messages(
             if not isinstance(event, nio.Event):
                 continue
             scanned_event_count += 1
-            if _record_scanned_room_message_source(
+            recorded_event_id = _record_scanned_room_message_source(
                 event,
-                thread_id=thread_id,
                 latest_edits_by_original_event_id=latest_edits_by_original_event_id,
                 scanned_message_sources=scanned_message_sources,
-            ):
+            )
+            if recorded_event_id == thread_id:
                 root_message_found = True
 
         if root_message_found or not response.end:
@@ -1134,6 +1133,194 @@ async def fetch_thread_event_sources_via_room_messages(
         page_count=page_count,
         scanned_event_count=scanned_event_count,
     )
+
+
+@dataclass(frozen=True)
+class _BulkThreadScanResult:
+    """Per-thread event sources recovered by one backward room scan."""
+
+    thread_event_sources: dict[str, list[dict[str, Any]]]
+    missing_root_ids: frozenset[str]
+    page_count: int
+    scanned_event_count: int
+
+
+@dataclass(frozen=True)
+class BulkThreadRefreshStats:
+    """Summary for one bulk thread-cache refresh pass over a room."""
+
+    requested_threads: int
+    stored_threads: int
+    missing_root_ids: frozenset[str]
+    room_scan_pages: int
+    scanned_event_count: int
+
+
+async def _group_scanned_sources_by_thread(
+    *,
+    room_id: str,
+    thread_root_ids: Collection[str],
+    scanned_message_sources: dict[str, dict[str, Any]],
+    latest_edits_by_original_event_id: dict[str, tuple[nio.RoomMessageText | nio.RoomMessageNotice, str | None]],
+) -> dict[str, list[dict[str, Any]]]:
+    """Bucket one room scan's event sources per requested thread with one canonical resolution."""
+    event_infos = {
+        event_id: EventInfo.from_event(event_source) for event_id, event_source in scanned_message_sources.items()
+    }
+    ordered_event_ids = ordered_event_ids_from_scanned_event_sources(scanned_message_sources.values())
+    resolved_thread_ids = await resolve_thread_ids_for_event_infos(
+        room_id,
+        event_infos=event_infos,
+        ordered_event_ids=ordered_event_ids,
+    )
+    grouped: dict[str, dict[str, dict[str, Any]]] = {
+        root_id: {root_id: scanned_message_sources[root_id]}
+        for root_id in thread_root_ids
+        if root_id in scanned_message_sources
+    }
+    for event_id in ordered_event_ids:
+        root_id = resolved_thread_ids.get(event_id)
+        if root_id is None or root_id == event_id:
+            continue
+        bucket = grouped.get(root_id)
+        if bucket is None or event_id in bucket:
+            continue
+        bucket[event_id] = scanned_message_sources[event_id]
+
+    thread_event_sources: dict[str, list[dict[str, Any]]] = {}
+    for root_id, bucket in grouped.items():
+        event_sources = sort_thread_event_sources_root_first(list(bucket.values()), thread_id=root_id)
+        member_event_ids = set(bucket)
+        event_sources.extend(
+            _event_source_for_cache(edit_event)
+            for original_event_id, (edit_event, edit_thread_id) in latest_edits_by_original_event_id.items()
+            if original_event_id in member_event_ids or edit_thread_id == root_id
+        )
+        thread_event_sources[root_id] = event_sources
+    return thread_event_sources
+
+
+async def _bulk_scan_thread_event_sources(
+    client: nio.AsyncClient,
+    room_id: str,
+    *,
+    thread_root_ids: Collection[str],
+) -> _BulkThreadScanResult:
+    """Walk room history backward once and recover every requested thread's event sources."""
+    latest_edits_by_original_event_id: dict[str, tuple[nio.RoomMessageText | nio.RoomMessageNotice, str | None]] = {}
+    scanned_message_sources: dict[str, dict[str, Any]] = {}
+    remaining_root_ids = set(thread_root_ids)
+    from_token: str | None = None
+    page_count = 0
+    scanned_event_count = 0
+
+    while remaining_root_ids:
+        response = await client.room_messages(
+            room_id,
+            start=from_token,
+            limit=100,
+            message_filter={"types": list(_ROOM_HISTORY_MESSAGE_TYPES)},
+            direction=nio.MessageDirection.back,
+        )
+        if not isinstance(response, nio.RoomMessagesResponse):
+            msg = f"bulk room scan failed for {room_id}: {response}"
+            logger.error("Failed bulk thread history scan", room_id=room_id, error=str(response))
+            raise RuntimeError(msg)  # noqa: TRY004
+        if not response.chunk:
+            break
+        page_count += 1
+        for event in response.chunk:
+            if not isinstance(event, nio.Event):
+                continue
+            scanned_event_count += 1
+            recorded_event_id = _record_scanned_room_message_source(
+                event,
+                latest_edits_by_original_event_id=latest_edits_by_original_event_id,
+                scanned_message_sources=scanned_message_sources,
+            )
+            if recorded_event_id is not None:
+                remaining_root_ids.discard(recorded_event_id)
+        if not response.end:
+            break
+        from_token = response.end
+
+    thread_event_sources = await _group_scanned_sources_by_thread(
+        room_id=room_id,
+        thread_root_ids=thread_root_ids,
+        scanned_message_sources=scanned_message_sources,
+        latest_edits_by_original_event_id=latest_edits_by_original_event_id,
+    )
+    return _BulkThreadScanResult(
+        thread_event_sources=thread_event_sources,
+        missing_root_ids=frozenset(remaining_root_ids),
+        page_count=page_count,
+        scanned_event_count=scanned_event_count,
+    )
+
+
+async def bulk_refresh_room_thread_histories(
+    client: nio.AsyncClient,
+    room_id: str,
+    event_cache: ConversationEventCache,
+    *,
+    thread_root_ids: Collection[str],
+    caller_label: str = "unknown",
+) -> BulkThreadRefreshStats:
+    """Warm the durable thread cache for many threads with one backward room scan.
+
+    The per-thread refresh walks room history until it sees that one thread's root, so bulk
+    backfills of dormant rooms degrade to O(threads x history) homeserver work. This performs one
+    O(history) walk, buckets every scanned event with the same canonical resolution rules as the
+    per-thread path, and stores each requested thread through the same guarded
+    ``replace_thread_if_not_newer`` path. Threads whose root never appeared in the scan are
+    reported in ``missing_root_ids`` and never stored.
+    """
+    fetch_started_at = time.time()
+    scan_result = await _bulk_scan_thread_event_sources(client, room_id, thread_root_ids=thread_root_ids)
+    stored_threads = 0
+    for thread_id, event_sources in scan_result.thread_event_sources.items():
+        if not _thread_history_fetch_is_cacheable(event_sources, thread_id=thread_id):
+            continue
+        if await _store_thread_history_cache(
+            event_cache,
+            room_id=room_id,
+            thread_id=thread_id,
+            event_sources=event_sources,
+            fetch_started_at=fetch_started_at,
+        ):
+            stored_threads += 1
+    stats = BulkThreadRefreshStats(
+        requested_threads=len(set(thread_root_ids)),
+        stored_threads=stored_threads,
+        missing_root_ids=scan_result.missing_root_ids,
+        room_scan_pages=scan_result.page_count,
+        scanned_event_count=scan_result.scanned_event_count,
+    )
+    logger.info(
+        "Bulk thread cache refresh completed",
+        room_id=room_id,
+        caller_label=caller_label,
+        requested_threads=stats.requested_threads,
+        stored_threads=stats.stored_threads,
+        missing_roots=len(stats.missing_root_ids),
+        room_scan_pages=stats.room_scan_pages,
+        scanned_event_count=stats.scanned_event_count,
+    )
+    return stats
+
+
+async def untrusted_cached_thread_ids(
+    event_cache: ConversationEventCache,
+    room_id: str,
+    thread_ids: Collection[str],
+) -> tuple[str, ...]:
+    """Return the given threads whose durable snapshots would not be served from cache."""
+    untrusted: list[str] = []
+    for thread_id in thread_ids:
+        cache_state = await event_cache.get_thread_cache_state(room_id, thread_id)
+        if thread_cache_rejection_reason(cache_state) is not None:
+            untrusted.append(thread_id)
+    return tuple(untrusted)
 
 
 async def get_room_threads_page(
@@ -1290,8 +1477,10 @@ async def enumerate_room_thread_root_ids(
 
 
 __all__ = [
+    "BulkThreadRefreshStats",
     "RoomThreadsPageError",
     "ThreadRoomScanRootNotFoundError",
+    "bulk_refresh_room_thread_histories",
     "enumerate_room_thread_root_ids",
     "fetch_dispatch_thread_history",
     "fetch_dispatch_thread_snapshot",
@@ -1299,4 +1488,5 @@ __all__ = [
     "fetch_thread_history",
     "get_room_threads_page",
     "refresh_thread_history_from_source",
+    "untrusted_cached_thread_ids",
 ]

--- a/src/mindroom/thread_export/execution.py
+++ b/src/mindroom/thread_export/execution.py
@@ -42,9 +42,10 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-# One bulk room scan replaces one per-thread history walk per untrusted thread, so it pays off as
-# soon as more than a handful of threads would miss the cache.
-_BULK_BACKFILL_MIN_THREADS = 10
+# The bulk scan stops as soon as every requested root has been seen, so its cost is roughly one
+# walk to the deepest requested root while the per-thread path pays one walk per thread. Two or
+# more untrusted threads therefore already favor the bulk path; a single one is a wash.
+_BULK_BACKFILL_MIN_THREADS = 2
 
 
 async def _bulk_backfill_untrusted_threads(

--- a/src/mindroom/thread_export/execution.py
+++ b/src/mindroom/thread_export/execution.py
@@ -7,10 +7,13 @@ from typing import TYPE_CHECKING
 
 import nio
 
+from mindroom.logging_config import get_logger
 from mindroom.matrix.client_thread_history import (
+    bulk_refresh_room_thread_histories,
     enumerate_room_thread_root_ids,
     fetch_thread_history,
     refresh_thread_history_from_source,
+    untrusted_cached_thread_ids,
 )
 from mindroom.thread_export.models import (
     ThreadExportAccumulator,
@@ -35,6 +38,54 @@ if TYPE_CHECKING:
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
     from mindroom.matrix.cache import ConversationEventCache
+
+
+logger = get_logger(__name__)
+
+# One bulk room scan replaces one per-thread history walk per untrusted thread, so it pays off as
+# soon as more than a handful of threads would miss the cache.
+_BULK_BACKFILL_MIN_THREADS = 10
+
+
+async def _bulk_backfill_untrusted_threads(
+    client: nio.AsyncClient,
+    room: ThreadExportRoom,
+    thread_ids: Sequence[str],
+    *,
+    event_cache: ConversationEventCache,
+) -> frozenset[str]:
+    """Warm the thread cache with one room scan when many threads would miss.
+
+    Returns the thread roots the scan proved absent so callers can fail them without paying one
+    full per-thread history walk each. Any bulk failure falls back to the per-thread path.
+    """
+    try:
+        untrusted = await untrusted_cached_thread_ids(event_cache, room.room_id, thread_ids)
+    except Exception as exc:
+        logger.warning(
+            "Untrusted-thread probe failed; using per-thread fetches",
+            room_id=room.room_id,
+            error=str(exc),
+        )
+        return frozenset()
+    if len(untrusted) < _BULK_BACKFILL_MIN_THREADS:
+        return frozenset()
+    try:
+        stats = await bulk_refresh_room_thread_histories(
+            client,
+            room.room_id,
+            event_cache,
+            thread_root_ids=untrusted,
+            caller_label="thread_export_bulk",
+        )
+    except Exception as exc:
+        logger.warning(
+            "Bulk thread cache refresh failed; using per-thread fetches",
+            room_id=room.room_id,
+            error=str(exc),
+        )
+        return frozenset()
+    return stats.missing_root_ids
 
 
 async def _joined_member_ids(client: nio.AsyncClient, room_id: str) -> frozenset[str]:
@@ -220,26 +271,68 @@ async def export_threads_for_targets_for_client(
             accumulator.threads_seen += len(thread_ids)
             if truncated:
                 accumulator.truncated_rooms += 1
-        room_changed = {id(accumulator): False for accumulator in authorized}
+        await _export_enumerated_room_threads(
+            client=client,
+            room=room,
+            thread_ids=thread_ids,
+            truncated=truncated,
+            event_cache=event_cache,
+            trusted_sender_ids=trusted_sender_ids,
+            prefer_cache=prefer_cache,
+            authorized=authorized,
+        )
 
-        for thread_id in thread_ids:
-            await _write_thread_to_targets(
-                client=client,
-                room=room,
-                thread_id=thread_id,
-                event_cache=event_cache,
-                trusted_sender_ids=trusted_sender_ids,
-                prefer_cache=prefer_cache,
-                accumulators=authorized,
-                room_changed=room_changed,
-            )
+    return accumulators
 
-        _finish_room_exports(
+
+async def _export_enumerated_room_threads(
+    *,
+    client: nio.AsyncClient,
+    room: ThreadExportRoom,
+    thread_ids: Sequence[str],
+    truncated: bool,
+    event_cache: ConversationEventCache,
+    trusted_sender_ids: frozenset[str],
+    prefer_cache: bool,
+    authorized: Sequence[ThreadExportAccumulator],
+) -> None:
+    """Export one enumerated room's threads to every authorized accumulator."""
+    room_changed = {id(accumulator): False for accumulator in authorized}
+    missing_root_ids: frozenset[str] = frozenset()
+    if prefer_cache and thread_ids:
+        missing_root_ids = await _bulk_backfill_untrusted_threads(
+            client,
             room,
             thread_ids,
-            truncated=truncated,
+            event_cache=event_cache,
+        )
+
+    for thread_id in thread_ids:
+        if thread_id in missing_root_ids:
+            for accumulator in authorized:
+                accumulator.failed_items.append(
+                    failure_for_room(
+                        room,
+                        "thread root not found during bulk room scan",
+                        thread_id=thread_id,
+                    ),
+                )
+            continue
+        await _write_thread_to_targets(
+            client=client,
+            room=room,
+            thread_id=thread_id,
+            event_cache=event_cache,
+            trusted_sender_ids=trusted_sender_ids,
+            prefer_cache=prefer_cache,
             accumulators=authorized,
             room_changed=room_changed,
         )
 
-    return accumulators
+    _finish_room_exports(
+        room,
+        thread_ids,
+        truncated=truncated,
+        accumulators=authorized,
+        room_changed=room_changed,
+    )

--- a/src/mindroom/thread_export/execution.py
+++ b/src/mindroom/thread_export/execution.py
@@ -42,11 +42,6 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-# The bulk scan stops as soon as every requested root has been seen, so its cost is roughly one
-# walk to the deepest requested root while the per-thread path pays one walk per thread. Two or
-# more untrusted threads therefore already favor the bulk path; a single one is a wash.
-_BULK_BACKFILL_MIN_THREADS = 2
-
 
 async def _bulk_backfill_untrusted_threads(
     client: nio.AsyncClient,
@@ -55,8 +50,10 @@ async def _bulk_backfill_untrusted_threads(
     *,
     event_cache: ConversationEventCache,
 ) -> frozenset[str]:
-    """Warm the thread cache with one room scan when many threads would miss.
+    """Warm the thread cache with one room scan covering every thread that would miss it.
 
+    The scan stops as soon as every requested root has been seen, so its cost is roughly one walk
+    to the deepest requested root while the per-thread path pays one walk per thread.
     Returns the thread roots the scan proved absent so callers can fail them without paying one
     full per-thread history walk each. Any bulk failure falls back to the per-thread path.
     """
@@ -69,7 +66,7 @@ async def _bulk_backfill_untrusted_threads(
             error=str(exc),
         )
         return frozenset()
-    if len(untrusted) < _BULK_BACKFILL_MIN_THREADS:
+    if not untrusted:
         return frozenset()
     try:
         stats = await bulk_refresh_room_thread_histories(

--- a/tach.toml
+++ b/tach.toml
@@ -3478,14 +3478,17 @@ from = ["mindroom.matrix.client_visible_messages"]
 [[interfaces]]
 expose = [
     "fetch_thread_event_sources_via_room_messages",
+    "BulkThreadRefreshStats",
     "RoomThreadsPageError",
     "ThreadRoomScanRootNotFoundError",
+    "bulk_refresh_room_thread_histories",
     "enumerate_room_thread_root_ids",
     "fetch_dispatch_thread_history",
     "fetch_dispatch_thread_snapshot",
     "fetch_thread_history",
     "get_room_threads_page",
     "refresh_thread_history_from_source",
+    "untrusted_cached_thread_ids",
 ]
 from = ["mindroom.matrix.client_thread_history"]
 

--- a/tests/test_bulk_thread_backfill.py
+++ b/tests/test_bulk_thread_backfill.py
@@ -34,6 +34,34 @@ def _message_event(
     )
 
 
+def _edit_event(
+    event_id: str,
+    original_event_id: str,
+    *,
+    timestamp: int,
+    thread_root_id: str,
+) -> nio.RoomMessageText:
+    return nio.RoomMessageText.from_dict(
+        {
+            "event_id": event_id,
+            "sender": "@alice:localhost",
+            "origin_server_ts": timestamp,
+            "room_id": _ROOM_ID,
+            "type": "m.room.message",
+            "content": {
+                "body": "* edited reply",
+                "msgtype": "m.text",
+                "m.relates_to": {"rel_type": "m.replace", "event_id": original_event_id},
+                "m.new_content": {
+                    "body": "edited reply",
+                    "msgtype": "m.text",
+                    "m.relates_to": {"rel_type": "m.thread", "event_id": thread_root_id},
+                },
+            },
+        },
+    )
+
+
 def _messages_response(chunk: list[nio.Event], *, end: str | None) -> nio.RoomMessagesResponse:
     return nio.RoomMessagesResponse(room_id=_ROOM_ID, chunk=chunk, start="", end=end)
 
@@ -46,6 +74,12 @@ async def test_bulk_refresh_scans_room_once_and_stores_each_thread() -> None:
         side_effect=[
             _messages_response(
                 [
+                    _edit_event(
+                        "$a1-edit:localhost",
+                        "$a1:localhost",
+                        timestamp=5000,
+                        thread_root_id="$a:localhost",
+                    ),
                     _message_event("$b1:localhost", "reply b", timestamp=4000, thread_root_id="$b:localhost"),
                     _message_event("$a1:localhost", "reply a", timestamp=3000, thread_root_id="$a:localhost"),
                 ],
@@ -83,7 +117,7 @@ async def test_bulk_refresh_scans_room_once_and_stores_each_thread() -> None:
         for call in event_cache.replace_thread_if_not_newer.await_args_list
     }
     assert stored == {
-        "$a:localhost": ["$a:localhost", "$a1:localhost"],
+        "$a:localhost": ["$a:localhost", "$a1:localhost", "$a1-edit:localhost"],
         "$b:localhost": ["$b:localhost", "$b1:localhost"],
     }
 

--- a/tests/test_bulk_thread_backfill.py
+++ b/tests/test_bulk_thread_backfill.py
@@ -1,0 +1,120 @@
+"""Tests for the bulk thread-cache backfill scan."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import nio
+import pytest
+
+from mindroom.matrix.client_thread_history import bulk_refresh_room_thread_histories
+
+_ROOM_ID = "!room:localhost"
+
+
+def _message_event(
+    event_id: str,
+    body: str,
+    *,
+    timestamp: int,
+    thread_root_id: str | None = None,
+) -> nio.RoomMessageText:
+    content: dict[str, object] = {"body": body, "msgtype": "m.text"}
+    if thread_root_id is not None:
+        content["m.relates_to"] = {"rel_type": "m.thread", "event_id": thread_root_id}
+    return nio.RoomMessageText.from_dict(
+        {
+            "event_id": event_id,
+            "sender": "@alice:localhost",
+            "origin_server_ts": timestamp,
+            "room_id": _ROOM_ID,
+            "type": "m.room.message",
+            "content": content,
+        },
+    )
+
+
+def _messages_response(chunk: list[nio.Event], *, end: str | None) -> nio.RoomMessagesResponse:
+    return nio.RoomMessagesResponse(room_id=_ROOM_ID, chunk=chunk, start="", end=end)
+
+
+@pytest.mark.asyncio
+async def test_bulk_refresh_scans_room_once_and_stores_each_thread() -> None:
+    """One backward walk should recover and store every requested thread's rows root-first."""
+    client = AsyncMock()
+    client.room_messages = AsyncMock(
+        side_effect=[
+            _messages_response(
+                [
+                    _message_event("$b1:localhost", "reply b", timestamp=4000, thread_root_id="$b:localhost"),
+                    _message_event("$a1:localhost", "reply a", timestamp=3000, thread_root_id="$a:localhost"),
+                ],
+                end="t1",
+            ),
+            _messages_response(
+                [
+                    _message_event("$b:localhost", "root b", timestamp=2000),
+                    _message_event("$a:localhost", "root a", timestamp=1000),
+                    _message_event("$solo:localhost", "no thread", timestamp=500),
+                ],
+                end="t2",
+            ),
+        ],
+    )
+    event_cache = AsyncMock()
+    event_cache.replace_thread_if_not_newer = AsyncMock(return_value=True)
+
+    stats = await bulk_refresh_room_thread_histories(
+        client,
+        _ROOM_ID,
+        event_cache,
+        thread_root_ids=["$a:localhost", "$b:localhost"],
+        caller_label="test",
+    )
+
+    assert client.room_messages.await_count == 2
+    assert stats.requested_threads == 2
+    assert stats.stored_threads == 2
+    assert stats.missing_root_ids == frozenset()
+    assert stats.room_scan_pages == 2
+
+    stored = {
+        call.args[1]: [source["event_id"] for source in call.args[2]]
+        for call in event_cache.replace_thread_if_not_newer.await_args_list
+    }
+    assert stored == {
+        "$a:localhost": ["$a:localhost", "$a1:localhost"],
+        "$b:localhost": ["$b:localhost", "$b1:localhost"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_bulk_refresh_reports_missing_roots_without_storing_partial_threads() -> None:
+    """Roots absent from a drained scan must be reported and never stored."""
+    client = AsyncMock()
+    client.room_messages = AsyncMock(
+        side_effect=[
+            _messages_response(
+                [
+                    _message_event("$a1:localhost", "reply a", timestamp=3000, thread_root_id="$a:localhost"),
+                    _message_event("$a:localhost", "root a", timestamp=1000),
+                ],
+                end=None,
+            ),
+        ],
+    )
+    event_cache = AsyncMock()
+    event_cache.replace_thread_if_not_newer = AsyncMock(return_value=True)
+
+    stats = await bulk_refresh_room_thread_histories(
+        client,
+        _ROOM_ID,
+        event_cache,
+        thread_root_ids=["$a:localhost", "$ghost:localhost"],
+        caller_label="test",
+    )
+
+    assert stats.stored_threads == 1
+    assert stats.missing_root_ids == frozenset({"$ghost:localhost"})
+    event_cache.replace_thread_if_not_newer.assert_awaited_once()
+    assert event_cache.replace_thread_if_not_newer.await_args.args[1] == "$a:localhost"

--- a/tests/test_thread_export_execution.py
+++ b/tests/test_thread_export_execution.py
@@ -916,8 +916,8 @@ async def test_prefer_cache_bulk_backfills_untrusted_threads(tmp_path: Path) -> 
 
 
 @pytest.mark.asyncio
-async def test_prefer_cache_skips_bulk_below_untrusted_threshold(tmp_path: Path) -> None:
-    """A single untrusted thread should not pay for a bulk room scan."""
+async def test_prefer_cache_skips_bulk_when_cache_is_trusted(tmp_path: Path) -> None:
+    """Rooms whose threads would all serve from cache should not pay for a bulk room scan."""
     config = _config(tmp_path)
     runtime_paths = runtime_paths_for(config)
     _write_matrix_state(tmp_path)
@@ -937,7 +937,7 @@ async def test_prefer_cache_skips_bulk_below_untrusted_threshold(tmp_path: Path)
         ),
         patch(
             "mindroom.thread_export.execution.untrusted_cached_thread_ids",
-            new=AsyncMock(return_value=("$t0:localhost",)),
+            new=AsyncMock(return_value=()),
         ),
         patch(
             "mindroom.thread_export.execution.bulk_refresh_room_thread_histories",

--- a/tests/test_thread_export_execution.py
+++ b/tests/test_thread_export_execution.py
@@ -917,7 +917,7 @@ async def test_prefer_cache_bulk_backfills_untrusted_threads(tmp_path: Path) -> 
 
 @pytest.mark.asyncio
 async def test_prefer_cache_skips_bulk_below_untrusted_threshold(tmp_path: Path) -> None:
-    """A handful of untrusted threads should not pay for a full room scan."""
+    """A single untrusted thread should not pay for a bulk room scan."""
     config = _config(tmp_path)
     runtime_paths = runtime_paths_for(config)
     _write_matrix_state(tmp_path)
@@ -937,7 +937,7 @@ async def test_prefer_cache_skips_bulk_below_untrusted_threshold(tmp_path: Path)
         ),
         patch(
             "mindroom.thread_export.execution.untrusted_cached_thread_ids",
-            new=AsyncMock(return_value=tuple(thread_ids)),
+            new=AsyncMock(return_value=("$t0:localhost",)),
         ),
         patch(
             "mindroom.thread_export.execution.bulk_refresh_room_thread_histories",

--- a/tests/test_thread_export_execution.py
+++ b/tests/test_thread_export_execution.py
@@ -861,3 +861,103 @@ async def test_export_threads_counts_only_enumerated_rooms(tmp_path: Path) -> No
     assert stats.rooms_exported == 1
     assert stats.failures == 1
     assert stats.failed_items[0].room_key == "lobby"
+
+
+@pytest.mark.asyncio
+async def test_prefer_cache_bulk_backfills_untrusted_threads(tmp_path: Path) -> None:
+    """Many untrusted threads should trigger one bulk warm-up and fail scan-proven-missing roots."""
+    config = _config(tmp_path)
+    runtime_paths = runtime_paths_for(config)
+    _write_matrix_state(tmp_path)
+    thread_ids = [f"$t{index}:localhost" for index in range(11)] + ["$missing:localhost"]
+    history = [
+        ResolvedVisibleMessage.synthetic(
+            sender="@alice:localhost",
+            body="cached",
+            event_id="$t0:localhost",
+        ),
+    ]
+    bulk_stats = Mock(missing_root_ids=frozenset({"$missing:localhost"}))
+
+    with (
+        patch(
+            "mindroom.thread_export.execution.enumerate_room_thread_root_ids",
+            new=AsyncMock(return_value=(thread_ids, False)),
+        ),
+        patch(
+            "mindroom.thread_export.execution.untrusted_cached_thread_ids",
+            new=AsyncMock(return_value=tuple(thread_ids)),
+        ),
+        patch(
+            "mindroom.thread_export.execution.bulk_refresh_room_thread_histories",
+            new=AsyncMock(return_value=bulk_stats),
+        ) as bulk_refresh,
+        patch(
+            "mindroom.thread_export.execution.fetch_thread_history",
+            new=AsyncMock(return_value=history),
+        ) as cache_fetch,
+    ):
+        stats = await _export_threads_for_client(
+            client=Mock(),
+            config=config,
+            runtime_paths=runtime_paths,
+            event_cache=Mock(),
+            rooms=_export_rooms(runtime_paths, "lobby"),
+            output_dir=tmp_path / "exports",
+            prefer_cache=True,
+        )
+
+    bulk_refresh.assert_awaited_once()
+    assert set(bulk_refresh.await_args.kwargs["thread_root_ids"]) == set(thread_ids)
+    assert cache_fetch.await_count == 11
+    assert stats.failures == 1
+    assert stats.failed_items[0].thread_id == "$missing:localhost"
+    assert "bulk room scan" in stats.failed_items[0].error
+
+
+@pytest.mark.asyncio
+async def test_prefer_cache_skips_bulk_below_untrusted_threshold(tmp_path: Path) -> None:
+    """A handful of untrusted threads should not pay for a full room scan."""
+    config = _config(tmp_path)
+    runtime_paths = runtime_paths_for(config)
+    _write_matrix_state(tmp_path)
+    thread_ids = ["$t0:localhost", "$t1:localhost", "$t2:localhost"]
+    history = [
+        ResolvedVisibleMessage.synthetic(
+            sender="@alice:localhost",
+            body="cached",
+            event_id="$t0:localhost",
+        ),
+    ]
+
+    with (
+        patch(
+            "mindroom.thread_export.execution.enumerate_room_thread_root_ids",
+            new=AsyncMock(return_value=(thread_ids, False)),
+        ),
+        patch(
+            "mindroom.thread_export.execution.untrusted_cached_thread_ids",
+            new=AsyncMock(return_value=tuple(thread_ids)),
+        ),
+        patch(
+            "mindroom.thread_export.execution.bulk_refresh_room_thread_histories",
+            new=AsyncMock(),
+        ) as bulk_refresh,
+        patch(
+            "mindroom.thread_export.execution.fetch_thread_history",
+            new=AsyncMock(return_value=history),
+        ) as cache_fetch,
+    ):
+        stats = await _export_threads_for_client(
+            client=Mock(),
+            config=config,
+            runtime_paths=runtime_paths,
+            event_cache=Mock(),
+            rooms=_export_rooms(runtime_paths, "lobby"),
+            output_dir=tmp_path / "exports",
+            prefer_cache=True,
+        )
+
+    bulk_refresh.assert_not_awaited()
+    assert cache_fetch.await_count == 3
+    assert stats.failures == 0

--- a/tests/test_thread_history.py
+++ b/tests/test_thread_history.py
@@ -27,7 +27,7 @@ from mindroom.matrix.client_delivery import build_threaded_edit_content as _buil
 from mindroom.matrix.client_thread_history import (
     _event_source_for_cache,
     _fetch_thread_history_via_room_messages_with_events,
-    _resolve_scanned_thread_message_sources,
+    _group_scanned_sources_by_thread,
     _resolve_thread_history_from_event_sources_timed,
 )
 from mindroom.matrix.conversation_cache import MatrixConversationCache
@@ -1263,9 +1263,10 @@ class TestThreadHistory:
     @pytest.mark.asyncio
     async def test_room_scan_does_not_promote_plain_reply_to_non_thread_root(self) -> None:
         """Cold room scans must not treat arbitrary room replies as threaded."""
-        resolved = await _resolve_scanned_thread_message_sources(
+        grouped = await _group_scanned_sources_by_thread(
             room_id="!room:localhost",
-            thread_id="$room_root",
+            thread_root_ids=("$room_root",),
+            latest_edits_by_original_event_id={},
             scanned_message_sources={
                 "$room_root": {
                     "event_id": "$room_root",
@@ -1286,14 +1287,15 @@ class TestThreadHistory:
             },
         )
 
-        assert list(resolved) == ["$room_root"]
+        assert [source["event_id"] for source in grouped["$room_root"]] == ["$room_root"]
 
     @pytest.mark.asyncio
     async def test_room_scan_revisits_inherited_replies_until_fixpoint(self) -> None:
         """Cold room scans should retain descendants even when they sort before their threaded parent."""
-        resolved = await _resolve_scanned_thread_message_sources(
+        grouped = await _group_scanned_sources_by_thread(
             room_id="!room:localhost",
-            thread_id="$root",
+            thread_root_ids=("$root",),
+            latest_edits_by_original_event_id={},
             scanned_message_sources={
                 "$root": {
                     "event_id": "$root",
@@ -1324,14 +1326,15 @@ class TestThreadHistory:
             },
         )
 
-        assert set(resolved) == {"$root", "$z-parent", "$a-child"}
+        assert {source["event_id"] for source in grouped["$root"]} == {"$root", "$z-parent", "$a-child"}
 
     @pytest.mark.asyncio
     async def test_room_scan_promotes_transitive_plain_reply_chain(self) -> None:
         """Cold room scans should keep a plain-reply chain inside the same thread transitively."""
-        resolved = await _resolve_scanned_thread_message_sources(
+        grouped = await _group_scanned_sources_by_thread(
             room_id="!room:localhost",
-            thread_id="$root",
+            thread_root_ids=("$root",),
+            latest_edits_by_original_event_id={},
             scanned_message_sources={
                 "$root": {
                     "event_id": "$root",
@@ -1372,7 +1375,7 @@ class TestThreadHistory:
             },
         )
 
-        assert list(resolved) == ["$root", "$thread_reply", "$plain1", "$plain2"]
+        assert [source["event_id"] for source in grouped["$root"]] == ["$root", "$thread_reply", "$plain1", "$plain2"]
 
     def test_ordered_event_ids_from_scanned_event_sources_preserves_input_order_on_timestamp_ties(self) -> None:
         """Scanned-source ordering should preserve first-seen order before falling back to event IDs."""


### PR DESCRIPTION
## Problem, with production evidence

Backfilling thread exports for a large dormant room on the mindroom-chat instance crawled to 1-2 threads/minute. Measured during the pass:

```
homeserver_fetch_ms: 85337.6, homeserver_scan_pages: 119, homeserver_scanned_event_count: 11900
homeserver_fetch_ms: 70005.6, homeserver_scan_pages: 119, homeserver_scanned_event_count: 11900
homeserver_fetch_ms: 55177.7, homeserver_scan_pages: 120, homeserver_scanned_event_count: 12000
```

Each dormant thread's refresh walks room history backward from the newest event until it sees that one thread's root, then throws the walk away. For threads rooted ~12k events deep that is 120 paginated calls and 50-85 seconds per thread, and the next thread repeats the same walk. For a room with H events and T dormant threads the total is O(T x H) homeserver work, plus rate-limit backoff (41 hits in one 30-minute window). The runtime never notices because dispatch only fetches one thread at a time; a bulk backfill is the pathological case.

## Fix

New `bulk_refresh_room_thread_histories(client, room_id, event_cache, *, thread_root_ids)` in `client_thread_history`:

- One backward walk of the room (same `room_messages` filter, stops early once every requested root has been seen).
- One canonical resolution pass (`resolve_thread_ids_for_event_infos`) buckets every scanned event by thread; per-thread rows are root-first sorted and carry the same latest-edit sidecars as the per-thread scan.
- Each requested thread is stored through the same guarded `replace_thread_if_not_newer` path with the scan's start time, so the store-race guard (PR #716) and root-required cacheability rule (PR #741) apply unchanged.
- Roots the drained scan never saw are returned in `missing_root_ids` and never stored (no partial snapshots).

The thread exporter uses it automatically in `prefer_cache` mode: after enumerating a room it probes which threads the durable cache would refuse to serve (`untrusted_cached_thread_ids`, same `thread_cache_rejection_reason` gate as reads), and when 10 or more would miss, it warms them with one scan. Scan-proven-missing roots are recorded as failures without paying one full per-thread walk each. Any bulk failure logs and falls back to the per-thread path unchanged.

## Why it fixes it

The same production room: ~700 threads x up to 130 pages each becomes one ~130-page walk plus SQLite reads. Homeserver work drops from O(T x H) to O(H), which also removes almost all of the rate-limit pressure. Reconstruction semantics are identical by construction: the bulk path reuses the existing scan recorder, resolution, ordering, and store primitives rather than reimplementing them.

## Testing

- `tests/test_bulk_thread_backfill.py`: one scan stores multiple threads root-first with correct bucketing; early stop after all roots found; drained scans report missing roots and store no partial threads.
- `tests/test_thread_export_execution.py`: prefer_cache passes with >= 10 untrusted threads trigger exactly one bulk refresh and fail missing roots without per-thread fetches; below the threshold the bulk path is skipped entirely.
- Existing per-thread scan behavior is untouched (`_record_scanned_room_message_source` refactor is signature-only); full thread-domain and export suites pass, pre-commit clean, new API exposed through the tach interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Thread exports can now refresh multiple cached conversation threads using a single backward room scan, reducing work for large exports.
  * When cache trust is enabled, untrusted cached thread roots are proactively warmed in bulk; otherwise the exporter falls back to per-thread retrieval.
  * Missing thread roots are reported and excluded so partial/unreliable histories are not exported.
* **New Features**
  * Added bulk refresh statistics reporting for requested, stored, missing roots, scan pages, and scanned event count.
* **Tests**
  * Added and updated tests covering bulk cache refresh and cache-preference behavior during thread export execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->