### PR TITLE
Reduce repeated per-turn prompt-assembly work with two narrow cache seams

### DIFF
--- a/scripts/testing/benchmark_prompt_assembly.py
+++ b/scripts/testing/benchmark_prompt_assembly.py
@@ -35,6 +35,7 @@ from mindroom.history.prompt_tokens import (
     agent_tool_definition_payloads_for_logging,
     estimate_agent_static_tokens,
 )
+from mindroom.model_defaults import CONFIG_INIT_MODEL_PRESETS
 from mindroom.tool_system import skills as skills_module
 from mindroom.tool_system.plugins import load_plugins
 
@@ -129,12 +130,13 @@ def _write_fixture(root: Path) -> Path:
             encoding="utf-8",
         )
 
+    default_model = CONFIG_INIT_MODEL_PRESETS["openai"]
     config_path = root / "config.yaml"
     config_path.write_text(
         "models:\n"
         "  default:\n"
-        "    provider: openai\n"
-        "    id: gpt-5.6\n"
+        f"    provider: {default_model.provider}\n"
+        f"    id: {default_model.id}\n"
         "router:\n"
         "  model: default\n"
         "plugins:\n"

--- a/scripts/testing/benchmark_prompt_assembly.py
+++ b/scripts/testing/benchmark_prompt_assembly.py
@@ -1,0 +1,263 @@
+"""Benchmark repeated warm agent preparation and per-turn tool-surface work.
+
+Measures wall time plus call counts for plugin loads, skill scans, skill-cache
+clears, tool-schema preparations, Function deep copies, and payload
+serializations across two phases:
+
+- ``agent_build``: repeated warm ``create_agent`` calls for one config.
+- ``tool_surface``: one turn's static token budgeting (execution preparation
+  plus the history-runtime re-estimate) and run-metadata payload assembly on
+  one fresh agent instance.
+"""
+
+from __future__ import annotations
+
+import argparse
+import functools
+import json
+import logging
+import tempfile
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import structlog
+from agno.tools.function import Function
+
+from mindroom import agents as agents_module
+from mindroom.agent_knowledge_descriptions import KnowledgeToolDescribingAgent
+from mindroom.agents import create_agent
+from mindroom.config.main import load_config
+from mindroom.constants import resolve_primary_runtime_paths
+from mindroom.history import prompt_tokens as prompt_tokens_module
+from mindroom.history.prompt_tokens import (
+    agent_static_token_estimator,
+    agent_tool_definition_payloads_for_logging,
+    estimate_agent_static_tokens,
+)
+from mindroom.tool_system import skills as skills_module
+from mindroom.tool_system.plugins import load_plugins
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from agno.skills.skill import Skill
+
+_COUNTERS: dict[str, int] = {}
+
+
+def _count(name: str) -> None:
+    _COUNTERS[name] = _COUNTERS.get(name, 0) + 1
+
+
+def _counting[**P, T](name: str, func: Callable[P, T]) -> Callable[P, T]:
+    @functools.wraps(func)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+        _count(name)
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+def _install_counters() -> None:
+    agents_module.load_plugins = _counting("plugin_loads", load_plugins)
+    skills_module.clear_skill_cache = _counting("skill_cache_clears", skills_module.clear_skill_cache)
+
+    original_local_skills = skills_module.LocalSkills
+
+    class _CountingLocalSkills(original_local_skills):  # type: ignore[misc, valid-type]
+        def load(self) -> list[Skill]:
+            _count("skill_scans")
+            return super().load()
+
+    skills_module.LocalSkills = _CountingLocalSkills
+
+    KnowledgeToolDescribingAgent.get_tools = _counting(
+        "agent_get_tools_calls",
+        KnowledgeToolDescribingAgent.get_tools,
+    )
+    prompt_tokens_module.stable_serialize = _counting(
+        "payload_serializations",
+        prompt_tokens_module.stable_serialize,
+    )
+
+    original_model_copy = Function.model_copy
+
+    def _counting_model_copy(self: Function, *, deep: bool = False) -> Function:
+        if deep:
+            _count("function_deep_copies")
+        return original_model_copy(self, deep=deep)
+
+    Function.model_copy = _counting_model_copy  # type: ignore[method-assign]
+
+
+def _write_fixture(root: Path) -> Path:
+    plugin_root = root / "plugins" / "demo"
+    plugin_root.mkdir(parents=True)
+    (plugin_root / "mindroom.plugin.json").write_text(
+        json.dumps({"name": "demo-plugin", "tools_module": "tools.py", "skills": ["skills"]}),
+        encoding="utf-8",
+    )
+    (plugin_root / "tools.py").write_text(
+        "from agno.tools import Toolkit\n"
+        "from mindroom.tool_system.declarations import ToolCategory\n"
+        "from mindroom.tool_system.registration import register_tool_with_metadata\n"
+        "\n"
+        "class DemoTool(Toolkit):\n"
+        "    def __init__(self) -> None:\n"
+        "        super().__init__(name='demo', tools=[self.echo])\n"
+        "\n"
+        "    def echo(self, text: str) -> str:\n"
+        '        """Echo the provided text back."""\n'
+        "        return text\n"
+        "\n"
+        "@register_tool_with_metadata(\n"
+        "    name='demo_plugin',\n"
+        "    display_name='Demo Plugin',\n"
+        "    description='Demo plugin tool',\n"
+        "    category=ToolCategory.DEVELOPMENT,\n"
+        ")\n"
+        "def demo_plugin_tools():\n"
+        "    return DemoTool\n",
+        encoding="utf-8",
+    )
+    for index in (1, 2):
+        skill_dir = plugin_root / "skills" / f"demo-skill-{index}"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: demo-skill-{index}\ndescription: Demo skill {index}\n---\n\n# Demo {index}\n",
+            encoding="utf-8",
+        )
+
+    config_path = root / "config.yaml"
+    config_path.write_text(
+        "models:\n"
+        "  default:\n"
+        "    provider: openai\n"
+        "    id: gpt-5.6\n"
+        "router:\n"
+        "  model: default\n"
+        "plugins:\n"
+        "  - ./plugins/demo\n"
+        "agents:\n"
+        "  helper:\n"
+        "    display_name: Helper\n"
+        "    role: Benchmark helper agent\n"
+        "    tools: [calculator, file, demo_plugin]\n"
+        "    skills: [demo-skill-1, demo-skill-2]\n",
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def _phase[T](
+    label: str,
+    iterations: int,
+    run_iteration: Callable[[T], None],
+    prepare_iteration: Callable[[], T],
+) -> dict[str, object]:
+    counters_before = dict(_COUNTERS)
+    samples: list[float] = []
+    for _ in range(iterations):
+        prepared = prepare_iteration()
+        started_at = time.perf_counter()
+        run_iteration(prepared)
+        samples.append((time.perf_counter() - started_at) * 1000)
+    counters = {
+        name: count - counters_before.get(name, 0)
+        for name, count in _COUNTERS.items()
+        if name not in counters_before or count != counters_before[name]
+    }
+    return {
+        "phase": label,
+        "iterations": iterations,
+        "total_ms": round(sum(samples), 3),
+        "mean_ms": round(sum(samples) / len(samples), 3),
+        "counters": counters,
+    }
+
+
+def main() -> None:
+    """Run the prompt-assembly benchmark and print JSON results."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--builds", type=int, default=25)
+    parser.add_argument("--turns", type=int, default=25)
+    args = parser.parse_args()
+
+    logging.getLogger().setLevel(logging.ERROR)
+    logging.getLogger("mindroom").setLevel(logging.ERROR)
+    structlog.configure(
+        wrapper_class=structlog.make_filtering_bound_logger(logging.ERROR),
+        cache_logger_on_first_use=False,
+    )
+
+    with tempfile.TemporaryDirectory(prefix="mindroom-prompt-assembly-benchmark-") as tmp:
+        root = Path(tmp)
+        config_path = _write_fixture(root)
+        runtime_paths = resolve_primary_runtime_paths(
+            config_path=config_path,
+            storage_path=root / "storage",
+            process_env={"OPENAI_API_KEY": "sk-benchmark"},
+        )
+        config = load_config(runtime_paths)
+
+        def _build_agent() -> KnowledgeToolDescribingAgent:
+            return create_agent(
+                "helper",
+                config,
+                runtime_paths,
+                execution_identity=None,
+                session_id="benchmark-session",
+                include_openai_compat_guidance=True,
+            )
+
+        _build_agent()  # Warm plugin/module/tool-registry caches once.
+        _install_counters()
+
+        results = [
+            _phase(
+                "agent_build",
+                args.builds,
+                lambda _prepared: _build_agent(),
+                prepare_iteration=lambda: None,
+            ),
+        ]
+
+        prompt = "Please summarize the latest benchmark results."
+
+        def _run_turn_surface(agent: KnowledgeToolDescribingAgent) -> None:
+            # Execution preparation: static budgeting with a request-local estimator.
+            agent_static_token_estimator(agent).estimate(prompt)
+            # History runtime: an independent re-estimate for replay planning.
+            estimate_agent_static_tokens(agent, prompt)
+            # Run metadata: model-visible tool schema payloads.
+            agent_tool_definition_payloads_for_logging(agent)
+
+        # A fresh agent per iteration mirrors production, where every turn
+        # rebuilds the agent instance before budgeting and metadata assembly.
+        results.append(
+            _phase(
+                "tool_surface_per_turn",
+                args.turns,
+                _run_turn_surface,
+                prepare_iteration=_build_agent,
+            ),
+        )
+
+        from mindroom.tool_schema_cache import _cached_processed_function_schema  # noqa: PLC0415
+
+        cache_info = _cached_processed_function_schema.cache_info()
+        results.append(
+            {
+                "phase": "tool_schema_lru",
+                "hits": cache_info.hits,
+                "misses": cache_info.misses,
+                "size": cache_info.currsize,
+            },
+        )
+
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mindroom/history/prompt_tokens.py
+++ b/src/mindroom/history/prompt_tokens.py
@@ -31,7 +31,7 @@ from agno.team._tools import _determine_tools_for_model
 from agno.tools import Toolkit
 from agno.tools.function import Function
 
-from mindroom.timing import timed, timed_block
+from mindroom.timing import timed_block
 from mindroom.token_budget import estimate_text_tokens, stable_serialize
 from mindroom.tool_schema_cache import cached_processed_schema
 
@@ -195,7 +195,6 @@ def _agent_prompt_tool_surface(agent: Agent) -> _PromptToolSurface:
     return surface
 
 
-@timed("system_prompt_assembly.history_prepare.static_token_estimate.agno_determine_tools")
 def _team_prompt_tool_surface(team: Team) -> _PromptToolSurface:
     """Prepare (or reuse) the prompt-only tool surface for one team instance.
 
@@ -203,7 +202,7 @@ def _team_prompt_tool_surface(team: Team) -> _PromptToolSurface:
     payload and `_tool_instructions` state that feed that prompt are only built by
     the internal `_determine_tools_for_model()` path. Using that single internal
     entrypoint is less brittle than re-implementing several private team helpers in
-    MindRoom. This logic is verified against `agno==2.5.13`; if Agno changes those
+    MindRoom. This logic is verified against `agno==2.6.12`; if Agno changes those
     internals, update this estimator to match the new team prompt builder.
     """
     cached_surface = _cached_tool_surface(team)
@@ -211,33 +210,34 @@ def _team_prompt_tool_surface(team: Team) -> _PromptToolSurface:
         return cached_surface
     previous_tool_instructions = team._tool_instructions
     try:
-        session, run_response, run_context = _team_prompt_estimation_inputs(team)
-        model = team.model
-        assert model is not None
-        prepared_tools = _determine_tools_for_model(
-            team=team,
-            model=model,
-            run_response=run_response,
-            run_context=run_context,
-            team_run_context={},
-            session=session,
-            check_mcp_tools=False,
-        )
-        payloads_by_name: dict[str, _ToolDefinition] = {}
-        for tool in prepared_tools:
-            if isinstance(tool, Function):
-                payload = _live_function_payload(tool)
-            elif _is_tool_definition_dict(tool):
-                payload = _dict_tool_payload(tool)
-            else:
-                continue
-            tool_name = payload["name"]
-            if isinstance(tool_name, str) and tool_name:
-                payloads_by_name[tool_name] = payload
-        surface = _build_prompt_tool_surface(
-            list(payloads_by_name.values()),
-            list(team._tool_instructions or ()),
-        )
+        with timed_block("system_prompt_assembly.history_prepare.static_token_estimate.agno_determine_tools"):
+            session, run_response, run_context = _team_prompt_estimation_inputs(team)
+            model = team.model
+            assert model is not None
+            prepared_tools = _determine_tools_for_model(
+                team=team,
+                model=model,
+                run_response=run_response,
+                run_context=run_context,
+                team_run_context={},
+                session=session,
+                check_mcp_tools=False,
+            )
+            payloads_by_name: dict[str, _ToolDefinition] = {}
+            for tool in prepared_tools:
+                if isinstance(tool, Function):
+                    payload = _live_function_payload(tool)
+                elif _is_tool_definition_dict(tool):
+                    payload = _dict_tool_payload(tool)
+                else:
+                    continue
+                tool_name = payload["name"]
+                if isinstance(tool_name, str) and tool_name:
+                    payloads_by_name[tool_name] = payload
+            surface = _build_prompt_tool_surface(
+                list(payloads_by_name.values()),
+                list(team._tool_instructions or ()),
+            )
     finally:
         team._tool_instructions = previous_tool_instructions
     _store_tool_surface(team, surface)
@@ -320,7 +320,7 @@ def _processed_function_payload(function: Function) -> _ToolDefinition:
     return {
         "name": function.name,
         "description": snapshot.description or "",
-        "parameters": deepcopy(snapshot.parameters) or _default_function_parameters(),
+        "parameters": snapshot.parameters or _default_function_parameters(),
     }
 
 

--- a/src/mindroom/history/prompt_tokens.py
+++ b/src/mindroom/history/prompt_tokens.py
@@ -5,14 +5,22 @@ message, tool schemas, tool instructions, and the current prompt text — by
 reusing Agno's own prompt-preparation paths. Nothing here touches history
 scopes, sessions, or summaries; compaction consumes these numbers through the
 resolved execution plan.
+
+The prompt-only tool surface (model-visible payloads plus tool instructions)
+is prepared once per agent or team instance and reused by static token
+budgeting and run-metadata assembly within that turn. Agent and team instances
+are rebuilt per response, so the surface never outlives one turn's tool state.
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
+from copy import deepcopy
 from dataclasses import dataclass, field
 from functools import partial
+from threading import Lock
 from typing import TYPE_CHECKING, TypeGuard, cast
+from weakref import ref
 
 from agno.run import RunContext
 from agno.run.agent import RunOutput
@@ -25,13 +33,32 @@ from agno.tools.function import Function
 
 from mindroom.timing import timed, timed_block
 from mindroom.token_budget import estimate_text_tokens, stable_serialize
-from mindroom.tool_schema_cache import process_function_schema_for_prompt
+from mindroom.tool_schema_cache import cached_processed_schema
 
 if TYPE_CHECKING:
     from agno.agent import Agent
     from agno.team import Team
 
 type _ToolDefinition = dict[str, object]
+
+
+@dataclass(frozen=True)
+class _PromptToolSurface:
+    """Prompt-only tool surface prepared once per agent or team instance.
+
+    ``payloads`` are canonical copies owned by the cache; treat them as
+    immutable and hand out deep copies at public boundaries.
+    """
+
+    payloads: tuple[_ToolDefinition, ...]
+    tool_instructions: tuple[str, ...]
+    definition_tokens: int
+
+
+# Keyed by entity id because Agno Agent/Team instances are unhashable; each
+# entry holds a weakref whose eviction callback removes the entry on GC.
+_TOOL_SURFACE_CACHE: dict[int, tuple[ref[object], _PromptToolSurface]] = {}
+_TOOL_SURFACE_CACHE_LOCK = Lock()
 
 
 @dataclass(slots=True)
@@ -65,21 +92,23 @@ def estimate_agent_static_tokens(agent: Agent, full_prompt: str) -> int:
 
 def _estimate_agent_non_prompt_static_tokens(agent: Agent) -> int:
     """Estimate system-message and tool tokens that do not depend on the prompt text."""
-    static_tokens = 0
+    surface = _agent_prompt_tool_surface(agent)
+    session, _run_response, run_context = _agent_prompt_estimation_inputs(agent)
     previous_tool_instructions = agent._tool_instructions
+    agent._tool_instructions = list(surface.tool_instructions)
     try:
-        session, run_context, prepared_tools = _prepare_agent_prompt_inputs_for_estimation(agent)
         system_message = agent.get_system_message(
             session=session,
             run_context=run_context,
-            tools=prepared_tools or None,
+            tools=cast("list[Function | dict]", list(surface.payloads)) or None,
             add_session_state_to_context=False,
         )
     finally:
         agent._tool_instructions = previous_tool_instructions
+    static_tokens = 0
     if system_message is not None and system_message.content is not None:
         static_tokens += estimate_text_tokens(str(system_message.content))
-    return static_tokens + _estimate_prepared_tool_definition_tokens(prepared_tools)
+    return static_tokens + surface.definition_tokens
 
 
 def estimate_team_static_tokens(team: Team, full_prompt: str) -> int:
@@ -89,88 +118,177 @@ def estimate_team_static_tokens(team: Team, full_prompt: str) -> int:
 
 def _estimate_team_non_prompt_static_tokens(team: Team) -> int:
     """Estimate team system-message and tool tokens that do not depend on prompt text."""
-    static_tokens = 0
+    surface = _team_prompt_tool_surface(team)
+    session, _run_response, _run_context = _team_prompt_estimation_inputs(team)
     previous_tool_instructions = team._tool_instructions
+    team._tool_instructions = list(surface.tool_instructions)
     try:
-        session, prepared_tools = _prepare_team_prompt_inputs_for_estimation(team)
         system_message = team.get_system_message(
             session=session,
-            tools=prepared_tools or None,
+            tools=cast("list[Function | dict]", list(surface.payloads)) or None,
             add_session_state_to_context=False,
         )
     finally:
         team._tool_instructions = previous_tool_instructions
+    static_tokens = 0
     if system_message is not None and system_message.content is not None:
         static_tokens += estimate_text_tokens(str(system_message.content))
-    return static_tokens + _estimate_prepared_tool_definition_tokens(prepared_tools)
+    return static_tokens + surface.definition_tokens
 
 
 def agent_tool_definition_payloads_for_logging(agent: Agent) -> list[dict[str, object]]:
     """Return model-visible agent tool schemas using Agno's prompt-preparation path."""
-    previous_tool_instructions = agent._tool_instructions
-    try:
-        _session, _run_context, prepared_tools = _prepare_agent_prompt_inputs_for_estimation(agent)
-    finally:
-        agent._tool_instructions = previous_tool_instructions
-    return _prepared_tool_definition_payloads(prepared_tools)
+    return [deepcopy(payload) for payload in _agent_prompt_tool_surface(agent).payloads]
 
 
 def team_tool_definition_payloads_for_logging(team: Team) -> list[dict[str, object]]:
     """Return model-visible team tool schemas using Agno's prompt-preparation path."""
+    return [deepcopy(payload) for payload in _team_prompt_tool_surface(team).payloads]
+
+
+def _cached_tool_surface(entity: Agent | Team) -> _PromptToolSurface | None:
+    with _TOOL_SURFACE_CACHE_LOCK:
+        entry = _TOOL_SURFACE_CACHE.get(id(entity))
+    if entry is None:
+        return None
+    entity_ref, surface = entry
+    if entity_ref() is not entity:
+        return None
+    return surface
+
+
+def _store_tool_surface(entity: Agent | Team, surface: _PromptToolSurface) -> None:
+    entity_key = id(entity)
+
+    def _evict(entity_ref: ref[object]) -> None:
+        with _TOOL_SURFACE_CACHE_LOCK:
+            entry = _TOOL_SURFACE_CACHE.get(entity_key)
+            if entry is not None and entry[0] is entity_ref:
+                del _TOOL_SURFACE_CACHE[entity_key]
+
+    with _TOOL_SURFACE_CACHE_LOCK:
+        _TOOL_SURFACE_CACHE[entity_key] = (ref(entity, _evict), surface)
+
+
+def _agent_prompt_tool_surface(agent: Agent) -> _PromptToolSurface:
+    """Prepare (or reuse) the prompt-only tool surface for one agent instance.
+
+    The estimator and run-metadata assembly only need model-visible schemas and
+    tool instructions, not executable validate-call wrappers. Preparing those
+    schemas here reuses cached Function schema metadata across fresh Agent
+    instances.
+    """
+    cached_surface = _cached_tool_surface(agent)
+    if cached_surface is not None:
+        return cached_surface
+    session, run_response, run_context = _agent_prompt_estimation_inputs(agent)
+    with timed_block("system_prompt_assembly.history_prepare.static_token_estimate.agno_get_tools"):
+        processed_tools = agent.get_tools(
+            run_response=run_response,
+            run_context=run_context,
+            session=session,
+            user_id=run_context.user_id,
+        )
+    with timed_block("system_prompt_assembly.history_prepare.static_token_estimate.tool_schema_prepare"):
+        surface = _prompt_tool_surface_for_tools(processed_tools)
+    _store_tool_surface(agent, surface)
+    return surface
+
+
+@timed("system_prompt_assembly.history_prepare.static_token_estimate.agno_determine_tools")
+def _team_prompt_tool_surface(team: Team) -> _PromptToolSurface:
+    """Prepare (or reuse) the prompt-only tool surface for one team instance.
+
+    Agno exposes `Team.get_system_message()` publicly, but the exact prepared tool
+    payload and `_tool_instructions` state that feed that prompt are only built by
+    the internal `_determine_tools_for_model()` path. Using that single internal
+    entrypoint is less brittle than re-implementing several private team helpers in
+    MindRoom. This logic is verified against `agno==2.5.13`; if Agno changes those
+    internals, update this estimator to match the new team prompt builder.
+    """
+    cached_surface = _cached_tool_surface(team)
+    if cached_surface is not None:
+        return cached_surface
     previous_tool_instructions = team._tool_instructions
     try:
-        _session, prepared_tools = _prepare_team_prompt_inputs_for_estimation(team)
+        session, run_response, run_context = _team_prompt_estimation_inputs(team)
+        model = team.model
+        assert model is not None
+        prepared_tools = _determine_tools_for_model(
+            team=team,
+            model=model,
+            run_response=run_response,
+            run_context=run_context,
+            team_run_context={},
+            session=session,
+            check_mcp_tools=False,
+        )
+        payloads_by_name: dict[str, _ToolDefinition] = {}
+        for tool in prepared_tools:
+            if isinstance(tool, Function):
+                payload = _live_function_payload(tool)
+            elif _is_tool_definition_dict(tool):
+                payload = _dict_tool_payload(tool)
+            else:
+                continue
+            tool_name = payload["name"]
+            if isinstance(tool_name, str) and tool_name:
+                payloads_by_name[tool_name] = payload
+        surface = _build_prompt_tool_surface(
+            list(payloads_by_name.values()),
+            list(team._tool_instructions or ()),
+        )
     finally:
         team._tool_instructions = previous_tool_instructions
-    return _prepared_tool_definition_payloads(prepared_tools)
+    _store_tool_surface(team, surface)
+    return surface
 
 
-def _estimate_prepared_tool_definition_tokens(
-    prepared_tools: Sequence[Function | dict[str, object]],
-    *,
-    tool_instructions: Sequence[str] = (),
-) -> int:
-    tool_definitions = _prepared_tool_definition_payloads(prepared_tools)
-    tool_definition_tokens = len(stable_serialize(tool_definitions)) // 4 if tool_definitions else 0
-    instruction_tokens = sum(estimate_text_tokens(instruction) for instruction in tool_instructions)
-    return tool_definition_tokens + instruction_tokens
+def _build_prompt_tool_surface(
+    payloads: list[_ToolDefinition],
+    tool_instructions: list[str],
+) -> _PromptToolSurface:
+    definition_tokens = len(stable_serialize(payloads)) // 4 if payloads else 0
+    return _PromptToolSurface(
+        payloads=tuple(payloads),
+        tool_instructions=tuple(tool_instructions),
+        definition_tokens=definition_tokens,
+    )
 
 
-def _prepare_tools_for_estimation(tools: object) -> tuple[list[Function | _ToolDefinition], list[str]]:
+def _prompt_tool_surface_for_tools(tools: object) -> _PromptToolSurface:
+    """Build the prompt-only tool surface for one agent's Agno tool list."""
     if not isinstance(tools, Sequence):
-        return [], []
+        return _build_prompt_tool_surface([], [])
 
-    prepared_tools: list[Function | _ToolDefinition] = []
+    payloads: list[_ToolDefinition] = []
     tool_instructions: list[str] = []
     seen_names: set[str] = set()
     for tool in tools:
-        for prepared_tool in _prepare_tool_for_estimation(tool):
-            tool_name = _prepared_tool_name(prepared_tool)
-            if tool_name is None or tool_name in seen_names:
+        for function, payload in _prompt_payload_candidates(tool):
+            tool_name = payload["name"]
+            if not isinstance(tool_name, str) or not tool_name or tool_name in seen_names:
                 continue
             seen_names.add(tool_name)
-            prepared_tools.append(prepared_tool)
-            if (
-                isinstance(prepared_tool, Function)
-                and prepared_tool.add_instructions
-                and prepared_tool.instructions is not None
-            ):
-                tool_instructions.append(prepared_tool.instructions)
+            payloads.append(payload)
+            if function is not None and function.add_instructions and function.instructions is not None:
+                tool_instructions.append(function.instructions)
 
         if isinstance(tool, Toolkit) and tool.add_instructions and tool.instructions is not None:
             tool_instructions.append(tool.instructions)
-    return prepared_tools, tool_instructions
+    return _build_prompt_tool_surface(payloads, tool_instructions)
 
 
-def _prepare_tool_for_estimation(tool: object) -> list[Function | _ToolDefinition]:
+def _prompt_payload_candidates(tool: object) -> list[tuple[Function | None, _ToolDefinition]]:
     if isinstance(tool, Function):
-        return [_prepare_function_for_estimation(tool)]
+        return [(tool, _processed_function_payload(tool))]
     if isinstance(tool, Toolkit):
-        return [_prepare_function_for_estimation(function) for function in _toolkit_functions(tool).values()]
+        return [(function, _processed_function_payload(function)) for function in _toolkit_functions(tool).values()]
     if _is_tool_definition_dict(tool):
-        return [tool]
+        return [(None, _dict_tool_payload(tool))]
     if callable(tool):
-        return [Function.from_callable(tool)]
+        function = Function.from_callable(tool)
+        return [(function, _live_function_payload(function))]
     return []
 
 
@@ -185,40 +303,33 @@ def _toolkit_functions(toolkit: Toolkit) -> dict[str, Function]:
     return functions
 
 
-def _prepare_function_for_estimation(function: Function) -> Function:
-    prepared_function = function.model_copy(deep=True)
-    if not prepared_function.skip_entrypoint_processing and prepared_function.entrypoint is not None:
-        effective_strict = False if prepared_function.strict is None else prepared_function.strict
-        process_function_schema_for_prompt(prepared_function, strict=effective_strict)
-    return prepared_function
+def _processed_function_payload(function: Function) -> _ToolDefinition:
+    """Build one prompt-only payload with a processed schema, never mutating the input."""
+    if function.skip_entrypoint_processing or function.entrypoint is None:
+        return _live_function_payload(function)
+    effective_strict = False if function.strict is None else function.strict
+    snapshot = cached_processed_schema(function, strict=effective_strict)
+    if snapshot is None:
+        prepared_function = function.model_copy(deep=True)
+        prepared_function.process_entrypoint(strict=effective_strict)
+        return {
+            "name": prepared_function.name,
+            "description": prepared_function.description or "",
+            "parameters": prepared_function.parameters or _default_function_parameters(),
+        }
+    return {
+        "name": function.name,
+        "description": snapshot.description or "",
+        "parameters": deepcopy(snapshot.parameters) or _default_function_parameters(),
+    }
 
 
-def _prepared_tool_definition_payloads(
-    prepared_tools: Sequence[Function | _ToolDefinition],
-) -> list[dict[str, object]]:
-    payloads_by_name: dict[str, dict[str, object]] = {}
-    for tool in prepared_tools:
-        payload = _function_payload(tool) if isinstance(tool, Function) else _dict_tool_payload(tool)
-        tool_name = payload.get("name")
-        if isinstance(tool_name, str) and tool_name:
-            payloads_by_name[tool_name] = payload
-    return list(payloads_by_name.values())
-
-
-def _prepared_tool_name(tool: Function | _ToolDefinition) -> str | None:
-    if isinstance(tool, Function):
-        return tool.name
-    tool_name = tool.get("name")
-    if isinstance(tool_name, str) and tool_name:
-        return tool_name
-    return None
-
-
-def _function_payload(function: Function) -> dict[str, object]:
+def _live_function_payload(function: Function) -> _ToolDefinition:
+    """Build one prompt-only payload from a Function's current schema fields."""
     return {
         "name": function.name,
         "description": function.description or "",
-        "parameters": function.parameters or _default_function_parameters(),
+        "parameters": deepcopy(function.parameters) if function.parameters else _default_function_parameters(),
     }
 
 
@@ -230,69 +341,17 @@ def _is_tool_definition_dict(tool: object) -> TypeGuard[_ToolDefinition]:
     return isinstance(tool_name, str) and bool(tool_name)
 
 
-def _dict_tool_payload(tool: _ToolDefinition) -> dict[str, object]:
+def _dict_tool_payload(tool: _ToolDefinition) -> _ToolDefinition:
     parameters = tool.get("parameters")
     return {
         "name": str(tool["name"]),
         "description": str(tool.get("description", "")),
-        "parameters": parameters if isinstance(parameters, dict) else _default_function_parameters(),
+        "parameters": deepcopy(parameters) if isinstance(parameters, dict) else _default_function_parameters(),
     }
 
 
 def _default_function_parameters() -> dict[str, object]:
     return {"type": "object", "properties": {}, "required": []}
-
-
-@timed("system_prompt_assembly.history_prepare.static_token_estimate.agno_determine_tools")
-def _prepare_team_prompt_inputs_for_estimation(
-    team: Team,
-) -> tuple[TeamSession, list[Function | _ToolDefinition]]:
-    """Reuse Agno's own team tool-preparation path for prompt budgeting.
-
-    Agno exposes `Team.get_system_message()` publicly, but the exact prepared tool
-    payload and `_tool_instructions` state that feed that prompt are only built by
-    the internal `_determine_tools_for_model()` path. Using that single internal
-    entrypoint is less brittle than re-implementing several private team helpers in
-    MindRoom. This logic is verified against `agno==2.5.13`; if Agno changes those
-    internals, update this estimator to match the new team prompt builder.
-    """
-    session, run_response, run_context = _team_prompt_estimation_inputs(team)
-    model = team.model
-    assert model is not None
-    prepared_tools = _determine_tools_for_model(
-        team=team,
-        model=model,
-        run_response=run_response,
-        run_context=run_context,
-        team_run_context={},
-        session=session,
-        check_mcp_tools=False,
-    )
-    return session, [tool for tool in prepared_tools if isinstance(tool, Function) or _is_tool_definition_dict(tool)]
-
-
-@timed("system_prompt_assembly.history_prepare.static_token_estimate.tool_schema_prepare")
-def _prepare_agent_prompt_inputs_for_estimation(
-    agent: Agent,
-) -> tuple[AgentSession, RunContext, list[Function | _ToolDefinition]]:
-    """Reuse Agno's agent tool-preparation path for prompt budgeting.
-
-    The estimator only needs model-visible schemas and tool instructions, not
-    executable validate-call wrappers. Preparing those schemas here lets us reuse
-    cached Function schema metadata across fresh Agent instances.
-    """
-    session, run_response, run_context = _agent_prompt_estimation_inputs(agent)
-    with timed_block("system_prompt_assembly.history_prepare.static_token_estimate.agno_get_tools"):
-        processed_tools = agent.get_tools(
-            run_response=run_response,
-            run_context=run_context,
-            session=session,
-            user_id=run_context.user_id,
-        )
-    with timed_block("system_prompt_assembly.history_prepare.static_token_estimate.tool_schema_prepare"):
-        prepared_tools, tool_instructions = _prepare_tools_for_estimation(processed_tools)
-    agent._tool_instructions = list(tool_instructions)
-    return session, run_context, prepared_tools
 
 
 def _team_prompt_estimation_inputs(team: Team) -> tuple[TeamSession, TeamRunOutput, RunContext]:

--- a/src/mindroom/tool_schema_cache.py
+++ b/src/mindroom/tool_schema_cache.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True, slots=True)
 class _ProcessedFunctionSchema:
-    """Processed prompt schema snapshot; treat nested containers as immutable."""
+    """Processed prompt schema snapshot for one Function."""
 
     parameters: dict[str, Any]
     description: str | None
@@ -26,11 +26,11 @@ class _ProcessedFunctionSchema:
 
 
 def cached_processed_schema(function: Function, *, strict: bool) -> _ProcessedFunctionSchema | None:
-    """Return the cached processed prompt schema for one Function without mutating it.
+    """Return a private copy of the cached processed prompt schema for one Function.
 
-    Returns ``None`` when the entrypoint or parameters cannot form a stable
-    cache key, in which case callers must fall back to full entrypoint
-    processing on a private copy.
+    Never mutates ``function``. Returns ``None`` when the entrypoint or
+    parameters cannot form a stable cache key, in which case callers must fall
+    back to full entrypoint processing on a private copy.
     """
     if function.entrypoint is None:
         return None
@@ -50,7 +50,7 @@ def cached_processed_schema(function: Function, *, strict: bool) -> _ProcessedFu
     except TypeError:
         return None
 
-    return _cached_processed_function_schema(
+    snapshot = _cached_processed_function_schema(
         source_callable,
         function.name,
         function.description,
@@ -60,6 +60,12 @@ def cached_processed_schema(function: Function, *, strict: bool) -> _ProcessedFu
         tuple(function.user_input_fields) if function.user_input_fields is not None else None,
         function.strict,
         strict,
+    )
+    # Copy at the boundary so callers can never corrupt the shared LRU entry.
+    return _ProcessedFunctionSchema(
+        parameters=deepcopy(snapshot.parameters),
+        description=snapshot.description,
+        user_input_schema=deepcopy(snapshot.user_input_schema) if snapshot.user_input_schema is not None else None,
     )
 
 

--- a/src/mindroom/tool_schema_cache.py
+++ b/src/mindroom/tool_schema_cache.py
@@ -18,36 +18,39 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True, slots=True)
 class _ProcessedFunctionSchema:
+    """Processed prompt schema snapshot; treat nested containers as immutable."""
+
     parameters: dict[str, Any]
     description: str | None
     user_input_schema: tuple[UserInputField, ...] | None
 
 
-def process_function_schema_for_prompt(function: Function, *, strict: bool) -> None:
-    """Process one Function schema using a cache for stable entrypoints."""
+def cached_processed_schema(function: Function, *, strict: bool) -> _ProcessedFunctionSchema | None:
+    """Return the cached processed prompt schema for one Function without mutating it.
+
+    Returns ``None`` when the entrypoint or parameters cannot form a stable
+    cache key, in which case callers must fall back to full entrypoint
+    processing on a private copy.
+    """
     if function.entrypoint is None:
-        function.process_entrypoint(strict=strict)
-        return
+        return None
 
     processor = function.process_entrypoint
     if isinstance(processor, MethodType) and processor.__func__ is not Function.process_entrypoint:
-        function.process_entrypoint(strict=strict)
-        return
+        return None
 
     source_callable = getattr(function.entrypoint, "__wrapped__", function.entrypoint)
     if isinstance(source_callable, MethodType) or ismethod(source_callable):
         source_callable = source_callable.__func__
     elif not isfunction(source_callable):
-        function.process_entrypoint(strict=strict)
-        return
+        return None
 
     try:
         parameters_json = json.dumps(function.parameters, sort_keys=True, separators=(",", ":"))
     except TypeError:
-        function.process_entrypoint(strict=strict)
-        return
+        return None
 
-    snapshot = _cached_processed_function_schema(
+    return _cached_processed_function_schema(
         source_callable,
         function.name,
         function.description,
@@ -57,11 +60,6 @@ def process_function_schema_for_prompt(function: Function, *, strict: bool) -> N
         tuple(function.user_input_fields) if function.user_input_fields is not None else None,
         function.strict,
         strict,
-    )
-    function.parameters = deepcopy(snapshot.parameters)
-    function.description = snapshot.description
-    function.user_input_schema = (
-        list(deepcopy(snapshot.user_input_schema)) if snapshot.user_input_schema is not None else None
     )
 
 

--- a/src/mindroom/tool_system/skills.py
+++ b/src/mindroom/tool_system/skills.py
@@ -242,9 +242,16 @@ class _ResolvedSkillFrontmatter:
 
 
 def set_plugin_skill_roots(roots: Sequence[Path]) -> None:
-    """Replace the plugin-provided skill roots."""
+    """Replace the plugin-provided skill roots, invalidating cached skills only on change.
+
+    Unchanged roots keep the snapshot-validated skill cache warm; per-root
+    mtime/size snapshots in ``_load_root_skills`` still catch file edits.
+    """
     global _PLUGIN_SKILL_ROOTS
-    _PLUGIN_SKILL_ROOTS = _unique_paths(roots)
+    unique_roots = _unique_paths(roots)
+    if unique_roots == _PLUGIN_SKILL_ROOTS:
+        return
+    _PLUGIN_SKILL_ROOTS = unique_roots
     clear_skill_cache()
 
 

--- a/tests/test_delegate_tools.py
+++ b/tests/test_delegate_tools.py
@@ -19,7 +19,7 @@ from mindroom.knowledge.availability import KnowledgeAvailability
 from mindroom.knowledge.indexing_config import IndexingSettings
 from mindroom.knowledge.utils import _KnowledgeResolution
 from mindroom.message_target import MessageTarget
-from mindroom.tool_schema_cache import process_function_schema_for_prompt
+from mindroom.tool_schema_cache import cached_processed_schema
 from mindroom.tool_system.metadata import TOOL_METADATA
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, get_tool_runtime_context, tool_runtime_context
 from mindroom.tool_system.worker_routing import ToolExecutionIdentity
@@ -145,10 +145,11 @@ class TestDelegateTools:
         """Test that the model-visible function description includes delegation targets."""
         function = tools.async_functions["delegate_task"].model_copy(deep=True)
 
-        process_function_schema_for_prompt(function, strict=False)
+        snapshot = cached_processed_schema(function, strict=False)
 
-        assert function.description is not None
-        description = function.description
+        assert snapshot is not None
+        assert snapshot.description is not None
+        description = snapshot.description
         assert "Allowed delegate targets for this caller:" in description
         for target in ("code", "research"):
             assert target in description

--- a/tests/test_history_prompt_tokens.py
+++ b/tests/test_history_prompt_tokens.py
@@ -3,11 +3,14 @@
 
 from __future__ import annotations
 
+import gc
 import inspect
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any
+from threading import Thread
+from typing import TYPE_CHECKING, Any, cast
 
+from agno.agent import Agent
 from agno.models.message import Message
 from agno.run import RunContext
 from agno.session.agent import AgentSession
@@ -21,9 +24,11 @@ from mindroom.history.compaction import (
     estimate_session_summary_tokens,
 )
 from mindroom.history.prompt_tokens import (
-    _estimate_prepared_tool_definition_tokens,
-    _prepare_tools_for_estimation,
+    _TOOL_SURFACE_CACHE,
+    _prompt_tool_surface_for_tools,
     _StaticTokenEstimator,
+    agent_static_token_estimator,
+    agent_tool_definition_payloads_for_logging,
     estimate_agent_static_tokens,
 )
 from mindroom.history.types import (
@@ -35,6 +40,9 @@ from mindroom.token_budget import estimate_text_tokens, stable_serialize
 from tests.conftest import (
     FakeModel,
 )
+
+if TYPE_CHECKING:
+    import pytest
 from tests.history_helpers import (  # noqa: F401
     _agent,
     _close_test_storages,
@@ -45,8 +53,10 @@ from tests.history_helpers import (  # noqa: F401
 
 def _tool_definition_tokens(tools: object) -> int:
     """Estimate model-visible tool schema and instruction tokens for one tool list."""
-    prepared_tools, tool_instructions = _prepare_tools_for_estimation(tools)
-    return _estimate_prepared_tool_definition_tokens(prepared_tools, tool_instructions=tool_instructions)
+    surface = _prompt_tool_surface_for_tools(tools)
+    return surface.definition_tokens + sum(
+        estimate_text_tokens(instruction) for instruction in surface.tool_instructions
+    )
 
 
 def test_estimate_static_tokens_includes_tool_definitions() -> None:
@@ -363,3 +373,148 @@ def test_estimate_session_summary_tokens_none() -> None:
 def test_estimate_session_summary_tokens_empty() -> None:
     assert estimate_session_summary_tokens("") == 0
     assert estimate_session_summary_tokens("   ") == 0
+
+
+def _docs_toolkit() -> Toolkit:
+    def search_docs(query: str, limit: int = 5) -> str:
+        """Search the engineering docs for a matching answer."""
+        return f"{query}:{limit}"
+
+    return Toolkit(
+        name="docs",
+        tools=[search_docs],
+        instructions="Always cite the relevant document section when using search_docs.",
+        add_instructions=True,
+    )
+
+
+def test_static_budgeting_and_metadata_reuse_one_tool_surface(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Budget estimators and run-metadata payloads must share one prepared surface per agent."""
+    agent = _agent()
+    agent.tools = [_docs_toolkit()]
+
+    get_tools_calls = 0
+    original_get_tools = Agent.get_tools
+
+    def _counting_get_tools(self: Agent, *args: object, **kwargs: object) -> list[object]:
+        nonlocal get_tools_calls
+        get_tools_calls += 1
+        return original_get_tools(self, *args, **kwargs)
+
+    monkeypatch.setattr(Agent, "get_tools", _counting_get_tools)
+
+    estimator = agent_static_token_estimator(agent)
+    first_estimate = estimator.estimate("Current prompt")
+    re_estimate = estimate_agent_static_tokens(agent, "Current prompt")
+    payloads = agent_tool_definition_payloads_for_logging(agent)
+
+    assert get_tools_calls == 1
+    assert first_estimate == re_estimate
+    assert [payload["name"] for payload in payloads] == ["search_docs"]
+
+
+def test_tool_definition_payloads_cached_equal_ordered_and_isolated() -> None:
+    """Cached payloads must deeply equal fresh ones and resist mutation through returns."""
+
+    def export_notes(title: str) -> str:
+        """Export the current working notes."""
+        return title
+
+    def make_agent() -> Agent:
+        agent = _agent()
+        agent.tools = [_docs_toolkit(), Function(name="export_notes", entrypoint=export_notes)]
+        return agent
+
+    warm_agent = make_agent()
+    first = agent_tool_definition_payloads_for_logging(warm_agent)
+    cached = agent_tool_definition_payloads_for_logging(warm_agent)
+    fresh = agent_tool_definition_payloads_for_logging(make_agent())
+
+    assert first == cached == fresh
+    assert [payload["name"] for payload in first] == ["search_docs", "export_notes"]
+
+    first[0]["name"] = "mutated"
+    cast("dict[str, object]", first[1]["parameters"])["injected"] = True
+
+    assert agent_tool_definition_payloads_for_logging(warm_agent) == cached
+
+
+def test_tool_surfaces_are_keyed_per_agent_instance() -> None:
+    """Two live agents with different tools must not share a cached surface."""
+
+    def other_tool(note: str) -> str:
+        """Record one note."""
+        return note
+
+    docs_agent = _agent()
+    docs_agent.tools = [_docs_toolkit()]
+    notes_agent = _agent()
+    notes_agent.tools = [Function(name="record_note", entrypoint=other_tool)]
+
+    docs_payloads = agent_tool_definition_payloads_for_logging(docs_agent)
+    notes_payloads = agent_tool_definition_payloads_for_logging(notes_agent)
+
+    assert [payload["name"] for payload in docs_payloads] == ["search_docs"]
+    assert [payload["name"] for payload in notes_payloads] == ["record_note"]
+
+
+def test_tool_surface_cache_evicts_entries_when_agent_is_collected() -> None:
+    """Surface cache entries must die with their agent instance."""
+    agent = _agent()
+    agent.tools = [_docs_toolkit()]
+    agent_tool_definition_payloads_for_logging(agent)
+    cache_key = id(agent)
+    assert cache_key in _TOOL_SURFACE_CACHE
+
+    del agent
+    gc.collect()
+
+    assert cache_key not in _TOOL_SURFACE_CACHE
+
+
+def test_prompt_payloads_distinguish_strict_functions() -> None:
+    """Function strictness must reach the shared schema cache key and the payload."""
+
+    def sync_event(title: str, include_attendees: bool = False) -> str:
+        """Sync one event."""
+        return f"{title}:{include_attendees}"
+
+    lax_surface = _prompt_tool_surface_for_tools(
+        [Function(name="sync_event", entrypoint=sync_event, strict=False)],
+    )
+    strict_surface = _prompt_tool_surface_for_tools(
+        [Function(name="sync_event", entrypoint=sync_event, strict=True)],
+    )
+
+    lax_parameters = cast("dict[str, object]", lax_surface.payloads[0]["parameters"])
+    strict_parameters = cast("dict[str, object]", strict_surface.payloads[0]["parameters"])
+    assert lax_parameters["required"] == ["title"]
+    assert strict_parameters["required"] == ["title", "include_attendees"]
+
+
+def test_concurrent_surface_preparation_stays_consistent() -> None:
+    """Concurrent estimator and payload calls across agents must not corrupt the cache."""
+    agents = []
+    for _ in range(8):
+        agent = _agent()
+        agent.tools = [_docs_toolkit()]
+        agents.append(agent)
+
+    errors: list[BaseException] = []
+
+    def _exercise(agent: Agent) -> None:
+        try:
+            for _ in range(10):
+                payloads = agent_tool_definition_payloads_for_logging(agent)
+                assert [payload["name"] for payload in payloads] == ["search_docs"]
+                assert estimate_agent_static_tokens(agent, "Current prompt") > 0
+        except BaseException as exc:
+            errors.append(exc)
+
+    threads = [Thread(target=_exercise, args=(agent,)) for agent in agents]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert errors == []

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -16,6 +16,7 @@ import pytest
 import mindroom.tool_system.metadata as metadata_module
 import mindroom.tool_system.plugin_imports as plugin_module
 import mindroom.tool_system.plugins as plugins_module
