### PR TITLE
Improve default Mind configuration guidance

### DIFF
--- a/skills/mindroom-docs/SKILL.md
+++ b/skills/mindroom-docs/SKILL.md
@@ -19,7 +19,7 @@ Use this skill when the user asks how MindRoom works, how to configure it, or wh
 3. Use `llms.txt` for high-level navigation only.
 4. Use `llms-full.txt` only when the answer spans many sections and page-level references are insufficient.
 5. For setup or administration requests, inspect the available capabilities before claiming the change cannot be performed. Discover and use `config_manager` for changes it supports, then use the documented config-file workflow for other requested changes.
-6. For dashboard questions, load the dashboard page reference and distinguish the MindRoom dashboard from Matrix clients such as Cinny or Element.
+6. Keep the hosted apps distinct: `https://mindroom.chat` is the Matrix homeserver, `https://chat.mindroom.chat` is the MindRoom Chat client, and the MindRoom dashboard is a separate app. For dashboard questions, load the dashboard page reference.
 7. Answer with concrete steps and include the exact reference filenames used.
 
 ## Rules

--- a/skills/mindroom-docs/SKILL.md
+++ b/skills/mindroom-docs/SKILL.md
@@ -18,7 +18,7 @@ Use this skill when the user asks how MindRoom works, how to configure it, or wh
 2. Load the smallest number of page references needed with `get_skill_reference(...)`.
 3. Use `llms.txt` for high-level navigation only.
 4. Use `llms-full.txt` only when the answer spans many sections and page-level references are insufficient.
-5. For setup or administration requests, check whether a structured configuration tool is available before claiming the change cannot be performed. Prefer `config_manager` when it is available.
+5. For setup or administration requests, inspect the available capabilities before claiming the change cannot be performed. Prefer `config_manager` for changes it supports, then use the documented config-file workflow for other requested changes.
 6. For dashboard questions, load the dashboard page reference and distinguish the MindRoom dashboard from Matrix clients such as Cinny or Element.
 7. Answer with concrete steps and include the exact reference filenames used.
 

--- a/skills/mindroom-docs/SKILL.md
+++ b/skills/mindroom-docs/SKILL.md
@@ -18,12 +18,15 @@ Use this skill when the user asks how MindRoom works, how to configure it, or wh
 2. Load the smallest number of page references needed with `get_skill_reference(...)`.
 3. Use `llms.txt` for high-level navigation only.
 4. Use `llms-full.txt` only when the answer spans many sections and page-level references are insufficient.
-5. Answer with concrete steps and include the exact reference filenames used.
+5. For setup or administration requests, check whether a structured configuration tool is available before claiming the change cannot be performed. Prefer `config_manager` when it is available.
+6. For dashboard questions, load the dashboard page reference and distinguish the MindRoom dashboard from Matrix clients such as Cinny or Element.
+7. Answer with concrete steps and include the exact reference filenames used.
 
 ## Rules
 
 - Prefer page-level references (`page__*.md`) over `llms-full.txt`.
 - Do not invent behavior not present in the references.
+- Inspect live configuration when the answer depends on current state; do not infer it from generic documentation.
 - If information is missing, state that it is not documented in this skill corpus.
 
 ## Available references

--- a/skills/mindroom-docs/SKILL.md
+++ b/skills/mindroom-docs/SKILL.md
@@ -18,7 +18,7 @@ Use this skill when the user asks how MindRoom works, how to configure it, or wh
 2. Load the smallest number of page references needed with `get_skill_reference(...)`.
 3. Use `llms.txt` for high-level navigation only.
 4. Use `llms-full.txt` only when the answer spans many sections and page-level references are insufficient.
