### PR TITLE
Batch historical sidecar cache hydration

### DIFF
--- a/src/mindroom/matrix/cache/event_cache.py
+++ b/src/mindroom/matrix/cache/event_cache.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
+    from collections.abc import Collection
+
     from .agent_message_snapshot import AgentMessageSnapshot
 
 
@@ -116,6 +118,15 @@ class ConversationEventCache(Protocol):
 
     async def get_mxc_text(self, room_id: str, event_id: str, mxc_url: str) -> str | None:
         """Return MXC plaintext only while a visible owning event still references it."""
+
+    async def get_mxc_texts(
+        self,
+        room_id: str,
+        references: Collection[tuple[str, str]],
+        *,
+        expected_membership_epoch: int,
+    ) -> dict[tuple[str, str], str]:
+        """Return scoped MXC plaintext for many surviving event references in one read."""
 
     async def store_event(
         self,

--- a/src/mindroom/matrix/cache/postgres_event_cache.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache.py
@@ -29,7 +29,7 @@ from .thread_cache_state import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Awaitable, Callable
+    from collections.abc import AsyncIterator, Awaitable, Callable, Collection
 
     from psycopg import AsyncConnection
 
@@ -1374,6 +1374,29 @@ class PostgresEventCache:
                 event_id=event_id,
                 mxc_url=mxc_url,
             ),
