### PR TITLE
feat(client-chart): configure navigation fallback exclusions

### DIFF
--- a/.github/workflows/publish-helm-charts.yml
+++ b/.github/workflows/publish-helm-charts.yml
@@ -280,6 +280,18 @@ jobs:
             --set serviceWorker.enabled=false \
             > "$render_dir/base-path.yaml"
           grep -F 'location = /mindroom/version.json' "$render_dir/base-path.yaml"
+          cat > "$render_dir/service-worker-values.yaml" <<'EOF'
+          serviceWorker:
+            navigationFallbackExcludePaths:
+              - /other-app
+              - /control-panel
+          EOF
+          helm template mindroom-client "$CLIENT_CHART_DIR" \
+            --namespace mindroom \
+            --values "$render_dir/service-worker-values.yaml" \
+            > "$render_dir/service-worker.yaml"
+          grep -F 'window.__SERVICE_WORKER_NAVIGATION_FALLBACK_EXCLUDE_PATHS__ = [\"/other-app\",\"/control-panel\"]' \
+            "$render_dir/service-worker.yaml"
           helm template mindroom-client "$CLIENT_CHART_DIR" \
             --namespace mindroom \
             --set config.existingConfigMap=existing-client-config \

--- a/.github/workflows/publish-helm-charts.yml
+++ b/.github/workflows/publish-helm-charts.yml
@@ -292,6 +292,13 @@ jobs:
             > "$render_dir/service-worker.yaml"
           grep -F 'window.__SERVICE_WORKER_NAVIGATION_FALLBACK_EXCLUDE_PATHS__ = [\"/other-app\",\"/control-panel\"]' \
             "$render_dir/service-worker.yaml"
+          if helm template mindroom-client "$CLIENT_CHART_DIR" \
+            --namespace mindroom \
+            --set-string 'serviceWorker.navigationFallbackExcludePaths[0]=/$host' \
+            > /dev/null 2>&1; then
+            echo "service-worker navigation exclusions unexpectedly accepted an nginx variable" >&2
+            exit 1
+          fi
           helm template mindroom-client "$CLIENT_CHART_DIR" \
             --namespace mindroom \
             --set config.existingConfigMap=existing-client-config \

--- a/cluster/k8s/client/README.md
+++ b/cluster/k8s/client/README.md
@@ -76,6 +76,18 @@ The chart serves `/runtime-config.js` directly from nginx because the image entr
 The client registers its service worker at `basePath/sw.js`, scoped to `basePath/`.
 Set `serviceWorker.enabled: false` to keep the client from registering it at all.
 
+When the client shares an origin with sibling applications, list their root-relative path prefixes
+so the PWA app-shell fallback leaves those navigations to the network:
+
+```yaml
+serviceWorker:
+  navigationFallbackExcludePaths:
+    - /other-app
+```
+
+Each prefix excludes its exact path and descendants without excluding similarly named client routes.
+Use a MindRoom Chat release that supports runtime navigation exclusions.
+
 A Matrix client that previously controlled the origin root is a known footgun: its root-scoped service worker keeps serving the old app for every path on the origin, including the new base path.
 Browsers replace a service worker by re-fetching its script URL, so the deterministic fix is to serve a worker at the old root `/sw.js` whose only job is to purge caches, release its clients into `basePath/`, and unregister itself.
 Enable that cleanup worker when migrating such an origin:

--- a/cluster/k8s/client/README.md
+++ b/cluster/k8s/client/README.md
@@ -76,8 +76,7 @@ The chart serves `/runtime-config.js` directly from nginx because the image entr
 The client registers its service worker at `basePath/sw.js`, scoped to `basePath/`.
 Set `serviceWorker.enabled: false` to keep the client from registering it at all.
 