-5. For setup or administration requests, inspect the available capabilities before claiming the change cannot be performed. Prefer `config_manager` for changes it supports, then use the documented config-file workflow for other requested changes.
+5. For setup or administration requests, inspect the available capabilities before claiming the change cannot be performed. Discover and use `config_manager` for changes it supports, then use the documented config-file workflow for other requested changes.
 6. For dashboard questions, load the dashboard page reference and distinguish the MindRoom dashboard from Matrix clients such as Cinny or Element.
 7. Answer with concrete steps and include the exact reference filenames used.
 

--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -990,8 +990,8 @@ agents:
       - MEMORY.md is curated long-term memory; daily files are short-lived notes and logs.
       - Ask before external or destructive actions.
       - Before answering prior-history questions, use search_memories first.
-      - For MindRoom setup or configuration, follow the MindRoom Configuration workflow in AGENTS.md and inspect the live state instead of guessing.
-      - Match the user's technical comfort and prefer performing an authorized scoped setup over exposing YAML or shell commands.
+      - When helping with MindRoom setup, follow AGENTS.md and check the live state — don't guess.
+      - Meet the user at their technical level. If they ask you to configure something, do it; skip YAML or shell details unless they ask.
 
 router:
   model: default

--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import platform
@@ -148,11 +149,32 @@ def _default_mind_workspace(storage_root: Path) -> Path:
     return agent_workspace_root_path(storage_root, "mind")
 
 
-def _ensure_mind_workspace(workspace_path: Path, *, force: bool) -> None:
+_MIND_CONFIG_PATH_NOTE_START = "<!-- mindroom:config-path:start -->"
+_MIND_CONFIG_PATH_NOTE_END = "<!-- mindroom:config-path:end -->"
+
+
+def _ensure_mind_workspace(workspace_path: Path, *, config_path: Path, force: bool) -> None:
     """Create the default Mind workspace files used by starter configs."""
     from mindroom.workspaces import ensure_workspace_template  # noqa: PLC0415
 
     ensure_workspace_template(workspace_path, template="mind", force=force)
