### PR TITLE
fix(history): preserve runs on safeguard refusal

### DIFF
--- a/src/mindroom/history/summary_call.py
+++ b/src/mindroom/history/summary_call.py
@@ -16,10 +16,11 @@ It enforces the call-side half of the compaction invariants
 
 4. Retry on provider failure is deterministic.
    ``SummaryRetryPolicy`` decides which error classes warrant a smaller retry
-   (timeouts, typed context-window errors, safeguard refusals, and named legacy
-   context-length fragments), which warrant one same-input retry (typed transient
-   provider errors), the shrink schedule (halving), and the give-up floor — no
-   inline string matching at call sites.
+   (timeouts, typed context-window errors, and named legacy context-length
+   fragments), which warrant one same-input retry (typed transient provider
+   errors), and which must abort without retry (typed safeguard refusals).
+   It also owns the shrink schedule (halving) and give-up floor, with no inline
+   string matching at call sites.
    Empty-text success responses also retry with less input because some providers
    surface rejected or oversized requests as an empty successful response.
 
@@ -89,7 +90,6 @@ _TYPED_SHRINKABLE_ERRORS = (
     _CompactionSummaryEmptyResultError,
     TimeoutError,
     ContextWindowExceededError,
-    ModelSafeguardRefusalError,
     CompactionSummaryOutputLimitError,
 )
 
@@ -112,6 +112,8 @@ class SummaryRetryPolicy:
 
     def should_shrink(self, error: Exception) -> bool:
         """Return whether a smaller summary input may resolve this provider failure."""
+        if isinstance(error, ModelSafeguardRefusalError):
+            return False
         if isinstance(error, _TYPED_SHRINKABLE_ERRORS):
             return True
         if self.should_retry_same_input(error):
@@ -121,7 +123,11 @@ class SummaryRetryPolicy:
 
     def should_retry_same_input(self, error: Exception) -> bool:
         """Return whether a transient provider failure warrants one unchanged retry."""
-        return isinstance(error, ModelProviderError) and error.status_code in TRANSIENT_PROVIDER_STATUS_CODES
+        return (
+            not isinstance(error, ModelSafeguardRefusalError)
+            and isinstance(error, ModelProviderError)
+            and error.status_code in TRANSIENT_PROVIDER_STATUS_CODES
+        )
 
     def retry_budget(self, *, attempt: int, budget: int, error: Exception) -> int | None:
         """Return the next input budget, preserving it for same-input retries."""

--- a/src/mindroom/history/summary_call.py
+++ b/src/mindroom/history/summary_call.py
@@ -49,7 +49,7 @@ from agno.session.summary import SessionSummary
 from mindroom.cancellation import request_task_cancel
 from mindroom.claude_prompt_cache import as_anthropic_claude
 from mindroom.constants import MINDROOM_COMPACTION_CHUNK_TIMEOUT_SECONDS
-from mindroom.error_handling import TRANSIENT_PROVIDER_STATUS_CODES, ModelSafeguardRefusalError
+from mindroom.error_handling import TRANSIENT_PROVIDER_STATUS_CODES, is_model_safeguard_refusal
 from mindroom.logging_config import get_logger
 from mindroom.timing import timed
 
@@ -112,7 +112,7 @@ class SummaryRetryPolicy:
 
     def should_shrink(self, error: Exception) -> bool:
         """Return whether a smaller summary input may resolve this provider failure."""
-        if isinstance(error, ModelSafeguardRefusalError):
+        if is_model_safeguard_refusal(error):
             return False
         if isinstance(error, _TYPED_SHRINKABLE_ERRORS):
             return True
@@ -124,7 +124,7 @@ class SummaryRetryPolicy:
     def should_retry_same_input(self, error: Exception) -> bool:
         """Return whether a transient provider failure warrants one unchanged retry."""
         return (
-            not isinstance(error, ModelSafeguardRefusalError)
+            not is_model_safeguard_refusal(error)
             and isinstance(error, ModelProviderError)
             and error.status_code in TRANSIENT_PROVIDER_STATUS_CODES
         )

