### PR TITLE
Surface Vertex Claude safeguard refusals

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
   "agno[anthropic,google,ollama,openai]==2.6.12",
   "aiohttp>=3.13.3",
   "aiosqlite>=0.20",
-  "anthropic>=0.70",
+  "anthropic>=0.77",
   "anyio>=4.10",
   "authlib>=1.6",
   "cerebras-cloud-sdk>=1.46",

--- a/src/mindroom/claude_stream_retry.py
+++ b/src/mindroom/claude_stream_retry.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING, cast
 from agno.exceptions import ContextWindowExceededError, ModelProviderError
 
 from mindroom.claude_prompt_cache import as_anthropic_claude
-from mindroom.error_handling import TRANSIENT_PROVIDER_STATUS_CODES
+from mindroom.error_handling import TRANSIENT_PROVIDER_STATUS_CODES, ModelSafeguardRefusalError
 from mindroom.logging_config import get_logger
 
 if TYPE_CHECKING:
@@ -51,7 +51,7 @@ _RETRY_BASE_DELAY_SECONDS = 1.0
 
 def _is_transient_model_error(error: BaseException) -> bool:
     """Return whether one model-call failure is worth re-issuing the request."""
-    if isinstance(error, ContextWindowExceededError):
+    if isinstance(error, (ContextWindowExceededError, ModelSafeguardRefusalError)):
         return False
     return isinstance(error, ModelProviderError) and error.status_code in TRANSIENT_PROVIDER_STATUS_CODES
 

--- a/src/mindroom/error_handling.py
+++ b/src/mindroom/error_handling.py
@@ -26,6 +26,10 @@ class AvatarSyncError(RuntimeError):
     """Raised when managed avatar sync cannot complete."""
 
 
+class ModelSafeguardRefusalError(ModelProviderError):
+    """Raised when a provider explicitly stops generation for safeguards."""
+
+
 def _extract_provider_from_error(error: Exception) -> str | None:
     """Try to extract the provider name from the exception's module."""
     module = type(error).__module__ or ""
@@ -109,6 +113,12 @@ def get_user_friendly_error_message(error: Exception, agent_name: str | None = N
         error_type=type(error).__name__,
         error=repr(error),
     )
+
+    if isinstance(error, ModelSafeguardRefusalError):
+        return (
+            f"{agent_prefix}⚠️ This model's safeguards blocked the request. "
+            "Choose a different model or revise the prompt, then try again."
+        )
 
     # Only distinguish the most important error types
     if any(x in error_str for x in ["401", "auth", "unauthorized", "api key", "api_key", "apikey"]):

