### PR TITLE
Add provider-neutral model cache usage telemetry

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -638,7 +638,10 @@ No plaintext-to-encrypted migration is performed automatically, so configure the
 
 ## Debug Logging
 
-`debug.log_llm_requests` enables pre-provider request assembly logging for troubleshooting.
+Every completed model request emits a privacy-safe structured `LLM usage` log event with provider, model, token, and prompt-cache counters.
+The event includes provider-normalized context input tokens, uncached input tokens, and a cache-read ratio without prompt content.
+The `usage_available` field is false when a provider returns no usage counters.
+`debug.log_llm_requests` additionally enables pre-provider request assembly logging for troubleshooting.
 When enabled, MindRoom writes JSONL request records under `debug.llm_request_log_dir` or `mindroom_data/logs/llm_requests` by default.
 Those records include prompts, messages, tool schemas, model parameters, correlation IDs, requester metadata, and source Matrix event metadata.
 The same flag also records successful tool-call rows in `mindroom_data/tracking/tool_calls.jsonl` so tool activity can be correlated with LLM request logs.

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -638,9 +638,9 @@ No plaintext-to-encrypted migration is performed automatically, so configure the
 
 ## Debug Logging
 
-Every completed model request emits a privacy-safe structured `LLM usage` log event with provider, model, token, and prompt-cache counters.
-The event includes provider-normalized context input tokens, uncached input tokens, and a cache-read ratio without prompt content.
-The `usage_available` field is false when a provider returns no usage counters.
+Every completed model request emits a privacy-safe structured `LLM usage` log event with provider and model identifiers.
+When provider usage data is available, the event also includes provider-normalized context input tokens, uncached input tokens, and a cache-read ratio without prompt content.
+When provider usage data is unavailable, the event sets `usage_available` to false and omits token and prompt-cache counters.
 `debug.log_llm_requests` additionally enables pre-provider request assembly logging for troubleshooting.
 When enabled, MindRoom writes JSONL request records under `debug.llm_request_log_dir` or `mindroom_data/logs/llm_requests` by default.
 Those records include prompts, messages, tool schemas, model parameters, correlation IDs, requester metadata, and source Matrix event metadata.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -1491,9 +1491,9 @@ No plaintext-to-encrypted migration is performed automatically, so configure the
 
 ## Debug Logging
 
-Every completed model request emits a privacy-safe structured `LLM usage` log event with provider, model, token, and prompt-cache counters.
-The event includes provider-normalized context input tokens, uncached input tokens, and a cache-read ratio without prompt content.
-The `usage_available` field is false when a provider returns no usage counters.
+Every completed model request emits a privacy-safe structured `LLM usage` log event with provider and model identifiers.
+When provider usage data is available, the event also includes provider-normalized context input tokens, uncached input tokens, and a cache-read ratio without prompt content.
+When provider usage data is unavailable, the event sets `usage_available` to false and omits token and prompt-cache counters.
 `debug.log_llm_requests` additionally enables pre-provider request assembly logging for troubleshooting.
 When enabled, MindRoom writes JSONL request records under `debug.llm_request_log_dir` or `mindroom_data/logs/llm_requests` by default.
 Those records include prompts, messages, tool schemas, model parameters, correlation IDs, requester metadata, and source Matrix event metadata.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -1491,7 +1491,10 @@ No plaintext-to-encrypted migration is performed automatically, so configure the
 
 ## Debug Logging
 
-`debug.log_llm_requests` enables pre-provider request assembly logging for troubleshooting.
+Every completed model request emits a privacy-safe structured `LLM usage` log event with provider, model, token, and prompt-cache counters.
+The event includes provider-normalized context input tokens, uncached input tokens, and a cache-read ratio without prompt content.
+The `usage_available` field is false when a provider returns no usage counters.
+`debug.log_llm_requests` additionally enables pre-provider request assembly logging for troubleshooting.
 When enabled, MindRoom writes JSONL request records under `debug.llm_request_log_dir` or `mindroom_data/logs/llm_requests` by default.
 Those records include prompts, messages, tool schemas, model parameters, correlation IDs, requester metadata, and source Matrix event metadata.
 The same flag also records successful tool-call rows in `mindroom_data/tracking/tool_calls.jsonl` so tool activity can be correlated with LLM request logs.

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -634,9 +634,9 @@ No plaintext-to-encrypted migration is performed automatically, so configure the
 
 ## Debug Logging
 
