### PR TITLE
Sanitize stale Claude tool-search references

### DIFF
--- a/src/mindroom/claude_prompt_cache.py
+++ b/src/mindroom/claude_prompt_cache.py
@@ -40,11 +40,12 @@ API rejects the request), which is why the ladder's tools marker targets the
 last non-deferred tool.
 
 The hook's third job is history repair: replayed tool-search results are
-stripped down to the request schema, and search uses missing their result are
-removed. Both response shapes otherwise produce a 400 on the next request.
-This is why the client proxy is installed unconditionally — the ladder and
-defer tagging gate themselves per request, but a cache-disabled model with no
-deferred tools can still replay poisoned history.
+stripped down to the request schema, references to tools absent from the
+current request are removed, and search uses missing their result are removed.
+These response shapes otherwise produce a 400 on the next request. This is why
+the client proxy is installed unconditionally — the ladder and defer tagging
+gate themselves per request, but a cache-disabled model with no deferred tools
+can still replay poisoned history.
 """
 
 from __future__ import annotations
@@ -71,6 +72,7 @@ _NATIVE_TOOL_SEARCH_PROVIDERS = frozenset({"anthropic", "vertexai_claude"})
 
 SERVER_TOOL_USE_BLOCK_TYPE = "server_tool_use"
 TOOL_SEARCH_RESULT_BLOCK_TYPE = "tool_search_tool_result"
+_TOOL_SEARCH_RESULT_CONTENT_TYPE = "tool_search_tool_search_result"
 # The request schema for replayed tool-search results accepts only these keys
 # (ToolSearchToolResultBlockParam); response blocks additionally carry
 # citations/parsed_output/text, which the API rejects as extra inputs.
@@ -250,6 +252,88 @@ def _tool_search_result_ids(content: list[Any]) -> set[str]:
     return result_ids
 
 
+def _request_tool_names(request_kwargs: dict[str, Any]) -> frozenset[str]:
+    """Return client tool names available on the current request."""
+    tools = request_kwargs.get("tools")
+    if not isinstance(tools, list):
+        return frozenset()
+    return frozenset(
+        name
+        for tool in tools
+        if (tool_dict := _as_dict(tool)) is not None and isinstance(name := tool_dict.get("name"), str)
+    )
+
+
+def _replay_safe_tool_search_result(
+    block_dict: dict[str, Any],
+    available_tool_names: frozenset[str],
+) -> tuple[dict[str, Any] | None, bool]:
+    """Sanitize one replayed search result, dropping references to unavailable tools."""
+    changed = not block_dict.keys() <= _TOOL_SEARCH_RESULT_INPUT_KEYS
+    prepared_block = {key: value for key, value in block_dict.items() if key in _TOOL_SEARCH_RESULT_INPUT_KEYS}
+    content = _as_dict(prepared_block.get("content"))
+    if content is None or content.get("type") != _TOOL_SEARCH_RESULT_CONTENT_TYPE:
+        return prepared_block, changed
+    tool_references = content.get("tool_references")
+    if not isinstance(tool_references, list):
+        return prepared_block, changed
+
+    available_references = []
+    for reference in tool_references:
+        reference_dict = _as_dict(reference)
+        tool_name = reference_dict.get("tool_name") if reference_dict is not None else None
+        if isinstance(tool_name, str) and tool_name not in available_tool_names:
+            changed = True
+            continue
+        available_references.append(reference)
+    if len(available_references) == len(tool_references):
+        return prepared_block, changed
+    if not available_references:
+        return None, True
+
+    prepared_content = dict(content)
+    prepared_content["tool_references"] = available_references
+    prepared_block["content"] = prepared_content
+    return prepared_block, True
+
+
+def _replay_safe_message_content(
+    content: list[Any],
+    available_tool_names: frozenset[str],
+) -> tuple[list[Any], bool]:
+    """Repair replayed tool-search blocks in one assistant message."""
+    prepared_content: list[Any] = []
+    changed = False
+    for block in content:
+        block_dict = _as_dict(block)
+        if block_dict is None or block_dict.get("type") != TOOL_SEARCH_RESULT_BLOCK_TYPE:
+            prepared_content.append(block)
+            continue
+        prepared_block, block_changed = _replay_safe_tool_search_result(
+            block_dict,
+            available_tool_names,
+        )
+        changed = changed or block_changed
+        if prepared_block is not None:
+            prepared_content.append(prepared_block)
+
+    paired_result_ids = _tool_search_result_ids(prepared_content)
+    sanitized_content: list[Any] = []
+    for block in prepared_content:
+        block_dict = _as_dict(block)
+        block_id = block_dict.get("id") if block_dict is not None else None
+        if (
+            block_dict is not None
+            and block_dict.get("type") == SERVER_TOOL_USE_BLOCK_TYPE
+            and block_dict.get("name") == _TOOL_SEARCH_TOOL_NAME
+            and (not isinstance(block_id, str) or block_id not in paired_result_ids)
+        ):
+            changed = True
+            continue
+        sanitized_content.append(block)
+    return sanitized_content, changed
+
+
 def _request_kwargs_with_replay_safe_tool_search_results(request_kwargs: dict[str, Any]) -> dict[str, Any]:
     """Repair replayed tool-search blocks before sending assistant history.
 
