### PR TITLE
Remove default assistant from config init

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -567,7 +567,7 @@ The `config` subgroup contains commands for creating, viewing, editing, and vali
 │ --help  -h        Show this message and exit.                                          │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
-│ init       Create a starter config.yaml with example agents and models.                │
+│ init       Create a starter config.yaml with a personal agent and model.               │
 │ show       Display the current config file with syntax highlighting.                   │
 │ edit       Open config.yaml in your default editor.                                    │
 │ validate   Validate config.yaml and check for common issues.                           │

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -583,7 +583,7 @@ The `config` subgroup contains commands for creating, viewing, editing, and vali
 
 ### config init
 
-Create a starter `config.yaml` with example agents, models, memory, and sensible defaults.
+Create a starter `config.yaml` with the personal Mind agent, one model, file-based memory, and sensible defaults.
 
 Matrix server presets (`--matrix-server`) choose where MindRoom should create Matrix users and rooms: `mindroom.chat` (default hosted Matrix) or `self-hosted` (your own homeserver).
 Provider presets (`--provider`) set the default model: `anthropic`, `codex`, `llama.cpp`, `ollama`, `openai`, `openrouter`, or `vertexai_claude`.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -18454,7 +18454,7 @@ The `config` subgroup contains commands for creating, viewing, editing, and vali
 
 ### config init
 
-Create a starter `config.yaml` with example agents, models, memory, and sensible defaults.
+Create a starter `config.yaml` with the personal Mind agent, one model, file-based memory, and sensible defaults.
 
 Matrix server presets (`--matrix-server`) choose where MindRoom should create Matrix users and rooms: `mindroom.chat` (default hosted Matrix) or `self-hosted` (your own homeserver).
 Provider presets (`--provider`) set the default model: `anthropic`, `codex`, `llama.cpp`, `ollama`, `openai`, `openrouter`, or `vertexai_claude`.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -18438,7 +18438,7 @@ The `config` subgroup contains commands for creating, viewing, editing, and vali
 │ --help  -h        Show this message and exit.                                          │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
-│ init       Create a starter config.yaml with example agents and models.                │
+│ init       Create a starter config.yaml with a personal agent and model.               │
 │ show       Display the current config file with syntax highlighting.                   │
 │ edit       Open config.yaml in your default editor.                                    │
 │ validate   Validate config.yaml and check for common issues.                           │

--- a/skills/mindroom-docs/references/page__cli__index.md
+++ b/skills/mindroom-docs/references/page__cli__index.md
@@ -579,7 +579,7 @@ The `config` subgroup contains commands for creating, viewing, editing, and vali
 
 ### config init
 
-Create a starter `config.yaml` with example agents, models, memory, and sensible defaults.
+Create a starter `config.yaml` with the personal Mind agent, one model, file-based memory, and sensible defaults.
 
 Matrix server presets (`--matrix-server`) choose where MindRoom should create Matrix users and rooms: `mindroom.chat` (default hosted Matrix) or `self-hosted` (your own homeserver).
 Provider presets (`--provider`) set the default model: `anthropic`, `codex`, `llama.cpp`, `ollama`, `openai`, `openrouter`, or `vertexai_claude`.

--- a/skills/mindroom-docs/references/page__cli__index.md
+++ b/skills/mindroom-docs/references/page__cli__index.md
@@ -563,7 +563,7 @@ The `config` subgroup contains commands for creating, viewing, editing, and vali
 │ --help  -h        Show this message and exit.                                          │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
-│ init       Create a starter config.yaml with example agents and models.                │
+│ init       Create a starter config.yaml with a personal agent and model.               │
 │ show       Display the current config file with syntax highlighting.                   │
 │ edit       Open config.yaml in your default editor.                                    │
 │ validate   Validate config.yaml and check for common issues.                           │

--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -438,9 +438,9 @@ def config_init(
         help="Never prompt: keep an existing config.yaml unchanged, create anything missing, and use the default provider preset.",
     ),
 ) -> None:
-    """Create a starter config.yaml with example agents and models.
+    """Create a starter config.yaml with a personal agent and model.
 
-    Generates a YAML config with starter agents, one model, and sensible defaults.
+    Generates a YAML config with the Mind agent, one model, and sensible defaults.
     """
     target = _resolve_config_path(path)
     env_path = target.parent / ".env"
@@ -949,16 +949,6 @@ models:
 {model_block}{additional_models_block}{commented_model_options_block}
 
 agents:
-  assistant:
-    display_name: Assistant
-    role: A helpful general-purpose assistant
-    model: default
-    rooms:
-      - lobby
-    accept_invites: true
-    tools: []
-    instructions:
-      - Be helpful and conversational
   mind:
     display_name: Mind
     role: Personal assistant with persistent file-based identity and memory

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -285,12 +285,13 @@ class TestConfigInit:
         assert config["models"]["default"]["provider"] == "openai"
         assert config["models"]["default"]["id"] == CONFIG_INIT_MODEL_PRESETS["openai"].id
 
-    def test_init_adds_mindroom_style_mind(self, tmp_path: Path) -> None:
-        """Starter config should include MindRoom-style Mind memory/context setup."""
+    def test_init_adds_only_mindroom_style_mind(self, tmp_path: Path) -> None:
+        """Starter config should include only the Mind agent in its personal room."""
         target = tmp_path / "config.yaml"
         result = runner.invoke(app, ["config", "init", "--path", str(target), "--provider", "openai"])
         assert result.exit_code == 0
         config = yaml.safe_load(target.read_text())
+        assert list(config["agents"]) == ["mind"]
         mind = config["agents"]["mind"]
 
         assert mind["display_name"] == "Mind"


### PR DESCRIPTION
## What changed

- Removed the weak assistant starter agent and its lobby room from mindroom config init.
- Kept the powerful mind agent in the personal room as the only starter agent.
- Tightened the config-init test to require exactly that one agent.

## Why

Creating both a limited assistant and the fully equipped personal Mind made the initial experience confusing. New configurations should present one clear, capable default.

## Impact

New mindroom config init runs create only the personal room with Mind. Existing configurations are unchanged.

## Validation

- uv run pytest -q
- uv run pytest tests/test_cli_config.py -q
- uv run pre-commit run --all-files

## Summary by Sourcery

Simplify config initialization to create a single personal Mind agent as the default starter setup.

Enhancements:
- Update config init template to remove the generic assistant agent and lobby room, leaving only the Mind agent in its personal room.
- Tighten CLI config-init behavior and tests to assert that exactly one Mind agent is created by default.

Tests:
- Strengthen config-init tests to verify that only the Mind agent is present in the generated configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `mindroom config init` now generates a simpler starter configuration with one personal Mind agent and a single model.

* **Documentation**
  * Updated CLI help and documentation to accurately describe the generated starter configuration.

* **Tests**
  * Improved coverage to verify that initialization creates only the Mind agent by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->