### PR TITLE
feat: seed AGENTS.md rescue docs in config init

### DIFF
--- a/src/mindroom/cli/agent_docs.py
+++ b/src/mindroom/cli/agent_docs.py
@@ -18,6 +18,8 @@ MindRoom is an open-source AI agent platform: agents live in Matrix chat rooms a
 
 - Source: https://github.com/mindroom-ai/mindroom
 - Documentation: https://docs.mindroom.chat/
+- LLM-readable docs index: https://raw.githubusercontent.com/mindroom-ai/mindroom/refs/heads/main/skills/mindroom-docs/references/llms.txt
+- Complete docs in one file (~1 MB): https://raw.githubusercontent.com/mindroom-ai/mindroom/refs/heads/main/skills/mindroom-docs/references/llms-full.txt
 
 If you are a coding agent asked to repair this installation (for example, MindRoom does not start after an upgrade), work from this directory using the notes below.
 
@@ -78,7 +80,10 @@ def ensure_config_agent_docs(
     created: list[Path] = []
 
     agents_path = config_dir / _AGENTS_DOC_NAME
-    if force or not agents_path.exists():
+    if force or not (agents_path.is_symlink() or agents_path.exists()):
+        # Unlink first so --force replaces a symlinked AGENTS.md instead of
+        # writing through it into the symlink target.
+        agents_path.unlink(missing_ok=True)
         agents_path.write_text(content, encoding="utf-8")
         created.append(agents_path)
 
@@ -93,7 +98,8 @@ def ensure_config_agent_docs(
         claude_path.symlink_to(_AGENTS_DOC_NAME)
     except OSError:
         # Symlinks can be unavailable (e.g. Windows without developer mode);
-        # a plain copy gives coding agents the same entry point.
-        claude_path.write_text(content, encoding="utf-8")
+        # a plain copy of AGENTS.md — which may hold preserved user content —
+        # gives coding agents the same entry point.
+        claude_path.write_text(agents_path.read_text(encoding="utf-8"), encoding="utf-8")
     created.append(claude_path)
     return created

--- a/src/mindroom/cli/agent_docs.py
+++ b/src/mindroom/cli/agent_docs.py
@@ -37,12 +37,14 @@ Use `mindroom <command>` if MindRoom is installed, otherwise `uvx mindroom <comm
 2. `mindroom doctor` — preflight checks for Matrix connectivity, credentials, and config.
 3. Read the newest `mindroom_*.log` under `logs/` in the storage root for the actual startup error.
 4. `mindroom config path` — confirm this is the config file MindRoom actually loads.
-5. `mindroom run --log-level DEBUG` — reproduce with verbose logging.
+5. `mindroom service status` — if MindRoom is installed as a background user service; shows state plus recent logs (`mindroom service logs` for the full log command).
+6. `mindroom run --log-level DEBUG` — reproduce with verbose logging.
 
 ## How to fix
 
 - Schema errors: make the smallest edit to `{config_file}` that makes `mindroom config validate` pass; the documentation above describes every field.
 - Missing API keys: add them to `.env` (`mindroom config validate` warns about missing provider keys).
+- After fixing, restart: `mindroom run` in a shell, or `mindroom service restart` when installed as a background service.
 - Roll back an upgrade by pinning the previous version: `uvx mindroom@<version> run`.
 - Last resort: `mindroom config init --force` regenerates a starter config — this discards customizations, so copy `{config_file}` aside first.
 

--- a/src/mindroom/cli/agent_docs.py
+++ b/src/mindroom/cli/agent_docs.py
@@ -1,0 +1,99 @@
+"""Agent rescue docs seeded into the config directory by `mindroom config init`.
+
+The config directory gets an AGENTS.md (plus a CLAUDE.md symlink) so that when an
+installation breaks — typically after an upgrade with an incompatible config — the
+user can point any coding agent at the directory and it knows what MindRoom is,
+where the docs are, and how to diagnose and fix the problem.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_AGENT_DOCS_TEMPLATE = """\
+# MindRoom Configuration
+
+This directory holds the configuration for a MindRoom installation.
+MindRoom is an open-source AI agent platform: agents live in Matrix chat rooms and are configured entirely from this directory.
+
+- Source: https://github.com/mindroom-ai/mindroom
+- Documentation: https://docs.mindroom.chat/
+
+If you are a coding agent asked to repair this installation (for example, MindRoom does not start after an upgrade), work from this directory using the notes below.
+
+## What lives where
+
+- `{config_file}` — the main configuration: models, agents, teams, rooms, authorization. It can pull in other YAML files with `!include`.
+- `.env` — environment variables and secrets (API keys, Matrix settings). Sensitive: never publish or commit its contents.
+- Runtime state (logs, sessions, credentials, Matrix encryption keys) lives in the storage root: the `MINDROOM_STORAGE_PATH` value in `.env` (initialized to `{storage_root}`).
+
+## How to diagnose
+
+Use `mindroom <command>` if MindRoom is installed, otherwise `uvx mindroom <command>`.
+
+1. `mindroom config validate` — parses the config and lists exactly which keys are invalid. After a failed upgrade, start here: the usual cause is a config schema change.
+2. `mindroom doctor` — preflight checks for Matrix connectivity, credentials, and config.
+3. Read the newest `mindroom_*.log` under `logs/` in the storage root for the actual startup error.
+4. `mindroom config path` — confirm this is the config file MindRoom actually loads.
+5. `mindroom run --log-level DEBUG` — reproduce with verbose logging.
+
+## How to fix
+
+- Schema errors: make the smallest edit to `{config_file}` that makes `mindroom config validate` pass; the documentation above describes every field.
+- Missing API keys: add them to `.env` (`mindroom config validate` warns about missing provider keys).
+- Roll back an upgrade by pinning the previous version: `uvx mindroom@<version> run`.
+- Last resort: `mindroom config init --force` regenerates a starter config — this discards customizations, so copy `{config_file}` aside first.
+
+## Cautions
+
+- Do not delete `encryption_keys/` or `matrix_state.yaml` from the storage root; that breaks Matrix sessions and end-to-end encryption.
+- Keep `.env` and the storage root's `credentials/` out of version control and out of anything you publish.
+"""
+
+_AGENTS_DOC_NAME = "AGENTS.md"
+_CLAUDE_DOC_NAME = "CLAUDE.md"
+
+
+def _render_config_agent_docs(*, config_path: Path, storage_root: Path) -> str:
+    """Render the AGENTS.md rescue guide for one config directory."""
+    return _AGENT_DOCS_TEMPLATE.format(
+        config_file=config_path.name,
+        storage_root=storage_root.expanduser().resolve(),
+    )
+
+
+def ensure_config_agent_docs(
+    config_dir: Path,
+    *,
+    config_path: Path,
+    storage_root: Path,
+    force: bool = False,
+) -> list[Path]:
+    """Seed AGENTS.md and a CLAUDE.md symlink next to the config file.
+
+    Existing files are left untouched unless ``force`` is set. Returns the paths
+    that were created or replaced.
+    """
+    content = _render_config_agent_docs(config_path=config_path, storage_root=storage_root)
+    created: list[Path] = []
+
+    agents_path = config_dir / _AGENTS_DOC_NAME
+    if force or not agents_path.exists():
+        agents_path.write_text(content, encoding="utf-8")
+        created.append(agents_path)
+
+    claude_path = config_dir / _CLAUDE_DOC_NAME
+    if claude_path.is_symlink() and claude_path.readlink() == Path(_AGENTS_DOC_NAME):
+        return created
+    if (claude_path.is_symlink() or claude_path.exists()) and not force:
+        return created
+
+    claude_path.unlink(missing_ok=True)
+    try:
+        claude_path.symlink_to(_AGENTS_DOC_NAME)
+    except OSError:
+        # Symlinks can be unavailable (e.g. Windows without developer mode);
+        # a plain copy gives coding agents the same entry point.
+        claude_path.write_text(content, encoding="utf-8")
+    created.append(claude_path)
+    return created

--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -19,6 +19,7 @@ from rich.console import Console
 from rich.syntax import Syntax
 
 from mindroom import constants
+from mindroom.cli.agent_docs import ensure_config_agent_docs
 from mindroom.cli.env_file import write_private_env_text
 from mindroom.model_defaults import (
     CONFIG_INIT_MODEL_ALTERNATIVES,
@@ -494,6 +495,15 @@ def config_init(
         target.write_text(content, encoding="utf-8")
 
     _ensure_mind_workspace(_default_mind_workspace(storage_root), config_path=target, force=force)
+
+    created_docs = ensure_config_agent_docs(
+        target.parent,
+        config_path=target,
+        storage_root=storage_root,
+        force=force,
+    )
+    if created_docs:
+        console.print(f"[green]Agent docs created:[/green] {', '.join(doc.name for doc in created_docs)}")
 
     env_changed = _write_env_file(
         env_path,

--- a/tach.toml
+++ b/tach.toml
@@ -2415,12 +2415,18 @@ path = "mindroom.cli"
 depends_on = []
 
 [[modules]]
+path = "mindroom.cli.agent_docs"
+depends_on = []
+visibility = ["mindroom.cli.config"]
+
+[[modules]]
 path = "mindroom.cli.banner"
 depends_on = []
 
 [[modules]]
 path = "mindroom.cli.config"
 depends_on = [
+    "mindroom.cli.agent_docs",
     "mindroom.cli.env_file",
     "mindroom.cli.owner",
     "mindroom.config.main",

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -25,6 +25,7 @@ import mindroom.constants as constants_module
 from mindroom.agents import ensure_default_agent_workspaces
 from mindroom.cli import config as config_cli
 from mindroom.cli import migrate as migrate_cli
+from mindroom.cli.agent_docs import ensure_config_agent_docs
 from mindroom.cli.config import _format_config_search_locations, activate_cli_runtime
 from mindroom.cli.main import _load_active_config_or_exit, _threads_export, app
 from mindroom.constants import OWNER_MATRIX_USER_ID_ENV, OWNER_MATRIX_USER_ID_PLACEHOLDER
@@ -178,6 +179,29 @@ def test_activate_cli_runtime_explicit_path_keeps_exported_storage_override(
     assert runtime_paths.storage_root == storage_path.resolve()
 
 
+def test_ensure_config_agent_docs_copies_when_symlinks_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without symlink support, CLAUDE.md becomes a plain copy of AGENTS.md."""
+
+    def _unsupported_symlink(*_args: object, **_kwargs: object) -> None:
+        message = "symlinks unsupported"
+        raise OSError(message)
+
+    monkeypatch.setattr(Path, "symlink_to", _unsupported_symlink)
+    created = ensure_config_agent_docs(
+        tmp_path,
+        config_path=tmp_path / "config.yaml",
+        storage_root=tmp_path / "mindroom_data",
+    )
+
+    claude_doc = tmp_path / "CLAUDE.md"
+    assert not claude_doc.is_symlink()
+    assert claude_doc.read_text(encoding="utf-8") == (tmp_path / "AGENTS.md").read_text(encoding="utf-8")
+    assert created == [tmp_path / "AGENTS.md", claude_doc]
+
+
 # ---------------------------------------------------------------------------
 # mindroom config init
 # ---------------------------------------------------------------------------
@@ -300,6 +324,66 @@ class TestConfigInit:
         assert not (workspace / "BOOT.md").exists()
         tools_notes = (workspace / "TOOLS.md").read_text(encoding="utf-8")
         assert f"- Active config file: {json.dumps(str(target.resolve()))}" in tools_notes
+
+    def test_init_creates_agent_rescue_docs(self, tmp_path: Path) -> None:
+        """Config init seeds AGENTS.md plus a CLAUDE.md symlink for repair agents."""
+        target = tmp_path / "config.yaml"
+        result = runner.invoke(app, ["config", "init", "--path", str(target), "--provider", "openai"])
+        assert result.exit_code == 0
+
+        agents_doc = tmp_path / "AGENTS.md"
+        claude_doc = tmp_path / "CLAUDE.md"
+        assert agents_doc.is_file()
+        assert claude_doc.is_symlink()
+        assert claude_doc.readlink() == Path("AGENTS.md")
+
+        content = agents_doc.read_text(encoding="utf-8")
+        assert "https://docs.mindroom.chat/" in content
+        assert "mindroom config validate" in content
+        assert "`config.yaml`" in content
+        assert str((tmp_path / "mindroom_data").resolve()) in content
+        assert claude_doc.read_text(encoding="utf-8") == content
+        assert "Agent docs created" in normalize_console_output(result.output)
+
+    def test_init_preserves_existing_agent_docs_without_force(self, tmp_path: Path) -> None:
+        """Config init must not clobber user-authored AGENTS.md or CLAUDE.md."""
+        target = tmp_path / "config.yaml"
+        agents_doc = tmp_path / "AGENTS.md"
+        claude_doc = tmp_path / "CLAUDE.md"
+        agents_doc.write_text("custom agents notes\n", encoding="utf-8")
+        claude_doc.write_text("custom claude notes\n", encoding="utf-8")
+
+        result = runner.invoke(app, ["config", "init", "--path", str(target), "--provider", "openai"])
+        assert result.exit_code == 0
+        assert agents_doc.read_text(encoding="utf-8") == "custom agents notes\n"
+        assert claude_doc.read_text(encoding="utf-8") == "custom claude notes\n"
+        assert not claude_doc.is_symlink()
+
+    def test_init_force_replaces_agent_docs(self, tmp_path: Path) -> None:
+        """Config init --force regenerates the agent docs and restores the symlink."""
+        target = tmp_path / "config.yaml"
+        agents_doc = tmp_path / "AGENTS.md"
+        claude_doc = tmp_path / "CLAUDE.md"
+        agents_doc.write_text("stale\n", encoding="utf-8")
+        claude_doc.write_text("stale\n", encoding="utf-8")
+
+        result = runner.invoke(app, ["config", "init", "--path", str(target), "--provider", "openai", "--force"])
+        assert result.exit_code == 0
+        assert "# MindRoom Configuration" in agents_doc.read_text(encoding="utf-8")
+        assert claude_doc.is_symlink()
+        assert claude_doc.readlink() == Path("AGENTS.md")
+
+    def test_init_rerun_keeps_agent_docs_symlink(self, tmp_path: Path) -> None:
+        """A second config init leaves the seeded docs and symlink in place."""
+        target = tmp_path / "config.yaml"
+        first = runner.invoke(app, ["config", "init", "--path", str(target), "--provider", "openai"])
+        assert first.exit_code == 0
+
+        second = runner.invoke(app, ["config", "init", "--path", str(target), "--no-input"])
+        assert second.exit_code == 0
+        claude_doc = tmp_path / "CLAUDE.md"
+        assert claude_doc.is_symlink()
+        assert "Agent docs created" not in normalize_console_output(second.output)
 
     def test_init_respects_storage_path_override(
         self,

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -397,6 +397,8 @@ class TestConfigInit:
             "skills/mindroom-docs/references/llms-full.txt" in content
         )
         assert "mindroom config validate" in content
+        assert "mindroom service status" in content
+        assert "mindroom service restart" in content
         assert "`config.yaml`" in content
         assert str((tmp_path / "mindroom_data").resolve()) in content
         assert claude_doc.read_text(encoding="utf-8") == content

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -202,6 +202,55 @@ def test_ensure_config_agent_docs_copies_when_symlinks_unavailable(
     assert created == [tmp_path / "AGENTS.md", claude_doc]
 
 
+def test_ensure_config_agent_docs_copy_mirrors_preserved_agents_doc(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The no-symlink fallback copies preserved user AGENTS.md content, not the template."""
+
+    def _unsupported_symlink(*_args: object, **_kwargs: object) -> None:
+        message = "symlinks unsupported"
+        raise OSError(message)
+
+    monkeypatch.setattr(Path, "symlink_to", _unsupported_symlink)
+    agents_doc = tmp_path / "AGENTS.md"
+    agents_doc.write_text("custom agents notes\n", encoding="utf-8")
+
+    created = ensure_config_agent_docs(
+        tmp_path,
+        config_path=tmp_path / "config.yaml",
+        storage_root=tmp_path / "mindroom_data",
+    )
+
+    claude_doc = tmp_path / "CLAUDE.md"
+    assert agents_doc.read_text(encoding="utf-8") == "custom agents notes\n"
+    assert claude_doc.read_text(encoding="utf-8") == "custom agents notes\n"
+    assert created == [claude_doc]
+
+
+def test_ensure_config_agent_docs_force_replaces_agents_symlink_without_clobbering_target(
+    tmp_path: Path,
+) -> None:
+    """Force must replace a symlinked AGENTS.md instead of writing through it."""
+    external_target = tmp_path / "external.md"
+    external_target.write_text("external notes\n", encoding="utf-8")
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    agents_doc = config_dir / "AGENTS.md"
+    agents_doc.symlink_to(external_target)
+
+    ensure_config_agent_docs(
+        config_dir,
+        config_path=config_dir / "config.yaml",
+        storage_root=config_dir / "mindroom_data",
+        force=True,
+    )
+
+    assert external_target.read_text(encoding="utf-8") == "external notes\n"
+    assert not agents_doc.is_symlink()
+    assert "# MindRoom Configuration" in agents_doc.read_text(encoding="utf-8")
+
+
 # ---------------------------------------------------------------------------
 # mindroom config init
 # ---------------------------------------------------------------------------
@@ -339,6 +388,14 @@ class TestConfigInit:
 
         content = agents_doc.read_text(encoding="utf-8")
         assert "https://docs.mindroom.chat/" in content
+        assert (
+            "https://raw.githubusercontent.com/mindroom-ai/mindroom/refs/heads/main/"
+            "skills/mindroom-docs/references/llms.txt" in content
+        )
+        assert (
+            "https://raw.githubusercontent.com/mindroom-ai/mindroom/refs/heads/main/"
+            "skills/mindroom-docs/references/llms-full.txt" in content
+        )
         assert "mindroom config validate" in content
         assert "`config.yaml`" in content
         assert str((tmp_path / "mindroom_data").resolve()) in content


### PR DESCRIPTION
## What

`mindroom config init` now seeds the config directory with an `AGENTS.md` rescue guide plus a `CLAUDE.md` symlink pointing at it.

## Why

If an upgrade lands with an incompatible config change, MindRoom may not come back up. With these files in place, the user can open any coding agent (Claude Code, Codex, ...) in their config directory and it immediately knows what MindRoom is, where the documentation lives, and how to diagnose and fix the installation — no memory of the project required.

## Content of the guide

Deliberately minimal — handles, not essays:
- what the directory is (`config.yaml`, `.env`, storage root via `MINDROOM_STORAGE_PATH`)
- how to diagnose: `mindroom config validate`, `mindroom doctor`, newest `mindroom_*.log` under the storage root's `logs/`, `mindroom config path`, `mindroom run --log-level DEBUG`
- how to fix: smallest edit that validates, `.env` keys, version rollback via `uvx mindroom@<version>`, `config init --force` as last resort
- cautions: never delete `encryption_keys/` / `matrix_state.yaml`, keep `.env` and `credentials/` private

## Behavior

- Existing `AGENTS.md` / `CLAUDE.md` files are never clobbered without `--force`.
- Re-running `config init` is idempotent (correct symlink is left alone).
- Where symlinks are unavailable (e.g. Windows without developer mode), `CLAUDE.md` is written as a plain copy.
- `--print` mode still writes nothing.

## Testing

- 5 new tests (seeding, preserve-without-force, `--force` replace, idempotent rerun, symlink-unavailable fallback); full `TestConfigInit` suite passes (57 tests).
- `uv run tach check --dependencies --interfaces` passes with the new `mindroom.cli.agent_docs` module entry.
- Pre-commit hooks pass on all touched files.