### PR TITLE
Add daily MindRoom update awareness

### DIFF
--- a/docs/tools/builtin.md
+++ b/docs/tools/builtin.md
@@ -27,5 +27,6 @@ icon: lucide/box
 | **Agent Orchestration** | subagents, delegate, dynamic_workflow, claude_agent, config_manager, openclaw_compat | [→ agent-orchestration](agent-orchestration.md) |
 | **Automation & Platforms** | aws_lambda, aws_ses, airflow, e2b, daytona, composio, custom_api | [→ automation-and-platforms](automation-and-platforms.md) |
 | **Location, Commerce & Home** | google_maps, openweather, shopify, homeassistant | [→ location-commerce-and-home](location-commerce-and-home.md) |
+| **Runtime Awareness** | update_awareness | [→ tools overview](index.md#mindroom-update-awareness) |
 
 For tool configuration, presets, and runtime context, see the [Tools Overview](index.md).

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -88,6 +88,19 @@ Callers must check `truncated` before claiming the unresolved list is complete.
 `thread_tags` intentionally replaces the removed experimental `thread_resolution` tool and does not auto-read old `com.mindroom.thread.resolution` markers.
 `matrix_api` defaults `room_id` to the active room, supports authorized cross-room targeting, never infers event IDs or state keys from thread context, and now also supports room-scoped full-text search through `action="search"`.
 
+## MindRoom Update Awareness
+
+Enable the `update_awareness` tool to add the installed MindRoom version and the latest published PyPI release to the agent's system prompt.
+The tool checks PyPI at most once every 24 hours and stores the result under `mindroom_data/cache/update_awareness.json`.
+Every prompt assembled during that cache window receives identical version text, so ordinary turns do not invalidate the prompt cache.
+When a newer release is available, the agent is instructed to notify the user briefly at a natural opportunity without repeating the notice in the same conversation.
+
+```yaml
+defaults:
+  tools:
+    - update_awareness
+```
+
 ## Worker-Routed Execution
 
 Some tools default to running in a sandboxed worker container instead of the primary agent process.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
   "mem0ai>=0.1.115",
   "mindroom-nio[e2e]>=0.27.1",
   "openai",
+  "packaging>=24",
   "pydantic>=2",
   "pydantic-settings>=2.10.1",
   "pygments>=2.20",
@@ -388,6 +389,7 @@ twilio = [
   "twilio",
 ]
 unsplash = []
+update_awareness = []
 visualization = [
   "matplotlib",
 ]

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -3014,6 +3014,19 @@ Callers must check `truncated` before claiming the unresolved list is complete.
 `thread_tags` intentionally replaces the removed experimental `thread_resolution` tool and does not auto-read old `com.mindroom.thread.resolution` markers.
 `matrix_api` defaults `room_id` to the active room, supports authorized cross-room targeting, never infers event IDs or state keys from thread context, and now also supports room-scoped full-text search through `action="search"`.
 
+## MindRoom Update Awareness
+
+Enable the `update_awareness` tool to add the installed MindRoom version and the latest published PyPI release to the agent's system prompt.
+The tool checks PyPI at most once every 24 hours and stores the result under `mindroom_data/cache/update_awareness.json`.
+Every prompt assembled during that cache window receives identical version text, so ordinary turns do not invalidate the prompt cache.
+When a newer release is available, the agent is instructed to notify the user briefly at a natural opportunity without repeating the notice in the same conversation.
+
+```yaml
+defaults:
+  tools:
+    - update_awareness
+```
+
 ## Worker-Routed Execution
 
 Some tools default to running in a sandboxed worker container instead of the primary agent process.
@@ -9721,6 +9734,7 @@ call_service("notify", "send_message", data='{"message": "Dinner is ready"}')
 | **Agent Orchestration** | subagents, delegate, dynamic_workflow, claude_agent, config_manager, openclaw_compat | [→ agent-orchestration](https://docs.mindroom.chat/tools/agent-orchestration/) |
 | **Automation & Platforms** | aws_lambda, aws_ses, airflow, e2b, daytona, composio, custom_api | [→ automation-and-platforms](https://docs.mindroom.chat/tools/automation-and-platforms/) |
 | **Location, Commerce & Home** | google_maps, openweather, shopify, homeassistant | [→ location-commerce-and-home](https://docs.mindroom.chat/tools/location-commerce-and-home/) |
+| **Runtime Awareness** | update_awareness | [→ tools overview](https://docs.mindroom.chat/tools/#mindroom-update-awareness) |
 
 For tool configuration, presets, and runtime context, see the [Tools Overview](https://docs.mindroom.chat/tools/).
 

--- a/skills/mindroom-docs/references/page__tools__builtin__index.md
+++ b/skills/mindroom-docs/references/page__tools__builtin__index.md
@@ -23,5 +23,6 @@
 | **Agent Orchestration** | subagents, delegate, dynamic_workflow, claude_agent, config_manager, openclaw_compat | [→ agent-orchestration](https://docs.mindroom.chat/tools/agent-orchestration/) |
 | **Automation & Platforms** | aws_lambda, aws_ses, airflow, e2b, daytona, composio, custom_api | [→ automation-and-platforms](https://docs.mindroom.chat/tools/automation-and-platforms/) |
 | **Location, Commerce & Home** | google_maps, openweather, shopify, homeassistant | [→ location-commerce-and-home](https://docs.mindroom.chat/tools/location-commerce-and-home/) |
+| **Runtime Awareness** | update_awareness | [→ tools overview](https://docs.mindroom.chat/tools/#mindroom-update-awareness) |
 
 For tool configuration, presets, and runtime context, see the [Tools Overview](https://docs.mindroom.chat/tools/).

--- a/skills/mindroom-docs/references/page__tools__index.md
+++ b/skills/mindroom-docs/references/page__tools__index.md
@@ -84,6 +84,19 @@ Callers must check `truncated` before claiming the unresolved list is complete.
 `thread_tags` intentionally replaces the removed experimental `thread_resolution` tool and does not auto-read old `com.mindroom.thread.resolution` markers.
 `matrix_api` defaults `room_id` to the active room, supports authorized cross-room targeting, never infers event IDs or state keys from thread context, and now also supports room-scoped full-text search through `action="search"`.
 
+## MindRoom Update Awareness
+
+Enable the `update_awareness` tool to add the installed MindRoom version and the latest published PyPI release to the agent's system prompt.
+The tool checks PyPI at most once every 24 hours and stores the result under `mindroom_data/cache/update_awareness.json`.
+Every prompt assembled during that cache window receives identical version text, so ordinary turns do not invalidate the prompt cache.
+When a newer release is available, the agent is instructed to notify the user briefly at a natural opportunity without repeating the notice in the same conversation.
+
+```yaml
+defaults:
+  tools:
+    - update_awareness
+```
+
 ## Worker-Routed Execution
 
 Some tools default to running in a sandboxed worker container instead of the primary agent process.

--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -952,6 +952,7 @@ agents:
       - website
       - browser
       - scheduler
+      - update_awareness
       - todo
       - subagents
       - matrix_message
@@ -1014,6 +1015,7 @@ defaults:
   worker_tools: []
   tools:
     - scheduler
+    - update_awareness
   markdown: true
   compaction:
     enabled: true

--- a/src/mindroom/custom_tools/update_awareness.py
+++ b/src/mindroom/custom_tools/update_awareness.py
@@ -1,0 +1,272 @@
+"""Daily-cached MindRoom release awareness for agent prompts."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from dataclasses import asdict, dataclass
+from importlib.metadata import version as installed_distribution_version
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import httpx
+from agno.tools import Toolkit
+from packaging.version import InvalidVersion, Version
+
+from mindroom.durable_write import write_json_file_durable
+from mindroom.logging_config import get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from mindroom.constants import RuntimePaths
+
+logger = get_logger(__name__)
+
+_PYPI_PROJECT_URL = "https://pypi.org/project/mindroom/"
+_PYPI_RELEASE_API_URL = "https://pypi.org/pypi/mindroom/json"
+_RELEASE_CACHE_TTL_SECONDS = 24 * 60 * 60
+_CACHE_RELATIVE_PATH = Path("cache") / "update_awareness.json"
+_RELEASE_REQUEST_TIMEOUT_SECONDS = 5.0
+_CACHE_LOCK = threading.Lock()
+
+
+class _ReleaseLookupError(RuntimeError):
+    """Raised when the latest MindRoom release cannot be read from PyPI."""
+
+
+@dataclass(frozen=True, slots=True)
+class _ReleaseCacheRecord:
+    checked_at: float
+    latest_version: str | None
+    refresh_succeeded: bool
+
+
+@dataclass(frozen=True, slots=True)
+class _MindRoomReleaseStatus:
+    """Installed and published MindRoom version state exposed to the agent."""
+
+    current_version: str
+    latest_version: str | None
+    update_available: bool | None
+    release_check_succeeded: bool
+
+
+_MEMORY_CACHE: dict[Path, _ReleaseCacheRecord] = {}
+
+
+def _normalize_version(raw_version: str) -> str:
+    version_text = raw_version.strip()
+    if not version_text:
+        msg = "MindRoom release metadata did not include a version"
+        raise _ReleaseLookupError(msg)
+    try:
+        return str(Version(version_text))
+    except InvalidVersion as exc:
+        msg = f"MindRoom release metadata included an invalid version: {version_text!r}"
+        raise _ReleaseLookupError(msg) from exc
+
+
+def _current_mindroom_version() -> str:
+    try:
+        return _normalize_version(installed_distribution_version("mindroom"))
+    except _ReleaseLookupError:
+        logger.warning("installed_mindroom_version_invalid")
+        return "unknown"
+
+
+def _fetch_latest_mindroom_version() -> str:
+    """Return the latest published MindRoom version from PyPI."""
+    try:
+        response = httpx.get(
+            _PYPI_RELEASE_API_URL,
+            headers={"Accept": "application/json", "User-Agent": "MindRoom update awareness"},
+            timeout=_RELEASE_REQUEST_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if not isinstance(payload, dict):
+            msg = "PyPI returned a non-object response"
+            raise _ReleaseLookupError(msg)
+        info = payload.get("info")
+        if not isinstance(info, dict) or not isinstance(info.get("version"), str):
+            msg = "PyPI response did not include info.version"
+            raise _ReleaseLookupError(msg)
+        return _normalize_version(info["version"])
+    except (httpx.HTTPError, ValueError) as exc:
+        msg = "Could not retrieve the latest MindRoom release from PyPI"
+        raise _ReleaseLookupError(msg) from exc
+
+
+def _cache_path(runtime_paths: RuntimePaths) -> Path:
+    return runtime_paths.storage_root / _CACHE_RELATIVE_PATH
+
+
+def _read_cache(path: Path) -> _ReleaseCacheRecord | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+
+    checked_at = payload.get("checked_at")
+    latest_version = payload.get("latest_version")
+    refresh_succeeded = payload.get("refresh_succeeded")
+    if (
+        not isinstance(checked_at, (int, float))
+        or isinstance(checked_at, bool)
+        or (latest_version is not None and not isinstance(latest_version, str))
+        or not isinstance(refresh_succeeded, bool)
+    ):
+        return None
+    try:
+        normalized_latest = _normalize_version(latest_version) if latest_version is not None else None
+    except _ReleaseLookupError:
+        return None
+    return _ReleaseCacheRecord(
+        checked_at=float(checked_at),
+        latest_version=normalized_latest,
+        refresh_succeeded=refresh_succeeded,
+    )
+
+
+def _cache_is_fresh(record: _ReleaseCacheRecord, now: float) -> bool:
+    age_seconds = now - record.checked_at
+    return 0 <= age_seconds < _RELEASE_CACHE_TTL_SECONDS
+
+
+def _write_cache(path: Path, record: _ReleaseCacheRecord) -> None:
+    try:
+        write_json_file_durable(path, asdict(record), indent=2, sort_keys=True, trailing_newline=True)
+    except OSError as exc:
+        logger.warning("mindroom_release_cache_write_failed", path=str(path), error=str(exc))
+
+
+def _refresh_release_cache(
+    path: Path,
+    previous: _ReleaseCacheRecord | None,
+    *,
+    now: float,
+    fetch_latest_version: Callable[[], str],
+) -> _ReleaseCacheRecord:
+    try:
+        latest_version = _normalize_version(fetch_latest_version())
+        record = _ReleaseCacheRecord(
+            checked_at=now,
+            latest_version=latest_version,
+            refresh_succeeded=True,
+        )
+    except _ReleaseLookupError as exc:
+        logger.warning("mindroom_release_check_failed", error=str(exc))
+        record = _ReleaseCacheRecord(
+            checked_at=now,
+            latest_version=previous.latest_version if previous is not None else None,
+            refresh_succeeded=False,
+        )
+    _MEMORY_CACHE[path] = record
+    _write_cache(path, record)
+    return record
+
+
+def _release_cache_record(
+    runtime_paths: RuntimePaths,
+    *,
+    now: float,
+    fetch_latest_version: Callable[[], str],
+) -> _ReleaseCacheRecord:
+    path = _cache_path(runtime_paths)
+    with _CACHE_LOCK:
+        record = _MEMORY_CACHE.get(path)
+        if record is not None and _cache_is_fresh(record, now):
+            return record
+
+        disk_record = _read_cache(path)
+        if disk_record is not None and (record is None or disk_record.checked_at > record.checked_at):
+            record = disk_record
+            _MEMORY_CACHE[path] = record
+        if record is not None and _cache_is_fresh(record, now):
+            return record
+        return _refresh_release_cache(
+            path,
+            record,
+            now=now,
+            fetch_latest_version=fetch_latest_version,
+        )
+
+
+def _update_available(current_version: str, latest_version: str | None) -> bool | None:
+    if current_version == "unknown" or latest_version is None:
+        return None
+    try:
+        return Version(current_version) < Version(latest_version)
+    except InvalidVersion:
+        return None
+
+
+def _mindroom_release_status(
+    runtime_paths: RuntimePaths,
+    *,
+    now: float | None = None,
+    fetch_latest_version: Callable[[], str] = _fetch_latest_mindroom_version,
+) -> _MindRoomReleaseStatus:
+    """Resolve installed and daily-cached published MindRoom versions."""
+    record = _release_cache_record(
+        runtime_paths,
+        now=time.time() if now is None else now,
+        fetch_latest_version=fetch_latest_version,
+    )
+    current_version = _current_mindroom_version()
+    return _MindRoomReleaseStatus(
+        current_version=current_version,
+        latest_version=record.latest_version,
+        update_available=_update_available(current_version, record.latest_version),
+        release_check_succeeded=record.refresh_succeeded,
+    )
+
+
+def _release_awareness_instructions(status: _MindRoomReleaseStatus) -> str:
+    latest_version = status.latest_version or "unknown"
+    lines = [
+        "<mindroom_update_awareness>",
+        f"This runtime is running MindRoom {status.current_version}.",
+    ]
+    if status.release_check_succeeded:
+        lines.append(f"The latest published MindRoom release on PyPI is {latest_version}.")
+    elif status.latest_version is not None:
+        lines.append(f"Today's PyPI check failed; the last known published MindRoom release is {latest_version}.")
+    else:
+        lines.append("Today's PyPI check failed, so the latest published MindRoom release is unknown.")
+
+    if status.update_available:
+        lines.append(
+            "A newer MindRoom release is available. Briefly notify the user at a natural opportunity and suggest "
+            "updating through the same installation method they originally used. Do not derail unrelated work, "
+            "repeat the notice in a conversation that already mentions it, or install the update without an "
+            "explicit user request.",
+        )
+        lines.append(f"Release page: {_PYPI_PROJECT_URL}")
+    elif status.release_check_succeeded and status.update_available is False:
+        lines.append("This runtime is not older than the latest published release, so do not suggest an update.")
+    else:
+        lines.append("Do not claim this runtime is up to date while the latest release is unknown or stale.")
+    lines.append("</mindroom_update_awareness>")
+    return "\n".join(lines)
+
+
+class UpdateAwarenessTools(Toolkit):
+    """Expose MindRoom release status and add it to the system prompt."""
+
+    def __init__(self, *, runtime_paths: RuntimePaths) -> None:
+        self.status = _mindroom_release_status(runtime_paths)
+        super().__init__(
+            name="update_awareness",
+            tools=[self.get_mindroom_update_status],
+            instructions=_release_awareness_instructions(self.status),
+            add_instructions=True,
+        )
+
+    def get_mindroom_update_status(self) -> str:
+        """Return the installed and daily-cached latest MindRoom versions."""
+        return json.dumps(asdict(self.status), sort_keys=True)

--- a/src/mindroom/custom_tools/update_awareness.py
+++ b/src/mindroom/custom_tools/update_awareness.py
@@ -6,6 +6,7 @@ import json
 import threading
 import time
 from dataclasses import asdict, dataclass
+from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as installed_distribution_version
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -71,8 +72,8 @@ def _normalize_version(raw_version: str) -> str:
 def _current_mindroom_version() -> str:
     try:
         return _normalize_version(installed_distribution_version("mindroom"))
-    except _ReleaseLookupError:
-        logger.warning("installed_mindroom_version_invalid")
+    except (PackageNotFoundError, _ReleaseLookupError) as exc:
+        logger.warning("installed_mindroom_version_invalid", error=str(exc))
         return "unknown"
 
 

--- a/src/mindroom/tools/__init__.py
+++ b/src/mindroom/tools/__init__.py
@@ -133,6 +133,7 @@ from mindroom.tools.trafilatura import trafilatura_tools
 from mindroom.tools.trello import trello_tools
 from mindroom.tools.twilio import twilio_tools
 from mindroom.tools.unsplash import unsplash_tools
+from mindroom.tools.update_awareness import update_awareness_tools
 from mindroom.tools.visualization import visualization_tools
 from mindroom.tools.web_browser_tools import web_browser_tools
 from mindroom.tools.webex import webex_tools
@@ -259,6 +260,7 @@ __all__ = [
     "trello_tools",
     "twilio_tools",
     "unsplash_tools",
+    "update_awareness_tools",
     "visualization_tools",
     "web_browser_tools",
     "webex_tools",

--- a/src/mindroom/tools/update_awareness.py
+++ b/src/mindroom/tools/update_awareness.py
@@ -1,0 +1,32 @@
+"""MindRoom update-awareness tool registration."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from mindroom.tool_system.declarations import SetupType, ToolCategory, ToolManagedInitArg, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
+
+if TYPE_CHECKING:
+    from mindroom.custom_tools.update_awareness import UpdateAwarenessTools
+
+
+@register_tool_with_metadata(
+    name="update_awareness",
+    display_name="MindRoom Update Awareness",
+    description="Add daily-cached installed and latest MindRoom release information to the agent system prompt",
+    category=ToolCategory.INFORMATION,
+    status=ToolStatus.AVAILABLE,
+    setup_type=SetupType.NONE,
+    icon="RefreshCw",
+    icon_color="text-cyan-500",
+    dependencies=["agno"],
+    docs_url="https://docs.mindroom.chat/tools/#mindroom-update-awareness",
+    managed_init_args=(ToolManagedInitArg.RUNTIME_PATHS,),
+    function_names=("get_mindroom_update_status",),
+)
+def update_awareness_tools() -> type[UpdateAwarenessTools]:
+    """Return the MindRoom update-awareness toolkit."""
+    from mindroom.custom_tools.update_awareness import UpdateAwarenessTools
+
+    return UpdateAwarenessTools

--- a/src/mindroom/tools_metadata.json
+++ b/src/mindroom/tools_metadata.json
@@ -6858,6 +6858,30 @@
     {
       "agent_override_fields": null,
       "auth_provider": null,
+      "category": "information",
+      "config_fields": null,
+      "consumes_workspace_paths": false,
+      "default_execution_target": "primary",
+      "dependencies": [
+        "agno"
+      ],
+      "description": "Add daily-cached installed and latest MindRoom release information to the agent system prompt",
+      "display_name": "MindRoom Update Awareness",
+      "docs_url": "https://docs.mindroom.chat/tools/#mindroom-update-awareness",
+      "function_names": [
+        "get_mindroom_update_status"
+      ],
+      "helper_text": null,
+      "icon": "RefreshCw",
+      "icon_color": "text-cyan-500",
+      "name": "update_awareness",
+      "requires_room_context": false,
+      "setup_type": "none",
+      "status": "available"
+    },
+    {
+      "agent_override_fields": null,
+      "auth_provider": null,
       "category": "integrations",
       "config_fields": [
         {

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -237,6 +237,7 @@ class TestConfigInit:
             "website",
             "browser",
             "scheduler",
+            "update_awareness",
             "todo",
             "subagents",
             "matrix_message",
@@ -255,6 +256,7 @@ class TestConfigInit:
             "include_entrypoint": False,
         }
         assert config["memory"]["auto_flush"]["enabled"] is True
+        assert config["defaults"]["tools"] == ["scheduler", "update_awareness"]
         assert "openclaw_compat" not in target.read_text()
 
         env_content = (tmp_path / ".env").read_text()

--- a/tests/test_update_awareness_tool.py
+++ b/tests/test_update_awareness_tool.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from importlib.metadata import PackageNotFoundError
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -16,6 +17,7 @@ from mindroom.constants import resolve_runtime_paths
 from mindroom.custom_tools.update_awareness import (
     _RELEASE_CACHE_TTL_SECONDS,
     UpdateAwarenessTools,
+    _current_mindroom_version,
     _mindroom_release_status,
     _MindRoomReleaseStatus,
     _ReleaseLookupError,
@@ -33,6 +35,15 @@ def _runtime_paths(tmp_path: Path) -> RuntimePaths:
         storage_path=tmp_path / "mindroom_data",
         process_env={},
     )
+
+
+def test_current_version_is_unknown_when_distribution_metadata_is_missing() -> None:
+    """A missing installed distribution should not prevent agent startup."""
+    with patch(
+        "mindroom.custom_tools.update_awareness.installed_distribution_version",
+        side_effect=PackageNotFoundError("mindroom"),
+    ):
+        assert _current_mindroom_version() == "unknown"
 
 
 def test_release_status_uses_persistent_cache_within_daily_ttl(tmp_path: Path) -> None:

--- a/tests/test_update_awareness_tool.py
+++ b/tests/test_update_awareness_tool.py
@@ -1,0 +1,156 @@
+"""Tests for daily-cached MindRoom update awareness."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from agno.agent import Agent
+from agno.agent._tools import parse_tools
+from agno.models.openai import OpenAIChat
+from agno.run import RunContext
+from agno.session import AgentSession
+
+from mindroom.constants import resolve_runtime_paths
+from mindroom.custom_tools.update_awareness import (
+    _RELEASE_CACHE_TTL_SECONDS,
+    UpdateAwarenessTools,
+    _mindroom_release_status,
+    _MindRoomReleaseStatus,
+    _ReleaseLookupError,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from mindroom.constants import RuntimePaths
+
+
+def _runtime_paths(tmp_path: Path) -> RuntimePaths:
+    return resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path / "mindroom_data",
+        process_env={},
+    )
+
+
+def test_release_status_uses_persistent_cache_within_daily_ttl(tmp_path: Path) -> None:
+    """A successful lookup should be reused until the daily TTL expires."""
+    runtime_paths = _runtime_paths(tmp_path)
+    fetches: list[str] = []
+
+    def fetch_latest() -> str:
+        fetches.append("fetch")
+        return "2.0.0"
+
+    with patch("mindroom.custom_tools.update_awareness.installed_distribution_version", return_value="1.0.0"):
+        first = _mindroom_release_status(runtime_paths, now=1000, fetch_latest_version=fetch_latest)
+        with patch.dict("mindroom.custom_tools.update_awareness._MEMORY_CACHE", clear=True):
+            second = _mindroom_release_status(runtime_paths, now=2000, fetch_latest_version=fetch_latest)
+
+    assert (
+        first
+        == second
+        == _MindRoomReleaseStatus(
+            current_version="1.0.0",
+            latest_version="2.0.0",
+            update_available=True,
+            release_check_succeeded=True,
+        )
+    )
+    assert fetches == ["fetch"]
+    cache_payload = json.loads((runtime_paths.storage_root / "cache" / "update_awareness.json").read_text())
+    assert cache_payload == {
+        "checked_at": 1000,
+        "latest_version": "2.0.0",
+        "refresh_succeeded": True,
+    }
+
+
+def test_release_status_refreshes_after_daily_ttl(tmp_path: Path) -> None:
+    """An expired cached release should trigger one new lookup."""
+    runtime_paths = _runtime_paths(tmp_path)
+    versions = iter(("1.0.0", "1.1.0"))
+
+    with patch("mindroom.custom_tools.update_awareness.installed_distribution_version", return_value="1.0.0"):
+        first = _mindroom_release_status(runtime_paths, now=1000, fetch_latest_version=lambda: next(versions))
+        refreshed = _mindroom_release_status(
+            runtime_paths,
+            now=1000 + _RELEASE_CACHE_TTL_SECONDS + 1,
+            fetch_latest_version=lambda: next(versions),
+        )
+
+    assert first.update_available is False
+    assert refreshed.latest_version == "1.1.0"
+    assert refreshed.update_available is True
+
+
+def test_failed_refresh_is_cached_and_preserves_last_known_release(tmp_path: Path) -> None:
+    """A failed daily lookup should retain stale data without retrying every turn."""
+    runtime_paths = _runtime_paths(tmp_path)
+    fetches = 0
+
+    def fail_fetch() -> str:
+        nonlocal fetches
+        fetches += 1
+        message = "offline"
+        raise _ReleaseLookupError(message)
+
+    with patch("mindroom.custom_tools.update_awareness.installed_distribution_version", return_value="1.0.0"):
+        _mindroom_release_status(runtime_paths, now=1000, fetch_latest_version=lambda: "2.0.0")
+        failed = _mindroom_release_status(
+            runtime_paths,
+            now=1000 + _RELEASE_CACHE_TTL_SECONDS + 1,
+            fetch_latest_version=fail_fetch,
+        )
+        cached_failure = _mindroom_release_status(
+            runtime_paths,
+            now=1000 + _RELEASE_CACHE_TTL_SECONDS + 2,
+            fetch_latest_version=fail_fetch,
+        )
+
+    assert (
+        failed
+        == cached_failure
+        == _MindRoomReleaseStatus(
+            current_version="1.0.0",
+            latest_version="2.0.0",
+            update_available=True,
+            release_check_succeeded=False,
+        )
+    )
+    assert fetches == 1
+
+
+def test_tool_adds_release_awareness_to_system_prompt(tmp_path: Path) -> None:
+    """The toolkit should render cached release status into Agno's system prompt."""
+    status = _MindRoomReleaseStatus(
+        current_version="1.0.0",
+        latest_version="2.0.0",
+        update_available=True,
+        release_check_succeeded=True,
+    )
+    with patch("mindroom.custom_tools.update_awareness._mindroom_release_status", return_value=status):
+        toolkit = UpdateAwarenessTools(runtime_paths=_runtime_paths(tmp_path))
+
+    model = OpenAIChat(id="test")
+    agent = Agent(id="assistant", model=model, tools=[toolkit], instructions=["Help the user."])
+    parse_tools(agent, [toolkit], model)
+    message = agent.get_system_message(
+        session=AgentSession(session_id="session", agent_id="assistant"),
+        run_context=RunContext(run_id="run", session_id="session", session_state={}),
+        tools=None,
+        add_session_state_to_context=False,
+    )
+
+    assert message is not None
+    assert "This runtime is running MindRoom 1.0.0." in str(message.content)
+    assert "The latest published MindRoom release on PyPI is 2.0.0." in str(message.content)
+    assert "A newer MindRoom release is available." in str(message.content)
+    assert json.loads(toolkit.get_mindroom_update_status()) == {
+        "current_version": "1.0.0",
+        "latest_version": "2.0.0",
+        "release_check_succeeded": True,
+        "update_available": True,
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -3986,6 +3986,7 @@ dependencies = [
     { name = "mem0ai" },
     { name = "mindroom-nio", extra = ["e2e"] },
     { name = "openai" },
+    { name = "packaging" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pygments" },
@@ -4455,6 +4456,7 @@ requires-dist = [
     { name = "openai", marker = "extra == 'openai'" },
     { name = "openbb", marker = "extra == 'openbb'" },
     { name = "oxylabs", marker = "extra == 'oxylabs'" },
+    { name = "packaging", specifier = ">=24" },
     { name = "pandas", marker = "extra == 'pandas'", specifier = ">=2.2" },
     { name = "playwright", marker = "extra == 'agentql'" },
     { name = "playwright", marker = "extra == 'browser'" },
@@ -4521,7 +4523,7 @@ requires-dist = [
     { name = "youtube-transcript-api", marker = "extra == 'youtube'" },
     { name = "zep-cloud", marker = "extra == 'zep'", specifier = ">=3.3" },
 ]
-provides-extras = ["agent-vault-access", "agentql", "airflow", "apify", "approved-egress", "arxiv", "attachments", "aws-bedrock", "aws-lambda", "aws-ses", "baidusearch", "bitbucket", "brandfetch", "brightdata", "browser", "browserbase", "cal-com", "calculator", "cartesia", "claude-agent", "clickup", "coding", "compact-context", "composio", "config-manager", "confluence", "crawl4ai", "csv", "custom-api", "dalle", "daytona", "delegate", "desi-vocal", "discord", "docker", "duckdb", "duckduckgo", "dynamic-tools", "dynamic-workflow", "e2b", "eleven-labs", "email", "exa", "external-trigger-manager", "fal", "file", "file-generation", "financial-datasets-api", "firecrawl", "gemini", "giphy", "github", "gmail", "google-bigquery", "google-calendar", "google-drive", "google-maps", "google-scholar", "google-sheets", "googlesearch", "groq", "hackernews", "homeassistant", "jina", "jira", "linear", "linkup", "lumalabs", "matrix-api", "matrix-calls", "matrix-e2ee", "matrix-message", "matrix-room", "matrix-voice-message", "mem0", "memory", "modelslabs", "moviepy-video-tools", "neo4j", "newspaper", "notion", "openai", "openbb", "openclaw-compat", "openweather", "oxylabs", "pandas", "postgres", "pubmed", "python", "reasoning", "reddit", "redshift", "replicate", "report-publishing", "resend", "scheduler", "scrapegraph", "searxng", "self-config", "sentence-transformers", "serpapi", "serper", "shell", "shopify", "slack", "sleep", "spider", "spotify", "sql", "subagents", "supabase", "tavily", "telegram", "thread-model", "thread-summary", "thread-tags", "todo", "todoist", "trafilatura", "trello", "twilio", "unsplash", "visualization", "web-browser-tools", "webex", "website", "whatsapp", "wikipedia", "x", "yfinance", "youtube", "zendesk", "zep", "zoom"]
+provides-extras = ["agent-vault-access", "agentql", "airflow", "apify", "approved-egress", "arxiv", "attachments", "aws-bedrock", "aws-lambda", "aws-ses", "baidusearch", "bitbucket", "brandfetch", "brightdata", "browser", "browserbase", "cal-com", "calculator", "cartesia", "claude-agent", "clickup", "coding", "compact-context", "composio", "config-manager", "confluence", "crawl4ai", "csv", "custom-api", "dalle", "daytona", "delegate", "desi-vocal", "discord", "docker", "duckdb", "duckduckgo", "dynamic-tools", "dynamic-workflow", "e2b", "eleven-labs", "email", "exa", "external-trigger-manager", "fal", "file", "file-generation", "financial-datasets-api", "firecrawl", "gemini", "giphy", "github", "gmail", "google-bigquery", "google-calendar", "google-drive", "google-maps", "google-scholar", "google-sheets", "googlesearch", "groq", "hackernews", "homeassistant", "jina", "jira", "linear", "linkup", "lumalabs", "matrix-api", "matrix-calls", "matrix-e2ee", "matrix-message", "matrix-room", "matrix-voice-message", "mem0", "memory", "modelslabs", "moviepy-video-tools", "neo4j", "newspaper", "notion", "openai", "openbb", "openclaw-compat", "openweather", "oxylabs", "pandas", "postgres", "pubmed", "python", "reasoning", "reddit", "redshift", "replicate", "report-publishing", "resend", "scheduler", "scrapegraph", "searxng", "self-config", "sentence-transformers", "serpapi", "serper", "shell", "shopify", "slack", "sleep", "spider", "spotify", "sql", "subagents", "supabase", "tavily", "telegram", "thread-model", "thread-summary", "thread-tags", "todo", "todoist", "trafilatura", "trello", "twilio", "unsplash", "update-awareness", "visualization", "web-browser-tools", "webex", "website", "whatsapp", "wikipedia", "x", "yfinance", "youtube", "zendesk", "zep", "zoom"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

- add an `update_awareness` tool that places the installed MindRoom version and latest published PyPI release in the system prompt
- persist successful and failed release checks for 24 hours so prompt text remains stable and PyPI is not queried on every turn
- expose the cached status through `get_mindroom_update_status`
- enable update awareness for both agents generated by `mindroom config init`
- document the tool and regenerate the committed tool metadata and documentation skill references

## Why

Agents currently cannot tell whether the MindRoom runtime hosting them is behind the latest release.
This adds low-frequency release awareness without continuously hitting the network or invalidating prompt-cache prefixes on ordinary turns.

## Validation

- `PUPPETEER_SKIP_DOWNLOAD=true uv run pytest -q`
- `PUPPETEER_SKIP_DOWNLOAD=true uv run pre-commit run --all-files`
- live parse of the official PyPI project JSON response


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added update awareness, which checks for newer MindRoom releases and makes version status available to the agent.
  * Added daily caching to limit external release checks and preserve consistent status information.
  * Enabled update awareness in the default and starter configurations.
* **Documentation**
  * Documented the new tool, configuration options, runtime behavior, and Runtime Awareness category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->