### PR TITLE
Complete team compaction guidance

### DIFF
--- a/docs/configuration/teams.md
+++ b/docs/configuration/teams.md
@@ -111,6 +111,8 @@ Crossing that soft trigger while still within the hard budget leaves the stored 
 You can tune team-scoped compaction behavior with these settings:
 
 - Use `replay_window_tokens` to cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
+- Use `reserve_tokens` to leave hard-budget headroom.
+- Use `model` to choose the summary model.
 - Set `enabled: false` to disable automatic pre-reply compaction for a team.
 
 When the active team model window is known, replay safety uses the smaller of it and `replay_window_tokens`.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -2745,6 +2745,8 @@ Crossing that soft trigger while still within the hard budget leaves the stored 
 You can tune team-scoped compaction behavior with these settings:
 
 - Use `replay_window_tokens` to cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
+- Use `reserve_tokens` to leave hard-budget headroom.
+- Use `model` to choose the summary model.
 - Set `enabled: false` to disable automatic pre-reply compaction for a team.
 
 When the active team model window is known, replay safety uses the smaller of it and `replay_window_tokens`.

--- a/skills/mindroom-docs/references/page__configuration__teams__index.md
+++ b/skills/mindroom-docs/references/page__configuration__teams__index.md
@@ -107,6 +107,8 @@ Crossing that soft trigger while still within the hard budget leaves the stored 
 You can tune team-scoped compaction behavior with these settings:
 
 - Use `replay_window_tokens` to cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
+- Use `reserve_tokens` to leave hard-budget headroom.
+- Use `model` to choose the summary model.
 - Set `enabled: false` to disable automatic pre-reply compaction for a team.
 
 When the active team model window is known, replay safety uses the smaller of it and `replay_window_tokens`.


### PR DESCRIPTION
## Motivation

PR #1564 documented the supported team-scoped compaction fields, but its tuning guide omitted explanations for `reserve_tokens` and `model`. This follow-up keeps team guidance aligned with the equivalent agent guidance.

## Changes

- Document `reserve_tokens` headroom for team compaction.
- Document `model` as the summary-model selector.
- Regenerate MindRoom docs skill references.

## Validation

- `uv run python .github/scripts/generate_skill_references.py`
- `git diff --check`
- Pre-commit hooks passed on the source commit.

## Summary by Sourcery

Clarify team-scoped compaction configuration guidance and refresh generated references.

Documentation:
- Explain the purpose of the `reserve_tokens` headroom setting in team compaction configuration.
- Document `model` as the selector for the summary model in team configuration guidance.

Chores:
- Regenerate MindRoom skill reference files to reflect updated team configuration documentation.