### PR TITLE
fix(knowledge): tolerate files vanishing during a refresh

### DIFF
--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -116,8 +116,10 @@ knowledge_bases:
 | `include_extensions` | list | `null` | Exact set of file extensions to index instead of the default text-like set (semantic mode only) |
 | `extra_extensions` | list | `[]` | File extensions to index in addition to the default text-like set (semantic mode only) |
 | `exclude_extensions` | list | `[]` | File extensions to exclude after include filtering (semantic mode only) |
+| `skip_hidden` | bool | `true` | Skip hidden files and folders (path components starting with `.`) during indexing, such as the dot-prefixed temp files of writers that update knowledge folders in place. Git-backed bases ignore this field and use `git.skip_hidden` instead |
 | `git` | object | `null` | Optional Git repository sync settings |
 
+Set `skip_hidden: false` if your knowledge folder intentionally contains dot-prefixed files or directories that should be indexed.
 Use smaller `chunk_size` values when your embedding server has lower token or batch limits.
 `chunk_size` and `chunk_overlap` only affect semantic mode.
 If chunking is too large, semantic indexing retries will fail with embedder 500 errors.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -12167,8 +12167,10 @@ knowledge_bases:
 | `include_extensions` | list | `null` | Exact set of file extensions to index instead of the default text-like set (semantic mode only) |
 | `extra_extensions` | list | `[]` | File extensions to index in addition to the default text-like set (semantic mode only) |
 | `exclude_extensions` | list | `[]` | File extensions to exclude after include filtering (semantic mode only) |
+| `skip_hidden` | bool | `true` | Skip hidden files and folders (path components starting with `.`) during indexing, such as the dot-prefixed temp files of writers that update knowledge folders in place. Git-backed bases ignore this field and use `git.skip_hidden` instead |
 | `git` | object | `null` | Optional Git repository sync settings |
 
+Set `skip_hidden: false` if your knowledge folder intentionally contains dot-prefixed files or directories that should be indexed.
 Use smaller `chunk_size` values when your embedding server has lower token or batch limits.
 `chunk_size` and `chunk_overlap` only affect semantic mode.
 If chunking is too large, semantic indexing retries will fail with embedder 500 errors.

--- a/skills/mindroom-docs/references/page__knowledge__index.md
+++ b/skills/mindroom-docs/references/page__knowledge__index.md
@@ -112,8 +112,10 @@ knowledge_bases:
 | `include_extensions` | list | `null` | Exact set of file extensions to index instead of the default text-like set (semantic mode only) |
 | `extra_extensions` | list | `[]` | File extensions to index in addition to the default text-like set (semantic mode only) |
 | `exclude_extensions` | list | `[]` | File extensions to exclude after include filtering (semantic mode only) |
+| `skip_hidden` | bool | `true` | Skip hidden files and folders (path components starting with `.`) during indexing, such as the dot-prefixed temp files of writers that update knowledge folders in place. Git-backed bases ignore this field and use `git.skip_hidden` instead |
 | `git` | object | `null` | Optional Git repository sync settings |
 
+Set `skip_hidden: false` if your knowledge folder intentionally contains dot-prefixed files or directories that should be indexed.
 Use smaller `chunk_size` values when your embedding server has lower token or batch limits.
 `chunk_size` and `chunk_overlap` only affect semantic mode.
 If chunking is too large, semantic indexing retries will fail with embedder 500 errors.

--- a/src/mindroom/config/knowledge.py
+++ b/src/mindroom/config/knowledge.py
@@ -116,7 +116,8 @@ class KnowledgeBaseConfig(BaseModel):
         default=True,
         description=(
             "Skip hidden files/folders (paths with components starting with '.') during indexing; "
-            "writers that update knowledge folders in place use dot-prefixed temp files"
+            "writers that update knowledge folders in place use dot-prefixed temp files. "
+            "Git-backed bases ignore this field and use git.skip_hidden instead"
         ),
     )
     git: KnowledgeGitConfig | None = Field(

--- a/src/mindroom/config/knowledge.py
+++ b/src/mindroom/config/knowledge.py
@@ -112,6 +112,13 @@ class KnowledgeBaseConfig(BaseModel):
         default_factory=list,
         description="Optional root-anchored glob patterns to exclude after include filtering",
     )
