### PR TITLE
Separate replay budget from model context limit

### DIFF
--- a/docs/configuration/agents.md
+++ b/docs/configuration/agents.md
@@ -185,13 +185,14 @@ Approval-gated tools are stricter than plain ad-hoc chat access.
 Approval-gated tools only work there while the router is already joined.
 
 MindRoom compacts in one visible lifecycle.
-Per-agent compaction supports `enabled`, `threshold_tokens`, `threshold_percent`, `reserve_tokens`, and `model`.
+Per-agent compaction supports `enabled`, `threshold_tokens`, `threshold_percent`, `replay_window_tokens`, `reserve_tokens`, and `model`.
 When the active runtime model has a known `context_window`, MindRoom always computes a per-run replay plan that reduces or disables persisted replay before the model call if needed.
 Automatic destructive compaction is enabled by default through `defaults.compaction`, but it runs only when raw history exceeds the hard replay budget for the next reply.
 `threshold_tokens` and `threshold_percent` set a soft trigger budget for planning metadata and compaction notices.
 Crossing that soft trigger while still within the hard budget leaves the stored session unchanged and relies on replay fitting.
+Use `replay_window_tokens` to cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
 Use `reserve_tokens` to leave hard-budget headroom, use `model` to choose the summary model, or set `enabled: false` to disable automatic pre-reply compaction for this agent.
-Replay safety always uses the active runtime model window.
+Replay safety uses the smaller of `replay_window_tokens` and the active runtime model window.
 If you set `compaction.model`, that summary model must also define its own `context_window`, but only for the durable summary-generation pass.
 If the current reply needs required compaction to preserve usable history, MindRoom sends `Compacting history...`, compacts before the model call, and edits that same notice with the result.
 Manual `compact_context` records a durable request that runs before the next reply in the same conversation scope.

--- a/docs/configuration/agents.md
+++ b/docs/configuration/agents.md
@@ -190,9 +190,16 @@ When the active runtime model has a known `context_window`, MindRoom always comp
 Automatic destructive compaction is enabled by default through `defaults.compaction`, but it runs only when raw history exceeds the hard replay budget for the next reply.
 `threshold_tokens` and `threshold_percent` set a soft trigger budget for planning metadata and compaction notices.
 Crossing that soft trigger while still within the hard budget leaves the stored session unchanged and relies on replay fitting.
-Use `replay_window_tokens` to cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
-Use `reserve_tokens` to leave hard-budget headroom, use `model` to choose the summary model, or set `enabled: false` to disable automatic pre-reply compaction for this agent.
-Replay safety uses the smaller of `replay_window_tokens` and the active runtime model window.
+
+You can tune compaction behavior with these settings:
+
+- Use `replay_window_tokens` to cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
+- Use `reserve_tokens` to leave hard-budget headroom.
+- Use `model` to choose the summary model.
+- Set `enabled: false` to disable automatic pre-reply compaction for this agent.
+
+When the active runtime model window is known, replay safety uses the smaller of it and `replay_window_tokens`.
+When that model window is unknown, an explicit `replay_window_tokens` still supplies the replay-planning window.
 If you set `compaction.model`, that summary model must also define its own `context_window`, but only for the durable summary-generation pass.
 If the current reply needs required compaction to preserve usable history, MindRoom sends `Compacting history...`, compacts before the model call, and edits that same notice with the result.
 Manual `compact_context` records a durable request that runs before the next reply in the same conversation scope.

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -382,6 +382,7 @@ defaults:
   compaction:
     enabled: true
     threshold_percent: 0.8
+    replay_window_tokens: null     # Optional persisted-replay cap; does not change the model's real context window
     reserve_tokens: 16384
   max_tool_calls_from_history: null  # Limit tool call messages replayed from history (null = no limit)
   show_tool_calls: true            # Default: true (show tool details inline; hidden mode still allows generic worker warmup copy)

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -33,7 +33,7 @@ Each model configuration supports the following fields:
 | `host` | No | `null` | Host URL for self-hosted models (e.g., Ollama) |
 | `api_key` | No | `null` | API key (usually read from environment variables) |
 | `extra_kwargs` | No | `null` | Additional provider-specific parameters |
-| `context_window` | No | `null` | Context window size in tokens; MindRoom needs it on the active runtime model to enforce replay budgets, an explicit `compaction.model` also needs its own `context_window` for destructive compaction, and on `vertexai_claude` models it additionally enables request-time fitting that trims replayed history when a request would exceed the window |
+| `context_window` | No | `null` | Actual model context window size in tokens; MindRoom needs it on the active runtime model to enforce request and replay budgets, and an explicit `compaction.model` also needs its own `context_window` for destructive compaction |
 
 ## Configuration Examples
 
@@ -243,7 +243,8 @@ For starter config generation, use `mindroom config init --provider bedrock_clau
 
 ## Context Window
 
-When `context_window` is set, MindRoom uses it to budget persisted replay and required destructive compaction.
+Set `context_window` to the model provider's actual limit.
+MindRoom uses it to budget persisted replay and required destructive compaction unless compaction config sets a smaller `replay_window_tokens` cap.
 MindRoom always applies a final replay-fit step when the active runtime model has a known `context_window`.
 That replay-fit step reduces or disables persisted replay for the current run when needed.
 On `vertexai_claude` models, a known `context_window` also enables a request-time guard inside the provider call.
@@ -255,6 +256,7 @@ Set `enabled: false` in `defaults.compaction` or a per-agent/per-team `compactio
 It runs only when history exceeds the hard replay budget for the next reply.
 Use `threshold_tokens` or `threshold_percent` to set the soft trigger budget that appears in planning metadata and compaction notices.
 Crossing that soft trigger while still within the hard budget leaves the stored session unchanged and relies on replay fitting for that reply.
+Use `replay_window_tokens` to keep persisted replay and required compaction within a smaller operational window without presenting that smaller value as the provider's request limit.
 Use `reserve_tokens` to leave hard-budget headroom for the current prompt and output.
 Manual `compact_context` records a durable request that runs before the next reply in the same conversation scope.
 Manual `compact_context` remains available when a compaction model and context window are configured.
@@ -273,6 +275,10 @@ models:
     provider: anthropic
     id: claude-sonnet-5
     context_window: 1000000  # 1M tokens
