### PR TITLE
Fix OpenAI replay of argument-free tool calls

### DIFF
--- a/src/mindroom/azure_openai_model.py
+++ b/src/mindroom/azure_openai_model.py
@@ -1,0 +1,22 @@
+"""Azure OpenAI model with cross-provider tool-call replay support.
+
+Kept out of :mod:`mindroom.openai_models`: importing
+``agno.models.azure.openai_chat`` runs the ``agno.models.azure`` package init,
+which imports its Claude model and with it the anthropic SDK (~200 ms).
+Only the ``azure`` provider branch should pay that.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# The concrete module, not agno.models.azure: the package init wraps
+# this import in a try/except stub whose fallback is not a Model.
+from agno.models.azure.openai_chat import AzureOpenAI
+
+from mindroom.openai_models import ChatToolArgumentsCompat
+
+
+@dataclass
+class MindRoomAzureOpenAI(ChatToolArgumentsCompat, AzureOpenAI):
+    """Azure OpenAI model that can replay tool calls from other providers."""

--- a/src/mindroom/codex_model.py
+++ b/src/mindroom/codex_model.py
@@ -18,7 +18,7 @@ from openai import AsyncOpenAI, OpenAI
 
 from mindroom.file_locks import advisory_file_lock
 from mindroom.model_defaults import CODEX_GPT, CODEX_GPT_ENDPOINT
-from mindroom.openai_responses_model import MindRoomOpenAIResponses
+from mindroom.openai_models import MindRoomOpenAIResponses
 from mindroom.prompts import CODEX_DEFAULT_INSTRUCTIONS
 
 if TYPE_CHECKING:

--- a/src/mindroom/model_loading.py
+++ b/src/mindroom/model_loading.py
@@ -199,7 +199,7 @@ def _create_model_for_provider(  # noqa: C901, PLR0911, PLR0912, PLR0915
         return Ollama(id=model_id, host=host, **extra_kwargs)
 
     if canonical_provider == "openrouter":
-        from agno.models.openrouter import OpenRouter  # noqa: PLC0415
+        from mindroom.openai_models import MindRoomOpenRouter  # noqa: PLC0415
 
         api_key = extra_kwargs.pop("api_key", None)
         if not api_key:
@@ -210,7 +210,7 @@ def _create_model_for_provider(  # noqa: C901, PLR0911, PLR0912, PLR0915
         # truncates long replies mid-sentence; None keeps the cap out of the
         # request so the provider's own model limit applies.
         extra_kwargs.setdefault("max_tokens", None)
-        return OpenRouter(id=model_id, api_key=api_key, **extra_kwargs)
+        return MindRoomOpenRouter(id=model_id, api_key=api_key, **extra_kwargs)
 
     if canonical_provider == "zai":
         # OpenAILike neither reads a provider env var nor rejects a missing key,
@@ -227,9 +227,9 @@ def _create_model_for_provider(  # noqa: C901, PLR0911, PLR0912, PLR0915
         extra_kwargs.setdefault("base_url", ZAI_BASE_URL_DEFAULT)
         extra_kwargs.setdefault("name", "ZAI")
         extra_kwargs.setdefault("provider", "ZAI")
-        from agno.models.openai.like import OpenAILike  # noqa: PLC0415
+        from mindroom.openai_models import MindRoomOpenAILike  # noqa: PLC0415
 
-        return OpenAILike(id=model_id, **extra_kwargs)
+        return MindRoomOpenAILike(id=model_id, **extra_kwargs)
 
     if canonical_provider in {"codex", "openai_codex"}:
         from mindroom.codex_model import (  # noqa: PLC0415
@@ -263,20 +263,18 @@ def _create_model_for_provider(  # noqa: C901, PLR0911, PLR0912, PLR0915
 
         base_url = extra_kwargs.get("base_url") or runtime_paths.env_value("OPENAI_BASE_URL")
         if openai_native_tool_search_supported(canonical_provider, model_id, base_url=base_url):
-            from mindroom.openai_responses_model import MindRoomOpenAIResponses  # noqa: PLC0415
+            from mindroom.openai_models import MindRoomOpenAIResponses  # noqa: PLC0415
 
             return MindRoomOpenAIResponses(id=model_id, **extra_kwargs)
 
-        from mindroom.openai_responses_model import MindRoomOpenAIChat  # noqa: PLC0415
+        from mindroom.openai_models import MindRoomOpenAIChat  # noqa: PLC0415
 
         return MindRoomOpenAIChat(id=model_id, **extra_kwargs)
 
     if canonical_provider == "azure":
-        # The concrete module, not agno.models.azure: the package init wraps
-        # this import in a try/except stub whose fallback is not a Model.
-        from agno.models.azure.openai_chat import AzureOpenAI  # noqa: PLC0415
+        from mindroom.openai_models import MindRoomAzureOpenAI  # noqa: PLC0415
 
-        return AzureOpenAI(id=model_id, **extra_kwargs)
+        return MindRoomAzureOpenAI(id=model_id, **extra_kwargs)
 
     if canonical_provider == "anthropic":
         from agno.models.anthropic import Claude  # noqa: PLC0415
@@ -298,9 +296,9 @@ def _create_model_for_provider(  # noqa: C901, PLR0911, PLR0912, PLR0915
         )
 
     if canonical_provider == "llama_cpp":
-        from agno.models.llama_cpp import LlamaCpp  # noqa: PLC0415
+        from mindroom.openai_models import MindRoomLlamaCpp  # noqa: PLC0415
 
-        return LlamaCpp(id=model_id, **extra_kwargs)
+        return MindRoomLlamaCpp(id=model_id, **extra_kwargs)
 
     if canonical_provider == "cerebras":
         from agno.models.cerebras import Cerebras  # noqa: PLC0415
@@ -313,9 +311,9 @@ def _create_model_for_provider(  # noqa: C901, PLR0911, PLR0912, PLR0915
         return Groq(id=model_id, **extra_kwargs)
 
     if canonical_provider == "deepseek":
-        from agno.models.deepseek import DeepSeek  # noqa: PLC0415
+        from mindroom.openai_models import MindRoomDeepSeek  # noqa: PLC0415
 
-        return DeepSeek(id=model_id, **extra_kwargs)
+        return MindRoomDeepSeek(id=model_id, **extra_kwargs)
 
     msg = f"Unsupported AI provider: {provider}"
     raise ValueError(msg)

--- a/src/mindroom/model_loading.py
+++ b/src/mindroom/model_loading.py
@@ -272,7 +272,7 @@ def _create_model_for_provider(  # noqa: C901, PLR0911, PLR0912, PLR0915
         return MindRoomOpenAIChat(id=model_id, **extra_kwargs)
 
     if canonical_provider == "azure":
-        from mindroom.openai_models import MindRoomAzureOpenAI  # noqa: PLC0415
+        from mindroom.azure_openai_model import MindRoomAzureOpenAI  # noqa: PLC0415
 
         return MindRoomAzureOpenAI(id=model_id, **extra_kwargs)
 

--- a/src/mindroom/model_loading.py
+++ b/src/mindroom/model_loading.py
@@ -267,9 +267,9 @@ def _create_model_for_provider(  # noqa: C901, PLR0911, PLR0912, PLR0915
 
             return MindRoomOpenAIResponses(id=model_id, **extra_kwargs)
 
-        from agno.models.openai import OpenAIChat  # noqa: PLC0415
+        from mindroom.openai_responses_model import MindRoomOpenAIChat  # noqa: PLC0415
 
-        return OpenAIChat(id=model_id, **extra_kwargs)
+        return MindRoomOpenAIChat(id=model_id, **extra_kwargs)
 
     if canonical_provider == "azure":
         # The concrete module, not agno.models.azure: the package init wraps

--- a/src/mindroom/openai_models.py
+++ b/src/mindroom/openai_models.py
@@ -5,9 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-# The concrete module, not agno.models.azure: the package init wraps
-# this import in a try/except stub whose fallback is not a Model.
-from agno.models.azure.openai_chat import AzureOpenAI
 from agno.models.deepseek import DeepSeek
 from agno.models.llama_cpp import LlamaCpp
 from agno.models.openai import OpenAIChat, OpenAIResponses
@@ -61,7 +58,7 @@ def _messages_with_openai_tool_arguments(messages: list[Message]) -> list[Messag
     return normalized_messages
 
 
-class _ChatToolArgumentsCompat:
+class ChatToolArgumentsCompat:
     """Repair replayed tool calls before OpenAI Chat Completions formatting.
 
     Mix in ahead of an ``OpenAIChat`` subclass; ``_format_all_messages`` is the