+import mindroom.tool_system.skills as skills_module
 import mindroom.tools  # noqa: F401
 from mindroom.config.main import Config, ConfigRuntimeValidationError, load_config
 from mindroom.constants import RuntimePaths, resolve_runtime_paths
@@ -3257,3 +3258,84 @@ def test_reload_plugins_skip_broken_plugins_keeps_healthy_plugin_when_explicit_p
         for module_name in set(sys.modules) - original_modules:
             if module_name.startswith("mindroom_plugin_"):
                 sys.modules.pop(module_name, None)
+
+
+def _write_skill_plugin(plugin_root: Path, *, description: str = "Demo skill") -> Path:
+    plugin_root.mkdir(parents=True, exist_ok=True)
+    (plugin_root / "mindroom.plugin.json").write_text(
+        json.dumps({"name": "skill-plugin", "skills": ["skills"]}),
+        encoding="utf-8",
+    )
+    skill_dir = plugin_root / "skills" / "demo-skill"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    skill_path = skill_dir / "SKILL.md"
+    skill_path.write_text(
+        f"---\nname: demo-skill\ndescription: {description}\n---\n\n# Demo\n",
+        encoding="utf-8",
+    )
+    return skill_path
+
+
+def test_repeated_load_plugins_with_unchanged_roots_keeps_skill_cache(tmp_path: Path) -> None:
+    """Warm per-agent plugin loads must not rescan unchanged plugin skill roots."""
+    plugin_root = tmp_path / "plugins" / "skill-plugin"
+    _write_skill_plugin(plugin_root)
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("agents: {}", encoding="utf-8")
+    config = _bind_runtime_paths(Config(plugins=["./plugins/skill-plugin"]), config_path)
+    skills_root = (plugin_root / "skills").resolve()
+
+    with _preserved_plugin_loader_state():
+        load_plugins(config, runtime_paths_for(config))
+        first_load = skills_module._load_root_skills(skills_root)
+        assert [skill.name for skill in first_load] == ["demo-skill"]
+
+        load_plugins(config, runtime_paths_for(config))
+
+        assert skills_module._load_root_skills(skills_root) is first_load
+        skills_module.clear_skill_cache()
+
+
+def test_reload_plugins_picks_up_skill_file_changes(tmp_path: Path) -> None:
+    """A plugin reload with unchanged roots must still surface edited skill files."""
+    plugin_root = tmp_path / "plugins" / "skill-plugin"
+    skill_path = _write_skill_plugin(plugin_root, description="Demo v1")
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("agents: {}", encoding="utf-8")
+    config = _bind_runtime_paths(Config(plugins=["./plugins/skill-plugin"]), config_path)
+    skills_root = (plugin_root / "skills").resolve()
+
+    with _preserved_plugin_loader_state():
+        load_plugins(config, runtime_paths_for(config))
+        first_load = skills_module._load_root_skills(skills_root)
+        assert first_load[0].description == "Demo v1"
+
+        old_mtime = skill_path.stat().st_mtime_ns
+        _write_skill_plugin(plugin_root, description="Demo v2")
+        os.utime(skill_path, ns=(old_mtime + 2_000_000_000, old_mtime + 2_000_000_000))
+        reload_plugins(config, runtime_paths_for(config))
+
+        refreshed = skills_module._load_root_skills(skills_root)
+        assert refreshed[0].description == "Demo v2"
+        skills_module.clear_skill_cache()
+
+
+def test_deactivating_plugins_clears_cached_plugin_skills(tmp_path: Path) -> None:
+    """Dropping plugin roots must invalidate skills cached for those roots."""
+    plugin_root = tmp_path / "plugins" / "skill-plugin"
+    _write_skill_plugin(plugin_root)
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("agents: {}", encoding="utf-8")
+    config = _bind_runtime_paths(Config(plugins=["./plugins/skill-plugin"]), config_path)
+    skills_root = (plugin_root / "skills").resolve()
+
+    with _preserved_plugin_loader_state():
+        load_plugins(config, runtime_paths_for(config))
+        first_load = skills_module._load_root_skills(skills_root)
+        assert [skill.name for skill in first_load] == ["demo-skill"]
+
+        plugins_module.deactivate_plugins()
+
+        assert _get_plugin_skill_roots() == []
+        assert skills_module._load_root_skills(skills_root) is not first_load
+        skills_module.clear_skill_cache()

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -763,3 +763,62 @@ def test_skill_tools_without_policy_stay_unwrapped(tmp_path: Path) -> None:
     instructions_tool = next(tool for tool in skills.get_tools() if tool.name == "get_skill_instructions")
     assert instructions_tool.entrypoint is not None
     assert json.loads(instructions_tool.entrypoint("demo"))["skill_name"] == "demo"
