### PR TITLE
Support authenticated proxies in Desktop Matrix client

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -238,14 +238,21 @@ Create and privately save the dedicated local desktop Matrix device.
  Log in once, create an Olm device, and save its access token privately.
 
 ╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ *  --user-id               TEXT  Dedicated Matrix user ID for this desktop device.     │
-│                                  [required]                                            │
-│    --homeserver            TEXT  Matrix homeserver URL; defaults to the configured     │
-│                                  MindRoom homeserver.                                  │
-│    --replace                     Replace the saved session with a fresh Matrix device. │
-│    --config        -c      PATH  MindRoom config path used for runtime env.            │
-│    --storage-path  -s      PATH  Desktop bridge state directory.                       │
-│    --help          -h            Show this message and exit.                           │
+│ *  --user-id                           TEXT  Dedicated Matrix user ID for this desktop │
+│                                              device.                                   │
+│                                              [required]                                │
+│    --homeserver                        TEXT  Matrix homeserver URL; defaults to the    │
+│                                              configured MindRoom homeserver.           │
+│    --replace                                 Replace the saved session with a fresh    │
+│                                              Matrix device.                            │
+│    --matrix-http-headers-file          PATH  Owner-only JSON file of HTTP headers      │
+│                                              added to every Matrix request.            │
+│                                              [env var:                                 │
+│                                              MINDROOM_DESKTOP_MATRIX_HTTP_HEADERS_FIL… │
+│    --config                    -c      PATH  MindRoom config path used for runtime     │
+│                                              env.                                      │
+│    --storage-path              -s      PATH  Desktop bridge state directory.           │
+│    --help                      -h            Show this message and exit.               │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 
 
@@ -327,6 +334,11 @@ Control remains disabled unless the local command grants a short lease.
 │                                                                   timeout.                   │
 │                                                                   [default: 90]              │
 │    --log-level                -l      TEXT                        [default: INFO]            │
+│    --matrix-http-headers-fi…          PATH                        Owner-only JSON file of    │
+│                                                                   HTTP headers added to      │
+│                                                                   every Matrix request.      │
+│                                                                   [env var:                  │
+│                                                                   MINDROOM_DESKTOP_MATRIX_H… │
 │    --config                   -c      PATH                        MindRoom config path used  │
 │                                                                   for runtime env.           │
 │    --storage-path             -s      PATH                        Desktop bridge state       │

--- a/docs/tools/desktop.md
+++ b/docs/tools/desktop.md
@@ -127,6 +127,36 @@ Ed25519: desktop-device-fingerprint
 
 Copy these exact public identity values to the cloud MindRoom configuration.
 
+### Homeservers Behind an Identity-Aware Proxy
+
+A command-line Matrix client cannot reuse an interactive browser login cookie.
+If an identity-aware proxy requires machine credentials, put its required request headers in a separate JSON file:
+
+```json
+{
+  "X-Access-Client-Id": "client-id",
+  "X-Access-Client-Secret": "client-secret"
+}
+```
+
+Use the exact header names issued by the proxy, restrict the file to its owner, and pass it during both login and bridge startup:
+
+```bash
+chmod 600 ~/.config/mindroom/matrix-http-headers.json
+
+mindroom desktop login \
+  --user-id @my-laptop:example.org \
+  --homeserver https://matrix.example.org \
+  --matrix-http-headers-file ~/.config/mindroom/matrix-http-headers.json
+```
+
+The file must contain one JSON object whose keys and values are strings.
+MindRoom refuses group-readable or world-readable header files on Unix.
+The headers apply to every Matrix request made by the desktop client, including login, sync, encryption-key, and media requests.
+They are not copied into the saved Matrix session.
+Set `MINDROOM_DESKTOP_MATRIX_HTTP_HEADERS_FILE` to the file path instead of repeating the option on both commands.
+Configure the proxy to accept these machine credentials only for the Matrix endpoints the desktop device needs, while keeping normal Matrix authentication enabled.
+
 ## 2. Configure the Cloud Agent
 
 Start cloud MindRoom at least once so the chosen agent has a persistent Matrix device.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
   "mdit-py-plugins>=0.5",
   "mem0ai>=0.1.115",
   # Arbitrary Olm to-device encryption uses the fork's tested internal API; update only with its round-trip tests.
-  "mindroom-nio[e2e]==0.27.2",
+  "mindroom-nio[e2e]==0.27.3",
   "openai",
   "packaging>=24",
   "pydantic>=2",

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -7459,6 +7459,36 @@ Ed25519: desktop-device-fingerprint
 
 Copy these exact public identity values to the cloud MindRoom configuration.
 
+### Homeservers Behind an Identity-Aware Proxy
+
+A command-line Matrix client cannot reuse an interactive browser login cookie.
+If an identity-aware proxy requires machine credentials, put its required request headers in a separate JSON file:
+
+```json
+{
+  "X-Access-Client-Id": "client-id",
+  "X-Access-Client-Secret": "client-secret"
+}
+```
+
+Use the exact header names issued by the proxy, restrict the file to its owner, and pass it during both login and bridge startup:
+
+```bash
+chmod 600 ~/.config/mindroom/matrix-http-headers.json
+
+mindroom desktop login \
+  --user-id @my-laptop:example.org \
+  --homeserver https://matrix.example.org \
+  --matrix-http-headers-file ~/.config/mindroom/matrix-http-headers.json
+```
+
+The file must contain one JSON object whose keys and values are strings.
+MindRoom refuses group-readable or world-readable header files on Unix.
+The headers apply to every Matrix request made by the desktop client, including login, sync, encryption-key, and media requests.
+They are not copied into the saved Matrix session.
+Set `MINDROOM_DESKTOP_MATRIX_HTTP_HEADERS_FILE` to the file path instead of repeating the option on both commands.
+Configure the proxy to accept these machine credentials only for the Matrix endpoints the desktop device needs, while keeping normal Matrix authentication enabled.
+
 ## 2. Configure the Cloud Agent
 
 Start cloud MindRoom at least once so the chosen agent has a persistent Matrix device.

--- a/skills/mindroom-docs/references/page__cli__index.md
+++ b/skills/mindroom-docs/references/page__cli__index.md
@@ -234,14 +234,21 @@ Create and privately save the dedicated local desktop Matrix device.
  Log in once, create an Olm device, and save its access token privately.
 
 ╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ *  --user-id               TEXT  Dedicated Matrix user ID for this desktop device.     │
-│                                  [required]                                            │
-│    --homeserver            TEXT  Matrix homeserver URL; defaults to the configured     │
-│                                  MindRoom homeserver.                                  │
-│    --replace                     Replace the saved session with a fresh Matrix device. │
-│    --config        -c      PATH  MindRoom config path used for runtime env.            │
-│    --storage-path  -s      PATH  Desktop bridge state directory.                       │
-│    --help          -h            Show this message and exit.                           │
+│ *  --user-id                           TEXT  Dedicated Matrix user ID for this desktop │
+│                                              device.                                   │
+│                                              [required]                                │
+│    --homeserver                        TEXT  Matrix homeserver URL; defaults to the    │
+│                                              configured MindRoom homeserver.           │
+│    --replace                                 Replace the saved session with a fresh    │
+│                                              Matrix device.                            │
+│    --matrix-http-headers-file          PATH  Owner-only JSON file of HTTP headers      │
+│                                              added to every Matrix request.            │
+│                                              [env var:                                 │
+│                                              MINDROOM_DESKTOP_MATRIX_HTTP_HEADERS_FIL… │
+│    --config                    -c      PATH  MindRoom config path used for runtime     │
+│                                              env.                                      │
+│    --storage-path              -s      PATH  Desktop bridge state directory.           │
+│    --help                      -h            Show this message and exit.               │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 
 
@@ -323,6 +330,11 @@ Control remains disabled unless the local command grants a short lease.
 │                                                                   timeout.                   │
 │                                                                   [default: 90]              │
 │    --log-level                -l      TEXT                        [default: INFO]            │
+│    --matrix-http-headers-fi…          PATH                        Owner-only JSON file of    │
+│                                                                   HTTP headers added to      │
+│                                                                   every Matrix request.      │
+│                                                                   [env var:                  │
+│                                                                   MINDROOM_DESKTOP_MATRIX_H… │
 │    --config                   -c      PATH                        MindRoom config path used  │
 │                                                                   for runtime env.           │
 │    --storage-path             -s      PATH                        Desktop bridge state       │

--- a/skills/mindroom-docs/references/page__tools__desktop__index.md
+++ b/skills/mindroom-docs/references/page__tools__desktop__index.md
@@ -123,6 +123,36 @@ Ed25519: desktop-device-fingerprint
 
 Copy these exact public identity values to the cloud MindRoom configuration.
 
+### Homeservers Behind an Identity-Aware Proxy
+
+A command-line Matrix client cannot reuse an interactive browser login cookie.
+If an identity-aware proxy requires machine credentials, put its required request headers in a separate JSON file:
+
+```json
+{
+  "X-Access-Client-Id": "client-id",
+  "X-Access-Client-Secret": "client-secret"
+}
+```
+
+Use the exact header names issued by the proxy, restrict the file to its owner, and pass it during both login and bridge startup:
+
+```bash
+chmod 600 ~/.config/mindroom/matrix-http-headers.json
+
+mindroom desktop login \
+  --user-id @my-laptop:example.org \
+  --homeserver https://matrix.example.org \
+  --matrix-http-headers-file ~/.config/mindroom/matrix-http-headers.json
+```
+
+The file must contain one JSON object whose keys and values are strings.
+MindRoom refuses group-readable or world-readable header files on Unix.
+The headers apply to every Matrix request made by the desktop client, including login, sync, encryption-key, and media requests.
+They are not copied into the saved Matrix session.
+Set `MINDROOM_DESKTOP_MATRIX_HTTP_HEADERS_FILE` to the file path instead of repeating the option on both commands.
+Configure the proxy to accept these machine credentials only for the Matrix endpoints the desktop device needs, while keeping normal Matrix authentication enabled.
+
 ## 2. Configure the Cloud Agent
 
 Start cloud MindRoom at least once so the chosen agent has a persistent Matrix device.

--- a/src/mindroom/cli/desktop.py
+++ b/src/mindroom/cli/desktop.py
@@ -12,6 +12,8 @@ import typer
 from rich.console import Console
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     import nio
 
     from mindroom.constants import RuntimePaths
@@ -70,6 +72,12 @@ def desktop_login(
         help="Matrix homeserver URL; defaults to the configured MindRoom homeserver.",
     ),
     replace: bool = typer.Option(False, "--replace", help="Replace the saved session with a fresh Matrix device."),
+    matrix_http_headers_file: Path | None = typer.Option(  # noqa: B008
+        None,
+        "--matrix-http-headers-file",
+        envvar="MINDROOM_DESKTOP_MATRIX_HTTP_HEADERS_FILE",
+        help="Owner-only JSON file of HTTP headers added to every Matrix request.",
+    ),
     config_path: Path | None = typer.Option(  # noqa: B008
         None,
         "--config",
@@ -86,17 +94,22 @@ def desktop_login(
     """Log in once, create an Olm device, and save its access token privately."""
     from mindroom.cli.config import activate_cli_runtime  # noqa: PLC0415
     from mindroom.constants import runtime_matrix_homeserver  # noqa: PLC0415
-    from mindroom.desktop.session import DesktopSessionError, desktop_session_path  # noqa: PLC0415
+    from mindroom.desktop.session import (  # noqa: PLC0415
+        DesktopSessionError,
+        desktop_session_path,
+        load_desktop_http_headers,
+    )
 
     runtime_paths = activate_cli_runtime(config_path, storage_path=storage_path)
     session_path = desktop_session_path(runtime_paths)
     if session_path.exists() and not replace:
         _error_console.print(f"[red]Error:[/red] Session already exists at {session_path}. Use --replace explicitly.")
         raise typer.Exit(1)
-    password = os.environ.get("MINDROOM_DESKTOP_MATRIX_PASSWORD")
-    if password is None:
-        password = typer.prompt("Matrix password", hide_input=True, confirmation_prompt=False)
     try:
+        http_headers = load_desktop_http_headers(matrix_http_headers_file)
+        password = os.environ.get("MINDROOM_DESKTOP_MATRIX_PASSWORD")
+        if password is None:
+            password = typer.prompt("Matrix password", hide_input=True, confirmation_prompt=False)
         asyncio.run(
             _login_and_save(
                 runtime_paths=runtime_paths,
@@ -104,6 +117,7 @@ def desktop_login(
                 user_id=user_id,
                 password=password,
                 session_path=session_path,
+                http_headers=http_headers,
             ),
         )
     except DesktopSessionError as exc:
@@ -118,6 +132,7 @@ async def _login_and_save(
     user_id: str,
     password: str,
     session_path: Path,
+    http_headers: Mapping[str, str] | None = None,
 ) -> None:
     from mindroom.desktop.session import (  # noqa: PLC0415
         client_ed25519_fingerprint,
@@ -130,6 +145,7 @@ async def _login_and_save(
         user_id=user_id,
         password=password,
         runtime_paths=runtime_paths,
+        http_headers=http_headers,
     )
     try:
         save_desktop_session(session_path, session)
@@ -204,6 +220,12 @@ def desktop_run(
         help="Local Playwright MCP call timeout.",
     ),
     log_level: str = typer.Option("INFO", "--log-level", "-l"),
+    matrix_http_headers_file: Path | None = typer.Option(  # noqa: B008
+        None,
+        "--matrix-http-headers-file",
+        envvar="MINDROOM_DESKTOP_MATRIX_HTTP_HEADERS_FILE",
+        help="Owner-only JSON file of HTTP headers added to every Matrix request.",
+    ),
     config_path: Path | None = typer.Option(  # noqa: B008
         None,
         "--config",
@@ -224,6 +246,7 @@ def desktop_run(
     from mindroom.desktop.session import (  # noqa: PLC0415
         DesktopSessionError,
         desktop_session_path,
+        load_desktop_http_headers,
         load_desktop_session,
     )
     from mindroom.logging_config import setup_logging  # noqa: PLC0415
@@ -237,6 +260,7 @@ def desktop_run(
     runtime_paths = activate_cli_runtime(config_path, storage_path=storage_path)
     setup_logging(level=log_level.upper(), runtime_paths=runtime_paths)
     try:
+        http_headers = load_desktop_http_headers(matrix_http_headers_file)
         session = load_desktop_session(desktop_session_path(runtime_paths))
         asyncio.run(
             _run_bridge(
@@ -256,6 +280,7 @@ def desktop_run(
                 browser_executable=browser_executable,
                 browser_user_data_dir=browser_user_data_dir,
                 browser_timeout_seconds=browser_timeout_seconds,
+                http_headers=http_headers,
             ),
         )
     except KeyboardInterrupt:
@@ -303,6 +328,7 @@ async def _run_bridge(
     browser_executable: Path | None = None,
     browser_user_data_dir: Path | None = None,
     browser_timeout_seconds: int = 90,
+    http_headers: Mapping[str, str] | None = None,
 ) -> None:
     from mindroom.desktop.bridge import DesktopBridge, DesktopBridgePolicy  # noqa: PLC0415
     from mindroom.desktop.playwright_mcp import PlaywrightMCPBrowserProvider  # noqa: PLC0415
@@ -330,7 +356,7 @@ async def _run_bridge(
         if browser_extension
         else None
     )
-    client = await open_desktop_client(session, runtime_paths=runtime_paths)
+    client = await open_desktop_client(session, runtime_paths=runtime_paths, http_headers=http_headers)
     tasks: set[asyncio.Task[None]] = set()
     try:
         provider = PyAutoGuiDesktopProvider(

--- a/src/mindroom/desktop/session.py
+++ b/src/mindroom/desktop/session.py
@@ -16,6 +16,7 @@ from mindroom.matrix.cross_signing import ensure_agent_cross_signing
 from mindroom.matrix.users import AgentMatrixUser
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from pathlib import Path
 
     from mindroom.constants import RuntimePaths
@@ -93,16 +94,43 @@ def load_desktop_session(path: Path) -> DesktopMatrixSession:
     return DesktopMatrixSession.from_payload(raw)
 
 
+def load_desktop_http_headers(path: Path | None) -> dict[str, str] | None:
+    """Load optional secret HTTP headers for the desktop Matrix transport."""
+    if path is None:
+        return None
+    path = path.expanduser()
+    try:
+        file_stat = path.stat()
+    except FileNotFoundError as exc:
+        msg = f"Desktop Matrix HTTP headers file not found at {path}."
+        raise DesktopSessionError(msg) from exc
+    if os.name != "nt" and stat.S_IMODE(file_stat.st_mode) & 0o077:
+        msg = f"Desktop Matrix HTTP headers file {path} must not be readable by group or other users."
+        raise DesktopSessionError(msg)
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        msg = f"Desktop Matrix HTTP headers file {path} is unreadable or malformed."
+        raise DesktopSessionError(msg) from exc
+    if not isinstance(raw, dict) or any(
+        not isinstance(name, str) or not name or not isinstance(value, str) for name, value in raw.items()
+    ):
+        msg = f"Desktop Matrix HTTP headers file {path} must contain one JSON object of string values."
+        raise DesktopSessionError(msg)
+    return cast("dict[str, str]", raw)
+
+
 async def login_desktop_client(
     *,
     homeserver: str,
     user_id: str,
     password: str,
     runtime_paths: RuntimePaths,
+    http_headers: Mapping[str, str] | None = None,
 ) -> tuple[nio.AsyncClient, DesktopMatrixSession]:
     """Create a fresh cross-signed Matrix desktop device and its restorable session."""
     try:
-        client = await login(homeserver, user_id, password, runtime_paths)
+        client = await login(homeserver, user_id, password, runtime_paths, http_headers=http_headers)
     except (PermanentMatrixStartupError, ValueError) as exc:
         msg = f"Desktop Matrix login failed: {exc}"
         raise DesktopSessionError(msg) from exc
@@ -142,9 +170,10 @@ async def restore_desktop_client(
     session: DesktopMatrixSession,
     *,
     runtime_paths: RuntimePaths,
+    http_headers: Mapping[str, str] | None = None,
 ) -> nio.AsyncClient:
     """Restore the exact desktop Matrix device and its Olm identity."""
-    client = await open_desktop_client(session, runtime_paths=runtime_paths)
+    client = await open_desktop_client(session, runtime_paths=runtime_paths, http_headers=http_headers)
     try:
         await prepare_desktop_client(client)
     except Exception:
@@ -157,6 +186,7 @@ async def open_desktop_client(
     session: DesktopMatrixSession,
     *,
     runtime_paths: RuntimePaths,
+    http_headers: Mapping[str, str] | None = None,
 ) -> nio.AsyncClient:
     """Restore a desktop Matrix client before consuming queued sync events."""
     if not olm_store_exists(session.user_id, session.device_id, runtime_paths):
@@ -169,6 +199,7 @@ async def open_desktop_client(
             session.device_id,
             session.access_token,
             runtime_paths,
+            http_headers=http_headers,
         )
     except (PermanentMatrixStartupError, ValueError) as exc:
         msg = f"Desktop Matrix session restore failed: {exc}"
@@ -213,6 +244,7 @@ __all__ = [
     "DesktopSessionError",
     "client_ed25519_fingerprint",
     "desktop_session_path",
+    "load_desktop_http_headers",
     "load_desktop_session",
     "login_desktop_client",
     "open_desktop_client",

--- a/src/mindroom/matrix/client_session.py
+++ b/src/mindroom/matrix/client_session.py
@@ -16,7 +16,7 @@ from mindroom.matrix.to_device import AuthenticatedToDeviceEvent
 from mindroom.startup_errors import PermanentStartupError
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator
+    from collections.abc import AsyncGenerator, Mapping
 
 logger = get_logger(__name__)
 
@@ -183,9 +183,12 @@ def olm_store_exists(user_id: str, device_id: str, runtime_paths: RuntimePaths) 
     return (olm_store_dir(user_id, runtime_paths) / f"{user_id}_{device_id}.db").is_file()
 
 
-def matrix_client_config() -> nio.AsyncClientConfig:
+def matrix_client_config(*, http_headers: Mapping[str, str] | None = None) -> nio.AsyncClientConfig:
     """Return the shared nio configuration used to read and write Olm stores."""
-    return nio.AsyncClientConfig(replace_rotated_device_keys=True)
+    return nio.AsyncClientConfig(
+        custom_headers=dict(http_headers) if http_headers is not None else None,
+        replace_rotated_device_keys=True,
+    )
 
 
 def _create_matrix_client(
@@ -194,6 +197,8 @@ def _create_matrix_client(
     user_id: str | None = None,
     access_token: str | None = None,
     store_path: str | None = None,
+    *,
+    http_headers: Mapping[str, str] | None = None,
 ) -> nio.AsyncClient:
     """Create a Matrix client with consistent configuration."""
     runtime_paths = _require_runtime_paths_arg(runtime_paths)
@@ -210,7 +215,7 @@ def _create_matrix_client(
         # Agents trust devices on first use and never verify interactively;
         # accept a peer device's re-registered olm identity (trust reset)
         # instead of keeping stale keys that silently break E2EE and calls.
-        config=matrix_client_config(),
+        config=matrix_client_config(http_headers=http_headers),
         ssl=ssl_context,  # ty: ignore[invalid-argument-type]
     )
     if user_id:
@@ -254,10 +259,12 @@ async def login(
     user_id: str,
     password: str,
     runtime_paths: RuntimePaths,
+    *,
+    http_headers: Mapping[str, str] | None = None,
 ) -> nio.AsyncClient:
     """Login to Matrix and return an authenticated client."""
     runtime_paths = _require_runtime_paths_arg(runtime_paths)
-    client = _create_matrix_client(homeserver, runtime_paths, user_id)
+    client = _create_matrix_client(homeserver, runtime_paths, user_id, http_headers=http_headers)
 
     response = await client.login(password)
     if isinstance(response, nio.LoginResponse):
@@ -277,10 +284,18 @@ async def restore_login(
     device_id: str,
     access_token: str,
     runtime_paths: RuntimePaths,
+    *,
+    http_headers: Mapping[str, str] | None = None,
 ) -> nio.AsyncClient:
     """Restore one authenticated Matrix session without creating a new device."""
     runtime_paths = _require_runtime_paths_arg(runtime_paths)
-    client = _create_matrix_client(homeserver, runtime_paths, user_id, access_token)
+    client = _create_matrix_client(
+        homeserver,
+        runtime_paths,
+        user_id,
+        access_token,
+        http_headers=http_headers,
+    )
     client.restore_login(user_id, device_id, access_token)
 
     response = await client.whoami()

--- a/tests/test_desktop_cli.py
+++ b/tests/test_desktop_cli.py
@@ -27,6 +27,9 @@ runner = CliRunner()
 def test_desktop_login_accepts_explicit_homeserver(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """A fresh local machine can target cloud Matrix without hidden environment setup."""
     runtime_paths = SimpleNamespace(storage_root=tmp_path)
+    headers_path = tmp_path / "matrix-http-headers.json"
+    headers_path.write_text('{"X-Access-Client": "test-secret"}', encoding="utf-8")
+    headers_path.chmod(0o600)
     login = AsyncMock()
     monkeypatch.setattr("mindroom.cli.config.activate_cli_runtime", lambda *_args, **_kwargs: runtime_paths)
     monkeypatch.setattr(desktop_cli, "_login_and_save", login)
@@ -40,11 +43,51 @@ def test_desktop_login_accepts_explicit_homeserver(monkeypatch: pytest.MonkeyPat
             "@laptop:example.org",
             "--homeserver",
             "https://matrix.example.org",
+            "--matrix-http-headers-file",
+            str(headers_path),
         ],
     )
 
     assert result.exit_code == 0, result.output
     assert login.await_args.kwargs["homeserver"] == "https://matrix.example.org"
+    assert login.await_args.kwargs["http_headers"] == {"X-Access-Client": "test-secret"}
+
+
+def test_desktop_run_loads_matrix_http_headers(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Long-running sync receives the same proxy headers as one-time login."""
+    runtime_paths = SimpleNamespace(storage_root=tmp_path)
+    headers_path = tmp_path / "matrix-http-headers.json"
+    headers_path.write_text('{"X-Access-Client": "test-secret"}', encoding="utf-8")
+    headers_path.chmod(0o600)
+    bridge = AsyncMock()
+    monkeypatch.setattr("mindroom.cli.config.activate_cli_runtime", lambda *_args, **_kwargs: runtime_paths)
+    monkeypatch.setattr("mindroom.logging_config.setup_logging", lambda **_kwargs: None)
+    monkeypatch.setattr("mindroom.desktop.session.load_desktop_session", lambda _path: object())
+    monkeypatch.setattr(desktop_cli, "_run_bridge", bridge)
+
+    result = runner.invoke(
+        desktop_app,
+        [
+            "run",
+            "--controller-user-id",
+            "@cloud:example.org",
+            "--controller-device-id",
+            "CLOUD",
+            "--controller-ed25519",
+            "fingerprint",
+            "--allow-requester",
+            "@alice:example.org",
+            "--allow-agent",
+            "computer",
+            "--allow-app",
+            "com.example.Editor",
+            "--matrix-http-headers-file",
+            str(headers_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert bridge.await_args.kwargs["http_headers"] == {"X-Access-Client": "test-secret"}
 
 
 def test_browser_profile_paths_require_extension_mode(tmp_path: Path) -> None:

--- a/tests/test_desktop_session.py
+++ b/tests/test_desktop_session.py
@@ -14,6 +14,7 @@ from mindroom.desktop.session import (
     DesktopMatrixSession,
     DesktopSessionError,
     _prepare_crypto,
+    load_desktop_http_headers,
     load_desktop_session,
     login_desktop_client,
     open_desktop_client,
@@ -88,6 +89,37 @@ def test_session_preserves_unexpected_filesystem_errors(tmp_path: Path, monkeypa
         load_desktop_session(path)
 
 
+def test_http_headers_file_loads_string_mapping(tmp_path: Path) -> None:
+    """Proxy credentials remain in a separate private file instead of session state."""
+    path = tmp_path / "matrix-http-headers.json"
+    path.write_text('{"X-Access-Client": "test-secret"}', encoding="utf-8")
+    path.chmod(0o600)
+
+    assert load_desktop_http_headers(path) == {"X-Access-Client": "test-secret"}
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Unix permission bits are not authoritative on Windows")
+def test_http_headers_file_refuses_group_readable_secrets(tmp_path: Path) -> None:
+    """An exposed proxy credential file stops before any Matrix request."""
+    path = tmp_path / "matrix-http-headers.json"
+    path.write_text('{"X-Access-Client": "test-secret"}', encoding="utf-8")
+    path.chmod(0o640)
+
+    with pytest.raises(DesktopSessionError, match="must not be readable"):
+        load_desktop_http_headers(path)
+
+
+@pytest.mark.parametrize("payload", ['["not-an-object"]', '{"X-Access-Client": 1}'])
+def test_http_headers_file_requires_string_mapping(tmp_path: Path, payload: str) -> None:
+    """Malformed header configuration fails before nio receives it."""
+    path = tmp_path / "matrix-http-headers.json"
+    path.write_text(payload, encoding="utf-8")
+    path.chmod(0o600)
+
+    with pytest.raises(DesktopSessionError, match="JSON object of string values"):
+        load_desktop_http_headers(path)
+
+
 @pytest.mark.asyncio
 async def test_initial_crypto_sync_does_not_announce_bridge_online() -> None:
     """Presence stays offline until the command callback is registered and sync-forever starts."""
@@ -105,9 +137,11 @@ async def test_initial_crypto_sync_does_not_announce_bridge_online() -> None:
 @pytest.mark.asyncio
 async def test_login_translates_expected_matrix_authentication_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     """Bad desktop credentials become one actionable session-domain error."""
+    runtime_paths = SimpleNamespace()
+    matrix_login = AsyncMock(side_effect=PermanentMatrixStartupError("invalid credentials"))
     monkeypatch.setattr(
         "mindroom.desktop.session.login",
-        AsyncMock(side_effect=PermanentMatrixStartupError("invalid credentials")),
+        matrix_login,
     )
 
     with pytest.raises(DesktopSessionError, match="invalid credentials"):
@@ -115,18 +149,34 @@ async def test_login_translates_expected_matrix_authentication_failure(monkeypat
             homeserver="https://matrix.example.org",
             user_id="@desktop:example.org",
             password="wrong-password",  # noqa: S106 - Test-only invalid credential.
-            runtime_paths=SimpleNamespace(),
+            runtime_paths=runtime_paths,
+            http_headers={"X-Access-Client": "test-secret"},
         )
+
+    matrix_login.assert_awaited_once_with(
+        "https://matrix.example.org",
+        "@desktop:example.org",
+        "wrong-password",
+        runtime_paths,
+        http_headers={"X-Access-Client": "test-secret"},
+    )
 
 
 @pytest.mark.asyncio
 async def test_restore_translates_expected_revoked_session_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     """A revoked saved access token becomes one actionable session-domain error."""
     monkeypatch.setattr("mindroom.desktop.session.olm_store_exists", lambda *_args: True)
+    matrix_restore = AsyncMock(side_effect=PermanentMatrixStartupError("access token revoked"))
     monkeypatch.setattr(
         "mindroom.desktop.session.restore_login",
-        AsyncMock(side_effect=PermanentMatrixStartupError("access token revoked")),
+        matrix_restore,
     )
 
     with pytest.raises(DesktopSessionError, match="access token revoked"):
-        await open_desktop_client(_session(), runtime_paths=SimpleNamespace())
+        await open_desktop_client(
+            _session(),
+            runtime_paths=SimpleNamespace(),
+            http_headers={"X-Access-Client": "test-secret"},
+        )
+
+    assert matrix_restore.await_args.kwargs["http_headers"] == {"X-Access-Client": "test-secret"}

--- a/tests/test_matrix_client_session.py
+++ b/tests/test_matrix_client_session.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 import nio
 
 from mindroom.constants import STREAM_STATUS_KEY
-from mindroom.matrix.client_session import _MindRoomAsyncClient
+from mindroom.matrix.client_session import _MindRoomAsyncClient, matrix_client_config
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -105,3 +105,13 @@ def test_explicit_zero_one_time_key_count_requests_replenishment(tmp_path: Path)
 
     assert client.olm.uploaded_key_count == 0
     assert client.should_upload_keys
+
+
+def test_matrix_client_config_copies_custom_http_headers() -> None:
+    """Caller-owned secrets cannot mutate a running client's request headers."""
+    headers = {"X-Access-Client": "test-secret"}
+
+    config = matrix_client_config(http_headers=headers)
+    headers.clear()
+
+    assert config.custom_headers == {"X-Access-Client": "test-secret"}

--- a/uv.lock
+++ b/uv.lock
@@ -4462,7 +4462,7 @@ requires-dist = [
     { name = "mdit-py-plugins", specifier = ">=0.5" },
     { name = "mem0ai", specifier = ">=0.1.115" },
     { name = "mem0ai", marker = "extra == 'mem0'", specifier = ">=0.1.115" },
-    { name = "mindroom-nio", extras = ["e2e"], specifier = "==0.27.2" },
+    { name = "mindroom-nio", extras = ["e2e"], specifier = "==0.27.3" },
     { name = "moviepy", marker = "extra == 'moviepy-video-tools'" },
     { name = "neo4j", marker = "extra == 'neo4j'" },
     { name = "newspaper4k", marker = "extra == 'newspaper'" },
@@ -4569,7 +4569,7 @@ dev = [
 
 [[package]]
 name = "mindroom-nio"
-version = "0.27.2"
+version = "0.27.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -4581,9 +4581,9 @@ dependencies = [
     { name = "pycryptodome" },
     { name = "unpaddedbase64" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/9c/659230051cab4498addfd678a1ceb15669efe576e6bf3ce8acc07dd00c29/mindroom_nio-0.27.2.tar.gz", hash = "sha256:81d1b5d4ba941c0433755afba9fb0d428cb85f430a763a84e3fb1815f0a6b7c9", size = 167872, upload-time = "2026-07-15T01:56:11.518Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/15/a7b8dc36422ab4efd6b0b2a22176aa4e751fb660d8de92bf1a2d90418705/mindroom_nio-0.27.3.tar.gz", hash = "sha256:3c9fe9e7a4a8c1398b4f2babbe8287bce69215e779cbe1e8853f179ec366ef74", size = 167944, upload-time = "2026-07-21T02:15:06.614Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/12/3d3bdc242840303694f03b10cc19e944dd6ddc5bcf65daa54b76a17fbd56/mindroom_nio-0.27.2-py3-none-any.whl", hash = "sha256:f353dc5efccc1ebcf4e3ebf62df87076254a1faec0779848a05200c2f74aa271", size = 195655, upload-time = "2026-07-15T01:56:10.093Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d6/b1f05b246ff6ee97ccb1139b4e84592dd7858eb4ceb9dd4c92ef07f56eda/mindroom_nio-0.27.3-py3-none-any.whl", hash = "sha256:3b33cd93a3e9c08bf50e8857a3fd31c7cdac43bb12f752cefe138eb0c2f8c562", size = 195713, upload-time = "2026-07-21T02:15:05.114Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Why

The local Desktop bridge is an outbound Matrix client and cannot reuse interactive browser authentication. Homeservers behind an identity-aware reverse proxy therefore need a safe way to attach machine-authentication headers before Matrix login, sync, key exchange, or media access can begin.

## What

- Add an owner-only JSON header-file option to `desktop login` and `desktop run`.
- Feed those headers into nio's existing client configuration so every Matrix request uses the same transport.
- Keep proxy credentials separate from the persisted Matrix session.
- Document the generic reverse-proxy setup and cover login, restore, long-running sync, permissions, and invalid files.

## Validation

- `uv run pytest -n auto --no-cov -q`
- `uv run pre-commit run --all-files`
- `uv run tach check --dependencies --interfaces`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for injecting custom Matrix HTTP headers from an owner-only JSON file.
  * Available during desktop login and bridge startup via `--matrix-http-headers-file` or `MINDROOM_DESKTOP_MATRIX_HTTP_HEADERS_FILE`.
  * Headers apply to all Matrix requests and are not saved into the desktop session.
  * The file permissions and JSON format are validated.

* **Documentation**
  * Added guidance for connecting to homeservers behind an identity-aware proxy (including the required header file setup).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->