### PR TITLE
Preserve hook-created rooms across later invites

### DIFF
--- a/src/mindroom/bot_room_lifecycle.py
+++ b/src/mindroom/bot_room_lifecycle.py
@@ -131,12 +131,6 @@ class BotRoomLifecycle:
             return set()
         return load_invited_rooms(self.invited_rooms_file_path())
 
-    def save_invited_rooms(self) -> None:
-        """Persist invited room IDs for one eligible entity."""
-        if not self.should_persist_invited_rooms():
-            return
-        save_invited_rooms(self.invited_rooms_file_path(), self.invited_rooms)
-
     def forget_invited_room(self, room_id: str) -> None:
         """Stop preserving an ad-hoc room after this bot leaves it."""
         if not self.should_persist_invited_rooms():

--- a/src/mindroom/bot_room_lifecycle.py
+++ b/src/mindroom/bot_room_lifecycle.py
@@ -141,6 +141,7 @@ class BotRoomLifecycle:
     def forget_invited_room(self, room_id: str) -> None:
         """Stop preserving an ad-hoc room after this bot leaves it."""
         if not self.should_persist_invited_rooms():
+            self.invited_rooms.discard(room_id)
             return
         self.invited_rooms = forget_invited_room(self.invited_rooms_file_path(), room_id)
 

