### PR TITLE
Polish provisioned Google OAuth onboarding

### DIFF
--- a/docs/deployment/hosted-matrix.md
+++ b/docs/deployment/hosted-matrix.md
@@ -107,7 +107,9 @@ They can only call provisioning-service endpoints that accept local client crede
 The Google app client configuration lets the local process exchange OAuth codes directly with Google; the provisioning service does not receive the resulting Google authorization code or tokens.
 Treat the local provisioning credentials as secrets because anyone who obtains them can use the same provisioning capabilities, including retrieving the Google desktop app client configuration.
 Revoke them from `Settings -> Local MindRoom` in the chat UI.
-After a confirmed provisioning-credential leak, the service operator should also treat the Google app client configuration as exposed and rotate that OAuth client secret.
+The distributed Google desktop client secret is not confidential in the installed-app model because every paired install can retrieve it.
+Provisioning keeps that client out of published artifacts, gates casual retrieval, and enables centralized rotation.
+Rotate the Google OAuth client in response to observed client abuse or as an operational rotation, not merely because one pairing credential leaked.
 
 ## Trust Model (Hosted Server vs Message Privacy)
 

--- a/frontend/src/components/Integrations/Integrations.test.tsx
+++ b/frontend/src/components/Integrations/Integrations.test.tsx
@@ -659,7 +659,7 @@ describe("Integrations", () => {
     });
   });
 
