### PR TITLE
Parameterize realtime call credential selection

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -520,6 +520,7 @@ calls:
   backend: realtime                # realtime (default) or cascaded
   agents: []                       # Shared agents allowed to join calls in their configured rooms (at most one per room)
   model: gpt-realtime-2.1          # OpenAI realtime speech-to-speech model
+  credentials_service: openai      # Credential service used by the realtime backend
   voice: null                      # Optional realtime voice preset
   stt: null                        # Cascaded SpeechServiceConfig; required with backend: cascaded
   tts: null                        # Cascaded SpeechServiceConfig; required with backend: cascaded

--- a/docs/voice-calls.md
+++ b/docs/voice-calls.md
@@ -34,12 +34,14 @@ calls:
   backend: realtime           # default; preserves OpenAI speech-to-speech
   agents: [assistant]        # shared agents that may join calls in their configured rooms
   model: gpt-realtime-2.1    # OpenAI realtime model
+  credentials_service: openai # strict credential service binding; defaults to openai
   voice: marin               # optional voice preset
   # livekit_service_url: https://rtc.example.org   # same-server .well-known override
 ```
 
 Voice calls require the `matrix_calls` extra (`pip install "mindroom[matrix_calls]"` or `uv sync --extra matrix_calls`).
-The realtime backend requires an `OPENAI_API_KEY` in your credentials and otherwise behaves as before.
+The realtime backend reads its API key only from `calls.credentials_service`, which defaults to the `openai` credential service seeded by `OPENAI_API_KEY`.
+Set a different service when voice and chat use different OpenAI credentials; a missing selected service does not fall back to another key.
 MindRoom enforces at most one calls-enabled agent per room.
 Calls only join rooms configured for that agent and only while the sole caller passes the normal room and per-agent reply permissions.
 Calls-enabled agents also join calls in ad-hoc rooms they accepted through their normal authorized-invite policy. This lets Matrix clients create a private, temporary voice room and invite one agent without adding that room to `config.yaml` first.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -1373,6 +1373,7 @@ calls:
   backend: realtime                # realtime (default) or cascaded
   agents: []                       # Shared agents allowed to join calls in their configured rooms (at most one per room)
   model: gpt-realtime-2.1          # OpenAI realtime speech-to-speech model
+  credentials_service: openai      # Credential service used by the realtime backend
   voice: null                      # Optional realtime voice preset
   stt: null                        # Cascaded SpeechServiceConfig; required with backend: cascaded
   tts: null                        # Cascaded SpeechServiceConfig; required with backend: cascaded
@@ -12965,12 +12966,14 @@ calls:
   backend: realtime           # default; preserves OpenAI speech-to-speech
   agents: [assistant]        # shared agents that may join calls in their configured rooms
   model: gpt-realtime-2.1    # OpenAI realtime model
+  credentials_service: openai # strict credential service binding; defaults to openai
   voice: marin               # optional voice preset
   # livekit_service_url: https://rtc.example.org   # same-server .well-known override
 ```
 
 Voice calls require the `matrix_calls` extra (`pip install "mindroom[matrix_calls]"` or `uv sync --extra matrix_calls`).
-The realtime backend requires an `OPENAI_API_KEY` in your credentials and otherwise behaves as before.
+The realtime backend reads its API key only from `calls.credentials_service`, which defaults to the `openai` credential service seeded by `OPENAI_API_KEY`.
+Set a different service when voice and chat use different OpenAI credentials; a missing selected service does not fall back to another key.
 MindRoom enforces at most one calls-enabled agent per room.
 Calls only join rooms configured for that agent and only while the sole caller passes the normal room and per-agent reply permissions.
 Calls-enabled agents also join calls in ad-hoc rooms they accepted through their normal authorized-invite policy. This lets Matrix clients create a private, temporary voice room and invite one agent without adding that room to `config.yaml` first.

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -516,6 +516,7 @@ calls:
   backend: realtime                # realtime (default) or cascaded
   agents: []                       # Shared agents allowed to join calls in their configured rooms (at most one per room)
   model: gpt-realtime-2.1          # OpenAI realtime speech-to-speech model
