### PR TITLE
fix(history): fall back after compaction safeguard refusal

### DIFF
--- a/docs/configuration/agents.md
+++ b/docs/configuration/agents.md
@@ -185,7 +185,7 @@ Approval-gated tools are stricter than plain ad-hoc chat access.
 Approval-gated tools only work there while the router is already joined.
 
 MindRoom compacts in one visible lifecycle.
-Per-agent compaction supports `enabled`, `threshold_tokens`, `threshold_percent`, `replay_window_tokens`, `reserve_tokens`, and `model`.
+Per-agent compaction supports `enabled`, `threshold_tokens`, `threshold_percent`, `replay_window_tokens`, `reserve_tokens`, `model`, and `fallback_model`.
 When the active runtime model has a known `context_window`, MindRoom always computes a per-run replay plan that reduces or disables persisted replay before the model call if needed.
 Automatic destructive compaction is enabled by default through `defaults.compaction`, but it runs only when raw history exceeds the hard replay budget for the next reply.
 `threshold_tokens` and `threshold_percent` set a soft trigger budget for planning metadata and compaction notices.
@@ -196,6 +196,7 @@ You can tune compaction behavior with these settings:
 - Use `replay_window_tokens` to cap persisted replay, required-compaction planning, and summary input chunks below the model's real context window without lowering the provider request limit.
 - Use `reserve_tokens` to leave hard-budget headroom.
 - Use `model` to choose the summary model.
+- Use `fallback_model` to name a different model config that resends the unchanged summary prompt and input once (only the target model differs) when the summary model refuses for safeguards; after a successful fallback, that model serves the remaining compaction chunks and is reported as the summary model.
 - Set `enabled: false` to disable automatic pre-reply compaction for this agent.
 
 When the active runtime model window is known, replay safety uses the smaller of it and `replay_window_tokens`.
@@ -204,6 +205,7 @@ The effective replay window also caps each compaction summary input chunk.
 Destructive compaction requires the resolved summary input budget to exceed 2,000 tokens.
 With the default `reserve_tokens`, this makes destructive compaction unavailable when the compaction model's context window is roughly 10,000 tokens or smaller; lowering `reserve_tokens` restores availability for such small windows.
 If you set `compaction.model`, that summary model must also define its own `context_window`, but only for the durable summary-generation pass.
+`compaction.fallback_model` must also name a configured model with its own `context_window`; a fallback naming the summary model's alias, or another alias resolving to the same provider and model ID, is ignored because it would resend the refused request to the same model.
 If the current reply needs required compaction to preserve usable history, MindRoom sends `Compacting history...`, compacts before the model call, and edits that same notice with the result.
 Manual `compact_context` records a durable request that runs before the next reply in the same conversation scope.
 Manual `compact_context` remains available when a compaction model and context window are configured and the resolved summary input budget exceeds 2,000 tokens.

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -260,6 +260,7 @@ You can tune compaction behavior with these settings:
 - Use `threshold_tokens` or `threshold_percent` to set the soft trigger budget. Crossing this soft trigger while still within the hard budget leaves the stored session unchanged and relies on replay fitting for that reply.
 - Use `replay_window_tokens` to keep persisted replay, required-compaction planning, and summary input chunks within a smaller operational window without presenting that smaller value as the provider's request limit.
 - Use `reserve_tokens` to leave hard-budget headroom for the current prompt and output.
+- Use `model` to choose the summary model, and `fallback_model` to name a different model config that resends the unchanged summary prompt and input once (only the target model differs) when the summary model refuses for safeguards; after a successful fallback, that model serves the remaining compaction chunks and is reported as the summary model.
 
 When the active runtime model window is known, replay safety uses the smaller of it and `replay_window_tokens`.
 When that model window is unknown, an explicit `replay_window_tokens` still supplies the replay-planning window.
@@ -271,6 +272,7 @@ Manual `compact_context` records a durable request that runs before the next rep
 Manual `compact_context` remains available when a compaction model and context window are configured and the resolved summary input budget exceeds 2,000 tokens.
 It still uses the active runtime window for the final replay-fit step, while an explicit `compaction.model` can supply the summary-generation window subject to the same minimum summary-input budget.
 If you set `compaction.model`, that summary model must also define its own `context_window` for the durable summary-generation pass.
+`compaction.fallback_model` must also name a configured model with its own `context_window`; a fallback naming the summary model's alias, or another alias resolving to the same provider and model ID, is ignored because it would resend the refused request to the same model.
 Required compaction runs before the reply with a Matrix lifecycle notice that is edited in place.
 Otherwise MindRoom leaves the session unchanged and relies on replay fitting for that reply.
 Replay planning uses a chars/4 approximation and reserves headroom for the current prompt and output.

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -33,7 +33,7 @@ Each model configuration supports the following fields:
 | `host` | No | `null` | Host URL for self-hosted models (e.g., Ollama) |
 | `api_key` | No | `null` | API key (usually read from environment variables) |
 | `extra_kwargs` | No | `null` | Additional provider-specific parameters |
-| `context_window` | No | `null` | Actual provider context window size in tokens; MindRoom uses it as the default replay-planning window unless compaction sets a smaller `replay_window_tokens`; an explicit `compaction.model` needs its own `context_window` for summary generation; on `vertexai_claude` it also enables request-time fitting |
+| `context_window` | No | `null` | Actual provider context window size in tokens; MindRoom uses it as the default replay-planning window unless compaction sets a smaller `replay_window_tokens`; an explicit `compaction.model` or `compaction.fallback_model` needs its own `context_window` for summary generation; on `vertexai_claude` it also enables request-time fitting |
 
 ## Configuration Examples
 

--- a/docs/configuration/teams.md
+++ b/docs/configuration/teams.md
@@ -102,7 +102,7 @@ Team YAML keys follow the same naming rules as agents: alphanumeric characters a
 `num_history_runs` and `num_history_messages` are mutually exclusive, just like the agent-level settings.
 When a named team sets these fields, the team scope uses the team-owned policy instead of inheriting one member's history policy.
 
-Team-scoped compaction supports `enabled`, `threshold_tokens`, `threshold_percent`, `replay_window_tokens`, `reserve_tokens`, and `model`.
+Team-scoped compaction supports `enabled`, `threshold_tokens`, `threshold_percent`, `replay_window_tokens`, `reserve_tokens`, `model`, and `fallback_model`.
 When the active team model has a known `context_window`, MindRoom always computes a final replay plan for the shared team scope and reduces or disables persisted replay for the run when needed.
 Automatic destructive compaction is enabled by default through `defaults.compaction`, but it runs only when raw history exceeds the hard replay budget for the next reply.
 `threshold_tokens` and `threshold_percent` set a soft trigger budget for planning metadata and compaction notices.
@@ -113,6 +113,7 @@ You can tune team-scoped compaction behavior with these settings:
 - Use `replay_window_tokens` to cap persisted replay, required-compaction planning, and summary input chunks below the model's real context window without lowering the provider request limit.
 - Use `reserve_tokens` to leave hard-budget headroom.
 - Use `model` to choose the summary model.
+- Use `fallback_model` to name a different model config that resends the unchanged summary prompt and input once (only the target model differs) when the summary model refuses for safeguards; after a successful fallback, that model serves the remaining compaction chunks and is reported as the summary model.
 - Set `enabled: false` to disable automatic pre-reply compaction for a team.
 
 When the active team model window is known, replay safety uses the smaller of it and `replay_window_tokens`.
@@ -121,6 +122,7 @@ The effective replay window also caps each compaction summary input chunk.
 Destructive compaction requires the resolved summary input budget to exceed 2,000 tokens.
 With the default `reserve_tokens`, this makes destructive compaction unavailable when the compaction model's context window is roughly 10,000 tokens or smaller; lowering `reserve_tokens` restores availability for such small windows.
 If you set `compaction.model`, that summary model must also define its own `context_window`, but only for the durable summary-generation pass.
+`compaction.fallback_model` must also name a configured model with its own `context_window`; a fallback naming the summary model's alias, or another alias resolving to the same provider and model ID, is ignored because it would resend the refused request to the same model.
 Manual `compact_context` remains available when a compaction model and context window are configured and the resolved summary input budget exceeds 2,000 tokens.
 Compaction uses an in-room lifecycle notice that is edited in place.
 

--- a/frontend/src/components/AgentEditor/AgentEditor.test.tsx
+++ b/frontend/src/components/AgentEditor/AgentEditor.test.tsx
@@ -1166,6 +1166,15 @@ describe("AgentEditor", () => {
     });
   });
 
