### PR TITLE
Enable full Google Drive write tools by default

### DIFF
--- a/docs/deployment/google-services-oauth.md
+++ b/docs/deployment/google-services-oauth.md
@@ -13,7 +13,7 @@ Public, unpaired, and organization-managed deployments can configure their own G
 
 | Tool | Provider ID | Callback path | Token service | Client config service | Settings service | Scopes |
 | --- | --- | --- | --- | --- | --- | --- |
-| Google Drive | `google_drive` | `/api/oauth/google_drive/callback` | `google_drive_oauth` | `google_drive_oauth_client` | `google_drive` | Drive read-only plus OpenID email/profile |
+| Google Drive | `google_drive` | `/api/oauth/google_drive/callback` | `google_drive_oauth` | `google_drive_oauth_client` | `google_drive` | Full Drive access plus OpenID email/profile |
 | Google Docs | `google_docs` | `/api/oauth/google_docs/callback` | `google_docs_oauth` | `google_docs_oauth_client` | `google_docs` | Docs view/edit/create/delete plus OpenID email/profile |
 | Google Calendar | `google_calendar` | `/api/oauth/google_calendar/callback` | `google_calendar_oauth` | `google_calendar_oauth_client` | `google_calendar` | Calendar events, calendar-list read-only, free/busy, and settings read-only plus OpenID email/profile |
 | Google Sheets | `google_sheets` | `/api/oauth/google_sheets/callback` | `google_sheets_oauth` | `google_sheets_oauth_client` | `google_sheets` | Sheets read/write, plus OpenID email/profile |
@@ -23,7 +23,9 @@ Public, unpaired, and organization-managed deployments can configure their own G
 
 MindRoom requests only the scopes required by the operations currently exposed to agents.
 
-- `drive.readonly` lets an agent search, list, and read existing files across the connected account without granting Drive write access.
+- `drive` lets an agent search, read, upload, create folders, move or rename files, and move files to trash across the connected account.
+- Existing `drive.readonly` grants remain usable for reads, but Drive write tools ask the user to reconnect and grant full Drive access.
+  Full Drive scope also authorizes permanent deletion at the Google API layer, but MindRoom exposes only trashing and no permanent-delete tool.
   The narrower `drive.file` scope cannot preserve account-wide search because it is limited to files created by or explicitly shared with the app.
 - `documents` lets an agent create documents, read complete document structure and content, and apply text edits without granting access to non-Docs Drive files.
   The scope also authorizes document deletion across the connected account, although MindRoom's `google_docs` tool does not expose a delete operation.

--- a/docs/dev/agent_configuration.md
+++ b/docs/dev/agent_configuration.md
@@ -491,7 +491,7 @@ Below is a representative selection:
 - **gmail** - Gmail integration (requires Google OAuth)
 - **google_calendar** - Calendar management (requires Google OAuth)
 - **google_docs** - Google Docs creation, reading, and text editing (requires Google OAuth)
-- **google_drive** - Google Drive file search and reading (requires Google OAuth)
+- **google_drive** - Google Drive file reading and management (requires Google OAuth)
 - **google_sheets** - Spreadsheet operations (requires Google OAuth)
 - **homeassistant** - Home Assistant device control (requires OAuth or long-lived access token)
 - **spotify** - Spotify playback and library (requires OAuth)

--- a/docs/tools/calendar-and-scheduling.md
+++ b/docs/tools/calendar-and-scheduling.md
@@ -37,7 +37,7 @@ MindRoom also includes `scheduler` in `defaults.tools` by default on this branch
 `google_calendar` exposes `list_events()`, `fetch_all_events()`, `find_available_slots()`, `list_calendars()`, `create_event()`, `update_event()`, and `delete_event()`.
 MindRoom loads the connected Google account from its unified credential store instead of relying on a per-process `token.json`.
 The OAuth provider requests narrowly targeted scopes for event access, calendar listing, availability, and working-hours settings, while MindRoom gates write methods with the `allow_update` setting.
-Write calls are still part of the tool surface, but they are only exposed when `allow_update: true` is configured.
+Write calls are enabled by default and can be removed from the tool surface with `allow_update: false`.
 When no usable MindRoom OAuth credentials exist, the wrapper raises `OAuthConnectionRequired` instead of falling back to Agno's local token flow.
 `find_available_slots()` derives openings from the user's current calendar events plus working-hours settings inferred from Google Calendar settings and locale.
 
@@ -46,7 +46,7 @@ When no usable MindRoom OAuth credentials exist, the wrapper raises `OAuthConnec
 | Option | Type | Required | Default | Notes |
 | --- | --- | --- | --- | --- |
 | `calendar_id` | `text` | `no` | `primary` | Google Calendar ID to query or update. |
-| `allow_update` | `boolean` | `no` | `false` | Expose create, update, and delete operations. |
+| `allow_update` | `boolean` | `no` | `true` | Expose create, update, and delete operations. |
 
 ### Example
 

--- a/docs/tools/data-and-databases.md
+++ b/docs/tools/data-and-databases.md
@@ -21,9 +21,9 @@ Use these tools when you need database access, dataframe-style analysis, Google 
 - [`csv`] - Pre-registered CSV reading and DuckDB-backed SQL queries over CSV files.
 - [`pandas`] - In-memory dataframe creation and dataframe method execution.
 - [`google_bigquery`] - BigQuery dataset inspection and SQL queries.
-- [`google_drive`] - Google Drive file listing, metadata search, file reading, and workspace downloads through the per-service Google Drive OAuth provider.
+- [`google_drive`] - Google Drive file listing, metadata search, file reading, workspace downloads, uploads, folder creation, moves, renames, and trashing through the per-service Google Drive OAuth provider.
 - [`google_docs`] - Google Docs creation, tab-aware structure reads, text insertion, and text replacement through the per-service Google Docs OAuth provider.
-- [`google_sheets`] - Google Sheets access through the per-service Google Sheets OAuth provider, with read support verified by default and create/update support when enabled.
+- [`google_sheets`] - Google Sheets read, create, and update access through the per-service Google Sheets OAuth provider.
 - [`openbb`] - Stock prices, company search, news, profiles, and price targets through OpenBB.
 - [`yfinance`] - Yahoo Finance market data, fundamentals, news, and history.
 - [`financial_datasets_api`] - Structured financial statements, filings, ownership, and crypto data from Financial Datasets.
@@ -442,15 +442,19 @@ run_sql_query("SELECT event_name, COUNT(*) AS total FROM events GROUP BY 1 ORDER
 
 ## [`google_drive`]
 
-`google_drive` is the Google Drive toolkit for listing, searching, reading, and downloading files from the connected user's Drive account.
+`google_drive` is the Google Drive toolkit for listing, searching, reading, downloading, uploading, and organizing files in the connected user's Drive account.
 
 ### What It Does
 
-MindRoom exposes `google_drive_list_files()`, `google_drive_search_files()`, `google_drive_read_file()`, and (when enabled) `google_drive_download_file()` through the Google Drive OAuth provider.
+MindRoom exposes `google_drive_list_files()`, `google_drive_search_files()`, `google_drive_read_file()`, `google_drive_download_file()`, `google_drive_upload_file()`, `google_drive_create_folder()`, `google_drive_move_file()`, and `google_drive_trash_file()` through the Google Drive OAuth provider.
 `google_drive_list_files()` returns recent Drive files visible to the connected account.
 `google_drive_search_files()` searches Drive metadata.
 `google_drive_read_file()` reads Google Workspace files and non-Google files up to the configured `max_read_size`.
 `google_drive_download_file()` downloads a Drive file, exporting Google Workspace files to their best native format, for example a complete Google Sheets workbook as `.xlsx`.
+`google_drive_upload_file()` uploads a local file and resolves relative paths from the agent workspace.
+`google_drive_create_folder()` creates a folder under the Drive root or an optional parent.
+`google_drive_move_file()` moves a file to a new parent and can rename it in the same request.
+`google_drive_trash_file()` moves a file to trash and never permanently deletes it.
 Downloads always land in the `google-drive-downloads/` directory inside the agent workspace, so the destination cannot be redirected elsewhere.
 When no usable MindRoom OAuth credentials exist, the wrapper raises `OAuthConnectionRequired` instead of falling back to a local token flow.
 
@@ -462,6 +466,7 @@ When no usable MindRoom OAuth credentials exist, the wrapper raises `OAuthConnec
 | `search_files` | `boolean` | `no` | `true` | Enable Drive metadata search. |
 | `read_file` | `boolean` | `no` | `true` | Enable file content reads. |
 | `download_file` | `boolean` | `no` | `false` | Enable file downloads and Workspace exports into the agent workspace. |
+| `write` | `boolean` | `no` | `true` | Enable uploads, folder creation, file moves or renames, and trashing. |
 | `max_read_size` | `number` | `no` | `10485760` | Maximum non-Google-Workspace file size to read in bytes. |
 
 ### Example
@@ -472,6 +477,7 @@ agents:
     tools:
       - google_drive:
           download_file: true
+          write: true
           max_read_size: 10485760
 ```
 
@@ -480,14 +486,35 @@ google_drive_list_files()
 google_drive_search_files("name contains 'budget'")
 google_drive_read_file("1AbCdEfGhIjKlMnOpQrStUvWxYz")
 google_drive_download_file("1AbCdEfGhIjKlMnOpQrStUvWxYz")
+google_drive_upload_file("reports/launch-plan.pdf", folder_id="1FolderId")
+google_drive_create_folder("Launch", parent_id="1FolderId")
+google_drive_move_file("1FileId", "1NewFolderId", name="Final plan.pdf")
+google_drive_trash_file("1OldFileId")
 ```
 
 ### Notes
 
 - `google_drive` uses the per-service `google_drive` OAuth provider and always runs in the primary MindRoom runtime.
 - Downloads require an agent workspace; when the agent has none (for example the default `mem0` memory backend without a `private` workspace), `download_file` is ignored and a warning is logged.
-- The provider requests Drive read-only access plus OpenID email/profile scopes.
+- The provider requests full Drive access plus OpenID email/profile scopes.
+- Existing connections that granted `drive.readonly` keep working for read operations, while write operations return a structured reconnect-required result until the connection grants full Drive access.
+- Full Drive scope authorizes permanent deletion at the Google API layer, but this toolkit exposes only `google_drive_trash_file()` and no permanent-delete function.
+- Set `write: false` to remove all Drive mutation functions from the agent's tool surface.
+- MindRoom's `tool_approval` rules can gate each write call behind a Matrix approval card.
 - Configure Google OAuth through [Google Services OAuth (Admin Setup)](../deployment/google-services-oauth.md) or [Google Services OAuth (Individual Setup)](../deployment/google-services-user-oauth.md).
+
+```yaml
+tool_approval:
+  rules:
+    - match: google_drive_upload_file
+      action: require_approval
+    - match: google_drive_create_folder
+      action: require_approval
+    - match: google_drive_move_file
+      action: require_approval
+    - match: google_drive_trash_file
+      action: require_approval
+```
 
 ## [`google_docs`]
 
