### PR TITLE
fix(scheduler): reject impossible crons on edit path (ISSUE-221)

### DIFF
--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -200,6 +200,15 @@ def _raise_schedule_edit_error(message: str) -> typing.NoReturn:
     raise ValueError(message)
 
 
+def _cron_validation_error(cron_expression: str) -> str | None:
+    """Return the validation error for a cron that can never fire (e.g. Feb 31), if any."""
+    try:
+        croniter(cron_expression, datetime.now(UTC)).get_next(datetime)
+    except (ValueError, CroniterError) as e:
+        return f"Invalid cron expression: {e!s}"
+    return None
+
+
 def build_scheduled_task_read_model(
     task: ScheduledTaskRecord,
     current_time: datetime | None = None,
@@ -274,10 +283,9 @@ def build_edited_scheduled_workflow(  # noqa: C901
                 _raise_schedule_edit_error(
                     "Invalid cron expression: Cron expression must have exactly 5 fields: minute hour day month weekday",
                 )
-            try:
-                croniter(raw_expression, datetime.now(UTC))
-            except (ValueError, CroniterError) as e:
-                _raise_schedule_edit_error(f"Invalid cron expression: {e!s}")
+            cron_error = _cron_validation_error(raw_expression)
+            if cron_error is not None:
+                _raise_schedule_edit_error(cron_error)
             minute, hour, day, month, weekday = fields
             cron_schedule = CronSchedule(minute=minute, hour=hour, day=day, month=month, weekday=weekday)
         if cron_schedule is None:
@@ -381,6 +389,13 @@ def _validate_parsed_workflow(workflow: ScheduledWorkflow) -> _WorkflowParseErro
             error="Could not determine the recurring schedule.",
             suggestion='Include an explicit cadence like "daily at 9am".',
         )
+    if workflow.schedule_type == "cron" and workflow.cron_schedule:
+        cron_error = _cron_validation_error(workflow.cron_schedule.to_cron_string())
+        if cron_error is not None:
+            return _WorkflowParseError(
+                error=cron_error,
+                suggestion='Use a schedule that maps to real dates, like "daily at 9am".',
+            )
     return _validate_conditional_workflow(workflow)
 
 

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -25,6 +25,7 @@ from mindroom.scheduling import (
     _persist_scheduled_task_state,
     _run_cron_task,
     _run_once_task,
+    _validate_parsed_workflow,
     build_edited_scheduled_workflow,
     build_scheduled_task_read_model,
     cancel_all_scheduled_tasks,
@@ -274,6 +275,31 @@ def test_build_edited_scheduled_workflow_rejects_invalid_field_combinations() ->
 
     with pytest.raises(ValueError, match="message cannot be empty"):
         build_edited_scheduled_workflow(existing_once, room_id="!room:server", message="   ")
+
+
+def test_impossible_cron_rejected_on_create_and_edit_paths() -> None:
+    """Syntactically valid but impossible crons (e.g. Feb 31) must be rejected, not persisted."""
+    existing_cron = ScheduledWorkflow(
+        schedule_type="cron",
+        cron_schedule=CronSchedule(minute="0", hour="9", day="*", month="*", weekday="*"),
+        message="original message",
+        description="Original description",
+    )
+
+    with pytest.raises(ValueError, match="Invalid cron expression"):
+        build_edited_scheduled_workflow(existing_cron, room_id="!room:server", cron_expression="0 0 31 2 *")
+
+    impossible_workflow = ScheduledWorkflow(
+        schedule_type="cron",
+        cron_schedule=CronSchedule(minute="0", hour="0", day="31", month="2", weekday="*"),
+        message="check email",
+        description="Check email",
+    )
+    parse_error = _validate_parsed_workflow(impossible_workflow)
+    assert parse_error is not None
+    assert "Invalid cron expression" in parse_error.error
+
+    assert _validate_parsed_workflow(existing_cron) is None
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## ISSUE-221 (P16): reject impossible crons instead of silently never firing

**Problem:** The schedule *edit* path validated cron expressions using only the `croniter(...)` constructor, which accepts syntactically-valid but impossible crons like `0 0 31 2 *` (Feb 31). Such a schedule was persisted successfully and then **silently never fired** — a member of the P16 schedule-failure class that has been the #1 recurring hard failure in the weekly tool-call quality analysis.

**Fix (minimal, 45 lines, no refactors):** Add a shared `_cron_validation_error()` helper that advances the iterator once via `croniter(...).get_next(datetime)` so impossible crons raise, and apply it **symmetrically on both the create/parse path (`_validate_parsed_workflow`) and the edit path (`build_edited_scheduled_workflow`)**. Reuses the existing error surfaces (`_raise_schedule_edit_error`, `_WorkflowParseError` with a `suggestion`).

**Tests:** adds `test_impossible_cron_rejected_on_create_and_edit_paths`; `tests/test_scheduling.py` + `tests/test_scheduler_tool.py` = **68 passed**.

Diff: `src/mindroom/scheduling.py` +23/-4, `tests/test_scheduling.py` +26.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cron schedule validation to reject dates that can never occur, such as February 31.
  * Applied consistent validation when creating, editing, or AI-generating scheduled workflows.
  * Added clearer error messages and guidance for correcting invalid schedules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->