### PR TITLE
Minimize Google OAuth scopes

### DIFF
--- a/docs/deployment/google-services-oauth.md
+++ b/docs/deployment/google-services-oauth.md
@@ -14,9 +14,29 @@ Public, unpaired, and organization-managed deployments can configure their own G
 | Tool | Provider ID | Callback path | Token service | Client config service | Settings service | Scopes |
 | --- | --- | --- | --- | --- | --- | --- |
 | Google Drive | `google_drive` | `/api/oauth/google_drive/callback` | `google_drive_oauth` | `google_drive_oauth_client` | `google_drive` | Drive read-only plus OpenID email/profile |
-| Google Calendar | `google_calendar` | `/api/oauth/google_calendar/callback` | `google_calendar_oauth` | `google_calendar_oauth_client` | `google_calendar` | Calendar read/write plus OpenID email/profile |
+| Google Calendar | `google_calendar` | `/api/oauth/google_calendar/callback` | `google_calendar_oauth` | `google_calendar_oauth_client` | `google_calendar` | Calendar events, calendar-list read-only, free/busy, and settings read-only plus OpenID email/profile |
 | Google Sheets | `google_sheets` | `/api/oauth/google_sheets/callback` | `google_sheets_oauth` | `google_sheets_oauth_client` | `google_sheets` | Sheets read/write, plus OpenID email/profile |
-| Gmail | `google_gmail` | `/api/oauth/google_gmail/callback` | `google_gmail_oauth` | `google_gmail_oauth_client` | `gmail` | Gmail readonly, modify, compose plus OpenID email/profile |
+| Gmail | `google_gmail` | `/api/oauth/google_gmail/callback` | `google_gmail_oauth` | `google_gmail_oauth_client` | `gmail` | Gmail modify plus OpenID email/profile |
+
+## Scope Rationale
+
+MindRoom requests only the scopes required by the operations currently exposed to agents.
+
+- `drive.readonly` lets an agent search, list, and read existing files across the connected account without granting Drive write access.
+  The narrower `drive.file` scope cannot preserve account-wide search because it is limited to files created by or explicitly shared with the app.
+- `calendar.events` lets an agent read events and, when `allow_update` is enabled, create, update, delete, move, and respond to events without granting calendar sharing or calendar deletion access.
+- `calendar.calendarlist.readonly` lets an agent list subscribed calendars without adding, removing, or editing subscriptions.
+- `calendar.freebusy` lets an agent check availability without exposing event details through that operation.
+- `calendar.settings.readonly` lets an agent infer working hours and locale without changing Calendar settings.
+- `spreadsheets` lets an agent read and, when enabled, create or update arbitrary spreadsheets named by the user.
+  A read-only scope would remove the existing create and update operations.
+- `gmail.modify` is the narrowest single Gmail scope that preserves mailbox search and reading, drafts and sending, replies, labels, archiving, and other mailbox organization.
+  MindRoom does not request `mail.google.com`, and `gmail.modify` does not permit bypassing the trash for permanent message deletion.
+- OpenID email and profile scopes identify the connected account and enforce optional account-domain restrictions.
+
+Google API data is used only for the user-facing agent operation requested by the user.
+Relevant results may be sent to the AI model provider configured by the installation solely to generate that requested response, as disclosed before connection and in the [Privacy Policy](../privacy.md).
+MindRoom does not use Google user data to train or improve generalized, foundational, or frontier AI models.
 
 ## Custom Google Cloud Setup
 

--- a/docs/tools/calendar-and-scheduling.md
+++ b/docs/tools/calendar-and-scheduling.md
@@ -36,7 +36,7 @@ MindRoom also includes `scheduler` in `defaults.tools` by default on this branch
 
 `google_calendar` exposes `list_events()`, `fetch_all_events()`, `find_available_slots()`, `list_calendars()`, `create_event()`, `update_event()`, and `delete_event()`.
 MindRoom loads the connected Google account from its unified credential store instead of relying on a per-process `token.json`.