@@ -534,7 +561,7 @@ google_docs_replace_text("1AbCdEfGhIjKlMnOpQrStUvWxYz", "DRAFT", "FINAL", match_
 
 - `google_docs` uses its own `google_docs` OAuth provider and `google_docs_oauth` token service, separate from Google Drive.
 - The provider requests `documents` plus OpenID email/profile scopes and does not request any Drive scope.
-- `google_drive` remains read-only and does not gain Docs write access when `google_docs` is enabled.
+- `google_drive` has its own full Drive grant and does not reuse the separate Docs grant when `google_docs` is enabled.
 - Google classifies the `documents` scope as sensitive, so public production clients need the verification follow-up described in [Google Services OAuth](../deployment/google-services-oauth.md#production-verification-follow-up).
 - `google_docs` always runs in the primary MindRoom runtime so Google OAuth tokens are never mirrored into worker containers.
 
@@ -558,8 +585,8 @@ When no usable MindRoom OAuth credentials exist, the wrapper raises `OAuthConnec
 | `spreadsheet_id` | `text` | `no` | `null` | Default spreadsheet ID. Leave unset to work with multiple spreadsheets by passing IDs per call. |
 | `spreadsheet_range` | `text` | `no` | `null` | Default range such as `Sheet1!A1:Z100`. |
 | `read` | `boolean` | `no` | `true` | Enable read operations. |
-| `create` | `boolean` | `no` | `false` | Enable spreadsheet creation. |
-| `update` | `boolean` | `no` | `false` | Enable sheet updates. |
+| `create` | `boolean` | `no` | `true` | Enable spreadsheet creation. |
+| `update` | `boolean` | `no` | `true` | Enable sheet updates. |
 
 ### Example
 

--- a/frontend/src/components/Integrations/Integrations.test.tsx
+++ b/frontend/src/components/Integrations/Integrations.test.tsx
@@ -214,7 +214,8 @@ vi.mock("./integrations/index", () => ({
         integration: {
           id: "google_drive",
           name: "Google Drive",
-          description: "Search and read files from your connected Google Drive",
+          description:
+            "Search, read, upload, and organize files in your connected Google Drive",
           category: "productivity",
           icon: <span>Google Drive Icon</span>,
           status: "available",
@@ -285,7 +286,8 @@ vi.mock("./integrations/index", () => ({
         integration: {
           id: "google_drive",
           name: "Google Drive",
-          description: "Search and read files from your connected Google Drive",
+          description:
+            "Search, read, upload, and organize files in your connected Google Drive",
           category: "productivity",
           icon: <span>Google Drive Icon</span>,
           status: "available",
@@ -498,7 +500,7 @@ describe("Integrations", () => {
       expect(screen.getByText("Google Drive")).toBeInTheDocument();
       expect(
         screen.getByText(
-          "Search and read files from your connected Google Drive",
+          "Search, read, upload, and organize files in your connected Google Drive",
         ),
       ).toBeInTheDocument();
       expect(screen.getByText("Spotify")).toBeInTheDocument();
@@ -834,7 +836,7 @@ describe("Integrations", () => {
     // But the elements might still be in the DOM, just hidden
     // So let's check for visibility instead
     const googleElement = screen.queryByText(
-      "Search and read files from your connected Google Drive",
+      "Search, read, upload, and organize files in your connected Google Drive",
     );
     if (googleElement) {
       // Check if it's hidden (parent tab panel might be hidden)
@@ -1292,7 +1294,7 @@ describe("Integrations", () => {
       {
         name: "google_drive",
         display_name: "Google Drive",
-        description: "Search and read files from Google Drive",
+        description: "Search, read, upload, and organize files in Google Drive",
         icon: "SiGoogledrive",
         icon_color: "text-green-600",
         category: "productivity",

--- a/frontend/src/components/Integrations/integrations/index.ts
+++ b/frontend/src/components/Integrations/integrations/index.ts
@@ -280,7 +280,8 @@ const googleDriveIntegration = new GenericOAuthIntegrationProvider(
   {
     id: "google_drive",
     name: "Google Drive",
-    description: "Search and read files from your connected Google Drive",
+    description:
+      "Search, read, upload, and organize files in your connected Google Drive",
     category: "productivity",
     icon: createElement(SiGoogledrive, {
       className: "h-5 w-5 text-green-600",

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -3846,9 +3846,9 @@ Use these tools when you need database access, dataframe-style analysis, Google 
 - [`csv`] - Pre-registered CSV reading and DuckDB-backed SQL queries over CSV files.
 - [`pandas`] - In-memory dataframe creation and dataframe method execution.
 - [`google_bigquery`] - BigQuery dataset inspection and SQL queries.
-- [`google_drive`] - Google Drive file listing, metadata search, file reading, and workspace downloads through the per-service Google Drive OAuth provider.
+- [`google_drive`] - Google Drive file listing, metadata search, file reading, workspace downloads, uploads, folder creation, moves, renames, and trashing through the per-service Google Drive OAuth provider.
 - [`google_docs`] - Google Docs creation, tab-aware structure reads, text insertion, and text replacement through the per-service Google Docs OAuth provider.
-- [`google_sheets`] - Google Sheets access through the per-service Google Sheets OAuth provider, with read support verified by default and create/update support when enabled.
+- [`google_sheets`] - Google Sheets read, create, and update access through the per-service Google Sheets OAuth provider.
 - [`openbb`] - Stock prices, company search, news, profiles, and price targets through OpenBB.
 - [`yfinance`] - Yahoo Finance market data, fundamentals, news, and history.
 - [`financial_datasets_api`] - Structured financial statements, filings, ownership, and crypto data from Financial Datasets.
@@ -4267,15 +4267,19 @@ run_sql_query("SELECT event_name, COUNT(*) AS total FROM events GROUP BY 1 ORDER
 
 ## [`google_drive`]
 
-`google_drive` is the Google Drive toolkit for listing, searching, reading, and downloading files from the connected user's Drive account.
+`google_drive` is the Google Drive toolkit for listing, searching, reading, downloading, uploading, and organizing files in the connected user's Drive account.
 
 ### What It Does
 
-MindRoom exposes `google_drive_list_files()`, `google_drive_search_files()`, `google_drive_read_file()`, and (when enabled) `google_drive_download_file()` through the Google Drive OAuth provider.
+MindRoom exposes `google_drive_list_files()`, `google_drive_search_files()`, `google_drive_read_file()`, `google_drive_download_file()`, `google_drive_upload_file()`, `google_drive_create_folder()`, `google_drive_move_file()`, and `google_drive_trash_file()` through the Google Drive OAuth provider.
 `google_drive_list_files()` returns recent Drive files visible to the connected account.
 `google_drive_search_files()` searches Drive metadata.
 `google_drive_read_file()` reads Google Workspace files and non-Google files up to the configured `max_read_size`.
 `google_drive_download_file()` downloads a Drive file, exporting Google Workspace files to their best native format, for example a complete Google Sheets workbook as `.xlsx`.
+`google_drive_upload_file()` uploads a local file and resolves relative paths from the agent workspace.
+`google_drive_create_folder()` creates a folder under the Drive root or an optional parent.
+`google_drive_move_file()` moves a file to a new parent and can rename it in the same request.
+`google_drive_trash_file()` moves a file to trash and never permanently deletes it.
 Downloads always land in the `google-drive-downloads/` directory inside the agent workspace, so the destination cannot be redirected elsewhere.
 When no usable MindRoom OAuth credentials exist, the wrapper raises `OAuthConnectionRequired` instead of falling back to a local token flow.
 
@@ -4287,6 +4291,7 @@ When no usable MindRoom OAuth credentials exist, the wrapper raises `OAuthConnec
 | `search_files` | `boolean` | `no` | `true` | Enable Drive metadata search. |
 | `read_file` | `boolean` | `no` | `true` | Enable file content reads. |
 | `download_file` | `boolean` | `no` | `false` | Enable file downloads and Workspace exports into the agent workspace. |
+| `write` | `boolean` | `no` | `true` | Enable uploads, folder creation, file moves or renames, and trashing. |
 | `max_read_size` | `number` | `no` | `10485760` | Maximum non-Google-Workspace file size to read in bytes. |
 
 ### Example
@@ -4297,6 +4302,7 @@ agents:
     tools:
       - google_drive:
           download_file: true
+          write: true
           max_read_size: 10485760
 ```
 
@@ -4305,14 +4311,35 @@ google_drive_list_files()
 google_drive_search_files("name contains 'budget'")
 google_drive_read_file("1AbCdEfGhIjKlMnOpQrStUvWxYz")
 google_drive_download_file("1AbCdEfGhIjKlMnOpQrStUvWxYz")
+google_drive_upload_file("reports/launch-plan.pdf", folder_id="1FolderId")
+google_drive_create_folder("Launch", parent_id="1FolderId")
+google_drive_move_file("1FileId", "1NewFolderId", name="Final plan.pdf")
+google_drive_trash_file("1OldFileId")
 ```
 
 ### Notes
 
 - `google_drive` uses the per-service `google_drive` OAuth provider and always runs in the primary MindRoom runtime.
 - Downloads require an agent workspace; when the agent has none (for example the default `mem0` memory backend without a `private` workspace), `download_file` is ignored and a warning is logged.
-- The provider requests Drive read-only access plus OpenID email/profile scopes.
+- The provider requests full Drive access plus OpenID email/profile scopes.
+- Existing connections that granted `drive.readonly` keep working for read operations, while write operations return a structured reconnect-required result until the connection grants full Drive access.
+- Full Drive scope authorizes permanent deletion at the Google API layer, but this toolkit exposes only `google_drive_trash_file()` and no permanent-delete function.
+- Set `write: false` to remove all Drive mutation functions from the agent's tool surface.
+- MindRoom's `tool_approval` rules can gate each write call behind a Matrix approval card.
 - Configure Google OAuth through [Google Services OAuth (Admin Setup)](https://docs.mindroom.chat/deployment/google-services-oauth/) or [Google Services OAuth (Individual Setup)](https://docs.mindroom.chat/deployment/google-services-user-oauth/).
+
+```yaml
+tool_approval:
+  rules:
+    - match: google_drive_upload_file
+      action: require_approval
+    - match: google_drive_create_folder
+      action: require_approval
+    - match: google_drive_move_file
+      action: require_approval
+    - match: google_drive_trash_file
+      action: require_approval
+```
 
 ## [`google_docs`]
 
@@ -4359,7 +4386,7 @@ google_docs_replace_text("1AbCdEfGhIjKlMnOpQrStUvWxYz", "DRAFT", "FINAL", match_
 
 - `google_docs` uses its own `google_docs` OAuth provider and `google_docs_oauth` token service, separate from Google Drive.
 - The provider requests `documents` plus OpenID email/profile scopes and does not request any Drive scope.
-- `google_drive` remains read-only and does not gain Docs write access when `google_docs` is enabled.
+- `google_drive` has its own full Drive grant and does not reuse the separate Docs grant when `google_docs` is enabled.
 - Google classifies the `documents` scope as sensitive, so public production clients need the verification follow-up described in [Google Services OAuth](https://docs.mindroom.chat/deployment/google-services-oauth/#production-verification-follow-up).
 - `google_docs` always runs in the primary MindRoom runtime so Google OAuth tokens are never mirrored into worker containers.
 
@@ -4383,8 +4410,8 @@ When no usable MindRoom OAuth credentials exist, the wrapper raises `OAuthConnec
 | `spreadsheet_id` | `text` | `no` | `null` | Default spreadsheet ID. Leave unset to work with multiple spreadsheets by passing IDs per call. |
 | `spreadsheet_range` | `text` | `no` | `null` | Default range such as `Sheet1!A1:Z100`. |
 | `read` | `boolean` | `no` | `true` | Enable read operations. |
-| `create` | `boolean` | `no` | `false` | Enable spreadsheet creation. |
-| `update` | `boolean` | `no` | `false` | Enable sheet updates. |
+| `create` | `boolean` | `no` | `true` | Enable spreadsheet creation. |
+| `update` | `boolean` | `no` | `true` | Enable sheet updates. |
 
 ### Example
 
@@ -8781,7 +8808,7 @@ MindRoom also includes `scheduler` in `defaults.tools` by default on this branch
 `google_calendar` exposes `list_events()`, `fetch_all_events()`, `find_available_slots()`, `list_calendars()`, `create_event()`, `update_event()`, and `delete_event()`.
 MindRoom loads the connected Google account from its unified credential store instead of relying on a per-process `token.json`.
 The OAuth provider requests narrowly targeted scopes for event access, calendar listing, availability, and working-hours settings, while MindRoom gates write methods with the `allow_update` setting.
-Write calls are still part of the tool surface, but they are only exposed when `allow_update: true` is configured.
+Write calls are enabled by default and can be removed from the tool surface with `allow_update: false`.
 When no usable MindRoom OAuth credentials exist, the wrapper raises `OAuthConnectionRequired` instead of falling back to Agno's local token flow.
 `find_available_slots()` derives openings from the user's current calendar events plus working-hours settings inferred from Google Calendar settings and locale.
 
@@ -8790,7 +8817,7 @@ When no usable MindRoom OAuth credentials exist, the wrapper raises `OAuthConnec
 | Option | Type | Required | Default | Notes |
 | --- | --- | --- | --- | --- |
 | `calendar_id` | `text` | `no` | `primary` | Google Calendar ID to query or update. |
-| `allow_update` | `boolean` | `no` | `false` | Expose create, update, and delete operations. |
+| `allow_update` | `boolean` | `no` | `true` | Expose create, update, and delete operations. |
 
 ### Example
 
@@ -16649,7 +16676,7 @@ Public, unpaired, and organization-managed deployments can configure their own G
 
 | Tool | Provider ID | Callback path | Token service | Client config service | Settings service | Scopes |
 | --- | --- | --- | --- | --- | --- | --- |
-| Google Drive | `google_drive` | `/api/oauth/google_drive/callback` | `google_drive_oauth` | `google_drive_oauth_client` | `google_drive` | Drive read-only plus OpenID email/profile |
+| Google Drive | `google_drive` | `/api/oauth/google_drive/callback` | `google_drive_oauth` | `google_drive_oauth_client` | `google_drive` | Full Drive access plus OpenID email/profile |
 | Google Docs | `google_docs` | `/api/oauth/google_docs/callback` | `google_docs_oauth` | `google_docs_oauth_client` | `google_docs` | Docs view/edit/create/delete plus OpenID email/profile |
 | Google Calendar | `google_calendar` | `/api/oauth/google_calendar/callback` | `google_calendar_oauth` | `google_calendar_oauth_client` | `google_calendar` | Calendar events, calendar-list read-only, free/busy, and settings read-only plus OpenID email/profile |
 | Google Sheets | `google_sheets` | `/api/oauth/google_sheets/callback` | `google_sheets_oauth` | `google_sheets_oauth_client` | `google_sheets` | Sheets read/write, plus OpenID email/profile |
@@ -16659,7 +16686,9 @@ Public, unpaired, and organization-managed deployments can configure their own G
 
 MindRoom requests only the scopes required by the operations currently exposed to agents.
 
-- `drive.readonly` lets an agent search, list, and read existing files across the connected account without granting Drive write access.
+- `drive` lets an agent search, read, upload, create folders, move or rename files, and move files to trash across the connected account.
+- Existing `drive.readonly` grants remain usable for reads, but Drive write tools ask the user to reconnect and grant full Drive access.
+  Full Drive scope also authorizes permanent deletion at the Google API layer, but MindRoom exposes only trashing and no permanent-delete tool.
   The narrower `drive.file` scope cannot preserve account-wide search because it is limited to files created by or explicitly shared with the app.
 - `documents` lets an agent create documents, read complete document structure and content, and apply text edits without granting access to non-Docs Drive files.
   The scope also authorizes document deletion across the connected account, although MindRoom's `google_docs` tool does not expose a delete operation.

--- a/skills/mindroom-docs/references/page__deployment__google-services-oauth__index.md
+++ b/skills/mindroom-docs/references/page__deployment__google-services-oauth__index.md
@@ -9,7 +9,7 @@ Public, unpaired, and organization-managed deployments can configure their own G
 
 | Tool | Provider ID | Callback path | Token service | Client config service | Settings service | Scopes |
 | --- | --- | --- | --- | --- | --- | --- |
-| Google Drive | `google_drive` | `/api/oauth/google_drive/callback` | `google_drive_oauth` | `google_drive_oauth_client` | `google_drive` | Drive read-only plus OpenID email/profile |
+| Google Drive | `google_drive` | `/api/oauth/google_drive/callback` | `google_drive_oauth` | `google_drive_oauth_client` | `google_drive` | Full Drive access plus OpenID email/profile |
 | Google Docs | `google_docs` | `/api/oauth/google_docs/callback` | `google_docs_oauth` | `google_docs_oauth_client` | `google_docs` | Docs view/edit/create/delete plus OpenID email/profile |
 | Google Calendar | `google_calendar` | `/api/oauth/google_calendar/callback` | `google_calendar_oauth` | `google_calendar_oauth_client` | `google_calendar` | Calendar events, calendar-list read-only, free/busy, and settings read-only plus OpenID email/profile |
 | Google Sheets | `google_sheets` | `/api/oauth/google_sheets/callback` | `google_sheets_oauth` | `google_sheets_oauth_client` | `google_sheets` | Sheets read/write, plus OpenID email/profile |
@@ -19,7 +19,9 @@ Public, unpaired, and organization-managed deployments can configure their own G
 
 MindRoom requests only the scopes required by the operations currently exposed to agents.
 
-- `drive.readonly` lets an agent search, list, and read existing files across the connected account without granting Drive write access.
+- `drive` lets an agent search, read, upload, create folders, move or rename files, and move files to trash across the connected account.
+- Existing `drive.readonly` grants remain usable for reads, but Drive write tools ask the user to reconnect and grant full Drive access.
+  Full Drive scope also authorizes permanent deletion at the Google API layer, but MindRoom exposes only trashing and no permanent-delete tool.
   The narrower `drive.file` scope cannot preserve account-wide search because it is limited to files created by or explicitly shared with the app.
 - `documents` lets an agent create documents, read complete document structure and content, and apply text edits without granting access to non-Docs Drive files.
   The scope also authorizes document deletion across the connected account, although MindRoom's `google_docs` tool does not expose a delete operation.

--- a/skills/mindroom-docs/references/page__tools__calendar-and-scheduling__index.md
+++ b/skills/mindroom-docs/references/page__tools__calendar-and-scheduling__index.md
@@ -33,7 +33,7 @@ MindRoom also includes `scheduler` in `defaults.tools` by default on this branch
 `google_calendar` exposes `list_events()`, `fetch_all_events()`, `find_available_slots()`, `list_calendars()`, `create_event()`, `update_event()`, and `delete_event()`.
 MindRoom loads the connected Google account from its unified credential store instead of relying on a per-process `token.json`.
 The OAuth provider requests narrowly targeted scopes for event access, calendar listing, availability, and working-hours settings, while MindRoom gates write methods with the `allow_update` setting.
-Write calls are still part of the tool surface, but they are only exposed when `allow_update: true` is configured.
+Write calls are enabled by default and can be removed from the tool surface with `allow_update: false`.
 When no usable MindRoom OAuth credentials exist, the wrapper raises `OAuthConnectionRequired` instead of falling back to Agno's local token flow.
 `find_available_slots()` derives openings from the user's current calendar events plus working-hours settings inferred from Google Calendar settings and locale.
 
@@ -42,7 +42,7 @@ When no usable MindRoom OAuth credentials exist, the wrapper raises `OAuthConnec
 | Option | Type | Required | Default | Notes |
 | --- | --- | --- | --- | --- |
 | `calendar_id` | `text` | `no` | `primary` | Google Calendar ID to query or update. |
-| `allow_update` | `boolean` | `no` | `false` | Expose create, update, and delete operations. |
+| `allow_update` | `boolean` | `no` | `true` | Expose create, update, and delete operations. |
 
 ### Example
 

--- a/skills/mindroom-docs/references/page__tools__data-and-databases__index.md
+++ b/skills/mindroom-docs/references/page__tools__data-and-databases__index.md
@@ -17,9 +17,9 @@ Use these tools when you need database access, dataframe-style analysis, Google 
 - [`csv`] - Pre-registered CSV reading and DuckDB-backed SQL queries over CSV files.
 - [`pandas`] - In-memory dataframe creation and dataframe method execution.
 - [`google_bigquery`] - BigQuery dataset inspection and SQL queries.
-- [`google_drive`] - Google Drive file listing, metadata search, file reading, and workspace downloads through the per-service Google Drive OAuth provider.
+- [`google_drive`] - Google Drive file listing, metadata search, file reading, workspace downloads, uploads, folder creation, moves, renames, and trashing through the per-service Google Drive OAuth provider.
 - [`google_docs`] - Google Docs creation, tab-aware structure reads, text insertion, and text replacement through the per-service Google Docs OAuth provider.
-- [`google_sheets`] - Google Sheets access through the per-service Google Sheets OAuth provider, with read support verified by default and create/update support when enabled.
+- [`google_sheets`] - Google Sheets read, create, and update access through the per-service Google Sheets OAuth provider.
 - [`openbb`] - Stock prices, company search, news, profiles, and price targets through OpenBB.
 - [`yfinance`] - Yahoo Finance market data, fundamentals, news, and history.
 - [`financial_datasets_api`] - Structured financial statements, filings, ownership, and crypto data from Financial Datasets.
@@ -438,15 +438,19 @@ run_sql_query("SELECT event_name, COUNT(*) AS total FROM events GROUP BY 1 ORDER
 
 ## [`google_drive`]
 
-`google_drive` is the Google Drive toolkit for listing, searching, reading, and downloading files from the connected user's Drive account.
+`google_drive` is the Google Drive toolkit for listing, searching, reading, downloading, uploading, and organizing files in the connected user's Drive account.
 
 ### What It Does
 
-MindRoom exposes `google_drive_list_files()`, `google_drive_search_files()`, `google_drive_read_file()`, and (when enabled) `google_drive_download_file()` through the Google Drive OAuth provider.
+MindRoom exposes `google_drive_list_files()`, `google_drive_search_files()`, `google_drive_read_file()`, `google_drive_download_file()`, `google_drive_upload_file()`, `google_drive_create_folder()`, `google_drive_move_file()`, and `google_drive_trash_file()` through the Google Drive OAuth provider.
 `google_drive_list_files()` returns recent Drive files visible to the connected account.
 `google_drive_search_files()` searches Drive metadata.
 `google_drive_read_file()` reads Google Workspace files and non-Google files up to the configured `max_read_size`.
 `google_drive_download_file()` downloads a Drive file, exporting Google Workspace files to their best native format, for example a complete Google Sheets workbook as `.xlsx`.
+`google_drive_upload_file()` uploads a local file and resolves relative paths from the agent workspace.
+`google_drive_create_folder()` creates a folder under the Drive root or an optional parent.
+`google_drive_move_file()` moves a file to a new parent and can rename it in the same request.
+`google_drive_trash_file()` moves a file to trash and never permanently deletes it.
 Downloads always land in the `google-drive-downloads/` directory inside the agent workspace, so the destination cannot be redirected elsewhere.
 When no usable MindRoom OAuth credentials exist, the wrapper raises `OAuthConnectionRequired` instead of falling back to a local token flow.
 
@@ -458,6 +462,7 @@ When no usable MindRoom OAuth credentials exist, the wrapper raises `OAuthConnec
 | `search_files` | `boolean` | `no` | `true` | Enable Drive metadata search. |
 | `read_file` | `boolean` | `no` | `true` | Enable file content reads. |
 | `download_file` | `boolean` | `no` | `false` | Enable file downloads and Workspace exports into the agent workspace. |
+| `write` | `boolean` | `no` | `true` | Enable uploads, folder creation, file moves or renames, and trashing. |
 | `max_read_size` | `number` | `no` | `10485760` | Maximum non-Google-Workspace file size to read in bytes. |
 
 ### Example
@@ -468,6 +473,7 @@ agents:
     tools:
       - google_drive:
           download_file: true
+          write: true
           max_read_size: 10485760
 ```
 
@@ -476,14 +482,35 @@ google_drive_list_files()
 google_drive_search_files("name contains 'budget'")
 google_drive_read_file("1AbCdEfGhIjKlMnOpQrStUvWxYz")
 google_drive_download_file("1AbCdEfGhIjKlMnOpQrStUvWxYz")
+google_drive_upload_file("reports/launch-plan.pdf", folder_id="1FolderId")
+google_drive_create_folder("Launch", parent_id="1FolderId")
+google_drive_move_file("1FileId", "1NewFolderId", name="Final plan.pdf")
+google_drive_trash_file("1OldFileId")
 ```
 
 ### Notes
 
 - `google_drive` uses the per-service `google_drive` OAuth provider and always runs in the primary MindRoom runtime.
 - Downloads require an agent workspace; when the agent has none (for example the default `mem0` memory backend without a `private` workspace), `download_file` is ignored and a warning is logged.
-- The provider requests Drive read-only access plus OpenID email/profile scopes.
+- The provider requests full Drive access plus OpenID email/profile scopes.
+- Existing connections that granted `drive.readonly` keep working for read operations, while write operations return a structured reconnect-required result until the connection grants full Drive access.
+- Full Drive scope authorizes permanent deletion at the Google API layer, but this toolkit exposes only `google_drive_trash_file()` and no permanent-delete function.
+- Set `write: false` to remove all Drive mutation functions from the agent's tool surface.
+- MindRoom's `tool_approval` rules can gate each write call behind a Matrix approval card.
 - Configure Google OAuth through [Google Services OAuth (Admin Setup)](https://docs.mindroom.chat/deployment/google-services-oauth/) or [Google Services OAuth (Individual Setup)](https://docs.mindroom.chat/deployment/google-services-user-oauth/).
+
+```yaml
+tool_approval:
+  rules:
+    - match: google_drive_upload_file
+      action: require_approval
+    - match: google_drive_create_folder
+      action: require_approval
+    - match: google_drive_move_file
+      action: require_approval
+    - match: google_drive_trash_file
+      action: require_approval
+```
 
 ## [`google_docs`]
 
@@ -530,7 +557,7 @@ google_docs_replace_text("1AbCdEfGhIjKlMnOpQrStUvWxYz", "DRAFT", "FINAL", match_
 
 - `google_docs` uses its own `google_docs` OAuth provider and `google_docs_oauth` token service, separate from Google Drive.
 - The provider requests `documents` plus OpenID email/profile scopes and does not request any Drive scope.
-- `google_drive` remains read-only and does not gain Docs write access when `google_docs` is enabled.
+- `google_drive` has its own full Drive grant and does not reuse the separate Docs grant when `google_docs` is enabled.
 - Google classifies the `documents` scope as sensitive, so public production clients need the verification follow-up described in [Google Services OAuth](https://docs.mindroom.chat/deployment/google-services-oauth/#production-verification-follow-up).
 - `google_docs` always runs in the primary MindRoom runtime so Google OAuth tokens are never mirrored into worker containers.
 
@@ -554,8 +581,8 @@ When no usable MindRoom OAuth credentials exist, the wrapper raises `OAuthConnec
 | `spreadsheet_id` | `text` | `no` | `null` | Default spreadsheet ID. Leave unset to work with multiple spreadsheets by passing IDs per call. |
 | `spreadsheet_range` | `text` | `no` | `null` | Default range such as `Sheet1!A1:Z100`. |
 | `read` | `boolean` | `no` | `true` | Enable read operations. |
-| `create` | `boolean` | `no` | `false` | Enable spreadsheet creation. |
-| `update` | `boolean` | `no` | `false` | Enable sheet updates. |
+| `create` | `boolean` | `no` | `true` | Enable spreadsheet creation. |
+| `update` | `boolean` | `no` | `true` | Enable sheet updates. |
 
 ### Example
 

--- a/src/mindroom/custom_tools/google_calendar.py
+++ b/src/mindroom/custom_tools/google_calendar.py
@@ -43,7 +43,7 @@ class GoogleCalendarTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin,
         unified credential storage and passes them to the Agno GoogleCalendarTools.
         """
         provided_creds = kwargs.pop("creds", None)
-        allow_update = kwargs.get("allow_update") is True
+        allow_update = kwargs.get("allow_update", True) is True
         kwargs.update(
             {
                 "create_event": allow_update,

--- a/src/mindroom/custom_tools/google_drive.py
+++ b/src/mindroom/custom_tools/google_drive.py
@@ -247,7 +247,11 @@ class GoogleDriveTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, Ag
     def _resolve_upload_path(self, local_path: str) -> Path:
         requested_path = Path(local_path).expanduser()
         if requested_path.is_absolute():
-            return requested_path.resolve()
+            resolved_path = requested_path.resolve()
+            if self._workspace_root is not None and not resolved_path.is_relative_to(self._workspace_root.resolve()):
+                msg = f"Google Drive local_path must stay within the workspace root: {self._workspace_root.resolve()}"
+                raise ValueError(msg)
+            return resolved_path
         if self._workspace_root is None:
             msg = "Google Drive relative local_path requires an agent workspace"
             raise ValueError(msg)
@@ -313,6 +317,8 @@ class GoogleDriveTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, Ag
         mime_type: str | None = None,
     ) -> str:
         """Upload one local file without blocking the async agent loop."""
+        if result := self._write_scope_upgrade_result():
+            return result
         return await asyncio.to_thread(
             self._upload_file,
             local_path,

--- a/src/mindroom/custom_tools/google_drive.py
+++ b/src/mindroom/custom_tools/google_drive.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import mimetypes
+from functools import wraps
 from pathlib import Path, PureWindowsPath
 from typing import TYPE_CHECKING, Any, cast
 
@@ -11,15 +13,25 @@ from agno.tools.google.drive import GoogleDriveTools as AgnoGoogleDriveTools
 from agno.tools.google.drive import MediaIoBaseDownload, WorkspaceType, authenticate
 from agno.utils.log import log_error
 from googleapiclient.errors import HttpError
+from googleapiclient.http import MediaFileUpload
 
 from mindroom.custom_tools.google_service import ThreadLocalGoogleServiceMixin, google_service_account_configured
 from mindroom.logging_config import get_logger
 from mindroom.oauth.client import ScopedOAuthClientMixin
-from mindroom.oauth.google_drive import google_drive_oauth_provider
+from mindroom.oauth.google_drive import (
+    GOOGLE_DRIVE_READ_OAUTH_SCOPES,
+    GOOGLE_DRIVE_WRITE_SCOPE,
+    google_drive_oauth_provider,
+)
+from mindroom.oauth.providers import OAuthConnectionRequired
+from mindroom.oauth.service import oauth_connect_url, oauth_credentials_have_scopes
 from mindroom.tool_system.metadata import coerce_optional_finite_number
 from mindroom.tool_system.toolkit_aliases import apply_toolkit_function_aliases
+from mindroom.workspaces import resolve_workspace_relative_path
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from mindroom.constants import RuntimePaths
     from mindroom.credentials import CredentialsManager
     from mindroom.tool_system.worker_routing import ResolvedWorkerTarget
@@ -31,7 +43,14 @@ _MODEL_FUNCTION_NAME_ALIASES = {
     "search_files": "google_drive_search_files",
     "read_file": "google_drive_read_file",
     "download_file": "google_drive_download_file",
+    "upload_file": "google_drive_upload_file",
+    "create_folder": "google_drive_create_folder",
+    "move_file": "google_drive_move_file",
+    "trash_file": "google_drive_trash_file",
 }
+_WRITE_FUNCTION_NAMES = ("upload_file", "create_folder", "move_file", "trash_file")
+_WRITE_RESULT_FIELDS = "id,name,mimeType,modifiedTime,size,parents,trashed,webViewLink"
+_FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"
 
 
 def _max_read_size_finite_error(value: object) -> TypeError | ValueError:
@@ -73,7 +92,7 @@ def _download_target_path(download_dir: str | Path, filename: str, extension: st
 
 
 class GoogleDriveTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, AgnoGoogleDriveTools):
-    """Google Drive toolkit that reads OAuth tokens from MindRoom's credential scopes."""
+    """Google Drive toolkit that uses MindRoom-scoped OAuth credentials."""
 
     _oauth_provider = google_drive_oauth_provider()
     _oauth_tool_name = "google_drive"
@@ -85,6 +104,7 @@ class GoogleDriveTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, Ag
         credentials_manager: CredentialsManager | None = None,
         worker_target: ResolvedWorkerTarget | None = None,
         tool_output_workspace_root: Path | None = None,
+        write: bool = True,
         **kwargs: Any,  # noqa: ANN401
     ) -> None:
         provided_creds = kwargs.pop("creds", None)
@@ -103,8 +123,11 @@ class GoogleDriveTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, Ag
                 kwargs["download_file"] = False
             else:
                 kwargs["download_dir"] = tool_output_workspace_root / "google-drive-downloads"
+        kwargs["upload_file"] = False
+        kwargs.setdefault("scopes", [GOOGLE_DRIVE_WRITE_SCOPE])
         self._runtime_paths = runtime_paths
         self._creds_manager = credentials_manager
+        self._workspace_root = tool_output_workspace_root
         defer_to_original_auth = self._apply_runtime_original_auth_kwargs(kwargs)
         creds = self._initialize_oauth_client(
             worker_target=worker_target,
@@ -113,9 +136,98 @@ class GoogleDriveTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, Ag
             defer_to_original_auth=defer_to_original_auth,
         )
         super().__init__(creds=creds, **kwargs)
+        if write:
+            self._register_write_tools()
         self._set_original_auth(AgnoGoogleDriveTools._auth)
         self._wrap_oauth_function_entrypoints()
+        self._wrap_write_scope_entrypoints()
         apply_toolkit_function_aliases(self, _MODEL_FUNCTION_NAME_ALIASES)
+
+    def _register_write_tools(self) -> None:
+        sync_tools = (
+            (self._upload_file, "upload_file"),
+            (self.create_folder, "create_folder"),
+            (self.move_file, "move_file"),
+            (self.trash_file, "trash_file"),
+        )
+        async_tools = (
+            (self._aupload_file, "upload_file"),
+            (self.acreate_folder, "create_folder"),
+            (self.amove_file, "move_file"),
+            (self.atrash_file, "trash_file"),
+        )
+        self.tools = (*self.tools, *(tool for tool, _name in sync_tools))
+        self._async_tools = (*self._async_tools, *async_tools)
+        for tool, name in sync_tools:
+            self.register(tool, name=name)
+        for tool, name in async_tools:
+            self.register(tool, name=name)
+
+    def _stored_credentials_have_required_scopes(self, token_data: dict[str, Any]) -> bool:
+        """Let old read-only grants continue authenticating read operations."""
+        return oauth_credentials_have_scopes(token_data, GOOGLE_DRIVE_READ_OAUTH_SCOPES)
+
+    def _write_scope_upgrade_result(self) -> str | None:
+        if self._provided_creds or self._should_fallback_to_original_auth():
+            return None
+        token_data = self._load_token_data()
+        if not token_data or oauth_credentials_have_scopes(token_data, self._oauth_provider.scopes):
+            return None
+        if not oauth_credentials_have_scopes(token_data, GOOGLE_DRIVE_READ_OAUTH_SCOPES):
+            return None
+
+        connect_url = oauth_connect_url(
+            self._oauth_provider,
+            self._runtime_paths,
+            worker_target=self._worker_target,
+        )
+        error = OAuthConnectionRequired(
+            "Google Drive reconnect required to grant write access. "
+            f"Reconnect with this MindRoom link, then retry the write: {connect_url}",
+            provider_id=self._oauth_provider.id,
+            connect_url=connect_url,
+            reason="missing_write_scope",
+        )
+        return self._structured_auth_failure(error)
+
+    def _wrap_write_scope_entrypoints(self) -> None:
+        """Require full Drive scope only for registered write functions."""
+        for function_name in _WRITE_FUNCTION_NAMES:
+            function = self.functions.get(function_name)
+            if function is None or function.entrypoint is None:
+                continue
+            entrypoint = function.entrypoint
+
+            @wraps(entrypoint)
+            def write_scope_entrypoint(
+                *args: object,
+                _entrypoint: Callable[..., object] = entrypoint,
+                **kwargs: object,
+            ) -> object:
+                if result := self._write_scope_upgrade_result():
+                    return result
+                return _entrypoint(*args, **kwargs)
+
+            function.entrypoint = write_scope_entrypoint
+            setattr(self, function_name, write_scope_entrypoint)
+
+        for function_name in _WRITE_FUNCTION_NAMES:
+            function = self.async_functions.get(function_name)
+            if function is None or function.entrypoint is None:
+                continue
+            entrypoint = function.entrypoint
+
+            @wraps(entrypoint)
+            async def write_scope_async_entrypoint(
+                *args: object,
+                _entrypoint: Callable[..., Any] = entrypoint,
+                **kwargs: object,
+            ) -> object:
+                if result := self._write_scope_upgrade_result():
+                    return result
+                return await _entrypoint(*args, **kwargs)
+
+            function.entrypoint = write_scope_async_entrypoint
 
     def _coerce_max_read_size(self, value: object) -> int | float | None:
         try:
@@ -132,6 +244,19 @@ class GoogleDriveTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, Ag
     def _should_fallback_to_original_auth(self) -> bool:
         return google_service_account_configured(self.service_account_path, self._runtime_paths)
 
+    def _resolve_upload_path(self, local_path: str) -> Path:
+        requested_path = Path(local_path).expanduser()
+        if requested_path.is_absolute():
+            return requested_path.resolve()
+        if self._workspace_root is None:
+            msg = "Google Drive relative local_path requires an agent workspace"
+            raise ValueError(msg)
+        return resolve_workspace_relative_path(
+            self._workspace_root,
+            requested_path,
+            field_name="Google Drive local_path",
+        )
+
     def _download_guidance(self) -> str:
         if "google_drive_download_file" in self.functions:
             return " Use google_drive_download_file instead."
@@ -140,6 +265,143 @@ class GoogleDriveTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, Ag
     def _get_file_metadata(self, file_id: str, fields: str) -> dict[str, Any]:
         service = cast("Any", self.service)
         return service.files().get(fileId=file_id, fields=fields, supportsAllDrives=True).execute()
+
+    @authenticate
+    def _upload_file(
+        self,
+        local_path: str,
+        folder_id: str | None = None,
+        name: str | None = None,
+        mime_type: str | None = None,
+    ) -> str:
+        """Upload one local file, resolving relative paths from the agent workspace."""
+        try:
+            path = self._resolve_upload_path(local_path)
+        except ValueError as exc:
+            return json.dumps({"error": str(exc)})
+        if not path.is_file():
+            return json.dumps({"error": f"The file '{path}' does not exist or is not a file."})
+
+        resolved_mime_type = mime_type or mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+        body: dict[str, object] = {"name": name or path.name}
+        if folder_id:
+            body["parents"] = [folder_id]
+        try:
+            service = cast("Any", self.service)
+            uploaded_file = (
+                service.files()
+                .create(
+                    body=body,
+                    media_body=MediaFileUpload(str(path), mimetype=resolved_mime_type),
+                    fields=_WRITE_RESULT_FIELDS,
+                    supportsAllDrives=True,
+                )
+                .execute()
+            )
+            return json.dumps(uploaded_file)
+        except HttpError as exc:
+            return json.dumps({"error": f"Google Drive API error: {exc}"})
+        except Exception as exc:
+            log_error(f"Could not upload file '{path}': {exc}")
+            return json.dumps({"error": f"Unexpected error: {type(exc).__name__}: {exc}"})
+
+    async def _aupload_file(
+        self,
+        local_path: str,
+        folder_id: str | None = None,
+        name: str | None = None,
+        mime_type: str | None = None,
+    ) -> str:
+        """Upload one local file without blocking the async agent loop."""
+        return await asyncio.to_thread(
+            self._upload_file,
+            local_path,
+            folder_id=folder_id,
+            name=name,
+            mime_type=mime_type,
+        )
+
+    @authenticate
+    def create_folder(self, name: str, parent_id: str | None = None) -> str:
+        """Create a Google Drive folder, optionally under one parent folder."""
+        if not name.strip():
+            return json.dumps({"error": "Google Drive folder name must not be empty"})
+        body: dict[str, object] = {"name": name, "mimeType": _FOLDER_MIME_TYPE}
+        if parent_id:
+            body["parents"] = [parent_id]
+        try:
+            service = cast("Any", self.service)
+            folder = service.files().create(body=body, fields=_WRITE_RESULT_FIELDS, supportsAllDrives=True).execute()
+            return json.dumps(folder)
+        except HttpError as exc:
+            return json.dumps({"error": f"Google Drive API error: {exc}"})
+        except Exception as exc:
+            log_error(f"Could not create Google Drive folder '{name}': {exc}")
+            return json.dumps({"error": f"Unexpected error: {type(exc).__name__}: {exc}"})
+
+    async def acreate_folder(self, name: str, parent_id: str | None = None) -> str:
+        """Create a Google Drive folder without blocking the async agent loop."""
+        return await asyncio.to_thread(self.create_folder, name, parent_id=parent_id)
+
+    @authenticate
+    def move_file(self, file_id: str, new_parent_id: str, name: str | None = None) -> str:
+        """Move one Drive file to a new parent and optionally rename it."""
+        if not new_parent_id.strip():
+            return json.dumps({"error": "Google Drive new_parent_id must not be empty"})
+        if name is not None and not name.strip():
+            return json.dumps({"error": "Google Drive file name must not be empty"})
+        try:
+            metadata = self._get_file_metadata(file_id, "parents")
+            current_parents = [parent for parent in metadata.get("parents", []) if isinstance(parent, str) and parent]
+            update_kwargs: dict[str, object] = {
+                "fileId": file_id,
+                "body": {"name": name} if name is not None else {},
+                "fields": _WRITE_RESULT_FIELDS,
+                "supportsAllDrives": True,
+            }
+            if new_parent_id not in current_parents:
+                update_kwargs["addParents"] = new_parent_id
+            removed_parents = [parent for parent in current_parents if parent != new_parent_id]
+            if removed_parents:
+                update_kwargs["removeParents"] = ",".join(removed_parents)
+            service = cast("Any", self.service)
+            moved_file = service.files().update(**update_kwargs).execute()
+            return json.dumps(moved_file)
+        except HttpError as exc:
+            return json.dumps({"error": f"Google Drive API error: {exc}"})
+        except Exception as exc:
+            log_error(f"Could not move Google Drive file '{file_id}': {exc}")
+            return json.dumps({"error": f"Unexpected error: {type(exc).__name__}: {exc}"})
+
+    async def amove_file(self, file_id: str, new_parent_id: str, name: str | None = None) -> str:
+        """Move one Drive file without blocking the async agent loop."""
+        return await asyncio.to_thread(self.move_file, file_id, new_parent_id, name=name)
+
+    @authenticate
+    def trash_file(self, file_id: str) -> str:
+        """Move one Drive file to trash without permanently deleting it."""
+        try:
+            service = cast("Any", self.service)
+            trashed_file = (
+                service.files()
+                .update(
+                    fileId=file_id,
+                    body={"trashed": True},
+                    fields=_WRITE_RESULT_FIELDS,
+                    supportsAllDrives=True,
+                )
+                .execute()
+            )
+            return json.dumps(trashed_file)
+        except HttpError as exc:
+            return json.dumps({"error": f"Google Drive API error: {exc}"})
+        except Exception as exc:
+            log_error(f"Could not trash Google Drive file '{file_id}': {exc}")
+            return json.dumps({"error": f"Unexpected error: {type(exc).__name__}: {exc}"})
+
+    async def atrash_file(self, file_id: str) -> str:
+        """Trash one Drive file without blocking the async agent loop."""
+        return await asyncio.to_thread(self.trash_file, file_id)
 
     @authenticate
     def search_files(self, query: str | None = None, max_results: int = 10, page_token: str | None = None) -> str:

--- a/src/mindroom/custom_tools/google_drive.py
+++ b/src/mindroom/custom_tools/google_drive.py
@@ -245,16 +245,16 @@ class GoogleDriveTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, Ag
         return google_service_account_configured(self.service_account_path, self._runtime_paths)
 
     def _resolve_upload_path(self, local_path: str) -> Path:
+        if self._workspace_root is None:
+            msg = "Google Drive local_path requires an agent workspace"
+            raise ValueError(msg)
         requested_path = Path(local_path).expanduser()
         if requested_path.is_absolute():
             resolved_path = requested_path.resolve()
-            if self._workspace_root is not None and not resolved_path.is_relative_to(self._workspace_root.resolve()):
+            if not resolved_path.is_relative_to(self._workspace_root.resolve()):
                 msg = f"Google Drive local_path must stay within the workspace root: {self._workspace_root.resolve()}"
                 raise ValueError(msg)
             return resolved_path
-        if self._workspace_root is None:
-            msg = "Google Drive relative local_path requires an agent workspace"
-            raise ValueError(msg)
         return resolve_workspace_relative_path(
             self._workspace_root,
             requested_path,

--- a/src/mindroom/custom_tools/google_sheets.py
+++ b/src/mindroom/custom_tools/google_sheets.py
@@ -76,6 +76,9 @@ class GoogleSheetsTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, A
     def _normalize_dashboard_config_kwargs(self, kwargs: dict[str, Any]) -> None:
         """Map dashboard field names onto Agno's constructor argument names."""
         for field_name, init_arg in _CONFIG_FIELD_INIT_ARG_ALIASES.items():
+            if field_name not in kwargs and init_arg not in kwargs:
+                kwargs[init_arg] = True
+                continue
             if field_name not in kwargs:
                 continue
             if init_arg in kwargs:

--- a/src/mindroom/custom_tools/todo_poke.py
+++ b/src/mindroom/custom_tools/todo_poke.py
@@ -443,7 +443,7 @@ def _read_poke_state(todo_root: Path) -> dict[str, Any]:
     if not isinstance(raw_state, dict):
         logger.warning("todo_poke_dedup_state_reset", path=str(path), error="state root must be an object")
         return {}
-    return cast("dict[str, Any]", raw_state)
+    return raw_state
 
 
 def _prune_poke_state(todo_root: Path, active_scope_keys: frozenset[str]) -> None:

--- a/src/mindroom/oauth/client.py
+++ b/src/mindroom/oauth/client.py
@@ -216,7 +216,7 @@ class ScopedOAuthClientMixin:
         token_data = self._load_token_data()
         if not token_data:
             return None
-        if not oauth_credentials_have_required_scopes(self._oauth_provider, token_data):
+        if not self._stored_credentials_have_required_scopes(token_data):
             self._oauth_logger.warning(
                 "oauth_credentials_missing_required_scopes",
                 tool_name=self._oauth_tool_name,
@@ -237,6 +237,10 @@ class ScopedOAuthClientMixin:
             return None
         self._oauth_logger.info("oauth_credentials_loaded", tool_name=self._oauth_tool_name)
         return creds
+
+    def _stored_credentials_have_required_scopes(self, token_data: dict[str, Any]) -> bool:
+        """Return whether stored credentials can authenticate this toolkit."""
+        return oauth_credentials_have_required_scopes(self._oauth_provider, token_data)
 
     def _should_fallback_to_original_auth(self) -> bool:
         """Return whether the tool should defer to its original auth flow."""
@@ -269,7 +273,7 @@ class ScopedOAuthClientMixin:
         token_data = self._load_token_data()
         if (
             not token_data
-            or not oauth_credentials_have_required_scopes(self._oauth_provider, token_data)
+            or not self._stored_credentials_have_required_scopes(token_data)
             or not oauth_credentials_satisfy_identity_policy(self._oauth_provider, self._runtime_paths, token_data)
         ):
             raise self._connection_required()

--- a/src/mindroom/oauth/google_drive.py
+++ b/src/mindroom/oauth/google_drive.py
@@ -9,9 +9,14 @@ import mindroom.oauth.google as google_oauth
 if TYPE_CHECKING:
     from mindroom.oauth.providers import OAuthProvider
 
-_GOOGLE_DRIVE_OAUTH_SCOPES = (
+GOOGLE_DRIVE_READ_OAUTH_SCOPES = (
     *google_oauth.GOOGLE_IDENTITY_SCOPES,
     "https://www.googleapis.com/auth/drive.readonly",
+)
+GOOGLE_DRIVE_WRITE_SCOPE = "https://www.googleapis.com/auth/drive"
+_GOOGLE_DRIVE_OAUTH_SCOPES = (
+    *google_oauth.GOOGLE_IDENTITY_SCOPES,
+    GOOGLE_DRIVE_WRITE_SCOPE,
 )
 
 
@@ -25,7 +30,7 @@ def google_drive_oauth_provider() -> OAuthProvider:
         tool_config_service="google_drive",
         client_config_services=("google_drive_oauth_client",),
         status_capabilities=(
-            "Drive file search",
-            "Drive file read",
+            "Drive file search and read",
+            "Drive file upload and organization",
         ),
     )

--- a/src/mindroom/oauth/service.py
+++ b/src/mindroom/oauth/service.py
@@ -20,7 +20,7 @@ from mindroom.oauth.providers import (
 from mindroom.oauth.state import consume_opaque_oauth_state, issue_opaque_oauth_state, read_opaque_oauth_state
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Collection, Mapping
     from pathlib import Path
 
     from mindroom.constants import RuntimePaths
@@ -79,6 +79,7 @@ __all__ = [
     "oauth_connect_url",
     "oauth_credential_target_payload",
     "oauth_credentials_have_required_scopes",
+    "oauth_credentials_have_scopes",
     "oauth_credentials_match_client_id",
     "oauth_credentials_satisfy_identity_policy",
     "oauth_credentials_usable",
@@ -530,8 +531,11 @@ def oauth_credentials_match_client_id(
     return isinstance(stored_client_id, str) and stored_client_id.strip() == client_config.client_id
 
 
-def oauth_credentials_have_required_scopes(provider: OAuthProvider, credentials: dict[str, object]) -> bool:
-    """Return whether stored credentials include every provider-required scope."""
+def oauth_credentials_have_scopes(
+    credentials: Mapping[str, object],
+    required_scopes: Collection[str],
+) -> bool:
+    """Return whether stored credentials include every requested scope."""
     granted_scopes: set[str] = set()
     raw_scopes = credentials.get("scopes")
     if isinstance(raw_scopes, list):
@@ -542,7 +546,12 @@ def oauth_credentials_have_required_scopes(provider: OAuthProvider, credentials:
     expanded_granted_scopes = set(granted_scopes)
     for scope in granted_scopes:
         expanded_granted_scopes.update(_SCOPE_IMPLICATIONS.get(scope, ()))
-    return set(provider.scopes).issubset(expanded_granted_scopes)
+    return set(required_scopes).issubset(expanded_granted_scopes)
+
+
+def oauth_credentials_have_required_scopes(provider: OAuthProvider, credentials: dict[str, object]) -> bool:
+    """Return whether stored credentials include every provider-required scope."""
+    return oauth_credentials_have_scopes(credentials, provider.scopes)
 
 
 def oauth_credentials_satisfy_identity_policy(

--- a/src/mindroom/tools/google_calendar.py
+++ b/src/mindroom/tools/google_calendar.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
             label="Allow Updates",
             type="boolean",
             required=False,
-            default=False,
+            default=True,
             description="Allow the agent to create, update, and delete calendar events",
         ),
     ],

--- a/src/mindroom/tools/google_drive.py
+++ b/src/mindroom/tools/google_drive.py
@@ -20,10 +20,11 @@ if TYPE_CHECKING:
 @register_tool_with_metadata(
     name="google_drive",
     display_name="Google Drive",
-    description="Search and read files from the connected user's Google Drive",
+    description="Search, read, upload, and organize files in the connected user's Google Drive",
     category=ToolCategory.PRODUCTIVITY,
     status=ToolStatus.REQUIRES_CONFIG,
     setup_type=SetupType.OAUTH,
+    consumes_workspace_paths=True,
     auth_provider="google_drive",
     icon="SiGoogledrive",
     icon_color="text-green-600",
@@ -61,6 +62,14 @@ if TYPE_CHECKING:
             description="Allow downloading or exporting Google Drive files.",
         ),
         ConfigField(
+            name="write",
+            label="Allow Write Operations",
+            type="boolean",
+            required=False,
+            default=True,
+            description="Allow uploading, creating folders, moving or renaming files, and trashing files.",
+        ),
+        ConfigField(
             name="max_read_size",
             label="Max Read Size",
             type="number",
@@ -87,10 +96,14 @@ if TYPE_CHECKING:
         "google_drive_search_files",
         "google_drive_read_file",
         "google_drive_download_file",
+        "google_drive_upload_file",
+        "google_drive_create_folder",
+        "google_drive_move_file",
+        "google_drive_trash_file",
     ),
 )
 def google_drive_tools() -> type[GoogleDriveTools]:
-    """Return Google Drive tools for file search and read access."""
+    """Return Google Drive tools for file reading and management."""
     from mindroom.custom_tools.google_drive import GoogleDriveTools
 
     return GoogleDriveTools

--- a/src/mindroom/tools/google_sheets.py
+++ b/src/mindroom/tools/google_sheets.py
@@ -57,7 +57,7 @@ if TYPE_CHECKING:
             label="Enable Create Operations",
             type="boolean",
             required=False,
-            default=False,
+            default=True,
             description="Allow creating new spreadsheets",
         ),
         ConfigField(
@@ -65,7 +65,7 @@ if TYPE_CHECKING:
             label="Enable Update Operations",
             type="boolean",
             required=False,
-            default=False,
+            default=True,
             description="Allow updating existing spreadsheets",
         ),
     ],

--- a/src/mindroom/tools_metadata.json
+++ b/src/mindroom/tools_metadata.json
@@ -4055,7 +4055,7 @@
         },
         {
           "authored_override": true,
-          "default": false,
+          "default": true,
           "description": "Allow creating new spreadsheets",
           "label": "Enable Create Operations",
           "name": "create",
@@ -4067,7 +4067,7 @@
         },
         {
           "authored_override": true,
-          "default": false,
+          "default": true,
           "description": "Allow updating existing spreadsheets",
           "label": "Enable Update Operations",
           "name": "update",
@@ -7908,7 +7908,7 @@
         },
         {
           "authored_override": true,
-          "default": false,
+          "default": true,
           "description": "Allow the agent to create, update, and delete calendar events",
           "label": "Allow Updates",
           "name": "allow_update",
@@ -8076,6 +8076,18 @@
         },
         {
           "authored_override": true,
+          "default": true,
+          "description": "Allow uploading, creating folders, moving or renaming files, and trashing files.",
+          "label": "Allow Write Operations",
+          "name": "write",
+          "options": null,
+          "placeholder": null,
+          "required": false,
+          "type": "boolean",
+          "validation": null
+        },
+        {
+          "authored_override": true,
           "default": 10485760,
           "description": "Maximum non-Google-Workspace file size to read in bytes.",
           "label": "Max Read Size",
@@ -8087,7 +8099,7 @@
           "validation": null
         }
       ],
-      "consumes_workspace_paths": false,
+      "consumes_workspace_paths": true,
       "default_execution_target": "primary",
       "dependencies": [
         "google-api-python-client",
@@ -8095,14 +8107,18 @@
         "google-auth-httplib2",
         "google-auth-oauthlib"
       ],
-      "description": "Search and read files from the connected user's Google Drive",
+      "description": "Search, read, upload, and organize files in the connected user's Google Drive",
       "display_name": "Google Drive",
       "docs_url": "https://docs.agno.com/tools/toolkits/others/google_drive",
       "function_names": [
         "google_drive_list_files",
         "google_drive_search_files",
         "google_drive_read_file",
-        "google_drive_download_file"
+        "google_drive_download_file",
+        "google_drive_upload_file",
+        "google_drive_create_folder",
+        "google_drive_move_file",
+        "google_drive_trash_file"
       ],
       "helper_text": null,
       "icon": "SiGoogledrive",

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -1918,7 +1918,7 @@ def test_get_tools_requires_oauth_token_for_generic_auth_provider(test_client: T
                 "openid",
                 "https://www.googleapis.com/auth/userinfo.email",
                 "https://www.googleapis.com/auth/userinfo.profile",
-                "https://www.googleapis.com/auth/drive.readonly",
+                "https://www.googleapis.com/auth/drive",
             ],
             "_source": "oauth",
         },

--- a/tests/test_google_calendar_oauth_tool.py
+++ b/tests/test_google_calendar_oauth_tool.py
@@ -102,7 +102,7 @@ def test_google_calendar_loads_tokens_from_oauth_service(tmp_path: Path) -> None
     assert "calendar_id" not in token_data
 
 
-def test_google_calendar_default_config_disables_write_methods(tmp_path: Path) -> None:
+def test_google_calendar_default_config_enables_write_methods(tmp_path: Path) -> None:
     tool = get_tool_by_name(
         "google_calendar",
         _runtime_paths(tmp_path),
@@ -112,12 +112,12 @@ def test_google_calendar_default_config_disables_write_methods(tmp_path: Path) -
     )
 
     assert isinstance(tool, GoogleCalendarTools)
-    assert "create_event" not in tool.functions
-    assert "update_event" not in tool.functions
-    assert "delete_event" not in tool.functions
-    assert "quick_add_event" not in tool.functions
-    assert "move_event" not in tool.functions
-    assert "respond_to_event" not in tool.functions
+    assert "create_event" in tool.functions
+    assert "update_event" in tool.functions
+    assert "delete_event" in tool.functions
+    assert "quick_add_event" in tool.functions
+    assert "move_event" in tool.functions
+    assert "respond_to_event" in tool.functions
     # Agno validates its own broad scope marker during toolkit construction.
     # MindRoom injects pre-authorized credentials carrying the granular provider scopes below.
     assert "https://www.googleapis.com/auth/calendar" in tool.scopes

--- a/tests/test_google_drive_oauth_tool.py
+++ b/tests/test_google_drive_oauth_tool.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from collections.abc import AsyncIterator, Iterator
 from datetime import UTC, datetime
@@ -539,6 +540,43 @@ def test_google_drive_readonly_grant_keeps_reads_and_requires_reconnect_for_writ
     assert service.files_resource.create_kwargs is None
 
 
+def test_google_drive_readonly_grant_blocks_direct_async_write_methods(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths_with_google_drive_client(
+        tmp_path,
+        {"MINDROOM_PUBLIC_URL": "https://mindroom.example.test"},
+    )
+    credentials_manager = CredentialsManager(tmp_path / "credentials")
+    credentials_manager.save_credentials(
+        "google_drive_oauth",
+        {
+            "token": "access-token",
+            "refresh_token": "refresh-token",
+            "client_id": "client-id",
+            "scopes": list(GOOGLE_DRIVE_READ_OAUTH_SCOPES),
+            "expires_at": datetime(2035, 1, 1, tzinfo=UTC).timestamp(),
+            "_source": "oauth",
+        },
+    )
+    tool = GoogleDriveTools(
+        runtime_paths=runtime_paths,
+        credentials_manager=credentials_manager,
+        worker_target=None,
+    )
+    service = _FakeDriveService()
+    tool.service = service
+
+    results = (
+        asyncio.run(tool._aupload_file("plan.txt")),
+        asyncio.run(tool.acreate_folder("Plans")),
+        asyncio.run(tool.amove_file("file-id", "parent-id")),
+        asyncio.run(tool.atrash_file("file-id")),
+    )
+
+    assert all(json.loads(result)["reason"] == "missing_write_scope" for result in results)
+    assert service.files_resource.create_kwargs is None
+    assert service.files_resource.update_kwargs is None
+
+
 def test_google_drive_rejects_stored_token_disallowed_by_new_identity_policy(tmp_path: Path) -> None:
     runtime_paths = _runtime_paths_with_google_drive_client(
         tmp_path,
@@ -787,6 +825,20 @@ def test_google_drive_upload_rejects_workspace_escape(
     outside_path.write_text("private")
 
     result = json.loads(tool.upload_file("../outside.txt"))
+
+    assert "must stay within the workspace root" in result["error"]
+    assert service.files_resource.create_kwargs is None
+
+
+def test_google_drive_upload_rejects_absolute_workspace_escape(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool, service, _workspace_root = _google_drive_write_tool(tmp_path, monkeypatch)
+    outside_path = tmp_path / "outside.txt"
+    outside_path.write_text("private")
+
+    result = json.loads(tool.upload_file(str(outside_path)))
 
     assert "must stay within the workspace root" in result["error"]
     assert service.files_resource.create_kwargs is None

--- a/tests/test_google_drive_oauth_tool.py
+++ b/tests/test_google_drive_oauth_tool.py
@@ -844,6 +844,28 @@ def test_google_drive_upload_rejects_absolute_workspace_escape(
     assert service.files_resource.create_kwargs is None
 
 
+def test_google_drive_upload_requires_workspace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("mindroom.custom_tools.google_drive.MediaFileUpload", _FakeMediaFileUpload)
+    outside_path = tmp_path / "outside.txt"
+    outside_path.write_text("private")
+    tool = GoogleDriveTools(
+        runtime_paths=_runtime_paths_with_google_drive_client(tmp_path),
+        credentials_manager=CredentialsManager(tmp_path / "credentials"),
+        creds=_ValidCredentials(),
+        tool_output_workspace_root=None,
+    )
+    service = _FakeDriveService()
+    tool.service = service
+
+    result = json.loads(tool.upload_file(str(outside_path)))
+
+    assert result["error"] == "Google Drive local_path requires an agent workspace"
+    assert service.files_resource.create_kwargs is None
+
+
 def test_google_drive_create_folder_uses_optional_parent(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_google_drive_oauth_tool.py
+++ b/tests/test_google_drive_oauth_tool.py
@@ -18,9 +18,11 @@ from agno.tools.function import Function
 
 from mindroom import constants
 from mindroom import tools as _mindroom_tools  # noqa: F401  # registers built-in tool metadata
+from mindroom.config.main import Config
 from mindroom.credentials import CredentialsManager, get_runtime_credentials_manager
 from mindroom.custom_tools.google_drive import GoogleDriveTools
-from mindroom.oauth.google_drive import _GOOGLE_DRIVE_OAUTH_SCOPES
+from mindroom.oauth.google_drive import _GOOGLE_DRIVE_OAUTH_SCOPES, GOOGLE_DRIVE_READ_OAUTH_SCOPES
+from mindroom.tool_approval import tool_requires_approval_for_openai_compat
 from mindroom.tool_system.metadata import get_tool_by_name
 from mindroom.tool_system.worker_routing import ToolExecutionIdentity, resolve_worker_target
 
@@ -69,6 +71,8 @@ class _FakeDriveFilesResource:
         self.get_kwargs: dict[str, object] | None = None
         self.get_media_kwargs: dict[str, object] | None = None
         self.export_media_kwargs: dict[str, object] | None = None
+        self.create_kwargs: dict[str, object] | None = None
+        self.update_kwargs: dict[str, object] | None = None
         self.file_metadata: dict[str, object] = {
             "name": "Shared folder",
             "mimeType": "application/vnd.google-apps.folder",
@@ -96,6 +100,18 @@ class _FakeDriveFilesResource:
         self.export_media_kwargs = kwargs
         return _FakeDriveRequest({})
 
+    def create(self, **kwargs: object) -> _FakeDriveRequest:
+        self.create_kwargs = kwargs
+        body = kwargs.get("body")
+        response = {"id": "created-id", **body} if isinstance(body, dict) else {"id": "created-id"}
+        return _FakeDriveRequest(response)
+
+    def update(self, **kwargs: object) -> _FakeDriveRequest:
+        self.update_kwargs = kwargs
+        body = kwargs.get("body")
+        response = {"id": kwargs["fileId"], **body} if isinstance(body, dict) else {"id": kwargs["fileId"]}
+        return _FakeDriveRequest(response)
+
 
 class _FakeDriveService:
     def __init__(self) -> None:
@@ -121,6 +137,12 @@ class _FakeMediaIoBaseDownload:
         return None, self._done
 
 
+class _FakeMediaFileUpload:
+    def __init__(self, filename: str, *, mimetype: str) -> None:
+        self.filename = filename
+        self.mimetype = mimetype
+
+
 def _google_drive_download_tool(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -139,6 +161,24 @@ def _google_drive_download_tool(
     service = _FakeDriveService()
     tool.service = service
     return tool, service
+
+
+def _google_drive_write_tool(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[GoogleDriveTools, _FakeDriveService, Path]:
+    monkeypatch.setattr("mindroom.custom_tools.google_drive.MediaFileUpload", _FakeMediaFileUpload)
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    tool = GoogleDriveTools(
+        runtime_paths=_runtime_paths_with_google_drive_client(tmp_path),
+        credentials_manager=CredentialsManager(tmp_path / "credentials"),
+        creds=_ValidCredentials(),
+        tool_output_workspace_root=workspace_root,
+    )
+    service = _FakeDriveService()
+    tool.service = service
+    return tool, service, workspace_root
 
 
 def _runtime_paths_with_google_drive_client(
@@ -227,7 +267,63 @@ def test_google_drive_model_functions_do_not_collide_with_local_file_tools(tmp_p
         "google_drive_list_files",
         "google_drive_search_files",
         "google_drive_read_file",
+        "google_drive_upload_file",
+        "google_drive_create_folder",
+        "google_drive_move_file",
+        "google_drive_trash_file",
     } <= function_names
+
+
+def test_google_drive_write_config_defaults_enabled_and_can_disable(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths_with_google_drive_client(tmp_path)
+    credentials_manager = CredentialsManager(tmp_path / "credentials")
+    enabled_tool = get_tool_by_name(
+        "google_drive",
+        runtime_paths,
+        credentials_manager=credentials_manager,
+        disable_sandbox_proxy=True,
+        tool_output_workspace_root=tmp_path,
+        worker_target=None,
+    )
+    disabled_tool = get_tool_by_name(
+        "google_drive",
+        runtime_paths,
+        credentials_manager=credentials_manager,
+        tool_config_overrides={"write": False},
+        disable_sandbox_proxy=True,
+        tool_output_workspace_root=tmp_path,
+        worker_target=None,
+    )
+    write_functions = {
+        "google_drive_upload_file",
+        "google_drive_create_folder",
+        "google_drive_move_file",
+        "google_drive_trash_file",
+    }
+
+    assert write_functions <= enabled_tool.functions.keys()
+    assert write_functions <= enabled_tool.async_functions.keys()
+    assert write_functions.isdisjoint(disabled_tool.functions)
+    assert write_functions.isdisjoint(disabled_tool.async_functions)
+    assert "google_drive_delete_file" not in enabled_tool.functions
+
+
+def test_google_drive_write_functions_can_require_approval() -> None:
+    write_functions = (
+        "google_drive_upload_file",
+        "google_drive_create_folder",
+        "google_drive_move_file",
+        "google_drive_trash_file",
+    )
+    config = Config.model_validate(
+        {
+            "tool_approval": {
+                "rules": [{"match": function_name, "action": "require_approval"} for function_name in write_functions],
+            },
+        },
+    )
+
+    assert all(tool_requires_approval_for_openai_compat(config, name) for name in write_functions)
 
 
 def test_google_drive_download_uses_namespaced_model_function(tmp_path: Path) -> None:
@@ -404,6 +500,43 @@ def test_google_drive_rejects_stored_token_missing_required_scopes(tmp_path: Pat
     result = json.loads(tool.search_files(query="name contains 'plan'", max_results=1))
 
     assert "Google Drive is not connected for this agent" in result["error"]
+
+
+def test_google_drive_readonly_grant_keeps_reads_and_requires_reconnect_for_writes(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths_with_google_drive_client(
+        tmp_path,
+        {"MINDROOM_PUBLIC_URL": "https://mindroom.example.test"},
+    )
+    credentials_manager = CredentialsManager(tmp_path / "credentials")
+    credentials_manager.save_credentials(
+        "google_drive_oauth",
+        {
+            "token": "access-token",
+            "refresh_token": "refresh-token",
+            "client_id": "client-id",
+            "scopes": list(GOOGLE_DRIVE_READ_OAUTH_SCOPES),
+            "expires_at": datetime(2035, 1, 1, tzinfo=UTC).timestamp(),
+            "_source": "oauth",
+        },
+    )
+    tool = GoogleDriveTools(
+        runtime_paths=runtime_paths,
+        credentials_manager=credentials_manager,
+        worker_target=None,
+    )
+    service = _FakeDriveService()
+    tool.service = service
+
+    read_result = json.loads(tool.search_files(max_results=1))
+    write_result = json.loads(tool.create_folder("Plans"))
+
+    assert read_result["count"] == 0
+    assert write_result["oauth_connection_required"] is True
+    assert write_result["provider"] == "google_drive"
+    assert write_result["reason"] == "missing_write_scope"
+    assert "reconnect required to grant write access" in write_result["error"]
+    assert write_result["connect_url"].startswith("https://mindroom.example.test/api/oauth/google_drive/authorize")
+    assert service.files_resource.create_kwargs is None
 
 
 def test_google_drive_rejects_stored_token_disallowed_by_new_identity_policy(tmp_path: Path) -> None:
@@ -610,6 +743,113 @@ def test_google_drive_search_includes_shared_drive_parameters(tmp_path: Path) ->
         "supportsAllDrives": True,
         "corpora": "allDrives",
         "pageToken": cursor,
+    }
+
+
+def test_google_drive_upload_resolves_workspace_path_and_sets_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool, service, workspace_root = _google_drive_write_tool(tmp_path, monkeypatch)
+    upload_path = workspace_root / "reports" / "plan.txt"
+    upload_path.parent.mkdir()
+    upload_path.write_text("ship it")
+
+    result = json.loads(
+        tool.upload_file(
+            "reports/plan.txt",
+            folder_id="folder-id",
+            name="Launch plan.txt",
+            mime_type="text/custom",
+        ),
+    )
+
+    assert result["id"] == "created-id"
+    assert service.files_resource.create_kwargs is not None
+    media = service.files_resource.create_kwargs["media_body"]
+    assert isinstance(media, _FakeMediaFileUpload)
+    assert Path(media.filename) == upload_path
+    assert media.mimetype == "text/custom"
+    assert service.files_resource.create_kwargs == {
+        "body": {"name": "Launch plan.txt", "parents": ["folder-id"]},
+        "media_body": media,
+        "fields": "id,name,mimeType,modifiedTime,size,parents,trashed,webViewLink",
+        "supportsAllDrives": True,
+    }
+
+
+def test_google_drive_upload_rejects_workspace_escape(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool, service, _workspace_root = _google_drive_write_tool(tmp_path, monkeypatch)
+    outside_path = tmp_path / "outside.txt"
+    outside_path.write_text("private")
+
+    result = json.loads(tool.upload_file("../outside.txt"))
+
+    assert "must stay within the workspace root" in result["error"]
+    assert service.files_resource.create_kwargs is None
+
+
+def test_google_drive_create_folder_uses_optional_parent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool, service, _workspace_root = _google_drive_write_tool(tmp_path, monkeypatch)
+
+    result = json.loads(tool.create_folder("Plans", parent_id="parent-id"))
+
+    assert result["id"] == "created-id"
+    assert service.files_resource.create_kwargs == {
+        "body": {
+            "name": "Plans",
+            "mimeType": "application/vnd.google-apps.folder",
+            "parents": ["parent-id"],
+        },
+        "fields": "id,name,mimeType,modifiedTime,size,parents,trashed,webViewLink",
+        "supportsAllDrives": True,
+    }
+
+
+def test_google_drive_move_file_replaces_parents_and_optionally_renames(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool, service, _workspace_root = _google_drive_write_tool(tmp_path, monkeypatch)
+    service.files_resource.file_metadata = {"parents": ["old-parent", "new-parent"]}
+
+    result = json.loads(tool.move_file("file-id", "new-parent", name="Renamed.txt"))
+
+    assert result == {"id": "file-id", "name": "Renamed.txt"}
+    assert service.files_resource.get_kwargs == {
+        "fileId": "file-id",
+        "fields": "parents",
+        "supportsAllDrives": True,
+    }
+    assert service.files_resource.update_kwargs == {
+        "fileId": "file-id",
+        "body": {"name": "Renamed.txt"},
+        "fields": "id,name,mimeType,modifiedTime,size,parents,trashed,webViewLink",
+        "supportsAllDrives": True,
+        "removeParents": "old-parent",
+    }
+
+
+def test_google_drive_trash_file_uses_soft_delete(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool, service, _workspace_root = _google_drive_write_tool(tmp_path, monkeypatch)
+
+    result = json.loads(tool.trash_file("file-id"))
+
+    assert result == {"id": "file-id", "trashed": True}
+    assert service.files_resource.update_kwargs == {
+        "fileId": "file-id",
+        "body": {"trashed": True},
+        "fields": "id,name,mimeType,modifiedTime,size,parents,trashed,webViewLink",
+        "supportsAllDrives": True,
     }
 
 

--- a/tests/test_google_oauth_providers.py
+++ b/tests/test_google_oauth_providers.py
@@ -89,7 +89,7 @@ GOOGLE_NARROW_EXTRA_AUTH_PARAMS = {
                 "credential_service": "google_drive_oauth",
                 "tool_config_service": "google_drive",
                 "client_config_services": ("google_drive_oauth_client",),
-                "status_capabilities": ("Drive file search", "Drive file read"),
+                "status_capabilities": ("Drive file search and read", "Drive file upload and organization"),
             },
         ),
         (

--- a/tests/test_google_sheets_oauth_tool.py
+++ b/tests/test_google_sheets_oauth_tool.py
@@ -135,6 +135,23 @@ def test_google_sheets_saved_dashboard_config_maps_to_upstream_init_args(tmp_pat
     ]
 
 
+def test_google_sheets_default_config_enables_read_and_write_methods(tmp_path: Path) -> None:
+    tool = get_tool_by_name(
+        "google_sheets",
+        _runtime_paths(tmp_path),
+        credentials_manager=CredentialsManager(tmp_path / "credentials"),
+        worker_target=None,
+        disable_sandbox_proxy=True,
+    )
+
+    assert isinstance(tool, GoogleSheetsTools)
+    assert {registered.__name__ for registered in tool.tools} == {
+        "read_sheet",
+        "create_sheet",
+        "update_sheet",
+    }
+
+
 def test_google_sheets_provider_uses_sheets_scope_without_drive_scope() -> None:
     provider = google_sheets_oauth_provider()
 

--- a/tests/test_oauth_registry.py
+++ b/tests/test_oauth_registry.py
@@ -47,7 +47,7 @@ def test_builtin_oauth_registry_includes_google_docs() -> None:
 
     assert providers["google_docs"].credential_service == "google_docs_oauth"
     assert providers["google_docs"].tool_config_service == "google_docs"
-    assert providers["google_drive"].scopes[-1] == "https://www.googleapis.com/auth/drive.readonly"
+    assert providers["google_drive"].scopes[-1] == "https://www.googleapis.com/auth/drive"
 
 
 def test_load_oauth_provider_registry_caches_loaded_registry(


### PR DESCRIPTION
## Why

Google integrations should expose their full read and write capability by default, with restrictions controlled through tool configuration and approval rules.
Google Drive was the outlier: OAuth requested only a read-only scope, and the toolkit exposed no write operations.

## What changed

- Request the full Google Drive OAuth scope and advertise read/write status capabilities.
- Add Drive upload, folder creation, move/rename, and trash operations.
- Resolve relative upload paths from the active agent workspace.
- Return a structured reconnect-required response when an existing read-only grant attempts a write.
- Enable Drive writes by default through a write config toggle.
- Enable Sheets create/update and Calendar event writes by default.
- Document per-function tool approval rules for Drive mutations.
- Regenerate tool metadata and MindRoom documentation references.

Drive exposes trash only; no permanent-delete function is added.
Existing read-only Drive grants continue to support reads through scope implication handling.

## Validation

- uv run pytest: 11229 passed, 54 skipped
- frontend unit tests: 29 passed, 1 skipped
- uv run pre-commit run --all-files
- uv run tach check --dependencies --interfaces
- strict type checks and Privata scan


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Google Drive now supports uploading, creating folders, moving/renaming files, and trashing files.
  * Added a Drive **write** option to enable/disable write actions, with per-action approval controls.
  * Google Sheets **create** and **update** are enabled by default.
  * Google Calendar **event write** actions are enabled by default.

* **Bug Fixes**
  * Existing Google Drive read-only connections now prompt reconnection when write actions are requested.

* **Documentation**
  * Updated Google provider docs to reflect full Drive access for writes, clearer scope rationale, and trash-only behavior (no permanent-delete).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->