### PR TITLE
fix(scheduler): accept restricted-cadence conditional crons and fix help examples

### DIFF
--- a/docs/chat-commands.md
+++ b/docs/chat-commands.md
@@ -101,9 +101,11 @@ Conditional requests are converted to recurring cron-based polling schedules.
 
 These are periodic checks, not real event subscriptions.
 
+For predictable behavior, include an explicit polling cadence.
+
 ```
-!schedule If I get an email about "urgent", @phone_agent call me
-!schedule When Bitcoin drops below $40k, @crypto_agent notify me
+!schedule Every 5 minutes, check if I got an email about "urgent"; if so, @phone_agent call me
+!schedule Every 10 minutes, check whether Bitcoin dropped below $40k; if so, @crypto_agent notify me
 ```
 
 Include `@agent_name` or `@team_name` in your schedule to target specific responders.

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -36,13 +36,15 @@ The `schedule()` tool accepts `new_thread=True` to start a fresh thread per fire
 
 Conditional or event-like requests are converted to recurring cron-based polling schedules.
 
-The AI picks an appropriate polling frequency based on urgency, and the condition is embedded in the task message so the scheduled responder checks it on each poll cycle.
+For predictable behavior, include an explicit polling cadence.
+
+The condition is embedded in the task message so the scheduled responder checks it on each poll cycle.
 
 These are **not** real event subscriptions — they are periodic checks.
 
 ```
-!schedule If I get an email about "urgent", @phone_agent call me
-!schedule When Bitcoin drops below $40k, @crypto_agent notify me
+!schedule Every 5 minutes, check if I got an email about "urgent"; if so, @phone_agent call me
+!schedule Every 10 minutes, check whether Bitcoin dropped below $40k; if so, @crypto_agent notify me
 ```
 
 ### Edit a Schedule

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -14413,9 +14413,11 @@ Conditional requests are converted to recurring cron-based polling schedules.
 
 These are periodic checks, not real event subscriptions.
 
+For predictable behavior, include an explicit polling cadence.
+
 ```
-!schedule If I get an email about "urgent", @phone_agent call me
-!schedule When Bitcoin drops below $40k, @crypto_agent notify me
+!schedule Every 5 minutes, check if I got an email about "urgent"; if so, @phone_agent call me
+!schedule Every 10 minutes, check whether Bitcoin dropped below $40k; if so, @crypto_agent notify me
 ```
 
 Include `@agent_name` or `@team_name` in your schedule to target specific responders.
@@ -14958,13 +14960,15 @@ The `schedule()` tool accepts `new_thread=True` to start a fresh thread per fire
 
 Conditional or event-like requests are converted to recurring cron-based polling schedules.
 
-The AI picks an appropriate polling frequency based on urgency, and the condition is embedded in the task message so the scheduled responder checks it on each poll cycle.
+For predictable behavior, include an explicit polling cadence.
+
+The condition is embedded in the task message so the scheduled responder checks it on each poll cycle.
 
 These are **not** real event subscriptions — they are periodic checks.
 
 ```
-!schedule If I get an email about "urgent", @phone_agent call me
-!schedule When Bitcoin drops below $40k, @crypto_agent notify me
+!schedule Every 5 minutes, check if I got an email about "urgent"; if so, @phone_agent call me
+!schedule Every 10 minutes, check whether Bitcoin dropped below $40k; if so, @crypto_agent notify me
 ```
 
 ### Edit a Schedule

--- a/skills/mindroom-docs/references/page__chat-commands__index.md
+++ b/skills/mindroom-docs/references/page__chat-commands__index.md
@@ -97,9 +97,11 @@ Conditional requests are converted to recurring cron-based polling schedules.
 
 These are periodic checks, not real event subscriptions.
 
+For predictable behavior, include an explicit polling cadence.
+
 ```
-!schedule If I get an email about "urgent", @phone_agent call me
-!schedule When Bitcoin drops below $40k, @crypto_agent notify me
+!schedule Every 5 minutes, check if I got an email about "urgent"; if so, @phone_agent call me
+!schedule Every 10 minutes, check whether Bitcoin dropped below $40k; if so, @crypto_agent notify me
 ```
 
 Include `@agent_name` or `@team_name` in your schedule to target specific responders.