+
+defaults:
+  compaction:
+    replay_window_tokens: 200000  # Compact persisted history around a smaller operational window
 ```
 
 This is useful for models with smaller context windows or long-running conversations that accumulate persisted history.

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -254,10 +254,16 @@ When the current turn alone cannot fit, the request fails with a clear provider 
 Automatic destructive compaction is enabled by default through `defaults.compaction`.
 Set `enabled: false` in `defaults.compaction` or a per-agent/per-team `compaction` override to disable automatic pre-reply compaction.
 It runs only when history exceeds the hard replay budget for the next reply.
-Use `threshold_tokens` or `threshold_percent` to set the soft trigger budget that appears in planning metadata and compaction notices.
-Crossing that soft trigger while still within the hard budget leaves the stored session unchanged and relies on replay fitting for that reply.
-Use `replay_window_tokens` to keep persisted replay and required compaction within a smaller operational window without presenting that smaller value as the provider's request limit.
-Use `reserve_tokens` to leave hard-budget headroom for the current prompt and output.
+
+You can tune compaction behavior with these settings:
+
+- Use `threshold_tokens` or `threshold_percent` to set the soft trigger budget. Crossing this soft trigger while still within the hard budget leaves the stored session unchanged and relies on replay fitting for that reply.
+- Use `replay_window_tokens` to keep persisted replay and required compaction within a smaller operational window without presenting that smaller value as the provider's request limit.
+- Use `reserve_tokens` to leave hard-budget headroom for the current prompt and output.
+
+When the active runtime model window is known, replay safety uses the smaller of it and `replay_window_tokens`.
+When that model window is unknown, an explicit `replay_window_tokens` still supplies the replay-planning window.
+
 Manual `compact_context` records a durable request that runs before the next reply in the same conversation scope.
 Manual `compact_context` remains available when a compaction model and context window are configured.
 It still uses the active runtime window for the final replay-fit step, but destructive compaction itself can be available whenever an explicit `compaction.model` has its own `context_window`.

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -33,7 +33,7 @@ Each model configuration supports the following fields:
 | `host` | No | `null` | Host URL for self-hosted models (e.g., Ollama) |
 | `api_key` | No | `null` | API key (usually read from environment variables) |
 | `extra_kwargs` | No | `null` | Additional provider-specific parameters |
-| `context_window` | No | `null` | Actual model context window size in tokens; MindRoom needs it on the active runtime model to enforce request and replay budgets, and an explicit `compaction.model` also needs its own `context_window` for destructive compaction |
+| `context_window` | No | `null` | Actual provider context window size in tokens; MindRoom uses it as the default replay-planning window unless compaction sets a smaller `replay_window_tokens`; an explicit `compaction.model` needs its own `context_window` for summary generation; on `vertexai_claude` it also enables request-time fitting |
 
 ## Configuration Examples
 

--- a/docs/configuration/teams.md
+++ b/docs/configuration/teams.md
@@ -102,13 +102,14 @@ Team YAML keys follow the same naming rules as agents: alphanumeric characters a
 `num_history_runs` and `num_history_messages` are mutually exclusive, just like the agent-level settings.
 When a named team sets these fields, the team scope uses the team-owned policy instead of inheriting one member's history policy.
 
-Team-scoped compaction supports `enabled`, `threshold_tokens`, `threshold_percent`, `reserve_tokens`, and `model`.
+Team-scoped compaction supports `enabled`, `threshold_tokens`, `threshold_percent`, `replay_window_tokens`, `reserve_tokens`, and `model`.
 When the active team model has a known `context_window`, MindRoom always computes a final replay plan for the shared team scope and reduces or disables persisted replay for the run when needed.
 Automatic destructive compaction is enabled by default through `defaults.compaction`, but it runs only when raw history exceeds the hard replay budget for the next reply.
 `threshold_tokens` and `threshold_percent` set a soft trigger budget for planning metadata and compaction notices.
 Crossing that soft trigger while still within the hard budget leaves the stored session unchanged and relies on replay fitting.
+Use `replay_window_tokens` to cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
 Use `enabled: false` to disable automatic pre-reply compaction for a team.
-Replay safety always uses the active team model window.
+Replay safety uses the smaller of `replay_window_tokens` and the active team model window.
 If you set `compaction.model`, that summary model must also define its own `context_window`, but only for the durable summary-generation pass.
 Manual `compact_context` remains available when a compaction model and context window are configured.
 Compaction uses an in-room lifecycle notice that is edited in place.

--- a/docs/configuration/teams.md
+++ b/docs/configuration/teams.md
@@ -107,9 +107,14 @@ When the active team model has a known `context_window`, MindRoom always compute
 Automatic destructive compaction is enabled by default through `defaults.compaction`, but it runs only when raw history exceeds the hard replay budget for the next reply.
 `threshold_tokens` and `threshold_percent` set a soft trigger budget for planning metadata and compaction notices.
 Crossing that soft trigger while still within the hard budget leaves the stored session unchanged and relies on replay fitting.
-Use `replay_window_tokens` to cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
-Use `enabled: false` to disable automatic pre-reply compaction for a team.
-Replay safety uses the smaller of `replay_window_tokens` and the active team model window.
+
+You can tune team-scoped compaction behavior with these settings:
+
+- Use `replay_window_tokens` to cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
+- Set `enabled: false` to disable automatic pre-reply compaction for a team.
+
+When the active team model window is known, replay safety uses the smaller of it and `replay_window_tokens`.
+When that model window is unknown, an explicit `replay_window_tokens` still supplies the replay-planning window.
 If you set `compaction.model`, that summary model must also define its own `context_window`, but only for the durable summary-generation pass.
 Manual `compact_context` remains available when a compaction model and context window are configured.
 Compaction uses an in-room lifecycle notice that is edited in place.

--- a/docs/dev/agent_configuration.md
+++ b/docs/dev/agent_configuration.md
@@ -184,9 +184,10 @@ agents:
 - **num_history_runs**: Number of prior Agno runs to include as history context (per-agent override)
 - **num_history_messages**: Max messages from history (mutually exclusive with `num_history_runs`)
 - **compress_tool_results**: Compress tool results in history to save context (per-agent override, inherits a default of `false`, and can invalidate Anthropic/Vertex Claude prompt caches when enabled)
-- **compaction**: Optional per-agent required-compaction overrides (`enabled`, `threshold_tokens`, `threshold_percent`, `reserve_tokens`, `model`); when the active runtime model has a known `context_window`, MindRoom always computes a replay plan for the current run and reduces or disables persisted replay when needed.
+- **compaction**: Optional per-agent required-compaction overrides (`enabled`, `threshold_tokens`, `threshold_percent`, `replay_window_tokens`, `reserve_tokens`, `model`); when the active runtime model has a known `context_window`, MindRoom always computes a replay plan for the current run and reduces or disables persisted replay when needed.
 Automatic destructive compaction is enabled by default through `defaults.compaction`, but it runs only when raw history exceeds the hard replay budget for the next reply.
 `threshold_tokens` and `threshold_percent` set a soft trigger budget for planning metadata and compaction notices; crossing that soft trigger while still within the hard budget leaves the stored session unchanged and relies on replay fitting.
+`replay_window_tokens` can cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
 Set `enabled: false` in defaults or the agent override to disable automatic pre-reply compaction.
 Manual `compact_context` records a durable request that runs before the next reply in the same conversation scope.
 Manual `compact_context` remains available when a compaction model and context window are configured.

--- a/docs/dev/agent_configuration.md
+++ b/docs/dev/agent_configuration.md
@@ -64,7 +64,7 @@ Each model entry supports these fields:
 - **host** - Optional host URL (e.g., for Ollama or OpenAI-compatible servers)
 - **api_key** - Optional API key (usually set via env vars instead)
 - **extra_kwargs** - Additional provider-specific parameters (e.g., `base_url`)
-- **context_window** - Context window size in tokens; when set, MindRoom budgets persisted replay and applies a final replay-fit step, which may reduce replay, fall back to summary-only replay, or disable persisted replay entirely for that run; on `vertexai_claude` models it additionally enables request-time fitting that trims replayed history when a request would exceed the window
+- **context_window** - Actual provider context window size in tokens; when set, MindRoom uses it as the default replay-planning window unless compaction config sets a smaller `replay_window_tokens`, and applies a final replay-fit step that may reduce or disable persisted replay for that run; on `vertexai_claude` models it additionally enables request-time fitting that trims replayed history when a request would exceed the window
 
 ### Supported Providers
 

--- a/docs/dev/agent_configuration.md
+++ b/docs/dev/agent_configuration.md
@@ -188,6 +188,7 @@ agents:
 Automatic destructive compaction is enabled by default through `defaults.compaction`, but it runs only when raw history exceeds the hard replay budget for the next reply.
 `threshold_tokens` and `threshold_percent` set a soft trigger budget for planning metadata and compaction notices; crossing that soft trigger while still within the hard budget leaves the stored session unchanged and relies on replay fitting.
 `replay_window_tokens` can cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
+If the active model window is unknown, an explicit `replay_window_tokens` still supplies the replay-planning window.
 Set `enabled: false` in defaults or the agent override to disable automatic pre-reply compaction.
 Manual `compact_context` records a durable request that runs before the next reply in the same conversation scope.
 Manual `compact_context` remains available when a compaction model and context window are configured.

--- a/frontend/src/components/AgentEditor/AgentEditor.test.tsx
+++ b/frontend/src/components/AgentEditor/AgentEditor.test.tsx
@@ -1181,6 +1181,34 @@ describe("AgentEditor", () => {
     });
   });
 
+  it("preserves replay-window-only compaction overrides as enabled", () => {
+    expect(
+      normalizeAgentUpdates(mockAgent, {
+        compaction: { replay_window_tokens: 200_000 },
+      }).compaction,
+    ).toEqual({
+      enabled: true,
+      replay_window_tokens: 200_000,
+    });
+  });
+
+  it("authors a replay window from the editor", async () => {
+    render(<AgentEditor />);
+
+    fireEvent.change(screen.getByLabelText("Replay Window Tokens"), {
+      target: { value: "200000" },
+    });
+
+    await waitFor(() => {
+      expect(mockStore.updateAgent).toHaveBeenCalledWith(
+        "test_agent",
+        expect.objectContaining({
+          compaction: { replay_window_tokens: 200_000 },
+        }),
+      );
+    });
+  });
+
   it("treats authored compaction overrides as enabled in the editor", () => {
     const compactionAgent: Agent = {
       ...mockAgent,
@@ -1320,6 +1348,35 @@ describe("AgentEditor", () => {
     expect(
       screen.getByLabelText("Enable automatic required compaction"),
     ).not.toBeChecked();
+  });
+
+  it("shows replay-window-only compaction as enabled when defaults are disabled", () => {
+    const compactionAgent: Agent = {
+      ...mockAgent,
+      compaction: { replay_window_tokens: 200_000 },
+    };
+    (useConfigStore as any).mockReturnValue({
+      ...mockStore,
+      agents: [compactionAgent],
+      config: {
+        ...mockConfig,
+        defaults: {
+          ...mockConfig.defaults,
+          compaction: {
+            enabled: false,
+            reserve_tokens: 16384,
+            threshold_percent: 0.8,
+          },
+        },
+        agents: { test_agent: compactionAgent },
+      },
+    });
+
+    render(<AgentEditor />);
+
+    expect(
+      screen.getByLabelText("Enable automatic required compaction"),
+    ).toBeChecked();
   });
 
   it("shows automatic required compaction as enabled when defaults.compaction is omitted", () => {

--- a/frontend/src/components/shared/HistoryContextSection.tsx
+++ b/frontend/src/components/shared/HistoryContextSection.tsx
@@ -333,7 +333,7 @@ export function HistoryContextSection<T extends HistoryContextFormValues>({
                   placeholder={
                     defaultCompaction?.threshold_tokens != null
                       ? `Default: ${defaultCompaction.threshold_tokens}`
-                      : "Default: derived from context window"
+                      : "Default: derived from replay window"
                   }
                   onChange={(e) => {
                     const value = parseOptionalInt(e.target.value, 1);
@@ -351,7 +351,7 @@ export function HistoryContextSection<T extends HistoryContextFormValues>({
 
               <FieldGroup
                 label="Threshold Percent"
-                helperText="Soft replay budget as a fraction of the context window. Crossing it records planning metadata; destructive compaction waits for the hard budget."
+                helperText="Soft replay budget as a fraction of the effective replay window. Crossing it records planning metadata; destructive compaction waits for the hard budget."
                 htmlFor="compaction_threshold_percent"
               >
                 <Input
@@ -396,6 +396,31 @@ export function HistoryContextSection<T extends HistoryContextFormValues>({
                           : "",
                       );
                     }
+                  }}
+                />
+              </FieldGroup>
+
+              <FieldGroup
+                label="Replay Window Tokens"
+                helperText="Optional persisted-replay and compaction-planning cap. This does not lower the model provider's request limit."
+                htmlFor="compaction_replay_window_tokens"
+              >
+                <Input
+                  id="compaction_replay_window_tokens"
+                  type="number"
+                  min={1}
+                  value={compactionConfig?.replay_window_tokens ?? ""}
+                  placeholder={
+                    defaultCompaction?.replay_window_tokens != null
+                      ? `Default: ${defaultCompaction.replay_window_tokens}`
+                      : "Default: model context window"
+                  }
+                  onChange={(e) => {
+                    const value = parseOptionalInt(e.target.value, 1);
+                    mutateCompaction((current) => ({
+                      ...(current ?? {}),
+                      replay_window_tokens: value ?? undefined,
+                    }));
                   }}
                 />
               </FieldGroup>

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -118,6 +118,7 @@ export interface CompactionConfig {
   enabled?: boolean;
   threshold_tokens?: number | null;
   threshold_percent?: number | null;
+  replay_window_tokens?: number | null;
   reserve_tokens?: number;
   model?: string | null;
 }
@@ -130,6 +131,7 @@ function isPureCompactionModelClear(compaction: CompactionConfig): boolean {
     compaction.enabled === undefined &&
     compaction.threshold_tokens === undefined &&
     compaction.threshold_percent === undefined &&
+    compaction.replay_window_tokens === undefined &&
     compaction.reserve_tokens === undefined
   );
 }
@@ -140,6 +142,7 @@ function isEmptyCompactionOverride(compaction: CompactionConfig): boolean {
     compaction.model === undefined &&
     compaction.threshold_tokens === undefined &&
     compaction.threshold_percent === undefined &&
+    compaction.replay_window_tokens === undefined &&
     compaction.reserve_tokens === undefined
   );
 }

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -1236,6 +1236,7 @@ defaults:
   compaction:
     enabled: true
     threshold_percent: 0.8
+    replay_window_tokens: null     # Optional persisted-replay cap; does not change the model's real context window
     reserve_tokens: 16384
   max_tool_calls_from_history: null  # Limit tool call messages replayed from history (null = no limit)
   show_tool_calls: true            # Default: true (show tool details inline; hidden mode still allows generic worker warmup copy)
@@ -1813,13 +1814,14 @@ Approval-gated tools are stricter than plain ad-hoc chat access.
 Approval-gated tools only work there while the router is already joined.
 
 MindRoom compacts in one visible lifecycle.
-Per-agent compaction supports `enabled`, `threshold_tokens`, `threshold_percent`, `reserve_tokens`, and `model`.
+Per-agent compaction supports `enabled`, `threshold_tokens`, `threshold_percent`, `replay_window_tokens`, `reserve_tokens`, and `model`.
 When the active runtime model has a known `context_window`, MindRoom always computes a per-run replay plan that reduces or disables persisted replay before the model call if needed.
 Automatic destructive compaction is enabled by default through `defaults.compaction`, but it runs only when raw history exceeds the hard replay budget for the next reply.
 `threshold_tokens` and `threshold_percent` set a soft trigger budget for planning metadata and compaction notices.
 Crossing that soft trigger while still within the hard budget leaves the stored session unchanged and relies on replay fitting.
+Use `replay_window_tokens` to cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
 Use `reserve_tokens` to leave hard-budget headroom, use `model` to choose the summary model, or set `enabled: false` to disable automatic pre-reply compaction for this agent.
-Replay safety always uses the active runtime model window.
+Replay safety uses the smaller of `replay_window_tokens` and the active runtime model window.
 If you set `compaction.model`, that summary model must also define its own `context_window`, but only for the durable summary-generation pass.
 If the current reply needs required compaction to preserve usable history, MindRoom sends `Compacting history...`, compacts before the model call, and edits that same notice with the result.
 Manual `compact_context` records a durable request that runs before the next reply in the same conversation scope.
@@ -2302,7 +2304,7 @@ Each model configuration supports the following fields:
 | `host` | No | `null` | Host URL for self-hosted models (e.g., Ollama) |
 | `api_key` | No | `null` | API key (usually read from environment variables) |
 | `extra_kwargs` | No | `null` | Additional provider-specific parameters |
-| `context_window` | No | `null` | Context window size in tokens; MindRoom needs it on the active runtime model to enforce replay budgets, an explicit `compaction.model` also needs its own `context_window` for destructive compaction, and on `vertexai_claude` models it additionally enables request-time fitting that trims replayed history when a request would exceed the window |
+| `context_window` | No | `null` | Actual model context window size in tokens; MindRoom needs it on the active runtime model to enforce request and replay budgets, and an explicit `compaction.model` also needs its own `context_window` for destructive compaction |
 
 ## Configuration Examples
 
@@ -2512,7 +2514,8 @@ For starter config generation, use `mindroom config init --provider bedrock_clau
 
 ## Context Window
 
