### PR TITLE
fix: derive mint_callback URL from the bound API server port (ISSUE-244)

### DIFF
--- a/docs/agent-callbacks.md
+++ b/docs/agent-callbacks.md
@@ -55,7 +55,9 @@ Unused callbacks do not expire automatically, so delete abandoned records with `
 
 ## Network Access
 
-Generated scripts call `http://127.0.0.1:8765` by default.
+Generated scripts use the embedded API server's bound address, including a non-default `--api-port`.
+
+When no embedded API server is running, they fall back to `http://127.0.0.1:8765`.
 
 Set `MINDROOM_URL` when the background process needs another address to reach the MindRoom API.
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -15059,7 +15059,9 @@ Unused callbacks do not expire automatically, so delete abandoned records with `
 
 ## Network Access
 
-Generated scripts call `http://127.0.0.1:8765` by default.
+Generated scripts use the embedded API server's bound address, including a non-default `--api-port`.
+
+When no embedded API server is running, they fall back to `http://127.0.0.1:8765`.
 
 Set `MINDROOM_URL` when the background process needs another address to reach the MindRoom API.
 

--- a/skills/mindroom-docs/references/page__agent-callbacks__index.md
+++ b/skills/mindroom-docs/references/page__agent-callbacks__index.md
@@ -51,7 +51,9 @@ Unused callbacks do not expire automatically, so delete abandoned records with `
 
 ## Network Access
 
-Generated scripts call `http://127.0.0.1:8765` by default.
+Generated scripts use the embedded API server's bound address, including a non-default `--api-port`.
+
+When no embedded API server is running, they fall back to `http://127.0.0.1:8765`.
 
 Set `MINDROOM_URL` when the background process needs another address to reach the MindRoom API.
 

--- a/src/mindroom/custom_tools/callback_manager.py
+++ b/src/mindroom/custom_tools/callback_manager.py
@@ -24,6 +24,7 @@ from mindroom.external_triggers.store import (
     ExternalTriggerStoreError,
     ExternalTriggerTarget,
 )
+from mindroom.runtime_state import get_api_server_address
 from mindroom.tool_system.worker_routing import resolve_agent_owned_path
 
 if TYPE_CHECKING:
@@ -38,7 +39,12 @@ _MAX_LABEL_LENGTH = 200
 def _callback_base_url(context: ToolRuntimeContext) -> str:
     configured_url = context.runtime_paths.env_value("MINDROOM_URL")
     base_url = configured_url.strip() if configured_url is not None else ""