-Every completed model request emits a privacy-safe structured `LLM usage` log event with provider, model, token, and prompt-cache counters.
-The event includes provider-normalized context input tokens, uncached input tokens, and a cache-read ratio without prompt content.
-The `usage_available` field is false when a provider returns no usage counters.
+Every completed model request emits a privacy-safe structured `LLM usage` log event with provider and model identifiers.
+When provider usage data is available, the event also includes provider-normalized context input tokens, uncached input tokens, and a cache-read ratio without prompt content.
+When provider usage data is unavailable, the event sets `usage_available` to false and omits token and prompt-cache counters.
 `debug.log_llm_requests` additionally enables pre-provider request assembly logging for troubleshooting.
 When enabled, MindRoom writes JSONL request records under `debug.llm_request_log_dir` or `mindroom_data/logs/llm_requests` by default.
 Those records include prompts, messages, tool schemas, model parameters, correlation IDs, requester metadata, and source Matrix event metadata.

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -634,7 +634,10 @@ No plaintext-to-encrypted migration is performed automatically, so configure the
 
 ## Debug Logging
 
-`debug.log_llm_requests` enables pre-provider request assembly logging for troubleshooting.
+Every completed model request emits a privacy-safe structured `LLM usage` log event with provider, model, token, and prompt-cache counters.
+The event includes provider-normalized context input tokens, uncached input tokens, and a cache-read ratio without prompt content.
+The `usage_available` field is false when a provider returns no usage counters.
+`debug.log_llm_requests` additionally enables pre-provider request assembly logging for troubleshooting.
 When enabled, MindRoom writes JSONL request records under `debug.llm_request_log_dir` or `mindroom_data/logs/llm_requests` by default.
 Those records include prompts, messages, tool schemas, model parameters, correlation IDs, requester metadata, and source Matrix event metadata.
 The same flag also records successful tool-call rows in `mindroom_data/tracking/tool_calls.jsonl` so tool activity can be correlated with LLM request logs.

--- a/src/mindroom/ai_run_metadata.py
+++ b/src/mindroom/ai_run_metadata.py
@@ -8,6 +8,7 @@ from agno.models.metrics import Metrics
 from agno.run.base import RunStatus
 
 from mindroom.constants import AI_RUN_METADATA_KEY
+from mindroom.model_usage import context_input_tokens_from_counts
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -111,44 +112,6 @@ def _build_context_payload(
     ):
         payload["cache_write_input_tokens"] = cache_write_tokens
     return payload
-
-
-def _provider_reports_cache_tokens_outside_input(
-    *,
-    provider: str | None,
-    configured_provider: str | None,
-    model_id: str | None,
-) -> bool:
-    """Return whether cache tokens must be added to input tokens for context occupancy."""
-    provider_key = (provider or configured_provider or "").lower()
-    configured_provider_key = (configured_provider or "").lower()
-    model_key = (model_id or "").lower()
-    if "anthropic" in provider_key or "bedrock" in provider_key:
-        return True
-    if configured_provider_key == "vertexai_claude":
-        return True
-    return "vertex" in provider_key and "claude" in model_key
-
-
-def _context_input_tokens_from_counts(
-    *,
-    input_tokens: int | None,
-    cache_read_tokens: int | None,
-    cache_write_tokens: int | None,
-    provider: str | None,
-    configured_provider: str | None,
-    model_id: str | None,
-) -> int | None:
-    """Return full request-context tokens from provider usage counters."""
-    if input_tokens is None:
-        return None
-    if not _provider_reports_cache_tokens_outside_input(
-        provider=provider,
-        configured_provider=configured_provider,
-        model_id=model_id,
-    ):
-        return input_tokens
-    return input_tokens + (cache_read_tokens or 0) + (cache_write_tokens or 0)
 
 
 def _int_usage_value(usage_payload: dict[str, Any] | None, key: str) -> int | None:
@@ -263,7 +226,7 @@ def build_ai_run_metadata_content(  # noqa: C901, PLR0912
     # Provider usage counters are authoritative for context occupancy; the
     # pre-flight `context_input_tokens` estimate is only a fallback when the
     # provider reported nothing (for example a request that failed early).
-    resolved_context_input_tokens = _context_input_tokens_from_counts(
+    resolved_context_input_tokens = context_input_tokens_from_counts(
         input_tokens=context_raw_input_tokens if explicit_context_scope else usage_input_tokens,
         cache_read_tokens=(
             context_cache_read_tokens

--- a/src/mindroom/llm_request_logging.py
+++ b/src/mindroom/llm_request_logging.py
@@ -345,6 +345,9 @@ def _log_llm_usage(
         "provider": model.provider or configured_provider,
         "usage_available": usage is not None,
     }
+    correlation_id = request_context.get("correlation_id")
+    if correlation_id is not None:
+        payload["correlation_id"] = correlation_id
     if usage is None:
         logger.info("LLM usage", **payload)
         return
@@ -356,10 +359,9 @@ def _log_llm_usage(
         configured_provider=configured_provider,
         model_id=model.id,
     )
-    cache_read_tokens = usage.cache_read_tokens or 0
-    uncached_input_tokens = context_input_tokens - cache_read_tokens if context_input_tokens is not None else None
+    uncached_input_tokens = context_input_tokens - usage.cache_read_tokens if context_input_tokens is not None else None
     cache_read_ratio = (
-        cache_read_tokens / context_input_tokens
+        usage.cache_read_tokens / context_input_tokens
         if context_input_tokens is not None and context_input_tokens > 0
         else 0.0
     )
@@ -375,9 +377,6 @@ def _log_llm_usage(
             "cache_read_ratio": round(cache_read_ratio, 6),
         },
     )
-    correlation_id = request_context.get("correlation_id")
-    if correlation_id is not None:
-        payload["correlation_id"] = correlation_id
     logger.info("LLM usage", **payload)
 
 
@@ -536,11 +535,14 @@ def install_llm_request_logging(
             # still record any usage already reported; awaiting during aclose()
             # is allowed for async generators as long as nothing is yielded.
             try:
-                with _model_call_scope(model):
-                    async for chunk in original_ainvoke_stream(*args, **kwargs):
-                        if chunk.response_usage is not None:
-                            last_usage = chunk.response_usage
-                        yield chunk
+                scoped_stream = context_bound_async_stream(
+                    context_factory=lambda: _model_call_scope(model),
+                    stream_factory=lambda: original_ainvoke_stream(*args, **kwargs),
+                )
+                async for chunk in scoped_stream:
+                    if chunk.response_usage is not None:
+                        last_usage = chunk.response_usage
+                    yield chunk
             finally:
                 await _write_llm_response_log(
                     model=model,

--- a/src/mindroom/llm_request_logging.py
+++ b/src/mindroom/llm_request_logging.py
@@ -1,4 +1,4 @@
-"""Opt-in LLM request logging."""
+"""Provider-neutral LLM usage telemetry and opt-in request logging."""
 
 from __future__ import annotations
 
@@ -17,6 +17,8 @@ from agno.models.message import Message
 from pydantic import BaseModel
 
 from mindroom.constants import MATRIX_SOURCE_EVENT_IDS_METADATA_KEY, MATRIX_SOURCE_EVENT_PROMPTS_METADATA_KEY
+from mindroom.logging_config import get_logger
+from mindroom.model_usage import context_input_tokens_from_counts
 from mindroom.redaction import redact_sensitive_data
 from mindroom.tool_system.context_bound_streams import context_bound_async_stream
 
@@ -30,6 +32,7 @@ if TYPE_CHECKING:
     from mindroom.config.models import DebugConfig
 
 _INSTALLED_ATTR = "_mindroom_llm_request_logging_installed"
+logger = get_logger(__name__)
 
 
 _SKIP_MODEL_PARAM_NAMES = {
@@ -64,6 +67,7 @@ _NON_API_MESSAGE_FIELDS = {
 type _JSONScalar = str | int | float | bool | None
 type _JSONValue = _JSONScalar | list["_JSONValue"] | dict[str, "_JSONValue"]
 _REQUEST_CONTEXT = ContextVar[dict[str, _JSONValue] | None]("mindroom_llm_request_log_context", default=None)
+_ACTIVE_MODEL_CALLS = ContextVar[frozenset[int]]("mindroom_llm_observability_active_models", default=frozenset())
 
 
 def _daily_log_path(log_dir: str | None, default_log_dir: Path, now: datetime) -> Path:
@@ -248,6 +252,17 @@ def bind_llm_request_log_context(**context: object) -> Iterator[None]:
         _REQUEST_CONTEXT.reset(token)
 
 
+@contextmanager
+def _model_call_scope(model: Model) -> Iterator[None]:
+    """Prevent one model method delegating to another from double-counting a request."""
+    active_model_calls = _ACTIVE_MODEL_CALLS.get()
+    token = _ACTIVE_MODEL_CALLS.set(active_model_calls | {id(model)})
+    try:
+        yield
+    finally:
+        _ACTIVE_MODEL_CALLS.reset(token)
+
+
 def stream_with_llm_request_log_context[StreamEventT](
     stream_generator: AsyncIterator[StreamEventT],
     *,
@@ -315,19 +330,76 @@ def _usage_payload(usage: MessageMetrics) -> dict[str, _JSONValue]:
     }
 
 
+def _log_llm_usage(
+    *,
+    model: Model,
+    model_name: str,
+    configured_provider: str | None,
+    usage: MessageMetrics | None,
+    request_context: dict[str, _JSONValue],
+) -> None:
+    """Emit privacy-safe token and cache telemetry for one provider response."""
+    payload: dict[str, _JSONValue] = {
+        "model_name": model_name,
+        "model_id": model.id,
+        "provider": model.provider or configured_provider,
+        "usage_available": usage is not None,
+    }
+    if usage is None:
+        logger.info("LLM usage", **payload)
+        return
+    context_input_tokens = context_input_tokens_from_counts(
+        input_tokens=usage.input_tokens,
+        cache_read_tokens=usage.cache_read_tokens,
+        cache_write_tokens=usage.cache_write_tokens,
+        provider=model.provider,
+        configured_provider=configured_provider,
+        model_id=model.id,
+    )
+    uncached_input_tokens = context_input_tokens - usage.cache_read_tokens if context_input_tokens is not None else None
+    cache_read_ratio = (
+        usage.cache_read_tokens / context_input_tokens
+        if context_input_tokens is not None and context_input_tokens > 0
+        else 0.0
+    )
+    payload.update(
+        {
+            "input_tokens": usage.input_tokens,
+            "context_input_tokens": context_input_tokens,
+            "output_tokens": usage.output_tokens,
+            "reasoning_tokens": usage.reasoning_tokens,
+            "cache_read_tokens": usage.cache_read_tokens,
+            "cache_write_tokens": usage.cache_write_tokens,
+            "uncached_input_tokens": uncached_input_tokens,
+            "cache_read_ratio": round(cache_read_ratio, 6),
+        },
+    )
+    correlation_id = request_context.get("correlation_id")
+    if correlation_id is not None:
+        payload["correlation_id"] = correlation_id
+    logger.info("LLM usage", **payload)
+
+
 async def _write_llm_response_log(
     *,
     model: Model,
     agent_name: str,
+    configured_provider: str | None = None,
     request_log_ref: _RequestLogRef | None,
     usage: MessageMetrics | None,
     request_context: dict[str, _JSONValue],
 ) -> None:
-    """Persist one compact response record with the provider-reported usage.
+    """Emit usage telemetry and optionally persist the provider-reported usage.
 
-    No-op when the request record was never written (nothing to join on) or
-    when the provider reported no usage metrics.
+    Durable logging is skipped when no request record exists.
     """
+    _log_llm_usage(
+        model=model,
+        model_name=agent_name,
+        configured_provider=configured_provider,
+        usage=usage,
+        request_context=request_context,
+    )
     if request_log_ref is None or usage is None:
         return
     now = datetime.now().astimezone()
@@ -378,16 +450,37 @@ async def _write_llm_request_log_if_present(
     return request_log_ref
 
 
+async def _write_llm_request_log_if_enabled(
+    *,
+    model: Model,
+    agent_name: str,
+    kwargs: dict[str, object],
+    debug_config: DebugConfig,
+    default_log_dir: Path,
+    request_context: dict[str, _JSONValue],
+) -> _RequestLogRef | None:
+    """Write the sensitive request record only when explicitly enabled."""
+    if not debug_config.log_llm_requests:
+        return None
+    return await _write_llm_request_log_if_present(
+        model=model,
+        agent_name=agent_name,
+        kwargs=kwargs,
+        log_dir=debug_config.llm_request_log_dir,
+        default_log_dir=default_log_dir,
+        request_context=request_context,
+    )
+
+
 def install_llm_request_logging(
     model: Model,
     *,
     agent_name: str,
     debug_config: DebugConfig,
     default_log_dir: Path,
+    configured_provider: str | None = None,
 ) -> None:
-    """Wrap one model instance so request summaries are written before invocation."""
-    if not debug_config.log_llm_requests:
-        return
+    """Wrap one model for usage telemetry and optional full request logging."""
     model_dict = vars(model)
     if model_dict.get(_INSTALLED_ATTR) is True:
         return
@@ -396,21 +489,25 @@ def install_llm_request_logging(
     original_ainvoke_stream = model.ainvoke_stream
 
     def _logged_ainvoke(*args: object, **kwargs: object) -> Coroutine[object, object, ModelResponse]:
+        if id(model) in _ACTIVE_MODEL_CALLS.get():
+            return original_ainvoke(*args, **kwargs)
         request_context = _snapshot_request_log_context()
 
         async def _invoke() -> ModelResponse:
-            request_log_ref = await _write_llm_request_log_if_present(
+            request_log_ref = await _write_llm_request_log_if_enabled(
                 model=model,
                 agent_name=agent_name,
                 kwargs=kwargs,
-                log_dir=debug_config.llm_request_log_dir,
+                debug_config=debug_config,
                 default_log_dir=default_log_dir,
                 request_context=request_context,
             )
-            response = await original_ainvoke(*args, **kwargs)
+            with _model_call_scope(model):
+                response = await original_ainvoke(*args, **kwargs)
             await _write_llm_response_log(
                 model=model,
                 agent_name=agent_name,
+                configured_provider=configured_provider,
                 request_log_ref=request_log_ref,
                 usage=response.response_usage,
                 request_context=request_context,
@@ -420,14 +517,16 @@ def install_llm_request_logging(
         return _invoke()
 
     def _logged_ainvoke_stream(*args: object, **kwargs: object) -> AsyncIterator[ModelResponse]:
+        if id(model) in _ACTIVE_MODEL_CALLS.get():
+            return original_ainvoke_stream(*args, **kwargs)
         request_context = _snapshot_request_log_context()
 
         async def _stream() -> AsyncIterator[ModelResponse]:
-            request_log_ref = await _write_llm_request_log_if_present(
+            request_log_ref = await _write_llm_request_log_if_enabled(
                 model=model,
                 agent_name=agent_name,
                 kwargs=kwargs,
-                log_dir=debug_config.llm_request_log_dir,
+                debug_config=debug_config,
                 default_log_dir=default_log_dir,
                 request_context=request_context,
             )
@@ -436,14 +535,16 @@ def install_llm_request_logging(
             # still record any usage already reported; awaiting during aclose()
             # is allowed for async generators as long as nothing is yielded.
             try:
-                async for chunk in original_ainvoke_stream(*args, **kwargs):
-                    if chunk.response_usage is not None:
-                        last_usage = chunk.response_usage
-                    yield chunk
+                with _model_call_scope(model):
+                    async for chunk in original_ainvoke_stream(*args, **kwargs):
+                        if chunk.response_usage is not None:
+                            last_usage = chunk.response_usage
+                        yield chunk
             finally:
                 await _write_llm_response_log(
                     model=model,
                     agent_name=agent_name,
+                    configured_provider=configured_provider,
                     request_log_ref=request_log_ref,
                     usage=last_usage,
                     request_context=request_context,

--- a/src/mindroom/llm_request_logging.py
+++ b/src/mindroom/llm_request_logging.py
@@ -356,9 +356,10 @@ def _log_llm_usage(
         configured_provider=configured_provider,
         model_id=model.id,
     )
-    uncached_input_tokens = context_input_tokens - usage.cache_read_tokens if context_input_tokens is not None else None
+    cache_read_tokens = usage.cache_read_tokens or 0
+    uncached_input_tokens = context_input_tokens - cache_read_tokens if context_input_tokens is not None else None
     cache_read_ratio = (
-        usage.cache_read_tokens / context_input_tokens
+        cache_read_tokens / context_input_tokens
         if context_input_tokens is not None and context_input_tokens > 0
         else 0.0
     )

--- a/src/mindroom/model_loading.py
+++ b/src/mindroom/model_loading.py
@@ -352,13 +352,13 @@ def get_model_instance(
         configured_id=model_id,
         effective_id=model.id,
     )
-    if config.debug.log_llm_requests:
-        install_llm_request_logging(
-            model,
-            agent_name=model_name,
-            debug_config=config.debug,
-            default_log_dir=runtime_paths.storage_root / "logs" / "llm_requests",
-        )
+    install_llm_request_logging(
+        model,
+        agent_name=model_name,
+        debug_config=config.debug,
+        default_log_dir=runtime_paths.storage_root / "logs" / "llm_requests",
+        configured_provider=provider,
+    )
     install_claude_prompt_cache_hook(model)
     install_claude_stream_retry_hook(model)
     return model

--- a/src/mindroom/model_usage.py
+++ b/src/mindroom/model_usage.py
@@ -1,0 +1,41 @@
+"""Leaf helpers for normalizing provider usage counters."""
+
+from __future__ import annotations
+
+
+def _provider_reports_cache_tokens_outside_input(
+    *,
+    provider: str | None,
+    configured_provider: str | None,
+    model_id: str | None,
+) -> bool:
+    """Return whether cache tokens must be added to input tokens for context occupancy."""
+    provider_key = (provider or configured_provider or "").lower()
+    configured_provider_key = (configured_provider or "").lower()
+    model_key = (model_id or "").lower()
+    if "anthropic" in provider_key or "bedrock" in provider_key:
+        return True
+    if configured_provider_key == "vertexai_claude":
+        return True
+    return "vertex" in provider_key and "claude" in model_key
+
+
+def context_input_tokens_from_counts(
+    *,
+    input_tokens: int | None,
+    cache_read_tokens: int | None,
+    cache_write_tokens: int | None,
+    provider: str | None,
+    configured_provider: str | None,
+    model_id: str | None,
+) -> int | None:
+    """Return full request-context tokens from provider usage counters."""
+    if input_tokens is None:
+        return None
+    if not _provider_reports_cache_tokens_outside_input(
+        provider=provider,
+        configured_provider=configured_provider,
+        model_id=model_id,
+    ):
+        return input_tokens
+    return input_tokens + (cache_read_tokens or 0) + (cache_write_tokens or 0)

--- a/tach.toml
+++ b/tach.toml
@@ -150,6 +150,15 @@ visibility = [
 path = "mindroom.ai_run_metadata"
 depends_on = [
     "mindroom.constants",
+    "mindroom.model_usage",
+]
+
+[[modules]]
+path = "mindroom.model_usage"
+depends_on = []
+visibility = [
+    "mindroom.ai_run_metadata",
+    "mindroom.llm_request_logging",
 ]
 
 [[modules]]

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -1956,6 +1956,7 @@ class TestUserIdPassthrough:
         class _DeferredLoggingModel:
             def __init__(self) -> None:
                 self.id = "test-model"
+                self.provider = "test"
                 self.system_prompt = None
                 self.temperature = 0.7
                 self.client = None

--- a/tests/test_issue_154_logging_integration.py
+++ b/tests/test_issue_154_logging_integration.py
@@ -66,6 +66,7 @@ def _reset_logging_after_test() -> Iterator[None]:
 @dataclass
 class _LoggingModel:
     id: str = "test-model"
+    provider: str | None = "OpenAI"
     system_prompt: str | None = None
     temperature: float | None = 0.7
     client: object | None = None

--- a/tests/test_llm_request_logging.py
+++ b/tests/test_llm_request_logging.py
@@ -367,6 +367,34 @@ async def test_llm_usage_telemetry_normalizes_anthropic_cache_tokens(tmp_path: P
 
 
 @pytest.mark.asyncio
+async def test_llm_usage_telemetry_handles_missing_cache_read_tokens(tmp_path: Path) -> None:
+    """Missing cache counters should not break telemetry after a successful response."""
+    usage = MessageMetrics(input_tokens=100)
+    # Agno's OpenAI Responses parser assigns its optional cached_tokens value directly.
+    vars(usage)["cache_read_tokens"] = None
+    model = _FakeModel(response_usage=usage)
+
+    with capture_logs() as logs:
+        install_llm_request_logging(
+            model,
+            agent_name="default",
+            debug_config=DebugConfig(),
+            default_log_dir=tmp_path,
+            configured_provider="openai",
+        )
+        await model.ainvoke(
+            messages=[Message(role="user", content="hello")],
+            assistant_message=Message(role="assistant"),
+            tools=[],
+        )
+
+    usage_log = logs[0]
+    assert usage_log["cache_read_tokens"] is None
+    assert usage_log["uncached_input_tokens"] == 100
+    assert usage_log["cache_read_ratio"] == 0.0
+
+
+@pytest.mark.asyncio
 async def test_llm_usage_telemetry_reports_missing_provider_metrics(tmp_path: Path) -> None:
     """Completed calls without provider metrics should remain visible in telemetry."""
     model = _FakeModel()

--- a/tests/test_llm_request_logging.py
+++ b/tests/test_llm_request_logging.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 from agno.models.message import Message, MessageMetrics
 from agno.models.response import ModelResponse
+from structlog.testing import capture_logs
 
 from mindroom.config.main import Config
 from mindroom.config.models import DebugConfig
@@ -29,6 +30,7 @@ if TYPE_CHECKING:
 @dataclass
 class _FakeModel:
     id: str = "test-model"
+    provider: str | None = "OpenAI"
     system_prompt: str | None = None
     temperature: float | None = 0.7
     client: object | None = None
@@ -289,21 +291,141 @@ async def test_llm_request_logging_uses_model_name_when_context_is_unbound(tmp_p
 
 
 @pytest.mark.asyncio
-async def test_llm_request_logging_disabled_creates_no_file(tmp_path: Path) -> None:
-    """Disabled request logging should leave the target log directory untouched."""
-    model = _FakeModel()
-    install_llm_request_logging(
-        model,
-        agent_name="default",
-        debug_config=DebugConfig(),
-        default_log_dir=tmp_path,
+async def test_llm_request_logging_disabled_still_emits_usage_telemetry(tmp_path: Path) -> None:
+    """Usage telemetry should stay enabled without writing full request logs."""
+    model = _FakeModel(
+        response_usage=MessageMetrics(
+            input_tokens=1_000,
+            output_tokens=50,
+            reasoning_tokens=20,
+            cache_read_tokens=800,
+            cache_write_tokens=100,
+        ),
     )
-    await model.ainvoke(
-        messages=[Message(role="user", content="hello")],
-        assistant_message=Message(role="assistant"),
-        tools=[],
-    )
+    with capture_logs() as logs:
+        install_llm_request_logging(
+            model,
+            agent_name="default",
+            debug_config=DebugConfig(),
+            default_log_dir=tmp_path,
+            configured_provider="openai",
+        )
+        with bind_llm_request_log_context(correlation_id="corr-1", full_prompt="private prompt"):
+            await model.ainvoke(
+                messages=[Message(role="user", content="hello")],
+                assistant_message=Message(role="assistant"),
+                tools=[],
+            )
+
     assert list(tmp_path.iterdir()) == []
+    assert logs == [
+        {
+            "event": "LLM usage",
+            "log_level": "info",
+            "model_name": "default",
+            "model_id": "test-model",
+            "provider": "OpenAI",
+            "usage_available": True,
+            "input_tokens": 1_000,
+            "context_input_tokens": 1_000,
+            "output_tokens": 50,
+            "reasoning_tokens": 20,
+            "cache_read_tokens": 800,
+            "cache_write_tokens": 100,
+            "uncached_input_tokens": 200,
+            "cache_read_ratio": 0.8,
+            "correlation_id": "corr-1",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_llm_usage_telemetry_normalizes_anthropic_cache_tokens(tmp_path: Path) -> None:
+    """Anthropic cache tokens should be added to raw input before calculating cache ratios."""
+    model = _FakeModel(
+        provider="Anthropic",
+        response_usage=MessageMetrics(input_tokens=200, cache_read_tokens=800, cache_write_tokens=100),
+    )
+    with capture_logs() as logs:
+        install_llm_request_logging(
+            model,
+            agent_name="claude",
+            debug_config=DebugConfig(),
+            default_log_dir=tmp_path,
+            configured_provider="anthropic",
+        )
+        await model.ainvoke(
+            messages=[Message(role="user", content="hello")],
+            assistant_message=Message(role="assistant"),
+            tools=[],
+        )
+
+    usage_log = logs[0]
+    assert usage_log["context_input_tokens"] == 1_100
+    assert usage_log["uncached_input_tokens"] == 300
+    assert usage_log["cache_read_ratio"] == 0.727273
+
+
+@pytest.mark.asyncio
+async def test_llm_usage_telemetry_reports_missing_provider_metrics(tmp_path: Path) -> None:
+    """Completed calls without provider metrics should remain visible in telemetry."""
+    model = _FakeModel()
+    with capture_logs() as logs:
+        install_llm_request_logging(
+            model,
+            agent_name="default",
+            debug_config=DebugConfig(),
+            default_log_dir=tmp_path,
+        )
+        await model.ainvoke(
+            messages=[Message(role="user", content="hello")],
+            assistant_message=Message(role="assistant"),
+            tools=[],
+        )
+
+    assert logs == [
+        {
+            "event": "LLM usage",
+            "log_level": "info",
+            "model_name": "default",
+            "model_id": "test-model",
+            "provider": "OpenAI",
+            "usage_available": False,
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_llm_usage_telemetry_does_not_double_count_invoke_via_stream(tmp_path: Path) -> None:
+    """A model whose invoke method consumes its stream should emit one usage event."""
+
+    @dataclass
+    class _InvokeViaStreamModel(_FakeModel):
+        async def ainvoke(self, *args: object, **kwargs: object) -> ModelResponse:
+            response = ModelResponse(content="")
+            async for chunk in self.ainvoke_stream(*args, **kwargs):
+                response.content = f"{response.content or ''}{chunk.content or ''}"
+                if chunk.response_usage is not None:
+                    response.response_usage = chunk.response_usage
+            return response
+
+    model = _InvokeViaStreamModel(response_usage=MessageMetrics(input_tokens=100, cache_read_tokens=80))
+    with capture_logs() as logs:
+        install_llm_request_logging(
+            model,
+            agent_name="default",
+            debug_config=DebugConfig(),
+            default_log_dir=tmp_path,
+        )
+        response = await model.ainvoke(
+            messages=[Message(role="user", content="hello")],
+            assistant_message=Message(role="assistant"),
+            tools=[],
+        )
+
+    assert response.content == "ok!"
+    assert [entry["event"] for entry in logs] == ["LLM usage"]
+    assert logs[0]["cache_read_ratio"] == 0.8
 
 
 @pytest.mark.asyncio

--- a/tests/test_llm_request_logging.py
+++ b/tests/test_llm_request_logging.py
@@ -367,34 +367,6 @@ async def test_llm_usage_telemetry_normalizes_anthropic_cache_tokens(tmp_path: P
 
 
 @pytest.mark.asyncio
-async def test_llm_usage_telemetry_handles_missing_cache_read_tokens(tmp_path: Path) -> None:
-    """Missing cache counters should not break telemetry after a successful response."""
-    usage = MessageMetrics(input_tokens=100)
-    # Agno's OpenAI Responses parser assigns its optional cached_tokens value directly.
-    vars(usage)["cache_read_tokens"] = None
-    model = _FakeModel(response_usage=usage)
-
-    with capture_logs() as logs:
-        install_llm_request_logging(
-            model,
-            agent_name="default",
-            debug_config=DebugConfig(),
-            default_log_dir=tmp_path,
-            configured_provider="openai",
-        )
-        await model.ainvoke(
-            messages=[Message(role="user", content="hello")],
-            assistant_message=Message(role="assistant"),
-            tools=[],
-        )
-
-    usage_log = logs[0]
-    assert usage_log["cache_read_tokens"] is None
-    assert usage_log["uncached_input_tokens"] == 100
-    assert usage_log["cache_read_ratio"] == 0.0
-
-
-@pytest.mark.asyncio
 async def test_llm_usage_telemetry_reports_missing_provider_metrics(tmp_path: Path) -> None:
     """Completed calls without provider metrics should remain visible in telemetry."""
     model = _FakeModel()
@@ -405,11 +377,12 @@ async def test_llm_usage_telemetry_reports_missing_provider_metrics(tmp_path: Pa
             debug_config=DebugConfig(),
             default_log_dir=tmp_path,
         )
-        await model.ainvoke(
-            messages=[Message(role="user", content="hello")],
-            assistant_message=Message(role="assistant"),
-            tools=[],
-        )
+        with bind_llm_request_log_context(correlation_id="corr-no-usage"):
+            await model.ainvoke(
+                messages=[Message(role="user", content="hello")],
+                assistant_message=Message(role="assistant"),
+                tools=[],
+            )
 
     assert logs == [
         {
@@ -419,6 +392,7 @@ async def test_llm_usage_telemetry_reports_missing_provider_metrics(tmp_path: Pa
             "model_id": "test-model",
             "provider": "OpenAI",
             "usage_available": False,
+            "correlation_id": "corr-no-usage",
         },
     ]
 
@@ -454,6 +428,37 @@ async def test_llm_usage_telemetry_does_not_double_count_invoke_via_stream(tmp_p
     assert response.content == "ok!"
     assert [entry["event"] for entry in logs] == ["LLM usage"]
     assert logs[0]["cache_read_ratio"] == 0.8
+
+
+@pytest.mark.asyncio
+async def test_llm_usage_telemetry_counts_call_while_stream_is_paused(tmp_path: Path) -> None:
+    """A real same-model call between stream pulls should emit its own usage event."""
+    model = _FakeModel(response_usage=MessageMetrics(input_tokens=100, cache_read_tokens=80))
+    install_llm_request_logging(
+        model,
+        agent_name="default",
+        debug_config=DebugConfig(),
+        default_log_dir=tmp_path,
+    )
+
+    with capture_logs() as logs:
+        stream = model.ainvoke_stream(
+            messages=[Message(role="user", content="stream")],
+            assistant_message=Message(role="assistant"),
+            tools=[],
+        )
+        first_chunk = await anext(stream)
+        nested_response = await model.ainvoke(
+            messages=[Message(role="user", content="nested")],
+            assistant_message=Message(role="assistant"),
+            tools=[],
+        )
+        remaining_chunks = [chunk async for chunk in stream]
+
+    assert first_chunk.content == "ok"
+    assert nested_response.content == "ok"
+    assert [chunk.content for chunk in remaining_chunks] == ["!"]
+    assert [entry["event"] for entry in logs] == ["LLM usage", "LLM usage"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
@@ -102,3 +103,27 @@ def test_anthropic_timeout_override_is_preserved(tmp_path: Path) -> None:
     model = get_model_instance(config, runtime_paths_for(config), "claude")
 
     assert model.timeout == 120.0
+
+
+def test_usage_telemetry_is_installed_when_full_request_logging_is_disabled(tmp_path: Path) -> None:
+    """Every configured model should get the shared usage telemetry wrapper."""
+    config = bind_runtime_paths(
+        Config(
+            models={
+                "default": ModelConfig(
+                    provider="openai",
+                    id="gpt-5.6",
+                    extra_kwargs={"api_key": "dummy-key"},
+                ),
+            },
+        ),
+        test_runtime_paths(tmp_path),
+    )
+
+    with patch("mindroom.model_loading.install_llm_request_logging") as install_logging:
+        model = get_model_instance(config, runtime_paths_for(config), "default")
+
+    install_logging.assert_called_once()
+    assert install_logging.call_args.args == (model,)
+    assert install_logging.call_args.kwargs["configured_provider"] == "openai"
+    assert install_logging.call_args.kwargs["debug_config"].log_llm_requests is False


### PR DESCRIPTION
## Summary

- Emit one privacy-safe structured `LLM usage` event for every completed model call, independent of full request logging.
- Report provider/model identity, raw usage, normalized context input, uncached input, cache reads/writes, cache-read ratio, and missing-usage status.
- Share provider normalization with Matrix run metadata and keep the helper at a slim import boundary.
- Prevent double-counting when a model's non-streaming method consumes its streaming method.
- Keep prompt/message request logs opt-in and regenerate the configuration references.

## Validation

- `uv run pytest` — 10030 passed, 54 skipped.
- `uv run pre-commit run --all-files` — passed.
- `uv run tach check --dependencies --interfaces` — passed.
- Live `config init --provider codex` test: two identical 5,431-input-token calls emitted exactly two usage events; the warm call reported 4,864 cached tokens, 567 uncached tokens, and an 89.5599% cache-read ratio.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added privacy-safe structured “LLM usage” telemetry for completed model requests (provider/model identifiers, normalized token counts, cache metrics, cache-read ratio).
  * Telemetry is emitted even when full request JSONL logging is disabled.
  * Clarifies when usage counters are unavailable (`usage_available: false`).

* **Bug Fixes**
  * Prevents double-counting across nested/streamed model invocations.

* **Documentation**
  * Expanded Debug Logging details for the new telemetry and `debug.log_llm_requests` behavior.

* **Tests**
  * Updated and added telemetry-focused coverage, including cache normalization and concurrency cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->