+  credentials_service: openai      # Credential service used by the realtime backend
   voice: null                      # Optional realtime voice preset
   stt: null                        # Cascaded SpeechServiceConfig; required with backend: cascaded
   tts: null                        # Cascaded SpeechServiceConfig; required with backend: cascaded

--- a/skills/mindroom-docs/references/page__voice-calls__index.md
+++ b/skills/mindroom-docs/references/page__voice-calls__index.md
@@ -34,12 +34,14 @@ calls:
   backend: realtime           # default; preserves OpenAI speech-to-speech
   agents: [assistant]        # shared agents that may join calls in their configured rooms
   model: gpt-realtime-2.1    # OpenAI realtime model
+  credentials_service: openai # strict credential service binding; defaults to openai
   voice: marin               # optional voice preset
   # livekit_service_url: https://rtc.example.org   # same-server .well-known override
 ```
 
 Voice calls require the `matrix_calls` extra (`pip install "mindroom[matrix_calls]"` or `uv sync --extra matrix_calls`).
-The realtime backend requires an `OPENAI_API_KEY` in your credentials and otherwise behaves as before.
+The realtime backend reads its API key only from `calls.credentials_service`, which defaults to the `openai` credential service seeded by `OPENAI_API_KEY`.
+Set a different service when voice and chat use different OpenAI credentials; a missing selected service does not fall back to another key.
 MindRoom enforces at most one calls-enabled agent per room.
 Calls only join rooms configured for that agent and only while the sole caller passes the normal room and per-agent reply permissions.
 Calls-enabled agents also join calls in ad-hoc rooms they accepted through their normal authorized-invite policy. This lets Matrix clients create a private, temporary voice room and invite one agent without adding that room to `config.yaml` first.

--- a/src/mindroom/config/calls.py
+++ b/src/mindroom/config/calls.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from typing import Literal, Self
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from mindroom.config.voice import SpeechServiceConfig  # noqa: TC001 - Pydantic needs the runtime model
+from mindroom.credentials import validate_service_name
 from mindroom.model_defaults import OPENAI_REALTIME
 
 
@@ -24,6 +25,10 @@ class CallsConfig(BaseModel):
         default=OPENAI_REALTIME,
         description="OpenAI realtime speech-to-speech model used during calls",
     )
+    credentials_service: str = Field(
+        default="openai",
+        description="Credential service containing the API key for OpenAI realtime calls",
+    )
     voice: str | None = Field(default=None, description="Realtime model voice preset")
     stt: SpeechServiceConfig | None = Field(default=None, description="Cascaded speech-to-text service")
     tts: SpeechServiceConfig | None = Field(default=None, description="Cascaded text-to-speech service")
@@ -35,6 +40,12 @@ class CallsConfig(BaseModel):
         default=None,
         description="Same-server MatrixRTC authorization service URL override (otherwise discovered from .well-known)",
     )
+
+    @field_validator("credentials_service")
+    @classmethod
+    def _validate_credentials_service(cls, value: str) -> str:
+        """Normalize the strict credential service binding for realtime calls."""
+        return validate_service_name(value)
 
     @model_validator(mode="after")
     def validate_cascaded_services(self) -> Self:

--- a/src/mindroom/credentials_sync.py
+++ b/src/mindroom/credentials_sync.py
@@ -392,8 +392,6 @@ def get_api_key_for_provider(provider: str, runtime_paths: RuntimePaths) -> str 
         The API key if found, None otherwise
 
     """
-    creds_manager = get_runtime_shared_credentials_manager(runtime_paths)
-
     # Special case for Ollama - return None as it doesn't use API keys
     if provider == "ollama":
         return None
@@ -402,7 +400,12 @@ def get_api_key_for_provider(provider: str, runtime_paths: RuntimePaths) -> str 
     if provider == "gemini":
         provider = "google"
 
-    return creds_manager.get_api_key(provider)
+    return get_api_key_for_service(provider, runtime_paths)
+
+
+def get_api_key_for_service(service: str, runtime_paths: RuntimePaths) -> str | None:
+    """Get an API key from one explicitly named shared credential service."""
+    return get_runtime_shared_credentials_manager(runtime_paths).get_api_key(service)
 
 
 def get_embedder_api_key(

--- a/src/mindroom/matrix_rtc/call_manager.py
+++ b/src/mindroom/matrix_rtc/call_manager.py
@@ -22,7 +22,7 @@ import nio
 
 from mindroom.authorization import is_authorized_sender, is_sender_allowed_for_agent_reply
 from mindroom.config.voice import normalize_speech_base_url
-from mindroom.credentials_sync import get_api_key_for_provider, get_secret_from_env
+from mindroom.credentials_sync import get_api_key_for_provider, get_api_key_for_service
 from mindroom.entity_resolution import configured_call_agent_name_for_room
 from mindroom.logging_config import get_logger
 from mindroom.matrix.identity import MatrixID
@@ -860,8 +860,8 @@ class CallManager:
     ) -> _ResolvedVoiceBackend | None:
         """Resolve backend-specific credentials without affecting call lifecycle."""
         if self._config.calls.backend == "realtime":
-            api_key = get_secret_from_env("OPENAI_API_KEY", self._runtime_paths) or get_api_key_for_provider(
-                "openai",
+            api_key = get_api_key_for_service(
+                self._config.calls.credentials_service,
                 self._runtime_paths,
             )
             if not api_key:

--- a/src/mindroom/matrix_rtc/call_manager.py
+++ b/src/mindroom/matrix_rtc/call_manager.py
@@ -866,7 +866,12 @@ class CallManager:
             )
             if not api_key:
                 if warn_if_unavailable:
-                    logger.warning("call_join_skipped_no_openai_key", room_id=room_id, agent=self._agent_name)
+                    logger.warning(
+                        "call_join_skipped_no_openai_key",
+                        room_id=room_id,
+                        agent=self._agent_name,
+                        credentials_service=self._config.calls.credentials_service,
+                    )
                 return None
             return _ResolvedVoiceBackend(realtime_api_key=api_key)
 

--- a/src/mindroom/matrix_rtc/call_manager.py
+++ b/src/mindroom/matrix_rtc/call_manager.py
@@ -22,7 +22,7 @@ import nio
 
 from mindroom.authorization import is_authorized_sender, is_sender_allowed_for_agent_reply
 from mindroom.config.voice import normalize_speech_base_url
-from mindroom.credentials_sync import get_api_key_for_provider
+from mindroom.credentials_sync import get_api_key_for_provider, get_secret_from_env
 from mindroom.entity_resolution import configured_call_agent_name_for_room
 from mindroom.logging_config import get_logger
 from mindroom.matrix.identity import MatrixID
@@ -860,7 +860,10 @@ class CallManager:
     ) -> _ResolvedVoiceBackend | None:
         """Resolve backend-specific credentials without affecting call lifecycle."""
         if self._config.calls.backend == "realtime":
-            api_key = get_api_key_for_provider("openai", self._runtime_paths)
+            api_key = get_secret_from_env("OPENAI_API_KEY", self._runtime_paths) or get_api_key_for_provider(
+                "openai",
+                self._runtime_paths,
+            )
             if not api_key:
                 if warn_if_unavailable:
                     logger.warning("call_join_skipped_no_openai_key", room_id=room_id, agent=self._agent_name)

--- a/tests/test_credentials_sync.py
+++ b/tests/test_credentials_sync.py
@@ -15,6 +15,7 @@ from mindroom.credentials_sync import (
     _EMBEDDER_KEYLESS_PLACEHOLDER_API_KEY,
     _ENV_TO_SERVICE_MAP,
     get_api_key_for_provider,
+    get_api_key_for_service,
     get_embedder_api_key,
     get_ollama_host,
     get_secret_from_env,
@@ -837,6 +838,18 @@ class TestCredentialsSync:
 
         # Test non-existent provider
         assert get_api_key_for_provider("anthropic", runtime_paths=runtime_paths) is None
+
+    def test_get_api_key_for_service_is_strict(self, credentials_manager: CredentialsManager) -> None:
+        """A named service resolves only that service's API key."""
+        credentials_manager.save_credentials("openai", {"api_key": "shared-key"})
+        credentials_manager.save_credentials("openai-realtime", {"api_key": "realtime-key"})
+        runtime_paths = _runtime_paths(
+            credentials_manager.storage_root,
+            shared_credentials_dir=credentials_manager.base_path,
+        )
+
+        assert get_api_key_for_service("openai-realtime", runtime_paths) == "realtime-key"
+        assert get_api_key_for_service("missing", runtime_paths) is None
 
     def test_get_ollama_host(self, credentials_manager: CredentialsManager) -> None:
         """Test getting Ollama host configuration."""

--- a/tests/test_matrix_rtc_call_manager.py
+++ b/tests/test_matrix_rtc_call_manager.py
@@ -1102,6 +1102,41 @@ def test_voice_backend_availability_requires_runtime_credentials(
         )
 
 
+def test_realtime_backend_prefers_direct_openai_key(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Realtime calls bypass a shared provider credential when a direct key exists."""
+    (tmp_path / ".env").write_text("OPENAI_API_KEY=sk-direct\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "mindroom.matrix_rtc.call_manager.get_api_key_for_provider",
+        lambda _provider, _paths: "sk-shared",
+    )
+    manager = _manager(_client(), FakeBridge(), tmp_path)
+
+    backend = manager._resolve_voice_backend(ROOM_ID)
+
+    assert backend is not None
+    assert backend.realtime_api_key == "sk-direct"
+
+
+def test_realtime_backend_falls_back_to_shared_provider_credential(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Realtime calls keep working for installs configured through credentials."""
+    monkeypatch.setattr(
+        "mindroom.matrix_rtc.call_manager.get_api_key_for_provider",
+        lambda _provider, _paths: "sk-shared",
+    )
+    manager = _manager(_client(), FakeBridge(), tmp_path)
+
+    backend = manager._resolve_voice_backend(ROOM_ID)
+
+    assert backend is not None
+    assert backend.realtime_api_key == "sk-shared"
+
+
 def test_build_call_instructions_appends_voice_guidance() -> None:
     """The exact chat prompt is retained, with voice guidance appended."""
     text = _build_call_instructions("CHAT SYSTEM PROMPT")

--- a/tests/test_matrix_rtc_call_manager.py
+++ b/tests/test_matrix_rtc_call_manager.py
@@ -326,6 +326,10 @@ def _stub_join_externals(monkeypatch: pytest.MonkeyPatch) -> None:
         "mindroom.matrix_rtc.call_manager.get_api_key_for_provider",
         lambda _provider, _paths: "sk-test",
     )
+    monkeypatch.setattr(
+        "mindroom.matrix_rtc.call_manager.get_api_key_for_service",
+        lambda _service, _paths: "sk-test",
+    )
 
     async def fake_grant(*_args: object, **_kwargs: object) -> SfuGrant:
         return GRANT
@@ -905,7 +909,7 @@ async def test_manager_reconciles_active_calls_after_sync(tmp_path: Path) -> Non
 @pytest.mark.asyncio
 async def test_manager_skips_join_without_openai_key(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Manager skips join without openai key."""
-    monkeypatch.setattr("mindroom.matrix_rtc.call_manager.get_api_key_for_provider", lambda _provider, _paths: None)
+    monkeypatch.setattr("mindroom.matrix_rtc.call_manager.get_api_key_for_service", lambda _service, _paths: None)
     client = _client()
     client.room_get_state.return_value = _state_response(_remote_member_event())
     bridge = FakeBridge()
@@ -919,18 +923,18 @@ async def test_manager_skips_join_without_openai_key(monkeypatch: pytest.MonkeyP
 
 
 @pytest.mark.asyncio
-async def test_manager_reads_openai_key_from_shared_credentials(
+async def test_manager_reads_key_from_configured_credentials_service(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Voice calls use the same dashboard-backed key source as model loading."""
-    requested_providers: list[str] = []
+    """Voice calls use their selected dashboard-backed credential service."""
+    requested_services: list[str] = []
 
-    def fake_api_key(provider: str, _paths: object) -> str:
-        requested_providers.append(provider)
+    def fake_api_key(service: str, _paths: object) -> str:
+        requested_services.append(service)
         return "sk-dashboard"
 
-    monkeypatch.setattr("mindroom.matrix_rtc.call_manager.get_api_key_for_provider", fake_api_key)
+    monkeypatch.setattr("mindroom.matrix_rtc.call_manager.get_api_key_for_service", fake_api_key)
     client = _client()
     client.room_get_state.return_value = _state_response(_remote_member_event())
     bridge = FakeBridge()
@@ -938,7 +942,7 @@ async def test_manager_reads_openai_key_from_shared_credentials(
 
     await manager.on_room_event(_room(), _member_unknown_event())
 
-    assert requested_providers == ["openai"]
+    assert requested_services == ["openai"]
     assert bridge.agent_options is not None
     assert bridge.agent_options.api_key == "sk-dashboard"
 
@@ -1085,8 +1089,8 @@ def test_voice_backend_availability_requires_runtime_credentials(
 ) -> None:
     """Presence readiness is false when the realtime backend cannot authenticate."""
     monkeypatch.setattr(
-        "mindroom.matrix_rtc.call_manager.get_api_key_for_provider",
-        lambda _provider, _paths: None,
+        "mindroom.matrix_rtc.call_manager.get_api_key_for_service",
+        lambda _service, _paths: None,
     )
     manager = _manager(_client(), FakeBridge(), tmp_path)
 
@@ -1102,32 +1106,42 @@ def test_voice_backend_availability_requires_runtime_credentials(
         )
 
 
-def test_realtime_backend_prefers_direct_openai_key(
+def test_realtime_backend_uses_configured_credential_service(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Realtime calls bypass a shared provider credential when a direct key exists."""
-    (tmp_path / ".env").write_text("OPENAI_API_KEY=sk-direct\n", encoding="utf-8")
-    monkeypatch.setattr(
-        "mindroom.matrix_rtc.call_manager.get_api_key_for_provider",
-        lambda _provider, _paths: "sk-shared",
+    """Realtime calls use the strictly configured credential service."""
+    selected_services: list[str] = []
+
+    def lookup(service: str, _paths: object) -> str:
+        selected_services.append(service)
+        return "sk-realtime"
+
+    monkeypatch.setattr("mindroom.matrix_rtc.call_manager.get_api_key_for_service", lookup)
+    config = _config()
+    config.calls = CallsConfig(
+        enabled=True,
+        agents=["helper"],
+        livekit_service_url=SERVICE_URL,
+        credentials_service="openai-realtime",
     )
-    manager = _manager(_client(), FakeBridge(), tmp_path)
+    manager = _manager(_client(), FakeBridge(), tmp_path, config)
 
     backend = manager._resolve_voice_backend(ROOM_ID)
 
     assert backend is not None
-    assert backend.realtime_api_key == "sk-direct"
+    assert backend.realtime_api_key == "sk-realtime"
+    assert selected_services == ["openai-realtime"]
 
 
-def test_realtime_backend_falls_back_to_shared_provider_credential(
+def test_realtime_backend_defaults_to_openai_credential_service(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Realtime calls keep working for installs configured through credentials."""
+    """Existing installs keep using the shared OpenAI credential by default."""
     monkeypatch.setattr(
-        "mindroom.matrix_rtc.call_manager.get_api_key_for_provider",
-        lambda _provider, _paths: "sk-shared",
+        "mindroom.matrix_rtc.call_manager.get_api_key_for_service",
+        lambda service, _paths: "sk-shared" if service == "openai" else None,
     )
     manager = _manager(_client(), FakeBridge(), tmp_path)
 
@@ -2835,6 +2849,13 @@ def test_calls_config_rejects_unknown_agents() -> None:
     """Call configuration may reference only declared agents."""
     with pytest.raises(ValueError, match=r"calls\.agents references unknown agent"):
         Config(models={}, calls=CallsConfig(enabled=True, agents=["missing"]))
+
+
+def test_calls_config_validates_realtime_credentials_service() -> None:
+    """Realtime credential bindings use safe normalized service names."""
+    assert CallsConfig(credentials_service=" openai-realtime ").credentials_service == "openai-realtime"
+    with pytest.raises(ValueError, match="Service name can only include"):
+        CallsConfig(credentials_service="../openai")
 
 
 def test_calls_config_rejects_requester_private_agents() -> None:

--- a/tests/test_matrix_rtc_call_manager.py
+++ b/tests/test_matrix_rtc_call_manager.py
@@ -202,7 +202,7 @@ def _state_response(*call_events: dict) -> nio.RoomGetStateResponse:
     return nio.RoomGetStateResponse(events, ROOM_ID)
 
 
-def _config(*, enabled: bool = True) -> Config:
+def _config(*, enabled: bool = True, credentials_service: str = "openai") -> Config:
     return Config(
         agents={
             "helper": AgentConfig(
@@ -216,6 +216,7 @@ def _config(*, enabled: bool = True) -> Config:
         authorization=AuthorizationConfig(global_users=["@alice:example.org"]),
         calls=CallsConfig(
             enabled=enabled,
+            credentials_service=credentials_service,
             agents=["helper"],
             livekit_service_url=SERVICE_URL,
         ),
@@ -1092,7 +1093,7 @@ def test_voice_backend_availability_requires_runtime_credentials(
         "mindroom.matrix_rtc.call_manager.get_api_key_for_service",
         lambda _service, _paths: None,
     )
-    manager = _manager(_client(), FakeBridge(), tmp_path)
+    manager = _manager(_client(), FakeBridge(), tmp_path, _config(credentials_service="openai-realtime"))
 
     with patch("mindroom.matrix_rtc.call_manager.logger.warning") as warning:
         assert manager.voice_backend_available is False
@@ -1103,6 +1104,7 @@ def test_voice_backend_availability_requires_runtime_credentials(
             "call_join_skipped_no_openai_key",
             room_id=ROOM_ID,
             agent="helper",
+            credentials_service="openai-realtime",
         )
 
 
@@ -1118,13 +1120,7 @@ def test_realtime_backend_uses_configured_credential_service(
         return "sk-realtime"
 
     monkeypatch.setattr("mindroom.matrix_rtc.call_manager.get_api_key_for_service", lookup)
-    config = _config()
-    config.calls = CallsConfig(
-        enabled=True,
-        agents=["helper"],
-        livekit_service_url=SERVICE_URL,
-        credentials_service="openai-realtime",
-    )
+    config = _config(credentials_service="openai-realtime")
     manager = _manager(_client(), FakeBridge(), tmp_path, config)
 
     backend = manager._resolve_voice_backend(ROOM_ID)


### PR DESCRIPTION
## Summary

- Add `calls.credentials_service` with a backward-compatible `openai` default.
- Resolve realtime voice credentials strictly from the selected service.
- Document custom voice/chat credential separation and add regression coverage.

## Why

Realtime voice and chat can require different OpenAI credentials. Credential selection must be explicit configuration, not hidden environment precedence.

## Tests

- `uv run pytest` (10,041 passed, 54 skipped)
- `uv run pre-commit run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `credentials_service` setting for realtime voice calls, defaulting to `openai`.
  - Realtime calls now use only the selected credential service, supporting separate credentials for voice and chat.

- **Bug Fixes**
  - Prevented unintended fallback to other API keys when the configured service lacks credentials.
  - Added validation and normalization for credential service names.

- **Documentation**
  - Updated configuration and voice-call guidance with the new setting and credential behavior.

- **Tests**
  - Expanded coverage for credential selection, validation, and missing-key scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->