### PR TITLE
Overlap file-memory prompt preparation

### DIFF
--- a/scripts/testing/benchmark_prompt_assembly.py
+++ b/scripts/testing/benchmark_prompt_assembly.py
@@ -228,7 +228,6 @@ async def _benchmark_prompt_branches(
             agent_name="benchmark",
             shared_scope_storage=None,
             pipeline_timing=None,
-            cancel_memory_on_agent_failure=True,
         )
 
     before_samples: list[float] = []

--- a/scripts/testing/benchmark_prompt_assembly.py
+++ b/scripts/testing/benchmark_prompt_assembly.py
@@ -53,6 +53,24 @@ if TYPE_CHECKING:
 _COUNTERS: dict[str, int] = {}
 
 
+def _positive_int(value: str) -> int:
+    """Parse a positive iteration count for benchmark arguments."""
+    parsed = int(value)
+    if parsed < 1:
+        msg = "must be at least 1"
+        raise argparse.ArgumentTypeError(msg)
+    return parsed
+
+
+def _nonnegative_float(value: str) -> float:
+    """Parse a nonnegative synthetic-delay value."""
+    parsed = float(value)
+    if parsed < 0:
+        msg = "must be nonnegative"
+        raise argparse.ArgumentTypeError(msg)
+    return parsed
+
+
 def _count(name: str) -> None:
     _COUNTERS[name] = _COUNTERS.get(name, 0) + 1
 
@@ -259,11 +277,11 @@ async def _benchmark_prompt_branches(
 def main() -> None:
     """Run the prompt-assembly benchmark and print JSON results."""
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--builds", type=int, default=25)
-    parser.add_argument("--turns", type=int, default=25)
-    parser.add_argument("--branch-runs", type=int, default=10)
-    parser.add_argument("--branch-memory-ms", type=float, default=20.0)
-    parser.add_argument("--branch-agent-ms", type=float, default=40.0)
+    parser.add_argument("--builds", type=_positive_int, default=25)
+    parser.add_argument("--turns", type=_positive_int, default=25)
+    parser.add_argument("--branch-runs", type=_positive_int, default=10)
+    parser.add_argument("--branch-memory-ms", type=_nonnegative_float, default=20.0)
+    parser.add_argument("--branch-agent-ms", type=_nonnegative_float, default=40.0)
     args = parser.parse_args()
 
     logging.getLogger().setLevel(logging.ERROR)

--- a/scripts/testing/benchmark_prompt_assembly.py
+++ b/scripts/testing/benchmark_prompt_assembly.py
@@ -2,24 +2,27 @@
 
 Measures wall time plus call counts for plugin loads, skill scans, skill-cache
 clears, tool-schema preparations, Function deep copies, and payload
-serializations across two phases:
+serializations across three phases:
 
 - ``agent_build``: repeated warm ``create_agent`` calls for one config.
 - ``tool_surface``: one turn's static token budgeting (execution preparation
   plus the history-runtime re-estimate) and run-metadata payload assembly on
   one fresh agent instance.
+- ``prompt_branches``: controlled file-memory and agent-build delays executed
+  sequentially (before) and concurrently (after).
 """
 
 from __future__ import annotations
 
 import argparse
+import asyncio
 import functools
 import json
 import logging
 import tempfile
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import structlog
 from agno.tools.function import Function
@@ -27,7 +30,7 @@ from agno.tools.function import Function
 from mindroom import agents as agents_module
 from mindroom.agent_knowledge_descriptions import KnowledgeToolDescribingAgent
 from mindroom.agents import create_agent
-from mindroom.config.main import load_config
+from mindroom.config.main import ResolvedRuntimeModel, load_config
 from mindroom.constants import resolve_primary_runtime_paths
 from mindroom.history import prompt_tokens as prompt_tokens_module
 from mindroom.history.prompt_tokens import (
@@ -35,13 +38,16 @@ from mindroom.history.prompt_tokens import (
     agent_tool_definition_payloads_for_logging,
     estimate_agent_static_tokens,
 )
+from mindroom.memory import MemoryPromptParts
 from mindroom.model_defaults import CONFIG_INIT_MODEL_PRESETS
+from mindroom.pre_model_preparation import prepare_prompt_branches
 from mindroom.tool_system import skills as skills_module
 from mindroom.tool_system.plugins import load_plugins
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from agno.agent import Agent
     from agno.skills.skill import Skill
 
 _COUNTERS: dict[str, int] = {}
@@ -179,11 +185,86 @@ def _phase[T](
     }
 
 
+def _sample_summary(samples: list[float]) -> dict[str, float]:
+    ordered = sorted(samples)
+    midpoint = len(ordered) // 2
+    median = ordered[midpoint] if len(ordered) % 2 else (ordered[midpoint - 1] + ordered[midpoint]) / 2
+    return {
+        "total_ms": round(sum(samples), 3),
+        "mean_ms": round(sum(samples) / len(samples), 3),
+        "p50_ms": round(median, 3),
+        "min_ms": round(ordered[0], 3),
+        "max_ms": round(ordered[-1], 3),
+    }
+
+
+async def _benchmark_prompt_branches(
+    *,
+    runs: int,
+    memory_delay_ms: float,
+    agent_delay_ms: float,
+) -> dict[str, object]:
+    """Compare old sequential branch timing with concurrent preparation."""
+    runtime_model = ResolvedRuntimeModel(model_name="benchmark", context_window=None)
+    memory_delay = memory_delay_ms / 1000
+    agent_delay = agent_delay_ms / 1000
+
+    async def prepare_memory() -> MemoryPromptParts:
+        await asyncio.to_thread(time.sleep, memory_delay)
+        return MemoryPromptParts()
+
+    def build_agent() -> tuple[ResolvedRuntimeModel, Agent]:
+        time.sleep(agent_delay)
+        return runtime_model, cast("Agent", object())
+
+    async def run_sequential() -> None:
+        await prepare_memory()
+        await asyncio.to_thread(build_agent)
+
+    async def run_parallel() -> None:
+        await prepare_prompt_branches(
+            prepare_memory=prepare_memory,
+            build_agent=build_agent,
+            agent_name="benchmark",
+            shared_scope_storage=None,
+            pipeline_timing=None,
+            cancel_memory_on_agent_failure=True,
+        )
+
+    before_samples: list[float] = []
+    after_samples: list[float] = []
+    for _ in range(runs):
+        started_at = time.perf_counter()
+        await run_sequential()
+        before_samples.append((time.perf_counter() - started_at) * 1000)
+
+        started_at = time.perf_counter()
+        await run_parallel()
+        after_samples.append((time.perf_counter() - started_at) * 1000)
+
+    before = _sample_summary(before_samples)
+    after = _sample_summary(after_samples)
+    return {
+        "phase": "prompt_branches",
+        "iterations": runs,
+        "configured_branch_ms": {
+            "file_memory": memory_delay_ms,
+            "agent_build": agent_delay_ms,
+        },
+        "before_sequential": before,
+        "after_parallel": after,
+        "mean_saved_ms": round(before["mean_ms"] - after["mean_ms"], 3),
+    }
+
+
 def main() -> None:
     """Run the prompt-assembly benchmark and print JSON results."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--builds", type=int, default=25)
     parser.add_argument("--turns", type=int, default=25)
