### PR TITLE
Publish a universal macOS app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,14 +61,23 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
       - name: Build universal uv binary
+        working-directory: ${{ runner.temp }}
         run: |
           UV_VERSION=$(uv --version | awk '{ print $2 }')
-          UV_X86_64_ARCHIVE="$RUNNER_TEMP/uv-x86_64-apple-darwin.tar.gz"
-          curl --fail --location --silent --show-error \
-            "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-apple-darwin.tar.gz" \
-            --output "$UV_X86_64_ARCHIVE"
-          tar -xzf "$UV_X86_64_ARCHIVE" -C "$RUNNER_TEMP"
-          lipo -create "$(command -v uv)" \
+          for ARCHITECTURE in aarch64 x86_64; do
+            UV_ARCHIVE="uv-${ARCHITECTURE}-apple-darwin.tar.gz"
+            curl --fail --location --silent --show-error \
+              "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/${UV_ARCHIVE}" \
+              --output "$UV_ARCHIVE"
+            curl --fail --location --silent --show-error \
+              "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/${UV_ARCHIVE}.sha256" \
+              --output "${UV_ARCHIVE}.sha256"
+          done
+          shasum --algorithm 256 --check uv-*-apple-darwin.tar.gz.sha256
+          tar -xzf uv-aarch64-apple-darwin.tar.gz
+          tar -xzf uv-x86_64-apple-darwin.tar.gz
+          lipo -create \
+            "$RUNNER_TEMP/uv-aarch64-apple-darwin/uv" \
             "$RUNNER_TEMP/uv-x86_64-apple-darwin/uv" \
             -output "$RUNNER_TEMP/uv-universal"
           chmod 755 "$RUNNER_TEMP/uv-universal"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,19 @@ jobs:
         run: git lfs pull
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+      - name: Build universal uv binary
+        run: |
+          UV_VERSION=$(uv --version | awk '{ print $2 }')
+          UV_X86_64_ARCHIVE="$RUNNER_TEMP/uv-x86_64-apple-darwin.tar.gz"
+          curl --fail --location --silent --show-error \
+            "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-apple-darwin.tar.gz" \
+            --output "$UV_X86_64_ARCHIVE"
+          tar -xzf "$UV_X86_64_ARCHIVE" -C "$RUNNER_TEMP"
+          lipo -create "$(command -v uv)" \
+            "$RUNNER_TEMP/uv-x86_64-apple-darwin/uv" \
+            -output "$RUNNER_TEMP/uv-universal"
+          chmod 755 "$RUNNER_TEMP/uv-universal"
+          lipo "$RUNNER_TEMP/uv-universal" -verify_arch arm64 x86_64
       - name: Import Developer ID certificate
         uses: apple-actions/import-codesign-certs@v7
         with:
@@ -87,12 +100,13 @@ jobs:
           APP_VERSION: ${{ inputs.release_ref }}
           BUILD_VERSION: ${{ github.run_number }}
           SPARKLE_PUBLIC_ED_KEY: ${{ vars.SPARKLE_PUBLIC_ED_KEY }}
+          UV_BINARY: ${{ runner.temp }}/uv-universal
         run: |
           if [[ -z "$SPARKLE_PUBLIC_ED_KEY" ]]; then
             echo "SPARKLE_PUBLIC_ED_KEY repository variable is required to enable Sparkle updates." >&2
             exit 1
           fi
-          NOTARIZE=1 macos/build-macos-app.sh --dmg
+          NOTARIZE=1 macos/build-macos-app.sh --universal --dmg
           ditto -c -k --keepParent dist/macos/MindRoom.app dist/macos/MindRoom.zip
       - name: Upload macOS app to GitHub Release
         env:

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Matrix E2EE support is installed by default.
 
 The menu bar app runs the local MindRoom service without keeping a terminal open.
 It bundles `uv`, uses `~/.mindroom` for config and state, and manages the `mindroom service` launchd service.
