### PR TITLE
fix(e2ee): heal peer devices that re-registered their olm identity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
   "mcp[cli]>=1.12.4",
   "mdit-py-plugins>=0.5",
   "mem0ai>=0.1.115",
-  "mindroom-nio[e2e]>=0.27.1",
+  "mindroom-nio[e2e]>=0.27.2",
   "openai",
   "packaging>=24",
   "pydantic>=2",

--- a/src/mindroom/matrix/client_session.py
+++ b/src/mindroom/matrix/client_session.py
@@ -202,6 +202,10 @@ def _create_matrix_client(
         homeserver,
         user_id or "",
         store_path=store_path,
+        # Agents trust devices on first use and never verify interactively;
+        # accept a peer device's re-registered olm identity (trust reset)
+        # instead of keeping stale keys that silently break E2EE and calls.
+        config=nio.AsyncClientConfig(replace_rotated_device_keys=True),
         ssl=ssl_context,  # ty: ignore[invalid-argument-type]
     )
     if user_id:

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ name = "cuda-bindings"
 version = "12.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/c1/dabe88f52c3e3760d861401bb994df08f672ec893b8f7592dc91626adcf3/cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fda147a344e8eaeca0c6ff113d2851ffca8f7dfc0a6c932374ee5c47caa649c8", size = 12151019, upload-time = "2025-10-21T14:51:43.167Z" },
@@ -4447,7 +4447,7 @@ requires-dist = [
     { name = "mdit-py-plugins", specifier = ">=0.5" },
     { name = "mem0ai", specifier = ">=0.1.115" },
     { name = "mem0ai", marker = "extra == 'mem0'", specifier = ">=0.1.115" },
-    { name = "mindroom-nio", extras = ["e2e"], specifier = ">=0.27.1" },
+    { name = "mindroom-nio", extras = ["e2e"], specifier = ">=0.27.2" },
     { name = "moviepy", marker = "extra == 'moviepy-video-tools'" },
     { name = "neo4j", marker = "extra == 'neo4j'" },
     { name = "newspaper4k", marker = "extra == 'newspaper'" },
@@ -4551,7 +4551,7 @@ dev = [
 
 [[package]]
 name = "mindroom-nio"
-version = "0.27.1"
+version = "0.27.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -4563,9 +4563,9 @@ dependencies = [
     { name = "pycryptodome" },
     { name = "unpaddedbase64" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2a/13/80f396172589882b9e662fc669e6bcc5e3ec641d8098457c690e26f41eb3/mindroom_nio-0.27.1.tar.gz", hash = "sha256:fde56dba40e7eed834393fb28b37f58c7638a918dd0faf95c70961d5b3ce2aec", size = 166956, upload-time = "2026-07-13T14:35:25.503Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/9c/659230051cab4498addfd678a1ceb15669efe576e6bf3ce8acc07dd00c29/mindroom_nio-0.27.2.tar.gz", hash = "sha256:81d1b5d4ba941c0433755afba9fb0d428cb85f430a763a84e3fb1815f0a6b7c9", size = 167872, upload-time = "2026-07-15T01:56:11.518Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/36/00b934e0095eca62b33d18643abd0f38cc573934627164343055f2352e71/mindroom_nio-0.27.1-py3-none-any.whl", hash = "sha256:94b0cc979f11d1754a73ad8472a2127f9695a934d01193176bbfa814cc0fe1a0", size = 194714, upload-time = "2026-07-13T14:35:23.928Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/12/3d3bdc242840303694f03b10cc19e944dd6ddc5bcf65daa54b76a17fbd56/mindroom_nio-0.27.2-py3-none-any.whl", hash = "sha256:f353dc5efccc1ebcf4e3ebf62df87076254a1faec0779848a05200c2f74aa271", size = 195655, upload-time = "2026-07-15T01:56:10.093Z" },
 ]
 
 [package.optional-dependencies]
@@ -5034,7 +5034,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -5045,7 +5045,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -5072,9 +5072,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -5085,7 +5085,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },


### PR DESCRIPTION
## What

Opt in to [mindroom-nio 0.27.2](https://github.com/mindroom-ai/mindroom-nio/pull/10)'s `replace_rotated_device_keys` policy in `_create_matrix_client`, and bump the dependency pin (`>=0.27.2`, lock updated).

## Why

**Incident (2026-07-14, mindroom.chat):** a `MindRoom Web` session lost its browser crypto store while keeping its access token, re-registered a fresh olm identity under the same device id, and every MatrixRTC call with the Mind agent afterwards connected with silent audio in both directions. nio kept the stale identity forever, so the agent rejected the caller's frame key (`call_key_olm_rejected, matching_device_count: 0`) and encrypted its own frame key to the dead curve25519 key. Only remedy was logging the client out.

Agents trust devices on first use and never verify interactively, so accepting a validly self-signed rotated identity (with trust reset; blacklists survive) is the intended behavior. With the flag, the poisoned cache heals on the next `/keys/query` triggered by any device-list change.

## Testing

- Live-tested end to end against a real Tuwunel homeserver (details in mindroom-ai/mindroom-nio#10): default policy reproduces the incident, the flag heals it, and the call-key provenance predicate (`client_session.py`'s curve25519 device match) passes after healing, surviving restarts.
- Server-side companion (reject the rotation at upload): mindroom-ai/mindroom-tuwunel#10, merged.

Already deployed to the production checkout on the `mindroom` host (services restarted with nio 0.27.2 and the flag active).

## Summary by Sourcery

Update Matrix client configuration to automatically heal peer devices that have rotated their Olm identity, preventing stale keys from breaking end-to-end encryption and calls.

Bug Fixes:
- Ensure peer devices that re-register their Olm identity under the same device ID are correctly recognized so E2EE and MatrixRTC calls continue to work instead of silently failing.

Build:
- Bump mindroom-nio[e2e] dependency to version 0.27.2 to enable the new rotated-device-keys handling behavior.