-The OAuth provider requests a consistent Google Calendar scope, while MindRoom gates write methods with the `allow_update` setting.
+The OAuth provider requests narrowly targeted scopes for event access, calendar listing, availability, and working-hours settings, while MindRoom gates write methods with the `allow_update` setting.
 Write calls are still part of the tool surface, but they are only exposed when `allow_update: true` is configured.
 When no usable MindRoom OAuth credentials exist, the wrapper raises `OAuthConnectionRequired` instead of falling back to Agno's local token flow.
 `find_available_slots()` derives openings from the user's current calendar events plus working-hours settings inferred from Google Calendar settings and locale.
@@ -75,7 +75,7 @@ create_event(
 ### Notes
 
 - `calendar_id` defaults to `primary`, and `list_calendars()` can return the other calendar IDs available to the connected account.
-- If the Google Calendar connection is missing the required calendar scope, `google_calendar` stays unavailable until the user reconnects and grants it.
+- If the Google Calendar connection is missing any required Calendar scope, `google_calendar` stays unavailable until the user reconnects and grants it.
 - Use the Google Services OAuth guides for consent-screen setup, redirect URIs, and environment variables.
 
 ## [`cal_com`]

--- a/docs/tools/messaging-and-social.md
+++ b/docs/tools/messaging-and-social.md
@@ -85,7 +85,7 @@ apply_label("is:unread category:promotions", "Needs Review", count=10)
 ### Notes
 
 - Connect Gmail through the `google_gmail` OAuth provider rather than storing a Gmail-specific API key.
-- The Gmail provider requests Gmail read, modify, and compose scopes.
+- The Gmail provider requests `gmail.modify`, which is the narrowest single scope that preserves mailbox reading, drafting, sending, labeling, and organization.
 - `gmail` always runs in the primary MindRoom runtime so worker runtimes do not receive Google OAuth secrets.
 - Agno's Gmail constructor accepts per-method selector kwargs (`get_latest_emails`, `get_unread_emails`, `search_emails`, etc.), and the MindRoom wrapper forwards them via `**kwargs`.
 - Use those selector kwargs to disable specific methods you do not want the agent calling.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -7219,7 +7219,7 @@ apply_label("is:unread category:promotions", "Needs Review", count=10)
 ### Notes
 
 - Connect Gmail through the `google_gmail` OAuth provider rather than storing a Gmail-specific API key.
-- The Gmail provider requests Gmail read, modify, and compose scopes.
+- The Gmail provider requests `gmail.modify`, which is the narrowest single scope that preserves mailbox reading, drafting, sending, labeling, and organization.
 - `gmail` always runs in the primary MindRoom runtime so worker runtimes do not receive Google OAuth secrets.
 - Agno's Gmail constructor accepts per-method selector kwargs (`get_latest_emails`, `get_unread_emails`, `search_emails`, etc.), and the MindRoom wrapper forwards them via `**kwargs`.
 - Use those selector kwargs to disable specific methods you do not want the agent calling.
@@ -8254,7 +8254,7 @@ MindRoom also includes `scheduler` in `defaults.tools` by default on this branch
 
 `google_calendar` exposes `list_events()`, `fetch_all_events()`, `find_available_slots()`, `list_calendars()`, `create_event()`, `update_event()`, and `delete_event()`.
 MindRoom loads the connected Google account from its unified credential store instead of relying on a per-process `token.json`.
-The OAuth provider requests a consistent Google Calendar scope, while MindRoom gates write methods with the `allow_update` setting.
+The OAuth provider requests narrowly targeted scopes for event access, calendar listing, availability, and working-hours settings, while MindRoom gates write methods with the `allow_update` setting.
 Write calls are still part of the tool surface, but they are only exposed when `allow_update: true` is configured.
 When no usable MindRoom OAuth credentials exist, the wrapper raises `OAuthConnectionRequired` instead of falling back to Agno's local token flow.
 `find_available_slots()` derives openings from the user's current calendar events plus working-hours settings inferred from Google Calendar settings and locale.
@@ -8293,7 +8293,7 @@ create_event(
 ### Notes
 
 - `calendar_id` defaults to `primary`, and `list_calendars()` can return the other calendar IDs available to the connected account.
-- If the Google Calendar connection is missing the required calendar scope, `google_calendar` stays unavailable until the user reconnects and grants it.
+- If the Google Calendar connection is missing any required Calendar scope, `google_calendar` stays unavailable until the user reconnects and grants it.
 - Use the Google Services OAuth guides for consent-screen setup, redirect URIs, and environment variables.
 
 ## [`cal_com`]
@@ -15920,9 +15920,29 @@ Public, unpaired, and organization-managed deployments can configure their own G
 | Tool | Provider ID | Callback path | Token service | Client config service | Settings service | Scopes |
 | --- | --- | --- | --- | --- | --- | --- |
 | Google Drive | `google_drive` | `/api/oauth/google_drive/callback` | `google_drive_oauth` | `google_drive_oauth_client` | `google_drive` | Drive read-only plus OpenID email/profile |
-| Google Calendar | `google_calendar` | `/api/oauth/google_calendar/callback` | `google_calendar_oauth` | `google_calendar_oauth_client` | `google_calendar` | Calendar read/write plus OpenID email/profile |
+| Google Calendar | `google_calendar` | `/api/oauth/google_calendar/callback` | `google_calendar_oauth` | `google_calendar_oauth_client` | `google_calendar` | Calendar events, calendar-list read-only, free/busy, and settings read-only plus OpenID email/profile |
 | Google Sheets | `google_sheets` | `/api/oauth/google_sheets/callback` | `google_sheets_oauth` | `google_sheets_oauth_client` | `google_sheets` | Sheets read/write, plus OpenID email/profile |
-| Gmail | `google_gmail` | `/api/oauth/google_gmail/callback` | `google_gmail_oauth` | `google_gmail_oauth_client` | `gmail` | Gmail readonly, modify, compose plus OpenID email/profile |
+| Gmail | `google_gmail` | `/api/oauth/google_gmail/callback` | `google_gmail_oauth` | `google_gmail_oauth_client` | `gmail` | Gmail modify plus OpenID email/profile |
+
+## Scope Rationale
+
+MindRoom requests only the scopes required by the operations currently exposed to agents.
+
+- `drive.readonly` lets an agent search, list, and read existing files across the connected account without granting Drive write access.
+  The narrower `drive.file` scope cannot preserve account-wide search because it is limited to files created by or explicitly shared with the app.
+- `calendar.events` lets an agent read events and, when `allow_update` is enabled, create, update, delete, move, and respond to events without granting calendar sharing or calendar deletion access.
+- `calendar.calendarlist.readonly` lets an agent list subscribed calendars without adding, removing, or editing subscriptions.
+- `calendar.freebusy` lets an agent check availability without exposing event details through that operation.
+- `calendar.settings.readonly` lets an agent infer working hours and locale without changing Calendar settings.
+- `spreadsheets` lets an agent read and, when enabled, create or update arbitrary spreadsheets named by the user.
+  A read-only scope would remove the existing create and update operations.
+- `gmail.modify` is the narrowest single Gmail scope that preserves mailbox search and reading, drafts and sending, replies, labels, archiving, and other mailbox organization.
+  MindRoom does not request `mail.google.com`, and `gmail.modify` does not permit bypassing the trash for permanent message deletion.
+- OpenID email and profile scopes identify the connected account and enforce optional account-domain restrictions.
+
+Google API data is used only for the user-facing agent operation requested by the user.
+Relevant results may be sent to the AI model provider configured by the installation solely to generate that requested response, as disclosed before connection and in the [Privacy Policy](https://docs.mindroom.chat/privacy/).
+MindRoom does not use Google user data to train or improve generalized, foundational, or frontier AI models.
 
 ## Custom Google Cloud Setup
 

--- a/skills/mindroom-docs/references/page__deployment__google-services-oauth__index.md
+++ b/skills/mindroom-docs/references/page__deployment__google-services-oauth__index.md
@@ -10,9 +10,29 @@ Public, unpaired, and organization-managed deployments can configure their own G
 | Tool | Provider ID | Callback path | Token service | Client config service | Settings service | Scopes |
 | --- | --- | --- | --- | --- | --- | --- |
 | Google Drive | `google_drive` | `/api/oauth/google_drive/callback` | `google_drive_oauth` | `google_drive_oauth_client` | `google_drive` | Drive read-only plus OpenID email/profile |
-| Google Calendar | `google_calendar` | `/api/oauth/google_calendar/callback` | `google_calendar_oauth` | `google_calendar_oauth_client` | `google_calendar` | Calendar read/write plus OpenID email/profile |
+| Google Calendar | `google_calendar` | `/api/oauth/google_calendar/callback` | `google_calendar_oauth` | `google_calendar_oauth_client` | `google_calendar` | Calendar events, calendar-list read-only, free/busy, and settings read-only plus OpenID email/profile |
 | Google Sheets | `google_sheets` | `/api/oauth/google_sheets/callback` | `google_sheets_oauth` | `google_sheets_oauth_client` | `google_sheets` | Sheets read/write, plus OpenID email/profile |
-| Gmail | `google_gmail` | `/api/oauth/google_gmail/callback` | `google_gmail_oauth` | `google_gmail_oauth_client` | `gmail` | Gmail readonly, modify, compose plus OpenID email/profile |
+| Gmail | `google_gmail` | `/api/oauth/google_gmail/callback` | `google_gmail_oauth` | `google_gmail_oauth_client` | `gmail` | Gmail modify plus OpenID email/profile |
+
+## Scope Rationale
+
+MindRoom requests only the scopes required by the operations currently exposed to agents.
+
+- `drive.readonly` lets an agent search, list, and read existing files across the connected account without granting Drive write access.
+  The narrower `drive.file` scope cannot preserve account-wide search because it is limited to files created by or explicitly shared with the app.
+- `calendar.events` lets an agent read events and, when `allow_update` is enabled, create, update, delete, move, and respond to events without granting calendar sharing or calendar deletion access.
+- `calendar.calendarlist.readonly` lets an agent list subscribed calendars without adding, removing, or editing subscriptions.
+- `calendar.freebusy` lets an agent check availability without exposing event details through that operation.
+- `calendar.settings.readonly` lets an agent infer working hours and locale without changing Calendar settings.
+- `spreadsheets` lets an agent read and, when enabled, create or update arbitrary spreadsheets named by the user.
+  A read-only scope would remove the existing create and update operations.
+- `gmail.modify` is the narrowest single Gmail scope that preserves mailbox search and reading, drafts and sending, replies, labels, archiving, and other mailbox organization.
+  MindRoom does not request `mail.google.com`, and `gmail.modify` does not permit bypassing the trash for permanent message deletion.
+- OpenID email and profile scopes identify the connected account and enforce optional account-domain restrictions.
+
+Google API data is used only for the user-facing agent operation requested by the user.
+Relevant results may be sent to the AI model provider configured by the installation solely to generate that requested response, as disclosed before connection and in the [Privacy Policy](https://docs.mindroom.chat/privacy/).
+MindRoom does not use Google user data to train or improve generalized, foundational, or frontier AI models.
 
 ## Custom Google Cloud Setup
 

--- a/skills/mindroom-docs/references/page__tools__calendar-and-scheduling__index.md
+++ b/skills/mindroom-docs/references/page__tools__calendar-and-scheduling__index.md
@@ -32,7 +32,7 @@ MindRoom also includes `scheduler` in `defaults.tools` by default on this branch
 
 `google_calendar` exposes `list_events()`, `fetch_all_events()`, `find_available_slots()`, `list_calendars()`, `create_event()`, `update_event()`, and `delete_event()`.
 MindRoom loads the connected Google account from its unified credential store instead of relying on a per-process `token.json`.
-The OAuth provider requests a consistent Google Calendar scope, while MindRoom gates write methods with the `allow_update` setting.
+The OAuth provider requests narrowly targeted scopes for event access, calendar listing, availability, and working-hours settings, while MindRoom gates write methods with the `allow_update` setting.
 Write calls are still part of the tool surface, but they are only exposed when `allow_update: true` is configured.
 When no usable MindRoom OAuth credentials exist, the wrapper raises `OAuthConnectionRequired` instead of falling back to Agno's local token flow.
 `find_available_slots()` derives openings from the user's current calendar events plus working-hours settings inferred from Google Calendar settings and locale.
@@ -71,7 +71,7 @@ create_event(
 ### Notes
 
 - `calendar_id` defaults to `primary`, and `list_calendars()` can return the other calendar IDs available to the connected account.
-- If the Google Calendar connection is missing the required calendar scope, `google_calendar` stays unavailable until the user reconnects and grants it.
+- If the Google Calendar connection is missing any required Calendar scope, `google_calendar` stays unavailable until the user reconnects and grants it.
 - Use the Google Services OAuth guides for consent-screen setup, redirect URIs, and environment variables.
 
 ## [`cal_com`]

--- a/skills/mindroom-docs/references/page__tools__messaging-and-social__index.md
+++ b/skills/mindroom-docs/references/page__tools__messaging-and-social__index.md
@@ -81,7 +81,7 @@ apply_label("is:unread category:promotions", "Needs Review", count=10)
 ### Notes
 
 - Connect Gmail through the `google_gmail` OAuth provider rather than storing a Gmail-specific API key.
-- The Gmail provider requests Gmail read, modify, and compose scopes.
+- The Gmail provider requests `gmail.modify`, which is the narrowest single scope that preserves mailbox reading, drafting, sending, labeling, and organization.
 - `gmail` always runs in the primary MindRoom runtime so worker runtimes do not receive Google OAuth secrets.
 - Agno's Gmail constructor accepts per-method selector kwargs (`get_latest_emails`, `get_unread_emails`, `search_emails`, etc.), and the MindRoom wrapper forwards them via `**kwargs`.
 - Use those selector kwargs to disable specific methods you do not want the agent calling.

--- a/src/mindroom/custom_tools/google_calendar.py
+++ b/src/mindroom/custom_tools/google_calendar.py
@@ -67,6 +67,9 @@ class GoogleCalendarTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin,
             defer_to_original_auth=defer_to_original_auth,
         )
 
+        # Agno's toolkit still validates its legacy broad scope markers during
+        # construction. Those markers are not used for MindRoom's OAuth flow:
+        # the credentials injected below carry the provider's granular scopes.
         super().__init__(**kwargs)
         self.creds = creds
 

--- a/src/mindroom/oauth/google_calendar.py
+++ b/src/mindroom/oauth/google_calendar.py
@@ -11,7 +11,10 @@ if TYPE_CHECKING:
 
 _GOOGLE_CALENDAR_OAUTH_SCOPES = (
     *google_oauth.GOOGLE_IDENTITY_SCOPES,
-    "https://www.googleapis.com/auth/calendar",
+    "https://www.googleapis.com/auth/calendar.events",
+    "https://www.googleapis.com/auth/calendar.calendarlist.readonly",
+    "https://www.googleapis.com/auth/calendar.freebusy",
+    "https://www.googleapis.com/auth/calendar.settings.readonly",
 )
 
 

--- a/src/mindroom/oauth/google_gmail.py
+++ b/src/mindroom/oauth/google_gmail.py
@@ -11,9 +11,7 @@ if TYPE_CHECKING:
 
 _GOOGLE_GMAIL_OAUTH_SCOPES = (
     *google_oauth.GOOGLE_IDENTITY_SCOPES,
-    "https://www.googleapis.com/auth/gmail.readonly",
     "https://www.googleapis.com/auth/gmail.modify",
-    "https://www.googleapis.com/auth/gmail.compose",
 )
 
 

--- a/src/mindroom/oauth/google_gmail.py
+++ b/src/mindroom/oauth/google_gmail.py
@@ -24,5 +24,5 @@ def google_gmail_oauth_provider() -> OAuthProvider:
         credential_service="google_gmail_oauth",
         tool_config_service="gmail",
         client_config_services=("google_gmail_oauth_client",),
-        status_capabilities=("Gmail read/modify/compose",),
+        status_capabilities=("Gmail read, send, draft, and mailbox management",),
     )

--- a/src/mindroom/oauth/service.py
+++ b/src/mindroom/oauth/service.py
@@ -43,7 +43,13 @@ _GOOGLE_SERVICE_ACCOUNT_PROVIDER_IDS = frozenset(
 )
 _SCOPE_IMPLICATIONS = {
     "https://www.googleapis.com/auth/calendar": frozenset(
-        {"https://www.googleapis.com/auth/calendar.readonly"},
+        {
+            "https://www.googleapis.com/auth/calendar.readonly",
+            "https://www.googleapis.com/auth/calendar.events",
+            "https://www.googleapis.com/auth/calendar.calendarlist.readonly",
+            "https://www.googleapis.com/auth/calendar.freebusy",
+            "https://www.googleapis.com/auth/calendar.settings.readonly",
+        },
     ),
     "https://www.googleapis.com/auth/drive": frozenset(
         {
@@ -52,7 +58,10 @@ _SCOPE_IMPLICATIONS = {
         },
     ),
     "https://www.googleapis.com/auth/gmail.modify": frozenset(
-        {"https://www.googleapis.com/auth/gmail.readonly"},
+        {
+            "https://www.googleapis.com/auth/gmail.readonly",
+            "https://www.googleapis.com/auth/gmail.compose",
+        },
     ),
     "https://www.googleapis.com/auth/spreadsheets": frozenset(
         {"https://www.googleapis.com/auth/spreadsheets.readonly"},

--- a/tests/api/test_oauth_api.py
+++ b/tests/api/test_oauth_api.py
@@ -4117,8 +4117,20 @@ def test_status_rejects_stored_oauth_token_missing_claims_when_identity_policy_c
 
 
 def test_required_scope_check_accepts_google_scope_supersets() -> None:
-    calendar_provider = _fake_provider(scopes=("https://www.googleapis.com/auth/calendar.readonly",))
-    gmail_provider = _fake_provider(scopes=("https://www.googleapis.com/auth/gmail.readonly",))
+    calendar_provider = _fake_provider(
+        scopes=(
+            "https://www.googleapis.com/auth/calendar.events",
+            "https://www.googleapis.com/auth/calendar.calendarlist.readonly",
+            "https://www.googleapis.com/auth/calendar.freebusy",
+            "https://www.googleapis.com/auth/calendar.settings.readonly",
+        ),
+    )
+    gmail_provider = _fake_provider(
+        scopes=(
+            "https://www.googleapis.com/auth/gmail.readonly",
+            "https://www.googleapis.com/auth/gmail.compose",
+        ),
+    )
     drive_provider = _fake_provider(scopes=("https://www.googleapis.com/auth/drive.file",))
     sheets_provider = _fake_provider(scopes=("https://www.googleapis.com/auth/spreadsheets.readonly",))
 

--- a/tests/test_google_calendar_oauth_tool.py
+++ b/tests/test_google_calendar_oauth_tool.py
@@ -13,6 +13,7 @@ from mindroom import constants
 from mindroom import tools as _mindroom_tools  # noqa: F401  # registers built-in tool metadata
 from mindroom.credentials import CredentialsManager
 from mindroom.custom_tools.google_calendar import GoogleCalendarTools
+from mindroom.oauth.google import GOOGLE_IDENTITY_SCOPES
 from mindroom.oauth.google_calendar import _GOOGLE_CALENDAR_OAUTH_SCOPES, google_calendar_oauth_provider
 from mindroom.oauth.providers import OAuthConnectionRequired
 from mindroom.tool_system.metadata import get_tool_by_name
@@ -117,6 +118,8 @@ def test_google_calendar_default_config_disables_write_methods(tmp_path: Path) -
     assert "quick_add_event" not in tool.functions
     assert "move_event" not in tool.functions
     assert "respond_to_event" not in tool.functions
+    # Agno validates its own broad scope marker during toolkit construction.
+    # MindRoom injects pre-authorized credentials carrying the granular provider scopes below.
     assert "https://www.googleapis.com/auth/calendar" in tool.scopes
 
 
@@ -139,6 +142,7 @@ def test_google_calendar_allow_update_enables_write_methods(tmp_path: Path) -> N
     assert "quick_add_event" in tool.functions
     assert "move_event" in tool.functions
     assert "respond_to_event" in tool.functions
+    # This is Agno's construction-time marker, not the scopes requested by MindRoom OAuth.
     assert "https://www.googleapis.com/auth/calendar" in tool.scopes
 
 
@@ -146,7 +150,7 @@ def test_google_calendar_provider_uses_narrow_scopes_for_every_tool_operation() 
     provider = google_calendar_oauth_provider()
 
     assert provider.scopes == _GOOGLE_CALENDAR_OAUTH_SCOPES
-    assert set(provider.scopes[3:]) == {
+    assert set(provider.scopes) - set(GOOGLE_IDENTITY_SCOPES) == {
         "https://www.googleapis.com/auth/calendar.events",
         "https://www.googleapis.com/auth/calendar.calendarlist.readonly",
         "https://www.googleapis.com/auth/calendar.freebusy",

--- a/tests/test_google_calendar_oauth_tool.py
+++ b/tests/test_google_calendar_oauth_tool.py
@@ -142,11 +142,17 @@ def test_google_calendar_allow_update_enables_write_methods(tmp_path: Path) -> N
     assert "https://www.googleapis.com/auth/calendar" in tool.scopes
 
 
-def test_google_calendar_provider_uses_write_scope_for_method_gated_tools() -> None:
+def test_google_calendar_provider_uses_narrow_scopes_for_every_tool_operation() -> None:
     provider = google_calendar_oauth_provider()
 
     assert provider.scopes == _GOOGLE_CALENDAR_OAUTH_SCOPES
-    assert "https://www.googleapis.com/auth/calendar" in provider.scopes
+    assert set(provider.scopes[3:]) == {
+        "https://www.googleapis.com/auth/calendar.events",
+        "https://www.googleapis.com/auth/calendar.calendarlist.readonly",
+        "https://www.googleapis.com/auth/calendar.freebusy",
+        "https://www.googleapis.com/auth/calendar.settings.readonly",
+    }
+    assert "https://www.googleapis.com/auth/calendar" not in provider.scopes
 
 
 def test_google_calendar_service_account_env_uses_upstream_auth(tmp_path: Path) -> None:

--- a/tests/test_google_oauth_providers.py
+++ b/tests/test_google_oauth_providers.py
@@ -84,7 +84,7 @@ GOOGLE_EXTRA_AUTH_PARAMS = {
                 "credential_service": "google_gmail_oauth",
                 "tool_config_service": "gmail",
                 "client_config_services": ("google_gmail_oauth_client",),
-                "status_capabilities": ("Gmail read/modify/compose",),
+                "status_capabilities": ("Gmail read, send, draft, and mailbox management",),
             },
         ),
         (

--- a/tests/test_google_oauth_providers.py
+++ b/tests/test_google_oauth_providers.py
@@ -14,6 +14,7 @@ from mindroom.credentials import get_runtime_credentials_manager
 from mindroom.oauth.google import (
     _GOOGLE_PROVISIONED_CLIENT_FETCHED_AT_KEY,
     _GOOGLE_PROVISIONED_CLIENT_TTL_SECONDS,
+    GOOGLE_IDENTITY_SCOPES,
     _google_oauth_provider,
     _google_runtime_bootstrapper,
     _google_token_parser,
@@ -112,6 +113,21 @@ def test_public_google_oauth_providers_preserve_service_specific_fields(
     assert provider.tool_config_service == expected["tool_config_service"]
     assert provider.client_config_services == expected["client_config_services"]
     assert provider.status_capabilities == expected["status_capabilities"]
+
+
+def test_google_providers_request_minimum_functionality_preserving_scopes() -> None:
+    """Google providers avoid broader or redundant scopes without removing tool operations."""
+    assert google_gmail_oauth_provider().scopes == (
+        *GOOGLE_IDENTITY_SCOPES,
+        "https://www.googleapis.com/auth/gmail.modify",
+    )
+    assert google_calendar_oauth_provider().scopes == (
+        *GOOGLE_IDENTITY_SCOPES,
+        "https://www.googleapis.com/auth/calendar.events",
+        "https://www.googleapis.com/auth/calendar.calendarlist.readonly",
+        "https://www.googleapis.com/auth/calendar.freebusy",
+        "https://www.googleapis.com/auth/calendar.settings.readonly",
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What changed

- replace redundant Gmail read/modify/compose grants with `gmail.modify`
- replace the broad Calendar grant with targeted event, calendar-list read-only, free/busy, and settings read-only scopes
- keep existing broad tokens usable after the scope reduction
- document the exact scope rationale and Google data flow

## Why

Google OAuth verification requires the narrowest scopes that preserve the implemented user-facing functionality.
The new scope set retains mailbox reading, drafting, sending, labeling, and organization as well as every Calendar event, listing, availability, and working-hours operation.
Drive and Sheets scopes remain unchanged because narrowing them would remove account-wide file search or spreadsheet write functionality.

## Validation

- `uv run pytest -q` (full suite)
- `uv run pre-commit run --all-files`
- targeted Google and OAuth tests
