### PR TITLE
Make default app guidance deployment-aware

### DIFF
--- a/skills/mindroom-docs/SKILL.md
+++ b/skills/mindroom-docs/SKILL.md
@@ -20,7 +20,8 @@ Use this skill when the user asks how MindRoom works, how to configure it, or wh
 4. Use `llms-full.txt` only when the answer spans many sections and page-level references are insufficient.
 5. For setup or administration requests, inspect the available capabilities before claiming the change cannot be performed. Discover and use `config_manager` for changes it supports, then use the documented config-file workflow for other requested changes.
 6. Keep the Matrix homeserver, Matrix client, and MindRoom dashboard distinct.
-   Do not assume deployment URLs.
+   Use the runtime context for the active homeserver instead of assuming one.
+   MindRoom Chat at `https://chat.mindroom.chat` supports custom homeservers.
    For questions about the MindRoom-hosted service, load `page__deployment__hosted-matrix__index.md`; for dashboard questions, load the dashboard page reference.
 7. Answer with concrete steps and include the exact reference filenames used.
 

--- a/skills/mindroom-docs/SKILL.md
+++ b/skills/mindroom-docs/SKILL.md
@@ -19,7 +19,7 @@ Use this skill when the user asks how MindRoom works, how to configure it, or wh
 3. Use `llms.txt` for high-level navigation only.
 4. Use `llms-full.txt` only when the answer spans many sections and page-level references are insufficient.
 5. For setup or administration requests, inspect the available capabilities before claiming the change cannot be performed. Discover and use `config_manager` for changes it supports, then use the documented config-file workflow for other requested changes.
-6. Keep the hosted apps distinct: `https://mindroom.chat` is the Matrix homeserver, `https://chat.mindroom.chat` is the MindRoom Chat client, and the MindRoom dashboard is a separate app. For dashboard questions, load the dashboard page reference.
+6. Keep the Matrix homeserver, Matrix client, and MindRoom dashboard distinct. Do not assume deployment URLs. For questions about the MindRoom-hosted service, load `page__deployment__hosted-matrix__index.md`; for dashboard questions, load the dashboard page reference.
 7. Answer with concrete steps and include the exact reference filenames used.
 
 ## Rules

--- a/skills/mindroom-docs/SKILL.md
+++ b/skills/mindroom-docs/SKILL.md
@@ -19,7 +19,9 @@ Use this skill when the user asks how MindRoom works, how to configure it, or wh
 3. Use `llms.txt` for high-level navigation only.
 4. Use `llms-full.txt` only when the answer spans many sections and page-level references are insufficient.
 5. For setup or administration requests, inspect the available capabilities before claiming the change cannot be performed. Discover and use `config_manager` for changes it supports, then use the documented config-file workflow for other requested changes.
-6. Keep the Matrix homeserver, Matrix client, and MindRoom dashboard distinct. Do not assume deployment URLs. For questions about the MindRoom-hosted service, load `page__deployment__hosted-matrix__index.md`; for dashboard questions, load the dashboard page reference.
+6. Keep the Matrix homeserver, Matrix client, and MindRoom dashboard distinct.
+   Do not assume deployment URLs.
+   For questions about the MindRoom-hosted service, load `page__deployment__hosted-matrix__index.md`; for dashboard questions, load the dashboard page reference.
 7. Answer with concrete steps and include the exact reference filenames used.
 
 ## Rules

--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -221,6 +221,14 @@ def _get_datetime_context(
     )
 
 
