### PR TITLE
Reuse cascaded agents across call turns

### DIFF
--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -133,6 +133,13 @@ def _append_additional_context(agent: Agent, context_chunk: str) -> None:
     agent.additional_context = f"{existing_context}\n\n{context_chunk}" if existing_context else context_chunk
 
 
+def _reset_reusable_agent_context(agent: Agent | None, base_context: str | None) -> Agent | None:
+    """Restore caller-owned context before or after one sequential turn."""
+    if agent is not None:
+        agent.additional_context = base_context
+    return agent
+
+
 def _compose_current_turn_prompt(
     *,
     raw_prompt: str,
@@ -369,6 +376,7 @@ def _build_agent_turn_callbacks(
     runtime_paths: RuntimePaths,
     config: Config,
     execution_identity: ToolExecutionIdentity | None,
+    retain_agent_runtime_state: bool = False,
 ) -> _AgentTurnCallbacks:
     """Build the entity-specific turn-driver callbacks for one agent response."""
 
@@ -389,6 +397,8 @@ def _build_agent_turn_callbacks(
         )
 
     def _close_runtime_dbs(scope_context: ScopeSessionContext | None) -> None:
+        if retain_agent_runtime_state:
+            return
         close_agent_runtime_state_dbs(
             holder.agent,
             shared_scope_storage=scope_context.storage if scope_context is not None else None,
@@ -1096,6 +1106,7 @@ async def _prepare_agent_and_prompt(
     current_prompt_is_structured: bool = False,
     pipeline_timing: DispatchPipelineTiming | None = None,
     eager_deferred_tools: bool = False,
+    reusable_agent: Agent | None = None,
 ) -> _PreparedAgentRun:
     """Prepare agent and full prompt for AI processing.
 
@@ -1118,23 +1129,25 @@ async def _prepare_agent_and_prompt(
             thread_id=ctx.thread_id,
             runtime_paths=runtime_paths,
         )
-        agent = create_agent(
-            agent_name,
-            config,
-            runtime_paths,
-            session_id=ctx.session_id,
-            history_storage=scope_context.storage if scope_context is not None else None,
-            active_model_name=runtime_model.model_name,
-            knowledge=knowledge,
-            include_interactive_questions=include_interactive_questions,
-            tool_function_filter=tool_function_filter,
-            include_openai_compat_guidance=include_openai_compat_guidance,
-            execution_identity=execution_identity,
-            delegation_depth=delegation_depth,
-            refresh_scheduler=refresh_scheduler,
-            dynamic_tool_continuation=True,
-            eager_deferred_tools=eager_deferred_tools,
-        )
+        agent = reusable_agent
+        if agent is None:
+            agent = create_agent(
+                agent_name,
+                config,
+                runtime_paths,
+                session_id=ctx.session_id,
+                history_storage=scope_context.storage if scope_context is not None else None,
+                active_model_name=runtime_model.model_name,
+                knowledge=knowledge,
+                include_interactive_questions=include_interactive_questions,
+                tool_function_filter=tool_function_filter,
+                include_openai_compat_guidance=include_openai_compat_guidance,
+                execution_identity=execution_identity,
+                delegation_depth=delegation_depth,
+                refresh_scheduler=refresh_scheduler,
+                dynamic_tool_continuation=True,
+                eager_deferred_tools=eager_deferred_tools,
+            )
         return runtime_model, agent
 
     parallel_branches = config.resolve_entity(agent_name).memory_backend == "mem0"
@@ -1271,6 +1284,7 @@ async def _prepare_agent_run_context(
     turn_recorder: TurnRecorder | None,
     pipeline_timing: DispatchPipelineTiming | None,
     eager_deferred_tools: bool = False,
+    reusable_agent: Agent | None = None,
 ) -> _AgentRunContext:
     """Prepare one agent response lifecycle through metadata assembly."""
     if pipeline_timing is not None:
@@ -1296,6 +1310,7 @@ async def _prepare_agent_run_context(
         current_prompt_is_structured=current_prompt_is_structured,
         pipeline_timing=pipeline_timing,
         eager_deferred_tools=eager_deferred_tools,
+        reusable_agent=reusable_agent,
     )
     if pipeline_timing is not None:
         pipeline_timing.mark("history_ready", overwrite=True)
@@ -1361,6 +1376,7 @@ async def ai_response(  # noqa: C901
     turn_recorder: TurnRecorder | None = None,
     pipeline_timing: DispatchPipelineTiming | None = None,
     eager_deferred_tools: bool = False,
+    reusable_agent: Agent | None = None,
 ) -> str:
     """Generates a response using the specified agno Agent with memory integration.
 
@@ -1402,6 +1418,8 @@ async def ai_response(  # noqa: C901
         turn_recorder: Optional lifecycle-owned recorder updated with trusted turn state.
         pipeline_timing: Optional dispatch timing collector updated with AI-stage milestones.
         eager_deferred_tools: Whether to materialize every deferred toolkit without the dynamic loader.
+        reusable_agent: Optional caller-owned agent materialized for repeated sequential turns.
+            The caller must serialize uses and close its runtime database handles.
 
     Returns:
         Agent response string
@@ -1435,6 +1453,7 @@ async def ai_response(  # noqa: C901
                 turn_recorder=turn_recorder,
                 pipeline_timing=pipeline_timing,
                 eager_deferred_tools=eager_deferred_tools,
+                reusable_agent=reusable_agent,
             ),
             show_tool_calls=show_tool_calls,
             tool_trace_collector=tool_trace_collector,
@@ -1458,6 +1477,7 @@ async def ai_response(  # noqa: C901
         return get_user_friendly_error_message(e, agent_name)
 
     holder = _AgentTurnHolder()
+    reusable_agent_base_context = reusable_agent.additional_context if reusable_agent is not None else None
     callbacks = _build_agent_turn_callbacks(
         holder,
         agent_name=agent_name,
@@ -1467,6 +1487,7 @@ async def ai_response(  # noqa: C901
         runtime_paths=runtime_paths,
         config=config,
         execution_identity=execution_identity,
+        retain_agent_runtime_state=reusable_agent is not None,
     )
 
     async def _run_blocking_attempt(
@@ -1498,6 +1519,7 @@ async def ai_response(  # noqa: C901
                 turn_recorder=turn_recorder,
                 pipeline_timing=pipeline_timing,
                 eager_deferred_tools=eager_deferred_tools,
+                reusable_agent=_reset_reusable_agent_context(reusable_agent, reusable_agent_base_context),
             )
         except Exception as e:
             logger.exception("Error preparing agent", agent=agent_name)
@@ -1598,19 +1620,22 @@ async def ai_response(  # noqa: C901
         on_scope_opened=callbacks.on_scope_opened,
         persist_standalone_replay=callbacks.persist_standalone_replay,
     )
-    return await run_blocking_response_turn(
-        ctx,
-        adapter,
-        TurnSinks(turn_recorder=turn_recorder, run_metadata_collector=run_metadata_collector),
-        continuation=_initial_agent_continuation(
-            prompt=prompt,
-            model_prompt=model_prompt,
-            current_timestamp_ms=current_timestamp_ms,
-            current_prompt_is_structured=current_prompt_is_structured,
-            current_event_id=ctx.reply_to_event_id,
-            run_id=ctx.run_id,
-        ),
-    )
+    try:
+        return await run_blocking_response_turn(
+            ctx,
+            adapter,
+            TurnSinks(turn_recorder=turn_recorder, run_metadata_collector=run_metadata_collector),
+            continuation=_initial_agent_continuation(
+                prompt=prompt,
+                model_prompt=model_prompt,
+                current_timestamp_ms=current_timestamp_ms,
+                current_prompt_is_structured=current_prompt_is_structured,
+                current_event_id=ctx.reply_to_event_id,
+                run_id=ctx.run_id,
+            ),
+        )
+    finally:
+        _reset_reusable_agent_context(reusable_agent, reusable_agent_base_context)
 
 
 @timed("model_request_to_completion")
@@ -1840,6 +1865,7 @@ async def stream_agent_response(  # noqa: C901, PLR0915
     turn_recorder: TurnRecorder | None = None,
     pipeline_timing: DispatchPipelineTiming | None = None,
     eager_deferred_tools: bool = False,
+    reusable_agent: Agent | None = None,
 ) -> AsyncIterator[AIStreamChunk]:
     """Generate streaming AI response using Agno's streaming API.
 
@@ -1877,6 +1903,8 @@ async def stream_agent_response(  # noqa: C901, PLR0915
         turn_recorder: Optional lifecycle-owned recorder updated with trusted turn state.
         pipeline_timing: Optional dispatch timing collector updated with AI-stage milestones.
         eager_deferred_tools: Whether to materialize every deferred toolkit without the dynamic loader.
+        reusable_agent: Optional caller-owned agent materialized for repeated sequential turns.
+            The caller must serialize uses and close its runtime database handles.
 
     Yields:
         Streaming chunks/events as they become available
@@ -1903,6 +1931,7 @@ async def stream_agent_response(  # noqa: C901, PLR0915
         return
 
     holder = _AgentTurnHolder(state=_StreamingAttemptState())
+    reusable_agent_base_context = reusable_agent.additional_context if reusable_agent is not None else None
     callbacks = _build_agent_turn_callbacks(
         holder,
         agent_name=agent_name,
@@ -1912,6 +1941,7 @@ async def stream_agent_response(  # noqa: C901, PLR0915
         runtime_paths=runtime_paths,
         config=config,
         execution_identity=execution_identity,
+        retain_agent_runtime_state=reusable_agent is not None,
     )
 
     def _finalize_streaming_attempt(scope_context: ScopeSessionContext | None) -> None:
@@ -1955,6 +1985,7 @@ async def stream_agent_response(  # noqa: C901, PLR0915
                 turn_recorder=turn_recorder,
                 pipeline_timing=pipeline_timing,
                 eager_deferred_tools=eager_deferred_tools,
+                reusable_agent=_reset_reusable_agent_context(reusable_agent, reusable_agent_base_context),
             )
         except Exception as e:
             logger.exception("Error preparing agent for streaming", agent=agent_name)
@@ -2181,6 +2212,9 @@ async def stream_agent_response(  # noqa: C901, PLR0915
     )
     # Close the driver generator deterministically when this wrapper unwinds so
     # its cleanup does not wait for event-loop async-generator finalization.
-    async with aclosing(response_stream) as closing_stream:
-        async for chunk in closing_stream:
-            yield chunk
+    try:
+        async with aclosing(response_stream) as closing_stream:
+            async for chunk in closing_stream:
+                yield chunk
+    finally:
+        _reset_reusable_agent_context(reusable_agent, reusable_agent_base_context)

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -1173,6 +1173,7 @@ async def _prepare_agent_and_prompt(
                     agent_name=agent_name,
                     shared_scope_storage=scope_context.storage if scope_context is not None else None,
                     pipeline_timing=pipeline_timing,
+                    caller_owned_agent=reusable_agent,
                 )
             finally:
                 _mark_pipeline_timing(pipeline_timing, "prompt_branches_ready")

--- a/src/mindroom/knowledge/utils.py
+++ b/src/mindroom/knowledge/utils.py
@@ -717,3 +717,13 @@ def _merge_knowledge(agent_name: str, knowledges: list[Knowledge]) -> Knowledge 
         max_results=max(knowledge.max_results for knowledge in queryable_knowledges),
         source_descriptions=source_descriptions,
     )
+
+
+def knowledge_runtime_identity(knowledge: Knowledge | None) -> tuple[int, ...]:
+    """Identify the stable runtime handles behind one resolved knowledge view."""
+    if knowledge is None:
+        return ()
+    vector_db = knowledge.vector_db
+    if isinstance(knowledge, KnowledgeWithSourceDescriptions) and isinstance(vector_db, _MultiKnowledgeVectorDb):
+        return tuple(id(source) for source in vector_db.vector_dbs)
+    return (id(knowledge),)

--- a/src/mindroom/matrix_rtc/call_manager.py
+++ b/src/mindroom/matrix_rtc/call_manager.py
@@ -938,6 +938,7 @@ class CallManager:
             tts=backend.tts,
             respond=tooling.responder,
             finalize_spoken_response=tooling.finalize_spoken_response,
+            close_responder=tooling.close,
             greeting_text="Hello, I joined the call.",
             on_conversation_turn=transcript.record,
             on_tools_executed=transcript.record_tool_use,

--- a/src/mindroom/matrix_rtc/call_tools.py
+++ b/src/mindroom/matrix_rtc/call_tools.py
@@ -559,8 +559,10 @@ async def _close_cascaded_call_resources(
     agent_cache: _CallAgentCache,
 ) -> None:
     """Settle playout reconciliation, then close the call-owned agent."""
-    await response_tracker.wait_for_settlements()
-    await agent_cache.aclose()
+    try:
+        await response_tracker.wait_for_settlements()
+    finally:
+        await agent_cache.aclose()
 
 
 def _call_agent_run_state(

--- a/src/mindroom/matrix_rtc/call_tools.py
+++ b/src/mindroom/matrix_rtc/call_tools.py
@@ -34,7 +34,11 @@ from agno.tools.function import Function, FunctionCall
 from mindroom.agent_run_context import append_knowledge_availability_enrichment
 from mindroom.agents import create_agent
 from mindroom.history.interrupted_replay import persist_interrupted_replay
-from mindroom.history.runtime import close_agent_runtime_state_dbs, open_resolved_scope_session_context
+from mindroom.history.runtime import (
+    close_agent_runtime_state_dbs,
+    create_scope_session_storage,
+    open_resolved_scope_session_context,
+)
 from mindroom.history.turn_recorder import TurnRecorder
 from mindroom.history.types import HistoryScope
 from mindroom.hooks import EnrichmentItem
@@ -255,27 +259,49 @@ class _CallAgentCache:
             await asyncio.to_thread(close_agent_runtime_state_dbs, self.agent)
             self.agent = None
         agent = await asyncio.to_thread(
-            functools.partial(
-                create_agent,
+            self._build_agent,
+            knowledge=knowledge,
+            refresh_scheduler=refresh_scheduler,
+        )
+        self.agent = agent
+        self.knowledge_identity = knowledge_identity
+        self.refresh_scheduler = refresh_scheduler
+        return agent
+
+    def _build_agent(
+        self,
+        *,
+        knowledge: KnowledgeProtocol | None,
+        refresh_scheduler: KnowledgeRefreshScheduler | None,
+    ) -> AgnoAgent:
+        """Build one cached agent with canonical prompt-sanitizing history storage."""
+        history_storage = create_scope_session_storage(
+            agent_name=self.agent_name,
+            scope=HistoryScope(kind="agent", scope_id=self.agent_name),
+            config=self.config,
+            runtime_paths=self.runtime_paths,
+            execution_identity=self.execution_identity,
+        )
+        try:
+            return create_agent(
                 self.agent_name,
                 self.config,
                 self.runtime_paths,
-                self.execution_identity,
+                execution_identity=self.execution_identity,
                 session_id=self.session_id,
                 hook_registry=self.context.hook_registry,
                 knowledge=knowledge,
+                history_storage=history_storage,
                 active_model_name=self.active_model_name,
                 include_interactive_questions=False,
                 tool_function_filter=self.context.tool_function_filter,
                 refresh_scheduler=refresh_scheduler,
                 dynamic_tool_continuation=True,
                 eager_deferred_tools=True,
-            ),
-        )
-        self.agent = agent
-        self.knowledge_identity = knowledge_identity
-        self.refresh_scheduler = refresh_scheduler
-        return agent
+            )
+        except Exception:
+            history_storage.close()
+            raise
 
 
 async def build_call_tools(
@@ -293,6 +319,18 @@ async def build_call_tools(
 ) -> CallAgentTooling:
     """Materialize the agent for the selected voice backend."""
     session_id = session_id or create_session_id(room_id, None)
+    if enable_responder:
+        runtime_model = await asyncio.to_thread(
+            functools.partial(
+                config.resolve_runtime_model,
+                entity_name=agent_name,
+                active_model_name=active_model_name,
+                room_id=room_id,
+                thread_id=None,
+                runtime_paths=runtime_paths,
+            ),
+        )
+        active_model_name = runtime_model.model_name
     target = MessageTarget(
         room_id=room_id,
         source_thread_id=None,

--- a/src/mindroom/matrix_rtc/call_tools.py
+++ b/src/mindroom/matrix_rtc/call_tools.py
@@ -38,7 +38,7 @@ from mindroom.history.runtime import close_agent_runtime_state_dbs, open_resolve
 from mindroom.history.turn_recorder import TurnRecorder
 from mindroom.history.types import HistoryScope
 from mindroom.hooks import EnrichmentItem
-from mindroom.knowledge.utils import resolve_agent_knowledge_access
+from mindroom.knowledge.utils import knowledge_runtime_identity, resolve_agent_knowledge_access
 from mindroom.logging_config import get_logger
 from mindroom.message_target import MessageTarget
 from mindroom.session_ids import create_session_id
@@ -49,10 +49,12 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
     from agno.agent import Agent as AgnoAgent
+    from agno.knowledge.protocol import KnowledgeProtocol
     from livekit.agents.llm import RawFunctionTool
 
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
+    from mindroom.knowledge.refresh_scheduler import KnowledgeRefreshScheduler
     from mindroom.tool_system.events import ToolTraceEntry
     from mindroom.tool_system.runtime_context import ToolRuntimeContext, ToolRuntimeSupport
     from mindroom.tool_system.worker_routing import ToolExecutionIdentity
@@ -206,27 +208,32 @@ class _CallAgentCache:
     session_id: str
     active_model_name: str | None
     agent: AgnoAgent | None = None
-    knowledge: object | None = None
-    refresh_scheduler: object | None = None
+    knowledge_identity: tuple[int, ...] = ()
+    refresh_scheduler: KnowledgeRefreshScheduler | None = None
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
     async def run(
         self,
         *,
-        knowledge: object | None,
-        refresh_scheduler: object | None,
+        knowledge: KnowledgeProtocol | None,
+        knowledge_identity: tuple[int, ...],
+        refresh_scheduler: KnowledgeRefreshScheduler | None,
         operation: Callable[[AgnoAgent], Awaitable[str]],
     ) -> str:
         """Run one turn, rebuilding only when call dependencies change identity."""
         async with self.lock:
-            agent = await self._get_agent(knowledge=knowledge, refresh_scheduler=refresh_scheduler)
+            agent = await self._get_agent(
+                knowledge=knowledge,
+                knowledge_identity=knowledge_identity,
+                refresh_scheduler=refresh_scheduler,
+            )
             return await operation(agent)
 
     async def aclose(self) -> None:
         """Close the cached agent's caller-owned runtime state."""
         async with self.lock:
             agent, self.agent = self.agent, None
-            self.knowledge = None
+            self.knowledge_identity = ()
             self.refresh_scheduler = None
             if agent is not None:
                 await asyncio.to_thread(close_agent_runtime_state_dbs, agent)
@@ -234,10 +241,15 @@ class _CallAgentCache:
     async def _get_agent(
         self,
         *,
-        knowledge: object | None,
-        refresh_scheduler: object | None,
+        knowledge: KnowledgeProtocol | None,
+        knowledge_identity: tuple[int, ...],
+        refresh_scheduler: KnowledgeRefreshScheduler | None,
     ) -> AgnoAgent:
-        if self.agent is not None and self.knowledge is knowledge and self.refresh_scheduler is refresh_scheduler:
+        if (
+            self.agent is not None
+            and self.knowledge_identity == knowledge_identity
+            and self.refresh_scheduler is refresh_scheduler
+        ):
             return self.agent
         if self.agent is not None:
             await asyncio.to_thread(close_agent_runtime_state_dbs, self.agent)
@@ -261,7 +273,7 @@ class _CallAgentCache:
             ),
         )
         self.agent = agent
-        self.knowledge = knowledge
+        self.knowledge_identity = knowledge_identity
         self.refresh_scheduler = refresh_scheduler
         return agent
 
@@ -519,6 +531,7 @@ async def _run_call_agent(
     try:
         response = await agent_cache.run(
             knowledge=knowledge_resolution.knowledge,
+            knowledge_identity=knowledge_runtime_identity(knowledge_resolution.knowledge),
             refresh_scheduler=refresh_scheduler,
             operation=_run_with_agent,
         )

--- a/src/mindroom/matrix_rtc/call_tools.py
+++ b/src/mindroom/matrix_rtc/call_tools.py
@@ -34,7 +34,7 @@ from agno.tools.function import Function, FunctionCall
 from mindroom.agent_run_context import append_knowledge_availability_enrichment
 from mindroom.agents import create_agent
 from mindroom.history.interrupted_replay import persist_interrupted_replay
-from mindroom.history.runtime import open_resolved_scope_session_context
+from mindroom.history.runtime import close_agent_runtime_state_dbs, open_resolved_scope_session_context
 from mindroom.history.turn_recorder import TurnRecorder
 from mindroom.history.types import HistoryScope
 from mindroom.hooks import EnrichmentItem
@@ -90,6 +90,7 @@ class CallAgentTooling:
     execution_identity: ToolExecutionIdentity
     responder: Callable[[str, Callable[[list[str]], None] | None], Awaitable[CallAgentResponse]] | None = None
     finalize_spoken_response: Callable[[str | None, str, bool], Awaitable[None] | None] | None = None
+    close: Callable[[], Awaitable[None]] | None = None
 
 
 @dataclass(frozen=True)
@@ -193,6 +194,78 @@ class _CallResponseTracker:
             )
 
 
+@dataclass
+class _CallAgentCache:
+    """Own one serially reused cascaded agent for the lifetime of a call."""
+
+    agent_name: str
+    config: Config
+    runtime_paths: RuntimePaths
+    context: ToolRuntimeContext
+    execution_identity: ToolExecutionIdentity
+    session_id: str
+    active_model_name: str | None
+    agent: AgnoAgent | None = None
+    knowledge: object | None = None
+    refresh_scheduler: object | None = None
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+    async def run(
+        self,
+        *,
+        knowledge: object | None,
+        refresh_scheduler: object | None,
+        operation: Callable[[AgnoAgent], Awaitable[str]],
+    ) -> str:
+        """Run one turn, rebuilding only when call dependencies change identity."""
+        async with self.lock:
+            agent = await self._get_agent(knowledge=knowledge, refresh_scheduler=refresh_scheduler)
+            return await operation(agent)
+
+    async def aclose(self) -> None:
+        """Close the cached agent's caller-owned runtime state."""
+        async with self.lock:
+            agent, self.agent = self.agent, None
+            self.knowledge = None
+            self.refresh_scheduler = None
+            if agent is not None:
+                await asyncio.to_thread(close_agent_runtime_state_dbs, agent)
+
+    async def _get_agent(
+        self,
+        *,
+        knowledge: object | None,
+        refresh_scheduler: object | None,
+    ) -> AgnoAgent:
+        if self.agent is not None and self.knowledge is knowledge and self.refresh_scheduler is refresh_scheduler:
+            return self.agent
+        if self.agent is not None:
+            await asyncio.to_thread(close_agent_runtime_state_dbs, self.agent)
+            self.agent = None
+        agent = await asyncio.to_thread(
+            functools.partial(
+                create_agent,
+                self.agent_name,
+                self.config,
+                self.runtime_paths,
+                self.execution_identity,
+                session_id=self.session_id,
+                hook_registry=self.context.hook_registry,
+                knowledge=knowledge,
+                active_model_name=self.active_model_name,
+                include_interactive_questions=False,
+                tool_function_filter=self.context.tool_function_filter,
+                refresh_scheduler=refresh_scheduler,
+                dynamic_tool_continuation=True,
+                eager_deferred_tools=True,
+            ),
+        )
+        self.agent = agent
+        self.knowledge = knowledge
+        self.refresh_scheduler = refresh_scheduler
+        return agent
+
+
 async def build_call_tools(
     *,
     agent_name: str,
@@ -247,6 +320,15 @@ async def build_call_tools(
             runtime_paths=runtime_paths,
             execution_identity=execution_identity,
         )
+        agent_cache = _CallAgentCache(
+            agent_name=agent_name,
+            config=config,
+            runtime_paths=runtime_paths,
+            context=context,
+            execution_identity=execution_identity,
+            session_id=session_id,
+            active_model_name=active_model_name,
+        )
         responder = functools.partial(
             _run_call_agent,
             agent_name=agent_name,
@@ -260,6 +342,7 @@ async def build_call_tools(
             session_id=session_id,
             voice_enrichment_items=voice_enrichment_items,
             response_tracker=response_tracker,
+            agent_cache=agent_cache,
             active_model_name=active_model_name,
         )
         return CallAgentTooling(
@@ -268,6 +351,7 @@ async def build_call_tools(
             execution_identity=execution_identity,
             responder=responder,
             finalize_spoken_response=response_tracker.finalize,
+            close=functools.partial(_close_cascaded_call_resources, response_tracker, agent_cache),
         )
 
     refresh_scheduler = context.orchestrator.knowledge_refresh_scheduler if context.orchestrator is not None else None
@@ -367,6 +451,7 @@ async def _run_call_agent(
     session_id: str,
     voice_enrichment_items: tuple[EnrichmentItem, ...],
     response_tracker: _CallResponseTracker,
+    agent_cache: _CallAgentCache,
     active_model_name: str | None,
 ) -> CallAgentResponse:
     """Run one finalized call transcript through the normal MindRoom agent."""
@@ -403,7 +488,7 @@ async def _run_call_agent(
     )
     run_metadata: dict[str, Any] = {}
 
-    async def _respond() -> str:
+    async def _respond(agent: AgnoAgent) -> str:
         try:
             return await ai_response(
                 turn,
@@ -420,12 +505,23 @@ async def _run_call_agent(
                 refresh_scheduler=refresh_scheduler,
                 turn_recorder=recorder,
                 eager_deferred_tools=True,
+                reusable_agent=agent,
             )
         finally:
             recorder.set_run_metadata({**(recorder.run_metadata or {}), **run_metadata})
 
+    async def _run_with_agent(agent: AgnoAgent) -> str:
+        return await tool_support.run_in_context(
+            tool_context=context,
+            operation=functools.partial(_respond, agent),
+        )
+
     try:
-        response = await tool_support.run_in_context(tool_context=context, operation=_respond)
+        response = await agent_cache.run(
+            knowledge=knowledge_resolution.knowledge,
+            refresh_scheduler=refresh_scheduler,
+            operation=_run_with_agent,
+        )
     except asyncio.CancelledError:
         state = _call_agent_run_state(recorder, session_id=session_id, fallback_run_id=fallback_run_id)
         await response_tracker.persist_unspoken(state, default_status=RunStatus.cancelled)
@@ -443,6 +539,15 @@ async def _run_call_agent(
     if not response and state.outcome == "interrupted":
         await response_tracker.persist_unspoken(state, default_status=RunStatus.cancelled)
     return CallAgentResponse(text=response, tool_names=tool_names, turn_id=turn_id)
+
+
+async def _close_cascaded_call_resources(
+    response_tracker: _CallResponseTracker,
+    agent_cache: _CallAgentCache,
+) -> None:
+    """Settle playout reconciliation, then close the call-owned agent."""
+    await response_tracker.wait_for_settlements()
+    await agent_cache.aclose()
 
 
 def _call_agent_run_state(

--- a/src/mindroom/matrix_rtc/voice_agent.py
+++ b/src/mindroom/matrix_rtc/voice_agent.py
@@ -296,6 +296,7 @@ class CascadedVoiceAgentOptions:
     tts: SpeechServiceOptions
     respond: Callable[[str, Callable[[list[str]], None] | None], Awaitable[CallAgentResponse]]
     finalize_spoken_response: Callable[[str | None, str, bool], Awaitable[None] | None] | None = None
+    close_responder: Callable[[], Awaitable[None]] | None = None
     greeting_text: str | None = None
     on_conversation_turn: Callable[[str, str], None] | None = None
     on_tools_executed: Callable[[list[str]], None] | None = None
@@ -641,6 +642,8 @@ class CascadedVoiceBridge(RealtimeVoiceBridge):
         if not isinstance(options, CascadedVoiceAgentOptions):
             msg = "CascadedVoiceBridge requires cascaded agent options"
             raise TypeError(msg)
+        if options.close_responder is not None:
+            self._owned_speech_resource_closers += (options.close_responder,)
 
         stt_client = AsyncOpenAI(
             api_key=options.stt.api_key,
@@ -656,7 +659,7 @@ class CascadedVoiceBridge(RealtimeVoiceBridge):
         except BaseException:
             await stt_client.close()
             raise
-        self._owned_speech_resource_closers = (stt_client.close, tts.aclose)
+        self._owned_speech_resource_closers += (stt_client.close, tts.aclose)
         mindroom_llm = _build_mindroom_llm(options.respond, options.on_tools_executed)
         session = AgentSession(
             stt=stt,
@@ -759,9 +762,9 @@ def _build_mindroom_llm(
 
     class _MindRoomLLMStream(llm.LLMStream):
         async def _run(self) -> None:
-            transcript = _latest_user_transcript(self._chat_ctx)
-            if not transcript:
-                logger.warning("cascaded_voice_turn_skipped_no_transcript")
+            transcript = _latest_user_transcript(self._chat_ctx).strip()
+            if not any(character.isalnum() for character in transcript):
+                logger.warning("cascaded_voice_turn_skipped_no_speech_content")
                 return
             result = await respond(transcript, on_tools_executed)
             if result.text:

--- a/src/mindroom/pre_model_preparation.py
+++ b/src/mindroom/pre_model_preparation.py
@@ -36,7 +36,13 @@ def _log_secondary_agent_error(agent_name: str, error: Exception) -> None:
     )
 
 
-def _close_unreturned_agent(agent: Agent, shared_scope_storage: BaseDb | None) -> None:
+def _close_unreturned_agent(
+    agent: Agent,
+    shared_scope_storage: BaseDb | None,
+    caller_owned_agent: Agent | None,
+) -> None:
+    if agent is caller_owned_agent:
+        return
     try:
         close_agent_runtime_state_dbs(agent, shared_scope_storage=shared_scope_storage)
     except Exception:
@@ -48,6 +54,7 @@ async def _drain_unreturned_agent_build(
     *,
     agent_name: str,
     shared_scope_storage: BaseDb | None,
+    caller_owned_agent: Agent | None,
 ) -> None:
     """Wait through repeated cancellation and clean an unreturned agent build."""
     while not build_future.done():
@@ -64,7 +71,7 @@ async def _drain_unreturned_agent_build(
     except Exception as error:
         _log_secondary_agent_error(agent_name, error)
     else:
-        _close_unreturned_agent(unreturned_agent, shared_scope_storage)
+        _close_unreturned_agent(unreturned_agent, shared_scope_storage, caller_owned_agent)
 
 
 def _discard_unreturned_agent_result(
@@ -72,12 +79,13 @@ def _discard_unreturned_agent_result(
     *,
     agent_name: str,
     shared_scope_storage: BaseDb | None,
+    caller_owned_agent: Agent | None,
 ) -> None:
     """Log a failed build or close an agent that preparation cannot return."""
     if isinstance(result, Exception):
         _log_secondary_agent_error(agent_name, result)
     else:
-        _close_unreturned_agent(result[1], shared_scope_storage)
+        _close_unreturned_agent(result[1], shared_scope_storage, caller_owned_agent)
 
 
 async def prepare_mem0_prompt_branches(
@@ -87,6 +95,7 @@ async def prepare_mem0_prompt_branches(
     agent_name: str,
     shared_scope_storage: BaseDb | None,
     pipeline_timing: DispatchPipelineTiming | None,
+    caller_owned_agent: Agent | None = None,
 ) -> tuple[MemoryPromptParts, ResolvedRuntimeModel, Agent]:
     """Overlap Mem0 preparation with agent construction and join both safely."""
 
@@ -127,6 +136,7 @@ async def prepare_mem0_prompt_branches(
             build_future,
             agent_name=agent_name,
             shared_scope_storage=shared_scope_storage,
+            caller_owned_agent=caller_owned_agent,
         )
         raise
 
@@ -138,6 +148,7 @@ async def prepare_mem0_prompt_branches(
             agent_result,
             agent_name=agent_name,
             shared_scope_storage=shared_scope_storage,
+            caller_owned_agent=caller_owned_agent,
         )
         raise
     if isinstance(memory_result, Exception):
@@ -145,6 +156,7 @@ async def prepare_mem0_prompt_branches(
             agent_result,
             agent_name=agent_name,
             shared_scope_storage=shared_scope_storage,
+            caller_owned_agent=caller_owned_agent,
         )
         raise memory_result
     if isinstance(agent_result, Exception):

--- a/tests/test_bot_knowledge.py
+++ b/tests/test_bot_knowledge.py
@@ -14,7 +14,7 @@ from agno.knowledge.knowledge import Knowledge
 from mindroom.bot import AgentBot
 from mindroom.config.knowledge import KnowledgeBaseConfig
 from mindroom.knowledge.availability import KnowledgeAvailability
-from mindroom.knowledge.utils import _MultiKnowledgeVectorDb
+from mindroom.knowledge.utils import _MultiKnowledgeVectorDb, knowledge_runtime_identity
 from mindroom.knowledge_source_descriptions import KnowledgeWithSourceDescriptions
 from tests.bot_helpers import (
     AgentBotTestBase,
@@ -184,6 +184,25 @@ class TestAgentBot(AgentBotTestBase):
 
         docs = vector_db.search(query="knowledge query", limit=4)
         assert [doc.content for doc in docs] == ["research 1", "legal 1", "research 2", "legal 2"]
+
+    def test_multi_knowledge_runtime_identity_tracks_underlying_handles(self) -> None:
+        """Fresh merged views over unchanged indexes keep the same runtime identity."""
+        sources = [_SyncStubVectorDb(documents=[]), _SyncStubVectorDb(documents=[])]
+        first = KnowledgeWithSourceDescriptions(
+            name="merged",
+            vector_db=_MultiKnowledgeVectorDb(vector_dbs=sources),
+        )
+        second = KnowledgeWithSourceDescriptions(
+            name="merged",
+            vector_db=_MultiKnowledgeVectorDb(vector_dbs=sources),
+        )
+        changed = KnowledgeWithSourceDescriptions(
+            name="merged",
+            vector_db=_MultiKnowledgeVectorDb(vector_dbs=[sources[0], _SyncStubVectorDb(documents=[])]),
+        )
+
+        assert knowledge_runtime_identity(first) == knowledge_runtime_identity(second)
+        assert knowledge_runtime_identity(first) != knowledge_runtime_identity(changed)
 
     def test_multi_knowledge_vector_db_sync_ignores_failing_source(self) -> None:
         """A failing knowledge source should not suppress healthy source results."""

--- a/tests/test_matrix_rtc_call_manager.py
+++ b/tests/test_matrix_rtc_call_manager.py
@@ -624,6 +624,8 @@ async def test_manager_selects_cascaded_backend_with_independent_speech_services
     ) -> CallAgentResponse:
         return CallAgentResponse("answer")
 
+    close_responder = AsyncMock()
+
     async def fake_tools(**kwargs: object) -> CallAgentTooling:
         assert kwargs["enable_responder"] is True
         assert kwargs["active_model_name"] == "call_fast"
@@ -633,6 +635,7 @@ async def test_manager_selects_cascaded_backend_with_independent_speech_services
             instructions="",
             execution_identity=_call_execution_identity_from_tool_kwargs(kwargs),
             responder=respond,
+            close=close_responder,
         )
 
     monkeypatch.setattr("mindroom.matrix_rtc.call_manager.build_call_tools", fake_tools)
@@ -657,6 +660,7 @@ async def test_manager_selects_cascaded_backend_with_independent_speech_services
         "http://127.0.0.1:9001/v1",
     )
     assert options.tts.extra_kwargs == {"voice": "ash"}
+    assert options.close_responder is close_responder
     await manager.shutdown()
 
 

--- a/tests/test_matrix_rtc_call_tools.py
+++ b/tests/test_matrix_rtc_call_tools.py
@@ -21,8 +21,10 @@ from mindroom.config.approval import ApprovalRuleConfig, ToolApprovalConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
 from mindroom.constants import AI_RUN_METADATA_KEY
+from mindroom.history.types import HistoryScope
 from mindroom.knowledge import KnowledgeAvailability, KnowledgeAvailabilityDetail
 from mindroom.matrix_rtc.call_tools import (
+    _CallAgentCache,
     _CallAgentRunState,
     _CallResponseTracker,
     _close_cascaded_call_resources,
@@ -121,6 +123,36 @@ def _wrap(function: Function):  # noqa: ANN202
         agent_name=AGENT,
         config=_config(),
     )
+
+
+def test_call_agent_cache_closes_history_storage_when_agent_build_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed cached-agent build must not leak its caller-opened history DB."""
+    history_storage = MagicMock()
+    monkeypatch.setattr(
+        "mindroom.matrix_rtc.call_tools.create_scope_session_storage",
+        MagicMock(return_value=history_storage),
+    )
+    monkeypatch.setattr(
+        "mindroom.matrix_rtc.call_tools.create_agent",
+        MagicMock(side_effect=RuntimeError("agent build failed")),
+    )
+    cache = _CallAgentCache(
+        agent_name=AGENT,
+        config=_config(),
+        runtime_paths=test_runtime_paths(tmp_path),
+        context=SimpleNamespace(hook_registry=None, tool_function_filter=None),  # type: ignore[arg-type]
+        execution_identity=SimpleNamespace(),  # type: ignore[arg-type]
+        session_id="call-session",
+        active_model_name="default",
+    )
+
+    with pytest.raises(RuntimeError, match="agent build failed"):
+        cache._build_agent(knowledge=None, refresh_scheduler=None)
+
+    history_storage.close.assert_called_once_with()
 
 
 @pytest.mark.asyncio
@@ -445,8 +477,14 @@ async def test_cascaded_responder_uses_normal_agent_turn_and_filters_unsafe_func
 
     cached_agent = SimpleNamespace(additional_context="base context")
     create_agent_mock = MagicMock(return_value=cached_agent)
+    history_storage = MagicMock()
+    create_scope_session_storage_mock = MagicMock(return_value=history_storage)
     close_agent_mock = MagicMock()
     monkeypatch.setattr("mindroom.matrix_rtc.call_tools.create_agent", create_agent_mock)
+    monkeypatch.setattr(
+        "mindroom.matrix_rtc.call_tools.create_scope_session_storage",
+        create_scope_session_storage_mock,
+    )
     monkeypatch.setattr("mindroom.matrix_rtc.call_tools.close_agent_runtime_state_dbs", close_agent_mock)
     monkeypatch.setattr(
         "mindroom.matrix_rtc.call_tools.resolve_agent_knowledge_access",
@@ -500,6 +538,14 @@ async def test_cascaded_responder_uses_normal_agent_turn_and_filters_unsafe_func
     assert kwargs["show_tool_calls"] is False
     assert kwargs["eager_deferred_tools"] is True
     assert kwargs["reusable_agent"] is cached_agent
+    assert create_agent_mock.call_args.kwargs["history_storage"] is history_storage
+    create_scope_session_storage_mock.assert_called_once_with(
+        agent_name=AGENT,
+        scope=HistoryScope(kind="agent", scope_id=AGENT),
+        config=config,
+        runtime_paths=runtime_paths,
+        execution_identity=execution_identity,
+    )
     assert tooling.finalize_spoken_response is not None
     finalize = tooling.finalize_spoken_response(response.turn_id, "It is", True)
     assert finalize is not None
@@ -591,11 +637,22 @@ async def test_cascaded_responder_uses_normal_agent_turn_and_filters_unsafe_func
 
 
 @pytest.mark.asyncio
-async def test_cascaded_responder_records_call_selected_model_metadata(
+@pytest.mark.parametrize(
+    ("active_model_name", "expected_model_name", "expected_model_id", "expected_context_window"),
+    [
+        ("call_fast", "call_fast", "fast-model", 16_000),
+        (None, "large", "large-model", 48_000),
+    ],
+)
+async def test_cascaded_responder_records_effective_selected_model_metadata(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    active_model_name: str | None,
+    expected_model_name: str,
+    expected_model_id: str,
+    expected_context_window: int,
 ) -> None:
-    """The call override drives real agent preparation and persisted run metadata."""
+    """Call and room model selection drive both cached-agent creation and metadata."""
     runtime_paths = test_runtime_paths(tmp_path)
     config = bind_runtime_paths(
         Config(
@@ -650,7 +707,7 @@ async def test_cascaded_responder_records_call_selected_model_metadata(
     mock_agent = MagicMock()
     mock_agent.model = MagicMock()
     mock_agent.model.__class__.__name__ = "OpenAIChat"
-    mock_agent.model.id = "fast-model"
+    mock_agent.model.id = expected_model_id
     mock_agent.name = "Helper"
     mock_agent.additional_context = "base context"
     mock_agent.add_history_to_context = False
@@ -658,7 +715,7 @@ async def test_cascaded_responder_records_call_selected_model_metadata(
     mock_run_output.run_id = "call-run-1"
     mock_run_output.session_id = "!room:example.org:call:metadata"
     mock_run_output.status = RunStatus.completed
-    mock_run_output.model = "fast-model"
+    mock_run_output.model = expected_model_id
     mock_run_output.model_provider = "openai"
     mock_run_output.metrics = Metrics(input_tokens=100, output_tokens=20, total_tokens=120)
     mock_run_output.tools = None
@@ -703,7 +760,7 @@ async def test_cascaded_responder_records_call_selected_model_metadata(
         requester_id=REQUESTER,
         session_id="!room:example.org:call:metadata",
         enable_responder=True,
-        active_model_name="call_fast",
+        active_model_name=active_model_name,
     )
 
     assert tooling.responder is not None
@@ -715,13 +772,13 @@ async def test_cascaded_responder_records_call_selected_model_metadata(
     assert finalize is not None
     await finalize
 
-    assert create_agent_mock.call_args.kwargs["active_model_name"] == "call_fast"
+    assert create_agent_mock.call_args.kwargs["active_model_name"] == expected_model_name
     run_metadata = persisted_interruptions[0]["run_metadata"]
     assert isinstance(run_metadata, dict)
     payload = run_metadata[AI_RUN_METADATA_KEY]
-    assert payload["model"]["config"] == "call_fast"
-    assert payload["model"]["id"] == "fast-model"
-    assert payload["context"]["window_tokens"] == 16_000
+    assert payload["model"]["config"] == expected_model_name
+    assert payload["model"]["id"] == expected_model_id
+    assert payload["context"]["window_tokens"] == expected_context_window
     assert (mock_agent.additional_context, ai_close_agent_mock.call_count) == ("base context", 0)
 
 

--- a/tests/test_matrix_rtc_call_tools.py
+++ b/tests/test_matrix_rtc_call_tools.py
@@ -25,6 +25,7 @@ from mindroom.knowledge import KnowledgeAvailability, KnowledgeAvailabilityDetai
 from mindroom.matrix_rtc.call_tools import (
     _CallAgentRunState,
     _CallResponseTracker,
+    _close_cascaded_call_resources,
     _wrap_agno_function,
     build_call_tools,
 )
@@ -751,9 +752,20 @@ def test_call_response_tracker_keeps_fifo_without_retaining_settled_tokens(tmp_p
     for _ in range(1_000):
         token = tracker.register(state)
         assert tracker.finalize(token, "done", False) is None
-
     assert tracker.pending == {}
     assert first not in tracker.pending
+
+
+@pytest.mark.asyncio
+async def test_cascaded_close_releases_agent_when_settlement_wait_is_cancelled() -> None:
+    """Call cancellation cannot leak the cached agent runtime."""
+    tracker = SimpleNamespace(wait_for_settlements=AsyncMock(side_effect=asyncio.CancelledError))
+    cache = SimpleNamespace(aclose=AsyncMock())
+
+    with pytest.raises(asyncio.CancelledError):
+        await _close_cascaded_call_resources(tracker, cache)  # type: ignore[arg-type]
+
+    cache.aclose.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_matrix_rtc_call_tools.py
+++ b/tests/test_matrix_rtc_call_tools.py
@@ -442,8 +442,11 @@ async def test_cascaded_responder_uses_normal_agent_turn_and_filters_unsafe_func
         )
         return "It is sunny."
 
-    create_agent_mock = MagicMock()
+    cached_agent = SimpleNamespace(additional_context="base context")
+    create_agent_mock = MagicMock(return_value=cached_agent)
+    close_agent_mock = MagicMock()
     monkeypatch.setattr("mindroom.matrix_rtc.call_tools.create_agent", create_agent_mock)
+    monkeypatch.setattr("mindroom.matrix_rtc.call_tools.close_agent_runtime_state_dbs", close_agent_mock)
     monkeypatch.setattr(
         "mindroom.matrix_rtc.call_tools.resolve_agent_knowledge_access",
         lambda *_args, **_kwargs: SimpleNamespace(knowledge=knowledge, unavailable=()),
@@ -480,7 +483,7 @@ async def test_cascaded_responder_uses_normal_agent_turn_and_filters_unsafe_func
     assert response.tool_names == ("weather",)
     assert response.turn_id is not None
     assert recorded_tool_uses == [["weather"]]
-    create_agent_mock.assert_not_called()
+    create_agent_mock.assert_called_once()
     turn, kwargs = calls[0]
     assert turn.entity_label == AGENT
     assert turn.requester_id == REQUESTER
@@ -495,6 +498,7 @@ async def test_cascaded_responder_uses_normal_agent_turn_and_filters_unsafe_func
     assert kwargs["include_interactive_questions"] is False
     assert kwargs["show_tool_calls"] is False
     assert kwargs["eager_deferred_tools"] is True
+    assert kwargs["reusable_agent"] is cached_agent
     assert tooling.finalize_spoken_response is not None
     finalize = tooling.finalize_spoken_response(response.turn_id, "It is", True)
     assert finalize is not None
@@ -580,6 +584,9 @@ async def test_cascaded_responder_uses_normal_agent_turn_and_filters_unsafe_func
     assert tool_filter(spawn) is False
     assert tool_filter(send) is False
     assert contexts[0].tool_function_filter is None
+    assert tooling.close is not None
+    await tooling.close()
+    close_agent_mock.assert_called_once_with(cached_agent)
 
 
 @pytest.mark.asyncio
@@ -644,6 +651,7 @@ async def test_cascaded_responder_records_call_selected_model_metadata(
     mock_agent.model.__class__.__name__ = "OpenAIChat"
     mock_agent.model.id = "fast-model"
     mock_agent.name = "Helper"
+    mock_agent.additional_context = "base context"
     mock_agent.add_history_to_context = False
     mock_run_output = MagicMock()
     mock_run_output.run_id = "call-run-1"
@@ -656,7 +664,9 @@ async def test_cascaded_responder_records_call_selected_model_metadata(
     mock_run_output.content = "It is sunny."
 
     create_agent_mock = MagicMock(return_value=mock_agent)
-    monkeypatch.setattr("mindroom.ai.create_agent", create_agent_mock)
+    ai_close_agent_mock = MagicMock()
+    monkeypatch.setattr("mindroom.matrix_rtc.call_tools.create_agent", create_agent_mock)
+    monkeypatch.setattr("mindroom.ai.close_agent_runtime_state_dbs", ai_close_agent_mock)
     monkeypatch.setattr(
         "mindroom.ai.build_memory_prompt_parts",
         AsyncMock(return_value=MemoryPromptParts()),
@@ -711,6 +721,7 @@ async def test_cascaded_responder_records_call_selected_model_metadata(
     assert payload["model"]["config"] == "call_fast"
     assert payload["model"]["id"] == "fast-model"
     assert payload["context"]["window_tokens"] == 16_000
+    assert (mock_agent.additional_context, ai_close_agent_mock.call_count) == ("base context", 0)
 
 
 def test_call_response_tracker_keeps_fifo_without_retaining_settled_tokens(tmp_path: Path) -> None:
@@ -852,7 +863,13 @@ async def test_cascaded_responder_refreshes_knowledge_and_availability_each_turn
         ai_calls.append((turn, kwargs))
         return f"answer-{len(ai_calls)}"
 
+    first_agent = SimpleNamespace(additional_context="first base")
+    second_agent = SimpleNamespace(additional_context="second base")
+    create_agent_mock = MagicMock(side_effect=(first_agent, second_agent))
+    close_agent_mock = MagicMock()
     monkeypatch.setattr("mindroom.matrix_rtc.call_tools.resolve_agent_knowledge_access", resolve_knowledge)
+    monkeypatch.setattr("mindroom.matrix_rtc.call_tools.create_agent", create_agent_mock)
+    monkeypatch.setattr("mindroom.matrix_rtc.call_tools.close_agent_runtime_state_dbs", close_agent_mock)
     monkeypatch.setattr("mindroom.ai.ai_response", fake_ai_response)
     tooling = await build_call_tools(
         agent_name=AGENT,
@@ -878,10 +895,17 @@ async def test_cascaded_responder_refreshes_knowledge_and_availability_each_turn
     assert all(call["execution_identity"] is execution_identity for call in resolver_calls)
     assert ai_calls[0][1]["knowledge"] is None
     assert ai_calls[1][1]["knowledge"] is ready_knowledge
+    assert ai_calls[0][1]["reusable_agent"] is first_agent
+    assert ai_calls[1][1]["reusable_agent"] is second_agent
+    assert create_agent_mock.call_count == 2
+    close_agent_mock.assert_called_once_with(first_agent)
     assert [item.key for item in ai_calls[0][0].system_enrichment_items] == ["voice_call"]
     assert [item.key for item in ai_calls[0][0].transient_enrichment_items] == ["knowledge_availability"]
     assert [item.key for item in ai_calls[1][0].system_enrichment_items] == ["voice_call"]
     assert ai_calls[1][0].transient_enrichment_items == ()
+    assert tooling.close is not None
+    await tooling.close()
+    assert close_agent_mock.call_args_list[-1].args == (second_agent,)
 
 
 @pytest.mark.asyncio
@@ -932,6 +956,10 @@ async def test_cascaded_responder_waits_for_interrupted_playout_settlement(
     monkeypatch.setattr(
         "mindroom.matrix_rtc.call_tools.resolve_agent_knowledge_access",
         lambda *_args, **_kwargs: SimpleNamespace(knowledge=None, unavailable={}),
+    )
+    monkeypatch.setattr(
+        "mindroom.matrix_rtc.call_tools.create_agent",
+        MagicMock(return_value=SimpleNamespace(additional_context="base context")),
     )
     monkeypatch.setattr("mindroom.ai.ai_response", fake_ai_response)
     monkeypatch.setattr(

--- a/tests/test_matrix_rtc_call_tools.py
+++ b/tests/test_matrix_rtc_call_tools.py
@@ -380,7 +380,7 @@ async def test_cascaded_responder_uses_normal_agent_turn_and_filters_unsafe_func
     config.tool_approval = ToolApprovalConfig(
         rules=[ApprovalRuleConfig(match="policy_approval", action="require_approval")],
     )
-    knowledge = object()
+    knowledge = SimpleNamespace(vector_db=None)
     refresh_scheduler = object()
     execution_identity = SimpleNamespace()
     calls: list[tuple[ResponseTurnContext, dict[str, object]]] = []
@@ -816,7 +816,7 @@ async def test_cascaded_responder_refreshes_knowledge_and_availability_each_turn
     second_scheduler = object()
     orchestrator = SimpleNamespace(knowledge_refresh_scheduler=first_scheduler)
     execution_identity = SimpleNamespace()
-    ready_knowledge = object()
+    ready_knowledge = SimpleNamespace(vector_db=None)
     resolver_calls: list[dict[str, object]] = []
     ai_calls: list[tuple[ResponseTurnContext, dict[str, object]]] = []
     resolutions = iter(

--- a/tests/test_matrix_rtc_voice_agent.py
+++ b/tests/test_matrix_rtc_voice_agent.py
@@ -288,6 +288,8 @@ async def test_cascaded_session_wires_stt_normal_agent_and_tts(  # noqa: C901, P
     async def finalize_spoken_response(token: str | None, text: str, interrupted: bool) -> None:
         finalized.append((token, text, interrupted))
 
+    close_responder = AsyncMock()
+
     fake_session = FakeSession()
     stt = FakeSpeechModel()
     tts = FakeSpeechModel()
@@ -344,6 +346,7 @@ async def test_cascaded_session_wires_stt_normal_agent_and_tts(  # noqa: C901, P
         ),
         respond=respond,
         finalize_spoken_response=finalize_spoken_response,
+        close_responder=close_responder,
         greeting_text="Hello.",
         on_conversation_turn=lambda role, text: turns.append((role, text)),
         on_tools_executed=tool_uses.append,
@@ -431,6 +434,7 @@ async def test_cascaded_session_wires_stt_normal_agent_and_tts(  # noqa: C901, P
     assert transcript_synchronizer.closed
     assert built["session_closed"] is True
     fake_audio_input.aclose.assert_awaited_once()
+    close_responder.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -517,6 +521,33 @@ async def test_cascaded_empty_transcript_is_ignored() -> None:
 
     assert chunks == []
     respond.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("transcript", ["   ", ".", "...?!", "—"])
+async def test_cascaded_transcript_without_speech_content_is_ignored(transcript: str) -> None:
+    """Whitespace and punctuation-only STT artifacts cannot start agent work."""
+    respond = AsyncMock()
+    context = llm.ChatContext.empty()
+    context.add_message(role="user", content=transcript)
+
+    chunks = [chunk async for chunk in _build_mindroom_llm(respond, None).chat(chat_ctx=context)]
+
+    assert chunks == []
+    respond.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cascaded_transcript_filter_accepts_unicode_speech() -> None:
+    """The structural noise filter must not guess which language is valid."""
+    respond = AsyncMock(return_value=CallAgentResponse(text="ok"))
+    context = llm.ChatContext.empty()
+    context.add_message(role="user", content="  はい  ")
+
+    chunks = [chunk async for chunk in _build_mindroom_llm(respond, None).chat(chat_ctx=context)]
+
+    assert [chunk.delta.content for chunk in chunks] == ["ok"]
+    respond.assert_awaited_once_with("はい", None)
 
 
 def test_voice_agent_import_keeps_livekit_and_openai_lazy() -> None:

--- a/tests/test_pre_model_preparation.py
+++ b/tests/test_pre_model_preparation.py
@@ -71,12 +71,51 @@ async def test_prepare_mem0_prompt_branches_propagates_failure_directly(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("agent_outcome", ["pending", "finished", "fails", "cancelled"])
-async def test_prepare_mem0_prompt_branches_cancellation_cleans_agent_build(  # noqa: C901, PLR0915
+async def test_prepare_mem0_prompt_branches_preserves_caller_owned_agent_on_memory_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed memory branch must not close a reusable agent owned by its caller."""
+    built_agent = MagicMock()
+    runtime_model = ResolvedRuntimeModel(model_name="default", context_window=None)
+    close_unreturned = MagicMock()
+
+    async def memory_branch() -> MemoryPromptParts:
+        await asyncio.sleep(0)
+        msg = "memory failed"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(pre_model_preparation_module, "close_agent_runtime_state_dbs", close_unreturned)
+
+    with pytest.raises(RuntimeError, match="memory failed"):
+        await prepare_mem0_prompt_branches(
+            prepare_memory=memory_branch,
+            build_agent=lambda: (runtime_model, built_agent),
+            agent_name="general",
+            shared_scope_storage=None,
+            pipeline_timing=None,
+            caller_owned_agent=built_agent,
+        )
+
+    close_unreturned.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("agent_outcome", "caller_owned"),
+    [
+        ("pending", False),
+        ("finished", False),
+        ("fails", False),
+        ("cancelled", False),
+        ("finished", True),
+    ],
+)
+async def test_prepare_mem0_prompt_branches_cancellation_settles_agent_build(  # noqa: C901, PLR0915
     monkeypatch: pytest.MonkeyPatch,
     agent_outcome: str,
+    caller_owned: bool,
 ) -> None:
-    """Cancellation drains construction and closes its agent without leaked tasks."""
+    """Cancellation drains construction without closing caller-owned agents or leaking tasks."""
     memory_started = asyncio.Event()
     memory_cleaned = asyncio.Event()
     agent_started = threading.Event()
@@ -121,6 +160,7 @@ async def test_prepare_mem0_prompt_branches_cancellation_cleans_agent_build(  # 
             agent_name="general",
             shared_scope_storage=None,
             pipeline_timing=None,
+            caller_owned_agent=built_agent if caller_owned else None,
         ),
     )
     try:
@@ -145,7 +185,7 @@ async def test_prepare_mem0_prompt_branches_cancellation_cleans_agent_build(  # 
         agent_release.set()
 
     assert agent_finished.is_set()
-    if agent_outcome in {"fails", "cancelled"}:
+    if agent_outcome in {"fails", "cancelled"} or caller_owned:
         close_unreturned.assert_not_called()
     else:
         close_unreturned.assert_called_once_with(built_agent, shared_scope_storage=None)


### PR DESCRIPTION
Cascaded calls currently rebuild the complete agent runtime for every finalized transcript. That adds avoidable latency and repeatedly opens runtime resources during one logical call. Speech-to-text can also emit punctuation-only artifacts that should not start an agent turn.

This change:

- owns one serialized, reusable agent per cascaded call
- rebuilds it only when the resolved knowledge or refresh scheduler changes
- restores transient prompt context between turns and closes caller-owned runtime state at call teardown
- ignores whitespace and punctuation-only transcripts while accepting speech in any language

Normal text responses keep their existing per-turn lifecycle.

Validation:

- `uv run pytest` (11,305 passed, 54 skipped)
- `uv run pre-commit run --all-files`
- `uv run tach check --dependencies --interfaces`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Voice calls now reuse AI agent sessions across turns, improving continuity and reducing setup overhead.
  * Added graceful cleanup for voice-call resources when a call ends.
  * Voice responses now ignore transcripts containing only whitespace, punctuation, or non-speech artifacts.

* **Bug Fixes**
  * Preserved agent context correctly between voice-call turns and during cleanup.
  * Improved handling of interrupted playback and call shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->