### PR TITLE
Fix hosted Desktop pairing login commands

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 MATRIX_HOMESERVER=http://localhost:8008  # Your Matrix homeserver URL
 # MATRIX_SSL_VERIFY=false  # Uncomment to disable SSL verification for self-signed certificates (dev only!)
 # MINDROOM_DESKTOP_MATRIX_HOMESERVER=https://matrix.example.org  # Public URL for Desktop pairing commands
-# MINDROOM_DESKTOP_CLOUDFLARE_ACCESS=false  # Add --cloudflare-access to Desktop pairing login commands
+# MINDROOM_DESKTOP_CLOUDFLARE_ACCESS=false  # Add --cloudflare-access to Desktop pairing commands
 
 # AI Provider API Keys (used by agno library for AI model access)
 # Set the ones you want to use based on which AI providers you configure in config.yaml

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 # Matrix connection settings
 MATRIX_HOMESERVER=http://localhost:8008  # Your Matrix homeserver URL
 # MATRIX_SSL_VERIFY=false  # Uncomment to disable SSL verification for self-signed certificates (dev only!)
+# MINDROOM_DESKTOP_MATRIX_HOMESERVER=https://matrix.example.org  # Public URL for Desktop pairing commands
+# MINDROOM_DESKTOP_CLOUDFLARE_ACCESS=false  # Add --cloudflare-access to Desktop pairing login commands
 
 # AI Provider API Keys (used by agno library for AI model access)
 # Set the ones you want to use based on which AI providers you configure in config.yaml

--- a/cluster/k8s/instance/templates/deployment-mindroom.yaml
+++ b/cluster/k8s/instance/templates/deployment-mindroom.yaml
@@ -143,6 +143,8 @@ spec:
           value: "shell,file,python"
         - name: MATRIX_HOMESERVER
           value: "http://synapse-{{ .Values.customer }}:8008"
+        - name: MINDROOM_DESKTOP_MATRIX_HOMESERVER
+          value: "https://{{ .Values.customer }}.matrix.{{ .Values.baseDomain }}"
         - name: MATRIX_SERVER_NAME
           value: "{{ .Values.customer }}.{{ .Values.baseDomain }}"
         - name: MATRIX_REGISTRATION_SHARED_SECRET_FILE

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -163,6 +163,8 @@ tool_approval:
 | `MATRIX_HOMESERVER` | Matrix homeserver URL | `http://localhost:8008` |
 | `MATRIX_SERVER_NAME` | Server name for federation | _(derived from homeserver)_ |
 | `MATRIX_SSL_VERIFY` | Verify SSL certificates | `true` |
+| `MINDROOM_DESKTOP_MATRIX_HOMESERVER` | Public Matrix URL printed by `!desktop setup` when it differs from the runtime's internal homeserver URL | `MATRIX_HOMESERVER` |
+| `MINDROOM_DESKTOP_CLOUDFLARE_ACCESS` | Include `--cloudflare-access` in the Desktop login command printed by `!desktop setup` | `false` |
 
 ### API Keys
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -164,7 +164,7 @@ tool_approval:
 | `MATRIX_SERVER_NAME` | Server name for federation | _(derived from homeserver)_ |
 | `MATRIX_SSL_VERIFY` | Verify SSL certificates | `true` |
 | `MINDROOM_DESKTOP_MATRIX_HOMESERVER` | Public Matrix URL printed by `!desktop setup` when it differs from the runtime's internal homeserver URL | `MATRIX_HOMESERVER` |
-| `MINDROOM_DESKTOP_CLOUDFLARE_ACCESS` | Include `--cloudflare-access` in the Desktop login command printed by `!desktop setup` | `false` |
+| `MINDROOM_DESKTOP_CLOUDFLARE_ACCESS` | Include `--cloudflare-access` in the Desktop login and pairing commands printed by `!desktop setup` | `false` |
 
 ### API Keys
 

--- a/docs/tools/desktop.md
+++ b/docs/tools/desktop.md
@@ -169,6 +169,10 @@ MindRoom reads the JWT's documented `exp` claim and reuses it only while current
 After expiry, the first Matrix request obtains a current token from `cloudflared`, prompting for browser reauthentication when needed.
 For an older saved session, `mindroom desktop run --cloudflare-access` enables Access for that invocation without rewriting the session.
 