-When `context_window` is set, MindRoom uses it to budget persisted replay and required destructive compaction.
+Set `context_window` to the model provider's actual limit.
+MindRoom uses it to budget persisted replay and required destructive compaction unless compaction config sets a smaller `replay_window_tokens` cap.
 MindRoom always applies a final replay-fit step when the active runtime model has a known `context_window`.
 That replay-fit step reduces or disables persisted replay for the current run when needed.
 On `vertexai_claude` models, a known `context_window` also enables a request-time guard inside the provider call.
@@ -2524,6 +2527,7 @@ Set `enabled: false` in `defaults.compaction` or a per-agent/per-team `compactio
 It runs only when history exceeds the hard replay budget for the next reply.
 Use `threshold_tokens` or `threshold_percent` to set the soft trigger budget that appears in planning metadata and compaction notices.
 Crossing that soft trigger while still within the hard budget leaves the stored session unchanged and relies on replay fitting for that reply.
+Use `replay_window_tokens` to keep persisted replay and required compaction within a smaller operational window without presenting that smaller value as the provider's request limit.
 Use `reserve_tokens` to leave hard-budget headroom for the current prompt and output.
 Manual `compact_context` records a durable request that runs before the next reply in the same conversation scope.
 Manual `compact_context` remains available when a compaction model and context window are configured.
@@ -2542,6 +2546,10 @@ models:
     provider: anthropic
     id: claude-sonnet-5
     context_window: 1000000  # 1M tokens
+
+defaults:
+  compaction:
+    replay_window_tokens: 200000  # Compact persisted history around a smaller operational window
 ```
 
 This is useful for models with smaller context windows or long-running conversations that accumulate persisted history.
