### PR TITLE
Support requester-private agents in MatrixRTC calls

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -524,7 +524,7 @@ voice:
 calls:
   enabled: false                   # Default: false
   backend: realtime                # realtime (default) or cascaded
-  agents: []                       # Shared agents allowed to join calls in their configured rooms (at most one per room)
+  agents: []                       # Agents allowed to join calls in their configured rooms (at most one per room)
   model: gpt-realtime-2.1          # OpenAI realtime speech-to-speech model
   credentials_service: openai      # Credential service used by the realtime backend
   voice: null                      # Optional realtime voice preset

--- a/docs/voice-calls.md
+++ b/docs/voice-calls.md
@@ -32,7 +32,7 @@ The agent leaves the call and clears its membership state event when the caller 
 calls:
   enabled: true
   backend: realtime           # default; preserves OpenAI speech-to-speech
-  agents: [assistant]        # shared agents that may join calls in their configured rooms
+  agents: [assistant]         # agents that may join calls in their configured rooms
   model: gpt-realtime-2.1    # OpenAI realtime model
   credentials_service: openai # strict credential service binding; defaults to openai
   voice: marin               # optional voice preset
@@ -46,7 +46,8 @@ MindRoom enforces at most one calls-enabled agent per room.
 Calls only join rooms configured for that agent and only while the sole caller passes the normal room and per-agent reply permissions.
 Calls-enabled agents also join calls in ad-hoc rooms they accepted through their normal authorized-invite policy. This lets Matrix clients create a private, temporary voice room and invite one agent without adding that room to `config.yaml` first.
 Calls-enabled agents advertise `📞 Voice calls` in their Matrix presence status only when their MatrixRTC runtime is available, so clients can show the call action only where it will be answered.
-Requester-private agents are not currently supported for calls.
+Requester-private agents use the sole authorized caller's verified Matrix user ID to resolve their workspace, memory, credentials, history, knowledge, and tool execution scope.
+The same caller scope applies in configured rooms and authorized ad-hoc invite rooms.
 
 ## Cascaded cloud example
 
@@ -159,7 +160,8 @@ Calls in unencrypted rooms need none of this and work with plain SFU media.
 ## Transcripts and memory
 
 Every call writes a markdown transcript incrementally.
-File-memory agents keep it under `calls/` in their canonical workspace, where their file tools can read it later; other agents keep it under `<storage>/calls/<agent>/`.
+Shared file-memory agents keep it under `calls/` in their canonical workspace, where their file tools can read it later; other shared agents keep it under `<storage>/calls/<agent>/`.
+Requester-private file-memory agents keep transcripts in their requester-scoped workspace, while other requester-private agents keep them in their requester-scoped state archive.
 When the call ends, file memory stores a relative transcript reference, Mem0 stores the transcript as recallable context, and disabled memory leaves only the transcript file.
 
 ## Limitations

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -1377,7 +1377,7 @@ voice:
 calls:
   enabled: false                   # Default: false
   backend: realtime                # realtime (default) or cascaded
-  agents: []                       # Shared agents allowed to join calls in their configured rooms (at most one per room)
+  agents: []                       # Agents allowed to join calls in their configured rooms (at most one per room)
   model: gpt-realtime-2.1          # OpenAI realtime speech-to-speech model
   credentials_service: openai      # Credential service used by the realtime backend
   voice: null                      # Optional realtime voice preset
@@ -13030,7 +13030,7 @@ The agent leaves the call and clears its membership state event when the caller 
 calls:
   enabled: true
   backend: realtime           # default; preserves OpenAI speech-to-speech
-  agents: [assistant]        # shared agents that may join calls in their configured rooms
+  agents: [assistant]         # agents that may join calls in their configured rooms
   model: gpt-realtime-2.1    # OpenAI realtime model
   credentials_service: openai # strict credential service binding; defaults to openai
   voice: marin               # optional voice preset
@@ -13044,7 +13044,8 @@ MindRoom enforces at most one calls-enabled agent per room.
 Calls only join rooms configured for that agent and only while the sole caller passes the normal room and per-agent reply permissions.
 Calls-enabled agents also join calls in ad-hoc rooms they accepted through their normal authorized-invite policy. This lets Matrix clients create a private, temporary voice room and invite one agent without adding that room to `config.yaml` first.
 Calls-enabled agents advertise `📞 Voice calls` in their Matrix presence status only when their MatrixRTC runtime is available, so clients can show the call action only where it will be answered.
-Requester-private agents are not currently supported for calls.
+Requester-private agents use the sole authorized caller's verified Matrix user ID to resolve their workspace, memory, credentials, history, knowledge, and tool execution scope.
+The same caller scope applies in configured rooms and authorized ad-hoc invite rooms.
 
 ## Cascaded cloud example
 
@@ -13157,7 +13158,8 @@ Calls in unencrypted rooms need none of this and work with plain SFU media.
 ## Transcripts and memory
 
 Every call writes a markdown transcript incrementally.
-File-memory agents keep it under `calls/` in their canonical workspace, where their file tools can read it later; other agents keep it under `<storage>/calls/<agent>/`.
+Shared file-memory agents keep it under `calls/` in their canonical workspace, where their file tools can read it later; other shared agents keep it under `<storage>/calls/<agent>/`.
+Requester-private file-memory agents keep transcripts in their requester-scoped workspace, while other requester-private agents keep them in their requester-scoped state archive.
 When the call ends, file memory stores a relative transcript reference, Mem0 stores the transcript as recallable context, and disabled memory leaves only the transcript file.
 
 ## Limitations

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -520,7 +520,7 @@ voice:
 calls:
   enabled: false                   # Default: false
   backend: realtime                # realtime (default) or cascaded