+When the MindRoom runtime reaches Matrix through an internal address, set `MINDROOM_DESKTOP_MATRIX_HOMESERVER` to the public Matrix URL that local Desktop clients can reach.
+This changes only the login command printed by `!desktop setup`; server-side Matrix traffic continues to use `MATRIX_HOMESERVER`.
+Set `MINDROOM_DESKTOP_CLOUDFLARE_ACCESS=true` when that public URL requires Cloudflare Access so the printed command includes `--cloudflare-access`.
+
 For unattended proxies that issue machine credentials instead, put their required request headers in a separate JSON file:
 
 ```json

--- a/docs/tools/desktop.md
+++ b/docs/tools/desktop.md
@@ -171,7 +171,7 @@ For an older saved session, `mindroom desktop run --cloudflare-access` enables A
 
 When the MindRoom runtime reaches Matrix through an internal address, set `MINDROOM_DESKTOP_MATRIX_HOMESERVER` to the public Matrix URL that local Desktop clients can reach.
 This changes only the login command printed by `!desktop setup`; server-side Matrix traffic continues to use `MATRIX_HOMESERVER`.
-Set `MINDROOM_DESKTOP_CLOUDFLARE_ACCESS=true` when that public URL requires Cloudflare Access so the printed command includes `--cloudflare-access`.
+Set `MINDROOM_DESKTOP_CLOUDFLARE_ACCESS=true` when that public URL requires Cloudflare Access so the printed login and pairing commands include `--cloudflare-access`.
 
 For unattended proxies that issue machine credentials instead, put their required request headers in a separate JSON file:
 

--- a/local/instances/deploy/docker-compose.synapse.yml
+++ b/local/instances/deploy/docker-compose.synapse.yml
@@ -88,6 +88,7 @@ services:
   mindroom:
     environment:
       - MATRIX_HOMESERVER=http://synapse:8008
+      - MINDROOM_DESKTOP_MATRIX_HOMESERVER=https://m-${INSTANCE_DOMAIN}
       - MATRIX_SERVER_NAME=m-${INSTANCE_DOMAIN}
     depends_on:
       synapse:

--- a/local/instances/deploy/docker-compose.tuwunel.yml
+++ b/local/instances/deploy/docker-compose.tuwunel.yml
@@ -61,6 +61,7 @@ services:
   mindroom:
     environment:
       MATRIX_HOMESERVER: http://tuwunel:6167
+      MINDROOM_DESKTOP_MATRIX_HOMESERVER: https://m-${INSTANCE_DOMAIN}
       MATRIX_SERVER_NAME: ${MATRIX_SERVER_NAME:-m-${INSTANCE_DOMAIN}}
     depends_on:
       - tuwunel

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -1020,6 +1020,8 @@ tool_approval:
 | `MATRIX_HOMESERVER` | Matrix homeserver URL | `http://localhost:8008` |
 | `MATRIX_SERVER_NAME` | Server name for federation | _(derived from homeserver)_ |
 | `MATRIX_SSL_VERIFY` | Verify SSL certificates | `true` |
+| `MINDROOM_DESKTOP_MATRIX_HOMESERVER` | Public Matrix URL printed by `!desktop setup` when it differs from the runtime's internal homeserver URL | `MATRIX_HOMESERVER` |
+| `MINDROOM_DESKTOP_CLOUDFLARE_ACCESS` | Include `--cloudflare-access` in the Desktop login command printed by `!desktop setup` | `false` |
 
 ### API Keys
 
