### PR TITLE
Preserve Vertex native tool search during token counting

### DIFF
--- a/src/mindroom/claude_prompt_cache.py
+++ b/src/mindroom/claude_prompt_cache.py
@@ -65,12 +65,12 @@ _MAX_CACHE_MARKERS = 4
 _MESSAGE_RUNG_COUNT = 2
 _MARKABLE_BLOCK_TYPES = frozenset({"text", "tool_result", "document", "image"})
 
-_TOOL_SEARCH_TOOL_TYPE = "tool_search_tool_regex_20251119"
+TOOL_SEARCH_TOOL_TYPE = "tool_search_tool_regex_20251119"
 _TOOL_SEARCH_TOOL_NAME = "tool_search_tool_regex"
 _NATIVE_TOOL_SEARCH_PROVIDERS = frozenset({"anthropic", "vertexai_claude"})
 
-_SERVER_TOOL_USE_BLOCK_TYPE = "server_tool_use"
-_TOOL_SEARCH_RESULT_BLOCK_TYPE = "tool_search_tool_result"
+SERVER_TOOL_USE_BLOCK_TYPE = "server_tool_use"
+TOOL_SEARCH_RESULT_BLOCK_TYPE = "tool_search_tool_result"
 # The request schema for replayed tool-search results accepts only these keys
 # (ToolSearchToolResultBlockParam); response blocks additionally carry
 # citations/parsed_output/text, which the API rejects as extra inputs.