--- a/skills/mindroom-docs/references/page__scheduling__index.md
+++ b/skills/mindroom-docs/references/page__scheduling__index.md
@@ -32,13 +32,15 @@ The `schedule()` tool accepts `new_thread=True` to start a fresh thread per fire
 
 Conditional or event-like requests are converted to recurring cron-based polling schedules.
 
-The AI picks an appropriate polling frequency based on urgency, and the condition is embedded in the task message so the scheduled responder checks it on each poll cycle.
+For predictable behavior, include an explicit polling cadence.
+
+The condition is embedded in the task message so the scheduled responder checks it on each poll cycle.
 
 These are **not** real event subscriptions — they are periodic checks.
 
 ```
-!schedule If I get an email about "urgent", @phone_agent call me
-!schedule When Bitcoin drops below $40k, @crypto_agent notify me
+!schedule Every 5 minutes, check if I got an email about "urgent"; if so, @phone_agent call me
+!schedule Every 10 minutes, check whether Bitcoin dropped below $40k; if so, @crypto_agent notify me
 ```
 
 ### Edit a Schedule

--- a/src/mindroom/commands/parsing.py
+++ b/src/mindroom/commands/parsing.py
@@ -298,7 +298,7 @@ Usage: `!schedule <time> <message>` - Schedule tasks, reminders, or agent/team w
 
 How it works:
 - **Time-based**: Executes at specific times or intervals
-- **Event-based**: Automatically converts to smart polling (e.g., "if email" → check every 1-2 min)
+- **Event-based**: Requires an explicit recurring polling cadence (e.g., "every 5 minutes")
 - **History limits**: Scheduled responders normally see full configured history; "with no history" uses none, and "last N messages" caps each run
 - Agents and teams receive clear instructions about conditions to check
 - Multiple agents collaborate when mentioned together; mention a team directly for its team workflow

--- a/src/mindroom/commands/parsing.py
+++ b/src/mindroom/commands/parsing.py
@@ -275,12 +275,12 @@ Usage: `!schedule <time> <message>` - Schedule tasks, reminders, or agent/team w
 - `ping me tomorrow about the meeting`
 - `remind me in 2 hours to review PRs`
 