-  agents: []                       # Shared agents allowed to join calls in their configured rooms (at most one per room)
+  agents: []                       # Agents allowed to join calls in their configured rooms (at most one per room)
   model: gpt-realtime-2.1          # OpenAI realtime speech-to-speech model
   credentials_service: openai      # Credential service used by the realtime backend
   voice: null                      # Optional realtime voice preset

--- a/skills/mindroom-docs/references/page__voice-calls__index.md
+++ b/skills/mindroom-docs/references/page__voice-calls__index.md
@@ -32,7 +32,7 @@ The agent leaves the call and clears its membership state event when the caller 
 calls:
   enabled: true
   backend: realtime           # default; preserves OpenAI speech-to-speech
-  agents: [assistant]        # shared agents that may join calls in their configured rooms
+  agents: [assistant]         # agents that may join calls in their configured rooms
   model: gpt-realtime-2.1    # OpenAI realtime model
   credentials_service: openai # strict credential service binding; defaults to openai
   voice: marin               # optional voice preset
@@ -46,7 +46,8 @@ MindRoom enforces at most one calls-enabled agent per room.
 Calls only join rooms configured for that agent and only while the sole caller passes the normal room and per-agent reply permissions.
 Calls-enabled agents also join calls in ad-hoc rooms they accepted through their normal authorized-invite policy. This lets Matrix clients create a private, temporary voice room and invite one agent without adding that room to `config.yaml` first.
 Calls-enabled agents advertise `📞 Voice calls` in their Matrix presence status only when their MatrixRTC runtime is available, so clients can show the call action only where it will be answered.
-Requester-private agents are not currently supported for calls.
+Requester-private agents use the sole authorized caller's verified Matrix user ID to resolve their workspace, memory, credentials, history, knowledge, and tool execution scope.
+The same caller scope applies in configured rooms and authorized ad-hoc invite rooms.
 
 ## Cascaded cloud example
 
@@ -159,7 +160,8 @@ Calls in unencrypted rooms need none of this and work with plain SFU media.
 ## Transcripts and memory
 
 Every call writes a markdown transcript incrementally.
-File-memory agents keep it under `calls/` in their canonical workspace, where their file tools can read it later; other agents keep it under `<storage>/calls/<agent>/`.
+Shared file-memory agents keep it under `calls/` in their canonical workspace, where their file tools can read it later; other shared agents keep it under `<storage>/calls/<agent>/`.
+Requester-private file-memory agents keep transcripts in their requester-scoped workspace, while other requester-private agents keep them in their requester-scoped state archive.
 When the call ends, file memory stores a relative transcript reference, Mem0 stores the transcript as recallable context, and disabled memory leaves only the transcript file.
 
 ## Limitations

--- a/src/mindroom/config/main.py
+++ b/src/mindroom/config/main.py
@@ -573,16 +573,6 @@ class Config(BaseModel):
             msg = f"calls.agents references unknown agent(s): {', '.join(unknown_agents)}"
             raise ValueError(msg)
 
-        private_agents = sorted(
-            agent_name for agent_name in self.calls.agents if self.agents[agent_name].private is not None
-        )
-        if private_agents:
-            msg = (
-                "calls.agents cannot reference requester-private agent(s): "
-                f"{', '.join(private_agents)}; call agents must currently be shared agents"
-            )
-            raise ValueError(msg)
-
         agents_by_room: dict[str, list[str]] = {}
         for agent_name in self.calls.agents:
             for room in self.agents[agent_name].rooms:

--- a/src/mindroom/matrix_rtc/call_manager.py
+++ b/src/mindroom/matrix_rtc/call_manager.py
@@ -600,6 +600,14 @@ class CallManager:
                 requester_id=members[0].user_id,
                 cascaded=self._config.calls.backend == "cascaded",
             )
+            transcript = CallTranscript.start(
+                agent_name=self._agent_name,
+                config=self._config,
+                runtime_paths=self._runtime_paths,
+                execution_identity=tooling.execution_identity,
+                room_id=room_id,
+                room_display_name=room.display_name or room_id,
+            )
         except Exception as error:
             logger.warning(
                 "call_join_skipped_agent_materialization_failed",
@@ -618,13 +626,6 @@ class CallManager:
                 error=str(error),
             )
             return "skip"
-        transcript = CallTranscript.start(
-            agent_name=self._agent_name,
-            config=self._config,
-            storage_path=self._runtime_paths.storage_root,
-            room_id=room_id,
-            room_display_name=room.display_name or room_id,
-        )
         bridge = self._bridge_factory(
             f"{self._client.user_id}:{device_id}",
             room.encrypted,
@@ -651,7 +652,6 @@ class CallManager:
                     on_stopped=lambda: transcript.finalize(
                         config=self._config,
                         runtime_paths=self._runtime_paths,
-                        storage_path=self._runtime_paths.storage_root,
                     ),
                     on_failure=lambda message: self._send_call_failure_notice(room_id, message),
                 ),

--- a/src/mindroom/matrix_rtc/call_tools.py
+++ b/src/mindroom/matrix_rtc/call_tools.py
@@ -87,7 +87,7 @@ class CallAgentTooling:
 
     tools: tuple[Any, ...]
     instructions: str
