### PR TITLE
Use Responses API for native OpenAI deferred tools

### DIFF
--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -125,6 +125,12 @@ models:
       base_url: http://localhost:8080/v1
 ```
 
+## OpenAI API Models
+
+GPT 5.4 and newer models on the first-party `openai` provider use the Responses API.
+This enables OpenAI's native deferred-tool search without disabling reasoning.
+Older GPT models and models configured with a custom `extra_kwargs.base_url` keep using Chat Completions for OpenAI-compatible endpoint support.
+
 ## Codex Subscription Models
 
 Use `provider: codex` when you want MindRoom to call models exposed through an authenticated local Codex CLI session instead of the regular OpenAI API.

--- a/docs/tools/dynamic-tools.md
+++ b/docs/tools/dynamic-tools.md
@@ -32,7 +32,7 @@ No flags means the tool is eager and appears in every request.
 
 ## Native Server-Side Tool Search
 
-Claude models since Opus 4.5 / Sonnet 4.5 / Haiku 4.5 on the `anthropic` and `vertexai_claude` providers, and GPT models 5.4 or newer on the `codex` and `openai_codex` providers, use the provider's server-side tool search automatically.
+Claude models since Opus 4.5 / Sonnet 4.5 / Haiku 4.5 on the `anthropic` and `vertexai_claude` providers, and GPT models 5.4 or newer on the first-party `openai`, `codex`, and `openai_codex` providers, use the provider's server-side tool search automatically.
 On this path every deferred tool ships in every request tagged `defer_loading: true` together with the provider's tool-search entry, so deferred schemas stay out of the model's rendered context until the model searches for them.
 Tool discovery never invalidates the prompt cache: Anthropic expands discovered tool references inline in the message stream, and OpenAI loads discovered tools at the end of the context window.
 The `dynamic_tools` manager, its prompt blocks, and session loaded-tool state are not used on this path; all deferred toolkits are attached at agent build, so discovered calls execute directly.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -2380,6 +2380,12 @@ models:
       base_url: http://localhost:8080/v1
 ```
 
+## OpenAI API Models
+
+GPT 5.4 and newer models on the first-party `openai` provider use the Responses API.
+This enables OpenAI's native deferred-tool search without disabling reasoning.
+Older GPT models and models configured with a custom `extra_kwargs.base_url` keep using Chat Completions for OpenAI-compatible endpoint support.
+
 ## Codex Subscription Models
 
 Use `provider: codex` when you want MindRoom to call models exposed through an authenticated local Codex CLI session instead of the regular OpenAI API.
@@ -3102,7 +3108,7 @@ No flags means the tool is eager and appears in every request.
 
 ## Native Server-Side Tool Search
 
-Claude models since Opus 4.5 / Sonnet 4.5 / Haiku 4.5 on the `anthropic` and `vertexai_claude` providers, and GPT models 5.4 or newer on the `codex` and `openai_codex` providers, use the provider's server-side tool search automatically.
+Claude models since Opus 4.5 / Sonnet 4.5 / Haiku 4.5 on the `anthropic` and `vertexai_claude` providers, and GPT models 5.4 or newer on the first-party `openai`, `codex`, and `openai_codex` providers, use the provider's server-side tool search automatically.
 On this path every deferred tool ships in every request tagged `defer_loading: true` together with the provider's tool-search entry, so deferred schemas stay out of the model's rendered context until the model searches for them.
 Tool discovery never invalidates the prompt cache: Anthropic expands discovered tool references inline in the message stream, and OpenAI loads discovered tools at the end of the context window.
 The `dynamic_tools` manager, its prompt blocks, and session loaded-tool state are not used on this path; all deferred toolkits are attached at agent build, so discovered calls execute directly.