-When the client shares an origin with sibling applications, list their root-relative path prefixes
-so the PWA app-shell fallback leaves those navigations to the network:
+When the client shares an origin with sibling applications, list their root-relative path prefixes so the PWA app-shell fallback leaves those navigations to the network:
 
 ```yaml
 serviceWorker:

--- a/cluster/k8s/client/templates/_helpers.tpl
+++ b/cluster/k8s/client/templates/_helpers.tpl
@@ -113,7 +113,8 @@ runtime-config.js straight from nginx and the Deployment bypasses the entrypoint
 {{- define "mindroom-client.defaultNginxConf" -}}
 {{- $base := include "mindroom-client.basePath" . -}}
 {{- $prefix := include "mindroom-client.pathPrefix" . -}}
-{{- $runtimeConfig := printf "window.__APP_BASE_PATH__ = \"%s\"; window.__ENABLE_SERVICE_WORKER__ = %t;" $base .Values.serviceWorker.enabled -}}
+{{- $navigationFallbackExcludePaths := .Values.serviceWorker.navigationFallbackExcludePaths | toJson -}}
+{{- $runtimeConfig := printf "window.__APP_BASE_PATH__ = \"%s\"; window.__ENABLE_SERVICE_WORKER__ = %t; window.__SERVICE_WORKER_NAVIGATION_FALLBACK_EXCLUDE_PATHS__ = %s;" $base .Values.serviceWorker.enabled $navigationFallbackExcludePaths -}}
 server {
   listen {{ .Values.nginx.port }};
 {{- if .Values.nginx.ipv6 }}
@@ -135,7 +136,7 @@ server {
   location = /runtime-config.js {
     default_type application/javascript;
     add_header Cache-Control "no-store, max-age=0" always;
-    return 200 '{{ $runtimeConfig }}';
+    return 200 {{ $runtimeConfig | quote }};
   }
 {{- if .Values.matrixRTC.enabled }}
 

--- a/cluster/k8s/client/templates/_helpers.tpl
+++ b/cluster/k8s/client/templates/_helpers.tpl
@@ -113,7 +113,7 @@ runtime-config.js straight from nginx and the Deployment bypasses the entrypoint
 {{- define "mindroom-client.defaultNginxConf" -}}
 {{- $base := include "mindroom-client.basePath" . -}}
 {{- $prefix := include "mindroom-client.pathPrefix" . -}}
-{{- $navigationFallbackExcludePaths := .Values.serviceWorker.navigationFallbackExcludePaths | toJson -}}
+{{- $navigationFallbackExcludePaths := default (list) .Values.serviceWorker.navigationFallbackExcludePaths | toJson -}}
 {{- $runtimeConfig := printf "window.__APP_BASE_PATH__ = \"%s\"; window.__ENABLE_SERVICE_WORKER__ = %t; window.__SERVICE_WORKER_NAVIGATION_FALLBACK_EXCLUDE_PATHS__ = %s;" $base .Values.serviceWorker.enabled $navigationFallbackExcludePaths -}}
 server {
   listen {{ .Values.nginx.port }};

--- a/cluster/k8s/client/templates/validate.yaml
+++ b/cluster/k8s/client/templates/validate.yaml
@@ -4,6 +4,9 @@
 {{- if and .Values.rootServiceWorkerCleanup.enabled (eq (include "mindroom-client.basePath" .) "/") -}}
 {{- fail "rootServiceWorkerCleanup.enabled requires a basePath other than / because /sw.js is the client service worker at the origin root" -}}
 {{- end -}}
+{{- if contains "$" (.Values.serviceWorker.navigationFallbackExcludePaths | toJson) -}}
+{{- fail "serviceWorker.navigationFallbackExcludePaths cannot contain $ because nginx expands variables in return bodies" -}}
+{{- end -}}
 {{- if and .Values.config.create (not .Values.config.existingConfigMap) (not .Values.config.data) (not .Values.matrix.homeserverUrl) (not .Values.matrix.defaultServerName) -}}
 {{- fail "matrix.homeserverUrl or matrix.defaultServerName is required when the chart renders the default client config" -}}
 {{- end -}}

--- a/cluster/k8s/client/values.yaml
+++ b/cluster/k8s/client/values.yaml
@@ -82,6 +82,9 @@ matrixRTC:
 serviceWorker:
   # Register the client service worker, scoped to basePath.
   enabled: true
+  # Root-relative sibling application paths that the PWA navigation fallback
+  # must leave to the network. Requires client support for runtime exclusions.
+  navigationFallbackExcludePaths: []
 
 # Serve a cleanup service worker at the origin-root /sw.js.
 # A Matrix client that previously controlled the origin root can leave a


### PR DESCRIPTION
The client chart serves runtime-config.js itself, so deployments need a chart value to use MindRoom Chat navigation exclusions. Without that bridge, a root-scoped PWA can still answer navigation requests intended for a sibling application on the same origin.

This adds an empty-by-default service-worker path list and serializes it safely into runtime-config.js. Configured prefixes remain deployment-owned; this repository contains only generic examples and no downstream hostnames or routes.

Depends on mindroom-ai/mindroom-chat#155 for client-side support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configuration for excluding selected paths from the service worker’s navigation fallback, allowing sibling applications to handle their own routes.
  - Added runtime configuration support for these exclusions, with the default behavior unchanged.

- **Documentation**
  - Added guidance and examples for configuring navigation fallback exclusions.
  - Documented the requirement for a compatible MindRoom Chat release.

- **Tests**
  - Added chart rendering validation to verify configured exclusions appear correctly in the generated service worker configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->