### PR TITLE
Make paired owner a managed-room admin

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -697,7 +697,7 @@ On success (default `--persist-env`), this writes to `.env` next to `config.yaml
 - `MINDROOM_LOCAL_CLIENT_SECRET`
 - `MINDROOM_NAMESPACE`
 
-If your config still contains the owner placeholder token `__MINDROOM_OWNER_USER_ID_FROM_PAIRING__`, `connect` will auto-replace it when pairing returns a valid `owner_user_id`.
+If your config still contains the owner placeholder token `__MINDROOM_OWNER_USER_ID_FROM_PAIRING__`, `connect` will auto-replace it in authorization and managed-room admin settings when pairing returns a valid `owner_user_id`.
 
 Use `--no-persist-env` if you want to export variables only for the current shell session.
 

--- a/docs/dev/agent_configuration.md
+++ b/docs/dev/agent_configuration.md
@@ -671,7 +671,7 @@ router:
 matrix_room_access:
   mode: single_user_private
   room_admins:
-    - "__MINDROOM_OWNER_USER_ID_FROM_PAIRING__"
+    - __MINDROOM_OWNER_USER_ID_FROM_PAIRING__
 
 # Timezone
 timezone: "America/Los_Angeles"
@@ -680,10 +680,10 @@ timezone: "America/Los_Angeles"
 authorization:
   default_room_access: false
   global_users:
-    - "__MINDROOM_OWNER_USER_ID_FROM_PAIRING__"
+    - __MINDROOM_OWNER_USER_ID_FROM_PAIRING__
   agent_reply_permissions:
     "*":
-      - "__MINDROOM_OWNER_USER_ID_FROM_PAIRING__"
+      - __MINDROOM_OWNER_USER_ID_FROM_PAIRING__
 ```
 
 ## Troubleshooting

--- a/docs/dev/agent_configuration.md
+++ b/docs/dev/agent_configuration.md
@@ -667,6 +667,12 @@ router:
   model: "default"
   accept_invites: true
 
+# Managed room access
+matrix_room_access:
+  mode: single_user_private
+  room_admins:
+    - "__MINDROOM_OWNER_USER_ID_FROM_PAIRING__"
+
 # Timezone
 timezone: "America/Los_Angeles"
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -18190,7 +18190,7 @@ On success (default `--persist-env`), this writes to `.env` next to `config.yaml
 - `MINDROOM_LOCAL_CLIENT_SECRET`
 - `MINDROOM_NAMESPACE`
 
-If your config still contains the owner placeholder token `__MINDROOM_OWNER_USER_ID_FROM_PAIRING__`, `connect` will auto-replace it when pairing returns a valid `owner_user_id`.
+If your config still contains the owner placeholder token `__MINDROOM_OWNER_USER_ID_FROM_PAIRING__`, `connect` will auto-replace it in authorization and managed-room admin settings when pairing returns a valid `owner_user_id`.
 
 Use `--no-persist-env` if you want to export variables only for the current shell session.
 

--- a/skills/mindroom-docs/references/page__cli__index.md
+++ b/skills/mindroom-docs/references/page__cli__index.md
@@ -693,7 +693,7 @@ On success (default `--persist-env`), this writes to `.env` next to `config.yaml
 - `MINDROOM_LOCAL_CLIENT_SECRET`
 - `MINDROOM_NAMESPACE`
 
-If your config still contains the owner placeholder token `__MINDROOM_OWNER_USER_ID_FROM_PAIRING__`, `connect` will auto-replace it when pairing returns a valid `owner_user_id`.
+If your config still contains the owner placeholder token `__MINDROOM_OWNER_USER_ID_FROM_PAIRING__`, `connect` will auto-replace it in authorization and managed-room admin settings when pairing returns a valid `owner_user_id`.
 
 Use `--no-persist-env` if you want to export variables only for the current shell session.
 

--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -974,7 +974,7 @@ router:
 matrix_room_access:
   mode: single_user_private
   room_admins:
-    # Pairing with MindRoom Chat replaces this with the paired owner's Matrix user ID.
+    # MindRoom Chat pairing writes the paired owner's Matrix user ID here.
     - {constants.OWNER_MATRIX_USER_ID_PLACEHOLDER}
 
 matrix_space:

--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -457,7 +457,7 @@ def config_init(
 
         # `connect` can run before `config init`, when no config exists to patch.
         # In that order, connect persists the owner MXID in .env so init can render
-        # authorization defaults without leaving pairing placeholders behind.
+        # owner access defaults without leaving pairing placeholders behind.
         if owner_user_id := _config_init_owner_user_id(target):
             from mindroom.cli.owner import replace_owner_placeholders_in_text  # noqa: PLC0415
 
@@ -973,6 +973,9 @@ router:
 {mindroom_user_block}
 matrix_room_access:
   mode: single_user_private
+  room_admins:
+    # Pairing with MindRoom Chat replaces this with the paired owner's Matrix user ID.
+    - {constants.OWNER_MATRIX_USER_ID_PLACEHOLDER}
 
 matrix_space:
   enabled: true

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -199,6 +199,8 @@ class TestConfigInit:
         assert "matrix_space:" in content
         assert "matrix_space:\n  enabled: true\n  name: MindRoom" in content
         assert OWNER_MATRIX_USER_ID_PLACEHOLDER in content
+        config = yaml.safe_load(content)
+        assert config["matrix_room_access"]["room_admins"] == [OWNER_MATRIX_USER_ID_PLACEHOLDER]
 
     def test_init_defaults_to_openai_for_mindroom_chat(self, tmp_path: Path) -> None:
         """mindroom.chat should default to OpenAI without prompting for a provider."""
@@ -515,7 +517,7 @@ class TestConfigInit:
         self,
         tmp_path: Path,
     ) -> None:
-        """Running `connect` before `config init` should still fill owner authorization."""
+        """Running `connect` before `config init` should still fill owner access settings."""
         target = tmp_path / "config.yaml"
         env_path = tmp_path / ".env"
         env_path.write_text(
@@ -546,6 +548,7 @@ class TestConfigInit:
         config_content = target.read_text(encoding="utf-8")
         config = yaml.safe_load(config_content)
         assert OWNER_MATRIX_USER_ID_PLACEHOLDER not in config_content
+        assert config["matrix_room_access"]["room_admins"] == ["@alice:mindroom.chat"]
         assert config["authorization"]["global_users"] == ["@alice:mindroom.chat"]
         assert config["authorization"]["agent_reply_permissions"]["*"] == ["@alice:mindroom.chat"]
 
@@ -995,7 +998,10 @@ class TestConfigInit:
         assert f"#   id: {OPENAI_GPT_TERRA}" in config_text
         assert "# openai_luna:" in config_text
         assert f"#   id: {OPENAI_GPT_LUNA}" in config_text
-        assert config["matrix_room_access"] == {"mode": "single_user_private"}
+        assert config["matrix_room_access"] == {
+            "mode": "single_user_private",
+            "room_admins": [OWNER_MATRIX_USER_ID_PLACEHOLDER],
+        }
 
     def test_init_anthropic_preset_uses_anthropic_models(self, tmp_path: Path) -> None:
         """Config init --provider anthropic prepopulates Anthropic defaults."""
@@ -3293,6 +3299,9 @@ class TestConnect:
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
             "models: {}\nagents: {}\nrouter:\n  model: default\n"
+            "matrix_room_access:\n"
+            "  room_admins:\n"
+            f"    - {OWNER_MATRIX_USER_ID_PLACEHOLDER}\n"
             "authorization:\n"
             "  default_room_access: false\n"
             "  global_users:\n"
@@ -3340,6 +3349,8 @@ class TestConnect:
         updated_config = cfg.read_text()
         assert OWNER_MATRIX_USER_ID_PLACEHOLDER not in updated_config
         assert "@alice:mindroom.chat" in updated_config
+        parsed_config = yaml.safe_load(updated_config)
+        assert parsed_config["matrix_room_access"]["room_admins"] == ["@alice:mindroom.chat"]
 
     def test_connect_path_overrides_env_and_config_target(
         self,

--- a/tests/test_cli_connect.py
+++ b/tests/test_cli_connect.py
@@ -69,7 +69,7 @@ def test_persist_local_provisioning_env_writes_credentials_only(tmp_path: Path) 
 
 
 def test_persist_local_provisioning_env_writes_owner_when_available(tmp_path: Path) -> None:
-    """Persisted owner MXID lets a later config init replace authorization placeholders."""
+    """Persisted owner MXID lets a later config init replace owner access placeholders."""
     config_path = tmp_path / "config.yaml"
     config_path.write_text("models: {}\nagents: {}\nrouter:\n  model: default\n")
 


### PR DESCRIPTION
## Summary

- Add the paired-owner placeholder to `matrix_room_access.room_admins` in the config-init template.
- Resolve the room-admin entry for both onboarding orders: `config init` before pairing and pairing before `config init`.
- Document the managed-room admin substitution and refresh generated MindRoom docs references.

## Why

The starter template previously used the pairing owner placeholder only for authorization. The managed-room runtime already grants configured `room_admins` power level 100 in newly created and existing managed rooms, but config init never enrolled the paired owner in that setting.

After this change, pairing fills the owner Matrix ID into `room_admins`, so the owner receives admin power in every MindRoom-managed room without a separate manual config edit.

## Validation

- `uv run pytest` — 10,064 passed, 179 skipped.
- `uv run pytest tests/test_cli_config.py tests/test_cli_connect.py` — 169 passed.
- `uv run pre-commit run --all-files` — all hooks passed.