### PR TITLE
Give scheduled and external-trigger new_thread fires a per-fire thread and session

### DIFF
--- a/docs/external-triggers.md
+++ b/docs/external-triggers.md
@@ -126,6 +126,7 @@ Example tool arguments:
 For a non-admin caller, the target agent and room are the current agent and current room, and either `target_thread_id` or `new_thread` may still choose placement inside that room.
 
 `target_thread_id` and `new_thread` are mutually exclusive.
+With `new_thread`, each delivery posts a room-level root and the responding agent answers in a new thread under it with a fresh session.
 
 For an admin caller, `target_agent` and `target_room_id` can additionally target a different agent, team, or room.
 

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -7,7 +7,7 @@ icon: lucide/calendar
 Schedule agents or teams to perform tasks at specific times or intervals using natural language.
 
 By default, tasks run in the same scope where they were created: the room timeline for room-level schedules, or the current thread for threaded schedules.
-The `schedule()` tool accepts `new_thread=True` to post each fire as a top-level room message that can become its own thread, instead of continuing in the current thread.
+The `schedule()` tool accepts `new_thread=True` to start a fresh thread per fire: each fire posts a room-level root and the responding agent answers in a new thread under it with a fresh session.
 
 ## Commands
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -14510,6 +14510,7 @@ Example tool arguments:
 For a non-admin caller, the target agent and room are the current agent and current room, and either `target_thread_id` or `new_thread` may still choose placement inside that room.
 
 `target_thread_id` and `new_thread` are mutually exclusive.
+With `new_thread`, each delivery posts a room-level root and the responding agent answers in a new thread under it with a fresh session.
 
 For an admin caller, `target_agent` and `target_room_id` can additionally target a different agent, team, or room.
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -14269,7 +14269,7 @@ This is used for structured live rendering where the full document is rebuilt on
 Schedule agents or teams to perform tasks at specific times or intervals using natural language.
 
 By default, tasks run in the same scope where they were created: the room timeline for room-level schedules, or the current thread for threaded schedules.
-The `schedule()` tool accepts `new_thread=True` to post each fire as a top-level room message that can become its own thread, instead of continuing in the current thread.
+The `schedule()` tool accepts `new_thread=True` to start a fresh thread per fire: each fire posts a room-level root and the responding agent answers in a new thread under it with a fresh session.
 
 ## Commands
 

--- a/skills/mindroom-docs/references/page__external-triggers__index.md
+++ b/skills/mindroom-docs/references/page__external-triggers__index.md
@@ -122,6 +122,7 @@ Example tool arguments:
 For a non-admin caller, the target agent and room are the current agent and current room, and either `target_thread_id` or `new_thread` may still choose placement inside that room.
 
 `target_thread_id` and `new_thread` are mutually exclusive.
+With `new_thread`, each delivery posts a room-level root and the responding agent answers in a new thread under it with a fresh session.
 
 For an admin caller, `target_agent` and `target_room_id` can additionally target a different agent, team, or room.
 

--- a/skills/mindroom-docs/references/page__scheduling__index.md
+++ b/skills/mindroom-docs/references/page__scheduling__index.md
@@ -3,7 +3,7 @@
 Schedule agents or teams to perform tasks at specific times or intervals using natural language.
 
 By default, tasks run in the same scope where they were created: the room timeline for room-level schedules, or the current thread for threaded schedules.
-The `schedule()` tool accepts `new_thread=True` to post each fire as a top-level room message that can become its own thread, instead of continuing in the current thread.
+The `schedule()` tool accepts `new_thread=True` to start a fresh thread per fire: each fire posts a room-level root and the responding agent answers in a new thread under it with a fresh session.
 
 ## Commands
 

--- a/src/mindroom/conversation_resolver.py
+++ b/src/mindroom/conversation_resolver.py
@@ -266,9 +266,7 @@ class ConversationResolver:
             if isinstance(event, PreparedTextEvent)
             else None
         )
-        config = self.deps.runtime.config
-        registry = entity_identity_registry(config, self.deps.runtime_paths)
-        source_kind_sender_is_trusted = registry.current_entity_name_for_user_id(event.sender) is not None
+        source_kind_sender_is_trusted = self._sender_is_managed_entity(event.sender)
         if resolved_source_kind is None and isinstance(content, dict):
             source_kind_override = source_kind_from_content(content)
             if source_kind_override is not None and source_kind_sender_is_trusted:
@@ -321,16 +319,18 @@ class ConversationResolver:
             trusted_user_relay=trusted_human_relay,
         )
 
-    def _is_trusted_scheduled_root(self, event_source: dict[str, Any]) -> bool:
-        """Return whether one relation-free event is a scheduled fire from a managed entity."""
+    def _sender_is_managed_entity(self, user_id: str) -> bool:
+        """Return whether one Matrix user ID belongs to a managed entity."""
+        registry = entity_identity_registry(self.deps.runtime.config, self.deps.runtime_paths)
+        return registry.current_entity_name_for_user_id(user_id) is not None
+
+    def _is_trusted_scheduled_fire(self, event_source: dict[str, Any]) -> bool:
+        """Return whether one event is a scheduled fire from a managed entity."""
         content = event_source.get("content")
         if not isinstance(content, dict) or source_kind_from_content(content) != SCHEDULED_SOURCE_KIND:
             return False
         sender = event_source.get("sender")