+    tools_path = workspace_path / "TOOLS.md"
+    content = tools_path.read_text(encoding="utf-8")
+    note = (
+        f"{_MIND_CONFIG_PATH_NOTE_START}\n"
+        "## MindRoom Installation\n\n"
+        f"- Active config file: {json.dumps(str(config_path.resolve()))}\n"
+        f"{_MIND_CONFIG_PATH_NOTE_END}"
+    )
+    start = content.find(_MIND_CONFIG_PATH_NOTE_START)
+    end = content.find(_MIND_CONFIG_PATH_NOTE_END, start)
+    if start >= 0 and end >= 0:
+        end += len(_MIND_CONFIG_PATH_NOTE_END)
+        updated = f"{content[:start]}{note}{content[end:]}"
+    else:
+        updated = f"{content.rstrip()}\n\n{note}\n"
+    if updated != content:
+        tools_path.write_text(updated, encoding="utf-8")
 
 
 def _write_env_file(
@@ -470,7 +492,7 @@ def config_init(
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text(content, encoding="utf-8")
 
-    _ensure_mind_workspace(_default_mind_workspace(storage_root), force=force)
+    _ensure_mind_workspace(_default_mind_workspace(storage_root), config_path=target, force=force)
 
     env_changed = _write_env_file(
         env_path,
@@ -948,7 +970,8 @@ agents:
       - shell
       - coding
       - memory
-      - config_manager
+      - name: config_manager
+        defer: true
       - duckduckgo
       - website
       - browser

--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -948,6 +948,7 @@ agents:
       - shell
       - coding
       - memory
+      - config_manager
       - duckduckgo
       - website
       - browser
@@ -966,6 +967,8 @@ agents:
       - MEMORY.md is curated long-term memory; daily files are short-lived notes and logs.
       - Ask before external or destructive actions.
       - Before answering prior-history questions, use search_memories first.
+      - For MindRoom setup or configuration, follow the MindRoom Configuration workflow in AGENTS.md and inspect the live state instead of guessing.
+      - Match the user's technical comfort and prefer performing an authorized scoped setup over exposing YAML or shell commands.
 
 router:
   model: default

--- a/src/mindroom/cli/templates/mind_data/AGENTS.md
+++ b/src/mindroom/cli/templates/mind_data/AGENTS.md
@@ -73,12 +73,14 @@ Capture what matters. Decisions, context, things to remember. Skip the secrets u
 - Anything that leaves the machine
 - Anything you're uncertain about
 
-## MindRoom Configuration
+## 🧭 MindRoom Setup
 
-- For setup questions, consult the `mindroom-docs` skill, discover and use `config_manager`, and inspect the live configuration before answering. Never guess current state, URLs, or UI labels; the Matrix client and MindRoom dashboard are different applications.
-- Prefer `config_manager` for supported agent, team, and room-assignment changes. For other explicitly requested configuration changes, use the active config path recorded in `TOOLS.md`, make the smallest necessary edit, preserve unrelated settings, and validate the result.
-- Match the human's technical comfort. A direct request to set something up authorizes that scoped change; preview genuinely broad or ambiguous changes once and avoid YAML or terminal instructions unless requested.
-- Treat authorization, credentials, and destructive Matrix cleanup as consequential and ask before changing them. Distinguish configuration changes from cleanup of existing Matrix rooms or memberships.
+Don't guess how MindRoom is configured. Check the real thing.
+
+- **Start with the docs:** Use the `mindroom-docs` skill, then discover and use `config_manager` to inspect the live setup. Remember that the Matrix client and MindRoom dashboard are different apps.
+- **Use the right path:** Prefer `config_manager` when it supports the change. If it cannot do the job, use the active config path recorded in `TOOLS.md`, edit only what was requested, preserve everything else, and validate afterward.
+- **Meet your human where they are:** A direct request to set something up is permission for that scoped change. Skip YAML and terminal details unless they ask, and preview genuinely broad or unclear changes once before acting.
+- **Slow down for sensitive stuff:** Ask before changing authorization or credentials, or doing destructive Matrix cleanup. Configuration changes and cleanup of old Matrix rooms or memberships are separate jobs.
 
 ## Group Chats
 

--- a/src/mindroom/cli/templates/mind_data/AGENTS.md
+++ b/src/mindroom/cli/templates/mind_data/AGENTS.md
@@ -75,8 +75,8 @@ Capture what matters. Decisions, context, things to remember. Skip the secrets u
 
 ## MindRoom Configuration
 
-- For setup questions, consult the `mindroom-docs` skill and inspect the live configuration with `config_manager` before answering. Never guess current state, URLs, or UI labels; the Matrix client and MindRoom dashboard are different applications.
-- Prefer `config_manager` for supported agent, team, and room-assignment changes. For other explicitly requested configuration changes, inspect the live config, make the smallest necessary edit, preserve unrelated settings, and validate the result.
+- For setup questions, consult the `mindroom-docs` skill, discover and use `config_manager`, and inspect the live configuration before answering. Never guess current state, URLs, or UI labels; the Matrix client and MindRoom dashboard are different applications.
+- Prefer `config_manager` for supported agent, team, and room-assignment changes. For other explicitly requested configuration changes, use the active config path recorded in `TOOLS.md`, make the smallest necessary edit, preserve unrelated settings, and validate the result.
 - Match the human's technical comfort. A direct request to set something up authorizes that scoped change; preview genuinely broad or ambiguous changes once and avoid YAML or terminal instructions unless requested.
 - Treat authorization, credentials, and destructive Matrix cleanup as consequential and ask before changing them. Distinguish configuration changes from cleanup of existing Matrix rooms or memberships.
 

--- a/src/mindroom/cli/templates/mind_data/AGENTS.md
+++ b/src/mindroom/cli/templates/mind_data/AGENTS.md
@@ -73,6 +73,13 @@ Capture what matters. Decisions, context, things to remember. Skip the secrets u
 - Anything that leaves the machine
 - Anything you're uncertain about
 
+## MindRoom Configuration
+
+- For setup questions, consult the `mindroom-docs` skill and inspect the live configuration with `config_manager` before answering. Never guess current state, URLs, or UI labels; the Matrix client and MindRoom dashboard are different applications.
+- Use `config_manager` for agents, teams, and room assignments. Do not edit `config.yaml` through shell unless the structured tool cannot express the requested change and the user approves that fallback.
+- Match the human's technical comfort. A direct request to set something up authorizes that scoped change; preview broader changes once and avoid YAML or terminal instructions unless requested.
+- Verify the resulting configuration after changes. Treat authorization, credentials, and destructive Matrix cleanup as consequential, and distinguish configuration changes from cleanup of existing Matrix rooms or memberships.
+
 ## Group Chats
 
 You have access to your human's stuff. That doesn't mean you _share_ their stuff. In groups, you're a participant — not their voice, not their proxy. Think before you speak.

--- a/src/mindroom/cli/templates/mind_data/AGENTS.md
+++ b/src/mindroom/cli/templates/mind_data/AGENTS.md
@@ -76,9 +76,9 @@ Capture what matters. Decisions, context, things to remember. Skip the secrets u
 ## MindRoom Configuration
 
 - For setup questions, consult the `mindroom-docs` skill and inspect the live configuration with `config_manager` before answering. Never guess current state, URLs, or UI labels; the Matrix client and MindRoom dashboard are different applications.
-- Use `config_manager` for agents, teams, and room assignments. Do not edit `config.yaml` through shell unless the structured tool cannot express the requested change and the user approves that fallback.
-- Match the human's technical comfort. A direct request to set something up authorizes that scoped change; preview broader changes once and avoid YAML or terminal instructions unless requested.
-- Verify the resulting configuration after changes. Treat authorization, credentials, and destructive Matrix cleanup as consequential, and distinguish configuration changes from cleanup of existing Matrix rooms or memberships.
+- Prefer `config_manager` for supported agent, team, and room-assignment changes. For other explicitly requested configuration changes, inspect the live config, make the smallest necessary edit, preserve unrelated settings, and validate the result.
+- Match the human's technical comfort. A direct request to set something up authorizes that scoped change; preview genuinely broad or ambiguous changes once and avoid YAML or terminal instructions unless requested.
+- Treat authorization, credentials, and destructive Matrix cleanup as consequential and ask before changing them. Distinguish configuration changes from cleanup of existing Matrix rooms or memberships.
 
 ## Group Chats
 

--- a/src/mindroom/cli/templates/mind_data/AGENTS.md
+++ b/src/mindroom/cli/templates/mind_data/AGENTS.md
@@ -77,7 +77,8 @@ Capture what matters. Decisions, context, things to remember. Skip the secrets u
 
 Don't guess how MindRoom is configured. Check the real thing.
 
-- **Start with the docs:** Use the `mindroom-docs` skill, then discover and use `config_manager` to inspect the live setup. Remember that the Matrix client and MindRoom dashboard are different apps.
+- **Start with the docs:** Use the `mindroom-docs` skill, then discover and use `config_manager` to inspect the live setup.
+- **Know the apps:** `https://mindroom.chat` is the hosted Matrix homeserver. `https://chat.mindroom.chat` is MindRoom Chat, the MindRoom-focused Matrix client. The MindRoom dashboard is a separate app.
 - **Use the right path:** Prefer `config_manager` when it supports the change. If it cannot do the job, use the active config path recorded in `TOOLS.md`, edit only what was requested, preserve everything else, and validate afterward.
 - **Meet your human where they are:** A direct request to set something up is permission for that scoped change. Skip YAML and terminal details unless they ask, and preview genuinely broad or unclear changes once before acting.
 - **Slow down for sensitive stuff:** Ask before changing authorization or credentials, or doing destructive Matrix cleanup. Configuration changes and cleanup of old Matrix rooms or memberships are separate jobs.

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -252,8 +252,14 @@ class TestConfigInit:
         ]
         assert "thread_resolution" not in mind["tools"]
         assert mind["skills"] == ["mindroom-docs"]
-        assert any("inspect the live state instead of guessing" in instruction for instruction in mind["instructions"])
-        assert any("technical comfort" in instruction for instruction in mind["instructions"])
+        assert (
+            "For MindRoom setup or configuration, follow the MindRoom Configuration workflow in AGENTS.md and "
+            "inspect the live state instead of guessing." in mind["instructions"]
+        )
+        assert (
+            "Match the user's technical comfort and prefer performing an authorized scoped setup over exposing YAML or "
+            "shell commands." in mind["instructions"]
+        )
         assert "knowledge_bases" not in config
         assert config["memory"]["backend"] == "file"
         assert config["memory"]["embedder"]["provider"] == "sentence_transformers"

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -257,12 +257,12 @@ class TestConfigInit:
         assert "thread_resolution" not in mind["tools"]
         assert mind["skills"] == ["mindroom-docs"]
         assert (
-            "For MindRoom setup or configuration, follow the MindRoom Configuration workflow in AGENTS.md and "
-            "inspect the live state instead of guessing." in mind["instructions"]
+            "When helping with MindRoom setup, follow AGENTS.md and check the live state — don't guess."
+            in mind["instructions"]
         )
         assert (
-            "Match the user's technical comfort and prefer performing an authorized scoped setup over exposing YAML or "
-            "shell commands." in mind["instructions"]
+            "Meet the user at their technical level. If they ask you to configure something, do it; skip YAML or shell "
+            "details unless they ask." in mind["instructions"]
         )
         assert "knowledge_bases" not in config
         assert config["memory"]["backend"] == "file"
@@ -321,9 +321,9 @@ class TestConfigInit:
         assert (workspace / "SOUL.md").exists()
         assert (workspace / "MEMORY.md").exists()
         agents_template = (workspace / "AGENTS.md").read_text(encoding="utf-8")
-        assert "## MindRoom Configuration" in agents_template
+        assert "## 🧭 MindRoom Setup" in agents_template
         assert "discover and use `config_manager`" in agents_template
-        assert "For other explicitly requested configuration changes" in agents_template
+        assert "active config path recorded in `TOOLS.md`" in agents_template
         assert "knowledge_bases" not in config
 
         env_content = (tmp_path / ".env").read_text()

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -324,6 +324,9 @@ class TestConfigInit:
         assert "## 🧭 MindRoom Setup" in agents_template
         assert "discover and use `config_manager`" in agents_template
         assert "active config path recorded in `TOOLS.md`" in agents_template
+        assert "`https://mindroom.chat` is the hosted Matrix homeserver" in agents_template
+        assert "`https://chat.mindroom.chat` is MindRoom Chat" in agents_template
+        assert "The MindRoom dashboard is a separate app" in agents_template
         assert "knowledge_bases" not in config
 
         env_content = (tmp_path / ".env").read_text()

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -238,6 +238,7 @@ class TestConfigInit:
             "shell",
             "coding",
             "memory",
+            "config_manager",
             "duckduckgo",
             "website",
             "browser",
@@ -251,6 +252,8 @@ class TestConfigInit:
         ]
         assert "thread_resolution" not in mind["tools"]
         assert mind["skills"] == ["mindroom-docs"]
+        assert any("inspect the live state instead of guessing" in instruction for instruction in mind["instructions"])
+        assert any("technical comfort" in instruction for instruction in mind["instructions"])
         assert "knowledge_bases" not in config
         assert config["memory"]["backend"] == "file"
         assert config["memory"]["embedder"]["provider"] == "sentence_transformers"
@@ -305,6 +308,9 @@ class TestConfigInit:
         assert (workspace / "memory").exists()
         assert (workspace / "SOUL.md").exists()
         assert (workspace / "MEMORY.md").exists()
+        agents_template = (workspace / "AGENTS.md").read_text(encoding="utf-8")
+        assert "## MindRoom Configuration" in agents_template
+        assert "inspect the live configuration with `config_manager`" in agents_template
         assert "knowledge_bases" not in config
 
         env_content = (tmp_path / ".env").read_text()

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -238,7 +238,7 @@ class TestConfigInit:
             "shell",
             "coding",
             "memory",
-            "config_manager",
+            {"name": "config_manager", "defer": True},
             "duckduckgo",
             "website",
             "browser",
@@ -250,6 +250,10 @@ class TestConfigInit:
             "thread_tags",
             "thread_summary",
         ]
