### PR TITLE
Reuse resolved thread projections across turns

### DIFF
--- a/docs/architecture/matrix-event-cache-security.md
+++ b/docs/architecture/matrix-event-cache-security.md
@@ -22,7 +22,15 @@ Both unencrypted `url` and encrypted `file.url` MXC representations are tracked.
 
 Plaintext persistence succeeds only while the owning event and its reference are visible and not tombstoned.
 
-Decrypted plaintext exists only in the durable principal-owned cache; there is no runtime-wide process-local plaintext cache.
+Durable plaintext exists only in the principal-owned event cache; there is no runtime-wide process-local plaintext cache shared across bots.
+
+Each bot may retain one process-local resolved thread projection across turns, including resolved message bodies and the exact sidecar plaintext on which they depend.
+
+That projection is scoped to one room and thread, and reuse requires an exact durable event revision, membership epoch, trusted-sender set, and sidecar-text match.
+
+Every serve revalidates sidecar plaintext through the principal- and room-scoped surviving-reference check; any mismatch or uncertainty falls back to full resolution.
+
+Durable invalidation prevents reuse through the normal freshness gate, resolution failures discard the projection, and process shutdown removes it.
 
 Hydration without complete principal, room, event, and MXC identity may return freshly downloaded content to the current call, but it cannot read or populate the durable cache.
 