@@ -84,32 +81,27 @@ class _ChatToolArgumentsCompat:
 
 
 @dataclass
-class MindRoomOpenAIChat(_ChatToolArgumentsCompat, OpenAIChat):
+class MindRoomOpenAIChat(ChatToolArgumentsCompat, OpenAIChat):
     """OpenAI Chat model that can replay tool calls from other providers."""
 
 
 @dataclass
-class MindRoomOpenAILike(_ChatToolArgumentsCompat, OpenAILike):
+class MindRoomOpenAILike(ChatToolArgumentsCompat, OpenAILike):
     """OpenAI-compatible endpoint model that can replay tool calls from other providers."""
 
 
 @dataclass
-class MindRoomAzureOpenAI(_ChatToolArgumentsCompat, AzureOpenAI):
-    """Azure OpenAI model that can replay tool calls from other providers."""
-
-
-@dataclass
-class MindRoomOpenRouter(_ChatToolArgumentsCompat, OpenRouter):
+class MindRoomOpenRouter(ChatToolArgumentsCompat, OpenRouter):
     """OpenRouter model that can replay tool calls from other providers."""
 
 
 @dataclass
-class MindRoomDeepSeek(_ChatToolArgumentsCompat, DeepSeek):
+class MindRoomDeepSeek(ChatToolArgumentsCompat, DeepSeek):
     """DeepSeek model that can replay tool calls from other providers."""
 
 
 @dataclass