@@ -2715,13 +2723,14 @@ Team YAML keys follow the same naming rules as agents: alphanumeric characters a
 `num_history_runs` and `num_history_messages` are mutually exclusive, just like the agent-level settings.
 When a named team sets these fields, the team scope uses the team-owned policy instead of inheriting one member's history policy.
 
-Team-scoped compaction supports `enabled`, `threshold_tokens`, `threshold_percent`, `reserve_tokens`, and `model`.
+Team-scoped compaction supports `enabled`, `threshold_tokens`, `threshold_percent`, `replay_window_tokens`, `reserve_tokens`, and `model`.
 When the active team model has a known `context_window`, MindRoom always computes a final replay plan for the shared team scope and reduces or disables persisted replay for the run when needed.
 Automatic destructive compaction is enabled by default through `defaults.compaction`, but it runs only when raw history exceeds the hard replay budget for the next reply.
 `threshold_tokens` and `threshold_percent` set a soft trigger budget for planning metadata and compaction notices.
 Crossing that soft trigger while still within the hard budget leaves the stored session unchanged and relies on replay fitting.
+Use `replay_window_tokens` to cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
 Use `enabled: false` to disable automatic pre-reply compaction for a team.
-Replay safety always uses the active team model window.
+Replay safety uses the smaller of `replay_window_tokens` and the active team model window.
 If you set `compaction.model`, that summary model must also define its own `context_window`, but only for the durable summary-generation pass.
 Manual `compact_context` remains available when a compaction model and context window are configured.
 Compaction uses an in-room lifecycle notice that is edited in place.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -1819,9 +1819,16 @@ When the active runtime model has a known `context_window`, MindRoom always comp
 Automatic destructive compaction is enabled by default through `defaults.compaction`, but it runs only when raw history exceeds the hard replay budget for the next reply.
 `threshold_tokens` and `threshold_percent` set a soft trigger budget for planning metadata and compaction notices.
 Crossing that soft trigger while still within the hard budget leaves the stored session unchanged and relies on replay fitting.
-Use `replay_window_tokens` to cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
-Use `reserve_tokens` to leave hard-budget headroom, use `model` to choose the summary model, or set `enabled: false` to disable automatic pre-reply compaction for this agent.
-Replay safety uses the smaller of `replay_window_tokens` and the active runtime model window.
+
+You can tune compaction behavior with these settings:
+
+- Use `replay_window_tokens` to cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
+- Use `reserve_tokens` to leave hard-budget headroom.
+- Use `model` to choose the summary model.
+- Set `enabled: false` to disable automatic pre-reply compaction for this agent.
+
+When the active runtime model window is known, replay safety uses the smaller of it and `replay_window_tokens`.
+When that model window is unknown, an explicit `replay_window_tokens` still supplies the replay-planning window.
 If you set `compaction.model`, that summary model must also define its own `context_window`, but only for the durable summary-generation pass.
 If the current reply needs required compaction to preserve usable history, MindRoom sends `Compacting history...`, compacts before the model call, and edits that same notice with the result.
 Manual `compact_context` records a durable request that runs before the next reply in the same conversation scope.