-**Event-Driven Workflows (New!):**
-- `!schedule If I get an email about "urgent", @phone_agent call me`
-- `!schedule When Bitcoin drops below $40k, @crypto_agent notify me`
-- `!schedule If server CPU > 80%, @ops_agent scale up`
-- `!schedule When someone mentions our product on Reddit, @analyst summarize it`
-- `!schedule Whenever I get email from boss, @notification_agent alert me immediately`
+**Event-Driven Workflows (New!):** _(include a polling cadence — they check on a schedule)_
+- `!schedule Every 5 minutes, check if I got an email about "urgent"; if so, @phone_agent call me`
+- `!schedule Every 10 minutes, check whether Bitcoin dropped below $40k; if so, @crypto_agent notify me`
+- `!schedule Every minute, check if server CPU > 80%; if so, @ops_agent scale up`
+- `!schedule Every 15 minutes, check for mentions of our product on Reddit; if any, @analyst summarize them`
+- `!schedule Every 5 minutes, check for new email from my boss; if any, @notification_agent alert me immediately`
 
 **Agent and Team Workflows:**
 - `!schedule Daily at 9am, @finance give me a market analysis`

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -363,31 +363,6 @@ def _cancelled_task_content(
     return cancelled_content
 
 
-def _is_polling_cron_schedule(cron_schedule: CronSchedule) -> bool:
-    """Return whether a cron schedule recurs often enough to poll a condition.
-
-    A conditional workflow only needs a schedule that fires more than once, so any
-    valid cron qualifies except a single fixed instant (all of minute, hour, day,
-    month and weekday pinned to one concrete value). Restricting to weekdays or a
-    daily/business-hours window (e.g. ``0 9 * * 1-5`` or ``*/15 9-17 * * *``) is a
-    perfectly good polling cadence.
-    """
-
-    def is_single_value(field: str) -> bool:
-        return field.strip().isdigit()
-
-    return not all(
-        is_single_value(field)
-        for field in (
-            cron_schedule.minute,
-            cron_schedule.hour,
-            cron_schedule.day,
-            cron_schedule.month,
-            cron_schedule.weekday,
-        )
-    )
-
-
 def _validate_parsed_workflow(workflow: ScheduledWorkflow) -> _WorkflowParseError | None:
     """Reject parses whose schedule fields do not support the declared schedule type."""
     if workflow.schedule_type == "once" and not workflow.execute_at:
@@ -413,7 +388,7 @@ def _validate_parsed_workflow(workflow: ScheduledWorkflow) -> _WorkflowParseErro
 def _validate_conditional_workflow(
     workflow: ScheduledWorkflow,
 ) -> _WorkflowParseError | None:
-    """Reject conditional parses that do not resolve to a polling-style recurring schedule."""
+    """Reject conditional parses that do not resolve to a recurring cron schedule."""
     if not workflow.is_conditional:
         return None
 
@@ -423,14 +398,7 @@ def _validate_conditional_workflow(
             suggestion="Try again, or specify the polling cadence explicitly.",
         )
 
-    cron_string = workflow.cron_schedule.to_cron_string()
-    if _is_polling_cron_schedule(workflow.cron_schedule):
-        return None
-
-    return _WorkflowParseError(
-        error=f"Conditional schedules must use a polling cron, but the parsed schedule was `{cron_string}`.",
-        suggestion="Try again, or specify the polling cadence explicitly.",
-    )
+    return None
 
 
 def _start_scheduled_task(

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -364,17 +364,28 @@ def _cancelled_task_content(
 
 
 def _is_polling_cron_schedule(cron_schedule: CronSchedule) -> bool:
-    """Return whether a cron schedule looks like an interval-based polling cadence."""
-    if cron_schedule.day != "*" or cron_schedule.month != "*" or cron_schedule.weekday != "*":
-        return False
+    """Return whether a cron schedule recurs often enough to poll a condition.
 
-    minute = cron_schedule.minute.strip()
-    hour = cron_schedule.hour.strip()
+    A conditional workflow only needs a schedule that fires more than once, so any
+    valid cron qualifies except a single fixed instant (all of minute, hour, day,
+    month and weekday pinned to one concrete value). Restricting to weekdays or a
+    daily/business-hours window (e.g. ``0 9 * * 1-5`` or ``*/15 9-17 * * *``) is a
+    perfectly good polling cadence.
+    """
 
-    def is_interval(field: str) -> bool:
-        return field == "*" or field.startswith("*/")
+    def is_single_value(field: str) -> bool:
+        return field.strip().isdigit()
 
-    return (is_interval(minute) and is_interval(hour)) or (minute.isdigit() and is_interval(hour))
+    return not all(
+        is_single_value(field)
+        for field in (
+            cron_schedule.minute,
+            cron_schedule.hour,
+            cron_schedule.day,
+            cron_schedule.month,
+            cron_schedule.weekday,
+        )
+    )
 
 
 def _validate_parsed_workflow(workflow: ScheduledWorkflow) -> _WorkflowParseError | None:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -275,6 +275,8 @@ def test_get_command_help() -> None:
     assert "Simple Reminders:" in schedule_help
     assert "Agent and Team Workflows:" in schedule_help
     assert "in 5 minutes" in schedule_help
+    assert "Requires an explicit recurring polling cadence" in schedule_help
+    assert "Automatically converts to smart polling" not in schedule_help
 
     list_schedules_help = get_command_help("list_schedules")
     assert "List Schedules Command" in list_schedules_help

--- a/tests/test_workflow_scheduling.py
+++ b/tests/test_workflow_scheduling.py
@@ -562,13 +562,13 @@ class TestParseWorkflowSchedule:
         mock_get_model: Mock,  # noqa: ARG002
         mock_config: MagicMock,
     ) -> None:
-        """Conditional schedules should fail instead of accepting a non-polling cron."""
+        """Conditional schedules should fail instead of accepting a single-instant cron."""
         mock_agent = AsyncMock()
         mock_response = MagicMock()
         mock_response.content = ScheduledWorkflow(
             schedule_type="cron",
             is_conditional=True,
-            cron_schedule=CronSchedule(minute="0", hour="9"),
+            cron_schedule=CronSchedule(minute="0", hour="9", day="5", month="6", weekday="1"),
             message="@general Check for messages containing urgent. If found, notify the team.",
             description="Monitor urgent mentions",
         )
@@ -584,7 +584,7 @@ class TestParseWorkflowSchedule:
 
         assert isinstance(result, _WorkflowParseError)
         assert "polling cron" in result.error
-        assert "0 9 * * *" in result.error
+        assert "0 9 5 6 1" in result.error
 
 
 @pytest.mark.asyncio
@@ -1214,12 +1214,17 @@ class TestValidateConditionalWorkflow:
             description="test",
         )
 
-    def test_conditional_with_non_polling_cron_returns_error(self) -> None:
-        """Reject conditional schedules that do not resolve to polling cron."""
-        result = _validate_conditional_workflow(self._workflow(""))
+    def test_conditional_with_single_instant_cron_returns_error(self) -> None:
+        """Reject conditional schedules pinned to a single fixed instant."""
+        result = _validate_conditional_workflow(
+            self._workflow(
+                "",
+                cron_schedule=CronSchedule(minute="0", hour="9", day="5", month="6", weekday="1"),
+            ),
+        )
         assert isinstance(result, _WorkflowParseError)
         assert "polling cron" in result.error
-        assert "0 9 * * *" in result.error
+        assert "0 9 5 6 1" in result.error
 
     def test_conditional_with_polling_cron_passes(self) -> None:
         """Allow conditional schedules that resolve to interval polling."""
@@ -1228,6 +1233,21 @@ class TestValidateConditionalWorkflow:
                 "@ops Check CPU usage. If above 80%, scale up.",
                 cron_schedule=CronSchedule(minute="*/5", hour="*", day="*", month="*", weekday="*"),
             ),