-class MindRoomLlamaCpp(_ChatToolArgumentsCompat, LlamaCpp):
+class MindRoomLlamaCpp(ChatToolArgumentsCompat, LlamaCpp):
     """llama.cpp server model that can replay tool calls from other providers."""
 
 

--- a/src/mindroom/openai_models.py
+++ b/src/mindroom/openai_models.py
@@ -1,11 +1,18 @@
-"""OpenAI models with cross-provider tool-call replay support."""
+"""OpenAI and OpenAI-compatible models with cross-provider tool-call replay support."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+# The concrete module, not agno.models.azure: the package init wraps
+# this import in a try/except stub whose fallback is not a Model.
+from agno.models.azure.openai_chat import AzureOpenAI
+from agno.models.deepseek import DeepSeek
+from agno.models.llama_cpp import LlamaCpp
 from agno.models.openai import OpenAIChat, OpenAIResponses
+from agno.models.openai.like import OpenAILike
+from agno.models.openrouter import OpenRouter
 from openai.types.responses import ResponseOutputItemDoneEvent
 
 from mindroom.openai_tool_search import (
@@ -52,9 +59,15 @@ def _messages_with_openai_tool_arguments(messages: list[Message]) -> list[Messag
     return normalized_messages
 
 
-@dataclass
-class MindRoomOpenAIChat(OpenAIChat):
-    """OpenAI Chat model that can replay tool calls from other providers."""
+class _ChatToolArgumentsCompat:
+    """Repair replayed tool calls before OpenAI Chat Completions formatting.
+
+    Mix in ahead of an ``OpenAIChat`` subclass; ``_format_all_messages`` is the
+    single choke point for all four request paths.  Deliberately not a
+    dataclass and not an ``OpenAIChat`` subclass: either would re-apply
+    ``OpenAIChat`` field defaults over provider-specific ones (base URL, name)
+    during dataclass field collection.
+    """
 
     def _format_all_messages(
         self,
@@ -62,10 +75,40 @@ class MindRoomOpenAIChat(OpenAIChat):
         compress_tool_results: bool = False,
     ) -> list[dict[str, Any]]:
         """Supply the arguments string required by OpenAI for every tool call."""
-        return super()._format_all_messages(
+        return super()._format_all_messages(  # ty: ignore[unresolved-attribute]  # resolved by the OpenAIChat sibling base
             _messages_with_openai_tool_arguments(messages),
             compress_tool_results,
         )
+
+
+@dataclass
+class MindRoomOpenAIChat(_ChatToolArgumentsCompat, OpenAIChat):
+    """OpenAI Chat model that can replay tool calls from other providers."""
+
+
+@dataclass
+class MindRoomOpenAILike(_ChatToolArgumentsCompat, OpenAILike):
+    """OpenAI-compatible endpoint model that can replay tool calls from other providers."""
+
+
+@dataclass
+class MindRoomAzureOpenAI(_ChatToolArgumentsCompat, AzureOpenAI):
+    """Azure OpenAI model that can replay tool calls from other providers."""
+
+
+@dataclass
+class MindRoomOpenRouter(_ChatToolArgumentsCompat, OpenRouter):
+    """OpenRouter model that can replay tool calls from other providers."""
+
+
+@dataclass
+class MindRoomDeepSeek(_ChatToolArgumentsCompat, DeepSeek):
+    """DeepSeek model that can replay tool calls from other providers."""
+
+
+@dataclass
+class MindRoomLlamaCpp(_ChatToolArgumentsCompat, LlamaCpp):
+    """llama.cpp server model that can replay tool calls from other providers."""
 
 
 @dataclass

--- a/src/mindroom/openai_models.py
+++ b/src/mindroom/openai_models.py
@@ -30,6 +30,8 @@ if TYPE_CHECKING:
     from pydantic import BaseModel
 
 
+# Agno now preserves empty arguments, but existing histories retain the old shape.
+# Remove this only after migrating them or dropping support for pre-fix histories.
 def _messages_with_openai_tool_arguments(messages: list[Message]) -> list[Message]:
     """Fill arguments omitted by providers that represent empty tool input as an object."""
     normalized_messages: list[Message] = []

--- a/src/mindroom/openai_responses_model.py
+++ b/src/mindroom/openai_responses_model.py
@@ -1,11 +1,11 @@
-"""OpenAI Responses model with native deferred-tool search replay."""
+"""OpenAI models with cross-provider tool-call replay support."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from agno.models.openai import OpenAIResponses
+from agno.models.openai import OpenAIChat, OpenAIResponses
 from openai.types.responses import ResponseOutputItemDoneEvent
 
 from mindroom.openai_tool_search import (
@@ -21,6 +21,51 @@ if TYPE_CHECKING:
     from agno.tools.function import Function
     from openai.types.responses import Response, ResponseStreamEvent
     from pydantic import BaseModel
+
+
+def _messages_with_openai_tool_arguments(messages: list[Message]) -> list[Message]:
+    """Fill arguments omitted by providers that represent empty tool input as an object."""
+    normalized_messages: list[Message] = []
+    for message in messages:
+        if not message.tool_calls:
+            normalized_messages.append(message)
+            continue
+
+        changed = False
+        normalized_tool_calls: list[dict[str, Any]] = []
+        for tool_call in message.tool_calls:
+            function = tool_call["function"]
+            if "arguments" in function:
+                normalized_tool_calls.append(tool_call)
+                continue
+            normalized_tool_calls.append(
+                {
+                    **tool_call,
+                    "function": {**function, "arguments": "{}"},
+                },
+            )
+            changed = True
+
+        normalized_messages.append(
+            message.model_copy(update={"tool_calls": normalized_tool_calls}) if changed else message,
+        )
+    return normalized_messages
+
+
+@dataclass
+class MindRoomOpenAIChat(OpenAIChat):
+    """OpenAI Chat model that can replay tool calls from other providers."""
+
+    def _format_all_messages(
+        self,
+        messages: list[Message],
+        compress_tool_results: bool = False,
+    ) -> list[dict[str, Any]]:
+        """Supply the arguments string required by OpenAI for every tool call."""
+        return super()._format_all_messages(
+            _messages_with_openai_tool_arguments(messages),
+            compress_tool_results,
+        )
 
 
 @dataclass
@@ -50,6 +95,7 @@ class MindRoomOpenAIResponses(OpenAIResponses):
         tools: list[Function | dict[str, Any]] | None = None,
     ) -> list[Any]:
         """Reinsert captured tool-search items that Agno drops from history."""
