### PR TITLE
Bootstrap Google OAuth for paired local installs

### DIFF
--- a/docs/deployment/google-services-oauth.md
+++ b/docs/deployment/google-services-oauth.md
@@ -6,8 +6,8 @@ icon: lucide/mail
 
 MindRoom uses the generic OAuth framework for Google tools.
 Each Google service has its own provider ID, callback URL, token service, OAuth client config service, and editable tool settings service.
-Local loopback installations use MindRoom's bundled public desktop OAuth client with PKCE and do not need Google Cloud setup.
-Public and organization-managed deployments can override the bundled client with their own Google Cloud Web application client.
+Paired local installations retrieve MindRoom's desktop OAuth client from the provisioning service and use it locally with PKCE.
+Public, unpaired, and organization-managed deployments can configure their own Google Cloud Web application client.
 
 ## Providers
 
@@ -94,8 +94,10 @@ GOOGLE_GMAIL_ALLOWED_HOSTED_DOMAINS=example.com
 ## Runtime Behavior
 
 Dashboard and agent-issued connect links use `/api/oauth/{provider}/connect` or `/api/oauth/{provider}/authorize`.
-The bundled desktop client is selected only when no stored custom client exists and the resolved callback hostname is a loopback hostname.
-Stored provider-specific or shared custom client config always takes precedence over the bundled client.
+The paired desktop client is fetched only when no stored custom client exists and is cached in the local credential store for resilience.
+The provisioning service supplies the app client configuration but never receives Google authorization codes, Google tokens, or Google API data.
+Stored provider-specific or shared custom client config always takes precedence over the provisioned client.
+The provisioned client is available only when the resolved callback hostname is a loopback hostname.
 OAuth callback state is stored server-side as an opaque token and bound to the authenticated dashboard user and scoped credential target.
 Connections made for a shared-scope agent are stored per agent, so other agents never inherit that account.
 Disconnecting a provider removes the token service for the selected scope and preserves that provider's editable tool settings.

--- a/docs/deployment/google-services-user-oauth.md
+++ b/docs/deployment/google-services-user-oauth.md
@@ -4,10 +4,11 @@ icon: lucide/user-round
 
 # Google Services OAuth For Local Installs
 
-MindRoom includes a public Google desktop OAuth client for local installations.
+Paired local installations automatically retrieve MindRoom's Google desktop OAuth client from the provisioning service.
 You do not need to create a Google Cloud project, register callback URLs, or copy a client secret.
-MindRoom distributes only the desktop client ID and never bundles or sends its optional client secret.
-The bundled client uses OAuth PKCE and is available when the provider callback uses `localhost`, `127.0.0.1`, or `::1`.
+The client configuration is not bundled in the package or committed to the source repository.
+The local runtime uses OAuth PKCE and a callback on `localhost`, `127.0.0.1`, or `::1`.
+Run `mindroom connect --pair-code ...` before connecting Google, or configure a custom Google OAuth client for an unpaired self-hosted installation.
 
 ## Choose Providers
 
@@ -44,7 +45,8 @@ MindRoom does not mirror Google OAuth tokens into worker containers.
 ## Privacy and Access Scope
 
 For a local installation, the MindRoom project maintainers do not automatically receive your OAuth tokens or Google data.
-Google returns the bundled desktop client's authorization response directly to the local loopback callback, so ownership of the OAuth app registration does not reveal your tokens or Google data to the project maintainers.
+The paired provisioning service sends the Google desktop app client configuration to the local runtime but does not receive the Google authorization code, access token, refresh token, or Google API data.
+Google returns the authorization response directly to the local loopback callback, and the local runtime performs the token exchange and stores the resulting connection.
 The software running on your machine stores the connection, while the Google API, your configured AI model provider, and your Matrix homeserver process the data sent to each of them.
 The installation operator and anyone with administrative or filesystem access to its storage may be able to access locally stored credentials and data.
 
@@ -59,7 +61,7 @@ See the [Privacy Policy](../privacy.md) for the complete data-handling disclosur
 
 ## Custom Google OAuth App
 
-A custom Google OAuth app is optional for a local installation.
+A custom Google OAuth app is optional for a paired local installation and required for an unpaired self-hosted installation.
 Use one when you operate a public MindRoom origin, need organization-specific Google policies, or want your own consent-screen branding.
 
 Select **Use custom client** in the dashboard and enter the client ID and client secret from a Google Cloud **Web application** OAuth client.

--- a/docs/deployment/hosted-matrix.md
+++ b/docs/deployment/hosted-matrix.md
@@ -105,7 +105,9 @@ Use `worker_scope: user_agent` when each requester should get separate per-agent
 
 They can only call provisioning-service endpoints that accept local client credentials, including agent registration and retrieval of the Google desktop app client configuration.
 The Google app client configuration lets the local process exchange OAuth codes directly with Google; the provisioning service does not receive the resulting Google authorization code or tokens.
+Treat the local provisioning credentials as secrets because anyone who obtains them can use the same provisioning capabilities, including retrieving the Google desktop app client configuration.
 Revoke them from `Settings -> Local MindRoom` in the chat UI.
+After a confirmed provisioning-credential leak, the service operator should also treat the Google app client configuration as exposed and rotate that OAuth client secret.
 
 ## Trust Model (Hosted Server vs Message Privacy)
 

--- a/docs/deployment/hosted-matrix.md
+++ b/docs/deployment/hosted-matrix.md
@@ -103,7 +103,8 @@ Use `worker_scope: user_agent` when each requester should get separate per-agent
 `MINDROOM_LOCAL_CLIENT_ID` and `MINDROOM_LOCAL_CLIENT_SECRET` are **not Matrix user access tokens**.
 `MINDROOM_NAMESPACE` is appended to managed agent usernames and room aliases to avoid collisions on shared homeservers.
 
-They can only call provisioning-service endpoints that accept local client credentials (for example agent registration flows).
+They can only call provisioning-service endpoints that accept local client credentials, including agent registration and retrieval of the Google desktop app client configuration.
+The Google app client configuration lets the local process exchange OAuth codes directly with Google; the provisioning service does not receive the resulting Google authorization code or tokens.
 Revoke them from `Settings -> Local MindRoom` in the chat UI.
 
 ## Trust Model (Hosted Server vs Message Privacy)

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -99,8 +99,8 @@ Information may be shared only as needed to:
 
 The MindRoom software running in your selected installation accesses Google user data only after you connect a Google integration and grant the requested permissions.
 Granting that access does not give the MindRoom project maintainers general access to your Google Account or automatically send them your OAuth tokens or Google data from a local or self-hosted installation.
-When a local installation uses the bundled desktop OAuth client, Google returns the authorization response directly to that installation's loopback callback.
-The bundled desktop flow uses a public client ID with PKCE and does not bundle or send a client secret.
+When a paired local installation uses MindRoom's desktop OAuth client, the provisioning service sends the app client configuration to that installation and Google returns the authorization response directly to its loopback callback.
+The local MindRoom process performs the token exchange with Google and stores the resulting tokens; the provisioning service does not receive the Google authorization code, tokens, or Google API data.
 Control of the OAuth app registration lets the project maintainers manage or disable the client, but it does not by itself reveal a user's OAuth tokens or Google data to them.
 
 Depending on the integrations you connect, this data can include your Google identity information, Gmail messages and metadata, Drive file metadata and contents, Calendar data, and Sheets spreadsheet values.

--- a/scripts/local_mindroom_provisioning_service.nix
+++ b/scripts/local_mindroom_provisioning_service.nix
@@ -36,6 +36,18 @@ in
       description = "File containing the Matrix registration token.";
     };
 
+    googleOAuthClientId = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "Google desktop OAuth client ID distributed to paired local runtimes.";
+    };
+
+    googleOAuthClientSecretFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "File containing the Google desktop OAuth client secret distributed to paired local runtimes.";
+    };
+
     listenHost = lib.mkOption {
       type = lib.types.str;
       default = "127.0.0.1";
@@ -68,6 +80,13 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = (cfg.googleOAuthClientId == null) == (cfg.googleOAuthClientSecretFile == null);
+        message = "googleOAuthClientId and googleOAuthClientSecretFile must be configured together.";
+      }
+    ];
+
     users.users.mindroom-local-provisioning = {
       isSystemUser = true;
       group = "mindroom-local-provisioning";
@@ -94,6 +113,9 @@ in
         MINDROOM_PROVISIONING_CORS_ORIGINS = lib.concatStringsSep "," cfg.corsOrigins;
       } // lib.optionalAttrs (cfg.matrixServerName != null) {
         MATRIX_SERVER_NAME = cfg.matrixServerName;
+      } // lib.optionalAttrs (cfg.googleOAuthClientId != null) {
+        MINDROOM_GOOGLE_OAUTH_CLIENT_ID = cfg.googleOAuthClientId;
+        MINDROOM_GOOGLE_OAUTH_CLIENT_SECRET_FILE = cfg.googleOAuthClientSecretFile;
       };
 
       serviceConfig = {

--- a/scripts/local_mindroom_provisioning_service.py
+++ b/scripts/local_mindroom_provisioning_service.py
@@ -340,6 +340,15 @@ def _load_service_config_from_env() -> ServiceConfig:
     if not cors_origins:
         cors_origins = [DEFAULT_CORS_ORIGINS]
 
+    google_oauth_client_id = os.getenv("MINDROOM_GOOGLE_OAUTH_CLIENT_ID", "").strip() or None
+    google_oauth_client_secret = _read_secret(
+        env_name="MINDROOM_GOOGLE_OAUTH_CLIENT_SECRET",
+        file_env_name="MINDROOM_GOOGLE_OAUTH_CLIENT_SECRET_FILE",
+    )
+    if (google_oauth_client_id is None) != (google_oauth_client_secret is None):
+        msg = "MINDROOM_GOOGLE_OAUTH_CLIENT_ID and its client secret must be configured together."
+        raise ValueError(msg)
+
     return ServiceConfig(
         matrix_homeserver=matrix_homeserver,
         matrix_server_name=matrix_server_name,
@@ -351,11 +360,8 @@ def _load_service_config_from_env() -> ServiceConfig:
         cors_origins=cors_origins,
         listen_host=os.getenv("MINDROOM_PROVISIONING_HOST", DEFAULT_LISTEN_HOST).strip(),
         listen_port=_env_int("MINDROOM_PROVISIONING_PORT", default=DEFAULT_LISTEN_PORT, minimum=1),
-        google_oauth_client_id=os.getenv("MINDROOM_GOOGLE_OAUTH_CLIENT_ID", "").strip() or None,
-        google_oauth_client_secret=_read_secret(
-            env_name="MINDROOM_GOOGLE_OAUTH_CLIENT_SECRET",
-            file_env_name="MINDROOM_GOOGLE_OAUTH_CLIENT_SECRET_FILE",
-        ),
+        google_oauth_client_id=google_oauth_client_id,
+        google_oauth_client_secret=google_oauth_client_secret,
     )
 
 

--- a/scripts/local_mindroom_provisioning_service.py
+++ b/scripts/local_mindroom_provisioning_service.py
@@ -53,7 +53,7 @@ from urllib.parse import quote
 
 import httpx
 import uvicorn
-from fastapi import APIRouter, Depends, FastAPI, Header, HTTPException, Request
+from fastapi import APIRouter, Depends, FastAPI, Header, HTTPException, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 
@@ -95,6 +95,8 @@ class ServiceConfig:
     cors_origins: list[str]
     listen_host: str
     listen_port: int
+    google_oauth_client_id: str | None = None
+    google_oauth_client_secret: str | None = None
 
 
 @dataclass(slots=True)
@@ -212,6 +214,13 @@ class RegisterAgentResponse(BaseModel):
 
     status: Literal["created", "user_in_use"]
     user_id: str
+
+
+class GoogleOAuthClientResponse(BaseModel):
+    """Installed-app OAuth client returned only to an authenticated local install."""
+
+    client_id: str
+    client_secret: str
 
 
 def _new_runtime_state() -> ProvisioningState:
@@ -342,6 +351,11 @@ def _load_service_config_from_env() -> ServiceConfig:
         cors_origins=cors_origins,
         listen_host=os.getenv("MINDROOM_PROVISIONING_HOST", DEFAULT_LISTEN_HOST).strip(),
         listen_port=_env_int("MINDROOM_PROVISIONING_PORT", default=DEFAULT_LISTEN_PORT, minimum=1),
+        google_oauth_client_id=os.getenv("MINDROOM_GOOGLE_OAUTH_CLIENT_ID", "").strip() or None,
+        google_oauth_client_secret=_read_secret(
+            env_name="MINDROOM_GOOGLE_OAUTH_CLIENT_SECRET",
+            file_env_name="MINDROOM_GOOGLE_OAUTH_CLIENT_SECRET_FILE",
+        ),
     )
 
 
