### PR TITLE
Expire orphaned tool-approval cards safely

### DIFF
--- a/src/mindroom/approval_events.py
+++ b/src/mindroom/approval_events.py
@@ -108,11 +108,11 @@ class PendingApproval:
             return self.initial_status
         content = latest_edit.get("content")
         if not isinstance(content, dict):
-            return "pending"
+            return self.initial_status
         status = visible_content_from_content(cast("dict[str, object]", content)).get("status")
         if status in {"pending", "approved", "denied", "expired"}:
             return cast("PendingApprovalStatus", status)
-        return "pending"
+        return self.initial_status
 
 
 def _approvable(content: dict[str, Any]) -> bool:

--- a/src/mindroom/approval_events.py
+++ b/src/mindroom/approval_events.py
@@ -28,6 +28,7 @@ class PendingApproval:
     arguments_preview_truncated: bool
     timeout_seconds: int
     created_at_ms: int
+    initial_status: PendingApprovalStatus
     approvable: bool = True
     full_arguments_available: bool = False
     thread_id: str | None = None
@@ -59,6 +60,10 @@ class PendingApproval:
         if approval_id is None or tool_name is None or approver_user_id is None:
             msg = "Approval card event is missing required approval fields."
             raise ValueError(msg)
+        status = content.get("status")
+        if status not in {"pending", "approved", "denied", "expired"}:
+            msg = "Approval card event has an invalid status."
+            raise ValueError(msg)
 
         arguments = content.get("arguments")
         if not isinstance(arguments, dict):
@@ -86,6 +91,7 @@ class PendingApproval:
             arguments_preview_truncated=bool(content.get("arguments_truncated")),
             timeout_seconds=timeout_seconds,
             created_at_ms=created_at_ms,
+            initial_status=cast("PendingApprovalStatus", status),
             approvable=_approvable(content),
             full_arguments_available=_full_arguments_available(content),
             thread_id=thread_id,
@@ -99,7 +105,7 @@ class PendingApproval:
     def latest_status(self, latest_edit: dict[str, Any] | None) -> PendingApprovalStatus:
         """Return the visible approval status after applying the latest cached edit."""
         if latest_edit is None:
-            return "pending"
+            return self.initial_status
         content = latest_edit.get("content")
         if not isinstance(content, dict):
             return "pending"

--- a/src/mindroom/approval_inbound.py
+++ b/src/mindroom/approval_inbound.py
@@ -8,7 +8,12 @@ from typing import TYPE_CHECKING, Literal
 from mindroom.authorization import is_authorized_sender
 from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.visible_body import strip_matrix_rich_reply_fallback
-from mindroom.tool_approval import MatrixApprovalAction, handle_matrix_approval_action, is_process_active_approval_card
+from mindroom.tool_approval import (
+    MatrixApprovalAction,
+    handle_matrix_approval_action,
+    is_process_active_approval_card,
+    is_process_approval_card,
+)
 
 if TYPE_CHECKING:
     import nio
