### PR TITLE
Use ledger recovery for entities without run storage

### DIFF
--- a/src/mindroom/conversation_state_writer.py
+++ b/src/mindroom/conversation_state_writer.py
@@ -42,6 +42,11 @@ class ConversationStateWriter:
 
     deps: ConversationStateWriterDeps
 
+    def supports_run_recovery(self) -> bool:
+        """Return whether this entity owns persisted Agno runs."""
+        config = self.deps.runtime.config
+        return self.deps.agent_name in config.agents or self.deps.agent_name in config.teams
+
     def history_scope(self) -> HistoryScope:
         """Return the persisted history scope backing this bot's runs."""
         if self.deps.agent_name in self.deps.runtime.config.teams:

--- a/src/mindroom/turn_store.py
+++ b/src/mindroom/turn_store.py
@@ -322,6 +322,8 @@ class TurnStore:
     ) -> TurnRecord | None:
         """Load, deterministically merge, and repair one durable turn record."""
         ledger_record_before_recovery = self._ledger.get_turn_record(original_event_id)
+        if not self.deps.state_writer.supports_run_recovery():
+            return ledger_record_before_recovery
         recovery_record = self._load_persisted_turn_record(
             _LoadPersistedTurnRequest(
                 room=room,

--- a/tests/test_conversation_state_writer.py
+++ b/tests/test_conversation_state_writer.py
@@ -13,7 +13,7 @@ from agno.run.agent import RunOutput
 from agno.session.agent import AgentSession
 
 from mindroom.agent_storage import create_state_storage, get_agent_session
-from mindroom.config.agent import AgentConfig, AgentPrivateConfig
+from mindroom.config.agent import AgentConfig, AgentPrivateConfig, TeamConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
 from mindroom.constants import MATRIX_RESPONSE_EVENT_ID_METADATA_KEY
@@ -31,7 +31,13 @@ def test_only_configured_agents_and_teams_support_run_recovery(tmp_path: Path) -
     """Router has ledger state but no persisted Agno run storage."""
     config = Config(
         agents={"member": AgentConfig(display_name="Member")},
-        teams={"crew": {"display_name": "Crew", "role": "Collaborate", "agents": ["member"]}},
+        teams={
+            "crew": TeamConfig(
+                display_name="Crew",
+                role="Collaborate",
+                agents=["member"],
+            ),
+        },
     )
     runtime = SimpleNamespace(config=config)
 

--- a/tests/test_conversation_state_writer.py
+++ b/tests/test_conversation_state_writer.py
@@ -27,6 +27,29 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
+def test_only_configured_agents_and_teams_support_run_recovery(tmp_path: Path) -> None:
+    """Router has ledger state but no persisted Agno run storage."""
+    config = Config(
+        agents={"member": AgentConfig(display_name="Member")},
+        teams={"crew": {"display_name": "Crew", "role": "Collaborate", "agents": ["member"]}},
+    )
+    runtime = SimpleNamespace(config=config)
+
+    def writer(entity_name: str) -> ConversationStateWriter:
+        return ConversationStateWriter(
+            ConversationStateWriterDeps(
+                runtime=runtime,
+                logger=MagicMock(),
+                runtime_paths=test_runtime_paths(tmp_path),
+                agent_name=entity_name,
+            ),
+        )
+
+    assert writer("member").supports_run_recovery()
+    assert writer("crew").supports_run_recovery()
+    assert not writer("router").supports_run_recovery()
+
+
 def test_persist_response_event_id_keeps_assistant_history_plain(tmp_path: Path) -> None:
     """Response linkage belongs in run metadata, not assistant-role content."""
     run = RunOutput(

--- a/tests/test_turn_store.py
+++ b/tests/test_turn_store.py
@@ -6,6 +6,7 @@ import ast
 import threading
 from dataclasses import dataclass, replace
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import ANY, MagicMock, patch
 
 import pytest
@@ -19,6 +20,7 @@ from agno.session.team import TeamSession
 from mindroom import constants
 from mindroom.bot import AgentBot
 from mindroom.config.main import Config
+from mindroom.conversation_state_writer import ConversationStateWriter, ConversationStateWriterDeps
 from mindroom.handled_turns import (
     SourceEventMetadata,
     TurnRecord,
@@ -1422,18 +1424,23 @@ def test_agent_bot_does_not_expose_removed_handled_turn_ledger_shim(tmp_path: Pa
 def test_router_turn_replay_uses_persisted_ledger_across_two_restarts(tmp_path: Path) -> None:
     """Router relay turns have durable ledger state but no Agno run storage."""
 
-    def router_bot() -> AgentBot:
+    def router_store() -> TurnStore:
         config = bind_runtime_paths(Config(), test_runtime_paths(tmp_path))
-        return AgentBot(
-            agent_user=AgentMatrixUser(
+        return TurnStore(
+            TurnStoreDeps(
                 agent_name="router",
-                user_id="@mindroom_router:localhost",
-                display_name="Router",
-                password=TEST_PASSWORD,
+                tracking_base_path=tmp_path / "tracking",
+                state_writer=ConversationStateWriter(
+                    ConversationStateWriterDeps(
+                        runtime=SimpleNamespace(config=config),
+                        logger=MagicMock(),
+                        runtime_paths=runtime_paths_for(config),
+                        agent_name="router",
+                    ),
+                ),
+                resolver=MagicMock(),
+                tool_runtime=MagicMock(),
             ),
-            storage_path=tmp_path,
-            config=config,
-            runtime_paths=runtime_paths_for(config),
         )
 
     target = MessageTarget.resolve("!room:localhost", "$thread", "$source")
@@ -1444,17 +1451,22 @@ def test_router_turn_replay_uses_persisted_ledger_across_two_restarts(tmp_path: 
         requester_id="@user:localhost",
         conversation_target=target,
     )
-    router_bot()._turn_store.record_turn(expected)
+    router_store().record_turn(expected)
 
     for _restart in range(2):
         _reset_handled_turn_ledger_runtime()
-        restarted = router_bot()
-        loaded = restarted._turn_store.load_turn(
-            room=MagicMock(room_id="!room:localhost"),
-            thread_id="$thread",
-            original_event_id="$source",
-            requester_user_id="@user:localhost",
-        )
+        restarted = router_store()
+        with patch.object(
+            restarted,
+            "_load_persisted_turn_record",
+            side_effect=AssertionError("ledger-only entity attempted run recovery"),
+        ):
+            loaded = restarted.load_turn(
+                room=MagicMock(room_id="!room:localhost"),
+                thread_id="$thread",
+                original_event_id="$source",
+                requester_user_id="@user:localhost",
+            )
 
         assert loaded is not None
         assert replace(loaded, timestamp=0.0) == replace(expected, timestamp=0.0)

--- a/tests/test_turn_store.py
+++ b/tests/test_turn_store.py
@@ -1419,6 +1419,48 @@ def test_agent_bot_does_not_expose_removed_handled_turn_ledger_shim(tmp_path: Pa
     assert removed_attr not in vars(bot)
 
 
+def test_router_turn_replay_uses_persisted_ledger_across_two_restarts(tmp_path: Path) -> None:
+    """Router relay turns have durable ledger state but no Agno run storage."""
+
+    def router_bot() -> AgentBot:
+        config = bind_runtime_paths(Config(), test_runtime_paths(tmp_path))
+        return AgentBot(
+            agent_user=AgentMatrixUser(
+                agent_name="router",
+                user_id="@mindroom_router:localhost",
+                display_name="Router",
+                password=TEST_PASSWORD,
+            ),
+            storage_path=tmp_path,
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+        )
+
+    target = MessageTarget.resolve("!room:localhost", "$thread", "$source")
+    expected = TurnRecord.create(
+        ["$source"],
+        response_event_id="$relay",
+        response_owner="router",
+        requester_id="@user:localhost",
+        conversation_target=target,
+    )
+    router_bot()._turn_store.record_turn(expected)
+
+    for _restart in range(2):
+        _reset_handled_turn_ledger_runtime()
+        restarted = router_bot()
+        loaded = restarted._turn_store.load_turn(
+            room=MagicMock(room_id="!room:localhost"),
+            thread_id="$thread",
+            original_event_id="$source",
+            requester_user_id="@user:localhost",
+        )
+
+        assert loaded is not None
+        assert replace(loaded, timestamp=0.0) == replace(expected, timestamp=0.0)
+        assert loaded.timestamp > 0
+
+
 def test_no_test_references_removed_bot_handled_turn_ledger_shim() -> None:
     """Tests should route all handled-turn access through TurnStore."""
     tests_root = Path(__file__).resolve().parent


### PR DESCRIPTION
## Why

Some runtime entities persist handled-turn records in the durable ledger but do not own persisted model-run storage. Replaying one of those turns attempted an impossible run-storage lookup before using the valid ledger record, turning a recoverable replay into a callback failure.

## What

- Make run-recovery capability explicit on the conversation-state writer.
- Return the durable ledger record directly for entities without run storage.
- Leave configured agent and team run recovery unchanged.
- Keep checkpoint certification fail-closed; no event skipping, quarantine, or forced checkpoint advancement is added.

## Validation

- Conversation-state, turn-store, sync-token, sync-trust, and sync-certification suites pass.
- Changed-file pre-commit hooks pass, including Ruff, ty, Tach, and module privacy.
- Full suite completed with one unrelated subprocess timing failure under parallel load; that test passed three consecutive isolated reruns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation recovery so only configured agents and teams use persisted recovery data.
  * Preserved reliable turn replay across application restarts, including router relay turns.

* **Tests**
  * Added coverage for recovery support detection and durable turn replay across multiple restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->