-  it("offers a custom client without blocking bundled OAuth", async () => {
+  it("offers a custom client without blocking provisioned OAuth", async () => {
     mockGoogleDriveLoadStatus.mockResolvedValueOnce({
       status: "available",
       connected: false,

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -15584,7 +15584,9 @@ They can only call provisioning-service endpoints that accept local client crede
 The Google app client configuration lets the local process exchange OAuth codes directly with Google; the provisioning service does not receive the resulting Google authorization code or tokens.
 Treat the local provisioning credentials as secrets because anyone who obtains them can use the same provisioning capabilities, including retrieving the Google desktop app client configuration.
 Revoke them from `Settings -> Local MindRoom` in the chat UI.
-After a confirmed provisioning-credential leak, the service operator should also treat the Google app client configuration as exposed and rotate that OAuth client secret.
+The distributed Google desktop client secret is not confidential in the installed-app model because every paired install can retrieve it.
+Provisioning keeps that client out of published artifacts, gates casual retrieval, and enables centralized rotation.
+Rotate the Google OAuth client in response to observed client abuse or as an operational rotation, not merely because one pairing credential leaked.
 
 ## Trust Model (Hosted Server vs Message Privacy)
 

--- a/skills/mindroom-docs/references/page__deployment__hosted-matrix__index.md
+++ b/skills/mindroom-docs/references/page__deployment__hosted-matrix__index.md
@@ -103,7 +103,9 @@ They can only call provisioning-service endpoints that accept local client crede
 The Google app client configuration lets the local process exchange OAuth codes directly with Google; the provisioning service does not receive the resulting Google authorization code or tokens.
 Treat the local provisioning credentials as secrets because anyone who obtains them can use the same provisioning capabilities, including retrieving the Google desktop app client configuration.
 Revoke them from `Settings -> Local MindRoom` in the chat UI.
-After a confirmed provisioning-credential leak, the service operator should also treat the Google app client configuration as exposed and rotate that OAuth client secret.
+The distributed Google desktop client secret is not confidential in the installed-app model because every paired install can retrieve it.
+Provisioning keeps that client out of published artifacts, gates casual retrieval, and enables centralized rotation.
+Rotate the Google OAuth client in response to observed client abuse or as an operational rotation, not merely because one pairing credential leaked.
 
 ## Trust Model (Hosted Server vs Message Privacy)
 

--- a/src/mindroom/api/credentials_oauth_policy.py
+++ b/src/mindroom/api/credentials_oauth_policy.py
@@ -14,6 +14,7 @@ from fastapi import HTTPException, Request
 from mindroom.api import config_lifecycle
 from mindroom.credential_policy import (
     OAUTH_CREDENTIAL_FIELDS,
+    RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY,
     dashboard_may_edit_oauth_service,
     filter_oauth_credential_fields,
     is_oauth_client_config_service,
@@ -207,11 +208,40 @@ def preserve_oauth_client_config_from_existing(
     oauth_service_match: OAuthCredentialServiceMatch | None,
 ) -> None:
     """Require or preserve OAuth client config identity fields from stored credentials."""
+    _reject_implicit_provisioned_client_resave(credentials, existing_credentials)
     _require_or_preserve_oauth_client_config_field(credentials, existing_credentials, "client_id")
     if _oauth_client_config_secret_required(oauth_service_match):
         _require_or_preserve_oauth_client_config_secret(credentials, existing_credentials)
     else:
         _preserve_optional_oauth_client_config_secret(credentials, existing_credentials)
+
+
+def _reject_implicit_provisioned_client_resave(
+    credentials: dict[str, Any],
+    existing_credentials: dict[str, Any],
+) -> None:
+    """Keep redacted dashboard saves from pinning a provisioned client as custom."""
+    if existing_credentials.get(RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY) is not True:
+        return
+    submitted_client_id = credentials.get("client_id")
+    existing_client_id = existing_credentials.get("client_id")
+    if (
+        isinstance(submitted_client_id, str)
+        and isinstance(existing_client_id, str)
+        and submitted_client_id.strip()
+        and submitted_client_id.strip() != existing_client_id.strip()
+    ):
+        return
+    submitted_secret = credentials.get("client_secret")
+    if isinstance(submitted_secret, str) and submitted_secret.strip():
+        return
+    raise HTTPException(
+        status_code=400,
+        detail=(
+            "Provisioned OAuth client configuration does not need to be saved. "
+            "Delete it to re-bootstrap, or provide a complete custom client configuration."
+        ),
+    )
 
 
 def _reject_non_client_config_fields(credentials: dict[str, Any]) -> None:

--- a/src/mindroom/credential_policy.py
+++ b/src/mindroom/credential_policy.py
@@ -7,6 +7,8 @@ from typing import Literal
 
 _WorkerScope = Literal["shared", "user", "user_agent"]
 
+RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY = "_oauth_client_runtime_bootstrap"
+
 OAUTH_CREDENTIAL_FIELDS = frozenset(
     {
         "_id_token",

--- a/src/mindroom/oauth/google.py
+++ b/src/mindroom/oauth/google.py
@@ -57,12 +57,12 @@ def _provisioning_client_credentials(runtime_paths: RuntimePaths) -> tuple[str, 
     provisioning_url = (runtime_paths.env_value("MINDROOM_PROVISIONING_URL") or "").strip().rstrip("/")
     client_id = (runtime_paths.env_value("MINDROOM_LOCAL_CLIENT_ID") or "").strip()
     client_secret = (runtime_paths.env_value("MINDROOM_LOCAL_CLIENT_SECRET") or "").strip()
-    if not provisioning_url and not client_id and not client_secret:
+    if not client_id and not client_secret:
         return None
     if not provisioning_url or not client_id or not client_secret:
         msg = (
             "Google OAuth bootstrap requires MINDROOM_PROVISIONING_URL, MINDROOM_LOCAL_CLIENT_ID, "
-            "and MINDROOM_LOCAL_CLIENT_SECRET. Run `mindroom connect --pair-code ...` again."
+            "and MINDROOM_LOCAL_CLIENT_SECRET. Run `mindroom connect --pair-code ...` to restore pairing."
         )
         raise OAuthProviderError(msg)
     parsed_url = httpx.URL(provisioning_url)
@@ -102,11 +102,11 @@ def _provisioned_google_client_is_fresh(credentials: Mapping[str, object] | None
 
 
 async def _google_runtime_bootstrapper(
-    _provider: OAuthProvider,
+    provider: OAuthProvider,
     runtime_paths: RuntimePaths,
 ) -> OAuthRuntimeEndpoints:
     """Fetch the installed-app client config through an authenticated local pairing."""
-    resolution = _provider.client_config_resolution(runtime_paths)
+    resolution = provider.client_config_resolution(runtime_paths)
     if resolution is not None and resolution.custom:
         return _google_runtime_endpoints()
 

--- a/src/mindroom/oauth/providers.py
+++ b/src/mindroom/oauth/providers.py
@@ -18,7 +18,7 @@ from authlib.common.errors import AuthlibBaseError
 from authlib.deprecate import AuthlibDeprecationWarning
 from httpx import HTTPError, HTTPStatusError
 
-from mindroom.credential_policy import is_oauth_client_config_service
+from mindroom.credential_policy import RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY, is_oauth_client_config_service
 from mindroom.credentials import get_runtime_credentials_manager, validate_service_name
 
 warnings.filterwarnings(
@@ -38,7 +38,6 @@ _DEFAULT_AUTHORIZE_TIMEOUT_SECONDS = 20.0
 _DEFAULT_REFRESH_SKEW_SECONDS = 60.0
 _DEFAULT_TOKEN_ENDPOINT_AUTH_METHOD: _TokenEndpointAuthMethod = "client_secret_post"  # noqa: S105
 _PUBLIC_TOKEN_ENDPOINT_AUTH_METHOD: _TokenEndpointAuthMethod = "none"  # noqa: S105
-RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY = "_oauth_client_runtime_bootstrap"
 _SUPPORTED_TOKEN_ENDPOINT_AUTH_METHODS = frozenset(
     {_PUBLIC_TOKEN_ENDPOINT_AUTH_METHOD, "client_secret_post", "client_secret_basic"},
 )

--- a/tests/api/test_credentials_api.py
+++ b/tests/api/test_credentials_api.py
@@ -13,6 +13,7 @@ from mindroom import constants
 from mindroom.api import credentials_oauth_policy, credentials_target, main
 from mindroom.api.main import app, initialize_api_app
 from mindroom.config.main import Config
+from mindroom.credential_policy import RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY
 from mindroom.credentials import get_runtime_credentials_manager
 from mindroom.mcp.config import MCPServerConfig
 from mindroom.mcp.oauth import mcp_oauth_provider
@@ -635,6 +636,29 @@ class TestCredentialsAPI:
         assert response.status_code == 400
         assert "client_secret is required when client_id changes" in response.json()["detail"]
         assert manager.load_credentials("google_drive_oauth_client") == existing_credentials
+
+    def test_provisioned_oauth_client_config_rejects_redacted_resave(
+        self,
+        client: TestClient,
+    ) -> None:
+        """Re-saving a provisioned client must not silently pin it as a custom client."""
+        runtime_paths = main._app_runtime_paths(client.app)
+        manager = get_runtime_credentials_manager(runtime_paths)
+        existing_credentials = {
+            "client_id": "provisioned-client-id",
+            "client_secret": "provisioned-client-secret",
+            RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY: True,
+        }
+        manager.save_credentials("google_oauth_client", existing_credentials)
+
+        response = client.post(
+            "/api/credentials/google_oauth_client",
+            json={"credentials": {"client_id": "provisioned-client-id"}},
+        )
+
+        assert response.status_code == 400
+        assert "Provisioned OAuth client configuration does not need to be saved" in response.json()["detail"]
+        assert manager.load_credentials("google_oauth_client") == existing_credentials
 
     def test_oauth_client_config_save_rejects_missing_first_time_secret(
         self,

--- a/tests/test_google_oauth_providers.py
+++ b/tests/test_google_oauth_providers.py
@@ -305,22 +305,17 @@ def test_google_oauth_provider_keeps_cached_client_after_unpairing(tmp_path: Pat
         process_env={"MINDROOM_PROVISIONING_URL": "https://provisioning.example"},
     )
     manager = get_runtime_credentials_manager(runtime_paths)
-    manager.save_credentials(
-        "google_oauth_client",
-        {
-            "client_id": PROVISIONED_CLIENT_ID,
-            "client_secret": PROVISIONED_CLIENT_SECRET,
-            RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY: True,
-            _GOOGLE_PROVISIONED_CLIENT_FETCHED_AT_KEY: 0.0,
-        },
-    )
+    stale_credentials = {
+        "client_id": PROVISIONED_CLIENT_ID,
+        "client_secret": PROVISIONED_CLIENT_SECRET,
+        RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY: True,
+        _GOOGLE_PROVISIONED_CLIENT_FETCHED_AT_KEY: 0.0,
+    }
+    manager.save_credentials("google_oauth_client", stale_credentials)
 
-    resolution = asyncio.run(google_drive_oauth_provider().client_config_resolution_async(runtime_paths))
+    asyncio.run(google_drive_oauth_provider().runtime_endpoints(runtime_paths))
 
-    assert resolution is not None
-    assert resolution.custom is False
-    assert resolution.service == "google_oauth_client"
-    assert resolution.config.client_id == PROVISIONED_CLIENT_ID
+    assert manager.load_credentials("google_oauth_client") == stale_credentials
 
 
 @pytest.mark.parametrize("hostname", ["localhost", "127.0.0.1", "[::1]"])

--- a/tests/test_google_oauth_providers.py
+++ b/tests/test_google_oauth_providers.py
@@ -259,6 +259,70 @@ def test_google_oauth_provider_requires_pairing_or_custom_client_on_fresh_instal
     assert resolution is None
 
 
+def test_google_oauth_provider_explains_unpaired_public_profile(tmp_path: Path) -> None:
+    """A seeded provisioning URL without pairing credentials uses the fresh-install guidance."""
+    runtime_paths = resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path,
+        process_env={"MINDROOM_PROVISIONING_URL": "https://provisioning.example"},
+    )
+
+    with pytest.raises(OAuthProviderError, match=r"Pair this local install.*custom Google OAuth client"):
+        asyncio.run(google_drive_oauth_provider().client_config_resolution_async(runtime_paths))
+
+
+@pytest.mark.parametrize("service", ["google_drive_oauth_client", "google_oauth_client"])
+def test_google_oauth_provider_preserves_custom_client_without_provisioning_fetch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    service: str,
+) -> None:
+    """Provider-specific and shared custom clients always take precedence over provisioning."""
+    requests = _install_provisioning_transport(monkeypatch)
+    runtime_paths = _paired_runtime_paths(tmp_path)
+    manager = get_runtime_credentials_manager(runtime_paths)
+    manager.save_credentials(
+        service,
+        {
+            "client_id": "custom-client.apps.googleusercontent.com",
+            "client_secret": "custom-client-secret",
+        },
+    )
+
+    resolution = asyncio.run(google_drive_oauth_provider().client_config_resolution_async(runtime_paths))
+
+    assert resolution is not None
+    assert resolution.custom is True
+    assert resolution.service == service
+    assert requests == []
+
+
+def test_google_oauth_provider_keeps_cached_client_after_unpairing(tmp_path: Path) -> None:
+    """A previously provisioned client remains usable if pairing environment values disappear."""
+    runtime_paths = resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path,
+        process_env={"MINDROOM_PROVISIONING_URL": "https://provisioning.example"},
+    )
+    manager = get_runtime_credentials_manager(runtime_paths)
+    manager.save_credentials(
+        "google_oauth_client",
+        {
+            "client_id": PROVISIONED_CLIENT_ID,
+            "client_secret": PROVISIONED_CLIENT_SECRET,
+            RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY: True,
+            _GOOGLE_PROVISIONED_CLIENT_FETCHED_AT_KEY: 0.0,
+        },
+    )
+
+    resolution = asyncio.run(google_drive_oauth_provider().client_config_resolution_async(runtime_paths))
+
+    assert resolution is not None
+    assert resolution.custom is False
+    assert resolution.service == "google_oauth_client"
+    assert resolution.config.client_id == PROVISIONED_CLIENT_ID
+
+
 @pytest.mark.parametrize("hostname", ["localhost", "127.0.0.1", "[::1]"])
 def test_google_oauth_provider_allows_http_provisioning_only_on_loopback(
     tmp_path: Path,


### PR DESCRIPTION
## What changed

- Show the intended pair-or-custom-client guidance for fresh public installs that only have the seeded provisioning URL.
- Prevent redacted dashboard saves from silently converting a provisioned OAuth client into a pinned custom client.
- Add regression coverage for custom-client precedence and cached-client fallback after unpairing.
- Clarify that distributed desktop client secrets are non-confidential installed-app credentials.

## Why

The public profile pre-seeds the provisioning URL before pairing, which made the fresh-install path look like a partially broken pairing.
Dashboard redaction could also preserve the provisioned secret while dropping its runtime-bootstrap marker, disabling future rotation.

## Validation

- `uv run pytest` — 10,109 passed, 148 skipped.
- `uv run pre-commit run --all-files`.
- `uv run tach check --dependencies --interfaces`.
- `bun --cwd frontend test --run src/components/Integrations/Integrations.test.tsx` — 29 passed, 1 skipped.
- Live isolated API check on port 9876: fresh unpaired status returned the actionable HTTP 503 guidance; redacted provisioned-client re-save returned HTTP 400.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved Google OAuth provisioning and pairing behavior when pairing settings are unavailable or removed.
  * Existing provisioned credentials continue to work after pairing environment values are cleared.
  * Custom Google OAuth clients are correctly prioritized when configured.
  * Updated deployment documentation to clarify Google OAuth client secret confidentiality under the installed-app model and when to rotate credentials.
* **Bug Fixes**
  * Prevented accidental overwriting of provisioned Google OAuth credentials via the generic save flow.
  * Refined recovery guidance for restoring pairing and adjusted error messaging accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->