+        messages = _messages_with_openai_tool_arguments(messages)
         formatted_input = super()._format_messages(messages, compress_tool_results, tools=tools)
         return formatted_input_with_tool_search_items(messages, formatted_input)
 

--- a/src/mindroom/openai_tool_search.py
+++ b/src/mindroom/openai_tool_search.py
@@ -9,7 +9,7 @@ Discovered tools load at the END of the context window (the opposite
 mechanism from Anthropic's inline tool_reference expansion, with the same
 effect), so tool discovery never invalidates the cached prompt prefix.
 
-:class:`~mindroom.openai_responses_model.MindRoomOpenAIResponses` owns the wire
+:class:`~mindroom.openai_models.MindRoomOpenAIResponses` owns the wire
 seams and calls into this module: :func:`request_params_with_deferred_tool_search` tags the
 registered tools and injects the search entry with a deterministic order
 (search tool, then non-deferred tools, then deferred sorted by name) so the
@@ -78,7 +78,7 @@ def install_openai_deferred_tool_search(model: object, *, deferred_tool_names: f
     """Register wire tool names for OpenAI server-side tool search on one model.
 
     Every request built by
-    :class:`~mindroom.openai_responses_model.MindRoomOpenAIResponses` sends the
+    :class:`~mindroom.openai_models.MindRoomOpenAIResponses` sends the
     named tools with ``defer_loading: true`` plus the hosted
     ``tool_search`` entry, so their schemas stay out of the rendered context
     and tool discovery never invalidates the prompt cache. No-op for

--- a/tach.toml
+++ b/tach.toml
@@ -299,7 +299,7 @@ depends_on = [
     "mindroom.claude_prompt_cache",
     "mindroom.claude_stream_retry",
     "mindroom.codex_model",
-    "mindroom.openai_responses_model",
+    "mindroom.openai_models",
     "mindroom.openai_tool_search",
     "mindroom.vertex_claude_compat",
 ]

--- a/tach.toml
+++ b/tach.toml
@@ -296,6 +296,7 @@ depends_on = [
     "mindroom.llm_request_logging",
     "mindroom.logging_config",
     "mindroom.tool_system.dependencies",
+    "mindroom.azure_openai_model",
     "mindroom.claude_prompt_cache",
     "mindroom.claude_stream_retry",
     "mindroom.codex_model",

--- a/tests/test_codex_model.py
+++ b/tests/test_codex_model.py
@@ -33,7 +33,7 @@ from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
 from mindroom.constants import resolve_runtime_paths
 from mindroom.model_loading import get_model_instance
-from mindroom.openai_responses_model import MindRoomOpenAIResponses
+from mindroom.openai_responses_model import MindRoomOpenAIChat, MindRoomOpenAIResponses
 from mindroom.openai_tool_search import (
     _DEFERRED_TOOL_NAMES_ATTR,
     install_openai_deferred_tool_search,
@@ -685,6 +685,44 @@ def test_tool_search_items_replay_to_non_openai_provider_without_crashing() -> N
 
     claude_wire, _system = claude_format_messages([assistant])
     assert claude_wire[0]["role"] == "assistant"
+
+
+def test_openai_chat_supplies_missing_tool_arguments_without_mutating_history() -> None:
+    """Chat Completions replay must repair zero-argument calls from another provider."""
+    assistant = Message(
+        role="assistant",
+        tool_calls=[
+            {
+                "id": "toolu_1",
+                "type": "function",
+                "function": {"name": "get_status"},
+            },
+        ],
+    )
+
+    formatted = MindRoomOpenAIChat(id="gpt-5.6", api_key="test-key")._format_all_messages([assistant])
+
+    assert formatted[0]["tool_calls"][0]["function"]["arguments"] == "{}"
+    assert "arguments" not in assistant.tool_calls[0]["function"]
+
+
+def test_openai_responses_supplies_missing_tool_arguments_without_mutating_history() -> None:
+    """Responses replay must repair zero-argument calls from another provider."""
+    assistant = Message(
+        role="assistant",
+        tool_calls=[
+            {
+                "id": "toolu_1",
+                "type": "function",
+                "function": {"name": "get_status"},
+            },
+        ],
+    )
+
+    formatted = MindRoomOpenAIResponses(id="gpt-5.6", api_key="test-key")._format_messages([assistant])
+
+    assert formatted[0]["arguments"] == "{}"
+    assert "arguments" not in assistant.tool_calls[0]["function"]
 
 
 def test_claude_server_tool_history_replays_to_codex_without_injection() -> None:

--- a/tests/test_codex_model.py
+++ b/tests/test_codex_model.py
@@ -33,7 +33,7 @@ from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
 from mindroom.constants import resolve_runtime_paths
 from mindroom.model_loading import get_model_instance
-from mindroom.openai_responses_model import MindRoomOpenAIChat, MindRoomOpenAIResponses
+from mindroom.openai_models import MindRoomOpenAIResponses
 from mindroom.openai_tool_search import (
     _DEFERRED_TOOL_NAMES_ATTR,
     install_openai_deferred_tool_search,
@@ -685,44 +685,6 @@ def test_tool_search_items_replay_to_non_openai_provider_without_crashing() -> N
 
     claude_wire, _system = claude_format_messages([assistant])
     assert claude_wire[0]["role"] == "assistant"
-
-
-def test_openai_chat_supplies_missing_tool_arguments_without_mutating_history() -> None:
-    """Chat Completions replay must repair zero-argument calls from another provider."""
-    assistant = Message(
-        role="assistant",
-        tool_calls=[
-            {
-                "id": "toolu_1",
-                "type": "function",
-                "function": {"name": "get_status"},
-            },
-        ],
-    )
-
-    formatted = MindRoomOpenAIChat(id="gpt-5.6", api_key="test-key")._format_all_messages([assistant])
-
-    assert formatted[0]["tool_calls"][0]["function"]["arguments"] == "{}"
-    assert "arguments" not in assistant.tool_calls[0]["function"]
-
-
-def test_openai_responses_supplies_missing_tool_arguments_without_mutating_history() -> None:
-    """Responses replay must repair zero-argument calls from another provider."""
-    assistant = Message(
-        role="assistant",
-        tool_calls=[
-            {
-                "id": "toolu_1",
-                "type": "function",
-                "function": {"name": "get_status"},
-            },
-        ],
-    )
-
-    formatted = MindRoomOpenAIResponses(id="gpt-5.6", api_key="test-key")._format_messages([assistant])
-
-    assert formatted[0]["arguments"] == "{}"
-    assert "arguments" not in assistant.tool_calls[0]["function"]
 
 
 def test_claude_server_tool_history_replays_to_codex_without_injection() -> None:

--- a/tests/test_import_graph.py
+++ b/tests/test_import_graph.py
@@ -209,6 +209,12 @@ def test_primary_runtime_does_not_import_provider_sdks() -> None:
     _assert_probe_clean("mindroom.orchestrator", _PROVIDER_SDK_ROOTS)
 
 
+def test_openai_wire_models_import_only_the_openai_sdk() -> None:
+    """Agno's azure package init pulls the anthropic SDK; only the azure branch should pay that."""
+    non_openai_roots = tuple(root for root in _PROVIDER_SDK_ROOTS if root != "openai")
+    _assert_probe_clean("mindroom.openai_models", non_openai_roots)
+
+
 def test_builtin_tool_manifest_does_not_import_runtime_catalog() -> None:
     """Built-in registration may write registry state without loading catalog behavior."""
     _assert_probe_clean(

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
-from agno.models.openai import OpenAIChat
-
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
 from mindroom.model_loading import get_model_instance
@@ -41,8 +39,6 @@ def test_first_party_openai_gpt_5_4_and_newer_use_responses(tmp_path: Path) -> N
     assert isinstance(current, MindRoomOpenAIResponses)
     assert isinstance(older, MindRoomOpenAIChat)
     assert isinstance(compatible, MindRoomOpenAIChat)
-    assert isinstance(older, OpenAIChat)
-    assert isinstance(compatible, OpenAIChat)
 
 
 def test_vertexai_claude_gets_explicit_timeout_so_large_outputs_can_run_non_streaming(tmp_path: Path) -> None:

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
+from mindroom.azure_openai_model import MindRoomAzureOpenAI
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
 from mindroom.model_loading import get_model_instance
 from mindroom.openai_models import (
-    MindRoomAzureOpenAI,
     MindRoomDeepSeek,
     MindRoomLlamaCpp,
     MindRoomOpenAIChat,

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -8,7 +8,15 @@ from unittest.mock import patch
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
 from mindroom.model_loading import get_model_instance
-from mindroom.openai_responses_model import MindRoomOpenAIChat, MindRoomOpenAIResponses
+from mindroom.openai_models import (
+    MindRoomAzureOpenAI,
+    MindRoomDeepSeek,
+    MindRoomLlamaCpp,
+    MindRoomOpenAIChat,
+    MindRoomOpenAILike,
+    MindRoomOpenAIResponses,
+    MindRoomOpenRouter,
+)
 from tests.conftest import bind_runtime_paths, runtime_paths_for, test_runtime_paths
 
 if TYPE_CHECKING:
@@ -39,6 +47,30 @@ def test_first_party_openai_gpt_5_4_and_newer_use_responses(tmp_path: Path) -> N
     assert isinstance(current, MindRoomOpenAIResponses)
     assert isinstance(older, MindRoomOpenAIChat)
     assert isinstance(compatible, MindRoomOpenAIChat)
+
+
+def test_openai_wire_providers_use_replay_compatible_models(tmp_path: Path) -> None:
+    """Every OpenAI-wire chat provider must use the tool-call replay-compatible subclass."""
+    expected = {
+        "azure": MindRoomAzureOpenAI,
+        "openrouter": MindRoomOpenRouter,
+        "zai": MindRoomOpenAILike,
+        "deepseek": MindRoomDeepSeek,
+        "llama_cpp": MindRoomLlamaCpp,
+    }
+    config = bind_runtime_paths(
+        Config(
+            models={
+                provider: ModelConfig(provider=provider, id="some-model", extra_kwargs={"api_key": "dummy-key"})
+                for provider in expected
+            },
+        ),
+        test_runtime_paths(tmp_path),
+    )
+
+    for provider, model_cls in expected.items():
+        model = get_model_instance(config, runtime_paths_for(config), provider)
+        assert isinstance(model, model_cls), provider
 
 
 def test_vertexai_claude_gets_explicit_timeout_so_large_outputs_can_run_non_streaming(tmp_path: Path) -> None:

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -10,7 +10,7 @@ from agno.models.openai import OpenAIChat
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
 from mindroom.model_loading import get_model_instance
-from mindroom.openai_responses_model import MindRoomOpenAIResponses
+from mindroom.openai_responses_model import MindRoomOpenAIChat, MindRoomOpenAIResponses
 from tests.conftest import bind_runtime_paths, runtime_paths_for, test_runtime_paths
 
 if TYPE_CHECKING:
@@ -39,6 +39,8 @@ def test_first_party_openai_gpt_5_4_and_newer_use_responses(tmp_path: Path) -> N
     compatible = get_model_instance(config, runtime_paths_for(config), "compatible")
 
     assert isinstance(current, MindRoomOpenAIResponses)
+    assert isinstance(older, MindRoomOpenAIChat)
+    assert isinstance(compatible, MindRoomOpenAIChat)
     assert isinstance(older, OpenAIChat)
     assert isinstance(compatible, OpenAIChat)
 

--- a/tests/test_openai_models.py
+++ b/tests/test_openai_models.py
@@ -1,0 +1,87 @@
+"""Tests for MindRoom's OpenAI-wire model subclasses."""
+
+from __future__ import annotations
+
+import pytest
+from agno.models.azure.openai_chat import AzureOpenAI
+from agno.models.deepseek import DeepSeek
+from agno.models.llama_cpp import LlamaCpp
+from agno.models.message import Message
+from agno.models.openai import OpenAIChat
+from agno.models.openai.like import OpenAILike
+from agno.models.openrouter import OpenRouter
+
+from mindroom.openai_models import (
+    MindRoomAzureOpenAI,
+    MindRoomDeepSeek,
+    MindRoomLlamaCpp,
+    MindRoomOpenAIChat,
+    MindRoomOpenAILike,
+    MindRoomOpenAIResponses,
+    MindRoomOpenRouter,
+)
+
+_CHAT_WIRE_PAIRS = [
+    (MindRoomOpenAIChat, OpenAIChat),
+    (MindRoomOpenAILike, OpenAILike),
+    (MindRoomAzureOpenAI, AzureOpenAI),
+    (MindRoomOpenRouter, OpenRouter),
+    (MindRoomDeepSeek, DeepSeek),
+    (MindRoomLlamaCpp, LlamaCpp),
+]
+
+
+def _assistant_with_argumentless_tool_call() -> Message:
+    """Anthropic saves zero-argument tool calls without a function.arguments field."""
+    return Message(
+        role="assistant",
+        tool_calls=[
+            {
+                "id": "toolu_1",
+                "type": "function",
+                "function": {"name": "get_status"},
+            },
+        ],
+    )
+
+
+@pytest.mark.parametrize(("model_cls", "_agno_cls"), _CHAT_WIRE_PAIRS)
+def test_chat_models_supply_missing_tool_arguments_without_mutating_history(
+    model_cls: type[OpenAIChat],
+    _agno_cls: type[OpenAIChat],
+) -> None:
+    """Chat Completions replay must repair zero-argument calls from another provider."""
+    assistant = _assistant_with_argumentless_tool_call()
+
+    formatted = model_cls(id="gpt-5.6", api_key="test-key")._format_all_messages([assistant])
+
+    assert formatted[0]["tool_calls"][0]["function"]["arguments"] == "{}"
+    assert "arguments" not in assistant.tool_calls[0]["function"]
+
+
+@pytest.mark.parametrize(("model_cls", "agno_cls"), _CHAT_WIRE_PAIRS)
+def test_chat_models_preserve_provider_dataclass_defaults(
+    model_cls: type[OpenAIChat],
+    agno_cls: type[OpenAIChat],
+) -> None:
+    """The compat mixin must not re-apply OpenAIChat defaults over provider-specific ones."""
+    ours = model_cls(api_key="test-key")
+    theirs = agno_cls(api_key="test-key")
+
+    assert (ours.id, ours.name, ours.provider, ours.base_url, ours.max_tokens) == (
+        theirs.id,
+        theirs.name,
+        theirs.provider,
+        theirs.base_url,
+        theirs.max_tokens,
+    )
+
+
+def test_openai_responses_supplies_missing_tool_arguments_without_mutating_history() -> None:
+    """Responses replay must repair zero-argument calls from another provider."""
+    assistant = _assistant_with_argumentless_tool_call()
+
+    formatted = MindRoomOpenAIResponses(id="gpt-5.6", api_key="test-key")._format_messages([assistant])
+
+    assert formatted[0]["arguments"] == "{}"
+    assert "arguments" not in assistant.tool_calls[0]["function"]

--- a/tests/test_openai_models.py
+++ b/tests/test_openai_models.py
@@ -11,8 +11,8 @@ from agno.models.openai import OpenAIChat
 from agno.models.openai.like import OpenAILike
 from agno.models.openrouter import OpenRouter
 
+from mindroom.azure_openai_model import MindRoomAzureOpenAI
 from mindroom.openai_models import (
-    MindRoomAzureOpenAI,
     MindRoomDeepSeek,
     MindRoomLlamaCpp,
     MindRoomOpenAIChat,


### PR DESCRIPTION
## Why

Conversations can switch between model providers. Some saved tool calls represent an empty input without an `arguments` field, while the OpenAI wire format requires that field even when the tool takes no arguments. Replaying that history through an OpenAI-wire model therefore fails before generation starts.

## What changed

Request formatting now fills only missing tool-call arguments with `"{}"`, without mutating saved messages.

The repair covers every OpenAI-wire path built by `model_loading`:
- `openai` via `MindRoomOpenAIChat` (Chat Completions, including custom `base_url` compatible endpoints) and `MindRoomOpenAIResponses` (Responses API, which `CodexResponses` also inherits).
- `openrouter`, `zai`, `deepseek`, and `llama_cpp` via new subclasses sharing a `ChatToolArgumentsCompat` mixin at the `_format_all_messages` choke point.
- `azure` via `MindRoomAzureOpenAI` in its own lazily imported `azure_openai_model.py`: importing `agno.models.azure.openai_chat` runs the `agno.models.azure` package init, which pulls in the anthropic SDK (~290 ms) — only the azure branch should pay that. A new `test_import_graph` guard pins that `mindroom.openai_models` loads no provider SDK other than `openai`.

`openai_responses_model.py` is renamed to `openai_models.py` since it now owns every MindRoom OpenAI-wire model class; the replay tests live in a matching `tests/test_openai_models.py`, parametrized across all wire classes plus a guard that provider dataclass defaults (base URL, name) survive the mixin.

`cerebras` and `groq` are untouched: they use their own SDK formatters outside the `OpenAIChat` hierarchy.

## Removal condition

Agno now preserves empty arguments for new histories, but it does not rewrite histories already saved in the incomplete shape. Keep this compatibility layer until pre-fix histories are migrated or explicitly no longer supported.