@@ -2525,10 +2532,16 @@ When the current turn alone cannot fit, the request fails with a clear provider 
 Automatic destructive compaction is enabled by default through `defaults.compaction`.
 Set `enabled: false` in `defaults.compaction` or a per-agent/per-team `compaction` override to disable automatic pre-reply compaction.
 It runs only when history exceeds the hard replay budget for the next reply.
-Use `threshold_tokens` or `threshold_percent` to set the soft trigger budget that appears in planning metadata and compaction notices.
-Crossing that soft trigger while still within the hard budget leaves the stored session unchanged and relies on replay fitting for that reply.
-Use `replay_window_tokens` to keep persisted replay and required compaction within a smaller operational window without presenting that smaller value as the provider's request limit.
-Use `reserve_tokens` to leave hard-budget headroom for the current prompt and output.
+
+You can tune compaction behavior with these settings:
+
+- Use `threshold_tokens` or `threshold_percent` to set the soft trigger budget. Crossing this soft trigger while still within the hard budget leaves the stored session unchanged and relies on replay fitting for that reply.
+- Use `replay_window_tokens` to keep persisted replay and required compaction within a smaller operational window without presenting that smaller value as the provider's request limit.
+- Use `reserve_tokens` to leave hard-budget headroom for the current prompt and output.
+
+When the active runtime model window is known, replay safety uses the smaller of it and `replay_window_tokens`.
+When that model window is unknown, an explicit `replay_window_tokens` still supplies the replay-planning window.
+
 Manual `compact_context` records a durable request that runs before the next reply in the same conversation scope.
 Manual `compact_context` remains available when a compaction model and context window are configured.
 It still uses the active runtime window for the final replay-fit step, but destructive compaction itself can be available whenever an explicit `compaction.model` has its own `context_window`.
@@ -2728,9 +2741,14 @@ When the active team model has a known `context_window`, MindRoom always compute
 Automatic destructive compaction is enabled by default through `defaults.compaction`, but it runs only when raw history exceeds the hard replay budget for the next reply.
 `threshold_tokens` and `threshold_percent` set a soft trigger budget for planning metadata and compaction notices.
 Crossing that soft trigger while still within the hard budget leaves the stored session unchanged and relies on replay fitting.
-Use `replay_window_tokens` to cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
-Use `enabled: false` to disable automatic pre-reply compaction for a team.
-Replay safety uses the smaller of `replay_window_tokens` and the active team model window.
+
+You can tune team-scoped compaction behavior with these settings:
+
+- Use `replay_window_tokens` to cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
+- Set `enabled: false` to disable automatic pre-reply compaction for a team.
+
+When the active team model window is known, replay safety uses the smaller of it and `replay_window_tokens`.
+When that model window is unknown, an explicit `replay_window_tokens` still supplies the replay-planning window.
 If you set `compaction.model`, that summary model must also define its own `context_window`, but only for the durable summary-generation pass.
 Manual `compact_context` remains available when a compaction model and context window are configured.
 Compaction uses an in-room lifecycle notice that is edited in place.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -2311,7 +2311,7 @@ Each model configuration supports the following fields:
 | `host` | No | `null` | Host URL for self-hosted models (e.g., Ollama) |
 | `api_key` | No | `null` | API key (usually read from environment variables) |
 | `extra_kwargs` | No | `null` | Additional provider-specific parameters |
-| `context_window` | No | `null` | Actual model context window size in tokens; MindRoom needs it on the active runtime model to enforce request and replay budgets, and an explicit `compaction.model` also needs its own `context_window` for destructive compaction |
+| `context_window` | No | `null` | Actual provider context window size in tokens; MindRoom uses it as the default replay-planning window unless compaction sets a smaller `replay_window_tokens`; an explicit `compaction.model` needs its own `context_window` for summary generation; on `vertexai_claude` it also enables request-time fitting |
 
 ## Configuration Examples
 

--- a/skills/mindroom-docs/references/page__configuration__agents__index.md
+++ b/skills/mindroom-docs/references/page__configuration__agents__index.md
@@ -186,9 +186,16 @@ When the active runtime model has a known `context_window`, MindRoom always comp
 Automatic destructive compaction is enabled by default through `defaults.compaction`, but it runs only when raw history exceeds the hard replay budget for the next reply.
 `threshold_tokens` and `threshold_percent` set a soft trigger budget for planning metadata and compaction notices.
 Crossing that soft trigger while still within the hard budget leaves the stored session unchanged and relies on replay fitting.
-Use `replay_window_tokens` to cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
-Use `reserve_tokens` to leave hard-budget headroom, use `model` to choose the summary model, or set `enabled: false` to disable automatic pre-reply compaction for this agent.
-Replay safety uses the smaller of `replay_window_tokens` and the active runtime model window.
+
+You can tune compaction behavior with these settings:
+
+- Use `replay_window_tokens` to cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
+- Use `reserve_tokens` to leave hard-budget headroom.
+- Use `model` to choose the summary model.
+- Set `enabled: false` to disable automatic pre-reply compaction for this agent.
+
+When the active runtime model window is known, replay safety uses the smaller of it and `replay_window_tokens`.
+When that model window is unknown, an explicit `replay_window_tokens` still supplies the replay-planning window.
 If you set `compaction.model`, that summary model must also define its own `context_window`, but only for the durable summary-generation pass.
 If the current reply needs required compaction to preserve usable history, MindRoom sends `Compacting history...`, compacts before the model call, and edits that same notice with the result.
 Manual `compact_context` records a durable request that runs before the next reply in the same conversation scope.

--- a/skills/mindroom-docs/references/page__configuration__agents__index.md
+++ b/skills/mindroom-docs/references/page__configuration__agents__index.md
@@ -181,13 +181,14 @@ Approval-gated tools are stricter than plain ad-hoc chat access.
 Approval-gated tools only work there while the router is already joined.
 
 MindRoom compacts in one visible lifecycle.
-Per-agent compaction supports `enabled`, `threshold_tokens`, `threshold_percent`, `reserve_tokens`, and `model`.
+Per-agent compaction supports `enabled`, `threshold_tokens`, `threshold_percent`, `replay_window_tokens`, `reserve_tokens`, and `model`.
 When the active runtime model has a known `context_window`, MindRoom always computes a per-run replay plan that reduces or disables persisted replay before the model call if needed.
 Automatic destructive compaction is enabled by default through `defaults.compaction`, but it runs only when raw history exceeds the hard replay budget for the next reply.
 `threshold_tokens` and `threshold_percent` set a soft trigger budget for planning metadata and compaction notices.
 Crossing that soft trigger while still within the hard budget leaves the stored session unchanged and relies on replay fitting.
