### PR TITLE
Expire orphaned tool-approval cards instead of ignoring responses

### DIFF
--- a/src/mindroom/approval_manager.py
+++ b/src/mindroom/approval_manager.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import json
 import threading
-import time
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable, Iterator
 from concurrent.futures import Future, InvalidStateError
@@ -59,6 +58,7 @@ _DEFAULT_TRUNCATED_APPROVAL_REASON = (
     "body — or auto-approve this tool via a script-based approval rule."
 )
 _STARTUP_DISCARD_REASON = "Bot restarted before approval — original request was cancelled."
+_DETACHED_CARD_REASON = "Original tool request is no longer active."
 _MAX_ARGUMENTS_PREVIEW_CHARS = 1200
 _MAX_FULL_ARGUMENTS_JSON_BYTES = 2_000_000
 _MAX_REMEMBERED_TERMINAL_CARD_IDS = 4096
@@ -356,18 +356,21 @@ class _ApprovalManager:
             with self._live_lock:
                 self._pending_by_card_event.pop(waiter.card_event_id, None)
 
-    async def discard_pending_on_startup(self, *, lookback_hours: int = 24) -> int:
-        """Expire cached, router-authored approval cards after startup."""
+    async def discard_pending_on_startup(self) -> int:
+        """Expire cached, router-authored approval cards after startup.
+
+        The scan is bounded by count, not age: an orphaned pending card must
+        stay cleanable no matter how long ago it was sent.
+        """
         transport_sender = self._transport_sender_id()
         if transport_sender is None:
             return 0
 
-        cutoff_ts_ms = _lookback_cutoff_ms(lookback_hours)
         discarded = 0
         for room_id in self._configured_approval_room_ids():
             for card_event in await self._scan_cached_room_cards(
                 room_id,
-                since_ts_ms=cutoff_ts_ms,
+                since_ts_ms=0,
                 limit=_STARTUP_DISCARD_SCAN_LIMIT,
             ):
                 try:
@@ -408,8 +411,11 @@ class _ApprovalManager:
                 reason=reason,
             )
 
-        consumed = self.knows_in_memory_approval_card(card_event_id)
-        return ApprovalActionResult(consumed=consumed, resolved=False, card_event_id=card_event_id)
+        return await self._handle_detached_card_response(
+            room_id=room_id,
+            sender_id=sender_id,
+            card_event_id=card_event_id,
+        )
 
     async def handle_live_approval_id_response(
         self,
@@ -733,6 +739,67 @@ class _ApprovalManager:
         checkpoint = loop.create_future()
         loop.call_soon(checkpoint.set_result, None)
         await checkpoint
+
+    async def _handle_detached_card_response(
+        self,
+        *,
+        room_id: str,
+        sender_id: str,
+        card_event_id: str,
+    ) -> ApprovalActionResult:
+        """Expire one trusted pending card whose live waiter no longer exists.
+
+        The detached tool call is never approved or executed; the card is only
+        terminally edited so it stops looking actionable.
+        """
+        pending = await self._cached_trusted_pending_card(room_id=room_id, card_event_id=card_event_id)
+        if pending is None:
+            consumed = self.knows_in_memory_approval_card(card_event_id)
+            return ApprovalActionResult(consumed=consumed, resolved=False, card_event_id=card_event_id)
+        if pending.approver_user_id != sender_id:
+            return ApprovalActionResult(
+                consumed=False,
+                resolved=False,
+                thread_id=pending.thread_id,
+                card_event_id=pending.card_event_id,
+            )
+        result = await self._discard_matrix_only_card(
+            pending=pending,
+            reason=_DETACHED_CARD_REASON,
+            resolved_by=self._transport_sender_id(),
+        )
+        if result.resolved:
+            logger.info(
+                "approval_detached_card_expired",
+                room_id=room_id,
+                card_event_id=card_event_id,
+                approval_id=pending.approval_id,
+            )
+        return result
+
+    async def _cached_trusted_pending_card(
+        self,
+        *,
+        room_id: str,
+        card_event_id: str,
+    ) -> PendingApproval | None:
+        """Return one cached, router-authored original card whose trusted state is still pending."""
+        transport_sender = self._transport_sender_id()
+        if transport_sender is None or self._event_cache is None:
+            return None
+        card_event = await self._event_cache.get_event(room_id, card_event_id)
+        if card_event is None or not is_original_approval_card(card_event):
+            return None
+        try:
+            pending = PendingApproval.from_card_event(card_event, room_id=room_id)
+        except (TypeError, ValueError):
+            return None
+        if pending.card_sender_id != transport_sender:
+            return None
+        latest_edit = await self._latest_trusted_edit(pending)
+        if pending.latest_status(latest_edit) != "pending":
+            return None
+        return pending
 
     async def _discard_matrix_only_card(
         self,
@@ -1238,10 +1305,6 @@ class _ApprovalManager:
             resolved_by=resolved_by,
             resolved_at=_utcnow(),
         )
-
-
-def _lookback_cutoff_ms(lookback_hours: int) -> int:
-    return int((time.time() - max(lookback_hours, 0) * 3600) * 1000)
 
 
 def get_approval_store() -> _ApprovalManager | None:

--- a/src/mindroom/approval_manager.py
+++ b/src/mindroom/approval_manager.py
@@ -373,14 +373,12 @@ class _ApprovalManager:
                 since_ts_ms=0,
                 limit=_STARTUP_DISCARD_SCAN_LIMIT,
             ):