+The signed universal app supports both Apple silicon and Intel Macs.
 
 ```bash
 brew install --cask mindroom-ai/tap/mindroom

--- a/docs/installation/macos-app.md
+++ b/docs/installation/macos-app.md
@@ -7,6 +7,7 @@ MindRoom config, secrets, and runtime state stay in `~/.mindroom`, so the app an
 ## Requirements
 
 - macOS 13 Ventura or later.
+- An Apple silicon or 64-bit Intel Mac.
 - Network access for installing the `mindroom` package and pairing with hosted MindRoom.
 - A model provider credential in `~/.mindroom/.env`, unless you configure a local or subscription-backed provider.
 

--- a/macos/build-macos-app.sh
+++ b/macos/build-macos-app.sh
@@ -163,7 +163,11 @@ require_architectures() {
         exit 1
     fi
     local architectures
-    architectures=" $(lipo -archs "$binary") "
+    if ! architectures=$(lipo -archs "$binary"); then
+        echo "Could not inspect architectures for required universal binary: $binary" >&2
+        exit 1
+    fi
+    architectures=" $architectures "
     for architecture in "$@"; do
         if [[ "$architectures" != *" $architecture "* ]]; then
             echo "$binary is missing the required $architecture architecture." >&2

--- a/macos/build-macos-app.sh
+++ b/macos/build-macos-app.sh
@@ -6,16 +6,18 @@ APP_NAME="MindRoom"
 DISPLAY_NAME="MindRoom"
 INSTALL=false
 CREATE_DMG=false
+UNIVERSAL=false
 
 usage() {
     cat <<'EOF'
-Usage: macos/build-macos-app.sh [--install] [--dmg]
+Usage: macos/build-macos-app.sh [--install] [--dmg] [--universal]
 
 Build the native macOS menu bar app for MindRoom.
 
 Options:
   --install   Copy the built app to /Applications and open it.
   --dmg       Create dist/macos/MindRoom.dmg.
+  --universal Build and verify an app for Apple silicon and Intel Macs.
   -h, --help  Show this help text.
 
 Environment:
@@ -46,6 +48,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --dmg)
             CREATE_DMG=true
+            shift
+            ;;
+        --universal)
+            UNIVERSAL=true
             shift
             ;;
         -h|--help)
@@ -84,7 +90,11 @@ if [[ "$(uname -s)" != "Darwin" ]]; then
     exit 1
 fi
 
-for required_tool in swift sips iconutil; do
+REQUIRED_TOOLS=(swift sips iconutil)
+if [[ "$UNIVERSAL" == true ]]; then
+    REQUIRED_TOOLS+=(lipo)
+fi
+for required_tool in "${REQUIRED_TOOLS[@]}"; do
     if ! command -v "$required_tool" >/dev/null 2>&1; then
         echo "$required_tool is required to build the MindRoom app." >&2
         exit 1
@@ -143,6 +153,19 @@ sign_app() {
 
 first_find_match() {
     find "$@" -print | sed -n '1p'
+}
+
+require_architectures() {
+    local binary="$1"
+    shift
+    local architectures
+    architectures=" $(lipo -archs "$binary") "
+    for architecture in "$@"; do
+        if [[ "$architectures" != *" $architecture "* ]]; then
+            echo "$binary is missing the required $architecture architecture." >&2
+            exit 1
+        fi
+    done
 }
 
 resolve_app_version() {
@@ -284,9 +307,14 @@ quit_running_app() {
     pkill -x "$APP_NAME" >/dev/null 2>&1 || true
 }
 
+SWIFT_BUILD_ARGS=(-c release --package-path "$PACKAGE_DIR" --product "$APP_NAME")
+if [[ "$UNIVERSAL" == true ]]; then
+    SWIFT_BUILD_ARGS+=(--arch arm64 --arch x86_64)
+fi
+
 echo "Building $DISPLAY_NAME..."
-swift build -c release --package-path "$PACKAGE_DIR" --product "$APP_NAME"
-BIN_DIR=$(swift build -c release --package-path "$PACKAGE_DIR" --product "$APP_NAME" --show-bin-path)
+swift build "${SWIFT_BUILD_ARGS[@]}"
+BIN_DIR=$(swift build "${SWIFT_BUILD_ARGS[@]}" --show-bin-path)
 EXPECTED_BINARY="$BIN_DIR/$APP_NAME"
 BINARY="$EXPECTED_BINARY"
 
@@ -328,6 +356,22 @@ ditto "$SPARKLE_FRAMEWORK" "$APP_DIR/Contents/Frameworks/Sparkle.framework"
 cp "$UV_BINARY" "$APP_DIR/Contents/Resources/bin/uv"
 cp "$APP_ICON_ICNS" "$APP_DIR/Contents/Resources/MindRoom.icns"
 chmod 755 "$APP_DIR/Contents/MacOS/$APP_NAME" "$APP_DIR/Contents/Resources/bin/uv"
+
+if [[ "$UNIVERSAL" == true ]]; then
+    UNIVERSAL_BINARIES=(
+        "$APP_DIR/Contents/MacOS/$APP_NAME"
+        "$APP_DIR/Contents/Resources/bin/uv"
+        "$APP_DIR/Contents/Frameworks/Sparkle.framework/Sparkle"
+        "$APP_DIR/Contents/Frameworks/Sparkle.framework/Versions/Current/Autoupdate"
+        "$APP_DIR/Contents/Frameworks/Sparkle.framework/Versions/Current/Updater.app/Contents/MacOS/Updater"
+        "$APP_DIR/Contents/Frameworks/Sparkle.framework/Versions/Current/XPCServices/Downloader.xpc/Contents/MacOS/Downloader"
+        "$APP_DIR/Contents/Frameworks/Sparkle.framework/Versions/Current/XPCServices/Installer.xpc/Contents/MacOS/Installer"
+    )
+    for binary in "${UNIVERSAL_BINARIES[@]}"; do
+        require_architectures "$binary" arm64 x86_64
+    done
+    echo "Verified Apple silicon and Intel support."
+fi
 
 if ! otool -l "$APP_DIR/Contents/MacOS/$APP_NAME" | grep -q '@executable_path/../Frameworks'; then
     install_name_tool -add_rpath "@executable_path/../Frameworks" "$APP_DIR/Contents/MacOS/$APP_NAME"

--- a/macos/build-macos-app.sh
+++ b/macos/build-macos-app.sh
@@ -158,6 +158,10 @@ first_find_match() {
 require_architectures() {
     local binary="$1"
     shift
+    if [[ ! -f "$binary" ]]; then
+        echo "Required universal binary not found: $binary" >&2
+        exit 1
+    fi
     local architectures
     architectures=" $(lipo -archs "$binary") "
     for architecture in "$@"; do

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -35,6 +35,7 @@ def test_release_builds_universal_macos_app(release_workflow: str, macos_build_s
     assert "UV_BINARY: ${{ runner.temp }}/uv-universal" in release_workflow
     assert "macos/build-macos-app.sh --universal --dmg" in release_workflow
     assert "--arch arm64 --arch x86_64" in macos_build_script
+    assert "Required universal binary not found: $binary" in macos_build_script
     assert 'require_architectures "$binary" arm64 x86_64' in macos_build_script
 
 

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -27,8 +27,11 @@ def macos_build_script() -> str:
 
 def test_release_builds_universal_macos_app(release_workflow: str, macos_build_script: str) -> None:
     """Published app binaries must support both Apple silicon and Intel Macs."""
+    assert "uv-aarch64-apple-darwin.tar.gz" in release_workflow
     assert "uv-x86_64-apple-darwin.tar.gz" in release_workflow
-    assert 'lipo -create "$(command -v uv)"' in release_workflow
+    assert "shasum --algorithm 256 --check" in release_workflow
+    assert '"$RUNNER_TEMP/uv-aarch64-apple-darwin/uv"' in release_workflow
+    assert '"$RUNNER_TEMP/uv-x86_64-apple-darwin/uv"' in release_workflow
     assert "UV_BINARY: ${{ runner.temp }}/uv-universal" in release_workflow
     assert "macos/build-macos-app.sh --universal --dmg" in release_workflow
     assert "--arch arm64 --arch x86_64" in macos_build_script

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -10,12 +10,29 @@ ROOT = Path(__file__).resolve().parents[1]
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
 README = ROOT / "README.md"
 MACOS_APP_DOC = ROOT / "docs" / "installation" / "macos-app.md"
+MACOS_BUILD_SCRIPT = ROOT / "macos" / "build-macos-app.sh"
 
 
 @pytest.fixture(scope="module")
 def release_workflow() -> str:
     """Return the release workflow text."""
     return RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def macos_build_script() -> str:
+    """Return the macOS app build script text."""
+    return MACOS_BUILD_SCRIPT.read_text(encoding="utf-8")
+
+
+def test_release_builds_universal_macos_app(release_workflow: str, macos_build_script: str) -> None:
+    """Published app binaries must support both Apple silicon and Intel Macs."""
+    assert "uv-x86_64-apple-darwin.tar.gz" in release_workflow
+    assert 'lipo -create "$(command -v uv)"' in release_workflow
+    assert "UV_BINARY: ${{ runner.temp }}/uv-universal" in release_workflow
+    assert "macos/build-macos-app.sh --universal --dmg" in release_workflow
+    assert "--arch arm64 --arch x86_64" in macos_build_script
+    assert 'require_architectures "$binary" arm64 x86_64' in macos_build_script
 
 
 def test_release_metadata_pr_reuses_open_metadata_pr(release_workflow: str) -> None:

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -36,6 +36,7 @@ def test_release_builds_universal_macos_app(release_workflow: str, macos_build_s
     assert "macos/build-macos-app.sh --universal --dmg" in release_workflow
     assert "--arch arm64 --arch x86_64" in macos_build_script
     assert "Required universal binary not found: $binary" in macos_build_script
+    assert "Could not inspect architectures for required universal binary: $binary" in macos_build_script
     assert 'require_architectures "$binary" arm64 x86_64' in macos_build_script
 
 


### PR DESCRIPTION
## Summary

- build the Swift app and Sparkle helpers as universal arm64/x86_64 binaries
- combine the official Apple silicon and Intel uv release binaries before packaging
- fail the release build when any bundled executable is missing either architecture
- document Apple silicon and Intel support

## Why

The macOS release workflow currently runs on an Apple silicon runner and publishes architecture-specific MindRoom assets under generic filenames. Intel MacBooks therefore receive an incompatible app. A single universal release preserves the existing Homebrew and Sparkle URLs while supporting both Mac architectures.

## Validation

- built an ad-hoc signed universal app and verified all bundled executable architectures
- codesign --verify --deep --strict dist/macos/MindRoom.app
- swift test --package-path macos/MindRoom (17 passed)
- uv run pytest (9,797 passed, 148 skipped)
- uv run pre-commit run --all-files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * macOS releases now provide a signed universal app compatible with both Apple silicon and Intel Macs.
  * The build process validates that required application components support both architectures.

* **Documentation**
  * Updated macOS requirements and app documentation to describe support for Apple silicon and 64-bit Intel Macs.

* **Tests**
  * Added coverage to verify universal macOS release builds and architecture validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->