-    return (base_url or DEFAULT_MINDROOM_URL).rstrip("/")
+    if base_url:
+        return base_url.rstrip("/")
+    api_address = get_api_server_address()
+    if api_address is not None:
+        return api_address.base_url
+    return DEFAULT_MINDROOM_URL
 
 
 class CallbackManagerTools(Toolkit):

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -65,6 +65,7 @@ from mindroom.mcp.toolkit import bind_mcp_server_manager
 from mindroom.memory import MemoryAutoFlushWorker, auto_flush_enabled
 from mindroom.runtime_shutdown import ORDERLY_SHUTDOWN
 from mindroom.runtime_state import (
+    clear_api_server_address,
     reset_runtime_state,
     set_api_server_address,
     set_runtime_failed,
@@ -120,6 +121,7 @@ from .runtime_support import (
 )
 
 if TYPE_CHECKING:
+    import socket
     from collections.abc import Awaitable, Callable, Iterable
     from pathlib import Path
     from types import FrameType
@@ -187,6 +189,19 @@ class _SignalAwareUvicornServer(uvicorn.Server):
     def __init__(self, config: uvicorn.Config, shutdown_requested: asyncio.Event | None) -> None:
         super().__init__(config)
         self._shutdown_requested = shutdown_requested
+
+    async def startup(self, sockets: list[socket.socket] | None = None) -> None:
+        """Publish the API address only after Uvicorn successfully binds it."""
+        await super().startup(sockets=sockets)
+        if not self.started:
+            return
+        listeners = self.servers[0].sockets
+        assert listeners is not None
+        bound_address = cast("tuple[str, int]", listeners[0].getsockname())
+        bound_host = bound_address[0]
+        bound_port = bound_address[1]
+        set_api_server_address(bound_host, bound_port)
+        logger.info("embedded_api_server_started", host=bound_host, port=bound_port)
 
     def handle_exit(self, sig: int, frame: FrameType | None) -> None:
         """Mirror Uvicorn signal handling and surface shutdown to the orchestrator."""
@@ -1799,12 +1814,14 @@ async def _run_api_server(
         api_main.bind_orchestrator_knowledge_refresh_scheduler(api_main.app, knowledge_refresh_scheduler)
     config = uvicorn.Config(api_main.app, host=host, port=port, log_level=log_level.lower())
     server = _SignalAwareUvicornServer(config, shutdown_requested)
-    set_api_server_address(host, port)
-    logger.info("embedded_api_server_started", **api_server.log_context())
+    logger.info("embedded_api_server_starting", **api_server.log_context())
     try:
-        await server.serve()
-    except SystemExit as exc:
-        _raise_embedded_api_server_exit(api_server, reason="server.serve() raised SystemExit", cause=exc)
+        try:
+            await server.serve()
+        except SystemExit as exc:
+            _raise_embedded_api_server_exit(api_server, reason="server.serve() raised SystemExit", cause=exc)
+    finally:
+        clear_api_server_address()
     shutdown_expected = shutdown_requested.is_set() if shutdown_requested is not None else False
     logger.info(
         "embedded_api_server_serve_returned",

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -64,7 +64,13 @@ from mindroom.mcp.registry import mcp_tool_name
 from mindroom.mcp.toolkit import bind_mcp_server_manager
 from mindroom.memory import MemoryAutoFlushWorker, auto_flush_enabled
 from mindroom.runtime_shutdown import ORDERLY_SHUTDOWN
-from mindroom.runtime_state import reset_runtime_state, set_runtime_failed, set_runtime_ready, set_runtime_starting
+from mindroom.runtime_state import (
+    reset_runtime_state,
+    set_api_server_address,
+    set_runtime_failed,
+    set_runtime_ready,
+    set_runtime_starting,
+)
 from mindroom.scheduling_executor import set_scheduling_hook_registry
 from mindroom.startup_errors import PermanentStartupError
 from mindroom.startup_maintenance import StartupMaintenanceController
@@ -1793,6 +1799,7 @@ async def _run_api_server(
         api_main.bind_orchestrator_knowledge_refresh_scheduler(api_main.app, knowledge_refresh_scheduler)
     config = uvicorn.Config(api_main.app, host=host, port=port, log_level=log_level.lower())
     server = _SignalAwareUvicornServer(config, shutdown_requested)
+    set_api_server_address(host, port)
     logger.info("embedded_api_server_started", **api_server.log_context())
     try:
         await server.serve()

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -197,7 +197,10 @@ class _SignalAwareUvicornServer(uvicorn.Server):
             return
         listeners = self.servers[0].sockets
         assert listeners is not None
-        bound_address = cast("tuple[str, int]", listeners[0].getsockname())
+        bound_address = cast(
+            "tuple[str, int] | tuple[str, int, int, int]",
+            listeners[0].getsockname(),
+        )
         bound_host = bound_address[0]
         bound_port = bound_address[1]
         set_api_server_address(bound_host, bound_port)

--- a/src/mindroom/runtime_state.py
+++ b/src/mindroom/runtime_state.py
@@ -5,6 +5,22 @@ from __future__ import annotations
 from dataclasses import dataclass
 from threading import Lock
 
+_LOOPBACK_BIND_HOSTS = ("0.0.0.0", "::")  # noqa: S104
+
+
+@dataclass(frozen=True, slots=True)
+class _ApiServerAddress:
+    """Bind address of the embedded dashboard/API server."""
+
+    host: str
+    port: int
+
+    @property
+    def base_url(self) -> str:
+        """Return the local-client base URL for this bind address."""
+        host = "127.0.0.1" if self.host in _LOOPBACK_BIND_HOSTS else self.host
+        return f"http://{host}:{self.port}"
+
 
 @dataclass(slots=True)
 class _RuntimeState:
@@ -12,6 +28,7 @@ class _RuntimeState:
 
     phase: str = "idle"
     detail: str | None = None
+    api_server_address: _ApiServerAddress | None = None
 
 
 _state = _RuntimeState()
@@ -21,7 +38,23 @@ _lock = Lock()
 def get_runtime_state() -> _RuntimeState:
     """Return a copy of the current runtime state."""
     with _lock:
-        return _RuntimeState(phase=_state.phase, detail=_state.detail)
+        return _RuntimeState(
+            phase=_state.phase,
+            detail=_state.detail,
+            api_server_address=_state.api_server_address,
+        )
+
+
+def set_api_server_address(host: str, port: int) -> None:
+    """Record the bind address of the embedded API server."""
+    with _lock:
+        _state.api_server_address = _ApiServerAddress(host=host, port=port)
+
+
+def get_api_server_address() -> _ApiServerAddress | None:
+    """Return the embedded API server bind address, if one was started."""
+    with _lock:
+        return _state.api_server_address
 
 
 def set_runtime_starting(detail: str = "MindRoom startup in progress") -> None:
@@ -50,3 +83,4 @@ def reset_runtime_state() -> None:
     with _lock:
         _state.phase = "idle"
         _state.detail = None
+        _state.api_server_address = None

--- a/src/mindroom/runtime_state.py
+++ b/src/mindroom/runtime_state.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from threading import Lock
 
-_LOOPBACK_BIND_HOSTS = ("0.0.0.0", "::")  # noqa: S104
+_IPV4_WILDCARD_BIND_HOST = "0.0.0.0"  # noqa: S104
+_IPV6_WILDCARD_BIND_HOST = "::"
 
 
 @dataclass(frozen=True, slots=True)
@@ -18,7 +19,14 @@ class _ApiServerAddress:
     @property
     def base_url(self) -> str:
         """Return the local-client base URL for this bind address."""
-        host = "127.0.0.1" if self.host in _LOOPBACK_BIND_HOSTS else self.host
+        if self.host == _IPV4_WILDCARD_BIND_HOST:
+            host = "127.0.0.1"
+        elif self.host == _IPV6_WILDCARD_BIND_HOST:
+            host = "::1"
+        else:
+            host = self.host
+        if ":" in host:
+            host = f"[{host}]"
         return f"http://{host}:{self.port}"
 
 
@@ -55,6 +63,12 @@ def get_api_server_address() -> _ApiServerAddress | None:
     """Return the embedded API server bind address, if one was started."""
     with _lock:
         return _state.api_server_address
+
+
+def clear_api_server_address() -> None:
+    """Clear the embedded API server address after it stops."""
+    with _lock:
+        _state.api_server_address = None
 
 
 def set_runtime_starting(detail: str = "MindRoom startup in progress") -> None:

--- a/tests/test_callback_manager_tool.py
+++ b/tests/test_callback_manager_tool.py
@@ -7,7 +7,9 @@ import os
 import stat
 import subprocess
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, cast
+
+import pytest
 
 from mindroom.config.main import Config
 from mindroom.constants import RuntimePaths, resolve_primary_runtime_paths
@@ -16,9 +18,6 @@ from mindroom.external_triggers.store import ExternalTriggerStore
 from mindroom.message_target import MessageTarget
 from mindroom.runtime_state import reset_runtime_state, set_api_server_address
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, tool_runtime_context
-
-if TYPE_CHECKING:
-    import pytest
 
 
 class _Client:
@@ -96,7 +95,7 @@ def test_mint_callback_writes_one_bound_script(tmp_path: Path) -> None:
     assert record.allowed_kinds == ("mindroom.callback.completed",)
 
     script_text = script_path.read_text(encoding="utf-8")
-    assert f"/api/triggers/{callback_id}" in script_text
+    assert f"CALLBACK_URL=http://127.0.0.1:8765/api/triggers/{callback_id}" in script_text
     assert "CALLBACK_TOKEN=mrt_" in script_text
     assert "mrt_" not in store.store_path.read_text(encoding="utf-8")
 
@@ -113,6 +112,30 @@ def test_mint_callback_targets_bound_api_server_port(tmp_path: Path) -> None:
     script_text = Path(payload["script_path"]).read_text(encoding="utf-8")
     assert "CALLBACK_URL=http://127.0.0.1:8766/api/triggers/callback_" in script_text
     assert ":8765" not in script_text
+
+
+@pytest.mark.parametrize(
+    ("host", "expected_base_url"),
+    [
+        ("::", "http://[::1]:8766"),
+        ("::1", "http://[::1]:8766"),
+    ],
+)
+def test_mint_callback_formats_ipv6_api_server_address(
+    tmp_path: Path,
+    host: str,
+    expected_base_url: str,
+) -> None:
+    """IPv6 bind addresses produce reachable, bracketed callback URLs."""
+    set_api_server_address(host, 8766)
+    try:
+        with tool_runtime_context(_context(tmp_path)):
+            payload = _payload(CallbackManagerTools().mint_callback("IPv6 address"))
+    finally:
+        reset_runtime_state()
+
+    script_text = Path(payload["script_path"]).read_text(encoding="utf-8")
+    assert f"{expected_base_url}/api/triggers/callback_" in script_text
 
 
 def test_mint_callback_prefers_explicit_mindroom_url(tmp_path: Path) -> None:

--- a/tests/test_callback_manager_tool.py
+++ b/tests/test_callback_manager_tool.py
@@ -14,6 +14,7 @@ from mindroom.constants import RuntimePaths, resolve_primary_runtime_paths
 from mindroom.custom_tools.callback_manager import CallbackManagerTools
 from mindroom.external_triggers.store import ExternalTriggerStore
 from mindroom.message_target import MessageTarget
+from mindroom.runtime_state import reset_runtime_state, set_api_server_address
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, tool_runtime_context
 
 if TYPE_CHECKING:
@@ -24,11 +25,11 @@ class _Client:
     user_id = "@mindroom_coder:example.org"
 
 
-def _runtime_paths(tmp_path: Path) -> RuntimePaths:
+def _runtime_paths(tmp_path: Path, process_env: dict[str, str] | None = None) -> RuntimePaths:
     return resolve_primary_runtime_paths(
         config_path=tmp_path / "config.yaml",
         storage_path=tmp_path / "mindroom_data",
-        process_env={},
+        process_env=process_env or {},
     )
 
 
@@ -46,14 +47,19 @@ def _config() -> Config:
     )
 
 
-def _context(tmp_path: Path, *, requester_id: str = "@owner:example.org") -> ToolRuntimeContext:
+def _context(
+    tmp_path: Path,
+    *,
+    requester_id: str = "@owner:example.org",
+    process_env: dict[str, str] | None = None,
+) -> ToolRuntimeContext:
     return ToolRuntimeContext(
         agent_name="coder",
         target=MessageTarget.resolve(room_id="lobby", thread_id="$thread", reply_to_event_id=None),
         requester_id=requester_id,
         client=cast("Any", _Client()),
         config=_config(),
-        runtime_paths=_runtime_paths(tmp_path),
+        runtime_paths=_runtime_paths(tmp_path, process_env),
         event_cache=cast("Any", object()),
         conversation_cache=cast("Any", object()),
     )
@@ -93,6 +99,34 @@ def test_mint_callback_writes_one_bound_script(tmp_path: Path) -> None:
     assert f"/api/triggers/{callback_id}" in script_text
     assert "CALLBACK_TOKEN=mrt_" in script_text
     assert "mrt_" not in store.store_path.read_text(encoding="utf-8")
+
+
+def test_mint_callback_targets_bound_api_server_port(tmp_path: Path) -> None:
+    """The script URL follows the port the running API server actually bound."""
+    set_api_server_address("0.0.0.0", 8766)  # noqa: S104
+    try:
+        with tool_runtime_context(_context(tmp_path)):
+            payload = _payload(CallbackManagerTools().mint_callback("non-default port"))
+    finally:
+        reset_runtime_state()
+
+    script_text = Path(payload["script_path"]).read_text(encoding="utf-8")
+    assert "CALLBACK_URL=http://127.0.0.1:8766/api/triggers/callback_" in script_text
+    assert ":8765" not in script_text
+
+
+def test_mint_callback_prefers_explicit_mindroom_url(tmp_path: Path) -> None:
+    """An explicit MINDROOM_URL wins over the bound API server address."""
+    set_api_server_address("0.0.0.0", 8766)  # noqa: S104
+    try:
+        env = {"MINDROOM_URL": "https://hub.example.org/"}
+        with tool_runtime_context(_context(tmp_path, process_env=env)):
+            payload = _payload(CallbackManagerTools().mint_callback("explicit url"))
+    finally:
+        reset_runtime_state()
+
+    script_text = Path(payload["script_path"]).read_text(encoding="utf-8")
+    assert "CALLBACK_URL=https://hub.example.org/api/triggers/callback_" in script_text
 
 
 def test_generated_script_posts_summary_and_deletes_itself(tmp_path: Path) -> None:

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -175,7 +175,11 @@ class TestAgentBot(AgentBotTestBase):
             assert address is not None
             listeners = server.servers[0].sockets
             assert listeners is not None
-            bound_port = cast("tuple[str, int]", listeners[0].getsockname())[1]
+            bound_address = cast(
+                "tuple[str, int] | tuple[str, int, int, int]",
+                listeners[0].getsockname(),
+            )
+            bound_port = bound_address[1]
             assert address.base_url == f"http://127.0.0.1:{bound_port}"
         finally:
             await server.shutdown()

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -54,7 +54,13 @@ from mindroom.orchestrator import (
     main,
 )
 from mindroom.runtime_shutdown import ORDERLY_SHUTDOWN
-from mindroom.runtime_state import get_runtime_state, reset_runtime_state, set_runtime_ready
+from mindroom.runtime_state import (
+    get_api_server_address,
+    get_runtime_state,
+    reset_runtime_state,
+    set_api_server_address,
+    set_runtime_ready,
+)
 from mindroom.runtime_support import StartupThreadPrewarmRegistry
 from mindroom.startup_errors import PermanentStartupError
 from mindroom.tool_approval import _shutdown_approval_store
@@ -147,6 +153,35 @@ class TestAgentBot(AgentBotTestBase):
         )
 
     @pytest.mark.asyncio
+    async def test_embedded_uvicorn_publishes_actual_bound_port_after_startup(self) -> None:
+        """Port-zero binds publish the listener's real port only after startup succeeds."""
+
+        async def app(scope: object, receive: object, send: object) -> None:
+            del scope
+            del receive
+            del send
+
+        server = _SignalAwareUvicornServer(
+            uvicorn.Config(app, host="0.0.0.0", port=0, lifespan="off"),  # noqa: S104
+            asyncio.Event(),
+        )
+        server.config.load()
+        server.lifespan = server.config.lifespan_class(server.config)
+        reset_runtime_state()
+        assert get_api_server_address() is None
+        try:
+            await server.startup()
+            address = get_api_server_address()
+            assert address is not None
+            listeners = server.servers[0].sockets
+            assert listeners is not None
+            bound_port = cast("tuple[str, int]", listeners[0].getsockname())[1]
+            assert address.base_url == f"http://127.0.0.1:{bound_port}"
+        finally:
+            await server.shutdown()
+            reset_runtime_state()
+
+    @pytest.mark.asyncio
     async def test_run_api_server_fails_fast_when_serve_returns_unexpectedly(self, tmp_path: Path) -> None:
         """server.serve() returning outside shutdown should be a fatal API lifecycle failure."""
 
@@ -158,7 +193,7 @@ class TestAgentBot(AgentBotTestBase):
                 pass
 
             async def serve(self) -> None:
-                return None
+                set_api_server_address("127.0.0.1", 8765)
 
         with (
             patch("mindroom.orchestrator.uvicorn.Config", return_value=object()),
@@ -178,6 +213,7 @@ class TestAgentBot(AgentBotTestBase):
 
         mock_error.assert_called_once()
         assert mock_error.call_args.args == ("fatal_embedded_api_server_exit",)
+        assert get_api_server_address() is None
 
     @pytest.mark.asyncio
     async def test_run_api_server_allows_expected_shutdown_after_serve_returns(self, tmp_path: Path) -> None:
@@ -191,7 +227,7 @@ class TestAgentBot(AgentBotTestBase):
                 pass
 
             async def serve(self) -> None:
-                return None
+                set_api_server_address("127.0.0.1", 8765)
 
         shutdown_requested = asyncio.Event()
         shutdown_requested.set()
@@ -212,6 +248,7 @@ class TestAgentBot(AgentBotTestBase):
             )
 
         mock_error.assert_not_called()
+        assert get_api_server_address() is None
 
     @pytest.mark.asyncio
     async def test_run_api_server_converts_uvicorn_system_exit_to_runtime_error(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

`mint_callback` generated scripts hardcoded `CALLBACK_URL=http://127.0.0.1:8765/...` whenever `MINDROOM_URL` was unset.
Deployments binding the API on another port, including `mindroom run --api-port 8766`, got callback scripts that failed on delivery.

## Root cause

`_callback_base_url()` in `custom_tools/callback_manager.py` fell back to `DEFAULT_MINDROOM_URL`.
The actual listener address created by Uvicorn was not visible to local tool code.

## Fix

- Publish the embedded API address only after Uvicorn successfully binds its listener.
- Record the listener's actual host and port, including the assigned port for `--api-port 0`.
- Clear the published address on every API server exit path.
- Map IPv4 and IPv6 wildcard listeners to their matching loopback addresses and bracket IPv6 URL authorities.
- Resolve callback URLs in this order: explicit `MINDROOM_URL`, bound embedded API address, then `DEFAULT_MINDROOM_URL`.
- Keep `callback_manager` local-only so it reads primary-process runtime state.
- Document the generated callback URL behavior and regenerate documentation references.

## Tests

- Callback scripts target a non-default bound API port.
- IPv6 wildcard and literal listener addresses produce reachable bracketed URLs.
- Explicit `MINDROOM_URL` still overrides the listener address.
- Uvicorn publishes the actual port after a successful port-zero bind and clears it after both normal and fatal exits.
- Full suite: 10,652 passed, 151 skipped.
- `pre-commit run --all-files`: clean.
- `tach check --dependencies --interfaces`: clean.

## Notes

Adjacent OAuth URL fallbacks remain outside this callback-specific fix.