+def _get_mind_runtime_context(agent_name: str, runtime_paths: constants.RuntimePaths) -> str:
+    """Render live installation facts for the default Mind agent."""
+    if agent_name != _DEFAULT_MIND_AGENT_NAME:
+        return ""
+    homeserver = constants.runtime_matrix_homeserver(runtime_paths=runtime_paths)
+    return f"\n## MindRoom Runtime\n- Active Matrix homeserver: `{homeserver}`\n"
+
+
 def _load_context_files(
     context_files: list[Path | str],
     runtime_paths: constants.RuntimePaths,
@@ -1431,8 +1439,8 @@ def _build_agent_role_context(
         datetime_context_template=config.get_prompt("DATETIME_CONTEXT_TEMPLATE"),
     )
 
-    # Combine identity and datetime contexts
-    full_context = identity_context + datetime_context
+    # Combine identity, datetime, and live installation contexts.
+    full_context = identity_context + datetime_context + _get_mind_runtime_context(agent_name, runtime_paths)
 
     if not disable_runtime_capabilities:
         workspace = agent_runtime.workspace

--- a/src/mindroom/cli/templates/mind_data/AGENTS.md
+++ b/src/mindroom/cli/templates/mind_data/AGENTS.md
@@ -78,7 +78,7 @@ Capture what matters. Decisions, context, things to remember. Skip the secrets u
 Don't guess how MindRoom is configured. Check the real thing.
 
 - **Start with the docs:** Use the `mindroom-docs` skill, then discover and use `config_manager` to inspect the live setup.
-- **Know the apps:** `https://mindroom.chat` is the hosted Matrix homeserver. `https://chat.mindroom.chat` is MindRoom Chat, the MindRoom-focused Matrix client. The MindRoom dashboard is a separate app.
+- **Know the apps:** The Matrix homeserver, Matrix client, and MindRoom dashboard are separate services. MindRoom Chat is the MindRoom-focused Matrix client. Use the live configuration and deployment docs for their URLs.
 - **Use the right path:** Prefer `config_manager` when it supports the change. If it cannot do the job, use the active config path recorded in `TOOLS.md`, edit only what was requested, preserve everything else, and validate afterward.
 - **Meet your human where they are:** A direct request to set something up is permission for that scoped change. Skip YAML and terminal details unless they ask, and preview genuinely broad or unclear changes once before acting.
 - **Slow down for sensitive stuff:** Ask before changing authorization or credentials, or doing destructive Matrix cleanup. Configuration changes and cleanup of old Matrix rooms or memberships are separate jobs.

--- a/src/mindroom/cli/templates/mind_data/AGENTS.md
+++ b/src/mindroom/cli/templates/mind_data/AGENTS.md
@@ -78,7 +78,9 @@ Capture what matters. Decisions, context, things to remember. Skip the secrets u
 Don't guess how MindRoom is configured. Check the real thing.
 
 - **Start with the docs:** Use the `mindroom-docs` skill, then discover and use `config_manager` to inspect the live setup.
-- **Know the apps:** The Matrix homeserver, Matrix client, and MindRoom dashboard are separate services. MindRoom Chat is the MindRoom-focused Matrix client. Use the live configuration and deployment docs for their URLs.
+- **Know the apps:** The Matrix homeserver, Matrix client, and MindRoom dashboard are separate services.
+  MindRoom Chat is the MindRoom-focused Matrix client.
+  Use the live configuration and deployment docs for their URLs.
 - **Use the right path:** Prefer `config_manager` when it supports the change. If it cannot do the job, use the active config path recorded in `TOOLS.md`, edit only what was requested, preserve everything else, and validate afterward.
 - **Meet your human where they are:** A direct request to set something up is permission for that scoped change. Skip YAML and terminal details unless they ask, and preview genuinely broad or unclear changes once before acting.
 - **Slow down for sensitive stuff:** Ask before changing authorization or credentials, or doing destructive Matrix cleanup. Configuration changes and cleanup of old Matrix rooms or memberships are separate jobs.

--- a/src/mindroom/cli/templates/mind_data/AGENTS.md
+++ b/src/mindroom/cli/templates/mind_data/AGENTS.md
@@ -78,9 +78,9 @@ Capture what matters. Decisions, context, things to remember. Skip the secrets u
 Don't guess how MindRoom is configured. Check the real thing.
 
 - **Start with the docs:** Use the `mindroom-docs` skill, then discover and use `config_manager` to inspect the live setup.
-- **Know the apps:** The Matrix homeserver, Matrix client, and MindRoom dashboard are separate services.
-  MindRoom Chat is the MindRoom-focused Matrix client.
-  Use the live configuration and deployment docs for their URLs.
+- **Know the apps:** The active Matrix homeserver is listed in the runtime context.
+  MindRoom Chat at `https://chat.mindroom.chat` is the MindRoom-focused Matrix client and supports custom homeservers.
+  The MindRoom dashboard is a separate app.
 - **Use the right path:** Prefer `config_manager` when it supports the change. If it cannot do the job, use the active config path recorded in `TOOLS.md`, edit only what was requested, preserve everything else, and validate afterward.
 - **Meet your human where they are:** A direct request to set something up is permission for that scoped change. Skip YAML and terminal details unless they ask, and preview genuinely broad or unclear changes once before acting.
 - **Slow down for sensitive stuff:** Ask before changing authorization or credentials, or doing destructive Matrix cleanup. Configuration changes and cleanup of old Matrix rooms or memberships are separate jobs.

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -268,6 +268,33 @@ def test_agent_identity_prompt_can_be_overridden_from_config() -> None:
     assert "OpenAI-compatible API" in openai_compat_agent.role
 
 
+def test_default_mind_role_includes_effective_matrix_homeserver(tmp_path: Path) -> None:
+    """The default Mind should receive the homeserver resolved from its runtime environment."""
+    (tmp_path / ".env").write_text("MATRIX_HOMESERVER=https://from-env-file.example\n", encoding="utf-8")
+    runtime_paths = resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path,
+        process_env={"MATRIX_HOMESERVER": "https://matrix.self-hosted.example"},
+    )
+    config = _bind_runtime_paths(
+        Config(
+            agents={
+                "mind": AgentConfig(display_name="Mind", role="Setup assistant", tools=[]),
+                "general": AgentConfig(display_name="General", role="General assistant", tools=[]),
+            },
+            models={"default": ModelConfig(provider="openai", id="gpt-4o-mini")},
+        ),
+        runtime_paths,
+    )
+
+    mind = _create_agent_for_test("mind", config)
+    general = _create_agent_for_test("general", config)
+
+    assert "## MindRoom Runtime" in mind.role
+    assert "Active Matrix homeserver: `https://matrix.self-hosted.example`" in mind.role
+    assert "## MindRoom Runtime" not in general.role
+
+
 def test_agent_identity_prompt_uses_persisted_current_matrix_id(tmp_path: Path) -> None:
     """Agent identity prompt should describe the live persisted Matrix account ID."""
     runtime_paths = _runtime_paths(tmp_path)

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -324,10 +324,11 @@ class TestConfigInit:
         assert "## 🧭 MindRoom Setup" in agents_template
         assert "discover and use `config_manager`" in agents_template
         assert "active config path recorded in `TOOLS.md`" in agents_template
