### PR TITLE
Add interactive Cloudflare Access auth to Desktop

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -266,6 +266,13 @@ Create and privately save the dedicated local desktop Matrix device.
 │                                                                    print the URL.      │
 │                                                                    [default:           │
 │                                                                    open-browser]       │
+│ --cloudflare-access                                                Authenticate Matrix │
+│                                                                    requests            │
+│                                                                    interactively with  │
+│                                                                    the local           │
+│                                                                    cloudflared CLI.    │
+│                                                                    [env var:           │
+│                                                                    MINDROOM_DESKTOP_C… │
 │ --replace                                                          Replace the saved   │
 │                                                                    session with a      │
 │                                                                    fresh Matrix        │
@@ -365,6 +372,12 @@ Control remains disabled unless the local command grants a short lease.
 │                                                                   timeout.                   │
 │                                                                   [default: 90]              │
 │    --log-level                -l      TEXT                        [default: INFO]            │
+│    --cloudflare-access                                            Authenticate Matrix        │
+│                                                                   requests interactively     │
+│                                                                   with the local cloudflared │
+│                                                                   CLI.                       │
+│                                                                   [env var:                  │
+│                                                                   MINDROOM_DESKTOP_CLOUDFLA… │
 │    --matrix-http-headers-fi…          PATH                        Owner-only JSON file of    │
 │                                                                   HTTP headers added to      │
 │                                                                   every Matrix request.      │

--- a/docs/tools/desktop.md
+++ b/docs/tools/desktop.md
@@ -152,7 +152,21 @@ Copy these exact public identity values to the cloud MindRoom configuration.
 ### Homeservers Behind an Identity-Aware Proxy
 
 A command-line Matrix client cannot reuse an interactive browser proxy cookie.
-If an identity-aware proxy requires machine credentials, put its required request headers in a separate JSON file:
+For a homeserver protected by Cloudflare Access, install the [`cloudflared` CLI](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/) and enable interactive Access authentication during desktop login:
+
+```bash
+mindroom desktop login \
+  --homeserver https://matrix.example.org \
+  --cloudflare-access
+```
+
+`cloudflared` opens the browser when the local Access session needs authentication.
+MindRoom passes the resulting user-scoped JWT as `cf-access-token` on Matrix requests without saving that token in the desktop session.
+The session remembers that Cloudflare Access is enabled, so later `mindroom desktop run` commands do not need the flag again.
+MindRoom reads the JWT's documented `exp` claim and reuses it only while current.
+The first Matrix request after expiry pauses for a fresh browser login, then continues with the new token.
+
+For unattended proxies that issue machine credentials instead, put their required request headers in a separate JSON file:
 
 ```json
 {
@@ -179,6 +193,7 @@ They are not copied into the saved Matrix session.
 Set `MINDROOM_DESKTOP_MATRIX_HTTP_HEADERS_FILE` to the file path instead of repeating the option on both commands.
 During Matrix SSO, the browser handles any interactive proxy authentication while the header file authenticates the CLI's login-method discovery, token exchange, and later Matrix requests.
 Configure the proxy to accept these machine credentials only for the Matrix endpoints the desktop device needs, while keeping normal Matrix authentication enabled.
+Do not combine `--cloudflare-access` with a static `cf-access-token` header.
 
 ## 2. Configure the Cloud Agent
 

--- a/docs/tools/desktop.md
+++ b/docs/tools/desktop.md
@@ -164,7 +164,8 @@ mindroom desktop login \
 MindRoom passes the resulting user-scoped JWT as `cf-access-token` on Matrix requests without saving that token in the desktop session.
 The session remembers that Cloudflare Access is enabled, so later `mindroom desktop run` commands do not need the flag again.
 MindRoom reads the JWT's documented `exp` claim and reuses it only while current.
-The first Matrix request after expiry pauses for a fresh browser login, then continues with the new token.
+After expiry, the first Matrix request obtains a current token from `cloudflared`, prompting for browser reauthentication when needed.
+For an older saved session, `mindroom desktop run --cloudflare-access` enables Access for that invocation without rewriting the session.
 
 For unattended proxies that issue machine credentials instead, put their required request headers in a separate JSON file:
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -7484,7 +7484,21 @@ Copy these exact public identity values to the cloud MindRoom configuration.
 ### Homeservers Behind an Identity-Aware Proxy
 
 A command-line Matrix client cannot reuse an interactive browser proxy cookie.
-If an identity-aware proxy requires machine credentials, put its required request headers in a separate JSON file:
+For a homeserver protected by Cloudflare Access, install the [`cloudflared` CLI](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/) and enable interactive Access authentication during desktop login:
+
+```bash
+mindroom desktop login \
+  --homeserver https://matrix.example.org \
+  --cloudflare-access
+```
+
+`cloudflared` opens the browser when the local Access session needs authentication.
+MindRoom passes the resulting user-scoped JWT as `cf-access-token` on Matrix requests without saving that token in the desktop session.
+The session remembers that Cloudflare Access is enabled, so later `mindroom desktop run` commands do not need the flag again.
+MindRoom reads the JWT's documented `exp` claim and reuses it only while current.
+The first Matrix request after expiry pauses for a fresh browser login, then continues with the new token.
+
+For unattended proxies that issue machine credentials instead, put their required request headers in a separate JSON file:
 
 ```json
 {
@@ -7511,6 +7525,7 @@ They are not copied into the saved Matrix session.
 Set `MINDROOM_DESKTOP_MATRIX_HTTP_HEADERS_FILE` to the file path instead of repeating the option on both commands.
 During Matrix SSO, the browser handles any interactive proxy authentication while the header file authenticates the CLI's login-method discovery, token exchange, and later Matrix requests.
 Configure the proxy to accept these machine credentials only for the Matrix endpoints the desktop device needs, while keeping normal Matrix authentication enabled.
+Do not combine `--cloudflare-access` with a static `cf-access-token` header.
 
 ## 2. Configure the Cloud Agent
 
@@ -18658,6 +18673,13 @@ Create and privately save the dedicated local desktop Matrix device.
 │                                                                    print the URL.      │
 │                                                                    [default:           │
 │                                                                    open-browser]       │
+│ --cloudflare-access                                                Authenticate Matrix │
+│                                                                    requests            │
+│                                                                    interactively with  │
+│                                                                    the local           │
+│                                                                    cloudflared CLI.    │
+│                                                                    [env var:           │
+│                                                                    MINDROOM_DESKTOP_C… │
 │ --replace                                                          Replace the saved   │
 │                                                                    session with a      │
 │                                                                    fresh Matrix        │
@@ -18757,6 +18779,12 @@ Control remains disabled unless the local command grants a short lease.
 │                                                                   timeout.                   │
 │                                                                   [default: 90]              │
 │    --log-level                -l      TEXT                        [default: INFO]            │
+│    --cloudflare-access                                            Authenticate Matrix        │
+│                                                                   requests interactively     │
+│                                                                   with the local cloudflared │
+│                                                                   CLI.                       │
+│                                                                   [env var:                  │
+│                                                                   MINDROOM_DESKTOP_CLOUDFLA… │
 │    --matrix-http-headers-fi…          PATH                        Owner-only JSON file of    │
 │                                                                   HTTP headers added to      │
 │                                                                   every Matrix request.      │

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -7496,7 +7496,8 @@ mindroom desktop login \
 MindRoom passes the resulting user-scoped JWT as `cf-access-token` on Matrix requests without saving that token in the desktop session.
 The session remembers that Cloudflare Access is enabled, so later `mindroom desktop run` commands do not need the flag again.
 MindRoom reads the JWT's documented `exp` claim and reuses it only while current.
-The first Matrix request after expiry pauses for a fresh browser login, then continues with the new token.
+After expiry, the first Matrix request obtains a current token from `cloudflared`, prompting for browser reauthentication when needed.
+For an older saved session, `mindroom desktop run --cloudflare-access` enables Access for that invocation without rewriting the session.
 
 For unattended proxies that issue machine credentials instead, put their required request headers in a separate JSON file:
 

--- a/skills/mindroom-docs/references/page__cli__index.md
+++ b/skills/mindroom-docs/references/page__cli__index.md
@@ -262,6 +262,13 @@ Create and privately save the dedicated local desktop Matrix device.
 │                                                                    print the URL.      │
 │                                                                    [default:           │
 │                                                                    open-browser]       │
+│ --cloudflare-access                                                Authenticate Matrix │
+│                                                                    requests            │
+│                                                                    interactively with  │
+│                                                                    the local           │
+│                                                                    cloudflared CLI.    │
+│                                                                    [env var:           │
+│                                                                    MINDROOM_DESKTOP_C… │
 │ --replace                                                          Replace the saved   │
 │                                                                    session with a      │
 │                                                                    fresh Matrix        │
@@ -361,6 +368,12 @@ Control remains disabled unless the local command grants a short lease.
 │                                                                   timeout.                   │
 │                                                                   [default: 90]              │
 │    --log-level                -l      TEXT                        [default: INFO]            │
+│    --cloudflare-access                                            Authenticate Matrix        │
+│                                                                   requests interactively     │
+│                                                                   with the local cloudflared │
+│                                                                   CLI.                       │
+│                                                                   [env var:                  │
+│                                                                   MINDROOM_DESKTOP_CLOUDFLA… │
 │    --matrix-http-headers-fi…          PATH                        Owner-only JSON file of    │
 │                                                                   HTTP headers added to      │
 │                                                                   every Matrix request.      │

--- a/skills/mindroom-docs/references/page__tools__desktop__index.md
+++ b/skills/mindroom-docs/references/page__tools__desktop__index.md
@@ -148,7 +148,21 @@ Copy these exact public identity values to the cloud MindRoom configuration.
 ### Homeservers Behind an Identity-Aware Proxy
 
 A command-line Matrix client cannot reuse an interactive browser proxy cookie.
-If an identity-aware proxy requires machine credentials, put its required request headers in a separate JSON file:
+For a homeserver protected by Cloudflare Access, install the [`cloudflared` CLI](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/) and enable interactive Access authentication during desktop login:
+
+```bash
+mindroom desktop login \
+  --homeserver https://matrix.example.org \
+  --cloudflare-access
+```
+
+`cloudflared` opens the browser when the local Access session needs authentication.
+MindRoom passes the resulting user-scoped JWT as `cf-access-token` on Matrix requests without saving that token in the desktop session.
+The session remembers that Cloudflare Access is enabled, so later `mindroom desktop run` commands do not need the flag again.
+MindRoom reads the JWT's documented `exp` claim and reuses it only while current.
+The first Matrix request after expiry pauses for a fresh browser login, then continues with the new token.
+
+For unattended proxies that issue machine credentials instead, put their required request headers in a separate JSON file:
 
 ```json
 {
@@ -175,6 +189,7 @@ They are not copied into the saved Matrix session.
 Set `MINDROOM_DESKTOP_MATRIX_HTTP_HEADERS_FILE` to the file path instead of repeating the option on both commands.
 During Matrix SSO, the browser handles any interactive proxy authentication while the header file authenticates the CLI's login-method discovery, token exchange, and later Matrix requests.
 Configure the proxy to accept these machine credentials only for the Matrix endpoints the desktop device needs, while keeping normal Matrix authentication enabled.
+Do not combine `--cloudflare-access` with a static `cf-access-token` header.
 
 ## 2. Configure the Cloud Agent
 

--- a/skills/mindroom-docs/references/page__tools__desktop__index.md
+++ b/skills/mindroom-docs/references/page__tools__desktop__index.md
@@ -160,7 +160,8 @@ mindroom desktop login \
 MindRoom passes the resulting user-scoped JWT as `cf-access-token` on Matrix requests without saving that token in the desktop session.
 The session remembers that Cloudflare Access is enabled, so later `mindroom desktop run` commands do not need the flag again.
 MindRoom reads the JWT's documented `exp` claim and reuses it only while current.
-The first Matrix request after expiry pauses for a fresh browser login, then continues with the new token.
+After expiry, the first Matrix request obtains a current token from `cloudflared`, prompting for browser reauthentication when needed.
+For an older saved session, `mindroom desktop run --cloudflare-access` enables Access for that invocation without rewriting the session.
 
 For unattended proxies that issue machine credentials instead, put their required request headers in a separate JSON file:
 

--- a/src/mindroom/cli/desktop.py
+++ b/src/mindroom/cli/desktop.py
@@ -114,6 +114,12 @@ def desktop_login(
         "--open-browser/--no-open-browser",
         help="Open Matrix SSO in the default browser; otherwise print the URL.",
     ),
+    cloudflare_access: bool = typer.Option(
+        False,
+        "--cloudflare-access",
+        envvar="MINDROOM_DESKTOP_CLOUDFLARE_ACCESS",
+        help="Authenticate Matrix requests interactively with the local cloudflared CLI.",
+    ),
     replace: bool = typer.Option(False, "--replace", help="Replace the saved session with a fresh Matrix device."),
     matrix_http_headers_file: Path | None = typer.Option(  # noqa: B008
         None,
@@ -137,6 +143,10 @@ def desktop_login(
     """Log in once, create an Olm device, and save its access token privately."""
     from mindroom.cli.config import activate_cli_runtime  # noqa: PLC0415
     from mindroom.constants import runtime_matrix_homeserver  # noqa: PLC0415
+    from mindroom.desktop.cloudflare_access import (  # noqa: PLC0415
+        CloudflareAccessError,
+        cloudflare_access_headers,
+    )
     from mindroom.desktop.session import (  # noqa: PLC0415
         DesktopSessionError,
         desktop_session_path,
@@ -151,8 +161,10 @@ def desktop_login(
         _error_console.print(f"[red]Error:[/red] Session already exists at {session_path}. Use --replace explicitly.")
         raise typer.Exit(1)
     try:
-        http_headers = load_desktop_http_headers(matrix_http_headers_file)
         resolved_homeserver = homeserver or runtime_matrix_homeserver(runtime_paths)
+        http_headers: Mapping[str, str] | None = load_desktop_http_headers(matrix_http_headers_file)
+        if cloudflare_access:
+            http_headers = cloudflare_access_headers(resolved_homeserver, http_headers)
         requested_login_method = _login_method_for_sso_idp(login_method, sso_idp=sso_idp)
         resolved_login_method = asyncio.run(
             resolve_desktop_login_method(
@@ -185,9 +197,10 @@ def desktop_login(
                 login_token=login_token,
                 session_path=session_path,
                 http_headers=http_headers,
+                cloudflare_access=cloudflare_access,
             ),
         )
-    except (DesktopSessionError, DesktopSsoError) as exc:
+    except (CloudflareAccessError, DesktopSessionError, DesktopSsoError) as exc:
         _error_console.print(f"[red]Desktop login failed:[/red] {exc}")
         raise typer.Exit(1) from None
 
@@ -227,6 +240,7 @@ async def _login_and_save(
     login_token: str | None,
     session_path: Path,
     http_headers: Mapping[str, str] | None = None,
+    cloudflare_access: bool = False,
 ) -> None:
     from mindroom.desktop.session import (  # noqa: PLC0415
         client_ed25519_fingerprint,
@@ -241,6 +255,7 @@ async def _login_and_save(
         login_token=login_token,
         runtime_paths=runtime_paths,
         http_headers=http_headers,
+        cloudflare_access=cloudflare_access,
     )
     try:
         save_desktop_session(session_path, session)
@@ -315,6 +330,12 @@ def desktop_run(
         help="Local Playwright MCP call timeout.",
     ),
     log_level: str = typer.Option("INFO", "--log-level", "-l"),
+    cloudflare_access: bool = typer.Option(
+        False,
+        "--cloudflare-access",
+        envvar="MINDROOM_DESKTOP_CLOUDFLARE_ACCESS",
+        help="Authenticate Matrix requests interactively with the local cloudflared CLI.",
+    ),
     matrix_http_headers_file: Path | None = typer.Option(  # noqa: B008
         None,
         "--matrix-http-headers-file",
@@ -336,6 +357,10 @@ def desktop_run(
 ) -> None:
     """Run the outbound-only Matrix sync loop and execute locally authorized commands."""
     from mindroom.cli.config import activate_cli_runtime  # noqa: PLC0415
+    from mindroom.desktop.cloudflare_access import (  # noqa: PLC0415
+        CloudflareAccessError,
+        cloudflare_access_headers,
+    )
     from mindroom.desktop.command_journal import DesktopCommandJournalError  # noqa: PLC0415
     from mindroom.desktop.provider import DesktopProviderError  # noqa: PLC0415
     from mindroom.desktop.session import (  # noqa: PLC0415
@@ -355,8 +380,10 @@ def desktop_run(
     runtime_paths = activate_cli_runtime(config_path, storage_path=storage_path)
     setup_logging(level=log_level.upper(), runtime_paths=runtime_paths)
     try:
-        http_headers = load_desktop_http_headers(matrix_http_headers_file)
+        http_headers: Mapping[str, str] | None = load_desktop_http_headers(matrix_http_headers_file)
         session = load_desktop_session(desktop_session_path(runtime_paths))
+        if cloudflare_access or session.cloudflare_access:
+            http_headers = cloudflare_access_headers(session.homeserver, http_headers)
         _ensure_desktop_dependencies(runtime_paths)
         asyncio.run(
             _run_bridge(
@@ -381,7 +408,13 @@ def desktop_run(
         )
     except KeyboardInterrupt:
         _console.print("\n[yellow]Desktop bridge stopped.[/yellow]")
-    except (DesktopCommandJournalError, DesktopProviderError, DesktopSessionError, OlmToDeviceError) as exc:
+    except (
+        CloudflareAccessError,
+        DesktopCommandJournalError,
+        DesktopProviderError,
+        DesktopSessionError,
+        OlmToDeviceError,
+    ) as exc:
         _error_console.print(f"[red]Desktop bridge failed:[/red] {exc}")
         raise typer.Exit(1) from None
 

--- a/src/mindroom/desktop/cloudflare_access.py
+++ b/src/mindroom/desktop/cloudflare_access.py
@@ -1,0 +1,177 @@
+"""Interactive Cloudflare Access headers for the local desktop Matrix client."""
+
+from __future__ import annotations
+
+import base64
+import json
+import shutil
+import subprocess
+import time
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+_ACCESS_HEADER = "cf-access-token"
+_TOKEN_TIMEOUT_SECONDS = 30
+
+
+class CloudflareAccessError(RuntimeError):
+    """Interactive Cloudflare Access authentication failed."""
+
+
+class _TokenProvider(Protocol):
+    def token(self) -> str:
+        """Return one current Access token."""
+        ...
+
+
+@dataclass(slots=True)
+class CloudflareAccessTokenProvider:
+    """Cache one user Access JWT and renew it through cloudflared after expiry."""
+
+    app_url: str
+    executable: str
+    clock: Callable[[], float] = time.time
+    _token: str | None = field(default=None, init=False, repr=False)
+    _expires_at: float = field(default=0, init=False, repr=False)
+
+    @classmethod
+    def create(cls, app_url: str) -> CloudflareAccessTokenProvider:
+        """Create a provider or report how to install its required CLI."""
+        executable = shutil.which("cloudflared")
+        if executable is None:
+            msg = (
+                "--cloudflare-access requires the cloudflared CLI. Install cloudflared, then rerun this command. "
+                "See https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/."
+            )
+            raise CloudflareAccessError(msg)
+        return cls(app_url=app_url.rstrip("/"), executable=executable)
+
+    def token(self) -> str:
+        """Return a current Access JWT, opening browser login only when needed."""
+        if self._token is not None and self._expires_at > self.clock():
+            return self._token
+
+        token = self._read_token()
+        if token is not None and self._remember_if_current(token):
+            return token
+
+        self._login()
+        token = self._read_token(required=True)
+        assert token is not None
+        if not self._remember_if_current(token):
+            msg = "cloudflared returned an expired Cloudflare Access token after login."
+            raise CloudflareAccessError(msg)
+        return token
+
+    def _remember_if_current(self, token: str) -> bool:
+        expires_at = _access_token_expiration(token)
+        if expires_at <= self.clock():
+            return False
+        self._token = token
+        self._expires_at = expires_at
+        return True
+
+    def _read_token(self, *, required: bool = False) -> str | None:
+        args = [self.executable, "access", "token", f"-app={self.app_url}"]
+        try:
+            completed = subprocess.run(
+                args,
+                capture_output=True,
+                check=False,
+                text=True,
+                timeout=_TOKEN_TIMEOUT_SECONDS,
+            )
+        except OSError as exc:
+            msg = f"Failed to run cloudflared access token: {exc}"
+            raise CloudflareAccessError(msg) from exc
+        except subprocess.TimeoutExpired as exc:
+            msg = "cloudflared access token timed out."
+            raise CloudflareAccessError(msg) from exc
+        token = completed.stdout.strip()
+        if completed.returncode == 0 and token:
+            return token
+        if not required:
+            return None
+        detail = completed.stderr.strip() or completed.stdout.strip() or f"exit {completed.returncode}"
+        msg = f"cloudflared access token failed after login: {detail}"
+        raise CloudflareAccessError(msg)
+
+    def _login(self) -> None:
+        try:
+            completed = subprocess.run(
+                [self.executable, "access", "login", self.app_url],
+                check=False,
+            )
+        except OSError as exc:
+            msg = f"Failed to run cloudflared access login: {exc}"
+            raise CloudflareAccessError(msg) from exc
+        if completed.returncode != 0:
+            msg = f"cloudflared access login failed with exit {completed.returncode}."
+            raise CloudflareAccessError(msg)
+
+
+class CloudflareAccessHeaders(Mapping[str, str]):
+    """Resolve the Access JWT when nio copies headers for each request."""
+
+    def __init__(
+        self,
+        provider: _TokenProvider,
+        static_headers: Mapping[str, str] | None = None,
+    ) -> None:
+        self._provider = provider
+        self._static_headers = dict(static_headers or {})
+        if any(name.lower() == _ACCESS_HEADER for name in self._static_headers):
+            msg = "--cloudflare-access cannot be combined with a cf-access-token header."
+            raise CloudflareAccessError(msg)
+
+    def __getitem__(self, name: str) -> str:
+        """Return one static header or the current interactive token."""
+        if name == _ACCESS_HEADER:
+            return self._provider.token()
+        return self._static_headers[name]
+
+    def __iter__(self) -> Iterator[str]:
+        """Yield static header names followed by the Access header."""
+        yield from self._static_headers
+        yield _ACCESS_HEADER
+
+    def __len__(self) -> int:
+        """Return combined static and interactive header count."""
+        return len(self._static_headers) + 1
+
+
+def cloudflare_access_headers(
+    app_url: str,
+    static_headers: Mapping[str, str] | None = None,
+) -> CloudflareAccessHeaders:
+    """Return request-time Cloudflare Access headers for one application."""
+    return CloudflareAccessHeaders(CloudflareAccessTokenProvider.create(app_url), static_headers)
+
+
+def _access_token_expiration(token: str) -> float:
+    """Read the documented JWT expiry for refresh scheduling, not authorization."""
+    try:
+        encoded_payload = token.split(".")[1]
+        padding = "=" * (-len(encoded_payload) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(encoded_payload + padding))
+        expires_at = payload["exp"]
+    except (IndexError, KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        msg = "cloudflared returned a malformed Cloudflare Access token."
+        raise CloudflareAccessError(msg) from exc
+    if not isinstance(expires_at, int | float) or isinstance(expires_at, bool):
+        msg = "cloudflared returned a Cloudflare Access token without a numeric expiry."
+        raise CloudflareAccessError(msg)
+    return float(expires_at)
+
+
+__all__ = [
+    "CloudflareAccessError",
+    "CloudflareAccessHeaders",
+    "CloudflareAccessTokenProvider",
+    "cloudflare_access_headers",
+]

--- a/src/mindroom/desktop/cloudflare_access.py
+++ b/src/mindroom/desktop/cloudflare_access.py
@@ -101,9 +101,6 @@ class CloudflareAccessTokenProvider:
                 text=True,
                 timeout=_TOKEN_TIMEOUT_SECONDS,
             )
-        except OSError as exc:
-            msg = f"Failed to run cloudflared access token: {exc}"
-            raise CloudflareAccessError(msg) from exc
         except subprocess.TimeoutExpired as exc:
             msg = "cloudflared access token timed out."
             raise CloudflareAccessError(msg) from exc
@@ -117,14 +114,10 @@ class CloudflareAccessTokenProvider:
         raise CloudflareAccessError(msg)
 
     def _login(self) -> None:
-        try:
-            completed = subprocess.run(
-                [self.executable, "access", "login", self.app_url],
-                check=False,
-            )
-        except OSError as exc:
-            msg = f"Failed to run cloudflared access login: {exc}"
-            raise CloudflareAccessError(msg) from exc
+        completed = subprocess.run(
+            [self.executable, "access", "login", self.app_url],
+            check=False,
+        )
         if completed.returncode != 0:
             msg = f"cloudflared access login failed with exit {completed.returncode}."
             raise CloudflareAccessError(msg)

--- a/src/mindroom/desktop/cloudflare_access.py
+++ b/src/mindroom/desktop/cloudflare_access.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 import shutil
 import subprocess
+import threading
 import time
 from collections.abc import Iterator, Mapping
 from dataclasses import dataclass, field
@@ -24,8 +26,12 @@ class CloudflareAccessError(RuntimeError):
 
 
 class _TokenProvider(Protocol):
+    def current_token(self) -> str | None:
+        """Return the cached token when it remains safe to send."""
+        ...
+
     def token(self) -> str:
-        """Return one current Access token."""
+        """Refresh if needed, then return one current Access token."""
         ...
 
 
@@ -38,6 +44,7 @@ class CloudflareAccessTokenProvider:
     clock: Callable[[], float] = time.time
     _token: str | None = field(default=None, init=False, repr=False)
     _expires_at: float = field(default=0, init=False, repr=False)
+    _refresh_lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
 
     @classmethod
     def create(cls, app_url: str) -> CloudflareAccessTokenProvider:
@@ -53,20 +60,28 @@ class CloudflareAccessTokenProvider:
 
     def token(self) -> str:
         """Return a current Access JWT, opening browser login only when needed."""
-        if self._token is not None and self._expires_at > self.clock():
-            return self._token
+        with self._refresh_lock:
+            current = self.current_token()
+            if current is not None:
+                return current
 
-        token = self._read_token()
-        if token is not None and self._remember_if_current(token):
+            token = self._read_token()
+            if token is not None and self._remember_if_current(token):
+                return token
+
+            self._login()
+            token = self._read_token(required=True)
+            assert token is not None
+            if not self._remember_if_current(token):
+                msg = "cloudflared returned an expired Cloudflare Access token after login."
+                raise CloudflareAccessError(msg)
             return token
 
-        self._login()
-        token = self._read_token(required=True)
-        assert token is not None
-        if not self._remember_if_current(token):
-            msg = "cloudflared returned an expired Cloudflare Access token after login."
-            raise CloudflareAccessError(msg)
-        return token
+    def current_token(self) -> str | None:
+        """Return the cached token until its documented expiry."""
+        if self._token is None or self._expires_at <= self.clock():
+            return None
+        return self._token
 
     def _remember_if_current(self, token: str) -> bool:
         expires_at = _access_token_expiration(token)
@@ -97,7 +112,7 @@ class CloudflareAccessTokenProvider:
             return token
         if not required:
             return None
-        detail = completed.stderr.strip() or completed.stdout.strip() or f"exit {completed.returncode}"
+        detail = completed.stderr.strip() or f"exit {completed.returncode}"
         msg = f"cloudflared access token failed after login: {detail}"
         raise CloudflareAccessError(msg)
 
@@ -131,9 +146,18 @@ class CloudflareAccessHeaders(Mapping[str, str]):
 
     def __getitem__(self, name: str) -> str:
         """Return one static header or the current interactive token."""
-        if name == _ACCESS_HEADER:
-            return self._provider.token()
+        if name.lower() == _ACCESS_HEADER:
+            token = self._provider.current_token()
+            if token is None:
+                msg = "Cloudflare Access headers were used before asynchronous token preparation."
+                raise CloudflareAccessError(msg)
+            return token
         return self._static_headers[name]
+
+    async def prepare(self) -> None:
+        """Refresh the token off the event loop before nio copies request headers."""
+        if self._provider.current_token() is None:
+            await asyncio.to_thread(self._provider.token)
 
     def __iter__(self) -> Iterator[str]:
         """Yield static header names followed by the Access header."""

--- a/src/mindroom/desktop/session.py
+++ b/src/mindroom/desktop/session.py
@@ -43,16 +43,20 @@ class DesktopMatrixSession:
     user_id: str
     device_id: str
     access_token: str
+    cloudflare_access: bool = False
 
-    def to_payload(self) -> dict[str, str | int]:
+    def to_payload(self) -> dict[str, str | int | bool]:
         """Serialize the minimum restorable device state."""
-        return {
+        payload: dict[str, str | int | bool] = {
             "v": 1,
             "homeserver": self.homeserver,
             "user_id": self.user_id,
             "device_id": self.device_id,
             "access_token": self.access_token,
         }
+        if self.cloudflare_access:
+            payload["cloudflare_access"] = True
+        return payload
 
     @classmethod
     def from_payload(cls, raw: object) -> DesktopMatrixSession:
@@ -71,7 +75,11 @@ class DesktopMatrixSession:
                 msg = f"Desktop Matrix session field {key} is missing."
                 raise DesktopSessionError(msg)
             values[key] = value
-        return cls(**values)
+        cloudflare_access = payload.get("cloudflare_access", False)
+        if not isinstance(cloudflare_access, bool):
+            msg = "Desktop Matrix session field cloudflare_access must be a boolean."
+            raise DesktopSessionError(msg)
+        return cls(**values, cloudflare_access=cloudflare_access)
 
 
 def desktop_session_path(runtime_paths: RuntimePaths) -> Path:
@@ -165,6 +173,7 @@ async def login_desktop_client(
     password: str | None = None,
     login_token: str | None = None,
     http_headers: Mapping[str, str] | None = None,
+    cloudflare_access: bool = False,
 ) -> tuple[nio.AsyncClient, DesktopMatrixSession]:
     """Create a fresh Matrix desktop device and its restorable session."""
     if (password is None) == (login_token is None):
@@ -191,7 +200,11 @@ async def login_desktop_client(
         raise DesktopSessionError(msg) from exc
     try:
         await _prepare_crypto(client)
-        authenticated_session = _session_from_authenticated_client(client, homeserver=homeserver)
+        authenticated_session = _session_from_authenticated_client(
+            client,
+            homeserver=homeserver,
+            cloudflare_access=cloudflare_access,
+        )
         if password is not None:
             await ensure_agent_cross_signing(
                 client,
@@ -210,7 +223,12 @@ async def login_desktop_client(
     return client, authenticated_session
 
 
-def _session_from_authenticated_client(client: nio.AsyncClient, *, homeserver: str) -> DesktopMatrixSession:
+def _session_from_authenticated_client(
+    client: nio.AsyncClient,
+    *,
+    homeserver: str,
+    cloudflare_access: bool,
+) -> DesktopMatrixSession:
     if client.user_id is None or client.device_id is None or client.access_token is None:
         msg = "Matrix login did not return complete desktop device credentials."
         raise DesktopSessionError(msg)
@@ -219,6 +237,7 @@ def _session_from_authenticated_client(client: nio.AsyncClient, *, homeserver: s
         user_id=client.user_id,
         device_id=client.device_id,
         access_token=client.access_token,
+        cloudflare_access=cloudflare_access,
     )
 
 

--- a/src/mindroom/matrix/client_session.py
+++ b/src/mindroom/matrix/client_session.py
@@ -6,7 +6,7 @@ import os
 import ssl as ssl_module
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import nio
 
@@ -185,9 +185,10 @@ def olm_store_exists(user_id: str, device_id: str, runtime_paths: RuntimePaths) 
 
 
 def matrix_client_config(*, http_headers: Mapping[str, str] | None = None) -> nio.AsyncClientConfig:
-    """Return the shared nio configuration used to read and write Olm stores."""
+    """Return nio config, copying plain headers while preserving request-time mappings."""
+    custom_headers = dict(http_headers) if isinstance(http_headers, dict) else http_headers
     return nio.AsyncClientConfig(
-        custom_headers=dict(http_headers) if http_headers is not None else None,
+        custom_headers=cast("dict[str, str] | None", custom_headers),
         replace_rotated_device_keys=True,
     )
 

--- a/src/mindroom/matrix/client_session.py
+++ b/src/mindroom/matrix/client_session.py
@@ -6,7 +6,7 @@ import os
 import ssl as ssl_module
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Protocol, cast, runtime_checkable
 
 import nio
 
@@ -51,8 +51,22 @@ class PermanentMatrixStartupError(PermanentStartupError):
     """Raised for Matrix startup failures that should not be retried."""
 
 
+@runtime_checkable
+class _AsyncRequestHeaders(Protocol):
+    async def prepare(self) -> None:
+        """Prepare dynamic headers without blocking the event loop."""
+        ...
+
+
 class _MindRoomAsyncClient(nio.AsyncClient):
     """Matrix client for MindRoom-specific encrypted event behavior."""
+
+    async def _send(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+        """Prepare dynamic request headers before nio copies them."""
+        headers = self.config.custom_headers
+        if isinstance(headers, _AsyncRequestHeaders):
+            await headers.prepare()
+        return await super()._send(*args, **kwargs)
 
     def encrypt(
         self,

--- a/src/mindroom/matrix/client_session.py
+++ b/src/mindroom/matrix/client_session.py
@@ -61,12 +61,12 @@ class _AsyncRequestHeaders(Protocol):
 class _MindRoomAsyncClient(nio.AsyncClient):
     """Matrix client for MindRoom-specific encrypted event behavior."""
 
-    async def _send(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
-        """Prepare dynamic request headers before nio copies them."""
+    async def send(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+        """Prepare dynamic request headers before every transport attempt."""
         headers = self.config.custom_headers
         if isinstance(headers, _AsyncRequestHeaders):
             await headers.prepare()
-        return await super()._send(*args, **kwargs)
+        return await super().send(*args, **kwargs)
 
     def encrypt(
         self,

--- a/tach.toml
+++ b/tach.toml
@@ -2165,6 +2165,11 @@ visibility = [
 ]
 
 [[modules]]
+path = "mindroom.desktop.cloudflare_access"
+depends_on = []
+visibility = ["mindroom.cli.desktop"]
+
+[[modules]]
 path = "mindroom.desktop.sso"
 depends_on = []
 visibility = ["mindroom.cli.desktop"]
@@ -2736,6 +2741,7 @@ depends_on = [
     "mindroom.cli.config",
     "mindroom.constants",
     "mindroom.desktop.bridge",
+    "mindroom.desktop.cloudflare_access",
     "mindroom.desktop.command_journal",
     "mindroom.desktop.identity",
     "mindroom.desktop.login_method",

--- a/tests/test_desktop_cli.py
+++ b/tests/test_desktop_cli.py
@@ -446,6 +446,7 @@ async def test_bridge_pins_controller_before_consuming_initial_sync(
     monkeypatch.setattr("mindroom.matrix.olm_to_device.resolve_pinned_device", resolve_device)
     monkeypatch.setattr("mindroom.desktop.provider.PyAutoGuiDesktopProvider", lambda **_kwargs: object())
     monkeypatch.setattr("mindroom.desktop.bridge.DesktopBridge", lambda **_kwargs: bridge)
+
     await desktop_cli._run_bridge(
         runtime_paths=SimpleNamespace(storage_root=tmp_path),
         session=DesktopMatrixSession(

--- a/tests/test_desktop_cli.py
+++ b/tests/test_desktop_cli.py
@@ -57,6 +57,42 @@ def test_desktop_login_accepts_explicit_homeserver(monkeypatch: pytest.MonkeyPat
     assert login.await_args.kwargs["http_headers"] == {"X-Access-Client": "test-secret"}
     assert login.await_args.kwargs["password"] == "test-password"  # noqa: S105 - Test-only password.
     assert login.await_args.kwargs["login_token"] is None
+    assert login.await_args.kwargs["cloudflare_access"] is False
+
+
+def test_desktop_login_uses_cloudflare_access_before_matrix_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """CLI authentication reaches login-method discovery and persists its transport mode."""
+    runtime_paths = SimpleNamespace(storage_root=tmp_path)
+    headers = {"cf-access-token": "access-token"}
+    access_headers = MagicMock(return_value=headers)
+    discover = AsyncMock(return_value=DesktopLoginMethod.PASSWORD)
+    login = AsyncMock()
+    monkeypatch.setattr("mindroom.cli.config.activate_cli_runtime", lambda *_args, **_kwargs: runtime_paths)
+    monkeypatch.setattr("mindroom.desktop.cloudflare_access.cloudflare_access_headers", access_headers)
+    monkeypatch.setattr("mindroom.desktop.session.resolve_desktop_login_method", discover)
+    monkeypatch.setattr(desktop_cli, "_login_and_save", login)
+    monkeypatch.setenv("MINDROOM_DESKTOP_MATRIX_PASSWORD", "test-password")
+
+    result = runner.invoke(
+        desktop_app,
+        [
+            "login",
+            "--user-id",
+            "@laptop:example.org",
+            "--homeserver",
+            "https://matrix.example.org",
+            "--cloudflare-access",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    access_headers.assert_called_once_with("https://matrix.example.org", None)
+    assert discover.await_args.kwargs["http_headers"] is headers
+    assert login.await_args.kwargs["http_headers"] is headers
+    assert login.await_args.kwargs["cloudflare_access"] is True
 
 
 def test_desktop_login_uses_browser_sso_without_password_or_user_id(
@@ -137,7 +173,10 @@ def test_desktop_run_loads_matrix_http_headers(monkeypatch: pytest.MonkeyPatch, 
     monkeypatch.setattr("mindroom.cli.config.activate_cli_runtime", lambda *_args, **_kwargs: runtime_paths)
     monkeypatch.setattr("mindroom.logging_config.setup_logging", lambda **_kwargs: None)
     monkeypatch.setattr(desktop_cli, "_ensure_desktop_dependencies", ensure_dependencies)
-    monkeypatch.setattr("mindroom.desktop.session.load_desktop_session", lambda _path: object())
+    monkeypatch.setattr(
+        "mindroom.desktop.session.load_desktop_session",
+        lambda _path: SimpleNamespace(homeserver="https://matrix.example.org", cloudflare_access=False),
+    )
     monkeypatch.setattr(desktop_cli, "_run_bridge", bridge)
 
     result = runner.invoke(
@@ -164,6 +203,47 @@ def test_desktop_run_loads_matrix_http_headers(monkeypatch: pytest.MonkeyPatch, 
     assert result.exit_code == 0, result.output
     ensure_dependencies.assert_called_once_with(runtime_paths)
     assert bridge.await_args.kwargs["http_headers"] == {"X-Access-Client": "test-secret"}
+
+
+def test_desktop_run_restores_saved_cloudflare_access_mode(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """One-time login choice automatically applies to later bridge runs."""
+    runtime_paths = SimpleNamespace(storage_root=tmp_path)
+    session = SimpleNamespace(homeserver="https://matrix.example.org", cloudflare_access=True)
+    headers = MagicMock()
+    access_headers = MagicMock(return_value=headers)
+    bridge = AsyncMock()
+    monkeypatch.setattr("mindroom.cli.config.activate_cli_runtime", lambda *_args, **_kwargs: runtime_paths)
+    monkeypatch.setattr("mindroom.logging_config.setup_logging", lambda **_kwargs: None)
+    monkeypatch.setattr(desktop_cli, "_ensure_desktop_dependencies", MagicMock())
+    monkeypatch.setattr("mindroom.desktop.session.load_desktop_session", lambda _path: session)
+    monkeypatch.setattr("mindroom.desktop.cloudflare_access.cloudflare_access_headers", access_headers)
+    monkeypatch.setattr(desktop_cli, "_run_bridge", bridge)
+
+    result = runner.invoke(
+        desktop_app,
+        [
+            "run",
+            "--controller-user-id",
+            "@cloud:example.org",
+            "--controller-device-id",
+            "CLOUD",
+            "--controller-ed25519",
+            "fingerprint",
+            "--allow-requester",
+            "@alice:example.org",
+            "--allow-agent",
+            "computer",
+            "--allow-app",
+            "com.example.Editor",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    access_headers.assert_called_once_with("https://matrix.example.org", None)
+    assert bridge.await_args.kwargs["http_headers"] is headers
 
 
 def test_desktop_dependencies_use_optional_extra_auto_install(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -366,7 +446,6 @@ async def test_bridge_pins_controller_before_consuming_initial_sync(
     monkeypatch.setattr("mindroom.matrix.olm_to_device.resolve_pinned_device", resolve_device)
     monkeypatch.setattr("mindroom.desktop.provider.PyAutoGuiDesktopProvider", lambda **_kwargs: object())
     monkeypatch.setattr("mindroom.desktop.bridge.DesktopBridge", lambda **_kwargs: bridge)
-
     await desktop_cli._run_bridge(
         runtime_paths=SimpleNamespace(storage_root=tmp_path),
         session=DesktopMatrixSession(

--- a/tests/test_desktop_cloudflare_access.py
+++ b/tests/test_desktop_cloudflare_access.py
@@ -8,6 +8,7 @@ import threading
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
+import aiohttp
 import nio
 import pytest
 
@@ -75,7 +76,6 @@ async def test_request_headers_cache_current_token_and_reauthenticate_after_expi
 
     await headers.prepare()
     assert dict(headers) == {"X-Static": "value", "cf-access-token": first_token}
-    assert dict(headers)["cf-access-token"] == first_token
     assert len(calls) == 1
 
     now[0] = 201.0
@@ -118,26 +118,34 @@ def test_nio_config_preserves_request_time_access_headers() -> None:
 
 
 @pytest.mark.asyncio
-async def test_nio_resolves_access_header_for_each_http_request(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A running sync client can replace an expired JWT without reconnecting."""
+async def test_nio_refreshes_access_header_for_each_transport_attempt(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An expired JWT is refreshed during nio's internal transport retry."""
     provider = _TestTokenProvider("first-token", "second-token")
     headers = CloudflareAccessHeaders(provider)
     client = _MindRoomAsyncClient(
         "https://matrix.example.org",
         config=matrix_client_config(http_headers=headers),
     )
-    request = AsyncMock(return_value=SimpleNamespace(status=200))
+    sent_tokens: list[str] = []
+
+    async def request(*_args: object, **kwargs: object) -> object:
+        request_headers = kwargs["headers"]
+        assert isinstance(request_headers, dict)
+        sent_tokens.append(request_headers["cf-access-token"])
+        if len(sent_tokens) == 1:
+            provider.expire()
+            message = "connection lost"
+            raise aiohttp.ClientConnectionError(message)
+        return SimpleNamespace(status=200)
+
     client.client_session = SimpleNamespace(request=request)  # type: ignore[assignment]
     monkeypatch.setattr(client, "create_matrix_response", AsyncMock(return_value=object()))
     monkeypatch.setattr(client, "receive_response", AsyncMock())
 
     event_loop_thread = threading.get_ident()
-    await client._send(nio.WhoamiResponse, "GET", "/first")
-    provider.expire()
-    await client._send(nio.WhoamiResponse, "GET", "/second")
+    await client._send(nio.WhoamiResponse, "GET", "/whoami")
 
-    assert request.await_args_list[0].kwargs["headers"]["cf-access-token"] == "first-token"
-    assert request.await_args_list[1].kwargs["headers"]["cf-access-token"] == "second-token"
+    assert sent_tokens == ["first-token", "second-token"]
     assert provider.token_threads
     assert all(thread_id != event_loop_thread for thread_id in provider.token_threads)
 

--- a/tests/test_desktop_cloudflare_access.py
+++ b/tests/test_desktop_cloudflare_access.py
@@ -1,0 +1,153 @@
+"""Tests for interactive Cloudflare Access on Desktop Matrix requests."""
+
+from __future__ import annotations
+
+import base64
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import nio
+import pytest
+
+from mindroom.desktop.cloudflare_access import (
+    CloudflareAccessError,
+    CloudflareAccessHeaders,
+    CloudflareAccessTokenProvider,
+    cloudflare_access_headers,
+)
+from mindroom.matrix.client_session import _MindRoomAsyncClient, matrix_client_config
+
+
+def _jwt(*, expires_at: int, marker: str) -> str:
+    payload = base64.urlsafe_b64encode(json.dumps({"exp": expires_at}).encode()).decode().rstrip("=")
+    return f"header.{payload}.{marker}"
+
+
+class _TestTokenProvider:
+    def __init__(self, *tokens: str) -> None:
+        self._tokens = iter(tokens)
+
+    def token(self) -> str:
+        return next(self._tokens)
+
+
+def test_request_headers_cache_current_token_and_reauthenticate_after_expiry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every request sees a current token without a guessed periodic refresh timer."""
+    now = [100.0]
+    first_token = _jwt(expires_at=200, marker="first")
+    second_token = _jwt(expires_at=300, marker="second")
+    results = iter(
+        [
+            SimpleNamespace(returncode=0, stdout=first_token, stderr=""),
+            SimpleNamespace(returncode=1, stdout="", stderr="expired"),
+            SimpleNamespace(returncode=0, stdout="", stderr=""),
+            SimpleNamespace(returncode=0, stdout=second_token, stderr=""),
+        ],
+    )
+    calls: list[list[str]] = []
+
+    def run(args: list[str], **_kwargs: object) -> object:
+        calls.append(args)
+        return next(results)
+
+    monkeypatch.setattr("mindroom.desktop.cloudflare_access.subprocess.run", run)
+    provider = CloudflareAccessTokenProvider(
+        app_url="https://matrix.example.org",
+        executable="/usr/bin/cloudflared",
+        clock=lambda: now[0],
+    )
+    headers = CloudflareAccessHeaders(provider, {"X-Static": "value"})
+
+    assert dict(headers) == {"X-Static": "value", "cf-access-token": first_token}
+    assert dict(headers)["cf-access-token"] == first_token
+    assert len(calls) == 1
+
+    now[0] = 201.0
+    assert dict(headers)["cf-access-token"] == second_token
+    assert calls == [
+        ["/usr/bin/cloudflared", "access", "token", "-app=https://matrix.example.org"],
+        ["/usr/bin/cloudflared", "access", "token", "-app=https://matrix.example.org"],
+        ["/usr/bin/cloudflared", "access", "login", "https://matrix.example.org"],
+        ["/usr/bin/cloudflared", "access", "token", "-app=https://matrix.example.org"],
+    ]
+
+
+def test_cloudflare_access_requires_cloudflared(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing binary fails before Matrix or browser login starts."""
+    monkeypatch.setattr("mindroom.desktop.cloudflare_access.shutil.which", lambda _name: None)
+
+    with pytest.raises(CloudflareAccessError, match="cloudflared CLI"):
+        cloudflare_access_headers("https://matrix.example.org")
+
+
+def test_cloudflare_access_rejects_duplicate_token_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A static token cannot silently override interactive renewal."""
+    monkeypatch.setattr("mindroom.desktop.cloudflare_access.shutil.which", lambda _name: "/usr/bin/cloudflared")
+
+    with pytest.raises(CloudflareAccessError, match="cannot be combined"):
+        cloudflare_access_headers(
+            "https://matrix.example.org",
+            {"CF-Access-Token": "static-token"},
+        )
+
+
+def test_nio_config_preserves_request_time_access_headers() -> None:
+    """Long-running Matrix client resolves the mapping again for every HTTP request."""
+    headers = CloudflareAccessHeaders(_TestTokenProvider("current-token"))
+
+    config = matrix_client_config(http_headers=headers)
+
+    assert config.custom_headers is headers
+
+
+@pytest.mark.asyncio
+async def test_nio_resolves_access_header_for_each_http_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A running sync client can replace an expired JWT without reconnecting."""
+    headers = CloudflareAccessHeaders(_TestTokenProvider("first-token", "second-token"))
+    client = _MindRoomAsyncClient(
+        "https://matrix.example.org",
+        config=matrix_client_config(http_headers=headers),
+    )
+    request = AsyncMock(return_value=SimpleNamespace(status=200))
+    client.client_session = SimpleNamespace(request=request)  # type: ignore[assignment]
+    monkeypatch.setattr(client, "create_matrix_response", AsyncMock(return_value=object()))
+    monkeypatch.setattr(client, "receive_response", AsyncMock())
+
+    await client._send(nio.WhoamiResponse, "GET", "/first")
+    await client._send(nio.WhoamiResponse, "GET", "/second")
+
+    assert request.await_args_list[0].kwargs["headers"]["cf-access-token"] == "first-token"
+    assert request.await_args_list[1].kwargs["headers"]["cf-access-token"] == "second-token"
+
+
+@pytest.mark.parametrize(
+    "token",
+    ["not-a-jwt", _jwt(expires_at=100, marker="expired")],
+)
+def test_cloudflare_access_rejects_invalid_token_after_login(
+    monkeypatch: pytest.MonkeyPatch,
+    token: str,
+) -> None:
+    """Successful CLI exit never makes malformed or expired output trusted."""
+    results = iter(
+        [
+            SimpleNamespace(returncode=1, stdout="", stderr="missing"),
+            SimpleNamespace(returncode=0, stdout="", stderr=""),
+            SimpleNamespace(returncode=0, stdout=token, stderr=""),
+        ],
+    )
+    monkeypatch.setattr(
+        "mindroom.desktop.cloudflare_access.subprocess.run",
+        lambda *_args, **_kwargs: next(results),
+    )
+    provider = CloudflareAccessTokenProvider(
+        app_url="https://matrix.example.org",
+        executable="/usr/bin/cloudflared",
+        clock=lambda: 100.0,
+    )
+
+    with pytest.raises(CloudflareAccessError):
+        provider.token()

--- a/tests/test_desktop_cloudflare_access.py
+++ b/tests/test_desktop_cloudflare_access.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import json
+import threading
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -27,12 +28,23 @@ def _jwt(*, expires_at: int, marker: str) -> str:
 class _TestTokenProvider:
     def __init__(self, *tokens: str) -> None:
         self._tokens = iter(tokens)
+        self._current: str | None = None
+        self.token_threads: list[int] = []
+
+    def current_token(self) -> str | None:
+        return self._current
 
     def token(self) -> str:
-        return next(self._tokens)
+        self.token_threads.append(threading.get_ident())
+        self._current = next(self._tokens)
+        return self._current
+
+    def expire(self) -> None:
+        self._current = None
 
 
-def test_request_headers_cache_current_token_and_reauthenticate_after_expiry(
+@pytest.mark.asyncio
+async def test_request_headers_cache_current_token_and_reauthenticate_after_expiry(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Every request sees a current token without a guessed periodic refresh timer."""
@@ -61,11 +73,13 @@ def test_request_headers_cache_current_token_and_reauthenticate_after_expiry(
     )
     headers = CloudflareAccessHeaders(provider, {"X-Static": "value"})
 
+    await headers.prepare()
     assert dict(headers) == {"X-Static": "value", "cf-access-token": first_token}
     assert dict(headers)["cf-access-token"] == first_token
     assert len(calls) == 1
 
     now[0] = 201.0
+    await headers.prepare()
     assert dict(headers)["cf-access-token"] == second_token
     assert calls == [
         ["/usr/bin/cloudflared", "access", "token", "-app=https://matrix.example.org"],
@@ -106,7 +120,8 @@ def test_nio_config_preserves_request_time_access_headers() -> None:
 @pytest.mark.asyncio
 async def test_nio_resolves_access_header_for_each_http_request(monkeypatch: pytest.MonkeyPatch) -> None:
     """A running sync client can replace an expired JWT without reconnecting."""
-    headers = CloudflareAccessHeaders(_TestTokenProvider("first-token", "second-token"))
+    provider = _TestTokenProvider("first-token", "second-token")
+    headers = CloudflareAccessHeaders(provider)
     client = _MindRoomAsyncClient(
         "https://matrix.example.org",
         config=matrix_client_config(http_headers=headers),
@@ -116,11 +131,50 @@ async def test_nio_resolves_access_header_for_each_http_request(monkeypatch: pyt
     monkeypatch.setattr(client, "create_matrix_response", AsyncMock(return_value=object()))
     monkeypatch.setattr(client, "receive_response", AsyncMock())
 
+    event_loop_thread = threading.get_ident()
     await client._send(nio.WhoamiResponse, "GET", "/first")
+    provider.expire()
     await client._send(nio.WhoamiResponse, "GET", "/second")
 
     assert request.await_args_list[0].kwargs["headers"]["cf-access-token"] == "first-token"
     assert request.await_args_list[1].kwargs["headers"]["cf-access-token"] == "second-token"
+    assert provider.token_threads
+    assert all(thread_id != event_loop_thread for thread_id in provider.token_threads)
+
+
+@pytest.mark.asyncio
+async def test_access_header_lookup_is_case_insensitive() -> None:
+    """HTTP casing does not affect lookup of the dynamic Access header."""
+    headers = CloudflareAccessHeaders(_TestTokenProvider("current-token"))
+
+    await headers.prepare()
+
+    assert headers["CF-Access-Token"] == "current-token"
+
+
+def test_failed_token_read_never_exposes_stdout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failed cloudflared call cannot copy token-shaped stdout into CLI errors."""
+    stdout_value = "header.payload.signature"
+    results = iter(
+        [
+            SimpleNamespace(returncode=1, stdout="", stderr="missing"),
+            SimpleNamespace(returncode=0, stdout="", stderr=""),
+            SimpleNamespace(returncode=1, stdout=stdout_value, stderr=""),
+        ],
+    )
+    monkeypatch.setattr(
+        "mindroom.desktop.cloudflare_access.subprocess.run",
+        lambda *_args, **_kwargs: next(results),
+    )
+    provider = CloudflareAccessTokenProvider(
+        app_url="https://matrix.example.org",
+        executable="/usr/bin/cloudflared",
+    )
+
+    with pytest.raises(CloudflareAccessError, match="exit 1") as error:
+        provider.token()
+
+    assert stdout_value not in str(error.value)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_desktop_session.py
+++ b/tests/test_desktop_session.py
@@ -49,6 +49,22 @@ def test_session_round_trip_uses_owner_only_permissions(tmp_path: Path) -> None:
         assert path.stat().st_mode & 0o777 == 0o600
 
 
+def test_session_round_trip_remembers_interactive_access_transport(tmp_path: Path) -> None:
+    """Bridge startup can renew Access without requiring the flag again."""
+    path = tmp_path / "desktop" / "matrix_session.json"
+    session = DesktopMatrixSession(
+        homeserver="https://matrix.example.org",
+        user_id="@desktop:example.org",
+        device_id="DESKTOP",
+        access_token="secret-access-token",  # noqa: S106 - Test-only persisted token fixture.
+        cloudflare_access=True,
+    )
+
+    save_desktop_session(path, session)
+
+    assert load_desktop_session(path) == session
+
+
 @pytest.mark.skipif(os.name == "nt", reason="Unix permission bits are not authoritative on Windows")
 def test_session_refuses_group_readable_token(tmp_path: Path) -> None:
     """An accidentally exposed token stops the bridge instead of being used."""
@@ -286,6 +302,7 @@ async def test_sso_login_uses_returned_identity_without_password(monkeypatch: py
         login_token="short-lived-token",  # noqa: S106 - Test-only login token.
         runtime_paths=runtime_paths,
         http_headers={"X-Access-Client": "test-secret"},
+        cloudflare_access=True,
     )
 
     assert returned_client is client
@@ -294,6 +311,7 @@ async def test_sso_login_uses_returned_identity_without_password(monkeypatch: py
         user_id="@desktop:example.org",
         device_id="DESKTOP",
         access_token="matrix-access-token",  # noqa: S106 - Test-only access token.
+        cloudflare_access=True,
     )
     token_login.assert_awaited_once_with(
         "https://matrix.example.org",


### PR DESCRIPTION
## Motivation

Desktop Matrix clients behind Cloudflare Access should authenticate as the local user through the browser. Requiring machine credentials for an interactive desktop session adds unnecessary setup and loses the user identity carried by Access.

## Changes

- add `--cloudflare-access` to `mindroom desktop login` and `run`
- use the local `cloudflared` CLI to obtain `cf-access-token` after interactive browser authentication
- remember the transport mode in the saved desktop session
- resolve the Access JWT at request time and reauthenticate after its documented `exp` value
- preserve static proxy-header support and reject conflicting token configuration
- document the interactive and unattended proxy paths and regenerate bundled docs

## Validation

- 11,311 tests passed, 54 skipped
- focused Desktop and Matrix session tests passed
- `ruff check` passed
- changed Python files pass `ty check`
- `tach check` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Cloudflare Access authentication for desktop login and run commands.
  * Interactive authentication uses the local `cloudflared` CLI and refreshes credentials after expiration.
  * Authentication settings are remembered for future desktop sessions.

* **Documentation**
  * Added setup, usage, token handling, and unattended deployment guidance.
  * Documented incompatibility with static Cloudflare access-token headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->