--- a/tests/test_compaction_invariants.py
+++ b/tests/test_compaction_invariants.py
@@ -638,12 +638,20 @@ def test_retry_policy_halves_budget_for_typed_context_window_error() -> None:
     assert DEFAULT_SUMMARY_RETRY_POLICY.retry_budget(attempt=1, budget=16_000, error=error) == 8_000
 
 
-def test_retry_policy_never_retries_typed_safeguard_refusal() -> None:
-    error = ModelSafeguardRefusalError(
-        message="input too long; provider-specific wording does not matter",
-        status_code=503,
-    )
-
+@pytest.mark.parametrize(
+    "error",
+    [
+        ModelSafeguardRefusalError(
+            message="input too long; provider-specific wording does not matter",
+            status_code=503,
+        ),
+        ModelProviderError(
+            message="Vertex Claude returned stop_reason=refusal",
+            status_code=503,
+        ),
+    ],
+)
+def test_retry_policy_never_retries_safeguard_refusal(error: ModelProviderError) -> None:
     assert DEFAULT_SUMMARY_RETRY_POLICY.should_shrink(error) is False
     assert DEFAULT_SUMMARY_RETRY_POLICY.should_retry_same_input(error) is False
     assert DEFAULT_SUMMARY_RETRY_POLICY.retry_budget(attempt=1, budget=16_000, error=error) is None

--- a/tests/test_compaction_invariants.py
+++ b/tests/test_compaction_invariants.py
@@ -638,10 +638,15 @@ def test_retry_policy_halves_budget_for_typed_context_window_error() -> None:
     assert DEFAULT_SUMMARY_RETRY_POLICY.retry_budget(attempt=1, budget=16_000, error=error) == 8_000
 
 
-def test_retry_policy_halves_budget_for_typed_safeguard_refusal() -> None:
-    error = ModelSafeguardRefusalError(message="provider-specific wording does not matter")
+def test_retry_policy_never_retries_typed_safeguard_refusal() -> None:
+    error = ModelSafeguardRefusalError(
+        message="input too long; provider-specific wording does not matter",
+        status_code=503,
+    )
 
-    assert DEFAULT_SUMMARY_RETRY_POLICY.retry_budget(attempt=1, budget=16_000, error=error) == 8_000
+    assert DEFAULT_SUMMARY_RETRY_POLICY.should_shrink(error) is False
+    assert DEFAULT_SUMMARY_RETRY_POLICY.should_retry_same_input(error) is False
+    assert DEFAULT_SUMMARY_RETRY_POLICY.retry_budget(attempt=1, budget=16_000, error=error) is None
     assert DEFAULT_SUMMARY_RETRY_POLICY.retry_budget(attempt=2, budget=8_000, error=error) is None
 
 

--- a/tests/test_history_compaction_rewrite.py
+++ b/tests/test_history_compaction_rewrite.py
@@ -266,7 +266,7 @@ async def test_rewrite_retries_summary_with_smaller_chunk_after_output_cap(tmp_p
 
 
 @pytest.mark.asyncio
-async def test_rewrite_retries_safeguard_refusal_with_smaller_chunk(tmp_path: Path) -> None:
+async def test_rewrite_aborts_safeguard_refusal_without_persisting(tmp_path: Path) -> None:
     config, runtime_paths = _make_config(tmp_path)
     storage = create_session_storage("test_agent", config, runtime_paths, execution_identity=None)
     working_session = _session(
@@ -288,12 +288,9 @@ async def test_rewrite_retries_safeguard_refusal_with_smaller_chunk(tmp_path: Pa
             ),
         ],
     )
+    storage.upsert_session(working_session)
     summary_mock = AsyncMock(
-        side_effect=[
-            ModelSafeguardRefusalError(message="Vertex Claude returned stop_reason=refusal"),
-            SessionSummary(summary="first chunk summary", updated_at=datetime.now(UTC)),
-            SessionSummary(summary="merged summary", updated_at=datetime.now(UTC)),
-        ],
+        side_effect=ModelSafeguardRefusalError(message="Vertex Claude returned stop_reason=refusal"),
     )
     retry_sleep = AsyncMock()
 