-        assert "The Matrix homeserver, Matrix client, and MindRoom dashboard are separate services" in agents_template
-        assert "MindRoom Chat is the MindRoom-focused Matrix client" in agents_template
-        assert "Use the live configuration and deployment docs for their URLs" in agents_template
-        assert "mindroom.chat" not in agents_template
+        assert "The active Matrix homeserver is listed in the runtime context" in agents_template
+        assert "MindRoom Chat at `https://chat.mindroom.chat`" in agents_template
+        assert "supports custom homeservers" in agents_template
+        assert "The MindRoom dashboard is a separate app" in agents_template
+        assert "`https://mindroom.chat`" not in agents_template
         assert "knowledge_bases" not in config
 
         env_content = (tmp_path / ".env").read_text()

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -324,9 +324,10 @@ class TestConfigInit:
         assert "## 🧭 MindRoom Setup" in agents_template
         assert "discover and use `config_manager`" in agents_template
         assert "active config path recorded in `TOOLS.md`" in agents_template
-        assert "`https://mindroom.chat` is the hosted Matrix homeserver" in agents_template
-        assert "`https://chat.mindroom.chat` is MindRoom Chat" in agents_template
-        assert "The MindRoom dashboard is a separate app" in agents_template
+        assert "The Matrix homeserver, Matrix client, and MindRoom dashboard are separate services" in agents_template
+        assert "MindRoom Chat is the MindRoom-focused Matrix client" in agents_template
+        assert "Use the live configuration and deployment docs for their URLs" in agents_template
+        assert "mindroom.chat" not in agents_template
         assert "knowledge_bases" not in config
 
         env_content = (tmp_path / ".env").read_text()


### PR DESCRIPTION
## Summary

- inject the effective `MATRIX_HOMESERVER` into the default Mind runtime context on each fresh agent instance
- identify `https://chat.mindroom.chat` as the MindRoom-focused client that supports custom homeservers
- keep the Matrix homeserver, Matrix client, and MindRoom dashboard roles distinct
- direct hosted-service questions to the dedicated hosted Matrix documentation reference
- cover runtime environment precedence, default-Mind scoping, and generated workspace guidance

## Why

The default workspace template is shared by hosted and self-hosted installations, so hardcoding the public homeserver there is incorrect. Removing all concrete information was also too conservative: the runtime already knows the effective homeserver, and the public MindRoom Chat frontend supports custom homeservers.

Resolving the homeserver during agent construction avoids a stale copy in `TOOLS.md` when an exported environment variable or the config-adjacent `.env` changes.

## Impact

The default Mind sees the active homeserver selected by normal runtime precedence. It can recommend the public MindRoom Chat client independently, while continuing to treat the dashboard as a separate app. Other agents do not receive the extra runtime context.

## Validation

- `uv run pytest tests/test_agents.py tests/test_cli_config.py tests/test_dynamic_toolkits.py -q`
- `uv run ruff check src/mindroom/agents.py tests/test_agents.py tests/test_cli_config.py`
- `uv run prek run --files src/mindroom/agents.py src/mindroom/cli/templates/mind_data/AGENTS.md skills/mindroom-docs/SKILL.md tests/test_agents.py tests/test_cli_config.py`