+        )
+        assert result is None
+
+    @pytest.mark.parametrize(
+        "cron_schedule",
+        [
+            CronSchedule(minute="0", hour="9", day="*", month="*", weekday="*"),  # daily 9am
+            CronSchedule(minute="0", hour="9", day="*", month="*", weekday="1-5"),  # weekdays 9am
+            CronSchedule(minute="*/15", hour="9-17", day="*", month="*", weekday="*"),  # business hrs
+        ],
+    )
+    def test_conditional_with_recurring_cron_passes(self, cron_schedule: CronSchedule) -> None:
+        """Allow conditional schedules whose cadence restricts days/hours but still recurs."""
+        result = _validate_conditional_workflow(
+            self._workflow("@ops check something; if true, alert me", cron_schedule=cron_schedule),
         )
         assert result is None
 

--- a/tests/test_workflow_scheduling.py
+++ b/tests/test_workflow_scheduling.py
@@ -556,13 +556,13 @@ class TestParseWorkflowSchedule:
 
     @patch("mindroom.model_loading.get_model_instance")
     @patch("mindroom.scheduling.Agent")
-    async def test_parse_conditional_schedule_rejects_non_polling_cron(
+    async def test_parse_conditional_schedule_accepts_numeric_cron(
         self,
         mock_agent_class: Mock,
         mock_get_model: Mock,  # noqa: ARG002
         mock_config: MagicMock,
     ) -> None:
-        """Conditional schedules should fail instead of accepting a single-instant cron."""
+        """Conditional schedules should accept numeric five-field crons because they recur."""
         mock_agent = AsyncMock()
         mock_response = MagicMock()
         mock_response.content = ScheduledWorkflow(
@@ -582,9 +582,9 @@ class TestParseWorkflowSchedule:
             available_responders=[_mid("general")],
         )
 
-        assert isinstance(result, _WorkflowParseError)
-        assert "polling cron" in result.error
-        assert "0 9 5 6 1" in result.error
+        assert isinstance(result, ScheduledWorkflow)
+        assert result.cron_schedule is not None
+        assert result.cron_schedule.to_cron_string() == "0 9 5 6 1"
 
 
 @pytest.mark.asyncio
@@ -1214,38 +1214,18 @@ class TestValidateConditionalWorkflow:
             description="test",
         )
 