@@ -304,34 +301,27 @@ async def test_rewrite_retries_safeguard_refusal_with_smaller_chunk(tmp_path: Pa
             "mindroom.history.compaction.record_compaction_chunk",
             wraps=record_compaction_chunk,
         ) as persist_spy,
+        pytest.raises(ModelSafeguardRefusalError, match="stop_reason=refusal"),
     ):
-        rewrite_result = await _rewrite_single_run(
+        await _rewrite_single_run(
             storage=storage,
             working_session=working_session,
             selected_run_ids=("run-1", "run-2"),
             summary_input_budget=12_000,
         )
 
-    assert rewrite_result is not None
-    summary_inputs = [call.kwargs["summary_input"] for call in summary_mock.await_args_list]
-    assert len(summary_inputs) == 3
-    assert "RUN1-MARKER" in summary_inputs[0]
-    assert "RUN2-MARKER" in summary_inputs[0]
-    assert estimate_text_tokens(summary_inputs[1]) < estimate_text_tokens(summary_inputs[0])
-    assert "RUN1-MARKER" in summary_inputs[1]
-    assert "RUN2-MARKER" not in summary_inputs[1]
-    assert "RUN2-MARKER" in summary_inputs[2]
+    summary_mock.assert_awaited_once()
+    summary_input = summary_mock.await_args.kwargs["summary_input"]
+    assert "RUN1-MARKER" in summary_input
+    assert "RUN2-MARKER" in summary_input
     retry_sleep.assert_not_awaited()
-    assert [call.kwargs["compacted_run_ids"] for call in persist_spy.call_args_list] == [
-        ("run-1",),
-        ("run-2",),
-    ]
-    assert rewrite_result.compacted_run_ids == ("run-1", "run-2")
+    persist_spy.assert_not_called()
+    assert working_session.summary is None
+    assert [run.run_id for run in working_session.runs or []] == ["run-1", "run-2"]
     persisted = get_agent_session(storage, "session-1")
     assert persisted is not None
-    assert persisted.summary is not None
-    assert persisted.summary.summary == "merged summary"
-    assert persisted.runs == []
+    assert persisted.summary is None
+    assert [run.run_id for run in persisted.runs or []] == ["run-1", "run-2"]
 
 
 @pytest.mark.parametrize(
@@ -388,21 +378,12 @@ async def test_rewrite_retries_transient_provider_error_with_same_input_and_one_
     assert persist_spy.call_args.kwargs["compacted_run_ids"] == ("run-1",)
 
 
-@pytest.mark.parametrize(
-    "error",
-    [
-        ModelSafeguardRefusalError(message="Vertex Claude returned stop_reason=refusal"),
-        ModelProviderError(message="service unavailable", status_code=503),
-    ],
-)
 @pytest.mark.asyncio
-async def test_rewrite_gives_up_after_one_bounded_retry(
-    tmp_path: Path,
-    error: ModelProviderError,
-) -> None:
+async def test_rewrite_gives_up_after_one_transient_retry(tmp_path: Path) -> None:
     config, runtime_paths = _make_config(tmp_path)
     storage = create_session_storage("test_agent", config, runtime_paths, execution_identity=None)
     working_session = _session("session-1", runs=[_completed_run("run-1")])
+    error = ModelProviderError(message="service unavailable", status_code=503)
     summary_mock = AsyncMock(side_effect=[error, error])
     retry_sleep = AsyncMock()
 
@@ -418,10 +399,7 @@ async def test_rewrite_gives_up_after_one_bounded_retry(
         await _rewrite_single_run(storage=storage, working_session=working_session)
 
     assert summary_mock.await_count == 2
-    if isinstance(error, ModelSafeguardRefusalError):
-        retry_sleep.assert_not_awaited()
-    else:
-        retry_sleep.assert_awaited_once_with(DEFAULT_SUMMARY_RETRY_POLICY.same_input_retry_delay_seconds)
+    retry_sleep.assert_awaited_once_with(DEFAULT_SUMMARY_RETRY_POLICY.same_input_retry_delay_seconds)
     persist_spy.assert_not_called()
     assert working_session.summary is None
     assert [run.run_id for run in working_session.runs or []] == ["run-1"]

--- a/tests/test_history_compaction_rewrite.py
+++ b/tests/test_history_compaction_rewrite.py
@@ -266,9 +266,10 @@ async def test_rewrite_retries_summary_with_smaller_chunk_after_output_cap(tmp_p
 
 
 @pytest.mark.asyncio
-async def test_rewrite_aborts_safeguard_refusal_without_persisting(tmp_path: Path) -> None:
+async def test_rewrite_aborts_safeguard_refusal_and_preserves_existing_state(tmp_path: Path) -> None:
     config, runtime_paths = _make_config(tmp_path)
     storage = create_session_storage("test_agent", config, runtime_paths, execution_identity=None)
+    existing_summary = SessionSummary(summary="existing summary", updated_at=datetime.now(UTC))
     working_session = _session(
         "session-1",
         runs=[
@@ -287,6 +288,7 @@ async def test_rewrite_aborts_safeguard_refusal_without_persisting(tmp_path: Pat
                 ],
             ),
         ],
+        summary=existing_summary,
     )
     storage.upsert_session(working_session)
     summary_mock = AsyncMock(
@@ -312,15 +314,17 @@ async def test_rewrite_aborts_safeguard_refusal_without_persisting(tmp_path: Pat
 
     summary_mock.assert_awaited_once()
     summary_input = summary_mock.await_args.kwargs["summary_input"]
+    assert "existing summary" in summary_input
     assert "RUN1-MARKER" in summary_input
     assert "RUN2-MARKER" in summary_input
     retry_sleep.assert_not_awaited()
     persist_spy.assert_not_called()
-    assert working_session.summary is None
+    assert working_session.summary is existing_summary
     assert [run.run_id for run in working_session.runs or []] == ["run-1", "run-2"]
     persisted = get_agent_session(storage, "session-1")
     assert persisted is not None
-    assert persisted.summary is None
+    assert persisted.summary is not None
+    assert persisted.summary.summary == "existing summary"
     assert [run.run_id for run in persisted.runs or []] == ["run-1", "run-2"]
 
 


### PR DESCRIPTION
## Problem

PR #1582 classified typed Vertex Claude safeguard refusals as smaller-input recoverable.
A smaller retry can omit later runs or truncate an oversized run even though a refusal is not evidence of an input-size problem.
If a truncated retry succeeds, compaction can tombstone the full run despite summarizing only an excerpt.
Without a configured fallback model, the safe behavior is to abort compaction and preserve every run.

## Change

- Make `ModelSafeguardRefusalError` non-retryable before transient-status and legacy message-fragment heuristics.
- Propagate the refusal on the first attempt so the existing runtime failure path continues without compaction.
- Preserve the working and durable session summary and every run.
- Keep smaller-input retries for size-related failures and exact-input retries for transient provider failures unchanged.

## Regression coverage

- A typed refusal remains non-retryable even when its message says `input too long` and its status is `503`.
- A two-run compaction refusal makes one provider call, performs no sleep or persistence, and leaves both working and durable sessions unchanged.
- Transient failures still receive their one bounded same-input retry.

## Verification

- Focused compaction and Vertex Claude suites: 91 passed.
- Full `uv run pytest`: 10,755 passed and 151 skipped.
- `uv run pre-commit run --all-files`: passed.
- `uv run tach check --dependencies --interfaces`: passed.

## Summary by Sourcery

Abort history compaction on typed model safeguard refusals and preserve existing session runs and summaries instead of retrying with smaller input.

Bug Fixes:
- Ensure safeguard refusal errors never trigger shrink or same-input retries and instead surface immediately without compaction or persistence.

Enhancements:
- Clarify and tighten summary retry policy semantics to distinguish shrinkable errors, transient provider retries, and non-retryable safeguard refusals.
- Strengthen compaction invariants and rewrite behavior tests to cover non-retryable safeguard refusals and transient retry handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Compaction now stops immediately when the model refuses a request for safety reasons.
  * Safeguard refusals no longer trigger retries, budget reductions, delays, or partial compaction data saves.
  * Existing summaries and selected session state are preserved when compaction is refused.
  * Transient provider failures continue to receive a bounded retry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->