### PR TITLE
feat(helm): support MatrixRTC in client chart

### DIFF
--- a/.github/workflows/publish-helm-charts.yml
+++ b/.github/workflows/publish-helm-charts.yml
@@ -284,6 +284,26 @@ jobs:
             --set config.existingConfigMap=existing-client-config \
             --set nginx.existingConfigMap=existing-client-nginx \
             > "$render_dir/existing-configmaps.yaml"
+          cat > "$render_dir/server-snippet-values.yaml" <<'EOF'
+          nginx:
+            serverSnippet: |
+              location = /chart-name {
+                return 200 "{{ .Chart.Name }}";
+              }
+          EOF
+          helm template mindroom-client "$CLIENT_CHART_DIR" \
+            --namespace mindroom \
+            --values "$render_dir/server-snippet-values.yaml" \
+            > "$render_dir/server-snippet.yaml"
+          grep -F 'return 200 "mindroom-client";' "$render_dir/server-snippet.yaml"
+          if helm template mindroom-client "$CLIENT_CHART_DIR" \
+            --namespace mindroom \
+            --values "$render_dir/server-snippet-values.yaml" \
+            --set nginx.existingConfigMap=existing-client-nginx \
+            > /dev/null 2>&1; then
+            echo "nginx.serverSnippet unexpectedly accepted an external nginx ConfigMap" >&2
+            exit 1
+          fi
 
       - name: Package client chart
         run: |

--- a/.github/workflows/publish-helm-charts.yml
+++ b/.github/workflows/publish-helm-charts.yml
@@ -279,6 +279,7 @@ jobs:
             --set matrix.defaultServerName=matrix.example.com \
             --set serviceWorker.enabled=false \
             > "$render_dir/base-path.yaml"
+          grep -F 'location = /mindroom/version.json' "$render_dir/base-path.yaml"
           helm template mindroom-client "$CLIENT_CHART_DIR" \
             --namespace mindroom \
             --set config.existingConfigMap=existing-client-config \
@@ -302,6 +303,30 @@ jobs:
             --set nginx.existingConfigMap=existing-client-nginx \
             > /dev/null 2>&1; then
             echo "nginx.serverSnippet unexpectedly accepted an external nginx ConfigMap" >&2
+            exit 1
+          fi
+          cat > "$render_dir/matrixrtc-values.yaml" <<'EOF'
+          matrixRTC:
+            enabled: true
+            livekitServiceUrl: https://matrix.example.com/livekit/jwt
+            proxy:
+              enabled: true
+              jwtServiceUpstream: http://matrixrtc-auth:8080
+              sfuUpstream: http://livekit:7880
+          EOF
+          helm template mindroom-client "$CLIENT_CHART_DIR" \
+            --namespace mindroom \
+            --values "$render_dir/matrixrtc-values.yaml" \
+            > "$render_dir/matrixrtc.yaml"
+          grep -F '"org.matrix.msc4143.rtc_foci"' "$render_dir/matrixrtc.yaml"
+          grep -F '"livekit_service_url":"https://matrix.example.com/livekit/jwt"' "$render_dir/matrixrtc.yaml"
+          grep -F 'proxy_pass http://matrixrtc-auth:8080/;' "$render_dir/matrixrtc.yaml"
+          grep -F 'proxy_pass http://livekit:7880/;' "$render_dir/matrixrtc.yaml"
+          if helm template mindroom-client "$CLIENT_CHART_DIR" \
+            --namespace mindroom \
+            --set matrixRTC.enabled=true \
+            > /dev/null 2>&1; then
+            echo "matrixRTC.enabled unexpectedly accepted a missing livekitServiceUrl" >&2
             exit 1
           fi
 

--- a/.github/workflows/publish-helm-charts.yml
+++ b/.github/workflows/publish-helm-charts.yml
@@ -306,6 +306,8 @@ jobs:
             exit 1
           fi
           cat > "$render_dir/matrixrtc-values.yaml" <<'EOF'
