### PR TITLE
Restore SQLite read cleanup ordering

### DIFF
--- a/docs/architecture/matrix-event-cache-security.md
+++ b/docs/architecture/matrix-event-cache-security.md
@@ -93,7 +93,7 @@ SQLite write operations begin with `BEGIN IMMEDIATE`, so tombstone and MXC-owner
 
 SQLite content writes establish a durable room-membership row, and reads use `BEGIN IMMEDIATE` so they are ordered strictly before or after departure, principal cleanup, redaction, and other content mutations committed through another connection.
 
-An SQLite read that cannot reserve the writer returns a cache miss instead of falling back to a snapshot concurrent with an unknown content mutation.
+An SQLite read attempts writer reservation without waiting and returns a cache miss instead of falling back to a snapshot concurrent with an unknown content mutation.
 
 If `SQLITE_BUSY` or `SQLITE_LOCKED` prevents a durable stale marker, that principal's cache generation and durable writes remain unavailable until a later transaction purges its cached content.
 

--- a/docs/architecture/matrix-event-cache-security.md
+++ b/docs/architecture/matrix-event-cache-security.md
@@ -93,6 +93,10 @@ SQLite write operations begin with `BEGIN IMMEDIATE`, so tombstone and MXC-owner
 
 SQLite content writes establish a durable room-membership row, and reads use `BEGIN IMMEDIATE` so they are ordered strictly before or after departure, principal cleanup, redaction, and other content mutations committed through another connection.
 
+An SQLite read that cannot reserve the writer returns a cache miss instead of falling back to a snapshot concurrent with an unknown content mutation.
+
+If `SQLITE_BUSY` or `SQLITE_LOCKED` prevents a durable stale marker, that principal's cache generation and durable writes remain unavailable until a later transaction purges its cached content.
+
 SQLite write results are reauthorized after commit while the operation lock is still held, so a concurrent leave cannot expose plaintext written before the fence.
 
 SQLite schema version 12 resets predecessor and older advisory cache contents inside one rollback-safe transaction because those rows have no provable principal owner, and it creates a new durable database-generation identifier.

--- a/src/mindroom/matrix/cache/sqlite_event_cache.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache.py
@@ -741,6 +741,10 @@ class SqliteEventCache:
                 await _rollback_sqlite_connection_best_effort(db, operation=operation)
                 if _is_sqlite_lock_contention(exc):
                     self._runtime.record_read_contention()
+                    logger.debug(
+                        "SQLite event cache read skipped because another writer owns storage",
+                        operation=operation,
+                    )
                     return disabled_result
                 raise
             except BaseException:

--- a/src/mindroom/matrix/cache/sqlite_event_cache.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache.py
@@ -53,6 +53,8 @@ _EVENT_CACHE_TABLES = (
 _REQUIRED_EVENT_CACHE_TABLES = frozenset(_EVENT_CACHE_TABLES)
 _DEFAULT_PRINCIPAL_ID = "__mindroom_default_principal__"
 _PRINCIPAL_PURGE_LOCK_SCOPE = "__mindroom_principal_purge__"
+_DEFAULT_BUSY_TIMEOUT = "PRAGMA busy_timeout=5000"
+_FAIL_FAST_BUSY_TIMEOUT = "PRAGMA busy_timeout=0"
 _T = TypeVar("_T")
 
 
@@ -95,6 +97,15 @@ async def _rollback_sqlite_connection_best_effort(db: aiosqlite.Connection, *, o
         )
 
 
+async def _begin_immediate_read(db: aiosqlite.Connection) -> None:
+    """Reserve the writer without waiting, then restore the normal write timeout."""
+    await db.execute(_FAIL_FAST_BUSY_TIMEOUT)
+    try:
+        await db.execute("BEGIN IMMEDIATE")
+    finally:
+        await db.execute(_DEFAULT_BUSY_TIMEOUT)
+
+
 async def _initialize_event_cache_db(
     db_path: Path,
 ) -> tuple[aiosqlite.Connection, CacheMaintenanceReport, str]:
@@ -103,7 +114,7 @@ async def _initialize_event_cache_db(
     db = await aiosqlite.connect(db_path)
     try:
         await db.execute("PRAGMA journal_mode=WAL")
-        await db.execute("PRAGMA busy_timeout=5000")
+        await db.execute(_DEFAULT_BUSY_TIMEOUT)
         await db.execute("BEGIN IMMEDIATE")
         (
             migrated_from_schema_version,
@@ -411,6 +422,7 @@ class _SqliteEventCacheRuntime:
         self._pending_principal_purges: set[str] = set()
         self._departed_rooms: set[tuple[str, str]] = set()
         self._room_departure_epochs: dict[tuple[str, str], int] = {}
+        self._read_contention_count = 0
 
     @property
     def db_path(self) -> Path:
@@ -446,6 +458,15 @@ class _SqliteEventCacheRuntime:
     def certification_generation(self) -> str | None:
         """Return the durable generation bound to certified sync checkpoints."""
         return self._certification_generation
+
+    @property
+    def read_contention_count(self) -> int:
+        """Return the number of reads rejected because another writer owned storage."""
+        return self._read_contention_count
+
+    def record_read_contention(self) -> None:
+        """Record one fail-closed read miss caused by SQLite lock contention."""
+        self._read_contention_count += 1
 
     def disable(self, reason: str) -> None:
         """Disable the advisory cache for the rest of the runtime."""
@@ -638,6 +659,7 @@ class SqliteEventCache:
                 self.principal_id,
             ),
             "cache_sqlite_departed_room_count": len(self._runtime.departed_room_ids(self.principal_id)),
+            "cache_sqlite_read_contention_count": self._runtime.read_contention_count,
             "cache_certification_generation_present": self.cache_generation is not None,
         }
         if self._runtime.disabled_reason is not None:
@@ -700,7 +722,7 @@ class SqliteEventCache:
                 return disabled_result
             pending_principal_purge = self._runtime.has_pending_principal_purge(self.principal_id)
             try:
-                await db.execute("BEGIN IMMEDIATE")
+                await _begin_immediate_read(db)
                 if pending_principal_purge:
                     await sqlite_event_cache_events.purge_principal_locked(
                         db,
@@ -718,6 +740,7 @@ class SqliteEventCache:
             except sqlite3.OperationalError as exc:
                 await _rollback_sqlite_connection_best_effort(db, operation=operation)
                 if _is_sqlite_lock_contention(exc):
+                    self._runtime.record_read_contention()
                     return disabled_result
                 raise
             except BaseException:

--- a/src/mindroom/matrix/cache/sqlite_event_cache.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache.py
@@ -700,7 +700,7 @@ class SqliteEventCache:
                 return disabled_result
             pending_principal_purge = self._runtime.has_pending_principal_purge(self.principal_id)
             try:
-                await db.execute("BEGIN IMMEDIATE" if pending_principal_purge else "BEGIN")
+                await db.execute("BEGIN IMMEDIATE")
                 if pending_principal_purge:
                     await sqlite_event_cache_events.purge_principal_locked(
                         db,
@@ -715,6 +715,11 @@ class SqliteEventCache:
                     )
                     result = disabled_result if membership_state != "joined" else await reader(db)
                 await db.commit()
+            except sqlite3.OperationalError as exc:
+                await _rollback_sqlite_connection_best_effort(db, operation=operation)
+                if _is_sqlite_lock_contention(exc):
+                    return disabled_result
+                raise
             except BaseException:
                 await _rollback_sqlite_connection_best_effort(db, operation=operation)
                 raise

--- a/tests/test_matrix_event_cache_security.py
+++ b/tests/test_matrix_event_cache_security.py
@@ -329,7 +329,7 @@ async def test_sqlite_lock_contention_quarantines_then_heals_principal(tmp_path:
         blocker.execute("BEGIN IMMEDIATE")
         try:
             readable_state = await alice.get_thread_cache_state(room_id, thread_id)
-            assert readable_state is not None
+            assert readable_state is None
             await mark_thread_stale_fail_closed(
                 alice,
                 room_id=room_id,
@@ -515,10 +515,14 @@ async def test_sqlite_cleanup_in_another_runtime_serializes_with_inflight_read( 
     event = _event(event_id, 1, sidecar_url=mxc_url)
     read_obtained_result = asyncio.Event()
     release_read = asyncio.Event()
+    cleanup_write_attempted = asyncio.Event()
+    cleanup_write_acquired = asyncio.Event()
     sqlite_loader = (
         sqlite_event_cache_events.load_event if lookup_kind == "event" else sqlite_event_cache_events.load_mxc_text
     )
     original_loader = cast("Callable[..., Awaitable[object]]", sqlite_loader)
+    departure_db = departure_root._runtime.require_db()
+    original_execute = departure_db.execute
 
     async def pause_after_read(*args: object, **kwargs: object) -> object:
         result = await original_loader(*args, **kwargs)
@@ -526,9 +530,18 @@ async def test_sqlite_cleanup_in_another_runtime_serializes_with_inflight_read( 
         await release_read.wait()
         return result
 
+    async def signal_cleanup_write(sql: str, *args: object, **kwargs: object) -> Cursor:
+        if sql != "BEGIN IMMEDIATE":
+            return await original_execute(sql, *args, **kwargs)
+        cleanup_write_attempted.set()
+        cursor = await original_execute(sql, *args, **kwargs)
+        cleanup_write_acquired.set()
+        return cursor
+
     try:
         await read_cache.store_event(event_id, room_id, event)
         assert await read_cache.store_mxc_text(room_id, event_id, mxc_url, "plaintext")
+        monkeypatch.setattr(departure_db, "execute", signal_cleanup_write)
         if lookup_kind == "event":
             monkeypatch.setattr(sqlite_event_cache_events, "load_event", pause_after_read)
             read_task = asyncio.create_task(read_cache.get_event(room_id, event_id))
@@ -553,8 +566,9 @@ async def test_sqlite_cleanup_in_another_runtime_serializes_with_inflight_read( 
                 )
 
         cleanup_task = asyncio.create_task(cleanup_room())
-        await asyncio.sleep(0)
-        assert not cleanup_task.done()
+        await asyncio.wait_for(cleanup_write_attempted.wait(), timeout=1)
+        with pytest.raises(TimeoutError):
+            await asyncio.wait_for(cleanup_write_acquired.wait(), timeout=0.25)
         release_read.set()
 
         assert await read_task == (event if lookup_kind == "event" else "plaintext")

--- a/tests/test_matrix_event_cache_security.py
+++ b/tests/test_matrix_event_cache_security.py
@@ -19,6 +19,7 @@ from mindroom.matrix.cache import (
     SharedConversationEventCache,
     postgres_event_cache_events,
     postgres_event_cache_threads,
+    sqlite_event_cache,
     sqlite_event_cache_events,
     sqlite_event_cache_threads,
 )
@@ -311,7 +312,10 @@ async def test_disabling_principal_view_does_not_disable_other_principals(
 
 
 @pytest.mark.asyncio
-async def test_sqlite_lock_contention_quarantines_then_heals_principal(tmp_path: Path) -> None:
+async def test_sqlite_lock_contention_quarantines_then_heals_principal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """A transient SQLite writer must fence stale data without disabling the principal forever."""
     root = SqliteEventCache(tmp_path / "event_cache.db")
     await root.initialize()
@@ -325,6 +329,8 @@ async def test_sqlite_lock_contention_quarantines_then_heals_principal(tmp_path:
         await replace_thread_unconditionally(alice, room_id, thread_id, [alice_event])
         await bob.store_event("$bob", room_id, bob_event)
         db = root._runtime.require_db()
+        read_logger = MagicMock()
+        monkeypatch.setattr(sqlite_event_cache, "logger", read_logger)
         blocker = sqlite3.connect(root.db_path, timeout=0)
         blocker.execute("BEGIN IMMEDIATE")
         try:
@@ -333,6 +339,10 @@ async def test_sqlite_lock_contention_quarantines_then_heals_principal(tmp_path:
                 timeout=0.5,
             )
             assert readable_state is None
+            read_logger.debug.assert_called_once_with(
+                "SQLite event cache read skipped because another writer owns storage",
+                operation="get_thread_cache_state",
+            )
             timeout_cursor = await db.execute("PRAGMA busy_timeout")
             assert await timeout_cursor.fetchone() == (5000,)
             await timeout_cursor.close()

--- a/tests/test_matrix_event_cache_security.py
+++ b/tests/test_matrix_event_cache_security.py
@@ -324,12 +324,19 @@ async def test_sqlite_lock_contention_quarantines_then_heals_principal(tmp_path:
     try:
         await replace_thread_unconditionally(alice, room_id, thread_id, [alice_event])
         await bob.store_event("$bob", room_id, bob_event)
-        await root._runtime.require_db().execute("PRAGMA busy_timeout=0")
+        db = root._runtime.require_db()
         blocker = sqlite3.connect(root.db_path, timeout=0)
         blocker.execute("BEGIN IMMEDIATE")
         try:
-            readable_state = await alice.get_thread_cache_state(room_id, thread_id)
+            readable_state = await asyncio.wait_for(
+                alice.get_thread_cache_state(room_id, thread_id),
+                timeout=0.5,
+            )
             assert readable_state is None
+            timeout_cursor = await db.execute("PRAGMA busy_timeout")
+            assert await timeout_cursor.fetchone() == (5000,)
+            await timeout_cursor.close()
+            await db.execute("PRAGMA busy_timeout=0")
             await mark_thread_stale_fail_closed(
                 alice,
                 room_id=room_id,
@@ -344,6 +351,7 @@ async def test_sqlite_lock_contention_quarantines_then_heals_principal(tmp_path:
         diagnostics = alice.runtime_diagnostics()
         assert diagnostics["cache_sqlite_principal_disabled"] is False
         assert diagnostics["cache_sqlite_pending_principal_purge"] is True
+        assert diagnostics["cache_sqlite_read_contention_count"] == 1
         assert alice.durable_writes_available is False
         assert alice.cache_generation is None
 


### PR DESCRIPTION
## Why

PR #1605 moved normal SQLite reads onto deferred snapshots to avoid writer contention. That also relaxed the security invariant introduced in #1583: cleanup in another runtime could commit while a read remained open, after which the reader could return pre-cleanup event or plaintext data.

## What changed

- reserve the SQLite writer for cache reads again so departure, principal purge, redaction, and reads remain strictly ordered across connections
- return a safe cache miss when a read cannot reserve the writer because of SQLITE_BUSY or SQLITE_LOCKED
- make the cross-runtime race test wait on the actual BEGIN IMMEDIATE acquisition instead of one event-loop tick
- document read-contention and stale-marker quarantine behavior

## Validation

- 9 focused SQLite security race cases
- 240 event-cache and security tests
- full suite: 11223 passed, 54 skipped
- Ruff and Ty pass for changed files
- repository pre-commit passes every hook except the pre-existing redundant-cast Ty warning in src/mindroom/custom_tools/todo_poke.py:446

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cache behavior during SQLite write contention by returning a cache miss instead of serving potentially outdated data.
  - Prevented lock contention from surfacing as read errors.
  - Improved coordination between cache reads and cleanup operations.

- **Diagnostics**
  - Added runtime metrics and debug logging for SQLite read contention.
  - Improved visibility into temporary database lock handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->