--- a/skills/mindroom-docs/references/page__configuration__models__index.md
+++ b/skills/mindroom-docs/references/page__configuration__models__index.md
@@ -121,6 +121,12 @@ models:
       base_url: http://localhost:8080/v1
 ```
 
+## OpenAI API Models
+
+GPT 5.4 and newer models on the first-party `openai` provider use the Responses API.
+This enables OpenAI's native deferred-tool search without disabling reasoning.
+Older GPT models and models configured with a custom `extra_kwargs.base_url` keep using Chat Completions for OpenAI-compatible endpoint support.
+
 ## Codex Subscription Models
 
 Use `provider: codex` when you want MindRoom to call models exposed through an authenticated local Codex CLI session instead of the regular OpenAI API.

--- a/skills/mindroom-docs/references/page__tools__dynamic-tools__index.md
+++ b/skills/mindroom-docs/references/page__tools__dynamic-tools__index.md
@@ -32,7 +32,7 @@ No flags means the tool is eager and appears in every request.
 
 ## Native Server-Side Tool Search
 
-Claude models since Opus 4.5 / Sonnet 4.5 / Haiku 4.5 on the `anthropic` and `vertexai_claude` providers, and GPT models 5.4 or newer on the `codex` and `openai_codex` providers, use the provider's server-side tool search automatically.
+Claude models since Opus 4.5 / Sonnet 4.5 / Haiku 4.5 on the `anthropic` and `vertexai_claude` providers, and GPT models 5.4 or newer on the first-party `openai`, `codex`, and `openai_codex` providers, use the provider's server-side tool search automatically.
 On this path every deferred tool ships in every request tagged `defer_loading: true` together with the provider's tool-search entry, so deferred schemas stay out of the model's rendered context until the model searches for them.
 Tool discovery never invalidates the prompt cache: Anthropic expands discovered tool references inline in the message stream, and OpenAI loads discovered tools at the end of the context window.
 The `dynamic_tools` manager, its prompt blocks, and session loaded-tool state are not used on this path; all deferred toolkits are attached at agent build, so discovered calls execute directly.

--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -1668,7 +1668,12 @@ def create_agent(
     runtime_model_config = config.models.get(active_model_name or agent_config.model or "default")
     native_deferred_tools = runtime_model_config is not None and (
         native_tool_search_supported(runtime_model_config.provider, runtime_model_config.id)
-        or openai_native_tool_search_supported(runtime_model_config.provider, runtime_model_config.id)
+        or openai_native_tool_search_supported(
+            runtime_model_config.provider,
+            runtime_model_config.id,
+            base_url=(runtime_model_config.extra_kwargs or {}).get("base_url")
+            or runtime_paths.env_value("OPENAI_BASE_URL"),
+        )
     )
 
     tool_assembly = _assemble_agent_toolkits(

--- a/src/mindroom/codex_model.py
+++ b/src/mindroom/codex_model.py
@@ -12,27 +12,18 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import httpx
-from agno.models.openai import OpenAIResponses
 from agno.models.response import ModelResponse
 from agno.utils.http import get_default_async_client, get_default_sync_client
 from openai import AsyncOpenAI, OpenAI
-from openai.types.responses import ResponseOutputItemDoneEvent
 
 from mindroom.file_locks import advisory_file_lock
 from mindroom.model_defaults import CODEX_GPT, CODEX_GPT_ENDPOINT
-from mindroom.openai_tool_search import (
-    formatted_input_with_tool_search_items,
-    model_deferred_tool_names,
-    record_tool_search_items,
-    request_params_with_deferred_tool_search,
-)
+from mindroom.openai_responses_model import MindRoomOpenAIResponses
 from mindroom.prompts import CODEX_DEFAULT_INSTRUCTIONS
 
 if TYPE_CHECKING:
     from agno.models.message import Message
     from agno.run.agent import RunOutput
-    from agno.tools.function import Function
-    from openai.types.responses import Response, ResponseStreamEvent
     from pydantic import BaseModel
 
     from mindroom.tool_system.worker_routing import ToolExecutionIdentity
@@ -261,7 +252,7 @@ def _merge_codex_extra_body(request_params: dict[str, Any], codex_extra_body: di
 
 
 @dataclass
-class CodexResponses(OpenAIResponses):
+class CodexResponses(MindRoomOpenAIResponses):
     """Agno Responses model backed by the local Codex CLI ChatGPT OAuth credentials."""
 
     id: str = CODEX_GPT
@@ -319,7 +310,6 @@ class CodexResponses(OpenAIResponses):
             tools=tools,
             tool_choice=tool_choice,
         )
-        request_params = request_params_with_deferred_tool_search(request_params, model_deferred_tool_names(self))
         request_params.setdefault("instructions", self._instructions_text())
         prompt_cache_key = self._prompt_cache_key()
         if prompt_cache_key:
@@ -337,34 +327,6 @@ class CodexResponses(OpenAIResponses):
         for param_name in _CODEX_UNSUPPORTED_REQUEST_PARAMS:
             request_params.pop(param_name, None)
         return request_params
-
-    def _format_messages(
-        self,
-        messages: list[Message],
-        compress_tool_results: bool = False,
-        tools: list[Function | dict[str, Any]] | None = None,
-    ) -> list[Any]:
-        """Reinsert captured tool_search items that Agno's formatter drops from history."""
-        formatted_input = super()._format_messages(messages, compress_tool_results, tools=tools)
-        return formatted_input_with_tool_search_items(messages, formatted_input)
-
-    def _parse_provider_response(self, response: Response, **kwargs: object) -> ModelResponse:
-        """Capture tool_search output items that Agno's response parser drops."""
-        model_response = super()._parse_provider_response(response, **kwargs)
-        record_tool_search_items(model_response, response.output)
-        return model_response
-
-    def _parse_provider_response_delta(
-        self,
-        stream_event: ResponseStreamEvent,
-        assistant_message: Message,
-        tool_use: dict[str, Any],
-    ) -> tuple[ModelResponse, dict[str, Any]]:
-        """Capture streamed tool_search output items that Agno's delta parser drops."""
-        model_response, tool_use = super()._parse_provider_response_delta(stream_event, assistant_message, tool_use)
-        if isinstance(stream_event, ResponseOutputItemDoneEvent):
-            record_tool_search_items(model_response, [stream_event.item])
-        return model_response, tool_use
 
     def invoke(
         self,

--- a/src/mindroom/model_loading.py
+++ b/src/mindroom/model_loading.py
@@ -259,6 +259,14 @@ def _create_model_for_provider(  # noqa: C901, PLR0911, PLR0912, PLR0915
         return AwsBedrockClaude(id=model_id, **extra_kwargs)
 
     if canonical_provider == "openai":
+        from mindroom.openai_tool_search import openai_native_tool_search_supported  # noqa: PLC0415
+
+        base_url = extra_kwargs.get("base_url") or runtime_paths.env_value("OPENAI_BASE_URL")
+        if openai_native_tool_search_supported(canonical_provider, model_id, base_url=base_url):
+            from mindroom.openai_responses_model import MindRoomOpenAIResponses  # noqa: PLC0415
+
+            return MindRoomOpenAIResponses(id=model_id, **extra_kwargs)
+
         from agno.models.openai import OpenAIChat  # noqa: PLC0415
 
         return OpenAIChat(id=model_id, **extra_kwargs)

--- a/src/mindroom/openai_responses_model.py
+++ b/src/mindroom/openai_responses_model.py
@@ -1,0 +1,72 @@
+"""OpenAI Responses model with native deferred-tool search replay."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from agno.models.openai import OpenAIResponses
+from openai.types.responses import ResponseOutputItemDoneEvent
+
+from mindroom.openai_tool_search import (
+    formatted_input_with_tool_search_items,
+    model_deferred_tool_names,
+    record_tool_search_items,
+    request_params_with_deferred_tool_search,
+)
+
+if TYPE_CHECKING:
+    from agno.models.message import Message
+    from agno.models.response import ModelResponse
+    from agno.tools.function import Function
+    from openai.types.responses import Response, ResponseStreamEvent
+    from pydantic import BaseModel
+
+
+@dataclass
+class MindRoomOpenAIResponses(OpenAIResponses):
+    """OpenAI Responses model that preserves native tool-search state."""
+
+    def get_request_params(
+        self,
+        messages: list[Message] | None = None,
+        response_format: dict[Any, Any] | type[BaseModel] | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: str | dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Tag deferred functions and add hosted tool search."""
+        request_params = super().get_request_params(
+            messages=messages,
+            response_format=response_format,
+            tools=tools,
+            tool_choice=tool_choice,
+        )
+        return request_params_with_deferred_tool_search(request_params, model_deferred_tool_names(self))
+
+    def _format_messages(
+        self,
+        messages: list[Message],
+        compress_tool_results: bool = False,
+        tools: list[Function | dict[str, Any]] | None = None,
+    ) -> list[Any]:
+        """Reinsert captured tool-search items that Agno drops from history."""
+        formatted_input = super()._format_messages(messages, compress_tool_results, tools=tools)
+        return formatted_input_with_tool_search_items(messages, formatted_input)
+
+    def _parse_provider_response(self, response: Response, **kwargs: object) -> ModelResponse:
+        """Capture tool-search output items that Agno's parser drops."""
+        model_response = super()._parse_provider_response(response, **kwargs)
+        record_tool_search_items(model_response, response.output)
+        return model_response
+
+    def _parse_provider_response_delta(
+        self,
+        stream_event: ResponseStreamEvent,
+        assistant_message: Message,
+        tool_use: dict[str, Any],
+    ) -> tuple[ModelResponse, dict[str, Any]]:
+        """Capture streamed tool-search output items that Agno drops."""
+        model_response, tool_use = super()._parse_provider_response_delta(stream_event, assistant_message, tool_use)
+        if isinstance(stream_event, ResponseOutputItemDoneEvent):
+            record_tool_search_items(model_response, [stream_event.item])
+        return model_response, tool_use

--- a/src/mindroom/openai_tool_search.py
+++ b/src/mindroom/openai_tool_search.py
@@ -1,16 +1,16 @@
 """OpenAI server-side tool search (defer_loading) for MindRoom deferred tools.
 
-On the Codex provider (OpenAI Responses API), authored ``defer: true`` tools
-are handled by OpenAI's server-side tool search instead of MindRoom's
-homegrown dynamic-tool loading. Every request sends each deferred tool's full
-definition with ``defer_loading: true`` plus a hosted ``tool_search`` entry,
-so deferred schemas stay out of the model's rendered context up front.
+On supported OpenAI Responses providers, authored ``defer: true`` tools are
+handled by OpenAI's server-side tool search instead of MindRoom's homegrown
+dynamic-tool loading. Every request sends each deferred tool's full definition
+with ``defer_loading: true`` plus a hosted ``tool_search`` entry, so deferred
+schemas stay out of the model's rendered context up front.
 Discovered tools load at the END of the context window (the opposite
 mechanism from Anthropic's inline tool_reference expansion, with the same
 effect), so tool discovery never invalidates the cached prompt prefix.
 
-:class:`~mindroom.codex_model.CodexResponses` owns the wire seams and calls
-into this module: :func:`request_params_with_deferred_tool_search` tags the
+:class:`~mindroom.openai_responses_model.MindRoomOpenAIResponses` owns the wire
+seams and calls into this module: :func:`request_params_with_deferred_tool_search` tags the
 registered tools and injects the search entry with a deterministic order
 (search tool, then non-deferred tools, then deferred sorted by name) so the
 cached prefix stays byte-stable; :func:`record_tool_search_items` captures the
@@ -41,7 +41,8 @@ _OPENAI_RESPONSES_CLASS = ("agno.models.openai.responses", "OpenAIResponses")
 _DEFERRED_TOOL_NAMES_ATTR = "_mindroom_openai_deferred_tool_names"
 _TOOL_SEARCH_ITEMS_KEY = "tool_search_items"
 _TOOL_SEARCH_ITEM_TYPES = frozenset({"tool_search_call", "tool_search_output"})
-_NATIVE_TOOL_SEARCH_PROVIDERS = frozenset({"codex", "openai_codex"})
+_NATIVE_TOOL_SEARCH_PROVIDERS = frozenset({"codex", "openai", "openai_codex"})
+_OPENAI_API_BASE_URL = "https://api.openai.com/v1"
 # LLM-plugin-style `openai-codex/gpt-N.M` ids match the same way as bare or
 # `-codex`-suffixed ids, so no prefix normalization is needed before the search.
 # A missing minor version counts as .0, so a major-only future release gates
@@ -49,16 +50,18 @@ _NATIVE_TOOL_SEARCH_PROVIDERS = frozenset({"codex", "openai_codex"})
 _GPT_VERSION_PATTERN = re.compile(r"gpt-(\d+)(?:\.(\d+))?")
 
 
-def openai_native_tool_search_supported(provider: str, model_id: str) -> bool:
+def openai_native_tool_search_supported(provider: str, model_id: str, *, base_url: str | None = None) -> bool:
     """Return whether one authored provider/model pair supports server-side tool search.
 
     Tool search is a Responses-API feature on gpt-5.4 and later, so the gate
-    covers the Codex provider only (the plain ``openai`` provider speaks Chat
-    Completions) and parses the ``gpt-N.M`` version from the model id instead
-    of keeping an allowlist that goes stale with each release.
+    covers the OpenAI API and Codex providers and parses the ``gpt-N.M``
+    version from the model id instead of keeping an allowlist that goes stale
+    with each release.
     """
     canonical_provider = provider.strip().lower().replace("-", "_")
     if canonical_provider not in _NATIVE_TOOL_SEARCH_PROVIDERS:
+        return False
+    if canonical_provider == "openai" and base_url is not None and base_url.rstrip("/") != _OPENAI_API_BASE_URL:
         return False
     version_match = _GPT_VERSION_PATTERN.search(model_id)
     if version_match is None:
@@ -70,8 +73,9 @@ def openai_native_tool_search_supported(provider: str, model_id: str) -> bool:
 def install_openai_deferred_tool_search(model: object, *, deferred_tool_names: frozenset[str]) -> None:
     """Register wire tool names for OpenAI server-side tool search on one model.
 
-    Every request built by :class:`~mindroom.codex_model.CodexResponses` sends
-    the named tools with ``defer_loading: true`` plus the hosted
+    Every request built by
+    :class:`~mindroom.openai_responses_model.MindRoomOpenAIResponses` sends the
+    named tools with ``defer_loading: true`` plus the hosted
     ``tool_search`` entry, so their schemas stay out of the rendered context
     and tool discovery never invalidates the prompt cache. No-op for
     non-Responses models and empty name sets.

--- a/src/mindroom/openai_tool_search.py
+++ b/src/mindroom/openai_tool_search.py
@@ -63,7 +63,7 @@ def openai_native_tool_search_supported(provider: str, model_id: str, *, base_ur
         return False
     if (
         canonical_provider == "openai"
-        and base_url is not None
+        and base_url not in (None, "")
         and (not isinstance(base_url, str) or base_url.rstrip("/") != _OPENAI_API_BASE_URL)
     ):
         return False

--- a/src/mindroom/openai_tool_search.py
+++ b/src/mindroom/openai_tool_search.py
@@ -50,7 +50,7 @@ _OPENAI_API_BASE_URL = "https://api.openai.com/v1"
 _GPT_VERSION_PATTERN = re.compile(r"gpt-(\d+)(?:\.(\d+))?")
 
 
-def openai_native_tool_search_supported(provider: str, model_id: str, *, base_url: str | None = None) -> bool:
+def openai_native_tool_search_supported(provider: str, model_id: str, *, base_url: object = None) -> bool:
     """Return whether one authored provider/model pair supports server-side tool search.
 
     Tool search is a Responses-API feature on gpt-5.4 and later, so the gate
@@ -61,7 +61,11 @@ def openai_native_tool_search_supported(provider: str, model_id: str, *, base_ur
     canonical_provider = provider.strip().lower().replace("-", "_")
     if canonical_provider not in _NATIVE_TOOL_SEARCH_PROVIDERS:
         return False
-    if canonical_provider == "openai" and base_url is not None and base_url.rstrip("/") != _OPENAI_API_BASE_URL:
+    if (
+        canonical_provider == "openai"
+        and base_url is not None
+        and (not isinstance(base_url, str) or base_url.rstrip("/") != _OPENAI_API_BASE_URL)
+    ):
         return False
     version_match = _GPT_VERSION_PATTERN.search(model_id)
     if version_match is None:

--- a/tach.toml
+++ b/tach.toml
@@ -299,6 +299,8 @@ depends_on = [
     "mindroom.claude_prompt_cache",
     "mindroom.claude_stream_retry",
     "mindroom.codex_model",
+    "mindroom.openai_responses_model",
+    "mindroom.openai_tool_search",
     "mindroom.vertex_claude_compat",
 ]
 visibility = [

--- a/tests/test_codex_model.py
+++ b/tests/test_codex_model.py
@@ -27,6 +27,7 @@ from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
 from mindroom.constants import resolve_runtime_paths
 from mindroom.model_loading import get_model_instance
+from mindroom.openai_responses_model import MindRoomOpenAIResponses
 from mindroom.openai_tool_search import (
     _DEFERRED_TOOL_NAMES_ATTR,
     install_openai_deferred_tool_search,
@@ -475,14 +476,27 @@ class _FakeCodexClient:
         ("codex", "gpt-5-codex", False),
         ("codex", "gpt-4.1", False),
         ("codex", "codex-mini-latest", False),
-        # The plain openai provider speaks Chat Completions; tool search is Responses-only.
-        ("openai", "gpt-5.6", False),
+        ("openai", "gpt-5.6", True),
         ("anthropic", "claude-opus-4-8", False),
     ],
 )
 def test_openai_native_tool_search_supported_gating(provider: str, model_id: str, *, expected: bool) -> None:
-    """Codex-family providers qualify when the model id parses to gpt-5.4 or newer."""
+    """OpenAI and Codex providers qualify when the model id parses to gpt-5.4 or newer."""
     assert openai_native_tool_search_supported(provider, model_id) is expected
+
+
+def test_openai_native_tool_search_rejects_custom_compatible_base_url() -> None:
+    """Chat-Completions-compatible endpoints do not implicitly opt into the Responses API."""
+    assert not openai_native_tool_search_supported(
+        "openai",
+        "gpt-5.6",
+        base_url="http://localhost:9292/v1",
+    )
+    assert openai_native_tool_search_supported(
+        "openai",
+        "gpt-5.6",
+        base_url="https://api.openai.com/v1/",
+    )
 
 
 def test_install_openai_deferred_tool_search_ignores_non_responses_models_and_empty_sets() -> None:
@@ -511,6 +525,20 @@ def test_codex_deferred_tool_search_tags_tools_and_injects_search_tool() -> None
     assert "defer_loading" not in wire_tools[1]
     for deferred_tool in wire_tools[2:]:
         assert deferred_tool["defer_loading"] is True
+
+
+def test_openai_responses_deferred_tool_search_tags_tools_and_injects_search_tool() -> None:
+    """The regular OpenAI Responses model uses the same native deferred-tool wire format."""
+    model = MindRoomOpenAIResponses(id="gpt-5.6", api_key="test-key")
+    install_openai_deferred_tool_search(model, deferred_tool_names=frozenset({"sleep"}))
+
+    request_params = model.get_request_params(tools=[_agno_tool("always_tool"), _agno_tool("sleep")])
+
+    wire_tools = request_params["tools"]
+    assert wire_tools[0] == {"type": "tool_search"}
+    assert [tool.get("name") for tool in wire_tools] == [None, "always_tool", "sleep"]
+    assert "defer_loading" not in wire_tools[1]
+    assert wire_tools[2]["defer_loading"] is True
 
 
 def test_codex_deferred_tool_search_leaves_requests_without_matching_tools_unchanged() -> None:

--- a/tests/test_codex_model.py
+++ b/tests/test_codex_model.py
@@ -497,6 +497,7 @@ def test_openai_native_tool_search_rejects_custom_compatible_base_url() -> None:
         "gpt-5.6",
         base_url="https://api.openai.com/v1/",
     )
+    assert openai_native_tool_search_supported("openai", "gpt-5.6", base_url="")
     assert not openai_native_tool_search_supported("openai", "gpt-5.6", base_url=123)
 
 

--- a/tests/test_codex_model.py
+++ b/tests/test_codex_model.py
@@ -497,6 +497,7 @@ def test_openai_native_tool_search_rejects_custom_compatible_base_url() -> None:
         "gpt-5.6",
         base_url="https://api.openai.com/v1/",
     )
+    assert not openai_native_tool_search_supported("openai", "gpt-5.6", base_url=123)
 
 
 def test_install_openai_deferred_tool_search_ignores_non_responses_models_and_empty_sets() -> None:

--- a/tests/test_dynamic_toolkits.py
+++ b/tests/test_dynamic_toolkits.py
@@ -838,11 +838,16 @@ def test_native_tool_search_attaches_deferred_toolkits_and_skips_homegrown_machi
     assert ("code", "thread-a") not in dynamic_toolkits_module._loaded_tools
 
 
-def test_codex_native_tool_search_attaches_deferred_toolkits_and_skips_homegrown_machinery(tmp_path: Path) -> None:
+@pytest.mark.parametrize(("provider", "model_id"), [("codex", "gpt-5.6"), ("openai", "gpt-5.6")])
+def test_openai_native_tool_search_attaches_deferred_toolkits_and_skips_homegrown_machinery(
+    tmp_path: Path,
+    provider: str,
+    model_id: str,
+) -> None:
     """OpenAI-native tool search attaches all deferred toolkits and drops the manager machinery."""
     raw = _base_config_data()
-    raw["models"]["codex_gpt"] = {"provider": "codex", "id": "gpt-5.6"}  # type: ignore[index]
-    raw["agents"]["code"]["model"] = "codex_gpt"  # type: ignore[index]
+    raw["models"]["native_gpt"] = {"provider": provider, "id": model_id}  # type: ignore[index]
+    raw["agents"]["code"]["model"] = "native_gpt"  # type: ignore[index]
     raw["agents"]["code"]["tools"] = [  # type: ignore[index]
         {"sleep": {"defer": True}},
         {"calculator": {"defer": True, "initial": True}},
@@ -916,20 +921,23 @@ def test_eager_tool_filter_drops_fully_filtered_deferred_toolkit(tmp_path: Path)
 
 
 @pytest.mark.parametrize(
-    ("provider", "model_id"),
+    ("provider", "model_id", "extra_kwargs"),
     [
-        ("openai", "gpt-4o-mini"),
-        # The plain openai provider speaks Chat Completions, where tool search
-        # is unavailable even on ids the Codex provider would gate native.
-        ("openai", "gpt-5.6"),
-        ("codex", "gpt-4.1"),
-        ("anthropic", "claude-opus-4-1"),
+        ("openai", "gpt-4o-mini", None),
+        ("openai", "gpt-5.6", {"base_url": "http://localhost:9292/v1"}),
+        ("codex", "gpt-4.1", None),
+        ("anthropic", "claude-opus-4-1", None),
     ],
 )
-def test_unsupported_models_keep_homegrown_dynamic_tools_path(tmp_path: Path, provider: str, model_id: str) -> None:
+def test_unsupported_models_keep_homegrown_dynamic_tools_path(
+    tmp_path: Path,
+    provider: str,
+    model_id: str,
+    extra_kwargs: dict[str, object] | None,
+) -> None:
     """Unsupported providers and models keep the load_tool machinery."""
     raw = _base_config_data()
-    raw["models"]["default"] = {"provider": provider, "id": model_id}  # type: ignore[index]
+    raw["models"]["default"] = {"provider": provider, "id": model_id, "extra_kwargs": extra_kwargs}  # type: ignore[index]
     raw["agents"]["code"]["tools"] = [  # type: ignore[index]
         {"sleep": {"defer": True}},
         {"calculator": {"defer": True, "initial": True}},

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -5,13 +5,42 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
+from agno.models.openai import OpenAIChat
+
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
 from mindroom.model_loading import get_model_instance
+from mindroom.openai_responses_model import MindRoomOpenAIResponses
 from tests.conftest import bind_runtime_paths, runtime_paths_for, test_runtime_paths
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+def test_first_party_openai_gpt_5_4_and_newer_use_responses(tmp_path: Path) -> None:
+    """First-party current GPT uses Responses while old and compatible models keep Chat Completions."""
+    config = bind_runtime_paths(
+        Config(
+            models={
+                "current": ModelConfig(provider="openai", id="gpt-5.6", extra_kwargs={"api_key": "dummy-key"}),
+                "older": ModelConfig(provider="openai", id="gpt-4o", extra_kwargs={"api_key": "dummy-key"}),
+                "compatible": ModelConfig(
+                    provider="openai",
+                    id="gpt-5.6",
+                    extra_kwargs={"api_key": "dummy-key", "base_url": "http://localhost:9292/v1"},
+                ),
+            },
+        ),
+        test_runtime_paths(tmp_path),
+    )
+
+    current = get_model_instance(config, runtime_paths_for(config), "current")
+    older = get_model_instance(config, runtime_paths_for(config), "older")
+    compatible = get_model_instance(config, runtime_paths_for(config), "compatible")
+
+    assert isinstance(current, MindRoomOpenAIResponses)
+    assert isinstance(older, OpenAIChat)
+    assert isinstance(compatible, OpenAIChat)
 
 
 def test_vertexai_claude_gets_explicit_timeout_so_large_outputs_can_run_non_streaming(tmp_path: Path) -> None:


### PR DESCRIPTION
## Why

The regular OpenAI provider always used Chat Completions.
That makes GPT-5.6 function tools incompatible with normal reasoning settings and forces deferred tools through MindRoom's multi-call loader, even though OpenAI supports native deferred-tool search through Responses.

## What changed

- Use the Responses API for first-party OpenAI GPT 5.4+ models.
- Share native deferred-tool request tagging and history replay between regular OpenAI and Codex models.
- Keep older GPT models and custom OpenAI-compatible base URLs on Chat Completions.
- Route supported regular OpenAI agents through native deferred tools instead of the homegrown loader.
- Document the provider behavior and regenerate docs references.

## Validation

- `uv run pytest -q`
- `uv run pre-commit run --all-files`
- `uv run tach check --dependencies --interfaces`
- Live GPT-5.6 test with medium reasoning: native tool search discovered and executed one deferred function, returning the correct result.
- Live exact-repeat cache test: telemetry reported 11,213 of 11,216 input tokens cached (99.973%), with 3 uncached tokens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * First-party OpenAI GPT 5.4+ models now use the Responses API.
  * Native server-side tool search is supported for eligible OpenAI and Codex models.
  * Deferred tools are preserved and discovered through OpenAI’s hosted tool search.

* **Documentation**
  * Added guidance explaining API selection, model compatibility, and custom endpoint behavior.
  * Clarified supported providers and model versions for native tool search.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->