### PR TITLE
Export Google Drive files into agent workspaces

### DIFF
--- a/docs/tools/data-and-databases.md
+++ b/docs/tools/data-and-databases.md
@@ -21,7 +21,7 @@ Use these tools when you need database access, dataframe-style analysis, Google 
 - [`csv`] - Pre-registered CSV reading and DuckDB-backed SQL queries over CSV files.
 - [`pandas`] - In-memory dataframe creation and dataframe method execution.
 - [`google_bigquery`] - BigQuery dataset inspection and SQL queries.
-- [`google_drive`] - Google Drive file listing, metadata search, and file reading through the per-service Google Drive OAuth provider.
+- [`google_drive`] - Google Drive file listing, metadata search, file reading, and workspace downloads through the per-service Google Drive OAuth provider.
 - [`google_sheets`] - Google Sheets access through the per-service Google Sheets OAuth provider, with read support verified by default and create/update support when enabled.
 - [`openbb`] - Stock prices, company search, news, profiles, and price targets through OpenBB.
 - [`yfinance`] - Yahoo Finance market data, fundamentals, news, and history.
@@ -441,14 +441,16 @@ run_sql_query("SELECT event_name, COUNT(*) AS total FROM events GROUP BY 1 ORDER
 
 ## [`google_drive`]
 
-`google_drive` is the Google Drive toolkit for listing, searching, and reading files from the connected user's Drive account.
+`google_drive` is the Google Drive toolkit for listing, searching, reading, and downloading files from the connected user's Drive account.
 
 ### What It Does
 
-MindRoom exposes `google_drive_list_files()`, `google_drive_search_files()`, and `google_drive_read_file()` through the Google Drive OAuth provider.
+MindRoom exposes `google_drive_list_files()`, `google_drive_search_files()`, `google_drive_read_file()`, and (when enabled) `google_drive_download_file()` through the Google Drive OAuth provider.
 `google_drive_list_files()` returns recent Drive files visible to the connected account.
 `google_drive_search_files()` searches Drive metadata.
 `google_drive_read_file()` reads Google Workspace files and non-Google files up to the configured `max_read_size`.
+`google_drive_download_file()` downloads a Drive file, exporting Google Workspace files to their best native format, for example a complete Google Sheets workbook as `.xlsx`.
+Downloads always land in the `google-drive-downloads/` directory inside the agent workspace, so the destination cannot be redirected elsewhere.
 When no usable MindRoom OAuth credentials exist, the wrapper raises `OAuthConnectionRequired` instead of falling back to a local token flow.
 
 ### Configuration
@@ -458,6 +460,7 @@ When no usable MindRoom OAuth credentials exist, the wrapper raises `OAuthConnec
 | `list_files` | `boolean` | `no` | `true` | Enable recent file listing. |
 | `search_files` | `boolean` | `no` | `true` | Enable Drive metadata search. |
 | `read_file` | `boolean` | `no` | `true` | Enable file content reads. |
+| `download_file` | `boolean` | `no` | `false` | Enable file downloads and Workspace exports into the agent workspace. |
 | `max_read_size` | `number` | `no` | `10485760` | Maximum non-Google-Workspace file size to read in bytes. |
 
 ### Example
@@ -467,6 +470,7 @@ agents:
   assistant:
     tools:
       - google_drive:
+          download_file: true
           max_read_size: 10485760
 ```
 
@@ -474,11 +478,13 @@ agents:
 google_drive_list_files()
 google_drive_search_files("name contains 'budget'")
 google_drive_read_file("1AbCdEfGhIjKlMnOpQrStUvWxYz")
+google_drive_download_file("1AbCdEfGhIjKlMnOpQrStUvWxYz")
 ```
 
 ### Notes
 
 - `google_drive` uses the per-service `google_drive` OAuth provider and always runs in the primary MindRoom runtime.
+- Downloads require an agent workspace; when the agent has none (for example the default `mem0` memory backend without a `private` workspace), `download_file` is ignored and a warning is logged.
 - The provider requests Drive read-only access plus OpenID email/profile scopes.
 - Configure Google OAuth through [Google Services OAuth (Admin Setup)](../deployment/google-services-oauth.md) or [Google Services OAuth (Individual Setup)](../deployment/google-services-user-oauth.md).
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -3756,7 +3756,7 @@ Use these tools when you need database access, dataframe-style analysis, Google 
 - [`csv`] - Pre-registered CSV reading and DuckDB-backed SQL queries over CSV files.
 - [`pandas`] - In-memory dataframe creation and dataframe method execution.
 - [`google_bigquery`] - BigQuery dataset inspection and SQL queries.
-- [`google_drive`] - Google Drive file listing, metadata search, and file reading through the per-service Google Drive OAuth provider.
+- [`google_drive`] - Google Drive file listing, metadata search, file reading, and workspace downloads through the per-service Google Drive OAuth provider.
 - [`google_sheets`] - Google Sheets access through the per-service Google Sheets OAuth provider, with read support verified by default and create/update support when enabled.
 - [`openbb`] - Stock prices, company search, news, profiles, and price targets through OpenBB.
 - [`yfinance`] - Yahoo Finance market data, fundamentals, news, and history.
@@ -4176,14 +4176,16 @@ run_sql_query("SELECT event_name, COUNT(*) AS total FROM events GROUP BY 1 ORDER
 
 ## [`google_drive`]
 
-`google_drive` is the Google Drive toolkit for listing, searching, and reading files from the connected user's Drive account.
+`google_drive` is the Google Drive toolkit for listing, searching, reading, and downloading files from the connected user's Drive account.
 
 ### What It Does
 
-MindRoom exposes `google_drive_list_files()`, `google_drive_search_files()`, and `google_drive_read_file()` through the Google Drive OAuth provider.
+MindRoom exposes `google_drive_list_files()`, `google_drive_search_files()`, `google_drive_read_file()`, and (when enabled) `google_drive_download_file()` through the Google Drive OAuth provider.
 `google_drive_list_files()` returns recent Drive files visible to the connected account.
 `google_drive_search_files()` searches Drive metadata.
 `google_drive_read_file()` reads Google Workspace files and non-Google files up to the configured `max_read_size`.
+`google_drive_download_file()` downloads a Drive file, exporting Google Workspace files to their best native format, for example a complete Google Sheets workbook as `.xlsx`.
+Downloads always land in the `google-drive-downloads/` directory inside the agent workspace, so the destination cannot be redirected elsewhere.
 When no usable MindRoom OAuth credentials exist, the wrapper raises `OAuthConnectionRequired` instead of falling back to a local token flow.
 
 ### Configuration
@@ -4193,6 +4195,7 @@ When no usable MindRoom OAuth credentials exist, the wrapper raises `OAuthConnec
 | `list_files` | `boolean` | `no` | `true` | Enable recent file listing. |
 | `search_files` | `boolean` | `no` | `true` | Enable Drive metadata search. |
 | `read_file` | `boolean` | `no` | `true` | Enable file content reads. |
+| `download_file` | `boolean` | `no` | `false` | Enable file downloads and Workspace exports into the agent workspace. |
 | `max_read_size` | `number` | `no` | `10485760` | Maximum non-Google-Workspace file size to read in bytes. |
 
 ### Example
@@ -4202,6 +4205,7 @@ agents:
   assistant:
     tools:
       - google_drive:
+          download_file: true
           max_read_size: 10485760
 ```
 
@@ -4209,11 +4213,13 @@ agents:
 google_drive_list_files()
 google_drive_search_files("name contains 'budget'")
 google_drive_read_file("1AbCdEfGhIjKlMnOpQrStUvWxYz")
+google_drive_download_file("1AbCdEfGhIjKlMnOpQrStUvWxYz")
 ```
 
 ### Notes
 
 - `google_drive` uses the per-service `google_drive` OAuth provider and always runs in the primary MindRoom runtime.
+- Downloads require an agent workspace; when the agent has none (for example the default `mem0` memory backend without a `private` workspace), `download_file` is ignored and a warning is logged.
 - The provider requests Drive read-only access plus OpenID email/profile scopes.
 - Configure Google OAuth through [Google Services OAuth (Admin Setup)](https://docs.mindroom.chat/deployment/google-services-oauth/) or [Google Services OAuth (Individual Setup)](https://docs.mindroom.chat/deployment/google-services-user-oauth/).
 

--- a/skills/mindroom-docs/references/page__tools__data-and-databases__index.md
+++ b/skills/mindroom-docs/references/page__tools__data-and-databases__index.md
@@ -17,7 +17,7 @@ Use these tools when you need database access, dataframe-style analysis, Google 
 - [`csv`] - Pre-registered CSV reading and DuckDB-backed SQL queries over CSV files.
 - [`pandas`] - In-memory dataframe creation and dataframe method execution.
 - [`google_bigquery`] - BigQuery dataset inspection and SQL queries.
-- [`google_drive`] - Google Drive file listing, metadata search, and file reading through the per-service Google Drive OAuth provider.
+- [`google_drive`] - Google Drive file listing, metadata search, file reading, and workspace downloads through the per-service Google Drive OAuth provider.
 - [`google_sheets`] - Google Sheets access through the per-service Google Sheets OAuth provider, with read support verified by default and create/update support when enabled.
 - [`openbb`] - Stock prices, company search, news, profiles, and price targets through OpenBB.
 - [`yfinance`] - Yahoo Finance market data, fundamentals, news, and history.
@@ -437,14 +437,16 @@ run_sql_query("SELECT event_name, COUNT(*) AS total FROM events GROUP BY 1 ORDER
 
 ## [`google_drive`]
 
-`google_drive` is the Google Drive toolkit for listing, searching, and reading files from the connected user's Drive account.
+`google_drive` is the Google Drive toolkit for listing, searching, reading, and downloading files from the connected user's Drive account.
 
 ### What It Does
 
-MindRoom exposes `google_drive_list_files()`, `google_drive_search_files()`, and `google_drive_read_file()` through the Google Drive OAuth provider.
+MindRoom exposes `google_drive_list_files()`, `google_drive_search_files()`, `google_drive_read_file()`, and (when enabled) `google_drive_download_file()` through the Google Drive OAuth provider.
 `google_drive_list_files()` returns recent Drive files visible to the connected account.
 `google_drive_search_files()` searches Drive metadata.
 `google_drive_read_file()` reads Google Workspace files and non-Google files up to the configured `max_read_size`.
+`google_drive_download_file()` downloads a Drive file, exporting Google Workspace files to their best native format, for example a complete Google Sheets workbook as `.xlsx`.
+Downloads always land in the `google-drive-downloads/` directory inside the agent workspace, so the destination cannot be redirected elsewhere.
 When no usable MindRoom OAuth credentials exist, the wrapper raises `OAuthConnectionRequired` instead of falling back to a local token flow.
 
 ### Configuration
@@ -454,6 +456,7 @@ When no usable MindRoom OAuth credentials exist, the wrapper raises `OAuthConnec
 | `list_files` | `boolean` | `no` | `true` | Enable recent file listing. |
 | `search_files` | `boolean` | `no` | `true` | Enable Drive metadata search. |
 | `read_file` | `boolean` | `no` | `true` | Enable file content reads. |
+| `download_file` | `boolean` | `no` | `false` | Enable file downloads and Workspace exports into the agent workspace. |
 | `max_read_size` | `number` | `no` | `10485760` | Maximum non-Google-Workspace file size to read in bytes. |
 
 ### Example
@@ -463,6 +466,7 @@ agents:
   assistant:
     tools:
       - google_drive:
+          download_file: true
           max_read_size: 10485760
 ```
 
@@ -470,11 +474,13 @@ agents:
 google_drive_list_files()
 google_drive_search_files("name contains 'budget'")
 google_drive_read_file("1AbCdEfGhIjKlMnOpQrStUvWxYz")
+google_drive_download_file("1AbCdEfGhIjKlMnOpQrStUvWxYz")
 ```
 
 ### Notes
 
 - `google_drive` uses the per-service `google_drive` OAuth provider and always runs in the primary MindRoom runtime.
+- Downloads require an agent workspace; when the agent has none (for example the default `mem0` memory backend without a `private` workspace), `download_file` is ignored and a warning is logged.
 - The provider requests Drive read-only access plus OpenID email/profile scopes.
 - Configure Google OAuth through [Google Services OAuth (Admin Setup)](https://docs.mindroom.chat/deployment/google-services-oauth/) or [Google Services OAuth (Individual Setup)](https://docs.mindroom.chat/deployment/google-services-user-oauth/).
 

--- a/src/mindroom/custom_tools/google_drive.py
+++ b/src/mindroom/custom_tools/google_drive.py
@@ -97,11 +97,12 @@ class GoogleDriveTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, Ag
                 kwargs.pop("max_read_size")
             else:
                 kwargs["max_read_size"] = max_read_size
-        if kwargs.get("download_file") is True:
+        if kwargs.get("download_file"):
             if tool_output_workspace_root is None:
-                msg = "Google Drive downloads require an agent workspace"
-                raise RuntimeError(msg)
-            kwargs["download_dir"] = tool_output_workspace_root / "google-drive-downloads"
+                logger.warning("Google Drive downloads are disabled because this agent has no workspace")
+                kwargs["download_file"] = False
+            else:
+                kwargs["download_dir"] = tool_output_workspace_root / "google-drive-downloads"
         self._runtime_paths = runtime_paths
         self._creds_manager = credentials_manager
         defer_to_original_auth = self._apply_runtime_original_auth_kwargs(kwargs)

--- a/src/mindroom/custom_tools/google_drive.py
+++ b/src/mindroom/custom_tools/google_drive.py
@@ -101,7 +101,7 @@ class GoogleDriveTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, Ag
             if tool_output_workspace_root is None:
                 msg = "Google Drive downloads require an agent workspace"
                 raise RuntimeError(msg)
-            kwargs["download_dir"] = tool_output_workspace_root
+            kwargs["download_dir"] = tool_output_workspace_root / "google-drive-downloads"
         self._runtime_paths = runtime_paths
         self._creds_manager = credentials_manager
         defer_to_original_auth = self._apply_runtime_original_auth_kwargs(kwargs)

--- a/src/mindroom/custom_tools/google_drive.py
+++ b/src/mindroom/custom_tools/google_drive.py
@@ -97,8 +97,7 @@ class GoogleDriveTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, Ag
                 kwargs.pop("max_read_size")
             else:
                 kwargs["max_read_size"] = max_read_size
-        self._download_function_enabled = kwargs.get("download_file") is True
-        if self._download_function_enabled:
+        if kwargs.get("download_file") is True:
             if tool_output_workspace_root is None:
                 msg = "Google Drive downloads require an agent workspace"
                 raise RuntimeError(msg)
@@ -133,7 +132,7 @@ class GoogleDriveTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, Ag
         return google_service_account_configured(self.service_account_path, self._runtime_paths)
 
     def _download_guidance(self) -> str:
-        if self._download_function_enabled:
+        if "google_drive_download_file" in self.functions:
             return " Use google_drive_download_file instead."
         return ""
 

--- a/src/mindroom/custom_tools/google_drive.py
+++ b/src/mindroom/custom_tools/google_drive.py
@@ -189,7 +189,10 @@ class GoogleDriveTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, Ag
                 export_mime = self.TEXT_EXPORT_TYPES[mime_type]
             elif mime_type.startswith(WorkspaceType.WORKSPACE_PREFIX):
                 return json.dumps(
-                    {"error": f"Cannot read {mime_type} as text. Use download_file instead.", "file": metadata},
+                    {
+                        "error": f"Cannot read {mime_type} as text. Use google_drive_download_file instead.",
+                        "file": metadata,
+                    },
                 )
             else:
                 export_mime = None
@@ -202,7 +205,8 @@ class GoogleDriveTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, Ag
                 if file_size > self.max_read_size:
                     return json.dumps(
                         {
-                            "error": f"File is {file_size} bytes, exceeds max_read_size ({self.max_read_size}). Use download_file instead.",
+                            "error": f"File is {file_size} bytes, exceeds max_read_size ({self.max_read_size}). "
+                            "Use google_drive_download_file instead.",
                             "file": metadata,
                         },
                     )

--- a/src/mindroom/custom_tools/google_drive.py
+++ b/src/mindroom/custom_tools/google_drive.py
@@ -30,6 +30,7 @@ _MODEL_FUNCTION_NAME_ALIASES = {
     "list_files": "google_drive_list_files",
     "search_files": "google_drive_search_files",
     "read_file": "google_drive_read_file",
+    "download_file": "google_drive_download_file",
 }
 
 
@@ -83,6 +84,7 @@ class GoogleDriveTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, Ag
         runtime_paths: RuntimePaths,
         credentials_manager: CredentialsManager | None = None,
         worker_target: ResolvedWorkerTarget | None = None,
+        tool_output_workspace_root: Path | None = None,
         **kwargs: Any,  # noqa: ANN401
     ) -> None:
         provided_creds = kwargs.pop("creds", None)
@@ -95,6 +97,11 @@ class GoogleDriveTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, Ag
                 kwargs.pop("max_read_size")
             else:
                 kwargs["max_read_size"] = max_read_size
+        if kwargs.get("download_file") is True:
+            if tool_output_workspace_root is None:
+                msg = "Google Drive downloads require an agent workspace"
+                raise RuntimeError(msg)
+            kwargs["download_dir"] = tool_output_workspace_root
         self._runtime_paths = runtime_paths
         self._creds_manager = credentials_manager
         defer_to_original_auth = self._apply_runtime_original_auth_kwargs(kwargs)

--- a/src/mindroom/custom_tools/google_drive.py
+++ b/src/mindroom/custom_tools/google_drive.py
@@ -97,7 +97,8 @@ class GoogleDriveTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, Ag
                 kwargs.pop("max_read_size")
             else:
                 kwargs["max_read_size"] = max_read_size
-        if kwargs.get("download_file") is True:
+        self._download_function_enabled = kwargs.get("download_file") is True
+        if self._download_function_enabled:
             if tool_output_workspace_root is None:
                 msg = "Google Drive downloads require an agent workspace"
                 raise RuntimeError(msg)
@@ -130,6 +131,11 @@ class GoogleDriveTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, Ag
 
     def _should_fallback_to_original_auth(self) -> bool:
         return google_service_account_configured(self.service_account_path, self._runtime_paths)
+
+    def _download_guidance(self) -> str:
+        if self._download_function_enabled:
+            return " Use google_drive_download_file instead."
+        return ""
 
     def _get_file_metadata(self, file_id: str, fields: str) -> dict[str, Any]:
         service = cast("Any", self.service)
@@ -190,7 +196,7 @@ class GoogleDriveTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, Ag
             elif mime_type.startswith(WorkspaceType.WORKSPACE_PREFIX):
                 return json.dumps(
                     {
-                        "error": f"Cannot read {mime_type} as text. Use google_drive_download_file instead.",
+                        "error": f"Cannot read {mime_type} as text.{self._download_guidance()}",
                         "file": metadata,
                     },
                 )
@@ -205,8 +211,8 @@ class GoogleDriveTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, Ag
                 if file_size > self.max_read_size:
                     return json.dumps(
                         {
-                            "error": f"File is {file_size} bytes, exceeds max_read_size ({self.max_read_size}). "
-                            "Use google_drive_download_file instead.",
+                            "error": f"File is {file_size} bytes, exceeds max_read_size ({self.max_read_size})."
+                            f"{self._download_guidance()}",
                             "file": metadata,
                         },
                     )

--- a/src/mindroom/tools/google_drive.py
+++ b/src/mindroom/tools/google_drive.py
@@ -53,6 +53,14 @@ if TYPE_CHECKING:
             description="Allow reading Google Drive file contents.",
         ),
         ConfigField(
+            name="download_file",
+            label="Download Files",
+            type="boolean",
+            required=False,
+            default=False,
+            description="Allow downloading or exporting Google Drive files.",
+        ),
+        ConfigField(
             name="max_read_size",
             label="Max Read Size",
             type="number",
@@ -65,6 +73,7 @@ if TYPE_CHECKING:
         ToolManagedInitArg.RUNTIME_PATHS,
         ToolManagedInitArg.CREDENTIALS_MANAGER,
         ToolManagedInitArg.WORKER_TARGET,
+        ToolManagedInitArg.TOOL_OUTPUT_WORKSPACE_ROOT,
     ),
     dependencies=[
         "google-api-python-client",
@@ -77,6 +86,7 @@ if TYPE_CHECKING:
         "google_drive_list_files",
         "google_drive_search_files",
         "google_drive_read_file",
+        "google_drive_download_file",
     ),
 )
 def google_drive_tools() -> type[GoogleDriveTools]:

--- a/src/mindroom/tools_metadata.json
+++ b/src/mindroom/tools_metadata.json
@@ -7901,6 +7901,18 @@
         },
         {
           "authored_override": true,
+          "default": false,
+          "description": "Allow downloading or exporting Google Drive files.",
+          "label": "Download Files",
+          "name": "download_file",
+          "options": null,
+          "placeholder": null,
+          "required": false,
+          "type": "boolean",
+          "validation": null
+        },
+        {
+          "authored_override": true,
           "default": 10485760,
           "description": "Maximum non-Google-Workspace file size to read in bytes.",
           "label": "Max Read Size",
@@ -7926,7 +7938,8 @@
       "function_names": [
         "google_drive_list_files",
         "google_drive_search_files",
-        "google_drive_read_file"
+        "google_drive_read_file",
+        "google_drive_download_file"
       ],
       "helper_text": null,
       "icon": "SiGoogledrive",

--- a/tests/test_google_drive_oauth_tool.py
+++ b/tests/test_google_drive_oauth_tool.py
@@ -8,8 +8,8 @@ import json
 from collections.abc import AsyncIterator, Iterator
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-import pytest
 from agno.agent import Agent
 from agno.agent._tools import parse_tools
 from agno.models.base import Model
@@ -23,6 +23,9 @@ from mindroom.custom_tools.google_drive import GoogleDriveTools
 from mindroom.oauth.google_drive import _GOOGLE_DRIVE_OAUTH_SCOPES
 from mindroom.tool_system.metadata import get_tool_by_name
 from mindroom.tool_system.worker_routing import ToolExecutionIdentity, resolve_worker_target
+
+if TYPE_CHECKING:
+    import pytest
 
 
 class MinimalModel(Model):
@@ -246,16 +249,35 @@ def test_google_drive_download_uses_namespaced_model_function(tmp_path: Path) ->
     assert tool.download_dir == tmp_path / "google-drive-downloads"
 
 
-def test_google_drive_download_requires_agent_workspace(tmp_path: Path) -> None:
+def test_google_drive_download_disabled_without_workspace(tmp_path: Path) -> None:
     runtime_paths = _runtime_paths_with_google_drive_client(tmp_path)
+    tool = get_tool_by_name(
+        "google_drive",
+        runtime_paths,
+        credentials_manager=CredentialsManager(tmp_path / "credentials"),
+        tool_config_overrides={"download_file": True},
+        disable_sandbox_proxy=True,
+        tool_output_workspace_root=None,
+        worker_target=None,
+    )
 
-    with pytest.raises(RuntimeError, match="Google Drive downloads require an agent workspace"):
-        GoogleDriveTools(
-            runtime_paths=runtime_paths,
-            credentials_manager=CredentialsManager(tmp_path / "credentials"),
-            creds=_ValidCredentials(),
-            download_file=True,
-        )
+    assert "google_drive_download_file" not in tool.functions
+    assert "google_drive_download_file" not in tool.async_functions
+    assert "google_drive_list_files" in tool.functions
+
+
+def test_google_drive_download_confines_truthy_non_bool_flag(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths_with_google_drive_client(tmp_path)
+    tool = GoogleDriveTools(
+        runtime_paths=runtime_paths,
+        credentials_manager=CredentialsManager(tmp_path / "credentials"),
+        creds=_ValidCredentials(),
+        download_file="true",
+        tool_output_workspace_root=tmp_path,
+    )
+
+    assert "google_drive_download_file" in tool.functions
+    assert tool.download_dir == tmp_path / "google-drive-downloads"
 
 
 def test_google_drive_connect_instruction_uses_redirect_uri_public_origin(tmp_path: Path) -> None:

--- a/tests/test_google_drive_oauth_tool.py
+++ b/tests/test_google_drive_oauth_tool.py
@@ -246,7 +246,7 @@ def test_google_drive_download_uses_namespaced_model_function(tmp_path: Path) ->
     assert "download_file" not in tool.functions
     assert "google_drive_download_file" in tool.async_functions
     assert "download_file" not in tool.async_functions
-    assert tool.download_dir == tmp_path
+    assert tool.download_dir == tmp_path / "google-drive-downloads"
 
 
 def test_google_drive_connect_instruction_uses_redirect_uri_public_origin(tmp_path: Path) -> None:
@@ -643,8 +643,8 @@ def test_google_drive_download_media_supports_shared_drive_files(
     result = json.loads(tool.download_file("shared-drive-file-id"))
 
     assert result["status"] == "downloaded"
-    assert Path(result["path"]) == tmp_path / "notes.txt"
-    assert (tmp_path / "notes.txt").read_text() == "hello"
+    assert Path(result["path"]) == tmp_path / "google-drive-downloads" / "notes.txt"
+    assert (tmp_path / "google-drive-downloads" / "notes.txt").read_text() == "hello"
     assert service.files_resource.get_media_kwargs == {
         "fileId": "shared-drive-file-id",
         "supportsAllDrives": True,
@@ -731,10 +731,11 @@ def test_google_drive_download_rejects_symlink_escape(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     download_dir = tmp_path / "downloads"
-    download_dir.mkdir()
+    target_dir = download_dir / "google-drive-downloads"
+    target_dir.mkdir(parents=True)
     outside_path = tmp_path / "outside.txt"
     outside_path.write_text("outside")
-    (download_dir / "notes.txt").symlink_to(outside_path)
+    (target_dir / "notes.txt").symlink_to(outside_path)
     tool, service = _google_drive_download_tool(tmp_path, monkeypatch, download_dir=download_dir)
     service.files_resource.file_metadata = {
         "name": "notes.txt",
@@ -765,8 +766,8 @@ def test_google_drive_download_adds_export_extension_inside_download_dir(
     result = json.loads(tool.download_file("shared-drive-file-id"))
 
     assert result["status"] == "exported"
-    assert Path(result["path"]) == tmp_path / "proposal.docx"
-    assert (tmp_path / "proposal.docx").read_bytes() == b"docx"
+    assert Path(result["path"]) == tmp_path / "google-drive-downloads" / "proposal.docx"
+    assert (tmp_path / "google-drive-downloads" / "proposal.docx").read_bytes() == b"docx"
     assert service.files_resource.export_media_kwargs == {
         "fileId": "shared-drive-file-id",
         "mimeType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
@@ -789,8 +790,8 @@ def test_google_drive_download_exports_complete_spreadsheet_as_xlsx(
     result = json.loads(tool.download_file("shared-drive-file-id"))
 
     assert result["status"] == "exported"
-    assert Path(result["path"]) == tmp_path / "hardware-baseline.xlsx"
-    assert (tmp_path / "hardware-baseline.xlsx").read_bytes() == b"xlsx workbook"
+    assert Path(result["path"]) == tmp_path / "google-drive-downloads" / "hardware-baseline.xlsx"
+    assert (tmp_path / "google-drive-downloads" / "hardware-baseline.xlsx").read_bytes() == b"xlsx workbook"
     assert service.files_resource.export_media_kwargs == {
         "fileId": "shared-drive-file-id",
         "mimeType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
@@ -813,9 +814,9 @@ def test_google_drive_download_preserves_existing_export_extension(
     result = json.loads(tool.download_file("shared-drive-file-id"))
 
     assert result["status"] == "exported"
-    assert Path(result["path"]) == tmp_path / "proposal.docx"
-    assert (tmp_path / "proposal.docx").read_bytes() == b"docx"
-    assert not (tmp_path / "proposal.docx.docx").exists()
+    assert Path(result["path"]) == tmp_path / "google-drive-downloads" / "proposal.docx"
+    assert (tmp_path / "google-drive-downloads" / "proposal.docx").read_bytes() == b"docx"
+    assert not (tmp_path / "google-drive-downloads" / "proposal.docx.docx").exists()
     assert service.files_resource.export_media_kwargs == {
         "fileId": "shared-drive-file-id",
         "mimeType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",

--- a/tests/test_google_drive_oauth_tool.py
+++ b/tests/test_google_drive_oauth_tool.py
@@ -244,6 +244,8 @@ def test_google_drive_download_uses_namespaced_model_function(tmp_path: Path) ->
 
     assert "google_drive_download_file" in tool.functions
     assert "download_file" not in tool.functions
+    assert "google_drive_download_file" in tool.async_functions
+    assert "download_file" not in tool.async_functions
     assert tool.download_dir == tmp_path
 
 

--- a/tests/test_google_drive_oauth_tool.py
+++ b/tests/test_google_drive_oauth_tool.py
@@ -594,7 +594,10 @@ def test_google_drive_read_metadata_supports_shared_drive_files(tmp_path: Path) 
 
     result = json.loads(tool.read_file("shared-drive-folder-id"))
 
-    assert result["error"] == "Cannot read application/vnd.google-apps.folder as text. Use download_file instead."
+    assert (
+        result["error"]
+        == "Cannot read application/vnd.google-apps.folder as text. Use google_drive_download_file instead."
+    )
     assert service.files_resource.get_kwargs == {
         "fileId": "shared-drive-folder-id",
         "fields": tool.READ_METADATA_FIELDS,
@@ -627,6 +630,29 @@ def test_google_drive_read_media_supports_shared_drive_files(tmp_path: Path) -> 
         "supportsAllDrives": True,
     }
     assert service.files_resource.export_media_kwargs is None
+
+
+def test_google_drive_large_file_error_names_exposed_download_function(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths_with_google_drive_client(tmp_path)
+    tool = GoogleDriveTools(
+        runtime_paths=runtime_paths,
+        credentials_manager=CredentialsManager(tmp_path / "credentials"),
+        creds=_ValidCredentials(),
+        max_read_size=4,
+    )
+    service = _FakeDriveService()
+    service.files_resource.file_metadata = {
+        "name": "notes.txt",
+        "mimeType": "text/plain",
+        "size": "5",
+        "webViewLink": "https://drive.google.com/file/d/example",
+    }
+    tool.service = service
+
+    result = json.loads(tool.read_file("shared-drive-file-id"))
+
+    assert result["error"] == ("File is 5 bytes, exceeds max_read_size (4). Use google_drive_download_file instead.")
+    assert service.files_resource.get_media_kwargs is None
 
 
 def test_google_drive_download_media_supports_shared_drive_files(

--- a/tests/test_google_drive_oauth_tool.py
+++ b/tests/test_google_drive_oauth_tool.py
@@ -134,7 +134,7 @@ def _google_drive_download_tool(
         credentials_manager=CredentialsManager(tmp_path / "credentials"),
         creds=_ValidCredentials(),
         download_file=True,
-        download_dir=download_dir or tmp_path,
+        tool_output_workspace_root=download_dir or tmp_path,
     )
     service = _FakeDriveService()
     tool.service = service
@@ -228,6 +228,23 @@ def test_google_drive_model_functions_do_not_collide_with_local_file_tools(tmp_p
         "google_drive_search_files",
         "google_drive_read_file",
     } <= function_names
+
+
+def test_google_drive_download_uses_namespaced_model_function(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths_with_google_drive_client(tmp_path)
+    tool = get_tool_by_name(
+        "google_drive",
+        runtime_paths,
+        credentials_manager=CredentialsManager(tmp_path / "credentials"),
+        tool_config_overrides={"download_file": True},
+        disable_sandbox_proxy=True,
+        tool_output_workspace_root=tmp_path,
+        worker_target=None,
+    )
+
+    assert "google_drive_download_file" in tool.functions
+    assert "download_file" not in tool.functions
+    assert tool.download_dir == tmp_path
 
 
 def test_google_drive_connect_instruction_uses_redirect_uri_public_origin(tmp_path: Path) -> None:
@@ -751,6 +768,30 @@ def test_google_drive_download_adds_export_extension_inside_download_dir(
     assert service.files_resource.export_media_kwargs == {
         "fileId": "shared-drive-file-id",
         "mimeType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    }
+    assert service.files_resource.get_media_kwargs is None
+
+
+def test_google_drive_download_exports_complete_spreadsheet_as_xlsx(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool, service = _google_drive_download_tool(tmp_path, monkeypatch)
+    service.files_resource.file_metadata = {
+        "name": "hardware-baseline",
+        "mimeType": "application/vnd.google-apps.spreadsheet",
+        "webViewLink": "https://drive.google.com/spreadsheets/d/example",
+    }
+    tool._download_bytes = lambda _request: b"xlsx workbook"
+
+    result = json.loads(tool.download_file("shared-drive-file-id"))
+
+    assert result["status"] == "exported"
+    assert Path(result["path"]) == tmp_path / "hardware-baseline.xlsx"
+    assert (tmp_path / "hardware-baseline.xlsx").read_bytes() == b"xlsx workbook"
+    assert service.files_resource.export_media_kwargs == {
+        "fileId": "shared-drive-file-id",
+        "mimeType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     }
     assert service.files_resource.get_media_kwargs is None
 

--- a/tests/test_google_drive_oauth_tool.py
+++ b/tests/test_google_drive_oauth_tool.py
@@ -8,8 +8,8 @@ import json
 from collections.abc import AsyncIterator, Iterator
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING
 
+import pytest
 from agno.agent import Agent
 from agno.agent._tools import parse_tools
 from agno.models.base import Model
@@ -23,9 +23,6 @@ from mindroom.custom_tools.google_drive import GoogleDriveTools
 from mindroom.oauth.google_drive import _GOOGLE_DRIVE_OAUTH_SCOPES
 from mindroom.tool_system.metadata import get_tool_by_name
 from mindroom.tool_system.worker_routing import ToolExecutionIdentity, resolve_worker_target
-
-if TYPE_CHECKING:
-    import pytest
 
 
 class MinimalModel(Model):
@@ -247,6 +244,18 @@ def test_google_drive_download_uses_namespaced_model_function(tmp_path: Path) ->
     assert "google_drive_download_file" in tool.async_functions
     assert "download_file" not in tool.async_functions
     assert tool.download_dir == tmp_path / "google-drive-downloads"
+
+
+def test_google_drive_download_requires_agent_workspace(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths_with_google_drive_client(tmp_path)
+
+    with pytest.raises(RuntimeError, match="Google Drive downloads require an agent workspace"):
+        GoogleDriveTools(
+            runtime_paths=runtime_paths,
+            credentials_manager=CredentialsManager(tmp_path / "credentials"),
+            creds=_ValidCredentials(),
+            download_file=True,
+        )
 
 
 def test_google_drive_connect_instruction_uses_redirect_uri_public_origin(tmp_path: Path) -> None:
@@ -594,10 +603,7 @@ def test_google_drive_read_metadata_supports_shared_drive_files(tmp_path: Path) 
 
     result = json.loads(tool.read_file("shared-drive-folder-id"))
 
-    assert (
-        result["error"]
-        == "Cannot read application/vnd.google-apps.folder as text. Use google_drive_download_file instead."
-    )
+    assert result["error"] == "Cannot read application/vnd.google-apps.folder as text."
     assert service.files_resource.get_kwargs == {
         "fileId": "shared-drive-folder-id",
         "fields": tool.READ_METADATA_FIELDS,
@@ -651,7 +657,22 @@ def test_google_drive_large_file_error_names_exposed_download_function(tmp_path:
 
     result = json.loads(tool.read_file("shared-drive-file-id"))
 
-    assert result["error"] == ("File is 5 bytes, exceeds max_read_size (4). Use google_drive_download_file instead.")
+    assert result["error"] == "File is 5 bytes, exceeds max_read_size (4)."
+    assert service.files_resource.get_media_kwargs is None
+
+
+def test_google_drive_read_error_names_enabled_download_function(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool, service = _google_drive_download_tool(tmp_path, monkeypatch)
+
+    result = json.loads(tool.read_file("shared-drive-folder-id"))
+
+    assert (
+        result["error"]
+        == "Cannot read application/vnd.google-apps.folder as text. Use google_drive_download_file instead."
+    )
     assert service.files_resource.get_media_kwargs is None
 
 


### PR DESCRIPTION
## Why

Google Drive can read a Google Sheet as CSV, but that exposes only one tab. The underlying integration already supports exporting the complete workbook as `.xlsx`; agents could not call that function.

## What changed

The Drive tool can now opt into a namespaced download function. Downloads are forced into the current agent workspace, so the destination cannot be redirected elsewhere. The option remains disabled by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional Google Drive download capability for file downloads and Google Workspace exports.
  * Downloads are saved under a dedicated `google-drive-downloads/` folder inside the agent workspace.
  * Introduced the `google_drive_download_file` action, with updated tool registration and config (`download_file`).

* **Bug Fixes**
  * Updated read-file guidance for unsupported text reads and oversized files to direct users to `google_drive_download_file`.

* **Documentation**
  * Expanded Google Drive tool docs and examples to cover the new download/export behavior and configuration notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->