+
+
+def test_set_plugin_skill_roots_unchanged_keeps_skill_cache(tmp_path: Path) -> None:
+    """Re-applying identical plugin skill roots must not drop cached skill loads."""
+    _write_skill(tmp_path, "alpha", "Alpha v1")
+    original_roots = skills_module.get_plugin_skill_roots()
+    try:
+        skills_module.set_plugin_skill_roots([tmp_path])
+        first_load = skills_module._load_root_skills(tmp_path)
+        assert [skill.name for skill in first_load] == ["alpha"]
+
+        skills_module.set_plugin_skill_roots([tmp_path])
+
+        assert skills_module._load_root_skills(tmp_path) is first_load
+    finally:
+        skills_module.set_plugin_skill_roots(original_roots)
+        skills_module.clear_skill_cache()
+
+
+def test_set_plugin_skill_roots_change_clears_skill_cache(tmp_path: Path) -> None:
+    """Changing plugin skill roots must invalidate cached skill loads."""
+    root_one = tmp_path / "one"
+    root_two = tmp_path / "two"
+    _write_skill(root_one, "alpha", "Alpha v1")
+    _write_skill(root_two, "beta", "Beta v1")
+    original_roots = skills_module.get_plugin_skill_roots()
+    try:
+        skills_module.set_plugin_skill_roots([root_one])
+        first_load = skills_module._load_root_skills(root_one)
+        assert [skill.name for skill in first_load] == ["alpha"]
+
+        skills_module.set_plugin_skill_roots([root_one, root_two])
+
+        assert skills_module._load_root_skills(root_one) is not first_load
+    finally:
+        skills_module.set_plugin_skill_roots(original_roots)
+        skills_module.clear_skill_cache()
+
+
+def test_skill_edits_stay_visible_when_plugin_roots_are_reapplied(tmp_path: Path) -> None:
+    """Snapshot validation must still catch file edits after a no-op root update."""
+    skill_path = _write_skill(tmp_path, "alpha", "Alpha v1")
+    original_roots = skills_module.get_plugin_skill_roots()
+    try:
+        skills_module.set_plugin_skill_roots([tmp_path])
+        first_load = skills_module._load_root_skills(tmp_path)
+        assert first_load[0].description == "Alpha v1"
+
+        old_mtime = skill_path.stat().st_mtime_ns
+        skill_path = _write_skill(tmp_path, "alpha", "Alpha v2")
+        os.utime(skill_path, ns=(old_mtime + 2_000_000_000, old_mtime + 2_000_000_000))
+        skills_module.set_plugin_skill_roots([tmp_path])
+
+        refreshed = skills_module._load_root_skills(tmp_path)
+        assert refreshed is not first_load
+        assert refreshed[0].description == "Alpha v2"
+    finally:
+        skills_module.set_plugin_skill_roots(original_roots)
+        skills_module.clear_skill_cache()