+    skip_hidden: bool = Field(
+        default=True,
+        description=(
+            "Skip hidden files/folders (paths with components starting with '.') during indexing; "
+            "writers that update knowledge folders in place use dot-prefixed temp files"
+        ),
+    )
     git: KnowledgeGitConfig | None = Field(
         default=None,
         description="Optional Git sync configuration for this knowledge base",

--- a/src/mindroom/knowledge/file_listing.py
+++ b/src/mindroom/knowledge/file_listing.py
@@ -149,7 +149,8 @@ def _include_knowledge_relative_path(config: Config, base_id: str, relative_path
         return False
 
     git_config = base_config.git
-    if git_config is not None and git_config.skip_hidden and _is_hidden_relative_path(path_obj):
+    skip_hidden = git_config.skip_hidden if git_config is not None else base_config.skip_hidden
+    if skip_hidden and _is_hidden_relative_path(path_obj):
         return False
 
     if git_config is None:

--- a/src/mindroom/knowledge/indexing_config.py
+++ b/src/mindroom/knowledge/indexing_config.py
@@ -52,6 +52,11 @@ class IndexingSettings:
     include_extensions: str
     exclude_extensions: str
     extra_extensions: str = ""
+    #: Effective hidden-path filtering for non-Git bases; "" for Git bases,
+    #: whose filtering is already identified by git_skip_hidden. Optional in
+    #: persisted metadata so pre-existing indexes (built while hidden paths
+    #: were still indexed) parse but no longer match the corpus key.
+    skip_hidden: str = ""
 
     @classmethod
     def from_metadata(cls, settings: Mapping[str, str]) -> IndexingSettings | None:
@@ -76,7 +81,7 @@ class IndexingSettings:
             "include_extensions",
             "exclude_extensions",
         }
-        optional_keys = {"include_patterns", "exclude_patterns", "extra_extensions"}
+        optional_keys = {"include_patterns", "exclude_patterns", "extra_extensions", "skip_hidden"}
         if not required_keys.issubset(settings) or set(settings) - required_keys - optional_keys:
             return None
         mode = settings["mode"]
@@ -104,6 +109,7 @@ class IndexingSettings:
             include_extensions=settings["include_extensions"],
             exclude_extensions=settings["exclude_extensions"],
             extra_extensions=settings.get("extra_extensions", ""),
+            skip_hidden=settings.get("skip_hidden", ""),
         )
 
     def to_metadata(self) -> dict[str, str]:
@@ -130,6 +136,7 @@ class IndexingSettings:
             "include_extensions": self.include_extensions,
             "exclude_extensions": self.exclude_extensions,
             "extra_extensions": self.extra_extensions,
+            "skip_hidden": self.skip_hidden,
         }
 
     def query_compatibility_key(self) -> tuple[str, str, str, str, str, str, str, str]:
@@ -147,7 +154,7 @@ class IndexingSettings:
 
     def corpus_compatibility_key(
         self,
-    ) -> tuple[str, str, str, str, str, str, str, str, str, str, str, str, str, str, str]:
+    ) -> tuple[str, str, str, str, str, str, str, str, str, str, str, str, str, str, str, str]:
         """Return fields that must match for safe source-corpus reuse."""
         return (
             self.base_id,
@@ -165,6 +172,7 @@ class IndexingSettings:
             self.include_extensions,
             self.exclude_extensions,
             self.extra_extensions,
+            self.skip_hidden,
         )
 
 
@@ -270,4 +278,5 @@ def indexing_settings_key(config: Config, storage_path: Path, base_id: str, know
         include_extensions=include_extensions,
         exclude_extensions=exclude_extensions,
         extra_extensions=extra_extensions,
+        skip_hidden=str(base_config.skip_hidden) if git_config is None else "",
     )

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -1002,22 +1002,7 @@ class KnowledgeManager:
     ) -> bool:
         """Index one file while the caller owns the operation lock."""
         relative_path = self._relative_path(resolved_path)