+        )
+
+    async def get_mxc_texts(
+        self,
+        room_id: str,
+        references: Collection[tuple[str, str]],
+        *,
+        expected_membership_epoch: int,
+    ) -> dict[tuple[str, str], str]:
+        """Return scoped MXC plaintext for many surviving event references in one read."""
+        if not references:
+            return {}
+        return await self._operation(
+            room_id,
+            operation="get_mxc_texts",
+            disabled_result={},
+            callback=lambda db: postgres_event_cache_events.load_mxc_texts(
+                db,
+                namespace=self._runtime.namespace,
+                room_id=room_id,
+                references=references,
+            ),
+            expected_membership_epoch=expected_membership_epoch,
         )
 
     async def store_event(

--- a/src/mindroom/matrix/cache/postgres_event_cache_events.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache_events.py
@@ -21,6 +21,8 @@ from .event_cache_events import (
 from .postgres_cursor import fetchall, fetchone, rowcount
 
 if TYPE_CHECKING:
+    from collections.abc import Collection
+
     from psycopg import AsyncConnection
 
 _ROOM_CONTENT_TABLES = (
@@ -232,6 +234,50 @@ async def load_mxc_text(
         (namespace, room_id, event_id, mxc_url),
     )
     return None if row is None else str(row[0])
+
+
+async def load_mxc_texts(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    room_id: str,
+    references: Collection[tuple[str, str]],
+) -> dict[tuple[str, str], str]:
+    """Return plaintext for exact visible references in one database round trip."""
+    unique_references = tuple(dict.fromkeys(references))
+    if not unique_references:
+        return {}
+    rows = await fetchall(
+        db,
+        """
+        WITH requested(event_id, mxc_url) AS (
+            SELECT *
+            FROM unnest(%s::text[], %s::text[])
+        )
+        SELECT reference.event_id, plaintext.mxc_url, plaintext.text_content
+        FROM requested
+        JOIN mindroom_event_cache_event_mxc_references AS reference
+          ON reference.event_id = requested.event_id
+         AND reference.mxc_url = requested.mxc_url
+        JOIN mindroom_event_cache_mxc_text AS plaintext
+          ON plaintext.namespace = reference.namespace
+         AND plaintext.room_id = reference.room_id
+         AND plaintext.mxc_url = reference.mxc_url
+        JOIN mindroom_event_cache_events AS events
+          ON events.namespace = reference.namespace
+         AND events.room_id = reference.room_id
+         AND events.event_id = reference.event_id
+        WHERE plaintext.namespace = %s
+          AND plaintext.room_id = %s
+        """,
+        (
+            [event_id for event_id, _mxc_url in unique_references],
+            [mxc_url for _event_id, mxc_url in unique_references],
+            namespace,
+            room_id,
+        ),
+    )
+    return {(str(event_id), str(mxc_url)): str(text_content) for event_id, mxc_url, text_content in rows}
 
 
 async def persist_mxc_text(

--- a/src/mindroom/matrix/cache/sqlite_event_cache.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache.py
@@ -30,7 +30,7 @@ from .thread_cache_state import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Awaitable, Callable
+    from collections.abc import AsyncIterator, Awaitable, Callable, Collection
     from pathlib import Path
 
     from .agent_message_snapshot import AgentMessageSnapshot
@@ -707,6 +707,7 @@ class SqliteEventCache:
         operation: str,
         disabled_result: _T,
         reader: Callable[[aiosqlite.Connection], Awaitable[_T]],
+        expected_membership_epoch: int | None = None,
     ) -> _T:
         if (
             self._runtime.is_disabled
@@ -730,12 +731,17 @@ class SqliteEventCache:
                     )
                     result = disabled_result
                 else:
-                    membership_state, _membership_epoch = await sqlite_event_cache_threads.load_room_membership_locked(
+                    membership_state, membership_epoch = await sqlite_event_cache_threads.load_room_membership_locked(
                         db,
                         principal_id=self.principal_id,
                         room_id=room_id,
                     )
-                    result = disabled_result if membership_state != "joined" else await reader(db)
+                    result = (
+                        disabled_result
+                        if membership_state != "joined"
+                        or (expected_membership_epoch is not None and membership_epoch != expected_membership_epoch)
+                        else await reader(db)
+                    )
                 await db.commit()
             except sqlite3.OperationalError as exc:
                 await _rollback_sqlite_connection_best_effort(db, operation=operation)
@@ -974,6 +980,29 @@ class SqliteEventCache:
                 event_id=event_id,
                 mxc_url=mxc_url,
             ),
+        )
+
+    async def get_mxc_texts(
+        self,
+        room_id: str,
+        references: Collection[tuple[str, str]],
+        *,
+        expected_membership_epoch: int,
+    ) -> dict[tuple[str, str], str]:
+        """Return scoped MXC plaintext for many surviving event references in one read."""
+        if not references:
+            return {}
+        return await self._read_operation(
+            room_id,
+            operation="get_mxc_texts",
+            disabled_result={},
+            reader=lambda db: sqlite_event_cache_events.load_mxc_texts(
+                db,
+                principal_id=self.principal_id,
+                room_id=room_id,
+                references=references,
+            ),
+            expected_membership_epoch=expected_membership_epoch,
         )
 
     async def store_event(

--- a/src/mindroom/matrix/cache/sqlite_event_cache_events.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache_events.py
@@ -272,8 +272,10 @@ async def load_mxc_texts(
             """,  # noqa: S608
             parameters,
         )
-        rows = await cursor.fetchall()
-        await cursor.close()
+        try:
+            rows = await cursor.fetchall()
+        finally:
+            await cursor.close()
         resolved.update(
             {(str(event_id), str(mxc_url)): str(text_content) for event_id, mxc_url, text_content in rows},
         )

--- a/src/mindroom/matrix/cache/sqlite_event_cache_events.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache_events.py
@@ -20,8 +20,11 @@ from .event_cache_events import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Collection
+
     import aiosqlite
 
+_MXC_TEXT_REFERENCE_BATCH_SIZE = 400
 _ROOM_CONTENT_TABLES = (
     "thread_events",
     "events",
@@ -231,6 +234,50 @@ async def load_mxc_text(
     row = await cursor.fetchone()
     await cursor.close()
     return None if row is None else str(row[0])
+
+
+async def load_mxc_texts(
+    db: aiosqlite.Connection,
+    *,
+    principal_id: str,
+    room_id: str,
+    references: Collection[tuple[str, str]],
+) -> dict[tuple[str, str], str]:
+    """Return plaintext for exact visible references with bounded SQLite parameter batches."""
+    unique_references = tuple(dict.fromkeys(references))
+    resolved: dict[tuple[str, str], str] = {}
+    for start in range(0, len(unique_references), _MXC_TEXT_REFERENCE_BATCH_SIZE):
+        batch = unique_references[start : start + _MXC_TEXT_REFERENCE_BATCH_SIZE]
+        reference_predicate = " OR ".join("(reference.event_id = ? AND plaintext.mxc_url = ?)" for _reference in batch)
+        parameters = (
+            principal_id,
+            room_id,
+            *(value for reference in batch for value in reference),
+        )
+        cursor = await db.execute(
+            f"""
+            SELECT reference.event_id, plaintext.mxc_url, plaintext.text_content
+            FROM mxc_text_cache AS plaintext
+            JOIN event_mxc_references AS reference
+              ON reference.principal_id = plaintext.principal_id
+             AND reference.room_id = plaintext.room_id
+             AND reference.mxc_url = plaintext.mxc_url
+            JOIN events
+              ON events.principal_id = reference.principal_id
+             AND events.room_id = reference.room_id
+             AND events.event_id = reference.event_id
+            WHERE plaintext.principal_id = ?
+              AND plaintext.room_id = ?
+              AND ({reference_predicate})
+            """,  # noqa: S608
+            parameters,
+        )
+        rows = await cursor.fetchall()
+        await cursor.close()
+        resolved.update(
+            {(str(event_id), str(mxc_url)): str(text_content) for event_id, mxc_url, text_content in rows},
+        )
+    return resolved
 
 
 async def _event_owns_mxc_text(

--- a/src/mindroom/matrix/client_thread_history.py
+++ b/src/mindroom/matrix/client_thread_history.py
@@ -74,7 +74,12 @@ from mindroom.matrix.media import (
     parse_matrix_media_event_source,
 )
 from mindroom.matrix.membership_fence import UNCERTIFIED_MEMBERSHIP_EPOCH
-from mindroom.matrix.message_content import extract_and_resolve_message, resolve_event_source_content
+from mindroom.matrix.message_content import (
+    SidecarHydrationBatch,
+    extract_and_resolve_message,
+    prepare_sidecar_hydration_batch,
+    resolve_event_source_content,
+)
 from mindroom.matrix.thread_diagnostics import (
     THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC,
     THREAD_HISTORY_DEGRADED_DIAGNOSTIC,
@@ -119,6 +124,10 @@ class OpaqueEncryptedThreadHistoryError(RuntimeError):
 
 class _UnresolvedOpaqueRoomHistoryError(OpaqueEncryptedThreadHistoryError):
     """Raised when opaque room history cannot be assigned to a specific thread."""
+
+
+class _SidecarMembershipChangedError(RuntimeError):
+    """Raised when request-scoped sidecar plaintext crosses a membership transition."""
 
 
 async def _capture_membership_epoch(event_cache: ConversationEventCache, room_id: str) -> int:
@@ -345,6 +354,22 @@ def _bundled_replacement_source(event_source: Mapping[str, Any]) -> dict[str, An
     return None
 
 
+async def _assert_sidecar_membership_epoch_unchanged(
+    event_cache: ConversationEventCache,
+    *,
+    room_id: str,
+    expected_membership_epoch: int | None,
+    hydration_batch: SidecarHydrationBatch | None,
+) -> None:
+    """Reject a request-scoped plaintext batch that crossed a membership transition."""
+    if hydration_batch is None:
+        return
+    current_membership_epoch = await event_cache.room_membership_epoch(room_id)
+    if current_membership_epoch != expected_membership_epoch:
+        msg = "Room membership changed during sidecar hydration"
+        raise _SidecarMembershipChangedError(msg)
+
+
 async def _resolve_thread_history_from_event_sources_timed(
     client: nio.AsyncClient,
     *,
@@ -355,6 +380,7 @@ async def _resolve_thread_history_from_event_sources_timed(
     event_cache: ConversationEventCache,
     expected_membership_epoch: int | None = None,
     trusted_sender_ids: Collection[str] = (),
+    register_sidecar_owners: bool = False,
 ) -> tuple[list[ResolvedVisibleMessage], float]:
     """Resolve visible thread history and return approximate sidecar hydration time."""
     input_order_by_event_id: dict[str, int] = {}
@@ -374,6 +400,17 @@ async def _resolve_thread_history_from_event_sources_timed(
     messages_by_event_id: dict[str, ResolvedVisibleMessage] = {}
     latest_edits_by_original_event_id: dict[str, tuple[nio.RoomMessageText | nio.RoomMessageNotice, str | None]] = {}
     sidecar_hydration_started = time.perf_counter()
+    hydration_batch = (
+        await prepare_sidecar_hydration_batch(
+            event_sources,
+            event_cache=event_cache,
+            room_id=room_id,
+            expected_membership_epoch=expected_membership_epoch,
+            register_owners=register_sidecar_owners,
+        )
+        if hydrate_sidecars
+        else None
+    )
     for event in parsed_events:
         event_info = EventInfo.from_event(event.source)
         bundled_replacement_source = _bundled_replacement_source(event.source)
@@ -400,6 +437,7 @@ async def _resolve_thread_history_from_event_sources_timed(
                 event_cache=event_cache,
                 room_id=room_id,
                 expected_membership_epoch=expected_membership_epoch,
+                hydration_batch=hydration_batch,
                 trusted_sender_ids=trusted_sender_ids,
             )
             if hydrate_sidecars
@@ -414,7 +452,14 @@ async def _resolve_thread_history_from_event_sources_timed(
         event_cache=event_cache,
         room_id=room_id,
         expected_membership_epoch=expected_membership_epoch,
+        hydration_batch=hydration_batch,
         trusted_sender_ids=trusted_sender_ids,
+    )
+    await _assert_sidecar_membership_epoch_unchanged(
+        event_cache,
+        room_id=room_id,
+        expected_membership_epoch=expected_membership_epoch,
+        hydration_batch=hydration_batch,
     )
     messages = list(messages_by_event_id.values())
     sort_thread_messages_root_first(
@@ -521,6 +566,17 @@ async def _resolve_cached_thread_history(
             thread_id=thread_id,
             event_sources=cached_event_sources,
             hydrate_sidecars=hydrate_sidecars,
+            event_cache=event_cache,
+            expected_membership_epoch=expected_membership_epoch,
+            trusted_sender_ids=trusted_sender_ids,
+        )
+    except _SidecarMembershipChangedError:
+        return await _resolve_thread_history_from_event_sources_timed(
+            client,
+            room_id=room_id,
+            thread_id=thread_id,
+            event_sources=cached_event_sources,
+            hydrate_sidecars=False,
             event_cache=event_cache,
             expected_membership_epoch=expected_membership_epoch,
             trusted_sender_ids=trusted_sender_ids,
@@ -877,6 +933,7 @@ async def _resolve_thread_history_message(
     event_cache: ConversationEventCache,
     room_id: str,
     expected_membership_epoch: int | None = None,
+    hydration_batch: SidecarHydrationBatch | None = None,
     trusted_sender_ids: Collection[str] = (),
 ) -> ResolvedVisibleMessage:
     """Resolve one room-message event into the normalized thread-history shape."""
@@ -887,6 +944,7 @@ async def _resolve_thread_history_message(
             event_cache=event_cache,
             room_id=room_id,
             expected_membership_epoch=expected_membership_epoch,
+            hydration_batch=hydration_batch,
             trusted_sender_ids=trusted_sender_ids,
         )
         return ResolvedVisibleMessage.from_message_data(
@@ -901,6 +959,7 @@ async def _resolve_thread_history_message(
         event_cache=event_cache,
         room_id=room_id,
         expected_membership_epoch=expected_membership_epoch,
+        hydration_batch=hydration_batch,
     )
     content = resolved_event_source.get("content", {})
     normalized_content = content if isinstance(content, dict) else {}
@@ -1108,6 +1167,7 @@ async def _fetch_thread_history_via_room_messages_with_events(
         event_cache=event_cache,
         expected_membership_epoch=expected_membership_epoch,
         trusted_sender_ids=trusted_sender_ids,
+        register_sidecar_owners=True,
     )
     return _ThreadHistoryFetchResult(
         history=history,

--- a/src/mindroom/matrix/client_thread_history.py
+++ b/src/mindroom/matrix/client_thread_history.py
@@ -370,6 +370,22 @@ async def _assert_sidecar_membership_epoch_unchanged(
         raise _SidecarMembershipChangedError(msg)
 
 
+def _sidecar_hydration_sources(
+    event_sources: Sequence[dict[str, Any]],
+    *,
+    hydrate_sidecars: bool,
+) -> list[dict[str, Any]]:
+    """Return sources whose sidecars this resolution pass may hydrate."""
+    hydration_sources: list[dict[str, Any]] = []
+    for event_source in event_sources:
+        bundled_replacement = _bundled_replacement_source(event_source)
+        if bundled_replacement is not None:
+            hydration_sources.append(bundled_replacement)
+        if hydrate_sidecars or EventInfo.from_event(event_source).is_edit:
+            hydration_sources.append(event_source)
+    return hydration_sources
+
+
 async def _resolve_thread_history_from_event_sources_timed(
     client: nio.AsyncClient,
     *,
@@ -400,16 +416,12 @@ async def _resolve_thread_history_from_event_sources_timed(
     messages_by_event_id: dict[str, ResolvedVisibleMessage] = {}
     latest_edits_by_original_event_id: dict[str, tuple[nio.RoomMessageText | nio.RoomMessageNotice, str | None]] = {}
     sidecar_hydration_started = time.perf_counter()
-    hydration_batch = (
-        await prepare_sidecar_hydration_batch(
-            event_sources,
-            event_cache=event_cache,
-            room_id=room_id,
-            expected_membership_epoch=expected_membership_epoch,
-            register_owners=register_sidecar_owners,
-        )
-        if hydrate_sidecars
-        else None
+    hydration_batch = await prepare_sidecar_hydration_batch(
+        _sidecar_hydration_sources(event_sources, hydrate_sidecars=hydrate_sidecars),
+        event_cache=event_cache,
+        room_id=room_id,
+        expected_membership_epoch=expected_membership_epoch,
+        register_owners=register_sidecar_owners,
     )
     for event in parsed_events:
         event_info = EventInfo.from_event(event.source)

--- a/src/mindroom/matrix/client_thread_history.py
+++ b/src/mindroom/matrix/client_thread_history.py
@@ -126,10 +126,6 @@ class _UnresolvedOpaqueRoomHistoryError(OpaqueEncryptedThreadHistoryError):
     """Raised when opaque room history cannot be assigned to a specific thread."""
 
 
-class _SidecarMembershipChangedError(RuntimeError):
-    """Raised when request-scoped sidecar plaintext crosses a membership transition."""
-
-
 async def _capture_membership_epoch(event_cache: ConversationEventCache, room_id: str) -> int:
     """Return a durable refill generation or a value that rejects every cache write."""
     try:
@@ -354,22 +350,6 @@ def _bundled_replacement_source(event_source: Mapping[str, Any]) -> dict[str, An
     return None
 
 
-async def _assert_sidecar_membership_epoch_unchanged(
-    event_cache: ConversationEventCache,
-    *,
-    room_id: str,
-    expected_membership_epoch: int | None,
-    hydration_batch: SidecarHydrationBatch | None,
-) -> None:
-    """Reject a request-scoped plaintext batch that crossed a membership transition."""
-    if hydration_batch is None:
-        return
-    current_membership_epoch = await event_cache.room_membership_epoch(room_id)
-    if current_membership_epoch != expected_membership_epoch:
-        msg = "Room membership changed during sidecar hydration"
-        raise _SidecarMembershipChangedError(msg)
-
-
 def _sidecar_hydration_sources(
     event_sources: Sequence[dict[str, Any]],
     *,
@@ -466,12 +446,6 @@ async def _resolve_thread_history_from_event_sources_timed(
         expected_membership_epoch=expected_membership_epoch,
         hydration_batch=hydration_batch,
         trusted_sender_ids=trusted_sender_ids,
-    )
-    await _assert_sidecar_membership_epoch_unchanged(
-        event_cache,
-        room_id=room_id,
-        expected_membership_epoch=expected_membership_epoch,
-        hydration_batch=hydration_batch,
     )
     messages = list(messages_by_event_id.values())
     sort_thread_messages_root_first(
@@ -578,17 +552,6 @@ async def _resolve_cached_thread_history(
             thread_id=thread_id,
             event_sources=cached_event_sources,
             hydrate_sidecars=hydrate_sidecars,
-            event_cache=event_cache,
-            expected_membership_epoch=expected_membership_epoch,
-            trusted_sender_ids=trusted_sender_ids,
-        )
-    except _SidecarMembershipChangedError:
-        return await _resolve_thread_history_from_event_sources_timed(
-            client,
-            room_id=room_id,
-            thread_id=thread_id,
-            event_sources=cached_event_sources,
-            hydrate_sidecars=False,
             event_cache=event_cache,
             expected_membership_epoch=expected_membership_epoch,
             trusted_sender_ids=trusted_sender_ids,

--- a/src/mindroom/matrix/client_visible_messages.py
+++ b/src/mindroom/matrix/client_visible_messages.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
     from mindroom.matrix.cache import ConversationEventCache
+    from mindroom.matrix.message_content import SidecarHydrationBatch
 
 _VISIBLE_ROOM_MESSAGE_EVENT_TYPES = (nio.RoomMessageText, nio.RoomMessageNotice)
 
@@ -393,6 +394,7 @@ async def apply_latest_edits_to_messages(
     event_cache: ConversationEventCache | None = None,
     room_id: str | None = None,
     expected_membership_epoch: int | None = None,
+    hydration_batch: SidecarHydrationBatch | None = None,
     trusted_sender_ids: Collection[str] = (),
 ) -> None:
     """Apply latest edits to message records and synthesize missing originals when allowed."""
@@ -410,6 +412,7 @@ async def apply_latest_edits_to_messages(
             event_cache=event_cache,
             room_id=room_id,
             expected_membership_epoch=expected_membership_epoch,
+            hydration_batch=hydration_batch,
             trusted_sender_ids=trusted_sender_ids,
         )
         if edited_body is None:

--- a/src/mindroom/matrix/message_content.py
+++ b/src/mindroom/matrix/message_content.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import nio
@@ -14,13 +15,21 @@ from mindroom.matrix.sidecar_content import sidecar_mxc_url
 from mindroom.matrix.visible_body import has_trusted_stream_body_metadata, visible_body_from_content
 
 if TYPE_CHECKING:
-    from collections.abc import Collection
+    from collections.abc import Collection, Mapping, Sequence
 
     from mindroom.matrix.cache import ConversationEventCache
 
 logger = get_logger(__name__)
 
 _MXC_TEXT_MAX_BYTES = 2 * 1024 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class SidecarHydrationBatch:
+    """Request-scoped durable sidecar hits and their visible owner event IDs."""
+
+    cached_texts: Mapping[tuple[str, str], str]
+    owner_event_ids: frozenset[str]
 
 
 def _extract_large_message_v2_content(payload_json: str) -> dict[str, Any] | None:
@@ -62,6 +71,72 @@ def _sidecar_content_for_resolution(content: dict[str, Any]) -> dict[str, Any] |
     return None
 
 
+def _sidecar_reference(event_source: Mapping[str, Any]) -> tuple[str, str] | None:
+    """Return one visible event's exact durable sidecar reference."""
+    event_id = event_source.get("event_id")
+    content = _normalized_content_dict(event_source.get("content"))
+    sidecar_content = _sidecar_content_for_resolution(content)
+    mxc_url = sidecar_mxc_url(sidecar_content) if sidecar_content is not None else None
+    if not isinstance(event_id, str) or not event_id or mxc_url is None:
+        return None
+    return event_id, mxc_url
+
+
+async def prepare_sidecar_hydration_batch(
+    event_sources: Sequence[dict[str, Any]],
+    *,
+    event_cache: ConversationEventCache,
+    room_id: str,
+    expected_membership_epoch: int | None,
+    register_owners: bool,
+) -> SidecarHydrationBatch | None:
+    """Prepare one bounded durable lookup for all sidecars in a history reconstruction."""
+    if expected_membership_epoch is None or expected_membership_epoch == UNCERTIFIED_MEMBERSHIP_EPOCH:
+        return None
+    source_by_event_id = {
+        reference[0]: event_source
+        for event_source in event_sources
+        if (reference := _sidecar_reference(event_source)) is not None
+    }
+    references = tuple(
+        reference
+        for event_source in source_by_event_id.values()
+        if (reference := _sidecar_reference(event_source)) is not None
+    )
+    if not references:
+        return None
+    if register_owners:
+        try:
+            await event_cache.store_events_batch(
+                [(event_id, room_id, source_by_event_id[event_id]) for event_id, _mxc_url in references],
+                expected_membership_epoch=expected_membership_epoch,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to batch-register long-text sidecar ownership",
+                room_id=room_id,
+                event_count=len(references),
+            )
+            return None
+    try:
+        cached_texts = await event_cache.get_mxc_texts(
+            room_id,
+            references,
+            expected_membership_epoch=expected_membership_epoch,
+        )
+    except Exception:
+        logger.exception(
+            "Failed to batch-read durable MXC text cache",
+            room_id=room_id,
+            reference_count=len(references),
+        )
+        return None
+    return SidecarHydrationBatch(
+        cached_texts=cached_texts,
+        owner_event_ids=frozenset(event_id for event_id, _mxc_url in references),
+    )
+
+
 async def _register_sidecar_owner(
     event_source: dict[str, Any],
     *,
@@ -69,6 +144,7 @@ async def _register_sidecar_owner(
     room_id: str | None,
     fallback_event_id: str | None = None,
     expected_membership_epoch: int | None = None,
+    hydration_batch: SidecarHydrationBatch | None = None,
 ) -> str | None:
     """Persist the visible event/reference before plaintext hydration begins."""
     content = _normalized_content_dict(event_source.get("content"))
@@ -78,7 +154,7 @@ async def _register_sidecar_owner(
         return event_id if isinstance(event_id, str) else fallback_event_id
     event_id_value = event_source.get("event_id")
     event_id = event_id_value if isinstance(event_id_value, str) and event_id_value else fallback_event_id
-    if event_cache is None:
+    if (hydration_batch is not None and event_id in hydration_batch.owner_event_ids) or event_cache is None:
         return event_id
     if room_id is None or event_id is None:
         return None
@@ -112,6 +188,7 @@ async def _resolve_event_content(
     room_id: str | None,
     fallback_event_id: str | None = None,
     expected_membership_epoch: int | None = None,
+    hydration_batch: SidecarHydrationBatch | None = None,
 ) -> tuple[dict[str, Any], bool]:
     """Register valid sidecar ownership and return canonical content plus whether it changed."""
     preview_content = _normalized_content_dict(event_source.get("content", {}))
@@ -121,6 +198,7 @@ async def _resolve_event_content(
         room_id=room_id,
         fallback_event_id=fallback_event_id,
         expected_membership_epoch=expected_membership_epoch,
+        hydration_batch=hydration_batch,
     )
     resolved_content = await _resolve_canonical_content(
         preview_content,
@@ -129,6 +207,7 @@ async def _resolve_event_content(
         room_id=room_id,
         event_id=event_id,
         expected_membership_epoch=expected_membership_epoch,
+        hydration_batch=hydration_batch,
     )
     return resolved_content, resolved_content is not preview_content
 
@@ -159,6 +238,7 @@ async def _download_mxc_text(  # noqa: PLR0911, PLR0912, PLR0915, C901
     room_id: str | None = None,
     event_id: str | None = None,
     expected_membership_epoch: int | None = None,
+    hydration_batch: SidecarHydrationBatch | None = None,
 ) -> str | None:
     """Download text content from an MXC URL with caching.
 
@@ -170,6 +250,7 @@ async def _download_mxc_text(  # noqa: PLR0911, PLR0912, PLR0915, C901
         room_id: Room scope for event-cache locking when a durable MXC cache is available
         event_id: Visible event that owns the room-scoped MXC reference
         expected_membership_epoch: Durable room transition expected by fetch-derived writes
+        hydration_batch: Request-scoped durable sidecar hits from one bounded cache read
     Returns:
         The downloaded text content, or None if download failed
 
@@ -178,23 +259,26 @@ async def _download_mxc_text(  # noqa: PLR0911, PLR0912, PLR0915, C901
         expected_membership_epoch is not None and expected_membership_epoch != UNCERTIFIED_MEMBERSHIP_EPOCH
     )
     if cache_writes_certified and event_cache is not None and room_id is not None and event_id is not None:
-        try:
-            cached_text = await event_cache.get_mxc_text(room_id, event_id, mxc_url)
-        except Exception:
-            logger.exception("Failed to read durable MXC text cache")
+        if hydration_batch is not None:
+            cached_text = hydration_batch.cached_texts.get((event_id, mxc_url))
         else:
-            if cached_text is not None:
-                if _text_size_bytes(cached_text) > _MXC_TEXT_MAX_BYTES:
-                    logger.warning(
-                        "durable_mxc_text_cache_entry_exceeds_byte_limit",
-                        mxc_url=mxc_url,
-                        room_id=room_id,
-                        size_bytes=_text_size_bytes(cached_text),
-                        limit_bytes=_MXC_TEXT_MAX_BYTES,
-                    )
-                    return None
-                logger.debug("mxc_text_cache_hit", mxc_url=mxc_url, room_id=room_id)
-                return cached_text
+            try:
+                cached_text = await event_cache.get_mxc_text(room_id, event_id, mxc_url)
+            except Exception:
+                logger.exception("Failed to read durable MXC text cache")
+                cached_text = None
+        if cached_text is not None:
+            if _text_size_bytes(cached_text) > _MXC_TEXT_MAX_BYTES:
+                logger.warning(
+                    "durable_mxc_text_cache_entry_exceeds_byte_limit",
+                    mxc_url=mxc_url,
+                    room_id=room_id,
+                    size_bytes=_text_size_bytes(cached_text),
+                    limit_bytes=_MXC_TEXT_MAX_BYTES,
+                )
+                return None
+            logger.debug("mxc_text_cache_hit", mxc_url=mxc_url, room_id=room_id)
+            return cached_text
 
     try:
         # Parse MXC URL
@@ -288,6 +372,7 @@ async def extract_and_resolve_message(
     event_cache: ConversationEventCache | None = None,
     room_id: str | None = None,
     expected_membership_epoch: int | None = None,
+    hydration_batch: SidecarHydrationBatch | None = None,
     trusted_sender_ids: Collection[str] = (),
 ) -> dict[str, Any]:
     """Extract message data and resolve large message content if needed.
@@ -301,6 +386,7 @@ async def extract_and_resolve_message(
         event_cache: Optional durable event cache used for restart-safe sidecar reuse
         room_id: Room scope for durable sidecar cache reads and writes
         expected_membership_epoch: Durable room transition expected by fetch-derived writes
+        hydration_batch: Request-scoped durable sidecar hits from one bounded cache read
         trusted_sender_ids: Exact trusted internal sender IDs allowed to override visible body
 
     Returns:
@@ -316,6 +402,7 @@ async def extract_and_resolve_message(
         room_id=room_id,
         fallback_event_id=event.event_id,
         expected_membership_epoch=expected_membership_epoch,
+        hydration_batch=hydration_batch,
     )
     resolved_body = visible_body_from_content(
         resolved_content,
@@ -353,6 +440,7 @@ async def extract_edit_body(
     event_cache: ConversationEventCache | None = None,
     room_id: str | None = None,
     expected_membership_epoch: int | None = None,
+    hydration_batch: SidecarHydrationBatch | None = None,
     trusted_sender_ids: Collection[str] = (),
 ) -> tuple[str | None, dict[str, Any] | None]:
     """Extract body/content from an edit event's ``m.new_content`` payload."""
@@ -362,6 +450,7 @@ async def extract_edit_body(
         event_cache=event_cache,
         room_id=room_id,
         expected_membership_epoch=expected_membership_epoch,
+        hydration_batch=hydration_batch,
     )
     new_content = _normalized_content_dict(resolved_content.get("m.new_content"))
     body = visible_body_from_content(
@@ -384,6 +473,7 @@ async def resolve_event_source_content(
     event_cache: ConversationEventCache | None = None,
     room_id: str | None = None,
     expected_membership_epoch: int | None = None,
+    hydration_batch: SidecarHydrationBatch | None = None,
 ) -> dict[str, Any]:
     """Return an event source with canonical v2 sidecar content hydrated when available."""
     resolved_content, content_changed = await _resolve_event_content(
@@ -392,6 +482,7 @@ async def resolve_event_source_content(
         event_cache=event_cache,
         room_id=room_id,
         expected_membership_epoch=expected_membership_epoch,
+        hydration_batch=hydration_batch,
     )
     if not content_changed:
         return event_source
@@ -409,6 +500,7 @@ async def _resolve_canonical_content(
     room_id: str | None,
     event_id: str | None,
     expected_membership_epoch: int | None,
+    hydration_batch: SidecarHydrationBatch | None,
 ) -> dict[str, Any]:
     """Hydrate canonical event content from a v2 JSON sidecar when available."""
     sidecar_content = _sidecar_content_for_resolution(content)
@@ -427,6 +519,7 @@ async def _resolve_canonical_content(
         room_id=room_id,
         event_id=event_id,
         expected_membership_epoch=expected_membership_epoch,
+        hydration_batch=hydration_batch,
     )
     if full_text is None:
         return content

--- a/src/mindroom/matrix/message_content.py
+++ b/src/mindroom/matrix/message_content.py
@@ -29,6 +29,7 @@ class SidecarHydrationBatch:
     """Request-scoped durable sidecar hits and their visible owner event IDs."""
 
     cached_texts: Mapping[tuple[str, str], str]
+    references: frozenset[tuple[str, str]]
     owner_event_ids: frozenset[str]
 
 
@@ -133,6 +134,7 @@ async def prepare_sidecar_hydration_batch(
         return None
     return SidecarHydrationBatch(
         cached_texts=cached_texts,
+        references=frozenset(references),
         owner_event_ids=frozenset(event_id for event_id, _mxc_url in references),
     )
 
@@ -259,7 +261,7 @@ async def _download_mxc_text(  # noqa: PLR0911, PLR0912, PLR0915, C901
         expected_membership_epoch is not None and expected_membership_epoch != UNCERTIFIED_MEMBERSHIP_EPOCH
     )
     if cache_writes_certified and event_cache is not None and room_id is not None and event_id is not None:
-        if hydration_batch is not None:
+        if hydration_batch is not None and (event_id, mxc_url) in hydration_batch.references:
             cached_text = hydration_batch.cached_texts.get((event_id, mxc_url))
         else:
             try:

--- a/src/mindroom/matrix/message_content.py
+++ b/src/mindroom/matrix/message_content.py
@@ -94,22 +94,19 @@ async def prepare_sidecar_hydration_batch(
     """Prepare one bounded durable lookup for all sidecars in a history reconstruction."""
     if expected_membership_epoch is None or expected_membership_epoch == UNCERTIFIED_MEMBERSHIP_EPOCH:
         return None
-    source_by_event_id = {
-        reference[0]: event_source
-        for event_source in event_sources
-        if (reference := _sidecar_reference(event_source)) is not None
-    }
-    references = tuple(
-        reference
-        for event_source in source_by_event_id.values()
-        if (reference := _sidecar_reference(event_source)) is not None
-    )
+    sidecars_by_event_id: dict[str, tuple[dict[str, Any], tuple[str, str]]] = {}
+    for event_source in event_sources:
+        reference = _sidecar_reference(event_source)
+        if reference is not None:
+            sidecars_by_event_id[reference[0]] = event_source, reference
+    references = tuple(reference for _event_source, reference in sidecars_by_event_id.values())
     if not references:
         return None
+    verified_owner_event_ids: frozenset[str] = frozenset()
     if register_owners:
         try:
             await event_cache.store_events_batch(
-                [(event_id, room_id, source_by_event_id[event_id]) for event_id, _mxc_url in references],
+                [(event_id, room_id, sidecars_by_event_id[event_id][0]) for event_id, _mxc_url in references],
                 expected_membership_epoch=expected_membership_epoch,
             )
         except Exception:
@@ -119,6 +116,7 @@ async def prepare_sidecar_hydration_batch(
                 event_count=len(references),
             )
             return None
+        verified_owner_event_ids = frozenset(event_id for event_id, _mxc_url in references)
     try:
         cached_texts = await event_cache.get_mxc_texts(
             room_id,
@@ -132,10 +130,12 @@ async def prepare_sidecar_hydration_batch(
             reference_count=len(references),
         )
         return None
+    if not register_owners:
+        verified_owner_event_ids = frozenset(event_id for event_id, _mxc_url in cached_texts)
     return SidecarHydrationBatch(
         cached_texts=cached_texts,
         references=frozenset(references),
-        owner_event_ids=frozenset(event_id for event_id, _mxc_url in references),
+        owner_event_ids=verified_owner_event_ids,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -784,6 +784,7 @@ def make_event_cache_mock() -> AsyncMock:
     event_cache.get_event.return_value = None
     event_cache.get_latest_edit.return_value = None
     event_cache.get_mxc_text.return_value = None
+    event_cache.get_mxc_texts.return_value = {}
     event_cache.get_recent_room_events.return_value = []
     event_cache.get_recent_room_thread_ids.return_value = []
     event_cache.get_thread_events.return_value = None

--- a/tests/test_event_cache_contract.py
+++ b/tests/test_event_cache_contract.py
@@ -10,6 +10,24 @@ from mindroom.matrix.cache import ConversationEventCache
 from tests.event_cache_test_support import replace_thread_unconditionally
 
 
+def _sidecar_message_event(event_id: str, timestamp: int, *, mxc_url: str) -> dict[str, Any]:
+    return {
+        "event_id": event_id,
+        "sender": "@user:localhost",
+        "origin_server_ts": timestamp,
+        "type": "m.room.message",
+        "content": {
+            "msgtype": "m.file",
+            "body": "preview",
+            "url": mxc_url,
+            "io.mindroom.long_text": {
+                "version": 2,
+                "encoding": "matrix_event_content_json",
+            },
+        },
+    }
+
+
 def _message_event(
     event_id: str,
     timestamp: int,
@@ -55,6 +73,14 @@ class TestConversationEventCacheContract:
         assert event_cache.durable_writes_available is False
         assert event_cache.cache_generation is None
         assert await event_cache.get_event("!room:localhost", "$missing") is None
+        assert (
+            await event_cache.get_mxc_texts(
+                "!room:localhost",
+                {("$missing", "mxc://server/missing")},
+                expected_membership_epoch=0,
+            )
+            == {}
+        )
         assert (
             await event_cache.get_recent_room_events(
                 "!room:localhost",
@@ -122,6 +148,80 @@ class TestConversationEventCacheContract:
                 sender="@other:localhost",
             )
             == other_sender_edit
+        )
+
+    @pytest.mark.asyncio
+    async def test_batched_plaintext_read_preserves_cache_security_boundaries(
+        self,
+        event_cache: ConversationEventCache,
+    ) -> None:
+        """Batch reads keep point-read principal, room, owner, redaction, and departure rules."""
+        room_id = "!room:localhost"
+        mxc_url = "mxc://server/owned"
+        owner = _sidecar_message_event("$owner:localhost", 1, mxc_url=mxc_url)
+        await event_cache.store_event("$owner:localhost", room_id, owner)
+        membership_epoch = await event_cache.room_membership_epoch(room_id)
+        assert membership_epoch is not None
+        assert await event_cache.store_mxc_text(
+            room_id,
+            "$owner:localhost",
+            mxc_url,
+            "owned plaintext",
+            expected_membership_epoch=membership_epoch,
+        )
+        references = {
+            ("$owner:localhost", mxc_url),
+            ("$missing:localhost", mxc_url),
+            ("$owner:localhost", "mxc://server/wrong"),
+        }
+
+        assert await event_cache.get_mxc_texts(
+            room_id,
+            references,
+            expected_membership_epoch=membership_epoch,
+        ) == {("$owner:localhost", mxc_url): "owned plaintext"}
+        assert (
+            await event_cache.get_mxc_texts(
+                "!wrong:localhost",
+                references,
+                expected_membership_epoch=membership_epoch,
+            )
+            == {}
+        )
+        assert (
+            await event_cache.for_principal("@other:localhost").get_mxc_texts(
+                room_id,
+                references,
+                expected_membership_epoch=membership_epoch,
+            )
+            == {}
+        )
+        assert (
+            await event_cache.get_mxc_texts(
+                room_id,
+                references,
+                expected_membership_epoch=membership_epoch + 1,
+            )
+            == {}
+        )
+
+        assert await event_cache.redact_event(room_id, "$owner:localhost") is True
+        assert (
+            await event_cache.get_mxc_texts(
+                room_id,
+                references,
+                expected_membership_epoch=membership_epoch,
+            )
+            == {}
+        )
+        event_cache.mark_room_departed(room_id)
+        assert (
+            await event_cache.get_mxc_texts(
+                room_id,
+                references,
+                expected_membership_epoch=membership_epoch,
+            )
+            == {}
         )
 
     @pytest.mark.asyncio

--- a/tests/test_matrix_event_cache_security.py
+++ b/tests/test_matrix_event_cache_security.py
@@ -195,6 +195,21 @@ async def test_room_scope_is_part_of_event_and_plaintext_identity(
         assert await cache.get_mxc_text("!a:localhost", "$same", mxc_url) == "plaintext A"
         assert await cache.get_mxc_text("!b:localhost", "$same", mxc_url) == "plaintext B"
         assert await cache.get_mxc_text("!wrong:localhost", "$same", mxc_url) is None
+        room_a_epoch = await cache.room_membership_epoch("!a:localhost")
+        assert room_a_epoch is not None
+        assert await cache.get_mxc_texts(
+            "!a:localhost",
+            {("$same", mxc_url), ("$missing", mxc_url)},
+            expected_membership_epoch=room_a_epoch,
+        ) == {("$same", mxc_url): "plaintext A"}
+        assert (
+            await cache.get_mxc_texts(
+                "!a:localhost",
+                {("$same", mxc_url)},
+                expected_membership_epoch=room_a_epoch + 1,
+            )
+            == {}
+        )
     finally:
         await root.close()
 

--- a/tests/test_message_content.py
+++ b/tests/test_message_content.py
@@ -23,6 +23,7 @@ from mindroom.matrix.client_visible_messages import (
 )
 from mindroom.matrix.membership_fence import UNCERTIFIED_MEMBERSHIP_EPOCH
 from mindroom.matrix.message_content import (
+    SidecarHydrationBatch,
     _download_mxc_text,
     extract_and_resolve_message,
     extract_edit_body,
@@ -777,6 +778,67 @@ class TestResolvedMessageExtraction:
 
 class TestDownloadMxcText:
     """Tests for _download_mxc_text function."""
+
+    @pytest.mark.asyncio
+    async def test_batch_reference_miss_skips_redundant_point_read(self) -> None:
+        """A reference covered by the batch may download directly after a proven cache miss."""
+        client = AsyncMock()
+        response = MagicMock(spec=nio.DownloadResponse)
+        response.body = b"fresh"
+        client.download.return_value = response
+        event_cache = AsyncMock()
+        event_cache.get_mxc_text.return_value = "stale"
+        reference = ("$event", "mxc://server/covered")
+        hydration_batch = SidecarHydrationBatch(
+            cached_texts={},
+            references=frozenset({reference}),
+            owner_event_ids=frozenset({"$event"}),
+        )
+
+        assert (
+            await _download_mxc_text(
+                client,
+                reference[1],
+                event_cache=event_cache,
+                room_id="!room:localhost",
+                event_id=reference[0],
+                expected_membership_epoch=1,
+                hydration_batch=hydration_batch,
+            )
+            == "fresh"
+        )
+        event_cache.get_mxc_text.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_reference_outside_batch_keeps_point_read_fallback(self) -> None:
+        """An uncovered bundled event must retain the exact point-cache lookup."""
+        client = AsyncMock()
+        client.download.side_effect = AssertionError("point-cache hit must not download")
+        event_cache = AsyncMock()
+        event_cache.get_mxc_text.return_value = "cached"
+        hydration_batch = SidecarHydrationBatch(
+            cached_texts={},
+            references=frozenset({("$other", "mxc://server/other")}),
+            owner_event_ids=frozenset({"$other"}),
+        )
+
+        assert (
+            await _download_mxc_text(
+                client,
+                "mxc://server/uncovered",
+                event_cache=event_cache,
+                room_id="!room:localhost",
+                event_id="$event",
+                expected_membership_epoch=1,
+                hydration_batch=hydration_batch,
+            )
+            == "cached"
+        )
+        event_cache.get_mxc_text.assert_awaited_once_with(
+            "!room:localhost",
+            "$event",
+            "mxc://server/uncovered",
+        )
 
     @pytest.mark.asyncio
     async def test_invalid_mxc_url(self) -> None:

--- a/tests/test_message_content.py
+++ b/tests/test_message_content.py
@@ -27,6 +27,7 @@ from mindroom.matrix.message_content import (
     _download_mxc_text,
     extract_and_resolve_message,
     extract_edit_body,
+    prepare_sidecar_hydration_batch,
     resolve_event_source_content,
 )
 from mindroom.matrix.sidecar_content import sidecar_mxc_url
@@ -776,8 +777,8 @@ class TestResolvedMessageExtraction:
         assert message_preview("  alpha   beta  \n gamma  ", max_length=12) == "alpha bet..."
 
 
-class TestDownloadMxcText:
-    """Tests for _download_mxc_text function."""
+class TestSidecarHydrationBatch:
+    """Tests for request-scoped batched sidecar hydration."""
 
     @pytest.mark.asyncio
     async def test_batch_reference_miss_skips_redundant_point_read(self) -> None:
@@ -839,6 +840,46 @@ class TestDownloadMxcText:
             "$event",
             "mxc://server/uncovered",
         )
+
+
+@pytest.mark.asyncio
+async def test_sidecar_batch_only_skips_registration_for_verified_owners() -> None:
+    """A read-only batch must not claim ownership for plaintext cache misses."""
+    hit_reference = ("$hit", "mxc://server/hit")
+    miss_reference = ("$miss", "mxc://server/miss")
+    sources = [
+        {
+            "event_id": event_id,
+            "content": {
+                "msgtype": "m.file",
+                "body": "preview",
+                "url": mxc_url,
+                "io.mindroom.long_text": {
+                    "version": 2,
+                    "encoding": "matrix_event_content_json",
+                },
+            },
+        }
+        for event_id, mxc_url in (hit_reference, miss_reference)
+    ]
+    event_cache = AsyncMock()
+    event_cache.get_mxc_texts.return_value = {hit_reference: "cached"}
+
+    hydration_batch = await prepare_sidecar_hydration_batch(
+        sources,
+        event_cache=event_cache,
+        room_id="!room:localhost",
+        expected_membership_epoch=1,
+        register_owners=False,
+    )
+
+    assert hydration_batch is not None
+    assert hydration_batch.references == frozenset({hit_reference, miss_reference})
+    assert hydration_batch.owner_event_ids == frozenset({"$hit"})
+
+
+class TestDownloadMxcText:
+    """Tests for _download_mxc_text function."""
 
     @pytest.mark.asyncio
     async def test_invalid_mxc_url(self) -> None:

--- a/tests/test_thread_history.py
+++ b/tests/test_thread_history.py
@@ -95,6 +95,100 @@ def build_threaded_edit_content(*args: object, **kwargs: object) -> dict[str, ob
 class TestThreadHistory:
     """Test thread history fetching functionality."""
 
+    @pytest.mark.asyncio
+    async def test_long_cached_sidecar_thread_uses_one_bounded_cache_read(self) -> None:
+        """Hydrate a long sidecar thread without one durable transaction per message."""
+        sidecar_count = 128
+        event_sources = [
+            {
+                "event_id": f"$event-{index}",
+                "origin_server_ts": index,
+                "type": "m.room.message",
+                "sender": "@agent:localhost",
+                "content": {
+                    "msgtype": "m.file",
+                    "body": f"Preview {index}",
+                    "io.mindroom.long_text": {
+                        "version": 2,
+                        "encoding": "matrix_event_content_json",
+                    },
+                    "url": f"mxc://server/sidecar-{index}",
+                    "m.relates_to": {
+                        "rel_type": "m.thread",
+                        "event_id": "$event-0",
+                    },
+                },
+            }
+            for index in range(sidecar_count)
+        ]
+        event_cache = _event_cache()
+        cached_payload = json.dumps(
+            {
+                "msgtype": "m.text",
+                "body": "Hydrated",
+            },
+        )
+        event_cache.get_mxc_texts.return_value = {
+            (f"$event-{index}", f"mxc://server/sidecar-{index}"): cached_payload for index in range(sidecar_count)
+        }
+        client = AsyncMock()
+
+        history, _sidecar_hydration_ms = await _resolve_thread_history_from_event_sources_timed(
+            client,
+            room_id="!room:localhost",
+            thread_id="$event-0",
+            event_sources=event_sources,
+            event_cache=event_cache,
+            expected_membership_epoch=0,
+        )
+
+        assert len(history) == sidecar_count
+        event_cache.get_mxc_texts.assert_awaited_once()
+        event_cache.room_membership_epoch.assert_awaited_once_with("!room:localhost")
+        event_cache.get_event.assert_not_awaited()
+        event_cache.get_mxc_text.assert_not_awaited()
+        event_cache.store_events_batch.assert_not_awaited()
+        client.download.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_long_cached_sidecar_thread_rejects_membership_epoch_change(self) -> None:
+        """Discard a batched plaintext snapshot when room membership changes during hydration."""
+        event_source = {
+            "event_id": "$root",
+            "origin_server_ts": 1,
+            "type": "m.room.message",
+            "sender": "@agent:localhost",
+            "content": {
+                "msgtype": "m.file",
+                "body": "Preview",
+                "io.mindroom.long_text": {
+                    "version": 2,
+                    "encoding": "matrix_event_content_json",
+                },
+                "url": "mxc://server/sidecar",
+            },
+        }
+        event_cache = _event_cache()
+        event_cache.get_mxc_texts.return_value = {
+            ("$root", "mxc://server/sidecar"): json.dumps(
+                {
+                    "msgtype": "m.text",
+                    "body": "Hydrated",
+                },
+            ),
+        }
+        event_cache.room_membership_epoch.return_value = 1
+
+        with pytest.raises(RuntimeError, match="membership changed"):
+            await _resolve_thread_history_from_event_sources_timed(
+                AsyncMock(),
+                room_id="!room:localhost",
+                thread_id="$root",
+                event_sources=[event_source],
+                event_cache=event_cache,
+                expected_membership_epoch=0,
+            )
+
     @staticmethod
     def _make_text_event(
         *,

--- a/tests/test_thread_history.py
+++ b/tests/test_thread_history.py
@@ -144,50 +144,11 @@ class TestThreadHistory:
 
         assert len(history) == sidecar_count
         event_cache.get_mxc_texts.assert_awaited_once()
-        event_cache.room_membership_epoch.assert_awaited_once_with("!room:localhost")
+        event_cache.room_membership_epoch.assert_not_awaited()
         event_cache.get_event.assert_not_awaited()
         event_cache.get_mxc_text.assert_not_awaited()
         event_cache.store_events_batch.assert_not_awaited()
         client.download.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_long_cached_sidecar_thread_rejects_membership_epoch_change(self) -> None:
-        """Discard a batched plaintext snapshot when room membership changes during hydration."""
-        event_source = {
-            "event_id": "$root",
-            "origin_server_ts": 1,
-            "type": "m.room.message",
-            "sender": "@agent:localhost",
-            "content": {
-                "msgtype": "m.file",
-                "body": "Preview",
-                "io.mindroom.long_text": {
-                    "version": 2,
-                    "encoding": "matrix_event_content_json",
-                },
-                "url": "mxc://server/sidecar",
-            },
-        }
-        event_cache = _event_cache()
-        event_cache.get_mxc_texts.return_value = {
-            ("$root", "mxc://server/sidecar"): json.dumps(
-                {
-                    "msgtype": "m.text",
-                    "body": "Hydrated",
-                },
-            ),
-        }
-        event_cache.room_membership_epoch.return_value = 1
-
-        with pytest.raises(RuntimeError, match="membership changed"):
-            await _resolve_thread_history_from_event_sources_timed(
-                AsyncMock(),
-                room_id="!room:localhost",
-                thread_id="$root",
-                event_sources=[event_source],
-                event_cache=event_cache,
-                expected_membership_epoch=0,
-            )
 
     @staticmethod
     def _make_text_event(


### PR DESCRIPTION
## Why

Reconstructing long Matrix histories with durable large-message sidecars performed serialized owner and plaintext cache operations for every message. Warm history resolution therefore scaled with sidecar count and could hold the shared cache lock for unrelated work.

## What

- Add one exact batched plaintext lookup to both durable cache backends.
- Batch-register sidecar owners during fresh history refills.
- Keep plaintext request-scoped and preserve exact event, room, principal, and MXC ownership checks.
- Require the captured membership epoch inside each batched durable read.
- Preserve point-read fallback for references outside the prepared batch, including bundled edits.
- Keep existing membership-transition semantics without adding post-hydration recertification or degraded-history states.

## Validation

- Full pytest suite passes.
- Focused history, message-content, cache-contract, and cache-security suites pass against SQLite and PostgreSQL.
- Deterministic bundled-edit, epoch-shift, and operation-count probes pass; warm hydration uses one batched plaintext read independent of sidecar count.
- Changed-file pre-commit hooks pass, including Ruff, ty, Tach, and module privacy.