+        config_manager_entry = next(
+            entry for entry in load_config_yaml(target).agents["mind"].tools if entry.name == "config_manager"
+        )
+        assert config_manager_entry.defer is True
         assert "thread_resolution" not in mind["tools"]
         assert mind["skills"] == ["mindroom-docs"]
         assert (
@@ -294,6 +298,8 @@ class TestConfigInit:
         assert (workspace / "HEARTBEAT.md").exists()
         assert (workspace / "MEMORY.md").exists()
         assert not (workspace / "BOOT.md").exists()
+        tools_notes = (workspace / "TOOLS.md").read_text(encoding="utf-8")
+        assert f"- Active config file: {json.dumps(str(target.resolve()))}" in tools_notes
 
     def test_init_respects_storage_path_override(
         self,
@@ -316,7 +322,7 @@ class TestConfigInit:
         assert (workspace / "MEMORY.md").exists()
         agents_template = (workspace / "AGENTS.md").read_text(encoding="utf-8")
         assert "## MindRoom Configuration" in agents_template
-        assert "inspect the live configuration with `config_manager`" in agents_template
+        assert "discover and use `config_manager`" in agents_template
         assert "For other explicitly requested configuration changes" in agents_template
         assert "knowledge_bases" not in config
 

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -317,6 +317,7 @@ class TestConfigInit:
         agents_template = (workspace / "AGENTS.md").read_text(encoding="utf-8")
         assert "## MindRoom Configuration" in agents_template
         assert "inspect the live configuration with `config_manager`" in agents_template
+        assert "For other explicitly requested configuration changes" in agents_template
         assert "knowledge_bases" not in config
 
         env_content = (tmp_path / ".env").read_text()


### PR DESCRIPTION
## Summary

- make the validated `config_manager` workflow available to the starter Mind through deferred, on-demand tool loading
- seed the resolved active `config.yaml` path into the generated Mind `TOOLS.md`
- add a concise workspace protocol that prefers structured operations but retains careful config-file edits for unsupported fields
- distinguish the hosted Matrix homeserver, the MindRoom Chat client, and the separate MindRoom dashboard
- cover the deferred tool entry, seeded path, and generated workspace guidance in config-init tests

## Why

The starter Mind had general shell access and product documentation, but no explicit workflow for inspecting live state. That made it too easy to guess deployment details or search for configuration paths manually. Loading `config_manager` only when needed adds validated common operations without paying its full rendered-schema cost on ordinary chat turns, while the seeded path preserves access to the complete configuration surface.

## Impact

Newly initialized Mind workspaces can discover validated configuration operations on demand and know the exact active config path. Structured tooling remains a preferred path rather than a ceiling on broader scoped configuration work. The guidance also makes clear that `mindroom.chat` is the hosted Matrix homeserver, `chat.mindroom.chat` is the MindRoom Chat client, and the dashboard is a separate app.

## Validation

- `uv run pytest tests/test_cli_config.py tests/test_dynamic_toolkits.py -q`
- `uv run ruff check src/mindroom/cli/config.py tests/test_cli_config.py`
- `uv run prek run --files src/mindroom/cli/config.py src/mindroom/cli/templates/mind_data/AGENTS.md skills/mindroom-docs/SKILL.md tests/test_cli_config.py`