--- a/tests/test_todo_builtin.py
+++ b/tests/test_todo_builtin.py
@@ -16,7 +16,7 @@ from mindroom.config.main import Config
 from mindroom.custom_tools.todo_state import todos_path
 from mindroom.message_target import MessageTarget
 from mindroom.session_ids import create_session_id
-from mindroom.tool_schema_cache import process_function_schema_for_prompt
+from mindroom.tool_schema_cache import cached_processed_schema
 from mindroom.tool_system.metadata import TOOL_METADATA, get_tool_by_name
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, tool_runtime_context
 from tests.conftest import (
@@ -121,13 +121,16 @@ def test_todo_tool_schemas_include_model_visible_arguments(tmp_path: Path) -> No
     """Runtime annotations should resolve so Agno exposes tool-call arguments."""
     config = _config(tmp_path)
     tool = get_tool_by_name("todo", runtime_paths_for(config), worker_target=None)
-    for function in tool.functions.values():
-        process_function_schema_for_prompt(function, strict=False)
+    schemas: dict[str, dict[str, object]] = {}
+    for name, function in tool.functions.items():
+        snapshot = cached_processed_schema(function, strict=False)
+        assert snapshot is not None
+        schemas[name] = snapshot.parameters
 
-    plan_params = tool.functions["plan"].parameters["properties"]
-    add_params = tool.functions["add_todo"].parameters["properties"]
-    update_params = tool.functions["update_todo"].parameters["properties"]
-    apply_template_params = tool.functions["apply_template"].parameters["properties"]
+    plan_params = schemas["plan"]["properties"]
+    add_params = schemas["add_todo"]["properties"]
+    update_params = schemas["update_todo"]["properties"]
+    apply_template_params = schemas["apply_template"]["properties"]
 
     assert "tasks" in plan_params
     assert "title" in add_params

--- a/tests/test_tool_schema_cache.py
+++ b/tests/test_tool_schema_cache.py
@@ -1,0 +1,28 @@
+"""Tests for the shared prompt tool-schema cache."""
+
+from __future__ import annotations
+
+from agno.tools.function import Function
+
+from mindroom.tool_schema_cache import cached_processed_schema
+
+
+def test_cached_processed_schema_returns_private_copies() -> None:
+    """Mutating a returned snapshot must not corrupt the shared LRU entry."""
+
+    def sync_event(title: str, include_attendees: bool = False) -> str:
+        """Sync one event."""
+        return f"{title}:{include_attendees}"
+
+    function = Function(name="sync_event", entrypoint=sync_event)
+
+    first = cached_processed_schema(function, strict=False)
+    assert first is not None
+    first.parameters["properties"]["injected"] = {"type": "string"}
+    first.parameters["required"].append("injected")
+
+    second = cached_processed_schema(function, strict=False)
+    assert second is not None
+    assert "injected" not in second.parameters["properties"]
+    assert second.parameters["required"] == ["title"]
+    assert second.parameters is not first.parameters


### PR DESCRIPTION
## Motivation

Every inbound turn rebuilds its agent, and two pieces of prompt-assembly work were being repeated inside that path:

1. **Skill rescans on every agent build.** `load_plugins()` runs during every agent construction and always ended with `set_plugin_skill_roots(...)`, which unconditionally cleared the snapshot-validated skill cache — even when the roots had not changed, and even in the default no-plugin setup (`set_plugin_skill_roots([])`). Every build therefore re-globbed every `SKILL.md` and rebuilt all skill objects.
2. **Triple tool-schema preparation per turn.** Static token budgeting (execution preparation), the history-runtime re-estimate, and run-metadata assembly each independently re-ran `agent.get_tools(...)` and deep-copied every model-visible `Function` before processing its schema and serializing the payloads.

Verified with call-count instrumentation before changing anything (`scripts/testing/benchmark_prompt_assembly.py`, added in this PR): each warm build performed 1 skill-cache clear + 2 skill root rescans, and each turn performed 3 `get_tools` calls, 69 whole-`Function` deep copies, and 2 payload serializations for a small 3-toolkit fixture.

## Changes

- **`tool_system/skills.py`** — `set_plugin_skill_roots()` is now a no-op when the resolved roots are unchanged. Root changes (including plugin deactivation) still clear the cache, and the per-root mtime/size snapshots in `_load_root_skills()` still pick up skill file edits immediately, including workspace skills.
- **`history/prompt_tokens.py`** — static budgeting and run-metadata assembly now share one immutable prompt-only tool surface (payload dicts, tool instructions, serialized token count) prepared once per `Agent`/`Team` instance. The memo is keyed by entity id with weakref eviction, so its lifetime is exactly one turn: agents and teams are rebuilt per response, and dynamic-tool continuations rebuild fresh instances, so dynamic load/unload, per-session visibility, execution-identity filtering, `tool_function_filter`, and strictness are all baked into the instance the surface was built from. Public payload functions return deep copies so cached state cannot be mutated through returned values.
- **`tool_schema_cache.py`** — the existing LRU is exposed through a non-mutating `cached_processed_schema()` accessor; payload construction uses it directly instead of deep-copying whole `Function` objects (the copy+process fallback remains for entrypoints that cannot form a stable cache key). The now-unused in-place `process_function_schema_for_prompt()` wrapper is removed.
- **`scripts/testing/benchmark_prompt_assembly.py`** — reproducible benchmark with call-count instrumentation for warm agent builds and per-turn tool-surface work.

No cross-turn caching was added beyond the pre-existing schema LRU; when a `Function` cannot be represented with a stable cache key, the code falls back to full processing on a private copy.

## Benchmarks

Same machine, same venv, 25 iterations, small fixture (1 plugin with 2 skills; `calculator`, `file`, and a plugin toolkit = 23 functions). Counters are per iteration.

| Metric | Before (base) | After |
| --- | --- | --- |
| Warm `create_agent` mean | 7.52 ms | 4.83 ms |
| Skill-cache clears / build | 1 | 0 |
| Skill root rescans / build | 2 | 0 |
| Per-turn budgeting + re-estimate + metadata mean | 3.54 ms | 2.19 ms |
| `agent.get_tools` calls / turn | 3 | 1 |
| Whole-`Function` deep copies / turn | 69 | 0 |
| Payload serializations / turn | 2 | 1 |

Savings scale with the number of configured tools and skills. No performance thresholds were added to CI.

## Testing

New behavioral tests (no wall-clock assertions):

- Unchanged plugin skill roots keep cached skill loads; changed roots and `deactivate_plugins()` invalidate them; skill file edits stay visible after a no-op root update and across `reload_plugins()` (`tests/test_skills.py`, `tests/test_plugins.py`).
- Budget estimators and run-metadata payloads share one prepared surface per agent (single `get_tools` call); cached and fresh payloads are deeply equal and ordered; mutating returned payloads does not affect the cache; surfaces are keyed per instance; strictness reaches the schema cache key; concurrent estimator/payload calls stay consistent; cache entries are evicted when the agent is collected (`tests/test_history_prompt_tokens.py`).

`uv run pre-commit run --all-files` passes. Full `pytest` run: the only failures are 23 pre-existing CLI/doctor ANSI-output assertion failures (`test_cli_config`, `test_cli_trigger`, `test_cli_doctor`, `test_plugin_check`, `test_plugin_install`) that fail identically on unmodified `main` in this environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved prompt-token estimation and tool-schema processing efficiency through caching and reusable tool surfaces.
  * Added a benchmark for measuring prompt assembly performance.

* **Bug Fixes**
  * Prevented unnecessary skill-cache invalidation when plugin roots are unchanged.
  * Improved cache safety, consistency, schema handling, and concurrent estimation behavior.

* **Tests**
  * Expanded coverage for prompt-token estimation, tool-schema caching, plugin reloads, skill updates, and cache invalidation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->