--- a/src/mindroom/bot_room_lifecycle.py
+++ b/src/mindroom/bot_room_lifecycle.py
@@ -15,8 +15,10 @@ from mindroom.constants import ROUTER_AGENT_NAME
 from mindroom.matrix.client_room_admin import get_joined_rooms, join_room
 from mindroom.matrix.decrypt_failure import raise_notice_floor
 from mindroom.matrix.invited_rooms_store import (
+    forget_invited_room,
     invited_rooms_path,
     load_invited_rooms,
+    remember_invited_room,
     save_invited_rooms,
     should_accept_invites,
     should_persist_invited_rooms,
@@ -138,10 +140,9 @@ class BotRoomLifecycle:
 
     def forget_invited_room(self, room_id: str) -> None:
         """Stop preserving an ad-hoc room after this bot leaves it."""
-        if room_id not in self.invited_rooms:
+        if not self.should_persist_invited_rooms():
             return
-        self.invited_rooms.remove(room_id)
-        self.save_invited_rooms()
+        self.invited_rooms = forget_invited_room(self.invited_rooms_file_path(), room_id)
 
     async def join_configured_rooms(self) -> None:
         """Join all rooms this bot should preserve across restarts."""
@@ -291,8 +292,7 @@ class BotRoomLifecycle:
                 # Pre-join encrypted history can never decrypt on this device;
                 # don't post decrypt-failure notices for it.
                 raise_notice_floor(client.user_id, room.room_id)
-            if self.should_persist_invited_rooms() and room.room_id not in self.invited_rooms:
-                self.invited_rooms.add(room.room_id)
-                self.save_invited_rooms()
+            if self.should_persist_invited_rooms():
+                self.invited_rooms = remember_invited_room(self.invited_rooms_file_path(), room.room_id)
             if self.deps.agent_name == ROUTER_AGENT_NAME:
                 await self.send_welcome_message_if_empty(room.room_id, event.sender)

--- a/src/mindroom/bot_room_lifecycle.py
+++ b/src/mindroom/bot_room_lifecycle.py
@@ -15,10 +15,8 @@ from mindroom.constants import ROUTER_AGENT_NAME
 from mindroom.matrix.client_room_admin import get_joined_rooms, join_room
 from mindroom.matrix.decrypt_failure import raise_notice_floor
 from mindroom.matrix.invited_rooms_store import (
-    forget_invited_room,
     invited_rooms_path,
     load_invited_rooms,
-    remember_invited_room,
     save_invited_rooms,
     should_accept_invites,
     should_persist_invited_rooms,
@@ -75,6 +73,7 @@ class BotRoomLifecycle:
     def __init__(self, deps: BotRoomLifecycleDeps) -> None:
         self.deps = deps
         self.invited_rooms = self.load_invited_rooms()
+        self._pending_forgotten_invited_rooms: set[str] = set()
         self._invite_join_locks: dict[str, asyncio.Lock] = {}
         self._welcome_locks: dict[str, asyncio.Lock] = {}
         self._handled_invite_room_ids: set[str] = set()
@@ -143,7 +142,21 @@ class BotRoomLifecycle:
         if not self.should_persist_invited_rooms():
             self.invited_rooms.discard(room_id)
             return
-        self.invited_rooms = forget_invited_room(self.invited_rooms_file_path(), room_id)
+        self._update_invited_room(room_id, remember=False)
+
+    def _update_invited_room(self, room_id: str, *, remember: bool) -> None:
+        """Merge one update with durable and in-memory state before saving."""
+        room_ids = load_invited_rooms(self.invited_rooms_file_path()) | self.invited_rooms
+        if remember:
+            self._pending_forgotten_invited_rooms.discard(room_id)
+            room_ids.add(room_id)
+        else:
+            self._pending_forgotten_invited_rooms.add(room_id)
+        room_ids.difference_update(self._pending_forgotten_invited_rooms)
+
+        if save_invited_rooms(self.invited_rooms_file_path(), room_ids):
+            self._pending_forgotten_invited_rooms.clear()
+        self.invited_rooms = room_ids
 
     async def join_configured_rooms(self) -> None:
         """Join all rooms this bot should preserve across restarts."""
@@ -294,6 +307,6 @@ class BotRoomLifecycle:
                 # don't post decrypt-failure notices for it.
                 raise_notice_floor(client.user_id, room.room_id)
             if self.should_persist_invited_rooms():
-                self.invited_rooms = remember_invited_room(self.invited_rooms_file_path(), room.room_id)
+                self._update_invited_room(room.room_id, remember=True)
             if self.deps.agent_name == ROUTER_AGENT_NAME:
                 await self.send_welcome_message_if_empty(room.room_id, event.sender)

--- a/src/mindroom/hooks/matrix_admin.py
+++ b/src/mindroom/hooks/matrix_admin.py
@@ -12,8 +12,7 @@ from mindroom.matrix.identity import managed_account_key, managed_account_user_i
 from mindroom.matrix.invited_rooms_store import (
     invited_room_entity_names,
     invited_rooms_path,
-    load_invited_rooms,
-    save_invited_rooms,
+    remember_invited_room,
     should_persist_invited_rooms,
 )
 from mindroom.matrix_identifiers import extract_server_name_from_homeserver
@@ -105,11 +104,7 @@ class _BoundHookMatrixAdmin:
         if entity_name is None or not should_persist_invited_rooms(self.config, entity_name):
             return
         path = invited_rooms_path(self.runtime_paths.storage_root, entity_name)
-        room_ids = load_invited_rooms(path)
-        if room_id in room_ids:
-            return
-        room_ids.add(room_id)
-        save_invited_rooms(path, room_ids)
+        remember_invited_room(path, room_id)
 
     def _managed_entity_name_for_user_id(self, user_id: str | None) -> str | None:
         """Return the configured bot entity name for one managed Matrix user ID."""

--- a/src/mindroom/matrix/invited_rooms_store.py
+++ b/src/mindroom/matrix/invited_rooms_store.py
@@ -47,7 +47,12 @@ def load_invited_rooms(path: Path) -> set[str]:
 
 
 def save_invited_rooms(path: Path, room_ids: set[str]) -> None:
-    """Persist invited rooms atomically for one eligible entity."""
+    """Replace invited rooms atomically for one eligible entity.
+
+    Single-room updates should use ``remember_invited_room`` or
+    ``forget_invited_room`` so a stale in-memory snapshot cannot discard
+    changes written by another runtime component.
+    """
     temp_path = path.with_name(f"{path.name}.{uuid4().hex}.tmp")
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -60,6 +65,24 @@ def save_invited_rooms(path: Path, room_ids: set[str]) -> None:
         logger.exception("failed_to_save_invited_rooms", path=str(path))
     finally:
         temp_path.unlink(missing_ok=True)
+
+
+def remember_invited_room(path: Path, room_id: str) -> set[str]:
+    """Add one room using fresh durable state and return the updated set."""
+    room_ids = load_invited_rooms(path)
+    if room_id not in room_ids:
+        room_ids.add(room_id)
+        save_invited_rooms(path, room_ids)
+    return room_ids
+
+
+def forget_invited_room(path: Path, room_id: str) -> set[str]:
+    """Remove one room using fresh durable state and return the updated set."""
+    room_ids = load_invited_rooms(path)
+    if room_id in room_ids:
+        room_ids.remove(room_id)
+        save_invited_rooms(path, room_ids)
+    return room_ids
 
 
 def should_accept_invites(config: Config, agent_name: str) -> bool:

--- a/src/mindroom/matrix/invited_rooms_store.py
+++ b/src/mindroom/matrix/invited_rooms_store.py
@@ -68,13 +68,13 @@ def save_invited_rooms(path: Path, room_ids: set[str]) -> bool:
     return True
 
 
-def remember_invited_room(path: Path, room_id: str) -> bool:
-    """Add one room using fresh durable state and report persistence success."""
+def remember_invited_room(path: Path, room_id: str) -> None:
+    """Add one room using fresh durable state."""
     room_ids = load_invited_rooms(path)
     if room_id in room_ids:
-        return True
+        return
     room_ids.add(room_id)
-    return save_invited_rooms(path, room_ids)
+    save_invited_rooms(path, room_ids)
 
 
 def should_accept_invites(config: Config, agent_name: str) -> bool:

--- a/src/mindroom/matrix/invited_rooms_store.py
+++ b/src/mindroom/matrix/invited_rooms_store.py
@@ -46,12 +46,11 @@ def load_invited_rooms(path: Path) -> set[str]:
     return set(room_ids)
 
 
-def save_invited_rooms(path: Path, room_ids: set[str]) -> None:
+def save_invited_rooms(path: Path, room_ids: set[str]) -> bool:
     """Replace invited rooms atomically for one eligible entity.
 
-    Single-room updates should use ``remember_invited_room`` or
-    ``forget_invited_room`` so a stale in-memory snapshot cannot discard
-    changes written by another runtime component.
+    Callers replacing a cached set must first merge fresh durable state so a
+    stale in-memory snapshot cannot discard another runtime component's write.
     """
     temp_path = path.with_name(f"{path.name}.{uuid4().hex}.tmp")
     try:
@@ -63,26 +62,19 @@ def save_invited_rooms(path: Path, room_ids: set[str]) -> None:
         safe_replace(temp_path, path)
     except OSError:
         logger.exception("failed_to_save_invited_rooms", path=str(path))
+        return False
     finally:
         temp_path.unlink(missing_ok=True)
+    return True
 
 
-def remember_invited_room(path: Path, room_id: str) -> set[str]:
-    """Add one room using fresh durable state and return the updated set."""
-    room_ids = load_invited_rooms(path)
-    if room_id not in room_ids:
-        room_ids.add(room_id)
-        save_invited_rooms(path, room_ids)
-    return room_ids
-
-
-def forget_invited_room(path: Path, room_id: str) -> set[str]:
-    """Remove one room using fresh durable state and return the updated set."""
+def remember_invited_room(path: Path, room_id: str) -> bool:
+    """Add one room using fresh durable state and report persistence success."""
     room_ids = load_invited_rooms(path)
     if room_id in room_ids:
-        room_ids.remove(room_id)
-        save_invited_rooms(path, room_ids)
-    return room_ids
+        return True
+    room_ids.add(room_id)
+    return save_invited_rooms(path, room_ids)
 
 
 def should_accept_invites(config: Config, agent_name: str) -> bool:

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -685,11 +685,9 @@ async def _put_scheduled_task_state_content(
         if admin_wrote:
             logger.info("scheduled_task_state_persisted_via_admin", room_id=room_id, task_id=task_id)
             return
-        active_write_failure = f"{active_write_failure}; privileged fallback failed. {permission_hint}"
+        active_write_failure = f"{active_write_failure}; privileged fallback failed"
 
-    if matrix_admin is None:
-        active_write_failure = f"{active_write_failure}. {permission_hint}"
-    msg = f"Failed to persist scheduled task state for task `{task_id}`: {active_write_failure}"
+    msg = f"Failed to persist scheduled task state for task `{task_id}`: {active_write_failure}. {permission_hint}"
     raise ValueError(msg)
 
 

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -651,6 +651,7 @@ async def _put_scheduled_task_state_content(
     matrix_admin: HookMatrixAdmin | None = None,
 ) -> None:
     """Write scheduled-task state, falling back to the admin-capable Matrix path on rejection."""
+    permission_hint = "Ensure the room router is joined with permission to write room state, then retry."
     active_write_failure: str | None = None
     try:
         response = await client.room_put_state(
@@ -677,14 +678,17 @@ async def _put_scheduled_task_state_content(
         except Exception as exc:
             msg = (
                 f"Failed to persist scheduled task state for task `{task_id}`: "
-                f"active write failed ({active_write_failure}); privileged fallback raised {type(exc).__name__}: {exc!s}"
+                f"active write failed ({active_write_failure}); privileged fallback raised {type(exc).__name__}: {exc!s}. "
+                f"{permission_hint}"
             )
             raise ValueError(msg) from exc
         if admin_wrote:
             logger.info("scheduled_task_state_persisted_via_admin", room_id=room_id, task_id=task_id)
             return
-        active_write_failure = f"{active_write_failure}; privileged fallback failed"
+        active_write_failure = f"{active_write_failure}; privileged fallback failed. {permission_hint}"
 
+    if matrix_admin is None:
+        active_write_failure = f"{active_write_failure}. {permission_hint}"
     msg = f"Failed to persist scheduled task state for task `{task_id}`: {active_write_failure}"
     raise ValueError(msg)
 

--- a/tests/test_bot_ready_hook.py
+++ b/tests/test_bot_ready_hook.py
@@ -294,8 +294,7 @@ async def test_sync_leave_section_forgets_invited_room_before_call_teardown(
     client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
     room_id = "!agent-call:localhost"
     bot.client = client
-    bot._room_lifecycle.invited_rooms = {room_id}
-    bot._room_lifecycle.save_invited_rooms()
+    bot._room_lifecycle._update_invited_room(room_id, remember=True)
     call_manager = MagicMock()
 
     async def assert_invite_was_forgotten(**_kwargs: object) -> None:

--- a/tests/test_room_invites.py
+++ b/tests/test_room_invites.py
@@ -20,6 +20,7 @@ from mindroom.config.auth import AuthorizationConfig
 from mindroom.config.main import Config
 from mindroom.config.models import RouterConfig
 from mindroom.constants import ROUTER_AGENT_NAME
+from mindroom.hooks.matrix_admin import build_hook_matrix_admin
 from mindroom.matrix.invited_rooms_store import invited_rooms_path
 from mindroom.matrix.room_cleanup import cleanup_all_orphaned_bots
 from mindroom.matrix.state import MatrixState
@@ -272,6 +273,56 @@ async def test_router_accepts_authorized_invite_persists_and_rejoins_on_startup(
     await restarted_bot.join_configured_rooms()
 
     join_room.assert_awaited_once_with(restarted_bot.client, "!router-invited:localhost")
+
+
+@pytest.mark.asyncio
+async def test_router_invite_preserves_room_created_after_lifecycle_loaded(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A later invite must not overwrite a hook-created room missing from the lifecycle cache."""
+    config = bind_runtime_paths(
+        Config(router=RouterConfig(model="default", accept_invites=True)),
+        test_runtime_paths(tmp_path),
+    )
+    bot = AgentBot(
+        agent_user=_router_user(),
+        storage_path=tmp_path,
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+    )
+    bot.client = AsyncMock()
+    bot.client.rooms = {}
+
+    creator_client = AsyncMock(spec=nio.AsyncClient)
+    creator_client.homeserver = "http://localhost:8008"
+    creator_client.user_id = bot.agent_user.user_id
+    with monkeypatch.context() as patch_context:
+        create_room = AsyncMock(return_value="!hook-created:localhost")
+        patch_context.setattr("mindroom.hooks.matrix_admin.create_room", create_room)
+        admin = build_hook_matrix_admin(
+            creator_client,
+            runtime_paths_for(config),
+            config=config,
+        )
+        await admin.create_room(name="Hook-created room")
+
+    assert bot._room_lifecycle.invited_rooms == set()
+
+    join_room = AsyncMock(return_value=True)
+    monkeypatch.setattr("mindroom.bot_room_lifecycle.is_authorized_sender", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr("mindroom.bot_room_lifecycle.join_room", join_room)
+    monkeypatch.setattr(bot._room_lifecycle, "send_welcome_message_if_empty", AsyncMock())
+    room = MagicMock(room_id="!later-invite:localhost", canonical_alias=None)
+    event = MagicMock(sender="@owner:localhost")
+
+    await bot._on_invite(room, event)
+
+    expected_rooms = {"!hook-created:localhost", "!later-invite:localhost"}
+    assert bot._room_lifecycle.invited_rooms == expected_rooms
+    assert _invited_rooms_path(config, ROUTER_AGENT_NAME).read_text(encoding="utf-8") == (
+        '[\n  "!hook-created:localhost",\n  "!later-invite:localhost"\n]\n'
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_room_invites.py
+++ b/tests/test_room_invites.py
@@ -457,8 +457,7 @@ def test_agent_forgets_persisted_invited_room_after_being_kicked(
         runtime_paths=runtime_paths_for(config),
     )
     room_id = "!agent-call:localhost"
-    bot._room_lifecycle.invited_rooms = {room_id}
-    bot._room_lifecycle.save_invited_rooms()
+    bot._room_lifecycle._update_invited_room(room_id, remember=True)
     bot._room_lifecycle.forget_invited_room(room_id)
 
     assert bot._room_lifecycle.invited_rooms == set()

--- a/tests/test_room_invites.py
+++ b/tests/test_room_invites.py
@@ -21,7 +21,7 @@ from mindroom.config.main import Config
 from mindroom.config.models import RouterConfig
 from mindroom.constants import ROUTER_AGENT_NAME
 from mindroom.hooks.matrix_admin import build_hook_matrix_admin
-from mindroom.matrix.invited_rooms_store import invited_rooms_path
+from mindroom.matrix.invited_rooms_store import invited_rooms_path, save_invited_rooms
 from mindroom.matrix.room_cleanup import cleanup_all_orphaned_bots
 from mindroom.matrix.state import MatrixState
 from mindroom.matrix.users import AgentMatrixUser
@@ -322,6 +322,52 @@ async def test_router_invite_preserves_room_created_after_lifecycle_loaded(
     assert bot._room_lifecycle.invited_rooms == expected_rooms
     assert _invited_rooms_path(config, ROUTER_AGENT_NAME).read_text(encoding="utf-8") == (
         '[\n  "!hook-created:localhost",\n  "!later-invite:localhost"\n]\n'
+    )
+
+
+@pytest.mark.asyncio
+async def test_router_invite_keeps_memory_after_transient_persistence_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A failed save must not let the next invite erase the first room from memory."""
+    config = bind_runtime_paths(
+        Config(router=RouterConfig(model="default", accept_invites=True)),
+        test_runtime_paths(tmp_path),
+    )
+    bot = AgentBot(
+        agent_user=_router_user(),
+        storage_path=tmp_path,
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+    )
+    bot.client = AsyncMock()
+    bot.client.rooms = {}
+
+    attempts = 0
+
+    def fail_first_save(path: Path, room_ids: set[str]) -> bool:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return False
+        return save_invited_rooms(path, room_ids)
+
+    monkeypatch.setattr("mindroom.bot_room_lifecycle.save_invited_rooms", fail_first_save)
+    monkeypatch.setattr("mindroom.bot_room_lifecycle.is_authorized_sender", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr("mindroom.bot_room_lifecycle.join_room", AsyncMock(return_value=True))
+    monkeypatch.setattr(bot._room_lifecycle, "send_welcome_message_if_empty", AsyncMock())
+
+    for room_id in ("!first:localhost", "!second:localhost"):
+        await bot._on_invite(
+            MagicMock(room_id=room_id, canonical_alias=None),
+            MagicMock(sender="@owner:localhost"),
+        )
+
+    expected_rooms = {"!first:localhost", "!second:localhost"}
+    assert bot._room_lifecycle.invited_rooms == expected_rooms
+    assert _invited_rooms_path(config, ROUTER_AGENT_NAME).read_text(encoding="utf-8") == (
+        '[\n  "!first:localhost",\n  "!second:localhost"\n]\n'
     )
 
 

--- a/tests/test_room_invites.py
+++ b/tests/test_room_invites.py
@@ -419,6 +419,40 @@ def test_agent_forgets_persisted_invited_room_after_being_kicked(
     assert _invited_rooms_path(config, "agent1").read_text(encoding="utf-8") == "[]\n"
 
 
+def test_nonpersisting_agent_forget_clears_in_memory_room(tmp_path: Path) -> None:
+    """Disabling invite persistence must not leave stale in-memory membership."""
+    config = bind_runtime_paths(
+        Config(
+            agents={
+                "agent1": AgentConfig(
+                    display_name="Agent 1",
+                    role="Test agent",
+                    accept_invites=False,
+                ),
+            },
+        ),
+        test_runtime_paths(tmp_path),
+    )
+    bot = AgentBot(
+        agent_user=AgentMatrixUser(
+            agent_name="agent1",
+            user_id="@mindroom_agent1:localhost",
+            display_name="Agent 1",
+            password=TEST_PASSWORD,
+        ),
+        storage_path=tmp_path,
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+    )
+    room_id = "!old-invite:localhost"
+    bot._room_lifecycle.invited_rooms = {room_id}
+
+    bot._room_lifecycle.forget_invited_room(room_id)
+
+    assert bot._room_lifecycle.invited_rooms == set()
+    assert not _invited_rooms_path(config, "agent1").exists()
+
+
 @pytest.mark.asyncio
 async def test_router_duplicate_invite_retries_failed_welcome_delivery(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -2231,7 +2231,7 @@ async def test_schedule_task_rejects_invalid_history_limit_before_parsing(
 
 
 @pytest.mark.asyncio
-async def test_schedule_task_returns_error_when_state_write_and_admin_fallback_fail(tmp_path: Path) -> None:
+async def test_schedule_task_returns_error_when_state_write_fails_without_admin_fallback(tmp_path: Path) -> None:
     """Scheduling must not return a task ID when Matrix state persistence fails."""
     client = AsyncMock()
     client.room_put_state = AsyncMock(side_effect=_forbidden_state_write)
@@ -2277,6 +2277,28 @@ async def test_schedule_task_returns_error_when_state_write_and_admin_fallback_f
     assert "Failed to persist scheduled task state" in message
     assert "Ensure the room router is joined" in message
     start_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_state_write_error_includes_hint_when_admin_fallback_raises() -> None:
+    """A raised privileged fallback must report the router recovery action."""
+    client = AsyncMock()
+    client.room_put_state = AsyncMock(side_effect=_forbidden_state_write)
+    matrix_admin = AsyncMock()
+    matrix_admin.put_room_state = AsyncMock(side_effect=RuntimeError("admin unavailable"))
+
+    with pytest.raises(ValueError, match="privileged fallback raised") as exc_info:
+        await scheduling._put_scheduled_task_state_content(
+            client=client,
+            room_id="!test:server",
+            task_id="taskfail",
+            content={},
+            matrix_admin=matrix_admin,
+        )
+
+    message = str(exc_info.value)
+    assert "privileged fallback raised RuntimeError: admin unavailable" in message
+    assert "Ensure the room router is joined" in message
 
 
 @pytest.mark.asyncio

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -2275,6 +2275,7 @@ async def test_schedule_task_returns_error_when_state_write_and_admin_fallback_f
     assert task_id is None
     assert "Failed to schedule" in message
     assert "Failed to persist scheduled task state" in message
+    assert "Ensure the room router is joined" in message
     start_task.assert_not_called()
 
 


### PR DESCRIPTION
## Why

Hook-created rooms are persisted directly, while bot room lifecycle also keeps an in-memory snapshot of persisted rooms. A later accepted invite could save that stale snapshot and silently discard rooms created since startup. Cleanup could then treat the creating bot as unconfigured and leave those rooms.

Scheduling already falls back to the room router when the active agent cannot write room state. When both writes fail, the returned error did not explain the usual recovery action.

## What changed

- Add merge-aware single-room remember/forget operations backed by fresh durable state.
- Use them for hook-created rooms, accepted invites, and explicit room removal.
- Add a regression test for the exact create-then-later-invite sequence.
- Add an actionable router membership/permission hint when scheduled-task state persistence fails.

## Validation

- `ruff check` on changed files
- `ty check` on changed source files
- 90 focused room-invite, hook-admin, and scheduling tests

## Summary by Sourcery

Preserve hook-created rooms when later invites are processed and improve error messaging for scheduled task state persistence.

New Features:
- Add merge-aware single-room invited-room update helpers to keep durable and in-memory room sets in sync.
- Persist hook-created rooms using the shared invited-room helpers so they survive subsequent lifecycle updates and invites.

Bug Fixes:
- Prevent later invite handling from overwriting previously hook-created rooms that were missing from the lifecycle cache.

Enhancements:
- Use fresh durable-state helpers for invite persistence and room removal in the bot room lifecycle to avoid stale snapshots discarding rooms.
- Improve scheduled-task state persistence errors with a concrete router membership and permission hint when both active and admin writes fail.

Tests:
- Add a regression test covering the create-then-later-invite sequence to ensure hook-created rooms are preserved.
- Extend scheduling failure tests to assert the new router permission hint appears in error messages.