-        try:
-            source_mtime_ns, source_size, source_digest = await asyncio.to_thread(
-                self._file_signature,
-                resolved_path,
-            )
-        except FileNotFoundError:
-            # Live source folders (e.g. thread exports) delete files while a
-            # refresh runs; a file vanishing between listing and indexing is
-            # not a refresh failure. Skip it — the trailing source-signature
-            # comparison or the next scheduled refresh reconciles the index.
-            logger.warning(
-                "Knowledge file vanished during refresh; skipping",
-                base_id=self.base_id,
-                path=relative_path,
-            )
-            return False
+        source_mtime_ns, source_size, source_digest = await asyncio.to_thread(self._file_signature, resolved_path)
         metadata = {
             _SOURCE_PATH_KEY: relative_path,
             _SOURCE_MTIME_NS_KEY: source_mtime_ns,
@@ -1124,30 +1109,14 @@ class KnowledgeManager:
         knowledge: Knowledge | None = None,
         indexed_files: set[str] | None = None,
         indexed_signatures: dict[str, _FileSignature | None] | None = None,
+        vanished_files: set[str] | None = None,
     ) -> int:
         """Reindex resolved files with bounded concurrency while holding the operation lock."""
         if not files:
             return 0
 
-        concurrency = min(_MAX_CONCURRENT_KNOWLEDGE_FILE_INDEXES, len(files))
-        if concurrency <= 1:
-            indexed_count = 0
-            for file_path in files:
-                indexed_count += int(
-                    await self._index_file_locked(
-                        file_path,
-                        upsert=True,
-                        knowledge=knowledge,
-                        indexed_files=indexed_files,
-                        indexed_signatures=indexed_signatures,
-                    ),
-                )
-            return indexed_count
-
-        semaphore = asyncio.Semaphore(concurrency)
-
-        async def _index_one(file_path: Path) -> bool:
-            async with semaphore:
+        async def _index_or_skip_vanished(file_path: Path) -> bool:
+            try:
                 return await self._index_file_locked(
                     file_path,
                     upsert=True,
@@ -1155,6 +1124,34 @@ class KnowledgeManager:
                     indexed_files=indexed_files,
                     indexed_signatures=indexed_signatures,
                 )
+            except FileNotFoundError:
+                # Live source folders (e.g. thread exports) delete files while
+                # a refresh runs; a file vanishing between listing and indexing
+                # is not an indexing failure. Record it so the caller can drop
+                # it from its completeness accounting: the trailing
+                # source-signature comparison then decides whether the
+                # surviving corpus is publishable or another refresh is needed.
+                logger.warning(
+                    "Knowledge file vanished during refresh; skipping",
+                    base_id=self.base_id,
+                    path=self._relative_path(file_path),
+                )
+                if vanished_files is not None:
+                    vanished_files.add(self._relative_path(file_path))
+                return False
+
+        concurrency = min(_MAX_CONCURRENT_KNOWLEDGE_FILE_INDEXES, len(files))
+        if concurrency <= 1:
+            indexed_count = 0
+            for file_path in files:
+                indexed_count += int(await _index_or_skip_vanished(file_path))
+            return indexed_count
+
+        semaphore = asyncio.Semaphore(concurrency)
+
+        async def _index_one(file_path: Path) -> bool:
+            async with semaphore:
+                return await _index_or_skip_vanished(file_path)
 
         results = await asyncio.gather(*(_index_one(file_path) for file_path in files))
         return sum(int(indexed) for indexed in results)
@@ -1179,6 +1176,7 @@ class KnowledgeManager:
             candidate_publish_state = _CandidatePublishState()
             candidate_indexed_files: set[str] = set()
             candidate_indexed_signatures: dict[str, _FileSignature | None] = {}
+            candidate_vanished_files: set[str] = set()
 
             try:
                 indexed_count = await self._reindex_files_locked(
@@ -1186,15 +1184,21 @@ class KnowledgeManager:
                     knowledge=candidate_knowledge,
                     indexed_files=candidate_indexed_files,
                     indexed_signatures=candidate_indexed_signatures,
+                    vanished_files=candidate_vanished_files,
                 )
-                if indexed_count != len(files):
+                # Files deleted mid-refresh by a live source (e.g. thread
+                # exports) are not indexing failures: drop them from the
+                # completeness accounting and let the live source-signature
+                # comparison below decide whether the surviving corpus still
+                # matches the folder.
+                if indexed_count != len(files) - len(candidate_vanished_files):
                     summary = f"Indexed {indexed_count} of {len(files)} managed knowledge files"
                     if self._last_file_index_error is not None:
                         summary = f"{summary} (first error: {self._last_file_index_error})"
                     self._last_refresh_error = summary
                     return indexed_count
 