@@ -121,7 +126,7 @@ async def maybe_handle_tool_approval_reply(
     reply_to_event_id = EventInfo.from_event(event.source).reply_to_event_id
     if reply_to_event_id is None:
         return False
-    if not is_process_active_approval_card(reply_to_event_id):
+    if is_process_approval_card(reply_to_event_id) and not is_process_active_approval_card(reply_to_event_id):
         return False
     return await handle_tool_approval_action(
         room=room,

--- a/src/mindroom/approval_inbound.py
+++ b/src/mindroom/approval_inbound.py
@@ -122,7 +122,7 @@ async def maybe_handle_tool_approval_reply(
     orchestrator: OrchestratorRuntime | None,
     logger: structlog.stdlib.BoundLogger,
 ) -> bool:
-    """Consume reply-to-approval messages as denial actions."""
+    """Deny live approvals or expire detached approval cards targeted by replies."""
     reply_to_event_id = EventInfo.from_event(event.source).reply_to_event_id
     if reply_to_event_id is None:
         return False

--- a/src/mindroom/approval_inbound.py
+++ b/src/mindroom/approval_inbound.py
@@ -123,8 +123,13 @@ async def maybe_handle_tool_approval_reply(
     logger: structlog.stdlib.BoundLogger,
 ) -> bool:
     """Deny live approvals or expire detached approval cards targeted by replies."""
-    reply_to_event_id = EventInfo.from_event(event.source).reply_to_event_id
+    event_info = EventInfo.from_event(event.source)
+    reply_to_event_id = event_info.reply_to_event_id
     if reply_to_event_id is None:
+        return False
+    content = event.source.get("content")
+    relates_to = content.get("m.relates_to") if isinstance(content, dict) else None
+    if event_info.is_thread and isinstance(relates_to, dict) and relates_to.get("is_falling_back") is True:
         return False
     if is_process_approval_card(reply_to_event_id) and not is_process_active_approval_card(reply_to_event_id):
         return False

--- a/src/mindroom/approval_manager.py
+++ b/src/mindroom/approval_manager.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import json
 import threading
-import time
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable, Iterator
 from concurrent.futures import Future, InvalidStateError
@@ -59,6 +58,7 @@ _DEFAULT_TRUNCATED_APPROVAL_REASON = (
     "body — or auto-approve this tool via a script-based approval rule."
 )
 _STARTUP_DISCARD_REASON = "Bot restarted before approval — original request was cancelled."
+_DETACHED_REQUEST_REASON = "Original tool request is no longer active."
 _MAX_ARGUMENTS_PREVIEW_CHARS = 1200
 _MAX_FULL_ARGUMENTS_JSON_BYTES = 2_000_000
 _MAX_REMEMBERED_TERMINAL_CARD_IDS = 4096
@@ -245,8 +245,8 @@ class _ActiveApprovalSend:
 class _ApprovalManager:
     """Coordinate live approval waiters against Matrix approval cards.
 
-    Cached approval cards are only a startup cleanup index; they never make an
-    approval actionable after the live waiter is gone.
+    Cached approval cards support terminal cleanup only; they never make an
+    approval actionable after its live waiter is gone.
     """
 
     def __init__(
@@ -356,28 +356,25 @@ class _ApprovalManager:
             with self._live_lock:
                 self._pending_by_card_event.pop(waiter.card_event_id, None)
 
-    async def discard_pending_on_startup(self, *, lookback_hours: int = 24) -> int:
+    async def discard_pending_on_startup(self) -> int:
         """Expire cached, router-authored approval cards after startup."""
         transport_sender = self._transport_sender_id()
         if transport_sender is None:
             return 0
 
-        cutoff_ts_ms = _lookback_cutoff_ms(lookback_hours)
         discarded = 0
         for room_id in self._configured_approval_room_ids():
             for card_event in await self._scan_cached_room_cards(
                 room_id,
-                since_ts_ms=cutoff_ts_ms,
+                since_ts_ms=0,
                 limit=_STARTUP_DISCARD_SCAN_LIMIT,
             ):
-                try:
-                    pending = PendingApproval.from_card_event(card_event, room_id=room_id)
-                except (TypeError, ValueError):
-                    continue
-                if pending.card_sender_id != transport_sender:
-                    continue
-                latest_edit = await self._latest_trusted_edit(pending)
-                if pending.latest_status(latest_edit) != "pending":
+                pending = await self._trusted_pending_from_card_event(
+                    card_event,
+                    room_id=room_id,
+                    transport_sender=transport_sender,
+                )
+                if pending is None:
                     continue
                 result = await self._discard_matrix_only_card(
                     pending=pending,
@@ -408,8 +405,20 @@ class _ApprovalManager:
                 reason=reason,
             )
 
-        consumed = self.knows_in_memory_approval_card(card_event_id)
-        return ApprovalActionResult(consumed=consumed, resolved=False, card_event_id=card_event_id)
+        if self.knows_in_memory_approval_card(card_event_id):
+            return ApprovalActionResult(consumed=True, resolved=False, card_event_id=card_event_id)
+
+        pending = await self._cached_trusted_pending_approval_for_card(
+            room_id=room_id,
+            card_event_id=card_event_id,
+        )
+        if pending is None or pending.approver_user_id != sender_id:
+            return ApprovalActionResult(consumed=False, resolved=False, card_event_id=card_event_id)
+        return await self._discard_matrix_only_card(
+            pending=pending,
+            reason=_DETACHED_REQUEST_REASON,
+            resolved_by=sender_id,
+        )
 
     async def handle_live_approval_id_response(
         self,
@@ -835,6 +844,51 @@ class _ApprovalManager:
             return None
         return pending
 
+    async def _cached_trusted_pending_approval_for_card(
+        self,
+        *,
+        room_id: str,
+        card_event_id: str,
+    ) -> PendingApproval | None:
+        if self._event_cache is None:
+            return None
+        card_event = await self._event_cache.get_event(room_id, card_event_id)
+        if card_event is None or not is_original_approval_card(card_event):
+            return None
+        transport_sender = self._transport_sender_id()
+        if transport_sender is None:
+            return None
+        return await self._trusted_pending_from_card_event(
+            card_event,
+            room_id=room_id,
+            transport_sender=transport_sender,
+            expected_card_event_id=card_event_id,
+        )
+
+    async def _trusted_pending_from_card_event(
+        self,
+        card_event: dict[str, Any],
+        *,
+        room_id: str,
+        transport_sender: str,
+        expected_card_event_id: str | None = None,
+    ) -> PendingApproval | None:
+        event_room_id = card_event.get("room_id")
+        if event_room_id is not None and event_room_id != room_id:
+            return None
+        try:
+            pending = PendingApproval.from_card_event(card_event, room_id=room_id)
+        except (TypeError, ValueError):
+            return None
+        if (
+            expected_card_event_id is not None and pending.card_event_id != expected_card_event_id
+        ) or pending.card_sender_id != transport_sender:
+            return None
+        latest_edit = await self._latest_trusted_edit(pending)
+        if pending.latest_status(latest_edit) != "pending":
+            return None
+        return pending
+
     async def _latest_edit(
         self,
         *,
@@ -871,6 +925,12 @@ class _ApprovalManager:
             since_ts_ms=since_ts_ms,
             limit=limit,
         )
+        if len(events) >= limit:
+            logger.warning(
+                "approval_startup_scan_truncated",
+                room_id=room_id,
+                scan_limit=limit,
+            )
         return [event for event in events if is_original_approval_card(event)]
 
     async def shutdown(self, *, reason: str) -> None:
@@ -1238,10 +1298,6 @@ class _ApprovalManager:
             resolved_by=resolved_by,
             resolved_at=_utcnow(),
         )
-
-
-def _lookback_cutoff_ms(lookback_hours: int) -> int:
-    return int((time.time() - max(lookback_hours, 0) * 3600) * 1000)
 
 
 def get_approval_store() -> _ApprovalManager | None:

--- a/src/mindroom/approval_transport.py
+++ b/src/mindroom/approval_transport.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
-from math import ceil
 from typing import TYPE_CHECKING, Any, Protocol, TypeVar
 
 import nio
@@ -28,7 +27,6 @@ from mindroom.tool_approval import (
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine
 
-    from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
     from mindroom.matrix.cache import ConversationEventCache
 
@@ -52,15 +50,6 @@ class _ApprovalTransportBot(Protocol):
     ) -> str | None:
         """Return the latest event id for one Matrix thread when known."""
         ...
-
-
-def _approval_startup_lookback_hours(config: Config) -> int:
-    """Return the cache lookback window needed to clean up live-only approval cards."""
-    timeout_days = config.tool_approval.timeout_days
-    for rule in config.tool_approval.rules:
-        if rule.timeout_days is not None:
-            timeout_days = max(timeout_days, rule.timeout_days)
-    return max(1, ceil(timeout_days * 24))
 
 
 def _approval_relation_agent_name(content: dict[str, Any], *, fallback: str) -> str:
@@ -108,7 +97,6 @@ class ApprovalMatrixTransport:
 
     runtime_paths: RuntimePaths
     bot_provider: Callable[[str], _ApprovalTransportBot | None]
-    config_provider: Callable[[], Config | None]
     event_cache_provider: Callable[[], ConversationEventCache]
     _runtime_loop: asyncio.AbstractEventLoop | None = field(default=None, init=False, repr=False)
     _cache_write_tasks: set[asyncio.Task[None]] = field(default_factory=set, init=False, repr=False)
@@ -473,13 +461,8 @@ class ApprovalMatrixTransport:
 
     async def _discard_orphaned_approval_cards_on_startup(self) -> None:
         """Discard orphaned approval cards once startup approval gates are ready."""
-        config = self.config_provider()
-        if config is None:
-            return
         try:
-            discarded_count = await expire_orphaned_approval_cards_on_startup(
-                lookback_hours=_approval_startup_lookback_hours(config),
-            )
+            discarded_count = await expire_orphaned_approval_cards_on_startup()
         except Exception as exc:
             logger.warning("tool_approval_startup_discard_failed", error=str(exc))
             return

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -291,7 +291,6 @@ class _MultiAgentOrchestrator:
         self._approval_transport = ApprovalMatrixTransport(
             runtime_paths=self.runtime_paths,
             bot_provider=lambda agent_name: self.agent_bots.get(agent_name),
-            config_provider=lambda: self.config,
             event_cache_provider=self._approval_event_cache,
         )
         self._startup_maintenance = StartupMaintenanceController(

--- a/src/mindroom/tool_approval.py
+++ b/src/mindroom/tool_approval.py
@@ -300,19 +300,21 @@ def is_process_active_approval_card(card_event_id: str) -> bool:
 
 
 async def handle_matrix_approval_action(action: MatrixApprovalAction) -> ApprovalActionResult:
-    """Resolve one Matrix approval action against live in-process approval state."""
+    """Resolve a live approval or expire a validated detached Matrix card."""
     manager = approval_manager.get_approval_store()
     if manager is None:
         return ApprovalActionResult(consumed=False, resolved=False)
     sanitized_reason = action.reason.strip() if isinstance(action.reason, str) and action.reason.strip() else None
     if action.approval_id is not None:
-        return await manager.handle_live_approval_id_response(
+        result = await manager.handle_live_approval_id_response(
             room_id=action.room_id,
             sender_id=action.sender_id,
             approval_id=action.approval_id,
             status=action.status,
             reason=sanitized_reason,
         )
+        if result.consumed or action.card_event_id is None:
+            return result
     if action.card_event_id is None:
         return ApprovalActionResult(consumed=False, resolved=False)
     return await manager.handle_card_response(
@@ -344,12 +346,12 @@ def initialize_approval_runtime(
     )
 
 
-async def expire_orphaned_approval_cards_on_startup(*, lookback_hours: int) -> int:
+async def expire_orphaned_approval_cards_on_startup() -> int:
     """Expire router-authored approval cards that can no longer have live waiters."""
     manager = approval_manager.get_approval_store()
     if manager is None:
         return 0
-    return await manager.discard_pending_on_startup(lookback_hours=lookback_hours)
+    return await manager.discard_pending_on_startup()
 
 
 async def shutdown_approval_runtime(reason: str = DEFAULT_SHUTDOWN_REASON) -> None:

--- a/tests/test_bot_reactions_approvals.py
+++ b/tests/test_bot_reactions_approvals.py
@@ -50,6 +50,27 @@ def mock_agent_user() -> AgentMatrixUser:
     return make_mock_agent_user()
 
 
+def _detached_approval_card() -> dict[str, Any]:
+    now = datetime.now(UTC)
+    return {
+        "event_id": "$approval",
+        "room_id": "!test:localhost",
+        "sender": "@mindroom_router:localhost",
+        "type": "io.mindroom.tool_approval",
+        "origin_server_ts": int(now.timestamp() * 1000),
+        "content": {
+            "approval_id": "approval-1",
+            "tool_name": "read_file",
+            "arguments": {"path": "notes.txt"},
+            "status": "pending",
+            "requester_id": "@user:localhost",
+            "approver_user_id": "@user:localhost",
+            "requested_at": now.isoformat(),
+            "expires_at": (now + timedelta(minutes=5)).isoformat(),
+        },
+    }
+
+
 class TestAgentBot(AgentBotTestBase):
     """Bot behavior tests moved verbatim from tests/test_multi_agent_bot.py."""
 
@@ -614,26 +635,8 @@ class TestAgentBot(AgentBotTestBase):
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths)
         bot._turn_controller.handle_text_event = AsyncMock()
         room = SimpleNamespace(room_id="!test:localhost", canonical_alias=None)
-        now = datetime.now(UTC)
-        card = {
-            "event_id": "$approval",
-            "room_id": "!test:localhost",
-            "sender": "@mindroom_router:localhost",
-            "type": "io.mindroom.tool_approval",
-            "origin_server_ts": int(now.timestamp() * 1000),
-            "content": {
-                "approval_id": "approval-1",
-                "tool_name": "read_file",
-                "arguments": {"path": "notes.txt"},
-                "status": "pending",
-                "requester_id": "@user:localhost",
-                "approver_user_id": "@user:localhost",
-                "requested_at": now.isoformat(),
-                "expires_at": (now + timedelta(minutes=5)).isoformat(),
-            },
-        }
         event_cache = MagicMock()
-        event_cache.get_event = AsyncMock(return_value=card)
+        event_cache.get_event = AsyncMock(return_value=_detached_approval_card())
         event_cache.get_latest_edit = AsyncMock(return_value=None)
         editor = AsyncMock(return_value=True)
         initialize_approval_store(
@@ -662,6 +665,55 @@ class TestAgentBot(AgentBotTestBase):
             replacement = editor.await_args.args[2]
             assert replacement["status"] == "expired"
             assert replacement["resolution_reason"] == "Original tool request is no longer active."
+        finally:
+            await _shutdown_approval_store()
+
+    @pytest.mark.asyncio
+    async def test_thread_fallback_to_detached_approval_remains_conversation_input(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """Thread fallback metadata must not turn ordinary text into an approval response."""
+        config = self._config_for_storage(tmp_path)
+        runtime_paths = runtime_paths_for(config)
+        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths)
+        bot._turn_controller.handle_text_event = AsyncMock()
+        room = SimpleNamespace(room_id="!test:localhost", canonical_alias=None)
+        event_cache = MagicMock()
+        event_cache.get_event = AsyncMock(return_value=_detached_approval_card())
+        editor = AsyncMock(return_value=True)
+        initialize_approval_store(
+            runtime_paths,
+            editor=editor,
+            event_cache=event_cache,
+            transport_sender=lambda: "@mindroom_router:localhost",
+        )
+        event = MagicMock(spec=nio.RoomMessageText)
+        event.event_id = "$thread-message"
+        event.sender = "@user:localhost"
+        event.body = "Please continue."
+        event.server_timestamp = 1234
+        event.source = {
+            "event_id": "$thread-message",
+            "sender": "@user:localhost",
+            "origin_server_ts": 1234,
+            "content": {
+                "m.relates_to": {
+                    "rel_type": "m.thread",
+                    "event_id": "$thread-root",
+                    "is_falling_back": True,
+                    "m.in_reply_to": {"event_id": "$approval"},
+                },
+            },
+        }
+
+        try:
+            await bot._on_message(room, event)
+
+            bot._turn_controller.handle_text_event.assert_awaited_once()
+            event_cache.get_event.assert_not_awaited()
+            editor.assert_not_awaited()
         finally:
             await _shutdown_approval_store()
 

--- a/tests/test_bot_reactions_approvals.py
+++ b/tests/test_bot_reactions_approvals.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import suppress
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -559,19 +560,19 @@ class TestAgentBot(AgentBotTestBase):
             await _shutdown_approval_store()
 
     @pytest.mark.asyncio
-    async def test_plain_rich_reply_does_not_probe_approval_cache(
+    async def test_plain_rich_reply_falls_through_after_approval_card_point_lookup(
         self,
         mock_agent_user: AgentMatrixUser,
         tmp_path: Path,
     ) -> None:
-        """Ordinary rich replies should not touch approval cache lookup."""
+        """Ordinary rich replies should fall through when their target is not an approval card."""
         config = self._config_for_storage(tmp_path)
         runtime_paths = runtime_paths_for(config)
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths)
         bot._turn_controller.handle_text_event = AsyncMock()
         room = SimpleNamespace(room_id="!test:localhost", canonical_alias=None)
         event_cache = MagicMock()
-        event_cache.get_event = AsyncMock(side_effect=RuntimeError("cache should not run"))
+        event_cache.get_event = AsyncMock(return_value=None)
         store = initialize_approval_store(
             runtime_paths,
             event_cache=event_cache,
@@ -596,8 +597,71 @@ class TestAgentBot(AgentBotTestBase):
             bot._turn_controller.handle_text_event.assert_awaited_once()
             assert bot._turn_controller.handle_text_event.await_args.args == (room, event)
             assert isinstance(bot._turn_controller.handle_text_event.await_args.kwargs["receipt_time"], float)
-            event_cache.get_event.assert_not_awaited()
+            event_cache.get_event.assert_awaited_once_with("!test:localhost", "$ordinary-message")
             assert store is get_approval_store()
+        finally:
+            await _shutdown_approval_store()
+
+    @pytest.mark.asyncio
+    async def test_reply_to_detached_pending_approval_is_consumed_and_expires_card(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """Detached approval replies should expire their card instead of entering conversation input."""
+        config = self._config_for_storage(tmp_path)
+        runtime_paths = runtime_paths_for(config)
+        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths)
+        bot._turn_controller.handle_text_event = AsyncMock()
+        room = SimpleNamespace(room_id="!test:localhost", canonical_alias=None)
+        now = datetime.now(UTC)
+        card = {
+            "event_id": "$approval",
+            "room_id": "!test:localhost",
+            "sender": "@mindroom_router:localhost",
+            "type": "io.mindroom.tool_approval",
+            "origin_server_ts": int(now.timestamp() * 1000),
+            "content": {
+                "approval_id": "approval-1",
+                "tool_name": "read_file",
+                "arguments": {"path": "notes.txt"},
+                "status": "pending",
+                "requester_id": "@user:localhost",
+                "approver_user_id": "@user:localhost",
+                "requested_at": now.isoformat(),
+                "expires_at": (now + timedelta(minutes=5)).isoformat(),
+            },
+        }
+        event_cache = MagicMock()
+        event_cache.get_event = AsyncMock(return_value=card)
+        event_cache.get_latest_edit = AsyncMock(return_value=None)
+        editor = AsyncMock(return_value=True)
+        initialize_approval_store(
+            runtime_paths,
+            editor=editor,
+            event_cache=event_cache,
+            transport_sender=lambda: "@mindroom_router:localhost",
+        )
+        event = MagicMock(spec=nio.RoomMessageText)
+        event.event_id = "$reply"
+        event.sender = "@user:localhost"
+        event.body = "Deny."
+        event.server_timestamp = 1234
+        event.source = {
+            "event_id": "$reply",
+            "sender": "@user:localhost",
+            "origin_server_ts": 1234,
+            "content": {"m.relates_to": {"m.in_reply_to": {"event_id": "$approval"}}},
+        }
+
+        try:
+            await bot._on_message(room, event)
+
+            bot._turn_controller.handle_text_event.assert_not_awaited()
+            assert editor.await_args.args[:2] == ("!test:localhost", "$approval")
+            replacement = editor.await_args.args[2]
+            assert replacement["status"] == "expired"
+            assert replacement["resolution_reason"] == "Original tool request is no longer active."
         finally:
             await _shutdown_approval_store()
 

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -1595,8 +1595,7 @@ class TestMultiAgentOrchestrator:
         async def _sync_runtime_support_services(*_: object, **__: object) -> None:
             call_order.append("support_services")
 
-        async def _discard_pending_on_startup(*, lookback_hours: int) -> int:
-            assert lookback_hours == 240
+        async def _discard_pending_on_startup() -> int:
             call_order.append("startup_discard")
             startup_discarded.set()
             return 2
@@ -1628,7 +1627,7 @@ class TestMultiAgentOrchestrator:
             "support_services",
             "startup_discard",
         ]
-        expire_orphaned_approval_cards_on_startup.assert_awaited_once_with(lookback_hours=240)
+        expire_orphaned_approval_cards_on_startup.assert_awaited_once_with()
         bot.try_start.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -1679,7 +1678,7 @@ class TestMultiAgentOrchestrator:
 
             await orchestrator._approval_transport.mark_startup_runtime_support_ready()
 
-        expire_orphaned_approval_cards_on_startup.assert_awaited_once_with(lookback_hours=240)
+        expire_orphaned_approval_cards_on_startup.assert_awaited_once_with()
 
     @pytest.mark.asyncio
     async def test_approval_transport_waits_for_router_ready_before_startup_discard(
@@ -1708,7 +1707,7 @@ class TestMultiAgentOrchestrator:
 
             await orchestrator.handle_bot_ready(bot)
 
-        expire_orphaned_approval_cards_on_startup.assert_awaited_once_with(lookback_hours=240)
+        expire_orphaned_approval_cards_on_startup.assert_awaited_once_with()
 
     @pytest.mark.asyncio
     async def test_approval_transport_concurrent_startup_gates_discard_once(
@@ -1737,7 +1736,7 @@ class TestMultiAgentOrchestrator:
                 orchestrator._approval_transport.mark_startup_runtime_support_ready(),
             )
 
-        expire_orphaned_approval_cards_on_startup.assert_awaited_once_with(lookback_hours=168)
+        expire_orphaned_approval_cards_on_startup.assert_awaited_once_with()
 
     @pytest.mark.asyncio
     async def test_approval_transport_reset_allows_fresh_startup_discard(

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -2043,6 +2043,15 @@ async def test_card_response_for_malformed_original_status_is_untouched(
     editor.assert_not_awaited()
 
 
+def test_pending_approval_ignores_malformed_edit_status() -> None:
+    card = _approval_card()
+    card["content"]["status"] = "approved"
+    pending = PendingApproval.from_card_event(card, room_id="!room:localhost")
+
+    assert pending.latest_status({"content": None}) == "approved"
+    assert pending.latest_status({"content": {"status": "invalid"}}) == "approved"
+
+
 @pytest.mark.asyncio
 async def test_card_response_for_cached_orphan_rejects_non_approver(tmp_path: Path) -> None:
     cache = FakeEventCache()

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import asyncio
 import json
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 from unittest.mock import AsyncMock, MagicMock, call
 
 import nio
@@ -811,11 +811,15 @@ async def test_handle_live_approval_id_response_rejects_waiter_from_wrong_room(t
 
 
 @pytest.mark.asyncio
-async def test_handle_card_response_orphan_approval_falls_through_until_startup_cleanup(tmp_path: Path) -> None:
+@pytest.mark.parametrize("response_status", ["approved", "denied"])
+async def test_public_matrix_action_expires_trusted_pending_orphan_without_approving(
+    tmp_path: Path,
+    response_status: Literal["approved", "denied"],
+) -> None:
     cache = FakeEventCache()
     await cache.store_event("$approval", "!room:localhost", _approval_card())
     editor = AsyncMock(return_value=True)
-    store = _ApprovalManager(
+    store = initialize_approval_store(
         test_runtime_paths(tmp_path),
         editor=editor,
         event_cache=cache,
@@ -823,21 +827,25 @@ async def test_handle_card_response_orphan_approval_falls_through_until_startup_
         transport_sender=lambda: "@mindroom_router:localhost",
     )
 
-    result = await store.handle_card_response(
-        room_id="!room:localhost",
-        sender_id="@user:localhost",
-        card_event_id="$approval",
-        status="approved",
-        reason=None,
+    result = await handle_matrix_approval_action(
+        MatrixApprovalAction(
+            room_id="!room:localhost",
+            sender_id="@user:localhost",
+            card_event_id="$approval",
+            approval_id="approval-1",
+            status=response_status,
+            reason=None,
+        ),
     )
 
-    assert result.consumed is False
-    assert result.resolved is False
-    editor.assert_not_awaited()
-
-    assert await store.discard_pending_on_startup() == 1
+    assert result.consumed is True
+    assert result.resolved is True
+    assert store.has_live_work() is False
     assert editor.await_args.args[:2] == ("!room:localhost", "$approval")
-    assert editor.await_args.args[2]["status"] == "expired"
+    replacement = editor.await_args.args[2]
+    assert replacement["status"] == "expired"
+    assert replacement["resolution_reason"] == "Original tool request is no longer active."
+    assert replacement["resolved_by"] == "@user:localhost"
 
 
 @pytest.mark.asyncio
@@ -1949,7 +1957,13 @@ async def test_card_response_for_resolved_card_is_not_consumed_without_live_wait
             },
         },
     )
-    store = _ApprovalManager(test_runtime_paths(tmp_path), event_cache=cache)
+    editor = AsyncMock(return_value=True)
+    store = _ApprovalManager(
+        test_runtime_paths(tmp_path),
+        editor=editor,
+        event_cache=cache,
+        transport_sender=lambda: "@mindroom_router:localhost",
+    )
 
     result = await store.handle_card_response(
         room_id="!room:localhost",
@@ -1961,10 +1975,76 @@ async def test_card_response_for_resolved_card_is_not_consumed_without_live_wait
 
     assert result.consumed is False
     assert result.resolved is False
+    editor.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_card_response_for_cached_approval_is_not_consumed_without_live_waiter(tmp_path: Path) -> None:
+@pytest.mark.parametrize("card_status", ["approved", "denied", "expired"])
+async def test_card_response_for_terminal_original_card_is_untouched(
+    tmp_path: Path,
+    card_status: Literal["approved", "denied", "expired"],
+) -> None:
+    cache = FakeEventCache()
+    card = _approval_card()
+    card["content"]["status"] = card_status
+    await cache.store_event("$approval", "!room:localhost", card)
+    editor = AsyncMock(return_value=True)
+    store = _ApprovalManager(
+        test_runtime_paths(tmp_path),
+        editor=editor,
+        event_cache=cache,
+        transport_sender=lambda: "@mindroom_router:localhost",
+    )
+
+    result = await store.handle_card_response(
+        room_id="!room:localhost",
+        sender_id="@user:localhost",
+        card_event_id="$approval",
+        status="approved",
+        reason=None,
+    )
+
+    assert result.consumed is False
+    assert result.resolved is False
+    editor.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("card_status", [None, "invalid"])
+async def test_card_response_for_malformed_original_status_is_untouched(
+    tmp_path: Path,
+    card_status: str | None,
+) -> None:
+    cache = FakeEventCache()
+    card = _approval_card()
+    if card_status is None:
+        card["content"].pop("status")
+    else:
+        card["content"]["status"] = card_status
+    await cache.store_event("$approval", "!room:localhost", card)
+    editor = AsyncMock(return_value=True)
+    store = _ApprovalManager(
+        test_runtime_paths(tmp_path),
+        editor=editor,
+        event_cache=cache,
+        transport_sender=lambda: "@mindroom_router:localhost",
+    )
+
+    result = await store.handle_card_response(
+        room_id="!room:localhost",
+        sender_id="@user:localhost",
+        card_event_id="$approval",
+        status="approved",
+        reason=None,
+    )
+
+    assert result.consumed is False
+    assert result.resolved is False
+    editor.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_card_response_for_cached_orphan_rejects_non_approver(tmp_path: Path) -> None:
     cache = FakeEventCache()
     card = _approval_card()
     await cache.store_event("$approval", "!room:localhost", card)
@@ -1978,7 +2058,7 @@ async def test_card_response_for_cached_approval_is_not_consumed_without_live_wa
 
     result = await store.handle_card_response(
         room_id="!room:localhost",
-        sender_id="@user:localhost",
+        sender_id="@other:localhost",
         card_event_id="$approval",
         status="denied",
         reason="Too late.",
@@ -2102,9 +2182,9 @@ async def test_response_for_unknown_card_does_not_emit_terminal_edit(tmp_path: P
 
 
 @pytest.mark.asyncio
-async def test_response_for_unknown_card_does_not_read_cache(tmp_path: Path) -> None:
+async def test_response_for_unknown_card_uses_bounded_point_lookup(tmp_path: Path) -> None:
     cache = MagicMock()
-    cache.get_event = AsyncMock(side_effect=RuntimeError("cache should not run"))
+    cache.get_event = AsyncMock(return_value=None)
     editor = AsyncMock(return_value=True)
     store = _ApprovalManager(
         test_runtime_paths(tmp_path),
@@ -2123,12 +2203,12 @@ async def test_response_for_unknown_card_does_not_read_cache(tmp_path: Path) -> 
 
     assert result.consumed is False
     assert result.resolved is False
-    cache.get_event.assert_not_awaited()
+    cache.get_event.assert_awaited_once_with("!room:localhost", "$approval")
     editor.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_card_response_ignores_same_router_cached_pending_without_history_scan(tmp_path: Path) -> None:
+async def test_card_response_expires_same_router_cached_pending_with_point_lookup(tmp_path: Path) -> None:
     cache = FakeEventCache()
     await cache.store_event("$approval", "!room:localhost", _approval_card())
     editor = AsyncMock(return_value=True)
@@ -2147,9 +2227,10 @@ async def test_card_response_ignores_same_router_cached_pending_without_history_
         reason="No.",
     )
 
-    assert result.consumed is False
-    assert result.resolved is False
-    editor.assert_not_awaited()
+    assert result.consumed is True
+    assert result.resolved is True
+    assert editor.await_args.args[2]["status"] == "expired"
+    assert editor.await_args.args[2]["resolution_reason"] == "Original tool request is no longer active."
 
 
 @pytest.mark.asyncio
@@ -2179,7 +2260,33 @@ async def test_card_response_ignores_cross_router_matrix_only_card(tmp_path: Pat
 
 
 @pytest.mark.asyncio
-async def test_concurrent_cached_response_events_fall_through_without_terminal_edits(tmp_path: Path) -> None:
+async def test_card_response_ignores_cached_card_from_different_room(tmp_path: Path) -> None:
+    cache = FakeEventCache()
+    foreign_card = _approval_card(room_id="!other:localhost")
+    await cache.store_event("$approval", "!room:localhost", foreign_card)
+    editor = AsyncMock(return_value=True)
+    store = _ApprovalManager(
+        test_runtime_paths(tmp_path),
+        editor=editor,
+        event_cache=cache,
+        transport_sender=lambda: "@mindroom_router:localhost",
+    )
+
+    result = await store.handle_card_response(
+        room_id="!room:localhost",
+        sender_id="@user:localhost",
+        card_event_id="$approval",
+        status="approved",
+        reason=None,
+    )
+
+    assert result.consumed is False
+    assert result.resolved is False
+    editor.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_cached_response_events_emit_one_expired_edit(tmp_path: Path) -> None:
     cache = FakeEventCache()
     await cache.store_event("$approval", "!room:localhost", _approval_card())
     edit_count = 0
@@ -2215,11 +2322,11 @@ async def test_concurrent_cached_response_events_fall_through_without_terminal_e
     )
     first_result, second_result = await asyncio.gather(first, second)
 
-    assert first_result.consumed is False
-    assert second_result.consumed is False
-    assert first_result.resolved is False
+    assert first_result.consumed is True
+    assert second_result.consumed is True
+    assert first_result.resolved is True
     assert second_result.resolved is False
-    assert edit_count == 0
+    assert edit_count == 1
 
 
 @pytest.mark.asyncio
@@ -2384,6 +2491,29 @@ async def test_discard_pending_on_startup_uses_cached_cards_without_history_scan
 
     assert await store.discard_pending_on_startup() == 1
     assert {call.args[1] for call in editor.await_args_list} == {"$cached-approval"}
+
+
+@pytest.mark.asyncio
+async def test_discard_pending_on_startup_expires_card_older_than_approval_timeout(tmp_path: Path) -> None:
+    cache = FakeEventCache()
+    old_timestamp = int((datetime.now(UTC) - timedelta(days=30)).timestamp() * 1000)
+    await cache.store_event(
+        "$old-approval",
+        "!room:localhost",
+        _approval_card(event_id="$old-approval", origin_server_ts=old_timestamp),
+    )
+    editor = AsyncMock(return_value=True)
+    store = _ApprovalManager(
+        test_runtime_paths(tmp_path),
+        editor=editor,
+        event_cache=cache,
+        approval_room_ids=lambda: {"!room:localhost"},
+        transport_sender=lambda: "@mindroom_router:localhost",
+    )
+
+    assert await store.discard_pending_on_startup() == 1
+    assert editor.await_args.args[1] == "$old-approval"
+    assert editor.await_args.args[2]["status"] == "expired"
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -420,6 +420,55 @@ async def test_live_card_response_ignores_cached_terminal_edit_from_different_se
 
 
 @pytest.mark.asyncio
+async def test_live_card_response_wins_when_approval_card_is_cached(tmp_path: Path) -> None:
+    cache = FakeEventCache()
+    sender = AsyncMock(return_value=SentApprovalEvent("$approval"))
+    editor = AsyncMock(return_value=True)
+    store = initialize_approval_store(
+        test_runtime_paths(tmp_path),
+        sender=sender,
+        editor=editor,
+        event_cache=cache,
+        transport_sender=lambda: "@mindroom_router:localhost",
+    )
+    task = asyncio.create_task(
+        store.request_approval(
+            tool_name="read_file",
+            arguments={"path": "notes.txt"},
+            room_id="!room:localhost",
+            requester_id="@user:localhost",
+            approver_user_id="@user:localhost",
+            timeout_seconds=30,
+        ),
+    )
+    pending = await _wait_for_pending(store, sender=sender)
+    await cache.store_event(
+        pending.card_event_id,
+        pending.room_id,
+        _approval_card(
+            approval_id=pending.approval_id,
+            event_id=pending.card_event_id,
+            room_id=pending.room_id,
+            sender=pending.card_sender_id,
+            approver=pending.approver_user_id,
+        ),
+    )
+
+    result = await store.handle_card_response(
+        room_id=pending.room_id,
+        sender_id=pending.approver_user_id,
+        card_event_id=pending.card_event_id,
+        status="approved",
+        reason=None,
+    )
+    decision = await task
+
+    assert result.resolved is True
+    assert decision.status == "approved"
+    assert editor.await_args.args[2]["status"] == "approved"
+
+
+@pytest.mark.asyncio
 async def test_handle_card_response_wrong_clicker_noops(tmp_path: Path) -> None:
     runtime_paths = test_runtime_paths(tmp_path)
     sender = AsyncMock(return_value=SentApprovalEvent("$approval"))
@@ -2240,6 +2289,42 @@ async def test_card_response_expires_same_router_cached_pending_with_point_looku
     assert result.resolved is True
     assert editor.await_args.args[2]["status"] == "expired"
     assert editor.await_args.args[2]["resolution_reason"] == "Original tool request is no longer active."
+
+
+@pytest.mark.asyncio
+async def test_detached_card_response_ignores_untrusted_terminal_edit(tmp_path: Path) -> None:
+    cache = FakeEventCache()
+    card = _approval_card()
+    await cache.store_event("$approval", "!room:localhost", card)
+    await cache.store_event(
+        "$fake-edit",
+        "!room:localhost",
+        _approval_edit(
+            card,
+            event_id="$fake-edit",
+            sender="@attacker:localhost",
+            status="approved",
+        ),
+    )
+    editor = AsyncMock(return_value=True)
+    store = _ApprovalManager(
+        test_runtime_paths(tmp_path),
+        editor=editor,
+        event_cache=cache,
+        transport_sender=lambda: "@mindroom_router:localhost",
+    )
+
+    result = await store.handle_card_response(
+        room_id="!room:localhost",
+        sender_id="@user:localhost",
+        card_event_id="$approval",
+        status="denied",
+        reason=None,
+    )
+
+    assert result.consumed is True
+    assert result.resolved is True
+    assert editor.await_args.args[2]["status"] == "expired"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Hardened alternative built on the same core approach as #1631.

## Why

Approval waiters intentionally live only in process memory. After restart, a cached Matrix approval card can still look actionable even though its tool call is permanently detached. Responses must fail closed, expire that card, and never resume or execute the tool call.

## What differs from #1631

- Handles button, reaction, custom-event, and explicit plain-text reply responses to detached cards. Explicit replies perform a room-scoped cache point lookup; Matrix thread fallbacks remain ordinary conversation input and do not probe the approval cache.
- Validates the original card status instead of assuming any original card without an edit is pending. Malformed and original-terminal cards remain untouched.
- Verifies the cached room, event id, trusted router sender, configured approver, and latest trusted status before emitting an expired edit.
- Records the actual responder in resolved_by.

## Shared behavior

- Detached tool calls are never approved or executed.
- Live approvals and denials keep their existing behavior.
- Startup cleanup keeps the bounded scan but removes the timeout-derived age cutoff, so old cached cards remain eligible.
- Foreign, untrusted, unauthorized, malformed, and terminal cards remain untouched.

## Validation

- uv run pytest -n 8: 11410 passed, 54 skipped.
- Pre-commit hooks pass for all changed files.