### PR TITLE
Make secret-assignment redaction linear on long unbroken runs

### DIFF
--- a/src/mindroom/redaction.py
+++ b/src/mindroom/redaction.py
@@ -26,9 +26,9 @@ _API_KEY_MESSAGE_PATTERN = re.compile(
     r"(?::\s*|\s+))(?P<token>[A-Za-z0-9._~+/=-]+)",
     re.IGNORECASE,
 )
-# Bounding inter-assignment whitespace and making every run possessive prevents the lazy value
-# scan from repeatedly rescanning the same long suffix while looking for the next assignment.
-_NEXT_ASSIGNMENT_PATTERN = r"\s{1,128}+(?:and\s{1,128}+)?[\"']?[A-Za-z0-9_.-]++[\"']?\s*+[:=]"
+# Starting only at the first whitespace in a run and making every run possessive prevents the lazy
+# value scan from repeatedly rescanning the same long suffix while looking for the next assignment.
+_NEXT_ASSIGNMENT_PATTERN = r"(?<!\s)\s++(?:and\s++)?[\"']?[A-Za-z0-9_.-]++[\"']?\s*+[:=]"
 # The key must start at a run boundary and be possessive: otherwise failed matches repeatedly
 # backtrack through long [A-Za-z0-9_.-] blobs (base64url, JWTs, hex dumps).
 _SECRET_ASSIGNMENT_PATTERN = re.compile(

--- a/src/mindroom/redaction.py
+++ b/src/mindroom/redaction.py
@@ -27,8 +27,11 @@ _API_KEY_MESSAGE_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _NEXT_ASSIGNMENT_PATTERN = r"\s+(?:and\s+)?[\"']?[A-Za-z0-9_.-]+[\"']?\s*[:=]"
+# The key must start at a run boundary and stay length-bounded: an open-ended key run makes
+# the scan quadratic on long unbroken [A-Za-z0-9_.-] blobs (base64url, JWTs, hex dumps).
 _SECRET_ASSIGNMENT_PATTERN = re.compile(
-    r"(?P<prefix>[\"']?(?P<key>[A-Za-z0-9_.-]+)[\"']?\s*[:=]\s*)"
+    r"(?<![A-Za-z0-9_.-])"
+    r"(?P<prefix>[\"']?(?P<key>[A-Za-z0-9_.-]{1,128})[\"']?\s*[:=]\s*)"
     rf"(?:(?P<quote>[\"'])(?P<quoted_value>.*?)(?P=quote)|(?P<value>.+?))"
     rf"(?=(?:{_NEXT_ASSIGNMENT_PATTERN})|[\r\n,&)\]}}]|$)",
     re.IGNORECASE,

--- a/src/mindroom/redaction.py
+++ b/src/mindroom/redaction.py
@@ -26,12 +26,14 @@ _API_KEY_MESSAGE_PATTERN = re.compile(
     r"(?::\s*|\s+))(?P<token>[A-Za-z0-9._~+/=-]+)",
     re.IGNORECASE,
 )
-_NEXT_ASSIGNMENT_PATTERN = r"\s+(?:and\s+)?[\"']?[A-Za-z0-9_.-]+[\"']?\s*[:=]"
-# The key must start at a run boundary and stay length-bounded: an open-ended key run makes
-# the scan quadratic on long unbroken [A-Za-z0-9_.-] blobs (base64url, JWTs, hex dumps).
+# Bounding inter-assignment whitespace and making every run possessive prevents the lazy value
+# scan from repeatedly rescanning the same long suffix while looking for the next assignment.
+_NEXT_ASSIGNMENT_PATTERN = r"\s{1,128}+(?:and\s{1,128}+)?[\"']?[A-Za-z0-9_.-]++[\"']?\s*+[:=]"
+# The key must start at a run boundary and be possessive: otherwise failed matches repeatedly
+# backtrack through long [A-Za-z0-9_.-] blobs (base64url, JWTs, hex dumps).
 _SECRET_ASSIGNMENT_PATTERN = re.compile(
     r"(?<![A-Za-z0-9_.-])"
-    r"(?P<prefix>[\"']?(?P<key>[A-Za-z0-9_.-]{1,128})[\"']?\s*[:=]\s*)"
+    r"(?P<prefix>[\"']?(?P<key>[A-Za-z0-9_.-]++)[\"']?\s*[:=]\s*)"
     rf"(?:(?P<quote>[\"'])(?P<quoted_value>.*?)(?P=quote)|(?P<value>.+?))"
     rf"(?=(?:{_NEXT_ASSIGNMENT_PATTERN})|[\r\n,&)\]}}]|$)",
     re.IGNORECASE,

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -281,6 +281,13 @@ def test_redact_sensitive_text_redacts_secret_assignments_with_long_keys() -> No
     assert redact_sensitive_text(f"{key}=hunter2") == f"{key}={REDACTED}"
 
 
+def test_redact_sensitive_text_preserves_long_inter_assignment_whitespace() -> None:
+    """Linear lookahead must not consume whitespace that separates assignments."""
+    separator = " " * 256
+
+    assert redact_sensitive_text(f"api_key=hunter2{separator}mode=safe") == f"api_key={REDACTED}{separator}mode=safe"
+
+
 def test_redact_sensitive_text_still_redacts_assignments_at_run_boundaries() -> None:
     """The assignment key guard must not lose ordinary key=value redaction."""
     redacted = redact_sensitive_text('api_key=hunter2 "password": "abc"')

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -266,8 +266,23 @@ def test_redact_sensitive_text_stays_linear_on_long_unbroken_runs() -> None:
     assert time.perf_counter() - start < 5.0
 
 
+def test_redact_sensitive_text_stays_linear_while_finding_value_terminator() -> None:
+    """Assignment lookahead must not repeatedly rescan long whitespace and key-like runs."""
+    value = "password=visible" + " " * 12_000 + "Ab3" * 4_000
+    start = time.perf_counter()
+    assert redact_sensitive_text(value) == f"password={REDACTED}"
+    assert time.perf_counter() - start < 5.0
+
+
+def test_redact_sensitive_text_redacts_secret_assignments_with_long_keys() -> None:
+    """Performance guards must not exempt long secret-bearing keys from redaction."""
+    key = "x" * 256 + "password"
+
+    assert redact_sensitive_text(f"{key}=hunter2") == f"{key}={REDACTED}"
+
+
 def test_redact_sensitive_text_still_redacts_assignments_at_run_boundaries() -> None:
-    """Bounding the assignment key must not lose ordinary key=value redaction."""
+    """The assignment key guard must not lose ordinary key=value redaction."""
     redacted = redact_sensitive_text('api_key=hunter2 "password": "abc"')
 
     assert "hunter2" not in redacted

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import json
+import time
 
-from mindroom.redaction import REDACTED, redact_sensitive_data
+from mindroom.redaction import REDACTED, redact_sensitive_data, redact_sensitive_text
 
 
 def test_redact_sensitive_data_redacts_nested_dicts_lists_and_header_variants() -> None:
@@ -255,3 +256,20 @@ def test_redact_sensitive_data_keeps_values_for_non_schema_label_keys() -> None:
         {"parameter": "client_secret_required", "value": False},
         {"variable": "secret_sauce_recipe", "value": "tomatoes"},
     ]
+
+
+def test_redact_sensitive_text_stays_linear_on_long_unbroken_runs() -> None:
+    """Long base64url/hex-like blobs must scan linearly, not quadratically."""
+    blob = "Ab3" * 40_000
+    start = time.perf_counter()
+    assert redact_sensitive_text(blob) == blob
+    assert time.perf_counter() - start < 5.0
+
+
+def test_redact_sensitive_text_still_redacts_assignments_at_run_boundaries() -> None:
+    """Bounding the assignment key must not lose ordinary key=value redaction."""
+    redacted = redact_sensitive_text('api_key=hunter2 "password": "abc"')
+
+    assert "hunter2" not in redacted
+    assert "abc" not in redacted
+    assert "api_key" in redacted


### PR DESCRIPTION
## Problem

`_SECRET_ASSIGNMENT_PATTERN` used an unbounded, backtracking key run `[A-Za-z0-9_.-]+` that had to be followed by `:` or `=`.
On any long unbroken run of those characters, the engine greedily consumed the rest of the run at every start offset, backtracked, failed, and retried, producing O(n²) behavior.
The character class includes `.`, `-`, and `_`, so base64url blobs, JWTs, and hex dumps are all pathological inputs.

Measured on a 32KB uniform run: **19.5s** in this one pattern, while every other redaction pattern is sub-millisecond.

Reachable from:

- `logging_config.py` console-output redaction, which is unbounded and processes log lines that embed entire prompts or payloads.
- `error_handling.py` via `str(error)`, including HTTP error bodies.
- Traceback sanitization with a 4KB budget.
- Approval-card full-argument redaction.

## Fix

Anchor assignment keys at a run boundary and make key runs possessive, preserving unbounded secret-bearing keys without allowing backtracking through them.
Start the value-terminating lookahead only at the first whitespace in a run and make its runs possessive so it cannot repeatedly rescan the same long suffix.

- 32KB uniform run: ~20s → <1ms; 200KB: ~2ms.
- Ordinary `key=value` and `"password": "..."` redaction is unchanged.
- Keys longer than 128 characters remain eligible for secret classification and redaction.
- Long whitespace followed by key-like text now scans linearly.

## Tests

Regression tests cover long unbroken blobs, the value-terminating lookahead, long secret-bearing keys, and normal assignment boundaries.

Validation:

- 206 focused redaction and caller tests passed.
- Full pytest suite passed.
- `pre-commit run --all-files` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of sensitive secret assignments in free-form text.
  * Ensured redaction works correctly across text run boundaries (while preserving assignment key names like `api_key`).
* **Performance**
  * Reduced excessive rescanning/backtracking by tightening redaction matching rules.
  * Added/expanded linear-time guards for long unbroken inputs, long whitespace separators, and very long secret-bearing keys.
* **Tests**
  * Added pytest cases covering correctness and performance characteristics for `redact_sensitive_text`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

