### PR TITLE
perf(thread-export): use libyaml loader/dumper for export storage

### DIFF
--- a/src/mindroom/thread_export/storage.py
+++ b/src/mindroom/thread_export/storage.py
@@ -21,6 +21,11 @@ if TYPE_CHECKING:
     from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
     from mindroom.thread_export.models import ThreadExportRoom
 
+# libyaml-backed classes parse ~20x faster than the pure-Python ones; export passes
+# re-read every thread document in a room, so the difference dominates pass cost.
+_YAML_SAFE_LOADER = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
+_YAML_SAFE_DUMPER = getattr(yaml, "CSafeDumper", yaml.SafeDumper)
+
 _EXPORT_SCHEMA_VERSION = 1
 _ROOM_INDEX_FILENAME = "index.json"
 _THREAD_SUMMARY_CONTENT_KEY = "io.mindroom.thread_summary"
@@ -244,7 +249,7 @@ def _thread_index_entry_at(directory_fd: int, filename: str) -> tuple[int, dict[
     if text is None:
         return None
     try:
-        payload = yaml.safe_load(text)
+        payload = yaml.load(text, Loader=_YAML_SAFE_LOADER)  # noqa: S506 - safe loader variant
     except yaml.YAMLError:
         return None
     if not isinstance(payload, dict):
@@ -448,7 +453,7 @@ def _existing_payload_matches(room_fd: int, filename: str, payload: dict[str, ob
     if text is None:
         return False
     try:
-        existing = yaml.safe_load(text)
+        existing = yaml.load(text, Loader=_YAML_SAFE_LOADER)  # noqa: S506 - safe loader variant
     except yaml.YAMLError:
         return False
     if not isinstance(existing, dict):
@@ -478,8 +483,9 @@ def write_thread_payload(
         filename = f"{_safe_path_segment(thread_id)}.yaml"
         if _existing_payload_matches(room_fd, filename, payload):
             return False
-        text = yaml.safe_dump(
+        text = yaml.dump(
             payload,
+            Dumper=_YAML_SAFE_DUMPER,
             default_flow_style=False,
             sort_keys=False,
             allow_unicode=True,

--- a/src/mindroom/thread_export/storage.py
+++ b/src/mindroom/thread_export/storage.py
@@ -14,17 +14,25 @@ from uuid import uuid4
 
 import yaml
 
+# libyaml-backed classes parse ~20x faster than the pure-Python ones; export passes
+# re-read every thread document in a room, so the difference dominates pass cost.
+try:
+    from yaml import CSafeDumper, CSafeLoader
+except ImportError:
+    from yaml import SafeDumper, SafeLoader
+
+    _YAML_SAFE_DUMPER = SafeDumper
+    _YAML_SAFE_LOADER = SafeLoader
+else:
+    _YAML_SAFE_DUMPER = CSafeDumper
+    _YAML_SAFE_LOADER = CSafeLoader
+
 if TYPE_CHECKING:
     from collections.abc import Collection, Sequence
     from pathlib import Path
 
     from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
     from mindroom.thread_export.models import ThreadExportRoom
-
-# libyaml-backed classes parse ~20x faster than the pure-Python ones; export passes
-# re-read every thread document in a room, so the difference dominates pass cost.
-_YAML_SAFE_LOADER = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
-_YAML_SAFE_DUMPER = getattr(yaml, "CSafeDumper", yaml.SafeDumper)
 
 _EXPORT_SCHEMA_VERSION = 1
 _ROOM_INDEX_FILENAME = "index.json"


### PR DESCRIPTION
## Summary

Switch the three YAML call sites in `thread_export/storage.py` to the libyaml-backed `CSafeLoader`/`CSafeDumper` (with automatic fallback to the pure-Python classes when libyaml is unavailable).

## Motivation

Export passes re-read and re-parse every thread document in a room to rebuild `index.json` (`_thread_index_entry_at`) and to compare payloads before each write (`_existing_payload_matches`), once per authorized target. With PyYAML's pure-Python `SafeLoader` this dominated pass cost and was the root cause of the `event_loop_stall_detected` storms on mindroom.chat (~5s of continuous parsing per changed room; 8 agent targets share the lobby room). The thread-export plugin now runs passes on a worker thread, so the stalls are gone — this change removes the CPU waste itself.

## Measurements (production data, mindroom.chat)

- 325 real exported thread files parsed with both loaders: **5.14s pure-Python → 0.33s C loader (16x)**, zero parse differences, clean dump/load roundtrips.
- Single largest thread file (170 KB): 0.21s → 0.01s.

## Notes

- `yaml.safe_load` never uses libyaml even when it is installed; you must pass the `CSafeLoader` class explicitly.
- Change detection compares parsed payloads (not text), so any formatting differences between the dumpers cannot trigger spurious rewrites.
- Follow-up idea (not in this PR): stop re-parsing whole thread documents just to build index entries — the exporter already has each payload in memory when it writes the file, so the index could be maintained incrementally.

## Testing

- `uv run pytest tests/test_thread_export_storage.py tests/test_thread_export_execution.py tests/test_thread_export_service.py -n 0 --no-cov` — 33 passed.
- `ruff` + full pre-commit (including `ty`) pass.
- Loader-equivalence sweep over all readable production export files: 0 mismatches.

## Summary by Sourcery

Enhancements:
- Use libyaml-backed safe loader and dumper for reading and writing exported thread payloads, falling back to the pure-Python implementations when libyaml is unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YAML parsing and serialization reliability by using the optimized “safe” YAML loader/dumper when available, with a safe fallback when not.
  * Preserved safe handling of thread index entries and payloads during reading, comparison, and writing to improve consistency and reduce parsing/formatting issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->