-                expected_paths = {self._relative_path(file_path) for file_path in files}
+                expected_paths = {self._relative_path(file_path) for file_path in files} - candidate_vanished_files
                 candidate_signatures = {
                     relative_path: signature
                     for relative_path, signature in candidate_indexed_signatures.items()

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -1131,13 +1131,14 @@ class KnowledgeManager:
                 # it from its completeness accounting: the trailing
                 # source-signature comparison then decides whether the
                 # surviving corpus is publishable or another refresh is needed.
+                relative_path = self._relative_path(file_path)
                 logger.warning(
                     "Knowledge file vanished during refresh; skipping",
                     base_id=self.base_id,
-                    path=self._relative_path(file_path),
+                    path=relative_path,
                 )
                 if vanished_files is not None:
-                    vanished_files.add(self._relative_path(file_path))
+                    vanished_files.add(relative_path)
                 return False
 
         concurrency = min(_MAX_CONCURRENT_KNOWLEDGE_FILE_INDEXES, len(files))

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -1002,7 +1002,22 @@ class KnowledgeManager:
     ) -> bool:
         """Index one file while the caller owns the operation lock."""
         relative_path = self._relative_path(resolved_path)
-        source_mtime_ns, source_size, source_digest = await asyncio.to_thread(self._file_signature, resolved_path)
+        try:
+            source_mtime_ns, source_size, source_digest = await asyncio.to_thread(
+                self._file_signature,
+                resolved_path,
+            )
+        except FileNotFoundError:
+            # Live source folders (e.g. thread exports) delete files while a
+            # refresh runs; a file vanishing between listing and indexing is
+            # not a refresh failure. Skip it — the trailing source-signature
+            # comparison or the next scheduled refresh reconciles the index.
+            logger.warning(
+                "Knowledge file vanished during refresh; skipping",
+                base_id=self.base_id,
+                path=relative_path,
+            )
+            return False
         metadata = {
             _SOURCE_PATH_KEY: relative_path,
             _SOURCE_MTIME_NS_KEY: source_mtime_ns,

--- a/tests/test_knowledge_indexing_config.py
+++ b/tests/test_knowledge_indexing_config.py
@@ -7,6 +7,7 @@ for vector collections, so their stability is the invariant pinned here.
 from __future__ import annotations
 
 import hashlib
+from dataclasses import replace
 from typing import TYPE_CHECKING
 
 from mindroom.knowledge.indexing_config import IndexingSettings, storage_key_for_base
@@ -84,11 +85,21 @@ def test_indexing_settings_from_metadata_rejects_invalid_payloads() -> None:
 
 
 def test_indexing_settings_from_metadata_defaults_optional_filter_keys() -> None:
-    """Older payloads without include/exclude patterns still parse."""
+    """Older payloads without include/exclude patterns or skip_hidden still parse."""
     metadata = _settings().to_metadata()
     del metadata["include_patterns"]
     del metadata["exclude_patterns"]
+    del metadata["skip_hidden"]
     parsed = IndexingSettings.from_metadata(metadata)
     assert parsed is not None
     assert parsed.include_patterns == ""
     assert parsed.exclude_patterns == ""
+    assert parsed.skip_hidden == ""
+
+
+def test_skip_hidden_changes_corpus_key_but_not_query_key() -> None:
+    """Indexes published before hidden-path filtering ('' from old metadata) must rebuild, not stay queryable."""
+    legacy = _settings()
+    current = replace(legacy, skip_hidden="True")
+    assert legacy.corpus_compatibility_key() != current.corpus_compatibility_key()
+    assert legacy.query_compatibility_key() == current.query_compatibility_key()

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -1427,6 +1427,44 @@ def test_knowledge_file_listing_rejects_symlinked_directory_escape(tmp_path: Pat
     assert list_knowledge_files(config, "docs", docs_path) == []
 
 
+def test_knowledge_file_listing_skips_hidden_files_for_directory_bases(tmp_path: Path) -> None:
+    """Dot-prefixed entries (e.g. in-place writers' atomic-write temp files) stay out of directory bases."""
+    docs_path = tmp_path / "docs"
+    (docs_path / ".staging").mkdir(parents=True)
+    (docs_path / "kept.md").write_text("kept", encoding="utf-8")
+    (docs_path / ".hidden.md").write_text("hidden", encoding="utf-8")
+    (docs_path / ".staging" / "nested.md").write_text("nested", encoding="utf-8")
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+
+    assert list_knowledge_files(config, "docs", docs_path) == [(docs_path / "kept.md").resolve()]
+
+    config.knowledge_bases["docs"].skip_hidden = False
+    assert list_knowledge_files(config, "docs", docs_path) == sorted(
+        [
+            (docs_path / "kept.md").resolve(),
+            (docs_path / ".hidden.md").resolve(),
+            (docs_path / ".staging" / "nested.md").resolve(),
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_index_file_locked_tolerates_files_vanishing_during_refresh(tmp_path: Path) -> None:
+    """A file deleted between listing and indexing is skipped instead of failing the refresh.
+
+    Live source folders such as thread exports delete files while a refresh
+    runs (stale-thread cleanup); the per-file stat used to raise
+    FileNotFoundError and abort the whole reindex subprocess.
+    """
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+    manager = KnowledgeManager("docs", config=config, runtime_paths=runtime_paths_for(config))
+
+    vanished = (docs_path / "gone.md").resolve()
+    assert await manager._index_file_locked(vanished, upsert=True) is False
+
+
 def test_knowledge_file_listing_filters_unsupported_extensions_before_filesystem_safety_checks(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -1449,7 +1449,7 @@ def test_knowledge_file_listing_skips_hidden_files_for_directory_bases(tmp_path:
 
 
 @pytest.mark.asyncio
-async def test_index_file_locked_tolerates_files_vanishing_during_refresh(tmp_path: Path) -> None:
+async def test_reindex_files_locked_records_files_vanishing_during_refresh(tmp_path: Path) -> None:
     """A file deleted between listing and indexing is skipped instead of failing the refresh.
 
     Live source folders such as thread exports delete files while a refresh
@@ -1462,7 +1462,43 @@ async def test_index_file_locked_tolerates_files_vanishing_during_refresh(tmp_pa
     manager = KnowledgeManager("docs", config=config, runtime_paths=runtime_paths_for(config))
 
     vanished = (docs_path / "gone.md").resolve()
-    assert await manager._index_file_locked(vanished, upsert=True) is False
+    vanished_files: set[str] = set()
+    indexed = await manager._reindex_files_locked([vanished], vanished_files=vanished_files)
+    assert indexed == 0
+    assert vanished_files == {"gone.md"}
+
+
+@pytest.mark.asyncio
+async def test_reindex_publishes_surviving_files_when_one_vanishes_mid_refresh(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A file deleted between listing and indexing must not mark the refresh incomplete.
+
+    The surviving corpus matches the live folder, so the refresh publishes it;
+    only genuine indexing failures may abort the pass.
+    """
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    (docs_path / "kept.md").write_text("survives the refresh", encoding="utf-8")
+    doomed = (docs_path / "doomed.md").resolve()
+    doomed.write_text("deleted mid-refresh", encoding="utf-8")
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+    manager = KnowledgeManager("docs", config=config, runtime_paths=runtime_paths_for(config))
+
+    original_signature = KnowledgeManager._file_signature
+
+    def vanishing_signature(self: KnowledgeManager, file_path: Path) -> object:
+        if file_path == doomed:
+            doomed.unlink(missing_ok=True)
+        return original_signature(self, file_path)
+
+    monkeypatch.setattr(KnowledgeManager, "_file_signature", vanishing_signature)
+
+    assert await manager.reindex_all() == 1
+    assert manager._last_refresh_error is None
+    assert "kept.md" in manager._indexed_files
+    assert "doomed.md" not in manager._indexed_files
 
 
 def test_knowledge_file_listing_filters_unsupported_extensions_before_filesystem_safety_checks(
@@ -3026,6 +3062,7 @@ async def test_refresh_discards_candidate_when_sources_change_before_publish(
         knowledge: object | None = None,
         indexed_files: set[str] | None = None,
         indexed_signatures: dict[str, tuple[int, int, str] | None] | None = None,
+        vanished_files: set[str] | None = None,
     ) -> int:
         indexed_count = await original_reindex_files_locked(
             self,
@@ -3033,6 +3070,7 @@ async def test_refresh_discards_candidate_when_sources_change_before_publish(
             knowledge=knowledge,
             indexed_files=indexed_files,
             indexed_signatures=indexed_signatures,
+            vanished_files=vanished_files,
         )
         (docs_path / "late.md").write_text("late addition", encoding="utf-8")
         return indexed_count

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -3976,6 +3976,35 @@ async def test_corpus_changing_config_mismatch_returns_no_index(
 
 
 @pytest.mark.asyncio
+async def test_skip_hidden_change_on_directory_base_returns_no_index(tmp_path: Path) -> None:
+    """Toggling skip_hidden on a directory base changes corpus membership, so old content must not be served."""
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    (docs_path / "doc.md").write_text("old corpus index", encoding="utf-8")
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+    runtime_paths = runtime_paths_for(config)
+    await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+
+    changed_config = config.model_copy(deep=True)
+    changed_config.knowledge_bases["docs"].skip_hidden = False
+    scheduler = MagicMock()
+    scheduler.is_refreshing = MagicMock(return_value=False)
+    scheduler.schedule_refresh = MagicMock()
+    resolution = resolve_agent_knowledge_access(
+        "helper",
+        changed_config,
+        runtime_paths,
+        refresh_scheduler=scheduler,
+    )
+
+    assert resolution.knowledge is None
+    assert {base_id: detail.availability for (base_id, detail) in resolution.unavailable.items()} == {
+        "docs": KnowledgeAvailability.CONFIG_MISMATCH,
+    }
+    scheduler.schedule_refresh.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_failed_refresh_after_config_change_preserves_published_settings(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Problem

The `openclaw_threads` knowledge base on the production deployment logged **"Background knowledge refresh failed" with `FileNotFoundError` 57× in one day**. Root cause is a filesystem race between the thread exporter and the knowledge indexer:

- The exporter churns its output directory by design: every thread YAML is written atomically via a dot-prefixed temp file + `os.replace` (`thread_export/storage.py:140`), stale thread files are unlinked (`storage.py:396`), and out-of-scope room directories are removed (`storage.py:421`). Export passes and knowledge refreshes are queued by the same hooks, so they run concurrently.
- In `_index_file_locked`, the per-file `stat()` (`_file_signature`) runs **before** the try/except that tolerates per-file indexing failures. A file deleted between listing and indexing raises `FileNotFoundError` that propagates through `reindex_all` and kills the whole refresh subprocess — even though `reindex_all` already handles concurrent churn gracefully a few lines later ("Knowledge source changed during refresh; refresh skipped" via source-signature comparison).

## Fix

1. **`knowledge/manager.py`** — catch `FileNotFoundError` per file at the `_reindex_files_locked` seam, record the vanished path, and drop it from the refresh's completeness accounting. The live source-signature comparison remains the final arbiter: if the deletion was the only churn, the surviving corpus publishes; further churn defers to the next refresh. Genuine indexing failures still abort the pass. (Review follow-up: the first iteration only skipped the file, which left the refresh marked incomplete and unpublished.)
2. **`config/knowledge.py` + `knowledge/file_listing.py` + `knowledge/indexing_config.py`** — promote `skip_hidden` from the git-only config to every knowledge base (default `true`, matching the git default). Directory bases previously indexed dot-prefixed entries; for `mode: files` bases (no extension filtering) that included the exporter's millisecond-lived `.NAME.HEX.tmp` files. Git bases keep honoring their own `git.skip_hidden` (documented on the field). `skip_hidden` is also part of `IndexingSettings` and the corpus-compatibility key (optional metadata key, empty for git bases), so indexes published while hidden paths were still indexed are treated as incompatible and rebuilt rather than staying queryable.

## Testing

- New `test_reindex_publishes_surviving_files_when_one_vanishes_mid_refresh` (refresh-level: the surviving file publishes with no refresh error), `test_reindex_files_locked_records_files_vanishing_during_refresh` (seam-level; raises `FileNotFoundError` before this change), and `test_knowledge_file_listing_skips_hidden_files_for_directory_bases` (covers the default and the `skip_hidden: false` opt-out).
- Full knowledge suites pass: `test_knowledge_manager.py`, `test_knowledge_indexing_config.py`, `test_knowledge_index_metadata.py`, `test_bot_knowledge.py`, `test_strict_knowledge.py`.

Note: `skip_hidden: true` becoming the default for directory bases is a deliberate behavior change — dot-prefixed files were previously indexed. Per-KB `skip_hidden: false` restores the old behavior.