-                try:
-                    pending = PendingApproval.from_card_event(card_event, room_id=room_id)
-                except (TypeError, ValueError):
-                    continue
-                if pending.card_sender_id != transport_sender:
-                    continue
-                latest_edit = await self._latest_trusted_edit(pending)
-                if pending.latest_status(latest_edit) != "pending":
+                pending = await self._trusted_pending_from_card_event(
+                    card_event,
+                    room_id=room_id,
+                    transport_sender=transport_sender,
+                )
+                if pending is None:
                     continue
                 result = await self._discard_matrix_only_card(
                     pending=pending,
@@ -790,6 +788,20 @@ class _ApprovalManager:
         card_event = await self._event_cache.get_event(room_id, card_event_id)
         if card_event is None or not is_original_approval_card(card_event):
             return None
+        return await self._trusted_pending_from_card_event(
+            card_event,
+            room_id=room_id,
+            transport_sender=transport_sender,
+        )
+
+    async def _trusted_pending_from_card_event(
+        self,
+        card_event: dict[str, Any],
+        *,
+        room_id: str,
+        transport_sender: str,
+    ) -> PendingApproval | None:
+        """Parse one original card and return it only while its trusted state is still pending."""
         try:
             pending = PendingApproval.from_card_event(card_event, room_id=room_id)
         except (TypeError, ValueError):
@@ -938,6 +950,12 @@ class _ApprovalManager:
             since_ts_ms=since_ts_ms,
             limit=limit,
         )
+        if len(events) >= limit:
+            logger.warning(
+                "approval_startup_scan_truncated",
+                room_id=room_id,
+                scan_limit=limit,
+            )
         return [event for event in events if is_original_approval_card(event)]
 
     async def shutdown(self, *, reason: str) -> None:

--- a/src/mindroom/approval_transport.py
+++ b/src/mindroom/approval_transport.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
-from math import ceil
 from typing import TYPE_CHECKING, Any, Protocol, TypeVar
 
 import nio
@@ -28,7 +27,6 @@ from mindroom.tool_approval import (
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine
 
-    from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
     from mindroom.matrix.cache import ConversationEventCache
 
@@ -52,15 +50,6 @@ class _ApprovalTransportBot(Protocol):
     ) -> str | None:
         """Return the latest event id for one Matrix thread when known."""
         ...
-
-
-def _approval_startup_lookback_hours(config: Config) -> int:
-    """Return the cache lookback window needed to clean up live-only approval cards."""
-    timeout_days = config.tool_approval.timeout_days
-    for rule in config.tool_approval.rules:
-        if rule.timeout_days is not None:
-            timeout_days = max(timeout_days, rule.timeout_days)
-    return max(1, ceil(timeout_days * 24))
 
 
 def _approval_relation_agent_name(content: dict[str, Any], *, fallback: str) -> str:
@@ -108,7 +97,6 @@ class ApprovalMatrixTransport:
 
     runtime_paths: RuntimePaths
     bot_provider: Callable[[str], _ApprovalTransportBot | None]
-    config_provider: Callable[[], Config | None]
     event_cache_provider: Callable[[], ConversationEventCache]
     _runtime_loop: asyncio.AbstractEventLoop | None = field(default=None, init=False, repr=False)
     _cache_write_tasks: set[asyncio.Task[None]] = field(default_factory=set, init=False, repr=False)
@@ -473,13 +461,8 @@ class ApprovalMatrixTransport:
 
     async def _discard_orphaned_approval_cards_on_startup(self) -> None:
         """Discard orphaned approval cards once startup approval gates are ready."""
-        config = self.config_provider()
-        if config is None:
-            return
         try:
-            discarded_count = await expire_orphaned_approval_cards_on_startup(
-                lookback_hours=_approval_startup_lookback_hours(config),
-            )
+            discarded_count = await expire_orphaned_approval_cards_on_startup()
         except Exception as exc:
             logger.warning("tool_approval_startup_discard_failed", error=str(exc))
             return

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -291,7 +291,6 @@ class _MultiAgentOrchestrator:
         self._approval_transport = ApprovalMatrixTransport(
             runtime_paths=self.runtime_paths,
             bot_provider=lambda agent_name: self.agent_bots.get(agent_name),
-            config_provider=lambda: self.config,
             event_cache_provider=self._approval_event_cache,
         )
         self._startup_maintenance = StartupMaintenanceController(

--- a/src/mindroom/tool_approval.py
+++ b/src/mindroom/tool_approval.py
@@ -306,13 +306,17 @@ async def handle_matrix_approval_action(action: MatrixApprovalAction) -> Approva
         return ApprovalActionResult(consumed=False, resolved=False)
     sanitized_reason = action.reason.strip() if isinstance(action.reason, str) and action.reason.strip() else None
     if action.approval_id is not None:
-        return await manager.handle_live_approval_id_response(
+        live_result = await manager.handle_live_approval_id_response(
             room_id=action.room_id,
             sender_id=action.sender_id,
             approval_id=action.approval_id,
             status=action.status,
             reason=sanitized_reason,
         )
+        # An unknown approval id can still carry a card reference; let the
+        # card path expire a detached card instead of ignoring the response.
+        if live_result.consumed or action.card_event_id is None:
+            return live_result
     if action.card_event_id is None:
         return ApprovalActionResult(consumed=False, resolved=False)
     return await manager.handle_card_response(
@@ -344,12 +348,12 @@ def initialize_approval_runtime(
     )
 
 
-async def expire_orphaned_approval_cards_on_startup(*, lookback_hours: int) -> int:
+async def expire_orphaned_approval_cards_on_startup() -> int:
     """Expire router-authored approval cards that can no longer have live waiters."""
     manager = approval_manager.get_approval_store()
     if manager is None:
         return 0
-    return await manager.discard_pending_on_startup(lookback_hours=lookback_hours)
+    return await manager.discard_pending_on_startup()
 
 
 async def shutdown_approval_runtime(reason: str = DEFAULT_SHUTDOWN_REASON) -> None:

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -1562,8 +1562,6 @@ class TestMultiAgentOrchestrator:
         """Router readiness should trigger Matrix-backed startup discard after room setup."""
         orchestrator = _MultiAgentOrchestrator(runtime_paths=TestAgentBot._runtime_paths(tmp_path))
         orchestrator.config = MagicMock()
-        orchestrator.config.tool_approval.timeout_days = 7.0
-        orchestrator.config.tool_approval.rules = [SimpleNamespace(timeout_days=10.0)]
 
         bot = MagicMock()
         bot.agent_name = "router"
@@ -1595,8 +1593,7 @@ class TestMultiAgentOrchestrator:
         async def _sync_runtime_support_services(*_: object, **__: object) -> None:
             call_order.append("support_services")
 
-        async def _discard_pending_on_startup(*, lookback_hours: int) -> int:
-            assert lookback_hours == 240
+        async def _discard_pending_on_startup() -> int:
             call_order.append("startup_discard")
             startup_discarded.set()
             return 2
@@ -1628,7 +1625,7 @@ class TestMultiAgentOrchestrator:
             "support_services",
             "startup_discard",
         ]
-        expire_orphaned_approval_cards_on_startup.assert_awaited_once_with(lookback_hours=240)
+        expire_orphaned_approval_cards_on_startup.assert_awaited_once_with()
         bot.try_start.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -1660,8 +1657,6 @@ class TestMultiAgentOrchestrator:
         """Router first sync alone must not discard startup approval cards before runtime support is ready."""
         orchestrator = _MultiAgentOrchestrator(runtime_paths=TestAgentBot._runtime_paths(tmp_path))
         orchestrator.config = MagicMock()
-        orchestrator.config.tool_approval.timeout_days = 7.0
-        orchestrator.config.tool_approval.rules = [SimpleNamespace(timeout_days=10.0)]
 
         bot = MagicMock()
         bot.agent_name = "router"
@@ -1679,7 +1674,7 @@ class TestMultiAgentOrchestrator:
 
             await orchestrator._approval_transport.mark_startup_runtime_support_ready()
 
-        expire_orphaned_approval_cards_on_startup.assert_awaited_once_with(lookback_hours=240)
+        expire_orphaned_approval_cards_on_startup.assert_awaited_once_with()
 
     @pytest.mark.asyncio
     async def test_approval_transport_waits_for_router_ready_before_startup_discard(
@@ -1689,8 +1684,6 @@ class TestMultiAgentOrchestrator:
         """Runtime support readiness alone must not discard startup approval cards before router first sync."""
         orchestrator = _MultiAgentOrchestrator(runtime_paths=TestAgentBot._runtime_paths(tmp_path))
         orchestrator.config = MagicMock()
-        orchestrator.config.tool_approval.timeout_days = 7.0
-        orchestrator.config.tool_approval.rules = [SimpleNamespace(timeout_days=10.0)]
 
         bot = MagicMock()
         bot.agent_name = "router"
@@ -1708,7 +1701,7 @@ class TestMultiAgentOrchestrator:
 
             await orchestrator.handle_bot_ready(bot)
 
-        expire_orphaned_approval_cards_on_startup.assert_awaited_once_with(lookback_hours=240)
+        expire_orphaned_approval_cards_on_startup.assert_awaited_once_with()
 
     @pytest.mark.asyncio
     async def test_approval_transport_concurrent_startup_gates_discard_once(
@@ -1718,8 +1711,6 @@ class TestMultiAgentOrchestrator:
         """Router-ready and runtime-ready races must still run startup discard once."""
         orchestrator = _MultiAgentOrchestrator(runtime_paths=TestAgentBot._runtime_paths(tmp_path))
         orchestrator.config = MagicMock()
-        orchestrator.config.tool_approval.timeout_days = 7.0
-        orchestrator.config.tool_approval.rules = []
 
         bot = MagicMock()
         bot.agent_name = "router"
@@ -1737,7 +1728,7 @@ class TestMultiAgentOrchestrator:
                 orchestrator._approval_transport.mark_startup_runtime_support_ready(),
             )
 
-        expire_orphaned_approval_cards_on_startup.assert_awaited_once_with(lookback_hours=168)
+        expire_orphaned_approval_cards_on_startup.assert_awaited_once_with()
 
     @pytest.mark.asyncio
     async def test_approval_transport_reset_allows_fresh_startup_discard(
@@ -1747,8 +1738,6 @@ class TestMultiAgentOrchestrator:
         """A fresh runtime start must be able to run startup discard after the previous run did."""
         orchestrator = _MultiAgentOrchestrator(runtime_paths=TestAgentBot._runtime_paths(tmp_path))
         orchestrator.config = MagicMock()
-        orchestrator.config.tool_approval.timeout_days = 7.0
-        orchestrator.config.tool_approval.rules = []
 
         bot = MagicMock()
         bot.agent_name = "router"

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import asyncio
 import json
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 from unittest.mock import AsyncMock, MagicMock, call
 
 import nio
@@ -810,18 +810,106 @@ async def test_handle_live_approval_id_response_rejects_waiter_from_wrong_room(t
     await task
 
 
-@pytest.mark.asyncio
-async def test_handle_card_response_orphan_approval_falls_through_until_startup_cleanup(tmp_path: Path) -> None:
-    cache = FakeEventCache()
-    await cache.store_event("$approval", "!room:localhost", _approval_card())
-    editor = AsyncMock(return_value=True)
-    store = _ApprovalManager(
+def _detached_card_store(
+    tmp_path: Path,
+    cache: FakeEventCache,
+    editor: AsyncMock,
+) -> _ApprovalManager:
+    return _ApprovalManager(
         test_runtime_paths(tmp_path),
         editor=editor,
         event_cache=cache,
         approval_room_ids=lambda: {"!room:localhost"},
         transport_sender=lambda: "@mindroom_router:localhost",
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["approved", "denied"])
+async def test_handle_card_response_expires_detached_trusted_pending_card(
+    tmp_path: Path,
+    status: Literal["approved", "denied"],
+) -> None:
+    """A response to an orphaned trusted pending card expires it and never executes the tool."""
+    cache = FakeEventCache()
+    await cache.store_event("$approval", "!room:localhost", _approval_card())
+    editor = AsyncMock(return_value=True)
+    store = _detached_card_store(tmp_path, cache, editor)
+
+    result = await store.handle_card_response(
+        room_id="!room:localhost",
+        sender_id="@user:localhost",
+        card_event_id="$approval",
+        status=status,
+        reason=None,
+    )
+
+    assert result.consumed is True
+    assert result.resolved is True
+    assert result.thread_id == "$thread"
+    assert editor.await_args.args[:2] == ("!room:localhost", "$approval")
+    replacement = editor.await_args.args[2]
+    assert replacement["status"] == "expired"
+    assert replacement["resolution_reason"] == "Original tool request is no longer active."
+
+
+@pytest.mark.asyncio
+async def test_handle_card_response_detached_card_ignores_non_approver(tmp_path: Path) -> None:
+    """Only the configured approver can expire an orphaned pending card."""
+    cache = FakeEventCache()
+    await cache.store_event("$approval", "!room:localhost", _approval_card())
+    editor = AsyncMock(return_value=True)
+    store = _detached_card_store(tmp_path, cache, editor)
+
+    result = await store.handle_card_response(
+        room_id="!room:localhost",
+        sender_id="@intruder:localhost",
+        card_event_id="$approval",
+        status="approved",
+        reason=None,
+    )
+
+    assert result.consumed is False
+    assert result.resolved is False
+    editor.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_card_response_detached_terminal_card_untouched(tmp_path: Path) -> None:
+    """A card whose trusted latest state is terminal stays untouched."""
+    cache = FakeEventCache()
+    card = _approval_card()
+    await cache.store_event("$approval", "!room:localhost", card)
+    await cache.store_event("$approval-edit", "!room:localhost", _approval_edit(card, status="approved"))
+    editor = AsyncMock(return_value=True)
+    store = _detached_card_store(tmp_path, cache, editor)
+
+    result = await store.handle_card_response(
+        room_id="!room:localhost",
+        sender_id="@user:localhost",
+        card_event_id="$approval",
+        status="denied",
+        reason=None,
+    )
+
+    assert result.consumed is False
+    assert result.resolved is False
+    editor.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_card_response_detached_card_ignores_untrusted_terminal_edit(tmp_path: Path) -> None:
+    """An attacker edit cannot make an orphaned pending card look terminal."""
+    cache = FakeEventCache()
+    card = _approval_card()
+    await cache.store_event("$approval", "!room:localhost", card)
+    await cache.store_event(
+        "$fake-edit",
+        "!room:localhost",
+        _approval_edit(card, event_id="$fake-edit", sender="@attacker:localhost", status="approved"),
+    )
+    editor = AsyncMock(return_value=True)
+    store = _detached_card_store(tmp_path, cache, editor)
 
     result = await store.handle_card_response(
         room_id="!room:localhost",
@@ -831,9 +919,98 @@ async def test_handle_card_response_orphan_approval_falls_through_until_startup_
         reason=None,
     )
 
-    assert result.consumed is False
-    assert result.resolved is False
-    editor.assert_not_awaited()
+    assert result.consumed is True
+    assert result.resolved is True
+    assert editor.await_args.args[2]["status"] == "expired"
+
+
+@pytest.mark.asyncio
+async def test_handle_matrix_approval_action_with_stale_approval_id_expires_detached_card(tmp_path: Path) -> None:
+    """A response carrying a dead approval id still expires the referenced detached card."""
+    cache = FakeEventCache()
+    await cache.store_event("$approval", "!room:localhost", _approval_card())
+    editor = AsyncMock(return_value=True)
+    initialize_approval_store(
+        test_runtime_paths(tmp_path),
+        editor=editor,
+        event_cache=cache,
+        approval_room_ids=lambda: {"!room:localhost"},
+        transport_sender=lambda: "@mindroom_router:localhost",
+    )
+
+    result = await handle_matrix_approval_action(
+        MatrixApprovalAction(
+            room_id="!room:localhost",
+            sender_id="@user:localhost",
+            card_event_id="$approval",
+            approval_id="stale-approval-id",
+            status="approved",
+            reason=None,
+        ),
+    )
+
+    assert result.consumed is True
+    assert result.resolved is True
+    assert editor.await_args.args[2]["status"] == "expired"
+
+
+@pytest.mark.asyncio
+async def test_handle_card_response_live_waiter_still_approves_with_cached_card(tmp_path: Path) -> None:
+    """The detached path must not preempt a live waiter whose card is also cached."""
+    cache = FakeEventCache()
+    sender = AsyncMock(return_value=SentApprovalEvent("$approval"))
+    editor = AsyncMock(return_value=True)
+    store = initialize_approval_store(
+        test_runtime_paths(tmp_path),
+        sender=sender,
+        editor=editor,
+        event_cache=cache,
+        approval_room_ids=lambda: {"!room:localhost"},
+        transport_sender=lambda: "@mindroom_router:localhost",
+    )
+    task = asyncio.create_task(
+        store.request_approval(
+            tool_name="read_file",
+            arguments={"path": "notes.txt"},
+            room_id="!room:localhost",
+            requester_id="@user:localhost",
+            approver_user_id="@user:localhost",
+            timeout_seconds=30,
+        ),
+    )
+    pending = await _wait_for_pending(store, sender=sender)
+    await cache.store_event(
+        pending.card_event_id,
+        "!room:localhost",
+        _approval_card(approval_id=pending.approval_id, event_id=pending.card_event_id),
+    )
+
+    result = await store.handle_card_response(
+        room_id="!room:localhost",
+        sender_id="@user:localhost",
+        card_event_id=pending.card_event_id,
+        status="approved",
+        reason=None,
+    )
+    decision = await task
+
+    assert result.consumed is True
+    assert result.resolved is True
+    assert decision.status == "approved"
+    assert editor.await_args.args[2]["status"] == "approved"
+
+
+@pytest.mark.asyncio
+async def test_discard_pending_on_startup_expires_cards_older_than_approval_timeout(tmp_path: Path) -> None:
+    """Startup cleanup has no age blind spot: long-expired orphaned cards still get cleaned."""
+    cache = FakeEventCache()
+    requested_at = datetime.now(UTC) - timedelta(days=45)
+    card = _approval_card(origin_server_ts=int(requested_at.timestamp() * 1000))
+    card["content"]["requested_at"] = requested_at.isoformat()
+    card["content"]["expires_at"] = (requested_at + timedelta(minutes=5)).isoformat()
+    await cache.store_event("$approval", "!room:localhost", card)
+    editor = AsyncMock(return_value=True)
+    store = _detached_card_store(tmp_path, cache, editor)
 
     assert await store.discard_pending_on_startup() == 1
     assert editor.await_args.args[:2] == ("!room:localhost", "$approval")
@@ -1964,32 +2141,6 @@ async def test_card_response_for_resolved_card_is_not_consumed_without_live_wait
 
 
 @pytest.mark.asyncio
-async def test_card_response_for_cached_approval_is_not_consumed_without_live_waiter(tmp_path: Path) -> None:
-    cache = FakeEventCache()
-    card = _approval_card()
-    await cache.store_event("$approval", "!room:localhost", card)
-    editor = AsyncMock(return_value=True)
-    store = _ApprovalManager(
-        test_runtime_paths(tmp_path),
-        editor=editor,
-        event_cache=cache,
-        transport_sender=lambda: "@mindroom_router:localhost",
-    )
-
-    result = await store.handle_card_response(
-        room_id="!room:localhost",
-        sender_id="@user:localhost",
-        card_event_id="$approval",
-        status="denied",
-        reason="Too late.",
-    )
-
-    assert result.consumed is False
-    assert result.resolved is False
-    editor.assert_not_awaited()
-
-
-@pytest.mark.asyncio
 async def test_live_pending_lookup_ignores_cached_card_after_live_waiter_is_gone(tmp_path: Path) -> None:
     cache = FakeEventCache()
     card = _approval_card()
@@ -2102,9 +2253,9 @@ async def test_response_for_unknown_card_does_not_emit_terminal_edit(tmp_path: P
 
 
 @pytest.mark.asyncio
-async def test_response_for_unknown_card_does_not_read_cache(tmp_path: Path) -> None:
+async def test_response_for_unknown_card_is_not_consumed(tmp_path: Path) -> None:
     cache = MagicMock()
-    cache.get_event = AsyncMock(side_effect=RuntimeError("cache should not run"))
+    cache.get_event = AsyncMock(return_value=None)
     editor = AsyncMock(return_value=True)
     store = _ApprovalManager(
         test_runtime_paths(tmp_path),
@@ -2119,32 +2270,6 @@ async def test_response_for_unknown_card_does_not_read_cache(tmp_path: Path) -> 
         card_event_id="$approval",
         status="denied",
         reason="Too late.",
-    )
-
-    assert result.consumed is False
-    assert result.resolved is False
-    cache.get_event.assert_not_awaited()
-    editor.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_card_response_ignores_same_router_cached_pending_without_history_scan(tmp_path: Path) -> None:
-    cache = FakeEventCache()
-    await cache.store_event("$approval", "!room:localhost", _approval_card())
-    editor = AsyncMock(return_value=True)
-    store = _ApprovalManager(
-        test_runtime_paths(tmp_path),
-        editor=editor,
-        event_cache=cache,
-        transport_sender=lambda: "@mindroom_router:localhost",
-    )
-
-    result = await store.handle_card_response(
-        room_id="!room:localhost",
-        sender_id="@user:localhost",
-        card_event_id="$approval",
-        status="denied",
-        reason="No.",
     )
 
     assert result.consumed is False
@@ -2179,7 +2304,7 @@ async def test_card_response_ignores_cross_router_matrix_only_card(tmp_path: Pat
 
 
 @pytest.mark.asyncio
-async def test_concurrent_cached_response_events_fall_through_without_terminal_edits(tmp_path: Path) -> None:
+async def test_concurrent_detached_response_events_emit_single_terminal_edit(tmp_path: Path) -> None:
     cache = FakeEventCache()
     await cache.store_event("$approval", "!room:localhost", _approval_card())
     edit_count = 0
@@ -2215,11 +2340,10 @@ async def test_concurrent_cached_response_events_fall_through_without_terminal_e
     )
     first_result, second_result = await asyncio.gather(first, second)
 
-    assert first_result.consumed is False
-    assert second_result.consumed is False
-    assert first_result.resolved is False
-    assert second_result.resolved is False
-    assert edit_count == 0
+    assert first_result.consumed is True
+    assert second_result.consumed is True
+    assert {first_result.resolved, second_result.resolved} == {True, False}
+    assert edit_count == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Bug

An `io.mindroom.tool_approval` card could remain visibly `pending` forever after its in-memory waiter disappeared (e.g. a restart):

- Responses to the card (client button clicks, ✅ reactions) were silently ignored, leaving an apparently actionable card that never reacts.
- Startup cleanup scanned only a time-bounded lookback window derived from the approval timeout, so an orphaned card older than that window escaped cleanup permanently.

## Fix

Two narrow changes, both fail-closed. Approval waiters remain in-memory only; nothing is persisted or resumed, and a detached tool call is never approved or executed.

**1. Detached card responses expire the card (`approval_manager.py`)**

When `handle_card_response` finds no live waiter, it now:
- loads the original card from the Matrix event cache (lookup is room-scoped),
- requires an original (non-edit) approval card authored by the trusted router transport sender,
- requires the responder to be the card's configured approver,
- requires the latest trusted (card-sender-authored) state to still be `pending`,
- then terminally edits the card to `expired` with reason `Original tool request is no longer active.` and consumes the response.

Anything else (unknown card, foreign router's card, non-approver, already-terminal card) is left untouched with the previous consumed/fall-through semantics. Concurrent responses are deduped by the existing resolution-claim mechanism, so exactly one terminal edit is emitted.

`handle_matrix_approval_action` also lets a response carrying a stale `approval_id` plus a card reference fall through to the card path instead of being dropped.

**2. Startup cleanup has no age blind spot (`approval_manager.py`, `approval_transport.py`)**

`discard_pending_on_startup` now scans cached cards bounded by the existing count limit (`_STARTUP_DISCARD_SCAN_LIMIT`, newest-first) instead of an age cutoff — no new grace period, and trusted-sender validation is unchanged. The lookback plumbing (`_approval_startup_lookback_hours`, transport `config_provider`) is removed.

## Intentionally unchanged

Plain-text replies to an orphaned card still fall through to normal conversation input: the reply gate stays keyed on live in-process waiters. Widening it would require a cache read on every inbound reply-shaped message and would swallow ordinary post-restart thread messages, because thread-fallback `m.in_reply_to` often points at the card. Orphaned cards are cleaned by the click path above or by startup cleanup.

## Tests

- Detached trusted pending card is expired on click (parametrized approve/deny — an approve click never yields an approved edit).
- Non-approver cannot alter a detached card.
- Foreign-router card untouched (existing `test_card_response_ignores_cross_router_matrix_only_card`).
- Trusted-terminal card untouched; untrusted attacker edit cannot fake terminality.
- Concurrent detached responses emit exactly one terminal edit.
- Live waiter still resolves approve normally, including when the card is also cached.
- Stale `approval_id` + card reference expires the detached card.
- Startup cleanup expires an orphaned card far older than any configured timeout.
- Removed/rewrote the tests that pinned the old fall-through design (`...falls_through_until_startup_cleanup`, `...is_not_consumed_without_live_waiter`, `...does_not_read_cache`, `...fall_through_without_terminal_edits`).

`tests/test_tool_approval.py`, `tests/test_orchestrator_runtime.py`, and `tests/test_bot_reactions_approvals.py` all pass. The `ty` pre-commit hook fails only on pre-existing macOS-only desktop modules (AppKit/Quartz unresolved on Linux), unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Approval cards without an active request can now expire safely when valid responses arrive, using cached approval cards in a detached flow.
  - Only the configured approver can expire orphaned pending detached approval cards.
  - Startup cleanup now expires orphaned approval cards via a bounded cache scan (no time-based lookback window).

- **Bug Fixes**
  - Detached responses are now terminally marked as expired without triggering any detached tool execution.
  - Stale, unknown, stale-id, terminal-edit, and concurrent response scenarios are handled more safely and consistently.

- **Tests**
  - Expanded/updated async coverage to match the new detached expiration and startup-cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->