### PR TITLE
Make config reload drain test deterministic

### DIFF
--- a/tests/test_config_lifecycle.py
+++ b/tests/test_config_lifecycle.py
@@ -173,23 +173,33 @@ async def test_stuck_drain_warns_then_forces_reload(
     tmp_path: Path,
 ) -> None:
     """A wedged drain should warn and then force the reload through."""
-    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_DEBOUNCE_SECONDS", 0.01)
-    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_IDLE_POLL_SECONDS", 0.01)
-    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_DRAIN_WARNING_AFTER_SECONDS", 0.02)
+    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_IDLE_POLL_SECONDS", 0)
+    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_DRAIN_WARNING_AFTER_SECONDS", 0.5)
     monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_DRAIN_WARNING_INTERVAL_SECONDS", 1.0)
-    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_DRAIN_FORCE_AFTER_SECONDS", 0.04)
+    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_DRAIN_FORCE_AFTER_SECONDS", 1.0)
     logger_mock = MagicMock()
     monkeypatch.setattr("mindroom.orchestration.config_lifecycle.logger", logger_mock)
-    lifecycle = _make_lifecycle(tmp_path, in_flight_response_count=lambda: 1)
-    lifecycle.update_config = AsyncMock(return_value=True)
+    lifecycle = _make_lifecycle(tmp_path)
+    drain_state = _ConfigReloadDrainState()
+    loop = MagicMock(spec=asyncio.AbstractEventLoop)
+    loop.time.side_effect = [10.0, 11.0]
 
-    lifecycle.request_reload()
-    task = lifecycle._reload_task
-    assert task is not None
+    should_defer = await lifecycle._should_defer_reload_for_active_responses(
+        drain_state=drain_state,
+        requested_at=1.0,
+        active_response_count=1,
+        loop=loop,
+    )
+    assert should_defer is True
 
-    await asyncio.wait_for(task, timeout=1)
+    should_defer = await lifecycle._should_defer_reload_for_active_responses(
+        drain_state=drain_state,
+        requested_at=1.0,
+        active_response_count=1,
+        loop=loop,
+    )
+    assert should_defer is False
 
-    lifecycle.update_config.assert_awaited_once()
     assert any(
         call.args and call.args[0] == "Configuration reload still waiting for active responses to finish"
         for call in logger_mock.warning.call_args_list

--- a/tests/test_config_lifecycle.py
+++ b/tests/test_config_lifecycle.py
@@ -191,9 +191,16 @@ async def test_stuck_drain_warns_then_forces_reload(
     monkeypatch.setattr("mindroom.orchestration.config_lifecycle.logger", logger_mock)
     lifecycle = _make_lifecycle(tmp_path)
     drain_state = _ConfigReloadDrainState()
-    drain_state.begin_wait(now=wait_started_at, requested_at=requested_at)
     loop = MagicMock(spec=asyncio.AbstractEventLoop)
-    loop.time.return_value = wait_started_at + force_after_seconds
+    loop.time.side_effect = [wait_started_at, wait_started_at + force_after_seconds]
+
+    should_defer = await lifecycle._should_defer_reload_for_active_responses(
+        drain_state=drain_state,
+        requested_at=requested_at,
+        active_response_count=1,
+        loop=loop,
+    )
+    assert should_defer is True
 
     should_defer = await lifecycle._should_defer_reload_for_active_responses(
         drain_state=drain_state,

--- a/tests/test_config_lifecycle.py
+++ b/tests/test_config_lifecycle.py
@@ -172,29 +172,32 @@ async def test_stuck_drain_warns_then_forces_reload(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """A wedged drain should warn and then force the reload through."""
+    """A wedged drain should warn and then stop deferring the reload."""
+    warning_after_seconds = 0.5
+    force_after_seconds = 1.0
+    requested_at = 1.0
+    wait_started_at = 10.0
     monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_IDLE_POLL_SECONDS", 0)
-    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_DRAIN_WARNING_AFTER_SECONDS", 0.5)
+    monkeypatch.setattr(
+        "mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_DRAIN_WARNING_AFTER_SECONDS",
+        warning_after_seconds,
+    )
     monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_DRAIN_WARNING_INTERVAL_SECONDS", 1.0)
-    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_DRAIN_FORCE_AFTER_SECONDS", 1.0)
+    monkeypatch.setattr(
+        "mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_DRAIN_FORCE_AFTER_SECONDS",
+        force_after_seconds,
+    )
     logger_mock = MagicMock()
     monkeypatch.setattr("mindroom.orchestration.config_lifecycle.logger", logger_mock)
     lifecycle = _make_lifecycle(tmp_path)
     drain_state = _ConfigReloadDrainState()
+    drain_state.begin_wait(now=wait_started_at, requested_at=requested_at)
     loop = MagicMock(spec=asyncio.AbstractEventLoop)
-    loop.time.side_effect = [10.0, 11.0]
+    loop.time.return_value = wait_started_at + force_after_seconds
 
     should_defer = await lifecycle._should_defer_reload_for_active_responses(
         drain_state=drain_state,
-        requested_at=1.0,
-        active_response_count=1,
-        loop=loop,
-    )
-    assert should_defer is True
-
-    should_defer = await lifecycle._should_defer_reload_for_active_responses(
-        drain_state=drain_state,
-        requested_at=1.0,
+        requested_at=requested_at,
         active_response_count=1,
         loop=loop,
     )
@@ -208,6 +211,27 @@ async def test_stuck_drain_warns_then_forces_reload(
         call.args and call.args[0] == "Forcing configuration reload while responses are still active"
         for call in logger_mock.error.call_args_list
     )
+
+
+@pytest.mark.asyncio
+async def test_forced_drain_decision_applies_queued_reload(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The reload loop should apply a queued reload after its drain timeout."""
+    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_DEBOUNCE_SECONDS", 0)
+    lifecycle = _make_lifecycle(tmp_path, in_flight_response_count=lambda: 1)
+    lifecycle.update_config = AsyncMock(return_value=True)
+    lifecycle._should_defer_reload_for_active_responses = AsyncMock(side_effect=[True, False])
+
+    lifecycle.request_reload()
+    task = lifecycle._reload_task
+    assert task is not None
+
+    await task
+
+    assert lifecycle._should_defer_reload_for_active_responses.await_count == 2
+    lifecycle.update_config.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Main pytest failed because `test_stuck_drain_warns_then_forces_reload` depended on a 40 ms real-time drain window. Under full xdist load, its worker could be starved past the outer one-second timeout even though the reload logic was correct.

## What changed

- drive the drain helper with explicit monotonic clock values
- assert the first decision defers and the second warns then permits the forced reload
- remove scheduler timing from this unit test

## Validation

- `uv run pytest tests/test_config_lifecycle.py -q -n auto`
- `uv run pytest -q`
- `uv run pre-commit run --all-files`

## Summary by Sourcery

Make the config reload drain unit test deterministic by driving reload decisions from mocked monotonic clock values instead of real-time scheduling.

Tests:
- Rework `test_stuck_drain_warns_then_forces_reload` to assert drain behavior via `_should_defer_reload_for_active_responses` using controlled loop time.
- Stop relying on short real-time timeouts and scheduler behavior in the config reload drain test while still asserting that warnings are emitted and forced reload eventually proceeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved coverage for configuration reload behavior when active responses delay reload, including deterministic timing to validate the lifecycle’s defer/force decision.
  * Refactored an existing reload test into a focused unit check of the reload-defer decision logic.
  * Added a new async test to verify queued reload behavior when the drain decision transitions from deferring to allowing, including expected logging and update handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->