-        if not isinstance(sender, str):
-            return False
-        registry = entity_identity_registry(self.deps.runtime.config, self.deps.runtime_paths)
-        return registry.current_entity_name_for_user_id(sender) is not None
+        return isinstance(sender, str) and self._sender_is_managed_entity(sender)
 
     def build_message_target(
         self,
@@ -358,7 +358,7 @@ class ConversationResolver:
                 # session even in room mode; otherwise every recurring fire in a
                 # room-mode room shares one room-level session and its history
                 # accumulates across fires.
-                scheduled_fire_root = self._is_trusted_scheduled_root(event_source)
+                scheduled_fire_root = self._is_trusted_scheduled_fire(event_source)
         return MessageTarget.resolve(
             room_id=room_id,
             thread_id=thread_id,

--- a/src/mindroom/conversation_resolver.py
+++ b/src/mindroom/conversation_resolver.py
@@ -12,7 +12,13 @@ from nio.responses import RoomGetEventError
 from mindroom.attachments import parse_attachment_ids_from_event_source
 from mindroom.constants import HOOK_MESSAGE_RECEIVED_DEPTH_KEY, HOOK_SOURCE_KEY, SKIP_MENTIONS_KEY
 from mindroom.dispatch_handoff import DispatchEvent, DispatchPayloadMetadata, PreparedTextEvent
-from mindroom.dispatch_source import IMAGE_SOURCE_KIND, MESSAGE_SOURCE_KIND, VOICE_SOURCE_KIND, source_kind_from_content
+from mindroom.dispatch_source import (
+    IMAGE_SOURCE_KIND,
+    MESSAGE_SOURCE_KIND,
+    SCHEDULED_SOURCE_KIND,
+    VOICE_SOURCE_KIND,
+    source_kind_from_content,
+)
 from mindroom.dispatch_thread_context import (
     DispatchThreadContext,
     context_with_dispatch_thread_context,
@@ -315,6 +321,17 @@ class ConversationResolver:
             trusted_user_relay=trusted_human_relay,
         )
 
+    def _is_trusted_scheduled_root(self, event_source: dict[str, Any]) -> bool:
+        """Return whether one relation-free event is a scheduled fire from a managed entity."""
+        content = event_source.get("content")
+        if not isinstance(content, dict) or source_kind_from_content(content) != SCHEDULED_SOURCE_KIND:
+            return False
+        sender = event_source.get("sender")
+        if not isinstance(sender, str):
+            return False
+        registry = entity_identity_registry(self.deps.runtime.config, self.deps.runtime_paths)
+        return registry.current_entity_name_for_user_id(sender) is not None
+
     def build_message_target(
         self,
         *,
@@ -332,16 +349,22 @@ class ConversationResolver:
             room_id=room_id,
         )
         thread_start_root_event_id = None
+        scheduled_fire_root = False
         if event_source is not None:
             event_info = EventInfo.from_event(event_source)
             if event_info.can_be_thread_root and reply_to_event_id is not None:
                 thread_start_root_event_id = reply_to_event_id
+                # A scheduled fire that is its own root owns a per-fire thread and
+                # session even in room mode; otherwise every recurring fire in a
+                # room-mode room shares one room-level session and its history
+                # accumulates across fires.
+                scheduled_fire_root = self._is_trusted_scheduled_root(event_source)
         return MessageTarget.resolve(
             room_id=room_id,
             thread_id=thread_id,
             reply_to_event_id=reply_to_event_id,
             thread_start_root_event_id=thread_start_root_event_id,
-            room_mode=effective_thread_mode == "room",
+            room_mode=effective_thread_mode == "room" and not scheduled_fire_root,
         )
 
     def build_message_envelope(

--- a/src/mindroom/conversation_resolver.py
+++ b/src/mindroom/conversation_resolver.py
@@ -15,9 +15,9 @@ from mindroom.dispatch_handoff import DispatchEvent, DispatchPayloadMetadata, Pr
 from mindroom.dispatch_source import (
     IMAGE_SOURCE_KIND,
     MESSAGE_SOURCE_KIND,
-    SCHEDULED_SOURCE_KIND,
     VOICE_SOURCE_KIND,
     source_kind_from_content,
+    source_kind_owns_per_fire_thread_root,
 )
 from mindroom.dispatch_thread_context import (
     DispatchThreadContext,
@@ -324,10 +324,12 @@ class ConversationResolver:
         registry = entity_identity_registry(self.deps.runtime.config, self.deps.runtime_paths)
         return registry.current_entity_name_for_user_id(user_id) is not None
 
-    def _is_trusted_scheduled_fire(self, event_source: dict[str, Any]) -> bool:
-        """Return whether one event is a scheduled fire from a managed entity."""
+    def _is_trusted_automation_fire(self, event_source: dict[str, Any]) -> bool:
+        """Return whether one event is a per-fire automation delivery from a managed entity."""
         content = event_source.get("content")
-        if not isinstance(content, dict) or source_kind_from_content(content) != SCHEDULED_SOURCE_KIND:
+        if not isinstance(content, dict) or not source_kind_owns_per_fire_thread_root(
+            source_kind_from_content(content),
+        ):
             return False
         sender = event_source.get("sender")
         return isinstance(sender, str) and self._sender_is_managed_entity(sender)
@@ -349,22 +351,22 @@ class ConversationResolver:
             room_id=room_id,
         )
         thread_start_root_event_id = None
-        scheduled_fire_root = False
+        automation_fire_root = False
         if event_source is not None:
             event_info = EventInfo.from_event(event_source)
             if event_info.can_be_thread_root and reply_to_event_id is not None:
                 thread_start_root_event_id = reply_to_event_id
-                # A scheduled fire that is its own root owns a per-fire thread and
-                # session even in room mode; otherwise every recurring fire in a
-                # room-mode room shares one room-level session and its history
-                # accumulates across fires.
-                scheduled_fire_root = self._is_trusted_scheduled_fire(event_source)
+                # A scheduled or external-trigger fire that is its own root owns a
+                # per-fire thread and session even in room mode; otherwise every
+                # recurring fire in a room-mode room shares one room-level session
+                # and its history accumulates across fires.
+                automation_fire_root = self._is_trusted_automation_fire(event_source)
         return MessageTarget.resolve(
             room_id=room_id,
             thread_id=thread_id,
             reply_to_event_id=reply_to_event_id,
             thread_start_root_event_id=thread_start_root_event_id,
-            room_mode=effective_thread_mode == "room" and not scheduled_fire_root,
+            room_mode=effective_thread_mode == "room" and not automation_fire_root,
         )
 
     def build_message_envelope(

--- a/src/mindroom/custom_tools/external_trigger_manager.py
+++ b/src/mindroom/custom_tools/external_trigger_manager.py
@@ -133,8 +133,10 @@ class ExternalTriggerManagerTools(Toolkit):
             target_agent: Optional target agent/team; non-admin callers use the current one.
             target_room_id: Optional target room; non-admin callers use the current room.
             target_thread_id: Optional Matrix thread id for delivery; mutually exclusive with new_thread.
-            new_thread: Start a fresh thread instead of appending to target_thread_id; mutually exclusive
-                with target_thread_id.
+            new_thread: Start a fresh thread per delivery instead of appending to
+                target_thread_id; mutually exclusive with target_thread_id. Each
+                delivery posts a room-level root and the responding agent answers
+                in a new thread under it with a fresh session.
             allowed_kinds: Optional list of accepted payload kind values.
             replay_window_seconds: Optional replay window capped by config policy.
             max_body_bytes: Optional body cap capped by config policy.

--- a/src/mindroom/custom_tools/scheduler.py
+++ b/src/mindroom/custom_tools/scheduler.py
@@ -36,8 +36,9 @@ class SchedulerTools(Toolkit):
         Args:
             request: The scheduling request, e.g. "in 5 minutes remind me to check logs"
             new_thread: Required delivery choice. Use `False` to post in the current
-                room/thread scope. Use `True` to schedule a future room-level root
-                message that can become its own thread when someone replies later.
+                room/thread scope. Use `True` to start a fresh thread per fire: each
+                fire posts a room-level root and the responding agent answers in a
+                new thread under it with a fresh session.
             history_limit: Max recent thread messages included as context each time
                 the task fires. Use 0 for no history (recommended for recurring
                 polling tasks), or leave unset for full history.

--- a/src/mindroom/dispatch_source.py
+++ b/src/mindroom/dispatch_source.py
@@ -69,6 +69,12 @@ _INTERNAL_RELAY_DETECTION_SOURCE_KINDS: frozenset[str] = frozenset(
         TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
     },
 )
+_PER_FIRE_THREAD_ROOT_SOURCE_KINDS: frozenset[str] = frozenset(
+    {
+        SCHEDULED_SOURCE_KIND,
+        EXTERNAL_TRIGGER_SOURCE_KIND,
+    },
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -117,6 +123,11 @@ def source_kind_bypasses_coalescing(source_kind: str | None) -> bool:
 def source_kind_allows_trusted_original_sender(source_kind: str | None) -> bool:
     """Return whether trusted senders may promote original-sender metadata for this source kind."""
     return source_kind in _TRUSTED_ORIGINAL_SENDER_SOURCE_KINDS
+
+
+def source_kind_owns_per_fire_thread_root(source_kind: str | None) -> bool:
+    """Return whether one automation fire roots its own per-fire thread and session."""
+    return source_kind in _PER_FIRE_THREAD_ROOT_SOURCE_KINDS
 
 
 def source_kind_allows_self_authored_ingress(source_kind: str | None) -> bool:

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -424,7 +424,6 @@ class _PreparedResponseRuntime:
     session_id: str
     model_prompt: str
     tool_dispatch: ToolDispatchContext
-    room_mode: bool = False
 
 
 @dataclass
@@ -1997,17 +1996,16 @@ class ResponseRunner:
         finally:
             self.in_flight_response_count -= 1
 
-    async def _prepare_response_runtime_common(
+    @timed("prepare_response_runtime")
+    async def prepare_response_runtime(
         self,
         request: ResponseRequest,
-        *,
-        existing_event_uses_thread_id: bool,
-        room_mode: bool,
     ) -> _PreparedResponseRuntime:
+        """Resolve shared runtime context for one streaming or non-streaming response."""
         resolved_target = request.response_envelope.target
         response_thread_id = (
             request.thread_id
-            if request.existing_event_id and existing_event_uses_thread_id
+            if request.existing_event_id and not request.existing_event_is_placeholder
             else request.response_envelope.target.resolved_thread_id
         )
         resolved_target = resolved_target.with_thread_root(response_thread_id)
@@ -2043,39 +2041,6 @@ class ResponseRunner:
             session_id=session_id,
             model_prompt=resolved_model_prompt,
             tool_dispatch=tool_dispatch,
-            room_mode=room_mode,
-        )
-
-    @timed("prepare_non_streaming_runtime")
-    async def prepare_non_streaming_runtime(
-        self,
-        request: ResponseRequest,
-    ) -> _PreparedResponseRuntime:
-        """Resolve non-streaming runtime context."""
-        return await self._prepare_response_runtime_common(
-            request,
-            existing_event_uses_thread_id=not request.existing_event_is_placeholder,
-            room_mode=False,
-        )
-
-    @timed("prepare_streaming_runtime")
-    async def prepare_streaming_runtime(
-        self,
-        request: ResponseRequest,
-    ) -> _PreparedResponseRuntime:
-        """Resolve streaming runtime context."""
-        room_mode = (
-            self.deps.runtime.config.get_entity_thread_mode(
-                self.deps.agent_name,
-                self.deps.runtime_paths,
-                room_id=request.room_id,
-            )
-            == "room"
-        )
-        return await self._prepare_response_runtime_common(
-            request,
-            existing_event_uses_thread_id=not request.existing_event_is_placeholder,
-            room_mode=room_mode,
         )
 
     @timed("non_streaming_response_generation")
@@ -2299,7 +2264,7 @@ class ResponseRunner:
         """Process a message and send a response without streaming."""
         if request.pipeline_timing is not None:
             request.pipeline_timing.mark("response_runtime_start")
-        runtime = await self.prepare_non_streaming_runtime(request)
+        runtime = await self.prepare_response_runtime(request)
         if request.pipeline_timing is not None:
             request.pipeline_timing.mark("response_runtime_ready")
         request = self._request_with_locked_target(request, runtime.resolved_target)
@@ -2441,7 +2406,7 @@ class ResponseRunner:
         """Process a message and send a streamed response."""
         if request.pipeline_timing is not None:
             request.pipeline_timing.mark("response_runtime_start")
-        runtime = await self.prepare_streaming_runtime(request)
+        runtime = await self.prepare_response_runtime(request)
         if request.pipeline_timing is not None:
             request.pipeline_timing.mark("response_runtime_ready")
         request = self._request_with_locked_target(request, runtime.resolved_target)

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -1414,7 +1414,7 @@ async def schedule_task(  # noqa: C901, PLR0912, PLR0915
     success_msg += f"**Will post:** {workflow_result.message}\n"
     if workflow_result.history_limit is not None:
         success_msg += f"**History:** {_history_limit_display(workflow_result.history_limit)}\n"
-    delivery = "New room-level thread root" if new_thread else "Current room/thread scope"
+    delivery = "New thread per fire" if new_thread else "Current room/thread scope"
     success_msg += f"**Delivery:** {delivery}\n"
     success_msg += f"\n**Task ID:** `{task_id}`"
 

--- a/tests/test_dispatch_source.py
+++ b/tests/test_dispatch_source.py
@@ -19,6 +19,7 @@ from mindroom.dispatch_source import (
     source_kind_allows_self_authored_ingress,
     source_kind_allows_trusted_original_sender,
     source_kind_bypasses_coalescing,
+    source_kind_owns_per_fire_thread_root,
 )
 
 
@@ -96,6 +97,29 @@ def test_source_kind_allows_trusted_original_sender_for_internal_provenance(sour
 def test_source_kind_allows_trusted_original_sender_rejects_plain_turns(source_kind: str | None) -> None:
     """Plain user-controlled source kinds must not promote original-sender metadata."""
     assert not source_kind_allows_trusted_original_sender(source_kind)
+
+
+@pytest.mark.parametrize("source_kind", [SCHEDULED_SOURCE_KIND, EXTERNAL_TRIGGER_SOURCE_KIND])
+def test_source_kind_owns_per_fire_thread_root_for_automation_fires(source_kind: str) -> None:
+    """Scheduled and external-trigger fires root their own per-fire thread and session."""
+    assert source_kind_owns_per_fire_thread_root(source_kind)
+
+
+@pytest.mark.parametrize(
+    "source_kind",
+    [
+        HOOK_SOURCE_KIND,
+        HOOK_DISPATCH_SOURCE_KIND,
+        TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
+        MESSAGE_SOURCE_KIND,
+        VOICE_SOURCE_KIND,
+        None,
+        "",
+    ],
+)
+def test_source_kind_owns_per_fire_thread_root_rejects_other_turns(source_kind: str | None) -> None:
+    """Hook, relay, and interactive turns never force a per-fire thread root."""
+    assert not source_kind_owns_per_fire_thread_root(source_kind)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_schedule_agent_validation.py
+++ b/tests/test_schedule_agent_validation.py
@@ -391,7 +391,7 @@ async def test_schedule_with_no_agent_mentions() -> None:
 
     assert task_id is not None
     assert "✅ Scheduled" in response
-    assert "New room-level thread root" in response
+    assert "New thread per fire" in response
     conversation_cache.get_thread_history.assert_not_called()
     available_agents = mock_parse.await_args.args[3]
     expected_agents = [

--- a/tests/test_scheduling_executor.py
+++ b/tests/test_scheduling_executor.py
@@ -166,10 +166,11 @@ async def test_fire_task_with_history_limit_annotates_message_content(tmp_path: 
 
 
 @pytest.mark.asyncio
-async def test_fire_new_thread_task_posts_room_level_message(tmp_path: Path) -> None:
-    """new_thread tasks deliver the raw message at room level without the automated wrapper."""
+@pytest.mark.parametrize("stale_thread_id", [None, "$stale-thread"])
+async def test_fire_new_thread_task_posts_room_level_message(tmp_path: Path, stale_thread_id: str | None) -> None:
+    """new_thread tasks deliver a relation-free root even when a stale thread_id is persisted."""
     config = _config(tmp_path)
-    workflow = _workflow("Kick off the weekly report", thread_id=None, new_thread=True)
+    workflow = _workflow("Kick off the weekly report", thread_id=stale_thread_id, new_thread=True)
     conversation_cache = _conversation_cache()
 
     with patch(

--- a/tests/test_thread_mode.py
+++ b/tests/test_thread_mode.py
@@ -19,9 +19,11 @@ from mindroom.commands.parsing import Command, CommandType
 from mindroom.config.agent import AgentConfig, TeamConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig, RouterConfig
-from mindroom.constants import ROUTER_AGENT_NAME, resolve_runtime_paths
+from mindroom.constants import ROUTER_AGENT_NAME, SOURCE_KIND_KEY, resolve_runtime_paths
 from mindroom.conversation_resolver import MessageContext
 from mindroom.delivery_gateway import SendTextRequest
+from mindroom.dispatch_source import SCHEDULED_SOURCE_KIND
+from mindroom.entity_resolution import entity_identity_registry
 from mindroom.matrix.cache import ThreadHistoryResult, thread_history_result
 from mindroom.matrix.cache.event_cache import ThreadCacheState
 from mindroom.matrix.cache.thread_reads import ThreadReadMode
@@ -1069,6 +1071,67 @@ class TestExtractMessageContextRoomMode:
         )
 
         assert target.reply_to_event_id == "$relation-event:localhost"
+        assert target.resolved_thread_id is None
+        assert target.session_id == create_session_id("!room:localhost", None)
+
+    def test_build_message_target_scheduled_root_starts_per_fire_thread_in_room_mode(
+        self,
+        room_mode_config: Config,
+        assistant_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """A trusted scheduled fire roots its own per-fire thread and session even in room mode."""
+        bot = _agent_bot(config=room_mode_config, agent_user=assistant_user, storage_path=tmp_path)
+        registry = entity_identity_registry(room_mode_config, runtime_paths_for(room_mode_config))
+
+        target = bot._conversation_resolver.build_message_target(
+            room_id="!room:localhost",
+            thread_id=None,
+            reply_to_event_id="$scheduled-fire:localhost",
+            event_source={
+                "content": {
+                    "body": "Kick off the weekly report",
+                    "msgtype": "m.text",
+                    SOURCE_KIND_KEY: SCHEDULED_SOURCE_KIND,
+                },
+                "event_id": "$scheduled-fire:localhost",
+                "sender": registry.current_id("assistant").full_id,
+                "origin_server_ts": 1234567890,
+                "room_id": "!room:localhost",
+                "type": "m.room.message",
+            },
+        )
+
+        assert target.resolved_thread_id == "$scheduled-fire:localhost"
+        assert target.session_id == create_session_id("!room:localhost", "$scheduled-fire:localhost")
+
+    def test_build_message_target_untrusted_scheduled_marker_keeps_room_mode(
+        self,
+        room_mode_config: Config,
+        assistant_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """A scheduled source-kind marker from a non-managed sender must not force a thread."""
+        bot = _agent_bot(config=room_mode_config, agent_user=assistant_user, storage_path=tmp_path)
+
+        target = bot._conversation_resolver.build_message_target(
+            room_id="!room:localhost",
+            thread_id=None,
+            reply_to_event_id="$spoofed-fire:localhost",
+            event_source={
+                "content": {
+                    "body": "pretend to be a scheduled fire",
+                    "msgtype": "m.text",
+                    SOURCE_KIND_KEY: SCHEDULED_SOURCE_KIND,
+                },
+                "event_id": "$spoofed-fire:localhost",
+                "sender": "@user:localhost",
+                "origin_server_ts": 1234567890,
+                "room_id": "!room:localhost",
+                "type": "m.room.message",
+            },
+        )
+
         assert target.resolved_thread_id is None
         assert target.session_id == create_session_id("!room:localhost", None)
 

--- a/tests/test_turn_controller_focused.py
+++ b/tests/test_turn_controller_focused.py
@@ -575,7 +575,12 @@ async def test_policy_respond_crosses_seam_as_immutable_values(config: Config, t
     assert harness.turn_store.is_handled(event.event_id) is True
 
 
-def _scheduled_fire_event(config: Config, *, extra_content: dict[str, Any]) -> nio.RoomMessageText:
+def _scheduled_fire_event(
+    config: Config,
+    *,
+    extra_content: dict[str, Any],
+    event_id: str = "$scheduled:localhost",
+) -> nio.RoomMessageText:
     """Build a self-authored scheduled-fire event as the scheduling executor sends it."""
     return nio.RoomMessageText.from_dict(
         {
@@ -586,12 +591,20 @@ def _scheduled_fire_event(config: Config, *, extra_content: dict[str, Any]) -> n
                 constants.ORIGINAL_SENDER_KEY: _SENDER,
                 **extra_content,
             },
-            "event_id": "$scheduled:localhost",
+            "event_id": event_id,
             "sender": _entity_user_id(config, "general"),
             "origin_server_ts": 1_000_000,
             "room_id": _ROOM_ID,
             "type": "m.room.message",
         },
+    )
+
+
+def _room_mode_config(tmp_path: Path) -> Config:
+    """Single room-mode agent bound to isolated runtime paths."""
+    return bind_runtime_paths(
+        Config(agents={"general": AgentConfig(display_name="General", thread_mode="room")}),
+        test_runtime_paths(tmp_path / "runtime"),
     )
 
 
@@ -690,6 +703,133 @@ async def test_user_message_cannot_spoof_scheduled_history_limit(config: Config,
     request = harness.runner.requests[0]
     assert request.scheduled_history_budget is None
     assert request.response_envelope.origin.intent is not TurnIntent.SCHEDULED_FIRE
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("thread_mode", ["thread", "room"])
+async def test_scheduled_fire_response_starts_per_fire_thread_session(tmp_path: Path, thread_mode: str) -> None:
+    """A room-level scheduled fire roots a per-fire thread and session in both thread modes."""
+    config = bind_runtime_paths(
+        Config(agents={"general": AgentConfig(display_name="General", thread_mode=thread_mode)}),
+        test_runtime_paths(tmp_path / "runtime"),
+    )
+    harness = _build_harness(config, tmp_path)
+    room = _room_with_members(config, "general")
+    event = _scheduled_fire_event(config, extra_content={})
+
+    await harness.deliver(room, event)
+
+    assert len(harness.runner.requests) == 1
+    target = harness.runner.requests[0].response_envelope.target
+    assert target.resolved_thread_id == "$scheduled:localhost"
+    assert target.session_id == f"{_ROOM_ID}:$scheduled:localhost"
+
+
+@pytest.mark.asyncio
+async def test_consecutive_scheduled_fires_resolve_distinct_sessions(tmp_path: Path) -> None:
+    """Two fires of one recurring room-mode schedule never share a thread root or session."""
+    config = _room_mode_config(tmp_path)
+    harness = _build_harness(config, tmp_path)
+    room = _room_with_members(config, "general")
+
+    await harness.deliver(room, _scheduled_fire_event(config, extra_content={}, event_id="$fire-one:localhost"))
+    await harness.deliver(room, _scheduled_fire_event(config, extra_content={}, event_id="$fire-two:localhost"))
+
+    assert len(harness.runner.requests) == 2
+    first_target = harness.runner.requests[0].response_envelope.target
+    second_target = harness.runner.requests[1].response_envelope.target
+    assert first_target.resolved_thread_id == "$fire-one:localhost"
+    assert second_target.resolved_thread_id == "$fire-two:localhost"
+    assert first_target.session_id == f"{_ROOM_ID}:$fire-one:localhost"
+    assert second_target.session_id == f"{_ROOM_ID}:$fire-two:localhost"
+    assert first_target.session_id != second_target.session_id
+
+
+@pytest.mark.asyncio
+async def test_scheduled_fire_into_persisted_thread_keeps_thread_session(config: Config, tmp_path: Path) -> None:
+    """A scheduled fire delivered into its persisted thread keeps that thread's session."""
+    fire_event_id = "$scheduled-in-thread:localhost"
+    persisted_thread_history = thread_history_result(
+        [
+            make_visible_message(
+                sender=_SENDER,
+                body="original schedule request",
+                event_id=_THREAD_ROOT,
+                timestamp=500_000,
+            ),
+        ],
+        is_full_history=True,
+    )
+    harness = _build_harness(config, tmp_path, thread_history=persisted_thread_history)
+    room = _room_with_members(config, "general")
+    event = nio.RoomMessageText.from_dict(
+        {
+            "content": {
+                "body": "⏰ [Automated Task]\nPoll the queue",
+                "msgtype": "m.text",
+                constants.SOURCE_KIND_KEY: SCHEDULED_SOURCE_KIND,
+                constants.ORIGINAL_SENDER_KEY: _SENDER,
+                "m.relates_to": {"rel_type": "m.thread", "event_id": _THREAD_ROOT},
+            },
+            "event_id": fire_event_id,
+            "sender": _entity_user_id(config, "general"),
+            "origin_server_ts": 1_000_000,
+            "room_id": _ROOM_ID,
+            "type": "m.room.message",
+        },
+    )
+
+    await harness.deliver(room, event)
+
+    assert len(harness.runner.requests) == 1
+    target = harness.runner.requests[0].response_envelope.target
+    assert target.resolved_thread_id == _THREAD_ROOT
+    assert target.session_id == f"{_ROOM_ID}:{_THREAD_ROOT}"
+
+
+@pytest.mark.asyncio
+async def test_room_mode_plain_user_message_keeps_room_session(tmp_path: Path) -> None:
+    """Non-scheduled room-level messages keep the shared room session in room mode."""
+    config = _room_mode_config(tmp_path)
+    harness = _build_harness(config, tmp_path)
+    room = _room_with_members(config, "general")
+    event = _text_event("hello there")
+
+    await harness.deliver(room, event)
+
+    assert len(harness.runner.requests) == 1
+    target = harness.runner.requests[0].response_envelope.target
+    assert target.resolved_thread_id is None
+    assert target.session_id == _ROOM_ID
+
+
+@pytest.mark.asyncio
+async def test_user_message_cannot_spoof_scheduled_thread_promotion(tmp_path: Path) -> None:
+    """A scheduled marker on an untrusted user message must not force a per-fire thread."""
+    config = _room_mode_config(tmp_path)
+    harness = _build_harness(config, tmp_path)
+    room = _room_with_members(config, "general")
+    event = nio.RoomMessageText.from_dict(
+        {
+            "content": {
+                "body": "pretend to be a scheduled fire",
+                "msgtype": "m.text",
+                constants.SOURCE_KIND_KEY: SCHEDULED_SOURCE_KIND,
+            },
+            "event_id": _EVENT_ID,
+            "sender": _SENDER,
+            "origin_server_ts": 1_000_000,
+            "room_id": _ROOM_ID,
+            "type": "m.room.message",
+        },
+    )
+
+    await harness.deliver(room, event)
+
+    assert len(harness.runner.requests) == 1
+    target = harness.runner.requests[0].response_envelope.target
+    assert target.resolved_thread_id is None
+    assert target.session_id == _ROOM_ID
 
 
 @pytest.mark.asyncio

--- a/tests/test_turn_controller_focused.py
+++ b/tests/test_turn_controller_focused.py
@@ -600,10 +600,10 @@ def _scheduled_fire_event(
     )
 
 
-def _room_mode_config(tmp_path: Path) -> Config:
-    """Single room-mode agent bound to isolated runtime paths."""
+def _single_agent_config(tmp_path: Path, thread_mode: str) -> Config:
+    """One-agent config with the given thread mode, bound to isolated runtime paths."""
     return bind_runtime_paths(
-        Config(agents={"general": AgentConfig(display_name="General", thread_mode="room")}),
+        Config(agents={"general": AgentConfig(display_name="General", thread_mode=thread_mode)}),
         test_runtime_paths(tmp_path / "runtime"),
     )
 
@@ -709,10 +709,7 @@ async def test_user_message_cannot_spoof_scheduled_history_limit(config: Config,
 @pytest.mark.parametrize("thread_mode", ["thread", "room"])
 async def test_scheduled_fire_response_starts_per_fire_thread_session(tmp_path: Path, thread_mode: str) -> None:
     """A room-level scheduled fire roots a per-fire thread and session in both thread modes."""
-    config = bind_runtime_paths(
-        Config(agents={"general": AgentConfig(display_name="General", thread_mode=thread_mode)}),
-        test_runtime_paths(tmp_path / "runtime"),
-    )
+    config = _single_agent_config(tmp_path, thread_mode)
     harness = _build_harness(config, tmp_path)
     room = _room_with_members(config, "general")
     event = _scheduled_fire_event(config, extra_content={})
@@ -728,7 +725,7 @@ async def test_scheduled_fire_response_starts_per_fire_thread_session(tmp_path: 
 @pytest.mark.asyncio
 async def test_consecutive_scheduled_fires_resolve_distinct_sessions(tmp_path: Path) -> None:
     """Two fires of one recurring room-mode schedule never share a thread root or session."""
-    config = _room_mode_config(tmp_path)
+    config = _single_agent_config(tmp_path, "room")
     harness = _build_harness(config, tmp_path)
     room = _room_with_members(config, "general")
 
@@ -748,7 +745,6 @@ async def test_consecutive_scheduled_fires_resolve_distinct_sessions(tmp_path: P
 @pytest.mark.asyncio
 async def test_scheduled_fire_into_persisted_thread_keeps_thread_session(config: Config, tmp_path: Path) -> None:
     """A scheduled fire delivered into its persisted thread keeps that thread's session."""
-    fire_event_id = "$scheduled-in-thread:localhost"
     persisted_thread_history = thread_history_result(
         [
             make_visible_message(
@@ -762,21 +758,10 @@ async def test_scheduled_fire_into_persisted_thread_keeps_thread_session(config:
     )
     harness = _build_harness(config, tmp_path, thread_history=persisted_thread_history)
     room = _room_with_members(config, "general")
-    event = nio.RoomMessageText.from_dict(
-        {
-            "content": {
-                "body": "⏰ [Automated Task]\nPoll the queue",
-                "msgtype": "m.text",
-                constants.SOURCE_KIND_KEY: SCHEDULED_SOURCE_KIND,
-                constants.ORIGINAL_SENDER_KEY: _SENDER,
-                "m.relates_to": {"rel_type": "m.thread", "event_id": _THREAD_ROOT},
-            },
-            "event_id": fire_event_id,
-            "sender": _entity_user_id(config, "general"),
-            "origin_server_ts": 1_000_000,
-            "room_id": _ROOM_ID,
-            "type": "m.room.message",
-        },
+    event = _scheduled_fire_event(
+        config,
+        extra_content={"m.relates_to": {"rel_type": "m.thread", "event_id": _THREAD_ROOT}},
+        event_id="$scheduled-in-thread:localhost",
     )
 
     await harness.deliver(room, event)
@@ -790,7 +775,7 @@ async def test_scheduled_fire_into_persisted_thread_keeps_thread_session(config:
 @pytest.mark.asyncio
 async def test_room_mode_plain_user_message_keeps_room_session(tmp_path: Path) -> None:
     """Non-scheduled room-level messages keep the shared room session in room mode."""
-    config = _room_mode_config(tmp_path)
+    config = _single_agent_config(tmp_path, "room")
     harness = _build_harness(config, tmp_path)
     room = _room_with_members(config, "general")
     event = _text_event("hello there")
@@ -806,7 +791,7 @@ async def test_room_mode_plain_user_message_keeps_room_session(tmp_path: Path) -
 @pytest.mark.asyncio
 async def test_user_message_cannot_spoof_scheduled_thread_promotion(tmp_path: Path) -> None:
     """A scheduled marker on an untrusted user message must not force a per-fire thread."""
-    config = _room_mode_config(tmp_path)
+    config = _single_agent_config(tmp_path, "room")
     harness = _build_harness(config, tmp_path)
     room = _room_with_members(config, "general")
     event = nio.RoomMessageText.from_dict(

--- a/tests/test_turn_controller_focused.py
+++ b/tests/test_turn_controller_focused.py
@@ -33,6 +33,7 @@ from mindroom.constants import ROUTER_AGENT_NAME
 from mindroom.conversation_resolver import ConversationResolver, ConversationResolverDeps
 from mindroom.conversation_state_writer import ConversationStateWriter, ConversationStateWriterDeps
 from mindroom.dispatch_source import (
+    EXTERNAL_TRIGGER_SOURCE_KIND,
     SCHEDULED_SOURCE_KIND,
     TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
     ScheduledHistoryBudget,
@@ -720,6 +721,36 @@ async def test_scheduled_fire_response_starts_per_fire_thread_session(tmp_path: 
     target = harness.runner.requests[0].response_envelope.target
     assert target.resolved_thread_id == "$scheduled:localhost"
     assert target.session_id == f"{_ROOM_ID}:$scheduled:localhost"
+
+
+@pytest.mark.asyncio
+async def test_external_trigger_fire_response_starts_per_fire_thread_session(tmp_path: Path) -> None:
+    """A room-level external trigger delivery roots a per-fire thread and session in room mode."""
+    config = _single_agent_config(tmp_path, "room")
+    harness = _build_harness(config, tmp_path)
+    room = _room_with_members(config, "general")
+    event = nio.RoomMessageText.from_dict(
+        {
+            "content": {
+                "body": "@general poll the webhook queue",
+                "msgtype": "m.text",
+                constants.SOURCE_KIND_KEY: EXTERNAL_TRIGGER_SOURCE_KIND,
+                constants.ORIGINAL_SENDER_KEY: _SENDER,
+            },
+            "event_id": "$trigger:localhost",
+            "sender": _entity_user_id(config, "general"),
+            "origin_server_ts": 1_000_000,
+            "room_id": _ROOM_ID,
+            "type": "m.room.message",
+        },
+    )
+
+    await harness.deliver(room, event)
+
+    assert len(harness.runner.requests) == 1
+    target = harness.runner.requests[0].response_envelope.target
+    assert target.resolved_thread_id == "$trigger:localhost"
+    assert target.session_id == f"{_ROOM_ID}:$trigger:localhost"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

A `new_thread=True` scheduled fire posts a relation-free room-level root (correct: a valid MSC3440 thread root needs no relation). But for agents in room thread-mode, `ConversationResolver.build_message_target` forced `room_mode=True`, so the response to the fire resolved room-level and `session_id` collapsed to the room id. Every fire of a recurring schedule therefore shared one persisted session: a recurring scheduled task accumulated history across fires, replaying all previous runs and forcing repeated compaction.

In default thread mode the existing `can_be_thread_root` promotion already gave each fire its own thread and session; the bug was specific to room-mode resolution (including per-room `room_thread_modes` overrides). External trigger deliveries with `new_thread=True` fire the identical relation-free root shape and had the same room-mode session collapse.

## Fix

In `ConversationResolver.build_message_target`, a **trusted automation fire that is itself a relation-free root** (scheduled fire or external trigger delivery) now roots its own thread even when the effective thread mode is `room`:

- The fire's own event is unchanged (still a plain room-level root, no `m.relates_to`).
- The agent's response threads under the fire (`rel_type: m.thread`, `event_id` = fire event), and the turn's session becomes `create_session_id(room_id, fire_event_id)` — a fresh session per fire.
- Which source kinds qualify is owned by a `dispatch_source` predicate (`source_kind_owns_per_fire_thread_root`); hook and relay turns stay excluded.
- Trust mirrors the envelope ingress rule: the source-kind content marker is only honored when the sender is a managed entity, so users cannot spoof the promotion.
- Streaming stays consistent automatically: `StreamingResponse` derives room mode from the resolved target, and edit content never carries the thread relation (`build_edit_event_content` strips `m.relates_to`).

Follow-up user messages inside the per-fire thread route to the same per-fire session in thread mode. In room mode, follow-ups inside the thread still flatten to the room-level session — room mode's general thread-flattening semantics, unchanged here.

Unchanged behavior, pinned by tests: `new_thread=False` schedules keep delivering into the persisted thread with that thread's session; non-scheduled room-level messages in room mode keep `session_id = room_id` and are not forcibly threaded.

## Cleanup

`_PreparedResponseRuntime.room_mode` was assigned but never read (streaming derives room mode from the resolved target), and the streaming/non-streaming runtime prep wrappers were identical apart from it. Collapsed into one `prepare_response_runtime`.

## Wording

`new_thread=True` was described as "New room-level thread root" (scheduler tool docstring, confirmation string, docs). Updated scheduler and external-trigger wording to say each fire starts its own thread with a fresh session.

## Tests

- `test_turn_controller_focused.py` (real resolver/policy/turn-store, recording runner/gateway seams): per-fire thread + session in both thread modes for scheduled fires and external trigger deliveries; two consecutive fires resolve distinct sessions; fire into a persisted thread keeps that session; room-mode plain user message keeps the room session; untrusted scheduled marker cannot force a thread.
- `test_thread_mode.py`: resolver-level promotion and spoof-guard pins for `build_message_target`.
- `test_scheduling_executor.py`: `new_thread` fire posts a relation-free root even when a stale `thread_id` is persisted on the workflow.
- `test_dispatch_source.py`: per-fire-root predicate accepts scheduled/external-trigger and rejects hook, relay, and interactive kinds.

## Live test

Verified end-to-end against a local Synapse with a room-mode agent backed by a local LLM: the agent scheduled a `new_thread=True` one-time task via its scheduler tool; the fire posted as a relation-free room-level root, the agent's streamed response was delivered with `rel_type: m.thread` rooted at the fire event, and the agent session store contained two distinct sessions — the room session and a per-fire `room:$fireEvent` session.

Full suite passes locally except pre-existing environment flakes in CLI-output tests, which fail identically on a clean `main` checkout in this environment.

## Known limitation (follow-up candidate)

When a scheduled fire is relayed through the router to a room-mode agent, the handoff reply is a reply-relation event, so that agent's response still resolves room-level. Fixing it (and room-mode follow-ups inside per-fire threads) needs a real conversation-scope concept separating session identity from delivery shape; deferred until a deployment actually hits it.