@@ -263,13 +347,16 @@ def _request_kwargs_with_replay_safe_tool_search_results(request_kwargs: dict[st
 
     Anthropic can also return a ``server_tool_use`` without its matching
     ``tool_search_tool_result`` when native search and client tools are called
-    together. Replaying that orphan produces another 400. Drop only unmatched
-    regex-search uses; valid pairs and other server-tool types remain intact.
-    The input structure is never mutated.
+    together. Replaying that orphan produces another 400. Search results can
+    likewise reference tools that are absent from a later request after its
+    dynamic tool surface changes. Drop unavailable references and remove a
+    search pair when none remain. Valid pairs and other server-tool types
+    remain intact. The input structure is never mutated.
     """
     messages = request_kwargs.get("messages")
     if not isinstance(messages, list):
         return request_kwargs
+    available_tool_names = _request_tool_names(request_kwargs)
     sanitized_messages = list(messages)
     changed = False
     for message_index, message in enumerate(sanitized_messages):
@@ -277,33 +364,10 @@ def _request_kwargs_with_replay_safe_tool_search_results(request_kwargs: dict[st
         content = message_dict.get("content") if message_dict is not None else None
         if message_dict is None or not isinstance(content, list):
             continue
-        paired_result_ids = _tool_search_result_ids(content)
-        sanitized_content: list[Any] = []
-        content_changed = False
-        for block in content:
-            block_dict = _as_dict(block)
-            if block_dict is None:
-                sanitized_content.append(block)
-                continue
-            block_id = block_dict.get("id")
-            if (
-                block_dict.get("type") == SERVER_TOOL_USE_BLOCK_TYPE
-                and block_dict.get("name") == _TOOL_SEARCH_TOOL_NAME
-                and (not isinstance(block_id, str) or block_id not in paired_result_ids)
-            ):
-                content_changed = True
-                continue
-            if (
-                block_dict.get("type") == TOOL_SEARCH_RESULT_BLOCK_TYPE
-                and not block_dict.keys() <= _TOOL_SEARCH_RESULT_INPUT_KEYS
-            ):
-                prepared_block = {
-                    key: value for key, value in block_dict.items() if key in _TOOL_SEARCH_RESULT_INPUT_KEYS
-                }
-                content_changed = True
-            else:
-                prepared_block = block
-            sanitized_content.append(prepared_block)
+        sanitized_content, content_changed = _replay_safe_message_content(
+            content,
+            available_tool_names,
+        )
         if content_changed:
             sanitized_message = dict(message_dict)
             sanitized_message["content"] = sanitized_content

--- a/src/mindroom/claude_prompt_cache.py
+++ b/src/mindroom/claude_prompt_cache.py
@@ -72,7 +72,6 @@ _NATIVE_TOOL_SEARCH_PROVIDERS = frozenset({"anthropic", "vertexai_claude"})
 
 SERVER_TOOL_USE_BLOCK_TYPE = "server_tool_use"
 TOOL_SEARCH_RESULT_BLOCK_TYPE = "tool_search_tool_result"
-_TOOL_SEARCH_RESULT_CONTENT_TYPE = "tool_search_tool_search_result"
 # The request schema for replayed tool-search results accepts only these keys
 # (ToolSearchToolResultBlockParam); response blocks additionally carry
 # citations/parsed_output/text, which the API rejects as extra inputs.
@@ -272,7 +271,7 @@ def _replay_safe_tool_search_result(
     changed = not block_dict.keys() <= _TOOL_SEARCH_RESULT_INPUT_KEYS
     prepared_block = {key: value for key, value in block_dict.items() if key in _TOOL_SEARCH_RESULT_INPUT_KEYS}
     content = _as_dict(prepared_block.get("content"))
-    if content is None or content.get("type") != _TOOL_SEARCH_RESULT_CONTENT_TYPE:
+    if content is None:
         return prepared_block, changed
     tool_references = content.get("tool_references")
     if not isinstance(tool_references, list):
@@ -282,14 +281,14 @@ def _replay_safe_tool_search_result(
     for reference in tool_references:
         reference_dict = _as_dict(reference)
         tool_name = reference_dict.get("tool_name") if reference_dict is not None else None
-        if isinstance(tool_name, str) and tool_name not in available_tool_names:
+        if not isinstance(tool_name, str) or tool_name not in available_tool_names:
             changed = True
             continue
         available_references.append(reference)
-    if len(available_references) == len(tool_references):
-        return prepared_block, changed
     if not available_references:
         return None, True
+    if len(available_references) == len(tool_references):
+        return prepared_block, changed
 
     prepared_content = dict(content)
     prepared_content["tool_references"] = available_references

--- a/tests/test_extra_kwargs.py
+++ b/tests/test_extra_kwargs.py
@@ -1236,10 +1236,11 @@ def test_replay_safe_tool_search_results_drops_unavailable_references() -> None:
     result_block = {
         **_DIRTY_TOOL_SEARCH_RESULT_BLOCK,
         "content": {
-            "type": "tool_search_tool_search_result",
             "tool_references": [
                 {"type": "tool_reference", "tool_name": "get_weather"},
                 {"type": "tool_reference", "tool_name": "retired_weather"},
+                {"type": "tool_reference"},
+                "malformed-reference",
             ],
         },
     }
@@ -1257,9 +1258,15 @@ def test_replay_safe_tool_search_results_drops_unavailable_references() -> None:
 
     assert prepared["messages"][0]["content"] == [
         _SERVER_TOOL_USE_BLOCK,
-        _TOOL_SEARCH_RESULT_BLOCK,
+        {
+            "type": "tool_search_tool_result",
+            "tool_use_id": "srvtoolu_01ABC",
+            "content": {
+                "tool_references": [{"type": "tool_reference", "tool_name": "get_weather"}],
+            },
+        },
     ]
-    assert len(request_kwargs["messages"][0]["content"][1]["content"]["tool_references"]) == 2
+    assert len(request_kwargs["messages"][0]["content"][1]["content"]["tool_references"]) == 4
     assert "citations" in request_kwargs["messages"][0]["content"][1]
     assert _request_kwargs_with_replay_safe_tool_search_results(prepared) is prepared
 
@@ -1290,6 +1297,51 @@ def test_replay_safe_tool_search_results_drops_pair_when_all_references_are_unav
     assert request_kwargs["messages"][0]["content"][1] == _SERVER_TOOL_USE_BLOCK
     assert request_kwargs["messages"][0]["content"][2] == _DIRTY_TOOL_SEARCH_RESULT_BLOCK
     assert _request_kwargs_with_replay_safe_tool_search_results(prepared) is prepared
+
+
+def test_replay_safe_tool_search_results_drops_pairs_without_a_tools_array() -> None:
+    """Missing current tools means every replayed tool reference is stale."""
+    request_kwargs = {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": [
+                    dict(_OTHER_SERVER_TOOL_USE_BLOCK),
+                    dict(_SERVER_TOOL_USE_BLOCK),
+                    dict(_TOOL_SEARCH_RESULT_BLOCK),
+                ],
+            },
+        ],
+    }
+
+    prepared = _request_kwargs_with_replay_safe_tool_search_results(request_kwargs)
+
+    assert prepared["messages"][0]["content"] == [_OTHER_SERVER_TOOL_USE_BLOCK]
+    assert request_kwargs["messages"][0]["content"] == [
+        _OTHER_SERVER_TOOL_USE_BLOCK,
+        _SERVER_TOOL_USE_BLOCK,
+        _TOOL_SEARCH_RESULT_BLOCK,
+    ]
+    assert _request_kwargs_with_replay_safe_tool_search_results(prepared) is prepared
+
+
+def test_replay_safe_tool_search_results_returns_original_when_references_are_available() -> None:
+    """A clean replay should preserve both payload bytes and object identity."""
+    request_kwargs = {
+        "tools": [_wire_tool("get_weather")],
+        "messages": [
+            {
+                "role": "assistant",
+                "content": [
+                    dict(_SERVER_TOOL_USE_BLOCK),
+                    dict(_TOOL_SEARCH_RESULT_BLOCK),
+                    dict(_OTHER_SERVER_TOOL_USE_BLOCK),
+                ],
+            },
+        ],
+    }
+
+    assert _request_kwargs_with_replay_safe_tool_search_results(request_kwargs) is request_kwargs
 
 
 @pytest.mark.asyncio

--- a/tests/test_extra_kwargs.py
+++ b/tests/test_extra_kwargs.py
@@ -1183,6 +1183,7 @@ def test_server_tool_blocks_replay_to_non_anthropic_provider_without_crashing() 
 def test_replay_safe_tool_search_results_strips_response_only_fields() -> None:
     """Replayed tool-search results must carry only request-schema fields."""
     request_kwargs = {
+        "tools": [_wire_tool("get_weather")],
         "messages": [
             {
                 "role": "assistant",
@@ -1202,6 +1203,7 @@ def test_replay_safe_tool_search_results_strips_response_only_fields() -> None:
 def test_replay_safe_tool_search_results_drops_only_orphaned_search_uses() -> None:
     """Only regex-search uses missing a same-message result should be removed."""
     request_kwargs = {
+        "tools": [_wire_tool("get_weather")],
         "messages": [
             {
                 "role": "assistant",
@@ -1226,6 +1228,67 @@ def test_replay_safe_tool_search_results_drops_only_orphaned_search_uses() -> No
     ]
     assert request_kwargs["messages"][0]["content"][0] == _ORPHAN_TOOL_SEARCH_USE_BLOCK
     assert "citations" in request_kwargs["messages"][0]["content"][3]
+    assert _request_kwargs_with_replay_safe_tool_search_results(prepared) is prepared
+
+
+def test_replay_safe_tool_search_results_drops_unavailable_references() -> None:
+    """A replayed search result should retain only tools available on the current request."""
+    result_block = {
+        **_DIRTY_TOOL_SEARCH_RESULT_BLOCK,
+        "content": {
+            "type": "tool_search_tool_search_result",
+            "tool_references": [
+                {"type": "tool_reference", "tool_name": "get_weather"},
+                {"type": "tool_reference", "tool_name": "retired_weather"},
+            ],
+        },
+    }
+    request_kwargs = {
+        "tools": [_wire_tool("get_weather")],
+        "messages": [
+            {
+                "role": "assistant",
+                "content": [dict(_SERVER_TOOL_USE_BLOCK), result_block],
+            },
+        ],
+    }
+
+    prepared = _request_kwargs_with_replay_safe_tool_search_results(request_kwargs)
+
+    assert prepared["messages"][0]["content"] == [
+        _SERVER_TOOL_USE_BLOCK,
+        _TOOL_SEARCH_RESULT_BLOCK,
+    ]
+    assert len(request_kwargs["messages"][0]["content"][1]["content"]["tool_references"]) == 2
+    assert "citations" in request_kwargs["messages"][0]["content"][1]
+    assert _request_kwargs_with_replay_safe_tool_search_results(prepared) is prepared
+
+
+def test_replay_safe_tool_search_results_drops_pair_when_all_references_are_unavailable() -> None:
+    """A search use and result should both disappear when no referenced tool remains available."""
+    request_kwargs = {
+        "tools": [_wire_tool("other_tool")],
+        "messages": [
+            {
+                "role": "assistant",
+                "content": [
+                    dict(_OTHER_SERVER_TOOL_USE_BLOCK),
+                    dict(_SERVER_TOOL_USE_BLOCK),
+                    dict(_DIRTY_TOOL_SEARCH_RESULT_BLOCK),
+                    {"type": "text", "text": "found it"},
+                ],
+            },
+        ],
+    }
+
+    prepared = _request_kwargs_with_replay_safe_tool_search_results(request_kwargs)
+
+    assert prepared["messages"][0]["content"] == [
+        _OTHER_SERVER_TOOL_USE_BLOCK,
+        {"type": "text", "text": "found it"},
+    ]
+    assert request_kwargs["messages"][0]["content"][1] == _SERVER_TOOL_USE_BLOCK
+    assert request_kwargs["messages"][0]["content"][2] == _DIRTY_TOOL_SEARCH_RESULT_BLOCK
     assert _request_kwargs_with_replay_safe_tool_search_results(prepared) is prepared
 
 
@@ -1325,14 +1388,14 @@ def _wire_tool_search_results(wire_messages: list[dict[str, object]]) -> list[ob
 
 
 def test_prompt_cache_hook_sanitizes_replayed_tool_search_results() -> None:
-    """A persisted tool-search result with response-only fields must not reach the wire."""
+    """A replayed search pair with no currently available tool must not reach the wire."""
     model = _vertex_claude_model()
     captured_kwargs = _install_fake_sync_client(model)
     install_claude_prompt_cache_hook(model)
 
     model.response(messages=_dirty_replay_messages(), compression_manager=None)
 
-    assert _wire_tool_search_results(captured_kwargs[0]["messages"]) == [_TOOL_SEARCH_RESULT_BLOCK]
+    assert _wire_tool_search_results(captured_kwargs[0]["messages"]) == []
 
 
 def test_prompt_cache_hook_sanitizes_replay_with_cache_disabled_and_no_deferred_tools() -> None:
@@ -1350,7 +1413,7 @@ def test_prompt_cache_hook_sanitizes_replay_with_cache_disabled_and_no_deferred_
     model.response(messages=_dirty_replay_messages(), compression_manager=None)
 
     wire_messages = captured_kwargs[0]["messages"]
-    assert _wire_tool_search_results(wire_messages) == [_TOOL_SEARCH_RESULT_BLOCK]
+    assert _wire_tool_search_results(wire_messages) == []
     assert _count_cache_markers({"messages": list(wire_messages)}) == 0
 
 


### PR DESCRIPTION
## Why

Claude replays server-side tool-search results in assistant history. When a dynamic tool surface changes, persisted references can name tools that are no longer present on the next request. Anthropic then rejects the request before the model can run, and later turns keep replaying the same invalid history.

## What changed

- Derive the client-tool names available on the current request.
- Remove unavailable names from replayed tool-search results.
- Remove the matching search-use/result pair when no valid references remain.
- Preserve valid references, unrelated server-tool blocks, input immutability, and idempotence.

## Validation

- `pytest -q tests/test_extra_kwargs.py`
- `pytest -q tests/test_vertex_claude_context_guard.py`
- `pytest -q tests/test_dynamic_toolkits.py`
- `pytest -q tests/test_prompt_cache_review.py`
- `ruff check src/mindroom/claude_prompt_cache.py tests/test_extra_kwargs.py`
- `ty check src/mindroom/claude_prompt_cache.py`