@@ -218,7 +218,7 @@ def _mark_last_tool(tools: object, cache_control: dict[str, str]) -> tuple[objec
     for tool_index in range(len(tools) - 1, -1, -1):
         tool_dict = _as_dict(tools[tool_index])
         if tool_dict is not None and (
-            tool_dict.get("defer_loading") is True or tool_dict.get("type") == _TOOL_SEARCH_TOOL_TYPE
+            tool_dict.get("defer_loading") is True or tool_dict.get("type") == TOOL_SEARCH_TOOL_TYPE
         ):
             continue
         if tool_dict is None or _block_has_cache_marker(tool_dict):
@@ -242,7 +242,7 @@ def _tool_search_result_ids(content: list[Any]) -> set[str]:
     result_ids: set[str] = set()
     for block in content:
         block_dict = _as_dict(block)
-        if block_dict is None or block_dict.get("type") != _TOOL_SEARCH_RESULT_BLOCK_TYPE:
+        if block_dict is None or block_dict.get("type") != TOOL_SEARCH_RESULT_BLOCK_TYPE:
             continue
         tool_use_id = block_dict.get("tool_use_id")
         if isinstance(tool_use_id, str):
@@ -287,14 +287,14 @@ def _request_kwargs_with_replay_safe_tool_search_results(request_kwargs: dict[st
                 continue
             block_id = block_dict.get("id")
             if (
-                block_dict.get("type") == _SERVER_TOOL_USE_BLOCK_TYPE
+                block_dict.get("type") == SERVER_TOOL_USE_BLOCK_TYPE
                 and block_dict.get("name") == _TOOL_SEARCH_TOOL_NAME
                 and (not isinstance(block_id, str) or block_id not in paired_result_ids)
             ):
                 content_changed = True
                 continue
             if (
-                block_dict.get("type") == _TOOL_SEARCH_RESULT_BLOCK_TYPE
+                block_dict.get("type") == TOOL_SEARCH_RESULT_BLOCK_TYPE
                 and not block_dict.keys() <= _TOOL_SEARCH_RESULT_INPUT_KEYS
             ):
                 prepared_block = {
@@ -348,7 +348,7 @@ def _request_kwargs_with_deferred_tool_search(
     deferred_tools.sort(key=lambda tool: str(tool.get("name")))
     prepared_kwargs = dict(request_kwargs)
     prepared_kwargs["tools"] = [
-        {"type": _TOOL_SEARCH_TOOL_TYPE, "name": _TOOL_SEARCH_TOOL_NAME},
+        {"type": TOOL_SEARCH_TOOL_TYPE, "name": _TOOL_SEARCH_TOOL_NAME},
         *non_deferred_tools,
         *deferred_tools,
     ]

--- a/src/mindroom/vertex_claude_compat.py
+++ b/src/mindroom/vertex_claude_compat.py
@@ -100,59 +100,111 @@ def _request_requires_exact_count(request_kwargs: dict[str, Any]) -> bool:
     return False
 
 
+def _referenced_tool_names(search_result_block: object) -> set[str]:
+    """Return tool names selected by one native search-result block."""
+    if not isinstance(search_result_block, dict):
+        return set()
+    block_dict = cast("dict[str, Any]", search_result_block)
+    if block_dict.get("type") != "tool_search_tool_result":
+        return set()
+    search_result = block_dict.get("content")
+    references = search_result.get("tool_references") if isinstance(search_result, dict) else None
+    if not isinstance(references, list):
+        return set()
+    names: set[str] = set()
+    for reference in references:
+        tool_name = reference.get("tool_name") if isinstance(reference, dict) else None
+        if isinstance(tool_name, str):
+            names.add(tool_name)
+    return names
+
+
+def _messages_for_vertex_token_count(messages: object) -> tuple[list[Any] | None, set[str]]:
+    """Convert native search history to text and collect selected tool names."""
+    referenced_tool_names: set[str] = set()
+    count_messages: list[Any] | None = None
+    if not isinstance(messages, list):
+        return count_messages, referenced_tool_names
+    for message_index, message in enumerate(messages):
+        if not isinstance(message, dict):
+            continue
+        message_dict = cast("dict[str, Any]", message)
+        content = message_dict.get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            referenced_tool_names.update(_referenced_tool_names(block))
+        count_content = [
+            {"type": "text", "text": stable_serialize(block)}
+            if isinstance(block, dict) and block.get("type") in _VERTEX_TOOL_SEARCH_HISTORY_BLOCK_TYPES
+            else block
+            for block in content
+        ]
+        if count_content != content:
+            if count_messages is None:
+                count_messages = list(messages)
+            count_message = dict(message_dict)
+            count_message["content"] = count_content
+            count_messages[message_index] = count_message
+    return count_messages, referenced_tool_names
+
+
+def _is_vertex_tool_search(tool: object) -> bool:
+    """Return whether one wire tool is Vertex's unsupported count entry."""
+    return isinstance(tool, dict) and cast("dict[str, Any]", tool).get("type") == _VERTEX_TOOL_SEARCH_TYPE
+
+
+def _tools_for_vertex_token_count(
+    tools: object,
+    referenced_tool_names: set[str],
+) -> tuple[list[Any] | None, bool]:
+    """Keep eager and selected tools in a schema accepted by token counting."""
+    if not isinstance(tools, list):
+        return None, False
+    has_native_search = any(_is_vertex_tool_search(tool) for tool in tools)
+    count_tools: list[Any] = []
+    for tool in tools:
+        if not isinstance(tool, dict):
+            count_tools.append(tool)
+            continue
+        tool_dict = cast("dict[str, Any]", tool)
+        if _is_vertex_tool_search(tool_dict):
+            continue
+        if tool_dict.get("defer_loading") is not True:
+            count_tools.append(tool_dict)
+        elif not has_native_search or tool_dict.get("name") in referenced_tool_names:
+            count_tool = dict(tool_dict)
+            count_tool.pop("defer_loading", None)
+            count_tools.append(count_tool)
+    return (count_tools if count_tools != tools else None), has_native_search
+
+
 def _request_for_vertex_token_count(request_kwargs: dict[str, Any]) -> tuple[dict[str, Any], int]:
     """Build a countable equivalent of a native tool-search request.
 
     Vertex generation accepts Anthropic's native tool-search schema, but its
     count-tokens endpoint rejects the search tool, ``defer_loading``, and the
-    two server-search history block types. Deferred definitions are absent
-    from the model context until selected, so omit them from the count payload.
-    Preserve prior search traces as text and reserve the fixed server-side
-    search prefix separately.
+    two server-search history block types. Count eager and previously selected
+    definitions, preserve search traces as text, and reserve the fixed
+    server-side search prefix separately.
     """
-    tools = request_kwargs.get("tools")
-    if not isinstance(tools, list) or not any(
-        isinstance(tool, dict) and tool.get("type") == _VERTEX_TOOL_SEARCH_TYPE for tool in tools
-    ):
-        return request_kwargs, 0
+    count_messages, referenced_tool_names = _messages_for_vertex_token_count(request_kwargs.get("messages"))
+    count_tools, has_native_search = _tools_for_vertex_token_count(
+        request_kwargs.get("tools"),
+        referenced_tool_names,
+    )
 
+    if count_messages is None and count_tools is None:
+        return request_kwargs, 0
     count_kwargs = dict(request_kwargs)
-    count_tools = [
-        tool
-        for tool in tools
-        if not (
-            isinstance(tool, dict)
-            and (tool.get("type") == _VERTEX_TOOL_SEARCH_TYPE or tool.get("defer_loading") is True)
-        )
-    ]
+    if count_messages is not None:
+        count_kwargs["messages"] = count_messages
     if count_tools:
         count_kwargs["tools"] = count_tools
-    else:
+    elif count_tools is not None:
         count_kwargs.pop("tools", None)
-
-    messages = request_kwargs.get("messages")
-    if isinstance(messages, list):
-        count_messages = list(messages)
-        for message_index, message in enumerate(messages):
-            if not isinstance(message, dict):
-                continue
-            message_dict = cast("dict[str, Any]", message)
-            content = message_dict.get("content")
-            if not isinstance(content, list):
-                continue
-            count_content = [
-                {"type": "text", "text": stable_serialize(block)}
-                if isinstance(block, dict) and block.get("type") in _VERTEX_TOOL_SEARCH_HISTORY_BLOCK_TYPES
-                else block
-                for block in content
-            ]
-            if count_content != content:
-                count_message = dict(message_dict)
-                count_message["content"] = count_content
-                count_messages[message_index] = count_message
-        count_kwargs["messages"] = count_messages
-
-    return count_kwargs, _VERTEX_TOOL_SEARCH_TOKEN_RESERVE
+    reserve = _VERTEX_TOOL_SEARCH_TOKEN_RESERVE if has_native_search else 0
+    return count_kwargs, reserve
 
 
 @dataclass

--- a/src/mindroom/vertex_claude_compat.py
+++ b/src/mindroom/vertex_claude_compat.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from agno.exceptions import ModelProviderError
 from agno.models.vertexai.claude import Claude as VertexAIClaude
@@ -26,6 +26,12 @@ logger = get_logger(__name__)
 
 _EXACT_COUNT_THRESHOLD_RATIO = 0.5
 _EXACT_COUNT_BLOCK_TYPES = frozenset({"document", "image"})
+_VERTEX_TOOL_SEARCH_TYPE = "tool_search_tool_regex_20251119"
+_VERTEX_TOOL_SEARCH_HISTORY_BLOCK_TYPES = frozenset({"server_tool_use", "tool_search_tool_result"})
+# Vertex generation reports 213 input tokens for the native regex search tool
+# on both Claude Haiku 4.5 and Sonnet 4.6. Keep a small margin because the
+# count-tokens endpoint cannot count that server-side prefix itself.
+_VERTEX_TOOL_SEARCH_TOKEN_RESERVE = 256
 
 
 def _strip_vertex_claude_tool_strict(
@@ -92,6 +98,61 @@ def _request_requires_exact_count(request_kwargs: dict[str, Any]) -> bool:
         if isinstance(content, list) and _blocks_require_exact_count(content):
             return True
     return False
+
+
+def _request_for_vertex_token_count(request_kwargs: dict[str, Any]) -> tuple[dict[str, Any], int]:
+    """Build a countable equivalent of a native tool-search request.
+
+    Vertex generation accepts Anthropic's native tool-search schema, but its
+    count-tokens endpoint rejects the search tool, ``defer_loading``, and the
+    two server-search history block types. Deferred definitions are absent
+    from the model context until selected, so omit them from the count payload.
+    Preserve prior search traces as text and reserve the fixed server-side
+    search prefix separately.
+    """
+    tools = request_kwargs.get("tools")
+    if not isinstance(tools, list) or not any(
+        isinstance(tool, dict) and tool.get("type") == _VERTEX_TOOL_SEARCH_TYPE for tool in tools
+    ):
+        return request_kwargs, 0
+
+    count_kwargs = dict(request_kwargs)
+    count_tools = [
+        tool
+        for tool in tools
+        if not (
+            isinstance(tool, dict)
+            and (tool.get("type") == _VERTEX_TOOL_SEARCH_TYPE or tool.get("defer_loading") is True)
+        )
+    ]
+    if count_tools:
+        count_kwargs["tools"] = count_tools
+    else:
+        count_kwargs.pop("tools", None)
+
+    messages = request_kwargs.get("messages")
+    if isinstance(messages, list):
+        count_messages = list(messages)
+        for message_index, message in enumerate(messages):
+            if not isinstance(message, dict):
+                continue
+            message_dict = cast("dict[str, Any]", message)
+            content = message_dict.get("content")
+            if not isinstance(content, list):
+                continue
+            count_content = [
+                {"type": "text", "text": stable_serialize(block)}
+                if isinstance(block, dict) and block.get("type") in _VERTEX_TOOL_SEARCH_HISTORY_BLOCK_TYPES
+                else block
+                for block in content
+            ]
+            if count_content != content:
+                count_message = dict(message_dict)
+                count_message["content"] = count_content
+                count_messages[message_index] = count_message
+        count_kwargs["messages"] = count_messages
+
+    return count_kwargs, _VERTEX_TOOL_SEARCH_TOKEN_RESERVE
 
 
 @dataclass
@@ -172,8 +233,9 @@ class MindroomVertexAIClaude(VertexAIClaude):
             response_format=response_format,
             compress_tool_results=compress_tool_results,
         )
-        response = await self.get_async_client().messages.count_tokens(**request_kwargs)
-        return response.input_tokens + count_schema_tokens(response_format, self.id)
+        count_kwargs, tool_search_reserve = _request_for_vertex_token_count(request_kwargs)
+        response = await self.get_async_client().messages.count_tokens(**count_kwargs)
+        return response.input_tokens + tool_search_reserve + count_schema_tokens(response_format, self.id)
 
     @staticmethod
     def _replay_trim_candidates(messages: list[Message]) -> list[int]:

--- a/src/mindroom/vertex_claude_compat.py
+++ b/src/mindroom/vertex_claude_compat.py
@@ -11,7 +11,12 @@ from agno.models.vertexai.claude import Claude as VertexAIClaude
 from agno.utils.models.claude import format_messages, format_tools_for_model
 from agno.utils.tokens import count_schema_tokens
 
-from mindroom.claude_prompt_cache import prepare_claude_request_kwargs
+from mindroom.claude_prompt_cache import (
+    SERVER_TOOL_USE_BLOCK_TYPE,
+    TOOL_SEARCH_RESULT_BLOCK_TYPE,
+    TOOL_SEARCH_TOOL_TYPE,
+    prepare_claude_request_kwargs,
+)
 from mindroom.logging_config import get_logger
 from mindroom.token_budget import estimate_compaction_input_tokens, stable_serialize
 
@@ -26,8 +31,9 @@ logger = get_logger(__name__)
 
 _EXACT_COUNT_THRESHOLD_RATIO = 0.5
 _EXACT_COUNT_BLOCK_TYPES = frozenset({"document", "image"})
-_VERTEX_TOOL_SEARCH_TYPE = "tool_search_tool_regex_20251119"
-_VERTEX_TOOL_SEARCH_HISTORY_BLOCK_TYPES = frozenset({"server_tool_use", "tool_search_tool_result"})
+_VERTEX_TOOL_SEARCH_HISTORY_BLOCK_TYPES = frozenset(
+    {SERVER_TOOL_USE_BLOCK_TYPE, TOOL_SEARCH_RESULT_BLOCK_TYPE},
+)
 # Vertex generation reports 213 input tokens for the native regex search tool
 # on both Claude Haiku 4.5 and Sonnet 4.6. Keep a small margin because the
 # count-tokens endpoint cannot count that server-side prefix itself.
@@ -105,7 +111,7 @@ def _referenced_tool_names(search_result_block: object) -> set[str]:
     if not isinstance(search_result_block, dict):
         return set()
     block_dict = cast("dict[str, Any]", search_result_block)
-    if block_dict.get("type") != "tool_search_tool_result":
+    if block_dict.get("type") != TOOL_SEARCH_RESULT_BLOCK_TYPE:
         return set()
     search_result = block_dict.get("content")
     references = search_result.get("tool_references") if isinstance(search_result, dict) else None
@@ -151,7 +157,7 @@ def _messages_for_vertex_token_count(messages: object) -> tuple[list[Any] | None
 
 def _is_vertex_tool_search(tool: object) -> bool:
     """Return whether one wire tool is Vertex's unsupported count entry."""
-    return isinstance(tool, dict) and cast("dict[str, Any]", tool).get("type") == _VERTEX_TOOL_SEARCH_TYPE
+    return isinstance(tool, dict) and cast("dict[str, Any]", tool).get("type") == TOOL_SEARCH_TOOL_TYPE
 
 
 def _tools_for_vertex_token_count(

--- a/src/mindroom/vertex_claude_compat.py
+++ b/src/mindroom/vertex_claude_compat.py
@@ -34,9 +34,9 @@ _EXACT_COUNT_BLOCK_TYPES = frozenset({"document", "image"})
 _VERTEX_TOOL_SEARCH_HISTORY_BLOCK_TYPES = frozenset(
     {SERVER_TOOL_USE_BLOCK_TYPE, TOOL_SEARCH_RESULT_BLOCK_TYPE},
 )
-# Vertex generation reports 213 input tokens for the native regex search tool
-# on both Claude Haiku 4.5 and Sonnet 4.6. Keep a small margin because the
-# count-tokens endpoint cannot count that server-side prefix itself.
+# Before any tools are discovered, Vertex generation reports 213 input tokens
+# for the native regex search tool on both Claude Haiku 4.5 and Sonnet 4.6.
+# Keep a small margin because count_tokens cannot count that server-tool prefix.
 _VERTEX_TOOL_SEARCH_TOKEN_RESERVE = 256
 
 
@@ -192,7 +192,9 @@ def _request_for_vertex_token_count(request_kwargs: dict[str, Any]) -> tuple[dic
     count-tokens endpoint rejects the search tool, ``defer_loading``, and the
     two server-search history block types. Count eager and previously selected
     definitions, preserve search traces as text, and reserve the fixed
-    server-side search prefix separately.
+    server-side search prefix separately. Definitions selected by a new search
+    are generated inside the server-tool loop and cannot be known by any
+    preflight count; they become countable on the following request.
     """
     count_messages, referenced_tool_names = _messages_for_vertex_token_count(request_kwargs.get("messages"))
     count_tools, has_native_search = _tools_for_vertex_token_count(

--- a/tests/test_vertex_claude_context_guard.py
+++ b/tests/test_vertex_claude_context_guard.py
@@ -147,6 +147,7 @@ def test_estimate_requires_exact_count_for_base64_documents() -> None:
 
 def test_vertex_token_count_request_preserves_native_tool_search_as_countable_text() -> None:
     """Only the count payload is adapted for Vertex's older request schema."""
+    large_schema_description = "large schema " * 10_000
     search_use = {
         "type": "server_tool_use",
         "id": "srvtoolu-1",
@@ -178,6 +179,13 @@ def test_vertex_token_count_request_preserves_native_tool_search_as_countable_te
             {"name": "always_tool", "input_schema": {"type": "object"}},
             {
                 "name": "weather_lookup",
+                "description": large_schema_description,
+                "input_schema": {"type": "object"},
+                "defer_loading": True,
+            },
+            {
+                "name": "unused_lookup",
+                "description": "Never selected.",
                 "input_schema": {"type": "object"},
                 "defer_loading": True,
             },
@@ -187,7 +195,14 @@ def test_vertex_token_count_request_preserves_native_tool_search_as_countable_te
     count_kwargs, reserve = _request_for_vertex_token_count(request_kwargs)
 
     assert reserve == _VERTEX_TOOL_SEARCH_TOKEN_RESERVE
-    assert count_kwargs["tools"] == [{"name": "always_tool", "input_schema": {"type": "object"}}]
+    assert count_kwargs["tools"] == [
+        {"name": "always_tool", "input_schema": {"type": "object"}},
+        {
+            "name": "weather_lookup",
+            "description": large_schema_description,
+            "input_schema": {"type": "object"},
+        },
+    ]
     assert count_kwargs["messages"][0]["content"] == [
         {"type": "text", "text": "Searching."},
         {
@@ -209,6 +224,36 @@ def test_vertex_token_count_request_preserves_native_tool_search_as_countable_te
     assert request_kwargs["tools"][0]["type"] == "tool_search_tool_regex_20251119"
     assert request_kwargs["messages"][0]["content"][1] is search_use
     assert request_kwargs["messages"][0]["content"][2] is search_result
+
+
+def test_vertex_token_count_adapts_search_history_without_current_search_tool() -> None:
+    """Replayed search blocks remain countable after the current tool surface changes."""
+    request_kwargs = {
+        "model": "claude-sonnet-4-6",
+        "messages": [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "server_tool_use",
+                        "id": "srvtoolu-1",
+                        "name": "tool_search_tool_regex",
+                        "input": {"pattern": "weather"},
+                    },
+                ],
+            },
+        ],
+    }
+
+    count_kwargs, reserve = _request_for_vertex_token_count(request_kwargs)
+
+    assert reserve == 0
+    assert count_kwargs["messages"][0]["content"][0] == {
+        "type": "text",
+        "text": (
+            '{"id":"srvtoolu-1","input":{"pattern":"weather"},"name":"tool_search_tool_regex","type":"server_tool_use"}'
+        ),
+    }
 
 
 def test_vertex_token_count_request_leaves_regular_requests_unchanged() -> None:

--- a/tests/test_vertex_claude_context_guard.py
+++ b/tests/test_vertex_claude_context_guard.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
 
@@ -12,7 +13,11 @@ from agno.models.message import Message
 from agno.models.response import ModelResponse
 from agno.models.vertexai.claude import Claude as VertexAIClaude
 
-from mindroom.vertex_claude_compat import MindroomVertexAIClaude
+from mindroom.vertex_claude_compat import (
+    _VERTEX_TOOL_SEARCH_TOKEN_RESERVE,
+    MindroomVertexAIClaude,
+    _request_for_vertex_token_count,
+)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -138,6 +143,122 @@ def test_estimate_requires_exact_count_for_base64_documents() -> None:
 
     assert estimated_tokens is None
     estimator.assert_not_called()
+
+
+def test_vertex_token_count_request_preserves_native_tool_search_as_countable_text() -> None:
+    """Only the count payload is adapted for Vertex's older request schema."""
+    search_use = {
+        "type": "server_tool_use",
+        "id": "srvtoolu-1",
+        "name": "tool_search_tool_regex",
+        "input": {"pattern": "weather"},
+    }
+    search_result = {
+        "type": "tool_search_tool_result",
+        "tool_use_id": "srvtoolu-1",
+        "content": {
+            "type": "tool_search_tool_search_result",
+            "tool_references": [{"type": "tool_reference", "tool_name": "weather_lookup"}],
+        },
+    }
+    request_kwargs = {
+        "model": "claude-sonnet-4-6",
+        "messages": [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "Searching."},
+                    search_use,
+                    search_result,
+                ],
+            },
+        ],
+        "tools": [
+            {"type": "tool_search_tool_regex_20251119", "name": "tool_search_tool_regex"},
+            {"name": "always_tool", "input_schema": {"type": "object"}},
+            {
+                "name": "weather_lookup",
+                "input_schema": {"type": "object"},
+                "defer_loading": True,
+            },
+        ],
+    }
+
+    count_kwargs, reserve = _request_for_vertex_token_count(request_kwargs)
+
+    assert reserve == _VERTEX_TOOL_SEARCH_TOKEN_RESERVE
+    assert count_kwargs["tools"] == [{"name": "always_tool", "input_schema": {"type": "object"}}]
+    assert count_kwargs["messages"][0]["content"] == [
+        {"type": "text", "text": "Searching."},
+        {
+            "type": "text",
+            "text": (
+                '{"id":"srvtoolu-1","input":{"pattern":"weather"},'
+                '"name":"tool_search_tool_regex","type":"server_tool_use"}'
+            ),
+        },
+        {
+            "type": "text",
+            "text": (
+                '{"content":{"tool_references":[{"tool_name":"weather_lookup",'
+                '"type":"tool_reference"}],"type":"tool_search_tool_search_result"},'
+                '"tool_use_id":"srvtoolu-1","type":"tool_search_tool_result"}'
+            ),
+        },
+    ]
+    assert request_kwargs["tools"][0]["type"] == "tool_search_tool_regex_20251119"
+    assert request_kwargs["messages"][0]["content"][1] is search_use
+    assert request_kwargs["messages"][0]["content"][2] is search_result
+
+
+def test_vertex_token_count_request_leaves_regular_requests_unchanged() -> None:
+    """Requests without native search keep their original count payload."""
+    request_kwargs = {
+        "model": "claude-sonnet-4-6",
+        "messages": [{"role": "user", "content": "hello"}],
+        "tools": [{"name": "lookup", "input_schema": {"type": "object"}}],
+    }
+
+    count_kwargs, reserve = _request_for_vertex_token_count(request_kwargs)
+
+    assert count_kwargs is request_kwargs
+    assert reserve == 0
+
+
+@pytest.mark.asyncio
+async def test_exact_count_uses_vertex_compatible_tool_search_payload() -> None:
+    """Exact counting includes the native-search reserve after sanitization."""
+    model = _model()
+    request_kwargs = {
+        "model": model.id,
+        "messages": [{"role": "user", "content": "hello"}],
+        "tools": [
+            {"type": "tool_search_tool_regex_20251119", "name": "tool_search_tool_regex"},
+            {"name": "always_tool", "input_schema": {"type": "object"}},
+            {"name": "deferred_tool", "input_schema": {"type": "object"}, "defer_loading": True},
+        ],
+    }
+    count_tokens = AsyncMock(return_value=SimpleNamespace(input_tokens=700))
+    client = SimpleNamespace(messages=SimpleNamespace(count_tokens=count_tokens))
+
+    with (
+        patch.object(model, "_request_input_kwargs", return_value=request_kwargs),
+        patch.object(model, "get_async_client", return_value=client),
+        patch("mindroom.vertex_claude_compat.count_schema_tokens", return_value=5),
+    ):
+        input_tokens = await model._count_request_input_tokens(
+            [Message(role="user", content="hello")],
+            tools=None,
+            response_format=None,
+            compress_tool_results=False,
+        )
+
+    assert input_tokens == 700 + _VERTEX_TOOL_SEARCH_TOKEN_RESERVE + 5
+    count_tokens.assert_awaited_once_with(
+        model=model.id,
+        messages=request_kwargs["messages"],
+        tools=[{"name": "always_tool", "input_schema": {"type": "object"}}],
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_vertex_claude_context_guard.py
+++ b/tests/test_vertex_claude_context_guard.py
@@ -13,6 +13,11 @@ from agno.models.message import Message
 from agno.models.response import ModelResponse
 from agno.models.vertexai.claude import Claude as VertexAIClaude
 
+from mindroom.claude_prompt_cache import (
+    SERVER_TOOL_USE_BLOCK_TYPE,
+    TOOL_SEARCH_RESULT_BLOCK_TYPE,
+    TOOL_SEARCH_TOOL_TYPE,
+)
 from mindroom.vertex_claude_compat import (
     _VERTEX_TOOL_SEARCH_TOKEN_RESERVE,
     MindroomVertexAIClaude,
@@ -149,13 +154,13 @@ def test_vertex_token_count_request_preserves_native_tool_search_as_countable_te
     """Only the count payload is adapted for Vertex's older request schema."""
     large_schema_description = "large schema " * 10_000
     search_use = {
-        "type": "server_tool_use",
+        "type": SERVER_TOOL_USE_BLOCK_TYPE,
         "id": "srvtoolu-1",
         "name": "tool_search_tool_regex",
         "input": {"pattern": "weather"},
     }
     search_result = {
-        "type": "tool_search_tool_result",
+        "type": TOOL_SEARCH_RESULT_BLOCK_TYPE,
         "tool_use_id": "srvtoolu-1",
         "content": {
             "type": "tool_search_tool_search_result",
@@ -175,7 +180,7 @@ def test_vertex_token_count_request_preserves_native_tool_search_as_countable_te
             },
         ],
         "tools": [
-            {"type": "tool_search_tool_regex_20251119", "name": "tool_search_tool_regex"},
+            {"type": TOOL_SEARCH_TOOL_TYPE, "name": "tool_search_tool_regex"},
             {"name": "always_tool", "input_schema": {"type": "object"}},
             {
                 "name": "weather_lookup",
@@ -221,7 +226,7 @@ def test_vertex_token_count_request_preserves_native_tool_search_as_countable_te
             ),
         },
     ]
-    assert request_kwargs["tools"][0]["type"] == "tool_search_tool_regex_20251119"
+    assert request_kwargs["tools"][0]["type"] == TOOL_SEARCH_TOOL_TYPE
     assert request_kwargs["messages"][0]["content"][1] is search_use
     assert request_kwargs["messages"][0]["content"][2] is search_result
 
@@ -235,7 +240,7 @@ def test_vertex_token_count_adapts_search_history_without_current_search_tool() 
                 "role": "assistant",
                 "content": [
                     {
-                        "type": "server_tool_use",
+                        "type": SERVER_TOOL_USE_BLOCK_TYPE,
                         "id": "srvtoolu-1",
                         "name": "tool_search_tool_regex",
                         "input": {"pattern": "weather"},
@@ -278,7 +283,7 @@ async def test_exact_count_uses_vertex_compatible_tool_search_payload() -> None:
         "model": model.id,
         "messages": [{"role": "user", "content": "hello"}],
         "tools": [
-            {"type": "tool_search_tool_regex_20251119", "name": "tool_search_tool_regex"},
+            {"type": TOOL_SEARCH_TOOL_TYPE, "name": "tool_search_tool_regex"},
             {"name": "always_tool", "input_schema": {"type": "object"}},
             {"name": "deferred_tool", "input_schema": {"type": "object"}, "defer_loading": True},
         ],


### PR DESCRIPTION
## Why

Vertex generation supports native Tool Search, but Vertex's token-count endpoint rejects the same search tool, `defer_loading`, and server-search history blocks. Exact request fitting can therefore fail before a valid generation request is sent.

## What changed

Generation requests remain untouched and keep native deferred tool loading. Only the token-count payload is adapted: the native search entry and untouched deferred definitions are omitted, definitions referenced by earlier searches are counted, prior search traces are represented as countable text, and a small reserve covers the server-side search prefix that Vertex cannot count directly.

A new search runs inside the provider's server-tool loop, so no preflight count can know which definitions that future search will select. Those definitions are counted on the next request, once their references exist in history. Counting the whole catalog instead would defeat Tool Search's context savings.
