### PR TITLE
Preserve requester identity during restart auto-resume

### DIFF
--- a/src/mindroom/dispatch_source.py
+++ b/src/mindroom/dispatch_source.py
@@ -25,6 +25,9 @@ HOOK_DISPATCH_SOURCE_KIND = "hook_dispatch"
 EXTERNAL_TRIGGER_SOURCE_KIND = "external_trigger"
 ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND = "active_thread_follow_up"
 TRUSTED_INTERNAL_RELAY_SOURCE_KIND = "trusted_internal_relay"
+AUTO_RESUME_MESSAGE = (
+    "[System: Previous response was interrupted by service restart. Please continue where you left off.]"
+)
 _KNOWN_SOURCE_KINDS: frozenset[str] = frozenset(
     {
         MESSAGE_SOURCE_KIND,
@@ -183,6 +186,11 @@ def is_visible_router_voice_echo_content(content: object) -> bool:
     if not isinstance(content, Mapping):
         return False
     return cast("Mapping[str, object]", content).get(VISIBLE_ROUTER_VOICE_ECHO_KEY) is True
+
+
+def is_auto_resume_relay_body(body: object) -> bool:
+    """Return whether one message body is the restart auto-resume relay."""
+    return isinstance(body, str) and AUTO_RESUME_MESSAGE in body
 
 
 def _trusted_source_kind_from_event_content(

--- a/src/mindroom/ingress_validation.py
+++ b/src/mindroom/ingress_validation.py
@@ -16,6 +16,7 @@ from mindroom.dispatch_source import (
     MEDIA_SOURCE_KIND,
     TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
     VOICE_SOURCE_KIND,
+    is_auto_resume_relay_body,
     is_visible_router_voice_echo_content,
     is_voice_event,
     source_kind_allows_self_authored_ingress,
@@ -199,6 +200,8 @@ class IngressValidator:
             return None
         content = event.source.get("content") if isinstance(event.source, dict) else None
         if not isinstance(content, dict):
+            return None
+        if is_auto_resume_relay_body(content.get("body")):
             return None
         relates_to = content.get("m.relates_to")
         if isinstance(relates_to, dict) and relates_to.get("is_falling_back") is True:

--- a/src/mindroom/matrix/stale_stream_cleanup.py
+++ b/src/mindroom/matrix/stale_stream_cleanup.py
@@ -24,7 +24,11 @@ from mindroom.constants import (
     STREAM_VISIBLE_BODY_KEY,
     STREAM_WARMUP_SUFFIX_KEY,
 )
-from mindroom.dispatch_source import TRUSTED_INTERNAL_RELAY_SOURCE_KIND
+from mindroom.dispatch_source import (
+    AUTO_RESUME_MESSAGE,
+    TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
+    is_auto_resume_relay_body,
+)
 from mindroom.entity_resolution import (
     MissingManagedEntityAccountError,
     current_entity_id,
@@ -84,9 +88,6 @@ _STOP_REACTION_KEYS = frozenset({"🛑", "⏹️"})
 _MAX_REQUESTER_RESOLUTION_DEPTH = 10
 _MAX_EXTRA_INTERRUPTED_HISTORY_PAGES = 10
 _INTERRUPTED_PARTIAL_TEXT_LIMIT = 280
-_AUTO_RESUME_MESSAGE = (
-    "[System: Previous response was interrupted by service restart. Please continue where you left off.]"
-)
 _TERMINAL_STREAM_STATUSES = frozenset(
     {STREAM_STATUS_CANCELLED, STREAM_STATUS_COMPLETED, STREAM_STATUS_ERROR, STREAM_STATUS_INTERRUPTED},
 )
@@ -472,6 +473,8 @@ def _later_thread_activity_is_internal(
         if not message.sender:
             msg = "Thread history contains a message without a trustworthy sender"
             raise ValueError(msg)
+        if message.sender in internal_sender_ids and is_auto_resume_relay_body(message.body):
+            continue
         effective_requester = _effective_requester_for_message(
             message,
             config=config,
@@ -861,7 +864,7 @@ def _auto_resume_target_event_ids(
     """Return interrupted event IDs that already have a queued auto-resume relay."""
     target_event_ids: set[str] = set()
     for message in messages:
-        if message.sender not in bot_user_ids or _AUTO_RESUME_MESSAGE not in message.body:
+        if message.sender not in bot_user_ids or not is_auto_resume_relay_body(message.body):
             continue
         reply_to_event_id = message.reply_to_event_id
         if reply_to_event_id is not None:
@@ -1833,13 +1836,13 @@ def _build_auto_resume_content(
     target_user_id = _current_configured_entity_user_id(interrupted_thread.agent_name, config, runtime_paths)
     display_name = _entity_display_name(interrupted_thread.agent_name, config)
 
-    body = _AUTO_RESUME_MESSAGE
+    body = AUTO_RESUME_MESSAGE
     formatted_body: str | None = None
     mentioned_user_ids: list[str] | None = None
     if target_user_id is not None:
-        body = f"@{display_name} {_AUTO_RESUME_MESSAGE}"
+        body = f"@{display_name} {AUTO_RESUME_MESSAGE}"
         formatted_body = markdown_to_html(
-            f"[@{display_name}](https://matrix.to/#/{target_user_id}) {_AUTO_RESUME_MESSAGE}",
+            f"[@{display_name}](https://matrix.to/#/{target_user_id}) {AUTO_RESUME_MESSAGE}",
         )
         mentioned_user_ids = [target_user_id]
 

--- a/src/mindroom/matrix/stale_stream_cleanup.py
+++ b/src/mindroom/matrix/stale_stream_cleanup.py
@@ -13,6 +13,7 @@ from nio.api import RelationshipType
 from mindroom.authorization import get_effective_sender_id_for_reply_permissions
 from mindroom.constants import (
     ORIGINAL_SENDER_KEY,
+    SOURCE_KIND_KEY,
     STREAM_STATUS_CANCELLED,
     STREAM_STATUS_COMPLETED,
     STREAM_STATUS_ERROR,
@@ -23,6 +24,7 @@ from mindroom.constants import (
     STREAM_VISIBLE_BODY_KEY,
     STREAM_WARMUP_SUFFIX_KEY,
 )
+from mindroom.dispatch_source import TRUSTED_INTERNAL_RELAY_SOURCE_KIND
 from mindroom.entity_resolution import (
     MissingManagedEntityAccountError,
     current_entity_id,
@@ -323,6 +325,14 @@ async def _auto_resume_interrupted_threads(
     resumed_count = 0
     delay_due = delay_before_first
     for interrupted_thread in candidate_threads:
+        if interrupted_thread.original_sender_id is None:
+            logger.warning(
+                "Skipping auto-resume because requester identity could not be resolved",
+                room_id=interrupted_thread.room_id,
+                thread_id=interrupted_thread.thread_id,
+                target_event_id=interrupted_thread.target_event_id,
+            )
+            continue
         if not await _interrupted_target_remains_latest_human_work(
             interrupted_thread,
             config=config,
@@ -1833,11 +1843,12 @@ def _build_auto_resume_content(
         )
         mentioned_user_ids = [target_user_id]
 
-    extra_content = (
-        {ORIGINAL_SENDER_KEY: interrupted_thread.original_sender_id}
-        if interrupted_thread.original_sender_id is not None
-        else None
-    )
+    extra_content = None
+    if interrupted_thread.original_sender_id is not None:
+        extra_content = {
+            SOURCE_KIND_KEY: TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
+            ORIGINAL_SENDER_KEY: interrupted_thread.original_sender_id,
+        }
     return build_message_content(
         body=body,
         formatted_body=formatted_body,

--- a/tests/test_ingress_validation.py
+++ b/tests/test_ingress_validation.py
@@ -1,0 +1,82 @@
+"""Focused tests for requester identity resolution at ingress."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+from mindroom.bot_runtime_view import BotRuntimeState
+from mindroom.config.main import Config
+from mindroom.constants import ORIGINAL_SENDER_KEY, SOURCE_KIND_KEY
+from mindroom.dispatch_source import TRUSTED_INTERNAL_RELAY_SOURCE_KIND
+from mindroom.ingress_validation import IngressValidator, IngressValidatorDeps
+from mindroom.matrix import stale_stream_cleanup
+from tests.conftest import bind_runtime_paths, runtime_paths_for, test_runtime_paths
+from tests.identity_helpers import entity_ids
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from mindroom.turn_policy import TurnPolicy
+    from mindroom.turn_store import TurnStore
+
+
+def test_auto_resume_relay_resolves_requester_to_original_human(tmp_path: Path) -> None:
+    """Router-authored auto-resume should preserve human requester without trusting outsiders."""
+    config = bind_runtime_paths(
+        Config(
+            agents={"test_agent": {"display_name": "Test Agent"}},
+            models={"default": {"provider": "test", "id": "test-model"}},
+            authorization={"default_room_access": True},
+        ),
+        test_runtime_paths(tmp_path),
+    )
+    runtime_paths = runtime_paths_for(config)
+    ids = entity_ids(config, runtime_paths)
+    human_sender = "@human:localhost"
+    content = stale_stream_cleanup._build_auto_resume_content(
+        stale_stream_cleanup._InterruptedThread(
+            room_id="!room:localhost",
+            thread_id="$thread",
+            target_event_id="$target",
+            partial_text="partial",
+            agent_name="test_agent",
+            original_sender_id=human_sender,
+        ),
+        config=config,
+        runtime_paths=runtime_paths,
+    )
+    runtime = BotRuntimeState(
+        client=None,
+        config=config,
+        runtime_paths=runtime_paths,
+        enable_streaming=False,
+        orchestrator=None,
+        event_cache=None,
+        event_cache_write_coordinator=None,
+    )
+    validator = IngressValidator(
+        IngressValidatorDeps(
+            runtime=runtime,
+            runtime_paths=runtime_paths,
+            matrix_id=ids["test_agent"],
+            turn_store=cast("TurnStore", object()),
+            turn_policy=cast("TurnPolicy", object()),
+        ),
+    )
+
+    assert content[ORIGINAL_SENDER_KEY] == human_sender
+    assert content[SOURCE_KIND_KEY] == TRUSTED_INTERNAL_RELAY_SOURCE_KIND
+    assert (
+        validator.requester_user_id(
+            sender=ids["router"].full_id,
+            source={"content": content},
+        )
+        == human_sender
+    )
+    assert (
+        validator.requester_user_id(
+            sender="@untrusted:localhost",
+            source={"content": content},
+        )
+        == "@untrusted:localhost"
+    )

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -781,10 +781,34 @@ async def test_auto_resume_sends_correctly_threaded_messages(tmp_path: Path) -> 
     assert first_content["m.relates_to"]["event_id"] == "$thread-one"
     assert first_content["m.relates_to"]["m.in_reply_to"] == {"event_id": "$target-one"}
     assert first_content[ORIGINAL_SENDER_KEY] == USER_ID
+    assert first_content[SOURCE_KIND_KEY] == TRUSTED_INTERNAL_RELAY_SOURCE_KIND
     assert second_content["body"] == f"@Test Agent {AUTO_RESUME_MESSAGE}"
     assert second_content["m.relates_to"]["event_id"] == "$thread-two"
     assert second_content[ORIGINAL_SENDER_KEY] == USER_ID
+    assert second_content[SOURCE_KIND_KEY] == TRUSTED_INTERNAL_RELAY_SOURCE_KIND
     mock_sleep.assert_awaited_once_with(2.0)
+
+
+@pytest.mark.asyncio
+async def test_auto_resume_skips_interruption_without_resolved_requester(tmp_path: Path) -> None:
+    """Auto-resume should fail closed when restart recovery cannot resolve requester identity."""
+    config = _make_config(tmp_path)
+    client = AsyncMock(spec=nio.AsyncClient)
+    interrupted = [
+        InterruptedThread(ROOM_ID, "$thread", "$target", "partial", "test_agent"),
+    ]
+
+    with patch("mindroom.matrix.stale_stream_cleanup.send_message_result", new=AsyncMock()) as mock_send:
+        resumed_count = await auto_resume_interrupted_threads(
+            client,
+            interrupted,
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            conversation_cache=_auto_resume_conversation_cache(interrupted),
+        )
+
+    assert resumed_count == 0
+    mock_send.assert_not_awaited()
 
 
 @pytest.mark.parametrize(
@@ -813,7 +837,15 @@ async def test_auto_resume_classifies_later_activity_by_effective_sender_and_his
     config = _make_config(tmp_path)
     client = AsyncMock(spec=nio.AsyncClient)
     interrupted = [
-        InterruptedThread(ROOM_ID, "$thread", "$target", "partial", "test_agent", timestamp_ms=100),
+        InterruptedThread(
+            ROOM_ID,
+            "$thread",
+            "$target",
+            "partial",
+            "test_agent",
+            original_sender_id=USER_ID,
+            timestamp_ms=100,
+        ),
     ]
     conversation_cache = _auto_resume_conversation_cache(interrupted)
     conversation_cache.get_strict_thread_history.side_effect = None
@@ -892,7 +924,15 @@ async def test_auto_resume_rechecks_after_delay_before_each_delivery(tmp_path: P
     config = _make_config(tmp_path)
     client = AsyncMock(spec=nio.AsyncClient)
     interrupted = [
-        InterruptedThread(ROOM_ID, f"$thread-{index}", f"$target-{index}", "partial", "test_agent", timestamp_ms=index)
+        InterruptedThread(
+            ROOM_ID,
+            f"$thread-{index}",
+            f"$target-{index}",
+            "partial",
+            "test_agent",
+            original_sender_id=USER_ID,
+            timestamp_ms=index,
+        )
         for index in range(5)
     ]
     conversation_cache = _auto_resume_conversation_cache(interrupted)
@@ -1045,6 +1085,7 @@ async def test_auto_resume_skips_thread_id_none(tmp_path: Path) -> None:
             target_event_id="$non-threaded",
             partial_text="Unthreaded",
             agent_name="test_agent",
+            original_sender_id=USER_ID,
         ),
         InterruptedThread(
             room_id=ROOM_ID,
@@ -1052,6 +1093,7 @@ async def test_auto_resume_skips_thread_id_none(tmp_path: Path) -> None:
             target_event_id="$target",
             partial_text="Threaded",
             agent_name="test_agent",
+            original_sender_id=USER_ID,
         ),
     ]
 
@@ -1085,6 +1127,7 @@ async def test_auto_resume_records_outbound_message_when_send_succeeds(tmp_path:
             target_event_id="$target",
             partial_text="Threaded",
             agent_name="test_agent",
+            original_sender_id=USER_ID,
         ),
     ]
     conversation_cache = _auto_resume_conversation_cache(interrupted)
@@ -2779,6 +2822,7 @@ async def test_auto_resume_dedupes_same_agent_and_thread_using_newest_target(tmp
             target_event_id="$older",
             partial_text="Older",
             agent_name="test_agent",
+            original_sender_id=USER_ID,
         ),
         InterruptedThread(
             room_id=ROOM_ID,
@@ -2786,6 +2830,7 @@ async def test_auto_resume_dedupes_same_agent_and_thread_using_newest_target(tmp
             target_event_id="$newer",
             partial_text="Newer",
             agent_name="test_agent",
+            original_sender_id=USER_ID,
         ),
     ]
 
@@ -2818,6 +2863,7 @@ async def test_auto_resume_sends_all_unique_threads_after_replacing_older_target
             target_event_id="$older-one",
             partial_text="Older one",
             agent_name="test_agent",
+            original_sender_id=USER_ID,
             timestamp_ms=100,
         ),
         InterruptedThread(
@@ -2826,6 +2872,7 @@ async def test_auto_resume_sends_all_unique_threads_after_replacing_older_target
             target_event_id="$thread-two-target",
             partial_text="Two",
             agent_name="test_agent",
+            original_sender_id=USER_ID,
             timestamp_ms=200,
         ),
         InterruptedThread(
@@ -2834,6 +2881,7 @@ async def test_auto_resume_sends_all_unique_threads_after_replacing_older_target
             target_event_id="$thread-three-target",
             partial_text="Three",
             agent_name="test_agent",
+            original_sender_id=USER_ID,
             timestamp_ms=300,
         ),
         InterruptedThread(
@@ -2842,6 +2890,7 @@ async def test_auto_resume_sends_all_unique_threads_after_replacing_older_target
             target_event_id="$newer-one",
             partial_text="Newer one",
             agent_name="test_agent",
+            original_sender_id=USER_ID,
             timestamp_ms=400,
         ),
     ]
@@ -2881,6 +2930,7 @@ async def test_auto_resume_sends_threads_from_every_room(tmp_path: Path) -> None
             target_event_id="$target-new",
             partial_text="New",
             agent_name="test_agent",
+            original_sender_id=USER_ID,
             timestamp_ms=500,
         ),
         InterruptedThread(
@@ -2889,6 +2939,7 @@ async def test_auto_resume_sends_threads_from_every_room(tmp_path: Path) -> None
             target_event_id="$target-old",
             partial_text="Old",
             agent_name="test_agent",
+            original_sender_id=USER_ID,
             timestamp_ms=100,
         ),
     ]
@@ -3371,6 +3422,7 @@ async def test_auto_resume_continues_after_send_exception(tmp_path: Path) -> Non
             target_event_id=f"$target-{index}",
             partial_text=f"Part {index}",
             agent_name="test_agent",
+            original_sender_id=USER_ID,
         )
         for index in range(3)
     ]

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -21,7 +21,7 @@ from mindroom.constants import (
     STREAM_STATUS_INTERRUPTED,
     STREAM_STATUS_KEY,
 )
-from mindroom.dispatch_source import TRUSTED_INTERNAL_RELAY_SOURCE_KIND
+from mindroom.dispatch_source import AUTO_RESUME_MESSAGE, TRUSTED_INTERNAL_RELAY_SOURCE_KIND
 from mindroom.entity_resolution import MissingManagedEntityAccountError, entity_identity_registry
 from mindroom.matrix import stale_stream_cleanup as stale_stream_cleanup_module
 from mindroom.matrix.cache import ThreadHistoryResult, thread_history_result
@@ -67,9 +67,6 @@ ROOM_ID = "!room:example.com"
 NOW_MS = 1_000_000
 STALE_AGE_MS = stale_stream_cleanup_module._STALE_STREAM_RECENCY_GUARD_MS + 60_000
 OLD_STALE_AGE_MS = stale_stream_cleanup_module._STALE_STREAM_LOOKBACK_MS + 60_000
-AUTO_RESUME_MESSAGE = (
-    "[System: Previous response was interrupted by service restart. Please continue where you left off.]"
-)
 USER_ID = "@user:example.com"
 OTHER_USER_ID = "@other-user:example.com"
 
@@ -277,10 +274,11 @@ def _history_message(
     sender: str = BOT_USER_ID,
     timestamp: int = 0,
     content: dict[str, object] | None = None,
+    body: str | None = None,
 ) -> ResolvedVisibleMessage:
     return ResolvedVisibleMessage.synthetic(
         sender=sender,
-        body=event_id,
+        body=event_id if body is None else body,
         event_id=event_id,
         timestamp=timestamp,
         content=content,
@@ -868,6 +866,52 @@ async def test_auto_resume_classifies_later_activity_by_effective_sender_and_his
 
     assert resumed_count == expected_resumes
     assert mock_send.await_count == expected_resumes
+
+
+@pytest.mark.asyncio
+async def test_prior_auto_resume_relay_does_not_suppress_sibling_resume(tmp_path: Path) -> None:
+    """A synthetic resume relay should not masquerade as newer human work."""
+    config = _make_config(tmp_path)
+    client = AsyncMock(spec=nio.AsyncClient)
+    interrupted = [
+        InterruptedThread(
+            ROOM_ID,
+            "$thread",
+            "$target",
+            "partial",
+            "test_agent",
+            original_sender_id=USER_ID,
+        ),
+    ]
+    conversation_cache = _auto_resume_conversation_cache(interrupted)
+    conversation_cache.get_strict_thread_history.side_effect = None
+    conversation_cache.get_strict_thread_history.return_value = _authoritative_history(
+        _history_message("$target"),
+        _history_message(
+            "$prior-resume",
+            sender=OTHER_BOT_USER_ID,
+            body=AUTO_RESUME_MESSAGE,
+            content={
+                SOURCE_KIND_KEY: TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
+                ORIGINAL_SENDER_KEY: USER_ID,
+            },
+        ),
+    )
+
+    with patch(
+        "mindroom.matrix.stale_stream_cleanup.send_message_result",
+        new=AsyncMock(side_effect=delivered_matrix_side_effect("$resume")),
+    ) as mock_send:
+        resumed_count = await auto_resume_interrupted_threads(
+            client,
+            interrupted,
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            conversation_cache=conversation_cache,
+        )
+
+    assert resumed_count == 1
+    mock_send.assert_awaited_once()
 
 
 @pytest.mark.parametrize("history_case", ["missing", "failed", "degraded", "missing_target", "untrusted_sender"])

--- a/tests/test_turn_dispatch_pipeline.py
+++ b/tests/test_turn_dispatch_pipeline.py
@@ -35,6 +35,7 @@ from mindroom.delivery_gateway import (
 )
 from mindroom.dispatch_handoff import PreparedTextEvent
 from mindroom.dispatch_source import (
+    AUTO_RESUME_MESSAGE,
     EXTERNAL_TRIGGER_SOURCE_KIND,
     MESSAGE_SOURCE_KIND,
     TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
@@ -1042,10 +1043,11 @@ class TestAgentBot(AgentBotTestBase):
         sender: str = "@mindroom_router:localhost",
         reply_to: str | None = "$user_msg:localhost",
         is_falling_back: bool = False,
+        body: str = "@mindroom_calculator:localhost could you help with this?",
     ) -> nio.RoomMessageText:
         content: dict[str, Any] = {
             "msgtype": "m.text",
-            "body": "@mindroom_calculator:localhost could you help with this?",
+            "body": body,
             ORIGINAL_SENDER_KEY: "@user:localhost",
             SOURCE_KIND_KEY: TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
         }
@@ -1116,11 +1118,16 @@ class TestAgentBot(AgentBotTestBase):
         fallback_relay = self._router_relay_event(reply_to="$latest:localhost", is_falling_back=True)
         replyless_relay = self._router_relay_event(reply_to=None)
         non_router_relay = self._router_relay_event(sender="@mindroom_general:localhost")
+        auto_resume_relay = self._router_relay_event(
+            reply_to="$interrupted_bot_message:localhost",
+            body=AUTO_RESUME_MESSAGE,
+        )
 
         assert validator.router_relay_original_event_id(explicit_relay) == "$user_msg:localhost"
         assert validator.router_relay_original_event_id(fallback_relay) is None
         assert validator.router_relay_original_event_id(replyless_relay) is None
         assert validator.router_relay_original_event_id(non_router_relay) is None
+        assert validator.router_relay_original_event_id(auto_resume_relay) is None
 
     @pytest.mark.asyncio
     async def test_external_trigger_to_private_agent_uses_trigger_owner_as_requester(


### PR DESCRIPTION
## Why

A restart-interrupted response is resumed through a router-authored relay. The relay preserved the human in `com.mindroom.original_sender`, but omitted the trusted relay source kind, so ingress rejected that requester metadata and treated the router bot as the requester. Private execution then selected a new bot-keyed workspace with the wrong memory and OAuth bindings.

Requester recovery is also best-effort after restart. If the original requester cannot be recovered, continuing as the bot is unsafe.

## What changed

- Mark auto-resume messages as `trusted_internal_relay` whenever they carry `com.mindroom.original_sender`.
- Skip auto-resume when restart recovery cannot resolve the requester identity.
- Cover relay content, ingress requester promotion, and the existing managed-bot trust boundary.

## Verification

- `uv run pytest tests/test_stale_stream_cleanup.py tests/test_ingress_validation.py -q`
- `uv run pre-commit run --all-files`
- Full suite reached 10,844 passing tests. PostgreSQL integration tests could not start because local Docker storage was full; unrelated timing-sensitive failures passed on immediate isolated rerun.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automatic conversation resumption by preserving the original sender’s identity when messages are relayed internally.
  - Prevented auto-resume messages from being sent when the original requester cannot be verified.
  - Strengthened validation so embedded sender identities are trusted only for verified internal relay messages.
  - Added safeguards to prevent untrusted external messages from impersonating another sender.
- **Tests**
  - Expanded coverage for sender verification and stale-stream auto-resume scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->