@@ -880,6 +894,31 @@ async def register_agent(
         _persist_state_unlocked(state, config.state_path)
 
     return await _register_agent_with_matrix(config, payload)
+
+
+@router.get("/v1/local-mindroom/oauth/google-client", response_model=GoogleOAuthClientResponse)
+async def google_oauth_client(
+    response: Response,
+    config: Annotated[ServiceConfig, Depends(_service_config_from_request)],
+    state: Annotated[ProvisioningState, Depends(_runtime_state_from_request)],
+    x_local_mindroom_client_id: Annotated[str | None, Header(alias="X-Local-MindRoom-Client-Id")] = None,
+    x_local_mindroom_client_secret: Annotated[str | None, Header(alias="X-Local-MindRoom-Client-Secret")] = None,
+) -> GoogleOAuthClientResponse:
+    """Return the Google installed-app client to one paired local runtime."""
+    now = _now_utc()
+    async with state.lock:
+        connection = _require_local_client(state, x_local_mindroom_client_id, x_local_mindroom_client_secret)
+        _enforce_rate_limit_unlocked(state, key=f"oauth:google-client:{connection.id}", limit=60, window_seconds=60)
+        connection.last_seen_at = now
+        _persist_state_unlocked(state, config.state_path)
+
+    if not config.google_oauth_client_id or not config.google_oauth_client_secret:
+        raise HTTPException(status_code=503, detail="Google OAuth client is not configured")
+    response.headers["Cache-Control"] = "no-store"
+    return GoogleOAuthClientResponse(
+        client_id=config.google_oauth_client_id,
+        client_secret=config.google_oauth_client_secret,
+    )
 
 
 def create_app(config: ServiceConfig | None = None) -> FastAPI:

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -15562,7 +15562,9 @@ Use `worker_scope: user_agent` when each requester should get separate per-agent
 
 They can only call provisioning-service endpoints that accept local client credentials, including agent registration and retrieval of the Google desktop app client configuration.
 The Google app client configuration lets the local process exchange OAuth codes directly with Google; the provisioning service does not receive the resulting Google authorization code or tokens.
+Treat the local provisioning credentials as secrets because anyone who obtains them can use the same provisioning capabilities, including retrieving the Google desktop app client configuration.
 Revoke them from `Settings -> Local MindRoom` in the chat UI.
+After a confirmed provisioning-credential leak, the service operator should also treat the Google app client configuration as exposed and rotate that OAuth client secret.
 
 ## Trust Model (Hosted Server vs Message Privacy)
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -15560,7 +15560,8 @@ Use `worker_scope: user_agent` when each requester should get separate per-agent
 `MINDROOM_LOCAL_CLIENT_ID` and `MINDROOM_LOCAL_CLIENT_SECRET` are **not Matrix user access tokens**.
 `MINDROOM_NAMESPACE` is appended to managed agent usernames and room aliases to avoid collisions on shared homeservers.
 
-They can only call provisioning-service endpoints that accept local client credentials (for example agent registration flows).
+They can only call provisioning-service endpoints that accept local client credentials, including agent registration and retrieval of the Google desktop app client configuration.
+The Google app client configuration lets the local process exchange OAuth codes directly with Google; the provisioning service does not receive the resulting Google authorization code or tokens.
 Revoke them from `Settings -> Local MindRoom` in the chat UI.
 
 ## Trust Model (Hosted Server vs Message Privacy)
@@ -15867,8 +15868,8 @@ Important data locations:
 
 MindRoom uses the generic OAuth framework for Google tools.
 Each Google service has its own provider ID, callback URL, token service, OAuth client config service, and editable tool settings service.
-Local loopback installations use MindRoom's bundled public desktop OAuth client with PKCE and do not need Google Cloud setup.
-Public and organization-managed deployments can override the bundled client with their own Google Cloud Web application client.
+Paired local installations retrieve MindRoom's desktop OAuth client from the provisioning service and use it locally with PKCE.
+Public, unpaired, and organization-managed deployments can configure their own Google Cloud Web application client.
 
 ## Providers
 
@@ -15955,18 +15956,21 @@ GOOGLE_GMAIL_ALLOWED_HOSTED_DOMAINS=example.com
 ## Runtime Behavior
 
 Dashboard and agent-issued connect links use `/api/oauth/{provider}/connect` or `/api/oauth/{provider}/authorize`.
-The bundled desktop client is selected only when no stored custom client exists and the resolved callback hostname is a loopback hostname.
-Stored provider-specific or shared custom client config always takes precedence over the bundled client.
+The paired desktop client is fetched only when no stored custom client exists and is cached in the local credential store for resilience.
+The provisioning service supplies the app client configuration but never receives Google authorization codes, Google tokens, or Google API data.
+Stored provider-specific or shared custom client config always takes precedence over the provisioned client.
+The provisioned client is available only when the resolved callback hostname is a loopback hostname.
 OAuth callback state is stored server-side as an opaque token and bound to the authenticated dashboard user and scoped credential target.
 Connections made for a shared-scope agent are stored per agent, so other agents never inherit that account.
 Disconnecting a provider removes the token service for the selected scope and preserves that provider's editable tool settings.
 
 # Google Services OAuth For Local Installs
 
-MindRoom includes a public Google desktop OAuth client for local installations.
+Paired local installations automatically retrieve MindRoom's Google desktop OAuth client from the provisioning service.
 You do not need to create a Google Cloud project, register callback URLs, or copy a client secret.
-MindRoom distributes only the desktop client ID and never bundles or sends its optional client secret.
-The bundled client uses OAuth PKCE and is available when the provider callback uses `localhost`, `127.0.0.1`, or `::1`.
+The client configuration is not bundled in the package or committed to the source repository.
+The local runtime uses OAuth PKCE and a callback on `localhost`, `127.0.0.1`, or `::1`.
+Run `mindroom connect --pair-code ...` before connecting Google, or configure a custom Google OAuth client for an unpaired self-hosted installation.
 
 ## Choose Providers
 
@@ -16003,7 +16007,8 @@ MindRoom does not mirror Google OAuth tokens into worker containers.
 ## Privacy and Access Scope
 
 For a local installation, the MindRoom project maintainers do not automatically receive your OAuth tokens or Google data.
-Google returns the bundled desktop client's authorization response directly to the local loopback callback, so ownership of the OAuth app registration does not reveal your tokens or Google data to the project maintainers.
+The paired provisioning service sends the Google desktop app client configuration to the local runtime but does not receive the Google authorization code, access token, refresh token, or Google API data.
+Google returns the authorization response directly to the local loopback callback, and the local runtime performs the token exchange and stores the resulting connection.
 The software running on your machine stores the connection, while the Google API, your configured AI model provider, and your Matrix homeserver process the data sent to each of them.
 The installation operator and anyone with administrative or filesystem access to its storage may be able to access locally stored credentials and data.
 
@@ -16018,7 +16023,7 @@ See the [Privacy Policy](https://docs.mindroom.chat/privacy/) for the complete d
 
 ## Custom Google OAuth App
 
-A custom Google OAuth app is optional for a local installation.
+A custom Google OAuth app is optional for a paired local installation and required for an unpaired self-hosted installation.
 Use one when you operate a public MindRoom origin, need organization-specific Google policies, or want your own consent-screen branding.
 
 Select **Use custom client** in the dashboard and enter the client ID and client secret from a Google Cloud **Web application** OAuth client.

--- a/skills/mindroom-docs/references/page__deployment__google-services-oauth__index.md
+++ b/skills/mindroom-docs/references/page__deployment__google-services-oauth__index.md
@@ -2,8 +2,8 @@
 
 MindRoom uses the generic OAuth framework for Google tools.
 Each Google service has its own provider ID, callback URL, token service, OAuth client config service, and editable tool settings service.
-Local loopback installations use MindRoom's bundled public desktop OAuth client with PKCE and do not need Google Cloud setup.
-Public and organization-managed deployments can override the bundled client with their own Google Cloud Web application client.
+Paired local installations retrieve MindRoom's desktop OAuth client from the provisioning service and use it locally with PKCE.
+Public, unpaired, and organization-managed deployments can configure their own Google Cloud Web application client.
 
 ## Providers
 
@@ -90,8 +90,10 @@ GOOGLE_GMAIL_ALLOWED_HOSTED_DOMAINS=example.com
 ## Runtime Behavior
 
 Dashboard and agent-issued connect links use `/api/oauth/{provider}/connect` or `/api/oauth/{provider}/authorize`.
-The bundled desktop client is selected only when no stored custom client exists and the resolved callback hostname is a loopback hostname.
-Stored provider-specific or shared custom client config always takes precedence over the bundled client.
+The paired desktop client is fetched only when no stored custom client exists and is cached in the local credential store for resilience.
+The provisioning service supplies the app client configuration but never receives Google authorization codes, Google tokens, or Google API data.
+Stored provider-specific or shared custom client config always takes precedence over the provisioned client.
+The provisioned client is available only when the resolved callback hostname is a loopback hostname.
 OAuth callback state is stored server-side as an opaque token and bound to the authenticated dashboard user and scoped credential target.
 Connections made for a shared-scope agent are stored per agent, so other agents never inherit that account.
 Disconnecting a provider removes the token service for the selected scope and preserves that provider's editable tool settings.

--- a/skills/mindroom-docs/references/page__deployment__google-services-user-oauth__index.md
+++ b/skills/mindroom-docs/references/page__deployment__google-services-user-oauth__index.md
@@ -1,9 +1,10 @@
 # Google Services OAuth For Local Installs
 
-MindRoom includes a public Google desktop OAuth client for local installations.
+Paired local installations automatically retrieve MindRoom's Google desktop OAuth client from the provisioning service.
 You do not need to create a Google Cloud project, register callback URLs, or copy a client secret.
-MindRoom distributes only the desktop client ID and never bundles or sends its optional client secret.
-The bundled client uses OAuth PKCE and is available when the provider callback uses `localhost`, `127.0.0.1`, or `::1`.
+The client configuration is not bundled in the package or committed to the source repository.
+The local runtime uses OAuth PKCE and a callback on `localhost`, `127.0.0.1`, or `::1`.
+Run `mindroom connect --pair-code ...` before connecting Google, or configure a custom Google OAuth client for an unpaired self-hosted installation.
 
 ## Choose Providers
 
@@ -40,7 +41,8 @@ MindRoom does not mirror Google OAuth tokens into worker containers.
 ## Privacy and Access Scope
 
 For a local installation, the MindRoom project maintainers do not automatically receive your OAuth tokens or Google data.
-Google returns the bundled desktop client's authorization response directly to the local loopback callback, so ownership of the OAuth app registration does not reveal your tokens or Google data to the project maintainers.
+The paired provisioning service sends the Google desktop app client configuration to the local runtime but does not receive the Google authorization code, access token, refresh token, or Google API data.
+Google returns the authorization response directly to the local loopback callback, and the local runtime performs the token exchange and stores the resulting connection.
 The software running on your machine stores the connection, while the Google API, your configured AI model provider, and your Matrix homeserver process the data sent to each of them.
 The installation operator and anyone with administrative or filesystem access to its storage may be able to access locally stored credentials and data.
 
@@ -55,7 +57,7 @@ See the [Privacy Policy](https://docs.mindroom.chat/privacy/) for the complete d
 
 ## Custom Google OAuth App
 
-A custom Google OAuth app is optional for a local installation.
+A custom Google OAuth app is optional for a paired local installation and required for an unpaired self-hosted installation.
 Use one when you operate a public MindRoom origin, need organization-specific Google policies, or want your own consent-screen branding.
 
 Select **Use custom client** in the dashboard and enter the client ID and client secret from a Google Cloud **Web application** OAuth client.

--- a/skills/mindroom-docs/references/page__deployment__hosted-matrix__index.md
+++ b/skills/mindroom-docs/references/page__deployment__hosted-matrix__index.md
@@ -101,7 +101,9 @@ Use `worker_scope: user_agent` when each requester should get separate per-agent
 
 They can only call provisioning-service endpoints that accept local client credentials, including agent registration and retrieval of the Google desktop app client configuration.
 The Google app client configuration lets the local process exchange OAuth codes directly with Google; the provisioning service does not receive the resulting Google authorization code or tokens.
+Treat the local provisioning credentials as secrets because anyone who obtains them can use the same provisioning capabilities, including retrieving the Google desktop app client configuration.
 Revoke them from `Settings -> Local MindRoom` in the chat UI.
+After a confirmed provisioning-credential leak, the service operator should also treat the Google app client configuration as exposed and rotate that OAuth client secret.
 
 ## Trust Model (Hosted Server vs Message Privacy)
 

--- a/skills/mindroom-docs/references/page__deployment__hosted-matrix__index.md
+++ b/skills/mindroom-docs/references/page__deployment__hosted-matrix__index.md
@@ -99,7 +99,8 @@ Use `worker_scope: user_agent` when each requester should get separate per-agent
 `MINDROOM_LOCAL_CLIENT_ID` and `MINDROOM_LOCAL_CLIENT_SECRET` are **not Matrix user access tokens**.
 `MINDROOM_NAMESPACE` is appended to managed agent usernames and room aliases to avoid collisions on shared homeservers.
 
-They can only call provisioning-service endpoints that accept local client credentials (for example agent registration flows).
+They can only call provisioning-service endpoints that accept local client credentials, including agent registration and retrieval of the Google desktop app client configuration.
+The Google app client configuration lets the local process exchange OAuth codes directly with Google; the provisioning service does not receive the resulting Google authorization code or tokens.
 Revoke them from `Settings -> Local MindRoom` in the chat UI.
 
 ## Trust Model (Hosted Server vs Message Privacy)

--- a/src/mindroom/api/oauth.py
+++ b/src/mindroom/api/oauth.py
@@ -106,18 +106,18 @@ async def _client_config_resolution_for_request(
     provider: OAuthProvider,
     runtime_paths: RuntimePaths,
     *,
-    reject_remote_bundled: bool,
+    reject_remote_provisioned: bool,
 ) -> OAuthClientConfigResolution | None:
     """Resolve an OAuth client that can return to the requesting browser host."""
     try:
         resolution = await provider.client_config_resolution_async(runtime_paths)
     except OAuthProviderError as exc:
         raise HTTPException(status_code=503, detail=str(exc)) from exc
-    if resolution is None or resolution.stored or is_oauth_loopback_hostname(request.url.hostname):
+    if resolution is None or resolution.custom or is_oauth_loopback_hostname(request.url.hostname):
         return resolution
-    if reject_remote_bundled:
+    if reject_remote_provisioned:
         detail = (
-            "The built-in OAuth client is available only when MindRoom is opened on localhost. "
+            "The provisioned OAuth client is available only when MindRoom is opened on localhost. "
             "Set MINDROOM_PUBLIC_URL (or MINDROOM_BASE_URL) and configure a custom OAuth client for remote access."
         )
         raise HTTPException(status_code=503, detail=detail)
@@ -136,7 +136,7 @@ async def _issue_authorization_url(
         request,
         provider,
         runtime_paths,
-        reject_remote_bundled=True,
+        reject_remote_provisioned=True,
     )
     if connect_token:
         try:
@@ -470,7 +470,7 @@ async def status(provider_id: str, request: Request, agent_name: str | None = No
             request,
             provider,
             runtime_paths,
-            reject_remote_bundled=False,
+            reject_remote_provisioned=False,
         )
     )
     has_client_config = client_config_resolution is not None
@@ -512,7 +512,7 @@ async def status(provider_id: str, request: Request, agent_name: str | None = No
         client_config_redirect_uri_supported=client_config_redirect_uri_supported,
         connected=connected,
         has_client_config=has_client_config,
-        has_custom_client_config=(client_config_resolution is not None and client_config_resolution.stored),
+        has_custom_client_config=(client_config_resolution is not None and client_config_resolution.custom),
         has_service_account_config=has_service_account_config,
         email=_claim_str(credentials, "email"),
         hosted_domain=_claim_str(credentials, "hd"),

--- a/src/mindroom/api/oauth.py
+++ b/src/mindroom/api/oauth.py
@@ -101,7 +101,7 @@ async def _require_oauth_browser_user(request: Request) -> RedirectResponse | No
     return None
 
 
-def _client_config_resolution_for_request(
+async def _client_config_resolution_for_request(
     request: Request,
     provider: OAuthProvider,
     runtime_paths: RuntimePaths,
@@ -109,7 +109,10 @@ def _client_config_resolution_for_request(
     reject_remote_bundled: bool,
 ) -> OAuthClientConfigResolution | None:
     """Resolve an OAuth client that can return to the requesting browser host."""
-    resolution = provider.client_config_resolution(runtime_paths)
+    try:
+        resolution = await provider.client_config_resolution_async(runtime_paths)
+    except OAuthProviderError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
     if resolution is None or resolution.stored or is_oauth_loopback_hostname(request.url.hostname):
         return resolution
     if reject_remote_bundled:
@@ -129,7 +132,7 @@ async def _issue_authorization_url(
     agent_name: str | None,
     connect_token: str | None = None,
 ) -> OAuthConnectResponse:
-    _client_config_resolution_for_request(
+    await _client_config_resolution_for_request(
         request,
         provider,
         runtime_paths,
@@ -459,14 +462,18 @@ async def status(provider_id: str, request: Request, agent_name: str | None = No
         )
         or {}
     )
-    client_config_resolution = _client_config_resolution_for_request(
-        request,
-        provider,
-        runtime_paths,
-        reject_remote_bundled=False,
+    has_service_account_config = oauth_provider_service_account_configured(provider, runtime_paths)
+    client_config_resolution = (
+        provider.client_config_resolution(runtime_paths)
+        if has_service_account_config
+        else await _client_config_resolution_for_request(
+            request,
+            provider,
+            runtime_paths,
+            reject_remote_bundled=False,
+        )
     )
     has_client_config = client_config_resolution is not None
-    has_service_account_config = oauth_provider_service_account_configured(provider, runtime_paths)
     credentials_usable = oauth_credentials_usable(provider, runtime_paths, credentials)
     if credentials_usable and has_client_config and not has_service_account_config:
         try:

--- a/src/mindroom/oauth/google.py
+++ b/src/mindroom/oauth/google.py
@@ -84,7 +84,7 @@ async def _google_runtime_bootstrapper(
 ) -> OAuthRuntimeEndpoints:
     """Fetch the installed-app client config through an authenticated local pairing."""
     resolution = _provider.client_config_resolution(runtime_paths)
-    if resolution is not None and resolution.stored:
+    if resolution is not None and resolution.custom:
         return _google_runtime_endpoints()
 
     manager = get_runtime_credentials_manager(runtime_paths)

--- a/src/mindroom/oauth/google.py
+++ b/src/mindroom/oauth/google.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, cast
 
@@ -34,6 +35,8 @@ _GOOGLE_AUTHORIZATION_URL = "https://accounts.google.com/o/oauth2/v2/auth"
 _GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"  # noqa: S105
 _GOOGLE_CLIENT_CONFIG_SERVICE = "google_oauth_client"
 _GOOGLE_PROVISIONING_PATH = "/v1/local-mindroom/oauth/google-client"
+_GOOGLE_PROVISIONED_CLIENT_FETCHED_AT_KEY = "_oauth_client_runtime_bootstrap_fetched_at"
+_GOOGLE_PROVISIONED_CLIENT_TTL_SECONDS = 60 * 60
 GOOGLE_IDENTITY_SCOPES = (
     "openid",
     "https://www.googleapis.com/auth/userinfo.email",
@@ -85,18 +88,33 @@ def _valid_provisioned_google_client(payload: object) -> tuple[str, str] | None:
     return client_id.strip(), client_secret.strip()
 
 
+def _provisioned_google_client_is_fresh(credentials: Mapping[str, object] | None) -> bool:
+    """Return whether cached provisioned credentials are complete and recent."""
+    if not credentials or credentials.get(RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY) is not True:
+        return False
+    if _valid_provisioned_google_client(credentials) is None:
+        return False
+    fetched_at = credentials.get(_GOOGLE_PROVISIONED_CLIENT_FETCHED_AT_KEY)
+    if isinstance(fetched_at, bool) or not isinstance(fetched_at, int | float):
+        return False
+    age = time.time() - fetched_at
+    return 0 <= age < _GOOGLE_PROVISIONED_CLIENT_TTL_SECONDS
+
+
 async def _google_runtime_bootstrapper(
     _provider: OAuthProvider,
     runtime_paths: RuntimePaths,
 ) -> OAuthRuntimeEndpoints:
     """Fetch the installed-app client config through an authenticated local pairing."""
     resolution = _provider.client_config_resolution(runtime_paths)
-    if resolution is not None:
+    if resolution is not None and resolution.custom:
         return _google_runtime_endpoints()
 
     manager = get_runtime_credentials_manager(runtime_paths)
     existing = manager.load_credentials(_GOOGLE_CLIENT_CONFIG_SERVICE)
     if existing and existing.get(RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY) is not True:
+        return _google_runtime_endpoints()
+    if _provisioned_google_client_is_fresh(existing):
         return _google_runtime_endpoints()
 
     provisioning_credentials = _provisioning_client_credentials(runtime_paths)
@@ -126,6 +144,7 @@ async def _google_runtime_bootstrapper(
         "client_id": client_id,
         "client_secret": client_secret,
         RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY: True,
+        _GOOGLE_PROVISIONED_CLIENT_FETCHED_AT_KEY: time.time(),
     }
     if existing != credentials:
         manager.save_credentials(_GOOGLE_CLIENT_CONFIG_SERVICE, credentials)

--- a/src/mindroom/oauth/google.py
+++ b/src/mindroom/oauth/google.py
@@ -3,18 +3,23 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
+import httpx
 from google.auth import exceptions as google_auth_exceptions
 from google.auth.transport.requests import Request as GoogleRequest
 from google.oauth2 import id_token as google_id_token
 from requests import exceptions as requests_exceptions
 
+from mindroom.credentials import get_runtime_credentials_manager
 from mindroom.logging_config import get_logger
 from mindroom.oauth.providers import (
+    RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY,
     OAuthClaimValidationError,
     OAuthClientConfig,
     OAuthProvider,
+    OAuthProviderError,
+    OAuthRuntimeEndpoints,
     OAuthTokenResult,
     oauth_expires_at_from_response,
 )
@@ -24,14 +29,135 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-# Installed apps distribute a public client ID and cannot keep a client secret.
-# PKCE protects the authorization-code exchange for this loopback-only client.
-_GOOGLE_PUBLIC_OAUTH_CLIENT_ID = "974295579207-ibhtamfcpa2pp4gjh36bf6cvnb423gk2.apps.googleusercontent.com"
+_GOOGLE_AUTHORIZATION_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+_GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"  # noqa: S105
+_GOOGLE_CLIENT_CONFIG_SERVICE = "google_oauth_client"
+_GOOGLE_PROVISIONING_PATH = "/v1/local-mindroom/oauth/google-client"
 GOOGLE_IDENTITY_SCOPES = (
     "openid",
     "https://www.googleapis.com/auth/userinfo.email",
     "https://www.googleapis.com/auth/userinfo.profile",
 )
+
+
+def _google_runtime_endpoints() -> OAuthRuntimeEndpoints:
+    """Return Google's fixed OAuth endpoints."""
+    return OAuthRuntimeEndpoints(
+        authorization_url=_GOOGLE_AUTHORIZATION_URL,
+        token_url=_GOOGLE_TOKEN_URL,
+    )
+
+
+def _provisioning_client_credentials(runtime_paths: RuntimePaths) -> tuple[str, str, str] | None:
+    """Return the paired provisioning endpoint and local client credentials."""
+    provisioning_url = (runtime_paths.env_value("MINDROOM_PROVISIONING_URL") or "").strip().rstrip("/")
+    client_id = (runtime_paths.env_value("MINDROOM_LOCAL_CLIENT_ID") or "").strip()
+    client_secret = (runtime_paths.env_value("MINDROOM_LOCAL_CLIENT_SECRET") or "").strip()
+    if not provisioning_url and not client_id and not client_secret:
+        return None
+    if not provisioning_url or not client_id or not client_secret:
+        msg = (
+            "Google OAuth bootstrap requires MINDROOM_PROVISIONING_URL, MINDROOM_LOCAL_CLIENT_ID, "
+            "and MINDROOM_LOCAL_CLIENT_SECRET. Run `mindroom connect --pair-code ...` again."
+        )
+        raise OAuthProviderError(msg)
+    return provisioning_url, client_id, client_secret
+
+
+def _valid_provisioned_google_client(payload: object) -> tuple[str, str] | None:
+    """Validate one provisioning response without accepting blank client fields."""
+    if not isinstance(payload, dict):
+        return None
+    typed_payload = cast("dict[str, object]", payload)
+    client_id = typed_payload.get("client_id")
+    client_secret = typed_payload.get("client_secret")
+    if not isinstance(client_id, str) or not client_id.strip():
+        return None
+    if not isinstance(client_secret, str) or not client_secret.strip():
+        return None
+    return client_id.strip(), client_secret.strip()
+
+
+async def _google_runtime_bootstrapper(
+    _provider: OAuthProvider,
+    runtime_paths: RuntimePaths,
+) -> OAuthRuntimeEndpoints:
+    """Fetch the installed-app client config through an authenticated local pairing."""
+    resolution = _provider.client_config_resolution(runtime_paths)
+    if resolution is not None and resolution.stored:
+        return _google_runtime_endpoints()
+
+    manager = get_runtime_credentials_manager(runtime_paths)
+    existing = manager.load_credentials(_GOOGLE_CLIENT_CONFIG_SERVICE)
+    if existing and existing.get(RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY) is not True:
+        return _google_runtime_endpoints()
+
+    provisioning_credentials = _provisioning_client_credentials(runtime_paths)
+    if provisioning_credentials is None:
+        if existing:
+            return _google_runtime_endpoints()
+        msg = (
+            "Google OAuth is not configured. Pair this local install with `mindroom connect --pair-code ...`, "
+            "or save a custom Google OAuth client in the dashboard."
+        )
+        raise OAuthProviderError(msg)
+
+    provisioning_url, local_client_id, local_client_secret = provisioning_credentials
+    headers = {
+        "X-Local-MindRoom-Client-Id": local_client_id,
+        "X-Local-MindRoom-Client-Secret": local_client_secret,
+    }
+    try:
+        client_id, client_secret = await _fetch_provisioned_google_client(provisioning_url, headers)
+    except OAuthProviderError as exc:
+        if existing:
+            logger.warning("google_oauth_client_bootstrap_unavailable", error_type=type(exc).__name__)
+            return _google_runtime_endpoints()
+        raise
+
+    credentials = {
+        "client_id": client_id,
+        "client_secret": client_secret,
+        RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY: True,
+    }
+    if existing != credentials:
+        manager.save_credentials(_GOOGLE_CLIENT_CONFIG_SERVICE, credentials)
+    return _google_runtime_endpoints()
+
+
+async def _fetch_provisioned_google_client(
+    provisioning_url: str,
+    headers: Mapping[str, str],
+) -> tuple[str, str]:
+    """Fetch and validate the desktop client from the provisioning service."""
+    try:
+        async with httpx.AsyncClient(timeout=10, follow_redirects=False) as client:
+            response = await client.get(
+                f"{provisioning_url}{_GOOGLE_PROVISIONING_PATH}",
+                headers=headers,
+            )
+    except httpx.HTTPError as exc:
+        msg = "Could not fetch the Google OAuth client configuration from the MindRoom provisioning service."
+        raise OAuthProviderError(msg) from exc
+
+    if not response.is_success:
+        if response.status_code in {401, 403}:
+            msg = "MindRoom pairing credentials are invalid or revoked. Run `mindroom connect --pair-code ...` again."
+        elif response.status_code == 503:
+            msg = "The MindRoom provisioning service has not configured the Google OAuth client yet."
+        else:
+            msg = f"MindRoom provisioning returned HTTP {response.status_code} for Google OAuth client bootstrap."
+        raise OAuthProviderError(msg)
+
+    try:
+        provisioned_client = _valid_provisioned_google_client(response.json())
+    except ValueError as exc:
+        msg = "MindRoom provisioning returned invalid JSON for Google OAuth client bootstrap."
+        raise OAuthProviderError(msg) from exc
+    if provisioned_client is None:
+        msg = "MindRoom provisioning returned an invalid Google OAuth client configuration."
+        raise OAuthProviderError(msg)
+    return provisioned_client
 
 
 def _google_token_parser(
@@ -123,13 +249,13 @@ def _google_oauth_provider(
     return OAuthProvider(
         id=provider_id,
         display_name=display_name,
-        authorization_url="https://accounts.google.com/o/oauth2/v2/auth",
-        token_url="https://oauth2.googleapis.com/token",  # noqa: S106
+        authorization_url=_GOOGLE_AUTHORIZATION_URL,
+        token_url=_GOOGLE_TOKEN_URL,
         scopes=scopes,
         credential_service=credential_service,
         tool_config_service=tool_config_service,
         client_config_services=client_config_services,
-        shared_client_config_services=("google_oauth_client",),
+        shared_client_config_services=(_GOOGLE_CLIENT_CONFIG_SERVICE,),
         allowed_email_domains_env=_google_domain_env_names(provider_id, "ALLOWED_EMAIL_DOMAINS"),
         allowed_hosted_domains_env=_google_domain_env_names(provider_id, "ALLOWED_HOSTED_DOMAINS"),
         extra_auth_params={
@@ -138,7 +264,7 @@ def _google_oauth_provider(
             "prompt": "consent",
         },
         pkce_code_challenge_method="S256",
-        loopback_client_id=_GOOGLE_PUBLIC_OAUTH_CLIENT_ID,
+        runtime_bootstrapper=_google_runtime_bootstrapper,
         status_capabilities=status_capabilities,
         token_parser=_google_token_parser,
     )

--- a/src/mindroom/oauth/google.py
+++ b/src/mindroom/oauth/google.py
@@ -21,6 +21,7 @@ from mindroom.oauth.providers import (
     OAuthProviderError,
     OAuthRuntimeEndpoints,
     OAuthTokenResult,
+    is_oauth_loopback_hostname,
     oauth_expires_at_from_response,
 )
 
@@ -61,6 +62,12 @@ def _provisioning_client_credentials(runtime_paths: RuntimePaths) -> tuple[str, 
             "and MINDROOM_LOCAL_CLIENT_SECRET. Run `mindroom connect --pair-code ...` again."
         )
         raise OAuthProviderError(msg)
+    parsed_url = httpx.URL(provisioning_url)
+    if parsed_url.scheme != "https" and not (
+        parsed_url.scheme == "http" and is_oauth_loopback_hostname(parsed_url.host)
+    ):
+        msg = "MINDROOM_PROVISIONING_URL must use HTTPS, except for localhost development."
+        raise OAuthProviderError(msg)
     return provisioning_url, client_id, client_secret
 
 
@@ -84,7 +91,7 @@ async def _google_runtime_bootstrapper(
 ) -> OAuthRuntimeEndpoints:
     """Fetch the installed-app client config through an authenticated local pairing."""
     resolution = _provider.client_config_resolution(runtime_paths)
-    if resolution is not None and resolution.custom:
+    if resolution is not None:
         return _google_runtime_endpoints()
 
     manager = get_runtime_credentials_manager(runtime_paths)

--- a/src/mindroom/oauth/providers.py
+++ b/src/mindroom/oauth/providers.py
@@ -47,7 +47,7 @@ _OAUTH_LOOPBACK_HOSTNAMES = frozenset({"localhost", "127.0.0.1", "::1"})
 
 
 def is_oauth_loopback_hostname(hostname: str | None) -> bool:
-    """Return whether a hostname is supported by the bundled loopback flow."""
+    """Return whether a hostname is supported by local loopback OAuth flows."""
     return hostname is not None and hostname.casefold() in _OAUTH_LOOPBACK_HOSTNAMES
 
 
@@ -122,7 +122,6 @@ class OAuthClientConfig:
     client_id: str
     client_secret: str | None
     redirect_uri: str
-    token_endpoint_auth_method: _TokenEndpointAuthMethod | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -140,7 +139,7 @@ class OAuthClientConfigResolution:
 
     config: OAuthClientConfig
     service: str
-    stored: bool = True
+    custom: bool = True
 
 
 @dataclass(frozen=True, slots=True)
@@ -398,8 +397,6 @@ class OAuthProvider:
     extra_token_params: Mapping[str, str] = field(default_factory=dict)
     token_endpoint_auth_method: _TokenEndpointAuthMethod = _DEFAULT_TOKEN_ENDPOINT_AUTH_METHOD
     pkce_code_challenge_method: _PKCECodeChallengeMethod | None = None
-    loopback_client_id: str | None = None
-    loopback_client_secret: str | None = None
     allow_empty_scopes: bool = False
     allowed_email_domains: tuple[str, ...] = ()
     allowed_hosted_domains: tuple[str, ...] = ()
@@ -455,19 +452,6 @@ class OAuthProvider:
         if self.pkce_code_challenge_method not in _SUPPORTED_PKCE_CODE_CHALLENGE_METHODS:
             msg = f"OAuth provider '{self.id}' supports only S256 PKCE"
             raise ValueError(msg)
-        if self.loopback_client_id is not None and not self.loopback_client_id.strip():
-            msg = f"OAuth provider '{self.id}' loopback_client_id must not be blank"
-            raise ValueError(msg)
-        if (
-            self.loopback_client_id is not None
-            and self.loopback_client_secret is None
-            and self.pkce_code_challenge_method is None
-        ):
-            msg = f"OAuth provider '{self.id}' public loopback client requires S256 PKCE"
-            raise ValueError(msg)
-        if self.loopback_client_secret is not None and self.loopback_client_id is None:
-            msg = f"OAuth provider '{self.id}' loopback_client_secret requires loopback_client_id"
-            raise ValueError(msg)
 
     def _validate_redirect_path(self) -> None:
         """Validate provider callback path shape."""
@@ -492,7 +476,7 @@ class OAuthProvider:
         return resolution.config if resolution is not None else None
 
     def client_config_resolution(self, runtime_paths: RuntimePaths) -> OAuthClientConfigResolution | None:
-        """Return stored or bundled OAuth app client settings and their source."""
+        """Return stored OAuth app client settings and their source."""
         manager = get_runtime_credentials_manager(runtime_paths)
         for service in self.client_config_services:
             credentials = manager.load_credentials(service)
@@ -501,7 +485,7 @@ class OAuthProvider:
                 return OAuthClientConfigResolution(
                     config=config,
                     service=service,
-                    stored=(credentials or {}).get(RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY) is not True,
+                    custom=(credentials or {}).get(RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY) is not True,
                 )
         for service in self.shared_client_config_services:
             credentials = manager.load_credentials(service)
@@ -510,30 +494,9 @@ class OAuthProvider:
                 return OAuthClientConfigResolution(
                     config=config,
                     service=service,
-                    stored=(credentials or {}).get(RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY) is not True,
+                    custom=(credentials or {}).get(RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY) is not True,
                 )
-        if self.loopback_client_id is None:
-            return None
-        redirect_uri = self.default_redirect_uri(runtime_paths)
-        if not is_oauth_loopback_hostname(urlparse(redirect_uri).hostname):
-            return None
-        service = (
-            self.client_config_services[0] if self.client_config_services else self.shared_client_config_services[0]
-        )
-        return OAuthClientConfigResolution(
-            config=OAuthClientConfig(
-                client_id=self.loopback_client_id,
-                client_secret=self.loopback_client_secret,
-                redirect_uri=redirect_uri,
-                token_endpoint_auth_method=(
-                    _DEFAULT_TOKEN_ENDPOINT_AUTH_METHOD
-                    if self.loopback_client_secret is not None
-                    else _PUBLIC_TOKEN_ENDPOINT_AUTH_METHOD
-                ),
-            ),
-            service=service,
-            stored=False,
-        )
+        return None
 
     async def client_config_resolution_async(
         self,
@@ -610,14 +573,9 @@ class OAuthProvider:
     def _runtime_token_endpoint_auth_method(
         self,
         endpoints: OAuthRuntimeEndpoints,
-        client_config: OAuthClientConfig,
     ) -> _TokenEndpointAuthMethod:
-        """Return the token endpoint auth method after client and endpoint resolution."""
-        return (
-            client_config.token_endpoint_auth_method
-            or endpoints.token_endpoint_auth_method
-            or self.token_endpoint_auth_method
-        )
+        """Return the token endpoint auth method after endpoint resolution."""
+        return endpoints.token_endpoint_auth_method or self.token_endpoint_auth_method
 
     def default_redirect_uri(self, runtime_paths: RuntimePaths) -> str:
         """Return the local default redirect URI for this provider."""
@@ -649,7 +607,7 @@ class OAuthProvider:
             client_secret=client_config.client_secret,
             scope=self.scopes,
             redirect_uri=client_config.redirect_uri,
-            token_endpoint_auth_method=self._runtime_token_endpoint_auth_method(endpoints, client_config),
+            token_endpoint_auth_method=self._runtime_token_endpoint_auth_method(endpoints),
         )
         auth_params = dict(self.extra_auth_params)
         if self.pkce_code_challenge_method is not None:
@@ -696,7 +654,7 @@ class OAuthProvider:
             client_secret=client_config.client_secret,
             scope=self.scopes,
             redirect_uri=client_config.redirect_uri,
-            token_endpoint_auth_method=self._runtime_token_endpoint_auth_method(endpoints, client_config),
+            token_endpoint_auth_method=self._runtime_token_endpoint_auth_method(endpoints),
             timeout=_DEFAULT_AUTHORIZE_TIMEOUT_SECONDS,
         ) as client:
             try:
@@ -742,7 +700,7 @@ class OAuthProvider:
             client_id=client_config.client_id,
             client_secret=client_config.client_secret,
             scope=self.scopes,
-            token_endpoint_auth_method=self._runtime_token_endpoint_auth_method(endpoints, client_config),
+            token_endpoint_auth_method=self._runtime_token_endpoint_auth_method(endpoints),
             timeout=_DEFAULT_AUTHORIZE_TIMEOUT_SECONDS,
         ) as client:
             try:

--- a/src/mindroom/oauth/providers.py
+++ b/src/mindroom/oauth/providers.py
@@ -38,6 +38,7 @@ _DEFAULT_AUTHORIZE_TIMEOUT_SECONDS = 20.0
 _DEFAULT_REFRESH_SKEW_SECONDS = 60.0
 _DEFAULT_TOKEN_ENDPOINT_AUTH_METHOD: _TokenEndpointAuthMethod = "client_secret_post"  # noqa: S105
 _PUBLIC_TOKEN_ENDPOINT_AUTH_METHOD: _TokenEndpointAuthMethod = "none"  # noqa: S105
+RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY = "_oauth_client_runtime_bootstrap"
 _SUPPORTED_TOKEN_ENDPOINT_AUTH_METHODS = frozenset(
     {_PUBLIC_TOKEN_ENDPOINT_AUTH_METHOD, "client_secret_post", "client_secret_basic"},
 )
@@ -494,13 +495,23 @@ class OAuthProvider:
         """Return stored or bundled OAuth app client settings and their source."""
         manager = get_runtime_credentials_manager(runtime_paths)
         for service in self.client_config_services:
-            config = self._stored_client_config_from_service(runtime_paths, manager.load_credentials(service), True)
+            credentials = manager.load_credentials(service)
+            config = self._stored_client_config_from_service(runtime_paths, credentials, True)
             if config is not None:
-                return OAuthClientConfigResolution(config=config, service=service)
+                return OAuthClientConfigResolution(
+                    config=config,
+                    service=service,
+                    stored=(credentials or {}).get(RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY) is not True,
+                )
         for service in self.shared_client_config_services:
-            config = self._stored_client_config_from_service(runtime_paths, manager.load_credentials(service), False)
+            credentials = manager.load_credentials(service)
+            config = self._stored_client_config_from_service(runtime_paths, credentials, False)
             if config is not None:
-                return OAuthClientConfigResolution(config=config, service=service)
+                return OAuthClientConfigResolution(
+                    config=config,
+                    service=service,
+                    stored=(credentials or {}).get(RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY) is not True,
+                )
         if self.loopback_client_id is None:
             return None
         redirect_uri = self.default_redirect_uri(runtime_paths)

--- a/tests/api/test_oauth_api.py
+++ b/tests/api/test_oauth_api.py
@@ -677,20 +677,6 @@ def test_oauth_provider_rejects_client_config_suffix_for_tool_config_service() -
         )
 
 
-def test_oauth_provider_rejects_public_loopback_client_without_pkce() -> None:
-    with pytest.raises(ValueError, match="public loopback client requires S256 PKCE"):
-        OAuthProvider(
-            id="public_mail",
-            display_name="Public Mail",
-            authorization_url="https://auth.example.test/authorize",
-            token_url="https://auth.example.test/token",
-            scopes=("mail.read",),
-            credential_service="public_mail_oauth",
-            client_config_services=("public_mail_oauth_client",),
-            loopback_client_id="bundled-public-client",
-        )
-
-
 def test_connect_generates_authorization_url_with_opaque_state(tmp_path: Path) -> None:
     runtime_paths = _runtime_paths(
         tmp_path,
@@ -804,7 +790,7 @@ def test_connect_generates_pkce_challenge_for_pkce_provider(tmp_path: Path) -> N
         ("GET", "/api/oauth/public_mail/authorize?agent_name=general"),
     ],
 )
-def test_oauth_entrypoints_reject_bundled_client_from_remote_request(
+def test_oauth_entrypoints_reject_runtime_bootstrapped_client_from_remote_request(
     tmp_path: Path,
     method: str,
     path: str,
@@ -814,6 +800,14 @@ def test_oauth_entrypoints_reject_bundled_client_from_remote_request(
         {constants.OWNER_MATRIX_USER_ID_ENV: "@alice:example.org"},
     )
     api_app = _make_test_app(runtime_paths, _config_payload())
+    get_runtime_credentials_manager(runtime_paths).save_credentials(
+        "public_mail_oauth_client",
+        {
+            "client_id": "provisioned-client-id",
+            "client_secret": "provisioned-client-secret",
+            RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY: True,
+        },
+    )
     provider = OAuthProvider(
         id="public_mail",
         display_name="Public Mail",
@@ -823,7 +817,6 @@ def test_oauth_entrypoints_reject_bundled_client_from_remote_request(
         credential_service="public_mail_oauth",
         client_config_services=("public_mail_oauth_client",),
         pkce_code_challenge_method="S256",
-        loopback_client_id="bundled-public-client",
     )
 
     with patch("mindroom.api.oauth.load_oauth_providers_for_snapshot", return_value={provider.id: provider}):
@@ -920,65 +913,6 @@ def test_provider_exchange_and_refresh_use_oauth_client(
     assert refreshed["token"] == "refreshed-access-token"
     assert refreshed["refresh_token"] == "refresh-token"
     assert refreshed["expires_at"] == 1300.0
-
-
-def test_provider_exchange_uses_public_auth_for_bundled_client(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    runtime_paths = _runtime_paths(tmp_path, {})
-    provider = OAuthProvider(
-        id="public_mail",
-        display_name="Public Mail",
-        authorization_url="https://auth.example.test/authorize",
-        token_url="https://auth.example.test/token",
-        scopes=("mail.read",),
-        credential_service="public_mail_oauth",
-        client_config_services=("public_mail_oauth_client",),
-        pkce_code_challenge_method="S256",
-        loopback_client_id="bundled-public-client",
-    )
-    seen: dict[str, Any] = {}
-
-    class FakeOAuth2Client:
-        def __init__(self, **kwargs: object) -> None:
-            seen["init_kwargs"] = kwargs
-
-        async def __aenter__(self) -> FakeOAuth2Client:
-            return self
-
-        async def __aexit__(self, *_args: object) -> None:
-            return None
-
-        async def fetch_token(self, url: str, **kwargs: object) -> dict[str, Any]:
-            seen["fetch"] = {"url": url, **kwargs}
-            return {"access_token": "access-token", "scope": "mail.read"}
-
-    monkeypatch.setattr("mindroom.oauth.providers.AsyncOAuth2Client", FakeOAuth2Client)
-
-    result = asyncio.run(
-        provider.exchange_code(
-            "auth-code",
-            runtime_paths,
-            code_verifier="pkce-verifier",
-        ),
-    )
-
-    assert seen["init_kwargs"] == {
-        "client_id": "bundled-public-client",
-        "client_secret": None,
-        "scope": ("mail.read",),
-        "redirect_uri": "http://localhost:8765/api/oauth/public_mail/callback",
-        "token_endpoint_auth_method": "none",
-        "timeout": 20.0,
-    }
-    assert seen["fetch"] == {
-        "url": "https://auth.example.test/token",
-        "code": "auth-code",
-        "grant_type": "authorization_code",
-        "code_verifier": "pkce-verifier",
-    }
-    assert result.token_data["client_id"] == "bundled-public-client"
 
 
 def test_provider_refresh_token_data_skips_unexpired_access_token(

--- a/tests/api/test_oauth_api.py
+++ b/tests/api/test_oauth_api.py
@@ -30,6 +30,7 @@ from mindroom.oauth import service as oauth_service
 from mindroom.oauth.google_calendar import google_calendar_oauth_provider
 from mindroom.oauth.google_drive import google_drive_oauth_provider
 from mindroom.oauth.providers import (
+    RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY,
     OAuthClientConfig,
     OAuthProviderError,
     OAuthRefreshRejectedError,
@@ -3643,7 +3644,7 @@ def test_google_status_reports_connected_with_service_account(tmp_path: Path) ->
         status_response = client.get(f"/api/oauth/{provider.id}/status?agent_name=general")
 
     assert status_response.status_code == 200
-    assert status_response.json()["has_client_config"] is True
+    assert status_response.json()["has_client_config"] is False
     assert status_response.json()["has_custom_client_config"] is False
     assert status_response.json()["client_config_service"] == "google_drive_oauth_client"
     assert status_response.json()["client_config_redirect_uri_supported"] is True
@@ -3651,13 +3652,21 @@ def test_google_status_reports_connected_with_service_account(tmp_path: Path) ->
     assert status_response.json()["connected"] is True
 
 
-def test_status_hides_bundled_client_from_remote_request(tmp_path: Path) -> None:
+def test_status_hides_runtime_bootstrapped_client_from_remote_request(tmp_path: Path) -> None:
     runtime_paths = _runtime_paths(
         tmp_path,
         {constants.OWNER_MATRIX_USER_ID_ENV: "@alice:example.org"},
     )
     api_app = _make_test_app(runtime_paths, _config_payload())
     provider = google_drive_oauth_provider()
+    get_runtime_credentials_manager(runtime_paths).save_credentials(
+        "google_oauth_client",
+        {
+            "client_id": "provisioned-client-id",
+            "client_secret": "provisioned-client-secret",
+            RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY: True,
+        },
+    )
 
     with TestClient(api_app, base_url="https://mindroom.example.test") as client:
         _login(client)

--- a/tests/test_google_oauth_providers.py
+++ b/tests/test_google_oauth_providers.py
@@ -6,12 +6,13 @@ import asyncio
 from typing import TYPE_CHECKING
 from urllib.parse import parse_qs, urlparse
 
+import httpx
 import pytest
 
 from mindroom.constants import resolve_runtime_paths
 from mindroom.oauth.google import (
-    _GOOGLE_PUBLIC_OAUTH_CLIENT_ID,
     _google_oauth_provider,
+    _google_runtime_bootstrapper,
     _google_token_parser,
 )
 from mindroom.oauth.google_calendar import _GOOGLE_CALENDAR_OAUTH_SCOPES, google_calendar_oauth_provider
@@ -24,10 +25,13 @@ from mindroom.oauth.service import build_oauth_connect_instruction, build_oauth_
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from mindroom.constants import RuntimePaths
     from mindroom.oauth.providers import OAuthProvider
 
 GOOGLE_AUTHORIZATION_URL = "https://accounts.google.com/o/oauth2/v2/auth"
 GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"  # noqa: S105
+PROVISIONED_CLIENT_ID = "provisioned-client.apps.googleusercontent.com"
+PROVISIONED_CLIENT_SECRET = "provisioned-client-secret"  # noqa: S105
 GOOGLE_EXTRA_AUTH_PARAMS = {
     "access_type": "offline",
     "include_granted_scopes": "true",
@@ -128,8 +132,9 @@ def test_public_google_oauth_providers_preserve_shared_google_oauth_fields(provi
     )
     assert provider.extra_auth_params == GOOGLE_EXTRA_AUTH_PARAMS
     assert provider.pkce_code_challenge_method == "S256"
-    assert provider.loopback_client_id == _GOOGLE_PUBLIC_OAUTH_CLIENT_ID
+    assert provider.loopback_client_id is None
     assert provider.loopback_client_secret is None
+    assert provider.runtime_bootstrapper is _google_runtime_bootstrapper
     assert provider.token_parser is _google_token_parser
 
 
@@ -164,14 +169,71 @@ def test_google_oauth_provider_helper_builds_common_google_provider_skeleton() -
     )
     assert provider.extra_auth_params == GOOGLE_EXTRA_AUTH_PARAMS
     assert provider.pkce_code_challenge_method == "S256"
-    assert provider.loopback_client_id == _GOOGLE_PUBLIC_OAUTH_CLIENT_ID
+    assert provider.loopback_client_id is None
     assert provider.loopback_client_secret is None
+    assert provider.runtime_bootstrapper is _google_runtime_bootstrapper
     assert provider.status_capabilities == ("Example read/write",)
     assert provider.token_parser is _google_token_parser
 
 
-def test_google_oauth_provider_uses_bundled_public_client_on_fresh_install(tmp_path: Path) -> None:
-    """A fresh local runtime can start Google OAuth without stored app credentials."""
+def _install_provisioning_transport(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Install a provisioning transport that validates paired-client authentication."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url == "https://provisioning.example/v1/local-mindroom/oauth/google-client"
+        assert request.headers["X-Local-MindRoom-Client-Id"] == "local-client"
+        assert request.headers["X-Local-MindRoom-Client-Secret"] == "local-secret"
+        return httpx.Response(
+            200,
+            json={
+                "client_id": PROVISIONED_CLIENT_ID,
+                "client_secret": PROVISIONED_CLIENT_SECRET,
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def client_factory(**kwargs: object) -> httpx.AsyncClient:
+        return real_async_client(transport=transport, **kwargs)
+
+    monkeypatch.setattr("mindroom.oauth.google.httpx.AsyncClient", client_factory)
+
+
+def _paired_runtime_paths(tmp_path: Path) -> RuntimePaths:
+    return resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path,
+        process_env={
+            "MINDROOM_PROVISIONING_URL": "https://provisioning.example",
+            "MINDROOM_LOCAL_CLIENT_ID": "local-client",
+            "MINDROOM_LOCAL_CLIENT_SECRET": "local-secret",
+        },
+    )
+
+
+def test_google_oauth_provider_bootstraps_client_for_paired_install(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A paired runtime fetches and stores the desktop client outside the package."""
+    _install_provisioning_transport(monkeypatch)
+    runtime_paths = _paired_runtime_paths(tmp_path)
+    provider = google_drive_oauth_provider()
+
+    resolution = asyncio.run(provider.client_config_resolution_async(runtime_paths))
+
+    assert resolution is not None
+    assert resolution.stored is False
+    assert resolution.service == "google_oauth_client"
+    assert resolution.config.client_id == PROVISIONED_CLIENT_ID
+    assert resolution.config.client_secret == PROVISIONED_CLIENT_SECRET
+    assert resolution.config.redirect_uri == "http://localhost:8765/api/oauth/google_drive/callback"
+    assert resolution.config.token_endpoint_auth_method is None
+
+
+def test_google_oauth_provider_requires_pairing_or_custom_client_on_fresh_install(tmp_path: Path) -> None:
+    """An unpaired runtime fails before sending users through a broken public-client flow."""
     runtime_paths = resolve_runtime_paths(
         config_path=tmp_path / "config.yaml",
         storage_path=tmp_path,
@@ -181,22 +243,16 @@ def test_google_oauth_provider_uses_bundled_public_client_on_fresh_install(tmp_p
 
     resolution = provider.client_config_resolution(runtime_paths)
 
-    assert resolution is not None
-    assert resolution.stored is False
-    assert resolution.service == "google_drive_oauth_client"
-    assert resolution.config.client_id == _GOOGLE_PUBLIC_OAUTH_CLIENT_ID
-    assert resolution.config.client_secret is None
-    assert resolution.config.redirect_uri == "http://localhost:8765/api/oauth/google_drive/callback"
-    assert resolution.config.token_endpoint_auth_method == "none"  # noqa: S105
+    assert resolution is None
 
 
-def test_google_oauth_provider_bundled_client_authorization_uses_pkce(tmp_path: Path) -> None:
-    """The bundled desktop client sends an S256 challenge and the local callback."""
-    runtime_paths = resolve_runtime_paths(
-        config_path=tmp_path / "config.yaml",
-        storage_path=tmp_path,
-        process_env={},
-    )
+def test_google_oauth_provider_bootstrapped_client_authorization_uses_pkce(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The provisioned desktop client sends an S256 challenge and the local callback."""
+    _install_provisioning_transport(monkeypatch)
+    runtime_paths = _paired_runtime_paths(tmp_path)
     provider = google_gmail_oauth_provider()
     code_verifier = provider.issue_pkce_code_verifier()
     assert code_verifier is not None
@@ -210,7 +266,7 @@ def test_google_oauth_provider_bundled_client_authorization_uses_pkce(tmp_path: 
     )
     params = parse_qs(urlparse(auth_url).query)
 
-    assert params["client_id"] == [_GOOGLE_PUBLIC_OAUTH_CLIENT_ID]
+    assert params["client_id"] == [PROVISIONED_CLIENT_ID]
     assert params["redirect_uri"] == ["http://localhost:8765/api/oauth/google_gmail/callback"]
     assert params["code_challenge_method"] == ["S256"]
     assert params["state"] == ["test-state"]

--- a/tests/test_google_oauth_providers.py
+++ b/tests/test_google_oauth_providers.py
@@ -19,7 +19,7 @@ from mindroom.oauth.google_calendar import _GOOGLE_CALENDAR_OAUTH_SCOPES, google
 from mindroom.oauth.google_drive import _GOOGLE_DRIVE_OAUTH_SCOPES, google_drive_oauth_provider
 from mindroom.oauth.google_gmail import _GOOGLE_GMAIL_OAUTH_SCOPES, google_gmail_oauth_provider
 from mindroom.oauth.google_sheets import _GOOGLE_SHEETS_OAUTH_SCOPES, google_sheets_oauth_provider
-from mindroom.oauth.providers import OAuthConnectionRequired, oauth_connection_required_payload
+from mindroom.oauth.providers import OAuthConnectionRequired, OAuthProviderError, oauth_connection_required_payload
 from mindroom.oauth.service import build_oauth_connect_instruction, build_oauth_reconnect_instruction
 
 if TYPE_CHECKING:
@@ -172,11 +172,16 @@ def test_google_oauth_provider_helper_builds_common_google_provider_skeleton() -
     assert provider.token_parser is _google_token_parser
 
 
-def _install_provisioning_transport(monkeypatch: pytest.MonkeyPatch) -> None:
+def _install_provisioning_transport(
+    monkeypatch: pytest.MonkeyPatch,
+    provisioning_url: str = "https://provisioning.example",
+) -> list[httpx.Request]:
     """Install a provisioning transport that validates paired-client authentication."""
+    requests: list[httpx.Request] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
-        assert request.url == "https://provisioning.example/v1/local-mindroom/oauth/google-client"
+        requests.append(request)
+        assert request.url == f"{provisioning_url}/v1/local-mindroom/oauth/google-client"
         assert request.headers["X-Local-MindRoom-Client-Id"] == "local-client"
         assert request.headers["X-Local-MindRoom-Client-Secret"] == "local-secret"
         return httpx.Response(
@@ -194,6 +199,7 @@ def _install_provisioning_transport(monkeypatch: pytest.MonkeyPatch) -> None:
         return real_async_client(transport=transport, **kwargs)
 
     monkeypatch.setattr("mindroom.oauth.google.httpx.AsyncClient", client_factory)
+    return requests
 
 
 def _paired_runtime_paths(tmp_path: Path) -> RuntimePaths:
@@ -241,12 +247,51 @@ def test_google_oauth_provider_requires_pairing_or_custom_client_on_fresh_instal
     assert resolution is None
 
 
+@pytest.mark.parametrize("hostname", ["localhost", "127.0.0.1", "[::1]"])
+def test_google_oauth_provider_allows_http_provisioning_only_on_loopback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    hostname: str,
+) -> None:
+    """Local development may use HTTP without exposing pairing credentials remotely."""
+    _install_provisioning_transport(monkeypatch, f"http://{hostname}")
+    runtime_paths = resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path,
+        process_env={
+            "MINDROOM_PROVISIONING_URL": f"http://{hostname}",
+            "MINDROOM_LOCAL_CLIENT_ID": "local-client",
+            "MINDROOM_LOCAL_CLIENT_SECRET": "local-secret",
+        },
+    )
+
+    resolution = asyncio.run(google_drive_oauth_provider().client_config_resolution_async(runtime_paths))
+
+    assert resolution is not None
+
+
+def test_google_oauth_provider_rejects_remote_http_provisioning(tmp_path: Path) -> None:
+    """Pairing credentials must never be sent to a plaintext remote endpoint."""
+    runtime_paths = resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path,
+        process_env={
+            "MINDROOM_PROVISIONING_URL": "http://provisioning.example",
+            "MINDROOM_LOCAL_CLIENT_ID": "local-client",
+            "MINDROOM_LOCAL_CLIENT_SECRET": "local-secret",
+        },
+    )
+
+    with pytest.raises(OAuthProviderError, match="must use HTTPS"):
+        asyncio.run(google_drive_oauth_provider().client_config_resolution_async(runtime_paths))
+
+
 def test_google_oauth_provider_bootstrapped_client_authorization_uses_pkce(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The provisioned desktop client sends an S256 challenge and the local callback."""
-    _install_provisioning_transport(monkeypatch)
+    requests = _install_provisioning_transport(monkeypatch)
     runtime_paths = _paired_runtime_paths(tmp_path)
     provider = google_gmail_oauth_provider()
     code_verifier = provider.issue_pkce_code_verifier()
@@ -265,6 +310,7 @@ def test_google_oauth_provider_bootstrapped_client_authorization_uses_pkce(
     assert params["redirect_uri"] == ["http://localhost:8765/api/oauth/google_gmail/callback"]
     assert params["code_challenge_method"] == ["S256"]
     assert params["state"] == ["test-state"]
+    assert len(requests) == 1
 
 
 def test_oauth_connection_required_payload_preserves_structured_fields() -> None:

--- a/tests/test_google_oauth_providers.py
+++ b/tests/test_google_oauth_providers.py
@@ -132,8 +132,6 @@ def test_public_google_oauth_providers_preserve_shared_google_oauth_fields(provi
     )
     assert provider.extra_auth_params == GOOGLE_EXTRA_AUTH_PARAMS
     assert provider.pkce_code_challenge_method == "S256"
-    assert provider.loopback_client_id is None
-    assert provider.loopback_client_secret is None
     assert provider.runtime_bootstrapper is _google_runtime_bootstrapper
     assert provider.token_parser is _google_token_parser
 
@@ -169,8 +167,6 @@ def test_google_oauth_provider_helper_builds_common_google_provider_skeleton() -
     )
     assert provider.extra_auth_params == GOOGLE_EXTRA_AUTH_PARAMS
     assert provider.pkce_code_challenge_method == "S256"
-    assert provider.loopback_client_id is None
-    assert provider.loopback_client_secret is None
     assert provider.runtime_bootstrapper is _google_runtime_bootstrapper
     assert provider.status_capabilities == ("Example read/write",)
     assert provider.token_parser is _google_token_parser
@@ -224,12 +220,11 @@ def test_google_oauth_provider_bootstraps_client_for_paired_install(
     resolution = asyncio.run(provider.client_config_resolution_async(runtime_paths))
 
     assert resolution is not None
-    assert resolution.stored is False
+    assert resolution.custom is False
     assert resolution.service == "google_oauth_client"
     assert resolution.config.client_id == PROVISIONED_CLIENT_ID
     assert resolution.config.client_secret == PROVISIONED_CLIENT_SECRET
     assert resolution.config.redirect_uri == "http://localhost:8765/api/oauth/google_drive/callback"
-    assert resolution.config.token_endpoint_auth_method is None
 
 
 def test_google_oauth_provider_requires_pairing_or_custom_client_on_fresh_install(tmp_path: Path) -> None:

--- a/tests/test_google_oauth_providers.py
+++ b/tests/test_google_oauth_providers.py
@@ -10,7 +10,10 @@ import httpx
 import pytest
 
 from mindroom.constants import resolve_runtime_paths
+from mindroom.credentials import get_runtime_credentials_manager
 from mindroom.oauth.google import (
+    _GOOGLE_PROVISIONED_CLIENT_FETCHED_AT_KEY,
+    _GOOGLE_PROVISIONED_CLIENT_TTL_SECONDS,
     _google_oauth_provider,
     _google_runtime_bootstrapper,
     _google_token_parser,
@@ -19,7 +22,12 @@ from mindroom.oauth.google_calendar import _GOOGLE_CALENDAR_OAUTH_SCOPES, google
 from mindroom.oauth.google_drive import _GOOGLE_DRIVE_OAUTH_SCOPES, google_drive_oauth_provider
 from mindroom.oauth.google_gmail import _GOOGLE_GMAIL_OAUTH_SCOPES, google_gmail_oauth_provider
 from mindroom.oauth.google_sheets import _GOOGLE_SHEETS_OAUTH_SCOPES, google_sheets_oauth_provider
-from mindroom.oauth.providers import OAuthConnectionRequired, OAuthProviderError, oauth_connection_required_payload
+from mindroom.oauth.providers import (
+    RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY,
+    OAuthConnectionRequired,
+    OAuthProviderError,
+    oauth_connection_required_payload,
+)
 from mindroom.oauth.service import build_oauth_connect_instruction, build_oauth_reconnect_instruction
 
 if TYPE_CHECKING:
@@ -175,6 +183,10 @@ def test_google_oauth_provider_helper_builds_common_google_provider_skeleton() -
 def _install_provisioning_transport(
     monkeypatch: pytest.MonkeyPatch,
     provisioning_url: str = "https://provisioning.example",
+    *,
+    client_id: str = PROVISIONED_CLIENT_ID,
+    client_secret: str = PROVISIONED_CLIENT_SECRET,
+    status_code: int = 200,
 ) -> list[httpx.Request]:
     """Install a provisioning transport that validates paired-client authentication."""
     requests: list[httpx.Request] = []
@@ -185,10 +197,10 @@ def _install_provisioning_transport(
         assert request.headers["X-Local-MindRoom-Client-Id"] == "local-client"
         assert request.headers["X-Local-MindRoom-Client-Secret"] == "local-secret"
         return httpx.Response(
-            200,
+            status_code,
             json={
-                "client_id": PROVISIONED_CLIENT_ID,
-                "client_secret": PROVISIONED_CLIENT_SECRET,
+                "client_id": client_id,
+                "client_secret": client_secret,
             },
         )
 
@@ -311,6 +323,64 @@ def test_google_oauth_provider_bootstrapped_client_authorization_uses_pkce(
     assert params["code_challenge_method"] == ["S256"]
     assert params["state"] == ["test-state"]
     assert len(requests) == 1
+
+
+def test_google_oauth_provider_refreshes_stale_provisioned_client(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stale provisioned client is refreshed after the app secret rotates."""
+    now = 1000.0 + _GOOGLE_PROVISIONED_CLIENT_TTL_SECONDS
+    rotated_client_secret = "rotated-client-secret"  # noqa: S105
+    monkeypatch.setattr("mindroom.oauth.google.time.time", lambda: now)
+    requests = _install_provisioning_transport(
+        monkeypatch,
+        client_id="rotated-client.apps.googleusercontent.com",
+        client_secret=rotated_client_secret,
+    )
+    runtime_paths = _paired_runtime_paths(tmp_path)
+    manager = get_runtime_credentials_manager(runtime_paths)
+    manager.save_credentials(
+        "google_oauth_client",
+        {
+            "client_id": PROVISIONED_CLIENT_ID,
+            "client_secret": PROVISIONED_CLIENT_SECRET,
+            RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY: True,
+            _GOOGLE_PROVISIONED_CLIENT_FETCHED_AT_KEY: 1000.0,
+        },
+    )
+
+    asyncio.run(google_drive_oauth_provider().runtime_endpoints(runtime_paths))
+
+    assert len(requests) == 1
+    assert manager.load_credentials("google_oauth_client") == {
+        "client_id": "rotated-client.apps.googleusercontent.com",
+        "client_secret": rotated_client_secret,
+        RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY: True,
+        _GOOGLE_PROVISIONED_CLIENT_FETCHED_AT_KEY: now,
+    }
+
+
+def test_google_oauth_provider_keeps_stale_client_when_refresh_is_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A provisioning outage does not discard the last usable cached client."""
+    requests = _install_provisioning_transport(monkeypatch, status_code=503)
+    runtime_paths = _paired_runtime_paths(tmp_path)
+    manager = get_runtime_credentials_manager(runtime_paths)
+    stale_credentials = {
+        "client_id": PROVISIONED_CLIENT_ID,
+        "client_secret": PROVISIONED_CLIENT_SECRET,
+        RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY: True,
+        _GOOGLE_PROVISIONED_CLIENT_FETCHED_AT_KEY: 0.0,
+    }
+    manager.save_credentials("google_oauth_client", stale_credentials)
+
+    asyncio.run(google_drive_oauth_provider().runtime_endpoints(runtime_paths))
+
+    assert len(requests) == 1
+    assert manager.load_credentials("google_oauth_client") == stale_credentials
 
 
 def test_oauth_connection_required_payload_preserves_structured_fields() -> None:

--- a/tests/test_local_mindroom_provisioning_service.py
+++ b/tests/test_local_mindroom_provisioning_service.py
@@ -40,6 +40,32 @@ def _service_config(
     )
 
 
+@pytest.mark.parametrize(
+    ("client_id", "client_secret"),
+    [("google-client-id", None), (None, "google-client-secret")],
+)
+def test_service_config_rejects_partial_google_oauth_client(
+    monkeypatch: pytest.MonkeyPatch,
+    client_id: str | None,
+    client_secret: str | None,
+) -> None:
+    """The provisioning service fails at startup when only half the Google client is configured."""
+    monkeypatch.setenv("MATRIX_REGISTRATION_TOKEN", "server-secret-token")
+    monkeypatch.delenv("MATRIX_REGISTRATION_TOKEN_FILE", raising=False)
+    monkeypatch.delenv("MINDROOM_GOOGLE_OAUTH_CLIENT_SECRET_FILE", raising=False)
+    if client_id is None:
+        monkeypatch.delenv("MINDROOM_GOOGLE_OAUTH_CLIENT_ID", raising=False)
+    else:
+        monkeypatch.setenv("MINDROOM_GOOGLE_OAUTH_CLIENT_ID", client_id)
+    if client_secret is None:
+        monkeypatch.delenv("MINDROOM_GOOGLE_OAUTH_CLIENT_SECRET", raising=False)
+    else:
+        monkeypatch.setenv("MINDROOM_GOOGLE_OAUTH_CLIENT_SECRET", client_secret)
+
+    with pytest.raises(ValueError, match="must be configured together"):
+        provisioning._load_service_config_from_env()
+
+
 def _patch_matrix_auth(monkeypatch: pytest.MonkeyPatch) -> None:
     token_to_user = {
         "token-alice": "@alice:mindroom.chat",

--- a/tests/test_local_mindroom_provisioning_service.py
+++ b/tests/test_local_mindroom_provisioning_service.py
@@ -18,7 +18,12 @@ if TYPE_CHECKING:
     import httpx
 
 
-def _service_config(state_path: Path) -> provisioning.ServiceConfig:
+def _service_config(
+    state_path: Path,
+    *,
+    google_oauth_client_id: str | None = None,
+    google_oauth_client_secret: str | None = None,
+) -> provisioning.ServiceConfig:
     return provisioning.ServiceConfig(
         matrix_homeserver="https://mindroom.chat",
         matrix_server_name="mindroom.chat",
@@ -30,6 +35,8 @@ def _service_config(state_path: Path) -> provisioning.ServiceConfig:
         cors_origins=["https://chat.mindroom.chat"],
         listen_host="127.0.0.1",
         listen_port=8776,
+        google_oauth_client_id=google_oauth_client_id,
+        google_oauth_client_secret=google_oauth_client_secret,
     )
 
 
@@ -231,6 +238,56 @@ def test_pairing_and_register_agent_flow(tmp_path: Path, monkeypatch: pytest.Mon
             },
         )
         assert register_after_revoke.status_code == 403
+
+
+def test_paired_client_fetches_google_oauth_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only an authenticated paired runtime receives the installed-app client."""
+    _patch_matrix_auth(monkeypatch)
+    app = provisioning.create_app(
+        _service_config(
+            tmp_path / "state.json",
+            google_oauth_client_id="google-client-id",
+            google_oauth_client_secret="google-client-secret",  # noqa: S106
+        ),
+    )
+
+    with TestClient(app) as client:
+        complete = _pair_local_client(client)
+        missing_auth = client.get("/v1/local-mindroom/oauth/google-client")
+        response = client.get(
+            "/v1/local-mindroom/oauth/google-client",
+            headers={
+                "X-Local-MindRoom-Client-Id": complete["client_id"],
+                "X-Local-MindRoom-Client-Secret": complete["client_secret"],
+            },
+        )
+
+    assert missing_auth.status_code == 401
+    assert response.status_code == 200
+    assert response.headers["Cache-Control"] == "no-store"
+    assert response.json() == {
+        "client_id": "google-client-id",
+        "client_secret": "google-client-secret",
+    }
+
+
+def test_google_oauth_client_endpoint_requires_server_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A paired client receives an explicit error when the server has no Google app."""
+    _patch_matrix_auth(monkeypatch)
+    app = provisioning.create_app(_service_config(tmp_path / "state.json"))
+
+    with TestClient(app) as client:
+        complete = _pair_local_client(client)
+        response = client.get(
+            "/v1/local-mindroom/oauth/google-client",
+            headers={
+                "X-Local-MindRoom-Client-Id": complete["client_id"],
+                "X-Local-MindRoom-Client-Secret": complete["client_secret"],
+            },
+        )
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Google OAuth client is not configured"
 
 
 def test_pair_status_accepts_session_header_without_pair_code_query(


### PR DESCRIPTION
## Summary

- retrieve the Google desktop OAuth client from the authenticated local provisioning service
- cache that client locally while preserving custom-client precedence and loopback-only behavior
- keep authorization-code exchange, Google tokens, and Google API data on the user's machine
- add provisioning-service and Nix configuration plus deployment documentation

## Root cause

Google desktop OAuth clients still require their generated client secret during token exchange.
Shipping only a public client ID lets authorization begin but causes the callback token exchange to fail.

## Validation

- full live test from a credential-free local state: the Mind agent returned the localhost connection link, Google consent completed in Brave, and a real Gmail tool call returned `CONNECTED`
- dashboard OAuth status and connect endpoints verified against the provisioned client
- `uv run pre-commit run --all-files`
- `uv run pytest -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Paired local installations can now automatically obtain and use Google OAuth configuration.
  * Google sign-in uses PKCE with a secure local callback and caches the retrieved configuration.
  * Custom OAuth applications remain supported for unpaired self-hosted deployments.

* **Documentation**
  * Clarified setup requirements, configuration precedence, privacy boundaries, and OAuth credential flows for different deployment types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->