@@ -7594,6 +7596,10 @@ The session remembers that Cloudflare Access is enabled, so later `mindroom desk
 MindRoom reads the JWT's documented `exp` claim and reuses it only while current.
 After expiry, the first Matrix request obtains a current token from `cloudflared`, prompting for browser reauthentication when needed.
 For an older saved session, `mindroom desktop run --cloudflare-access` enables Access for that invocation without rewriting the session.
+
+When the MindRoom runtime reaches Matrix through an internal address, set `MINDROOM_DESKTOP_MATRIX_HOMESERVER` to the public Matrix URL that local Desktop clients can reach.
+This changes only the login command printed by `!desktop setup`; server-side Matrix traffic continues to use `MATRIX_HOMESERVER`.
+Set `MINDROOM_DESKTOP_CLOUDFLARE_ACCESS=true` when that public URL requires Cloudflare Access so the printed command includes `--cloudflare-access`.
 
 For unattended proxies that issue machine credentials instead, put their required request headers in a separate JSON file:
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -1021,7 +1021,7 @@ tool_approval:
 | `MATRIX_SERVER_NAME` | Server name for federation | _(derived from homeserver)_ |
 | `MATRIX_SSL_VERIFY` | Verify SSL certificates | `true` |
 | `MINDROOM_DESKTOP_MATRIX_HOMESERVER` | Public Matrix URL printed by `!desktop setup` when it differs from the runtime's internal homeserver URL | `MATRIX_HOMESERVER` |
-| `MINDROOM_DESKTOP_CLOUDFLARE_ACCESS` | Include `--cloudflare-access` in the Desktop login command printed by `!desktop setup` | `false` |
+| `MINDROOM_DESKTOP_CLOUDFLARE_ACCESS` | Include `--cloudflare-access` in the Desktop login and pairing commands printed by `!desktop setup` | `false` |
 
 ### API Keys
 
@@ -7599,7 +7599,7 @@ For an older saved session, `mindroom desktop run --cloudflare-access` enables A
 
 When the MindRoom runtime reaches Matrix through an internal address, set `MINDROOM_DESKTOP_MATRIX_HOMESERVER` to the public Matrix URL that local Desktop clients can reach.
 This changes only the login command printed by `!desktop setup`; server-side Matrix traffic continues to use `MATRIX_HOMESERVER`.
-Set `MINDROOM_DESKTOP_CLOUDFLARE_ACCESS=true` when that public URL requires Cloudflare Access so the printed command includes `--cloudflare-access`.
+Set `MINDROOM_DESKTOP_CLOUDFLARE_ACCESS=true` when that public URL requires Cloudflare Access so the printed login and pairing commands include `--cloudflare-access`.
 
 For unattended proxies that issue machine credentials instead, put their required request headers in a separate JSON file:
 

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -159,6 +159,8 @@ tool_approval:
 | `MATRIX_HOMESERVER` | Matrix homeserver URL | `http://localhost:8008` |
 | `MATRIX_SERVER_NAME` | Server name for federation | _(derived from homeserver)_ |
 | `MATRIX_SSL_VERIFY` | Verify SSL certificates | `true` |
+| `MINDROOM_DESKTOP_MATRIX_HOMESERVER` | Public Matrix URL printed by `!desktop setup` when it differs from the runtime's internal homeserver URL | `MATRIX_HOMESERVER` |
+| `MINDROOM_DESKTOP_CLOUDFLARE_ACCESS` | Include `--cloudflare-access` in the Desktop login command printed by `!desktop setup` | `false` |
 
 ### API Keys
 

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -160,7 +160,7 @@ tool_approval:
 | `MATRIX_SERVER_NAME` | Server name for federation | _(derived from homeserver)_ |
 | `MATRIX_SSL_VERIFY` | Verify SSL certificates | `true` |
 | `MINDROOM_DESKTOP_MATRIX_HOMESERVER` | Public Matrix URL printed by `!desktop setup` when it differs from the runtime's internal homeserver URL | `MATRIX_HOMESERVER` |
-| `MINDROOM_DESKTOP_CLOUDFLARE_ACCESS` | Include `--cloudflare-access` in the Desktop login command printed by `!desktop setup` | `false` |
+| `MINDROOM_DESKTOP_CLOUDFLARE_ACCESS` | Include `--cloudflare-access` in the Desktop login and pairing commands printed by `!desktop setup` | `false` |
 
 ### API Keys
 