--- a/src/mindroom/error_handling.py
+++ b/src/mindroom/error_handling.py
@@ -117,7 +117,7 @@ def get_user_friendly_error_message(error: Exception, agent_name: str | None = N
     if isinstance(error, ModelSafeguardRefusalError):
         return (
             f"{agent_prefix}⚠️ This model's safeguards blocked the request. "
-            "Choose a different model or revise the prompt, then try again."
+            "Choose a different model (`!model list`) or revise the prompt, then try again."
         )
 
     # Only distinguish the most important error types

--- a/src/mindroom/error_handling.py
+++ b/src/mindroom/error_handling.py
@@ -16,6 +16,7 @@ logger = get_logger(__name__)
 # the Claude mid-stream SSE error case: the HTTP response was already committed
 # before the provider emitted an error event.
 TRANSIENT_PROVIDER_STATUS_CODES = frozenset({200, 408, 409, 429, 500, 502, 503, 504, 529})
+MODEL_SAFEGUARD_REFUSAL_MESSAGE = "Vertex Claude returned stop_reason=refusal"
 
 
 class AvatarGenerationError(RuntimeError):
@@ -28,6 +29,11 @@ class AvatarSyncError(RuntimeError):
 
 class ModelSafeguardRefusalError(ModelProviderError):
     """Raised when a provider explicitly stops generation for safeguards."""
+
+
+def is_model_safeguard_refusal(error: Exception | str) -> bool:
+    """Recognize typed refusals and the exact text Agno preserves in errored runs."""
+    return isinstance(error, ModelSafeguardRefusalError) or str(error).strip() == MODEL_SAFEGUARD_REFUSAL_MESSAGE
 
 
 def _extract_provider_from_error(error: Exception) -> str | None:
@@ -114,7 +120,7 @@ def get_user_friendly_error_message(error: Exception, agent_name: str | None = N
         error=repr(error),
     )
 
-    if isinstance(error, ModelSafeguardRefusalError):
+    if is_model_safeguard_refusal(error):
         return (
             f"{agent_prefix}⚠️ This model's safeguards blocked the request. "
             "Choose a different model (`!model list`) or revise the prompt, then try again."

--- a/src/mindroom/media_fallback.py
+++ b/src/mindroom/media_fallback.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from agno.exceptions import ContextWindowExceededError, ModelProviderError
 
+from mindroom.error_handling import is_model_safeguard_refusal
 from mindroom.media_inputs import MediaInputs, MediaKind
 
 if TYPE_CHECKING:
@@ -129,6 +130,8 @@ def retry_media_inputs_after_failure(
     ``extra_present_kinds`` (media pinned to thread-history messages in the
     run input).
     """
+    if is_model_safeguard_refusal(error):
+        return _no_media_retry_decision(media_inputs)
     present_kinds = media_inputs.kinds() | extra_present_kinds
     if not present_kinds:
         return _no_media_retry_decision(media_inputs)

--- a/src/mindroom/vertex_claude_compat.py
+++ b/src/mindroom/vertex_claude_compat.py
@@ -28,34 +28,6 @@ if TYPE_CHECKING:
     from agno.models.message import Message
     from agno.models.response import ModelResponse
     from agno.run.agent import RunOutput
-    from anthropic.lib.streaming._beta_types import (
-        BetaRawContentBlockStartEvent,
-        ParsedBetaContentBlockStopEvent,
-        ParsedBetaMessageStopEvent,
-    )
-    from anthropic.types import (
-        ContentBlockDeltaEvent,
-        ContentBlockStartEvent,
-        ContentBlockStopEvent,
-        MessageStopEvent,
-    )
-    from anthropic.types import (
-        Message as AnthropicMessage,
-    )
-    from anthropic.types.beta import BetaRawContentBlockDeltaEvent
-    from anthropic.types.beta.beta_message import BetaMessage
-
-    type ClaudeProviderResponse = AnthropicMessage | BetaMessage
-    type ClaudeProviderStreamEvent = (
-        ContentBlockStartEvent
-        | ContentBlockDeltaEvent
-        | ContentBlockStopEvent
-        | MessageStopEvent
-        | BetaRawContentBlockDeltaEvent
-        | BetaRawContentBlockStartEvent
-        | ParsedBetaContentBlockStopEvent
-        | ParsedBetaMessageStopEvent
-    )
 
 logger = get_logger(__name__)
 
@@ -494,28 +466,28 @@ class MindroomVertexAIClaude(VertexAIClaude):
 
     def _parse_provider_response(
         self,
-        response: ClaudeProviderResponse,
+        response: object,
         response_format: dict[str, Any] | type[Any] | None = None,
         **kwargs: object,
     ) -> ModelResponse:
         """Preserve Vertex Claude's non-streaming safeguard signal."""
         self._raise_for_safeguard_refusal(response)
-        return super()._parse_provider_response(response, response_format=response_format, **kwargs)
+        return super()._parse_provider_response(cast("Any", response), response_format=response_format, **kwargs)
 
     def _parse_provider_response_delta(
         self,
-        response: ClaudeProviderStreamEvent,
+        response: object,
         response_format: dict[str, Any] | type[Any] | None = None,
     ) -> ModelResponse:
         """Preserve Vertex Claude's final streaming safeguard signal."""
         self._raise_for_safeguard_refusal(response)
-        return super()._parse_provider_response_delta(response, response_format=response_format)
+        return super()._parse_provider_response_delta(cast("Any", response), response_format=response_format)
 
     def _handle_api_error(self, e: Exception) -> NoReturn:
         """Keep typed safeguard refusals intact for MindRoom's user error path."""
         if isinstance(e, ModelSafeguardRefusalError):
             raise e
-        super()._handle_api_error(e)
+        return super()._handle_api_error(e)
 
     def _prepare_request_kwargs(
         self,

--- a/src/mindroom/vertex_claude_compat.py
+++ b/src/mindroom/vertex_claude_compat.py
@@ -17,15 +17,45 @@ from mindroom.claude_prompt_cache import (
     TOOL_SEARCH_TOOL_TYPE,
     prepare_claude_request_kwargs,
 )
+from mindroom.error_handling import ModelSafeguardRefusalError
 from mindroom.logging_config import get_logger
 from mindroom.token_budget import estimate_compaction_input_tokens, stable_serialize
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
+    from typing import NoReturn
 
     from agno.models.message import Message
     from agno.models.response import ModelResponse
     from agno.run.agent import RunOutput
+    from anthropic.lib.streaming._beta_types import (
+        BetaRawContentBlockStartEvent,
+        ParsedBetaContentBlockStopEvent,
+        ParsedBetaMessageStopEvent,
+    )
+    from anthropic.types import (
+        ContentBlockDeltaEvent,
+        ContentBlockStartEvent,
+        ContentBlockStopEvent,
+        MessageStopEvent,
+    )
+    from anthropic.types import (
+        Message as AnthropicMessage,
+    )
+    from anthropic.types.beta import BetaRawContentBlockDeltaEvent
+    from anthropic.types.beta.beta_message import BetaMessage
+
+    type ClaudeProviderResponse = AnthropicMessage | BetaMessage
+    type ClaudeProviderStreamEvent = (
+        ContentBlockStartEvent
+        | ContentBlockDeltaEvent
+        | ContentBlockStopEvent
+        | MessageStopEvent
+        | BetaRawContentBlockDeltaEvent
+        | BetaRawContentBlockStartEvent
+        | ParsedBetaContentBlockStopEvent
+        | ParsedBetaMessageStopEvent
+    )
 
 logger = get_logger(__name__)
 
@@ -38,6 +68,7 @@ _VERTEX_TOOL_SEARCH_HISTORY_BLOCK_TYPES = frozenset(
 # for the native regex search tool on both Claude Haiku 4.5 and Sonnet 4.6.
 # Keep a small margin because count_tokens cannot count that server-tool prefix.
 _VERTEX_TOOL_SEARCH_TOKEN_RESERVE = 256
+_CLAUDE_SAFEGUARD_STOP_REASON = "refusal"
 
 
 def _strip_vertex_claude_tool_strict(
@@ -442,6 +473,49 @@ class MindroomVertexAIClaude(VertexAIClaude):
             compress_tool_results=compress_tool_results,
         ):
             yield response
+
+    def _raise_for_safeguard_refusal(self, provider_response: object) -> None:
+        """Raise when Vertex Claude explicitly ends generation for safeguards."""
+        message = getattr(provider_response, "message", None)
+        response_with_stop_reason = message if message is not None else provider_response
+        stop_reason = getattr(response_with_stop_reason, "stop_reason", None)
+        if stop_reason != _CLAUDE_SAFEGUARD_STOP_REASON:
+            return
+        logger.warning(
+            "vertex_claude_safeguard_refusal",
+            model_id=self.id,
+            stop_reason=stop_reason,
+        )
+        raise ModelSafeguardRefusalError(
+            message="Vertex Claude returned stop_reason=refusal",
+            model_name=self.name,
+            model_id=self.id,
+        )
+
+    def _parse_provider_response(
+        self,
+        response: ClaudeProviderResponse,
+        response_format: dict[str, Any] | type[Any] | None = None,
+        **kwargs: object,
+    ) -> ModelResponse:
+        """Preserve Vertex Claude's non-streaming safeguard signal."""
+        self._raise_for_safeguard_refusal(response)
+        return super()._parse_provider_response(response, response_format=response_format, **kwargs)
+
+    def _parse_provider_response_delta(
+        self,
+        response: ClaudeProviderStreamEvent,
+        response_format: dict[str, Any] | type[Any] | None = None,
+    ) -> ModelResponse:
+        """Preserve Vertex Claude's final streaming safeguard signal."""
+        self._raise_for_safeguard_refusal(response)
+        return super()._parse_provider_response_delta(response, response_format=response_format)
+
+    def _handle_api_error(self, e: Exception) -> NoReturn:
+        """Keep typed safeguard refusals intact for MindRoom's user error path."""
+        if isinstance(e, ModelSafeguardRefusalError):
+            raise e
+        super()._handle_api_error(e)
 
     def _prepare_request_kwargs(
         self,

--- a/src/mindroom/vertex_claude_compat.py
+++ b/src/mindroom/vertex_claude_compat.py
@@ -10,7 +10,7 @@ from agno.exceptions import ContextWindowExceededError, ModelProviderError
 from agno.models.vertexai.claude import Claude as VertexAIClaude
 from agno.utils.models.claude import format_messages, format_tools_for_model
 from agno.utils.tokens import count_schema_tokens
-from anthropic.lib.streaming import MessageStopEvent, ParsedBetaMessageStopEvent
+from anthropic.lib.streaming import MessageStopEvent, ParsedBetaMessageStopEvent, ParsedMessageStopEvent
 from anthropic.types import Message as AnthropicMessage
 from anthropic.types.beta import BetaMessage
 
@@ -451,7 +451,7 @@ class MindroomVertexAIClaude(VertexAIClaude):
 
     def _raise_for_safeguard_refusal(self, provider_response: object) -> None:
         """Raise when Vertex Claude explicitly ends generation for safeguards."""
-        if isinstance(provider_response, (MessageStopEvent, ParsedBetaMessageStopEvent)):
+        if isinstance(provider_response, (MessageStopEvent, ParsedMessageStopEvent, ParsedBetaMessageStopEvent)):
             stop_reason = provider_response.message.stop_reason
         elif isinstance(provider_response, (AnthropicMessage, BetaMessage)):
             stop_reason = provider_response.stop_reason

--- a/src/mindroom/vertex_claude_compat.py
+++ b/src/mindroom/vertex_claude_compat.py
@@ -6,10 +6,13 @@ import asyncio
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
-from agno.exceptions import ContextWindowExceededError
+from agno.exceptions import ContextWindowExceededError, ModelProviderError
 from agno.models.vertexai.claude import Claude as VertexAIClaude
 from agno.utils.models.claude import format_messages, format_tools_for_model
 from agno.utils.tokens import count_schema_tokens
+from anthropic.lib.streaming import MessageStopEvent, ParsedBetaMessageStopEvent
+from anthropic.types import Message as AnthropicMessage
+from anthropic.types.beta import BetaMessage
 
 from mindroom.claude_prompt_cache import (
     SERVER_TOOL_USE_BLOCK_TYPE,
@@ -448,9 +451,12 @@ class MindroomVertexAIClaude(VertexAIClaude):
 
     def _raise_for_safeguard_refusal(self, provider_response: object) -> None:
         """Raise when Vertex Claude explicitly ends generation for safeguards."""
-        message = getattr(provider_response, "message", None)
-        response_with_stop_reason = message if message is not None else provider_response
-        stop_reason = getattr(response_with_stop_reason, "stop_reason", None)
+        if isinstance(provider_response, (MessageStopEvent, ParsedBetaMessageStopEvent)):
+            stop_reason = provider_response.message.stop_reason
+        elif isinstance(provider_response, (AnthropicMessage, BetaMessage)):
+            stop_reason = provider_response.stop_reason
+        else:
+            return
         if stop_reason != _CLAUDE_SAFEGUARD_STOP_REASON:
             return
         logger.warning(
@@ -466,13 +472,13 @@ class MindroomVertexAIClaude(VertexAIClaude):
 
     def _parse_provider_response(
         self,
-        response: object,
+        response: AnthropicMessage | BetaMessage,
         response_format: dict[str, Any] | type[Any] | None = None,
         **kwargs: object,
     ) -> ModelResponse:
         """Preserve Vertex Claude's non-streaming safeguard signal."""
         self._raise_for_safeguard_refusal(response)
-        return super()._parse_provider_response(cast("Any", response), response_format=response_format, **kwargs)
+        return super()._parse_provider_response(response, response_format=response_format, **kwargs)
 
     def _parse_provider_response_delta(
         self,
@@ -488,6 +494,10 @@ class MindroomVertexAIClaude(VertexAIClaude):
         if isinstance(e, ModelSafeguardRefusalError):
             raise e
         return super()._handle_api_error(e)
+
+    def _is_retryable_error(self, error: ModelProviderError) -> bool:
+        """Exclude deterministic safeguard refusals from Agno's configured retries."""
+        return not isinstance(error, ModelSafeguardRefusalError) and super()._is_retryable_error(error)
 
     def _prepare_request_kwargs(
         self,

--- a/src/mindroom/vertex_claude_compat.py
+++ b/src/mindroom/vertex_claude_compat.py
@@ -20,7 +20,7 @@ from mindroom.claude_prompt_cache import (
     TOOL_SEARCH_TOOL_TYPE,
     prepare_claude_request_kwargs,
 )
-from mindroom.error_handling import ModelSafeguardRefusalError
+from mindroom.error_handling import MODEL_SAFEGUARD_REFUSAL_MESSAGE, ModelSafeguardRefusalError
 from mindroom.logging_config import get_logger
 from mindroom.token_budget import estimate_compaction_input_tokens, stable_serialize
 
@@ -465,7 +465,7 @@ class MindroomVertexAIClaude(VertexAIClaude):
             stop_reason=stop_reason,
         )
         raise ModelSafeguardRefusalError(
-            message="Vertex Claude returned stop_reason=refusal",
+            message=MODEL_SAFEGUARD_REFUSAL_MESSAGE,
             model_name=self.name,
             model_id=self.id,
         )

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -53,6 +53,7 @@ from mindroom.constants import (
     MATRIX_TURN_DISCOVERY_EVENT_IDS_METADATA_KEY,
 )
 from mindroom.dynamic_tool_continuation import DYNAMIC_TOOL_CONTINUATION_LIMIT
+from mindroom.error_handling import MODEL_SAFEGUARD_REFUSAL_MESSAGE
 from mindroom.execution_preparation import _PreparedExecutionContext
 from mindroom.history.turn_recorder import TurnRecorder
 from mindroom.history.types import PreparedHistoryState
@@ -1545,6 +1546,43 @@ class TestUserIdPassthrough:
         assert "Inline media unavailable for this model" in str(second_prompt[-1].content)
 
     @pytest.mark.asyncio
+    async def test_ai_response_surfaces_stringified_safeguard_refusal_without_media_retry(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Agno's errored RunOutput text must retain refusal handling and stop fallback."""
+        mock_agent = MagicMock()
+        mock_agent.model = MagicMock()
+        mock_agent.model.__class__.__name__ = "Claude"
+        mock_agent.model.id = "claude-sonnet-4-6"
+        mock_agent.name = "GeneralAgent"
+        mock_agent.add_history_to_context = False
+        mock_agent.arun = AsyncMock(
+            return_value=RunOutput(content=MODEL_SAFEGUARD_REFUSAL_MESSAGE, status=RunStatus.error),
+        )
+        document_file = File(
+            filepath=str(tmp_path / "report.pdf"),
+            filename="report.pdf",
+            mime_type="application/pdf",
+        )
+
+        with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
+            mock_prepare.return_value = _prepared_prompt_result(mock_agent)
+            response = await ai_response(
+                make_turn_context("general", session_id="session1"),
+                prompt="test",
+                runtime_paths=_runtime_paths(tmp_path),
+                config=_config(),
+                media=MediaInputs(files=[document_file]),
+            )
+
+        assert response == (
+            "[general] ⚠️ This model's safeguards blocked the request. "
+            "Choose a different model (`!model list`) or revise the prompt, then try again."
+        )
+        assert mock_agent.arun.await_count == 1
+
+    @pytest.mark.asyncio
     async def test_ai_response_learns_media_unsupported_for_same_model_route(self, tmp_path: Path) -> None:
         """A successful without-media retry teaches the route to omit media on later calls."""
         reset_model_media_capability_cache()
@@ -1865,6 +1903,48 @@ class TestUserIdPassthrough:
         assert not second_prompt[-1].files
         assert "Inline media unavailable for this model" in str(second_prompt[-1].content)
         assert any(isinstance(chunk, RunContentEvent) and chunk.content == "Recovered stream" for chunk in chunks)
+
+    @pytest.mark.asyncio
+    async def test_stream_agent_response_surfaces_stringified_safeguard_refusal_without_media_retry(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Agno's RunErrorEvent text must retain refusal handling and stop fallback."""
+        mock_agent = MagicMock()
+        mock_agent.model = MagicMock()
+        mock_agent.model.__class__.__name__ = "Claude"
+        mock_agent.model.id = "claude-sonnet-4-6"
+        mock_agent.name = "GeneralAgent"
+        mock_agent.add_history_to_context = False
+
+        async def refusal_stream() -> AsyncIterator[object]:
+            yield RunErrorEvent(content=MODEL_SAFEGUARD_REFUSAL_MESSAGE)
+
+        mock_agent.arun = MagicMock(return_value=refusal_stream())
+        document_file = File(
+            filepath=str(tmp_path / "report.pdf"),
+            filename="report.pdf",
+            mime_type="application/pdf",
+        )
+
+        with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
+            mock_prepare.return_value = _prepared_prompt_result(mock_agent)
+            chunks = [
+                chunk
+                async for chunk in stream_agent_response(
+                    make_turn_context("general", session_id="session1"),
+                    prompt="test",
+                    runtime_paths=_runtime_paths(tmp_path),
+                    config=_config(),
+                    media=MediaInputs(files=[document_file]),
+                )
+            ]
+
+        assert chunks == [
+            "[general] ⚠️ This model's safeguards blocked the request. "
+            "Choose a different model (`!model list`) or revise the prompt, then try again.",
+        ]
+        assert mock_agent.arun.call_count == 1
 
     @pytest.mark.asyncio
     async def test_stream_agent_response_rebuilds_request_log_context_for_retry(self, tmp_path: Path) -> None:

--- a/tests/test_claude_stream_retry.py
+++ b/tests/test_claude_stream_retry.py
@@ -11,6 +11,7 @@ from agno.models.response import ModelResponse
 
 from mindroom import claude_stream_retry
 from mindroom.claude_stream_retry import install_claude_stream_retry_hook
+from mindroom.error_handling import ModelSafeguardRefusalError
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterator
@@ -149,6 +150,23 @@ async def test_does_not_retry_non_transient_error() -> None:
     with pytest.raises(ModelProviderError):
         await _collect(model.ainvoke_stream([], object()))
 
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_does_not_retry_safeguard_refusal() -> None:
+    """A deterministic model safeguard refusal must surface after one request."""
+    refusal = ModelSafeguardRefusalError(
+        message="Vertex Claude returned stop_reason=refusal",
+        model_name="Claude",
+        model_id="claude-sonnet-5",
+    )
+    model, calls = _hooked_model_with_async_attempts([[refusal]])
+
+    with pytest.raises(ModelSafeguardRefusalError) as raised:
+        await _collect(model.ainvoke_stream([], object()))
+
+    assert raised.value is refusal
     assert len(calls) == 1
 
 

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -6,6 +6,7 @@ from anthropic import AuthenticationError as AnthropicAuthError
 from openai import AuthenticationError as OpenAIAuthError
 
 from mindroom.error_handling import (
+    MODEL_SAFEGUARD_REFUSAL_MESSAGE,
     ModelSafeguardRefusalError,
     _extract_provider_from_error,
     get_user_friendly_error_message,
@@ -71,6 +72,17 @@ def test_model_safeguard_refusal_gives_actionable_guidance() -> None:
     )
 
     message = get_user_friendly_error_message(error, "mind")
+
+    assert message == (
+        "[mind] ⚠️ This model's safeguards blocked the request. "
+        "Choose a different model (`!model list`) or revise the prompt, then try again."
+    )
+    assert "stop_reason" not in message
+
+
+def test_stringified_model_safeguard_refusal_gives_actionable_guidance() -> None:
+    """Agno run errors preserve provider failures as text rather than exception types."""
+    message = get_user_friendly_error_message(Exception(MODEL_SAFEGUARD_REFUSAL_MESSAGE), "mind")
 
     assert message == (
         "[mind] ⚠️ This model's safeguards blocked the request. "

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -74,7 +74,7 @@ def test_model_safeguard_refusal_gives_actionable_guidance() -> None:
 
     assert message == (
         "[mind] ⚠️ This model's safeguards blocked the request. "
-        "Choose a different model or revise the prompt, then try again."
+        "Choose a different model (`!model list`) or revise the prompt, then try again."
     )
     assert "stop_reason" not in message
 

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -5,7 +5,11 @@ from agno.exceptions import ModelProviderError
 from anthropic import AuthenticationError as AnthropicAuthError
 from openai import AuthenticationError as OpenAIAuthError
 
-from mindroom.error_handling import _extract_provider_from_error, get_user_friendly_error_message
+from mindroom.error_handling import (
+    ModelSafeguardRefusalError,
+    _extract_provider_from_error,
+    get_user_friendly_error_message,
+)
 
 _MOCK_RESPONSE = httpx.Response(status_code=401, request=httpx.Request("POST", "https://api.example.com"))
 
@@ -56,6 +60,23 @@ def test_generic_api_word_not_false_positive() -> None:
     # Should NOT be auth error - just contains 'api' but no auth keywords
     assert "Authentication failed" not in message
     assert "Error:" in message
+
+
+def test_model_safeguard_refusal_gives_actionable_guidance() -> None:
+    """Explicit safeguard stops should not look like empty model responses."""
+    error = ModelSafeguardRefusalError(
+        message="Vertex Claude returned stop_reason=refusal",
+        model_name="Claude",
+        model_id="claude-fable-5",
+    )
+
+    message = get_user_friendly_error_message(error, "mind")
+
+    assert message == (
+        "[mind] ⚠️ This model's safeguards blocked the request. "
+        "Choose a different model or revise the prompt, then try again."
+    )
+    assert "stop_reason" not in message
 
 
 def test_rate_limit_error() -> None:

--- a/tests/test_media_fallback.py
+++ b/tests/test_media_fallback.py
@@ -11,6 +11,7 @@ from agno.models.message import Message
 from agno.models.openai import OpenAIChat
 
 from mindroom import ai_runtime
+from mindroom.error_handling import MODEL_SAFEGUARD_REFUSAL_MESSAGE, ModelSafeguardRefusalError
 from mindroom.media_fallback import (
     ModelMediaRoute,
     build_model_media_route,
@@ -91,6 +92,24 @@ def test_no_media_present_never_retries() -> None:
     decision = retry_media_inputs_after_failure(_route(), "audio input is not supported", MediaInputs())
 
     assert decision.should_retry is False
+    assert decision.removed_kinds == frozenset()
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        ModelSafeguardRefusalError(message=MODEL_SAFEGUARD_REFUSAL_MESSAGE),
+        MODEL_SAFEGUARD_REFUSAL_MESSAGE,
+    ],
+)
+def test_safeguard_refusal_never_retries_without_media(error: Exception | str) -> None:
+    """A deterministic refusal must not enter the generic media fallback loop."""
+    media = _media_inputs()
+
+    decision = retry_media_inputs_after_failure(_route(), error, media)
+
+    assert decision.should_retry is False
+    assert decision.media_inputs == media
     assert decision.removed_kinds == frozenset()
 
 

--- a/tests/test_team_media_fallback.py
+++ b/tests/test_team_media_fallback.py
@@ -34,6 +34,7 @@ from mindroom.config.agent import AgentConfig, AgentPrivateConfig, TeamConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
 from mindroom.constants import AI_RUN_METADATA_KEY, ROUTER_AGENT_NAME
+from mindroom.error_handling import MODEL_SAFEGUARD_REFUSAL_MESSAGE
 from mindroom.execution_preparation import (
     ThreadHistoryRenderLimits,
     _prepare_bound_team_execution_context,
@@ -307,6 +308,42 @@ async def test_team_response_retries_without_inline_media_on_validation_error() 
     assert isinstance(second_prompt, str)
     assert first_prompt[-1].audio == [audio_input]
     assert "Inline media unavailable for this model" in second_prompt
+
+
+@pytest.mark.asyncio
+async def test_team_response_surfaces_stringified_safeguard_refusal_without_media_retry() -> None:
+    """An errored team output must retain refusal handling and stop fallback."""
+    config = _build_test_config()
+    orchestrator = MagicMock()
+    orchestrator.config = config
+    orchestrator.runtime_paths = runtime_paths_for(config)
+    orchestrator.knowledge_managers = {}
+    orchestrator.agent_bots = {"general": MagicMock()}
+
+    mock_team = _make_test_team()
+    mock_team.arun = AsyncMock(
+        return_value=TeamRunOutput(content=MODEL_SAFEGUARD_REFUSAL_MESSAGE, status=RunStatus.error),
+    )
+    fake_agent = _make_test_agent("GeneralAgent")
+    with (
+        patch("mindroom.teams.create_agent", return_value=fake_agent),
+        patch("mindroom.teams.resolve_agent_knowledge_access", return_value=_KnowledgeResolution(knowledge=None)),
+        patch("mindroom.teams._create_team_instance", return_value=mock_team),
+    ):
+        response = await team_response(
+            agent_names=["general"],
+            mode=TeamMode.COORDINATE,
+            message="Analyze this.",
+            turn_recorder=_team_turn_recorder("Analyze this."),
+            orchestrator=orchestrator,
+            execution_identity=None,
+            ctx=make_turn_context(session_id=None),
+            media=MediaInputs(audio=[MagicMock(name="audio_input")]),
+        )
+
+    assert "This model's safeguards blocked the request" in response
+    assert "stop_reason" not in response
+    assert mock_team.arun.await_count == 1
 
 
 @pytest.mark.asyncio
@@ -3876,6 +3913,47 @@ async def test_team_stream_retries_without_inline_media_on_streamed_run_error() 
 
     rendered_output = "".join(chunk.content if hasattr(chunk, "content") else str(chunk) for chunk in chunks)
     assert "Recovered stream" in rendered_output
+
+
+@pytest.mark.asyncio
+async def test_team_stream_surfaces_stringified_safeguard_refusal_without_media_retry() -> None:
+    """A team RunErrorEvent must retain refusal handling and stop fallback."""
+    config = _build_test_config()
+    orchestrator = MagicMock()
+    orchestrator.config = config
+    orchestrator.runtime_paths = runtime_paths_for(config)
+    orchestrator.knowledge_managers = {}
+    orchestrator.agent_bots = {"general": MagicMock()}
+
+    async def refusal_stream() -> AsyncIterator[object]:
+        yield TeamRunErrorEvent(content=MODEL_SAFEGUARD_REFUSAL_MESSAGE)
+
+    mock_team = _make_test_team()
+    mock_team.arun = MagicMock(return_value=refusal_stream())
+    fake_agent = _make_test_agent("GeneralAgent")
+    with (
+        patch("mindroom.teams.create_agent", return_value=fake_agent),
+        patch("mindroom.teams.resolve_agent_knowledge_access", return_value=_KnowledgeResolution(knowledge=None)),
+        patch("mindroom.teams._create_team_instance", return_value=mock_team),
+    ):
+        chunks = [
+            chunk
+            async for chunk in team_response_stream(
+                agent_ids=[entity_ids(config, runtime_paths_for(config))["general"]],
+                mode=TeamMode.COORDINATE,
+                message="Analyze this.",
+                turn_recorder=_team_turn_recorder("Analyze this."),
+                orchestrator=orchestrator,
+                execution_identity=None,
+                ctx=make_turn_context(session_id=None),
+                media=MediaInputs(audio=[MagicMock(name="audio_input")]),
+            )
+        ]
+
+    rendered_output = "".join(chunk.content if hasattr(chunk, "content") else str(chunk) for chunk in chunks)
+    assert "This model's safeguards blocked the request" in rendered_output
+    assert "stop_reason" not in rendered_output
+    assert mock_team.arun.call_count == 1
 
 
 class _DirectTeamAgentBot:

--- a/tests/test_vertex_claude_context_guard.py
+++ b/tests/test_vertex_claude_context_guard.py
@@ -12,7 +12,6 @@ from agno.media import Image
 from agno.models.message import Message
 from agno.models.response import ModelResponse
 from agno.models.vertexai.claude import Claude as VertexAIClaude
-from anthropic.lib.streaming._types import MessageStopEvent
 from anthropic.types import Message as AnthropicMessage
 from anthropic.types import Usage
 
@@ -88,7 +87,7 @@ def test_non_streaming_safeguard_refusal_raises_typed_error() -> None:
 def test_streaming_safeguard_refusal_raises_typed_error() -> None:
     """Streaming exposes stop_reason on the final message_stop payload."""
     model = _model()
-    message_stop = MessageStopEvent(message=_safeguard_refusal_message(), type="message_stop")
+    message_stop = SimpleNamespace(message=_safeguard_refusal_message(), type="message_stop")
 
     with pytest.raises(ModelSafeguardRefusalError, match="stop_reason=refusal"):
         model._parse_provider_response_delta(message_stop)

--- a/tests/test_vertex_claude_context_guard.py
+++ b/tests/test_vertex_claude_context_guard.py
@@ -12,9 +12,9 @@ from agno.media import Image
 from agno.models.message import Message
 from agno.models.response import ModelResponse
 from agno.models.vertexai.claude import Claude as VertexAIClaude
-from anthropic.lib.streaming import MessageStopEvent
+from anthropic.lib.streaming import ParsedMessageStopEvent
 from anthropic.types import Message as AnthropicMessage
-from anthropic.types import Usage
+from anthropic.types import ParsedMessage, Usage
 
 from mindroom.claude_prompt_cache import (
     SERVER_TOOL_USE_BLOCK_TYPE,
@@ -88,7 +88,8 @@ def test_non_streaming_safeguard_refusal_raises_typed_error() -> None:
 def test_streaming_safeguard_refusal_raises_typed_error() -> None:
     """Streaming exposes stop_reason on the final message_stop payload."""
     model = _model()
-    message_stop = MessageStopEvent(type="message_stop", message=_safeguard_refusal_message())
+    parsed_message = ParsedMessage[object].model_validate(_safeguard_refusal_message().model_dump())
+    message_stop = ParsedMessageStopEvent(type="message_stop", message=parsed_message)
 
     with pytest.raises(ModelSafeguardRefusalError, match="stop_reason=refusal"):
         model._parse_provider_response_delta(message_stop)

--- a/tests/test_vertex_claude_context_guard.py
+++ b/tests/test_vertex_claude_context_guard.py
@@ -12,6 +12,7 @@ from agno.media import Image
 from agno.models.message import Message
 from agno.models.response import ModelResponse
 from agno.models.vertexai.claude import Claude as VertexAIClaude
+from anthropic.lib.streaming import MessageStopEvent
 from anthropic.types import Message as AnthropicMessage
 from anthropic.types import Usage
 
@@ -87,7 +88,7 @@ def test_non_streaming_safeguard_refusal_raises_typed_error() -> None:
 def test_streaming_safeguard_refusal_raises_typed_error() -> None:
     """Streaming exposes stop_reason on the final message_stop payload."""
     model = _model()
-    message_stop = SimpleNamespace(message=_safeguard_refusal_message(), type="message_stop")
+    message_stop = MessageStopEvent(type="message_stop", message=_safeguard_refusal_message())
 
     with pytest.raises(ModelSafeguardRefusalError, match="stop_reason=refusal"):
         model._parse_provider_response_delta(message_stop)
@@ -106,6 +107,18 @@ def test_safeguard_refusal_survives_agno_error_translation() -> None:
         model._handle_api_error(error)
 
     assert raised.value is error
+
+
+def test_safeguard_refusal_is_not_retryable_by_agno() -> None:
+    """Agno's configured model retry loop must not repeat a refusal."""
+    model = _model()
+    error = ModelSafeguardRefusalError(
+        message="Vertex Claude returned stop_reason=refusal",
+        model_name=model.name,
+        model_id=model.id,
+    )
+
+    assert model._is_retryable_error(error) is False
 
 
 def test_estimate_request_input_tokens_uses_full_provider_payload() -> None:

--- a/tests/test_vertex_claude_context_guard.py
+++ b/tests/test_vertex_claude_context_guard.py
@@ -12,6 +12,9 @@ from agno.media import Image
 from agno.models.message import Message
 from agno.models.response import ModelResponse
 from agno.models.vertexai.claude import Claude as VertexAIClaude
+from anthropic.lib.streaming._types import MessageStopEvent
+from anthropic.types import Message as AnthropicMessage
+from anthropic.types import Usage
 
 from mindroom.claude_prompt_cache import (
     SERVER_TOOL_USE_BLOCK_TYPE,
@@ -19,6 +22,7 @@ from mindroom.claude_prompt_cache import (
     TOOL_SEARCH_TOOL_TYPE,
 )
 from mindroom.claude_stream_retry import install_claude_stream_retry_hook
+from mindroom.error_handling import ModelSafeguardRefusalError
 from mindroom.vertex_claude_compat import (
     _VERTEX_TOOL_SEARCH_TOKEN_RESERVE,
     MindroomVertexAIClaude,
@@ -58,6 +62,51 @@ def _tool_loop_messages() -> list[Message]:
         ),
         Message(role="tool", tool_call_id="call-1", content="large result"),
     ]
+
+
+def _safeguard_refusal_message() -> AnthropicMessage:
+    return AnthropicMessage(
+        id="msg-refusal",
+        content=[],
+        model="claude-fable-5",
+        role="assistant",
+        stop_reason="refusal",
+        stop_sequence=None,
+        type="message",
+        usage=Usage(input_tokens=100, output_tokens=4),
+    )
+
+
+def test_non_streaming_safeguard_refusal_raises_typed_error() -> None:
+    """Anthropic Messages exposes safeguards as stop_reason=refusal."""
+    model = _model()
+
+    with pytest.raises(ModelSafeguardRefusalError, match="stop_reason=refusal"):
+        model._parse_provider_response(_safeguard_refusal_message())
+
+
+def test_streaming_safeguard_refusal_raises_typed_error() -> None:
+    """Streaming exposes stop_reason on the final message_stop payload."""
+    model = _model()
+    message_stop = MessageStopEvent(message=_safeguard_refusal_message(), type="message_stop")
+
+    with pytest.raises(ModelSafeguardRefusalError, match="stop_reason=refusal"):
+        model._parse_provider_response_delta(message_stop)
+
+
+def test_safeguard_refusal_survives_agno_error_translation() -> None:
+    """Agno must not replace the typed refusal with a generic provider error."""
+    model = _model()
+    error = ModelSafeguardRefusalError(
+        message="Vertex Claude returned stop_reason=refusal",
+        model_name=model.name,
+        model_id=model.id,
+    )
+
+    with pytest.raises(ModelSafeguardRefusalError) as raised:
+        model._handle_api_error(error)
+
+    assert raised.value is error
 
 
 def test_estimate_request_input_tokens_uses_full_provider_payload() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -4368,7 +4368,7 @@ requires-dist = [
     { name = "agno", extras = ["anthropic", "google", "ollama", "openai"], specifier = "==2.6.12" },
     { name = "aiohttp", specifier = ">=3.13.3" },
     { name = "aiosqlite", specifier = ">=0.20" },
-    { name = "anthropic", specifier = ">=0.70" },
+    { name = "anthropic", specifier = ">=0.77" },
     { name = "anyio", specifier = ">=4.10" },
     { name = "apify-client", marker = "platform_machine != 'aarch64' and extra == 'apify'", specifier = ">=1.12.2" },
     { name = "arxiv", marker = "extra == 'arxiv'" },


### PR DESCRIPTION
## Why

Vertex Claude can complete a successful Messages request with `stop_reason="refusal"` when safeguards block generation. Agno currently drops that stop reason, leaving MindRoom to misclassify the result as an empty model response and retry it.

## What changed

- Detect `stop_reason="refusal"` in both non-streaming responses and final streaming message events.
- Preserve it as a typed, non-retryable provider outcome.
- Tell the user to choose another model or revise the prompt.
- Cover a real Anthropic SDK response, the final streaming event shape, error translation, and user-facing text.

## Validation

- Focused provider and error-handler tests
- Empty-response, team replay, compaction, and Claude stream-retry tests
- Full pre-commit hooks, including Ruff, ty, Vulture, and Tach

## Summary by Sourcery

Handle explicit Vertex Claude safeguard refusals as a typed, non-retryable outcome and surface clear guidance to users.

Bug Fixes:
- Detect Vertex Claude safeguard stops with stop_reason=refusal in both non-streaming and streaming responses instead of treating them as empty outputs.

Enhancements:
- Introduce a ModelSafeguardRefusalError type and ensure it propagates through Vertex Claude compatibility and API error handling.
- Update user-facing error messaging to describe safeguard blocks and advise choosing another model or revising the prompt.

Tests:
- Add tests covering non-streaming and streaming safeguard refusals, Agno error translation behavior, and the new user-facing error message for safeguard refusals.