-    execution_identity: ToolExecutionIdentity | None = None
+    execution_identity: ToolExecutionIdentity
     responder: Callable[[str, Callable[[list[str]], None] | None], Awaitable[CallAgentResponse]] | None = None
     finalize_spoken_response: Callable[[str | None, str, bool], Awaitable[None] | None] | None = None
 

--- a/src/mindroom/matrix_rtc/call_tools.py
+++ b/src/mindroom/matrix_rtc/call_tools.py
@@ -87,6 +87,7 @@ class CallAgentTooling:
 
     tools: tuple[Any, ...]
     instructions: str
+    execution_identity: ToolExecutionIdentity | None = None
     responder: Callable[[str, Callable[[list[str]], None] | None], Awaitable[CallAgentResponse]] | None = None
     finalize_spoken_response: Callable[[str | None, str, bool], Awaitable[None] | None] | None = None
 
@@ -256,6 +257,7 @@ async def build_call_tools(
         return CallAgentTooling(
             tools=(),
             instructions="",
+            execution_identity=execution_identity,
             responder=responder,
             finalize_spoken_response=response_tracker.finalize,
         )
@@ -335,7 +337,11 @@ async def build_call_tools(
         )
     instructions = await _render_system_prompt(agent, session, run_context, visible_functions)
     logger.info("call_tools_built", agent=agent_name, room_id=room_id, tool_count=len(tools))
-    return CallAgentTooling(tools=tuple(tools), instructions=instructions)
+    return CallAgentTooling(
+        tools=tuple(tools),
+        instructions=instructions,
+        execution_identity=execution_identity,
+    )
 
 
 async def _run_call_agent(

--- a/src/mindroom/matrix_rtc/transcript.py
+++ b/src/mindroom/matrix_rtc/transcript.py
@@ -16,35 +16,52 @@ from uuid import uuid4
 
 from mindroom.logging_config import get_logger
 from mindroom.memory import add_agent_memory
-from mindroom.tool_system.worker_routing import agent_workspace_root_path
+from mindroom.runtime_resolution import resolve_agent_runtime
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
+    from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
 logger = get_logger(__name__)
 
 _TRANSCRIPT_DIRNAME = "calls"
 
 
-def _call_transcript_path(
-    *,
-    agent_name: str,
-    config: Config,
-    storage_path: Path,
-    room_id: str,
-    started_at: datetime,
-) -> Path:
-    """Choose a transcript location compatible with the agent's runtime."""
-    if config.resolve_entity(agent_name).memory_backend == "file":
-        base = agent_workspace_root_path(storage_path, agent_name) / _TRANSCRIPT_DIRNAME
-    else:
-        base = storage_path / _TRANSCRIPT_DIRNAME / agent_name
+def _new_call_transcript_path(base: Path, *, room_id: str, started_at: datetime) -> Path:
+    """Create one collision-safe transcript path under an already-resolved root."""
     safe_room = re.sub(r"[^A-Za-z0-9_.-]", "_", room_id)
     stamp = started_at.strftime("%Y-%m-%d_%H-%M-%S")
     return base / f"{stamp}_{uuid4().hex}_{safe_room}.md"
+
+
+def _call_transcript_roots(
+    *,
+    agent_name: str,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    execution_identity: ToolExecutionIdentity | None,
+) -> tuple[Path, Path]:
+    """Resolve transcript storage and portable-reference roots for one caller scope."""
+    agent_runtime = resolve_agent_runtime(
+        agent_name,
+        config,
+        runtime_paths,
+        execution_identity=execution_identity,
+        create=True,
+    )
+    if config.resolve_entity(agent_name).memory_backend == "file":
+        workspace = agent_runtime.workspace
+        if workspace is None:
+            msg = f"File-memory agent '{agent_name}' has no resolved workspace"
+            raise ValueError(msg)
+        return workspace.root / _TRANSCRIPT_DIRNAME, workspace.root
+    if agent_runtime.execution.is_private:
+        return agent_runtime.state_root / _TRANSCRIPT_DIRNAME, agent_runtime.state_root
+    storage_root = runtime_paths.storage_root.expanduser().resolve()
+    return storage_root / _TRANSCRIPT_DIRNAME / agent_name, storage_root
 
 
 @dataclass
@@ -56,6 +73,8 @@ class CallTranscript:
     room_id: str
     room_display_name: str
     started_at: datetime
+    reference_root: Path
+    execution_identity: ToolExecutionIdentity | None
     _turns: int = field(default=0, init=False)
     _write_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
     _pending: list[str] = field(default_factory=list, init=False)
@@ -68,25 +87,28 @@ class CallTranscript:
         *,
         agent_name: str,
         config: Config,
-        storage_path: Path,
+        runtime_paths: RuntimePaths,
+        execution_identity: ToolExecutionIdentity | None,
         room_id: str,
         room_display_name: str,
     ) -> CallTranscript:
         """Create the transcript for a call starting now."""
         started_at = datetime.now(tz=UTC)
-        path = _call_transcript_path(
+        transcript_root, reference_root = _call_transcript_roots(
             agent_name=agent_name,
             config=config,
-            storage_path=storage_path,
-            room_id=room_id,
-            started_at=started_at,
+            runtime_paths=runtime_paths,
+            execution_identity=execution_identity,
         )
+        path = _new_call_transcript_path(transcript_root, room_id=room_id, started_at=started_at)
         return cls(
             path=path,
             agent_name=agent_name,
             room_id=room_id,
             room_display_name=room_display_name,
             started_at=started_at,
+            reference_root=reference_root,
+            execution_identity=execution_identity,
         )
 
     def record(self, speaker: str, text: str) -> None:
@@ -159,7 +181,7 @@ class CallTranscript:
         del self._pending[: len(lines)]
         self._header_written = True
 
-    async def finalize(self, *, config: Config, runtime_paths: RuntimePaths, storage_path: Path) -> None:
+    async def finalize(self, *, config: Config, runtime_paths: RuntimePaths) -> None:
         """Flush remaining turns and store a memory reference for the call."""
         ended_at = datetime.now(tz=UTC)
         duration_minutes = max(1, round((ended_at - self.started_at).total_seconds() / 60))
@@ -178,12 +200,7 @@ class CallTranscript:
         memory_backend = config.resolve_entity(self.agent_name).memory_backend
         if memory_backend == "none":
             return
-        if memory_backend == "file":
-            transcript_path = self.path.relative_to(
-                agent_workspace_root_path(storage_path, self.agent_name),
-            ).as_posix()
-        else:
-            transcript_path = self.path.relative_to(storage_path).as_posix()
+        transcript_path = self.path.relative_to(self.reference_root).as_posix()
         summary = (
             f"Joined a voice call in {self.room_display_name} ({self.room_id}): "
             f"{self._turns} spoken turns over ~{duration_minutes} min. "
@@ -197,10 +214,11 @@ class CallTranscript:
             await add_agent_memory(
                 memory_content,
                 self.agent_name,
-                storage_path,
+                runtime_paths.storage_root,
                 config,
                 runtime_paths,
                 metadata={"source": "matrix_rtc_call", "transcript_path": transcript_path},
+                execution_identity=self.execution_identity,
             )
         except Exception as error:
             logger.warning("call_memory_reference_failed", agent=self.agent_name, error=str(error))

--- a/tach.toml
+++ b/tach.toml
@@ -2283,7 +2283,7 @@ path = "mindroom.matrix_rtc.transcript"
 depends_on = [
     "mindroom.logging_config",
     "mindroom.memory",
-    "mindroom.tool_system.worker_routing",
+    "mindroom.runtime_resolution",
 ]
 
 [[modules]]

--- a/tests/test_matrix_rtc_call_manager.py
+++ b/tests/test_matrix_rtc_call_manager.py
@@ -245,6 +245,16 @@ def _call_execution_identity(
     )
 
 
+def _call_execution_identity_from_tool_kwargs(kwargs: dict[str, object]) -> ToolExecutionIdentity:
+    return _call_execution_identity(
+        runtime_paths=cast("RuntimePaths", kwargs["runtime_paths"]),
+        requester_id=cast("str", kwargs["requester_id"]),
+        room_id=cast("str", kwargs["room_id"]),
+        agent_name=cast("str", kwargs["agent_name"]),
+        session_id=cast("str | None", kwargs["session_id"]),
+    )
+
+
 def _cascaded_config(*, local: bool = False) -> Config:
     config = _config()
     if local:
@@ -359,8 +369,12 @@ def _stub_join_externals(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr("mindroom.matrix_rtc.call_manager.request_sfu_grant", fake_grant)
 
-    async def fake_tools(**_kwargs: object) -> CallAgentTooling:
-        return CallAgentTooling(tools=(), instructions="You are Helper.")
+    async def fake_tools(**kwargs: object) -> CallAgentTooling:
+        return CallAgentTooling(
+            tools=(),
+            instructions="You are Helper.",
+            execution_identity=_call_execution_identity_from_tool_kwargs(kwargs),
+        )
 
     monkeypatch.setattr("mindroom.matrix_rtc.call_manager.build_call_tools", fake_tools)
 
@@ -426,13 +440,7 @@ async def test_manager_joins_requester_private_agent_in_owned_rooms(
         return CallAgentTooling(
             tools=(),
             instructions="Private helper",
-            execution_identity=_call_execution_identity(
-                runtime_paths=cast("RuntimePaths", kwargs["runtime_paths"]),
-                requester_id=requester_id,
-                room_id=cast("str", kwargs["room_id"]),
-                agent_name=cast("str", kwargs["agent_name"]),
-                session_id=cast("str | None", kwargs["session_id"]),
-            ),
+            execution_identity=_call_execution_identity_from_tool_kwargs(kwargs),
         )
 
     monkeypatch.setattr("mindroom.matrix_rtc.call_manager.build_call_tools", fake_tools)
@@ -599,7 +607,12 @@ async def test_manager_selects_cascaded_backend_with_independent_speech_services
     async def fake_tools(**kwargs: object) -> CallAgentTooling:
         assert kwargs["enable_responder"] is True
         assert str(kwargs["session_id"]).startswith(f"{ROOM_ID}:call:")
-        return CallAgentTooling(tools=(), instructions="", responder=respond)
+        return CallAgentTooling(
+            tools=(),
+            instructions="",
+            execution_identity=_call_execution_identity_from_tool_kwargs(kwargs),
+            responder=respond,
+        )
 
     monkeypatch.setattr("mindroom.matrix_rtc.call_manager.build_call_tools", fake_tools)
     client = _client()
@@ -639,8 +652,13 @@ async def test_cascaded_agent_start_failure_tears_down_and_retries(
     ) -> CallAgentResponse:
         return CallAgentResponse("answer")
 
-    async def fake_tools(**_kwargs: object) -> CallAgentTooling:
-        return CallAgentTooling(tools=(), instructions="", responder=respond)
+    async def fake_tools(**kwargs: object) -> CallAgentTooling:
+        return CallAgentTooling(
+            tools=(),
+            instructions="",
+            execution_identity=_call_execution_identity_from_tool_kwargs(kwargs),
+            responder=respond,
+        )
 
     monkeypatch.setattr("mindroom.matrix_rtc.call_manager.build_call_tools", fake_tools)
     client = _client()
@@ -936,7 +954,11 @@ async def test_manager_restarts_when_sole_requester_changes(
 
     async def fake_tools(**kwargs: object) -> CallAgentTooling:
         requesters.append(str(kwargs["requester_id"]))
-        return CallAgentTooling(tools=(), instructions="You are Helper.")
+        return CallAgentTooling(
+            tools=(),
+            instructions="You are Helper.",
+            execution_identity=_call_execution_identity_from_tool_kwargs(kwargs),
+        )
 
     monkeypatch.setattr("mindroom.matrix_rtc.call_manager.build_call_tools", fake_tools)
     config = _config()
@@ -1692,7 +1714,11 @@ async def test_manager_passes_same_agent_tools_and_prompt(
 
     async def fake_build_call_tools(**kwargs: object) -> CallAgentTooling:
         tool_kwargs.update(kwargs)
-        return CallAgentTooling(tools=(sentinel_tool,), instructions="CHAT PROMPT")
+        return CallAgentTooling(
+            tools=(sentinel_tool,),
+            instructions="CHAT PROMPT",
+            execution_identity=_call_execution_identity_from_tool_kwargs(kwargs),
+        )
 
     monkeypatch.setattr("mindroom.matrix_rtc.call_manager.build_call_tools", fake_build_call_tools)
     client = _client()
@@ -2383,7 +2409,11 @@ async def test_cascaded_retries_reuse_logical_call_session_id(
 
     async def fake_tools(**kwargs: object) -> CallAgentTooling:
         session_ids.append(cast("str", kwargs["session_id"]))
-        return CallAgentTooling(tools=(), instructions="")
+        return CallAgentTooling(
+            tools=(),
+            instructions="",
+            execution_identity=_call_execution_identity_from_tool_kwargs(kwargs),
+        )
 
     monkeypatch.setattr("mindroom.matrix_rtc.call_manager.build_call_tools", fake_tools)
     client = _client()

--- a/tests/test_matrix_rtc_call_manager.py
+++ b/tests/test_matrix_rtc_call_manager.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import time
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Literal, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
@@ -49,6 +49,7 @@ from mindroom.matrix_rtc.voice_agent import (
 )
 from mindroom.model_defaults import LOCAL_OPENAI_API_KEY_DEFAULT
 from mindroom.model_loading import get_model_instance
+from mindroom.tool_system.worker_routing import ToolExecutionIdentity, build_tool_execution_identity
 from tests.conftest import test_runtime_paths
 
 if TYPE_CHECKING:
@@ -57,6 +58,7 @@ if TYPE_CHECKING:
 
     from agno.models.openai.chat import OpenAIChat
 
+    from mindroom.constants import RuntimePaths
     from mindroom.matrix_rtc.events import CallMember
 
 BOT_USER = "@helper:example.org"
@@ -223,6 +225,26 @@ def _config(*, enabled: bool = True, credentials_service: str = "openai") -> Con
     )
 
 
+def _call_execution_identity(
+    *,
+    runtime_paths: RuntimePaths,
+    requester_id: str,
+    room_id: str = ROOM_ID,
+    agent_name: str = "helper",
+    session_id: str | None = None,
+) -> ToolExecutionIdentity:
+    return build_tool_execution_identity(
+        channel="matrix",
+        agent_name=agent_name,
+        runtime_paths=runtime_paths,
+        requester_id=requester_id,
+        room_id=room_id,
+        thread_id=None,
+        resolved_thread_id=None,
+        session_id=session_id or room_id,
+    )
+
+
 def _cascaded_config(*, local: bool = False) -> Config:
     config = _config()
     if local:
@@ -386,6 +408,62 @@ async def test_manager_joins_call_in_authorized_ad_hoc_invited_room(tmp_path: Pa
     await manager.on_room_event(_room(), _member_unknown_event())
 
     assert bridge.connected_grant == GRANT
+
+
+@pytest.mark.parametrize("invited_room", [False, True])
+@pytest.mark.asyncio
+async def test_manager_joins_requester_private_agent_in_owned_rooms(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    invited_room: bool,
+) -> None:
+    """Private call agents use verified caller state in configured and accepted-invite rooms."""
+    seen_requesters: list[str] = []
+
+    async def fake_tools(**kwargs: object) -> CallAgentTooling:
+        requester_id = cast("str", kwargs["requester_id"])
+        seen_requesters.append(requester_id)
+        return CallAgentTooling(
+            tools=(),
+            instructions="Private helper",
+            execution_identity=_call_execution_identity(
+                runtime_paths=cast("RuntimePaths", kwargs["runtime_paths"]),
+                requester_id=requester_id,
+                room_id=cast("str", kwargs["room_id"]),
+                agent_name=cast("str", kwargs["agent_name"]),
+                session_id=cast("str | None", kwargs["session_id"]),
+            ),
+        )
+
+    monkeypatch.setattr("mindroom.matrix_rtc.call_manager.build_call_tools", fake_tools)
+    config = Config(
+        agents={
+            "helper": AgentConfig(
+                display_name="Helper",
+                rooms=[] if invited_room else [ROOM_ID],
+                private=AgentPrivateConfig(per="user_agent"),
+            ),
+        },
+        models={},
+        authorization=AuthorizationConfig(global_users=["@alice:example.org"]),
+        calls=CallsConfig(enabled=True, agents=["helper"], livekit_service_url=SERVICE_URL),
+    )
+    client = _client()
+    client.room_get_state.return_value = _state_response(_remote_member_event())
+    bridge = FakeBridge()
+    manager = _manager(
+        client,
+        bridge,
+        tmp_path,
+        config,
+        invited_rooms_by_agent={"helper": {ROOM_ID}} if invited_room else None,
+    )
+
+    await manager.on_room_event(_room(), _member_unknown_event())
+
+    assert bridge.connected_grant == GRANT
+    assert seen_requesters == ["@alice:example.org"]
+    await manager.shutdown()
 
 
 @pytest.mark.asyncio
@@ -2854,19 +2932,21 @@ def test_calls_config_validates_realtime_credentials_service() -> None:
         CallsConfig(credentials_service="../openai")
 
 
-def test_calls_config_rejects_requester_private_agents() -> None:
-    """Call transcript and memory lifecycle currently require shared agents."""
-    with pytest.raises(ValueError, match=r"calls\.agents cannot reference requester-private agent"):
-        Config(
-            models={},
-            agents={
-                "private": AgentConfig(
-                    display_name="Private",
-                    private=AgentPrivateConfig(per="user_agent"),
-                ),
-            },
-            calls=CallsConfig(enabled=True, agents=["private"]),
-        )
+@pytest.mark.parametrize("private_scope", ["user", "user_agent"])
+def test_calls_config_accepts_requester_private_agents(private_scope: Literal["user", "user_agent"]) -> None:
+    """Both requester-private partition modes may opt into voice calls."""
+    config = Config(
+        models={},
+        agents={
+            "private": AgentConfig(
+                display_name="Private",
+                private=AgentPrivateConfig(per=private_scope),
+            ),
+        },
+        calls=CallsConfig(enabled=True, agents=["private"]),
+    )
+
+    assert config.calls.agents == ["private"]
 
 
 def test_calls_config_rejects_agents_sharing_a_room() -> None:

--- a/tests/test_matrix_rtc_call_tools.py
+++ b/tests/test_matrix_rtc_call_tools.py
@@ -27,6 +27,7 @@ from mindroom.matrix_rtc.call_tools import (
 )
 from mindroom.tool_system.events import ToolTraceEntry
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, get_tool_runtime_context
+from mindroom.tool_system.worker_routing import build_tool_execution_identity
 from tests.conftest import test_runtime_paths
 
 if TYPE_CHECKING:
@@ -276,6 +277,17 @@ async def test_build_call_tools_returns_same_agent_prompt_and_tools(
     refresh_scheduler = object()
     config = _config()
     runtime_paths = test_runtime_paths(tmp_path)
+    execution_identity = build_tool_execution_identity(
+        channel="matrix",
+        agent_name=AGENT,
+        runtime_paths=runtime_paths,
+        requester_id=REQUESTER,
+        room_id="!room:example.org",
+        thread_id=None,
+        resolved_thread_id=None,
+        session_id="!room:example.org",
+    )
+    knowledge_calls: list[dict[str, object]] = []
 
     def fake_create_agent(*args: object, **kwargs: object) -> FakeAgnoAgent:
         create_calls.append(args)
@@ -286,10 +298,12 @@ async def test_build_call_tools_returns_same_agent_prompt_and_tools(
         "mindroom.matrix_rtc.call_tools.create_agent",
         fake_create_agent,
     )
-    monkeypatch.setattr(
-        "mindroom.matrix_rtc.call_tools.resolve_agent_knowledge_access",
-        lambda *_args, **_kwargs: SimpleNamespace(knowledge=knowledge),
-    )
+
+    def fake_resolve_knowledge(*_args: object, **kwargs: object) -> SimpleNamespace:
+        knowledge_calls.append(kwargs)
+        return SimpleNamespace(knowledge=knowledge)
+
+    monkeypatch.setattr("mindroom.matrix_rtc.call_tools.resolve_agent_knowledge_access", fake_resolve_knowledge)
     seen_targets: list[MessageTarget] = []
 
     class StrictToolSupport:
@@ -317,11 +331,11 @@ async def test_build_call_tools_returns_same_agent_prompt_and_tools(
             target: MessageTarget,
             user_id: str | None,
             agent_name: str | None = None,
-        ) -> SimpleNamespace:
+        ) -> object:
             assert user_id == REQUESTER
             assert agent_name == AGENT
             seen_targets.append(target)
-            return SimpleNamespace()
+            return execution_identity
 
     tooling = await build_call_tools(
         agent_name=AGENT,
@@ -339,7 +353,9 @@ async def test_build_call_tools_returns_same_agent_prompt_and_tools(
     assert create_kwargs["refresh_scheduler"] is refresh_scheduler
     assert create_kwargs["tool_function_filter"] is not None
     assert create_calls
-    assert create_calls[0][3] is not None
+    assert create_calls[0][3] is execution_identity
+    assert knowledge_calls[0]["execution_identity"] is execution_identity
+    assert tooling.execution_identity is execution_identity
     assert len(seen_targets) == 2
     assert seen_targets[0] is seen_targets[1]
     assert seen_targets[0].session_id == "!room:example.org"
@@ -445,6 +461,7 @@ async def test_cascaded_responder_uses_normal_agent_turn_and_filters_unsafe_func
 
     assert tooling.tools == ()
     assert tooling.instructions == ""
+    assert tooling.execution_identity is execution_identity
     assert tooling.responder is not None
     response = await tooling.responder("What is the weather?", recorded_tool_uses.append)
 

--- a/tests/test_matrix_rtc_transcript.py
+++ b/tests/test_matrix_rtc_transcript.py
@@ -8,22 +8,30 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from mindroom.config.agent import AgentConfig
+from mindroom.config.agent import AgentConfig, AgentPrivateConfig
 from mindroom.config.calls import CallsConfig
 from mindroom.config.main import Config
-from mindroom.matrix_rtc.transcript import CallTranscript, _call_transcript_path
-from mindroom.tool_system.worker_routing import agent_workspace_root_path
+from mindroom.matrix_rtc.transcript import CallTranscript
+from mindroom.runtime_resolution import resolve_agent_runtime
+from mindroom.tool_system.worker_routing import ToolExecutionIdentity, build_tool_execution_identity
 from tests.conftest import test_runtime_paths
 
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from mindroom.constants import RuntimePaths
+
 AGENT = "helper"
 ROOM_ID = "!room:example.org"
 
 
-def _config(*, memory_backend: Literal["file", "mem0", "none"] = "mem0") -> Config:
-    agent = AgentConfig(display_name="Helper", memory_backend=memory_backend)
+def _config(
+    *,
+    memory_backend: Literal["file", "mem0", "none"] = "mem0",
+    private_scope: Literal["user", "user_agent"] | None = None,
+) -> Config:
+    private = AgentPrivateConfig(per=private_scope) if private_scope is not None else None
+    agent = AgentConfig(display_name="Helper", memory_backend=memory_backend, private=private)
     return Config(
         agents={AGENT: agent},
         models={},
@@ -31,12 +39,35 @@ def _config(*, memory_backend: Literal["file", "mem0", "none"] = "mem0") -> Conf
     )
 
 
-def _transcript(tmp_path: Path, config: Config | None = None) -> CallTranscript:
+def _execution_identity(
+    runtime_paths: RuntimePaths,
+    *,
+    requester_id: str = "@alice:example.org",
+) -> ToolExecutionIdentity:
+    return build_tool_execution_identity(
+        channel="matrix",
+        agent_name=AGENT,
+        runtime_paths=runtime_paths,
+        requester_id=requester_id,
+        room_id=ROOM_ID,
+        thread_id=None,
+        resolved_thread_id=None,
+        session_id=ROOM_ID,
+    )
+
+
+def _transcript(
+    tmp_path: Path,
+    config: Config | None = None,
+    *,
+    execution_identity: ToolExecutionIdentity | None = None,
+) -> CallTranscript:
     config = config or _config()
     return CallTranscript.start(
         agent_name=AGENT,
         config=config,
-        storage_path=tmp_path,
+        runtime_paths=test_runtime_paths(tmp_path),
+        execution_identity=execution_identity,
         room_id=ROOM_ID,
         room_display_name="Lobby",
     )
@@ -73,7 +104,7 @@ async def test_finalize_stores_relative_transcript_memory_reference(
     transcript = _transcript(tmp_path)
     transcript.record("user", "Ping")
 
-    await transcript.finalize(config=config, runtime_paths=runtime_paths, storage_path=tmp_path)
+    await transcript.finalize(config=config, runtime_paths=runtime_paths)
 
     add_memory.assert_awaited_once()
     memory_content = add_memory.await_args.args[0]
@@ -95,7 +126,7 @@ async def test_file_memory_stores_workspace_relative_reference(
     transcript = _transcript(tmp_path, config)
     transcript.record("user", "Ping")
 
-    await transcript.finalize(config=config, runtime_paths=test_runtime_paths(tmp_path), storage_path=tmp_path)
+    await transcript.finalize(config=config, runtime_paths=test_runtime_paths(tmp_path))
 
     memory_content = add_memory.await_args.args[0]
     assert f"Transcript: calls/{transcript.path.name}" in memory_content
@@ -110,7 +141,7 @@ async def test_finalize_without_turns_skips_memory(tmp_path: Path, monkeypatch: 
     config = _config()
     transcript = _transcript(tmp_path, config)
 
-    await transcript.finalize(config=config, runtime_paths=test_runtime_paths(tmp_path), storage_path=tmp_path)
+    await transcript.finalize(config=config, runtime_paths=test_runtime_paths(tmp_path))
 
     add_memory.assert_not_awaited()
     assert not transcript.path.exists()
@@ -128,7 +159,7 @@ async def test_disabled_memory_keeps_transcript_without_memory_entry(
     transcript = _transcript(tmp_path, config)
     transcript.record("user", "Ping")
 
-    await transcript.finalize(config=config, runtime_paths=test_runtime_paths(tmp_path), storage_path=tmp_path)
+    await transcript.finalize(config=config, runtime_paths=test_runtime_paths(tmp_path))
 
     add_memory.assert_not_awaited()
     assert transcript.path.exists()
@@ -203,7 +234,6 @@ async def test_finalize_contains_transcript_io_failure(tmp_path: Path) -> None:
     await transcript.finalize(
         config=_config(),
         runtime_paths=test_runtime_paths(tmp_path),
-        storage_path=tmp_path,
     )
 
     assert transcript._pending == ["- preserved\n"]
@@ -211,30 +241,77 @@ async def test_finalize_contains_transcript_io_failure(tmp_path: Path) -> None:
 
 def test_transcript_path_routes_by_memory_backend(tmp_path: Path) -> None:
     """File agents use their workspace; other agents use the call archive."""
-    from datetime import UTC, datetime  # noqa: PLC0415
-
-    started = datetime.now(tz=UTC)
-    workspace_path = _call_transcript_path(
+    runtime_paths = test_runtime_paths(tmp_path)
+    workspace_path = CallTranscript.start(
         agent_name=AGENT,
         config=_config(memory_backend="file"),
-        storage_path=tmp_path,
+        runtime_paths=runtime_paths,
+        execution_identity=None,
         room_id=ROOM_ID,
-        started_at=started,
+        room_display_name="Lobby",
+    ).path
+    workspace_runtime = resolve_agent_runtime(
+        AGENT,
+        _config(memory_backend="file"),
+        runtime_paths,
+        execution_identity=None,
     )
-    assert workspace_path.is_relative_to(agent_workspace_root_path(tmp_path, AGENT))
-    archive_path = _call_transcript_path(
+    assert workspace_runtime.workspace is not None
+    assert workspace_path.is_relative_to(workspace_runtime.workspace.root)
+    archive_path = CallTranscript.start(
         agent_name=AGENT,
         config=_config(),
-        storage_path=tmp_path,
+        runtime_paths=runtime_paths,
+        execution_identity=None,
         room_id=ROOM_ID,
-        started_at=started,
-    )
-    assert archive_path.is_relative_to(tmp_path / "calls" / AGENT)
-    second_archive_path = _call_transcript_path(
+        room_display_name="Lobby",
+    ).path
+    assert archive_path.is_relative_to(runtime_paths.storage_root / "calls" / AGENT)
+    second_archive_path = CallTranscript.start(
         agent_name=AGENT,
         config=_config(),
-        storage_path=tmp_path,
+        runtime_paths=runtime_paths,
+        execution_identity=None,
         room_id=ROOM_ID,
-        started_at=started,
-    )
+        room_display_name="Lobby",
+    ).path
     assert second_archive_path != archive_path
+
+
+def test_private_transcript_requires_requester_identity(tmp_path: Path) -> None:
+    """A private call cannot fall back to shared transcript storage."""
+    with pytest.raises(ValueError, match="requires an active execution identity"):
+        _transcript(tmp_path, _config(private_scope="user_agent"))
+
+
+@pytest.mark.parametrize("private_scope", ["user", "user_agent"])
+@pytest.mark.parametrize("memory_backend", ["file", "mem0"])
+@pytest.mark.asyncio
+async def test_private_transcripts_and_memory_are_requester_scoped(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    private_scope: Literal["user", "user_agent"],
+    memory_backend: Literal["file", "mem0"],
+) -> None:
+    """Transcript storage and memory finalization use the verified caller scope."""
+    add_memory = AsyncMock()
+    monkeypatch.setattr("mindroom.matrix_rtc.transcript.add_agent_memory", add_memory)
+    config = _config(memory_backend=memory_backend, private_scope=private_scope)
+    runtime_paths = test_runtime_paths(tmp_path)
+    alice_identity = _execution_identity(runtime_paths)
+    bob_identity = _execution_identity(runtime_paths, requester_id="@bob:example.org")
+
+    alice = _transcript(tmp_path, config, execution_identity=alice_identity)
+    bob = _transcript(tmp_path, config, execution_identity=bob_identity)
+    alice_runtime = resolve_agent_runtime(AGENT, config, runtime_paths, execution_identity=alice_identity)
+    bob_runtime = resolve_agent_runtime(AGENT, config, runtime_paths, execution_identity=bob_identity)
+
+    assert alice.path.parent != bob.path.parent
+    assert alice.path.is_relative_to(alice_runtime.state_root)
+    assert bob.path.is_relative_to(bob_runtime.state_root)
+    alice.record("user", "private ping")
+    await alice.finalize(config=config, runtime_paths=runtime_paths)
+
+    assert add_memory.await_args.kwargs["execution_identity"] is alice_identity
+    assert add_memory.await_args.args[2] == runtime_paths.storage_root
+    assert "Transcript: calls/" in add_memory.await_args.args[0]


### PR DESCRIPTION
## Why

MatrixRTC already admits exactly one authorized human Matrix user per call, but calls.agents rejected requester-private agents even though that verified caller identity is available before agent materialization.

This prevented private agents from joining voice calls and left transcript persistence as the remaining shared-state path.

## What changed

- Allow requester-private agents in calls.agents while retaining existing one-agent-per-room validation.
- Carry the verified caller execution identity from call materialization into transcript creation and memory finalization.
- Store private transcripts under requester-scoped runtime roots and resolve memory through the same identity used by workspace, history, knowledge, credentials, and tools.
- Keep configured rooms and authorized accepted-invite rooms on the existing ownership path, including fail-closed ambiguity checks.
- Add coverage for user and user_agent private scopes, file and Mem0 memory, caller isolation, configured rooms, accepted-invite rooms, and missing-identity rejection.

## Validation

- uv sync --all-extras
- uv run pytest: 10175 passed, 54 skipped
- uv run tach check --dependencies --interfaces
- uv run pre-commit run --all-files