+          matrix:
+            homeserverUrl: https://matrix.example.com
           matrixRTC:
             enabled: true
             livekitServiceUrl: https://matrix.example.com/livekit/jwt
@@ -324,11 +326,14 @@ jobs:
           grep -F 'proxy_pass http://livekit:7880/;' "$render_dir/matrixrtc.yaml"
           if helm template mindroom-client "$CLIENT_CHART_DIR" \
             --namespace mindroom \
+            --set matrix.homeserverUrl=https://matrix.example.com \
             --set matrixRTC.enabled=true \
-            > /dev/null 2>&1; then
+            > /dev/null 2> "$render_dir/matrixrtc-missing-livekit.err"; then
             echo "matrixRTC.enabled unexpectedly accepted a missing livekitServiceUrl" >&2
             exit 1
           fi
+          grep -F 'matrixRTC.livekitServiceUrl is required when matrixRTC.enabled=true' \
+            "$render_dir/matrixrtc-missing-livekit.err"
 
       - name: Package client chart
         run: |

--- a/.github/workflows/publish-helm-charts.yml
+++ b/.github/workflows/publish-helm-charts.yml
@@ -324,6 +324,11 @@ jobs:
           grep -F '"livekit_service_url":"https://matrix.example.com/livekit/jwt"' "$render_dir/matrixrtc.yaml"
           grep -F 'proxy_pass http://matrixrtc-auth:8080/;' "$render_dir/matrixrtc.yaml"
           grep -F 'proxy_pass http://livekit:7880/;' "$render_dir/matrixrtc.yaml"
+          grep -F 'add_header Access-Control-Allow-Methods "GET, OPTIONS" always;' "$render_dir/matrixrtc.yaml"
+          if grep -F 'proxy_set_header Accept-Encoding' "$render_dir/matrixrtc.yaml"; then
+            echo "MatrixRTC WebSocket proxy unexpectedly forces Accept-Encoding" >&2
+            exit 1
+          fi
           if helm template mindroom-client "$CLIENT_CHART_DIR" \
             --namespace mindroom \
             --set matrix.homeserverUrl=https://matrix.example.com \

--- a/cluster/k8s/client/README.md
+++ b/cluster/k8s/client/README.md
@@ -34,6 +34,30 @@ matrix:
 When `defaultServerName` is set, the login form shows that server name instead of the URL, and the name must publish `/.well-known/matrix/client` pointing at `homeserverUrl`.
 Set `config.data` to a full JSON document when you need client options beyond the homeserver entry, or point `config.existingConfigMap` at a ConfigMap you manage yourself.
 
+## MatrixRTC Calls
+
+The chart can publish MatrixRTC discovery and optionally proxy the standard authorization and LiveKit signaling paths through its chart-managed nginx server.
+LiveKit and the MatrixRTC authorization service remain separately managed services.
+
+```yaml
+matrix:
+  homeserverUrl: https://matrix.example.com
+
+matrixRTC:
+  enabled: true
+  livekitServiceUrl: https://matrix.example.com/livekit/jwt
+  proxy:
+    enabled: true
+    jwtServiceUpstream: http://matrixrtc-auth:8080
+    sfuUpstream: http://livekit:7880
+```
+
+When enabled, nginx serves `/.well-known/matrix/client` with the configured homeserver and `org.matrix.msc4143.rtc_foci` announcement.
+Route that well-known path from the Matrix server-name origin to this Service when the client uses a different hostname.
+The optional proxy strips `/livekit/jwt/` and `/livekit/sfu/` before forwarding to the configured internal services, and the SFU route supports WebSocket signaling.
+The chart does not deploy either backend, expose LiveKit media ports, configure TURN, issue TLS certificates, or manage backend credentials.
+See [Voice Calls](../../../docs/voice-calls.md) for the MindRoom agent configuration and complete backend requirements.
+
 ## Base Path
 
 Set `basePath` to serve the client under a URL prefix instead of the origin root:
@@ -43,6 +67,7 @@ basePath: /mindroom
 ```
 
 The chart-managed nginx config serves the app shell, `config.json`, and the service worker under the base path, redirects `/` and the bare base path to `basePath/`, and resolves hashed build assets referenced from any route depth.
+It also serves `version.json` under the base path without caching so the client can detect and load a newly published build.
 The client always loads `/runtime-config.js` from the origin root, so route the full origin host to this Service even when `basePath` is not `/`.
 The chart serves `/runtime-config.js` directly from nginx because the image entrypoint would otherwise write it into the app directory, which the unprivileged read-only container forbids.
 

--- a/cluster/k8s/client/README.md
+++ b/cluster/k8s/client/README.md
@@ -65,6 +65,23 @@ rootServiceWorkerCleanup:
 The cleanup worker requires a `basePath` other than `/`, because at the origin root `/sw.js` is the client's own service worker.
 Once stale clients have cycled through the cleanup worker, the flag can be disabled again.
 
+## Extending nginx
+
+Set `nginx.serverSnippet` to add directives to the chart-managed nginx server block without replacing the complete config.
+This is useful for extra same-origin discovery responses, health endpoints, or reverse-proxy locations.
+The snippet is evaluated as a Helm template before it is indented into the server block.
+
+```yaml
+nginx:
+  serverSnippet: |
+    location = /healthz {
+      default_type text/plain;
+      return 200 "{{ .Chart.Name }}";
+    }
+```
+
+The chart rejects `nginx.serverSnippet` when the nginx config is not chart-managed, because an external ConfigMap cannot receive the snippet.
+
 ## Custom nginx Config
 
 Point `nginx.existingConfigMap` at your own ConfigMap to take full control of the server config:

--- a/cluster/k8s/client/templates/_helpers.tpl
+++ b/cluster/k8s/client/templates/_helpers.tpl
@@ -130,6 +130,11 @@ server {
     add_header Cache-Control "no-store, max-age=0" always;
     return 200 '{{ $runtimeConfig }}';
   }
+{{- with .Values.nginx.serverSnippet }}
+
+  # Additional server directives supplied through nginx.serverSnippet.
+{{ tpl . $ | nindent 2 }}
+{{- end }}
 
   location = {{ $prefix }}/config.json {
     alias /usr/share/nginx/html/config.json;

--- a/cluster/k8s/client/templates/_helpers.tpl
+++ b/cluster/k8s/client/templates/_helpers.tpl
@@ -181,7 +181,7 @@ server {
 {{- with .Values.nginx.serverSnippet }}
 
   # Additional server directives supplied through nginx.serverSnippet.
-{{ tpl . $ | nindent 2 }}
+{{ tpl . $ | indent 2 }}
 {{- end }}
 
   location = {{ $prefix }}/config.json {

--- a/cluster/k8s/client/templates/_helpers.tpl
+++ b/cluster/k8s/client/templates/_helpers.tpl
@@ -97,6 +97,13 @@ Path prefix prepended to client file locations; empty at the origin root.
 }
 {{- end -}}
 
+{{- define "mindroom-client.matrixClientWellKnown" -}}
+{{- $wellKnown := dict "m.homeserver" (dict "base_url" .Values.matrix.homeserverUrl) -}}
+{{- $focus := dict "type" "livekit" "livekit_service_url" .Values.matrixRTC.livekitServiceUrl -}}
+{{- $_ := set $wellKnown "org.matrix.msc4143.rtc_foci" (list $focus) -}}
+{{- $wellKnown | toJson -}}
+{{- end -}}
+
 {{/*
 The nginx server config serving the client under basePath.
 The image entrypoint normally writes runtime-config.js into the app directory,
@@ -130,6 +137,47 @@ server {
     add_header Cache-Control "no-store, max-age=0" always;
     return 200 '{{ $runtimeConfig }}';
   }
+{{- if .Values.matrixRTC.enabled }}
+
+  # MatrixRTC backend discovery for Matrix voice and video calls.
+  location = /.well-known/matrix/client {
+    default_type application/json;
+    add_header Cache-Control "no-store, max-age=0" always;
+    add_header Access-Control-Allow-Origin "*" always;
+    add_header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS" always;
+    add_header Access-Control-Allow-Headers "X-Requested-With, Content-Type, Authorization" always;
+    return 200 '{{ include "mindroom-client.matrixClientWellKnown" . }}';
+  }
+{{- end }}
+{{- if .Values.matrixRTC.proxy.enabled }}
+
+  # MatrixRTC authorization service. The trailing proxy_pass slash strips the
+  # public /livekit/jwt/ prefix before forwarding the request.
+  location ^~ /livekit/jwt/ {
+    proxy_pass {{ .Values.matrixRTC.proxy.jwtServiceUpstream | trimSuffix "/" }}/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  # LiveKit WebSocket signaling. WebRTC media uses the networking configured
+  # for the separately managed LiveKit service.
+  location ^~ /livekit/sfu/ {
+    proxy_pass {{ .Values.matrixRTC.proxy.sfuUpstream | trimSuffix "/" }}/;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Accept-Encoding gzip;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_send_timeout 120s;
+    proxy_read_timeout 120s;
+    proxy_buffering off;
+  }
+{{- end }}
 {{- with .Values.nginx.serverSnippet }}
 
   # Additional server directives supplied through nginx.serverSnippet.
@@ -138,6 +186,13 @@ server {
 
   location = {{ $prefix }}/config.json {
     alias /usr/share/nginx/html/config.json;
+    default_type application/json;
+    add_header Cache-Control "no-store, no-cache, must-revalidate, max-age=0" always;
+  }
+
+  # The client polls this manifest and reloads after a new build is published.
+  location = {{ $prefix }}/version.json {
+    alias /usr/share/nginx/html/version.json;
     default_type application/json;
     add_header Cache-Control "no-store, no-cache, must-revalidate, max-age=0" always;
   }

--- a/cluster/k8s/client/templates/_helpers.tpl
+++ b/cluster/k8s/client/templates/_helpers.tpl
@@ -144,7 +144,7 @@ server {
     default_type application/json;
     add_header Cache-Control "no-store, max-age=0" always;
     add_header Access-Control-Allow-Origin "*" always;
-    add_header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS" always;
+    add_header Access-Control-Allow-Methods "GET, OPTIONS" always;
     add_header Access-Control-Allow-Headers "X-Requested-With, Content-Type, Authorization" always;
     return 200 '{{ include "mindroom-client.matrixClientWellKnown" . }}';
   }
@@ -170,7 +170,6 @@ server {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_set_header Accept-Encoding gzip;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
     proxy_send_timeout 120s;

--- a/cluster/k8s/client/templates/validate.yaml
+++ b/cluster/k8s/client/templates/validate.yaml
@@ -16,3 +16,21 @@
 {{- if and .Values.nginx.serverSnippet (or (not .Values.nginx.create) .Values.nginx.existingConfigMap) -}}
 {{- fail "nginx.serverSnippet requires the chart-managed nginx config" -}}
 {{- end -}}
+{{- if and .Values.matrixRTC.enabled (not .Values.matrix.homeserverUrl) -}}
+{{- fail "matrix.homeserverUrl is required when matrixRTC.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.matrixRTC.enabled (not .Values.matrixRTC.livekitServiceUrl) -}}
+{{- fail "matrixRTC.livekitServiceUrl is required when matrixRTC.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.matrixRTC.enabled (or (not .Values.nginx.create) .Values.nginx.existingConfigMap) -}}
+{{- fail "matrixRTC.enabled requires the chart-managed nginx config" -}}
+{{- end -}}
+{{- if and .Values.matrixRTC.proxy.enabled (not .Values.matrixRTC.enabled) -}}
+{{- fail "matrixRTC.proxy.enabled requires matrixRTC.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.matrixRTC.proxy.enabled (not .Values.matrixRTC.proxy.jwtServiceUpstream) -}}
+{{- fail "matrixRTC.proxy.jwtServiceUpstream is required when matrixRTC.proxy.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.matrixRTC.proxy.enabled (not .Values.matrixRTC.proxy.sfuUpstream) -}}
+{{- fail "matrixRTC.proxy.sfuUpstream is required when matrixRTC.proxy.enabled=true" -}}
+{{- end -}}

--- a/cluster/k8s/client/templates/validate.yaml
+++ b/cluster/k8s/client/templates/validate.yaml
@@ -13,3 +13,6 @@
 {{- if and (not .Values.nginx.create) (not .Values.nginx.existingConfigMap) -}}
 {{- fail "nginx.existingConfigMap is required when nginx.create=false" -}}
 {{- end -}}
+{{- if and .Values.nginx.serverSnippet (or (not .Values.nginx.create) .Values.nginx.existingConfigMap) -}}
+{{- fail "nginx.serverSnippet requires the chart-managed nginx config" -}}
+{{- end -}}

--- a/cluster/k8s/client/values.yaml
+++ b/cluster/k8s/client/values.yaml
@@ -64,6 +64,21 @@ matrix:
   # Allow logging in to homeservers outside the configured entry.
   allowCustomHomeservers: false
 
+# Optional MatrixRTC discovery and same-origin proxy routes for voice and video calls.
+# LiveKit and the MatrixRTC authorization service must already exist.
+matrixRTC:
+  enabled: false
+  # Public MatrixRTC authorization service URL advertised through
+  # /.well-known/matrix/client, for example https://matrix.example.com/livekit/jwt.
+  livekitServiceUrl: ""
+  proxy:
+    # Proxy the conventional /livekit/jwt and /livekit/sfu paths through nginx.
+    enabled: false
+    # Internal MatrixRTC authorization service URL, for example http://matrixrtc-auth:8080.
+    jwtServiceUpstream: ""
+    # Internal LiveKit SFU URL, for example http://livekit:7880.
+    sfuUpstream: ""
+
 serviceWorker:
   # Register the client service worker, scoped to basePath.
   enabled: true

--- a/cluster/k8s/client/values.yaml
+++ b/cluster/k8s/client/values.yaml
@@ -98,6 +98,9 @@ nginx:
   create: true
   existingConfigMap: ""
   key: default.conf
+  # Additional directives inserted into the chart-managed nginx server block.
+  # The snippet is evaluated as a Helm template before it is rendered.
+  serverSnippet: ""
   # Key in the nginx ConfigMap holding the root cleanup service worker script.
   # An existing ConfigMap must provide this key when rootServiceWorkerCleanup is enabled.
   cleanupWorkerKey: root-cleanup-sw.js


### PR DESCRIPTION
## Summary

- Add first-class MatrixRTC discovery through the client well-known response.
- Add optional same-origin proxy routes for the MatrixRTC authorization service and LiveKit WebSocket signaling.
- Add a generic nginx.serverSnippet extension point for other server directives.
- Serve version.json correctly under a non-root base path so published-version reloads keep working.
- Validate incompatible values and exercise all new render paths in the chart workflow.

The chart keeps backend workloads, media networking, TLS, and credentials outside its scope.

## Testing

- helm lint cluster/k8s/client
- Exact client-chart workflow render step
- Generated nginx configuration syntax check
- uv run pytest (10026 passed, 54 skipped)
- uv run pre-commit run --all-files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added MatrixRTC support, including optional `/.well-known/matrix/client` discovery and chart-managed proxying for `/livekit/jwt/` and `/livekit/sfu/`.
  - Added `nginx.serverSnippet` to extend the chart-managed nginx server block (Helm-templated).
- **Bug Fixes**
  - Enhanced Helm validations to reject incompatible snippet usage when nginx isn’t chart-managed, and to enforce required MatrixRTC configuration.
- **Documentation**
  - Updated base-path behavior: `version.json` is served under the base path without caching.
  - Added configuration examples for MatrixRTC calls and extending nginx.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->