+Use `replay_window_tokens` to cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
 Use `reserve_tokens` to leave hard-budget headroom, use `model` to choose the summary model, or set `enabled: false` to disable automatic pre-reply compaction for this agent.
-Replay safety always uses the active runtime model window.
+Replay safety uses the smaller of `replay_window_tokens` and the active runtime model window.
 If you set `compaction.model`, that summary model must also define its own `context_window`, but only for the durable summary-generation pass.
 If the current reply needs required compaction to preserve usable history, MindRoom sends `Compacting history...`, compacts before the model call, and edits that same notice with the result.
 Manual `compact_context` records a durable request that runs before the next reply in the same conversation scope.

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -378,6 +378,7 @@ defaults:
   compaction:
     enabled: true
     threshold_percent: 0.8
+    replay_window_tokens: null     # Optional persisted-replay cap; does not change the model's real context window
     reserve_tokens: 16384
   max_tool_calls_from_history: null  # Limit tool call messages replayed from history (null = no limit)
   show_tool_calls: true            # Default: true (show tool details inline; hidden mode still allows generic worker warmup copy)

--- a/skills/mindroom-docs/references/page__configuration__models__index.md
+++ b/skills/mindroom-docs/references/page__configuration__models__index.md
@@ -29,7 +29,7 @@ Each model configuration supports the following fields:
 | `host` | No | `null` | Host URL for self-hosted models (e.g., Ollama) |
 | `api_key` | No | `null` | API key (usually read from environment variables) |
 | `extra_kwargs` | No | `null` | Additional provider-specific parameters |
-| `context_window` | No | `null` | Actual model context window size in tokens; MindRoom needs it on the active runtime model to enforce request and replay budgets, and an explicit `compaction.model` also needs its own `context_window` for destructive compaction |
+| `context_window` | No | `null` | Actual provider context window size in tokens; MindRoom uses it as the default replay-planning window unless compaction sets a smaller `replay_window_tokens`; an explicit `compaction.model` needs its own `context_window` for summary generation; on `vertexai_claude` it also enables request-time fitting |
 
 ## Configuration Examples
 

--- a/skills/mindroom-docs/references/page__configuration__models__index.md
+++ b/skills/mindroom-docs/references/page__configuration__models__index.md
@@ -250,10 +250,16 @@ When the current turn alone cannot fit, the request fails with a clear provider 
 Automatic destructive compaction is enabled by default through `defaults.compaction`.
 Set `enabled: false` in `defaults.compaction` or a per-agent/per-team `compaction` override to disable automatic pre-reply compaction.
 It runs only when history exceeds the hard replay budget for the next reply.
-Use `threshold_tokens` or `threshold_percent` to set the soft trigger budget that appears in planning metadata and compaction notices.
-Crossing that soft trigger while still within the hard budget leaves the stored session unchanged and relies on replay fitting for that reply.
-Use `replay_window_tokens` to keep persisted replay and required compaction within a smaller operational window without presenting that smaller value as the provider's request limit.
-Use `reserve_tokens` to leave hard-budget headroom for the current prompt and output.
+
+You can tune compaction behavior with these settings:
+
+- Use `threshold_tokens` or `threshold_percent` to set the soft trigger budget. Crossing this soft trigger while still within the hard budget leaves the stored session unchanged and relies on replay fitting for that reply.
+- Use `replay_window_tokens` to keep persisted replay and required compaction within a smaller operational window without presenting that smaller value as the provider's request limit.
+- Use `reserve_tokens` to leave hard-budget headroom for the current prompt and output.
+
+When the active runtime model window is known, replay safety uses the smaller of it and `replay_window_tokens`.
+When that model window is unknown, an explicit `replay_window_tokens` still supplies the replay-planning window.
+
 Manual `compact_context` records a durable request that runs before the next reply in the same conversation scope.
 Manual `compact_context` remains available when a compaction model and context window are configured.
 It still uses the active runtime window for the final replay-fit step, but destructive compaction itself can be available whenever an explicit `compaction.model` has its own `context_window`.

--- a/skills/mindroom-docs/references/page__configuration__models__index.md
+++ b/skills/mindroom-docs/references/page__configuration__models__index.md
@@ -29,7 +29,7 @@ Each model configuration supports the following fields:
 | `host` | No | `null` | Host URL for self-hosted models (e.g., Ollama) |
 | `api_key` | No | `null` | API key (usually read from environment variables) |
 | `extra_kwargs` | No | `null` | Additional provider-specific parameters |
-| `context_window` | No | `null` | Context window size in tokens; MindRoom needs it on the active runtime model to enforce replay budgets, an explicit `compaction.model` also needs its own `context_window` for destructive compaction, and on `vertexai_claude` models it additionally enables request-time fitting that trims replayed history when a request would exceed the window |
+| `context_window` | No | `null` | Actual model context window size in tokens; MindRoom needs it on the active runtime model to enforce request and replay budgets, and an explicit `compaction.model` also needs its own `context_window` for destructive compaction |
 
 ## Configuration Examples
 
@@ -239,7 +239,8 @@ For starter config generation, use `mindroom config init --provider bedrock_clau
 
 ## Context Window
 
-When `context_window` is set, MindRoom uses it to budget persisted replay and required destructive compaction.
+Set `context_window` to the model provider's actual limit.
+MindRoom uses it to budget persisted replay and required destructive compaction unless compaction config sets a smaller `replay_window_tokens` cap.
 MindRoom always applies a final replay-fit step when the active runtime model has a known `context_window`.
 That replay-fit step reduces or disables persisted replay for the current run when needed.
 On `vertexai_claude` models, a known `context_window` also enables a request-time guard inside the provider call.
@@ -251,6 +252,7 @@ Set `enabled: false` in `defaults.compaction` or a per-agent/per-team `compactio
 It runs only when history exceeds the hard replay budget for the next reply.
 Use `threshold_tokens` or `threshold_percent` to set the soft trigger budget that appears in planning metadata and compaction notices.
 Crossing that soft trigger while still within the hard budget leaves the stored session unchanged and relies on replay fitting for that reply.
+Use `replay_window_tokens` to keep persisted replay and required compaction within a smaller operational window without presenting that smaller value as the provider's request limit.
 Use `reserve_tokens` to leave hard-budget headroom for the current prompt and output.
 Manual `compact_context` records a durable request that runs before the next reply in the same conversation scope.
 Manual `compact_context` remains available when a compaction model and context window are configured.
@@ -269,6 +271,10 @@ models:
     provider: anthropic
     id: claude-sonnet-5
     context_window: 1000000  # 1M tokens
