### PR TITLE
feat: publish cron descriptions in scheduled task state

### DIFF
--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -746,6 +746,9 @@ async def _persist_scheduled_task_state(
         content={
             "task_id": task_id,
             "workflow": workflow.model_dump_json(),
+            "cron_description": (
+                workflow.cron_schedule.to_natural_language() if workflow.cron_schedule is not None else None
+            ),
             "status": status,
             "created_at": _serialize_scheduled_task_created_at(created_at),
             "updated_at": datetime.now(UTC).isoformat(),

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -747,7 +747,9 @@ async def _persist_scheduled_task_state(
             "task_id": task_id,
             "workflow": workflow.model_dump_json(),
             "cron_description": (
-                workflow.cron_schedule.to_natural_language() if workflow.cron_schedule is not None else None
+                workflow.cron_schedule.to_natural_language()
+                if workflow.schedule_type == "cron" and workflow.cron_schedule is not None
+                else None
             ),
             "status": status,
             "created_at": _serialize_scheduled_task_created_at(created_at),

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -2128,6 +2128,33 @@ async def test_persist_scheduled_task_state_raises_on_matrix_error() -> None:
 
 
 @pytest.mark.asyncio
+async def test_persist_scheduled_task_state_includes_cron_description() -> None:
+    """Matrix state should expose the backend-owned recurring schedule description."""
+    client = AsyncMock()
+    client.room_put_state.return_value = nio.RoomPutStateResponse.from_dict(
+        {"event_id": "$state"},
+        room_id="!test:server",
+    )
+    workflow = ScheduledWorkflow(
+        schedule_type="cron",
+        cron_schedule=CronSchedule(minute="0", hour="9"),
+        message="check logs",
+        description="check logs",
+        room_id="!test:server",
+    )
+
+    await _persist_scheduled_task_state(
+        client=client,
+        room_id="!test:server",
+        task_id="task1234",
+        workflow=workflow,
+    )
+
+    content = client.room_put_state.await_args.kwargs["content"]
+    assert content["cron_description"] == "At 09:00"
+
+
+@pytest.mark.asyncio
 async def test_schedule_task_persists_via_admin_when_active_agent_lacks_state_power(tmp_path: Path) -> None:
     """A successful schedule must be visible in Matrix state even when the active agent cannot write state."""
     client = AsyncMock()

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -2155,6 +2155,34 @@ async def test_persist_scheduled_task_state_includes_cron_description() -> None:
 
 
 @pytest.mark.asyncio
+async def test_persist_scheduled_task_state_omits_cron_description_for_one_time_task() -> None:
+    """One-time state must not expose a stale or contradictory cron description."""
+    client = AsyncMock()
+    client.room_put_state.return_value = nio.RoomPutStateResponse.from_dict(
+        {"event_id": "$state"},
+        room_id="!test:server",
+    )
+    workflow = ScheduledWorkflow(
+        schedule_type="once",
+        execute_at=datetime.now(UTC) + timedelta(minutes=5),
+        cron_schedule=CronSchedule(minute="0", hour="9"),
+        message="check logs",
+        description="check logs",
+        room_id="!test:server",
+    )
+
+    await _persist_scheduled_task_state(
+        client=client,
+        room_id="!test:server",
+        task_id="task1234",
+        workflow=workflow,
+    )
+
+    content = client.room_put_state.await_args.kwargs["content"]
+    assert content["cron_description"] is None
+
+
+@pytest.mark.asyncio
 async def test_schedule_task_persists_via_admin_when_active_agent_lacks_state_power(tmp_path: Path) -> None:
     """A successful schedule must be visible in Matrix state even when the active agent cannot write state."""
     client = AsyncMock()


### PR DESCRIPTION
## Problem

MindRoom already owns cron parsing and human-readable schedule descriptions, but scheduled-task Matrix state only exposed the serialized workflow.
MindRoom Chat therefore had to reconstruct scheduler semantics in the browser to show recurring timing.

## Change

- Publish the existing backend-generated `cron_description` as a top-level scheduled-task state field.
- Keep the field null for one-time schedules.
- Cover the Matrix persistence contract with a focused test.

## Validation

- `uv run pytest tests/test_scheduling.py -x -n 0 --no-cov -q`
- `uv run pre-commit run --all-files`
- Full pytest reached 11,324 passing tests; six unrelated Git metadata and shell-buffer timing tests failed under the parallel full-suite load and all six passed together in an isolated serial rerun.

## Related

Paired with mindroom-ai/mindroom-chat#188, which consumes this field and removes client-side cron evaluation.