-    def test_conditional_with_single_instant_cron_returns_error(self) -> None:
-        """Reject conditional schedules pinned to a single fixed instant."""
-        result = _validate_conditional_workflow(
-            self._workflow(
-                "",
-                cron_schedule=CronSchedule(minute="0", hour="9", day="5", month="6", weekday="1"),
-            ),
-        )
-        assert isinstance(result, _WorkflowParseError)
-        assert "polling cron" in result.error
-        assert "0 9 5 6 1" in result.error
-
-    def test_conditional_with_polling_cron_passes(self) -> None:
-        """Allow conditional schedules that resolve to interval polling."""
-        result = _validate_conditional_workflow(
-            self._workflow(
-                "@ops Check CPU usage. If above 80%, scale up.",
-                cron_schedule=CronSchedule(minute="*/5", hour="*", day="*", month="*", weekday="*"),
-            ),
-        )
-        assert result is None
-
     @pytest.mark.parametrize(
         "cron_schedule",
         [
+            CronSchedule(minute="*/5", hour="*", day="*", month="*", weekday="*"),  # interval
             CronSchedule(minute="0", hour="9", day="*", month="*", weekday="*"),  # daily 9am
             CronSchedule(minute="0", hour="9", day="*", month="*", weekday="1-5"),  # weekdays 9am
             CronSchedule(minute="*/15", hour="9-17", day="*", month="*", weekday="*"),  # business hrs
+            CronSchedule(minute="0", hour="9", day="5", month="6", weekday="1"),  # numeric fields
         ],
     )
     def test_conditional_with_recurring_cron_passes(self, cron_schedule: CronSchedule) -> None:
-        """Allow conditional schedules whose cadence restricts days/hours but still recurs."""
+        """Allow every valid five-field cron because none can encode a single year."""
         result = _validate_conditional_workflow(
             self._workflow("@ops check something; if true, alert me", cron_schedule=cron_schedule),
         )


### PR DESCRIPTION
Small follow-up to ISSUE-221 (#1608). This fixes conditional cron cadence classification and aligns runtime help with public docs.

## 1. Accept all valid five-field conditional crons

`_is_polling_cron_schedule` previously required unrestricted day, month, and weekday fields, so valid recurring polling cadences such as these were rejected:

- `0 9 * * 1-5` — weekday mornings
- `*/15 9-17 * * *` — every 15 minutes during business hours
- `0 9 * * *` — daily at 9am

The first attempted widening still rejected all-numeric expressions as a supposed single fixed instant. Five-field cron has no year field, so every valid expression recurs. Conditional validation now requires a cron schedule and relies on the existing cron validation path to reject expressions that cannot produce a real date.

## 2. Fix `!schedule` help and docs examples

Event-driven examples now include explicit polling cadences so their behavior is predictable rather than depending on the parser to choose a cadence. The same examples are synchronized across runtime help, public docs, and bundled MindRoom docs references.

## Tests

- Added coverage for interval, daily, weekday, business-hours, and all-numeric recurring crons.
- Replaced tests that encoded the false single-instant assumption.
- `tests/test_workflow_scheduling.py`: 43 passed.
- Full `pytest` passed.
- Full pre-commit suite passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conditional schedules now support recurring cron expressions, including numeric five-field formats.

* **Documentation**
  * Updated scheduling guidance to require an explicit polling cadence for predictable conditional workflows.
  * Clarified that conditional schedules use recurring checks rather than real-time event subscriptions.
  * Refreshed help text and examples with concrete intervals such as every 5 or 10 minutes.

* **Bug Fixes**
  * Broadened validation to accept valid recurring cron schedules without incorrectly rejecting non-interval patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->