--- a/skills/mindroom-docs/references/page__tools__desktop__index.md
+++ b/skills/mindroom-docs/references/page__tools__desktop__index.md
@@ -165,6 +165,10 @@ MindRoom reads the JWT's documented `exp` claim and reuses it only while current
 After expiry, the first Matrix request obtains a current token from `cloudflared`, prompting for browser reauthentication when needed.
 For an older saved session, `mindroom desktop run --cloudflare-access` enables Access for that invocation without rewriting the session.
 
+When the MindRoom runtime reaches Matrix through an internal address, set `MINDROOM_DESKTOP_MATRIX_HOMESERVER` to the public Matrix URL that local Desktop clients can reach.
+This changes only the login command printed by `!desktop setup`; server-side Matrix traffic continues to use `MATRIX_HOMESERVER`.
+Set `MINDROOM_DESKTOP_CLOUDFLARE_ACCESS=true` when that public URL requires Cloudflare Access so the printed command includes `--cloudflare-access`.
+
 For unattended proxies that issue machine credentials instead, put their required request headers in a separate JSON file:
 
 ```json

--- a/skills/mindroom-docs/references/page__tools__desktop__index.md
+++ b/skills/mindroom-docs/references/page__tools__desktop__index.md
@@ -167,7 +167,7 @@ For an older saved session, `mindroom desktop run --cloudflare-access` enables A
 
 When the MindRoom runtime reaches Matrix through an internal address, set `MINDROOM_DESKTOP_MATRIX_HOMESERVER` to the public Matrix URL that local Desktop clients can reach.
 This changes only the login command printed by `!desktop setup`; server-side Matrix traffic continues to use `MATRIX_HOMESERVER`.
-Set `MINDROOM_DESKTOP_CLOUDFLARE_ACCESS=true` when that public URL requires Cloudflare Access so the printed command includes `--cloudflare-access`.
+Set `MINDROOM_DESKTOP_CLOUDFLARE_ACCESS=true` when that public URL requires Cloudflare Access so the printed login and pairing commands include `--cloudflare-access`.
 
 For unattended proxies that issue machine credentials instead, put their required request headers in a separate JSON file:
 

--- a/src/mindroom/commands/desktop_commands.py
+++ b/src/mindroom/commands/desktop_commands.py
@@ -70,13 +70,17 @@ def _setup_response(scope: DesktopCommandScope) -> str:
         requester_id=scope.requester_id,
         agent_name=scope.agent_name,
     )
-    login_command = " ".join(
-        (
-            "mindroom desktop login",
-            f"--user-id {shlex.quote(scope.requester_id)}",
-            f"--homeserver {shlex.quote(runtime_matrix_homeserver(scope.runtime_paths))}",
-        ),
+    homeserver = scope.runtime_paths.env_value("MINDROOM_DESKTOP_MATRIX_HOMESERVER") or runtime_matrix_homeserver(
+        scope.runtime_paths,
     )
+    login_parts = [
+        "mindroom desktop login",
+        f"--user-id {shlex.quote(scope.requester_id)}",
+        f"--homeserver {shlex.quote(homeserver)}",
+    ]
+    if scope.runtime_paths.env_flag("MINDROOM_DESKTOP_CLOUDFLARE_ACCESS"):
+        login_parts.append("--cloudflare-access")
+    login_command = " ".join(login_parts)
     pairing_command = " ".join(
         (
             "mindroom desktop pair",

--- a/src/mindroom/commands/desktop_commands.py
+++ b/src/mindroom/commands/desktop_commands.py
@@ -73,23 +73,25 @@ def _setup_response(scope: DesktopCommandScope) -> str:
     homeserver = scope.runtime_paths.env_value("MINDROOM_DESKTOP_MATRIX_HOMESERVER") or runtime_matrix_homeserver(
         scope.runtime_paths,
     )
+    cloudflare_access = scope.runtime_paths.env_flag("MINDROOM_DESKTOP_CLOUDFLARE_ACCESS")
     login_parts = [
         "mindroom desktop login",
         f"--user-id {shlex.quote(scope.requester_id)}",
         f"--homeserver {shlex.quote(homeserver)}",
     ]
-    if scope.runtime_paths.env_flag("MINDROOM_DESKTOP_CLOUDFLARE_ACCESS"):
+    if cloudflare_access:
         login_parts.append("--cloudflare-access")
     login_command = " ".join(login_parts)
-    pairing_command = " ".join(
-        (
-            "mindroom desktop pair",
-            f"--code {shlex.quote(pairing.token)}",
-            f"--controller-user-id {shlex.quote(controller.user_id)}",
-            f"--controller-device-id {shlex.quote(controller.device_id)}",
-            f"--controller-ed25519 {shlex.quote(controller.ed25519)}",
-        ),
-    )
+    pairing_parts = [
+        "mindroom desktop pair",
+        f"--code {shlex.quote(pairing.token)}",
+        f"--controller-user-id {shlex.quote(controller.user_id)}",
+        f"--controller-device-id {shlex.quote(controller.device_id)}",
+        f"--controller-ed25519 {shlex.quote(controller.ed25519)}",
+    ]
+    if cloudflare_access:
+        pairing_parts.append("--cloudflare-access")
+    pairing_command = " ".join(pairing_parts)
     return (
         "🔐 **Desktop pairing started**\n\n"
         "On your computer, log in once if you have not already:\n\n"

--- a/src/mindroom/desktop/cloudflare_access.py
+++ b/src/mindroom/desktop/cloudflare_access.py
@@ -116,9 +116,8 @@ class CloudflareAccessTokenProvider:
     def _login(self) -> None:
         completed = subprocess.run(
             [self.executable, "access", "login", self.app_url],
-            capture_output=True,
             check=False,
-            text=True,
+            stdout=subprocess.DEVNULL,
         )
         if completed.returncode != 0:
             msg = f"cloudflared access login failed with exit {completed.returncode}."

--- a/src/mindroom/desktop/cloudflare_access.py
+++ b/src/mindroom/desktop/cloudflare_access.py
@@ -116,7 +116,9 @@ class CloudflareAccessTokenProvider:
     def _login(self) -> None:
         completed = subprocess.run(
             [self.executable, "access", "login", self.app_url],
+            capture_output=True,
             check=False,
+            text=True,
         )
         if completed.returncode != 0:
             msg = f"cloudflared access login failed with exit {completed.returncode}."

--- a/src/mindroom/desktop/cloudflare_access.py
+++ b/src/mindroom/desktop/cloudflare_access.py
@@ -115,9 +115,8 @@ class CloudflareAccessTokenProvider:
 
     def _login(self) -> None:
         completed = subprocess.run(
-            [self.executable, "access", "login", self.app_url],
+            [self.executable, "access", "login", "--quiet", self.app_url],
             check=False,
-            stdout=subprocess.DEVNULL,
         )
         if completed.returncode != 0:
             msg = f"cloudflared access login failed with exit {completed.returncode}."

--- a/tests/test_desktop_cloudflare_access.py
+++ b/tests/test_desktop_cloudflare_access.py
@@ -61,9 +61,11 @@ async def test_request_headers_cache_current_token_and_reauthenticate_after_expi
         ],
     )
     calls: list[list[str]] = []
+    run_options: list[dict[str, object]] = []
 
-    def run(args: list[str], **_kwargs: object) -> object:
+    def run(args: list[str], **kwargs: object) -> object:
         calls.append(args)
+        run_options.append(kwargs)
         return next(results)
 
     monkeypatch.setattr("mindroom.desktop.cloudflare_access.subprocess.run", run)
@@ -87,6 +89,8 @@ async def test_request_headers_cache_current_token_and_reauthenticate_after_expi
         ["/usr/bin/cloudflared", "access", "login", "https://matrix.example.org"],
         ["/usr/bin/cloudflared", "access", "token", "-app=https://matrix.example.org"],
     ]
+    assert run_options[2]["capture_output"] is True
+    assert run_options[2]["text"] is True
 
 
 def test_cloudflare_access_requires_cloudflared(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_desktop_cloudflare_access.py
+++ b/tests/test_desktop_cloudflare_access.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import base64
 import json
-import subprocess
 import threading
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -62,11 +61,9 @@ async def test_request_headers_cache_current_token_and_reauthenticate_after_expi
         ],
     )
     calls: list[list[str]] = []
-    run_options: list[dict[str, object]] = []
 
-    def run(args: list[str], **kwargs: object) -> object:
+    def run(args: list[str], **_kwargs: object) -> object:
         calls.append(args)
-        run_options.append(kwargs)
         return next(results)
 
     monkeypatch.setattr("mindroom.desktop.cloudflare_access.subprocess.run", run)
@@ -87,11 +84,9 @@ async def test_request_headers_cache_current_token_and_reauthenticate_after_expi
     assert calls == [
         ["/usr/bin/cloudflared", "access", "token", "-app=https://matrix.example.org"],
         ["/usr/bin/cloudflared", "access", "token", "-app=https://matrix.example.org"],
-        ["/usr/bin/cloudflared", "access", "login", "https://matrix.example.org"],
+        ["/usr/bin/cloudflared", "access", "login", "--quiet", "https://matrix.example.org"],
         ["/usr/bin/cloudflared", "access", "token", "-app=https://matrix.example.org"],
     ]
-    assert run_options[2]["stdout"] is subprocess.DEVNULL
-    assert "stderr" not in run_options[2]
 
 
 def test_cloudflare_access_requires_cloudflared(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_desktop_cloudflare_access.py
+++ b/tests/test_desktop_cloudflare_access.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import json
+import subprocess
 import threading
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -89,8 +90,8 @@ async def test_request_headers_cache_current_token_and_reauthenticate_after_expi
         ["/usr/bin/cloudflared", "access", "login", "https://matrix.example.org"],
         ["/usr/bin/cloudflared", "access", "token", "-app=https://matrix.example.org"],
     ]
-    assert run_options[2]["capture_output"] is True
-    assert run_options[2]["text"] is True
+    assert run_options[2]["stdout"] is subprocess.DEVNULL
+    assert "stderr" not in run_options[2]
 
 
 def test_cloudflare_access_requires_cloudflared(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_desktop_pairing.py
+++ b/tests/test_desktop_pairing.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 import sqlite3
+from dataclasses import replace
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, Mock
@@ -372,6 +373,22 @@ def test_chat_confirmation_saves_only_the_initiating_requester_agent_scope(
 
     setup_response = handle_desktop_command("setup", scope=alice_scope)
     assert "mindroom desktop login --user-id @alice:example.org --homeserver http://localhost:8008" in setup_response
+    public_runtime_paths = replace(
+        runtime_paths,
+        process_env={
+            **runtime_paths.process_env,
+            "MINDROOM_DESKTOP_MATRIX_HOMESERVER": "https://matrix.example.org",
+            "MINDROOM_DESKTOP_CLOUDFLARE_ACCESS": "true",
+        },
+    )
+    public_setup_response = handle_desktop_command(
+        "setup",
+        scope=replace(alice_scope, runtime_paths=public_runtime_paths),
+    )
+    assert (
+        "mindroom desktop login --user-id @alice:example.org "
+        "--homeserver https://matrix.example.org --cloudflare-access"
+    ) in public_setup_response
     token_match = re.search(r"--code ([A-Za-z0-9_-]+)", setup_response)
     assert token_match is not None
     token = token_match.group(1)

--- a/tests/test_desktop_pairing.py
+++ b/tests/test_desktop_pairing.py
@@ -319,6 +319,65 @@ def test_pairing_receiver_registration_owns_desktop_enablement_check(tmp_path: P
     assert event_type is AuthenticatedToDeviceEvent
 
 
+def test_setup_command_uses_public_homeserver_and_access_flag(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hosted runtimes can print a reachable Desktop login command."""
+    runtime_paths = test_runtime_paths(tmp_path)
+    config = Config.validate_with_runtime(
+        {
+            "defaults": {"tools": []},
+            "agents": {
+                "computer": {
+                    "display_name": "Computer",
+                    "role": "Operate local apps",
+                    "tools": ["desktop"],
+                },
+            },
+        },
+        runtime_paths,
+    )
+    monkeypatch.setattr(
+        "mindroom.commands.desktop_commands.controller_identity_for_entity",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            user_id="@computer:example.org",
+            device_id="CLOUD",
+            ed25519="cloud-fingerprint",
+        ),
+    )
+    scope = DesktopCommandScope(
+        config=config,
+        runtime_paths=runtime_paths,
+        agent_name="computer",
+        requester_id="@alice:example.org",
+    )
+
+    setup_response = handle_desktop_command("setup", scope=scope)
+    login_command = next(line for line in setup_response.splitlines() if line.startswith("mindroom desktop login"))
+    assert login_command == ("mindroom desktop login --user-id @alice:example.org --homeserver http://localhost:8008")
+
+    public_runtime_paths = replace(
+        runtime_paths,
+        process_env={
+            **runtime_paths.process_env,
+            "MINDROOM_DESKTOP_MATRIX_HOMESERVER": "https://matrix.example.org",
+            "MINDROOM_DESKTOP_CLOUDFLARE_ACCESS": "true",
+        },
+    )
+    public_setup_response = handle_desktop_command(
+        "setup",
+        scope=replace(scope, runtime_paths=public_runtime_paths),
+    )
+    public_login_command = next(
+        line for line in public_setup_response.splitlines() if line.startswith("mindroom desktop login")
+    )
+    assert public_login_command == (
+        "mindroom desktop login --user-id @alice:example.org "
+        "--homeserver https://matrix.example.org --cloudflare-access"
+    )
+
+
 def test_chat_confirmation_saves_only_the_initiating_requester_agent_scope(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -373,22 +432,6 @@ def test_chat_confirmation_saves_only_the_initiating_requester_agent_scope(
 
     setup_response = handle_desktop_command("setup", scope=alice_scope)
     assert "mindroom desktop login --user-id @alice:example.org --homeserver http://localhost:8008" in setup_response
-    public_runtime_paths = replace(
-        runtime_paths,
-        process_env={
-            **runtime_paths.process_env,
-            "MINDROOM_DESKTOP_MATRIX_HOMESERVER": "https://matrix.example.org",
-            "MINDROOM_DESKTOP_CLOUDFLARE_ACCESS": "true",
-        },
-    )
-    public_setup_response = handle_desktop_command(
-        "setup",
-        scope=replace(alice_scope, runtime_paths=public_runtime_paths),
-    )
-    assert (
-        "mindroom desktop login --user-id @alice:example.org "
-        "--homeserver https://matrix.example.org --cloudflare-access"
-    ) in public_setup_response
     token_match = re.search(r"--code ([A-Za-z0-9_-]+)", setup_response)
     assert token_match is not None
     token = token_match.group(1)

--- a/tests/test_desktop_pairing.py
+++ b/tests/test_desktop_pairing.py
@@ -355,7 +355,9 @@ def test_setup_command_uses_public_homeserver_and_access_flag(
 
     setup_response = handle_desktop_command("setup", scope=scope)
     login_command = next(line for line in setup_response.splitlines() if line.startswith("mindroom desktop login"))
+    pairing_command = next(line for line in setup_response.splitlines() if line.startswith("mindroom desktop pair"))
     assert login_command == ("mindroom desktop login --user-id @alice:example.org --homeserver http://localhost:8008")
+    assert "--cloudflare-access" not in pairing_command
 
     public_runtime_paths = replace(
         runtime_paths,
@@ -372,10 +374,14 @@ def test_setup_command_uses_public_homeserver_and_access_flag(
     public_login_command = next(
         line for line in public_setup_response.splitlines() if line.startswith("mindroom desktop login")
     )
+    public_pairing_command = next(
+        line for line in public_setup_response.splitlines() if line.startswith("mindroom desktop pair")
+    )
     assert public_login_command == (
         "mindroom desktop login --user-id @alice:example.org "
         "--homeserver https://matrix.example.org --cloudflare-access"
     )
+    assert public_pairing_command.endswith("--cloudflare-access")
 
 
 def test_chat_confirmation_saves_only_the_initiating_requester_agent_scope(

--- a/tests/test_helm_instance_worker_isolation.py
+++ b/tests/test_helm_instance_worker_isolation.py
@@ -468,6 +468,20 @@ def test_instance_chart_uses_tenant_worker_auth_secret() -> None:
     assert "data" not in worker_auth_secret
 
 
+def test_instance_chart_exposes_public_matrix_url_to_desktop_pairing() -> None:
+    """Hosted pairing commands should use the tenant's reachable Matrix ingress."""
+    docs = _render_chart(
+        Path("cluster/k8s/instance"),
+        "customer=alice",
+        "baseDomain=staging.mindroom.chat",
+    )
+    deployment = _resource(docs, "Deployment", "mindroom-alice")
+    env = _env_by_name(_container(deployment, "mindroom"))
+
+    assert env["MATRIX_HOMESERVER"]["value"] == "http://synapse-alice:8008"
+    assert env["MINDROOM_DESKTOP_MATRIX_HOMESERVER"]["value"] == "https://alice.matrix.staging.mindroom.chat"
+
+
 def test_instance_chart_static_runner_uses_shared_credentials_encryption_key_secret() -> None:
     """Static runner mode should give both runtime containers the same Secret-backed credential key."""
     credentials_encryption_key = "test-encryption-key"

--- a/tests/test_local_instance_deploy.py
+++ b/tests/test_local_instance_deploy.py
@@ -287,6 +287,20 @@ def test_matrix_compose_files_publish_localhost_ports() -> None:
     assert synapse_compose["services"]["synapse"]["ports"] == ["${MATRIX_PORT:-8448}:8008"]
 
 
+def test_matrix_compose_files_expose_public_url_to_desktop_pairing() -> None:
+    """Local hosted pairing commands should use the Matrix ingress URL."""
+    tuwunel_compose = yaml.safe_load(Path("local/instances/deploy/docker-compose.tuwunel.yml").read_text())
+    synapse_compose = yaml.safe_load(Path("local/instances/deploy/docker-compose.synapse.yml").read_text())
+
+    assert tuwunel_compose["services"]["mindroom"]["environment"]["MINDROOM_DESKTOP_MATRIX_HOMESERVER"] == (
+        "https://m-${INSTANCE_DOMAIN}"
+    )
+    assert (
+        "MINDROOM_DESKTOP_MATRIX_HOMESERVER=https://m-${INSTANCE_DOMAIN}"
+        in (synapse_compose["services"]["mindroom"]["environment"])
+    )
+
+
 def test_copy_config_to_instance_uses_repo_root_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Instance config seeding should read the repo-root config file."""
     instance = _instance("alpha", matrix_type=None, data_root=tmp_path)


### PR DESCRIPTION
## Why

`!desktop setup` currently prints the runtime `MATRIX_HOMESERVER` in the local login command. Clustered installations often use an internal address for server-side Matrix traffic, which is unreachable from a user computer. Proxy-protected public homeservers may also require the Desktop CLI interactive Access mode.

The fallback `cloudflared access login` command prints the fetched Access token unless quiet mode is requested, exposing a bearer credential in captured terminal output.

## What

- Add `MINDROOM_DESKTOP_MATRIX_HOMESERVER` as an optional public URL used only in generated Desktop commands.
- Wire the public Matrix URL automatically in hosted Helm and local Docker deployments.
- Add `MINDROOM_DESKTOP_CLOUDFLARE_ACCESS` to append `--cloudflare-access` to generated login and pairing commands.
- Keep server-side Matrix traffic on `MATRIX_HOMESERVER`.
- Use native `cloudflared access login --quiet` so the JWT stays hidden while interactive guidance remains visible.
- Document both settings and cover command generation and rendered deployments with tests.

## Validation

- `uv run pytest -q`
- `uv run pre-commit run --all-files`
- Rendered the hosted Helm chart and both local Matrix Compose variants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Desktop setup commands can now use a publicly reachable Matrix homeserver when the runtime uses an internal address.
  * Login and pairing commands can automatically include Cloudflare Access support when enabled.

* **Bug Fixes**
  * Improved Cloudflare Access login behavior by running authentication quietly.

* **Documentation**
  * Added configuration guidance for public Matrix URLs and Cloudflare Access settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->