--- a/scripts/testing/benchmark_thread_history_reuse.py
+++ b/scripts/testing/benchmark_thread_history_reuse.py
@@ -1,0 +1,184 @@
+"""Benchmark durable-cache thread resolution with and without process-local reuse.
+
+Generates one synthetic long agent thread where every agent response was streamed via
+``m.replace`` edits (the raw-row inflation seen in production), then measures three reads:
+
+- ``cold_full``: full re-parse and re-resolution of every raw row (pre-change behavior).
+- ``warm_reuse``: identical rows served from the process-local resolution snapshot.
+- ``warm_incremental``: one appended user message resolved as a suffix and merged.
+
+Run with ``uv run python scripts/testing/benchmark_thread_history_reuse.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import statistics
+import time
+from typing import Any
+from unittest.mock import AsyncMock
+
+from mindroom.matrix.client_thread_history import _resolve_cached_thread_history
+from mindroom.matrix.thread_resolution_reuse import ThreadResolutionReuseCache
+
+ROOM = "!room:localhost"
+THREAD = "$root"
+TRUSTED_SENDER_IDS = ("@mindroom_agent:localhost",)
+
+
+def make_streaming_thread(
+    *,
+    visible_messages: int,
+    edits_per_agent_message: int,
+    final_body_chars: int,
+) -> list[dict[str, Any]]:
+    """Build a thread where every other message is an agent response streamed via edits."""
+    timestamp = 1_700_000_000_000
+    sources: list[dict[str, Any]] = [
+        {
+            "event_id": THREAD,
+            "origin_server_ts": timestamp,
+            "type": "m.room.message",
+            "sender": "@user:localhost",
+            "content": {"msgtype": "m.text", "body": "root message"},
+        },
+    ]
+    for index in range(1, visible_messages):
+        timestamp += 10_000
+        is_agent = index % 2 == 1
+        sender = "@mindroom_agent:localhost" if is_agent else "@user:localhost"
+        original_id = f"$msg-{index}"
+        body = f"message {index} " + "x" * (final_body_chars if is_agent else 80)
+        sources.append(
+            {
+                "event_id": original_id,
+                "origin_server_ts": timestamp,
+                "type": "m.room.message",
+                "sender": sender,
+                "content": {
+                    "msgtype": "m.text",
+                    "body": body[:200],
+                    "m.relates_to": {"rel_type": "m.thread", "event_id": THREAD},
+                },
+            },
+        )
+        if not is_agent:
+            continue
+        for edit_index in range(1, edits_per_agent_message + 1):
+            timestamp += 500
+            partial = body[: max(200, int(len(body) * edit_index / edits_per_agent_message))]
+            sources.append(
+                {
+                    "event_id": f"$msg-{index}-edit-{edit_index}",
+                    "origin_server_ts": timestamp,
+                    "type": "m.room.message",
+                    "sender": sender,
+                    "content": {
+                        "msgtype": "m.text",
+                        "body": f"* {partial}",
+                        "m.new_content": {"msgtype": "m.text", "body": partial},
+                        "m.relates_to": {"rel_type": "m.replace", "event_id": original_id},
+                    },
+                },
+            )
+    return sources
+
+
+def _appended_user_message(rows: list[dict[str, Any]], turn: int) -> dict[str, Any]:
+    return {
+        "event_id": f"$turn-{turn}",
+        "origin_server_ts": rows[-1]["origin_server_ts"] + 10_000,
+        "type": "m.room.message",
+        "sender": "@user:localhost",
+        "content": {
+            "msgtype": "m.text",
+            "body": f"follow-up question {turn}",
+            "m.relates_to": {"rel_type": "m.thread", "event_id": THREAD},
+        },
+    }
+
+
+def _event_cache() -> AsyncMock:
+    event_cache = AsyncMock()
+    event_cache.get_mxc_texts.return_value = {}
+    return event_cache
+
+
+async def _timed_resolve(
+    rows: list[dict[str, Any]],
+    *,
+    reuse: ThreadResolutionReuseCache | None,
+) -> tuple[float, int, str]:
+    started = time.perf_counter()
+    messages, _sidecar_ms, kind = await _resolve_cached_thread_history(
+        AsyncMock(),
+        room_id=ROOM,
+        thread_id=THREAD,
+        event_cache=_event_cache(),
+        cached_event_sources=rows,
+        expected_membership_epoch=0,
+        trusted_sender_ids=TRUSTED_SENDER_IDS,
+        resolution_reuse=reuse,
+    )
+    elapsed_ms = (time.perf_counter() - started) * 1000
+    assert messages is not None
+    return elapsed_ms, len(messages), kind
+
+
+def _report(label: str, timings: list[float], *, raw_rows: int, visible: int, kind: str) -> None:
+    print(
+        f"{label:<18} raw_rows={raw_rows:>6} visible={visible:>5} kind={kind:<11} "
+        f"median={statistics.median(timings):8.1f} ms min={min(timings):8.1f} ms max={max(timings):8.1f} ms",
+    )
+
+
+async def run_benchmark(*, visible_messages: int, edits_per_agent_message: int, turns: int) -> None:
+    """Measure cold full resolution, warm snapshot reuse, and warm incremental merges."""
+    rows = make_streaming_thread(
+        visible_messages=visible_messages,
+        edits_per_agent_message=edits_per_agent_message,
+        final_body_chars=4000,
+    )
+
+    cold_timings: list[float] = []
+    for _ in range(turns):
+        elapsed_ms, visible, kind = await _timed_resolve(rows, reuse=None)
+        cold_timings.append(elapsed_ms)
+    _report("cold_full", cold_timings, raw_rows=len(rows), visible=visible, kind=kind)
+
+    reuse = ThreadResolutionReuseCache()
+    await _timed_resolve(rows, reuse=reuse)  # populate the snapshot once
+    warm_timings: list[float] = []
+    for _ in range(turns):
+        elapsed_ms, visible, kind = await _timed_resolve(rows, reuse=reuse)
+        warm_timings.append(elapsed_ms)
+    _report("warm_reuse", warm_timings, raw_rows=len(rows), visible=visible, kind=kind)
+
+    incremental_timings: list[float] = []
+    grown = list(rows)
+    for turn in range(turns):
+        grown = [*grown, _appended_user_message(grown, turn)]
+        elapsed_ms, visible, kind = await _timed_resolve(grown, reuse=reuse)
+        incremental_timings.append(elapsed_ms)
+    _report("warm_incremental", incremental_timings, raw_rows=len(grown), visible=visible, kind=kind)
+
+
+def main() -> None:
+    """Parse benchmark sizing arguments and run the benchmark."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--visible-messages", type=int, default=400)
+    parser.add_argument("--edits-per-agent-message", type=int, default=40)
+    parser.add_argument("--turns", type=int, default=5)
+    args = parser.parse_args()
+    asyncio.run(
+        run_benchmark(
+            visible_messages=args.visible_messages,
+            edits_per_agent_message=args.edits_per_agent_message,
+            turns=args.turns,
+        ),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/testing/benchmark_thread_history_reuse.py
+++ b/scripts/testing/benchmark_thread_history_reuse.py
@@ -14,12 +14,17 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import gc
 import statistics
+import tempfile
 import time
+import tracemalloc
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock
 
-from mindroom.matrix.client_thread_history import _resolve_cached_thread_history
+from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
+from mindroom.matrix.client_thread_history import _load_cached_thread_history_if_usable
 from mindroom.matrix.thread_resolution_reuse import ThreadResolutionReuseCache
 
 ROOM = "!room:localhost"
@@ -85,10 +90,10 @@ def make_streaming_thread(
     return sources
 
 
-def _appended_user_message(rows: list[dict[str, Any]], turn: int) -> dict[str, Any]:
+def _appended_user_message(last_timestamp: int, turn: int) -> dict[str, Any]:
     return {
         "event_id": f"$turn-{turn}",
-        "origin_server_ts": rows[-1]["origin_server_ts"] + 10_000,
+        "origin_server_ts": last_timestamp + 10_000,
         "type": "m.room.message",
         "sender": "@user:localhost",
         "content": {
@@ -99,31 +104,25 @@ def _appended_user_message(rows: list[dict[str, Any]], turn: int) -> dict[str, A
     }
 
 
-def _event_cache() -> AsyncMock:
-    event_cache = AsyncMock()
-    event_cache.get_mxc_texts.return_value = {}
-    return event_cache
-
-
 async def _timed_resolve(
-    rows: list[dict[str, Any]],
+    event_cache: SqliteEventCache,
     *,
     reuse: ThreadResolutionReuseCache | None,
 ) -> tuple[float, int, str]:
     started = time.perf_counter()
-    messages, _sidecar_ms, kind = await _resolve_cached_thread_history(
+    result, rejection = await _load_cached_thread_history_if_usable(
         AsyncMock(),
         room_id=ROOM,
         thread_id=THREAD,
-        event_cache=_event_cache(),
-        cached_event_sources=rows,
-        expected_membership_epoch=0,
+        event_cache=event_cache,
+        hydrate_sidecars=True,
         trusted_sender_ids=TRUSTED_SENDER_IDS,
         resolution_reuse=reuse,
     )
     elapsed_ms = (time.perf_counter() - started) * 1000
-    assert messages is not None
-    return elapsed_ms, len(messages), kind
+    assert rejection is None
+    assert result is not None
+    return elapsed_ms, len(result), str(result.diagnostics["thread_resolution_reuse"])
 
 
 def _report(label: str, timings: list[float], *, raw_rows: int, visible: int, kind: str) -> None:
@@ -135,41 +134,86 @@ def _report(label: str, timings: list[float], *, raw_rows: int, visible: int, ki
 
 async def run_benchmark(*, visible_messages: int, edits_per_agent_message: int, turns: int) -> None:
     """Measure cold full resolution, warm snapshot reuse, and warm incremental merges."""
-    rows = make_streaming_thread(
-        visible_messages=visible_messages,
-        edits_per_agent_message=edits_per_agent_message,
-        final_body_chars=4000,
-    )
+    with tempfile.TemporaryDirectory() as temp_dir:
+        event_cache = SqliteEventCache(Path(temp_dir) / "event_cache.db")
+        await event_cache.initialize()
+        rows = make_streaming_thread(
+            visible_messages=visible_messages,
+            edits_per_agent_message=edits_per_agent_message,
+            final_body_chars=4000,
+        )
+        raw_rows = len(rows)
+        last_timestamp = int(rows[-1]["origin_server_ts"])
+        fetch_started_at = time.time()
+        replaced = await event_cache.replace_thread_if_not_newer(
+            ROOM,
+            THREAD,
+            rows,
+            expected_membership_epoch=0,
+            fetch_started_at=fetch_started_at,
+            validated_at=fetch_started_at,
+        )
+        assert replaced
+        del rows
+        gc.collect()
 
-    cold_timings: list[float] = []
-    for _ in range(turns):
-        elapsed_ms, visible, kind = await _timed_resolve(rows, reuse=None)
-        cold_timings.append(elapsed_ms)
-    _report("cold_full", cold_timings, raw_rows=len(rows), visible=visible, kind=kind)
+        try:
+            cold_timings: list[float] = []
+            for _ in range(turns):
+                elapsed_ms, visible, kind = await _timed_resolve(event_cache, reuse=None)
+                cold_timings.append(elapsed_ms)
+            _report("cold_full", cold_timings, raw_rows=raw_rows, visible=visible, kind=kind)
 
-    reuse = ThreadResolutionReuseCache()
-    await _timed_resolve(rows, reuse=reuse)  # populate the snapshot once
-    warm_timings: list[float] = []
-    for _ in range(turns):
-        elapsed_ms, visible, kind = await _timed_resolve(rows, reuse=reuse)
-        warm_timings.append(elapsed_ms)
-    _report("warm_reuse", warm_timings, raw_rows=len(rows), visible=visible, kind=kind)
+            reuse = ThreadResolutionReuseCache()
+            tracemalloc.start()
+            retained_before, _peak_before = tracemalloc.get_traced_memory()
+            await _timed_resolve(event_cache, reuse=reuse)
+            gc.collect()
+            retained_after, _peak_after = tracemalloc.get_traced_memory()
+            tracemalloc.stop()
+            print(f"snapshot_retained={(retained_after - retained_before) / (1024 * 1024):.1f} MiB")
 
-    incremental_timings: list[float] = []
-    grown = list(rows)
-    for turn in range(turns):
-        grown = [*grown, _appended_user_message(grown, turn)]
-        elapsed_ms, visible, kind = await _timed_resolve(grown, reuse=reuse)
-        incremental_timings.append(elapsed_ms)
-    _report("warm_incremental", incremental_timings, raw_rows=len(grown), visible=visible, kind=kind)
+            warm_timings: list[float] = []
+            for _ in range(turns):
+                elapsed_ms, visible, kind = await _timed_resolve(event_cache, reuse=reuse)
+                warm_timings.append(elapsed_ms)
+            _report("warm_reuse", warm_timings, raw_rows=raw_rows, visible=visible, kind=kind)
+
+            incremental_timings: list[float] = []
+            for turn in range(turns):
+                appended = _appended_user_message(last_timestamp, turn)
+                last_timestamp = int(appended["origin_server_ts"])
+                await event_cache.mark_thread_stale(ROOM, THREAD, reason="live_thread_mutation")
+                assert await event_cache.append_event(ROOM, THREAD, appended)
+                assert await event_cache.revalidate_thread_after_incremental_update(ROOM, THREAD)
+                elapsed_ms, visible, kind = await _timed_resolve(event_cache, reuse=reuse)
+                incremental_timings.append(elapsed_ms)
+            _report(
+                "warm_incremental",
+                incremental_timings,
+                raw_rows=raw_rows + turns,
+                visible=visible,
+                kind=kind,
+            )
+        finally:
+            await event_cache.close()
+
+
+def _positive_int(value: str) -> int:
+    """Parse a strictly positive benchmark size."""
+    parsed = int(value)
+    if parsed < 1:
+        message = "must be at least 1"
+        raise argparse.ArgumentTypeError(message)
+    return parsed
 
 
 def main() -> None:
     """Parse benchmark sizing arguments and run the benchmark."""
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--visible-messages", type=int, default=400)
-    parser.add_argument("--edits-per-agent-message", type=int, default=40)
-    parser.add_argument("--turns", type=int, default=5)
+    parser.add_argument("--visible-messages", type=_positive_int, default=400)
+    parser.add_argument("--edits-per-agent-message", type=_positive_int, default=40)
+    parser.add_argument("--turns", type=_positive_int, default=5)
     args = parser.parse_args()
     asyncio.run(
         run_benchmark(

--- a/src/mindroom/matrix/cache/__init__.py
+++ b/src/mindroom/matrix/cache/__init__.py
@@ -29,7 +29,7 @@ Main invariants:
 """
 
 from .agent_message_snapshot import AgentMessageSnapshot
-from .event_cache import ConversationEventCache, SharedConversationEventCache, ThreadCacheState
+from .event_cache import ConversationEventCache, SharedConversationEventCache, ThreadCacheState, ThreadRevision
 from .event_normalization import is_opaque_encrypted_event_source, normalize_nio_event_for_cache
 from .thread_cache_helpers import thread_cache_rejection_reason
 from .thread_history_result import ThreadHistoryResult, thread_history_result
@@ -42,6 +42,7 @@ __all__ = [
     "SharedConversationEventCache",
     "ThreadCacheState",
     "ThreadHistoryResult",
+    "ThreadRevision",
     "is_opaque_encrypted_event_source",
     "normalize_nio_event_for_cache",
     "thread_cache_rejection_reason",

--- a/src/mindroom/matrix/cache/event_cache.py
+++ b/src/mindroom/matrix/cache/event_cache.py
@@ -20,6 +20,9 @@ class ThreadCacheState:
     invalidation_reason: str | None
     room_invalidated_at: float | None
     room_invalidation_reason: str | None
+    event_count: int = 0
+    max_write_seq: int | None = None
+    max_origin_server_ts: int | None = None
 
 
 class EventCacheBackendUnavailableError(RuntimeError):
@@ -77,6 +80,16 @@ class ConversationEventCache(Protocol):
 
     async def get_thread_events(self, room_id: str, thread_id: str) -> list[dict[str, Any]] | None:
         """Return cached events for one thread sorted by timestamp."""
+
+    async def get_thread_events_written_between(
+        self,
+        room_id: str,
+        thread_id: str,
+        *,
+        after_write_seq: int,
+        through_write_seq: int,
+    ) -> list[dict[str, Any]]:
+        """Return thread events written in one durable sequence interval."""
 
     async def get_recent_room_thread_ids(self, room_id: str, *, limit: int) -> list[str]:
         """Return locally known thread IDs for one room ordered by newest cached activity."""

--- a/src/mindroom/matrix/cache/event_cache.py
+++ b/src/mindroom/matrix/cache/event_cache.py
@@ -22,6 +22,7 @@ class ThreadCacheState:
     room_invalidation_reason: str | None
     event_count: int = 0
     max_write_seq: int | None = None
+    max_thread_write_seq: int | None = None
     max_origin_server_ts: int | None = None
 
 
@@ -88,8 +89,10 @@ class ConversationEventCache(Protocol):
         *,
         after_write_seq: int,
         through_write_seq: int,
+        after_thread_write_seq: int,
+        through_thread_write_seq: int,
     ) -> list[dict[str, Any]]:
-        """Return thread events written in one durable sequence interval."""
+        """Return thread events changed in bounded payload or thread-index intervals."""
 
     async def get_recent_room_thread_ids(self, room_id: str, *, limit: int) -> list[str]:
         """Return locally known thread IDs for one room ordered by newest cached activity."""

--- a/src/mindroom/matrix/cache/event_cache.py
+++ b/src/mindroom/matrix/cache/event_cache.py
@@ -20,10 +20,16 @@ class ThreadCacheState:
     invalidation_reason: str | None
     room_invalidated_at: float | None
     room_invalidation_reason: str | None
-    event_count: int = 0
-    max_write_seq: int | None = None
-    max_thread_write_seq: int | None = None
-    max_origin_server_ts: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ThreadRevision:
+    """Durable revision identity of one non-empty thread's raw rows."""
+
+    event_count: int
+    max_write_seq: int
+    max_thread_write_seq: int
+    max_origin_server_ts: int
 
 
 class EventCacheBackendUnavailableError(RuntimeError):
@@ -99,6 +105,9 @@ class ConversationEventCache(Protocol):
 
     async def get_thread_cache_state(self, room_id: str, thread_id: str) -> ThreadCacheState | None:
         """Return durable freshness metadata for one cached thread."""
+
+    async def get_thread_revision(self, room_id: str, thread_id: str) -> ThreadRevision | None:
+        """Return the durable revision identity of one non-empty cached thread."""
 
     async def get_event(self, room_id: str, event_id: str) -> dict[str, Any] | None:
         """Return one cached event payload by event ID."""

--- a/src/mindroom/matrix/cache/postgres_event_cache.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache.py
@@ -1252,6 +1252,29 @@ class PostgresEventCache:
             ),
         )
 
+    async def get_thread_events_written_between(
+        self,
+        room_id: str,
+        thread_id: str,
+        *,
+        after_write_seq: int,
+        through_write_seq: int,
+    ) -> list[dict[str, Any]]:
+        """Return thread events written in one durable sequence interval."""
+        return await self._operation(
+            room_id,
+            operation="get_thread_events_written_between",
+            disabled_result=[],
+            callback=lambda db: postgres_event_cache_threads.load_thread_events_written_between(
+                db,
+                namespace=self._runtime.namespace,
+                room_id=room_id,
+                thread_id=thread_id,
+                after_write_seq=after_write_seq,
+                through_write_seq=through_write_seq,
+            ),
+        )
+
     async def get_recent_room_thread_ids(self, room_id: str, *, limit: int) -> list[str]:
         """Return locally known thread IDs for one room ordered by newest cached activity."""
         return await self._operation(

--- a/src/mindroom/matrix/cache/postgres_event_cache.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache.py
@@ -1259,8 +1259,10 @@ class PostgresEventCache:
         *,
         after_write_seq: int,
         through_write_seq: int,
+        after_thread_write_seq: int,
+        through_thread_write_seq: int,
     ) -> list[dict[str, Any]]:
-        """Return thread events written in one durable sequence interval."""
+        """Return thread events changed in bounded payload or thread-index intervals."""
         return await self._operation(
             room_id,
             operation="get_thread_events_written_between",
@@ -1272,6 +1274,8 @@ class PostgresEventCache:
                 thread_id=thread_id,
                 after_write_seq=after_write_seq,
                 through_write_seq=through_write_seq,
+                after_thread_write_seq=after_thread_write_seq,
+                through_thread_write_seq=through_thread_write_seq,
             ),
         )
 

--- a/src/mindroom/matrix/cache/postgres_event_cache.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 
     from .agent_message_snapshot import AgentMessageSnapshot
     from .cache_maintenance import CacheMaintenanceReport
-    from .event_cache import ThreadCacheState
+    from .event_cache import ThreadCacheState, ThreadRevision
 
 
 _POSTGRES_EVENT_CACHE_SCHEMA_VERSION = 3
@@ -1276,6 +1276,20 @@ class PostgresEventCache:
                 through_write_seq=through_write_seq,
                 after_thread_write_seq=after_thread_write_seq,
                 through_thread_write_seq=through_thread_write_seq,
+            ),
+        )
+
+    async def get_thread_revision(self, room_id: str, thread_id: str) -> ThreadRevision | None:
+        """Return the durable revision identity of one non-empty cached thread."""
+        return await self._operation(
+            room_id,
+            operation="get_thread_revision",
+            disabled_result=None,
+            callback=lambda db: postgres_event_cache_threads.load_thread_revision(
+                db,
+                namespace=self._runtime.namespace,
+                room_id=room_id,
+                thread_id=thread_id,
             ),
         )
 

--- a/src/mindroom/matrix/cache/postgres_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache_threads.py
@@ -28,12 +28,13 @@ from .thread_cache_state import (
     is_incremental_thread_revalidation_reason,
     thread_cache_state_changed_after,
     thread_cache_state_row,
+    thread_revision_row,
 )
 
 if TYPE_CHECKING:
     from psycopg import AsyncConnection
 
-    from .event_cache import ThreadCacheState
+    from .event_cache import ThreadCacheState, ThreadRevision
 
 
 async def load_thread_events(
@@ -108,6 +109,36 @@ async def load_thread_events_written_between(
     return [json.loads(row[2]) for row in rows]
 
 
+async def load_thread_revision(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    room_id: str,
+    thread_id: str,
+) -> ThreadRevision | None:
+    """Return the durable revision identity of one non-empty cached thread."""
+    row = await fetchone(
+        db,
+        """
+        SELECT
+            COUNT(*),
+            MAX(events.write_seq),
+            MAX(thread_events.write_seq),
+            MAX(thread_events.origin_server_ts)
+        FROM mindroom_event_cache_thread_events AS thread_events
+        JOIN mindroom_event_cache_events AS events
+            ON events.namespace = thread_events.namespace
+            AND events.room_id = thread_events.room_id
+            AND events.event_id = thread_events.event_id
+        WHERE thread_events.namespace = %s
+            AND thread_events.room_id = %s
+            AND thread_events.thread_id = %s
+        """,
+        (namespace, room_id, thread_id),
+    )
+    return thread_revision_row(row)
+
+
 async def load_recent_room_thread_ids(
     db: AsyncConnection,
     *,
@@ -147,11 +178,7 @@ async def _load_thread_cache_state_row(
             mindroom_event_cache_thread_state.invalidated_at,
             mindroom_event_cache_thread_state.invalidation_reason,
             mindroom_event_cache_room_state.invalidated_at,
-            mindroom_event_cache_room_state.invalidation_reason,
-            COALESCE(thread_stats.event_count, 0),
-            thread_stats.max_write_seq,
-            thread_stats.max_thread_write_seq,
-            thread_stats.max_origin_server_ts
+            mindroom_event_cache_room_state.invalidation_reason
         FROM (SELECT %s AS requested_namespace, %s AS requested_room_id, %s AS requested_thread_id) AS requested
         LEFT JOIN mindroom_event_cache_thread_state
             ON mindroom_event_cache_thread_state.namespace = requested.requested_namespace
@@ -160,24 +187,8 @@ async def _load_thread_cache_state_row(
         LEFT JOIN mindroom_event_cache_room_state
             ON mindroom_event_cache_room_state.namespace = requested.requested_namespace
             AND mindroom_event_cache_room_state.room_id = requested.requested_room_id
-        LEFT JOIN (
-            SELECT
-                COUNT(*) AS event_count,
-                MAX(events.write_seq) AS max_write_seq,
-                MAX(thread_events.write_seq) AS max_thread_write_seq,
-                MAX(thread_events.origin_server_ts) AS max_origin_server_ts
-            FROM mindroom_event_cache_thread_events AS thread_events
-            JOIN mindroom_event_cache_events AS events
-                ON events.namespace = thread_events.namespace
-                AND events.room_id = thread_events.room_id
-                AND events.event_id = thread_events.event_id
-            WHERE thread_events.namespace = %s
-                AND thread_events.room_id = %s
-                AND thread_events.thread_id = %s
-        ) AS thread_stats
-            ON TRUE
         """,
-        (namespace, room_id, thread_id, namespace, room_id, thread_id),
+        (namespace, room_id, thread_id),
     )
     return thread_cache_state_row(row)
 

--- a/src/mindroom/matrix/cache/postgres_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache_threads.py
@@ -65,6 +65,37 @@ async def load_thread_events(
     return [json.loads(row[2]) for row in rows]
 
 
+async def load_thread_events_written_between(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    room_id: str,
+    thread_id: str,
+    after_write_seq: int,
+    through_write_seq: int,
+) -> list[dict[str, Any]]:
+    """Return cached thread events written in one durable sequence interval."""
+    rows = await fetchall(
+        db,
+        """
+        SELECT thread_events.origin_server_ts, thread_events.write_seq, events.event_json
+        FROM mindroom_event_cache_thread_events AS thread_events
+        JOIN mindroom_event_cache_events AS events
+            ON events.namespace = thread_events.namespace
+            AND events.room_id = thread_events.room_id
+            AND events.event_id = thread_events.event_id
+        WHERE thread_events.namespace = %s
+            AND thread_events.room_id = %s
+            AND thread_events.thread_id = %s
+            AND events.write_seq > %s
+            AND events.write_seq <= %s
+        ORDER BY thread_events.origin_server_ts ASC, thread_events.write_seq ASC
+        """,
+        (namespace, room_id, thread_id, after_write_seq, through_write_seq),
+    )
+    return [json.loads(row[2]) for row in rows]
+
+
 async def load_recent_room_thread_ids(
     db: AsyncConnection,
     *,
@@ -104,7 +135,10 @@ async def _load_thread_cache_state_row(
             mindroom_event_cache_thread_state.invalidated_at,
             mindroom_event_cache_thread_state.invalidation_reason,
             mindroom_event_cache_room_state.invalidated_at,
-            mindroom_event_cache_room_state.invalidation_reason
+            mindroom_event_cache_room_state.invalidation_reason,
+            COALESCE(thread_stats.event_count, 0),
+            thread_stats.max_write_seq,
+            thread_stats.max_origin_server_ts
         FROM (SELECT %s AS requested_namespace, %s AS requested_room_id, %s AS requested_thread_id) AS requested
         LEFT JOIN mindroom_event_cache_thread_state
             ON mindroom_event_cache_thread_state.namespace = requested.requested_namespace
@@ -113,8 +147,23 @@ async def _load_thread_cache_state_row(
         LEFT JOIN mindroom_event_cache_room_state
             ON mindroom_event_cache_room_state.namespace = requested.requested_namespace
             AND mindroom_event_cache_room_state.room_id = requested.requested_room_id
+        LEFT JOIN (
+            SELECT
+                COUNT(*) AS event_count,
+                MAX(events.write_seq) AS max_write_seq,
+                MAX(thread_events.origin_server_ts) AS max_origin_server_ts
+            FROM mindroom_event_cache_thread_events AS thread_events
+            JOIN mindroom_event_cache_events AS events
+                ON events.namespace = thread_events.namespace
+                AND events.room_id = thread_events.room_id
+                AND events.event_id = thread_events.event_id
+            WHERE thread_events.namespace = %s
+                AND thread_events.room_id = %s
+                AND thread_events.thread_id = %s
+        ) AS thread_stats
+            ON TRUE
         """,
-        (namespace, room_id, thread_id),
+        (namespace, room_id, thread_id, namespace, room_id, thread_id),
     )
     return thread_cache_state_row(row)
 

--- a/src/mindroom/matrix/cache/postgres_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache_threads.py
@@ -73,8 +73,10 @@ async def load_thread_events_written_between(
     thread_id: str,
     after_write_seq: int,
     through_write_seq: int,
+    after_thread_write_seq: int,
+    through_thread_write_seq: int,
 ) -> list[dict[str, Any]]:
-    """Return cached thread events written in one durable sequence interval."""
+    """Return cached thread events changed in bounded durable revision intervals."""
     rows = await fetchall(
         db,
         """
@@ -87,11 +89,21 @@ async def load_thread_events_written_between(
         WHERE thread_events.namespace = %s
             AND thread_events.room_id = %s
             AND thread_events.thread_id = %s
-            AND events.write_seq > %s
-            AND events.write_seq <= %s
+            AND (
+                (events.write_seq > %s AND events.write_seq <= %s)
+                OR (thread_events.write_seq > %s AND thread_events.write_seq <= %s)
+            )
         ORDER BY thread_events.origin_server_ts ASC, thread_events.write_seq ASC
         """,
-        (namespace, room_id, thread_id, after_write_seq, through_write_seq),
+        (
+            namespace,
+            room_id,
+            thread_id,
+            after_write_seq,
+            through_write_seq,
+            after_thread_write_seq,
+            through_thread_write_seq,
+        ),
     )
     return [json.loads(row[2]) for row in rows]
 
@@ -138,6 +150,7 @@ async def _load_thread_cache_state_row(
             mindroom_event_cache_room_state.invalidation_reason,
             COALESCE(thread_stats.event_count, 0),
             thread_stats.max_write_seq,
+            thread_stats.max_thread_write_seq,
             thread_stats.max_origin_server_ts
         FROM (SELECT %s AS requested_namespace, %s AS requested_room_id, %s AS requested_thread_id) AS requested
         LEFT JOIN mindroom_event_cache_thread_state
@@ -151,6 +164,7 @@ async def _load_thread_cache_state_row(
             SELECT
                 COUNT(*) AS event_count,
                 MAX(events.write_seq) AS max_write_seq,
+                MAX(thread_events.write_seq) AS max_thread_write_seq,
                 MAX(thread_events.origin_server_ts) AS max_origin_server_ts
             FROM mindroom_event_cache_thread_events AS thread_events
             JOIN mindroom_event_cache_events AS events

--- a/src/mindroom/matrix/cache/sqlite_event_cache.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache.py
@@ -865,8 +865,10 @@ class SqliteEventCache:
         *,
         after_write_seq: int,
         through_write_seq: int,
+        after_thread_write_seq: int,
+        through_thread_write_seq: int,
     ) -> list[dict[str, Any]]:
-        """Return thread events written in one durable sequence interval."""
+        """Return thread events changed in bounded payload or thread-index intervals."""
         return await self._read_operation(
             room_id,
             operation="get_thread_events_written_between",
@@ -878,6 +880,8 @@ class SqliteEventCache:
                 thread_id=thread_id,
                 after_write_seq=after_write_seq,
                 through_write_seq=through_write_seq,
+                after_thread_write_seq=after_thread_write_seq,
+                through_thread_write_seq=through_thread_write_seq,
             ),
         )
 

--- a/src/mindroom/matrix/cache/sqlite_event_cache.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 
     from .agent_message_snapshot import AgentMessageSnapshot
     from .cache_maintenance import CacheMaintenanceReport
-    from .event_cache import ThreadCacheState
+    from .event_cache import ThreadCacheState, ThreadRevision
 
 _EVENT_CACHE_SCHEMA_VERSION = 12
 _EVENT_CACHE_TABLES = (
@@ -882,6 +882,20 @@ class SqliteEventCache:
                 through_write_seq=through_write_seq,
                 after_thread_write_seq=after_thread_write_seq,
                 through_thread_write_seq=through_thread_write_seq,
+            ),
+        )
+
+    async def get_thread_revision(self, room_id: str, thread_id: str) -> ThreadRevision | None:
+        """Return the durable revision identity of one non-empty cached thread."""
+        return await self._read_operation(
+            room_id,
+            operation="get_thread_revision",
+            disabled_result=None,
+            reader=lambda db: sqlite_event_cache_threads.load_thread_revision(
+                db,
+                principal_id=self.principal_id,
+                room_id=room_id,
+                thread_id=thread_id,
             ),
         )
 

--- a/src/mindroom/matrix/cache/sqlite_event_cache.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache.py
@@ -858,6 +858,29 @@ class SqliteEventCache:
             ),
         )
 
+    async def get_thread_events_written_between(
+        self,
+        room_id: str,
+        thread_id: str,
+        *,
+        after_write_seq: int,
+        through_write_seq: int,
+    ) -> list[dict[str, Any]]:
+        """Return thread events written in one durable sequence interval."""
+        return await self._read_operation(
+            room_id,
+            operation="get_thread_events_written_between",
+            disabled_result=[],
+            reader=lambda db: sqlite_event_cache_threads.load_thread_events_written_between(
+                db,
+                principal_id=self.principal_id,
+                room_id=room_id,
+                thread_id=thread_id,
+                after_write_seq=after_write_seq,
+                through_write_seq=through_write_seq,
+            ),
+        )
+
     async def get_recent_room_thread_ids(self, room_id: str, *, limit: int) -> list[str]:
         """Return locally known thread IDs for one room ordered by newest cached activity."""
         return await self._read_operation(

--- a/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
@@ -50,12 +50,13 @@ from .thread_cache_state import (
     is_incremental_thread_revalidation_reason,
     thread_cache_state_changed_after,
     thread_cache_state_row,
+    thread_revision_row,
 )
 
 if TYPE_CHECKING:
     import aiosqlite
 
-    from .event_cache import ThreadCacheState
+    from .event_cache import ThreadCacheState, ThreadRevision
 
 
 async def load_thread_events(
@@ -132,6 +133,37 @@ async def load_thread_events_written_between(
     return [json.loads(row[2]) for row in rows]
 
 
+async def load_thread_revision(
+    db: aiosqlite.Connection,
+    *,
+    principal_id: str,
+    room_id: str,
+    thread_id: str,
+) -> ThreadRevision | None:
+    """Return the durable revision identity of one non-empty cached thread."""
+    cursor = await db.execute(
+        """
+        SELECT
+            COUNT(*),
+            MAX(events.write_seq),
+            MAX(thread_events.write_seq),
+            MAX(thread_events.origin_server_ts)
+        FROM thread_events
+        JOIN events
+            ON events.principal_id = thread_events.principal_id
+            AND events.room_id = thread_events.room_id
+            AND events.event_id = thread_events.event_id
+        WHERE thread_events.principal_id = ?
+            AND thread_events.room_id = ?
+            AND thread_events.thread_id = ?
+        """,
+        (principal_id, room_id, thread_id),
+    )
+    row = await cursor.fetchone()
+    await cursor.close()
+    return thread_revision_row(row)
+
+
 async def load_recent_room_thread_ids(
     db: aiosqlite.Connection,
     *,
@@ -171,11 +203,7 @@ async def _load_thread_cache_state_row(
             thread_cache_state.invalidated_at,
             thread_cache_state.invalidation_reason,
             room_cache_state.invalidated_at,
-            room_cache_state.invalidation_reason,
-            COALESCE(thread_stats.event_count, 0),
-            thread_stats.max_write_seq,
-            thread_stats.max_thread_write_seq,
-            thread_stats.max_origin_server_ts
+            room_cache_state.invalidation_reason
         FROM (
             SELECT ? AS requested_principal_id, ? AS requested_room_id, ? AS requested_thread_id
         ) AS requested
@@ -186,24 +214,8 @@ async def _load_thread_cache_state_row(
         LEFT JOIN room_cache_state
             ON room_cache_state.principal_id = requested.requested_principal_id
             AND room_cache_state.room_id = requested.requested_room_id
-        LEFT JOIN (
-            SELECT
-                COUNT(*) AS event_count,
-                MAX(events.write_seq) AS max_write_seq,
-                MAX(thread_events.write_seq) AS max_thread_write_seq,
-                MAX(thread_events.origin_server_ts) AS max_origin_server_ts
-            FROM thread_events
-            JOIN events
-                ON events.principal_id = thread_events.principal_id
-                AND events.room_id = thread_events.room_id
-                AND events.event_id = thread_events.event_id
-            WHERE thread_events.principal_id = ?
-                AND thread_events.room_id = ?
-                AND thread_events.thread_id = ?
-        ) AS thread_stats
-            ON TRUE
         """,
-        (principal_id, room_id, thread_id, principal_id, room_id, thread_id),
+        (principal_id, room_id, thread_id),
     )
     row = await cursor.fetchone()
     await cursor.close()

--- a/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
@@ -88,6 +88,38 @@ async def load_thread_events(
     return [json.loads(row[2]) for row in rows]
 
 
+async def load_thread_events_written_between(
+    db: aiosqlite.Connection,
+    *,
+    principal_id: str,
+    room_id: str,
+    thread_id: str,
+    after_write_seq: int,
+    through_write_seq: int,
+) -> list[dict[str, Any]]:
+    """Return cached thread events written in one durable sequence interval."""
+    cursor = await db.execute(
+        """
+        SELECT thread_events.origin_server_ts, thread_events.write_seq, events.event_json
+        FROM thread_events
+        JOIN events
+            ON events.principal_id = thread_events.principal_id
+            AND events.room_id = thread_events.room_id
+            AND events.event_id = thread_events.event_id
+        WHERE thread_events.principal_id = ?
+            AND thread_events.room_id = ?
+            AND thread_events.thread_id = ?
+            AND events.write_seq > ?
+            AND events.write_seq <= ?
+        ORDER BY thread_events.origin_server_ts ASC, thread_events.write_seq ASC
+        """,
+        (principal_id, room_id, thread_id, after_write_seq, through_write_seq),
+    )
+    rows = await cursor.fetchall()
+    await cursor.close()
+    return [json.loads(row[2]) for row in rows]
+
+
 async def load_recent_room_thread_ids(
     db: aiosqlite.Connection,
     *,
@@ -127,7 +159,10 @@ async def _load_thread_cache_state_row(
             thread_cache_state.invalidated_at,
             thread_cache_state.invalidation_reason,
             room_cache_state.invalidated_at,
-            room_cache_state.invalidation_reason
+            room_cache_state.invalidation_reason,
+            COALESCE(thread_stats.event_count, 0),
+            thread_stats.max_write_seq,
+            thread_stats.max_origin_server_ts
         FROM (
             SELECT ? AS requested_principal_id, ? AS requested_room_id, ? AS requested_thread_id
         ) AS requested
@@ -138,8 +173,23 @@ async def _load_thread_cache_state_row(
         LEFT JOIN room_cache_state
             ON room_cache_state.principal_id = requested.requested_principal_id
             AND room_cache_state.room_id = requested.requested_room_id
+        LEFT JOIN (
+            SELECT
+                COUNT(*) AS event_count,
+                MAX(events.write_seq) AS max_write_seq,
+                MAX(thread_events.origin_server_ts) AS max_origin_server_ts
+            FROM thread_events
+            JOIN events
+                ON events.principal_id = thread_events.principal_id
+                AND events.room_id = thread_events.room_id
+                AND events.event_id = thread_events.event_id
+            WHERE thread_events.principal_id = ?
+                AND thread_events.room_id = ?
+                AND thread_events.thread_id = ?
+        ) AS thread_stats
+            ON TRUE
         """,
-        (principal_id, room_id, thread_id),
+        (principal_id, room_id, thread_id, principal_id, room_id, thread_id),
     )
     row = await cursor.fetchone()
     await cursor.close()

--- a/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
@@ -96,8 +96,10 @@ async def load_thread_events_written_between(
     thread_id: str,
     after_write_seq: int,
     through_write_seq: int,
+    after_thread_write_seq: int,
+    through_thread_write_seq: int,
 ) -> list[dict[str, Any]]:
-    """Return cached thread events written in one durable sequence interval."""
+    """Return cached thread events changed in bounded durable revision intervals."""
     cursor = await db.execute(
         """
         SELECT thread_events.origin_server_ts, thread_events.write_seq, events.event_json
@@ -109,11 +111,21 @@ async def load_thread_events_written_between(
         WHERE thread_events.principal_id = ?
             AND thread_events.room_id = ?
             AND thread_events.thread_id = ?
-            AND events.write_seq > ?
-            AND events.write_seq <= ?
+            AND (
+                (events.write_seq > ? AND events.write_seq <= ?)
+                OR (thread_events.write_seq > ? AND thread_events.write_seq <= ?)
+            )
         ORDER BY thread_events.origin_server_ts ASC, thread_events.write_seq ASC
         """,
-        (principal_id, room_id, thread_id, after_write_seq, through_write_seq),
+        (
+            principal_id,
+            room_id,
+            thread_id,
+            after_write_seq,
+            through_write_seq,
+            after_thread_write_seq,
+            through_thread_write_seq,
+        ),
     )
     rows = await cursor.fetchall()
     await cursor.close()
@@ -162,6 +174,7 @@ async def _load_thread_cache_state_row(
             room_cache_state.invalidation_reason,
             COALESCE(thread_stats.event_count, 0),
             thread_stats.max_write_seq,
+            thread_stats.max_thread_write_seq,
             thread_stats.max_origin_server_ts
         FROM (
             SELECT ? AS requested_principal_id, ? AS requested_room_id, ? AS requested_thread_id
@@ -177,6 +190,7 @@ async def _load_thread_cache_state_row(
             SELECT
                 COUNT(*) AS event_count,
                 MAX(events.write_seq) AS max_write_seq,
+                MAX(thread_events.write_seq) AS max_thread_write_seq,
                 MAX(thread_events.origin_server_ts) AS max_origin_server_ts
             FROM thread_events
             JOIN events

--- a/src/mindroom/matrix/cache/thread_cache_state.py
+++ b/src/mindroom/matrix/cache/thread_cache_state.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from .event_cache import ThreadCacheState
+from .event_cache import ThreadCacheState, ThreadRevision
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -53,10 +53,6 @@ class ThreadCacheStateRow:
     invalidation_reason: str | None
     room_invalidated_at: float | None
     room_invalidation_reason: str | None
-    event_count: int
-    max_write_seq: int | None
-    max_thread_write_seq: int | None
-    max_origin_server_ts: int | None
 
     def as_public_state(self) -> ThreadCacheState:
         """Return the public cache-state value."""
@@ -66,10 +62,6 @@ class ThreadCacheStateRow:
             invalidation_reason=self.invalidation_reason,
             room_invalidated_at=self.room_invalidated_at,
             room_invalidation_reason=self.room_invalidation_reason,
-            event_count=self.event_count,
-            max_write_seq=self.max_write_seq,
-            max_thread_write_seq=self.max_thread_write_seq,
-            max_origin_server_ts=self.max_origin_server_ts,
         )
 
 
@@ -77,10 +69,10 @@ def thread_cache_state_row(values: Sequence[float | str | None] | None) -> Threa
     """Normalize one backend storage row into backend-neutral cache-state values."""
     if values is None:
         return None
-    if len(values) != 9:
-        msg = f"Thread cache-state row must contain exactly 9 values, got {len(values)}"
+    if len(values) != 5:
+        msg = f"Thread cache-state row must contain exactly 5 values, got {len(values)}"
         raise ValueError(msg)
-    if all(value is None for value in values[:5]):
+    if all(value is None for value in values):
         return None
     return ThreadCacheStateRow(
         validated_at=None if values[0] is None else float(values[0]),
@@ -88,10 +80,24 @@ def thread_cache_state_row(values: Sequence[float | str | None] | None) -> Threa
         invalidation_reason=values[2] if isinstance(values[2], str) else None,
         room_invalidated_at=None if values[3] is None else float(values[3]),
         room_invalidation_reason=values[4] if isinstance(values[4], str) else None,
-        event_count=0 if values[5] is None else int(values[5]),
-        max_write_seq=None if values[6] is None else int(values[6]),
-        max_thread_write_seq=None if values[7] is None else int(values[7]),
-        max_origin_server_ts=None if values[8] is None else int(values[8]),
+    )
+
+
+def thread_revision_row(values: Sequence[float | int | None] | None) -> ThreadRevision | None:
+    """Normalize one backend aggregate row into a revision, absent for empty threads."""
+    if values is None:
+        return None
+    if len(values) != 4:
+        msg = f"Thread revision row must contain exactly 4 values, got {len(values)}"
+        raise ValueError(msg)
+    event_count = 0 if values[0] is None else int(values[0])
+    if event_count <= 0 or values[1] is None or values[2] is None or values[3] is None:
+        return None
+    return ThreadRevision(
+        event_count=event_count,
+        max_write_seq=int(values[1]),
+        max_thread_write_seq=int(values[2]),
+        max_origin_server_ts=int(values[3]),
     )
 
 

--- a/src/mindroom/matrix/cache/thread_cache_state.py
+++ b/src/mindroom/matrix/cache/thread_cache_state.py
@@ -53,6 +53,9 @@ class ThreadCacheStateRow:
     invalidation_reason: str | None
     room_invalidated_at: float | None
     room_invalidation_reason: str | None
+    event_count: int
+    max_write_seq: int | None
+    max_origin_server_ts: int | None
 
     def as_public_state(self) -> ThreadCacheState:
         """Return the public cache-state value."""
@@ -62,6 +65,9 @@ class ThreadCacheStateRow:
             invalidation_reason=self.invalidation_reason,
             room_invalidated_at=self.room_invalidated_at,
             room_invalidation_reason=self.room_invalidation_reason,
+            event_count=self.event_count,
+            max_write_seq=self.max_write_seq,
+            max_origin_server_ts=self.max_origin_server_ts,
         )
 
 
@@ -69,10 +75,10 @@ def thread_cache_state_row(values: Sequence[float | str | None] | None) -> Threa
     """Normalize one backend storage row into backend-neutral cache-state values."""
     if values is None:
         return None
-    if len(values) != 5:
-        msg = f"Thread cache-state row must contain exactly 5 values, got {len(values)}"
+    if len(values) != 8:
+        msg = f"Thread cache-state row must contain exactly 8 values, got {len(values)}"
         raise ValueError(msg)
-    if all(value is None for value in values):
+    if all(value is None for value in values[:5]):
         return None
     return ThreadCacheStateRow(
         validated_at=None if values[0] is None else float(values[0]),
@@ -80,6 +86,9 @@ def thread_cache_state_row(values: Sequence[float | str | None] | None) -> Threa
         invalidation_reason=values[2] if isinstance(values[2], str) else None,
         room_invalidated_at=None if values[3] is None else float(values[3]),
         room_invalidation_reason=values[4] if isinstance(values[4], str) else None,
+        event_count=0 if values[5] is None else int(values[5]),
+        max_write_seq=None if values[6] is None else int(values[6]),
+        max_origin_server_ts=None if values[7] is None else int(values[7]),
     )
 
 

--- a/src/mindroom/matrix/cache/thread_cache_state.py
+++ b/src/mindroom/matrix/cache/thread_cache_state.py
@@ -55,6 +55,7 @@ class ThreadCacheStateRow:
     room_invalidation_reason: str | None
     event_count: int
     max_write_seq: int | None
+    max_thread_write_seq: int | None
     max_origin_server_ts: int | None
 
     def as_public_state(self) -> ThreadCacheState:
@@ -67,6 +68,7 @@ class ThreadCacheStateRow:
             room_invalidation_reason=self.room_invalidation_reason,
             event_count=self.event_count,
             max_write_seq=self.max_write_seq,
+            max_thread_write_seq=self.max_thread_write_seq,
             max_origin_server_ts=self.max_origin_server_ts,
         )
 
@@ -75,8 +77,8 @@ def thread_cache_state_row(values: Sequence[float | str | None] | None) -> Threa
     """Normalize one backend storage row into backend-neutral cache-state values."""
     if values is None:
         return None
-    if len(values) != 8:
-        msg = f"Thread cache-state row must contain exactly 8 values, got {len(values)}"
+    if len(values) != 9:
+        msg = f"Thread cache-state row must contain exactly 9 values, got {len(values)}"
         raise ValueError(msg)
     if all(value is None for value in values[:5]):
         return None
@@ -88,7 +90,8 @@ def thread_cache_state_row(values: Sequence[float | str | None] | None) -> Threa
         room_invalidation_reason=values[4] if isinstance(values[4], str) else None,
         event_count=0 if values[5] is None else int(values[5]),
         max_write_seq=None if values[6] is None else int(values[6]),
-        max_origin_server_ts=None if values[7] is None else int(values[7]),
+        max_thread_write_seq=None if values[7] is None else int(values[7]),
+        max_origin_server_ts=None if values[8] is None else int(values[8]),
     )
 
 

--- a/src/mindroom/matrix/client_thread_history.py
+++ b/src/mindroom/matrix/client_thread_history.py
@@ -77,6 +77,7 @@ from mindroom.matrix.membership_fence import UNCERTIFIED_MEMBERSHIP_EPOCH
 from mindroom.matrix.message_content import (
     SidecarHydrationBatch,
     extract_and_resolve_message,
+    has_sidecar_references,
     prepare_sidecar_hydration_batch,
     resolve_event_source_content,
 )
@@ -100,6 +101,12 @@ from mindroom.matrix.thread_projection import (
     resolve_thread_ids_for_event_infos,
     sort_thread_event_sources_root_first,
     sort_thread_messages_root_first,
+)
+from mindroom.matrix.thread_resolution_reuse import (
+    ThreadResolutionReuseCache,
+    ThreadResolutionSnapshot,
+    build_thread_resolution_snapshot,
+    reusable_event_source_suffix,
 )
 from mindroom.matrix.visible_body import visible_body_from_event_source
 from mindroom.timing import elapsed_ms_since
@@ -366,6 +373,17 @@ def _sidecar_hydration_sources(
     return hydration_sources
 
 
+@dataclass(slots=True)
+class _ResolvedThreadEventSources:
+    """One resolution pass over raw thread rows plus the inputs needed to reuse it later."""
+
+    messages: list[ResolvedVisibleMessage]
+    sidecar_hydration_ms: float
+    input_order_by_event_id: dict[str, int]
+    related_event_id_by_event_id: dict[str, str]
+    hydration_complete: bool
+
+
 async def _resolve_thread_history_from_event_sources_timed(
     client: nio.AsyncClient,
     *,
@@ -377,7 +395,7 @@ async def _resolve_thread_history_from_event_sources_timed(
     expected_membership_epoch: int | None = None,
     trusted_sender_ids: Collection[str] = (),
     register_sidecar_owners: bool = False,
-) -> tuple[list[ResolvedVisibleMessage], float]:
+) -> _ResolvedThreadEventSources:
     """Resolve visible thread history and return approximate sidecar hydration time."""
     input_order_by_event_id: dict[str, int] = {}
     related_event_id_by_event_id: dict[str, str] = {}
@@ -396,8 +414,9 @@ async def _resolve_thread_history_from_event_sources_timed(
     messages_by_event_id: dict[str, ResolvedVisibleMessage] = {}
     latest_edits_by_original_event_id: dict[str, tuple[nio.RoomMessageText | nio.RoomMessageNotice, str | None]] = {}
     sidecar_hydration_started = time.perf_counter()
+    hydration_sources = _sidecar_hydration_sources(event_sources, hydrate_sidecars=hydrate_sidecars)
     hydration_batch = await prepare_sidecar_hydration_batch(
-        _sidecar_hydration_sources(event_sources, hydrate_sidecars=hydrate_sidecars),
+        hydration_sources,
         event_cache=event_cache,
         room_id=room_id,
         expected_membership_epoch=expected_membership_epoch,
@@ -454,7 +473,17 @@ async def _resolve_thread_history_from_event_sources_timed(
         input_order_by_event_id=input_order_by_event_id,
         related_event_id_by_event_id=related_event_id_by_event_id,
     )
-    return messages, elapsed_ms_since(sidecar_hydration_started, clock=time.perf_counter)
+    if hydration_batch is None:
+        hydration_complete = not has_sidecar_references(hydration_sources)
+    else:
+        hydration_complete = hydration_batch.references <= frozenset(hydration_batch.cached_texts)
+    return _ResolvedThreadEventSources(
+        messages=messages,
+        sidecar_hydration_ms=elapsed_ms_since(sidecar_hydration_started, clock=time.perf_counter),
+        input_order_by_event_id=input_order_by_event_id,
+        related_event_id_by_event_id=related_event_id_by_event_id,
+        hydration_complete=hydration_complete,
+    )
 
 
 async def _load_stale_cached_thread_history(
@@ -497,7 +526,7 @@ async def _load_stale_cached_thread_history(
         return None
 
     resolution_started = time.perf_counter()
-    resolved_history, sidecar_hydration_ms = await _resolve_cached_thread_history(
+    resolved_history, sidecar_hydration_ms, _reuse_kind = await _resolve_cached_thread_history(
         client,
         room_id=room_id,
         thread_id=thread_id,
@@ -543,18 +572,20 @@ async def _resolve_cached_thread_history(
     hydrate_sidecars: bool = True,
     expected_membership_epoch: int,
     trusted_sender_ids: Collection[str] = (),
-) -> tuple[list[ResolvedVisibleMessage] | None, float]:
+    resolution_reuse: ThreadResolutionReuseCache | None = None,
+) -> tuple[list[ResolvedVisibleMessage] | None, float, str]:
     """Resolve cached thread history or invalidate the cache entry on corruption."""
     try:
-        return await _resolve_thread_history_from_event_sources_timed(
+        return await _resolve_cached_thread_history_with_reuse(
             client,
             room_id=room_id,
             thread_id=thread_id,
-            event_sources=cached_event_sources,
-            hydrate_sidecars=hydrate_sidecars,
             event_cache=event_cache,
+            cached_event_sources=cached_event_sources,
+            hydrate_sidecars=hydrate_sidecars,
             expected_membership_epoch=expected_membership_epoch,
             trusted_sender_ids=trusted_sender_ids,
+            resolution_reuse=resolution_reuse,
         )
     except Exception as exc:
         logger.warning(
@@ -563,8 +594,133 @@ async def _resolve_cached_thread_history(
             thread_id=thread_id,
             error=str(exc),
         )
+        if resolution_reuse is not None:
+            resolution_reuse.discard(room_id, thread_id)
         await _invalidate_thread_cache_entry(event_cache, room_id=room_id, thread_id=thread_id)
-        return None, 0.0
+        return None, 0.0, "full"
+
+
+async def _resolve_cached_thread_history_with_reuse(
+    client: nio.AsyncClient,
+    *,
+    room_id: str,
+    thread_id: str,
+    event_cache: ConversationEventCache,
+    cached_event_sources: Sequence[dict[str, Any]],
+    hydrate_sidecars: bool,
+    expected_membership_epoch: int,
+    trusted_sender_ids: Collection[str],
+    resolution_reuse: ThreadResolutionReuseCache | None,
+) -> tuple[list[ResolvedVisibleMessage], float, str]:
+    """Serve one durable-cache read, reusing the prior resolution when provably identical."""
+    # Reuse only applies to fully hydrated reads: snapshot-mode bodies are intentionally degraded
+    # and must never be frozen into (or served from) a reusable resolution.
+    reuse_cache = resolution_reuse if hydrate_sidecars else None
+    snapshot_trusted_sender_ids = frozenset(trusted_sender_ids)
+    if reuse_cache is not None:
+        snapshot = reuse_cache.get(room_id, thread_id)
+        if snapshot is not None:
+            suffix = reusable_event_source_suffix(
+                snapshot,
+                cached_event_sources,
+                trusted_sender_ids=snapshot_trusted_sender_ids,
+                membership_epoch=expected_membership_epoch,
+            )
+            if suffix is not None:
+                if not suffix:
+                    return snapshot.cloned_messages(), 0.0, "reuse"
+                merged = await _resolve_reused_thread_suffix(
+                    client,
+                    room_id=room_id,
+                    thread_id=thread_id,
+                    event_cache=event_cache,
+                    cached_event_sources=cached_event_sources,
+                    snapshot=snapshot,
+                    suffix=suffix,
+                    expected_membership_epoch=expected_membership_epoch,
+                    trusted_sender_ids=trusted_sender_ids,
+                    resolution_reuse=reuse_cache,
+                )
+                if merged is not None:
+                    return merged
+    resolved = await _resolve_thread_history_from_event_sources_timed(
+        client,
+        room_id=room_id,
+        thread_id=thread_id,
+        event_sources=cached_event_sources,
+        hydrate_sidecars=hydrate_sidecars,
+        event_cache=event_cache,
+        expected_membership_epoch=expected_membership_epoch,
+        trusted_sender_ids=trusted_sender_ids,
+    )
+    if reuse_cache is not None and resolved.hydration_complete:
+        reuse_cache.store(
+            room_id,
+            thread_id,
+            build_thread_resolution_snapshot(
+                event_sources=cached_event_sources,
+                messages=resolved.messages,
+                input_order_by_event_id=resolved.input_order_by_event_id,
+                related_event_id_by_event_id=resolved.related_event_id_by_event_id,
+                trusted_sender_ids=snapshot_trusted_sender_ids,
+                membership_epoch=expected_membership_epoch,
+            ),
+        )
+    return resolved.messages, resolved.sidecar_hydration_ms, "full"
+
+
+async def _resolve_reused_thread_suffix(
+    client: nio.AsyncClient,
+    *,
+    room_id: str,
+    thread_id: str,
+    event_cache: ConversationEventCache,
+    cached_event_sources: Sequence[dict[str, Any]],
+    snapshot: ThreadResolutionSnapshot,
+    suffix: list[dict[str, Any]],
+    expected_membership_epoch: int,
+    trusted_sender_ids: Collection[str],
+    resolution_reuse: ThreadResolutionReuseCache,
+) -> tuple[list[ResolvedVisibleMessage], float, str] | None:
+    """Resolve only the appended raw rows and merge them onto the reusable snapshot."""
+    suffix_resolution = await _resolve_thread_history_from_event_sources_timed(
+        client,
+        room_id=room_id,
+        thread_id=thread_id,
+        event_sources=suffix,
+        hydrate_sidecars=True,
+        event_cache=event_cache,
+        expected_membership_epoch=expected_membership_epoch,
+        trusted_sender_ids=trusted_sender_ids,
+    )
+    if not suffix_resolution.hydration_complete:
+        return None
+    prefix_length = len(snapshot.event_sources)
+    input_order_by_event_id = dict(snapshot.input_order_by_event_id)
+    for event_id, suffix_index in suffix_resolution.input_order_by_event_id.items():
+        input_order_by_event_id[event_id] = prefix_length + suffix_index
+    related_event_id_by_event_id = dict(snapshot.related_event_id_by_event_id)
+    related_event_id_by_event_id.update(suffix_resolution.related_event_id_by_event_id)
+    messages = snapshot.cloned_messages() + suffix_resolution.messages
+    sort_thread_messages_root_first(
+        messages,
+        thread_id=thread_id,
+        input_order_by_event_id=input_order_by_event_id,
+        related_event_id_by_event_id=related_event_id_by_event_id,
+    )
+    resolution_reuse.store(
+        room_id,
+        thread_id,
+        build_thread_resolution_snapshot(
+            event_sources=cached_event_sources,
+            messages=messages,
+            input_order_by_event_id=input_order_by_event_id,
+            related_event_id_by_event_id=related_event_id_by_event_id,
+            trusted_sender_ids=snapshot.trusted_sender_ids,
+            membership_epoch=expected_membership_epoch,
+        ),
+    )
+    return messages, suffix_resolution.sidecar_hydration_ms, "incremental"
 
 
 def _cache_reject_diagnostics(
@@ -599,6 +755,7 @@ async def _load_cached_thread_history_if_usable(
     event_cache: ConversationEventCache,
     hydrate_sidecars: bool,
     trusted_sender_ids: Collection[str] = (),
+    resolution_reuse: ThreadResolutionReuseCache | None = None,
 ) -> tuple[ThreadHistoryResult | None, dict[str, str | int | float | bool] | None]:
     """Return a durable thread snapshot when the current runtime may safely trust it."""
     cached_membership_epoch = await _capture_membership_epoch(event_cache, room_id)
@@ -639,7 +796,7 @@ async def _load_cached_thread_history_if_usable(
         return None, cache_reject_diagnostics
 
     resolution_started = time.perf_counter()
-    resolved_history, sidecar_hydration_ms = await _resolve_cached_thread_history(
+    resolved_history, sidecar_hydration_ms, resolution_reuse_kind = await _resolve_cached_thread_history(
         client,
         room_id=room_id,
         thread_id=thread_id,
@@ -648,6 +805,7 @@ async def _load_cached_thread_history_if_usable(
         hydrate_sidecars=hydrate_sidecars,
         expected_membership_epoch=cached_membership_epoch,
         trusted_sender_ids=trusted_sender_ids,
+        resolution_reuse=resolution_reuse,
     )
     if resolved_history is None:
         return None, {
@@ -661,6 +819,7 @@ async def _load_cached_thread_history_if_usable(
             "cache_read_ms": elapsed_ms_since(cache_read_started, clock=time.perf_counter),
             "resolution_ms": elapsed_ms_since(resolution_started, clock=time.perf_counter),
             "sidecar_hydration_ms": sidecar_hydration_ms,
+            "thread_resolution_reuse": resolution_reuse_kind,
             THREAD_HISTORY_SOURCE_DIAGNOSTIC: THREAD_HISTORY_SOURCE_CACHE,
         },
     ), None
@@ -965,6 +1124,7 @@ async def fetch_thread_history(
     trusted_sender_ids: Collection[str] = (),
     caller_label: str = "unknown",
     coordinator_queue_wait_ms: float = 0.0,
+    resolution_reuse: ThreadResolutionReuseCache | None = None,
 ) -> ThreadHistoryResult:
     """Fetch all messages in a thread."""
     cache_reject_diagnostics: dict[str, str | int | float | bool] | None = None
@@ -976,6 +1136,7 @@ async def fetch_thread_history(
             event_cache=event_cache,
             hydrate_sidecars=True,
             trusted_sender_ids=trusted_sender_ids,
+            resolution_reuse=resolution_reuse,
         )
     except Exception as exc:
         logger.warning(
@@ -1019,6 +1180,7 @@ async def fetch_dispatch_thread_history(
     trusted_sender_ids: Collection[str] = (),
     caller_label: str = "unknown",
     coordinator_queue_wait_ms: float = 0.0,
+    resolution_reuse: ThreadResolutionReuseCache | None = None,
 ) -> ThreadHistoryResult:
     """Fetch strict full thread history for dispatch using only fresh cache data or a homeserver refill."""
     cache_reject_diagnostics: dict[str, str | int | float | bool] | None = None
@@ -1030,6 +1192,7 @@ async def fetch_dispatch_thread_history(
             event_cache=event_cache,
             hydrate_sidecars=True,
             trusted_sender_ids=trusted_sender_ids,
+            resolution_reuse=resolution_reuse,
         )
     except Exception as exc:
         logger.warning(
@@ -1074,6 +1237,7 @@ async def fetch_dispatch_thread_snapshot(
     trusted_sender_ids: Collection[str] = (),
     caller_label: str = "unknown",
     coordinator_queue_wait_ms: float = 0.0,
+    resolution_reuse: ThreadResolutionReuseCache | None = None,
 ) -> ThreadHistoryResult:
     """Fetch strict lightweight dispatch context using only fresh cache data or a homeserver refill."""
     cache_reject_diagnostics: dict[str, str | int | float | bool] | None = None
@@ -1085,6 +1249,7 @@ async def fetch_dispatch_thread_snapshot(
             event_cache=event_cache,
             hydrate_sidecars=False,
             trusted_sender_ids=trusted_sender_ids,
+            resolution_reuse=resolution_reuse,
         )
     except Exception as exc:
         logger.warning(
@@ -1133,7 +1298,7 @@ async def _fetch_thread_history_via_room_messages_with_events(
     fetch_started = time.perf_counter()
     scan_result = await fetch_thread_event_sources_via_room_messages(client, room_id, thread_id)
     resolution_started = time.perf_counter()
-    history, sidecar_hydration_ms = await _resolve_thread_history_from_event_sources_timed(
+    resolution = await _resolve_thread_history_from_event_sources_timed(
         client,
         room_id=room_id,
         thread_id=thread_id,
@@ -1145,13 +1310,13 @@ async def _fetch_thread_history_via_room_messages_with_events(
         register_sidecar_owners=True,
     )
     return _ThreadHistoryFetchResult(
-        history=history,
+        history=resolution.messages,
         event_sources=scan_result.event_sources,
         fetch_ms=elapsed_ms_since(fetch_started, clock=time.perf_counter),
         room_scan_pages=scan_result.page_count,
         scanned_event_count=scan_result.scanned_event_count,
         resolution_ms=elapsed_ms_since(resolution_started, clock=time.perf_counter),
-        sidecar_hydration_ms=sidecar_hydration_ms,
+        sidecar_hydration_ms=resolution.sidecar_hydration_ms,
     )
 
 

--- a/src/mindroom/matrix/client_thread_history.py
+++ b/src/mindroom/matrix/client_thread_history.py
@@ -54,6 +54,7 @@ from mindroom.logging_config import get_logger
 from mindroom.matrix.cache import (
     ThreadCacheState,
     ThreadHistoryResult,
+    ThreadRevision,
     is_opaque_encrypted_event_source,
     normalize_nio_event_for_cache,
     thread_cache_rejection_reason,
@@ -105,7 +106,6 @@ from mindroom.matrix.thread_projection import (
 from mindroom.matrix.thread_resolution_reuse import (
     ThreadResolutionReuseCache,
     ThreadResolutionSnapshot,
-    ThreadRevision,
     build_thread_resolution_snapshot,
     reusable_event_source_suffix,
     snapshot_matches_revision,
@@ -577,7 +577,7 @@ async def _resolve_cached_thread_history(
     expected_membership_epoch: int,
     trusted_sender_ids: Collection[str] = (),
     resolution_reuse: ThreadResolutionReuseCache | None = None,
-    cache_state: ThreadCacheState | None = None,
+    revision: ThreadRevision | None = None,
 ) -> tuple[list[ResolvedVisibleMessage] | None, float]:
     """Resolve cached thread history or invalidate the cache entry on corruption."""
     try:
@@ -591,7 +591,7 @@ async def _resolve_cached_thread_history(
             expected_membership_epoch=expected_membership_epoch,
             trusted_sender_ids=trusted_sender_ids,
             resolution_reuse=resolution_reuse,
-            cache_state=cache_state,
+            revision=revision,
         )
     except Exception as exc:
         logger.warning(
@@ -617,7 +617,7 @@ async def _resolve_cached_thread_history_with_reuse(
     expected_membership_epoch: int,
     trusted_sender_ids: Collection[str],
     resolution_reuse: ThreadResolutionReuseCache | None,
-    cache_state: ThreadCacheState | None,
+    revision: ThreadRevision | None,
 ) -> tuple[list[ResolvedVisibleMessage], float]:
     """Fully resolve one durable-cache read and retain its reusable projection."""
     resolved = await _resolve_thread_history_from_event_sources_timed(
@@ -630,7 +630,9 @@ async def _resolve_cached_thread_history_with_reuse(
         expected_membership_epoch=expected_membership_epoch,
         trusted_sender_ids=trusted_sender_ids,
     )
-    revision = _thread_cache_state_revision(cache_state)
+    # The revision may predate the rows just resolved. Sequences are monotonic, so a stale
+    # revision can never produce a false exact match later, and the known-ID suffix guard
+    # rejects any delta row the snapshot already contains; the race costs one full re-resolve.
     if resolution_reuse is not None and resolved.hydration_complete and revision is not None:
         resolution_reuse.store(
             room_id,
@@ -730,41 +732,19 @@ def _cache_reject_diagnostics(
     return diagnostics
 
 
-def _thread_cache_state_revision(cache_state: ThreadCacheState | None) -> ThreadRevision | None:
-    """Return the durable revision when state identifies one non-empty thread snapshot."""
-    if (
-        cache_state is None
-        or cache_state.event_count <= 0
-        or cache_state.max_write_seq is None
-        or cache_state.max_thread_write_seq is None
-        or cache_state.max_origin_server_ts is None
-    ):
-        return None
-    return ThreadRevision(
-        event_count=cache_state.event_count,
-        max_write_seq=cache_state.max_write_seq,
-        max_thread_write_seq=cache_state.max_thread_write_seq,
-        max_origin_server_ts=cache_state.max_origin_server_ts,
-    )
-
-
 async def _try_reuse_cached_thread_resolution(
     client: nio.AsyncClient,
     *,
     room_id: str,
     thread_id: str,
     event_cache: ConversationEventCache,
-    cache_state: ThreadCacheState | None,
+    revision: ThreadRevision | None,
     membership_epoch: int,
     trusted_sender_ids: Collection[str],
     resolution_reuse: ThreadResolutionReuseCache | None,
 ) -> tuple[list[ResolvedVisibleMessage], float, str] | None:
     """Reuse an exact projection or merge a complete append-only durable delta."""
-    if (
-        resolution_reuse is None
-        or (revision := _thread_cache_state_revision(cache_state)) is None
-        or (snapshot := resolution_reuse.get(room_id, thread_id)) is None
-    ):
+    if resolution_reuse is None or revision is None or (snapshot := resolution_reuse.get(room_id, thread_id)) is None:
         return None
     snapshot_trusted_sender_ids = frozenset(trusted_sender_ids)
     if snapshot_matches_revision(
@@ -932,12 +912,13 @@ async def _load_cached_thread_history_if_usable(
     # Reuse only applies to fully hydrated reads: snapshot-mode bodies are intentionally degraded
     # and must never be frozen into (or served from) a reusable resolution.
     reuse_cache = resolution_reuse if hydrate_sidecars else None
+    revision = None if reuse_cache is None else await event_cache.get_thread_revision(room_id, thread_id)
     reused = await _try_reuse_cached_thread_resolution(
         client,
         room_id=room_id,
         thread_id=thread_id,
         event_cache=event_cache,
-        cache_state=cache_state,
+        revision=revision,
         membership_epoch=cached_membership_epoch,
         trusted_sender_ids=trusted_sender_ids,
         resolution_reuse=reuse_cache,
@@ -978,7 +959,7 @@ async def _load_cached_thread_history_if_usable(
             expected_membership_epoch=cached_membership_epoch,
             trusted_sender_ids=trusted_sender_ids,
             resolution_reuse=reuse_cache,
-            cache_state=cache_state,
+            revision=revision,
         )
     if resolved_history is None:
         return None, {

--- a/src/mindroom/matrix/client_thread_history.py
+++ b/src/mindroom/matrix/client_thread_history.py
@@ -105,6 +105,7 @@ from mindroom.matrix.thread_projection import (
 from mindroom.matrix.thread_resolution_reuse import (
     ThreadResolutionReuseCache,
     ThreadResolutionSnapshot,
+    ThreadRevision,
     build_thread_resolution_snapshot,
     reusable_event_source_suffix,
     snapshot_matches_revision,
@@ -529,7 +530,7 @@ async def _load_stale_cached_thread_history(
         return None
 
     resolution_started = time.perf_counter()
-    resolved_history, sidecar_hydration_ms, _reuse_kind = await _resolve_cached_thread_history(
+    resolved_history, sidecar_hydration_ms = await _resolve_cached_thread_history(
         client,
         room_id=room_id,
         thread_id=thread_id,
@@ -577,7 +578,7 @@ async def _resolve_cached_thread_history(
     trusted_sender_ids: Collection[str] = (),
     resolution_reuse: ThreadResolutionReuseCache | None = None,
     cache_state: ThreadCacheState | None = None,
-) -> tuple[list[ResolvedVisibleMessage] | None, float, str]:
+) -> tuple[list[ResolvedVisibleMessage] | None, float]:
     """Resolve cached thread history or invalidate the cache entry on corruption."""
     try:
         return await _resolve_cached_thread_history_with_reuse(
@@ -602,7 +603,7 @@ async def _resolve_cached_thread_history(
         if resolution_reuse is not None:
             resolution_reuse.discard(room_id, thread_id)
         await _invalidate_thread_cache_entry(event_cache, room_id=room_id, thread_id=thread_id)
-        return None, 0.0, "full"
+        return None, 0.0
 
 
 async def _resolve_cached_thread_history_with_reuse(
@@ -617,12 +618,8 @@ async def _resolve_cached_thread_history_with_reuse(
     trusted_sender_ids: Collection[str],
     resolution_reuse: ThreadResolutionReuseCache | None,
     cache_state: ThreadCacheState | None,
-) -> tuple[list[ResolvedVisibleMessage], float, str]:
+) -> tuple[list[ResolvedVisibleMessage], float]:
     """Fully resolve one durable-cache read and retain its reusable projection."""
-    # Reuse only applies to fully hydrated reads: snapshot-mode bodies are intentionally degraded
-    # and must never be frozen into (or served from) a reusable resolution.
-    reuse_cache = resolution_reuse if hydrate_sidecars else None
-    snapshot_trusted_sender_ids = frozenset(trusted_sender_ids)
     resolved = await _resolve_thread_history_from_event_sources_timed(
         client,
         room_id=room_id,
@@ -633,12 +630,9 @@ async def _resolve_cached_thread_history_with_reuse(
         expected_membership_epoch=expected_membership_epoch,
         trusted_sender_ids=trusted_sender_ids,
     )
-    if reuse_cache is not None and resolved.hydration_complete and _thread_cache_state_has_revision(cache_state):
-        assert cache_state is not None
-        assert cache_state.max_write_seq is not None
-        assert cache_state.max_thread_write_seq is not None
-        assert cache_state.max_origin_server_ts is not None
-        reuse_cache.store(
+    revision = _thread_cache_state_revision(cache_state)
+    if resolution_reuse is not None and resolved.hydration_complete and revision is not None:
+        resolution_reuse.store(
             room_id,
             thread_id,
             build_thread_resolution_snapshot(
@@ -646,16 +640,13 @@ async def _resolve_cached_thread_history_with_reuse(
                 messages=resolved.messages,
                 input_order_by_event_id=resolved.input_order_by_event_id,
                 related_event_id_by_event_id=resolved.related_event_id_by_event_id,
-                trusted_sender_ids=snapshot_trusted_sender_ids,
+                trusted_sender_ids=frozenset(trusted_sender_ids),
                 membership_epoch=expected_membership_epoch,
-                event_count=cache_state.event_count,
-                max_write_seq=cache_state.max_write_seq,
-                max_thread_write_seq=cache_state.max_thread_write_seq,
-                max_origin_server_ts=cache_state.max_origin_server_ts,
+                revision=revision,
                 sidecar_texts=resolved.sidecar_texts,
             ),
         )
-    return resolved.messages, resolved.sidecar_hydration_ms, "full"
+    return resolved.messages, resolved.sidecar_hydration_ms
 
 
 async def _resolve_reused_thread_suffix(
@@ -666,7 +657,7 @@ async def _resolve_reused_thread_suffix(
     event_cache: ConversationEventCache,
     snapshot: ThreadResolutionSnapshot,
     suffix: list[dict[str, Any]],
-    cache_state: ThreadCacheState,
+    revision: ThreadRevision,
     expected_membership_epoch: int,
     trusted_sender_ids: Collection[str],
     resolution_reuse: ThreadResolutionReuseCache,
@@ -684,10 +675,7 @@ async def _resolve_reused_thread_suffix(
     )
     if not suffix_resolution.hydration_complete:
         return None
-    assert cache_state.max_write_seq is not None
-    assert cache_state.max_thread_write_seq is not None
-    assert cache_state.max_origin_server_ts is not None
-    prefix_length = snapshot.event_count
+    prefix_length = snapshot.revision.event_count
     input_order_by_event_id = dict(snapshot.input_order_by_event_id)
     for event_id, suffix_index in suffix_resolution.input_order_by_event_id.items():
         input_order_by_event_id[event_id] = prefix_length + suffix_index
@@ -710,10 +698,7 @@ async def _resolve_reused_thread_suffix(
             related_event_id_by_event_id=related_event_id_by_event_id,
             trusted_sender_ids=snapshot.trusted_sender_ids,
             membership_epoch=expected_membership_epoch,
-            event_count=cache_state.event_count,
-            max_write_seq=cache_state.max_write_seq,
-            max_thread_write_seq=cache_state.max_thread_write_seq,
-            max_origin_server_ts=cache_state.max_origin_server_ts,
+            revision=revision,
             sidecar_texts={**snapshot.sidecar_texts, **suffix_resolution.sidecar_texts},
             prior_known_event_ids=snapshot.known_event_ids,
         ),
@@ -745,14 +730,21 @@ def _cache_reject_diagnostics(
     return diagnostics
 
 
-def _thread_cache_state_has_revision(cache_state: ThreadCacheState | None) -> bool:
-    """Return whether durable state can identify one non-empty thread snapshot."""
-    return (
-        cache_state is not None
-        and cache_state.event_count > 0
-        and cache_state.max_write_seq is not None
-        and cache_state.max_thread_write_seq is not None
-        and cache_state.max_origin_server_ts is not None
+def _thread_cache_state_revision(cache_state: ThreadCacheState | None) -> ThreadRevision | None:
+    """Return the durable revision when state identifies one non-empty thread snapshot."""
+    if (
+        cache_state is None
+        or cache_state.event_count <= 0
+        or cache_state.max_write_seq is None
+        or cache_state.max_thread_write_seq is None
+        or cache_state.max_origin_server_ts is None
+    ):
+        return None
+    return ThreadRevision(
+        event_count=cache_state.event_count,
+        max_write_seq=cache_state.max_write_seq,
+        max_thread_write_seq=cache_state.max_thread_write_seq,
+        max_origin_server_ts=cache_state.max_origin_server_ts,
     )
 
 
@@ -768,26 +760,18 @@ async def _try_reuse_cached_thread_resolution(
     resolution_reuse: ThreadResolutionReuseCache | None,
 ) -> tuple[list[ResolvedVisibleMessage], float, str] | None:
     """Reuse an exact projection or merge a complete append-only durable delta."""
-    snapshot = (
-        None
-        if resolution_reuse is None or not _thread_cache_state_has_revision(cache_state)
-        else resolution_reuse.get(room_id, thread_id)
-    )
-    if snapshot is None:
+    if (
+        resolution_reuse is None
+        or (revision := _thread_cache_state_revision(cache_state)) is None
+        or (snapshot := resolution_reuse.get(room_id, thread_id)) is None
+    ):
         return None
-    assert resolution_reuse is not None
-    assert cache_state is not None
-    assert cache_state.max_write_seq is not None
-    assert cache_state.max_thread_write_seq is not None
-    assert cache_state.max_origin_server_ts is not None
     snapshot_trusted_sender_ids = frozenset(trusted_sender_ids)
     if snapshot_matches_revision(
         snapshot,
         trusted_sender_ids=snapshot_trusted_sender_ids,
         membership_epoch=membership_epoch,
-        event_count=cache_state.event_count,
-        max_write_seq=cache_state.max_write_seq,
-        max_thread_write_seq=cache_state.max_thread_write_seq,
+        revision=revision,
     ):
         if not await _snapshot_sidecars_unchanged(
             event_cache,
@@ -801,7 +785,7 @@ async def _try_reuse_cached_thread_resolution(
     if (
         snapshot.trusted_sender_ids != snapshot_trusted_sender_ids
         or snapshot.membership_epoch != membership_epoch
-        or cache_state.event_count <= snapshot.event_count
+        or revision.event_count <= snapshot.revision.event_count
     ):
         return None
     if not await _snapshot_sidecars_unchanged(
@@ -817,7 +801,7 @@ async def _try_reuse_cached_thread_resolution(
         room_id=room_id,
         thread_id=thread_id,
         event_cache=event_cache,
-        cache_state=cache_state,
+        revision=revision,
         membership_epoch=membership_epoch,
         trusted_sender_ids=trusted_sender_ids,
         resolution_reuse=resolution_reuse,
@@ -860,7 +844,7 @@ async def _try_merge_cached_thread_delta(
     room_id: str,
     thread_id: str,
     event_cache: ConversationEventCache,
-    cache_state: ThreadCacheState,
+    revision: ThreadRevision,
     membership_epoch: int,
     trusted_sender_ids: Collection[str],
     resolution_reuse: ThreadResolutionReuseCache,
@@ -868,22 +852,19 @@ async def _try_merge_cached_thread_delta(
     snapshot_trusted_sender_ids: frozenset[str],
 ) -> tuple[list[ResolvedVisibleMessage], float, str] | None:
     """Load and merge one complete append-only durable delta."""
-    assert cache_state.max_write_seq is not None
-    assert cache_state.max_thread_write_seq is not None
-    assert cache_state.max_origin_server_ts is not None
     if (
-        cache_state.max_write_seq <= snapshot.max_write_seq
-        and cache_state.max_thread_write_seq <= snapshot.max_thread_write_seq
+        revision.max_write_seq <= snapshot.revision.max_write_seq
+        and revision.max_thread_write_seq <= snapshot.revision.max_thread_write_seq
     ):
         return None
     try:
         candidate_suffix = await event_cache.get_thread_events_written_between(
             room_id,
             thread_id,
-            after_write_seq=snapshot.max_write_seq,
-            through_write_seq=cache_state.max_write_seq,
-            after_thread_write_seq=snapshot.max_thread_write_seq,
-            through_thread_write_seq=cache_state.max_thread_write_seq,
+            after_write_seq=snapshot.revision.max_write_seq,
+            through_write_seq=revision.max_write_seq,
+            after_thread_write_seq=snapshot.revision.max_thread_write_seq,
+            through_thread_write_seq=revision.max_thread_write_seq,
         )
     except Exception as exc:
         logger.debug(
@@ -898,10 +879,7 @@ async def _try_merge_cached_thread_delta(
         candidate_suffix,
         trusted_sender_ids=snapshot_trusted_sender_ids,
         membership_epoch=membership_epoch,
-        event_count=cache_state.event_count,
-        max_write_seq=cache_state.max_write_seq,
-        max_thread_write_seq=cache_state.max_thread_write_seq,
-        max_origin_server_ts=cache_state.max_origin_server_ts,
+        revision=revision,
     )
     if suffix is None:
         return None
@@ -912,7 +890,7 @@ async def _try_merge_cached_thread_delta(
         event_cache=event_cache,
         snapshot=snapshot,
         suffix=suffix,
-        cache_state=cache_state,
+        revision=revision,
         expected_membership_epoch=membership_epoch,
         trusted_sender_ids=trusted_sender_ids,
         resolution_reuse=resolution_reuse,
@@ -946,11 +924,13 @@ async def _load_cached_thread_history_if_usable(
         )
         return None, cache_reject_diagnostics
 
-    cache_read_started = time.perf_counter()
     resolution_started = time.perf_counter()
+    cache_read_ms = 0.0
     resolved_history: list[ResolvedVisibleMessage] | None = None
     sidecar_hydration_ms = 0.0
     resolution_reuse_kind = "full"
+    # Reuse only applies to fully hydrated reads: snapshot-mode bodies are intentionally degraded
+    # and must never be frozen into (or served from) a reusable resolution.
     reuse_cache = resolution_reuse if hydrate_sidecars else None
     reused = await _try_reuse_cached_thread_resolution(
         client,
@@ -966,7 +946,9 @@ async def _load_cached_thread_history_if_usable(
         resolved_history, sidecar_hydration_ms, resolution_reuse_kind = reused
 
     if resolved_history is None:
+        cache_read_started = time.perf_counter()
         cached_event_sources = await event_cache.get_thread_events(room_id, thread_id)
+        cache_read_ms = elapsed_ms_since(cache_read_started, clock=time.perf_counter)
         if cached_event_sources is None:
             cache_reject_diagnostics: dict[str, str | int | float | bool] = {
                 THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC: "cache_rows_missing",
@@ -986,7 +968,7 @@ async def _load_cached_thread_history_if_usable(
             )
             return None, payload_reject_diagnostics
 
-        resolved_history, sidecar_hydration_ms, resolution_reuse_kind = await _resolve_cached_thread_history(
+        resolved_history, sidecar_hydration_ms = await _resolve_cached_thread_history(
             client,
             room_id=room_id,
             thread_id=thread_id,
@@ -995,7 +977,7 @@ async def _load_cached_thread_history_if_usable(
             hydrate_sidecars=hydrate_sidecars,
             expected_membership_epoch=cached_membership_epoch,
             trusted_sender_ids=trusted_sender_ids,
-            resolution_reuse=resolution_reuse,
+            resolution_reuse=reuse_cache,
             cache_state=cache_state,
         )
     if resolved_history is None:
@@ -1007,7 +989,7 @@ async def _load_cached_thread_history_if_usable(
         resolved_history,
         is_full_history=hydrate_sidecars,
         diagnostics={
-            "cache_read_ms": elapsed_ms_since(cache_read_started, clock=time.perf_counter),
+            "cache_read_ms": cache_read_ms,
             "resolution_ms": elapsed_ms_since(resolution_started, clock=time.perf_counter),
             "sidecar_hydration_ms": sidecar_hydration_ms,
             "thread_resolution_reuse": resolution_reuse_kind,

--- a/src/mindroom/matrix/client_thread_history.py
+++ b/src/mindroom/matrix/client_thread_history.py
@@ -107,6 +107,7 @@ from mindroom.matrix.thread_resolution_reuse import (
     ThreadResolutionSnapshot,
     build_thread_resolution_snapshot,
     reusable_event_source_suffix,
+    snapshot_matches_revision,
 )
 from mindroom.matrix.visible_body import visible_body_from_event_source
 from mindroom.timing import elapsed_ms_since
@@ -382,6 +383,7 @@ class _ResolvedThreadEventSources:
     input_order_by_event_id: dict[str, int]
     related_event_id_by_event_id: dict[str, str]
     hydration_complete: bool
+    sidecar_texts: dict[tuple[str, str], str]
 
 
 async def _resolve_thread_history_from_event_sources_timed(
@@ -483,6 +485,7 @@ async def _resolve_thread_history_from_event_sources_timed(
         input_order_by_event_id=input_order_by_event_id,
         related_event_id_by_event_id=related_event_id_by_event_id,
         hydration_complete=hydration_complete,
+        sidecar_texts={} if hydration_batch is None else dict(hydration_batch.cached_texts),
     )
 
 
@@ -573,6 +576,7 @@ async def _resolve_cached_thread_history(
     expected_membership_epoch: int,
     trusted_sender_ids: Collection[str] = (),
     resolution_reuse: ThreadResolutionReuseCache | None = None,
+    cache_state: ThreadCacheState | None = None,
 ) -> tuple[list[ResolvedVisibleMessage] | None, float, str]:
     """Resolve cached thread history or invalidate the cache entry on corruption."""
     try:
@@ -586,6 +590,7 @@ async def _resolve_cached_thread_history(
             expected_membership_epoch=expected_membership_epoch,
             trusted_sender_ids=trusted_sender_ids,
             resolution_reuse=resolution_reuse,
+            cache_state=cache_state,
         )
     except Exception as exc:
         logger.warning(
@@ -611,38 +616,13 @@ async def _resolve_cached_thread_history_with_reuse(
     expected_membership_epoch: int,
     trusted_sender_ids: Collection[str],
     resolution_reuse: ThreadResolutionReuseCache | None,
+    cache_state: ThreadCacheState | None,
 ) -> tuple[list[ResolvedVisibleMessage], float, str]:
-    """Serve one durable-cache read, reusing the prior resolution when provably identical."""
+    """Fully resolve one durable-cache read and retain its reusable projection."""
     # Reuse only applies to fully hydrated reads: snapshot-mode bodies are intentionally degraded
     # and must never be frozen into (or served from) a reusable resolution.
     reuse_cache = resolution_reuse if hydrate_sidecars else None
     snapshot_trusted_sender_ids = frozenset(trusted_sender_ids)
-    if reuse_cache is not None:
-        snapshot = reuse_cache.get(room_id, thread_id)
-        if snapshot is not None:
-            suffix = reusable_event_source_suffix(
-                snapshot,
-                cached_event_sources,
-                trusted_sender_ids=snapshot_trusted_sender_ids,
-                membership_epoch=expected_membership_epoch,
-            )
-            if suffix is not None:
-                if not suffix:
-                    return snapshot.cloned_messages(), 0.0, "reuse"
-                merged = await _resolve_reused_thread_suffix(
-                    client,
-                    room_id=room_id,
-                    thread_id=thread_id,
-                    event_cache=event_cache,
-                    cached_event_sources=cached_event_sources,
-                    snapshot=snapshot,
-                    suffix=suffix,
-                    expected_membership_epoch=expected_membership_epoch,
-                    trusted_sender_ids=trusted_sender_ids,
-                    resolution_reuse=reuse_cache,
-                )
-                if merged is not None:
-                    return merged
     resolved = await _resolve_thread_history_from_event_sources_timed(
         client,
         room_id=room_id,
@@ -653,7 +633,10 @@ async def _resolve_cached_thread_history_with_reuse(
         expected_membership_epoch=expected_membership_epoch,
         trusted_sender_ids=trusted_sender_ids,
     )
-    if reuse_cache is not None and resolved.hydration_complete:
+    if reuse_cache is not None and resolved.hydration_complete and _thread_cache_state_has_revision(cache_state):
+        assert cache_state is not None
+        assert cache_state.max_write_seq is not None
+        assert cache_state.max_origin_server_ts is not None
         reuse_cache.store(
             room_id,
             thread_id,
@@ -664,6 +647,10 @@ async def _resolve_cached_thread_history_with_reuse(
                 related_event_id_by_event_id=resolved.related_event_id_by_event_id,
                 trusted_sender_ids=snapshot_trusted_sender_ids,
                 membership_epoch=expected_membership_epoch,
+                event_count=cache_state.event_count,
+                max_write_seq=cache_state.max_write_seq,
+                max_origin_server_ts=cache_state.max_origin_server_ts,
+                sidecar_texts=resolved.sidecar_texts,
             ),
         )
     return resolved.messages, resolved.sidecar_hydration_ms, "full"
@@ -675,9 +662,9 @@ async def _resolve_reused_thread_suffix(
     room_id: str,
     thread_id: str,
     event_cache: ConversationEventCache,
-    cached_event_sources: Sequence[dict[str, Any]],
     snapshot: ThreadResolutionSnapshot,
     suffix: list[dict[str, Any]],
+    cache_state: ThreadCacheState,
     expected_membership_epoch: int,
     trusted_sender_ids: Collection[str],
     resolution_reuse: ThreadResolutionReuseCache,
@@ -695,7 +682,9 @@ async def _resolve_reused_thread_suffix(
     )
     if not suffix_resolution.hydration_complete:
         return None
-    prefix_length = len(snapshot.event_sources)
+    assert cache_state.max_write_seq is not None
+    assert cache_state.max_origin_server_ts is not None
+    prefix_length = snapshot.event_count
     input_order_by_event_id = dict(snapshot.input_order_by_event_id)
     for event_id, suffix_index in suffix_resolution.input_order_by_event_id.items():
         input_order_by_event_id[event_id] = prefix_length + suffix_index
@@ -712,12 +701,17 @@ async def _resolve_reused_thread_suffix(
         room_id,
         thread_id,
         build_thread_resolution_snapshot(
-            event_sources=cached_event_sources,
+            event_sources=suffix,
             messages=messages,
             input_order_by_event_id=input_order_by_event_id,
             related_event_id_by_event_id=related_event_id_by_event_id,
             trusted_sender_ids=snapshot.trusted_sender_ids,
             membership_epoch=expected_membership_epoch,
+            event_count=cache_state.event_count,
+            max_write_seq=cache_state.max_write_seq,
+            max_origin_server_ts=cache_state.max_origin_server_ts,
+            sidecar_texts={**snapshot.sidecar_texts, **suffix_resolution.sidecar_texts},
+            prior_known_event_ids=snapshot.known_event_ids,
         ),
     )
     return messages, suffix_resolution.sidecar_hydration_ms, "incremental"
@@ -745,6 +739,153 @@ def _cache_reject_diagnostics(
     if cache_state.room_invalidation_reason is not None:
         diagnostics["room_cache_invalidation_reason"] = cache_state.room_invalidation_reason
     return diagnostics
+
+
+def _thread_cache_state_has_revision(cache_state: ThreadCacheState | None) -> bool:
+    """Return whether durable state can identify one non-empty thread snapshot."""
+    return (
+        cache_state is not None
+        and cache_state.event_count > 0
+        and cache_state.max_write_seq is not None
+        and cache_state.max_origin_server_ts is not None
+    )
+
+
+async def _try_reuse_cached_thread_resolution(
+    client: nio.AsyncClient,
+    *,
+    room_id: str,
+    thread_id: str,
+    event_cache: ConversationEventCache,
+    cache_state: ThreadCacheState | None,
+    membership_epoch: int,
+    trusted_sender_ids: Collection[str],
+    resolution_reuse: ThreadResolutionReuseCache | None,
+) -> tuple[list[ResolvedVisibleMessage], float, str] | None:
+    """Reuse an exact projection or merge a complete append-only durable delta."""
+    snapshot = (
+        None
+        if resolution_reuse is None or not _thread_cache_state_has_revision(cache_state)
+        else resolution_reuse.get(room_id, thread_id)
+    )
+    if snapshot is None:
+        return None
+    assert resolution_reuse is not None
+    assert cache_state is not None
+    assert cache_state.max_write_seq is not None
+    assert cache_state.max_origin_server_ts is not None
+    snapshot_trusted_sender_ids = frozenset(trusted_sender_ids)
+    if not await _snapshot_sidecars_unchanged(
+        event_cache,
+        room_id=room_id,
+        membership_epoch=membership_epoch,
+        snapshot=snapshot,
+    ):
+        return None
+    if snapshot_matches_revision(
+        snapshot,
+        trusted_sender_ids=snapshot_trusted_sender_ids,
+        membership_epoch=membership_epoch,
+        event_count=cache_state.event_count,
+        max_write_seq=cache_state.max_write_seq,
+    ):
+        return snapshot.cloned_messages(), 0.0, "reuse"
+    return await _try_merge_cached_thread_delta(
+        client,
+        room_id=room_id,
+        thread_id=thread_id,
+        event_cache=event_cache,
+        cache_state=cache_state,
+        membership_epoch=membership_epoch,
+        trusted_sender_ids=trusted_sender_ids,
+        resolution_reuse=resolution_reuse,
+        snapshot=snapshot,
+        snapshot_trusted_sender_ids=snapshot_trusted_sender_ids,
+    )
+
+
+async def _snapshot_sidecars_unchanged(
+    event_cache: ConversationEventCache,
+    *,
+    room_id: str,
+    membership_epoch: int,
+    snapshot: ThreadResolutionSnapshot,
+) -> bool:
+    """Return whether every sidecar dependency still has its exact cached text."""
+    if not snapshot.sidecar_texts:
+        return True
+    try:
+        current_texts = await event_cache.get_mxc_texts(
+            room_id,
+            tuple(snapshot.sidecar_texts),
+            expected_membership_epoch=membership_epoch,
+        )
+    except Exception as exc:
+        logger.debug(
+            "Thread resolution sidecar check failed; falling back to full resolution",
+            room_id=room_id,
+            error=str(exc),
+        )
+        return False
+    return current_texts == snapshot.sidecar_texts
+
+
+async def _try_merge_cached_thread_delta(
+    client: nio.AsyncClient,
+    *,
+    room_id: str,
+    thread_id: str,
+    event_cache: ConversationEventCache,
+    cache_state: ThreadCacheState,
+    membership_epoch: int,
+    trusted_sender_ids: Collection[str],
+    resolution_reuse: ThreadResolutionReuseCache,
+    snapshot: ThreadResolutionSnapshot,
+    snapshot_trusted_sender_ids: frozenset[str],
+) -> tuple[list[ResolvedVisibleMessage], float, str] | None:
+    """Load and merge one complete append-only durable delta."""
+    assert cache_state.max_write_seq is not None
+    assert cache_state.max_origin_server_ts is not None
+    if cache_state.max_write_seq <= snapshot.max_write_seq:
+        return None
+    try:
+        candidate_suffix = await event_cache.get_thread_events_written_between(
+            room_id,
+            thread_id,
+            after_write_seq=snapshot.max_write_seq,
+            through_write_seq=cache_state.max_write_seq,
+        )
+    except Exception as exc:
+        logger.debug(
+            "Thread resolution delta read failed; falling back to full resolution",
+            room_id=room_id,
+            thread_id=thread_id,
+            error=str(exc),
+        )
+        return None
+    suffix = reusable_event_source_suffix(
+        snapshot,
+        candidate_suffix,
+        trusted_sender_ids=snapshot_trusted_sender_ids,
+        membership_epoch=membership_epoch,
+        event_count=cache_state.event_count,
+        max_write_seq=cache_state.max_write_seq,
+        max_origin_server_ts=cache_state.max_origin_server_ts,
+    )
+    if suffix is None:
+        return None
+    return await _resolve_reused_thread_suffix(
+        client,
+        room_id=room_id,
+        thread_id=thread_id,
+        event_cache=event_cache,
+        snapshot=snapshot,
+        suffix=suffix,
+        cache_state=cache_state,
+        expected_membership_epoch=membership_epoch,
+        trusted_sender_ids=trusted_sender_ids,
+        resolution_reuse=resolution_reuse,
+    )
 
 
 async def _load_cached_thread_history_if_usable(
@@ -775,38 +916,57 @@ async def _load_cached_thread_history_if_usable(
         return None, cache_reject_diagnostics
 
     cache_read_started = time.perf_counter()
-    cached_event_sources = await event_cache.get_thread_events(room_id, thread_id)
-    if cached_event_sources is None:
-        cache_reject_diagnostics: dict[str, str | int | float | bool] = {
-            THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC: "cache_rows_missing",
-        }
-        return None, cache_reject_diagnostics
-    cached_rejection_reason = _thread_history_cache_rejection_reason(cached_event_sources, thread_id=thread_id)
-    if cached_rejection_reason is not None:
-        await _invalidate_thread_cache_entry(event_cache, room_id=room_id, thread_id=thread_id)
-        cache_reject_diagnostics: dict[str, str | int | float | bool] = {
-            THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC: f"cache_{cached_rejection_reason}",
-        }
-        logger.info(
-            "Thread cache rejected for read",
-            room_id=room_id,
-            thread_id=thread_id,
-            **cache_reject_diagnostics,
-        )
-        return None, cache_reject_diagnostics
-
     resolution_started = time.perf_counter()
-    resolved_history, sidecar_hydration_ms, resolution_reuse_kind = await _resolve_cached_thread_history(
+    resolved_history: list[ResolvedVisibleMessage] | None = None
+    sidecar_hydration_ms = 0.0
+    resolution_reuse_kind = "full"
+    reuse_cache = resolution_reuse if hydrate_sidecars else None
+    reused = await _try_reuse_cached_thread_resolution(
         client,
         room_id=room_id,
         thread_id=thread_id,
         event_cache=event_cache,
-        cached_event_sources=cached_event_sources,
-        hydrate_sidecars=hydrate_sidecars,
-        expected_membership_epoch=cached_membership_epoch,
+        cache_state=cache_state,
+        membership_epoch=cached_membership_epoch,
         trusted_sender_ids=trusted_sender_ids,
-        resolution_reuse=resolution_reuse,
+        resolution_reuse=reuse_cache,
     )
+    if reused is not None:
+        resolved_history, sidecar_hydration_ms, resolution_reuse_kind = reused
+
+    if resolved_history is None:
+        cached_event_sources = await event_cache.get_thread_events(room_id, thread_id)
+        if cached_event_sources is None:
+            cache_reject_diagnostics: dict[str, str | int | float | bool] = {
+                THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC: "cache_rows_missing",
+            }
+            return None, cache_reject_diagnostics
+        cached_rejection_reason = _thread_history_cache_rejection_reason(cached_event_sources, thread_id=thread_id)
+        if cached_rejection_reason is not None:
+            await _invalidate_thread_cache_entry(event_cache, room_id=room_id, thread_id=thread_id)
+            payload_reject_diagnostics: dict[str, str | int | float | bool] = {
+                THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC: f"cache_{cached_rejection_reason}",
+            }
+            logger.info(
+                "Thread cache rejected for read",
+                room_id=room_id,
+                thread_id=thread_id,
+                **payload_reject_diagnostics,
+            )
+            return None, payload_reject_diagnostics
+
+        resolved_history, sidecar_hydration_ms, resolution_reuse_kind = await _resolve_cached_thread_history(
+            client,
+            room_id=room_id,
+            thread_id=thread_id,
+            event_cache=event_cache,
+            cached_event_sources=cached_event_sources,
+            hydrate_sidecars=hydrate_sidecars,
+            expected_membership_epoch=cached_membership_epoch,
+            trusted_sender_ids=trusted_sender_ids,
+            resolution_reuse=resolution_reuse,
+            cache_state=cache_state,
+        )
     if resolved_history is None:
         return None, {
             THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC: "cache_payload_unresolvable",

--- a/src/mindroom/matrix/client_thread_history.py
+++ b/src/mindroom/matrix/client_thread_history.py
@@ -781,13 +781,6 @@ async def _try_reuse_cached_thread_resolution(
     assert cache_state.max_thread_write_seq is not None
     assert cache_state.max_origin_server_ts is not None
     snapshot_trusted_sender_ids = frozenset(trusted_sender_ids)
-    if not await _snapshot_sidecars_unchanged(
-        event_cache,
-        room_id=room_id,
-        membership_epoch=membership_epoch,
-        snapshot=snapshot,
-    ):
-        return None
     if snapshot_matches_revision(
         snapshot,
         trusted_sender_ids=snapshot_trusted_sender_ids,
@@ -796,7 +789,29 @@ async def _try_reuse_cached_thread_resolution(
         max_write_seq=cache_state.max_write_seq,
         max_thread_write_seq=cache_state.max_thread_write_seq,
     ):
+        if not await _snapshot_sidecars_unchanged(
+            event_cache,
+            room_id=room_id,
+            thread_id=thread_id,
+            membership_epoch=membership_epoch,
+            snapshot=snapshot,
+        ):
+            return None
         return snapshot.cloned_messages(), 0.0, "reuse"
+    if (
+        snapshot.trusted_sender_ids != snapshot_trusted_sender_ids
+        or snapshot.membership_epoch != membership_epoch
+        or cache_state.event_count <= snapshot.event_count
+    ):
+        return None
+    if not await _snapshot_sidecars_unchanged(
+        event_cache,
+        room_id=room_id,
+        thread_id=thread_id,
+        membership_epoch=membership_epoch,
+        snapshot=snapshot,
+    ):
+        return None
     return await _try_merge_cached_thread_delta(
         client,
         room_id=room_id,
@@ -815,6 +830,7 @@ async def _snapshot_sidecars_unchanged(
     event_cache: ConversationEventCache,
     *,
     room_id: str,
+    thread_id: str,
     membership_epoch: int,
     snapshot: ThreadResolutionSnapshot,
 ) -> bool:
@@ -831,6 +847,7 @@ async def _snapshot_sidecars_unchanged(
         logger.debug(
             "Thread resolution sidecar check failed; falling back to full resolution",
             room_id=room_id,
+            thread_id=thread_id,
             error=str(exc),
         )
         return False

--- a/src/mindroom/matrix/client_thread_history.py
+++ b/src/mindroom/matrix/client_thread_history.py
@@ -636,6 +636,7 @@ async def _resolve_cached_thread_history_with_reuse(
     if reuse_cache is not None and resolved.hydration_complete and _thread_cache_state_has_revision(cache_state):
         assert cache_state is not None
         assert cache_state.max_write_seq is not None
+        assert cache_state.max_thread_write_seq is not None
         assert cache_state.max_origin_server_ts is not None
         reuse_cache.store(
             room_id,
@@ -649,6 +650,7 @@ async def _resolve_cached_thread_history_with_reuse(
                 membership_epoch=expected_membership_epoch,
                 event_count=cache_state.event_count,
                 max_write_seq=cache_state.max_write_seq,
+                max_thread_write_seq=cache_state.max_thread_write_seq,
                 max_origin_server_ts=cache_state.max_origin_server_ts,
                 sidecar_texts=resolved.sidecar_texts,
             ),
@@ -683,6 +685,7 @@ async def _resolve_reused_thread_suffix(
     if not suffix_resolution.hydration_complete:
         return None
     assert cache_state.max_write_seq is not None
+    assert cache_state.max_thread_write_seq is not None
     assert cache_state.max_origin_server_ts is not None
     prefix_length = snapshot.event_count
     input_order_by_event_id = dict(snapshot.input_order_by_event_id)
@@ -709,6 +712,7 @@ async def _resolve_reused_thread_suffix(
             membership_epoch=expected_membership_epoch,
             event_count=cache_state.event_count,
             max_write_seq=cache_state.max_write_seq,
+            max_thread_write_seq=cache_state.max_thread_write_seq,
             max_origin_server_ts=cache_state.max_origin_server_ts,
             sidecar_texts={**snapshot.sidecar_texts, **suffix_resolution.sidecar_texts},
             prior_known_event_ids=snapshot.known_event_ids,
@@ -747,6 +751,7 @@ def _thread_cache_state_has_revision(cache_state: ThreadCacheState | None) -> bo
         cache_state is not None
         and cache_state.event_count > 0
         and cache_state.max_write_seq is not None
+        and cache_state.max_thread_write_seq is not None
         and cache_state.max_origin_server_ts is not None
     )
 
@@ -773,6 +778,7 @@ async def _try_reuse_cached_thread_resolution(
     assert resolution_reuse is not None
     assert cache_state is not None
     assert cache_state.max_write_seq is not None
+    assert cache_state.max_thread_write_seq is not None
     assert cache_state.max_origin_server_ts is not None
     snapshot_trusted_sender_ids = frozenset(trusted_sender_ids)
     if not await _snapshot_sidecars_unchanged(
@@ -788,6 +794,7 @@ async def _try_reuse_cached_thread_resolution(
         membership_epoch=membership_epoch,
         event_count=cache_state.event_count,
         max_write_seq=cache_state.max_write_seq,
+        max_thread_write_seq=cache_state.max_thread_write_seq,
     ):
         return snapshot.cloned_messages(), 0.0, "reuse"
     return await _try_merge_cached_thread_delta(
@@ -845,8 +852,12 @@ async def _try_merge_cached_thread_delta(
 ) -> tuple[list[ResolvedVisibleMessage], float, str] | None:
     """Load and merge one complete append-only durable delta."""
     assert cache_state.max_write_seq is not None
+    assert cache_state.max_thread_write_seq is not None
     assert cache_state.max_origin_server_ts is not None
-    if cache_state.max_write_seq <= snapshot.max_write_seq:
+    if (
+        cache_state.max_write_seq <= snapshot.max_write_seq
+        and cache_state.max_thread_write_seq <= snapshot.max_thread_write_seq
+    ):
         return None
     try:
         candidate_suffix = await event_cache.get_thread_events_written_between(
@@ -854,6 +865,8 @@ async def _try_merge_cached_thread_delta(
             thread_id,
             after_write_seq=snapshot.max_write_seq,
             through_write_seq=cache_state.max_write_seq,
+            after_thread_write_seq=snapshot.max_thread_write_seq,
+            through_thread_write_seq=cache_state.max_thread_write_seq,
         )
     except Exception as exc:
         logger.debug(
@@ -870,6 +883,7 @@ async def _try_merge_cached_thread_delta(
         membership_epoch=membership_epoch,
         event_count=cache_state.event_count,
         max_write_seq=cache_state.max_write_seq,
+        max_thread_write_seq=cache_state.max_thread_write_seq,
         max_origin_server_ts=cache_state.max_origin_server_ts,
     )
     if suffix is None:

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -50,6 +50,7 @@ from mindroom.matrix.message_content import extract_edit_body
 from mindroom.matrix.thread_bookkeeping import ThreadMutationResolver
 from mindroom.matrix.thread_diagnostics import is_thread_history_degraded
 from mindroom.matrix.thread_membership import resolve_event_thread_membership
+from mindroom.matrix.thread_resolution_reuse import ThreadResolutionReuseCache
 from mindroom.matrix.thread_room_scan import (
     fetch_event_info_for_client,
     lookup_thread_id_from_conversation_cache,
@@ -394,9 +395,11 @@ class MatrixConversationCache(ConversationCacheProtocol):
     _outbound: ThreadOutboundWritePolicy = field(init=False, repr=False)
     _live: ThreadLiveWritePolicy = field(init=False, repr=False)
     _sync: ThreadSyncWritePolicy = field(init=False, repr=False)
+    _thread_resolution_reuse: ThreadResolutionReuseCache = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
         """Bind extracted read/write collaborators to this facade."""
+        self._thread_resolution_reuse = ThreadResolutionReuseCache()
         self._reads = ThreadReadPolicy(
             logger_getter=lambda: self.logger,
             runtime=self.runtime,
@@ -681,6 +684,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
             trusted_sender_ids=self._trusted_sender_ids(),
             caller_label=caller_label,
             coordinator_queue_wait_ms=coordinator_queue_wait_ms,
+            resolution_reuse=self._thread_resolution_reuse,
         )
 
     async def _refresh_dispatch_thread_snapshot_for_startup_prewarm(

--- a/src/mindroom/matrix/message_content.py
+++ b/src/mindroom/matrix/message_content.py
@@ -83,6 +83,11 @@ def _sidecar_reference(event_source: Mapping[str, Any]) -> tuple[str, str] | Non
     return event_id, mxc_url
 
 
+def has_sidecar_references(event_sources: Sequence[dict[str, Any]]) -> bool:
+    """Return whether any event source carries a durable long-text sidecar reference."""
+    return any(_sidecar_reference(event_source) is not None for event_source in event_sources)
+
+
 async def prepare_sidecar_hydration_batch(
     event_sources: Sequence[dict[str, Any]],
     *,

--- a/src/mindroom/matrix/thread_resolution_reuse.py
+++ b/src/mindroom/matrix/thread_resolution_reuse.py
@@ -34,6 +34,16 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
 
 
+@dataclass(frozen=True, slots=True)
+class ThreadRevision:
+    """Durable revision identity of one non-empty thread's raw rows."""
+
+    event_count: int
+    max_write_seq: int
+    max_thread_write_seq: int
+    max_origin_server_ts: int
+
+
 @dataclass(slots=True)
 class ThreadResolutionSnapshot:
     """One complete thread resolution keyed by its durable row revision."""
@@ -44,10 +54,7 @@ class ThreadResolutionSnapshot:
     known_event_ids: frozenset[str]
     trusted_sender_ids: frozenset[str]
     membership_epoch: int
-    event_count: int
-    max_write_seq: int
-    max_thread_write_seq: int
-    max_origin_server_ts: int
+    revision: ThreadRevision
     sidecar_texts: dict[tuple[str, str], str]
 
     def cloned_messages(self) -> list[ResolvedVisibleMessage]:
@@ -77,10 +84,7 @@ def build_thread_resolution_snapshot(
     related_event_id_by_event_id: dict[str, str],
     trusted_sender_ids: frozenset[str],
     membership_epoch: int,
-    event_count: int,
-    max_write_seq: int,
-    max_thread_write_seq: int,
-    max_origin_server_ts: int,
+    revision: ThreadRevision,
     sidecar_texts: Mapping[tuple[str, str], str],
     prior_known_event_ids: frozenset[str] = frozenset(),
 ) -> ThreadResolutionSnapshot:
@@ -104,10 +108,7 @@ def build_thread_resolution_snapshot(
         known_event_ids=frozenset(known_event_ids),
         trusted_sender_ids=trusted_sender_ids,
         membership_epoch=membership_epoch,
-        event_count=event_count,
-        max_write_seq=max_write_seq,
-        max_thread_write_seq=max_thread_write_seq,
-        max_origin_server_ts=max_origin_server_ts,
+        revision=revision,
         sidecar_texts=dict(sidecar_texts),
     )
 
@@ -142,25 +143,25 @@ def reusable_event_source_suffix(
     *,
     trusted_sender_ids: frozenset[str],
     membership_epoch: int,
-    event_count: int,
-    max_write_seq: int,
-    max_thread_write_seq: int,
-    max_origin_server_ts: int,
+    revision: ThreadRevision,
 ) -> list[dict[str, Any]] | None:
     """Return a complete append-only delta when it is safe to merge, else None."""
     unsafe_timestamp = any(
         not isinstance(origin_server_ts := event_source.get("origin_server_ts"), int)
         or isinstance(origin_server_ts, bool)
-        or origin_server_ts < snapshot.max_origin_server_ts
+        or origin_server_ts < snapshot.revision.max_origin_server_ts
         for event_source in suffix
     )
     if (
         snapshot.trusted_sender_ids != trusted_sender_ids
         or snapshot.membership_epoch != membership_epoch
-        or event_count <= snapshot.event_count
-        or (max_write_seq <= snapshot.max_write_seq and max_thread_write_seq <= snapshot.max_thread_write_seq)
-        or len(suffix) != event_count - snapshot.event_count
-        or max_origin_server_ts < snapshot.max_origin_server_ts
+        or revision.event_count <= snapshot.revision.event_count
+        or (
+            revision.max_write_seq <= snapshot.revision.max_write_seq
+            and revision.max_thread_write_seq <= snapshot.revision.max_thread_write_seq
+        )
+        or len(suffix) != revision.event_count - snapshot.revision.event_count
+        or revision.max_origin_server_ts < snapshot.revision.max_origin_server_ts
         or unsafe_timestamp
     ):
         return None
@@ -175,17 +176,13 @@ def snapshot_matches_revision(
     *,
     trusted_sender_ids: frozenset[str],
     membership_epoch: int,
-    event_count: int,
-    max_write_seq: int,
-    max_thread_write_seq: int,
+    revision: ThreadRevision,
 ) -> bool:
     """Return whether durable state still names the snapshot's exact raw rows."""
     return (
         snapshot.trusted_sender_ids == trusted_sender_ids
         and snapshot.membership_epoch == membership_epoch
-        and snapshot.event_count == event_count
-        and snapshot.max_write_seq == max_write_seq
-        and snapshot.max_thread_write_seq == max_thread_write_seq
+        and snapshot.revision == revision
     )
 
 
@@ -236,6 +233,7 @@ def _bundled_edit_target_ids(event_source: Mapping[str, Any]) -> Iterable[str]:
 __all__ = [
     "ThreadResolutionReuseCache",
     "ThreadResolutionSnapshot",
+    "ThreadRevision",
     "build_thread_resolution_snapshot",
     "clone_resolved_visible_message",
     "reusable_event_source_suffix",

--- a/src/mindroom/matrix/thread_resolution_reuse.py
+++ b/src/mindroom/matrix/thread_resolution_reuse.py
@@ -1,0 +1,206 @@
+"""Process-local reuse of resolved thread history across repeated durable-cache reads.
+
+Long agent threads accumulate one raw ``m.replace`` event per streaming edit, so the durable
+row count grows 10-50x faster than the visible message count. Re-parsing and re-resolving every
+raw row on each turn is the measured post-lock hotspot. This module keeps one bounded per-bot
+snapshot of the last complete resolution per thread and only re-resolves the raw-row suffix that
+was appended since.
+
+Safety model (any doubt falls back to full resolution by returning ``None``):
+
+1. A snapshot is only comparable when the trusted internal sender set and the durable room
+   membership epoch are identical to the ones the snapshot was resolved under.
+2. The fresh durable rows must start with the snapshot's exact raw rows (dict equality), so any
+   in-place row change (redaction pruning, snapshot replacement, reordering) forces full
+   resolution.
+3. Suffix rows must be plain ``m.room.message`` events with new, unique event IDs that were never
+   seen by the snapshot (including edit targets, reply targets, and synthesized originals), and
+   every suffix edit - explicit or bundled - must target a suffix-local event, so no suffix row
+   can mutate or duplicate an already-resolved message.
+4. Snapshots are only stored by the caller when sidecar hydration was fully served from the
+   durable cache, so degraded preview bodies are never frozen into future turns.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
+from mindroom.matrix.event_info import EventInfo
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+_MAX_SNAPSHOTS_PER_CACHE = 8
+
+
+@dataclass(slots=True)
+class ThreadResolutionSnapshot:
+    """One complete thread resolution keyed by the exact durable rows that produced it."""
+
+    event_sources: list[dict[str, Any]]
+    messages: list[ResolvedVisibleMessage]
+    input_order_by_event_id: dict[str, int]
+    related_event_id_by_event_id: dict[str, str]
+    known_event_ids: frozenset[str]
+    trusted_sender_ids: frozenset[str]
+    membership_epoch: int
+
+    def cloned_messages(self) -> list[ResolvedVisibleMessage]:
+        """Return caller-owned message copies so later turns never see caller mutations."""
+        return [clone_resolved_visible_message(message) for message in self.messages]
+
+
+def clone_resolved_visible_message(message: ResolvedVisibleMessage) -> ResolvedVisibleMessage:
+    """Return one independent copy of a resolved visible message."""
+    return ResolvedVisibleMessage(
+        sender=message.sender,
+        body=message.body,
+        timestamp=message.timestamp,
+        event_id=message.event_id,
+        content=dict(message.content),
+        thread_id=message.thread_id,
+        latest_event_id=message.latest_event_id,
+        stream_status=message.stream_status,
+    )
+
+
+def build_thread_resolution_snapshot(
+    *,
+    event_sources: Sequence[dict[str, Any]],
+    messages: Sequence[ResolvedVisibleMessage],
+    input_order_by_event_id: dict[str, int],
+    related_event_id_by_event_id: dict[str, str],
+    trusted_sender_ids: frozenset[str],
+    membership_epoch: int,
+) -> ThreadResolutionSnapshot:
+    """Build one reusable snapshot with private message copies and the full known-ID closure."""
+    known_event_ids: set[str] = set()
+    for event_source in event_sources:
+        event_id = event_source.get("event_id")
+        if isinstance(event_id, str):
+            known_event_ids.add(event_id)
+    for message in messages:
+        known_event_ids.add(message.event_id)
+        known_event_ids.add(message.latest_event_id)
+    # Relation targets cover edits whose original never resolved to a message: a suffix row
+    # reusing such an ID could change how those prior edits apply, so it must force full
+    # resolution.
+    known_event_ids.update(related_event_id_by_event_id.values())
+    return ThreadResolutionSnapshot(
+        event_sources=list(event_sources),
+        messages=[clone_resolved_visible_message(message) for message in messages],
+        input_order_by_event_id=input_order_by_event_id,
+        related_event_id_by_event_id=related_event_id_by_event_id,
+        known_event_ids=frozenset(known_event_ids),
+        trusted_sender_ids=trusted_sender_ids,
+        membership_epoch=membership_epoch,
+    )
+
+
+class ThreadResolutionReuseCache:
+    """Bounded per-bot LRU of reusable thread resolutions keyed by (room_id, thread_id)."""
+
+    def __init__(self, max_entries: int = _MAX_SNAPSHOTS_PER_CACHE) -> None:
+        self._max_entries = max_entries
+        self._snapshots: OrderedDict[tuple[str, str], ThreadResolutionSnapshot] = OrderedDict()
+
+    def get(self, room_id: str, thread_id: str) -> ThreadResolutionSnapshot | None:
+        """Return the stored snapshot for one thread when present."""
+        key = (room_id, thread_id)
+        snapshot = self._snapshots.get(key)
+        if snapshot is not None:
+            self._snapshots.move_to_end(key)
+        return snapshot
+
+    def store(self, room_id: str, thread_id: str, snapshot: ThreadResolutionSnapshot) -> None:
+        """Store one snapshot, evicting the least recently used entry beyond the cap."""
+        key = (room_id, thread_id)
+        self._snapshots[key] = snapshot
+        self._snapshots.move_to_end(key)
+        while len(self._snapshots) > self._max_entries:
+            self._snapshots.popitem(last=False)
+
+    def discard(self, room_id: str, thread_id: str) -> None:
+        """Drop one snapshot after its durable counterpart was invalidated."""
+        self._snapshots.pop((room_id, thread_id), None)
+
+
+def reusable_event_source_suffix(
+    snapshot: ThreadResolutionSnapshot,
+    event_sources: Sequence[dict[str, Any]],
+    *,
+    trusted_sender_ids: frozenset[str],
+    membership_epoch: int,
+) -> list[dict[str, Any]] | None:
+    """Return the appended raw rows when the snapshot is a safe exact prefix, else None."""
+    if snapshot.trusted_sender_ids != trusted_sender_ids or snapshot.membership_epoch != membership_epoch:
+        return None
+    prefix_length = len(snapshot.event_sources)
+    if len(event_sources) < prefix_length:
+        return None
+    if any(
+        row != snapshot_row
+        for row, snapshot_row in zip(event_sources[:prefix_length], snapshot.event_sources, strict=True)
+    ):
+        return None
+    suffix = list(event_sources[prefix_length:])
+    if not _suffix_is_safely_appendable(snapshot, suffix):
+        return None
+    return suffix
+
+
+def _suffix_is_safely_appendable(
+    snapshot: ThreadResolutionSnapshot,
+    suffix: Sequence[dict[str, Any]],
+) -> bool:
+    """Return whether suffix rows can only introduce new messages or edits to new messages."""
+    suffix_event_ids: set[str] = set()
+    for event_source in suffix:
+        if event_source.get("type") != "m.room.message":
+            return False
+        event_id = event_source.get("event_id")
+        if not isinstance(event_id, str) or not event_id:
+            return False
+        if event_id in snapshot.known_event_ids or event_id in suffix_event_ids:
+            return False
+        suffix_event_ids.add(event_id)
+    for event_source in suffix:
+        event_info = EventInfo.from_event(event_source)
+        if event_info.is_edit and event_info.original_event_id not in suffix_event_ids:
+            return False
+        if any(target not in suffix_event_ids for target in _bundled_edit_target_ids(event_source)):
+            return False
+    return True
+
+
+def _bundled_edit_target_ids(event_source: Mapping[str, Any]) -> Iterable[str]:
+    """Yield original-event targets of any bundled ``m.replace`` aggregation on one row."""
+    unsigned = event_source.get("unsigned")
+    if not isinstance(unsigned, Mapping):
+        return
+    relations = unsigned.get("m.relations")
+    if not isinstance(relations, Mapping):
+        return
+    replacement = relations.get("m.replace")
+    if not isinstance(replacement, Mapping):
+        return
+    for candidate in (replacement.get("event"), replacement.get("latest_event"), replacement):
+        if not isinstance(candidate, Mapping):
+            continue
+        normalized_candidate = {key: value for key, value in candidate.items() if isinstance(key, str)}
+        target = EventInfo.from_event(normalized_candidate).original_event_id
+        if target is not None:
+            yield target
+
+
+__all__ = [
+    "ThreadResolutionReuseCache",
+    "ThreadResolutionSnapshot",
+    "build_thread_resolution_snapshot",
+    "clone_resolved_visible_message",
+    "reusable_event_source_suffix",
+]

--- a/src/mindroom/matrix/thread_resolution_reuse.py
+++ b/src/mindroom/matrix/thread_resolution_reuse.py
@@ -9,9 +9,9 @@ Safety model (any doubt falls back to full resolution by returning ``None``):
 
 1. A snapshot is only comparable when the trusted internal sender set and the durable room
    membership epoch are identical to the ones the snapshot was resolved under.
-2. The durable event count and monotonic write sequence prove whether the thread is unchanged or
-   whether every changed row is present in a bounded delta read. Any deletion, replacement, or
-   in-place update forces full resolution.
+2. The durable event count plus monotonic payload and thread-index write sequences prove whether
+   the thread is unchanged or whether every changed row is present in a bounded delta read. Any
+   deletion, replacement, or in-place update forces full resolution.
 3. Suffix rows must be plain ``m.room.message`` events with new, unique event IDs that were never
    seen by the snapshot (including edit targets, reply targets, and synthesized originals), and
    every suffix edit - explicit or bundled - must target a suffix-local event, so no suffix row
@@ -46,6 +46,7 @@ class ThreadResolutionSnapshot:
     membership_epoch: int
     event_count: int
     max_write_seq: int
+    max_thread_write_seq: int
     max_origin_server_ts: int
     sidecar_texts: dict[tuple[str, str], str]
 
@@ -78,6 +79,7 @@ def build_thread_resolution_snapshot(
     membership_epoch: int,
     event_count: int,
     max_write_seq: int,
+    max_thread_write_seq: int,
     max_origin_server_ts: int,
     sidecar_texts: Mapping[tuple[str, str], str],
     prior_known_event_ids: frozenset[str] = frozenset(),
@@ -104,6 +106,7 @@ def build_thread_resolution_snapshot(
         membership_epoch=membership_epoch,
         event_count=event_count,
         max_write_seq=max_write_seq,
+        max_thread_write_seq=max_thread_write_seq,
         max_origin_server_ts=max_origin_server_ts,
         sidecar_texts=dict(sidecar_texts),
     )
@@ -141,6 +144,7 @@ def reusable_event_source_suffix(
     membership_epoch: int,
     event_count: int,
     max_write_seq: int,
+    max_thread_write_seq: int,
     max_origin_server_ts: int,
 ) -> list[dict[str, Any]] | None:
     """Return a complete append-only delta when it is safe to merge, else None."""
@@ -154,7 +158,7 @@ def reusable_event_source_suffix(
         snapshot.trusted_sender_ids != trusted_sender_ids
         or snapshot.membership_epoch != membership_epoch
         or event_count <= snapshot.event_count
-        or max_write_seq <= snapshot.max_write_seq
+        or (max_write_seq <= snapshot.max_write_seq and max_thread_write_seq <= snapshot.max_thread_write_seq)
         or len(suffix) != event_count - snapshot.event_count
         or max_origin_server_ts < snapshot.max_origin_server_ts
         or unsafe_timestamp
@@ -173,6 +177,7 @@ def snapshot_matches_revision(
     membership_epoch: int,
     event_count: int,
     max_write_seq: int,
+    max_thread_write_seq: int,
 ) -> bool:
     """Return whether durable state still names the snapshot's exact raw rows."""
     return (
@@ -180,6 +185,7 @@ def snapshot_matches_revision(
         and snapshot.membership_epoch == membership_epoch
         and snapshot.event_count == event_count
         and snapshot.max_write_seq == max_write_seq
+        and snapshot.max_thread_write_seq == max_thread_write_seq
     )
 
 

--- a/src/mindroom/matrix/thread_resolution_reuse.py
+++ b/src/mindroom/matrix/thread_resolution_reuse.py
@@ -33,15 +33,7 @@ from mindroom.matrix.event_info import EventInfo
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
 
-
-@dataclass(frozen=True, slots=True)
-class ThreadRevision:
-    """Durable revision identity of one non-empty thread's raw rows."""
-
-    event_count: int
-    max_write_seq: int
-    max_thread_write_seq: int
-    max_origin_server_ts: int
+    from mindroom.matrix.cache import ThreadRevision
 
 
 @dataclass(slots=True)
@@ -233,7 +225,6 @@ def _bundled_edit_target_ids(event_source: Mapping[str, Any]) -> Iterable[str]:
 __all__ = [
     "ThreadResolutionReuseCache",
     "ThreadResolutionSnapshot",
-    "ThreadRevision",
     "build_thread_resolution_snapshot",
     "clone_resolved_visible_message",
     "reusable_event_source_suffix",

--- a/src/mindroom/matrix/thread_resolution_reuse.py
+++ b/src/mindroom/matrix/thread_resolution_reuse.py
@@ -2,17 +2,16 @@
 
 Long agent threads accumulate one raw ``m.replace`` event per streaming edit, so the durable
 row count grows 10-50x faster than the visible message count. Re-parsing and re-resolving every
-raw row on each turn is the measured post-lock hotspot. This module keeps one bounded per-bot
-snapshot of the last complete resolution per thread and only re-resolves the raw-row suffix that
-was appended since.
+raw row on each turn is the measured post-lock hotspot. This module keeps the last complete
+resolution for one thread per bot and only re-resolves newly written durable rows.
 
 Safety model (any doubt falls back to full resolution by returning ``None``):
 
 1. A snapshot is only comparable when the trusted internal sender set and the durable room
    membership epoch are identical to the ones the snapshot was resolved under.
-2. The fresh durable rows must start with the snapshot's exact raw rows (dict equality), so any
-   in-place row change (redaction pruning, snapshot replacement, reordering) forces full
-   resolution.
+2. The durable event count and monotonic write sequence prove whether the thread is unchanged or
+   whether every changed row is present in a bounded delta read. Any deletion, replacement, or
+   in-place update forces full resolution.
 3. Suffix rows must be plain ``m.room.message`` events with new, unique event IDs that were never
    seen by the snapshot (including edit targets, reply targets, and synthesized originals), and
    every suffix edit - explicit or bundled - must target a suffix-local event, so no suffix row
@@ -23,8 +22,8 @@ Safety model (any doubt falls back to full resolution by returning ``None``):
 
 from __future__ import annotations
 
-from collections import OrderedDict
 from collections.abc import Mapping
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -34,20 +33,21 @@ from mindroom.matrix.event_info import EventInfo
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
 
-_MAX_SNAPSHOTS_PER_CACHE = 8
-
 
 @dataclass(slots=True)
 class ThreadResolutionSnapshot:
-    """One complete thread resolution keyed by the exact durable rows that produced it."""
+    """One complete thread resolution keyed by its durable row revision."""
 
-    event_sources: list[dict[str, Any]]
     messages: list[ResolvedVisibleMessage]
     input_order_by_event_id: dict[str, int]
     related_event_id_by_event_id: dict[str, str]
     known_event_ids: frozenset[str]
     trusted_sender_ids: frozenset[str]
     membership_epoch: int
+    event_count: int
+    max_write_seq: int
+    max_origin_server_ts: int
+    sidecar_texts: dict[tuple[str, str], str]
 
     def cloned_messages(self) -> list[ResolvedVisibleMessage]:
         """Return caller-owned message copies so later turns never see caller mutations."""
@@ -61,7 +61,7 @@ def clone_resolved_visible_message(message: ResolvedVisibleMessage) -> ResolvedV
         body=message.body,
         timestamp=message.timestamp,
         event_id=message.event_id,
-        content=dict(message.content),
+        content=deepcopy(message.content),
         thread_id=message.thread_id,
         latest_event_id=message.latest_event_id,
         stream_status=message.stream_status,
@@ -76,9 +76,14 @@ def build_thread_resolution_snapshot(
     related_event_id_by_event_id: dict[str, str],
     trusted_sender_ids: frozenset[str],
     membership_epoch: int,
+    event_count: int,
+    max_write_seq: int,
+    max_origin_server_ts: int,
+    sidecar_texts: Mapping[tuple[str, str], str],
+    prior_known_event_ids: frozenset[str] = frozenset(),
 ) -> ThreadResolutionSnapshot:
     """Build one reusable snapshot with private message copies and the full known-ID closure."""
-    known_event_ids: set[str] = set()
+    known_event_ids = set(prior_known_event_ids)
     for event_source in event_sources:
         event_id = event_source.get("event_id")
         if isinstance(event_id, str):
@@ -91,66 +96,91 @@ def build_thread_resolution_snapshot(
     # resolution.
     known_event_ids.update(related_event_id_by_event_id.values())
     return ThreadResolutionSnapshot(
-        event_sources=list(event_sources),
         messages=[clone_resolved_visible_message(message) for message in messages],
         input_order_by_event_id=input_order_by_event_id,
         related_event_id_by_event_id=related_event_id_by_event_id,
         known_event_ids=frozenset(known_event_ids),
         trusted_sender_ids=trusted_sender_ids,
         membership_epoch=membership_epoch,
+        event_count=event_count,
+        max_write_seq=max_write_seq,
+        max_origin_server_ts=max_origin_server_ts,
+        sidecar_texts=dict(sidecar_texts),
     )
 
 
 class ThreadResolutionReuseCache:
-    """Bounded per-bot LRU of reusable thread resolutions keyed by (room_id, thread_id)."""
+    """Keep the latest reusable thread resolution for one bot."""
 
-    def __init__(self, max_entries: int = _MAX_SNAPSHOTS_PER_CACHE) -> None:
-        self._max_entries = max_entries
-        self._snapshots: OrderedDict[tuple[str, str], ThreadResolutionSnapshot] = OrderedDict()
+    def __init__(self) -> None:
+        self._key: tuple[str, str] | None = None
+        self._snapshot: ThreadResolutionSnapshot | None = None
 
     def get(self, room_id: str, thread_id: str) -> ThreadResolutionSnapshot | None:
         """Return the stored snapshot for one thread when present."""
         key = (room_id, thread_id)
-        snapshot = self._snapshots.get(key)
-        if snapshot is not None:
-            self._snapshots.move_to_end(key)
-        return snapshot
+        return self._snapshot if key == self._key else None
 
     def store(self, room_id: str, thread_id: str, snapshot: ThreadResolutionSnapshot) -> None:
-        """Store one snapshot, evicting the least recently used entry beyond the cap."""
-        key = (room_id, thread_id)
-        self._snapshots[key] = snapshot
-        self._snapshots.move_to_end(key)
-        while len(self._snapshots) > self._max_entries:
-            self._snapshots.popitem(last=False)
+        """Replace the prior snapshot with the bot's latest resolved thread."""
+        self._key = (room_id, thread_id)
+        self._snapshot = snapshot
 
     def discard(self, room_id: str, thread_id: str) -> None:
         """Drop one snapshot after its durable counterpart was invalidated."""
-        self._snapshots.pop((room_id, thread_id), None)
+        if self._key == (room_id, thread_id):
+            self._key = None
+            self._snapshot = None
 
 
 def reusable_event_source_suffix(
     snapshot: ThreadResolutionSnapshot,
-    event_sources: Sequence[dict[str, Any]],
+    suffix: Sequence[dict[str, Any]],
     *,
     trusted_sender_ids: frozenset[str],
     membership_epoch: int,
+    event_count: int,
+    max_write_seq: int,
+    max_origin_server_ts: int,
 ) -> list[dict[str, Any]] | None:
-    """Return the appended raw rows when the snapshot is a safe exact prefix, else None."""
-    if snapshot.trusted_sender_ids != trusted_sender_ids or snapshot.membership_epoch != membership_epoch:
-        return None
-    prefix_length = len(snapshot.event_sources)
-    if len(event_sources) < prefix_length:
-        return None
-    if any(
-        row != snapshot_row
-        for row, snapshot_row in zip(event_sources[:prefix_length], snapshot.event_sources, strict=True)
+    """Return a complete append-only delta when it is safe to merge, else None."""
+    unsafe_timestamp = any(
+        not isinstance(origin_server_ts := event_source.get("origin_server_ts"), int)
+        or isinstance(origin_server_ts, bool)
+        or origin_server_ts < snapshot.max_origin_server_ts
+        for event_source in suffix
+    )
+    if (
+        snapshot.trusted_sender_ids != trusted_sender_ids
+        or snapshot.membership_epoch != membership_epoch
+        or event_count <= snapshot.event_count
+        or max_write_seq <= snapshot.max_write_seq
+        or len(suffix) != event_count - snapshot.event_count
+        or max_origin_server_ts < snapshot.max_origin_server_ts
+        or unsafe_timestamp
     ):
         return None
-    suffix = list(event_sources[prefix_length:])
-    if not _suffix_is_safely_appendable(snapshot, suffix):
+    resolved_suffix = list(suffix)
+    if not _suffix_is_safely_appendable(snapshot, resolved_suffix):
         return None
-    return suffix
+    return resolved_suffix
+
+
+def snapshot_matches_revision(
+    snapshot: ThreadResolutionSnapshot,
+    *,
+    trusted_sender_ids: frozenset[str],
+    membership_epoch: int,
+    event_count: int,
+    max_write_seq: int,
+) -> bool:
+    """Return whether durable state still names the snapshot's exact raw rows."""
+    return (
+        snapshot.trusted_sender_ids == trusted_sender_ids
+        and snapshot.membership_epoch == membership_epoch
+        and snapshot.event_count == event_count
+        and snapshot.max_write_seq == max_write_seq
+    )
 
 
 def _suffix_is_safely_appendable(
@@ -203,4 +233,5 @@ __all__ = [
     "build_thread_resolution_snapshot",
     "clone_resolved_visible_message",
     "reusable_event_source_suffix",
+    "snapshot_matches_revision",
 ]

--- a/tach.toml
+++ b/tach.toml
@@ -1928,6 +1928,7 @@ depends_on = [
     "mindroom.matrix.message_content",
     "mindroom.matrix.thread_bookkeeping",
     "mindroom.matrix.thread_membership",
+    "mindroom.matrix.thread_resolution_reuse",
     "mindroom.matrix.thread_room_scan",
     "mindroom.matrix.visible_body",
 ]
@@ -2329,6 +2330,7 @@ visibility = [
     "mindroom.matrix.client",
     "mindroom.matrix.client_thread_history",
     "mindroom.matrix.stale_stream_cleanup",
+    "mindroom.matrix.thread_resolution_reuse",
     "mindroom.response_runner",
     "mindroom.routing",
     "mindroom.thread_export.selection",
@@ -2391,6 +2393,7 @@ depends_on = [
     "mindroom.matrix.message_content",
     "mindroom.matrix.thread_membership",
     "mindroom.matrix.thread_projection",
+    "mindroom.matrix.thread_resolution_reuse",
     "mindroom.matrix.visible_body",
 ]
 visibility = [
@@ -2402,6 +2405,17 @@ visibility = [
     "mindroom.matrix.conversation_cache",
     "mindroom.matrix.thread_room_scan",
     "mindroom.thread_export.execution",
+]
+
+[[modules]]
+path = "mindroom.matrix.thread_resolution_reuse"
+depends_on = [
+    "mindroom.matrix.client_visible_messages",
+    "mindroom.matrix.event_info",
+]
+visibility = [
+    "mindroom.matrix.client_thread_history",
+    "mindroom.matrix.conversation_cache",
 ]
 
 [[modules]]

--- a/tach.toml
+++ b/tach.toml
@@ -2410,6 +2410,7 @@ visibility = [
 [[modules]]
 path = "mindroom.matrix.thread_resolution_reuse"
 depends_on = [
+    "mindroom.matrix.cache",
     "mindroom.matrix.client_visible_messages",
     "mindroom.matrix.event_info",
 ]
@@ -3764,6 +3765,7 @@ expose = [
     "SharedConversationEventCache",
     "ThreadCacheState",
     "ThreadHistoryResult",
+    "ThreadRevision",
     "is_opaque_encrypted_event_source",
     "normalize_nio_event_for_cache",
     "thread_cache_rejection_reason",
@@ -3778,6 +3780,7 @@ expose = [
     "EventCacheBackendUnavailableError",
     "SharedConversationEventCache",
     "ThreadCacheState",
+    "ThreadRevision",
 ]
 from = ["mindroom.matrix.cache.event_cache"]
 visibility = ["mindroom.matrix.cache"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -789,6 +789,7 @@ def make_event_cache_mock() -> AsyncMock:
     event_cache.get_recent_room_thread_ids.return_value = []
     event_cache.get_thread_events.return_value = None
     event_cache.get_thread_cache_state.return_value = None
+    event_cache.get_thread_revision.return_value = None
     event_cache.get_thread_id_for_event.return_value = None
     event_cache.get_latest_agent_message_snapshot.return_value = None
     event_cache.pending_durable_write_room_ids.return_value = ()

--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -3004,10 +3004,10 @@ async def test_mxc_text_cache_round_trips_across_event_cache_reopen(
 
 
 @pytest.mark.asyncio
-async def test_thread_cache_revision_tracks_point_payload_updates(
+async def test_thread_revision_tracks_point_payload_updates(
     event_cache_factory: Callable[[], ConversationEventCache],
 ) -> None:
-    """Thread revision metadata and delta reads include changed lookup payloads."""
+    """Thread revisions and delta reads include changed lookup payloads."""
     cache = event_cache_factory()
     await cache.initialize()
     root = {
@@ -3019,16 +3019,12 @@ async def test_thread_cache_revision_tracks_point_payload_updates(
     }
     try:
         await _replace_thread(cache, "!room:localhost", "$thread_root", [root])
-        before = await cache.get_thread_cache_state("!room:localhost", "$thread_root")
+        before = await cache.get_thread_revision("!room:localhost", "$thread_root")
         updated = {**root, "content": {"msgtype": "m.text", "body": "updated"}}
         await cache.store_event("$thread_root", "!room:localhost", updated)
-        after = await cache.get_thread_cache_state("!room:localhost", "$thread_root")
+        after = await cache.get_thread_revision("!room:localhost", "$thread_root")
         assert before is not None
-        assert before.max_write_seq is not None
-        assert before.max_thread_write_seq is not None
         assert after is not None
-        assert after.max_write_seq is not None
-        assert after.max_thread_write_seq is not None
         changed_rows = await cache.get_thread_events_written_between(
             "!room:localhost",
             "$thread_root",
@@ -3047,10 +3043,10 @@ async def test_thread_cache_revision_tracks_point_payload_updates(
 
 
 @pytest.mark.asyncio
-async def test_thread_cache_revision_tracks_index_replacements(
+async def test_thread_revision_tracks_index_replacements(
     event_cache_factory: Callable[[], ConversationEventCache],
 ) -> None:
-    """Thread revision metadata detects membership changes when payload writes are refused."""
+    """Thread revisions detect membership changes when payload writes are refused."""
     cache = event_cache_factory()
     await cache.initialize()
     room_id = "!room:localhost"
@@ -3077,20 +3073,16 @@ async def test_thread_cache_revision_tracks_index_replacements(
     try:
         await cache.store_event("$new", room_id, new_reply)
         await _replace_thread(cache, room_id, thread_id, [root, old_reply, shared_reply])
-        before = await cache.get_thread_cache_state(room_id, thread_id)
+        before = await cache.get_thread_revision(room_id, thread_id)
         replacement = [
             _opaque_payload(thread_id, origin_server_ts=1000),
             _opaque_payload("$new", thread_root_id=thread_id, origin_server_ts=2000),
             _opaque_payload("$shared", thread_root_id=thread_id, origin_server_ts=3000),
         ]
         await _replace_thread(cache, room_id, thread_id, replacement)
-        after = await cache.get_thread_cache_state(room_id, thread_id)
+        after = await cache.get_thread_revision(room_id, thread_id)
         assert before is not None
-        assert before.max_write_seq is not None
-        assert before.max_thread_write_seq is not None
         assert after is not None
-        assert after.max_write_seq is not None
-        assert after.max_thread_write_seq is not None
         changed_rows = await cache.get_thread_events_written_between(
             room_id,
             thread_id,

--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -3025,20 +3025,87 @@ async def test_thread_cache_revision_tracks_point_payload_updates(
         after = await cache.get_thread_cache_state("!room:localhost", "$thread_root")
         assert before is not None
         assert before.max_write_seq is not None
+        assert before.max_thread_write_seq is not None
         assert after is not None
         assert after.max_write_seq is not None
+        assert after.max_thread_write_seq is not None
         changed_rows = await cache.get_thread_events_written_between(
             "!room:localhost",
             "$thread_root",
             after_write_seq=before.max_write_seq,
             through_write_seq=after.max_write_seq,
+            after_thread_write_seq=before.max_thread_write_seq,
+            through_thread_write_seq=after.max_thread_write_seq,
         )
     finally:
         await cache.close()
 
     assert before.event_count == after.event_count == 1
     assert after.max_write_seq > before.max_write_seq
+    assert after.max_thread_write_seq == before.max_thread_write_seq
     assert changed_rows == [updated]
+
+
+@pytest.mark.asyncio
+async def test_thread_cache_revision_tracks_index_replacements(
+    event_cache_factory: Callable[[], ConversationEventCache],
+) -> None:
+    """Thread revision metadata detects membership changes when payload writes are refused."""
+    cache = event_cache_factory()
+    await cache.initialize()
+    room_id = "!room:localhost"
+    thread_id = "$thread_root"
+    root = _clear_payload(thread_id, body="root", origin_server_ts=1000)
+    old_reply = _clear_payload(
+        "$old",
+        body="old",
+        thread_root_id=thread_id,
+        origin_server_ts=2000,
+    )
+    new_reply = _clear_payload(
+        "$new",
+        body="new",
+        thread_root_id=thread_id,
+        origin_server_ts=2000,
+    )
+    shared_reply = _clear_payload(
+        "$shared",
+        body="shared",
+        thread_root_id=thread_id,
+        origin_server_ts=3000,
+    )
+    try:
+        await cache.store_event("$new", room_id, new_reply)
+        await _replace_thread(cache, room_id, thread_id, [root, old_reply, shared_reply])
+        before = await cache.get_thread_cache_state(room_id, thread_id)
+        replacement = [
+            _opaque_payload(thread_id, origin_server_ts=1000),
+            _opaque_payload("$new", thread_root_id=thread_id, origin_server_ts=2000),
+            _opaque_payload("$shared", thread_root_id=thread_id, origin_server_ts=3000),
+        ]
+        await _replace_thread(cache, room_id, thread_id, replacement)
+        after = await cache.get_thread_cache_state(room_id, thread_id)
+        assert before is not None
+        assert before.max_write_seq is not None
+        assert before.max_thread_write_seq is not None
+        assert after is not None
+        assert after.max_write_seq is not None
+        assert after.max_thread_write_seq is not None
+        changed_rows = await cache.get_thread_events_written_between(
+            room_id,
+            thread_id,
+            after_write_seq=before.max_write_seq,
+            through_write_seq=after.max_write_seq,
+            after_thread_write_seq=before.max_thread_write_seq,
+            through_thread_write_seq=after.max_thread_write_seq,
+        )
+    finally:
+        await cache.close()
+
+    assert before.event_count == after.event_count == 3
+    assert after.max_write_seq == before.max_write_seq
+    assert after.max_thread_write_seq > before.max_thread_write_seq
+    assert [row["event_id"] for row in changed_rows] == [thread_id, "$new", "$shared"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -372,6 +372,7 @@ async def test_conversation_cache_thread_reads_forward_client_fetch_metadata(
                 trusted_sender_ids=conversation_cache._trusted_sender_ids(),
                 caller_label=f"caller-{method_name}",
                 coordinator_queue_wait_ms=queue_wait_ms,
+                resolution_reuse=conversation_cache._thread_resolution_reuse,
             )
     finally:
         await event_cache.close()
@@ -871,6 +872,7 @@ async def test_conversation_cache_startup_prewarm_fetch_preserves_fixed_metadata
             trusted_sender_ids=conversation_cache._trusted_sender_ids(),
             caller_label="startup_thread_prewarm",
             coordinator_queue_wait_ms=0.0,
+            resolution_reuse=conversation_cache._thread_resolution_reuse,
         )
     finally:
         await event_cache.close()
@@ -2999,6 +3001,44 @@ async def test_mxc_text_cache_round_trips_across_event_cache_reopen(
         await reopened_cache.close()
 
     assert cached_text == "Full text sidecar"
+
+
+@pytest.mark.asyncio
+async def test_thread_cache_revision_tracks_point_payload_updates(
+    event_cache_factory: Callable[[], ConversationEventCache],
+) -> None:
+    """Thread revision metadata and delta reads include changed lookup payloads."""
+    cache = event_cache_factory()
+    await cache.initialize()
+    root = {
+        "event_id": "$thread_root",
+        "origin_server_ts": 1000,
+        "type": "m.room.message",
+        "sender": "@user:localhost",
+        "content": {"msgtype": "m.text", "body": "original"},
+    }
+    try:
+        await _replace_thread(cache, "!room:localhost", "$thread_root", [root])
+        before = await cache.get_thread_cache_state("!room:localhost", "$thread_root")
+        updated = {**root, "content": {"msgtype": "m.text", "body": "updated"}}
+        await cache.store_event("$thread_root", "!room:localhost", updated)
+        after = await cache.get_thread_cache_state("!room:localhost", "$thread_root")
+        assert before is not None
+        assert before.max_write_seq is not None
+        assert after is not None
+        assert after.max_write_seq is not None
+        changed_rows = await cache.get_thread_events_written_between(
+            "!room:localhost",
+            "$thread_root",
+            after_write_seq=before.max_write_seq,
+            through_write_seq=after.max_write_seq,
+        )
+    finally:
+        await cache.close()
+
+    assert before.event_count == after.event_count == 1
+    assert after.max_write_seq > before.max_write_seq
+    assert changed_rows == [updated]
 
 
 @pytest.mark.asyncio

--- a/tests/test_event_cache_semantics.py
+++ b/tests/test_event_cache_semantics.py
@@ -6,7 +6,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from mindroom.matrix.cache.thread_cache_state import thread_cache_state_row
+from mindroom.matrix.cache import ThreadRevision
+from mindroom.matrix.cache.thread_cache_state import thread_cache_state_row, thread_revision_row
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -18,17 +19,44 @@ if TYPE_CHECKING:
         (),
         (1.0,),
         (1.0, 2.0, "reason", 3.0),
-        (1.0, 2.0, "reason", 3.0, "room_reason", 4.0, 5.0),
+        (1.0, 2.0, "reason", 3.0, "room_reason", 4.0),
     ],
 )
 def test_thread_cache_state_row_rejects_malformed_storage_width(
     values: Sequence[float | str | None],
 ) -> None:
-    """Storage rows must match the nine-column query contract exactly."""
-    with pytest.raises(ValueError, match=r"must contain exactly 9 values, got \d+"):
+    """Storage rows must match the five-column query contract exactly."""
+    with pytest.raises(ValueError, match=r"must contain exactly 5 values, got \d+"):
         thread_cache_state_row(values)
 
 
 def test_thread_cache_state_row_treats_full_null_row_as_absent() -> None:
     """A complete outer-join miss remains an absent cache-state row."""
-    assert thread_cache_state_row((None, None, None, None, None, 0, None, None, None)) is None
+    assert thread_cache_state_row((None, None, None, None, None)) is None
+
+
+@pytest.mark.parametrize("values", [(), (1,), (1, 2, 3), (1, 2, 3, 4, 5)])
+def test_thread_revision_row_rejects_malformed_storage_width(
+    values: Sequence[float | int | None],
+) -> None:
+    """Aggregate rows must match the four-column revision query contract exactly."""
+    with pytest.raises(ValueError, match=r"must contain exactly 4 values, got \d+"):
+        thread_revision_row(values)
+
+
+@pytest.mark.parametrize("values", [None, (0, None, None, None), (1, None, 2, 3)])
+def test_thread_revision_row_treats_empty_thread_as_absent(
+    values: Sequence[float | int | None] | None,
+) -> None:
+    """Empty or partially aggregated threads never produce a revision."""
+    assert thread_revision_row(values) is None
+
+
+def test_thread_revision_row_normalizes_backend_values() -> None:
+    """Backend numeric values normalize into one integer revision."""
+    assert thread_revision_row((3, 7, 9, 1000)) == ThreadRevision(
+        event_count=3,
+        max_write_seq=7,
+        max_thread_write_seq=9,
+        max_origin_server_ts=1000,
+    )

--- a/tests/test_event_cache_semantics.py
+++ b/tests/test_event_cache_semantics.py
@@ -18,17 +18,17 @@ if TYPE_CHECKING:
         (),
         (1.0,),
         (1.0, 2.0, "reason", 3.0),
-        (1.0, 2.0, "reason", 3.0, "room_reason", 4.0),
+        (1.0, 2.0, "reason", 3.0, "room_reason", 4.0, 5.0),
     ],
 )
 def test_thread_cache_state_row_rejects_malformed_storage_width(
     values: Sequence[float | str | None],
 ) -> None:
-    """Storage rows must match the five-column query contract exactly."""
-    with pytest.raises(ValueError, match=r"must contain exactly 5 values, got \d+"):
+    """Storage rows must match the eight-column query contract exactly."""
+    with pytest.raises(ValueError, match=r"must contain exactly 8 values, got \d+"):
         thread_cache_state_row(values)
 
 
 def test_thread_cache_state_row_treats_full_null_row_as_absent() -> None:
     """A complete outer-join miss remains an absent cache-state row."""
-    assert thread_cache_state_row((None, None, None, None, None)) is None
+    assert thread_cache_state_row((None, None, None, None, None, 0, None, None)) is None

--- a/tests/test_event_cache_semantics.py
+++ b/tests/test_event_cache_semantics.py
@@ -24,11 +24,11 @@ if TYPE_CHECKING:
 def test_thread_cache_state_row_rejects_malformed_storage_width(
     values: Sequence[float | str | None],
 ) -> None:
-    """Storage rows must match the eight-column query contract exactly."""
-    with pytest.raises(ValueError, match=r"must contain exactly 8 values, got \d+"):
+    """Storage rows must match the nine-column query contract exactly."""
+    with pytest.raises(ValueError, match=r"must contain exactly 9 values, got \d+"):
         thread_cache_state_row(values)
 
 
 def test_thread_cache_state_row_treats_full_null_row_as_absent() -> None:
     """A complete outer-join miss remains an absent cache-state row."""
-    assert thread_cache_state_row((None, None, None, None, None, 0, None, None)) is None
+    assert thread_cache_state_row((None, None, None, None, None, 0, None, None, None)) is None

--- a/tests/test_thread_history.py
+++ b/tests/test_thread_history.py
@@ -133,7 +133,7 @@ class TestThreadHistory:
         }
         client = AsyncMock()
 
-        history, _sidecar_hydration_ms = await _resolve_thread_history_from_event_sources_timed(
+        resolution = await _resolve_thread_history_from_event_sources_timed(
             client,
             room_id="!room:localhost",
             thread_id="$event-0",
@@ -141,6 +141,7 @@ class TestThreadHistory:
             event_cache=event_cache,
             expected_membership_epoch=0,
         )
+        history = resolution.messages
 
         assert len(history) == sidecar_count
         event_cache.get_mxc_texts.assert_awaited_once()
@@ -1523,7 +1524,7 @@ class TestThreadHistory:
         """Same-timestamp reference descendants should sort after their related parent."""
         client = AsyncMock()
 
-        history, _sidecar_ms = await _resolve_thread_history_from_event_sources_timed(
+        resolution = await _resolve_thread_history_from_event_sources_timed(
             client,
             room_id="!room:localhost",
             thread_id="$root",
@@ -1561,6 +1562,7 @@ class TestThreadHistory:
             hydrate_sidecars=True,
             event_cache=_event_cache(),
         )
+        history = resolution.messages
 
         assert [message.event_id for message in history] == ["$root", "$zzz_parent", "$aaa_child"]
 
@@ -1721,13 +1723,14 @@ class TestThreadHistory:
             },
         )
 
-        history, _sidecar_hydration_ms = await _resolve_thread_history_from_event_sources_timed(
+        resolution = await _resolve_thread_history_from_event_sources_timed(
             client,
             room_id="!room:localhost",
             thread_id="$thread_root",
             event_sources=[_event_source_for_cache(root_event), _event_source_for_cache(edit_only_event)],
             event_cache=_event_cache(),
         )
+        history = resolution.messages
 
         assert [message.event_id for message in history] == ["$thread_root"]
 
@@ -1764,13 +1767,14 @@ class TestThreadHistory:
             "mindroom.matrix.client_visible_messages.extract_edit_body",
             new_callable=AsyncMock,
         ) as mock_extract_edit_body:
-            history, _sidecar_hydration_ms = await _resolve_thread_history_from_event_sources_timed(
+            resolution = await _resolve_thread_history_from_event_sources_timed(
                 client,
                 room_id="!room:localhost",
                 thread_id="$thread_root",
                 event_sources=[_event_source_for_cache(root_event), _event_source_for_cache(unrelated_edit)],
                 event_cache=_event_cache(),
             )
+        history = resolution.messages
 
         assert [message.event_id for message in history] == ["$thread_root"]
         mock_extract_edit_body.assert_not_awaited()
@@ -1808,13 +1812,14 @@ class TestThreadHistory:
             },
         )
 
-        history, _sidecar_hydration_ms = await _resolve_thread_history_from_event_sources_timed(
+        resolution = await _resolve_thread_history_from_event_sources_timed(
             client,
             room_id="!room:localhost",
             thread_id="$thread_root",
             event_sources=[_event_source_for_cache(root_event), _event_source_for_cache(edit_only_event)],
             event_cache=_event_cache(),
         )
+        history = resolution.messages
 
         assert [message.event_id for message in history] == ["$thread_root", "$missing_original"]
         assert history[1].body == "Final answer"

--- a/tests/test_thread_resolution_reuse.py
+++ b/tests/test_thread_resolution_reuse.py
@@ -134,6 +134,7 @@ async def _resolve(
         room_invalidation_reason=None,
         event_count=len(rows),
         max_write_seq=max_write_seq,
+        max_thread_write_seq=max_write_seq,
         max_origin_server_ts=max(int(row["origin_server_ts"]) for row in rows),
     )
     cache.get_thread_events.return_value = rows
@@ -176,6 +177,7 @@ def _guard_suffix(
         membership_epoch=EPOCH,
         event_count=snapshot.event_count + len(suffix),
         max_write_seq=snapshot.max_write_seq + len(suffix),
+        max_thread_write_seq=snapshot.max_thread_write_seq + len(suffix),
         max_origin_server_ts=max(
             snapshot.max_origin_server_ts,
             *(int(row["origin_server_ts"]) for row in suffix),
@@ -398,6 +400,7 @@ class TestSnapshotReuse:
                     room_invalidation_reason=None,
                     event_count=1,
                     max_write_seq=2,
+                    max_thread_write_seq=2,
                     max_origin_server_ts=1000,
                 ),
             )
@@ -549,6 +552,7 @@ class TestSuffixSafetyGuards:
             membership_epoch=EPOCH,
             event_count=0,
             max_write_seq=0,
+            max_thread_write_seq=0,
             max_origin_server_ts=0,
             sidecar_texts={},
         )
@@ -571,6 +575,7 @@ class TestReuseCacheBounds:
             membership_epoch=EPOCH,
             event_count=1,
             max_write_seq=1,
+            max_thread_write_seq=1,
             max_origin_server_ts=1,
             sidecar_texts={},
         )
@@ -675,4 +680,60 @@ class TestFetchPathIntegration:
             await cache.close()
 
         assert [message.body for message in second] == ["root", "updated"]
+        assert second.diagnostics["thread_resolution_reuse"] == "full"
+
+    @pytest.mark.asyncio
+    async def test_thread_reindex_forces_full_resolution_when_payload_revision_is_unchanged(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A replaced thread index cannot masquerade as an unchanged payload revision."""
+        from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache  # noqa: PLC0415
+
+        cache = SqliteEventCache(tmp_path / "event_cache.db")
+        await cache.initialize()
+        root = _message_row(THREAD, 1000, "root")
+        old_reply = _message_row("$old", 2000, "old")
+        shared_reply = _message_row("$shared", 3000, "shared")
+        new_reply = _message_row("$new", 2000, "new")
+        await cache.store_event("$new", ROOM, new_reply)
+        await replace_thread_unconditionally(cache, ROOM, THREAD, [root, old_reply, shared_reply])
+
+        client = MagicMock()
+        client.user_id = "@mindroom_general:localhost"
+        client.room_messages = AsyncMock(side_effect=AssertionError("should not refetch fresh cache"))
+        reuse = ThreadResolutionReuseCache()
+        try:
+            await fetch_thread_history(client, ROOM, THREAD, event_cache=cache, resolution_reuse=reuse)
+            before = await cache.get_thread_cache_state(ROOM, THREAD)
+            opaque_rows = [
+                {
+                    "event_id": row["event_id"],
+                    "origin_server_ts": row["origin_server_ts"],
+                    "type": "m.room.encrypted",
+                    "sender": row["sender"],
+                    "content": {"algorithm": "m.megolm.v1.aes-sha2", "ciphertext": "opaque"},
+                }
+                for row in (root, new_reply, shared_reply)
+            ]
+            await replace_thread_unconditionally(cache, ROOM, THREAD, opaque_rows)
+            after = await cache.get_thread_cache_state(ROOM, THREAD)
+            second = await fetch_thread_history(
+                client,
+                ROOM,
+                THREAD,
+                event_cache=cache,
+                resolution_reuse=reuse,
+            )
+        finally:
+            await cache.close()
+
+        assert before is not None
+        assert after is not None
+        assert before.event_count == after.event_count == 3
+        assert before.max_write_seq == after.max_write_seq
+        assert before.max_thread_write_seq is not None
+        assert after.max_thread_write_seq is not None
+        assert after.max_thread_write_seq > before.max_thread_write_seq
+        assert [message.event_id for message in second] == [THREAD, "$new", "$shared"]
         assert second.diagnostics["thread_resolution_reuse"] == "full"

--- a/tests/test_thread_resolution_reuse.py
+++ b/tests/test_thread_resolution_reuse.py
@@ -12,11 +12,10 @@ from weakref import WeakKeyDictionary
 import pytest
 
 import mindroom.matrix.client_thread_history as matrix_client_module
-from mindroom.matrix.cache import ThreadCacheState
+from mindroom.matrix.cache import ThreadCacheState, ThreadRevision
 from mindroom.matrix.client_thread_history import fetch_thread_history
 from mindroom.matrix.thread_resolution_reuse import (
     ThreadResolutionReuseCache,
-    ThreadRevision,
     build_thread_resolution_snapshot,
     reusable_event_source_suffix,
 )
@@ -151,6 +150,8 @@ async def _resolve(
         invalidation_reason=None,
         room_invalidated_at=None,
         room_invalidation_reason=None,
+    )
+    cache.get_thread_revision.return_value = ThreadRevision(
         event_count=len(rows),
         max_write_seq=max_write_seq,
         max_thread_write_seq=max_write_seq,
@@ -433,12 +434,7 @@ class TestSnapshotReuse:
                 expected_membership_epoch=EPOCH + 1,
                 trusted_sender_ids=(),
                 resolution_reuse=reuse,
-                cache_state=ThreadCacheState(
-                    validated_at=1.0,
-                    invalidated_at=None,
-                    invalidation_reason=None,
-                    room_invalidated_at=None,
-                    room_invalidation_reason=None,
+                revision=ThreadRevision(
                     event_count=1,
                     max_write_seq=2,
                     max_thread_write_seq=2,
@@ -749,7 +745,7 @@ class TestFetchPathIntegration:
         reuse = ThreadResolutionReuseCache()
         try:
             await fetch_thread_history(client, ROOM, THREAD, event_cache=cache, resolution_reuse=reuse)
-            before = await cache.get_thread_cache_state(ROOM, THREAD)
+            before = await cache.get_thread_revision(ROOM, THREAD)
             opaque_rows = [
                 {
                     "event_id": row["event_id"],
@@ -761,7 +757,7 @@ class TestFetchPathIntegration:
                 for row in (root, new_reply, shared_reply)
             ]
             await replace_thread_unconditionally(cache, ROOM, THREAD, opaque_rows)
-            after = await cache.get_thread_cache_state(ROOM, THREAD)
+            after = await cache.get_thread_revision(ROOM, THREAD)
             second = await fetch_thread_history(
                 client,
                 ROOM,
@@ -776,8 +772,6 @@ class TestFetchPathIntegration:
         assert after is not None
         assert before.event_count == after.event_count == 3
         assert before.max_write_seq == after.max_write_seq
-        assert before.max_thread_write_seq is not None
-        assert after.max_thread_write_seq is not None
         assert after.max_thread_write_seq > before.max_thread_write_seq
         assert [message.event_id for message in second] == [THREAD, "$new", "$shared"]
         assert second.diagnostics["thread_resolution_reuse"] == "full"

--- a/tests/test_thread_resolution_reuse.py
+++ b/tests/test_thread_resolution_reuse.py
@@ -16,6 +16,7 @@ from mindroom.matrix.cache import ThreadCacheState
 from mindroom.matrix.client_thread_history import fetch_thread_history
 from mindroom.matrix.thread_resolution_reuse import (
     ThreadResolutionReuseCache,
+    ThreadRevision,
     build_thread_resolution_snapshot,
     reusable_event_source_suffix,
 )
@@ -193,12 +194,14 @@ def _guard_suffix(
         suffix,
         trusted_sender_ids=frozenset(),
         membership_epoch=EPOCH,
-        event_count=snapshot.event_count + len(suffix),
-        max_write_seq=snapshot.max_write_seq + len(suffix),
-        max_thread_write_seq=snapshot.max_thread_write_seq + len(suffix),
-        max_origin_server_ts=max(
-            snapshot.max_origin_server_ts,
-            *(int(row["origin_server_ts"]) for row in suffix),
+        revision=ThreadRevision(
+            event_count=snapshot.revision.event_count + len(suffix),
+            max_write_seq=snapshot.revision.max_write_seq + len(suffix),
+            max_thread_write_seq=snapshot.revision.max_thread_write_seq + len(suffix),
+            max_origin_server_ts=max(
+                snapshot.revision.max_origin_server_ts,
+                *(int(row["origin_server_ts"]) for row in suffix),
+            ),
         ),
     )
 
@@ -420,7 +423,7 @@ class TestSnapshotReuse:
             "_resolve_thread_history_from_event_sources_timed",
             AsyncMock(side_effect=ValueError("corrupt cached payload")),
         ):
-            messages, _sidecar_ms, kind = await matrix_client_module._resolve_cached_thread_history(
+            messages, _sidecar_ms = await matrix_client_module._resolve_cached_thread_history(
                 AsyncMock(),
                 room_id=ROOM,
                 thread_id=THREAD,
@@ -444,7 +447,6 @@ class TestSnapshotReuse:
             )
 
         assert messages is None
-        assert kind == "full"
         assert reuse.get(ROOM, THREAD) is None
         event_cache.invalidate_thread.assert_awaited_with(ROOM, THREAD)
 
@@ -588,10 +590,12 @@ class TestSuffixSafetyGuards:
             related_event_id_by_event_id={},
             trusted_sender_ids=frozenset(),
             membership_epoch=EPOCH,
-            event_count=0,
-            max_write_seq=0,
-            max_thread_write_seq=0,
-            max_origin_server_ts=0,
+            revision=ThreadRevision(
+                event_count=0,
+                max_write_seq=0,
+                max_thread_write_seq=0,
+                max_origin_server_ts=0,
+            ),
             sidecar_texts={},
         )
         missing_id = {"origin_server_ts": 1000, "type": "m.room.message", "content": {}}
@@ -611,10 +615,12 @@ class TestReuseCacheBounds:
             related_event_id_by_event_id={},
             trusted_sender_ids=frozenset(),
             membership_epoch=EPOCH,
-            event_count=1,
-            max_write_seq=1,
-            max_thread_write_seq=1,
-            max_origin_server_ts=1,
+            revision=ThreadRevision(
+                event_count=1,
+                max_write_seq=1,
+                max_thread_write_seq=1,
+                max_origin_server_ts=1,
+            ),
             sidecar_texts={},
         )
 

--- a/tests/test_thread_resolution_reuse.py
+++ b/tests/test_thread_resolution_reuse.py
@@ -1,0 +1,555 @@
+"""Tests for process-local reuse of resolved thread history across durable-cache reads."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import mindroom.matrix.client_thread_history as matrix_client_module
+from mindroom.matrix.client_thread_history import fetch_thread_history
+from mindroom.matrix.thread_resolution_reuse import (
+    ThreadResolutionReuseCache,
+    build_thread_resolution_snapshot,
+    reusable_event_source_suffix,
+)
+from tests.conftest import make_event_cache_mock
+from tests.event_cache_test_support import replace_thread_unconditionally
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import nio
+
+    from mindroom.matrix.client_thread_history import _ResolvedThreadEventSources
+    from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
+    from mindroom.matrix.thread_resolution_reuse import ThreadResolutionSnapshot
+
+ROOM = "!room:localhost"
+THREAD = "$root"
+EPOCH = 1
+
+
+def _message_row(
+    event_id: str,
+    timestamp: int,
+    body: str,
+    *,
+    sender: str = "@user:localhost",
+) -> dict[str, Any]:
+    content: dict[str, Any] = {"msgtype": "m.text", "body": body}
+    if event_id != THREAD:
+        content["m.relates_to"] = {"rel_type": "m.thread", "event_id": THREAD}
+    return {
+        "event_id": event_id,
+        "origin_server_ts": timestamp,
+        "type": "m.room.message",
+        "sender": sender,
+        "content": content,
+    }
+
+
+def _edit_row(
+    event_id: str,
+    timestamp: int,
+    *,
+    target: str,
+    body: str,
+    sender: str = "@user:localhost",
+) -> dict[str, Any]:
+    return {
+        "event_id": event_id,
+        "origin_server_ts": timestamp,
+        "type": "m.room.message",
+        "sender": sender,
+        "content": {
+            "msgtype": "m.text",
+            "body": f"* {body}",
+            "m.new_content": {
+                "msgtype": "m.text",
+                "body": body,
+                "m.relates_to": {"rel_type": "m.thread", "event_id": THREAD},
+            },
+            "m.relates_to": {"rel_type": "m.replace", "event_id": target},
+        },
+    }
+
+
+def _sidecar_row(event_id: str, timestamp: int) -> dict[str, Any]:
+    return {
+        "event_id": event_id,
+        "origin_server_ts": timestamp,
+        "type": "m.room.message",
+        "sender": "@agent:localhost",
+        "content": {
+            "msgtype": "m.file",
+            "body": "Preview",
+            "io.mindroom.long_text": {"version": 2, "encoding": "matrix_event_content_json"},
+            "url": f"mxc://server/sidecar-{event_id.lstrip('$')}",
+            "m.relates_to": {"rel_type": "m.thread", "event_id": THREAD},
+        },
+    }
+
+
+async def _resolve(
+    rows: list[dict[str, Any]],
+    *,
+    reuse: ThreadResolutionReuseCache | None,
+    epoch: int = EPOCH,
+    trusted: tuple[str, ...] = (),
+    hydrate_sidecars: bool = True,
+    event_cache: AsyncMock | None = None,
+    thread_id: str = THREAD,
+) -> tuple[list[ResolvedVisibleMessage], str]:
+    messages, _sidecar_ms, kind = await matrix_client_module._resolve_cached_thread_history(
+        AsyncMock(),
+        room_id=ROOM,
+        thread_id=thread_id,
+        event_cache=event_cache if event_cache is not None else make_event_cache_mock(),
+        cached_event_sources=rows,
+        hydrate_sidecars=hydrate_sidecars,
+        expected_membership_epoch=epoch,
+        trusted_sender_ids=trusted,
+        resolution_reuse=reuse,
+    )
+    assert messages is not None
+    return messages, kind
+
+
+def _counting_resolver() -> tuple[Any, list[int]]:
+    """Wrap the raw-row resolver to record how many rows each invocation resolves."""
+    original = matrix_client_module._resolve_thread_history_from_event_sources_timed
+    resolved_row_counts: list[int] = []
+
+    async def wrapper(client: nio.AsyncClient, **kwargs: Any) -> _ResolvedThreadEventSources:  # noqa: ANN401
+        resolved_row_counts.append(len(kwargs["event_sources"]))
+        return await original(client, **kwargs)
+
+    return wrapper, resolved_row_counts
+
+
+class TestSnapshotReuse:
+    """Reuse and incremental resolution through `_resolve_cached_thread_history`."""
+
+    @pytest.mark.asyncio
+    async def test_unchanged_thread_serves_snapshot_without_reresolution(self) -> None:
+        """An identical second read serves the snapshot without re-resolving any rows."""
+        rows = [_message_row(THREAD, 1000, "root"), _message_row("$m1", 2000, "first reply")]
+        reuse = ThreadResolutionReuseCache()
+        wrapper, resolved_row_counts = _counting_resolver()
+
+        with patch.object(matrix_client_module, "_resolve_thread_history_from_event_sources_timed", wrapper):
+            first, first_kind = await _resolve(rows, reuse=reuse)
+            second, second_kind = await _resolve(rows, reuse=reuse)
+
+        assert first_kind == "full"
+        assert second_kind == "reuse"
+        assert second == first
+        assert resolved_row_counts == [2]
+
+    @pytest.mark.asyncio
+    async def test_reused_messages_are_caller_owned_copies(self) -> None:
+        """Mutating a returned history must not corrupt the stored snapshot."""
+        rows = [_message_row(THREAD, 1000, "root")]
+        reuse = ThreadResolutionReuseCache()
+
+        first, _ = await _resolve(rows, reuse=reuse)
+        first[0].body = "mutated"
+        first[0].content["body"] = "mutated"
+
+        second, kind = await _resolve(rows, reuse=reuse)
+        assert kind == "reuse"
+        assert second[0].body == "root"
+        assert second[0].content["body"] == "root"
+
+    @pytest.mark.asyncio
+    async def test_appended_message_resolves_only_suffix(self) -> None:
+        """One appended message re-resolves only the suffix and matches a full resolve."""
+        rows = [_message_row(THREAD, 1000, "root"), _message_row("$m1", 2000, "first")]
+        grown = [*rows, _message_row("$m2", 3000, "second", sender="@agent:localhost")]
+        reuse = ThreadResolutionReuseCache()
+        wrapper, resolved_row_counts = _counting_resolver()
+
+        with patch.object(matrix_client_module, "_resolve_thread_history_from_event_sources_timed", wrapper):
+            await _resolve(rows, reuse=reuse)
+            incremental, kind = await _resolve(grown, reuse=reuse)
+        full, _ = await _resolve(grown, reuse=None)
+
+        assert kind == "incremental"
+        assert incremental == full
+        assert [message.event_id for message in incremental] == [THREAD, "$m1", "$m2"]
+        assert resolved_row_counts == [2, 1]
+
+    @pytest.mark.asyncio
+    async def test_appended_edit_of_existing_message_forces_full_and_applies(self) -> None:
+        """An edit targeting a snapshot message falls back to full resolution and applies."""
+        rows = [_message_row(THREAD, 1000, "root"), _message_row("$m1", 2000, "draft")]
+        grown = [*rows, _edit_row("$e1", 3000, target="$m1", body="final")]
+        reuse = ThreadResolutionReuseCache()
+
+        await _resolve(rows, reuse=reuse)
+        edited, kind = await _resolve(grown, reuse=reuse)
+        full, _ = await _resolve(grown, reuse=None)
+
+        assert kind == "full"
+        assert edited == full
+        assert [message.body for message in edited] == ["root", "final"]
+
+    @pytest.mark.asyncio
+    async def test_redaction_pruned_row_forces_full(self) -> None:
+        """A row removed from the durable cache (redaction) invalidates the snapshot."""
+        rows = [
+            _message_row(THREAD, 1000, "root"),
+            _message_row("$m1", 2000, "kept"),
+            _message_row("$m2", 3000, "redacted later"),
+        ]
+        pruned = [rows[0], rows[1]]
+        reuse = ThreadResolutionReuseCache()
+
+        await _resolve(rows, reuse=reuse)
+        after, kind = await _resolve(pruned, reuse=reuse)
+
+        assert kind == "full"
+        assert [message.event_id for message in after] == [THREAD, "$m1"]
+
+    @pytest.mark.asyncio
+    async def test_in_place_row_change_forces_full(self) -> None:
+        """A changed prefix row breaks prefix equality and forces full resolution."""
+        rows = [_message_row(THREAD, 1000, "root"), _message_row("$m1", 2000, "original")]
+        changed = [rows[0], _message_row("$m1", 2000, "rewritten")]
+        reuse = ThreadResolutionReuseCache()
+
+        await _resolve(rows, reuse=reuse)
+        after, kind = await _resolve(changed, reuse=reuse)
+
+        assert kind == "full"
+        assert after[1].body == "rewritten"
+
+    @pytest.mark.asyncio
+    async def test_membership_epoch_change_forces_full(self) -> None:
+        """A membership-epoch change invalidates any prior snapshot."""
+        rows = [_message_row(THREAD, 1000, "root")]
+        reuse = ThreadResolutionReuseCache()
+
+        await _resolve(rows, reuse=reuse, epoch=1)
+        _, kind = await _resolve(rows, reuse=reuse, epoch=2)
+
+        assert kind == "full"
+
+    @pytest.mark.asyncio
+    async def test_trusted_sender_change_forces_full(self) -> None:
+        """A different trusted-sender set (identity change) invalidates the snapshot."""
+        rows = [_message_row(THREAD, 1000, "root")]
+        reuse = ThreadResolutionReuseCache()
+
+        await _resolve(rows, reuse=reuse, trusted=("@mindroom_a:localhost",))
+        _, kind = await _resolve(rows, reuse=reuse, trusted=("@mindroom_b:localhost",))
+
+        assert kind == "full"
+
+    @pytest.mark.asyncio
+    async def test_threads_do_not_share_snapshots(self) -> None:
+        """Snapshots are keyed per thread; a different thread never reuses them."""
+        rows = [_message_row(THREAD, 1000, "root")]
+        reuse = ThreadResolutionReuseCache()
+
+        await _resolve(rows, reuse=reuse, thread_id=THREAD)
+        _, kind = await _resolve(rows, reuse=reuse, thread_id="$other_root")
+
+        assert kind == "full"
+
+    @pytest.mark.asyncio
+    async def test_snapshot_mode_read_never_uses_or_stores_reuse(self) -> None:
+        """Reads with ``hydrate_sidecars=False`` neither use nor populate the reuse cache."""
+        rows = [_message_row(THREAD, 1000, "root")]
+        reuse = ThreadResolutionReuseCache()
+
+        _, first_kind = await _resolve(rows, reuse=reuse, hydrate_sidecars=False)
+        _, second_kind = await _resolve(rows, reuse=reuse, hydrate_sidecars=False)
+        _, hydrated_kind = await _resolve(rows, reuse=reuse, hydrate_sidecars=True)
+
+        assert first_kind == "full"
+        assert second_kind == "full"
+        assert hydrated_kind == "full"
+
+    @pytest.mark.asyncio
+    async def test_incomplete_sidecar_hydration_is_never_frozen(self) -> None:
+        """Histories with unhydrated sidecar references are never stored for reuse."""
+        rows = [_message_row(THREAD, 1000, "root"), _sidecar_row("$m1", 2000)]
+        reuse = ThreadResolutionReuseCache()
+        event_cache = make_event_cache_mock()
+        event_cache.get_mxc_texts.return_value = {}
+
+        _, first_kind = await _resolve(rows, reuse=reuse, event_cache=event_cache)
+        _, second_kind = await _resolve(rows, reuse=reuse, event_cache=event_cache)
+
+        assert first_kind == "full"
+        assert second_kind == "full"
+
+    @pytest.mark.asyncio
+    async def test_resolution_failure_discards_snapshot_and_invalidates(self) -> None:
+        """A resolution failure drops the snapshot alongside the durable cache entry."""
+        rows = [_message_row(THREAD, 1000, "root")]
+        reuse = ThreadResolutionReuseCache()
+        event_cache = make_event_cache_mock()
+
+        await _resolve(rows, reuse=reuse, event_cache=event_cache)
+        assert reuse.get(ROOM, THREAD) is not None
+
+        with patch.object(
+            matrix_client_module,
+            "_resolve_thread_history_from_event_sources_timed",
+            AsyncMock(side_effect=ValueError("corrupt cached payload")),
+        ):
+            messages, _sidecar_ms, kind = await matrix_client_module._resolve_cached_thread_history(
+                AsyncMock(),
+                room_id=ROOM,
+                thread_id=THREAD,
+                event_cache=event_cache,
+                cached_event_sources=rows,
+                hydrate_sidecars=True,
+                expected_membership_epoch=EPOCH + 1,
+                trusted_sender_ids=(),
+                resolution_reuse=reuse,
+            )
+
+        assert messages is None
+        assert kind == "full"
+        assert reuse.get(ROOM, THREAD) is None
+        event_cache.invalidate_thread.assert_awaited_with(ROOM, THREAD)
+
+    @pytest.mark.asyncio
+    async def test_concurrent_same_thread_reads_return_identical_histories(self) -> None:
+        """Concurrent same-thread reads all match a full resolve, before and after growth."""
+        rows = [_message_row(THREAD, 1000, "root")]
+        rows += [_message_row(f"$m{index}", 1001 + index, f"body {index}") for index in range(19)]
+        reuse = ThreadResolutionReuseCache()
+
+        results = await asyncio.gather(*(_resolve(rows, reuse=reuse) for _ in range(4)))
+        full, _ = await _resolve(rows, reuse=None)
+
+        for messages, _kind in results:
+            assert messages == full
+
+        grown = [*rows, _message_row("$late", 9000, "late reply")]
+        after, _kind = await _resolve(grown, reuse=reuse)
+        full_after, _ = await _resolve(grown, reuse=None)
+        assert after == full_after
+
+    @pytest.mark.asyncio
+    async def test_incremental_reuse_matches_full_resolution_across_growth(self) -> None:
+        """Every growth step (replies, streaming edits, redaction) matches a fresh full resolve."""
+        reuse = ThreadResolutionReuseCache()
+        rows: list[dict[str, Any]] = [_message_row(THREAD, 1000, "root")]
+        steps: list[list[dict[str, Any]]] = [list(rows)]
+        rows.append(_message_row("$a1", 2000, "thinking...", sender="@agent:localhost"))
+        steps.append(list(rows))
+        for index in range(3):
+            rows.append(
+                _edit_row(
+                    f"$a1-edit-{index}",
+                    2100 + index,
+                    target="$a1",
+                    body=f"draft {index}",
+                    sender="@agent:localhost",
+                ),
+            )
+            steps.append(list(rows))
+        rows.append(_message_row("$u2", 3000, "user follow-up"))
+        steps.append(list(rows))
+        rows = [row for row in rows if row["event_id"] != "$u2"]  # redaction pruning
+        steps.append(list(rows))
+        rows.append(_message_row("$a2", 4000, "second answer", sender="@agent:localhost"))
+        steps.append(list(rows))
+
+        for step_rows in steps:
+            with_reuse, _kind = await _resolve(step_rows, reuse=reuse)
+            without_reuse, _ = await _resolve(step_rows, reuse=None)
+            assert with_reuse == without_reuse
+
+
+class TestSuffixSafetyGuards:
+    """Direct guard checks on `reusable_event_source_suffix`."""
+
+    async def _snapshot(self, rows: list[dict[str, Any]]) -> ThreadResolutionSnapshot:
+        reuse = ThreadResolutionReuseCache()
+        await _resolve(rows, reuse=reuse)
+        snapshot = reuse.get(ROOM, THREAD)
+        assert snapshot is not None
+        return snapshot
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_message_suffix_row(self) -> None:
+        """Any non-``m.room.message`` suffix row rejects reuse."""
+        rows = [_message_row(THREAD, 1000, "root")]
+        snapshot = await self._snapshot(rows)
+        redaction = {
+            "event_id": "$r1",
+            "origin_server_ts": 2000,
+            "type": "m.room.redaction",
+            "sender": "@user:localhost",
+            "redacts": THREAD,
+            "content": {},
+        }
+
+        suffix = reusable_event_source_suffix(
+            snapshot,
+            [*rows, redaction],
+            trusted_sender_ids=frozenset(),
+            membership_epoch=EPOCH,
+        )
+        assert suffix is None
+
+    @pytest.mark.asyncio
+    async def test_rejects_duplicate_and_known_suffix_event_ids(self) -> None:
+        """Suffix rows replaying known IDs or duplicating each other reject reuse."""
+        rows = [_message_row(THREAD, 1000, "root"), _message_row("$m1", 2000, "reply")]
+        snapshot = await self._snapshot(rows)
+
+        replayed_known = reusable_event_source_suffix(
+            snapshot,
+            [*rows, _message_row("$m1", 3000, "replayed")],
+            trusted_sender_ids=frozenset(),
+            membership_epoch=EPOCH,
+        )
+        duplicated_new = reusable_event_source_suffix(
+            snapshot,
+            [*rows, _message_row("$m2", 3000, "one"), _message_row("$m2", 3100, "two")],
+            trusted_sender_ids=frozenset(),
+            membership_epoch=EPOCH,
+        )
+        assert replayed_known is None
+        assert duplicated_new is None
+
+    @pytest.mark.asyncio
+    async def test_rejects_suffix_row_reusing_synthesized_edit_target(self) -> None:
+        """A suffix row must not reuse the original ID of a prefix edit whose original was missing."""
+        rows = [
+            _message_row(THREAD, 1000, "root"),
+            _edit_row("$e1", 2000, target="$missing_original", body="synthesized"),
+        ]
+        snapshot = await self._snapshot(rows)
+
+        suffix = reusable_event_source_suffix(
+            snapshot,
+            [*rows, _message_row("$missing_original", 3000, "late arrival")],
+            trusted_sender_ids=frozenset(),
+            membership_epoch=EPOCH,
+        )
+        assert suffix is None
+
+    @pytest.mark.asyncio
+    async def test_rejects_bundled_replacement_targeting_prefix_message(self) -> None:
+        """A bundled ``m.replace`` aggregation targeting a prefix message rejects reuse."""
+        rows = [_message_row(THREAD, 1000, "root"), _message_row("$m1", 2000, "draft")]
+        snapshot = await self._snapshot(rows)
+        bundled = _message_row("$m2", 3000, "new message")
+        bundled["unsigned"] = {
+            "m.relations": {
+                "m.replace": {
+                    "event": {
+                        "event_id": "$agg-edit",
+                        "type": "m.room.message",
+                        "sender": "@user:localhost",
+                        "origin_server_ts": 3100,
+                        "content": {
+                            "msgtype": "m.text",
+                            "body": "* rewritten",
+                            "m.new_content": {"msgtype": "m.text", "body": "rewritten"},
+                            "m.relates_to": {"rel_type": "m.replace", "event_id": "$m1"},
+                        },
+                    },
+                },
+            },
+        }
+
+        suffix = reusable_event_source_suffix(
+            snapshot,
+            [*rows, bundled],
+            trusted_sender_ids=frozenset(),
+            membership_epoch=EPOCH,
+        )
+        assert suffix is None
+
+    def test_rejects_rows_without_string_event_id(self) -> None:
+        """Suffix rows lacking a string event ID reject reuse."""
+        snapshot = build_thread_resolution_snapshot(
+            event_sources=[],
+            messages=[],
+            input_order_by_event_id={},
+            related_event_id_by_event_id={},
+            trusted_sender_ids=frozenset(),
+            membership_epoch=EPOCH,
+        )
+        missing_id = {"origin_server_ts": 1000, "type": "m.room.message", "content": {}}
+
+        suffix = reusable_event_source_suffix(
+            snapshot,
+            [missing_id],
+            trusted_sender_ids=frozenset(),
+            membership_epoch=EPOCH,
+        )
+        assert suffix is None
+
+
+class TestReuseCacheBounds:
+    """LRU behavior of the per-bot reuse cache."""
+
+    def _snapshot(self) -> ThreadResolutionSnapshot:
+        return build_thread_resolution_snapshot(
+            event_sources=[],
+            messages=[],
+            input_order_by_event_id={},
+            related_event_id_by_event_id={},
+            trusted_sender_ids=frozenset(),
+            membership_epoch=EPOCH,
+        )
+
+    def test_evicts_least_recently_used_beyond_cap(self) -> None:
+        """The cache keeps at most ``max_entries`` snapshots, evicting the least recent."""
+        cache = ThreadResolutionReuseCache(max_entries=2)
+        cache.store(ROOM, "$t1", self._snapshot())
+        cache.store(ROOM, "$t2", self._snapshot())
+        assert cache.get(ROOM, "$t1") is not None  # refresh recency
+        cache.store(ROOM, "$t3", self._snapshot())
+
+        assert cache.get(ROOM, "$t2") is None
+        assert cache.get(ROOM, "$t1") is not None
+        assert cache.get(ROOM, "$t3") is not None
+
+    def test_discard_removes_entry(self) -> None:
+        """``discard`` removes a stored snapshot."""
+        cache = ThreadResolutionReuseCache()
+        cache.store(ROOM, "$t1", self._snapshot())
+        cache.discard(ROOM, "$t1")
+        assert cache.get(ROOM, "$t1") is None
+
+
+class TestFetchPathIntegration:
+    """End-to-end plumbing through the public fetch helpers and a real durable cache."""
+
+    @pytest.mark.asyncio
+    async def test_fetch_thread_history_reports_reuse_on_unchanged_thread(self, tmp_path: Path) -> None:
+        """A second unchanged fetch through the public helper reports snapshot reuse."""
+        from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache  # noqa: PLC0415
+
+        cache = SqliteEventCache(tmp_path / "event_cache.db")
+        await cache.initialize()
+        rows = [_message_row(THREAD, 1000, "root"), _message_row("$m1", 2000, "reply")]
+        await replace_thread_unconditionally(cache, ROOM, THREAD, rows)
+
+        client = MagicMock()
+        client.user_id = "@mindroom_general:localhost"
+        client.room_messages = AsyncMock(side_effect=AssertionError("should not refetch fresh cache"))
+        reuse = ThreadResolutionReuseCache()
+        try:
+            first = await fetch_thread_history(client, ROOM, THREAD, event_cache=cache, resolution_reuse=reuse)
+            second = await fetch_thread_history(client, ROOM, THREAD, event_cache=cache, resolution_reuse=reuse)
+        finally:
+            await cache.close()
+
+        assert list(second) == list(first)
+        assert first.diagnostics["thread_resolution_reuse"] == "full"
+        assert second.diagnostics["thread_resolution_reuse"] == "reuse"

--- a/tests/test_thread_resolution_reuse.py
+++ b/tests/test_thread_resolution_reuse.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import json
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, patch
+from weakref import WeakKeyDictionary
 
 import pytest
 
@@ -32,6 +34,17 @@ if TYPE_CHECKING:
 ROOM = "!room:localhost"
 THREAD = "$root"
 EPOCH = 1
+
+
+@dataclass(slots=True)
+class _SyntheticDurableState:
+    """Durable revision state used by the unit-test cache simulation."""
+
+    rows: list[dict[str, Any]] | None = None
+    write_seq: int = 0
+
+
+_SYNTHETIC_DURABLE_STATES: WeakKeyDictionary[ThreadResolutionReuseCache, _SyntheticDurableState] = WeakKeyDictionary()
 
 
 def _message_row(
@@ -106,8 +119,13 @@ async def _resolve(
     thread_id: str = THREAD,
 ) -> tuple[list[ResolvedVisibleMessage], str]:
     cache = event_cache if event_cache is not None else make_event_cache_mock()
-    previous_rows = getattr(reuse, "_test_rows", None) if reuse is not None else None
-    previous_write_seq = getattr(reuse, "_test_write_seq", 0) if reuse is not None else 0
+    synthetic_state = (
+        _SYNTHETIC_DURABLE_STATES.setdefault(reuse, _SyntheticDurableState())
+        if reuse is not None
+        else _SyntheticDurableState()
+    )
+    previous_rows = synthetic_state.rows
+    previous_write_seq = synthetic_state.write_seq
     if previous_rows == rows:
         max_write_seq = previous_write_seq
         suffix: list[dict[str, Any]] = []
@@ -122,8 +140,8 @@ async def _resolve(
         suffix = []
         max_write_seq = previous_write_seq + max(len(rows), 1)
     if reuse is not None:
-        reuse._test_rows = list(rows)  # type: ignore[attr-defined]
-        reuse._test_write_seq = max_write_seq  # type: ignore[attr-defined]
+        synthetic_state.rows = list(rows)
+        synthetic_state.write_seq = max_write_seq
 
     cache.room_membership_epoch.return_value = epoch
     cache.get_thread_cache_state.return_value = ThreadCacheState(

--- a/tests/test_thread_resolution_reuse.py
+++ b/tests/test_thread_resolution_reuse.py
@@ -386,6 +386,26 @@ class TestSnapshotReuse:
         assert second_kind == "full"
 
     @pytest.mark.asyncio
+    async def test_non_growing_revision_skips_preliminary_sidecar_check(self) -> None:
+        """A known full fallback should hydrate sidecars only during full resolution."""
+        rows = [_message_row(THREAD, 1000, "root"), _sidecar_row("$m1", 2000)]
+        changed = [_message_row(THREAD, 1000, "rewritten"), rows[1]]
+        reuse = ThreadResolutionReuseCache()
+        event_cache = make_event_cache_mock()
+        reference = ("$m1", "mxc://server/sidecar-m1")
+        event_cache.get_mxc_texts.return_value = {
+            reference: json.dumps({"msgtype": "m.text", "body": "sidecar body"}),
+        }
+
+        await _resolve(rows, reuse=reuse, event_cache=event_cache)
+        event_cache.get_mxc_texts.reset_mock()
+        second, second_kind = await _resolve(changed, reuse=reuse, event_cache=event_cache)
+
+        assert second_kind == "full"
+        assert second[0].body == "rewritten"
+        event_cache.get_mxc_texts.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_resolution_failure_discards_snapshot_and_invalidates(self) -> None:
         """A resolution failure drops the snapshot alongside the durable cache entry."""
         rows = [_message_row(THREAD, 1000, "root")]

--- a/tests/test_thread_resolution_reuse.py
+++ b/tests/test_thread_resolution_reuse.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 import mindroom.matrix.client_thread_history as matrix_client_module
+from mindroom.matrix.cache import ThreadCacheState
 from mindroom.matrix.client_thread_history import fetch_thread_history
 from mindroom.matrix.thread_resolution_reuse import (
     ThreadResolutionReuseCache,
@@ -103,19 +105,51 @@ async def _resolve(
     event_cache: AsyncMock | None = None,
     thread_id: str = THREAD,
 ) -> tuple[list[ResolvedVisibleMessage], str]:
-    messages, _sidecar_ms, kind = await matrix_client_module._resolve_cached_thread_history(
+    cache = event_cache if event_cache is not None else make_event_cache_mock()
+    previous_rows = getattr(reuse, "_test_rows", None) if reuse is not None else None
+    previous_write_seq = getattr(reuse, "_test_write_seq", 0) if reuse is not None else 0
+    if previous_rows == rows:
+        max_write_seq = previous_write_seq
+        suffix: list[dict[str, Any]] = []
+    elif (
+        isinstance(previous_rows, list)
+        and len(rows) > len(previous_rows)
+        and rows[: len(previous_rows)] == previous_rows
+    ):
+        suffix = rows[len(previous_rows) :]
+        max_write_seq = previous_write_seq + len(suffix)
+    else:
+        suffix = []
+        max_write_seq = previous_write_seq + max(len(rows), 1)
+    if reuse is not None:
+        reuse._test_rows = list(rows)  # type: ignore[attr-defined]
+        reuse._test_write_seq = max_write_seq  # type: ignore[attr-defined]
+
+    cache.room_membership_epoch.return_value = epoch
+    cache.get_thread_cache_state.return_value = ThreadCacheState(
+        validated_at=1.0,
+        invalidated_at=None,
+        invalidation_reason=None,
+        room_invalidated_at=None,
+        room_invalidation_reason=None,
+        event_count=len(rows),
+        max_write_seq=max_write_seq,
+        max_origin_server_ts=max(int(row["origin_server_ts"]) for row in rows),
+    )
+    cache.get_thread_events.return_value = rows
+    cache.get_thread_events_written_between.return_value = suffix
+    result, rejection = await matrix_client_module._load_cached_thread_history_if_usable(
         AsyncMock(),
         room_id=ROOM,
         thread_id=thread_id,
-        event_cache=event_cache if event_cache is not None else make_event_cache_mock(),
-        cached_event_sources=rows,
+        event_cache=cache,
         hydrate_sidecars=hydrate_sidecars,
-        expected_membership_epoch=epoch,
         trusted_sender_ids=trusted,
         resolution_reuse=reuse,
     )
-    assert messages is not None
-    return messages, kind
+    assert rejection is None
+    assert result is not None
+    return list(result), str(result.diagnostics["thread_resolution_reuse"])
 
 
 def _counting_resolver() -> tuple[Any, list[int]]:
@@ -128,6 +162,25 @@ def _counting_resolver() -> tuple[Any, list[int]]:
         return await original(client, **kwargs)
 
     return wrapper, resolved_row_counts
+
+
+def _guard_suffix(
+    snapshot: ThreadResolutionSnapshot,
+    suffix: list[dict[str, Any]],
+) -> list[dict[str, Any]] | None:
+    """Apply the append-only guard with a matching synthetic durable revision."""
+    return reusable_event_source_suffix(
+        snapshot,
+        suffix,
+        trusted_sender_ids=frozenset(),
+        membership_epoch=EPOCH,
+        event_count=snapshot.event_count + len(suffix),
+        max_write_seq=snapshot.max_write_seq + len(suffix),
+        max_origin_server_ts=max(
+            snapshot.max_origin_server_ts,
+            *(int(row["origin_server_ts"]) for row in suffix),
+        ),
+    )
 
 
 class TestSnapshotReuse:
@@ -152,17 +205,19 @@ class TestSnapshotReuse:
     @pytest.mark.asyncio
     async def test_reused_messages_are_caller_owned_copies(self) -> None:
         """Mutating a returned history must not corrupt the stored snapshot."""
-        rows = [_message_row(THREAD, 1000, "root")]
+        rows = [_message_row(THREAD, 1000, "root"), _message_row("$m1", 2000, "reply")]
         reuse = ThreadResolutionReuseCache()
 
         first, _ = await _resolve(rows, reuse=reuse)
         first[0].body = "mutated"
         first[0].content["body"] = "mutated"
+        first[1].content["m.relates_to"]["event_id"] = "$mutated"
 
         second, kind = await _resolve(rows, reuse=reuse)
         assert kind == "reuse"
         assert second[0].body == "root"
         assert second[0].content["body"] == "root"
+        assert second[1].content["m.relates_to"]["event_id"] == THREAD
 
     @pytest.mark.asyncio
     async def test_appended_message_resolves_only_suffix(self) -> None:
@@ -256,7 +311,8 @@ class TestSnapshotReuse:
         reuse = ThreadResolutionReuseCache()
 
         await _resolve(rows, reuse=reuse, thread_id=THREAD)
-        _, kind = await _resolve(rows, reuse=reuse, thread_id="$other_root")
+        other_rows = [{**rows[0], "event_id": "$other_root"}]
+        _, kind = await _resolve(other_rows, reuse=reuse, thread_id="$other_root")
 
         assert kind == "full"
 
@@ -289,6 +345,27 @@ class TestSnapshotReuse:
         assert second_kind == "full"
 
     @pytest.mark.asyncio
+    async def test_changed_sidecar_text_forces_full_resolution(self) -> None:
+        """Exact reuse verifies sidecar plaintext dependencies before serving a snapshot."""
+        rows = [_message_row(THREAD, 1000, "root"), _sidecar_row("$m1", 2000)]
+        reuse = ThreadResolutionReuseCache()
+        event_cache = make_event_cache_mock()
+        reference = ("$m1", "mxc://server/sidecar-m1")
+        event_cache.get_mxc_texts.return_value = {
+            reference: json.dumps({"msgtype": "m.text", "body": "first body"}),
+        }
+
+        first, _first_kind = await _resolve(rows, reuse=reuse, event_cache=event_cache)
+        event_cache.get_mxc_texts.return_value = {
+            reference: json.dumps({"msgtype": "m.text", "body": "second body"}),
+        }
+        second, second_kind = await _resolve(rows, reuse=reuse, event_cache=event_cache)
+
+        assert first[1].body == "first body"
+        assert second[1].body == "second body"
+        assert second_kind == "full"
+
+    @pytest.mark.asyncio
     async def test_resolution_failure_discards_snapshot_and_invalidates(self) -> None:
         """A resolution failure drops the snapshot alongside the durable cache entry."""
         rows = [_message_row(THREAD, 1000, "root")]
@@ -313,6 +390,16 @@ class TestSnapshotReuse:
                 expected_membership_epoch=EPOCH + 1,
                 trusted_sender_ids=(),
                 resolution_reuse=reuse,
+                cache_state=ThreadCacheState(
+                    validated_at=1.0,
+                    invalidated_at=None,
+                    invalidation_reason=None,
+                    room_invalidated_at=None,
+                    room_invalidation_reason=None,
+                    event_count=1,
+                    max_write_seq=2,
+                    max_origin_server_ts=1000,
+                ),
             )
 
         assert messages is None
@@ -394,12 +481,7 @@ class TestSuffixSafetyGuards:
             "content": {},
         }
 
-        suffix = reusable_event_source_suffix(
-            snapshot,
-            [*rows, redaction],
-            trusted_sender_ids=frozenset(),
-            membership_epoch=EPOCH,
-        )
+        suffix = _guard_suffix(snapshot, [redaction])
         assert suffix is None
 
     @pytest.mark.asyncio
@@ -408,17 +490,10 @@ class TestSuffixSafetyGuards:
         rows = [_message_row(THREAD, 1000, "root"), _message_row("$m1", 2000, "reply")]
         snapshot = await self._snapshot(rows)
 
-        replayed_known = reusable_event_source_suffix(
+        replayed_known = _guard_suffix(snapshot, [_message_row("$m1", 3000, "replayed")])
+        duplicated_new = _guard_suffix(
             snapshot,
-            [*rows, _message_row("$m1", 3000, "replayed")],
-            trusted_sender_ids=frozenset(),
-            membership_epoch=EPOCH,
-        )
-        duplicated_new = reusable_event_source_suffix(
-            snapshot,
-            [*rows, _message_row("$m2", 3000, "one"), _message_row("$m2", 3100, "two")],
-            trusted_sender_ids=frozenset(),
-            membership_epoch=EPOCH,
+            [_message_row("$m2", 3000, "one"), _message_row("$m2", 3100, "two")],
         )
         assert replayed_known is None
         assert duplicated_new is None
@@ -432,12 +507,7 @@ class TestSuffixSafetyGuards:
         ]
         snapshot = await self._snapshot(rows)
 
-        suffix = reusable_event_source_suffix(
-            snapshot,
-            [*rows, _message_row("$missing_original", 3000, "late arrival")],
-            trusted_sender_ids=frozenset(),
-            membership_epoch=EPOCH,
-        )
+        suffix = _guard_suffix(snapshot, [_message_row("$missing_original", 3000, "late arrival")])
         assert suffix is None
 
     @pytest.mark.asyncio
@@ -465,12 +535,7 @@ class TestSuffixSafetyGuards:
             },
         }
 
-        suffix = reusable_event_source_suffix(
-            snapshot,
-            [*rows, bundled],
-            trusted_sender_ids=frozenset(),
-            membership_epoch=EPOCH,
-        )
+        suffix = _guard_suffix(snapshot, [bundled])
         assert suffix is None
 
     def test_rejects_rows_without_string_event_id(self) -> None:
@@ -482,20 +547,19 @@ class TestSuffixSafetyGuards:
             related_event_id_by_event_id={},
             trusted_sender_ids=frozenset(),
             membership_epoch=EPOCH,
+            event_count=0,
+            max_write_seq=0,
+            max_origin_server_ts=0,
+            sidecar_texts={},
         )
         missing_id = {"origin_server_ts": 1000, "type": "m.room.message", "content": {}}
 
-        suffix = reusable_event_source_suffix(
-            snapshot,
-            [missing_id],
-            trusted_sender_ids=frozenset(),
-            membership_epoch=EPOCH,
-        )
+        suffix = _guard_suffix(snapshot, [missing_id])
         assert suffix is None
 
 
 class TestReuseCacheBounds:
-    """LRU behavior of the per-bot reuse cache."""
+    """Single-snapshot behavior of the per-bot reuse cache."""
 
     def _snapshot(self) -> ThreadResolutionSnapshot:
         return build_thread_resolution_snapshot(
@@ -505,19 +569,20 @@ class TestReuseCacheBounds:
             related_event_id_by_event_id={},
             trusted_sender_ids=frozenset(),
             membership_epoch=EPOCH,
+            event_count=1,
+            max_write_seq=1,
+            max_origin_server_ts=1,
+            sidecar_texts={},
         )
 
-    def test_evicts_least_recently_used_beyond_cap(self) -> None:
-        """The cache keeps at most ``max_entries`` snapshots, evicting the least recent."""
-        cache = ThreadResolutionReuseCache(max_entries=2)
+    def test_new_thread_replaces_previous_snapshot(self) -> None:
+        """The cache retains only the bot's latest resolved thread."""
+        cache = ThreadResolutionReuseCache()
         cache.store(ROOM, "$t1", self._snapshot())
         cache.store(ROOM, "$t2", self._snapshot())
-        assert cache.get(ROOM, "$t1") is not None  # refresh recency
-        cache.store(ROOM, "$t3", self._snapshot())
 
-        assert cache.get(ROOM, "$t2") is None
-        assert cache.get(ROOM, "$t1") is not None
-        assert cache.get(ROOM, "$t3") is not None
+        assert cache.get(ROOM, "$t1") is None
+        assert cache.get(ROOM, "$t2") is not None
 
     def test_discard_removes_entry(self) -> None:
         """``discard`` removes a stored snapshot."""
@@ -553,3 +618,61 @@ class TestFetchPathIntegration:
         assert list(second) == list(first)
         assert first.diagnostics["thread_resolution_reuse"] == "full"
         assert second.diagnostics["thread_resolution_reuse"] == "reuse"
+
+    @pytest.mark.asyncio
+    async def test_fetch_thread_history_reads_only_new_rows_for_safe_append(self, tmp_path: Path) -> None:
+        """A fresh append is merged from the durable write-sequence delta."""
+        from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache  # noqa: PLC0415
+
+        cache = SqliteEventCache(tmp_path / "event_cache.db")
+        await cache.initialize()
+        rows = [_message_row(THREAD, 1000, "root"), _message_row("$m1", 2000, "reply")]
+        await replace_thread_unconditionally(cache, ROOM, THREAD, rows)
+
+        client = MagicMock()
+        client.user_id = "@mindroom_general:localhost"
+        client.room_messages = AsyncMock(side_effect=AssertionError("should not refetch fresh cache"))
+        reuse = ThreadResolutionReuseCache()
+        try:
+            first = await fetch_thread_history(client, ROOM, THREAD, event_cache=cache, resolution_reuse=reuse)
+            appended = _message_row("$m2", 3000, "new reply")
+            await cache.mark_thread_stale(ROOM, THREAD, reason="live_thread_mutation")
+            assert await cache.append_event(ROOM, THREAD, appended)
+            assert await cache.revalidate_thread_after_incremental_update(ROOM, THREAD)
+            with patch.object(
+                cache,
+                "get_thread_events",
+                AsyncMock(side_effect=AssertionError("incremental reuse should not read the full thread")),
+            ):
+                second = await fetch_thread_history(client, ROOM, THREAD, event_cache=cache, resolution_reuse=reuse)
+        finally:
+            await cache.close()
+
+        assert [message.event_id for message in first] == [THREAD, "$m1"]
+        assert [message.event_id for message in second] == [THREAD, "$m1", "$m2"]
+        assert second.diagnostics["thread_resolution_reuse"] == "incremental"
+
+    @pytest.mark.asyncio
+    async def test_point_payload_upgrade_forces_full_resolution(self, tmp_path: Path) -> None:
+        """A changed lookup payload is detected even when its thread-index row is unchanged."""
+        from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache  # noqa: PLC0415
+
+        cache = SqliteEventCache(tmp_path / "event_cache.db")
+        await cache.initialize()
+        rows = [_message_row(THREAD, 1000, "root"), _message_row("$m1", 2000, "original")]
+        await replace_thread_unconditionally(cache, ROOM, THREAD, rows)
+
+        client = MagicMock()
+        client.user_id = "@mindroom_general:localhost"
+        client.room_messages = AsyncMock(side_effect=AssertionError("should not refetch fresh cache"))
+        reuse = ThreadResolutionReuseCache()
+        try:
+            await fetch_thread_history(client, ROOM, THREAD, event_cache=cache, resolution_reuse=reuse)
+            updated = _message_row("$m1", 2000, "updated")
+            await cache.store_event("$m1", ROOM, updated, expected_membership_epoch=0)
+            second = await fetch_thread_history(client, ROOM, THREAD, event_cache=cache, resolution_reuse=reuse)
+        finally:
+            await cache.close()
+
+        assert [message.body for message in second] == ["root", "updated"]
+        assert second.diagnostics["thread_resolution_reuse"] == "full"

--- a/tests/test_turn_dispatch_pipeline.py
+++ b/tests/test_turn_dispatch_pipeline.py
@@ -378,6 +378,7 @@ class TestAgentBot(AgentBotTestBase):
             trusted_sender_ids=trusted_sender_ids,
             caller_label="dispatch_context",
             coordinator_queue_wait_ms=ANY,
+            resolution_reuse=ANY,
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Why

Long threads can contain many raw streaming-edit rows for a much smaller visible conversation. A durable-cache hit still decoded and resolved every raw row on every turn, making repeated reads scale with the entire raw history.

## What changed

- Keep one process-local resolved projection per bot, without retaining raw event dictionaries.
- Key reuse to durable event count, payload and thread-index revisions, membership epoch, trusted senders, and exact sidecar-text dependencies.
- Read and resolve only a bounded append delta when strict relation, timestamp, and count guards prove it is independent.
- Fall back to the existing full read for edits, replacements, deletions, redactions, backfills, trust changes, incomplete hydration, or any uncertain state.
- Cover the revision contract on SQLite and PostgreSQL and add a reproducible synthetic benchmark.

## Evidence

The default benchmark (8,400 raw rows / 400 visible messages) measured approximately:

- cold full resolution: 359 ms
- unchanged reuse: 13 ms
- append-only update: 22 ms
- retained snapshot: 3 MiB

These are local measurements, not CI thresholds.

## Validation

- Full pytest suite
- Focused SQLite and PostgreSQL event-cache tests
- Changed-file pre-commit hooks, including ruff, ty, vulture, and Tach checks
- `scripts/testing/benchmark_thread_history_reuse.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved repeated thread-history reads by reusing previously resolved results when safe.
  * Reduced unnecessary work by supporting incremental reuse for newly appended thread messages.
  * Added safeguards to automatically fall back to full resolution when cached data may be outdated or unsafe.

* **New Features**
  * Extended the event-cache interface to support querying thread events written within bounded sequence ranges.
  * Added process-local reuse logic to accelerate thread-resolution across related fetches.

* **Testing**
  * Expanded unit and semantics coverage for reuse, incremental updates, invalidation, edits, sidecars, and concurrency.
  * Added a benchmark to measure thread-history resolution time and memory usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->