+  it("preserves explicit compaction fallback model clears during normalization", () => {
+    expect(
+      normalizeAgentUpdates(mockAgent, { compaction: { fallback_model: null } })
+        .compaction,
+    ).toEqual({
+      fallback_model: null,
+    });
+  });
+
   it("enables authored compaction overrides and clears the inherited sibling threshold", () => {
     expect(
       normalizeAgentUpdates(mockAgent, {
@@ -1296,6 +1305,35 @@ describe("AgentEditor", () => {
     const compactionAgent: Agent = {
       ...mockAgent,
       compaction: { model: null },
+    };
+    (useConfigStore as any).mockReturnValue({
+      ...mockStore,
+      agents: [compactionAgent],
+      config: {
+        ...mockConfig,
+        defaults: {
+          ...mockConfig.defaults,
+          compaction: {
+            enabled: false,
+            reserve_tokens: 16384,
+            threshold_percent: 0.8,
+          },
+        },
+        agents: { test_agent: compactionAgent },
+      },
+    });
+
+    render(<AgentEditor />);
+
+    expect(
+      screen.getByLabelText("Enable automatic required compaction"),
+    ).not.toBeChecked();
+  });
+
+  it("shows automatic required compaction as disabled for a pure fallback model clear when defaults are disabled", () => {
+    const compactionAgent: Agent = {
+      ...mockAgent,
+      compaction: { fallback_model: null },
     };
     (useConfigStore as any).mockReturnValue({
       ...mockStore,

--- a/frontend/src/components/TeamEditor/TeamEditor.test.tsx
+++ b/frontend/src/components/TeamEditor/TeamEditor.test.tsx
@@ -452,62 +452,77 @@ describe("TeamEditor", () => {
     });
   });
 
-  it("shows automatic required compaction as disabled for a pure team model clear when defaults are disabled", () => {
-    const compactionTeam: Team = {
-      ...mockTeam,
-      compaction: { model: null },
-    };
-    (useConfigStore as any).mockReturnValue({
-      teams: [compactionTeam],
-      agents: mockAgents,
-      rooms: [
-        {
-          id: "dev",
-          display_name: "Dev",
-          description: "Development room",
-          agents: ["code", "shell"],
-        },
-        {
-          id: "lobby",
-          display_name: "Lobby",
-          description: "Main lobby",
-          agents: [],
-        },
-        {
-          id: "research",
-          display_name: "Research",
-          description: "Research room",
-          agents: ["research"],
-        },
-      ],
-      config: {
-        ...mockConfig,
-        defaults: {
-          ...mockConfig.defaults,
-          compaction: {
-            enabled: false,
-            reserve_tokens: 16384,
-            threshold_percent: 0.8,
-          },
-        },
-        teams: { dev_team: compactionTeam },
-      },
-      selectedTeamId: "dev_team",
-      updateTeam: mockUpdateTeam,
-      deleteTeam: mockDeleteTeam,
-      saveConfig: mockSaveConfig,
-      isDirty: false,
-      diagnostics: [],
-      agentPoliciesByAgent: mockAgentPoliciesByAgent,
-      selectTeam: vi.fn(),
-    });
-
-    render(<TeamEditor />);
-
+  it("preserves explicit team compaction fallback model clears during normalization", () => {
     expect(
-      screen.getByLabelText("Enable automatic required compaction"),
-    ).not.toBeChecked();
+      normalizeTeamUpdates(mockTeam, { compaction: { fallback_model: null } })
+        .compaction,
+    ).toEqual({
+      fallback_model: null,
+    });
   });
+
+  it.each([
+    ["model", { model: null }],
+    ["fallback model", { fallback_model: null }],
+  ])(
+    "shows automatic required compaction as disabled for a pure team %s clear when defaults are disabled",
+    (_label, compaction) => {
+      const compactionTeam: Team = {
+        ...mockTeam,
+        compaction,
+      };
+      (useConfigStore as any).mockReturnValue({
+        teams: [compactionTeam],
+        agents: mockAgents,
+        rooms: [
+          {
+            id: "dev",
+            display_name: "Dev",
+            description: "Development room",
+            agents: ["code", "shell"],
+          },
+          {
+            id: "lobby",
+            display_name: "Lobby",
+            description: "Main lobby",
+            agents: [],
+          },
+          {
+            id: "research",
+            display_name: "Research",
+            description: "Research room",
+            agents: ["research"],
+          },
+        ],
+        config: {
+          ...mockConfig,
+          defaults: {
+            ...mockConfig.defaults,
+            compaction: {
+              enabled: false,
+              reserve_tokens: 16384,
+              threshold_percent: 0.8,
+            },
+          },
+          teams: { dev_team: compactionTeam },
+        },
+        selectedTeamId: "dev_team",
+        updateTeam: mockUpdateTeam,
+        deleteTeam: mockDeleteTeam,
+        saveConfig: mockSaveConfig,
+        isDirty: false,
+        diagnostics: [],
+        agentPoliciesByAgent: mockAgentPoliciesByAgent,
+        selectTeam: vi.fn(),
+      });
+
+      render(<TeamEditor />);
+
+      expect(
+        screen.getByLabelText("Enable automatic required compaction"),
+      ).not.toBeChecked();
+    },
+  );
 
   it("shows automatic required compaction as disabled for an empty team compaction override when defaults are disabled", () => {
     const compactionTeam: Team = {

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -121,13 +121,16 @@ export interface CompactionConfig {
   replay_window_tokens?: number | null;
   reserve_tokens?: number;
   model?: string | null;
+  fallback_model?: string | null;
 }
 
 const DEFAULT_INHERITED_TOOLS = ["scheduler"] as const;
 
 function isPureCompactionModelClear(compaction: CompactionConfig): boolean {
+  const modelFields = [compaction.model, compaction.fallback_model];
   return (
-    compaction.model === null &&
+    modelFields.some((value) => value === null) &&
+    modelFields.every((value) => value === null || value === undefined) &&
     compaction.enabled === undefined &&
     compaction.threshold_tokens === undefined &&
     compaction.threshold_percent === undefined &&
@@ -140,6 +143,7 @@ function isEmptyCompactionOverride(compaction: CompactionConfig): boolean {
   return (
     compaction.enabled === undefined &&
     compaction.model === undefined &&
+    compaction.fallback_model === undefined &&
     compaction.threshold_tokens === undefined &&
     compaction.threshold_percent === undefined &&
     compaction.replay_window_tokens === undefined &&
@@ -382,18 +386,21 @@ function normalizeCompactionConfig(
     return compaction;
   }
 
-  const normalizedModel =
-    compaction.model === null
+  const normalizeModelName = (
+    modelName: string | null | undefined,
+  ): string | null | undefined =>
+    modelName === null
       ? null
-      : compaction.model?.trim()
-        ? compaction.model.trim()
+      : modelName?.trim()
+        ? modelName.trim()
         : undefined;
   const hasExplicitNullClear = Object.values(compaction).some(
     (value) => value === null,
   );
   const normalizedCompaction: CompactionConfig = {
     ...compaction,
-    model: normalizedModel,
+    model: normalizeModelName(compaction.model),
+    fallback_model: normalizeModelName(compaction.fallback_model),
   };
 
   if (

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -2344,7 +2344,7 @@ Each model configuration supports the following fields:
 | `host` | No | `null` | Host URL for self-hosted models (e.g., Ollama) |
 | `api_key` | No | `null` | API key (usually read from environment variables) |
 | `extra_kwargs` | No | `null` | Additional provider-specific parameters |
-| `context_window` | No | `null` | Actual provider context window size in tokens; MindRoom uses it as the default replay-planning window unless compaction sets a smaller `replay_window_tokens`; an explicit `compaction.model` needs its own `context_window` for summary generation; on `vertexai_claude` it also enables request-time fitting |
+| `context_window` | No | `null` | Actual provider context window size in tokens; MindRoom uses it as the default replay-planning window unless compaction sets a smaller `replay_window_tokens`; an explicit `compaction.model` or `compaction.fallback_model` needs its own `context_window` for summary generation; on `vertexai_claude` it also enables request-time fitting |
 
 ## Configuration Examples
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -1824,7 +1824,7 @@ Approval-gated tools are stricter than plain ad-hoc chat access.
 Approval-gated tools only work there while the router is already joined.
 
 MindRoom compacts in one visible lifecycle.
-Per-agent compaction supports `enabled`, `threshold_tokens`, `threshold_percent`, `replay_window_tokens`, `reserve_tokens`, and `model`.
+Per-agent compaction supports `enabled`, `threshold_tokens`, `threshold_percent`, `replay_window_tokens`, `reserve_tokens`, `model`, and `fallback_model`.
 When the active runtime model has a known `context_window`, MindRoom always computes a per-run replay plan that reduces or disables persisted replay before the model call if needed.
 Automatic destructive compaction is enabled by default through `defaults.compaction`, but it runs only when raw history exceeds the hard replay budget for the next reply.
 `threshold_tokens` and `threshold_percent` set a soft trigger budget for planning metadata and compaction notices.
@@ -1835,6 +1835,7 @@ You can tune compaction behavior with these settings:
 - Use `replay_window_tokens` to cap persisted replay, required-compaction planning, and summary input chunks below the model's real context window without lowering the provider request limit.
 - Use `reserve_tokens` to leave hard-budget headroom.
 - Use `model` to choose the summary model.
+- Use `fallback_model` to name a different model config that resends the unchanged summary prompt and input once (only the target model differs) when the summary model refuses for safeguards; after a successful fallback, that model serves the remaining compaction chunks and is reported as the summary model.
 - Set `enabled: false` to disable automatic pre-reply compaction for this agent.
 
 When the active runtime model window is known, replay safety uses the smaller of it and `replay_window_tokens`.
@@ -1843,6 +1844,7 @@ The effective replay window also caps each compaction summary input chunk.
 Destructive compaction requires the resolved summary input budget to exceed 2,000 tokens.
 With the default `reserve_tokens`, this makes destructive compaction unavailable when the compaction model's context window is roughly 10,000 tokens or smaller; lowering `reserve_tokens` restores availability for such small windows.
 If you set `compaction.model`, that summary model must also define its own `context_window`, but only for the durable summary-generation pass.
+`compaction.fallback_model` must also name a configured model with its own `context_window`; a fallback naming the summary model's alias, or another alias resolving to the same provider and model ID, is ignored because it would resend the refused request to the same model.
 If the current reply needs required compaction to preserve usable history, MindRoom sends `Compacting history...`, compacts before the model call, and edits that same notice with the result.
 Manual `compact_context` records a durable request that runs before the next reply in the same conversation scope.
 Manual `compact_context` remains available when a compaction model and context window are configured and the resolved summary input budget exceeds 2,000 tokens.
@@ -2569,6 +2571,7 @@ You can tune compaction behavior with these settings:
 - Use `threshold_tokens` or `threshold_percent` to set the soft trigger budget. Crossing this soft trigger while still within the hard budget leaves the stored session unchanged and relies on replay fitting for that reply.
 - Use `replay_window_tokens` to keep persisted replay, required-compaction planning, and summary input chunks within a smaller operational window without presenting that smaller value as the provider's request limit.
 - Use `reserve_tokens` to leave hard-budget headroom for the current prompt and output.
+- Use `model` to choose the summary model, and `fallback_model` to name a different model config that resends the unchanged summary prompt and input once (only the target model differs) when the summary model refuses for safeguards; after a successful fallback, that model serves the remaining compaction chunks and is reported as the summary model.
 
 When the active runtime model window is known, replay safety uses the smaller of it and `replay_window_tokens`.
 When that model window is unknown, an explicit `replay_window_tokens` still supplies the replay-planning window.
@@ -2580,6 +2583,7 @@ Manual `compact_context` records a durable request that runs before the next rep
 Manual `compact_context` remains available when a compaction model and context window are configured and the resolved summary input budget exceeds 2,000 tokens.
 It still uses the active runtime window for the final replay-fit step, while an explicit `compaction.model` can supply the summary-generation window subject to the same minimum summary-input budget.
 If you set `compaction.model`, that summary model must also define its own `context_window` for the durable summary-generation pass.
+`compaction.fallback_model` must also name a configured model with its own `context_window`; a fallback naming the summary model's alias, or another alias resolving to the same provider and model ID, is ignored because it would resend the refused request to the same model.
 Required compaction runs before the reply with a Matrix lifecycle notice that is edited in place.
 Otherwise MindRoom leaves the session unchanged and relies on replay fitting for that reply.
 Replay planning uses a chars/4 approximation and reserves headroom for the current prompt and output.
@@ -2772,7 +2776,7 @@ Team YAML keys follow the same naming rules as agents: alphanumeric characters a
 `num_history_runs` and `num_history_messages` are mutually exclusive, just like the agent-level settings.
 When a named team sets these fields, the team scope uses the team-owned policy instead of inheriting one member's history policy.
 
-Team-scoped compaction supports `enabled`, `threshold_tokens`, `threshold_percent`, `replay_window_tokens`, `reserve_tokens`, and `model`.
+Team-scoped compaction supports `enabled`, `threshold_tokens`, `threshold_percent`, `replay_window_tokens`, `reserve_tokens`, `model`, and `fallback_model`.
 When the active team model has a known `context_window`, MindRoom always computes a final replay plan for the shared team scope and reduces or disables persisted replay for the run when needed.
 Automatic destructive compaction is enabled by default through `defaults.compaction`, but it runs only when raw history exceeds the hard replay budget for the next reply.
 `threshold_tokens` and `threshold_percent` set a soft trigger budget for planning metadata and compaction notices.
@@ -2783,6 +2787,7 @@ You can tune team-scoped compaction behavior with these settings:
 - Use `replay_window_tokens` to cap persisted replay, required-compaction planning, and summary input chunks below the model's real context window without lowering the provider request limit.
 - Use `reserve_tokens` to leave hard-budget headroom.
 - Use `model` to choose the summary model.
+- Use `fallback_model` to name a different model config that resends the unchanged summary prompt and input once (only the target model differs) when the summary model refuses for safeguards; after a successful fallback, that model serves the remaining compaction chunks and is reported as the summary model.
 - Set `enabled: false` to disable automatic pre-reply compaction for a team.
 
 When the active team model window is known, replay safety uses the smaller of it and `replay_window_tokens`.
@@ -2791,6 +2796,7 @@ The effective replay window also caps each compaction summary input chunk.
 Destructive compaction requires the resolved summary input budget to exceed 2,000 tokens.
 With the default `reserve_tokens`, this makes destructive compaction unavailable when the compaction model's context window is roughly 10,000 tokens or smaller; lowering `reserve_tokens` restores availability for such small windows.
 If you set `compaction.model`, that summary model must also define its own `context_window`, but only for the durable summary-generation pass.
+`compaction.fallback_model` must also name a configured model with its own `context_window`; a fallback naming the summary model's alias, or another alias resolving to the same provider and model ID, is ignored because it would resend the refused request to the same model.
 Manual `compact_context` remains available when a compaction model and context window are configured and the resolved summary input budget exceeds 2,000 tokens.
 Compaction uses an in-room lifecycle notice that is edited in place.
 

--- a/skills/mindroom-docs/references/page__configuration__agents__index.md
+++ b/skills/mindroom-docs/references/page__configuration__agents__index.md
@@ -181,7 +181,7 @@ Approval-gated tools are stricter than plain ad-hoc chat access.
 Approval-gated tools only work there while the router is already joined.
 
 MindRoom compacts in one visible lifecycle.
-Per-agent compaction supports `enabled`, `threshold_tokens`, `threshold_percent`, `replay_window_tokens`, `reserve_tokens`, and `model`.
+Per-agent compaction supports `enabled`, `threshold_tokens`, `threshold_percent`, `replay_window_tokens`, `reserve_tokens`, `model`, and `fallback_model`.
 When the active runtime model has a known `context_window`, MindRoom always computes a per-run replay plan that reduces or disables persisted replay before the model call if needed.
 Automatic destructive compaction is enabled by default through `defaults.compaction`, but it runs only when raw history exceeds the hard replay budget for the next reply.
 `threshold_tokens` and `threshold_percent` set a soft trigger budget for planning metadata and compaction notices.
@@ -192,6 +192,7 @@ You can tune compaction behavior with these settings:
 - Use `replay_window_tokens` to cap persisted replay, required-compaction planning, and summary input chunks below the model's real context window without lowering the provider request limit.
 - Use `reserve_tokens` to leave hard-budget headroom.
 - Use `model` to choose the summary model.
+- Use `fallback_model` to name a different model config that resends the unchanged summary prompt and input once (only the target model differs) when the summary model refuses for safeguards; after a successful fallback, that model serves the remaining compaction chunks and is reported as the summary model.
 - Set `enabled: false` to disable automatic pre-reply compaction for this agent.
 
 When the active runtime model window is known, replay safety uses the smaller of it and `replay_window_tokens`.
@@ -200,6 +201,7 @@ The effective replay window also caps each compaction summary input chunk.
 Destructive compaction requires the resolved summary input budget to exceed 2,000 tokens.
 With the default `reserve_tokens`, this makes destructive compaction unavailable when the compaction model's context window is roughly 10,000 tokens or smaller; lowering `reserve_tokens` restores availability for such small windows.
 If you set `compaction.model`, that summary model must also define its own `context_window`, but only for the durable summary-generation pass.
+`compaction.fallback_model` must also name a configured model with its own `context_window`; a fallback naming the summary model's alias, or another alias resolving to the same provider and model ID, is ignored because it would resend the refused request to the same model.
 If the current reply needs required compaction to preserve usable history, MindRoom sends `Compacting history...`, compacts before the model call, and edits that same notice with the result.
 Manual `compact_context` records a durable request that runs before the next reply in the same conversation scope.
 Manual `compact_context` remains available when a compaction model and context window are configured and the resolved summary input budget exceeds 2,000 tokens.

--- a/skills/mindroom-docs/references/page__configuration__models__index.md
+++ b/skills/mindroom-docs/references/page__configuration__models__index.md
@@ -29,7 +29,7 @@ Each model configuration supports the following fields:
 | `host` | No | `null` | Host URL for self-hosted models (e.g., Ollama) |
 | `api_key` | No | `null` | API key (usually read from environment variables) |
 | `extra_kwargs` | No | `null` | Additional provider-specific parameters |
-| `context_window` | No | `null` | Actual provider context window size in tokens; MindRoom uses it as the default replay-planning window unless compaction sets a smaller `replay_window_tokens`; an explicit `compaction.model` needs its own `context_window` for summary generation; on `vertexai_claude` it also enables request-time fitting |
+| `context_window` | No | `null` | Actual provider context window size in tokens; MindRoom uses it as the default replay-planning window unless compaction sets a smaller `replay_window_tokens`; an explicit `compaction.model` or `compaction.fallback_model` needs its own `context_window` for summary generation; on `vertexai_claude` it also enables request-time fitting |
 
 ## Configuration Examples
 

--- a/skills/mindroom-docs/references/page__configuration__models__index.md
+++ b/skills/mindroom-docs/references/page__configuration__models__index.md
@@ -256,6 +256,7 @@ You can tune compaction behavior with these settings:
 - Use `threshold_tokens` or `threshold_percent` to set the soft trigger budget. Crossing this soft trigger while still within the hard budget leaves the stored session unchanged and relies on replay fitting for that reply.
 - Use `replay_window_tokens` to keep persisted replay, required-compaction planning, and summary input chunks within a smaller operational window without presenting that smaller value as the provider's request limit.
 - Use `reserve_tokens` to leave hard-budget headroom for the current prompt and output.
+- Use `model` to choose the summary model, and `fallback_model` to name a different model config that resends the unchanged summary prompt and input once (only the target model differs) when the summary model refuses for safeguards; after a successful fallback, that model serves the remaining compaction chunks and is reported as the summary model.
 
 When the active runtime model window is known, replay safety uses the smaller of it and `replay_window_tokens`.
 When that model window is unknown, an explicit `replay_window_tokens` still supplies the replay-planning window.
@@ -267,6 +268,7 @@ Manual `compact_context` records a durable request that runs before the next rep
 Manual `compact_context` remains available when a compaction model and context window are configured and the resolved summary input budget exceeds 2,000 tokens.
 It still uses the active runtime window for the final replay-fit step, while an explicit `compaction.model` can supply the summary-generation window subject to the same minimum summary-input budget.
 If you set `compaction.model`, that summary model must also define its own `context_window` for the durable summary-generation pass.
+`compaction.fallback_model` must also name a configured model with its own `context_window`; a fallback naming the summary model's alias, or another alias resolving to the same provider and model ID, is ignored because it would resend the refused request to the same model.
 Required compaction runs before the reply with a Matrix lifecycle notice that is edited in place.
 Otherwise MindRoom leaves the session unchanged and relies on replay fitting for that reply.
 Replay planning uses a chars/4 approximation and reserves headroom for the current prompt and output.

--- a/skills/mindroom-docs/references/page__configuration__teams__index.md
+++ b/skills/mindroom-docs/references/page__configuration__teams__index.md
@@ -98,7 +98,7 @@ Team YAML keys follow the same naming rules as agents: alphanumeric characters a
 `num_history_runs` and `num_history_messages` are mutually exclusive, just like the agent-level settings.
 When a named team sets these fields, the team scope uses the team-owned policy instead of inheriting one member's history policy.
 
-Team-scoped compaction supports `enabled`, `threshold_tokens`, `threshold_percent`, `replay_window_tokens`, `reserve_tokens`, and `model`.
+Team-scoped compaction supports `enabled`, `threshold_tokens`, `threshold_percent`, `replay_window_tokens`, `reserve_tokens`, `model`, and `fallback_model`.
 When the active team model has a known `context_window`, MindRoom always computes a final replay plan for the shared team scope and reduces or disables persisted replay for the run when needed.
 Automatic destructive compaction is enabled by default through `defaults.compaction`, but it runs only when raw history exceeds the hard replay budget for the next reply.
 `threshold_tokens` and `threshold_percent` set a soft trigger budget for planning metadata and compaction notices.
@@ -109,6 +109,7 @@ You can tune team-scoped compaction behavior with these settings:
 - Use `replay_window_tokens` to cap persisted replay, required-compaction planning, and summary input chunks below the model's real context window without lowering the provider request limit.
 - Use `reserve_tokens` to leave hard-budget headroom.
 - Use `model` to choose the summary model.
+- Use `fallback_model` to name a different model config that resends the unchanged summary prompt and input once (only the target model differs) when the summary model refuses for safeguards; after a successful fallback, that model serves the remaining compaction chunks and is reported as the summary model.
 - Set `enabled: false` to disable automatic pre-reply compaction for a team.
 
 When the active team model window is known, replay safety uses the smaller of it and `replay_window_tokens`.
@@ -117,6 +118,7 @@ The effective replay window also caps each compaction summary input chunk.
 Destructive compaction requires the resolved summary input budget to exceed 2,000 tokens.
 With the default `reserve_tokens`, this makes destructive compaction unavailable when the compaction model's context window is roughly 10,000 tokens or smaller; lowering `reserve_tokens` restores availability for such small windows.
 If you set `compaction.model`, that summary model must also define its own `context_window`, but only for the durable summary-generation pass.
+`compaction.fallback_model` must also name a configured model with its own `context_window`; a fallback naming the summary model's alias, or another alias resolving to the same provider and model ID, is ignored because it would resend the refused request to the same model.
 Manual `compact_context` remains available when a compaction model and context window are configured and the resolved summary input budget exceeds 2,000 tokens.
 Compaction uses an in-room lifecycle notice that is edited in place.
 

--- a/src/mindroom/config/main.py
+++ b/src/mindroom/config/main.py
@@ -45,6 +45,7 @@ from mindroom.config.matrix import (
 from mindroom.config.memory import MemoryBackend, MemoryConfig, MemorySearchConfig
 from mindroom.config.models import (
     CompactionConfig,
+    CompactionOverrideConfig,
     DebugConfig,
     DefaultsConfig,
     EffectiveToolConfig,
@@ -216,9 +217,10 @@ class _AuthoredOptionalModel:
 
 @dataclass(frozen=True)
 class _StaticCompactionConfigSemantics:
-    """Static compaction semantics for one config scope."""
+    """Static compaction semantics for one optional model field in one config scope."""
 
     scope_label: str
+    field_name: str
     authored_model: _AuthoredOptionalModel
 
 
@@ -279,17 +281,34 @@ def _strip_empty_root_sections(payload: dict[str, Any]) -> dict[str, Any]:
     return authored_payload
 
 
+def _authored_compaction_model_fields(
+    compaction: CompactionConfig | CompactionOverrideConfig,
+) -> dict[str, _AuthoredOptionalModel]:
+    """Return authored tri-state semantics for every optional compaction model field."""
+    return {
+        "model": _authored_optional_model(
+            compaction.model,
+            field_is_set="model" in compaction.model_fields_set,
+        ),
+        "fallback_model": _authored_optional_model(
+            compaction.fallback_model,
+            field_is_set="fallback_model" in compaction.model_fields_set,
+        ),
+    }
+
+
 def _effective_static_compaction_enabled(
     *,
     defaults_enabled: bool,
     override_enabled: bool | None,
     override_fields_set: set[str],
-    authored_model: _AuthoredOptionalModel,
+    authored_model_fields: dict[str, _AuthoredOptionalModel],
 ) -> bool:
     """Resolve whether one authored override block is statically enabled."""
     if "enabled" in override_fields_set:
         return override_enabled is True
-    if authored_model.kind == "clear" and override_fields_set == {"model"}:
+    cleared_model_fields = {name for name, authored in authored_model_fields.items() if authored.kind == "clear"}
+    if override_fields_set and override_fields_set <= cleared_model_fields:
         return defaults_enabled
     if override_fields_set:
         return True
@@ -631,7 +650,7 @@ class Config(BaseModel):
         return self
 
     def _invalid_compaction_model_references(self) -> list[str]:
-        """Return any compaction.model references that point at unknown models."""
+        """Return any compaction model references that point at unknown models."""
         invalid_references: list[str] = []
         for semantics in self._static_compaction_semantics():
             if semantics.authored_model.kind != "value":
@@ -639,13 +658,13 @@ class Config(BaseModel):
             assert semantics.authored_model.value is not None
             if semantics.authored_model.value not in self.models:
                 invalid_references.append(
-                    f"{semantics.scope_label}.compaction.model -> {semantics.authored_model.value}",
+                    f"{semantics.scope_label}.compaction.{semantics.field_name} -> {semantics.authored_model.value}",
                 )
 
         return invalid_references
 
     def _compaction_models_missing_context_window(self) -> list[str]:
-        """Return explicit compaction.model references whose target model lacks context_window."""
+        """Return explicit compaction model references whose target model lacks context_window."""
         invalid_references: list[str] = []
         for semantics in self._static_compaction_semantics():
             if semantics.authored_model.kind != "value":
@@ -653,59 +672,36 @@ class Config(BaseModel):
             assert semantics.authored_model.value is not None
             if self.models[semantics.authored_model.value].context_window is None:
                 invalid_references.append(
-                    f"{semantics.scope_label}.compaction.model -> {semantics.authored_model.value}",
+                    f"{semantics.scope_label}.compaction.{semantics.field_name} -> {semantics.authored_model.value}",
                 )
 
         return invalid_references
 
     def _static_compaction_semantics(self) -> list[_StaticCompactionConfigSemantics]:
         """Return static compaction semantics for defaults, agents, and teams."""
-        semantics: list[_StaticCompactionConfigSemantics] = []
+        scoped_compactions: list[tuple[str, CompactionConfig | CompactionOverrideConfig]] = []
         defaults_compaction = self.defaults.compaction
 
         if defaults_compaction is not None:
-            authored_model = _authored_optional_model(
-                defaults_compaction.model,
-                field_is_set="model" in defaults_compaction.model_fields_set,
-            )
-            semantics.append(
-                _StaticCompactionConfigSemantics(
-                    scope_label="defaults",
-                    authored_model=authored_model,
-                ),
-            )
+            scoped_compactions.append(("defaults", defaults_compaction))
 
         for agent_name, agent_config in self.agents.items():
-            override = agent_config.compaction
-            if override is None:
-                continue
-            authored_model = _authored_optional_model(
-                override.model,
-                field_is_set="model" in override.model_fields_set,
-            )
-            semantics.append(
-                _StaticCompactionConfigSemantics(
-                    scope_label=f"agents.{agent_name}",
-                    authored_model=authored_model,
-                ),
-            )
+            if agent_config.compaction is not None:
+                scoped_compactions.append((f"agents.{agent_name}", agent_config.compaction))
 
         for team_name, team_config in self.teams.items():
-            override = team_config.compaction
-            if override is None:
-                continue
-            authored_model = _authored_optional_model(
-                override.model,
-                field_is_set="model" in override.model_fields_set,
-            )
-            semantics.append(
-                _StaticCompactionConfigSemantics(
-                    scope_label=f"teams.{team_name}",
-                    authored_model=authored_model,
-                ),
-            )
+            if team_config.compaction is not None:
+                scoped_compactions.append((f"teams.{team_name}", team_config.compaction))
 
-        return semantics
+        return [
+            _StaticCompactionConfigSemantics(
+                scope_label=scope_label,
+                field_name=field_name,
+                authored_model=authored_model,
+            )
+            for scope_label, compaction in scoped_compactions
+            for field_name, authored_model in _authored_compaction_model_fields(compaction).items()
+        ]
 
     @model_validator(mode="after")
     def validate_compaction_model_references(self) -> Config:
@@ -1192,10 +1188,6 @@ class Config(BaseModel):
             raise ValueError(msg)
         if override is not None:
             authored_override = override.model_dump(exclude_unset=True)
-            authored_model = _authored_optional_model(
-                override.model,
-                field_is_set="model" in override.model_fields_set,
-            )
             explicit_enabled = authored_override.pop(
                 "enabled",
                 override.enabled if "enabled" in override.model_fields_set else None,
@@ -1213,7 +1205,7 @@ class Config(BaseModel):
                 defaults_enabled=defaults_enabled,
                 override_enabled=explicit_enabled,
                 override_fields_set=override.model_fields_set,
-                authored_model=authored_model,
+                authored_model_fields=_authored_compaction_model_fields(override),
             )
         return CompactionConfig.model_validate(merged)
 

--- a/src/mindroom/config/main.py
+++ b/src/mindroom/config/main.py
@@ -705,7 +705,7 @@ class Config(BaseModel):
 
     @model_validator(mode="after")
     def validate_compaction_model_references(self) -> Config:
-        """Ensure explicit compaction.model references are statically valid."""
+        """Ensure explicit compaction model and fallback_model references are statically valid."""
         invalid_references = self._invalid_compaction_model_references()
         if invalid_references:
             msg = "Compaction model references unknown models: " + ", ".join(sorted(invalid_references))
@@ -713,7 +713,7 @@ class Config(BaseModel):
 
         missing_context_windows = self._compaction_models_missing_context_window()
         if missing_context_windows:
-            msg = "Explicit compaction.model requires a model with context_window: " + ", ".join(
+            msg = "Explicit compaction model references require a model with context_window: " + ", ".join(
                 sorted(missing_context_windows),
             )
             raise ValueError(msg)

--- a/src/mindroom/config/models.py
+++ b/src/mindroom/config/models.py
@@ -258,6 +258,10 @@ class CompactionOverrideConfig(BaseModel):
         default=None,
         description="Optional model config name to use for summary generation",
     )
+    fallback_model: str | None = Field(
+        default=None,
+        description="Optional model config name retried once when the summary model refuses for safeguards",
+    )
 
     @model_validator(mode="after")
     def validate_threshold_choice(self) -> Self:
@@ -306,6 +310,10 @@ class CompactionConfig(BaseModel):
     model: str | None = Field(
         default=None,
         description="Optional model config name to use for summary generation",
+    )
+    fallback_model: str | None = Field(
+        default=None,
+        description="Optional model config name retried once when the summary model refuses for safeguards",
     )
 
     @model_validator(mode="after")

--- a/src/mindroom/config/models.py
+++ b/src/mindroom/config/models.py
@@ -568,7 +568,8 @@ class ModelConfig(BaseModel):
         description=(
             "Actual provider context window size in tokens. MindRoom uses it as the default replay-planning "
             "window unless compaction.replay_window_tokens sets a smaller cap. An explicit compaction.model "
-            "also needs its own context_window for summary generation. On vertexai_claude models it additionally "
+            "or compaction.fallback_model also needs its own context_window for summary generation. "
+            "On vertexai_claude models it additionally "
             "enables request-time fitting that trims replayed history when a request would exceed the window"
         ),
     )

--- a/src/mindroom/history/compaction.py
+++ b/src/mindroom/history/compaction.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel
 
 from mindroom.claude_prompt_cache import as_anthropic_claude
 from mindroom.constants import MINDROOM_COMPACTION_CHUNK_TIMEOUT_SECONDS, prompt_roles_for_history_storage
+from mindroom.error_handling import is_model_safeguard_refusal
 from mindroom.history.storage import (
     compacted_run_ids_with,
     is_model_history_visible_run,
@@ -84,12 +85,19 @@ class _CompactionRewriteResult:
     compacted_run_count: int
     compacted_run_ids: tuple[str, ...]
     compacted_messages: tuple[Message, ...]
+    # The model that actually served the final persisted summary chunk; differs
+    # from the configured primary after a safeguard-refusal fallback switch.
+    summary_model: Model
+    summary_model_name: str
 
 
 @dataclass(frozen=True)
 class _GeneratedSummaryChunk:
     summary: SessionSummary
     included_runs: list[RunOutput | TeamRunOutput]
+    # The model that actually served this chunk (fallback after a refusal switch).
+    model: Model
+    model_name: str
 
 
 def _persist_cleared_force_state_if_needed(
@@ -176,6 +184,8 @@ async def compact_scope_history(
     replay_window_tokens: int | None,
     threshold_tokens: int | None,
     summary_prompt: str,
+    fallback_summary_model: Model | None = None,
+    fallback_summary_model_name: str | None = None,
     lifecycle_notice_event_id: str | None = None,
     progress_callback: Callable[[CompactionLifecycleProgress], Awaitable[None]] | None = None,
 ) -> CompactionOutcome | None:
@@ -237,6 +247,8 @@ async def compact_scope_history(
         working_session=working_session,
         summary_model=summary_model,
         summary_model_name=summary_model_name,
+        fallback_summary_model=fallback_summary_model,
+        fallback_summary_model_name=fallback_summary_model_name,
         session_id=session.session_id,
         scope=scope,
         state=state,
@@ -265,7 +277,7 @@ async def compact_scope_history(
     compacted_at = _iso_utc_now()
     new_state = HistoryScopeState(
         last_compacted_at=compacted_at,
-        last_summary_model=_model_identifier(summary_model),
+        last_summary_model=_model_identifier(rewrite_result.summary_model),
         last_compacted_run_count=rewrite_result.compacted_run_count,
         compacted_run_ids=compacted_run_ids_with(state, rewrite_result.compacted_run_ids),
         force_compact_before_next_run=False,
@@ -285,7 +297,7 @@ async def compact_scope_history(
         session_id=session.session_id,
         scope=scope.key,
         compacted_runs=rewrite_result.compacted_run_count,
-        model=_model_identifier(summary_model),
+        model=_model_identifier(rewrite_result.summary_model),
     )
 
     after_visible_runs = scope_visible_runs(session, scope)
@@ -299,7 +311,7 @@ async def compact_scope_history(
         session_id=session.session_id,
         scope=scope.key,
         summary=rewrite_result.summary_text,
-        summary_model=summary_model_name,
+        summary_model=rewrite_result.summary_model_name,
         before_tokens=before_tokens,
         after_tokens=after_tokens,
         window_tokens=replay_window_tokens or 0,
@@ -344,14 +356,12 @@ async def _rewrite_working_session_for_compaction(  # noqa: C901
     progress_callback: Callable[[CompactionLifecycleProgress], Awaitable[None]] | None,
     collect_compaction_hook_messages: bool,
     summary_prompt: str,
+    fallback_summary_model: Model | None = None,
+    fallback_summary_model_name: str | None = None,
     before_persist_callback: Callable[[Sequence[RunOutput | TeamRunOutput]], Awaitable[None]] | None = None,
 ) -> _CompactionRewriteResult | None:
     final_summary_text = _current_summary_text(working_session) or ""
-    token_estimator = partial(
-        estimate_compaction_input_tokens,
-        model_id=summary_model.id,
-        conservative_fallback=as_anthropic_claude(summary_model) is not None,
-    )
+    token_estimator = _compaction_token_estimator(summary_model)
     total_compacted_run_count = 0
     all_compacted_run_ids: list[str] = []
     all_compacted_run_id_set: set[str] = set()
@@ -389,6 +399,7 @@ async def _rewrite_working_session_for_compaction(  # noqa: C901
 
         new_summary = await _generate_compaction_summary_with_retry(
             model=summary_model,
+            model_name=summary_model_name,
             previous_summary=_current_summary_text(working_session),
             compactable_runs=compactable_runs,
             initial_summary_input=summary_input,
@@ -399,7 +410,17 @@ async def _rewrite_working_session_for_compaction(  # noqa: C901
             history_settings=history_settings,
             summary_prompt=summary_prompt,
             token_estimator=token_estimator,
+            fallback_model=fallback_summary_model,
+            fallback_model_name=fallback_summary_model_name,
         )
+        if new_summary.model is not summary_model:
+            # A safeguard-refusal fallback served this chunk; it becomes the
+            # summary model for every later chunk, including token estimation.
+            summary_model = new_summary.model
+            summary_model_name = new_summary.model_name
+            token_estimator = _compaction_token_estimator(summary_model)
+            fallback_summary_model = None
+            fallback_summary_model_name = None
         included_runs = new_summary.included_runs
         generated_summary = new_summary.summary
         if before_persist_callback is not None:
@@ -454,6 +475,17 @@ async def _rewrite_working_session_for_compaction(  # noqa: C901
         compacted_run_count=total_compacted_run_count,
         compacted_run_ids=tuple(all_compacted_run_ids),
         compacted_messages=tuple(compacted_messages),
+        summary_model=summary_model,
+        summary_model_name=summary_model_name,
+    )
+
+
+def _compaction_token_estimator(summary_model: Model) -> Callable[[str], int]:
+    """Return the summary-input token estimator tuned for one loaded summary model."""
+    return partial(
+        estimate_compaction_input_tokens,
+        model_id=summary_model.id,
+        conservative_fallback=as_anthropic_claude(summary_model) is not None,
     )
 
 
@@ -504,6 +536,7 @@ async def _emit_lifecycle_progress_after_persist(
 async def _generate_compaction_summary_with_retry(
     *,
     model: Model,
+    model_name: str,
     previous_summary: str | None,
     compactable_runs: Sequence[RunOutput | TeamRunOutput],
     initial_summary_input: str,
@@ -514,8 +547,20 @@ async def _generate_compaction_summary_with_retry(
     history_settings: ResolvedHistorySettings,
     summary_prompt: str,
     token_estimator: Callable[[str], int],
+    fallback_model: Model | None = None,
+    fallback_model_name: str | None = None,
 ) -> _GeneratedSummaryChunk:
-    """Generate one summary chunk, retrying the same or smaller input when safe."""
+    """Generate one summary chunk, retrying the same or smaller input when safe.
+
+    A safeguard refusal from the primary model switches once to
+    ``fallback_model``, keeping the ``summary_prompt`` and ``summary_input``
+    bytes, included runs, and budget unchanged (only the target model
+    differs); a refusal or failure from the fallback propagates. The switch
+    shares the retry policy's attempt bound, so a
+    refusal after an earlier shrink or transient retry propagates without a
+    fallback call. All other failures keep the existing shrink and transient
+    same-input retry behavior.
+    """
     summary_input = initial_summary_input
     included_runs = initial_included_runs
     budget = summary_input_budget
@@ -533,6 +578,7 @@ async def _generate_compaction_summary_with_retry(
             "Compaction summary chunk request",
             session_id=session_id,
             scope=scope.key,
+            model_name=model_name,
             attempt=attempt,
             candidate_runs=len(compactable_runs),
             included_runs=len(included_runs),
@@ -552,6 +598,7 @@ async def _generate_compaction_summary_with_retry(
                 "Compaction summary chunk failed",
                 session_id=session_id,
                 scope=scope.key,
+                model_name=model_name,
                 attempt=attempt,
                 candidate_runs=len(compactable_runs),
                 included_runs=len(included_runs),
@@ -561,6 +608,27 @@ async def _generate_compaction_summary_with_retry(
                 duration_ms=duration_ms,
                 error=str(exc) or type(exc).__name__,
             )
+            # The attempt bound covers the fallback call too: a refusal after an
+            # earlier shrink or transient retry propagates instead of issuing a
+            # third provider call.
+            if fallback_model is not None and attempt < retry_policy.max_attempts and is_model_safeguard_refusal(exc):
+                logger.info(
+                    "Compaction summary refused; switching to fallback model",
+                    session_id=session_id,
+                    scope=scope.key,
+                    attempt=attempt,
+                    refused_model=model_name,
+                    fallback_model=fallback_model_name,
+                )
+                assert fallback_model_name is not None
+                model = fallback_model
+                model_name = fallback_model_name
+                # The fallback resends the unchanged prompt and input bytes
+                # exactly once; only the target model differs.
+                fallback_model = None
+                fallback_model_name = None
+                attempt += 1
+                continue
             retry_decision: SummaryRetryDecision | None = retry_policy.retry_budget(
                 attempt=attempt,
                 budget=budget,
@@ -595,6 +663,7 @@ async def _generate_compaction_summary_with_retry(
             "Compaction summary chunk completed",
             session_id=session_id,
             scope=scope.key,
+            model_name=model_name,
             attempt=attempt,
             candidate_runs=len(compactable_runs),
             included_runs=len(included_runs),
@@ -603,7 +672,12 @@ async def _generate_compaction_summary_with_retry(
             timeout_seconds=MINDROOM_COMPACTION_CHUNK_TIMEOUT_SECONDS,
             duration_ms=duration_ms,
         )
-        return _GeneratedSummaryChunk(summary=summary, included_runs=included_runs)
+        return _GeneratedSummaryChunk(
+            summary=summary,
+            included_runs=included_runs,
+            model=model,
+            model_name=model_name,
+        )
 
 
 @timed("system_prompt_assembly.history_prepare.compaction.summary_input_build")

--- a/src/mindroom/history/policy.py
+++ b/src/mindroom/history/policy.py
@@ -80,6 +80,7 @@ def resolve_history_execution_plan(
         summary_input_budget_tokens=summary_input_budget_tokens,
         unavailable_reason=unavailable_reason,
         hard_replay_budget_tokens=hard_replay_budget_tokens,
+        compaction_fallback_model_name=compaction_config.fallback_model,
     )
 
 

--- a/src/mindroom/history/runtime.py
+++ b/src/mindroom/history/runtime.py
@@ -565,7 +565,20 @@ async def _run_scope_compaction(
         primary_model_name=execution_plan.compaction_model_name,
         fallback_model_name=fallback_model_name,
     ):
-        fallback_model = _load_compaction_model(config, runtime_paths, fallback_model_name)
+        # The fallback is an optional resilience knob: when its construction
+        # fails (missing SDK, credentials, client setup), compaction still
+        # runs on the healthy primary instead of aborting before any call.
+        try:
+            fallback_model = _load_compaction_model(config, runtime_paths, fallback_model_name)
+        except Exception:
+            logger.warning(
+                "Compaction fallback model failed to load; continuing without a fallback",
+                session_id=session.session_id,
+                scope=scope.key,
+                compaction_model=execution_plan.compaction_model_name,
+                fallback_model=fallback_model_name,
+                exc_info=True,
+            )
     return await compact_scope_history(
         storage=storage,
         session=session,

--- a/src/mindroom/history/runtime.py
+++ b/src/mindroom/history/runtime.py
@@ -127,15 +127,23 @@ def _compaction_fallback_is_distinct(
     ``vertexai_claude`` count as the same serving model.
     """
     if fallback_model_name == primary_model_name:
-        return False
-    primary_config = config.models.get(primary_model_name)
-    fallback_config = config.models.get(fallback_model_name)
-    if primary_config is None or fallback_config is None:
-        return True
-    return (model_loading.canonical_provider(primary_config.provider), primary_config.id) != (
-        model_loading.canonical_provider(fallback_config.provider),
-        fallback_config.id,
-    )
+        is_distinct = False
+    else:
+        primary_config = config.models.get(primary_model_name)
+        fallback_config = config.models.get(fallback_model_name)
+        if primary_config is None or fallback_config is None:
+            return True
+        is_distinct = (model_loading.canonical_provider(primary_config.provider), primary_config.id) != (
+            model_loading.canonical_provider(fallback_config.provider),
+            fallback_config.id,
+        )
+    if not is_distinct:
+        logger.warning(
+            "Compaction fallback resolves to the primary serving model; continuing without a fallback",
+            compaction_model=primary_model_name,
+            fallback_model=fallback_model_name,
+        )
+    return is_distinct
 
 
 @dataclass(frozen=True)

--- a/src/mindroom/history/runtime.py
+++ b/src/mindroom/history/runtime.py
@@ -121,7 +121,10 @@ def _compaction_fallback_is_distinct(
 
     A fallback that names the primary alias, or a different alias resolving to
     the same ``(provider, id)``, would resend the refused request to the same
-    model, so it is not loaded at all.
+    model, so it is not loaded at all. Providers are compared through
+    ``model_loading.canonical_provider`` — the same normalization model
+    dispatch uses — so spelling variants like ``vertexai-claude`` and
+    ``vertexai_claude`` count as the same serving model.
     """
     if fallback_model_name == primary_model_name:
         return False
@@ -129,7 +132,10 @@ def _compaction_fallback_is_distinct(
     fallback_config = config.models.get(fallback_model_name)
     if primary_config is None or fallback_config is None:
         return True
-    return (primary_config.provider, primary_config.id) != (fallback_config.provider, fallback_config.id)
+    return (model_loading.canonical_provider(primary_config.provider), primary_config.id) != (
+        model_loading.canonical_provider(fallback_config.provider),
+        fallback_config.id,
+    )
 
 
 @dataclass(frozen=True)
@@ -458,13 +464,18 @@ async def _run_scope_compaction_with_lifecycle(
         ),
     )
 
+    # Progress events report the model that actually served each persisted
+    # chunk, so failure notices after a fallback switch name the fallback
+    # instead of the configured primary.
+    serving_summary_model = execution_plan.compaction_model_name
+
     def _failure_event(status: Literal["failed", "timeout"], failure_reason: str) -> CompactionLifecycleFailure:
         return CompactionLifecycleFailure(
             notice_event_id=notice_event_id,
             mode=mode,
             session_id=session.session_id,
             scope=scope.key,
-            summary_model=execution_plan.compaction_model_name,
+            summary_model=serving_summary_model,
             status=status,
             duration_ms=_elapsed_ms(compaction_start),
             failure_reason=failure_reason,
@@ -472,6 +483,8 @@ async def _run_scope_compaction_with_lifecycle(
         )
 
     async def _progress(event: CompactionLifecycleProgress) -> None:
+        nonlocal serving_summary_model
+        serving_summary_model = event.summary_model
         await lifecycle.progress(replace(event, duration_ms=_elapsed_ms(compaction_start)))
 
     progress_callback = _progress if lifecycle.enabled else None

--- a/src/mindroom/history/runtime.py
+++ b/src/mindroom/history/runtime.py
@@ -111,6 +111,27 @@ def _load_compaction_model(
     return model_loading.get_model_instance(config, runtime_paths, model_name)
 
 
+def _compaction_fallback_is_distinct(
+    config: Config,
+    *,
+    primary_model_name: str,
+    fallback_model_name: str,
+) -> bool:
+    """Return whether the configured fallback targets a different serving model.
+
+    A fallback that names the primary alias, or a different alias resolving to
+    the same ``(provider, id)``, would resend the refused request to the same
+    model, so it is not loaded at all.
+    """
+    if fallback_model_name == primary_model_name:
+        return False
+    primary_config = config.models.get(primary_model_name)
+    fallback_config = config.models.get(fallback_model_name)
+    if primary_config is None or fallback_config is None:
+        return True
+    return (primary_config.provider, primary_config.id) != (fallback_config.provider, fallback_config.id)
+
+
 @dataclass(frozen=True)
 class ScopeSessionContext:
     """Resolved storage/session context for one logical history scope."""
@@ -524,6 +545,14 @@ async def _run_scope_compaction(
         runtime_paths,
         execution_plan.compaction_model_name,
     )
+    fallback_model_name = execution_plan.compaction_fallback_model_name
+    fallback_model: Model | None = None
+    if fallback_model_name is not None and _compaction_fallback_is_distinct(
+        config,
+        primary_model_name=execution_plan.compaction_model_name,
+        fallback_model_name=fallback_model_name,
+    ):
+        fallback_model = _load_compaction_model(config, runtime_paths, fallback_model_name)
     return await compact_scope_history(
         storage=storage,
         session=session,
@@ -537,6 +566,8 @@ async def _run_scope_compaction(
         replay_window_tokens=execution_plan.replay_window_tokens,
         threshold_tokens=execution_plan.trigger_threshold_tokens,
         summary_prompt=config.get_prompt("COMPACTION_SUMMARY_PROMPT"),
+        fallback_summary_model=fallback_model,
+        fallback_summary_model_name=fallback_model_name if fallback_model is not None else None,
         lifecycle_notice_event_id=lifecycle_notice_event_id,
         progress_callback=progress_callback,
     )

--- a/src/mindroom/history/summary_call.py
+++ b/src/mindroom/history/summary_call.py
@@ -16,11 +16,16 @@ It enforces the call-side half of the compaction invariants
 
 4. Retry on provider failure is deterministic.
    ``SummaryRetryPolicy`` decides which error classes warrant a smaller retry
-   (timeouts, typed context-window and safeguard errors, empty results, output
-   limits, and named legacy context-length fragments), the shrink schedule
+   (timeouts, typed context-window errors, empty results, output limits, and
+   named legacy context-length fragments), the shrink schedule
    (halving, clamped to the caller's smallest progress-preserving rebuild), and the
    give-up floor — no inline string matching at call sites. Selected typed
-   transient provider errors get one delayed same-budget retry.
+   transient provider errors get one delayed same-budget retry. Safeguard
+   refusals are deliberately not shrinkable: the retry wrapper in
+   ``history.compaction`` switches once to the configured fallback model,
+   keeping the summary prompt and summary input bytes, included runs, and
+   budget unchanged (only the target model differs) instead of shrinking a
+   request the model refused on content grounds.
 
 5. Output-capped summaries use an explicit retry signal.
    ``generate_compaction_summary`` refuses to return a likely truncated summary,
@@ -48,7 +53,7 @@ from agno.session.summary import SessionSummary
 from mindroom.cancellation import request_task_cancel
 from mindroom.claude_prompt_cache import as_anthropic_claude
 from mindroom.constants import MINDROOM_COMPACTION_CHUNK_TIMEOUT_SECONDS
-from mindroom.error_handling import TRANSIENT_PROVIDER_STATUS_CODES, ModelSafeguardRefusalError
+from mindroom.error_handling import TRANSIENT_PROVIDER_STATUS_CODES
 from mindroom.history.types import COMPACTION_SUMMARY_RETRY_FLOOR_TOKENS
 from mindroom.logging_config import get_logger
 from mindroom.timing import timed
@@ -63,7 +68,7 @@ _COMPACTION_CANCEL_DRAIN_TIMEOUT_SECONDS = 1.0
 
 # Status 502 is excluded because ``ModelProviderError`` uses it for unclassified
 # errors. Default-502 errors retry only when their cause chain proves a typed
-# network failure. Safeguard refusals shrink before either transient path.
+# network failure.
 _TRANSIENT_SUMMARY_STATUS_CODES = TRANSIENT_PROVIDER_STATUS_CODES - {502}
 
 _SHRINKABLE_PROVIDER_ERROR_FRAGMENTS = (
@@ -126,7 +131,6 @@ _TYPED_SHRINKABLE_ERRORS = (
     _CompactionSummaryEmptyResultError,
     TimeoutError,
     ContextWindowExceededError,
-    ModelSafeguardRefusalError,
     CompactionSummaryOutputLimitError,
 )
 

--- a/src/mindroom/history/types.py
+++ b/src/mindroom/history/types.py
@@ -130,6 +130,7 @@ class ResolvedHistoryExecutionPlan:
     summary_input_budget_tokens: int | None
     unavailable_reason: CompactionAvailabilityReason | None = None
     hard_replay_budget_tokens: int | None = None
+    compaction_fallback_model_name: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/mindroom/model_loading.py
+++ b/src/mindroom/model_loading.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-__all__ = ["get_model_instance"]
+__all__ = ["canonical_provider", "get_model_instance"]
 
 _BEDROCK_CLAUDE_PROVIDER = "bedrock_claude"
 # The anthropic SDK rejects non-streaming requests whose max_tokens project past
@@ -38,8 +38,8 @@ _BEDROCK_CLAUDE_PROVIDER = "bedrock_claude"
 _CLAUDE_REQUEST_TIMEOUT_SECONDS = 3600.0
 
 
-def _canonical_provider(provider: str) -> str:
-    """Return normalized provider key for model dispatch."""
+def canonical_provider(provider: str) -> str:
+    """Return the normalized provider key used for model dispatch and identity checks."""
     return provider.strip().lower().replace("-", "_")
 
 
@@ -151,18 +151,18 @@ def _create_model_for_provider(  # noqa: C901, PLR0911, PLR0912, PLR0915
     module never imports a provider SDK; only the configured provider's SDK
     loads at first model construction (#1436).
     """
-    canonical_provider = _canonical_provider(provider)
+    canonical_provider_key = canonical_provider(provider)
 
     if (
-        canonical_provider
+        canonical_provider_key
         not in {"ollama", "llama_cpp", "vertexai_claude", "codex", "openai_codex", _BEDROCK_CLAUDE_PROVIDER}
         and "api_key" not in extra_kwargs
     ):
-        api_key = get_api_key_for_provider(canonical_provider, runtime_paths=runtime_paths)
+        api_key = get_api_key_for_provider(canonical_provider_key, runtime_paths=runtime_paths)
         if api_key:
             extra_kwargs["api_key"] = api_key
 
-    if canonical_provider == "vertexai_claude":
+    if canonical_provider_key == "vertexai_claude":
         if "project_id" not in extra_kwargs:
             project_id = runtime_paths.env_value(VERTEXAI_CLAUDE_ENV_BY_KEY["project_id"])
             if project_id:
@@ -183,27 +183,27 @@ def _create_model_for_provider(  # noqa: C901, PLR0911, PLR0912, PLR0915
         if client_params:
             extra_kwargs["client_params"] = client_params
 
-    if canonical_provider == "azure":
+    if canonical_provider_key == "azure":
         _populate_azure_openai_runtime_kwargs(extra_kwargs, runtime_paths)
 
-    if canonical_provider in {"anthropic", "vertexai_claude", _BEDROCK_CLAUDE_PROVIDER}:
+    if canonical_provider_key in {"anthropic", "vertexai_claude", _BEDROCK_CLAUDE_PROVIDER}:
         extra_kwargs.setdefault("cache_system_prompt", True)
         extra_kwargs.setdefault("extended_cache_time", True)
         extra_kwargs.setdefault("timeout", _CLAUDE_REQUEST_TIMEOUT_SECONDS)
 
-    if canonical_provider == "ollama":
+    if canonical_provider_key == "ollama":
         from agno.models.ollama import Ollama  # noqa: PLC0415
 
         host = model_config.host or get_ollama_host(runtime_paths=runtime_paths) or OLLAMA_HOST_DEFAULT
         logger.debug("using_ollama_host", host=host)
         return Ollama(id=model_id, host=host, **extra_kwargs)
 
-    if canonical_provider == "openrouter":
+    if canonical_provider_key == "openrouter":
         from mindroom.openai_models import MindRoomOpenRouter  # noqa: PLC0415
 
         api_key = extra_kwargs.pop("api_key", None)
         if not api_key:
-            api_key = get_api_key_for_provider(canonical_provider, runtime_paths=runtime_paths)
+            api_key = get_api_key_for_provider(canonical_provider_key, runtime_paths=runtime_paths)
         if not api_key:
             logger.warning("No OpenRouter API key found in environment or CredentialsManager")
         # Agno's OpenRouter dataclass defaults max_tokens to 1024, which silently
@@ -212,7 +212,7 @@ def _create_model_for_provider(  # noqa: C901, PLR0911, PLR0912, PLR0915
         extra_kwargs.setdefault("max_tokens", None)
         return MindRoomOpenRouter(id=model_id, api_key=api_key, **extra_kwargs)
 
-    if canonical_provider == "zai":
+    if canonical_provider_key == "zai":
         # OpenAILike neither reads a provider env var nor rejects a missing key,
         # so resolve the env fallback here and keep falsy keys out of the kwargs
         # (a falsy api_key would make agno's OpenAI client fall back to
@@ -231,7 +231,7 @@ def _create_model_for_provider(  # noqa: C901, PLR0911, PLR0912, PLR0915
 
         return MindRoomOpenAILike(id=model_id, **extra_kwargs)
 
-    if canonical_provider in {"codex", "openai_codex"}:
+    if canonical_provider_key in {"codex", "openai_codex"}:
         from mindroom.codex_model import (  # noqa: PLC0415
             CodexResponses,
             derive_codex_prompt_cache_key,
@@ -245,7 +245,7 @@ def _create_model_for_provider(  # noqa: C901, PLR0911, PLR0912, PLR0915
                 extra_kwargs["prompt_cache_key"] = prompt_cache_key
         return CodexResponses(id=normalize_codex_model_id(model_id), **extra_kwargs)
 
-    if canonical_provider == _BEDROCK_CLAUDE_PROVIDER:
+    if canonical_provider_key == _BEDROCK_CLAUDE_PROVIDER:
         extra_kwargs.pop("api_key", None)
         ensure_optional_deps(
             ["boto3"],
@@ -258,11 +258,11 @@ def _create_model_for_provider(  # noqa: C901, PLR0911, PLR0912, PLR0915
 
         return AwsBedrockClaude(id=model_id, **extra_kwargs)
 
-    if canonical_provider == "openai":
+    if canonical_provider_key == "openai":
         from mindroom.openai_tool_search import openai_native_tool_search_supported  # noqa: PLC0415
 
         base_url = extra_kwargs.get("base_url") or runtime_paths.env_value("OPENAI_BASE_URL")
-        if openai_native_tool_search_supported(canonical_provider, model_id, base_url=base_url):
+        if openai_native_tool_search_supported(canonical_provider_key, model_id, base_url=base_url):
             from mindroom.openai_models import MindRoomOpenAIResponses  # noqa: PLC0415
 
             return MindRoomOpenAIResponses(id=model_id, **extra_kwargs)
@@ -271,22 +271,22 @@ def _create_model_for_provider(  # noqa: C901, PLR0911, PLR0912, PLR0915
 
         return MindRoomOpenAIChat(id=model_id, **extra_kwargs)
 
-    if canonical_provider == "azure":
+    if canonical_provider_key == "azure":
         from mindroom.azure_openai_model import MindRoomAzureOpenAI  # noqa: PLC0415
 
         return MindRoomAzureOpenAI(id=model_id, **extra_kwargs)
 
-    if canonical_provider == "anthropic":
+    if canonical_provider_key == "anthropic":
         from agno.models.anthropic import Claude  # noqa: PLC0415
 
         return Claude(id=model_id, **extra_kwargs)
 
-    if canonical_provider in {"gemini", "google"}:
+    if canonical_provider_key in {"gemini", "google"}:
         from agno.models.google import Gemini  # noqa: PLC0415
 
         return Gemini(id=model_id, **extra_kwargs)
 
-    if canonical_provider == "vertexai_claude":
+    if canonical_provider_key == "vertexai_claude":
         from mindroom.vertex_claude_compat import MindroomVertexAIClaude  # noqa: PLC0415
 
         return MindroomVertexAIClaude(
@@ -295,22 +295,22 @@ def _create_model_for_provider(  # noqa: C901, PLR0911, PLR0912, PLR0915
             **extra_kwargs,
         )
 
-    if canonical_provider == "llama_cpp":
+    if canonical_provider_key == "llama_cpp":
         from mindroom.openai_models import MindRoomLlamaCpp  # noqa: PLC0415
 
         return MindRoomLlamaCpp(id=model_id, **extra_kwargs)
 
-    if canonical_provider == "cerebras":
+    if canonical_provider_key == "cerebras":
         from agno.models.cerebras import Cerebras  # noqa: PLC0415
 
         return Cerebras(id=model_id, **extra_kwargs)
 
-    if canonical_provider == "groq":
+    if canonical_provider_key == "groq":
         from agno.models.groq import Groq  # noqa: PLC0415
 
         return Groq(id=model_id, **extra_kwargs)
 
-    if canonical_provider == "deepseek":
+    if canonical_provider_key == "deepseek":
         from mindroom.openai_models import MindRoomDeepSeek  # noqa: PLC0415
 
         return MindRoomDeepSeek(id=model_id, **extra_kwargs)
@@ -344,7 +344,7 @@ def get_model_instance(
     if model_api_key:
         extra_kwargs["api_key"] = model_api_key
 
-    if _canonical_provider(provider) in {"codex", "openai_codex"}:
+    if canonical_provider(provider) in {"codex", "openai_codex"}:
         extra_kwargs.setdefault("default_instructions", config.get_prompt("CODEX_DEFAULT_INSTRUCTIONS"))
 
     model = _create_model_for_provider(

--- a/tests/test_compaction_invariants.py
+++ b/tests/test_compaction_invariants.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from copy import deepcopy
 from datetime import UTC, datetime
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -759,9 +759,11 @@ def test_retry_policy_propagates_second_typed_context_window_error() -> None:
     )
 
 
-def test_retry_policy_shrinks_budget_for_safeguard_refusal() -> None:
+def test_retry_policy_does_not_shrink_safeguard_refusal() -> None:
+    """A safeguard refusal is a content decision, not a size problem: no shrink retry."""
     error = ModelSafeguardRefusalError("provider-specific refusal wording")
 
+    assert DEFAULT_SUMMARY_RETRY_POLICY.should_shrink(error) is False
     assert (
         _retry_budget_value(
             DEFAULT_SUMMARY_RETRY_POLICY,
@@ -770,24 +772,13 @@ def test_retry_policy_shrinks_budget_for_safeguard_refusal() -> None:
             input_tokens=16_000,
             error=error,
         )
-        == 8_000
-    )
-    assert (
-        _retry_budget_value(
-            DEFAULT_SUMMARY_RETRY_POLICY,
-            attempt=2,
-            budget=8_000,
-            input_tokens=8_000,
-            error=error,
-        )
         is None
     )
 
 
-def test_retry_policy_should_shrink_for_refusal_and_empty_result() -> None:
+def test_retry_policy_should_shrink_for_empty_result() -> None:
     policy = DEFAULT_SUMMARY_RETRY_POLICY
 
-    assert policy.should_shrink(ModelSafeguardRefusalError("provider-specific refusal wording")) is True
     assert policy.should_shrink(_CompactionSummaryEmptyResultError("summary generation returned no result")) is True
 
 
@@ -811,7 +802,7 @@ def test_retry_policy_clamps_shrink_target_to_minimum_progress_input() -> None:
         budget=10_000,
         input_tokens=8_573,
         minimum_progress_input_tokens=6_230,
-        error=ModelSafeguardRefusalError("provider-specific refusal wording"),
+        error=CompactionSummaryOutputLimitError("renamed owned output-limit signal"),
     )
 
     assert decision == SummaryRetryDecision(budget=6_230, kind="shrink")
@@ -878,7 +869,7 @@ def test_retry_policy_does_not_resend_non_transient_shrink_errors_at_floor() -> 
             attempt=1,
             budget=16_000,
             input_tokens=1_000,
-            error=ModelSafeguardRefusalError("provider-specific refusal wording"),
+            error=CompactionSummaryOutputLimitError("renamed owned output-limit signal"),
         )
         is None
     )
@@ -1140,7 +1131,7 @@ def test_retry_schedule_halves_deterministically() -> None:
 async def test_retry_helper_propagates_original_error_when_rebuilt_input_is_not_smaller() -> None:
     """A defensive estimate guard prevents a shrink retry from resending equal-size input."""
     run = _completed_run("run-1")
-    original_error = ModelSafeguardRefusalError("provider-specific refusal wording")
+    original_error = CompactionSummaryOutputLimitError("renamed owned output-limit signal")
     generate_summary = AsyncMock(side_effect=original_error)
 
     with (
@@ -1152,10 +1143,11 @@ async def test_retry_helper_propagates_original_error_when_rebuilt_input_is_not_
             "mindroom.history.compaction._build_summary_input",
             return_value=("rebuilt request with the same estimate", [run]),
         ),
-        pytest.raises(ModelSafeguardRefusalError) as raised,
+        pytest.raises(CompactionSummaryOutputLimitError) as raised,
     ):
         await _generate_compaction_summary_with_retry(
             model=FakeModel(id="summary-model", provider="fake"),
+            model_name="summary-model",
             previous_summary=None,
             compactable_runs=[run],
             initial_summary_input="original request",
@@ -1194,6 +1186,7 @@ async def test_retry_helper_honors_transient_fallthrough_for_shrink_message_at_f
     ):
         generated = await _generate_compaction_summary_with_retry(
             model=FakeModel(id="summary-model", provider="fake"),
+            model_name="summary-model",
             previous_summary=None,
             compactable_runs=[run],
             initial_summary_input="original request",
@@ -1223,7 +1216,7 @@ async def test_retry_helper_shrinks_around_a_large_durable_summary() -> None:
     Regression: the halved shrink target used to fall below the previous-summary
     block, the rebuild came back run-less, and the original error propagated
     without any smaller attempt — so the next turn reselected required
-    compaction and resent the identical refusal-prone request.
+    compaction and resent the identical failing request.
     """
     previous_summary = "s" * 24_000
     runs = [_completed_run(f"run-{index}", padding=2_000) for index in range(3)]
@@ -1241,12 +1234,13 @@ async def test_retry_helper_shrinks_around_a_large_durable_summary() -> None:
     assert _chars_per_token_estimator(previous_summary) > initial_tokens // 2
     recovered_summary = SessionSummary(summary="recovered summary", updated_at=datetime.now(UTC))
     generate_summary = AsyncMock(
-        side_effect=[ModelSafeguardRefusalError("provider-specific refusal wording"), recovered_summary],
+        side_effect=[CompactionSummaryOutputLimitError("renamed owned output-limit signal"), recovered_summary],
     )
 
     with patch("mindroom.history.compaction.generate_compaction_summary", new=generate_summary):
         generated = await _generate_compaction_summary_with_retry(
             model=FakeModel(id="summary-model", provider="fake"),
+            model_name="summary-model",
             previous_summary=previous_summary,
             compactable_runs=runs,
             initial_summary_input=initial_input,
@@ -1282,15 +1276,16 @@ async def test_retry_helper_propagates_error_when_no_smaller_progress_input_exis
         token_estimator=_chars_per_token_estimator,
     )
     assert [run.run_id for run in initial_runs] == ["run-1"]
-    original_error = ModelSafeguardRefusalError("provider-specific refusal wording")
+    original_error = CompactionSummaryOutputLimitError("renamed owned output-limit signal")
     generate_summary = AsyncMock(side_effect=original_error)
 
     with (
         patch("mindroom.history.compaction.generate_compaction_summary", new=generate_summary),
-        pytest.raises(ModelSafeguardRefusalError) as raised,
+        pytest.raises(CompactionSummaryOutputLimitError) as raised,
     ):
         await _generate_compaction_summary_with_retry(
             model=FakeModel(id="summary-model", provider="fake"),
+            model_name="summary-model",
             previous_summary=previous_summary,
             compactable_runs=runs,
             initial_summary_input=initial_input,
@@ -1487,8 +1482,162 @@ async def test_compaction_retries_empty_summary_result_with_smaller_input(tmp_pa
 
 
 @pytest.mark.asyncio
-async def test_compaction_shrinks_input_after_safeguard_refusal(tmp_path: Path) -> None:
-    """A safeguard refusal retries with a smaller input and persists the result."""
+async def test_retry_helper_switches_to_fallback_once_with_unchanged_prompt_and_input() -> None:
+    """A primary refusal resends the unchanged prompt and input bytes once to the fallback model."""
+    run = _completed_run("run-1")
+    primary = FakeModel(id="summary-model", provider="fake")
+    fallback = FakeModel(id="fallback-model-id", provider="fake")
+    recovered_summary = SessionSummary(summary="recovered summary", updated_at=datetime.now(UTC))
+    generate_summary = AsyncMock(
+        side_effect=[ModelSafeguardRefusalError("provider-specific refusal wording"), recovered_summary],
+    )
+    retry_sleep = AsyncMock()
+    logger_mock = MagicMock()
+
+    with (
+        patch("mindroom.history.compaction.generate_compaction_summary", new=generate_summary),
+        patch("mindroom.history.compaction.asyncio.sleep", new=retry_sleep),
+        patch("mindroom.history.compaction.logger", logger_mock),
+    ):
+        generated = await _generate_compaction_summary_with_retry(
+            model=primary,
+            model_name="summary-model",
+            previous_summary=None,
+            compactable_runs=[run],
+            initial_summary_input="original request",
+            initial_included_runs=[run],
+            summary_input_budget=4_000,
+            session_id="session-1",
+            scope=_SCOPE,
+            history_settings=_HISTORY_SETTINGS,
+            summary_prompt=COMPACTION_SUMMARY_PROMPT,
+            token_estimator=lambda _value: 2_000,
+            fallback_model=fallback,
+            fallback_model_name="fallback-model",
+        )
+
+    assert generated.summary is recovered_summary
+    assert generated.included_runs == [run]
+    assert generated.model is fallback
+    assert generated.model_name == "fallback-model"
+    assert generate_summary.await_count == 2
+    assert [call.kwargs["model"] for call in generate_summary.await_args_list] == [primary, fallback]
+    assert [call.kwargs["summary_input"] for call in generate_summary.await_args_list] == [
+        "original request",
+        "original request",
+    ]
+    assert [call.kwargs["summary_prompt"] for call in generate_summary.await_args_list] == [
+        COMPACTION_SUMMARY_PROMPT,
+        COMPACTION_SUMMARY_PROMPT,
+    ]
+    retry_sleep.assert_not_awaited()
+    # Structured request/failure/completion logs identify the actual serving model.
+    assert [
+        call.kwargs["model_name"]
+        for call in logger_mock.info.call_args_list
+        if call.args[0] == "Compaction summary chunk request"
+    ] == ["summary-model", "fallback-model"]
+    assert [
+        call.kwargs["model_name"]
+        for call in logger_mock.warning.call_args_list
+        if call.args[0] == "Compaction summary chunk failed"
+    ] == ["summary-model"]
+    assert [
+        call.kwargs["model_name"]
+        for call in logger_mock.info.call_args_list
+        if call.args[0] == "Compaction summary chunk completed"
+    ] == ["fallback-model"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "fallback_error",
+    [
+        pytest.param(ModelSafeguardRefusalError("fallback also refused"), id="fallback-refusal"),
+        pytest.param(ModelProviderError("invalid request", status_code=400), id="fallback-failure"),
+    ],
+)
+async def test_retry_helper_propagates_fallback_refusal_or_failure(fallback_error: Exception) -> None:
+    """The fallback call is the one bounded second attempt; its errors propagate."""
+    run = _completed_run("run-1")
+    primary = FakeModel(id="summary-model", provider="fake")
+    fallback = FakeModel(id="fallback-model-id", provider="fake")
+    generate_summary = AsyncMock(
+        side_effect=[ModelSafeguardRefusalError("provider-specific refusal wording"), fallback_error],
+    )
+
+    with (
+        patch("mindroom.history.compaction.generate_compaction_summary", new=generate_summary),
+        pytest.raises(type(fallback_error)) as raised,
+    ):
+        await _generate_compaction_summary_with_retry(
+            model=primary,
+            model_name="summary-model",
+            previous_summary=None,
+            compactable_runs=[run],
+            initial_summary_input="original request",
+            initial_included_runs=[run],
+            summary_input_budget=4_000,
+            session_id="session-1",
+            scope=_SCOPE,
+            history_settings=_HISTORY_SETTINGS,
+            summary_prompt=COMPACTION_SUMMARY_PROMPT,
+            token_estimator=lambda _value: 2_000,
+            fallback_model=fallback,
+            fallback_model_name="fallback-model",
+        )
+
+    assert raised.value is fallback_error
+    assert generate_summary.await_count == 2
+    assert [call.kwargs["summary_input"] for call in generate_summary.await_args_list] == [
+        "original request",
+        "original request",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_retry_helper_refusal_after_transient_retry_propagates_within_attempt_bound() -> None:
+    """A refusal on the bounded second attempt propagates instead of issuing a third fallback call."""
+    run = _completed_run("run-1")
+    primary = FakeModel(id="summary-model", provider="fake")
+    fallback = FakeModel(id="fallback-model-id", provider="fake")
+    refusal = ModelSafeguardRefusalError("provider-specific refusal wording")
+    generate_summary = AsyncMock(
+        side_effect=[ModelProviderError("temporary provider failure", status_code=503), refusal],
+    )
+    retry_sleep = AsyncMock()
+
+    with (
+        patch("mindroom.history.compaction.generate_compaction_summary", new=generate_summary),
+        patch("mindroom.history.compaction.asyncio.sleep", new=retry_sleep),
+        pytest.raises(ModelSafeguardRefusalError) as raised,
+    ):
+        await _generate_compaction_summary_with_retry(
+            model=primary,
+            model_name="summary-model",
+            previous_summary=None,
+            compactable_runs=[run],
+            initial_summary_input="original request",
+            initial_included_runs=[run],
+            summary_input_budget=4_000,
+            session_id="session-1",
+            scope=_SCOPE,
+            history_settings=_HISTORY_SETTINGS,
+            summary_prompt=COMPACTION_SUMMARY_PROMPT,
+            token_estimator=lambda _value: 2_000,
+            fallback_model=fallback,
+            fallback_model_name="fallback-model",
+        )
+
+    assert raised.value is refusal
+    assert generate_summary.await_count == 2
+    assert [call.kwargs["model"] for call in generate_summary.await_args_list] == [primary, primary]
+    retry_sleep.assert_awaited_once_with(DEFAULT_SUMMARY_RETRY_POLICY.same_input_retry_delay_seconds)
+
+
+@pytest.mark.asyncio
+async def test_compaction_fallback_serves_later_chunks_state_and_outcome(tmp_path: Path) -> None:
+    """After a fallback switch, the fallback serves later chunks and is the reported summary model."""
     config, runtime_paths = _make_config(tmp_path)
     storage = create_session_storage("test_agent", config, runtime_paths, execution_identity=None)
     session = _session(
@@ -1499,11 +1648,12 @@ async def test_compaction_shrinks_input_after_safeguard_refusal(tmp_path: Path) 
     )
     write_scope_state(session, _SCOPE, HistoryScopeState(force_compact_before_next_run=True))
     storage.upsert_session(session)
+    primary = FakeModel(id="summary-model", provider="fake")
+    fallback = FakeModel(id="fallback-model-id", provider="fake")
+    attempts: list[tuple[str, str]] = []
 
-    attempts: list[str] = []
-
-    async def flaky_summary(*, summary_input: str, **_kwargs: object) -> SessionSummary:
-        attempts.append(summary_input)
+    async def flaky_summary(*, model: FakeModel, summary_input: str, **_kwargs: object) -> SessionSummary:
+        attempts.append((model.id, summary_input))
         if len(attempts) == 1:
             msg = "provider-specific refusal wording"
             raise ModelSafeguardRefusalError(msg)
@@ -1521,21 +1671,27 @@ async def test_compaction_shrinks_input_after_safeguard_refusal(tmp_path: Path) 
             history_settings=_HISTORY_SETTINGS,
             available_history_budget=None,
             summary_input_budget=10_000,
-            summary_model=FakeModel(id="summary-model", provider="fake"),
+            summary_model=primary,
             summary_model_name="summary-model",
             replay_window_tokens=64_000,
             threshold_tokens=None,
             summary_prompt=COMPACTION_SUMMARY_PROMPT,
+            fallback_summary_model=fallback,
+            fallback_summary_model_name="fallback-model",
         )
 
     assert outcome is not None
-    assert len(attempts) == 3
-    assert estimate_compaction_input_tokens(attempts[1]) < estimate_compaction_input_tokens(attempts[0])
-    assert attempts[2] != attempts[1]
+    # Chunk 1 refuses on the primary and resends the unchanged prompt and
+    # input to the fallback; chunk 2 goes straight to the fallback.
+    assert [model_id for model_id, _ in attempts] == ["summary-model", "fallback-model-id", "fallback-model-id"]
+    assert attempts[1][1] == attempts[0][1]
+    assert "RUN2-MARKER" in attempts[2][1]
+    assert outcome.summary_model == "fallback-model"
     persisted = get_agent_session(storage, "session-1")
     assert persisted is not None
     assert persisted.summary is not None
     assert persisted.summary.summary == "recovered summary"
+    assert read_scope_state(persisted, _SCOPE).last_summary_model == "fallback-model-id"
     storage.close()
 
 
@@ -1602,8 +1758,8 @@ async def test_minimum_available_budget_can_issue_smaller_degradation_retry(tmp_
     async def flaky_summary(*, summary_input: str, **_kwargs: object) -> SessionSummary:
         attempts.append(summary_input)
         if len(attempts) == 1:
-            message = "provider-specific refusal wording"
-            raise ModelSafeguardRefusalError(message)
+            message = "summary generation returned no result"
+            raise _CompactionSummaryEmptyResultError(message)
         return SessionSummary(summary="recovered summary", updated_at=datetime.now(UTC))
 
     with (

--- a/tests/test_history_compaction_rewrite.py
+++ b/tests/test_history_compaction_rewrite.py
@@ -77,6 +77,8 @@ from tests.history_helpers import (  # noqa: F401
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
     from agno.db.base import BaseDb
     from agno.session.agent import AgentSession
 
@@ -89,13 +91,19 @@ async def _rewrite_single_run(
     working_session: AgentSession,
     selected_run_ids: tuple[str, ...] = ("run-1",),
     summary_input_budget: int = 8_000,
+    summary_model: FakeModel | None = None,
+    fallback_summary_model: FakeModel | None = None,
+    fallback_summary_model_name: str | None = None,
+    progress_callback: Callable[[CompactionLifecycleProgress], Awaitable[None]] | None = None,
 ) -> _CompactionRewriteResult | None:
     return await _rewrite_working_session_for_compaction(
         storage=storage,
         persisted_session=working_session,
         working_session=working_session,
-        summary_model=FakeModel(id="summary-model", provider="fake"),
+        summary_model=summary_model or FakeModel(id="summary-model", provider="fake"),
         summary_model_name="summary-model",
+        fallback_summary_model=fallback_summary_model,
+        fallback_summary_model_name=fallback_summary_model_name,
         session_id=working_session.session_id,
         scope=HistoryScope(kind="agent", scope_id="test_agent"),
         state=HistoryScopeState(force_compact_before_next_run=True),
@@ -108,7 +116,7 @@ async def _rewrite_single_run(
         threshold_tokens=None,
         summary_prompt=COMPACTION_SUMMARY_PROMPT,
         lifecycle_notice_event_id=None,
-        progress_callback=None,
+        progress_callback=progress_callback,
         collect_compaction_hook_messages=False,
     )
 
@@ -266,7 +274,8 @@ async def test_rewrite_retries_summary_with_smaller_chunk_after_output_cap(tmp_p
 
 
 @pytest.mark.asyncio
-async def test_rewrite_retries_safeguard_refusal_with_smaller_chunk(tmp_path: Path) -> None:
+async def test_rewrite_switches_to_fallback_and_uses_it_for_later_chunks(tmp_path: Path) -> None:
+    """A refusal switches once to the fallback; the fallback then serves later chunks and reporting."""
     config, runtime_paths = _make_config(tmp_path)
     storage = create_session_storage("test_agent", config, runtime_paths, execution_identity=None)
     working_session = _session(
@@ -275,25 +284,92 @@ async def test_rewrite_retries_safeguard_refusal_with_smaller_chunk(tmp_path: Pa
             _completed_run(
                 "run-1",
                 messages=[
-                    Message(role="user", content="RUN1-MARKER " + ("u" * 8_000)),
-                    Message(role="assistant", content="a" * 8_000),
+                    Message(role="user", content="RUN1-MARKER " + ("u" * 16_000)),
+                    Message(role="assistant", content="a" * 16_000),
                 ],
             ),
             _completed_run(
                 "run-2",
                 messages=[
-                    Message(role="user", content="RUN2-MARKER " + ("u" * 8_000)),
-                    Message(role="assistant", content="a" * 8_000),
+                    Message(role="user", content="RUN2-MARKER " + ("u" * 16_000)),
+                    Message(role="assistant", content="b" * 16_000),
                 ],
             ),
         ],
     )
+    primary = FakeModel(id="summary-model", provider="fake")
+    fallback = FakeModel(id="fallback-model-id", provider="fake")
     summary_mock = AsyncMock(
         side_effect=[
             ModelSafeguardRefusalError(message="Vertex Claude returned stop_reason=refusal"),
             SessionSummary(summary="first chunk summary", updated_at=datetime.now(UTC)),
             SessionSummary(summary="merged summary", updated_at=datetime.now(UTC)),
         ],
+    )
+    retry_sleep = AsyncMock()
+    progress_events: list[CompactionLifecycleProgress] = []
+
+    async def record_progress(event: CompactionLifecycleProgress) -> None:
+        progress_events.append(event)
+
+    with (
+        patch("mindroom.history.compaction.generate_compaction_summary", new=summary_mock),
+        patch("mindroom.history.compaction.asyncio.sleep", new=retry_sleep),
+        patch(
+            "mindroom.history.compaction.record_compaction_chunk",
+            wraps=record_compaction_chunk,
+        ) as persist_spy,
+        patch(
+            "mindroom.history.compaction._build_summary_input",
+            wraps=_build_summary_input,
+        ) as build_summary_input_spy,
+    ):
+        rewrite_result = await _rewrite_single_run(
+            storage=storage,
+            working_session=working_session,
+            selected_run_ids=("run-1", "run-2"),
+            summary_input_budget=6_000,
+            summary_model=primary,
+            fallback_summary_model=fallback,
+            fallback_summary_model_name="fallback-model",
+            progress_callback=record_progress,
+        )
+
+    assert rewrite_result is not None
+    summary_inputs = [call.kwargs["summary_input"] for call in summary_mock.await_args_list]
+    summary_models = [call.kwargs["model"] for call in summary_mock.await_args_list]
+    assert len(summary_inputs) == 3
+    # The fallback receives the refused first chunk's unchanged summary input.
+    assert summary_inputs[1] == summary_inputs[0]
+    assert summary_models == [primary, fallback, fallback]
+    assert "RUN1-MARKER" in summary_inputs[0]
+    assert "RUN2-MARKER" in summary_inputs[2]
+    retry_sleep.assert_not_awaited()
+    # The second chunk rebuilds its input with the fallback's token estimator.
+    assert build_summary_input_spy.call_args_list[-1].kwargs["token_estimator"].keywords["model_id"] == fallback.id
+    assert [call.kwargs["compacted_run_ids"] for call in persist_spy.call_args_list] == [
+        ("run-1",),
+        ("run-2",),
+    ]
+    assert rewrite_result.compacted_run_ids == ("run-1", "run-2")
+    assert rewrite_result.summary_model is fallback
+    assert rewrite_result.summary_model_name == "fallback-model"
+    assert [event.summary_model for event in progress_events] == ["fallback-model"]
+    persisted = get_agent_session(storage, "session-1")
+    assert persisted is not None
+    assert persisted.summary is not None
+    assert persisted.summary.summary == "merged summary"
+    assert persisted.runs == []
+
+
+@pytest.mark.asyncio
+async def test_rewrite_propagates_fallback_refusal_without_persisting(tmp_path: Path) -> None:
+    """A refusing fallback propagates after its single unchanged-input attempt."""
+    config, runtime_paths = _make_config(tmp_path)
+    storage = create_session_storage("test_agent", config, runtime_paths, execution_identity=None)
+    working_session = _session("session-1", runs=[_completed_run("run-1")])
+    summary_mock = AsyncMock(
+        side_effect=ModelSafeguardRefusalError(message="Vertex Claude returned stop_reason=refusal"),
     )
     retry_sleep = AsyncMock()
 
@@ -304,34 +380,22 @@ async def test_rewrite_retries_safeguard_refusal_with_smaller_chunk(tmp_path: Pa
             "mindroom.history.compaction.record_compaction_chunk",
             wraps=record_compaction_chunk,
         ) as persist_spy,
+        pytest.raises(ModelSafeguardRefusalError),
     ):
-        rewrite_result = await _rewrite_single_run(
+        await _rewrite_single_run(
             storage=storage,
             working_session=working_session,
-            selected_run_ids=("run-1", "run-2"),
-            summary_input_budget=12_000,
+            fallback_summary_model=FakeModel(id="fallback-model-id", provider="fake"),
+            fallback_summary_model_name="fallback-model",
         )
 
-    assert rewrite_result is not None
+    assert summary_mock.await_count == 2
     summary_inputs = [call.kwargs["summary_input"] for call in summary_mock.await_args_list]
-    assert len(summary_inputs) == 3
-    assert "RUN1-MARKER" in summary_inputs[0]
-    assert "RUN2-MARKER" in summary_inputs[0]
-    assert estimate_text_tokens(summary_inputs[1]) < estimate_text_tokens(summary_inputs[0])
-    assert "RUN1-MARKER" in summary_inputs[1]
-    assert "RUN2-MARKER" not in summary_inputs[1]
-    assert "RUN2-MARKER" in summary_inputs[2]
+    assert summary_inputs[1] == summary_inputs[0]
     retry_sleep.assert_not_awaited()
-    assert [call.kwargs["compacted_run_ids"] for call in persist_spy.call_args_list] == [
-        ("run-1",),
-        ("run-2",),
-    ]
-    assert rewrite_result.compacted_run_ids == ("run-1", "run-2")
-    persisted = get_agent_session(storage, "session-1")
-    assert persisted is not None
-    assert persisted.summary is not None
-    assert persisted.summary.summary == "merged summary"
-    assert persisted.runs == []
+    persist_spy.assert_not_called()
+    assert working_session.summary is None
+    assert [run.run_id for run in working_session.runs or []] == ["run-1"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_history_prepare_lifecycle.py
+++ b/tests/test_history_prepare_lifecycle.py
@@ -17,6 +17,7 @@ from agno.session.summary import SessionSummary
 
 from mindroom.agent_storage import create_session_storage, get_agent_session
 from mindroom.config.models import CompactionOverrideConfig
+from mindroom.error_handling import ModelSafeguardRefusalError
 from mindroom.execution_preparation import (
     _prepare_bound_team_execution_context,
     prepare_agent_execution_context,
@@ -1049,6 +1050,128 @@ async def test_prepare_history_for_run_persists_successful_compaction_chunks_bef
     assert summary_mock.await_count == 2
     assert read_scope_state(persisted, scope).force_compact_before_next_run is False
     assert prepared.compaction_outcomes == []
+
+
+@pytest.mark.asyncio
+async def test_prepare_history_for_run_failure_notice_reports_serving_fallback_model(
+    tmp_path: Path,
+) -> None:
+    """A chunk-2 failure after a fallback-served chunk 1 reports the fallback, not the primary."""
+    config, runtime_paths = _make_config(
+        tmp_path,
+        compaction=CompactionOverrideConfig(enabled=True),
+        context_window=64_000,
+    )
+    storage = create_session_storage("test_agent", config, runtime_paths, execution_identity=None)
+    session = _session(
+        "session-1",
+        runs=[
+            _completed_run(
+                "run-1",
+                messages=[
+                    Message(role="user", content="u" * 200),
+                    Message(role="assistant", content="a" * 200),
+                ],
+            ),
+            _completed_run(
+                "run-2",
+                messages=[
+                    Message(role="user", content="v" * 200),
+                    Message(role="assistant", content="b" * 200),
+                ],
+            ),
+        ],
+    )
+    scope = HistoryScope(kind="agent", scope_id="test_agent")
+    write_scope_state(session, scope, HistoryScopeState(force_compact_before_next_run=True))
+    storage.upsert_session(session)
+    visible_runs = list(session.runs or [])
+    first_summary_text = "first chunk summary"
+
+    summary_input_budget = next(
+        budget
+        for budget in range(1, 10_000)
+        if len(
+            _build_summary_input(
+                previous_summary=None,
+                compacted_runs=visible_runs,
+                max_input_tokens=budget,
+                history_settings=_ALL_HISTORY_SETTINGS,
+            )[1],
+        )
+        == 1
+        and len(
+            _build_summary_input(
+                previous_summary=first_summary_text,
+                compacted_runs=visible_runs[1:],
+                max_input_tokens=budget,
+                history_settings=_ALL_HISTORY_SETTINGS,
+            )[1],
+        )
+        == 1
+    )
+    execution_plan = ResolvedHistoryExecutionPlan(
+        authored_compaction_enabled=True,
+        destructive_compaction_available=True,
+        explicit_compaction_model=True,
+        compaction_model_name="summary-model",
+        compaction_context_window=4_096,
+        replay_window_tokens=64_000,
+        trigger_threshold_tokens=1,
+        reserve_tokens=0,
+        static_prompt_tokens=0,
+        replay_budget_tokens=1,
+        hard_replay_budget_tokens=1,
+        summary_input_budget_tokens=summary_input_budget,
+        compaction_fallback_model_name="fallback-model",
+    )
+    # Chunk 1: primary refuses, the fallback serves the retry; chunk 2 then
+    # fails hard on the fallback.
+    summary_mock = AsyncMock(
+        side_effect=[
+            ModelSafeguardRefusalError("provider-specific refusal wording"),
+            SessionSummary(summary=first_summary_text, updated_at=datetime.now(UTC)),
+            RuntimeError("summary failed"),
+        ],
+    )
+    lifecycle = RecordingCompactionLifecycle()
+
+    with (
+        patch(
+            "mindroom.model_loading.get_model_instance",
+            side_effect=lambda _config, _paths, name, **_kwargs: FakeModel(id=f"{name}-id", provider="fake"),
+        ),
+        patch(
+            "mindroom.history.compaction.generate_compaction_summary",
+            new=summary_mock,
+        ),
+    ):
+        await prepare_history_for_run_for_test(
+            agent=_agent(db=storage),
+            agent_name="test_agent",
+            full_prompt="Current prompt",
+            session_id="session-1",
+            runtime_paths=runtime_paths,
+            config=config,
+            execution_identity=None,
+            storage=storage,
+            session=session,
+            execution_plan=execution_plan,
+            compaction_lifecycle=lifecycle,
+        )
+
+    assert summary_mock.await_count == 3
+    start_events = [event for event in lifecycle.events if isinstance(event, CompactionLifecycleStart)]
+    assert [event.summary_model for event in start_events] == ["summary-model"]
+    progress_events = [event for event in lifecycle.events if isinstance(event, CompactionLifecycleProgress)]
+    assert [event.summary_model for event in progress_events] == ["fallback-model"]
+    failure_events = [event for event in lifecycle.events if isinstance(event, CompactionLifecycleFailure)]
+    assert [event.summary_model for event in failure_events] == ["fallback-model"]
+    persisted = get_agent_session(storage, "session-1")
+    assert persisted is not None
+    assert persisted.summary is not None
+    assert persisted.summary.summary == first_summary_text
+    assert [run.run_id for run in persisted.runs or []] == ["run-2"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_history_prepare_lifecycle.py
+++ b/tests/test_history_prepare_lifecycle.py
@@ -1175,6 +1175,86 @@ async def test_prepare_history_for_run_failure_notice_reports_serving_fallback_m
 
 
 @pytest.mark.asyncio
+async def test_prepare_history_for_run_compacts_on_primary_when_fallback_construction_fails(
+    tmp_path: Path,
+) -> None:
+    """A fallback that fails to load is logged and unavailable; the healthy primary still compacts."""
+    config, runtime_paths = _make_config(
+        tmp_path,
+        compaction=CompactionOverrideConfig(enabled=True),
+        context_window=64_000,
+    )
+    storage = create_session_storage("test_agent", config, runtime_paths, execution_identity=None)
+    session = _session("session-1", runs=[_completed_run("run-1")])
+    scope = HistoryScope(kind="agent", scope_id="test_agent")
+    write_scope_state(session, scope, HistoryScopeState(force_compact_before_next_run=True))
+    storage.upsert_session(session)
+    execution_plan = ResolvedHistoryExecutionPlan(
+        authored_compaction_enabled=True,
+        destructive_compaction_available=True,
+        explicit_compaction_model=True,
+        compaction_model_name="summary-model",
+        compaction_context_window=4_096,
+        replay_window_tokens=64_000,
+        trigger_threshold_tokens=1,
+        reserve_tokens=0,
+        static_prompt_tokens=0,
+        replay_budget_tokens=1,
+        hard_replay_budget_tokens=1,
+        summary_input_budget_tokens=16_000,
+        compaction_fallback_model_name="fallback-model",
+    )
+
+    def _load_model(_config: object, _paths: object, name: str = "default", **_kwargs: object) -> FakeModel:
+        if name == "fallback-model":
+            message = "fallback provider SDK unavailable"
+            raise RuntimeError(message)
+        return FakeModel(id=f"{name}-id", provider="fake")
+
+    summary_mock = AsyncMock(
+        return_value=SessionSummary(summary="primary summary", updated_at=datetime.now(UTC)),
+    )
+    lifecycle = RecordingCompactionLifecycle()
+
+    with (
+        patch("mindroom.model_loading.get_model_instance", side_effect=_load_model),
+        patch("mindroom.history.compaction.generate_compaction_summary", new=summary_mock),
+        patch("mindroom.history.runtime.logger.warning") as warning_mock,
+    ):
+        prepared = await prepare_history_for_run_for_test(
+            agent=_agent(db=storage),
+            agent_name="test_agent",
+            full_prompt="Current prompt",
+            session_id="session-1",
+            runtime_paths=runtime_paths,
+            config=config,
+            execution_identity=None,
+            storage=storage,
+            session=session,
+            execution_plan=execution_plan,
+            compaction_lifecycle=lifecycle,
+        )
+
+    assert len(prepared.compaction_outcomes) == 1
+    assert prepared.compaction_outcomes[0].summary_model == "summary-model"
+    assert summary_mock.await_count == 1
+    assert summary_mock.await_args.kwargs["model"].id == "summary-model-id"
+    fallback_warnings = [
+        call
+        for call in warning_mock.call_args_list
+        if call.args[0] == "Compaction fallback model failed to load; continuing without a fallback"
+    ]
+    assert len(fallback_warnings) == 1
+    assert fallback_warnings[0].kwargs["fallback_model"] == "fallback-model"
+    assert not any(isinstance(event, CompactionLifecycleFailure) for event in lifecycle.events)
+    persisted = get_agent_session(storage, "session-1")
+    assert persisted is not None
+    assert persisted.summary is not None
+    assert persisted.summary.summary == "primary summary"
+    assert read_scope_state(persisted, scope).last_summary_model == "summary-model-id"
+
+
+@pytest.mark.asyncio
 async def test_prepare_history_for_run_reuses_completed_auto_compaction(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_history_replay_planning.py
+++ b/tests/test_history_replay_planning.py
@@ -740,38 +740,49 @@ def test_compaction_fallback_is_distinct_guards_same_alias_and_same_target(tmp_p
         _runtime_paths(tmp_path),
     )
 
-    assert (
-        _compaction_fallback_is_distinct(
-            config,
-            primary_model_name="summary-model",
-            fallback_model_name="summary-model",
+    with patch("mindroom.history.runtime.logger.warning") as warning_mock:
+        assert (
+            _compaction_fallback_is_distinct(
+                config,
+                primary_model_name="summary-model",
+                fallback_model_name="summary-model",
+            )
+            is False
         )
-        is False
-    )
-    assert (
-        _compaction_fallback_is_distinct(
-            config,
-            primary_model_name="summary-model",
-            fallback_model_name="summary-model-alias",
+        assert (
+            _compaction_fallback_is_distinct(
+                config,
+                primary_model_name="summary-model",
+                fallback_model_name="summary-model-alias",
+            )
+            is False
         )
-        is False
-    )
-    assert (
-        _compaction_fallback_is_distinct(
-            config,
-            primary_model_name="vertex-summary",
-            fallback_model_name="vertex-summary-spelling-variant",
+        assert (
+            _compaction_fallback_is_distinct(
+                config,
+                primary_model_name="vertex-summary",
+                fallback_model_name="vertex-summary-spelling-variant",
+            )
+            is False
         )
-        is False
-    )
-    assert (
-        _compaction_fallback_is_distinct(
-            config,
-            primary_model_name="summary-model",
-            fallback_model_name="fallback-model",
+        assert (
+            _compaction_fallback_is_distinct(
+                config,
+                primary_model_name="summary-model",
+                fallback_model_name="fallback-model",
+            )
+            is True
         )
-        is True
+
+    assert warning_mock.call_count == 3
+    assert all(
+        call.args[0] == "Compaction fallback resolves to the primary serving model; continuing without a fallback"
+        for call in warning_mock.call_args_list
     )
+    assert warning_mock.call_args_list[0].kwargs == {
+        "compaction_model": "summary-model",
+        "fallback_model": "summary-model",
+    }
 
 
 def test_resolve_history_execution_plan_uses_compaction_model_window_only_for_summary_budget(

--- a/tests/test_history_replay_planning.py
+++ b/tests/test_history_replay_planning.py
@@ -25,6 +25,7 @@ from mindroom.history.policy import (
     resolve_history_execution_plan,
 )
 from mindroom.history.runtime import (
+    _compaction_fallback_is_distinct,
     _plan_replay_that_fits,
     apply_replay_plan,
 )
@@ -599,6 +600,157 @@ def test_resolved_compaction_config_inherits_disabled_defaults_for_pure_model_cl
 
     assert compaction_config.enabled is False
     assert compaction_config.model is None
+
+
+def test_validate_compaction_fallback_model_rejects_unknown_model(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(tmp_path)
+
+    with pytest.raises(
+        ValueError,
+        match=r"Compaction model references unknown models: agents\.test_agent\.compaction\.fallback_model -> missing-model",
+    ):
+        bind_runtime_paths(
+            Config(
+                agents={
+                    "test_agent": AgentConfig(
+                        display_name="Test Agent",
+                        compaction=CompactionOverrideConfig(fallback_model="missing-model"),
+                    ),
+                },
+                defaults=DefaultsConfig(tools=[]),
+                models={
+                    "default": ModelConfig(provider="openai", id="test-model", context_window=48_000),
+                },
+            ),
+            runtime_paths,
+        )
+
+
+def test_validate_compaction_fallback_model_rejects_missing_context_window(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(tmp_path)
+
+    with pytest.raises(
+        ValueError,
+        match=r"context_window: defaults\.compaction\.fallback_model -> fallback-model",
+    ):
+        bind_runtime_paths(
+            Config(
+                defaults=DefaultsConfig(
+                    tools=[],
+                    compaction=CompactionConfig(fallback_model="fallback-model"),
+                ),
+                models={
+                    "default": ModelConfig(provider="openai", id="test-model", context_window=48_000),
+                    "fallback-model": ModelConfig(provider="openai", id="fallback-model-id", context_window=None),
+                },
+            ),
+            runtime_paths,
+        )
+
+
+def _fallback_inheritance_config(tmp_path: Path, *, override: CompactionOverrideConfig) -> Config:
+    return bind_runtime_paths(
+        Config(
+            agents={
+                "test_agent": AgentConfig(display_name="Test Agent", compaction=override),
+            },
+            defaults=DefaultsConfig(
+                tools=[],
+                compaction=CompactionConfig(
+                    enabled=False,
+                    model="summary-model",
+                    fallback_model="fallback-model",
+                ),
+            ),
+            models={
+                "default": ModelConfig(provider="openai", id="test-model", context_window=48_000),
+                "summary-model": ModelConfig(provider="openai", id="summary-model-id", context_window=32_000),
+                "fallback-model": ModelConfig(provider="openai", id="fallback-model-id", context_window=32_000),
+            },
+        ),
+        _runtime_paths(tmp_path),
+    )
+
+
+def test_resolved_compaction_config_inherits_fallback_model_from_defaults(tmp_path: Path) -> None:
+    config = _fallback_inheritance_config(tmp_path, override=CompactionOverrideConfig(enabled=True))
+
+    compaction_config = config.resolve_entity("test_agent").compaction_config
+
+    assert compaction_config.enabled is True
+    assert compaction_config.model == "summary-model"
+    assert compaction_config.fallback_model == "fallback-model"
+
+
+def test_resolved_compaction_config_inherits_disabled_defaults_for_pure_model_field_clears(tmp_path: Path) -> None:
+    """Clearing only inherited model fields must not statically enable compaction."""
+    for override in (
+        CompactionOverrideConfig(fallback_model=None),
+        CompactionOverrideConfig(model=None, fallback_model=None),
+    ):
+        config = _fallback_inheritance_config(tmp_path, override=override)
+
+        compaction_config = config.resolve_entity("test_agent").compaction_config
+
+        assert compaction_config.enabled is False
+        assert compaction_config.fallback_model is None
+
+
+def test_resolve_history_execution_plan_carries_fallback_model_name(tmp_path: Path) -> None:
+    config = _fallback_inheritance_config(tmp_path, override=CompactionOverrideConfig(enabled=True))
+
+    execution_plan = resolve_history_execution_plan(
+        config=config,
+        compaction_config=config.resolve_entity("test_agent").compaction_config,
+        has_authored_compaction_config=True,
+        active_model_name="default",
+        active_context_window=48_000,
+        static_prompt_tokens=1_000,
+    )
+
+    assert execution_plan.compaction_model_name == "summary-model"
+    assert execution_plan.compaction_fallback_model_name == "fallback-model"
+
+
+def test_compaction_fallback_is_distinct_guards_same_alias_and_same_target(tmp_path: Path) -> None:
+    """A fallback naming the primary alias or the same (provider, id) target is never loaded."""
+    config = bind_runtime_paths(
+        Config(
+            defaults=DefaultsConfig(tools=[]),
+            models={
+                "default": ModelConfig(provider="openai", id="test-model", context_window=48_000),
+                "summary-model": ModelConfig(provider="openai", id="summary-model-id", context_window=32_000),
+                "summary-model-alias": ModelConfig(provider="openai", id="summary-model-id", context_window=32_000),
+                "fallback-model": ModelConfig(provider="anthropic", id="summary-model-id", context_window=32_000),
+            },
+        ),
+        _runtime_paths(tmp_path),
+    )
+
+    assert (
+        _compaction_fallback_is_distinct(
+            config,
+            primary_model_name="summary-model",
+            fallback_model_name="summary-model",
+        )
+        is False
+    )
+    assert (
+        _compaction_fallback_is_distinct(
+            config,
+            primary_model_name="summary-model",
+            fallback_model_name="summary-model-alias",
+        )
+        is False
+    )
+    assert (
+        _compaction_fallback_is_distinct(
+            config,
+            primary_model_name="summary-model",
+            fallback_model_name="fallback-model",
+        )
+        is True
+    )
 
 
 def test_resolve_history_execution_plan_uses_compaction_model_window_only_for_summary_budget(

--- a/tests/test_history_replay_planning.py
+++ b/tests/test_history_replay_planning.py
@@ -473,7 +473,7 @@ def test_validate_compaction_model_references_rejects_explicit_model_without_con
 
     with pytest.raises(
         ValueError,
-        match=r"Explicit compaction\.model requires a model with context_window: agents\.test_agent\.compaction\.model -> summary-model",
+        match=r"Explicit compaction model references require a model with context_window: agents\.test_agent\.compaction\.model -> summary-model",
     ):
         bind_runtime_paths(
             Config(
@@ -508,7 +508,7 @@ def test_validate_compaction_model_references_rejects_disabled_explicit_model_wi
 
     with pytest.raises(
         ValueError,
-        match=r"Explicit compaction\.model requires a model with context_window",
+        match=r"Explicit compaction model references require a model with context_window",
     ):
         bind_runtime_paths(
             Config(
@@ -713,7 +713,7 @@ def test_resolve_history_execution_plan_carries_fallback_model_name(tmp_path: Pa
 
 
 def test_compaction_fallback_is_distinct_guards_same_alias_and_same_target(tmp_path: Path) -> None:
-    """A fallback naming the primary alias or the same (provider, id) target is never loaded."""
+    """A fallback naming the primary alias or the same canonical (provider, id) target is never loaded."""
     config = bind_runtime_paths(
         Config(
             defaults=DefaultsConfig(tools=[]),
@@ -722,6 +722,19 @@ def test_compaction_fallback_is_distinct_guards_same_alias_and_same_target(tmp_p
                 "summary-model": ModelConfig(provider="openai", id="summary-model-id", context_window=32_000),
                 "summary-model-alias": ModelConfig(provider="openai", id="summary-model-id", context_window=32_000),
                 "fallback-model": ModelConfig(provider="anthropic", id="summary-model-id", context_window=32_000),
+                "vertex-summary": ModelConfig(
+                    provider="vertexai_claude",
+                    id="claude-sonnet-5",
+                    context_window=32_000,
+                ),
+                # Same serving model as vertex-summary; the provider spelling
+                # differs only by hyphenation and case, which model loading
+                # canonicalizes away.
+                "vertex-summary-spelling-variant": ModelConfig(
+                    provider="Vertexai-Claude",
+                    id="claude-sonnet-5",
+                    context_window=32_000,
+                ),
             },
         ),
         _runtime_paths(tmp_path),
@@ -740,6 +753,14 @@ def test_compaction_fallback_is_distinct_guards_same_alias_and_same_target(tmp_p
             config,
             primary_model_name="summary-model",
             fallback_model_name="summary-model-alias",
+        )
+        is False
+    )
+    assert (
+        _compaction_fallback_is_distinct(
+            config,
+            primary_model_name="vertex-summary",
+            fallback_model_name="vertex-summary-spelling-variant",
         )
         is False
     )


### PR DESCRIPTION
## Summary

Production evidence showed that the compaction incident is a content safeguard refusal, not a size failure:

- Vertex Claude Fable 5 returns `stop_reason=refusal` with category `reasoning_extraction`.
- Shrinking from the original packed chunk to a smaller complete-run chunk still refused.
- Vertex Claude Opus 4.8 successfully summarized the same prompt and input bytes.

This PR adds an optional inherited `compaction.fallback_model` at the compaction call boundary.

On a typed safeguard refusal, MindRoom sends the unchanged summary prompt and input to one distinct configured fallback model.
The fallback shares the existing two-attempt bound.
Refusals are no longer treated as size evidence, while genuine context/size errors keep the existing bounded shrink behavior.
After fallback success, later chunks use the fallback model and its estimator, and progress, logs, outcomes, and persisted state report the actual serving model.
No persistence occurs before a valid summary.

Same-name fallbacks and different aliases resolving to the same `(provider, id)` are ignored.
If no distinct fallback is configured, or the fallback fails, the existing bounded degradation path preserves the session and lets the reply continue.

This supersedes the closed abort-only #1587 while preserving the valid protections merged in #1582 and #1588.

## Live production-copy proof

The fallback driver in implementation commit `f9078a600` was exercised against a read-only copy of the actual production `openclaw` session with the real Vertex models:

- Reconstructed known refused input: `181,876` UTF-8 bytes, SHA-256 `90924bdec2a8b0d6635ab07c789b532673a8f1159bf4ef51ea54a5824780ff61`.
- Exact provider token count from the prior independent probe: `90,873`.
- Attempt 1: `claude-fable-5` refused in 2.4 seconds.
- Attempt 2: `claude-opus-4-8` received the same `181,876` input bytes and same `1,155` prompt bytes.
- Opus succeeded in 60.3 seconds with a valid `11,487`-character summary.
- Driver result: exactly two calls, serving model `opus` / `claude-opus-4-8`, `unchanged_prompt_and_input=true`.
- Production source DB SHA-256 was identical before and after the probe.
- The probe used commit `f9078a600` from an isolated `/tmp` clone and the sandbox was removed afterward.

No conversation content was printed or saved by the probe.

Follow-up commit `b28da8a50` does not change the provider-call driver.
It canonicalizes provider aliases for the same-target guard, carries the already-reported serving model into later lifecycle failures, and generalizes validation wording, each with a focused regression.

## Verification

- Focused compaction/config backend tests: pass.
- Full `pytest -n 0 -q` on the provider-driver implementation commit: pass.
- Focused compaction, lifecycle, config, and model-loading suites on follow-up commit `b28da8a50`: pass.
- Default parallel full suite: one run passed; two later runs each hit the same unrelated xdist timing flake in `test_stuck_drain_warns_then_forces_reload`.
- The unrelated test passed 15/15 in isolation and its full file passed 15/15.
- `uv run pre-commit run --all-files`: pass.
- `uv run tach check --dependencies --interfaces`: pass.
- Frontend typecheck: pass.
- Frontend config-store tests: 101/101 pass.
- Agent/Team editor tests: 103/103 pass.

## Review-sensitive invariants

- Total provider calls remain bounded to two, including mixed transient/shrink-then-refusal sequences.
- The fallback changes only the target model; summary prompt/input bytes, included runs, and budget remain unchanged.
- A fallback refusal or failure does not trigger another retry.
- Oversized-run excerpt behavior is intentionally unchanged.
- Existing context/size shrinking and one same-input transient retry are unchanged.
