### PR TITLE
Fix replay after sparse OpenAI tool-call streams

### DIFF
--- a/src/mindroom/openai_models.py
+++ b/src/mindroom/openai_models.py
@@ -33,7 +33,7 @@ def _messages_with_openai_tool_arguments(messages: list[Message]) -> list[Messag
     """Fill arguments omitted by providers that represent empty tool input as an object."""
     normalized_messages: list[Message] = []
     for message in messages:
-        if not message.tool_calls:
+        if message.role != "assistant" or not message.tool_calls:
             normalized_messages.append(message)
             continue
 

--- a/src/mindroom/openai_models.py
+++ b/src/mindroom/openai_models.py
@@ -30,9 +30,12 @@ if TYPE_CHECKING:
 # Agno now preserves empty arguments, but existing histories retain the old shape.
 # Remove this only after migrating them or dropping support for pre-fix histories.
 def _messages_with_openai_tool_arguments(messages: list[Message]) -> list[Message]:
-    """Fill arguments omitted by providers that represent empty tool input as an object."""
+    """Repair function calls and remove sparse-stream placeholders from replay."""
     normalized_messages: list[Message] = []
+    removed_tool_call_ids: set[str] = set()
     for message in messages:
+        if message.role == "tool" and message.tool_call_id in removed_tool_call_ids:
+            continue
         if message.role != "assistant" or not message.tool_calls:
             normalized_messages.append(message)
             continue
@@ -40,7 +43,13 @@ def _messages_with_openai_tool_arguments(messages: list[Message]) -> list[Messag
         changed = False
         normalized_tool_calls: list[dict[str, Any]] = []
         for tool_call in message.tool_calls:
-            function = tool_call["function"]
+            function = tool_call.get("function")
+            if not isinstance(function, dict):
+                tool_call_id = tool_call.get("id")
+                if isinstance(tool_call_id, str):
+                    removed_tool_call_ids.add(tool_call_id)
+                changed = True
+                continue
             if "arguments" in function:
                 normalized_tool_calls.append(tool_call)
                 continue
@@ -67,6 +76,11 @@ class ChatToolArgumentsCompat:
     ``OpenAIChat`` field defaults over provider-specific ones (base URL, name)
     during dataclass field collection.
     """
+
+    def parse_tool_calls(self, tool_calls_data: list[Any]) -> list[dict[str, Any]]:
+        """Drop empty slots created when a streamed tool-call index starts above zero."""
+        parsed = super().parse_tool_calls(tool_calls_data)  # ty: ignore[unresolved-attribute]
+        return [tool_call for tool_call in parsed if isinstance(tool_call.get("function"), dict)]
 
     def _format_all_messages(
         self,

--- a/src/mindroom/openai_models.py
+++ b/src/mindroom/openai_models.py
@@ -27,8 +27,8 @@ if TYPE_CHECKING:
     from pydantic import BaseModel
 
 
-# Agno now preserves empty arguments, but existing histories retain the old shape.
-# Remove this only after migrating them or dropping support for pre-fix histories.
+# Agno 2.6.12 omits arguments for empty Anthropic tool inputs; agno-agi/agno#8970 proposes the source fix.
+# Remove this repair only after upgrading to a release with that fix and migrating or dropping older histories.
 def _messages_with_openai_tool_arguments(messages: list[Message]) -> list[Message]:
     """Repair function calls and remove sparse-stream placeholders from replay."""
     normalized_messages: list[Message] = []

--- a/tests/test_openai_models.py
+++ b/tests/test_openai_models.py
@@ -45,6 +45,26 @@ def _assistant_with_argumentless_tool_call() -> Message:
     )
 
 
+def _legacy_gemini_combined_tool_results() -> Message:
+    """Older Gemini histories bundle multiple tool results into one tool message."""
+    return Message(
+        role="tool",
+        content=["first result", "second result"],
+        tool_calls=[
+            {
+                "tool_call_id": "toolu_1",
+                "tool_name": "first_tool",
+                "content": "first result",
+            },
+            {
+                "tool_call_id": "toolu_2",
+                "tool_name": "second_tool",
+                "content": "second result",
+            },
+        ],
+    )
+
+
 @pytest.mark.parametrize(("model_cls", "_agno_cls"), _CHAT_WIRE_PAIRS)
 def test_chat_models_supply_missing_tool_arguments_without_mutating_history(
     model_cls: type[OpenAIChat],
@@ -85,3 +105,31 @@ def test_openai_responses_supplies_missing_tool_arguments_without_mutating_histo
 
     assert formatted[0]["arguments"] == "{}"
     assert "arguments" not in assistant.tool_calls[0]["function"]
+
+
+@pytest.mark.parametrize(("model_cls", "_agno_cls"), _CHAT_WIRE_PAIRS)
+def test_chat_models_leave_legacy_combined_tool_results_for_agno_normalization(
+    model_cls: type[OpenAIChat],
+    _agno_cls: type[OpenAIChat],
+) -> None:
+    """Argument repair must not interpret old Gemini tool-result bundles as function calls."""
+    tool_results = _legacy_gemini_combined_tool_results()
+
+    formatted = model_cls(id="gpt-5.6", api_key="test-key")._format_all_messages([tool_results])
+
+    assert formatted == [
+        {"role": "tool", "content": "first result", "tool_call_id": "toolu_1"},
+        {"role": "tool", "content": "second result", "tool_call_id": "toolu_2"},
+    ]
+
+
+def test_openai_responses_leaves_legacy_combined_tool_results_for_agno_normalization() -> None:
+    """Responses replay must preserve Agno's existing old-Gemini normalization path."""
+    tool_results = _legacy_gemini_combined_tool_results()
+
+    formatted = MindRoomOpenAIResponses(id="gpt-5.6", api_key="test-key")._format_messages([tool_results])
+
+    assert formatted == [
+        {"type": "function_call_output", "call_id": "toolu_1", "output": "first result"},
+        {"type": "function_call_output", "call_id": "toolu_2", "output": "second result"},
+    ]

--- a/tests/test_openai_models.py
+++ b/tests/test_openai_models.py
@@ -10,6 +10,7 @@ from agno.models.message import Message
 from agno.models.openai import OpenAIChat
 from agno.models.openai.like import OpenAILike
 from agno.models.openrouter import OpenRouter
+from openai.types.chat.chat_completion_chunk import ChoiceDeltaToolCall, ChoiceDeltaToolCallFunction
 
 from mindroom.azure_openai_model import MindRoomAzureOpenAI
 from mindroom.openai_models import (
@@ -45,24 +46,50 @@ def _assistant_with_argumentless_tool_call() -> Message:
     )
 
 
-def _legacy_gemini_combined_tool_results() -> Message:
-    """Older Gemini histories bundle multiple tool results into one tool message."""
-    return Message(
-        role="tool",
-        content=["first result", "second result"],
-        tool_calls=[
-            {
-                "tool_call_id": "toolu_1",
-                "tool_name": "first_tool",
-                "content": "first result",
-            },
-            {
-                "tool_call_id": "toolu_2",
-                "tool_name": "second_tool",
-                "content": "second result",
-            },
-        ],
+def _messages_with_sparse_stream_placeholder() -> list[Message]:
+    """Recreate history left by a tool-call stream whose first index was one."""
+    return [
+        Message(
+            role="assistant",
+            tool_calls=[
+                {"id": "phantom-call"},
+                {
+                    "id": "call_abcdefghijklmnopqrstuvwx",
+                    "type": "function",
+                    "function": {"name": "get_status", "arguments": "{}"},
+                },
+            ],
+        ),
+        Message(role="tool", content="tool unavailable", tool_call_id="phantom-call"),
+        Message(role="tool", content="ready", tool_call_id="call_abcdefghijklmnopqrstuvwx"),
+    ]
+
+
+def _sparse_tool_call_delta() -> ChoiceDeltaToolCall:
+    """Return one valid call at stream index one, leaving index zero empty in Agno."""
+    return ChoiceDeltaToolCall(
+        index=1,
+        id="call_abcdefghijklmnopqrstuvwx",
+        type="function",
+        function=ChoiceDeltaToolCallFunction(name="get_status", arguments="{}"),
     )
+
+
+@pytest.mark.parametrize(("model_cls", "_agno_cls"), _CHAT_WIRE_PAIRS)
+def test_chat_models_drop_sparse_stream_placeholders(
+    model_cls: type[OpenAIChat],
+    _agno_cls: type[OpenAIChat],
+) -> None:
+    """A missing lower stream index must not become an id-only assistant tool call."""
+    parsed = model_cls(id="gpt-5.6", api_key="test-key").parse_tool_calls([_sparse_tool_call_delta()])
+
+    assert parsed == [
+        {
+            "id": "call_abcdefghijklmnopqrstuvwx",
+            "type": "function",
+            "function": {"name": "get_status", "arguments": "{}"},
+        },
+    ]
 
 
 @pytest.mark.parametrize(("model_cls", "_agno_cls"), _CHAT_WIRE_PAIRS)
@@ -108,28 +135,43 @@ def test_openai_responses_supplies_missing_tool_arguments_without_mutating_histo
 
 
 @pytest.mark.parametrize(("model_cls", "_agno_cls"), _CHAT_WIRE_PAIRS)
-def test_chat_models_leave_legacy_combined_tool_results_for_agno_normalization(
+def test_chat_models_remove_persisted_sparse_placeholder_and_orphan_result(
     model_cls: type[OpenAIChat],
     _agno_cls: type[OpenAIChat],
 ) -> None:
-    """Argument repair must not interpret old Gemini tool-result bundles as function calls."""
-    tool_results = _legacy_gemini_combined_tool_results()
+    """Replay must retain real calls while removing a saved placeholder pair."""
+    messages = _messages_with_sparse_stream_placeholder()
 
-    formatted = model_cls(id="gpt-5.6", api_key="test-key")._format_all_messages([tool_results])
+    formatted = model_cls(id="gpt-5.6", api_key="test-key")._format_all_messages(messages)
 
     assert formatted == [
-        {"role": "tool", "content": "first result", "tool_call_id": "toolu_1"},
-        {"role": "tool", "content": "second result", "tool_call_id": "toolu_2"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_abcdefghijklmnopqrstuvwx",
+                    "type": "function",
+                    "function": {"name": "get_status", "arguments": "{}"},
+                },
+            ],
+        },
+        {"role": "tool", "content": "ready", "tool_call_id": "call_abcdefghijklmnopqrstuvwx"},
     ]
 
 
-def test_openai_responses_leaves_legacy_combined_tool_results_for_agno_normalization() -> None:
-    """Responses replay must preserve Agno's existing old-Gemini normalization path."""
-    tool_results = _legacy_gemini_combined_tool_results()
+def test_openai_responses_removes_persisted_sparse_placeholder_and_orphan_result() -> None:
+    """Responses replay must retain real calls while removing a saved placeholder pair."""
+    messages = _messages_with_sparse_stream_placeholder()
 
-    formatted = MindRoomOpenAIResponses(id="gpt-5.6", api_key="test-key")._format_messages([tool_results])
+    formatted = MindRoomOpenAIResponses(id="gpt-5.6", api_key="test-key")._format_messages(messages)
 
-    assert formatted == [
-        {"type": "function_call_output", "call_id": "toolu_1", "output": "first result"},
-        {"type": "function_call_output", "call_id": "toolu_2", "output": "second result"},
-    ]
+    assert len(formatted) == 2
+    assert formatted[0]["type"] == "function_call"
+    assert formatted[0]["name"] == "get_status"
+    assert formatted[0]["arguments"] == "{}"
+    assert formatted[1] == {
+        "type": "function_call_output",
+        "call_id": formatted[0]["call_id"],
+        "output": "ready",
+    }

--- a/tests/test_openai_models.py
+++ b/tests/test_openai_models.py
@@ -65,6 +65,26 @@ def _messages_with_sparse_stream_placeholder() -> list[Message]:
     ]
 
 
+def _legacy_combined_tool_results() -> Message:
+    """Recreate the combined tool-result shape handled by Agno's normalizer."""
+    return Message(
+        role="tool",
+        content=["first result", "second result"],
+        tool_calls=[
+            {
+                "tool_call_id": "toolu_1",
+                "tool_name": "first_tool",
+                "content": "first result",
+            },
+            {
+                "tool_call_id": "toolu_2",
+                "tool_name": "second_tool",
+                "content": "second result",
+            },
+        ],
+    )
+
+
 def _sparse_tool_call_delta() -> ChoiceDeltaToolCall:
     """Return one valid call at stream index one, leaving index zero empty in Agno."""
     return ChoiceDeltaToolCall(
@@ -132,6 +152,34 @@ def test_openai_responses_supplies_missing_tool_arguments_without_mutating_histo
 
     assert formatted[0]["arguments"] == "{}"
     assert "arguments" not in assistant.tool_calls[0]["function"]
+
+
+@pytest.mark.parametrize(("model_cls", "_agno_cls"), _CHAT_WIRE_PAIRS)
+def test_chat_models_leave_combined_tool_results_for_agno_normalization(
+    model_cls: type[OpenAIChat],
+    _agno_cls: type[OpenAIChat],
+) -> None:
+    """Argument repair must not consume non-assistant combined tool results."""
+    tool_results = _legacy_combined_tool_results()
+
+    formatted = model_cls(id="gpt-5.6", api_key="test-key")._format_all_messages([tool_results])
+
+    assert formatted == [
+        {"role": "tool", "content": "first result", "tool_call_id": "toolu_1"},
+        {"role": "tool", "content": "second result", "tool_call_id": "toolu_2"},
+    ]
+
+
+def test_openai_responses_leaves_combined_tool_results_for_agno_normalization() -> None:
+    """Responses replay must preserve Agno's combined-result normalization path."""
+    tool_results = _legacy_combined_tool_results()
+
+    formatted = MindRoomOpenAIResponses(id="gpt-5.6", api_key="test-key")._format_messages([tool_results])
+
+    assert formatted == [
+        {"type": "function_call_output", "call_id": "toolu_1", "output": "first result"},
+        {"type": "function_call_output", "call_id": "toolu_2", "output": "second result"},
+    ]
 
 
 @pytest.mark.parametrize(("model_cls", "_agno_cls"), _CHAT_WIRE_PAIRS)


### PR DESCRIPTION
A Chat Completions stream can report its first function call at index 1. Agno fills the missing index 0 with an empty entry and later assigns it an ID, leaving an id-only tool call beside the real calls. The next replay then crashes when compatibility code expects that entry to contain a function.

Filter empty stream slots at parse time so new histories stay valid. For histories that already contain the placeholder, remove both the id-only call and its matching orphan tool result before replay. Real function calls still receive missing empty arguments as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved normalization for assistant tool calls, ensuring empty/invalid streamed tool-call entries are discarded.
  * Prevented replayed tool-call placeholders from being carried forward, keeping tool-call/output associations consistent across chat and responses formats.

* **Tests**
  * Added coverage for sparse tool-call streams starting at a non-zero index.
  * Verified both chat and responses formatting remove persisted sparse placeholders and orphan results while retaining the real tool call (with normalized function arguments).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->