### PR TITLE
Fix SQLite cache healing after lock contention

### DIFF
--- a/src/mindroom/matrix/cache/sqlite_cache_maintenance.py
+++ b/src/mindroom/matrix/cache/sqlite_cache_maintenance.py
@@ -107,9 +107,10 @@ async def run_startup_maintenance(
     destructive_reset: bool,
     normalized_legacy_thread_payload_rows: int,
 ) -> CacheMaintenanceReport:
-    """Repair atomically, then recount without retaining the SQLite writer."""
+    """Repair atomically, then recount from one nonblocking read snapshot."""
     repaired_counts = await _repair_orphan_derived_rows(db)
     await db.commit()
+    await db.execute("BEGIN")
     return await _collect_maintenance_report(
         db,
         schema_version=schema_version,

--- a/src/mindroom/matrix/cache/sqlite_cache_maintenance.py
+++ b/src/mindroom/matrix/cache/sqlite_cache_maintenance.py
@@ -107,8 +107,9 @@ async def run_startup_maintenance(
     destructive_reset: bool,
     normalized_legacy_thread_payload_rows: int,
 ) -> CacheMaintenanceReport:
-    """Audit, safely repair, and recount one SQLite cache transaction."""
+    """Repair atomically, then recount without retaining the SQLite writer."""
     repaired_counts = await _repair_orphan_derived_rows(db)
+    await db.commit()
     return await _collect_maintenance_report(
         db,
         schema_version=schema_version,

--- a/src/mindroom/matrix/cache/sqlite_event_cache.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import sqlite3
 import time
 import uuid
 from contextlib import asynccontextmanager
@@ -15,6 +16,7 @@ from mindroom.logging_config import get_logger
 
 from . import sqlite_event_cache_events, sqlite_event_cache_threads
 from .event_batching import group_lookup_events_by_room
+from .event_cache import EventCacheBackendUnavailableError
 from .event_normalization import normalize_event_source_for_cache
 from .sqlite_agent_message_snapshot import load_sqlite_agent_message_snapshot
 from .sqlite_cache_maintenance import (
@@ -52,6 +54,13 @@ _REQUIRED_EVENT_CACHE_TABLES = frozenset(_EVENT_CACHE_TABLES)
 _DEFAULT_PRINCIPAL_ID = "__mindroom_default_principal__"
 _PRINCIPAL_PURGE_LOCK_SCOPE = "__mindroom_principal_purge__"
 _T = TypeVar("_T")
+
+
+def _is_sqlite_lock_contention(exc: sqlite3.OperationalError) -> bool:
+    """Return whether SQLite rejected an operation because another writer owns the database."""
+    error_name = getattr(exc, "sqlite_errorname", None)
+    return isinstance(error_name, str) and error_name.startswith(("SQLITE_BUSY", "SQLITE_LOCKED"))
+
 
 logger = get_logger(__name__)
 
@@ -598,6 +607,7 @@ class SqliteEventCache:
             self._runtime.is_initialized
             and not self._runtime.is_disabled
             and not self._runtime.is_principal_disabled(self.principal_id)
+            and not self._runtime.has_pending_principal_purge(self.principal_id)
         )
 
     @property
@@ -690,7 +700,7 @@ class SqliteEventCache:
                 return disabled_result
             pending_principal_purge = self._runtime.has_pending_principal_purge(self.principal_id)
             try:
-                await db.execute("BEGIN IMMEDIATE")
+                await db.execute("BEGIN IMMEDIATE" if pending_principal_purge else "BEGIN")
                 if pending_principal_purge:
                     await sqlite_event_cache_events.purge_principal_locked(
                         db,
@@ -1067,32 +1077,46 @@ class SqliteEventCache:
 
     async def mark_thread_stale(self, room_id: str, thread_id: str, *, reason: str) -> None:
         """Persist one durable thread invalidation marker."""
-        await self._write_operation(
-            room_id,
-            operation="mark_thread_stale",
-            disabled_result=None,
-            writer=lambda db: sqlite_event_cache_threads.mark_thread_stale_locked(
-                db,
-                principal_id=self.principal_id,
-                room_id=room_id,
-                thread_id=thread_id,
-                reason=reason,
-            ),
-        )
+        try:
+            await self._write_operation(
+                room_id,
+                operation="mark_thread_stale",
+                disabled_result=None,
+                writer=lambda db: sqlite_event_cache_threads.mark_thread_stale_locked(
+                    db,
+                    principal_id=self.principal_id,
+                    room_id=room_id,
+                    thread_id=thread_id,
+                    reason=reason,
+                ),
+            )
+        except sqlite3.OperationalError as exc:
+            if not _is_sqlite_lock_contention(exc):
+                raise
+            self._runtime.record_pending_principal_purge(self.principal_id)
+            msg = "SQLite event cache unavailable while marking thread stale"
+            raise EventCacheBackendUnavailableError(msg) from exc
 
     async def mark_room_threads_stale(self, room_id: str, *, reason: str) -> None:
         """Persist a durable invalidate-and-refetch marker for every cached thread in one room."""
-        await self._write_operation(
-            room_id,
-            operation="mark_room_threads_stale",
-            disabled_result=None,
-            writer=lambda db: sqlite_event_cache_threads.mark_room_stale_locked(
-                db,
-                principal_id=self.principal_id,
-                room_id=room_id,
-                reason=reason,
-            ),
-        )
+        try:
+            await self._write_operation(
+                room_id,
+                operation="mark_room_threads_stale",
+                disabled_result=None,
+                writer=lambda db: sqlite_event_cache_threads.mark_room_stale_locked(
+                    db,
+                    principal_id=self.principal_id,
+                    room_id=room_id,
+                    reason=reason,
+                ),
+            )
+        except sqlite3.OperationalError as exc:
+            if not _is_sqlite_lock_contention(exc):
+                raise
+            self._runtime.record_pending_principal_purge(self.principal_id)
+            msg = "SQLite event cache unavailable while marking room stale"
+            raise EventCacheBackendUnavailableError(msg) from exc
 
     async def append_event(self, room_id: str, thread_id: str, event: dict[str, Any]) -> bool:
         """Append one event when the thread already has cached data."""

--- a/src/mindroom/matrix/cache/sqlite_event_cache.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache.py
@@ -1234,9 +1234,6 @@ class SqliteEventCache:
         """Remove a departure fence only after any pending purge commits."""
         if self.room_departure_epoch(room_id) != expected_departure_epoch:
             return
-        if not self.durable_writes_available:
-            return
-
         if self._runtime.has_pending_room_purge(self.principal_id, room_id):
             await self._write_operation(
                 room_id,
@@ -1245,6 +1242,8 @@ class SqliteEventCache:
                 writer=_noop_write,
                 allow_departed=True,
             )
+        if not self.durable_writes_available:
+            return
         if self._runtime.has_pending_room_purge(self.principal_id, room_id):
             return
 

--- a/tach.toml
+++ b/tach.toml
@@ -1863,6 +1863,7 @@ path = "mindroom.matrix.cache.sqlite_event_cache"
 depends_on = [
     "mindroom.matrix.cache.event_batching",
     "mindroom.matrix.cache.cache_maintenance",
+    "mindroom.matrix.cache.event_cache",
     "mindroom.matrix.cache.event_normalization",
     "mindroom.matrix.cache.thread_cache_state",
     "mindroom.logging_config",

--- a/tests/test_event_cache_storage_maintenance.py
+++ b/tests/test_event_cache_storage_maintenance.py
@@ -17,6 +17,7 @@ from psycopg.conninfo import make_conninfo
 from mindroom.matrix.cache import (
     ThreadCacheState,
     postgres_event_cache,
+    sqlite_cache_maintenance,
     sqlite_event_cache,
 )
 from mindroom.matrix.cache.postgres_cache_maintenance import migrate_postgres_schema
@@ -284,6 +285,38 @@ async def test_sqlite_unsupported_schema_reset_reports_destructive_reset(tmp_pat
         assert diagnostics["cache_event_rows"] == 0
     finally:
         await cache.close()
+
+
+@pytest.mark.asyncio
+async def test_sqlite_startup_report_does_not_retain_writer_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Slow startup diagnostics must not block writes from the active cache runtime."""
+    db_path = tmp_path / "event_cache.db"
+    primary = SqliteEventCache(db_path)
+    await primary.initialize()
+    await primary._runtime.require_db().execute("PRAGMA busy_timeout=0")
+    report_started = asyncio.Event()
+    release_report = asyncio.Event()
+    collect_report = sqlite_cache_maintenance._collect_maintenance_report
+
+    async def held_report(*args: object, **kwargs: object) -> object:
+        report_started.set()
+        await release_report.wait()
+        return await collect_report(*args, **kwargs)
+
+    monkeypatch.setattr(sqlite_cache_maintenance, "_collect_maintenance_report", held_report)
+    secondary = SqliteEventCache(db_path)
+    initialize_secondary = asyncio.create_task(secondary.initialize())
+    try:
+        await asyncio.wait_for(report_started.wait(), timeout=1)
+        await primary.mark_thread_stale(_ROOM_ID, _THREAD_ID, reason="concurrent_startup_report")
+    finally:
+        release_report.set()
+        await initialize_secondary
+        await secondary.close()
+        await primary.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_event_cache_storage_maintenance.py
+++ b/tests/test_event_cache_storage_maintenance.py
@@ -288,25 +288,31 @@ async def test_sqlite_unsupported_schema_reset_reports_destructive_reset(tmp_pat
 
 
 @pytest.mark.asyncio
-async def test_sqlite_startup_report_does_not_retain_writer_lock(
+async def test_sqlite_startup_report_uses_nonblocking_read_snapshot(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Slow startup diagnostics must not block writes from the active cache runtime."""
+    """Startup diagnostics must stay coherent without blocking active cache writes."""
     db_path = tmp_path / "event_cache.db"
     primary = SqliteEventCache(db_path)
     await primary.initialize()
     await primary._runtime.require_db().execute("PRAGMA busy_timeout=0")
     report_started = asyncio.Event()
     release_report = asyncio.Event()
-    collect_report = sqlite_cache_maintenance._collect_maintenance_report
+    scalar_count = sqlite_cache_maintenance._scalar_count
 
-    async def held_report(*args: object, **kwargs: object) -> object:
-        report_started.set()
-        await release_report.wait()
-        return await collect_report(*args, **kwargs)
+    async def held_first_count(
+        db: aiosqlite.Connection,
+        query: str,
+        parameters: tuple[object, ...] = (),
+    ) -> int:
+        result = await scalar_count(db, query, parameters)
+        if query == "SELECT COUNT(*) FROM events":
+            report_started.set()
+            await release_report.wait()
+        return result
 
-    monkeypatch.setattr(sqlite_cache_maintenance, "_collect_maintenance_report", held_report)
+    monkeypatch.setattr(sqlite_cache_maintenance, "_scalar_count", held_first_count)
     secondary = SqliteEventCache(db_path)
     initialize_secondary = asyncio.create_task(secondary.initialize())
     try:
@@ -315,8 +321,14 @@ async def test_sqlite_startup_report_does_not_retain_writer_lock(
     finally:
         release_report.set()
         await initialize_secondary
+        diagnostics = secondary.runtime_diagnostics()
         await secondary.close()
         await primary.close()
+
+    assert diagnostics["cache_event_rows"] == 0
+    assert diagnostics["cache_thread_state_rows"] == 0
+    assert diagnostics["cache_room_state_rows"] == 0
+    assert diagnostics["cache_stale_thread_markers"] == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_matrix_event_cache_security.py
+++ b/tests/test_matrix_event_cache_security.py
@@ -361,6 +361,33 @@ async def test_sqlite_lock_contention_quarantines_then_heals_principal(tmp_path:
 
 
 @pytest.mark.asyncio
+async def test_sqlite_pending_principal_purge_does_not_strand_rejoined_room(tmp_path: Path) -> None:
+    """A rejoin must flush a pending principal purge before lifting its departure fence."""
+    root = SqliteEventCache(tmp_path / "event_cache.db")
+    await root.initialize()
+    alice = root.for_principal("@alice:localhost")
+    room_id = "!room:localhost"
+    event_id = "$event"
+    event = _event(event_id, 1)
+    try:
+        await alice.store_event(event_id, room_id, event)
+        departure_epoch = alice.mark_room_departed(room_id)
+        root._runtime.record_pending_principal_purge(alice.principal_id)
+
+        await alice.mark_room_joined(room_id, expected_departure_epoch=departure_epoch)
+
+        diagnostics = alice.runtime_diagnostics()
+        assert diagnostics["cache_sqlite_pending_principal_purge"] is False
+        assert diagnostics["cache_sqlite_departed_room_count"] == 0
+        assert alice.durable_writes_available is True
+        assert await alice.get_event(room_id, event_id) is None
+        await alice.store_event(event_id, room_id, event)
+        assert await alice.get_event(room_id, event_id) == event
+    finally:
+        await root.close()
+
+
+@pytest.mark.asyncio
 async def test_failed_room_purge_blocks_reads_until_recovery(
     event_cache_factory: Callable[[], ConversationEventCache],
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_matrix_event_cache_security.py
+++ b/tests/test_matrix_event_cache_security.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import sqlite3
 import time
 import uuid
 from contextlib import asynccontextmanager
@@ -23,6 +24,7 @@ from mindroom.matrix.cache import (
 )
 from mindroom.matrix.cache.postgres_event_cache import PostgresEventCache
 from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
+from mindroom.matrix.cache.thread_cache_invalidation import mark_thread_stale_fail_closed
 from mindroom.matrix.message_content import resolve_event_source_content
 from mindroom.matrix.rooms import leave_non_dm_rooms
 from mindroom.matrix.sync_cache_trust import SyncCacheTrust
@@ -304,6 +306,56 @@ async def test_disabling_principal_view_does_not_disable_other_principals(
 
         assert bob.durable_writes_available is False
         assert await bob.get_event(room_id, "$bob") is None
+    finally:
+        await root.close()
+
+
+@pytest.mark.asyncio
+async def test_sqlite_lock_contention_quarantines_then_heals_principal(tmp_path: Path) -> None:
+    """A transient SQLite writer must fence stale data without disabling the principal forever."""
+    root = SqliteEventCache(tmp_path / "event_cache.db")
+    await root.initialize()
+    alice = root.for_principal("@alice:localhost")
+    bob = root.for_principal("@bob:localhost")
+    room_id = "!room:localhost"
+    thread_id = "$thread"
+    alice_event = _event(thread_id, 1)
+    bob_event = _event("$bob", 2)
+    try:
+        await replace_thread_unconditionally(alice, room_id, thread_id, [alice_event])
+        await bob.store_event("$bob", room_id, bob_event)
+        await root._runtime.require_db().execute("PRAGMA busy_timeout=0")
+        blocker = sqlite3.connect(root.db_path, timeout=0)
+        blocker.execute("BEGIN IMMEDIATE")
+        try:
+            readable_state = await alice.get_thread_cache_state(room_id, thread_id)
+            assert readable_state is not None
+            await mark_thread_stale_fail_closed(
+                alice,
+                room_id=room_id,
+                thread_id=thread_id,
+                reason="outbound_thread_mutation",
+                logger=MagicMock(),
+            )
+        finally:
+            blocker.rollback()
+            blocker.close()
+
+        diagnostics = alice.runtime_diagnostics()
+        assert diagnostics["cache_sqlite_principal_disabled"] is False
+        assert diagnostics["cache_sqlite_pending_principal_purge"] is True
+        assert alice.durable_writes_available is False
+        assert alice.cache_generation is None
+
+        assert await alice.get_thread_cache_state(room_id, thread_id) is None
+        assert alice.runtime_diagnostics()["cache_sqlite_pending_principal_purge"] is False
+        assert await bob.get_event(room_id, "$bob") == bob_event
+
+        await replace_thread_unconditionally(alice, room_id, thread_id, [alice_event])
+        healed_state = await alice.get_thread_cache_state(room_id, thread_id)
+        assert healed_state is not None
+        assert healed_state.validated_at is not None
+        assert healed_state.invalidated_at is None
     finally:
         await root.close()
 


### PR DESCRIPTION
## Summary

- release the SQLite writer before slow startup maintenance reporting
- keep normal cache reads on read transactions instead of reserving the writer
- turn `SQLITE_BUSY`/`SQLITE_LOCKED` during fail-closed invalidation into an existing principal-scoped pending purge, so the cache remains fenced and then heals

This is deliberately narrow: it reuses the existing purge lifecycle and does not change opaque-encrypted-event or principal-isolation semantics.

## Tests

- `uv run pytest -q tests/test_event_cache.py tests/test_event_cache_backends.py`
- `uv run pytest -q tests/test_event_cache_storage_maintenance.py tests/test_matrix_event_cache_security.py`
- targeted `ty`, Ruff, Tach, vulture, and repository pre-commit checks

Addresses ISSUE-249.