### PR TITLE
Keep scoped exports when membership cannot be verified

### DIFF
--- a/src/mindroom/thread_export/execution.py
+++ b/src/mindroom/thread_export/execution.py
@@ -21,7 +21,7 @@ from mindroom.thread_export.models import (
     ThreadExportTarget,
     failure_for_room,
 )
-from mindroom.thread_export.policy import target_accepts_room
+from mindroom.thread_export.policy import target_accepts_room, target_retains_unverified_room
 from mindroom.thread_export.selection import trusted_sender_ids_for_export
 from mindroom.thread_export.storage import (
     remove_room_export,
@@ -137,7 +137,7 @@ async def _authorized_room_accumulators(
     room: ThreadExportRoom,
     accumulators: Sequence[ThreadExportAccumulator],
 ) -> list[ThreadExportAccumulator]:
-    """Return targets authorized for one room and remove fail-closed exports."""
+    """Return targets authorized for one room, removing exports only on definitive revocation."""
     eligible = [accumulator for accumulator in accumulators if target_accepts_room(accumulator.target, room)]
     for accumulator in accumulators:
         if not target_accepts_room(accumulator.target, room):
@@ -150,8 +150,14 @@ async def _authorized_room_accumulators(
     try:
         member_ids = await _joined_member_ids(client, room.room_id)
     except Exception as exc:
+        # Authorization is unknown here, not revoked: removal is a retraction action and must be
+        # driven by a definitive "not a member" answer, never by a lookup error. A boot-time 429
+        # burst on joined_members once deleted every previously exported room before this guard.
         for accumulator in scoped:
-            remove_room_export(accumulator.target.output_dir, room)
+            if target_retains_unverified_room(accumulator.target, room):
+                accumulator.retained_room_keys.add(room.key)
+            else:
+                remove_room_export(accumulator.target.output_dir, room)
             accumulator.failed_items.append(failure_for_room(room, str(exc)))
         return authorized
 

--- a/src/mindroom/thread_export/execution.py
+++ b/src/mindroom/thread_export/execution.py
@@ -21,7 +21,7 @@ from mindroom.thread_export.models import (
     ThreadExportTarget,
     failure_for_room,
 )
-from mindroom.thread_export.policy import target_accepts_room, target_retains_unverified_room
+from mindroom.thread_export.policy import target_accepts_room
 from mindroom.thread_export.selection import trusted_sender_ids_for_export
 from mindroom.thread_export.storage import (
     remove_room_export,
@@ -154,10 +154,7 @@ async def _authorized_room_accumulators(
         # driven by a definitive "not a member" answer, never by a lookup error. A boot-time 429
         # burst on joined_members once deleted every previously exported room before this guard.
         for accumulator in scoped:
-            if target_retains_unverified_room(accumulator.target, room):
-                accumulator.retained_room_keys.add(room.key)
-            else:
-                remove_room_export(accumulator.target.output_dir, room)
+            accumulator.retained_room_keys.add(room.key)
             accumulator.failed_items.append(failure_for_room(room, str(exc)))
         return authorized
 

--- a/src/mindroom/thread_export/policy.py
+++ b/src/mindroom/thread_export/policy.py
@@ -1,4 +1,11 @@
-"""Pure authorization policy for thread-export targets."""
+"""Pure authorization policy for thread-export targets.
+
+Removal of previously exported data is a retraction action, so it may only follow a definitive
+authorization answer: the target no longer accepts the room's source category, or a successful
+membership lookup proves the scoped user is not a member. When authorization cannot be verified
+(membership lookup errors, account failures), targets keep their existing exports and simply skip
+the room for that pass; a transient homeserver error must never destroy authorized data.
+"""
 
 from mindroom.thread_export.models import ThreadExportRoom, ThreadExportTarget
 
@@ -9,5 +16,5 @@ def target_accepts_room(target: ThreadExportTarget, room: ThreadExportRoom) -> b
 
 
 def target_retains_unverified_room(target: ThreadExportTarget, room: ThreadExportRoom) -> bool:
-    """Return whether stale data may remain when source authorization cannot be verified."""
-    return target.required_member_user_id is None and target_accepts_room(target, room)
+    """Return whether existing exports stay when source authorization cannot be verified."""
+    return target_accepts_room(target, room)

--- a/src/mindroom/thread_export/policy.py
+++ b/src/mindroom/thread_export/policy.py
@@ -13,8 +13,3 @@ from mindroom.thread_export.models import ThreadExportRoom, ThreadExportTarget
 def target_accepts_room(target: ThreadExportTarget, room: ThreadExportRoom) -> bool:
     """Return whether one target includes the room's source category."""
     return target.include_invited_rooms or not room.invited
-
-
-def target_retains_unverified_room(target: ThreadExportTarget, room: ThreadExportRoom) -> bool:
-    """Return whether existing exports stay when source authorization cannot be verified."""
-    return target_accepts_room(target, room)

--- a/src/mindroom/thread_export/service.py
+++ b/src/mindroom/thread_export/service.py
@@ -18,7 +18,7 @@ from mindroom.thread_export.models import (
     ThreadExportTarget,
     failure_for_room,
 )
-from mindroom.thread_export.policy import target_accepts_room, target_retains_unverified_room
+from mindroom.thread_export.policy import target_accepts_room
 from mindroom.thread_export.selection import (
     build_export_groups,
     export_rooms,
@@ -60,17 +60,14 @@ def _record_group_failure(
     rooms: Sequence[ThreadExportRoom],
     error: str,
 ) -> None:
-    """Record one account-level failure without leaking scoped room exports."""
+    """Record an account-level failure without retracting rooms whose authorization is unknown."""
     for room in rooms:
         for accumulator in accumulators:
             target = accumulator.target
             if not target_accepts_room(target, room):
                 remove_room_export(target.output_dir, room)
                 continue
-            if target_retains_unverified_room(target, room):
-                accumulator.retained_room_keys.add(room.key)
-            else:
-                remove_room_export(target.output_dir, room)
+            accumulator.retained_room_keys.add(room.key)
             accumulator.failed_items.append(failure_for_room(room, error))
 
 
@@ -143,8 +140,9 @@ async def export_threads_to_targets_once(
     Only use it while the runtime keeps the cache fresh (in-process or alongside a live ``mindroom run``).
 
     Each source thread is fetched once per room and fanned out to every authorized target.
-    Scoped targets retain only rooms where their required member is currently joined; failed
-    membership checks remove any prior room export before recording a failure.
+    Scoped targets export only rooms where their required member is currently joined.
+    A failed membership check leaves prior exports untouched, records a failure, and writes nothing new.
+    A successful check that proves the member absent removes the prior room export.
     """
     resolved_targets = tuple(targets)
     if not resolved_targets:

--- a/tests/test_thread_export_execution.py
+++ b/tests/test_thread_export_execution.py
@@ -754,8 +754,8 @@ async def test_target_membership_and_invited_room_setting_are_both_enforced(tmp_
 
 
 @pytest.mark.asyncio
-async def test_member_filter_records_failure_when_membership_lookup_fails(tmp_path: Path) -> None:
-    """A failed membership lookup should fail closed and surface as a room failure."""
+async def test_member_filter_lookup_failure_keeps_exports_and_records_failure(tmp_path: Path) -> None:
+    """A failed membership lookup must keep existing exports: unknown is not revoked."""
     config = _config(tmp_path)
     runtime_paths = runtime_paths_for(config)
     _write_matrix_state(tmp_path)
@@ -784,7 +784,8 @@ async def test_member_filter_records_failure_when_membership_lookup_fails(tmp_pa
     assert stats.failures == 2
     assert all("Membership lookup failed" in failure.error for failure in stats.failed_items)
     enumerate_threads.assert_not_awaited()
-    assert not any((tmp_path / "exports").iterdir())
+    for room_key in ("lobby", "dev"):
+        assert (tmp_path / "exports" / room_key / "old.yaml").read_text(encoding="utf-8") == "secret"
 
 
 @pytest.mark.asyncio

--- a/tests/test_thread_export_execution.py
+++ b/tests/test_thread_export_execution.py
@@ -770,19 +770,26 @@ async def test_member_filter_lookup_failure_keeps_exports_and_records_failure(tm
         "mindroom.thread_export.execution.enumerate_room_thread_root_ids",
         new=AsyncMock(),
     ) as enumerate_threads:
-        stats = await _export_threads_for_client(
+        accumulators = await _export_threads_for_targets_for_client(
             client=client,
             config=config,
             runtime_paths=runtime_paths,
             event_cache=Mock(),
-            output_dir=tmp_path / "exports",
             rooms=_export_rooms(runtime_paths, None),
-            required_member_user_id="@alice:localhost",
+            targets=(
+                ThreadExportTarget(
+                    output_dir=tmp_path / "exports",
+                    required_member_user_id="@alice:localhost",
+                ),
+            ),
         )
 
+    accumulator = accumulators[0]
+    stats = accumulator.stats()
     assert stats.rooms_exported == 0
     assert stats.failures == 2
     assert all("Membership lookup failed" in failure.error for failure in stats.failed_items)
+    assert accumulator.retained_room_keys == {"lobby", "dev"}
     enumerate_threads.assert_not_awaited()
     for room_key in ("lobby", "dev"):
         assert (tmp_path / "exports" / room_key / "old.yaml").read_text(encoding="utf-8") == "secret"

--- a/tests/test_thread_export_service.py
+++ b/tests/test_thread_export_service.py
@@ -10,6 +10,7 @@ import pytest
 
 from mindroom.matrix.users import INTERNAL_USER_ACCOUNT_KEY
 from mindroom.thread_export import ThreadExportTarget, export_threads_once, export_threads_to_targets_once
+from mindroom.thread_export.models import ThreadExportGroupFailure, ThreadExportRoom
 from tests.conftest import runtime_paths_for
 from tests.thread_export_helpers import (
     mock_runtime_support,
@@ -258,3 +259,48 @@ async def test_failed_export_groups_do_not_create_runtime_support(tmp_path: Path
     assert stats[0].failures == 1
     assert stats[0].failed_items[0].room_id == "!user-room:localhost"
     assert stats[1].failures == 0
+
+
+@pytest.mark.asyncio
+async def test_full_pass_retains_scoped_exports_when_account_group_cannot_run(tmp_path: Path) -> None:
+    """An account-group failure must not let full-pass reconciliation retract scoped exports."""
+    config = thread_export_config(tmp_path)
+    runtime_paths = runtime_paths_for(config)
+    write_thread_export_matrix_state(tmp_path)
+    rooms = (
+        ThreadExportRoom(
+            key="lobby",
+            room_id="!lobby:localhost",
+            alias="#lobby:localhost",
+            name="Lobby",
+        ),
+        ThreadExportRoom(
+            key="dev",
+            room_id="!dev:localhost",
+            alias="#dev:localhost",
+            name="Dev",
+        ),
+    )
+    output_dir = tmp_path / "exports"
+    for room in rooms:
+        room_dir = output_dir / room.key
+        room_dir.mkdir(parents=True)
+        (room_dir / "old.yaml").write_text("secret", encoding="utf-8")
+
+    group_failure = ThreadExportGroupFailure(rooms=rooms, error="No usable Matrix account")
+    with patch("mindroom.thread_export.service.build_export_groups", return_value=[group_failure]):
+        stats = await export_threads_to_targets_once(
+            config=config,
+            runtime_paths=runtime_paths,
+            targets=(
+                ThreadExportTarget(
+                    output_dir=output_dir,
+                    required_member_user_id="@alice:localhost",
+                ),
+            ),
+        )
+
+    assert stats[0].failures == 2
+    assert all("No usable Matrix account" in failure.error for failure in stats[0].failed_items)
+    for room in rooms:
+        assert (output_dir / room.key / "old.yaml").read_text(encoding="utf-8") == "secret"


### PR DESCRIPTION
## The incident

Right after the #1500 deploy restart at 22:45, the thread-export tree on the mindroom-chat host went from 806 files to 0. Cause chain, from the journal: the 13 bots' boot sync plus the exporter's per-room `joined_members` calls tripped Tuwunel rate limiting (7x429 in the first minutes), every scoped membership check raised, and `_authorized_room_accumulators` treated each lookup **error** exactly like a verified "not a member": it removed the room's exports for every scoped target. The same pass rebuilt everything minutes later (thanks to the bulk backfill), but with the old per-thread fetch path this would have re-cost hours.

## The principle

Removing previously exported data is a **retraction action**. It is correct when authorization is definitively gone: the target no longer accepts the room's source category, or a successful membership lookup proves the scoped user is not a member. A lookup **error** answers nothing. Treating unknown as revoked converts any transient homeserver hiccup into data destruction, and it buys no confidentiality: an attacker who can induce a 429 gains a deletion, not access. Fail-closed for errors should mean *fail static* - write nothing new, delete nothing, surface the failure - not *fail destructive*.

The codebase already encoded this idea for account-level failures (`target_retains_unverified_room` in `_record_group_failure`), but the policy excluded membership-scoped targets, and the room-level lookup-failure branch bypassed it entirely.

## The change

- `target_retains_unverified_room` now retains for **every** target that accepts the room's source category; the policy module docstring states the definitive-vs-unknown rule.
- The room-level lookup-failure branch marks the room as retained (so full-pass directory reconciliation keeps the directory too - skipping the mid-pass removal alone would not have been enough), records the failure on each scoped accumulator, and skips the room for that pass.
- Definitive revocation is untouched: a successful lookup that shows the user absent still removes the room's exports, as do category rejections.

## Testing

- The test that pinned the old behavior (pre-seeded "secret" files wiped on lookup failure) is rewritten to the new contract: files intact byte-for-byte, failures still recorded, nothing exported, enumeration never attempted.
- All thread-export suites (execution, service, storage, selection, bulk backfill) pass; pre-commit clean.