### PR TITLE
fix(history): shrink compaction chunk on typed context overflow (ISSUE-242)

### DIFF
--- a/src/mindroom/history/summary_call.py
+++ b/src/mindroom/history/summary_call.py
@@ -16,8 +16,9 @@ It enforces the call-side half of the compaction invariants
 
 4. Retry on provider failure is deterministic.
    ``SummaryRetryPolicy`` decides which error classes warrant a smaller retry
-   (timeouts and the named context-length fragments), the shrink schedule
-   (halving), and the give-up floor — no inline string matching at call sites.
+   (timeouts, typed context-window errors, and named legacy context-length
+   fragments), the shrink schedule (halving), and the give-up floor — no inline
+   string matching at call sites.
    Empty-text success responses also retry with less input because some providers
    surface rejected or oversized requests as an empty successful response.
 
@@ -39,6 +40,7 @@ from datetime import UTC, datetime
 from functools import partial
 from typing import TYPE_CHECKING
 
+from agno.exceptions import ContextWindowExceededError
 from agno.models.message import Message
 from agno.session.summary import SessionSummary
 
@@ -96,7 +98,7 @@ class SummaryRetryPolicy:
 
     def should_shrink(self, error: Exception) -> bool:
         """Return whether a smaller summary input may resolve this provider failure."""
-        if isinstance(error, TimeoutError | CompactionSummaryOutputLimitError):
+        if isinstance(error, TimeoutError | ContextWindowExceededError | CompactionSummaryOutputLimitError):
             return True
         message = str(error).lower()
         return any(fragment in message for fragment in _RETRYABLE_PROVIDER_ERROR_FRAGMENTS)

--- a/tests/test_compaction_invariants.py
+++ b/tests/test_compaction_invariants.py
@@ -18,6 +18,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from agno.agent import Agent
+from agno.exceptions import ContextWindowExceededError
 from agno.models.anthropic import Claude
 from agno.models.message import Message
 from agno.models.response import ModelResponse
@@ -616,7 +617,7 @@ def test_build_summary_request_messages_is_the_single_request_seam() -> None:
 # --- Invariant 4: deterministic budget shrink on provider failure --------------
 
 
-def test_retry_policy_shrinks_on_timeout_and_context_length_errors() -> None:
+def test_retry_policy_shrinks_on_timeout_and_output_limit() -> None:
     policy = DEFAULT_SUMMARY_RETRY_POLICY
 
     assert policy.retry_budget(attempt=1, budget=16_000, error=TimeoutError()) == 8_000
@@ -628,6 +629,23 @@ def test_retry_policy_shrinks_on_timeout_and_context_length_errors() -> None:
         )
         == 8_000
     )
+
+
+def test_retry_policy_halves_budget_for_typed_context_window_error() -> None:
+    error = ContextWindowExceededError(message="provider-specific wording does not matter")
+
+    assert DEFAULT_SUMMARY_RETRY_POLICY.retry_budget(attempt=1, budget=16_000, error=error) == 8_000
+
+
+def test_retry_policy_propagates_second_typed_context_window_error() -> None:
+    error = ContextWindowExceededError(message="provider-specific wording does not matter")
+
+    assert DEFAULT_SUMMARY_RETRY_POLICY.retry_budget(attempt=2, budget=8_000, error=error) is None
+
+
+def test_retry_policy_preserves_context_error_fragment_matches() -> None:
+    policy = DEFAULT_SUMMARY_RETRY_POLICY
+
     assert policy.retry_budget(attempt=1, budget=16_000, error=RuntimeError("context_length_exceeded")) == 8_000
     assert policy.retry_budget(attempt=1, budget=16_000, error=RuntimeError("request too large")) == 8_000
     assert (


### PR DESCRIPTION
## Problem

Context compaction fails deterministically and loops forever on affected threads. Since Jul 14 the production journal shows 22 `Compaction summary chunk failed` events; one thread failed 7x byte-identically over 12h with:

```
Vertex Claude request uses 256984 input tokens; limit is 167232.
```

## Root cause (empirically verified)

Full RCA in the linked report. Verified by reconstructing the failing thread from the persisted session DB and reproducing both journaled numbers via Vertex `messages.count_tokens`:

1. The compaction chunk selector sizes Claude input with tiktoken's `o200k_base` fallback (tiktoken doesn't know Claude models), undercounting by ~1.63x: **157,464 estimated vs 256,984 exact** on the failing chunk. Repeated `tools_schema` copies in run metadata make up 70.5% of the serialized payload.
2. The Vertex request guard (b869b973e) exact-counts the request and raises typed `ContextWindowExceededError`. Compaction's summary payload is two fresh messages (no `from_history` cut points), so the fitter can only validate-and-raise.
3. **`SummaryRetryPolicy.should_shrink()` did not recognize the typed error** - it only matched timeouts, output-limit errors, and legacy string fragments. The existing bounded half-budget retry never engaged.
4. A failed first chunk persists nothing, so the next trigger greedily selects the same oldest runs and fails identically, forever.

## Fix

Classify `ContextWindowExceededError` as shrinkable by type in `should_shrink()`. The existing halving schedule and `max_attempts=2` bound are unchanged. For the production failing thread, the half-budget rebuild selects 2 runs at 125,272 exact tokens - under the 167,232 guard - so recovery is verified against real data, not hypothetical.

Deliberately out of scope (tracked separately): provider-correct chunk sizing, `tools_schema` serialization bloat, stale `context_window` runtime config, and the 180s summary timeout / compaction model selection (independent Jul 14 timeout mode).

## Tests

- New: typed overflow halves the budget (revert-sensitive - fails on parent commit), second failure still propagates (bounded), legacy fragment matching preserved.
- Full suite: 10,562 passed / 120 skipped. Ruff, format, tach clean.

## Review

Two independent reviewers (Codex GPT-5.6, Claude Fable 5) on the frozen commit: both APPROVE, round 1, zero blocking findings. Reviewer verification included tracing the guard-to-retry call path end to end, a live probe of the retry wrapper (2 attempts, input shrank 5,052 to 2,049 tokens), revert-sensitivity checks of the new tests against the parent commit, and confirming the policy has exactly one production call site.

## Summary by Sourcery

Handle typed context window overflows during history compaction by shrinking the summary budget deterministically instead of looping on repeated failures.

Bug Fixes:
- Treat typed ContextWindowExceededError as a shrinkable error in summary retry policy to allow successful compaction after context overflows.
- Ensure second consecutive typed context window overflows stop retrying and propagate the error rather than shrinking indefinitely.

Enhancements:
- Clarify summary retry policy documentation to include typed context-window errors alongside timeouts and legacy context-length fragments.
- Extend retry policy tests to cover typed context window errors and preserve existing fragment-based matching behavior.