### PR TITLE
fix(history): omit bulky metadata from compaction summaries (ISSUE-242 item 3)

### DIFF
--- a/src/mindroom/history/compaction.py
+++ b/src/mindroom/history/compaction.py
@@ -55,7 +55,7 @@ logger = get_logger(__name__)
 
 _WRAPPER_OVERHEAD_TOKENS = 200
 _OVERSIZED_RUN_NOTE = "Run truncated to fit compaction budget."
-_EXCERPT_METADATA_OMIT_KEYS = frozenset(
+_SUMMARY_METADATA_OMIT_KEYS = frozenset(
     {
         "model_params",
         "tools_schema",
@@ -733,9 +733,9 @@ def _compaction_replay_messages(
 def _excerpt_blocks(run: RunOutput | TeamRunOutput, history_settings: ResolvedHistorySettings) -> list[_ExcerptBlock]:
     blocks: list[_ExcerptBlock] = []
     if run.metadata:
-        blocks.append(
-            _ExcerptBlock("<run_metadata>", stable_serialize(_metadata_for_excerpt(run.metadata)), "</run_metadata>"),
-        )
+        metadata = _metadata_for_summary(run.metadata)
+        if metadata:
+            blocks.append(_ExcerptBlock("<run_metadata>", stable_serialize(metadata), "</run_metadata>"))
     for message in _compaction_replay_messages(run, history_settings):
         content = _render_message_content(message)
         if not content:
@@ -744,9 +744,9 @@ def _excerpt_blocks(run: RunOutput | TeamRunOutput, history_settings: ResolvedHi
     return blocks
 
 
-def _metadata_for_excerpt(metadata: dict[str, object]) -> dict[str, object]:
-    """Keep compact identity metadata for oversized excerpts without tool schema bulk."""
-    return {key: value for key, value in metadata.items() if key not in _EXCERPT_METADATA_OMIT_KEYS}
+def _metadata_for_summary(metadata: dict[str, object]) -> dict[str, object]:
+    """Omit bulky request metadata from compaction summary inputs."""
+    return {key: value for key, value in metadata.items() if key not in _SUMMARY_METADATA_OMIT_KEYS}
 
 
 def _truncate_excerpt(text: str, max_chars: int) -> str:
@@ -788,8 +788,9 @@ def _messages_for_runs(
 def _serialize_run(run: RunOutput | TeamRunOutput, index: int, history_settings: ResolvedHistorySettings) -> str:
     lines = [_run_open_tag(run, index)]
     if run.metadata:
-        metadata = _metadata_for_excerpt(run.metadata)
-        lines.extend(["<run_metadata>", _escape_xml_content(stable_serialize(metadata)), "</run_metadata>"])
+        metadata = _metadata_for_summary(run.metadata)
+        if metadata:
+            lines.extend(["<run_metadata>", _escape_xml_content(stable_serialize(metadata)), "</run_metadata>"])
     for message in _compaction_replay_messages(run, history_settings):
         lines.extend(_serialize_message(message))
     lines.append("</run>")

--- a/src/mindroom/history/compaction.py
+++ b/src/mindroom/history/compaction.py
@@ -788,7 +788,8 @@ def _messages_for_runs(
 def _serialize_run(run: RunOutput | TeamRunOutput, index: int, history_settings: ResolvedHistorySettings) -> str:
     lines = [_run_open_tag(run, index)]
     if run.metadata:
-        lines.extend(["<run_metadata>", _escape_xml_content(stable_serialize(run.metadata)), "</run_metadata>"])
+        metadata = _metadata_for_excerpt(run.metadata)
+        lines.extend(["<run_metadata>", _escape_xml_content(stable_serialize(metadata)), "</run_metadata>"])
     for message in _compaction_replay_messages(run, history_settings):
         lines.extend(_serialize_message(message))
     lines.append("</run>")

--- a/tests/test_compaction_invariants.py
+++ b/tests/test_compaction_invariants.py
@@ -732,7 +732,7 @@ def test_compaction_input_estimate_keeps_known_model_encoding() -> None:
 
 
 @pytest.mark.asyncio
-async def test_claude_compaction_splits_dense_tool_schema_before_the_input_limit(tmp_path: Path) -> None:
+async def test_claude_compaction_splits_dense_preserved_metadata_before_the_input_limit(tmp_path: Path) -> None:
     """Regression for the production request that tiktoken underestimated by 1.63x."""
     config, runtime_paths = _make_config(tmp_path)
     storage = create_session_storage("test_agent", config, runtime_paths, execution_identity=None)
@@ -740,14 +740,14 @@ async def test_claude_compaction_splits_dense_tool_schema_before_the_input_limit
     for run_index in range(20):
         run = _completed_run(f"run-{run_index}")
         run.metadata = {
-            "tools_schema": [
+            "durable_outcomes": [
                 {
-                    "name": f"tool_{run_index}_{tool_index}",
+                    "name": f"outcome_{run_index}_{outcome_index}",
                     "description": "".join(
-                        f"{run_index * 100_000 + tool_index * 1_000 + value:08x}" for value in range(50)
+                        f"{run_index * 100_000 + outcome_index * 1_000 + value:08x}" for value in range(50)
                     ),
                 }
-                for tool_index in range(20)
+                for outcome_index in range(20)
             ],
         }
         runs.append(run)

--- a/tests/test_history_summary_call.py
+++ b/tests/test_history_summary_call.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from agno.media import Image
 from agno.models.message import Message
 from agno.models.response import ModelResponse
 from structlog.testing import capture_logs
@@ -452,6 +453,60 @@ def test_build_summary_input_oversized_run_preserves_messages_before_tool_schema
     assert [included_run.run_id for included_run in included_runs] == ["run-big-metadata"]
     assert root_request in summary_input
     assert "tools_schema" not in summary_input
+
+
+def test_build_summary_input_normal_run_omits_only_bulky_metadata() -> None:
+    run = _completed_run(
+        "run-normal-metadata",
+        messages=[
+            Message(role="user", content="Look up the deployment outcome."),
+            Message(
+                role="assistant",
+                content="I will inspect it.",
+                tool_calls=[
+                    {
+                        "id": "call-deployment",
+                        "type": "function",
+                        "function": {"name": "deployment_status", "arguments": '{"deployment_id":"deploy-1"}'},
+                    },
+                ],
+            ),
+            Message(
+                role="tool",
+                content='{"state":"succeeded"}',
+                tool_call_id="call-deployment",
+                images=[Image(url="https://example.test/deployment.png")],
+            ),
+            Message(role="assistant", content="The deployment succeeded."),
+        ],
+    )
+    run.metadata = {
+        "matrix_event_id": "$request",
+        "started_at": "2026-07-17T20:00:00Z",
+        "durable_outcome": {"state": "delivered"},
+        "tools_schema": [{"name": "deployment_status", "description": "x" * 1_000}],
+        "model_params": {"temperature": 0.2},
+    }
+
+    summary_input, included_runs = _build_summary_input(
+        previous_summary=None,
+        compacted_runs=[run],
+        max_input_tokens=10_000,
+        history_settings=_ALL_HISTORY_SETTINGS,
+    )
+
+    assert included_runs == [run]
+    assert "tools_schema" not in summary_input
+    assert "model_params" not in summary_input
+    assert "$request" in summary_input
+    assert "2026-07-17T20:00:00Z" in summary_input
+    assert "durable_outcome" in summary_input
+    assert "Look up the deployment outcome." in summary_input
+    assert "call-deployment" in summary_input
+    assert "deployment_status" in summary_input
+    assert '{"state":"succeeded"}' in summary_input
+    assert "The deployment succeeded." in summary_input
+    assert "https://example.test/deployment.png" in summary_input
 
 
 def test_build_summary_input_skips_when_previous_summary_cannot_be_preserved() -> None:

--- a/tests/test_history_summary_call.py
+++ b/tests/test_history_summary_call.py
@@ -455,6 +455,49 @@ def test_build_summary_input_oversized_run_preserves_messages_before_tool_schema
     assert "tools_schema" not in summary_input
 
 
+def test_build_summary_input_oversized_run_omits_empty_filtered_metadata() -> None:
+    run = _completed_run(
+        "run-big-bulky-metadata",
+        messages=[
+            Message(role="user", content="u" * 800),
+            Message(role="assistant", content="a" * 800),
+        ],
+    )
+    run.metadata = {
+        "tools_schema": [{"name": "deployment_status", "description": "x" * 2_000}],
+        "model_params": {"temperature": 0.2},
+    }
+
+    summary_input, included_runs = _build_summary_input(
+        previous_summary=None,
+        compacted_runs=[run],
+        max_input_tokens=220,
+        history_settings=_ALL_HISTORY_SETTINGS,
+    )
+
+    assert included_runs == [run]
+    assert "Run truncated to fit compaction budget." in summary_input
+    assert "<run_metadata>" not in summary_input
+
+
+def test_build_summary_input_normal_run_omits_empty_filtered_metadata() -> None:
+    run = _completed_run("run-bulky-metadata")
+    run.metadata = {
+        "tools_schema": [{"name": "deployment_status", "description": "x" * 1_000}],
+        "model_params": {"temperature": 0.2},
+    }
+
+    summary_input, included_runs = _build_summary_input(
+        previous_summary=None,
+        compacted_runs=[run],
+        max_input_tokens=10_000,
+        history_settings=_ALL_HISTORY_SETTINGS,
+    )
+
+    assert included_runs == [run]
+    assert "<run_metadata>" not in summary_input
+
+
 def test_build_summary_input_normal_run_omits_only_bulky_metadata() -> None:
     run = _completed_run(
         "run-normal-metadata",
@@ -480,13 +523,14 @@ def test_build_summary_input_normal_run_omits_only_bulky_metadata() -> None:
             Message(role="assistant", content="The deployment succeeded."),
         ],
     )
-    run.metadata = {
+    metadata = {
         "matrix_event_id": "$request",
         "started_at": "2026-07-17T20:00:00Z",
         "durable_outcome": {"state": "delivered"},
         "tools_schema": [{"name": "deployment_status", "description": "x" * 1_000}],
         "model_params": {"temperature": 0.2},
     }
+    run.metadata = metadata.copy()
 
     summary_input, included_runs = _build_summary_input(
         previous_summary=None,
@@ -496,6 +540,7 @@ def test_build_summary_input_normal_run_omits_only_bulky_metadata() -> None:
     )
 
     assert included_runs == [run]
+    assert run.metadata == metadata
     assert "tools_schema" not in summary_input
     assert "model_params" not in summary_input
     assert "$request" in summary_input


### PR DESCRIPTION
Follow-up to #1575 (same RCA: recurring compaction failures).

## Problem

Normal `_serialize_run()` embeds the entire `run.metadata` dict per run in the compaction summary input.
`run.metadata.tools_schema` contains the full tool catalog (~116 tool JSON schemas) and is repeated in **every** serialized run.

Measured on the production failing chunk from the ISSUE-242 RCA:

- Repeated `tools_schema`: **464,790 of 658,894 serialized chars (70.5%)**
- Full 25-run request: **1,229,586 exact Vertex tokens** unfiltered vs **384,631** with `tools_schema` + `model_params` removed

The summary model gets zero value from tool schemas.
The oversized-excerpt path already filtered these fields; the ordinary-run path did not.
Post-#1575, these bloated ~800k-token chunks also started drawing `stop_reason=refusal` from Vertex safeguards in production, so the bloat is now a correctness problem, not just cost.

## Fix

Route normal run serialization through the shared `_metadata_for_summary()` projection, a pure dict comprehension omitting exactly `tools_schema` and `model_params`.
Ordinary runs and oversized excerpts now use the same projection and omit the `<run_metadata>` block entirely when every metadata key is filtered.
Persisted run data is untouched; only the summary input string changes.
Messages, tool calls, tool results, identity/timing metadata, durable outcomes, and media snapshots all remain serialized.

The conservative Claude chunk-sizing regression fixture from #1563 moved its dense payload from `tools_schema` to `durable_outcomes`, a preserved key, so it keeps guarding the conservative-fallback path.

## Tests

- Normal-run serialization omits only the bulky keys while retaining messages, tool call/result linkage, identity and timing metadata, a durable outcome, and an image URL.
- Normal and oversized serialization both omit an empty filtered metadata block.
- The projection is explicitly verified not to mutate `run.metadata`.
- Focused compaction suites: **56 passed**.
- Full local suite: **10,650 passed, 151 skipped**.
- Full pre-commit suite passed, including Ruff, formatting, types, Tach boundaries, docs generation, frontend lint/type checks, and lock-file validation.

## Review

- Initial zero-tolerance review found the empty-block behavior and stale excerpt-only naming; both were fixed in `2ca055652`.
- Both inline review threads were answered and resolved.
- Post-push Greptile review: **5/5, no files requiring attention**.
- Post-push CodeRabbit review: **no actionable comments**.
- Independent Claude Code Fable 5 review in an isolated worktree at exact head `2ca05565202cbd425c37c23c6bc8ba91fff673b9`: **✅ APPROVE**.
- Final GitHub status: **0 failing, 0 pending**, with all required CI and AI review checks complete.
