### PR TITLE
Expose Matrix user kicks to hook plugins

### DIFF
--- a/src/mindroom/hooks/matrix_admin.py
+++ b/src/mindroom/hooks/matrix_admin.py
@@ -63,6 +63,11 @@ class _BoundHookMatrixAdmin:
         """Invite one user into one room."""
         return await invite_to_room(self.client, room_id, user_id)
 
+    async def kick_user(self, room_id: str, user_id: str, *, reason: str | None = None) -> bool:
+        """Kick one joined user from one room."""
+        response = await self.client.room_kick(room_id, user_id, reason=reason)
+        return isinstance(response, nio.RoomKickResponse)
+
     async def get_room_members(self, room_id: str) -> set[str] | None:
         """Return the current joined members for one room, or ``None`` when the fetch fails."""
         return await get_room_members(self.client, room_id)

--- a/src/mindroom/hooks/types.py
+++ b/src/mindroom/hooks/types.py
@@ -130,6 +130,9 @@ class HookMatrixAdmin(Protocol):
     async def invite_user(self, room_id: str, user_id: str) -> bool:
         """Invite one user into one room."""
 
+    async def kick_user(self, room_id: str, user_id: str, *, reason: str | None = None) -> bool:
+        """Kick one joined user from one room."""
+
     async def get_room_members(self, room_id: str) -> set[str] | None:
         """Return joined members for one room, or ``None`` when the fetch fails."""
 

--- a/tests/test_hook_matrix_admin.py
+++ b/tests/test_hook_matrix_admin.py
@@ -184,6 +184,12 @@ async def test_build_hook_matrix_admin_delegates_existing_room_helpers(tmp_path:
 
         room_id = await admin.create_room(name="Personal Room", alias_localpart="personal-user", topic="Hello")
         invited = await admin.invite_user("!created:localhost", "@user:localhost")
+        client.room_kick.return_value = nio.RoomKickResponse()
+        kicked = await admin.kick_user(
+            "!created:localhost",
+            "@user:localhost",
+            reason="Reset membership",
+        )
         members = await admin.get_room_members("!created:localhost")
         added = await admin.add_room_to_space("!space:localhost", "!created:localhost")
         client.room_put_state.return_value = nio.RoomPutStateResponse.from_dict(
@@ -199,6 +205,7 @@ async def test_build_hook_matrix_admin_delegates_existing_room_helpers(tmp_path:
 
     assert room_id == "!created:localhost"
     assert invited is True
+    assert kicked is True
     assert members == {"@user:localhost", "@mindroom_router:localhost"}
     assert added is True
     assert wrote_state is True
@@ -210,6 +217,11 @@ async def test_build_hook_matrix_admin_delegates_existing_room_helpers(tmp_path:
         power_users=None,
     )
     mock_invite.assert_awaited_once_with(client, "!created:localhost", "@user:localhost")
+    client.room_kick.assert_awaited_once_with(
+        "!created:localhost",
+        "@user:localhost",
+        reason="Reset membership",
+    )
     client.room_put_state.assert_awaited_once_with(
         room_id="!created:localhost",
         event_type="com.mindroom.scheduled.task",
@@ -218,6 +230,20 @@ async def test_build_hook_matrix_admin_delegates_existing_room_helpers(tmp_path:
     )
     mock_members.assert_awaited_once_with(client, "!created:localhost")
     mock_add.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_hook_matrix_admin_kick_user_returns_false_on_error(tmp_path: Path) -> None:
+    """User kicks should fail closed on Matrix error responses."""
+    module = _matrix_admin_module()
+    client = AsyncMock(spec=nio.AsyncClient)
+    client.homeserver = "http://localhost:8008"
+    client.room_kick.return_value = nio.RoomKickError("forbidden", status_code="M_FORBIDDEN")
+
+    admin = module.build_hook_matrix_admin(client, runtime_paths=test_runtime_paths(tmp_path))
+
+    assert await admin.kick_user("!room:localhost", "@user:localhost") is False
+    client.room_kick.assert_awaited_once_with("!room:localhost", "@user:localhost", reason=None)
 
 
 @pytest.mark.asyncio

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -74,6 +74,7 @@ post_params  # unused variable (src/mindroom/workers/backends/kubernetes_resourc
 response_type  # unused variable (src/mindroom/workers/backends/kubernetes_resources.py)
 collection_formats  # unused variable (src/mindroom/workers/backends/kubernetes_resources.py)
 _.invite_user  # unused method (src/mindroom/hooks/types.py)
+_.kick_user  # hook plugins call this public Matrix admin method (src/mindroom/hooks/types.py)
 _.make_request  # unused method (src/mindroom/tools/custom_api.py)
 _._async_crawl  # unused method (src/mindroom/tools/crawl4ai.py)
 _.redirect_request  # unused method (src/mindroom/tools/approved_egress.py)


### PR DESCRIPTION
## Why

Hook plugins that manage room membership can invite users but cannot remove an existing member through the typed hook admin surface.
That forces plugins to bypass the public helper or attempt to write membership state directly instead of using Matrix's kick endpoint.

## What

- Add `HookMatrixAdmin.kick_user()` with an optional reason.
- Delegate to the Matrix client's room-kick API.
- Return `False` for Matrix error responses, matching the existing helper style.
- Cover successful delegation and error handling.

## Validation

- `uv run pytest`
- `uv run pre-commit run --all-files`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for administrators to remove users from rooms.
  * Administrators can optionally provide a reason when removing a user.
  * The operation reports whether the removal succeeded.

* **Bug Fixes**
  * Failed removal attempts now return a clear unsuccessful result instead of being treated as successful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->