### PR TITLE
Silence progressive stream notifications

### DIFF
--- a/src/mindroom/matrix/client_delivery.py
+++ b/src/mindroom/matrix/client_delivery.py
@@ -580,7 +580,10 @@ def build_edit_event_content(
     edit_content = build_matrix_edit_content(event_id, replacement_content)
     edit_content.update(
         {
-            "msgtype": "m.text",
+            # Keep the fallback event's notification semantics aligned with
+            # the replacement. In-progress streams use m.notice; terminal
+            # updates return to m.text.
+            "msgtype": replacement_content.get("msgtype", "m.text"),
             "body": f"* {new_text}",
             "format": "org.matrix.custom.html",
             "formatted_body": new_content.get("formatted_body", new_text),

--- a/src/mindroom/matrix/client_session.py
+++ b/src/mindroom/matrix/client_session.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import ssl as ssl_module
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import nio
 
-from mindroom.constants import RuntimePaths, encryption_keys_dir, runtime_matrix_ssl_verify
+from mindroom.constants import STREAM_STATUS_KEY, RuntimePaths, encryption_keys_dir, runtime_matrix_ssl_verify
 from mindroom.logging_config import get_logger
 from mindroom.matrix.to_device import AuthenticatedToDeviceEvent
 from mindroom.startup_errors import PermanentStartupError
@@ -34,7 +34,20 @@ class PermanentMatrixStartupError(PermanentStartupError):
 
 
 class _MindRoomAsyncClient(nio.AsyncClient):
-    """Matrix client preserving authenticated provenance for custom Olm events."""
+    """Matrix client for MindRoom-specific encrypted event behavior."""
+
+    def encrypt(
+        self,
+        room_id: str,
+        message_type: str,
+        content: dict[Any, Any],
+    ) -> tuple[str, dict[str, str]]:
+        """Expose only the coarse stream state needed for encrypted push routing."""
+        encrypted_message_type, encrypted_content = super().encrypt(room_id, message_type, content)
+        stream_status = content.get(STREAM_STATUS_KEY)
+        if isinstance(stream_status, str):
+            encrypted_content[STREAM_STATUS_KEY] = stream_status
+        return encrypted_message_type, encrypted_content
 
     def _handle_decrypt_to_device(self, to_device_event: nio.ToDeviceEvent) -> nio.ToDeviceEvent | None:
         decrypted = super()._handle_decrypt_to_device(to_device_event)

--- a/src/mindroom/matrix/client_session.py
+++ b/src/mindroom/matrix/client_session.py
@@ -41,7 +41,7 @@ class _MindRoomAsyncClient(nio.AsyncClient):
         room_id: str,
         message_type: str,
         content: dict[Any, Any],
-    ) -> tuple[str, dict[str, str]]:
+    ) -> tuple[str, dict[str, Any]]:
         """Expose only the coarse stream state needed for encrypted push routing."""
         encrypted_message_type, encrypted_content = super().encrypt(room_id, message_type, content)
         stream_status = content.get(STREAM_STATUS_KEY)

--- a/src/mindroom/matrix/large_messages.py
+++ b/src/mindroom/matrix/large_messages.py
@@ -229,7 +229,7 @@ def _build_nonterminal_streaming_edit_preview(
             original_size=original_size,
         )
         modified_content: dict[str, Any] = {
-            "msgtype": "m.text",
+            "msgtype": source_content.get("msgtype", "m.text"),
             "body": f"* {preview}",
             "format": "org.matrix.custom.html",
             "formatted_body": formatted_preview,
@@ -598,7 +598,7 @@ async def prepare_large_message(
 
     if is_edit and "m.new_content" in content:
         modified_content = {
-            "msgtype": "m.text",
+            "msgtype": source_content.get("msgtype", "m.text"),
             "body": f"* {modified_content['body']}",
             "m.new_content": modified_content,
             "m.relates_to": content.get("m.relates_to", {}),

--- a/src/mindroom/matrix/large_messages.py
+++ b/src/mindroom/matrix/large_messages.py
@@ -462,9 +462,10 @@ def _build_text_fallback_content(
 ) -> dict[str, Any]:
     """Build a text preview when the full-content sidecar is unavailable."""
     preview_limit = max(0, size_limit - _LARGE_MESSAGE_PREVIEW_OVERHEAD_BYTES)
+    preview_msgtype = "m.notice" if source_content.get("msgtype") == "m.notice" else "m.text"
     while True:
         preview_content: dict[str, Any] = {
-            "msgtype": "m.text",
+            "msgtype": preview_msgtype,
             "body": _create_preview(
                 preview_text,
                 preview_limit,

--- a/src/mindroom/matrix/stale_stream_cleanup.py
+++ b/src/mindroom/matrix/stale_stream_cleanup.py
@@ -762,10 +762,10 @@ async def _collect_room_history_events(
     bot_user_id: str,
     now_ms: int,
     scan_policy: _CleanupScanPolicy,
-) -> tuple[dict[str, _MessageState], list[nio.RoomMessageText]]:
-    """Return room history text events plus tracked stop reactions."""
+) -> tuple[dict[str, _MessageState], list[nio.RoomMessageText | nio.RoomMessageNotice]]:
+    """Return visible room-message events plus tracked stop reactions."""
     message_states: dict[str, _MessageState] = {}
-    message_events: list[nio.RoomMessageText] = []
+    message_events: list[nio.RoomMessageText | nio.RoomMessageNotice] = []
     from_token: str | None = None
     lookback_pages_scanned = 0
 
@@ -789,7 +789,7 @@ async def _collect_room_history_events(
 
         for event in response.chunk:
             try:
-                if isinstance(event, nio.RoomMessageText):
+                if isinstance(event, (nio.RoomMessageText, nio.RoomMessageNotice)):
                     message_events.append(event)
                 elif isinstance(event, nio.Event):
                     _record_stop_reaction(
@@ -865,7 +865,7 @@ def _merge_resolved_message_state(
 
 
 async def _scanned_message_data_by_event_id(
-    message_events: list[nio.RoomMessageText],
+    message_events: list[nio.RoomMessageText | nio.RoomMessageNotice],
 ) -> dict[str, ResolvedVisibleMessage]:
     """Return raw scanned room-history messages keyed by exact event ID."""
     event_infos = {
@@ -1203,7 +1203,7 @@ async def _fetch_message_data_for_event_id(
         return None
 
     event_info = EventInfo.from_event(event_source)
-    if isinstance(event, nio.RoomMessageText):
+    if isinstance(event, (nio.RoomMessageText, nio.RoomMessageNotice)):
         if event_info.is_edit:
             edited_body, edited_content = await extract_edit_body(
                 event_source,

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -381,6 +381,11 @@ def _prepare_delivery_from_snapshot(snapshot: _StreamingDeliverySnapshot) -> _Pr
         tool_trace=tool_trace if snapshot.show_tool_calls else None,
         extra_content=extra_content,
     )
+    if snapshot.stream_status in {STREAM_STATUS_PENDING, STREAM_STATUS_STREAMING}:
+        # Matrix suppresses m.notice before evaluating mention rules. Streaming
+        # updates may already contain mentions, so using m.text here would make
+        # every progressive edit eligible for a push notification.
+        content["msgtype"] = "m.notice"
     canonical_visible_body = content["body"]
     if snapshot.warmup_suffix_lines:
         content[STREAM_VISIBLE_BODY_KEY] = canonical_visible_body

--- a/tests/test_large_messages.py
+++ b/tests/test_large_messages.py
@@ -471,6 +471,46 @@ async def test_prepare_edit_message_upload_failure_falls_back_to_text() -> None:
 
 
 @pytest.mark.asyncio
+async def test_prepare_nonterminal_streaming_edit_double_fallback_preserves_notice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The last-resort inline edit must keep nonterminal notice semantics."""
+
+    def fail_rich_preview(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "mindroom.matrix.large_messages._build_nonterminal_streaming_edit_preview",
+        fail_rich_preview,
+    )
+    client = _UploadClient(RuntimeError("upload failed"))
+    text = "streaming fallback " + ("y" * 50000)
+    relates_to = {"rel_type": "m.replace", "event_id": "$abc"}
+    edit_content = {
+        "body": "* " + text,
+        "m.new_content": {
+            "body": text,
+            "msgtype": "m.notice",
+            STREAM_STATUS_KEY: STREAM_STATUS_STREAMING,
+        },
+        "m.relates_to": relates_to,
+        "msgtype": "m.notice",
+        STREAM_STATUS_KEY: STREAM_STATUS_STREAMING,
+    }
+
+    result = await prepare_large_message(client, "!room:server", edit_content)
+
+    assert result["msgtype"] == "m.notice"
+    assert result[STREAM_STATUS_KEY] == STREAM_STATUS_STREAMING
+    assert result["m.relates_to"] == relates_to
+    inner = result["m.new_content"]
+    assert inner["msgtype"] == "m.notice"
+    assert inner[STREAM_STATUS_KEY] == STREAM_STATUS_STREAMING
+    assert _SIDECAR_UPLOAD_FALLBACK_TEXT in inner["body"]
+    assert _calculate_event_size(result) <= _MATRIX_EVENT_HARD_LIMIT
+
+
+@pytest.mark.asyncio
 async def test_prepare_large_message_valid_sidecar_keeps_file_preview() -> None:
     """Successful JSON sidecar uploads should keep the existing m.file preview behavior."""
     client = _UploadClient(nio.UploadResponse("mxc://server/sidecar"))

--- a/tests/test_large_messages_integration.py
+++ b/tests/test_large_messages_integration.py
@@ -428,7 +428,8 @@ async def test_streaming_multiple_edits_with_growth(monkeypatch: pytest.MonkeyPa
     assert len(client.messages_sent) == len(sizes)
 
     nonterminal_large_edit = client.messages_sent[-2][2]
-    assert nonterminal_large_edit["m.new_content"]["msgtype"] == "m.text"
+    assert nonterminal_large_edit["msgtype"] == "m.notice"
+    assert nonterminal_large_edit["m.new_content"]["msgtype"] == "m.notice"
     assert nonterminal_large_edit["m.new_content"][STREAM_STATUS_KEY] == STREAM_STATUS_STREAMING
     assert nonterminal_large_edit["m.new_content"]["format"] == "org.matrix.custom.html"
     assert "Streaming preview truncated" in nonterminal_large_edit["m.new_content"]["formatted_body"]

--- a/tests/test_matrix_client_session.py
+++ b/tests/test_matrix_client_session.py
@@ -1,0 +1,75 @@
+"""Tests for MindRoom-specific Matrix client behavior."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import nio
+
+from mindroom.constants import STREAM_STATUS_KEY
+from mindroom.matrix.client_session import _MindRoomAsyncClient
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def test_encryption_exposes_only_mindroom_stream_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Encrypted stream events expose status but no private message fields."""
+    relation = {"event_id": "$original:example.org", "rel_type": "m.replace"}
+
+    def fake_encrypt(
+        _client: nio.AsyncClient,
+        _room_id: str,
+        _message_type: str,
+        _content: dict[Any, Any],
+    ) -> tuple[str, dict[str, Any]]:
+        return "m.room.encrypted", {
+            "algorithm": "m.megolm.v1.aes-sha2",
+            "ciphertext": "encrypted payload",
+            "m.relates_to": relation,
+        }
+
+    monkeypatch.setattr(nio.AsyncClient, "encrypt", fake_encrypt)
+    client = _MindRoomAsyncClient("https://example.org", "@mindroom_agent:example.org")
+
+    message_type, encrypted_content = client.encrypt(
+        "!room:example.org",
+        "m.room.message",
+        {
+            "body": "private answer text",
+            "m.mentions": {"user_ids": ["@private:example.org"]},
+            "msgtype": "m.notice",
+            STREAM_STATUS_KEY: "streaming",
+        },
+    )
+
+    assert message_type == "m.room.encrypted"
+    assert encrypted_content == {
+        "algorithm": "m.megolm.v1.aes-sha2",
+        "ciphertext": "encrypted payload",
+        "m.relates_to": relation,
+        STREAM_STATUS_KEY: "streaming",
+    }
+
+
+def test_encryption_does_not_add_metadata_to_ordinary_events(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ordinary encrypted messages retain nio's standard envelope."""
+
+    def fake_encrypt(
+        _client: nio.AsyncClient,
+        _room_id: str,
+        _message_type: str,
+        _content: dict[Any, Any],
+    ) -> tuple[str, dict[str, str]]:
+        return "m.room.encrypted", {"ciphertext": "encrypted payload"}
+
+    monkeypatch.setattr(nio.AsyncClient, "encrypt", fake_encrypt)
+    client = _MindRoomAsyncClient("https://example.org", "@mindroom_agent:example.org")
+
+    _, encrypted_content = client.encrypt(
+        "!room:example.org",
+        "m.room.message",
+        {"body": "private answer text", "msgtype": "m.text"},
+    )
+
+    assert encrypted_content == {"ciphertext": "encrypted payload"}

--- a/tests/test_matrix_delivery.py
+++ b/tests/test_matrix_delivery.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 import nio
 import pytest
 
-from mindroom.matrix.client_delivery import send_message_result
+from mindroom.matrix.client_delivery import build_edit_event_content, send_message_result
 
 
 def _mock_client(*, encrypted: bool = False) -> AsyncMock:
@@ -38,3 +38,20 @@ async def test_send_message_result_ignores_unverified_devices_in_encrypted_room(
     await send_message_result(client, "!room:localhost", {"body": "hello", "msgtype": "m.text"})
 
     assert client.room_send.await_args.kwargs["ignore_unverified_devices"] is True
+
+
+def test_edit_fallback_preserves_replacement_message_type() -> None:
+    """A notice replacement must also be a notice to suppress edit mention pushes."""
+    content = build_edit_event_content(
+        event_id="$original:localhost",
+        new_content={
+            "body": "Streaming answer",
+            "msgtype": "m.notice",
+            "m.mentions": {"user_ids": ["@user:localhost"]},
+        },
+        new_text="Streaming answer",
+    )
+
+    assert content["msgtype"] == "m.notice"
+    assert content["m.new_content"]["msgtype"] == "m.notice"
+    assert content["m.mentions"] == {"user_ids": ["@user:localhost"]}

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -126,6 +126,42 @@ def _make_message_event(
     return cast("nio.RoomMessageText", event)
 
 
+def _make_notice_event(
+    *,
+    event_id: str,
+    body: str,
+    timestamp_ms: int,
+    sender: str = BOT_USER_ID,
+    room_id: str = ROOM_ID,
+    relates_to: dict[str, object] | None = None,
+    extra_content: dict[str, object] | None = None,
+    new_content: dict[str, object] | None = None,
+) -> nio.RoomMessageNotice:
+    content: dict[str, object] = {
+        "body": body,
+        "msgtype": "m.notice",
+    }
+    if relates_to is not None:
+        content["m.relates_to"] = relates_to
+    if extra_content is not None:
+        content.update(extra_content)
+    if new_content is not None:
+        content["m.new_content"] = new_content
+
+    event = nio.RoomMessageNotice.from_dict(
+        {
+            "content": content,
+            "event_id": event_id,
+            "sender": sender,
+            "origin_server_ts": timestamp_ms,
+            "type": "m.room.message",
+            "room_id": room_id,
+        },
+    )
+    event.source = event.__dict__["source"]
+    return cast("nio.RoomMessageNotice", event)
+
+
 def _make_reaction_event(
     *,
     event_id: str,
@@ -2297,11 +2333,23 @@ async def test_cleanup_sets_terminal_stream_status(tmp_path: Path) -> None:
     client2 = AsyncMock(spec=nio.AsyncClient)
     client2.rooms = _joined_room_cache()
     client2.room_messages.return_value = _room_messages_response(
-        _make_message_event(
+        _make_notice_event(
             event_id="$msg-pending",
             body="Still typing",
-            timestamp_ms=NOW_MS - STALE_AGE_MS,
+            timestamp_ms=NOW_MS - (STALE_AGE_MS + 1_000),
             extra_content={STREAM_STATUS_KEY: "pending", "io.mindroom.tool_trace": {"version": 2}},
+        ),
+        _make_notice_event(
+            event_id="$msg-streaming-edit",
+            body="* Still typing an answer",
+            timestamp_ms=NOW_MS - STALE_AGE_MS,
+            relates_to={"rel_type": "m.replace", "event_id": "$msg-pending"},
+            new_content={
+                "body": "Still typing an answer",
+                "msgtype": "m.notice",
+                STREAM_STATUS_KEY: "streaming",
+                "io.mindroom.tool_trace": {"version": 2},
+            },
         ),
     )
     client2.room_get_event_relations = MagicMock(return_value=_aiter())

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -175,9 +175,11 @@ async def test_placeholder_progressive_edits_and_final_tool_trace(config: Config
 
     placeholder, first_text, tool_started, tool_completed, more_text, final = gateway.ops
     assert placeholder.content["body"] == _PROGRESS_PLACEHOLDER
+    assert placeholder.content["msgtype"] == "m.notice"
     assert placeholder.content[STREAM_STATUS_KEY] == STREAM_STATUS_PENDING
 
     assert first_text.display_text == "Hello"
+    assert first_text.content["msgtype"] == "m.notice"
     assert first_text.content[STREAM_STATUS_KEY] == STREAM_STATUS_STREAMING
 
     assert tool_started.display_text.startswith("Hello")
@@ -192,7 +194,9 @@ async def test_placeholder_progressive_edits_and_final_tool_trace(config: Config
     assert completed_trace[0]["tool_name"] == "search_web"
 
     assert more_text.display_text.endswith("Done.")
+    assert more_text.content["msgtype"] == "m.notice"
     assert final.display_text == more_text.display_text
+    assert final.content["msgtype"] == "m.text"
     assert final.content[STREAM_STATUS_KEY] == STREAM_STATUS_COMPLETED
     assert final.content[_TOOL_TRACE_KEY]["events"] == completed_trace
 
@@ -312,7 +316,9 @@ async def test_cancellation_mid_stream_appends_cancelled_note(config: Config) ->
 
     partial, cancelled = gateway.ops
     assert partial.content["body"] == "Partial answer"
+    assert partial.content["msgtype"] == "m.notice"
     assert cancelled.display_text == f"Partial answer\n\n{_CANCELLED_RESPONSE_NOTE}"
+    assert cancelled.content["msgtype"] == "m.text"
     assert cancelled.content[STREAM_STATUS_KEY] == STREAM_STATUS_CANCELLED
 
     transport_outcome = exc_info.value.transport_outcome


### PR DESCRIPTION
## What changed

- Send pending and progressive agent stream updates as `m.notice`.
- Return terminal stream states to `m.text`.
- Preserve the replacement message type in Matrix edit fallbacks and oversized-message wrappers.
- Preserve `m.notice` even in the last-resort large-message text fallback when preview construction and sidecar upload both fail.
- Expose only `io.mindroom.stream_status` beside ciphertext from MindRoom's existing `AsyncClient` subclass; bodies, mentions, and message types stay encrypted.
- Include `m.notice` events in stale-stream history recovery and exact-event resolution.

## Why

Progressive MindRoom edits can already contain mention metadata. Matrix evaluates notice suppression before those mention rules, so marking in-progress updates as notices prevents every streaming edit from producing a push notification.

The companion homeserver change in mindroom-ai/mindroom-tuwunel#9 suppresses active states on events that opt into the namespaced stream protocol and makes terminal edits eligible for normal push evaluation. The encrypted metadata policy stays in MindRoom's product-specific client subclass; no general `mindroom-nio` change is required.

## Rollout

Merge and deploy this PR with mindroom-ai/mindroom-tuwunel#9.

## Validation

- Focused streaming, stale-recovery, encryption, delivery, and large-message pytest suite (all passed; one skipped)
- Ruff on all changed Python files
- `ty check` on all changed Python files