+
+defaults:
+  compaction:
+    replay_window_tokens: 200000  # Compact persisted history around a smaller operational window
 ```
 
 This is useful for models with smaller context windows or long-running conversations that accumulate persisted history.

--- a/skills/mindroom-docs/references/page__configuration__teams__index.md
+++ b/skills/mindroom-docs/references/page__configuration__teams__index.md
@@ -98,13 +98,14 @@ Team YAML keys follow the same naming rules as agents: alphanumeric characters a
 `num_history_runs` and `num_history_messages` are mutually exclusive, just like the agent-level settings.
 When a named team sets these fields, the team scope uses the team-owned policy instead of inheriting one member's history policy.
 
-Team-scoped compaction supports `enabled`, `threshold_tokens`, `threshold_percent`, `reserve_tokens`, and `model`.
+Team-scoped compaction supports `enabled`, `threshold_tokens`, `threshold_percent`, `replay_window_tokens`, `reserve_tokens`, and `model`.
 When the active team model has a known `context_window`, MindRoom always computes a final replay plan for the shared team scope and reduces or disables persisted replay for the run when needed.
 Automatic destructive compaction is enabled by default through `defaults.compaction`, but it runs only when raw history exceeds the hard replay budget for the next reply.
 `threshold_tokens` and `threshold_percent` set a soft trigger budget for planning metadata and compaction notices.
 Crossing that soft trigger while still within the hard budget leaves the stored session unchanged and relies on replay fitting.
+Use `replay_window_tokens` to cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
 Use `enabled: false` to disable automatic pre-reply compaction for a team.
-Replay safety always uses the active team model window.
+Replay safety uses the smaller of `replay_window_tokens` and the active team model window.
 If you set `compaction.model`, that summary model must also define its own `context_window`, but only for the durable summary-generation pass.
 Manual `compact_context` remains available when a compaction model and context window are configured.
 Compaction uses an in-room lifecycle notice that is edited in place.

--- a/skills/mindroom-docs/references/page__configuration__teams__index.md
+++ b/skills/mindroom-docs/references/page__configuration__teams__index.md
@@ -103,9 +103,14 @@ When the active team model has a known `context_window`, MindRoom always compute
 Automatic destructive compaction is enabled by default through `defaults.compaction`, but it runs only when raw history exceeds the hard replay budget for the next reply.
 `threshold_tokens` and `threshold_percent` set a soft trigger budget for planning metadata and compaction notices.
 Crossing that soft trigger while still within the hard budget leaves the stored session unchanged and relies on replay fitting.
-Use `replay_window_tokens` to cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
-Use `enabled: false` to disable automatic pre-reply compaction for a team.
-Replay safety uses the smaller of `replay_window_tokens` and the active team model window.
+
+You can tune team-scoped compaction behavior with these settings:
+
+- Use `replay_window_tokens` to cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
+- Set `enabled: false` to disable automatic pre-reply compaction for a team.
+
+When the active team model window is known, replay safety uses the smaller of it and `replay_window_tokens`.
+When that model window is unknown, an explicit `replay_window_tokens` still supplies the replay-planning window.
 If you set `compaction.model`, that summary model must also define its own `context_window`, but only for the durable summary-generation pass.
 Manual `compact_context` remains available when a compaction model and context window are configured.
 Compaction uses an in-room lifecycle notice that is edited in place.

--- a/src/mindroom/config/models.py
+++ b/src/mindroom/config/models.py
@@ -241,6 +241,11 @@ class CompactionOverrideConfig(BaseModel):
         lt=1,
         description="Soft replay trigger budget as a fraction of the context window",
     )
+    replay_window_tokens: int | None = Field(
+        default=None,
+        ge=1,
+        description="Optional context-window cap used only for persisted replay and compaction planning",
+    )
     reserve_tokens: int | None = Field(
         default=None,
         ge=0,
@@ -278,6 +283,11 @@ class CompactionConfig(BaseModel):
         gt=0,
         lt=1,
         description="Soft replay trigger budget as a fraction of the context window",
+    )
+    replay_window_tokens: int | None = Field(
+        default=None,
+        ge=1,
+        description="Optional context-window cap used only for persisted replay and compaction planning",
     )
     reserve_tokens: int = Field(
         default=16384,

--- a/src/mindroom/config/models.py
+++ b/src/mindroom/config/models.py
@@ -239,7 +239,7 @@ class CompactionOverrideConfig(BaseModel):
         default=None,
         gt=0,
         lt=1,
-        description="Soft replay trigger budget as a fraction of the context window",
+        description="Soft replay trigger budget as a fraction of the effective replay window",
     )
     replay_window_tokens: int | None = Field(
         default=None,
@@ -276,13 +276,16 @@ class CompactionConfig(BaseModel):
     threshold_tokens: int | None = Field(
         default=None,
         ge=1,
-        description="Soft replay trigger budget in tokens (defaults to 80% of context window when both thresholds are None)",
+        description=(
+            "Soft replay trigger budget in tokens "
+            "(defaults to 80% of the effective replay window when both thresholds are None)"
+        ),
     )
     threshold_percent: float | None = Field(
         default=None,
         gt=0,
         lt=1,
-        description="Soft replay trigger budget as a fraction of the context window",
+        description="Soft replay trigger budget as a fraction of the effective replay window",
     )
     replay_window_tokens: int | None = Field(
         default=None,

--- a/src/mindroom/config/models.py
+++ b/src/mindroom/config/models.py
@@ -551,7 +551,12 @@ class ModelConfig(BaseModel):
     context_window: int | None = Field(
         default=None,
         ge=1,
-        description="Context window size in tokens. MindRoom needs it on the active runtime model to enforce replay budgets, an explicit compaction.model also needs its own context_window for destructive compaction, and on vertexai_claude models it additionally enables request-time fitting that trims replayed history when a request would exceed the window",
+        description=(
+            "Actual provider context window size in tokens. MindRoom uses it as the default replay-planning "
+            "window unless compaction.replay_window_tokens sets a smaller cap. An explicit compaction.model "
+            "also needs its own context_window for summary generation. On vertexai_claude models it additionally "
+            "enables request-time fitting that trims replayed history when a request would exceed the window"
+        ),
     )
 
 

--- a/src/mindroom/history/policy.py
+++ b/src/mindroom/history/policy.py
@@ -30,7 +30,10 @@ def resolve_history_execution_plan(
         active_context_window=active_context_window,
     )
     compaction_context_window = compaction_runtime.context_window
-    replay_window_tokens = active_context_window
+    replay_window_tokens = _resolve_replay_window(
+        active_context_window=active_context_window,
+        configured_replay_window=compaction_config.replay_window_tokens,
+    )
     summary_input_budget_tokens, unavailable_reason = _resolve_summary_input_budget(
         compaction_context_window=compaction_context_window,
         reserve_tokens=compaction_config.reserve_tokens,
@@ -201,6 +204,17 @@ def context_budget_after_reserve(context_window_tokens: int, reserve_tokens: int
     """Return the usable context budget after clamped reserve and known prompt cost."""
     normalized_reserve_tokens = _normalize_compaction_budget_tokens(reserve_tokens, context_window_tokens)
     return max(0, context_window_tokens - normalized_reserve_tokens - spent_tokens)
+
+
+def _resolve_replay_window(
+    *,
+    active_context_window: int | None,
+    configured_replay_window: int | None,
+) -> int | None:
+    """Cap persisted replay without changing the provider's real context window."""
+    if active_context_window is None or configured_replay_window is None:
+        return active_context_window
+    return min(active_context_window, configured_replay_window)
 
 
 def _resolve_replay_budget_tokens(

--- a/src/mindroom/history/policy.py
+++ b/src/mindroom/history/policy.py
@@ -253,15 +253,15 @@ class _ResolvedCompactionRuntime:
     context_window: int | None
 
 
-def _resolve_effective_compaction_threshold(compaction_config: CompactionConfig, context_window: int) -> int:
+def _resolve_effective_compaction_threshold(compaction_config: CompactionConfig, replay_window_tokens: int) -> int:
     """Resolve the soft replay trigger budget in tokens."""
     threshold_tokens = compaction_config.threshold_tokens
     if threshold_tokens is not None:
         return threshold_tokens
     threshold_percent = compaction_config.threshold_percent
     if threshold_percent is not None:
-        return int(context_window * threshold_percent)
-    return int(context_window * 0.8)
+        return int(replay_window_tokens * threshold_percent)
+    return int(replay_window_tokens * 0.8)
 
 
 def _normalize_compaction_budget_tokens(tokens: int, context_window: int | None) -> int:

--- a/src/mindroom/history/policy.py
+++ b/src/mindroom/history/policy.py
@@ -212,8 +212,10 @@ def _resolve_replay_window(
     configured_replay_window: int | None,
 ) -> int | None:
     """Cap persisted replay without changing the provider's real context window."""
-    if active_context_window is None or configured_replay_window is None:
+    if configured_replay_window is None:
         return active_context_window
+    if active_context_window is None:
+        return configured_replay_window
     return min(active_context_window, configured_replay_window)
 
 

--- a/tests/test_config_entity_view.py
+++ b/tests/test_config_entity_view.py
@@ -66,6 +66,7 @@ def _representative_config() -> Config:
             compaction=CompactionConfig(
                 enabled=False,
                 threshold_tokens=12_000,
+                replay_window_tokens=24_000,
                 reserve_tokens=2_048,
                 model="summary-model",
             ),
@@ -107,6 +108,7 @@ def test_compaction_resolution() -> None:
     assert merged.enabled is True
     assert merged.threshold_tokens is None
     assert merged.threshold_percent == 0.6
+    assert merged.replay_window_tokens == 24_000
     assert merged.reserve_tokens == 2_048
     assert merged.model == "summary-model"
 
@@ -119,6 +121,7 @@ def test_compaction_resolution() -> None:
         assert inherited == CompactionConfig(
             enabled=False,
             threshold_tokens=12_000,
+            replay_window_tokens=24_000,
             reserve_tokens=2_048,
             model="summary-model",
         )

--- a/tests/test_history_replay_planning.py
+++ b/tests/test_history_replay_planning.py
@@ -713,6 +713,49 @@ def test_resolve_history_execution_plan_keeps_replay_headroom_when_compaction_di
     assert execution_plan.replay_budget_tokens == 490
 
 
+@pytest.mark.parametrize(
+    ("active_context_window", "expected_replay_window"),
+    [
+        (1_000_000, 200_000),
+        (100_000, 100_000),
+    ],
+)
+def test_resolve_history_execution_plan_caps_replay_without_changing_model_window(
+    tmp_path: Path,
+    active_context_window: int,
+    expected_replay_window: int,
+) -> None:
+    config, _runtime_paths_value = _make_config(
+        tmp_path,
+        compaction=CompactionOverrideConfig(replay_window_tokens=200_000),
+        context_window=active_context_window,
+    )
+
+    execution_plan = resolve_history_execution_plan(
+        config=config,
+        compaction_config=config.resolve_entity("test_agent").compaction_config,
+        has_authored_compaction_config=config.resolve_entity("test_agent").has_authored_compaction_config,
+        active_model_name="default",
+        active_context_window=active_context_window,
+        static_prompt_tokens=10_000,
+    )
+
+    assert execution_plan.compaction_context_window == active_context_window
+    assert execution_plan.replay_window_tokens == expected_replay_window
+    assert execution_plan.trigger_threshold_tokens == int(expected_replay_window * 0.8)
+    hard_replay_budget = execution_plan.hard_replay_budget_tokens
+    assert hard_replay_budget is not None
+    assert hard_replay_budget == expected_replay_window - 16_384 - 10_000
+
+    decision = classify_compaction_decision(
+        plan=execution_plan,
+        force_compact_before_next_run=False,
+        current_history_tokens=hard_replay_budget + 1,
+    )
+    assert decision.mode == "required"
+    assert decision.reason == "history_exceeds_hard_budget"
+
+
 def test_classify_compaction_decision_forced_compaction_takes_priority() -> None:
     execution_plan = ResolvedHistoryExecutionPlan(
         authored_compaction_enabled=True,

--- a/tests/test_history_replay_planning.py
+++ b/tests/test_history_replay_planning.py
@@ -546,7 +546,10 @@ def test_resolve_history_execution_plan_uses_compaction_model_window_only_for_su
             agents={
                 "test_agent": AgentConfig(
                     display_name="Test Agent",
-                    compaction=CompactionOverrideConfig(model="summary-model"),
+                    compaction=CompactionOverrideConfig(
+                        model="summary-model",
+                        replay_window_tokens=20_000,
+                    ),
                 ),
             },
             defaults=DefaultsConfig(tools=[]),
@@ -576,10 +579,20 @@ def test_resolve_history_execution_plan_uses_compaction_model_window_only_for_su
     )
 
     assert execution_plan.compaction_context_window == 32_000
-    assert execution_plan.replay_window_tokens is None
+    assert execution_plan.replay_window_tokens == 20_000
     assert execution_plan.summary_input_budget_tokens is not None
-    assert execution_plan.replay_budget_tokens is None
+    assert execution_plan.trigger_threshold_tokens == 16_000
+    assert execution_plan.replay_budget_tokens == 8_000
+    assert execution_plan.hard_replay_budget_tokens == 8_000
     assert execution_plan.destructive_compaction_available is True
+
+    decision = classify_compaction_decision(
+        plan=execution_plan,
+        force_compact_before_next_run=False,
+        current_history_tokens=8_001,
+    )
+    assert decision.mode == "required"
+    assert decision.reason == "history_exceeds_hard_budget"
 
 
 def test_resolve_runtime_model_uses_room_override_for_team(


### PR DESCRIPTION
## Why

Models can support a larger request context than the persisted-history window operators want to retain. Treating a smaller replay policy as the model context causes request guards to reject valid current turns.

## What

- add optional `compaction.replay_window_tokens` config
- use the smaller of that cap and the active model context for replay and required-compaction planning
- keep `models.*.context_window` as the provider's actual request limit
- document the distinction and cover cap, fallback, inheritance, and compaction-trigger behavior

## Validation

- `uv run ruff check` and `ruff format --check` on changed Python files
- `uv run ty check` on changed Python files
- focused replay, compaction, Vertex guard, model-loading, and history integration tests
- regenerated bundled documentation references

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable **Replay Window Tokens** setting for agents, teams, and default compaction.
  * Replay planning now uses the smaller of the model context window and configured replay window.
  * Added editor support for configuring and inheriting replay window limits.

* **Documentation**
  * Updated configuration guidance and examples to explain replay-window tuning, thresholds, reserves, and model context limits.
  * Clarified behavior when a model’s context window is unknown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->