### PR TITLE
Keep local credential files private

### DIFF
--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -18,6 +18,7 @@ from rich.console import Console
 from rich.syntax import Syntax
 
 from mindroom import constants
+from mindroom.cli.env_file import write_private_env_text
 from mindroom.model_defaults import (
     CONFIG_INIT_MODEL_ALTERNATIVES,
     CONFIG_INIT_MODEL_PRESETS,
@@ -165,7 +166,7 @@ def _write_env_file(
 ) -> bool:
     """Create or update .env and return whether the file changed."""
     if not env_path.exists():
-        env_path.write_text(_env_template(matrix_server, selected_preset, storage_root), encoding="utf-8")
+        write_private_env_text(env_path, _env_template(matrix_server, selected_preset, storage_root))
         console.print(f"[green]Env file created:[/green] {env_path}")
         return True
 
@@ -181,7 +182,7 @@ def _write_env_file(
             )
         return False
 
-    env_path.write_text(_env_template(matrix_server, selected_preset, storage_root), encoding="utf-8")
+    write_private_env_text(env_path, _env_template(matrix_server, selected_preset, storage_root))
     console.print(f"[green]Env file overwritten:[/green] {env_path}")
     return True
 
@@ -209,7 +210,7 @@ def _append_missing_env_defaults(
 
     appended_lines = [f"# {title}", *(f"{key}={value}" for key, value in missing_defaults)]
     appended_content = "\n".join(appended_lines)
-    env_path.write_text(f"{current_content}{separator}{appended_content}\n", encoding="utf-8")
+    write_private_env_text(env_path, f"{current_content}{separator}{appended_content}\n")
     console.print(f"[green]Env file updated:[/green] {env_path}")
     return True
 

--- a/src/mindroom/cli/env_file.py
+++ b/src/mindroom/cli/env_file.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import re
+import secrets
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -20,12 +21,20 @@ def env_path_for_config(config_path: str | Path) -> Path:
 def write_private_env_text(env_path: Path, content: str) -> None:
     """Write an env file that only the owning OS user can read or modify."""
     env_path.parent.mkdir(parents=True, exist_ok=True)
-    fd = os.open(env_path, os.O_RDWR | os.O_CREAT, 0o600)
-    with os.fdopen(fd, "r+", encoding="utf-8") as f:
-        os.fchmod(f.fileno(), 0o600)
-        f.seek(0)
-        f.truncate()
-        f.write(content)
+    if env_path.is_symlink():
+        msg = f"Refusing to write env file through a symlink: {env_path}"
+        raise ValueError(msg)
+
+    tmp_path = env_path.with_name(f".{env_path.name}.{secrets.token_hex(8)}.tmp")
+    fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        tmp_path.replace(env_path)
+    finally:
+        tmp_path.unlink(missing_ok=True)
 
 
 def upsert_env_values(env_path: Path, values: Mapping[str, str]) -> Path:

--- a/src/mindroom/cli/env_file.py
+++ b/src/mindroom/cli/env_file.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -16,6 +17,17 @@ def env_path_for_config(config_path: str | Path) -> Path:
     return resolved_config_path.parent / ".env"
 
 
+def write_private_env_text(env_path: Path, content: str) -> None:
+    """Write an env file that only the owning OS user can read or modify."""
+    env_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(env_path, os.O_RDWR | os.O_CREAT, 0o600)
+    with os.fdopen(fd, "r+", encoding="utf-8") as f:
+        os.fchmod(f.fileno(), 0o600)
+        f.seek(0)
+        f.truncate()
+        f.write(content)
+
+
 def upsert_env_values(env_path: Path, values: Mapping[str, str]) -> Path:
     """Upsert KEY=value entries while preserving unrelated lines."""
     env_path.parent.mkdir(parents=True, exist_ok=True)
@@ -24,7 +36,7 @@ def upsert_env_values(env_path: Path, values: Mapping[str, str]) -> Path:
     for key, value in values.items():
         _upsert_env_value(lines, key, value)
 
-    env_path.write_text(f"{'\n'.join(lines)}\n", encoding="utf-8")
+    write_private_env_text(env_path, f"{'\n'.join(lines)}\n")
     return env_path
 
 

--- a/src/mindroom/credentials.py
+++ b/src/mindroom/credentials.py
@@ -154,12 +154,19 @@ def _ensure_private_directory(path: Path, *, harden_existing: bool = False) -> N
 
 
 def _credential_owned_directory_chain(path: Path) -> list[Path]:
-    """Return credential-owned directories that should be private when encryption is enabled."""
+    """Return credential-owned directories that should be private."""
     chain = [path, *path.parents]
     for index, directory_path in enumerate(chain):
         if directory_path.name == _PRIMARY_RUNTIME_SCOPED_CREDENTIALS_DIRNAME:
             return list(reversed(chain[: index + 1]))
     return [path]
+
+
+def _harden_existing_credential_files(path: Path) -> None:
+    """Make existing credential payloads owner-readable only."""
+    for credentials_path in path.glob("*_credentials.json"):
+        if credentials_path.is_file():
+            credentials_path.chmod(0o600)
 
 
 def _atomic_write_private_file(path: Path, payload: bytes) -> None:
@@ -221,16 +228,10 @@ class CredentialsManager:
             else None
         )
 
-        encrypted_storage_enabled = self._encryption_key is not None
-        if encrypted_storage_enabled:
-            _ensure_private_directory(self.base_path, harden_existing=True)
-        else:
-            self.base_path.mkdir(parents=True, exist_ok=True)
-        if self.shared_base_path != self.base_path:
-            if encrypted_storage_enabled:
-                _ensure_private_directory(self.shared_base_path, harden_existing=True)
-            else:
-                self.shared_base_path.mkdir(parents=True, exist_ok=True)
+        credential_paths = {self.base_path, self.shared_base_path}
+        for credential_path in credential_paths:
+            _ensure_private_directory(credential_path, harden_existing=True)
+            _harden_existing_credential_files(credential_path)
 
     @property
     def storage_root(self) -> Path:
@@ -379,8 +380,7 @@ class CredentialsManager:
         if credentials_path.exists() and _has_encrypted_credentials_magic(credentials_path):
             msg = f"Stored credentials for {normalized_service} are encrypted; refusing to overwrite without a key"
             raise ValueError(msg)
-        with credentials_path.open("w", encoding="utf-8") as f:
-            json.dump(credentials, f, indent=2)
+        _atomic_write_private_file(credentials_path, json.dumps(credentials, indent=2).encode("utf-8"))
 
     def delete_credentials(self, service: str) -> None:
         """Delete credentials for a service.

--- a/src/mindroom/credentials.py
+++ b/src/mindroom/credentials.py
@@ -150,7 +150,19 @@ def _ensure_private_directory(path: Path, *, harden_existing: bool = False) -> N
             if directory_path not in directories_to_chmod:
                 directories_to_chmod.append(directory_path)
     for directory_path in directories_to_chmod:
-        directory_path.chmod(0o700)
+        _set_private_permissions(directory_path, 0o700)
+
+
+def _set_private_permissions(path: Path, mode: int) -> None:
+    """Set a private mode or fail with actionable ownership guidance."""
+    try:
+        path.chmod(mode)
+    except PermissionError as exc:
+        msg = (
+            f"Cannot secure credential path '{path}' with mode {mode:#05o}. "
+            "Ensure the MindRoom OS user owns this path and can change its permissions."
+        )
+        raise PermissionError(msg) from exc
 
 
 def _credential_owned_directory_chain(path: Path) -> list[Path]:
@@ -166,7 +178,7 @@ def _harden_existing_credential_files(path: Path) -> None:
     """Make existing credential payloads owner-readable only."""
     for credentials_path in path.glob("*_credentials.json"):
         if credentials_path.is_file():
-            credentials_path.chmod(0o600)
+            _set_private_permissions(credentials_path, 0o600)
 
 
 def _atomic_write_private_file(path: Path, payload: bytes) -> None:

--- a/src/mindroom/credentials.py
+++ b/src/mindroom/credentials.py
@@ -177,8 +177,25 @@ def _credential_owned_directory_chain(path: Path) -> list[Path]:
 def _harden_existing_credential_files(path: Path) -> None:
     """Make existing credential payloads owner-readable only."""
     for credentials_path in path.glob("*_credentials.json"):
-        if credentials_path.is_file():
+        if not credentials_path.is_symlink() and credentials_path.is_file():
             _set_private_permissions(credentials_path, 0o600)
+
+
+def _existing_worker_credential_paths(storage_root: Path) -> tuple[Path, ...]:
+    """Return real credential directories belonging to existing workers."""
+    workers_root = storage_root / "workers"
+    if workers_root.is_symlink() or not workers_root.is_dir():
+        return ()
+
+    paths: list[Path] = []
+    for worker_root in workers_root.iterdir():
+        if worker_root.is_symlink() or not worker_root.is_dir():
+            continue
+        for directory_name in ("credentials", _WORKER_SHARED_CREDENTIALS_DIRNAME):
+            credential_path = worker_root / directory_name
+            if not credential_path.is_symlink() and credential_path.is_dir():
+                paths.append(credential_path)
+    return tuple(paths)
 
 
 def _atomic_write_private_file(path: Path, payload: bytes) -> None:
@@ -241,6 +258,8 @@ class CredentialsManager:
         )
 
         credential_paths = {self.base_path, self.shared_base_path}
+        if self.current_worker_key is None and self.base_path.name == "credentials":
+            credential_paths.update(_existing_worker_credential_paths(self.storage_root))
         for credential_path in credential_paths:
             _ensure_private_directory(credential_path, harden_existing=True)
             _harden_existing_credential_files(credential_path)

--- a/tach.toml
+++ b/tach.toml
@@ -2408,6 +2408,7 @@ depends_on = []
 [[modules]]
 path = "mindroom.cli.config"
 depends_on = [
+    "mindroom.cli.env_file",
     "mindroom.cli.owner",
     "mindroom.config.main",
     "mindroom.config.yaml_includes",
@@ -2431,6 +2432,7 @@ depends_on = [
 path = "mindroom.cli.env_file"
 depends_on = []
 visibility = [
+    "mindroom.cli.config",
     "mindroom.cli.connect",
     "mindroom.cli.local_stack",
 ]

--- a/tests/test_cli_connect.py
+++ b/tests/test_cli_connect.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import stat
 from typing import TYPE_CHECKING
 
 import httpx
@@ -66,6 +67,7 @@ def test_persist_local_provisioning_env_writes_credentials_only(tmp_path: Path) 
     assert "MINDROOM_LOCAL_CLIENT_SECRET=secret-123" in content
     assert "MINDROOM_NAMESPACE=a1b2c3d4" in content
     assert "MINDROOM_OWNER_USER_ID=" not in content
+    assert stat.S_IMODE(env_path.stat().st_mode) == 0o600
 
 
 def test_persist_local_provisioning_env_writes_owner_when_available(tmp_path: Path) -> None:

--- a/tests/test_cli_env_file.py
+++ b/tests/test_cli_env_file.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import stat
 from typing import TYPE_CHECKING
 
+import pytest
+
 from mindroom.cli.env_file import env_path_for_config, upsert_env_values
 
 if TYPE_CHECKING:
@@ -59,3 +61,16 @@ def test_upsert_env_values_hardens_existing_env_file(tmp_path: Path) -> None:
     upsert_env_values(env_path, {"NEW": "secret"})
 
     assert stat.S_IMODE(env_path.stat().st_mode) == 0o600
+
+
+def test_upsert_env_values_refuses_symlink_destination(tmp_path: Path) -> None:
+    """Env writes should never follow a destination symlink."""
+    target_path = tmp_path / "target"
+    target_path.write_text("preserve-me\n", encoding="utf-8")
+    env_path = tmp_path / ".env"
+    env_path.symlink_to(target_path)
+
+    with pytest.raises(ValueError, match="Refusing to write env file through a symlink"):
+        upsert_env_values(env_path, {"NEW": "secret"})
+
+    assert target_path.read_text(encoding="utf-8") == "preserve-me\n"

--- a/tests/test_cli_env_file.py
+++ b/tests/test_cli_env_file.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import stat
 from typing import TYPE_CHECKING
 
 from mindroom.cli.env_file import env_path_for_config, upsert_env_values
@@ -46,3 +47,15 @@ def test_upsert_env_values_creates_parent_directory_and_file(tmp_path: Path) -> 
     upsert_env_values(env_path, {"MINDROOM_NAMESPACE": "a1b2c3d4"})
 
     assert env_path.read_text(encoding="utf-8") == "MINDROOM_NAMESPACE=a1b2c3d4\n"
+    assert stat.S_IMODE(env_path.stat().st_mode) == 0o600
+
+
+def test_upsert_env_values_hardens_existing_env_file(tmp_path: Path) -> None:
+    """Updating an existing env file should remove access for other OS users."""
+    env_path = tmp_path / ".env"
+    env_path.write_text("EXISTING=value\n", encoding="utf-8")
+    env_path.chmod(0o644)
+
+    upsert_env_values(env_path, {"NEW": "secret"})
+
+    assert stat.S_IMODE(env_path.stat().st_mode) == 0o600

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -138,6 +138,29 @@ class TestCredentialsManager:
         assert stat.S_IMODE(existing_path.stat().st_mode) == 0o600
         assert stat.S_IMODE(manager.get_credentials_path("new").stat().st_mode) == 0o600
 
+    def test_credentials_hardening_permission_error_is_actionable(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Permission failures should identify the path, mode, and ownership fix."""
+        credentials_dir = tmp_path / "credentials"
+        credentials_dir.mkdir()
+        original_chmod = Path.chmod
+
+        def deny_credentials_chmod(path: Path, mode: int) -> None:
+            if path == credentials_dir:
+                raise PermissionError
+            original_chmod(path, mode)
+
+        monkeypatch.setattr(Path, "chmod", deny_credentials_chmod)
+
+        with pytest.raises(
+            PermissionError,
+            match=rf"{credentials_dir}.*0o700.*MindRoom OS user owns",
+        ):
+            CredentialsManager(credentials_dir)
+
     def test_encrypted_save_and_load_credentials_round_trip(
         self,
         tmp_path: Path,

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -123,6 +123,21 @@ class TestCredentialsManager:
         loaded_creds = credentials_manager.load_credentials("test_service")
         assert loaded_creds == test_creds
 
+    def test_plaintext_credentials_storage_is_private(self, tmp_path: Path) -> None:
+        """Plaintext credential storage should only be accessible to the owning OS user."""
+        credentials_dir = tmp_path / "credentials"
+        credentials_dir.mkdir(mode=0o755)
+        existing_path = credentials_dir / "existing_credentials.json"
+        existing_path.write_text('{"token":"existing"}', encoding="utf-8")
+        existing_path.chmod(0o644)
+
+        manager = CredentialsManager(credentials_dir)
+        manager.save_credentials("new", {"token": "new"})
+
+        assert stat.S_IMODE(credentials_dir.stat().st_mode) == 0o700
+        assert stat.S_IMODE(existing_path.stat().st_mode) == 0o600
+        assert stat.S_IMODE(manager.get_credentials_path("new").stat().st_mode) == 0o600
+
     def test_encrypted_save_and_load_credentials_round_trip(
         self,
         tmp_path: Path,

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -161,6 +161,28 @@ class TestCredentialsManager:
         ):
             CredentialsManager(credentials_dir)
 
+    def test_primary_manager_hardens_existing_worker_credentials(self, tmp_path: Path) -> None:
+        """Root initialization should secure dormant worker credential stores."""
+        storage_root = tmp_path / "mindroom_data"
+        worker_root = storage_root / "workers" / "worker-existing"
+        worker_credentials = worker_root / "credentials"
+        worker_shared_credentials = worker_root / ".shared_credentials"
+        worker_credentials.mkdir(parents=True, mode=0o755)
+        worker_shared_credentials.mkdir(mode=0o755)
+        credentials_path = worker_credentials / "google_credentials.json"
+        shared_credentials_path = worker_shared_credentials / "openai_credentials.json"
+        credentials_path.write_text('{"token":"worker"}', encoding="utf-8")
+        shared_credentials_path.write_text('{"api_key":"shared"}', encoding="utf-8")
+        credentials_path.chmod(0o644)
+        shared_credentials_path.chmod(0o644)
+
+        CredentialsManager(storage_root / "credentials")
+
+        assert stat.S_IMODE(worker_credentials.stat().st_mode) == 0o700
+        assert stat.S_IMODE(worker_shared_credentials.stat().st_mode) == 0o700
+        assert stat.S_IMODE(credentials_path.stat().st_mode) == 0o600
+        assert stat.S_IMODE(shared_credentials_path.stat().st_mode) == 0o600
+
     def test_encrypted_save_and_load_credentials_round_trip(
         self,
         tmp_path: Path,


### PR DESCRIPTION
## What changed

- write local credential JSON files with owner-only `0600` permissions
- keep credential directories at owner-only `0700`
- harden existing credential files and directories when the credentials manager starts
- write CLI-managed `.env` files with owner-only `0600` permissions

## Why

Local OAuth refresh tokens, provisioning credentials, and provider keys must not be readable by other OS users on a multi-user machine.

## Validation

- live Google OAuth flow from a fresh localhost MindRoom install
- live agent-level `get_latest_emails` call through the Gmail tool
- `uv run pytest` — 10,111 passed, 148 skipped
- `uv run pre-commit run --all-files`
- `uv run tach check --dependencies --interfaces`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * CLI-managed `.env` files are now written with restrictive permissions and protected against unsafe symlink updates.
  * Credential directories and files receive stronger private-permission protection, including existing worker credential data.
  * Credential updates use safer atomic file writes to help prevent partial or unauthorized file changes.

* **Tests**
  * Added coverage verifying secure permissions, symlink protection, and actionable permission errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->