+    parser.add_argument("--branch-runs", type=int, default=10)
+    parser.add_argument("--branch-memory-ms", type=float, default=20.0)
+    parser.add_argument("--branch-agent-ms", type=float, default=40.0)
     args = parser.parse_args()
 
     logging.getLogger().setLevel(logging.ERROR)
@@ -256,6 +337,15 @@ def main() -> None:
                 "misses": cache_info.misses,
                 "size": cache_info.currsize,
             },
+        )
+        results.append(
+            asyncio.run(
+                _benchmark_prompt_branches(
+                    runs=args.branch_runs,
+                    memory_delay_ms=args.branch_memory_ms,
+                    agent_delay_ms=args.branch_agent_ms,
+                ),
+            ),
         )
 
     print(json.dumps(results, indent=2))

--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -193,6 +193,15 @@ def ensure_default_agent_workspaces(config: Config, storage_path: Path) -> None:
             _ensure_default_mind_workspace(storage_path)
 
 
+def agent_build_can_overlap_file_memory(agent_name: str, config: Config, storage_path: Path) -> bool:
+    """Return whether agent construction cannot create file-memory content mid-read."""
+    agent_config = config.get_agent(agent_name)
+    if not _uses_default_mind_workspace_scaffold(agent_name, agent_config):
+        return True
+    memory_path = agent_workspace_root_path(storage_path, agent_name) / "MEMORY.md"
+    return memory_path.is_file()
+
+
 def _get_datetime_context(
     timezone_str: str,
     *,
@@ -1865,6 +1874,7 @@ def create_agent(
 
 
 __all__ = [
+    "agent_build_can_overlap_file_memory",
     "build_agent_toolkit",
     "create_agent",
     "describe_agent",

--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -194,7 +194,7 @@ def ensure_default_agent_workspaces(config: Config, storage_path: Path) -> None:
 
 
 def agent_build_can_overlap_file_memory(agent_name: str, config: Config, storage_path: Path) -> bool:
-    """Return whether agent construction cannot create file-memory content mid-read."""
+    """Return True when it is safe to overlap agent construction with file-memory reads."""
     agent_config = config.get_agent(agent_name)
     if not _uses_default_mind_workspace_scaffold(agent_name, agent_config):
         return True

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -1190,7 +1190,6 @@ async def _prepare_agent_and_prompt(
                     shared_scope_storage=scope_context.storage if scope_context is not None else None,
                     pipeline_timing=pipeline_timing,
                     caller_owned_agent=reusable_agent,
-                    cancel_memory_on_agent_failure=memory_backend == "file",
                 )
             finally:
                 _mark_pipeline_timing(pipeline_timing, "prompt_branches_ready")
@@ -1249,7 +1248,7 @@ async def _prepare_agent_and_prompt(
         thread_history=thread_history,
         runtime_paths=runtime_paths,
         config=config,
-        resolved_runtime_model=runtime_model if memory_backend == "mem0" else None,
+        resolved_runtime_model=runtime_model,
         compaction_lifecycle=compaction_lifecycle,
         current_sender_id=None if include_openai_compat_guidance else ctx.requester_id,
         current_timestamp_ms=current_timestamp_ms,

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -25,7 +25,7 @@ from agno.run.agent import (
 from agno.run.base import RunStatus
 
 from mindroom import ai_runtime
-from mindroom.agents import create_agent
+from mindroom.agents import agent_build_can_overlap_file_memory, create_agent
 from mindroom.ai_run_metadata import (
     build_ai_run_metadata_content,
     build_model_request_metrics_fallback,
@@ -72,7 +72,7 @@ from mindroom.media_fallback import (
 from mindroom.media_inputs import MediaInputs, MediaKind
 from mindroom.memory import build_memory_prompt_parts, strip_user_turn_time_prefix
 from mindroom.metadata_merge import deep_merge_metadata
-from mindroom.pre_model_preparation import prepare_mem0_prompt_branches
+from mindroom.pre_model_preparation import prepare_prompt_branches
 from mindroom.response_turn import (
     AttemptResolved,
     BlockingAttemptResolution,
@@ -1150,17 +1150,33 @@ async def _prepare_agent_and_prompt(
             )
         return runtime_model, agent
 
-    parallel_branches = config.resolve_entity(agent_name).memory_backend == "mem0"
+    memory_backend = config.resolve_entity(agent_name).memory_backend
+    parallel_branches = memory_backend == "mem0"
+    serial_reason: str | None = None
+    if memory_backend == "file":
+        parallel_branches = reusable_agent is not None or await asyncio.to_thread(
+            agent_build_can_overlap_file_memory,
+            agent_name,
+            config,
+            storage_path,
+        )
+        if not parallel_branches:
+            serial_reason = "default_workspace_scaffold_pending"
     if pipeline_timing is not None:
-        pipeline_timing.note(prompt_branches_parallel=parallel_branches)
+        pipeline_timing.note(
+            prompt_branches_parallel=parallel_branches,
+            prompt_branches_memory_backend=memory_backend,
+            prompt_branches_serial_reason=serial_reason,
+        )
     if parallel_branches:
         _mark_pipeline_timing(pipeline_timing, "prompt_branches_start")
         with timed_block(
             "system_prompt_assembly.memory_agent_join",
             parallel=True,
+            memory_backend=memory_backend,
         ):
             try:
-                prompt_parts, runtime_model, agent = await prepare_mem0_prompt_branches(
+                prompt_parts, runtime_model, agent = await prepare_prompt_branches(
                     prepare_memory=lambda: build_memory_prompt_parts(
                         prompt,
                         agent_name,
@@ -1174,6 +1190,7 @@ async def _prepare_agent_and_prompt(
                     shared_scope_storage=scope_context.storage if scope_context is not None else None,
                     pipeline_timing=pipeline_timing,
                     caller_owned_agent=reusable_agent,
+                    cancel_memory_on_agent_failure=memory_backend == "file",
                 )
             finally:
                 _mark_pipeline_timing(pipeline_timing, "prompt_branches_ready")
@@ -1232,7 +1249,7 @@ async def _prepare_agent_and_prompt(
         thread_history=thread_history,
         runtime_paths=runtime_paths,
         config=config,
-        resolved_runtime_model=runtime_model if parallel_branches else None,
+        resolved_runtime_model=runtime_model if memory_backend == "mem0" else None,
         compaction_lifecycle=compaction_lifecycle,
         current_sender_id=None if include_openai_compat_guidance else ctx.requester_id,
         current_timestamp_ms=current_timestamp_ms,

--- a/src/mindroom/pre_model_preparation.py
+++ b/src/mindroom/pre_model_preparation.py
@@ -1,4 +1,4 @@
-"""Concurrent pre-model preparation for Mem0-backed agent turns."""
+"""Concurrent pre-model preparation for agent turns."""
 
 from __future__ import annotations
 
@@ -88,7 +88,18 @@ def _discard_unreturned_agent_result(
         _close_unreturned_agent(result[1], shared_scope_storage, caller_owned_agent)
 
 
-async def prepare_mem0_prompt_branches(
+def _cancel_pending_memory(
+    memory_task: asyncio.Task[MemoryPromptParts | Exception],
+    *,
+    enabled: bool,
+) -> bool:
+    if not enabled or memory_task.done():
+        return False
+    memory_task.cancel()
+    return True
+
+
+async def prepare_prompt_branches(
     *,
     prepare_memory: Callable[[], Awaitable[MemoryPromptParts]],
     build_agent: Callable[[], tuple[ResolvedRuntimeModel, Agent]],
@@ -96,8 +107,9 @@ async def prepare_mem0_prompt_branches(
     shared_scope_storage: BaseDb | None,
     pipeline_timing: DispatchPipelineTiming | None,
     caller_owned_agent: Agent | None = None,
+    cancel_memory_on_agent_failure: bool = False,
 ) -> tuple[MemoryPromptParts, ResolvedRuntimeModel, Agent]:
-    """Overlap Mem0 preparation with agent construction and join both safely."""
+    """Overlap memory preparation with agent construction and join both safely."""
 
     async def _memory_branch() -> MemoryPromptParts | Exception:
         _mark_pipeline_timing(pipeline_timing, "memory_prepare_start")
@@ -115,21 +127,29 @@ async def prepare_mem0_prompt_branches(
         lambda _future: _mark_pipeline_timing(pipeline_timing, "agent_build_ready"),
     )
 
+    memory_cancelled_for_agent_failure = False
+    memory_task: asyncio.Task[MemoryPromptParts | Exception]
+
     async def _agent_branch() -> tuple[ResolvedRuntimeModel, Agent] | Exception:
+        nonlocal memory_cancelled_for_agent_failure
         try:
             return await asyncio.shield(build_future)
         except Exception as error:
+            memory_cancelled_for_agent_failure = _cancel_pending_memory(
+                memory_task,
+                enabled=cancel_memory_on_agent_failure,
+            )
             return error
 
     try:
         async with asyncio.TaskGroup() as task_group:
-            agent_task = task_group.create_task(
-                _agent_branch(),
-                name=f"agent_prepare:{agent_name}",
-            )
             memory_task = task_group.create_task(
                 _memory_branch(),
                 name=f"memory_prepare:{agent_name}",
+            )
+            agent_task = task_group.create_task(
+                _agent_branch(),
+                name=f"agent_prepare:{agent_name}",
             )
     except BaseException:
         await _drain_unreturned_agent_build(
@@ -141,6 +161,9 @@ async def prepare_mem0_prompt_branches(
         raise
 
     agent_result = agent_task.result()
+    if memory_cancelled_for_agent_failure:
+        assert isinstance(agent_result, Exception)
+        raise agent_result
     try:
         memory_result = memory_task.result()
     except BaseException:

--- a/src/mindroom/pre_model_preparation.py
+++ b/src/mindroom/pre_model_preparation.py
@@ -88,17 +88,6 @@ def _discard_unreturned_agent_result(
         _close_unreturned_agent(result[1], shared_scope_storage, caller_owned_agent)
 
 
-def _cancel_pending_memory(
-    memory_task: asyncio.Task[MemoryPromptParts | Exception],
-    *,
-    enabled: bool,
-) -> bool:
-    if not enabled or memory_task.done():
-        return False
-    memory_task.cancel()
-    return True
-
-
 async def prepare_prompt_branches(
     *,
     prepare_memory: Callable[[], Awaitable[MemoryPromptParts]],
@@ -107,7 +96,6 @@ async def prepare_prompt_branches(
     shared_scope_storage: BaseDb | None,
     pipeline_timing: DispatchPipelineTiming | None,
     caller_owned_agent: Agent | None = None,
-    cancel_memory_on_agent_failure: bool = False,
 ) -> tuple[MemoryPromptParts, ResolvedRuntimeModel, Agent]:
     """Overlap memory preparation with agent construction and join both safely."""
 
@@ -127,29 +115,21 @@ async def prepare_prompt_branches(
         lambda _future: _mark_pipeline_timing(pipeline_timing, "agent_build_ready"),
     )
 
-    memory_cancelled_for_agent_failure = False
-    memory_task: asyncio.Task[MemoryPromptParts | Exception]
-
     async def _agent_branch() -> tuple[ResolvedRuntimeModel, Agent] | Exception:
-        nonlocal memory_cancelled_for_agent_failure
         try:
             return await asyncio.shield(build_future)
         except Exception as error:
-            memory_cancelled_for_agent_failure = _cancel_pending_memory(
-                memory_task,
-                enabled=cancel_memory_on_agent_failure,
-            )
             return error
 
     try:
         async with asyncio.TaskGroup() as task_group:
-            memory_task = task_group.create_task(
-                _memory_branch(),
-                name=f"memory_prepare:{agent_name}",
-            )
             agent_task = task_group.create_task(
                 _agent_branch(),
                 name=f"agent_prepare:{agent_name}",
+            )
+            memory_task = task_group.create_task(
+                _memory_branch(),
+                name=f"memory_prepare:{agent_name}",
             )
     except BaseException:
         await _drain_unreturned_agent_build(
@@ -161,9 +141,6 @@ async def prepare_prompt_branches(
         raise
 
     agent_result = agent_task.result()
-    if memory_cancelled_for_agent_failure:
-        assert isinstance(agent_result, Exception)
-        raise agent_result
     try:
         memory_result = memory_task.result()
     except BaseException:

--- a/tach.toml
+++ b/tach.toml
@@ -3568,14 +3568,15 @@ from = ["mindroom.history.summary_call"]
 
 [[interfaces]]
 expose = [
+    "agent_build_can_overlap_file_memory",
+    "build_agent_toolkit",
     "create_agent",
     "describe_agent",
     "enable_all_history_replay",
     "ensure_default_agent_workspaces",
-    "show_tool_calls_for_agent",
-    "build_agent_toolkit",
     "get_agent_toolkit_names",
     "remove_run_by_event_id",
+    "show_tool_calls_for_agent",
 ]
 from = ["mindroom.agents"]
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -29,6 +29,7 @@ from mindroom.agents import (
     _PRIVATE_CULTURE_MANAGER_CACHE,
     _load_context_files,
     _prune_toolkit_functions,
+    agent_build_can_overlap_file_memory,
     build_agent_toolkit,
     create_agent,
     get_agent_toolkit_names,
@@ -2299,6 +2300,7 @@ def test_create_agent_scaffolds_default_mind_workspace_under_runtime_storage_roo
         models={"default": ModelConfig(provider="openai", id="gpt-4")},
     )
 
+    assert not agent_build_can_overlap_file_memory("mind", config, runtime_storage)
     agent = _create_agent_for_test("mind", config=_bind_runtime_paths(config, _runtime_paths(runtime_storage)))
 
     workspace = runtime_storage / "agents" / "mind" / "workspace"
@@ -2310,6 +2312,7 @@ def test_create_agent_scaffolds_default_mind_workspace_under_runtime_storage_roo
     assert (workspace / "HEARTBEAT.md").exists()
     assert (workspace / "MEMORY.md").exists()
     assert "## Personality Context" in agent.role
+    assert agent_build_can_overlap_file_memory("mind", config, runtime_storage)
 
 
 @patch("mindroom.agents.get_tool_by_name")

--- a/tests/test_event_loop_offloading.py
+++ b/tests/test_event_loop_offloading.py
@@ -21,6 +21,7 @@ from mindroom.history.types import PreparedHistoryState
 from mindroom.hooks import render_transient_context
 from mindroom.memory import MemoryPromptParts
 from mindroom.memory._file_backend import FileMemoryBackend
+from mindroom.timing import DispatchPipelineTiming
 from tests.conftest import bind_runtime_paths, make_turn_context, test_runtime_paths
 
 if TYPE_CHECKING:
@@ -97,12 +98,14 @@ async def test_prepare_agent_and_prompt_builds_agent_off_event_loop(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("first_finished", ["memory", "agent"])
-async def test_prepare_agent_and_prompt_joins_overlapping_mem0_branches_before_history(  # noqa: PLR0915
+@pytest.mark.parametrize("memory_backend", ["mem0", "file"])
+async def test_prepare_agent_and_prompt_joins_overlapping_branches_before_history(  # noqa: PLR0915
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     first_finished: str,
+    memory_backend: str,
 ) -> None:
-    """Mem0 preparation and agent construction overlap, then both join before history."""
+    """Memory preparation and agent construction overlap, then both join before history."""
     memory_started = asyncio.Event()
     memory_release = asyncio.Event()
     memory_finished = asyncio.Event()
@@ -141,7 +144,10 @@ async def test_prepare_agent_and_prompt_joins_overlapping_mem0_branches_before_h
         assert len(kwargs["transient_context_messages"]) == 1
         assert kwargs["transient_context_messages"][0].content == render_transient_context(("turn memory",))
         assert kwargs["transient_context_messages"][0].add_to_agent_memory is False
-        assert kwargs["resolved_runtime_model"].model_name == "default"
+        if memory_backend == "mem0":
+            assert kwargs["resolved_runtime_model"].model_name == "default"
+        else:
+            assert kwargs["resolved_runtime_model"] is None
         return SimpleNamespace(
             prepared_history=PreparedHistoryState(),
             replay_plan=None,
@@ -165,7 +171,8 @@ async def test_prepare_agent_and_prompt_joins_overlapping_mem0_branches_before_h
     monkeypatch.setattr(ai_module, "_compose_current_turn_prompt", compose_prompt)
     monkeypatch.setattr(ai_module, "prepare_agent_execution_context", prepare_history)
 
-    config = _prompt_preparation_config()
+    config = _prompt_preparation_config(memory_backend)
+    pipeline_timing = DispatchPipelineTiming(source_event_id="$event", room_id="!room")
     prepare_task = asyncio.create_task(
         ai_module._prepare_agent_and_prompt(
             make_turn_context("general"),
@@ -173,6 +180,7 @@ async def test_prepare_agent_and_prompt_joins_overlapping_mem0_branches_before_h
             runtime_paths=test_runtime_paths(tmp_path),
             config=config,
             model_prompt="model metadata",
+            pipeline_timing=pipeline_timing,
         ),
     )
     try:
@@ -200,14 +208,18 @@ async def test_prepare_agent_and_prompt_joins_overlapping_mem0_branches_before_h
     assert prepared_run.agent is built_agent
     assert prepared_run.prompt_text == "raw prompt\n\nmodel metadata"
     assert built_agent.additional_context == "existing context\n\nsession memory"
+    assert pipeline_timing.metadata["prompt_branches_parallel"] is True
+    assert pipeline_timing.metadata["prompt_branches_memory_backend"] == memory_backend
+    assert "prompt_branches_start" in pipeline_timing.marks
+    assert "prompt_branches_ready" in pipeline_timing.marks
 
 
 @pytest.mark.asyncio
-async def test_prepare_agent_and_prompt_keeps_file_memory_before_agent_build(
+async def test_prepare_agent_and_prompt_keeps_cold_default_workspace_serial(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """File-memory preparation stays serial so workspace scaffolding cannot change its read."""
+    """Cold default workspace stays serial so construction cannot change memory reads."""
     memory_finished = False
     built_agent = MagicMock()
     built_agent.additional_context = ""
@@ -238,16 +250,180 @@ async def test_prepare_agent_and_prompt_keeps_file_memory_before_agent_build(
         prepare_history,
     )
 
-    config = _prompt_preparation_config("file")
+    config = Config.model_validate(
+        {
+            "agents": {
+                "mind": {
+                    "display_name": "Mind",
+                    "role": "test",
+                    "memory_backend": "file",
+                    "context_files": [
+                        "SOUL.md",
+                        "AGENTS.md",
+                        "USER.md",
+                        "IDENTITY.md",
+                        "TOOLS.md",
+                        "HEARTBEAT.md",
+                    ],
+                },
+            },
+        },
+    )
+    pipeline_timing = DispatchPipelineTiming(source_event_id="$event", room_id="!room")
     prepared = await ai_module._prepare_agent_and_prompt(
-        make_turn_context("general"),
+        make_turn_context("mind"),
         prompt="hello",
         runtime_paths=test_runtime_paths(tmp_path),
         config=config,
+        pipeline_timing=pipeline_timing,
     )
 
     assert prepared.agent is built_agent
     assert prepare_history.await_args.kwargs["resolved_runtime_model"] is None
+    assert pipeline_timing.metadata["prompt_branches_parallel"] is False
+    assert pipeline_timing.metadata["prompt_branches_serial_reason"] == "default_workspace_scaffold_pending"
+
+
+@pytest.mark.asyncio
+async def test_prepare_agent_and_prompt_file_memory_preserves_reusable_agent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """File-memory overlap reuses caller-owned agent without rebuilding it."""
+    reusable_agent = MagicMock()
+    reusable_agent.additional_context = "caller context"
+    create_agent_mock = MagicMock(side_effect=AssertionError("caller-owned agent must not be rebuilt"))
+
+    async def prepare_history(*_args: object, **kwargs: object) -> SimpleNamespace:
+        assert kwargs["agent"] is reusable_agent
+        assert kwargs["resolved_runtime_model"] is None
+        transient_messages = kwargs["transient_context_messages"]
+        assert [message.content for message in transient_messages] == [render_transient_context(("turn memory",))]
+        return SimpleNamespace(
+            prepared_history=PreparedHistoryState(prepared_context_tokens=42),
+            replay_plan=None,
+            unseen_event_ids=["$memory"],
+            messages=(
+                *transient_messages,
+                Message(role="user", content=kwargs["prompt"]),
+            ),
+        )
+
+    monkeypatch.setattr(
+        ai_module,
+        "build_memory_prompt_parts",
+        AsyncMock(
+            return_value=MemoryPromptParts(
+                session_preamble="session memory",
+                transient_turn_context="turn memory",
+            ),
+        ),
+    )
+    monkeypatch.setattr(ai_module, "create_agent", create_agent_mock)
+    monkeypatch.setattr(ai_module, "prepare_agent_execution_context", prepare_history)
+
+    prepared = await ai_module._prepare_agent_and_prompt(
+        make_turn_context("general"),
+        prompt="hello",
+        runtime_paths=test_runtime_paths(tmp_path),
+        config=_prompt_preparation_config("file"),
+        reusable_agent=reusable_agent,
+    )
+
+    assert prepared.agent is reusable_agent
+    assert reusable_agent.additional_context == "caller context\n\nsession memory"
+    assert prepared.unseen_event_ids == ["$memory"]
+    assert prepared.prepared_history.prepared_context_tokens == 42
+    create_agent_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_parallel_file_prompt_matches_sequential_output_and_bookkeeping(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Parallel file preparation preserves sequential prompt and history results."""
+    built_agents: list[MagicMock] = []
+    history_inputs: list[tuple[str, tuple[str, ...], object]] = []
+
+    async def prepare_memory(*_args: object, **_kwargs: object) -> MemoryPromptParts:
+        return MemoryPromptParts(
+            session_preamble="session memory",
+            transient_turn_context="retrieved memory",
+        )
+
+    def build_agent(*_args: object, **_kwargs: object) -> MagicMock:
+        agent = MagicMock()
+        agent.additional_context = "base context"
+        built_agents.append(agent)
+        return agent
+
+    async def prepare_history(*_args: object, **kwargs: object) -> SimpleNamespace:
+        transient_messages = tuple(kwargs["transient_context_messages"])
+        history_inputs.append(
+            (
+                kwargs["prompt"],
+                tuple(message.content for message in transient_messages),
+                kwargs["resolved_runtime_model"],
+            ),
+        )
+        return SimpleNamespace(
+            prepared_history=PreparedHistoryState(prepared_context_tokens=73),
+            replay_plan=None,
+            unseen_event_ids=["$one", "$two"],
+            messages=(
+                Message(role="system", content="stable system context"),
+                *transient_messages,
+                Message(role="user", content=kwargs["prompt"]),
+            ),
+        )
+
+    monkeypatch.setattr(ai_module, "build_memory_prompt_parts", prepare_memory)
+    monkeypatch.setattr(ai_module, "create_agent", build_agent)
+    monkeypatch.setattr(ai_module, "prepare_agent_execution_context", prepare_history)
+
+    config = _prompt_preparation_config("file")
+    runtime_paths = test_runtime_paths(tmp_path)
+    monkeypatch.setattr(ai_module, "agent_build_can_overlap_file_memory", lambda *_args: False)
+    sequential = await ai_module._prepare_agent_and_prompt(
+        make_turn_context("general"),
+        prompt="raw prompt",
+        runtime_paths=runtime_paths,
+        config=config,
+        model_prompt="model metadata",
+    )
+    monkeypatch.setattr(ai_module, "agent_build_can_overlap_file_memory", lambda *_args: True)
+    parallel = await ai_module._prepare_agent_and_prompt(
+        make_turn_context("general"),
+        prompt="raw prompt",
+        runtime_paths=runtime_paths,
+        config=config,
+        model_prompt="model metadata",
+    )
+
+    assert [(message.role, message.content, message.add_to_agent_memory) for message in parallel.messages] == [
+        (message.role, message.content, message.add_to_agent_memory) for message in sequential.messages
+    ]
+    assert parallel.prompt_text == sequential.prompt_text
+    assert parallel.unseen_event_ids == sequential.unseen_event_ids == ["$one", "$two"]
+    assert parallel.prepared_history == sequential.prepared_history
+    assert parallel.runtime_model_name == sequential.runtime_model_name
+    assert [agent.additional_context for agent in built_agents] == [
+        "base context\n\nsession memory",
+        "base context\n\nsession memory",
+    ]
+    assert history_inputs == [
+        (
+            "raw prompt\n\nmodel metadata",
+            (render_transient_context(("retrieved memory",)),),
+            None,
+        ),
+        (
+            "raw prompt\n\nmodel metadata",
+            (render_transient_context(("retrieved memory",)),),
+            None,
+        ),
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_event_loop_offloading.py
+++ b/tests/test_event_loop_offloading.py
@@ -144,10 +144,7 @@ async def test_prepare_agent_and_prompt_joins_overlapping_branches_before_histor
         assert len(kwargs["transient_context_messages"]) == 1
         assert kwargs["transient_context_messages"][0].content == render_transient_context(("turn memory",))
         assert kwargs["transient_context_messages"][0].add_to_agent_memory is False
-        if memory_backend == "mem0":
-            assert kwargs["resolved_runtime_model"].model_name == "default"
-        else:
-            assert kwargs["resolved_runtime_model"] is None
+        assert kwargs["resolved_runtime_model"].model_name == "default"
         return SimpleNamespace(
             prepared_history=PreparedHistoryState(),
             replay_plan=None,
@@ -279,7 +276,7 @@ async def test_prepare_agent_and_prompt_keeps_cold_default_workspace_serial(
     )
 
     assert prepared.agent is built_agent
-    assert prepare_history.await_args.kwargs["resolved_runtime_model"] is None
+    assert prepare_history.await_args.kwargs["resolved_runtime_model"].model_name == "default"
     assert pipeline_timing.metadata["prompt_branches_parallel"] is False
     assert pipeline_timing.metadata["prompt_branches_serial_reason"] == "default_workspace_scaffold_pending"
 
@@ -296,7 +293,7 @@ async def test_prepare_agent_and_prompt_file_memory_preserves_reusable_agent(
 
     async def prepare_history(*_args: object, **kwargs: object) -> SimpleNamespace:
         assert kwargs["agent"] is reusable_agent
-        assert kwargs["resolved_runtime_model"] is None
+        assert kwargs["resolved_runtime_model"].model_name == "default"
         transient_messages = kwargs["transient_context_messages"]
         assert [message.content for message in transient_messages] == [render_transient_context(("turn memory",))]
         return SimpleNamespace(
@@ -344,7 +341,7 @@ async def test_parallel_file_prompt_matches_sequential_output_and_bookkeeping(
 ) -> None:
     """Parallel file preparation preserves sequential prompt and history results."""
     built_agents: list[MagicMock] = []
-    history_inputs: list[tuple[str, tuple[str, ...], object]] = []
+    history_inputs: list[tuple[str, tuple[str, ...], str]] = []
 
     async def prepare_memory(*_args: object, **_kwargs: object) -> MemoryPromptParts:
         return MemoryPromptParts(
@@ -364,7 +361,7 @@ async def test_parallel_file_prompt_matches_sequential_output_and_bookkeeping(
             (
                 kwargs["prompt"],
                 tuple(message.content for message in transient_messages),
-                kwargs["resolved_runtime_model"],
+                kwargs["resolved_runtime_model"].model_name,
             ),
         )
         return SimpleNamespace(
@@ -416,12 +413,12 @@ async def test_parallel_file_prompt_matches_sequential_output_and_bookkeeping(
         (
             "raw prompt\n\nmodel metadata",
             (render_transient_context(("retrieved memory",)),),
-            None,
+            "default",
         ),
         (
             "raw prompt\n\nmodel metadata",
             (render_transient_context(("retrieved memory",)),),
-            None,
+            "default",
         ),
     ]
 

--- a/tests/test_pre_model_preparation.py
+++ b/tests/test_pre_model_preparation.py
@@ -1,4 +1,4 @@
-"""Tests for concurrent Mem0 prompt preparation."""
+"""Tests for concurrent prompt preparation."""
 
 from __future__ import annotations
 
@@ -11,12 +11,12 @@ import pytest
 import mindroom.pre_model_preparation as pre_model_preparation_module
 from mindroom.config.main import ResolvedRuntimeModel
 from mindroom.memory import MemoryPromptParts
-from mindroom.pre_model_preparation import prepare_mem0_prompt_branches
+from mindroom.pre_model_preparation import prepare_prompt_branches
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("failing_branch", ["memory", "agent", "both", "memory_cancelled"])
-async def test_prepare_mem0_prompt_branches_propagates_failure_directly(
+async def test_prepare_prompt_branches_propagates_failure_directly(
     monkeypatch: pytest.MonkeyPatch,
     failing_branch: str,
 ) -> None:
@@ -50,7 +50,7 @@ async def test_prepare_mem0_prompt_branches_propagates_failure_directly(
 
     expected_error_type = asyncio.CancelledError if failing_branch == "memory_cancelled" else RuntimeError
     with pytest.raises(expected_error_type) as raised:
-        await prepare_mem0_prompt_branches(
+        await prepare_prompt_branches(
             prepare_memory=memory_branch,
             build_agent=agent_branch,
             agent_name="general",
@@ -71,7 +71,99 @@ async def test_prepare_mem0_prompt_branches_propagates_failure_directly(
 
 
 @pytest.mark.asyncio
-async def test_prepare_mem0_prompt_branches_preserves_caller_owned_agent_on_memory_failure(
+async def test_prepare_prompt_branches_agent_failure_cancels_memory_sibling() -> None:
+    """File-mode agent failure cancels and joins its async memory sibling."""
+    memory_started = threading.Event()
+    memory_cleaned = asyncio.Event()
+    agent_error = RuntimeError("agent failed")
+
+    async def blocked_memory() -> MemoryPromptParts:
+        memory_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            memory_cleaned.set()
+
+    def failed_agent() -> tuple[ResolvedRuntimeModel, MagicMock]:
+        if not memory_started.wait(5.0):
+            msg = "timed out waiting for memory preparation"
+            raise TimeoutError(msg)
+        raise agent_error
+
+    baseline_tasks = set(asyncio.all_tasks())
+    with pytest.raises(RuntimeError) as raised:
+        await prepare_prompt_branches(
+            prepare_memory=blocked_memory,
+            build_agent=failed_agent,
+            agent_name="general",
+            shared_scope_storage=None,
+            pipeline_timing=None,
+            cancel_memory_on_agent_failure=True,
+        )
+
+    assert raised.value is agent_error
+    assert memory_cleaned.is_set()
+    await asyncio.sleep(0)
+    leaked_tasks = {task for task in asyncio.all_tasks() - baseline_tasks if not task.done()}
+    assert leaked_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_prepare_prompt_branches_memory_failure_joins_agent_sibling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Memory failure waits for uninterruptible construction and closes its agent."""
+    agent_started = threading.Event()
+    agent_release = threading.Event()
+    agent_finished = threading.Event()
+    memory_failed = asyncio.Event()
+    memory_error = RuntimeError("memory failed")
+    runtime_model = ResolvedRuntimeModel(model_name="default", context_window=None)
+    built_agent = MagicMock()
+    close_unreturned = MagicMock()
+
+    async def failed_memory() -> MemoryPromptParts:
+        assert await asyncio.to_thread(agent_started.wait, 5.0)
+        memory_failed.set()
+        raise memory_error
+
+    def blocked_agent() -> tuple[ResolvedRuntimeModel, MagicMock]:
+        agent_started.set()
+        if not agent_release.wait(5.0):
+            msg = "timed out waiting to release agent construction"
+            raise TimeoutError(msg)
+        agent_finished.set()
+        return runtime_model, built_agent
+
+    monkeypatch.setattr(pre_model_preparation_module, "close_agent_runtime_state_dbs", close_unreturned)
+
+    prepare_task = asyncio.create_task(
+        prepare_prompt_branches(
+            prepare_memory=failed_memory,
+            build_agent=blocked_agent,
+            agent_name="general",
+            shared_scope_storage=None,
+            pipeline_timing=None,
+            cancel_memory_on_agent_failure=True,
+        ),
+    )
+    try:
+        await asyncio.wait_for(memory_failed.wait(), timeout=1.0)
+        await asyncio.sleep(0)
+        assert not prepare_task.done()
+        agent_release.set()
+        with pytest.raises(RuntimeError) as raised:
+            await prepare_task
+    finally:
+        agent_release.set()
+
+    assert raised.value is memory_error
+    assert agent_finished.is_set()
+    close_unreturned.assert_called_once_with(built_agent, shared_scope_storage=None)
+
+
+@pytest.mark.asyncio
+async def test_prepare_prompt_branches_preserves_caller_owned_agent_on_memory_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A failed memory branch must not close a reusable agent owned by its caller."""
@@ -87,7 +179,7 @@ async def test_prepare_mem0_prompt_branches_preserves_caller_owned_agent_on_memo
     monkeypatch.setattr(pre_model_preparation_module, "close_agent_runtime_state_dbs", close_unreturned)
 
     with pytest.raises(RuntimeError, match="memory failed"):
-        await prepare_mem0_prompt_branches(
+        await prepare_prompt_branches(
             prepare_memory=memory_branch,
             build_agent=lambda: (runtime_model, built_agent),
             agent_name="general",
@@ -110,7 +202,7 @@ async def test_prepare_mem0_prompt_branches_preserves_caller_owned_agent_on_memo
         ("finished", True),
     ],
 )
-async def test_prepare_mem0_prompt_branches_cancellation_settles_agent_build(  # noqa: C901, PLR0915
+async def test_prepare_prompt_branches_cancellation_settles_agent_build(  # noqa: C901, PLR0915
     monkeypatch: pytest.MonkeyPatch,
     agent_outcome: str,
     caller_owned: bool,
@@ -154,7 +246,7 @@ async def test_prepare_mem0_prompt_branches_cancellation_settles_agent_build(  #
 
     baseline_tasks = set(asyncio.all_tasks())
     prepare_task = asyncio.create_task(
-        prepare_mem0_prompt_branches(
+        prepare_prompt_branches(
             prepare_memory=blocked_memory,
             build_agent=blocked_agent,
             agent_name="general",

--- a/tests/test_pre_model_preparation.py
+++ b/tests/test_pre_model_preparation.py
@@ -71,44 +71,6 @@ async def test_prepare_prompt_branches_propagates_failure_directly(
 
 
 @pytest.mark.asyncio
-async def test_prepare_prompt_branches_agent_failure_cancels_memory_sibling() -> None:
-    """File-mode agent failure cancels and joins its async memory sibling."""
-    memory_started = threading.Event()
-    memory_cleaned = asyncio.Event()
-    agent_error = RuntimeError("agent failed")
-
-    async def blocked_memory() -> MemoryPromptParts:
-        memory_started.set()
-        try:
-            await asyncio.Event().wait()
-        finally:
-            memory_cleaned.set()
-
-    def failed_agent() -> tuple[ResolvedRuntimeModel, MagicMock]:
-        if not memory_started.wait(5.0):
-            msg = "timed out waiting for memory preparation"
-            raise TimeoutError(msg)
-        raise agent_error
-
-    baseline_tasks = set(asyncio.all_tasks())
-    with pytest.raises(RuntimeError) as raised:
-        await prepare_prompt_branches(
-            prepare_memory=blocked_memory,
-            build_agent=failed_agent,
-            agent_name="general",
-            shared_scope_storage=None,
-            pipeline_timing=None,
-            cancel_memory_on_agent_failure=True,
-        )
-
-    assert raised.value is agent_error
-    assert memory_cleaned.is_set()
-    await asyncio.sleep(0)
-    leaked_tasks = {task for task in asyncio.all_tasks() - baseline_tasks if not task.done()}
-    assert leaked_tasks == set()
-
-
-@pytest.mark.asyncio
 async def test_prepare_prompt_branches_memory_failure_joins_agent_sibling(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -144,7 +106,6 @@ async def test_prepare_prompt_branches_memory_failure_joins_agent_sibling(
             agent_name="general",
             shared_scope_storage=None,
             pipeline_timing=None,
-            cancel_memory_on_agent_failure=True,
         ),
     )
     try:


### PR DESCRIPTION
## Why

File-backed memory preparation and agent construction were serialized even though they are independent after workspace scaffolding.
That adds their latencies on every turn.

## What changed

- Reuse the existing concurrent prompt-preparation join for file-memory agents.
- Keep the first default `mind` workspace turn serial until `MEMORY.md` has been scaffolded, preserving deterministic first-turn prompt content.
- Forward the already-resolved runtime model into history preparation instead of resolving it again.
- Preserve the existing failure precedence, cancellation draining, and caller-owned agent cleanup behavior.
- Extend prompt-assembly timing metadata and the existing benchmark.

## Safety

The overlap is skipped only for the one path where agent construction can create memory content during the read.
Tests cover cold scaffolding, serial/parallel output equivalence, both completion orders, failures, cancellation, reusable agents, and task cleanup.

## Validation

- `uv run pytest` — 11,436 passed, 54 skipped.
- Focused prompt, agent, memory, and event-loop tests passed.
- Ruff, ty, Tach, and changed-file pre-commit hooks passed.
- Controlled benchmark with 1 second of memory work and 2 seconds of agent work: about 3.02 seconds sequential versus 2.01 seconds overlapped.

## Summary by Sourcery

Overlap memory prompt preparation with agent construction for both mem0 and file-backed agents while preserving safety and determinism, and extend timing/benchmark coverage for the new behavior.

Enhancements:
- Allow file-backed agents to overlap memory preparation with agent construction when workspace scaffolding is complete, keeping the initial default workspace turn serial until MEMORY.md exists.
- Refactor the concurrent prompt-branch helper into a generic prepare_prompt_branches utility reused across agent types and expose agent_build_can_overlap_file_memory for workspace-aware decisions.
- Forward the resolved runtime model from the agent-build path into history preparation to avoid redundant resolution and keep branch outputs aligned.

Build:
- Update Tach interface exposure to include agent_build_can_overlap_file_memory for use in benchmarking and tooling.

Tests:
- Expand event-loop, pre-model-preparation, and agent tests to cover file-backed memory overlap, cancellation and failure behavior, reusable agents, and serial vs parallel equivalence.
- Extend the prompt-assembly benchmark script with a new prompt_branches phase that measures sequential versus parallel branch timing under configurable delays.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Prompt-branch preparation can overlap with memory work when it’s safe, with behavior tailored to the active memory backend.
  * Default workspace preparation remains serial when overlap could change memory-read behavior.

* **Reliability**
  * Enhanced handling for failure/cancellation across parallel prompt branches, ensuring correct cleanup and no leaked runtime state.
  * Preserves caller-owned/reusable agent context during overlapping preparations.

* **Observability**
  * Expanded prompt-branch timing and diagnostic metadata, including backend and serialization reason details.
  * Improved benchmarking to measure the additional prompt-branch phase and report richer timing stats.

* **Tests**
  * Updated and added coverage for overlapping prompt preparation across memory backends and for bookkeeping correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->