### PR TITLE
Make macOS Desktop bridge setup self-contained

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -436,6 +436,7 @@ zoom = [
   "requests",
 ]
 desktop = [
+  "pillow>=10.2",
   "pyautogui>=0.9.54",
   "pyobjc-framework-applicationservices>=12.2.1; sys_platform=='darwin'",
   "pyobjc-framework-cocoa>=12.2.1; sys_platform=='darwin'",

--- a/src/mindroom/cli/desktop.py
+++ b/src/mindroom/cli/desktop.py
@@ -70,6 +70,26 @@ def _ensure_desktop_dependencies(runtime_paths: RuntimePaths) -> None:
         raise DesktopProviderError(str(exc)) from exc
 
 
+def _request_required_desktop_permissions() -> None:
+    """Request required local permissions before connecting the Desktop bridge."""
+    from mindroom.desktop.provider import (  # noqa: PLC0415
+        DesktopProviderError,
+        request_macos_desktop_permissions,
+    )
+
+    missing_permissions = request_macos_desktop_permissions()
+    if not missing_permissions:
+        return
+    permission_names = " and ".join(missing_permissions)
+    permission_label = "permission" if len(missing_permissions) == 1 else "permissions"
+    msg = (
+        f"macOS requested {permission_names} {permission_label}. Grant the requested access to the terminal app "
+        "running this command in System Settings > Privacy & Security, fully quit and reopen that app, then run "
+        "`mindroom desktop run` again."
+    )
+    raise DesktopProviderError(msg)
+
+
 @desktop_app.command("login")
 def desktop_login(
     user_id: str | None = typer.Option(
@@ -619,6 +639,7 @@ async def _run_bridge(
     from mindroom.matrix.olm_to_device import PinnedMatrixDevice, resolve_pinned_device  # noqa: PLC0415
     from mindroom.matrix.to_device import AuthenticatedToDeviceEvent  # noqa: PLC0415
 
+    _request_required_desktop_permissions()
     controller = PinnedMatrixDevice(
         user_id=controller_user_id,
         device_id=controller_device_id,

--- a/src/mindroom/desktop/provider.py
+++ b/src/mindroom/desktop/provider.py
@@ -33,6 +33,34 @@ class DesktopEmergencyStopError(DesktopProviderError):
     """The local pointer fail-safe revoked input for this bridge process."""
 
 
+def request_macos_desktop_permissions() -> tuple[str, ...]:
+    """Request the macOS permissions needed by the Desktop bridge."""
+    if sys.platform != "darwin":
+        return ()
+
+    import ApplicationServices  # noqa: PLC0415
+    import Quartz  # noqa: PLC0415
+
+    accessibility_allowed = bool(ApplicationServices.AXIsProcessTrusted())  # ty: ignore[unresolved-attribute]
+    if not accessibility_allowed:
+        accessibility_allowed = bool(
+            ApplicationServices.AXIsProcessTrustedWithOptions(  # ty: ignore[unresolved-attribute]
+                {ApplicationServices.kAXTrustedCheckOptionPrompt: True},  # ty: ignore[unresolved-attribute]
+            ),
+        )
+
+    screen_recording_allowed = bool(Quartz.CGPreflightScreenCaptureAccess())  # ty: ignore[unresolved-attribute]
+    if not screen_recording_allowed:
+        screen_recording_allowed = bool(Quartz.CGRequestScreenCaptureAccess())  # ty: ignore[unresolved-attribute]
+
+    missing: list[str] = []
+    if not accessibility_allowed:
+        missing.append("Accessibility")
+    if not screen_recording_allowed:
+        missing.append("Screen Recording")
+    return tuple(missing)
+
+
 @dataclass(frozen=True, slots=True)
 class ScreenCapture:
     """Encoded screenshot plus its logical desktop and capture geometry."""
@@ -524,4 +552,5 @@ __all__ = [
     "DesktopProviderError",
     "PyAutoGuiDesktopProvider",
     "ScreenCapture",
+    "request_macos_desktop_permissions",
 ]

--- a/tests/test_desktop_cli.py
+++ b/tests/test_desktop_cli.py
@@ -516,6 +516,7 @@ async def test_bridge_pins_controller_before_consuming_initial_sync(
     """Fresh stores can authenticate queued commands before the initial sync acknowledges them."""
     client = _FakeBridgeClient()
     bridge = SimpleNamespace(on_to_device_event=AsyncMock())
+    request_permissions = MagicMock(return_value=())
     lifecycle: list[str] = []
     controller_resolved = False
 
@@ -545,6 +546,7 @@ async def test_bridge_pins_controller_before_consuming_initial_sync(
     monkeypatch.setattr("mindroom.desktop.session.prepare_desktop_client", prepare_client)
     monkeypatch.setattr("mindroom.matrix.olm_to_device.resolve_pinned_device", resolve_device)
     monkeypatch.setattr("mindroom.desktop.provider.PyAutoGuiDesktopProvider", lambda **_kwargs: object())
+    monkeypatch.setattr(desktop_cli, "_request_required_desktop_permissions", request_permissions)
     monkeypatch.setattr("mindroom.desktop.bridge.DesktopBridge", lambda **_kwargs: bridge)
 
     await desktop_cli._run_bridge(
@@ -568,6 +570,7 @@ async def test_bridge_pins_controller_before_consuming_initial_sync(
     )
 
     assert lifecycle == ["open", "resolve", "prepare"]
+    request_permissions.assert_called_once_with()
     bridge.on_to_device_event.assert_awaited_once()
 
 

--- a/tests/test_desktop_provider.py
+++ b/tests/test_desktop_provider.py
@@ -17,6 +17,7 @@ from mindroom.desktop.provider import (
     _capture_macos_primary_screen,
     _capture_macos_window,
     _type_macos_unicode,
+    request_macos_desktop_permissions,
 )
 
 if TYPE_CHECKING:
@@ -317,6 +318,28 @@ def test_macos_capture_requires_screen_recording_permission(monkeypatch: pytest.
 
     with pytest.raises(DesktopProviderError, match="Screen Recording permission"):
         _capture_macos_primary_screen()
+
+
+def test_macos_desktop_permissions_are_requested_when_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Starting the bridge asks macOS for both required privacy grants."""
+    accessibility_requests: list[dict[str, bool]] = []
+    screen_recording_requests: list[bool] = []
+    application_services = SimpleNamespace(
+        AXIsProcessTrusted=lambda: False,
+        AXIsProcessTrustedWithOptions=lambda options: accessibility_requests.append(options) or False,
+        kAXTrustedCheckOptionPrompt="prompt",
+    )
+    quartz = SimpleNamespace(
+        CGPreflightScreenCaptureAccess=lambda: False,
+        CGRequestScreenCaptureAccess=lambda: screen_recording_requests.append(True) or False,
+    )
+    monkeypatch.setattr("mindroom.desktop.provider.sys.platform", "darwin")
+    monkeypatch.setitem(sys.modules, "ApplicationServices", application_services)
+    monkeypatch.setitem(sys.modules, "Quartz", quartz)
+
+    assert request_macos_desktop_permissions() == ("Accessibility", "Screen Recording")
+    assert accessibility_requests == [{"prompt": True}]
+    assert screen_recording_requests == [True]
 
 
 def test_macos_window_capture_binds_process_and_exact_bounds(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -4088,6 +4088,8 @@ desi-vocal = [
     { name = "requests" },
 ]
 desktop = [
+    { name = "pillow", version = "10.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "pillow", version = "11.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "pyautogui" },
     { name = "pyobjc-framework-applicationservices", marker = "sys_platform == 'darwin'" },
     { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
@@ -4475,6 +4477,7 @@ requires-dist = [
     { name = "oxylabs", marker = "extra == 'oxylabs'" },
     { name = "packaging", specifier = ">=24" },
     { name = "pandas", marker = "extra == 'pandas'", specifier = ">=2.2" },
+    { name = "pillow", marker = "extra == 'desktop'", specifier = ">=10.2" },
     { name = "playwright", marker = "extra == 'agentql'" },
     { name = "playwright", marker = "extra == 'browser'" },
     { name = "playwright", marker = "extra == 'browserbase'" },


### PR DESCRIPTION
Desktop setup had two avoidable local failures:

- Screenshots import Pillow directly, but the `desktop` extra relied on PyScreeze to install it transitively. PyScreeze only declares Pillow for Python versions through 3.11, so newer Python installations could fail with `ModuleNotFoundError: No module named PIL`.
- The bridge detected missing macOS privacy grants only after an agent attempted Desktop actions. Users had to discover and grant Accessibility and Screen Recording permissions manually.

This change adds Pillow as a direct dependency of the `desktop` extra. On macOS, `mindroom desktop run` now uses native APIs to request Accessibility and Screen Recording before connecting the bridge. If macOS still requires an application restart, the command exits with focused instructions instead of advertising an unusable bridge.

Validation:

- Built the wheel and installed it with `[desktop]` into a clean Python 3.14 environment
- Imported both Pillow and PyAutoGUI from that environment
- `uv lock --check`
- Ruff and ty
- Desktop provider, bridge, CLI, and session tests: 88 passed