### PR TITLE
Require explicit scheduler placement

### DIFF
--- a/src/mindroom/custom_tools/scheduler.py
+++ b/src/mindroom/custom_tools/scheduler.py
@@ -28,18 +28,16 @@ class SchedulerTools(Toolkit):
             tools=[self.schedule, self.edit_schedule, self.list_schedules, self.cancel_schedule],
         )
 
-    async def schedule(self, request: str, new_thread: bool = False, history_limit: int | None = None) -> str:
+    async def schedule(self, request: str, new_thread: bool, history_limit: int | None = None) -> str:
         """Schedule a task using natural language.
 
         This uses the exact same scheduling backend as the `!schedule` command.
-        By default, the task posts back into the current scope.
-        Set `new_thread=True` to schedule a future room-level root message instead.
 
         Args:
             request: The scheduling request, e.g. "in 5 minutes remind me to check logs"
-            new_thread: When `False`, post in the current room/thread scope.
-                When `True`, schedule a future room-level root message that can become
-                its own thread when someone replies later.
+            new_thread: Required delivery choice. Use `False` to post in the current
+                room/thread scope. Use `True` to schedule a future room-level root
+                message that can become its own thread when someone replies later.
             history_limit: Max recent thread messages included as context each time
                 the task fires. Use 0 for no history (recommended for recurring
                 polling tasks), or leave unset for full history.

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -1412,8 +1412,8 @@ async def schedule_task(  # noqa: C901, PLR0912, PLR0915
     success_msg += f"**Will post:** {workflow_result.message}\n"
     if workflow_result.history_limit is not None:
         success_msg += f"**History:** {_history_limit_display(workflow_result.history_limit)}\n"
-    if new_thread:
-        success_msg += "**Delivery:** New room-level thread root\n"
+    delivery = "New room-level thread root" if new_thread else "Current room/thread scope"
+    success_msg += f"**Delivery:** {delivery}\n"
     success_msg += f"\n**Task ID:** `{task_id}`"
 
     return (task_id, success_msg)

--- a/tests/test_scheduler_tool.py
+++ b/tests/test_scheduler_tool.py
@@ -63,9 +63,17 @@ async def test_scheduler_tool_requires_context() -> None:
     """Tool should fail clearly when called outside Matrix response context."""
     tools = SchedulerTools()
 
-    result = await tools.schedule("in 10 minutes remind me to check logs")
+    result = await tools.schedule("in 10 minutes remind me to check logs", new_thread=False)
 
     assert "unavailable" in result
+
+
+def test_scheduler_tool_requires_explicit_delivery_mode() -> None:
+    """The model-facing schema must not silently choose a delivery scope."""
+    function = SchedulerTools().async_functions["schedule"].model_copy(deep=True)
+    function.process_entrypoint()
+
+    assert set(function.parameters["required"]) == {"request", "new_thread"}
 
 
 @pytest.mark.asyncio
@@ -83,9 +91,9 @@ async def test_scheduler_tool_uses_shared_backend() -> None:
         ) as mock_schedule,
         tool_runtime_context(context),
     ):
-        result = await tools.schedule("tomorrow at 3pm check deployment")
+        result = await tools.schedule("tomorrow at 3pm check deployment", new_thread=False)
         new_thread_result = await tools.schedule("tomorrow at 4pm check deployment", new_thread=True)
-        limited_result = await tools.schedule("every 25 minutes poll the queue", history_limit=0)
+        limited_result = await tools.schedule("every 25 minutes poll the queue", new_thread=False, history_limit=0)
 
     assert result == "✅ Scheduled"
     assert new_thread_result == "✅ Scheduled"
@@ -147,7 +155,7 @@ async def test_scheduler_tool_raises_when_backend_rejects_request() -> None:
         tool_runtime_context(context),
         pytest.raises(RuntimeError, match="schedule is not valid"),
     ):
-        await tools.schedule("next message")
+        await tools.schedule("next message", new_thread=False)
 
 
 @pytest.mark.asyncio

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -2086,6 +2086,7 @@ async def test_schedule_task_persists_via_admin_when_active_agent_lacks_state_po
 
     assert task_id == "task1234"
     assert "✅ Scheduled" in message
+    assert "**Delivery:** Current room/thread scope" in message
     matrix_admin.put_room_state.assert_awaited_once()
     tasks = await get_scheduled_tasks_for_room(client=client, room_id="!test:server")
     assert [task.task_id for task in tasks] == ["task1234"]


### PR DESCRIPTION
## Why

Scheduler placement determines where future output appears. A defaulted model-facing field lets an incomplete tool call silently choose the current scope, which hides the requested delivery intent.

## What

- Require `new_thread` in the model-facing schedule tool schema.
- Describe both placement choices directly in the tool argument.
- Show the selected delivery mode in every successful schedule confirmation.
- Add schema, forwarding, and confirmation regression coverage.

## Validation

- `uv run pytest -q tests/test_scheduler_tool.py tests/test_scheduling.py`
- `uv run pre-commit run --all-files`