### PR TITLE
Add real Matrix cache fuzzing and harden duplicate dispatch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -451,6 +451,7 @@ repository = "https://github.com/mindroom-ai/mindroom"
 [dependency-groups]
 dev = [
   "aioresponses>=0.7.8",
+  "hypothesis>=6.161.1",
   "markdown>=3.10.2",
   "markdown-code-runner>=2.4",
   "markdown-gfm-admonition",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,6 +7,8 @@ This directory contains utility scripts for MindRoom self-hosting.
 ### 🧪 Testing
 - **`testing/benchmark_matrix_throughput.py`** - Benchmark Matrix message throughput performance
 - **`testing/benchmark_tool_call_overhead.py`** - Benchmark synthetic tool-call bridge overhead
+- **`testing/fuzz_matrix_event_cache.py`** - Replay deterministic randomized mutations directly against both cache backends
+- **`testing/fuzz_live_matrix.py`** - Replay concurrent Matrix mutations through disposable Tuwunel and MindRoom stacks
 
 ### 🔧 Utilities
 - **`utilities/cleanup_agent_edits.sh`** - Clean up agent-edited files in Matrix database
@@ -40,6 +42,13 @@ If you're looking for platform deployment scripts (infrastructure, database migr
 ### Benchmark tool-call overhead
 ```bash
 uv run python scripts/testing/benchmark_tool_call_overhead.py --iterations 1000 --warmup 100
+```
+
+### Fuzz Matrix cache behavior
+```bash
+uv run python scripts/testing/fuzz_matrix_event_cache.py --seed 42 --steps 500
+uv run python scripts/testing/fuzz_live_matrix.py --seed 42 --steps 200 --threads 45
+uv run python scripts/testing/fuzz_live_matrix.py --profile saturation
 ```
 
 ### Generate and sync managed avatars

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -51,6 +51,8 @@ uv run python scripts/testing/fuzz_live_matrix.py --seed 42 --steps 200 --thread
 uv run python scripts/testing/fuzz_live_matrix.py --profile saturation
 ```
 
+The saturation profile uses a 180-second per-reply deadline because its slow 12-way stream workload intentionally queues much more work than normal fuzz runs.
+
 ### Generate and sync managed avatars
 Run MindRoom at least once before syncing so the router account exists in Matrix state.
 When you run this from a source checkout, generated files are written under `./avatars/`.

--- a/scripts/testing/fuzz_live_matrix.py
+++ b/scripts/testing/fuzz_live_matrix.py
@@ -1,0 +1,1570 @@
+"""Replay concurrent Matrix mutations against disposable Tuwunel and MindRoom.
+
+Unlike ``fuzz_matrix_event_cache.py``, this runner crosses the real Matrix
+transport and the complete MindRoom sync/dispatch/cache path. It starts an
+isolated Tuwunel, a deterministic OpenAI-compatible stub, and the current
+worktree's MindRoom process. Every run uses disposable Matrix accounts and
+removes the isolated stack afterward.
+
+Run with ``uv run python scripts/testing/fuzz_live_matrix.py --seed 42``.
+Use ``--save-trace`` and ``--trace`` to replay the same logical event history
+on a new disposable server.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import itertools
+import json
+import os
+import random
+import secrets
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from collections import defaultdict
+from dataclasses import asdict, dataclass
+from enum import StrEnum
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+from urllib.parse import quote
+
+import httpx
+import yaml
+
+if TYPE_CHECKING:
+    from collections.abc import Collection, Mapping
+    from io import TextIOWrapper
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+INSTANCE_REGISTRY = PROJECT_ROOT / "local" / "instances" / "deploy" / "instances.json"
+MODEL_ID = "mindroom-live-fuzz"
+AGENT_NAME = "general"
+ROOM_KEY = "lobby"
+
+
+def _required_int(value: Mapping[str, object], key: str) -> int:
+    field = value.get(key)
+    if not isinstance(field, int) or isinstance(field, bool):
+        msg = f"Live Matrix fuzz operation field {key!r} must be an integer"
+        raise TypeError(msg)
+    return field
+
+
+def _required_string(value: Mapping[str, object], key: str) -> str:
+    field = value.get(key)
+    if not isinstance(field, str):
+        msg = f"Live Matrix fuzz operation field {key!r} must be a string"
+        raise TypeError(msg)
+    return field
+
+
+class LiveOperationKind(StrEnum):
+    """User-visible Matrix mutation families."""
+
+    THREAD_MESSAGE = "thread_message"
+    PLAIN_REPLY = "plain_reply"
+    EDIT = "edit"
+    REACTION = "reaction"
+    REDACTION = "redaction"
+    IDEMPOTENT_RETRY = "idempotent_retry"
+    RESTART_MINDROOM = "restart_mindroom"
+
+
+@dataclass(frozen=True, slots=True)
+class LiveOperation:
+    """One replayable live Matrix action."""
+
+    operation_id: int
+    kind: LiveOperationKind
+    thread: int
+    target: str | None
+
+    @property
+    def event_ref(self) -> str:
+        """Return the logical reference for this operation's event."""
+        return f"op:{self.operation_id}"
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, object]) -> LiveOperation:
+        """Parse one serialized operation."""
+        raw_target = value.get("target")
+        if raw_target is not None and not isinstance(raw_target, str):
+            msg = "Live Matrix fuzz operation target must be a string or null"
+            raise TypeError(msg)
+        return cls(
+            operation_id=_required_int(value, "operation_id"),
+            kind=LiveOperationKind(_required_string(value, "kind")),
+            thread=_required_int(value, "thread"),
+            target=raw_target,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class LiveFuzzScenario:
+    """Concurrent live batches with logical references instead of event IDs."""
+
+    thread_count: int
+    batches: tuple[tuple[LiveOperation, ...], ...]
+    profile: str = "fuzz"
+
+    def to_json(self) -> str:
+        """Serialize the complete trace for exact replay on a fresh server."""
+        return json.dumps(
+            {
+                "version": 1,
+                "profile": self.profile,
+                "thread_count": self.thread_count,
+                "batches": [[asdict(operation) for operation in batch] for batch in self.batches],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+
+    @classmethod
+    def from_json(cls, value: str) -> LiveFuzzScenario:
+        """Load a trace emitted by :meth:`to_json`."""
+        payload = json.loads(value)
+        if not isinstance(payload, dict) or payload.get("version") != 1:
+            msg = "unsupported live Matrix fuzz trace"
+            raise ValueError(msg)
+        raw_batches = payload.get("batches")
+        if not isinstance(raw_batches, list):
+            msg = "live Matrix fuzz trace is missing batches"
+            raise TypeError(msg)
+        scenario = cls(
+            thread_count=_required_int(payload, "thread_count"),
+            batches=tuple(
+                tuple(LiveOperation.from_dict(cast("dict[str, object]", operation)) for operation in batch)
+                for batch in raw_batches
+            ),
+            profile=_required_string(payload, "profile"),
+        )
+        scenario.validate()
+        return scenario
+
+    def validate(self) -> None:
+        """Reject traces with impossible same-batch or forward dependencies."""
+        if self.thread_count < 1:
+            msg = "live Matrix fuzz trace must contain at least one thread"
+            raise ValueError(msg)
+        if self.profile not in {"fuzz", "saturation"}:
+            msg = f"unsupported live Matrix fuzz profile {self.profile!r}"
+            raise ValueError(msg)
+        known_events = {f"root:{thread}" for thread in range(self.thread_count)}
+        known_responses = {f"response:root:{thread}" for thread in range(self.thread_count)}
+        message_events = set(known_events)
+        operation_ids: set[int] = set()
+
+        for batch in self.batches:
+            if not batch:
+                msg = "live Matrix fuzz batches must not be empty"
+                raise ValueError(msg)
+            restart_operations = [
+                operation for operation in batch if operation.kind is LiveOperationKind.RESTART_MINDROOM
+            ]
+            if restart_operations and len(batch) != 1:
+                msg = "MindRoom restart must be a singleton batch"
+                raise ValueError(msg)
+
+            new_events: set[str] = set()
+            new_responses: set[str] = set()
+            new_messages: set[str] = set()
+            for operation in batch:
+                _validate_live_operation(
+                    operation,
+                    thread_count=self.thread_count,
+                    operation_ids=operation_ids,
+                    allowed_targets=known_events | known_responses,
+                    message_events=message_events,
+                )
+                if operation.kind is not LiveOperationKind.IDEMPOTENT_RETRY:
+                    new_events.add(operation.event_ref)
+                if operation.kind in {
+                    LiveOperationKind.THREAD_MESSAGE,
+                    LiveOperationKind.PLAIN_REPLY,
+                }:
+                    new_messages.add(operation.event_ref)
+                    new_responses.add(f"response:{operation.event_ref}")
+
+            known_events.update(new_events)
+            known_responses.update(new_responses)
+            message_events.update(new_messages)
+
+
+def _validate_live_operation(
+    operation: LiveOperation,
+    *,
+    thread_count: int,
+    operation_ids: set[int],
+    allowed_targets: set[str],
+    message_events: set[str],
+) -> None:
+    if operation.operation_id in operation_ids:
+        msg = f"duplicate live Matrix fuzz operation ID {operation.operation_id}"
+        raise ValueError(msg)
+    operation_ids.add(operation.operation_id)
+    if not 0 <= operation.thread < thread_count:
+        msg = f"invalid thread {operation.thread}"
+        raise ValueError(msg)
+    if operation.kind is LiveOperationKind.RESTART_MINDROOM:
+        if operation.target is not None:
+            msg = "MindRoom restart must not have a target"
+            raise ValueError(msg)
+        return
+    if operation.target is None:
+        msg = f"{operation.kind} requires a target"
+        raise ValueError(msg)
+    if operation.target not in allowed_targets:
+        msg = f"unknown or same-batch target {operation.target!r}"
+        raise ValueError(msg)
+    if operation.kind is LiveOperationKind.IDEMPOTENT_RETRY and operation.target not in message_events:
+        msg = "idempotent retries may only target messages"
+        raise ValueError(msg)
+
+
+_WEIGHTED_KINDS = (
+    LiveOperationKind.THREAD_MESSAGE,
+    LiveOperationKind.THREAD_MESSAGE,
+    LiveOperationKind.THREAD_MESSAGE,
+    LiveOperationKind.PLAIN_REPLY,
+    LiveOperationKind.PLAIN_REPLY,
+    LiveOperationKind.EDIT,
+    LiveOperationKind.EDIT,
+    LiveOperationKind.REACTION,
+    LiveOperationKind.REACTION,
+    LiveOperationKind.REACTION,
+    LiveOperationKind.REDACTION,
+    LiveOperationKind.IDEMPOTENT_RETRY,
+)
+
+
+@dataclass(slots=True)
+class _ScenarioGenerationState:
+    messages: dict[int, list[str]]
+    responses: dict[int, list[str]]
+    editable: dict[int, list[str]]
+    reaction_targets: dict[int, list[str]]
+    redactable: dict[int, list[str]]
+    redacted: set[str]
+
+
+def _initial_generation_state(thread_count: int) -> _ScenarioGenerationState:
+    return _ScenarioGenerationState(
+        messages={thread: [f"root:{thread}"] for thread in range(thread_count)},
+        responses={thread: [f"response:root:{thread}"] for thread in range(thread_count)},
+        editable={thread: [f"root:{thread}"] for thread in range(thread_count)},
+        reaction_targets={thread: [f"root:{thread}", f"response:root:{thread}"] for thread in range(thread_count)},
+        redactable={thread: [f"root:{thread}"] for thread in range(thread_count)},
+        redacted=set(),
+    )
+
+
+def _choose_operation(
+    randomizer: random.Random,
+    state: _ScenarioGenerationState,
+    *,
+    operation_id: int,
+    thread_count: int,
+) -> LiveOperation:
+    thread = randomizer.randrange(thread_count)
+    kind = randomizer.choice(_WEIGHTED_KINDS)
+    available_edits = [target for target in state.editable[thread] if target not in state.redacted]
+    available_redactions = [target for target in state.redactable[thread] if target not in state.redacted]
+    available_retries = [target for target in state.messages[thread] if target not in state.redacted]
+
+    if kind is LiveOperationKind.THREAD_MESSAGE:
+        target = randomizer.choice(state.messages[thread])
+    elif kind is LiveOperationKind.PLAIN_REPLY:
+        target = randomizer.choice(state.responses[thread])
+    elif kind is LiveOperationKind.EDIT:
+        target = randomizer.choice(available_edits or state.messages[thread])
+    elif kind is LiveOperationKind.REACTION:
+        target = randomizer.choice(state.reaction_targets[thread])
+    elif kind is LiveOperationKind.REDACTION and available_redactions:
+        target = randomizer.choice(available_redactions)
+    elif kind is LiveOperationKind.IDEMPOTENT_RETRY and available_retries:
+        target = randomizer.choice(available_retries)
+    else:
+        kind = LiveOperationKind.REACTION
+        target = randomizer.choice(state.reaction_targets[thread])
+    return LiveOperation(operation_id=operation_id, kind=kind, thread=thread, target=target)
+
+
+def _update_generation_state(
+    state: _ScenarioGenerationState,
+    operations: Collection[LiveOperation],
+) -> None:
+    for operation in operations:
+        if operation.kind in {
+            LiveOperationKind.THREAD_MESSAGE,
+            LiveOperationKind.PLAIN_REPLY,
+        }:
+            state.messages[operation.thread].append(operation.event_ref)
+            state.responses[operation.thread].append(f"response:{operation.event_ref}")
+            state.editable[operation.thread].append(operation.event_ref)
+            state.reaction_targets[operation.thread].extend(
+                (operation.event_ref, f"response:{operation.event_ref}"),
+            )
+            state.redactable[operation.thread].append(operation.event_ref)
+        elif operation.kind in {LiveOperationKind.EDIT, LiveOperationKind.REACTION}:
+            state.reaction_targets[operation.thread].append(operation.event_ref)
+            state.redactable[operation.thread].append(operation.event_ref)
+        elif operation.kind is LiveOperationKind.REDACTION:
+            assert operation.target is not None
+            state.redacted.add(operation.target)
+
+
+def live_scenario_from_seed(
+    seed: int,
+    *,
+    steps: int,
+    thread_count: int = 45,
+    max_batch_size: int = 16,
+    restart_interval: int = 100,
+) -> LiveFuzzScenario:
+    """Generate realistic concurrent batches with only prior-batch dependencies."""
+    if steps < 1 or thread_count < 1 or max_batch_size < 1 or restart_interval < 0:
+        msg = "steps, threads, and batch size must be positive; restart interval must be non-negative"
+        raise ValueError(msg)
+
+    randomizer = random.Random(seed)  # noqa: S311 - deterministic test trace generation
+    state = _initial_generation_state(thread_count)
+    batches: list[tuple[LiveOperation, ...]] = []
+    operation_id = 0
+    generated = 0
+    next_restart = restart_interval
+
+    while generated < steps:
+        if restart_interval and generated >= next_restart:
+            batches.append(
+                (
+                    LiveOperation(
+                        operation_id=operation_id,
+                        kind=LiveOperationKind.RESTART_MINDROOM,
+                        thread=0,
+                        target=None,
+                    ),
+                ),
+            )
+            operation_id += 1
+            next_restart += restart_interval
+
+        batch_size = min(steps - generated, randomizer.randint(1, max_batch_size))
+        operations = [
+            _choose_operation(
+                randomizer,
+                state,
+                operation_id=operation_id + offset,
+                thread_count=thread_count,
+            )
+            for offset in range(batch_size)
+        ]
+        operation_id += batch_size
+
+        batches.append(tuple(operations))
+        generated += len(operations)
+        _update_generation_state(state, operations)
+
+    scenario = LiveFuzzScenario(thread_count=thread_count, batches=tuple(batches))
+    scenario.validate()
+    return scenario
+
+
+def saturation_scenario(
+    *,
+    hot_turns: int = 100,
+    parallel_threads: int = 12,
+    parallel_turns: int = 8,
+) -> LiveFuzzScenario:
+    """Reproduce the long-thread plus 12-way saturation workload."""
+    thread_count = parallel_threads + 1
+    batches: list[tuple[LiveOperation, ...]] = []
+    operation_id = 0
+    hot_parent = "response:root:0"
+    for _ in range(hot_turns):
+        operation = LiveOperation(
+            operation_id=operation_id,
+            kind=LiveOperationKind.THREAD_MESSAGE,
+            thread=0,
+            target=hot_parent,
+        )
+        batches.append((operation,))
+        hot_parent = f"response:{operation.event_ref}"
+        operation_id += 1
+
+    parallel_parents = {thread: f"response:root:{thread}" for thread in range(1, thread_count)}
+    for _ in range(parallel_turns):
+        batch: list[LiveOperation] = []
+        for thread in range(1, thread_count):
+            operation = LiveOperation(
+                operation_id=operation_id,
+                kind=LiveOperationKind.THREAD_MESSAGE,
+                thread=thread,
+                target=parallel_parents[thread],
+            )
+            batch.append(operation)
+            parallel_parents[thread] = f"response:{operation.event_ref}"
+            operation_id += 1
+        batches.append(tuple(batch))
+
+    scenario = LiveFuzzScenario(
+        thread_count=thread_count,
+        batches=tuple(batches),
+        profile="saturation",
+    )
+    scenario.validate()
+    return scenario
+
+
+class _ModelHandler(BaseHTTPRequestHandler):
+    """Small deterministic OpenAI-compatible endpoint for live transport tests."""
+
+    protocol_version = "HTTP/1.1"
+    call_ids = itertools.count(1)
+    stream_segments = 4
+    stream_delay = 0.001
+
+    def _send_json(self, payload: Mapping[str, object]) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:
+        if self.path.rstrip("/") == "/v1/models":
+            self._send_json(
+                {
+                    "object": "list",
+                    "data": [{"id": MODEL_ID, "object": "model", "owned_by": "mindroom-fuzz"}],
+                },
+            )
+            return
+        self.send_error(HTTPStatus.NOT_FOUND)
+
+    def do_POST(self) -> None:
+        if self.path.rstrip("/") != "/v1/chat/completions":
+            self.send_error(HTTPStatus.NOT_FOUND)
+            return
+        content_length = int(self.headers.get("Content-Length", "0"))
+        payload = json.loads(self.rfile.read(content_length))
+        call_id = next(self.call_ids)
+        content = self._response_text(call_id)
+        if payload.get("stream") is True:
+            self._send_stream(call_id, content)
+            return
+        self._send_json(
+            {
+                "id": f"live-fuzz-response-{call_id}",
+                "object": "chat.completion",
+                "created": int(time.time()),
+                "model": MODEL_ID,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": content},
+                        "finish_reason": "stop",
+                    },
+                ],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            },
+        )
+
+    @classmethod
+    def _response_text(cls, call_id: int) -> str:
+        segments = " ".join(f"segment-{index:03d}" for index in range(cls.stream_segments))
+        return f"LIVE-FUZZ call={call_id} {segments} END call={call_id}"
+
+    def _send_stream(self, call_id: int, content: str) -> None:
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Connection", "close")
+        self.end_headers()
+        base = {
+            "id": f"live-fuzz-response-{call_id}",
+            "object": "chat.completion.chunk",
+            "created": int(time.time()),
+            "model": MODEL_ID,
+        }
+        self._write_sse(
+            {
+                **base,
+                "choices": [{"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}],
+            },
+        )
+        words = content.split()
+        for index in range(0, len(words), 2):
+            chunk_text = " ".join(words[index : index + 2])
+            if index + 2 < len(words):
+                chunk_text += " "
+            self._write_sse(
+                {
+                    **base,
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"content": chunk_text},
+                            "finish_reason": None,
+                        },
+                    ],
+                },
+            )
+            time.sleep(self.stream_delay)
+        self._write_sse(
+            {
+                **base,
+                "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            },
+        )
+        self.wfile.write(b"data: [DONE]\n\n")
+        self.wfile.flush()
+        self.close_connection = True
+
+    def _write_sse(self, payload: Mapping[str, object]) -> None:
+        self.wfile.write(f"data: {json.dumps(payload)}\n\n".encode())
+        self.wfile.flush()
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002, ANN401
+        """Keep hundreds of deterministic model calls out of test output."""
+
+
+def _available_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return cast("int", sock.getsockname()[1])
+
+
+def _run_command(*command: str) -> str:
+    result = subprocess.run(
+        command,
+        check=False,
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode:
+        msg = f"command failed ({' '.join(command)}):\n{result.stdout}\n{result.stderr}"
+        raise RuntimeError(msg)
+    return result.stdout
+
+
+class ManagedTuwunelStack:
+    """Disposable Tuwunel plus the current worktree's MindRoom runtime."""
+
+    def __init__(self, *, stream_segments: int = 4, stream_delay: float = 0.001) -> None:
+        token = secrets.token_hex(4)
+        self.instance_name = f"fuzz{token}"
+        self.namespace = self.instance_name
+        self.temp_dir = tempfile.TemporaryDirectory(prefix="mindroom-live-matrix-fuzz-")
+        self.root = Path(self.temp_dir.name)
+        self.storage_path = self.root / "mindroom_data"
+        self.config_path = self.root / "config.yaml"
+        self.log_path = self.root / "mindroom.log"
+        self.api_port = _available_port()
+        self.homeserver = ""
+        self.server_name = ""
+        self.room_id = ""
+        self.agent_id = ""
+        self._created = False
+        self._model_server: ThreadingHTTPServer | None = None
+        self._model_thread: threading.Thread | None = None
+        self._mindroom_process: subprocess.Popen[str] | None = None
+        self._log_handle: TextIOWrapper | None = None
+        self._env: dict[str, str] = {}
+        self._stream_segments = stream_segments
+        self._stream_delay = stream_delay
+
+    def start(self) -> None:
+        """Create every live dependency and wait for the managed room."""
+        _run_command("just", "local-instances-create", self.instance_name, "tuwunel")
+        self._created = True
+        registry = json.loads(INSTANCE_REGISTRY.read_text(encoding="utf-8"))
+        instance = registry["instances"][self.instance_name]
+        matrix_port = int(instance["matrix_port"])
+        domain = str(instance["domain"])
+        self.homeserver = f"http://127.0.0.1:{matrix_port}"
+        self.server_name = f"m-{domain}"
+        self.agent_id = f"@mindroom_{AGENT_NAME}_{self.namespace}:{self.server_name}"
+
+        _run_command("just", "local-instances-start-matrix", self.instance_name)
+        self._wait_for_url(f"{self.homeserver}/_matrix/client/versions", timeout=30)
+        model_port = self._start_model_server()
+        self._write_config(model_port)
+        self._env = {
+            **os.environ,
+            "MATRIX_HOMESERVER": self.homeserver,
+            "MATRIX_SERVER_NAME": self.server_name,
+            "MATRIX_SSL_VERIFY": "false",
+            "MINDROOM_CONFIG_PATH": str(self.config_path),
+            "MINDROOM_NAMESPACE": self.namespace,
+            "MINDROOM_STORAGE_PATH": str(self.storage_path),
+            "MINDROOM_LOG_LEVEL": "INFO",
+            "OPENAI_API_KEY": "sk-live-fuzz",
+            "UV_PYTHON": "3.13",
+        }
+        self._log_handle = self.log_path.open("a", encoding="utf-8")
+        self._start_mindroom()
+
+    def restart_mindroom(self) -> None:
+        """Restart only MindRoom while preserving its cache and Matrix account."""
+        self._stop_mindroom()
+        self._start_mindroom()
+
+    def close(self) -> None:
+        """Stop child processes and delete the exact disposable instance."""
+        self._stop_mindroom()
+        if self._log_handle is not None:
+            self._log_handle.close()
+            self._log_handle = None
+        if self._model_server is not None:
+            self._model_server.shutdown()
+            self._model_server.server_close()
+            self._model_server = None
+        if self._model_thread is not None:
+            self._model_thread.join(timeout=5)
+            self._model_thread = None
+        if self._created:
+            _run_command("just", "local-instances-remove", self.instance_name)
+            self._created = False
+        self.temp_dir.cleanup()
+
+    def log_tail(self, lines: int = 80) -> str:
+        """Return recent MindRoom output when a live invariant fails."""
+        if not self.log_path.exists():
+            return ""
+        return "\n".join(self.log_path.read_text(encoding="utf-8", errors="replace").splitlines()[-lines:])
+
+    def diagnostic_counts(self) -> dict[str, int]:
+        """Count saturation signals in the complete runtime output."""
+        if not self.log_path.exists():
+            return {}
+        log = self.log_path.read_text(encoding="utf-8", errors="replace")
+        return {
+            "cache_coordinator_timeouts": log.count("thread_read_error=cache_coordinator_timeout"),
+            "degraded_thread_reads": log.count("matrix_cache_thread_read_degraded"),
+            "dispatch_read_timeouts": log.count("thread_read_error=dispatch_read_timeout"),
+            "event_loop_stalls": log.count("event_loop_stall_detected"),
+        }
+
+    def _start_model_server(self) -> int:
+        _ModelHandler.stream_segments = self._stream_segments
+        _ModelHandler.stream_delay = self._stream_delay
+        self._model_server = ThreadingHTTPServer(("127.0.0.1", 0), _ModelHandler)
+        port = self._model_server.server_address[1]
+        self._model_thread = threading.Thread(
+            target=self._model_server.serve_forever,
+            name="mindroom-live-fuzz-model",
+            daemon=True,
+        )
+        self._model_thread.start()
+        return port
+
+    def _write_config(self, model_port: int) -> None:
+        config = {
+            "models": {
+                "default": {
+                    "provider": "openai",
+                    "id": MODEL_ID,
+                    "extra_kwargs": {"base_url": f"http://127.0.0.1:{model_port}/v1"},
+                },
+            },
+            "agents": {
+                AGENT_NAME: {
+                    "display_name": "Live Fuzz Agent",
+                    "role": "Return a deterministic acknowledgement.",
+                    "model": "default",
+                    "tools": [],
+                    "rooms": [ROOM_KEY],
+                    "learning": False,
+                },
+            },
+            "defaults": {"tools": [], "enable_streaming": True, "markdown": False},
+            "memory": {"backend": "file"},
+            "router": {"model": "default"},
+            "mindroom_user": {"username": "livefuzzowner", "display_name": "Live Fuzz Owner"},
+            "matrix_room_access": {
+                "mode": "multi_user",
+                "multi_user_join_rule": "public",
+                "publish_to_room_directory": False,
+                "invite_only_rooms": [],
+                "reconcile_existing_rooms": False,
+            },
+            "authorization": {
+                "default_room_access": True,
+                "global_users": [],
+                "agent_reply_permissions": {},
+            },
+        }
+        self.config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+
+    def _start_mindroom(self) -> None:
+        assert self._log_handle is not None
+        self._mindroom_process = subprocess.Popen(
+            [
+                "uv",
+                "run",
+                "mindroom",
+                "run",
+                "--api-port",
+                str(self.api_port),
+                "--log-level",
+                "INFO",
+            ],
+            cwd=PROJECT_ROOT,
+            env=self._env,
+            stdout=self._log_handle,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        self._wait_for_url(f"http://127.0.0.1:{self.api_port}/api/health", timeout=60)
+        state_path = self.storage_path / "matrix_state.yaml"
+        deadline = time.monotonic() + 60
+        while time.monotonic() < deadline:
+            if self._mindroom_process.poll() is not None:
+                msg = f"MindRoom exited during startup:\n{self.log_tail()}"
+                raise RuntimeError(msg)
+            if state_path.exists():
+                state = yaml.safe_load(state_path.read_text(encoding="utf-8"))
+                room = state.get("rooms", {}).get(ROOM_KEY, {}) if isinstance(state, dict) else {}
+                room_id = room.get("room_id") if isinstance(room, dict) else None
+                if isinstance(room_id, str):
+                    self.room_id = room_id
+                    return
+            time.sleep(0.2)
+        msg = f"MindRoom did not create {ROOM_KEY!r}:\n{self.log_tail()}"
+        raise TimeoutError(msg)
+
+    def _stop_mindroom(self) -> None:
+        process = self._mindroom_process
+        if process is None:
+            return
+        if process.poll() is None:
+            process.send_signal(signal.SIGINT)
+            try:
+                process.wait(timeout=20)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=10)
+        self._mindroom_process = None
+
+    @staticmethod
+    def _wait_for_url(url: str, *, timeout: float) -> None:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                response = httpx.get(url, timeout=1)
+                if response.is_success:
+                    return
+            except httpx.HTTPError:
+                pass
+            time.sleep(0.2)
+        msg = f"timed out waiting for {url}"
+        raise TimeoutError(msg)
+
+
+@dataclass(frozen=True, slots=True)
+class _SentPayload:
+    event_type: str
+    txn_id: str
+    content: dict[str, Any]
+
+
+class LiveMatrixClient:
+    """Minimal real Matrix client used by the live fuzzer."""
+
+    def __init__(self, homeserver: str, room_id: str) -> None:
+        self.homeserver = homeserver.rstrip("/")
+        self.room_id = room_id
+        self.http = httpx.AsyncClient(timeout=30)
+        self.access_token = ""
+        self.next_batch: str | None = None
+        self.seen_events: dict[str, dict[str, Any]] = {}
+
+    async def close(self) -> None:
+        """Close the underlying HTTP connection pool."""
+        await self.http.aclose()
+
+    async def register(self) -> str:
+        """Register one disposable account without exposing its token."""
+        username = f"livefuzz{secrets.token_hex(6)}"
+        password = secrets.token_urlsafe(24)
+        payload: dict[str, Any] = {
+            "auth": {"type": "m.login.dummy"},
+            "username": username,
+            "password": password,
+        }
+        response = await self.http.post(f"{self.homeserver}/_matrix/client/v3/register", json=payload)
+        if response.status_code == HTTPStatus.UNAUTHORIZED:
+            session = response.json().get("session")
+            if isinstance(session, str):
+                payload["auth"]["session"] = session
+                response = await self.http.post(
+                    f"{self.homeserver}/_matrix/client/v3/register",
+                    json=payload,
+                )
+        response.raise_for_status()
+        data = response.json()
+        token = data.get("access_token")
+        user_id = data.get("user_id")
+        if not isinstance(token, str) or not isinstance(user_id, str):
+            msg = "Matrix registration omitted access_token or user_id"
+            raise TypeError(msg)
+        self.access_token = token
+        return user_id
+
+    async def join_room(self) -> None:
+        """Join the managed public room."""
+        room_id = quote(self.room_id, safe="")
+        await self._request("POST", f"/_matrix/client/v3/join/{room_id}", json_body={})
+
+    async def send_event(
+        self,
+        event_type: str,
+        txn_id: str,
+        content: Mapping[str, Any],
+    ) -> str:
+        """Send one event with a caller-stable transaction ID."""
+        room_id = quote(self.room_id, safe="")
+        encoded_type = quote(event_type, safe="")
+        encoded_txn = quote(txn_id, safe="")
+        data = await self._request(
+            "PUT",
+            f"/_matrix/client/v3/rooms/{room_id}/send/{encoded_type}/{encoded_txn}",
+            json_body=content,
+        )
+        event_id = data.get("event_id")
+        if not isinstance(event_id, str):
+            msg = f"Matrix send omitted event_id: {data}"
+            raise TypeError(msg)
+        return event_id
+
+    async def redact(self, target_event_id: str, txn_id: str) -> str:
+        """Redact one event authored by the disposable account."""
+        room_id = quote(self.room_id, safe="")
+        event_id = quote(target_event_id, safe="")
+        encoded_txn = quote(txn_id, safe="")
+        data = await self._request(
+            "PUT",
+            f"/_matrix/client/v3/rooms/{room_id}/redact/{event_id}/{encoded_txn}",
+            json_body={"reason": "live cache fuzz"},
+        )
+        redaction_id = data.get("event_id")
+        if not isinstance(redaction_id, str):
+            msg = f"Matrix redaction omitted event_id: {data}"
+            raise TypeError(msg)
+        return redaction_id
+
+    async def sync(self, since: str | None, *, timeout_ms: int) -> dict[str, Any]:
+        """Read one incremental sync window from the real homeserver."""
+        params: dict[str, str | int] = {
+            "timeout": timeout_ms,
+            "filter": json.dumps({"room": {"timeline": {"limit": 2000}}}),
+        }
+        if since is not None:
+            params["since"] = since
+        return await self._request("GET", "/_matrix/client/v3/sync", params=params)
+
+    async def sync_incremental(
+        self,
+        *,
+        timeout_ms: int,
+        allow_limited: bool = False,
+    ) -> None:
+        """Advance this client's private sync cursor and retain room events."""
+        data = await self.sync(self.next_batch, timeout_ms=timeout_ms)
+        next_batch = data.get("next_batch")
+        if not isinstance(next_batch, str):
+            msg = "Matrix sync omitted next_batch"
+            raise TypeError(msg)
+        joined = data.get("rooms", {}).get("join", {})
+        room = joined.get(self.room_id, {}) if isinstance(joined, dict) else {}
+        timeline = room.get("timeline", {}) if isinstance(room, dict) else {}
+        if timeline.get("limited") is True and not allow_limited:
+            msg = "incremental Matrix fuzz sync unexpectedly returned a limited timeline"
+            raise AssertionError(msg)
+        events = timeline.get("events", [])
+        if not isinstance(events, list):
+            msg = "Matrix sync room timeline events must be a list"
+            raise TypeError(msg)
+        for raw_event in events:
+            if not isinstance(raw_event, dict):
+                continue
+            event = cast("dict[str, Any]", raw_event)
+            event_id = event.get("event_id")
+            if isinstance(event_id, str):
+                self.seen_events[event_id] = event
+        self.next_batch = next_batch
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_body: Mapping[str, Any] | None = None,
+        params: Mapping[str, str | int] | None = None,
+    ) -> dict[str, Any]:
+        response = await self.http.request(
+            method,
+            f"{self.homeserver}{path}",
+            headers={"Authorization": f"Bearer {self.access_token}"},
+            json=json_body,
+            params=params,
+        )
+        response.raise_for_status()
+        data = response.json()
+        if not isinstance(data, dict):
+            msg = f"Matrix {method} {path} returned non-object JSON"
+            raise TypeError(msg)
+        return data
+
+
+class ExactReplyOracle:
+    """Track canonical agent replies from real incremental `/sync` responses."""
+
+    def __init__(self, client: LiveMatrixClient, agent_id: str) -> None:
+        self.client = client
+        self.agent_id = agent_id
+        self.next_batch: str | None = None
+        self.expected_sources: dict[str, str] = {}
+        self.response_ids: dict[str, set[str]] = defaultdict(set)
+        self.response_event_by_ref: dict[str, str] = {}
+        self.seen_event_ids: set[str] = set()
+        self._last_response_at = time.monotonic()
+
+    async def initialize(self) -> None:
+        """Establish a sync token before the fuzz traffic starts."""
+        await self._sync_once(timeout_ms=0, allow_limited=True)
+
+    def expect(self, logical_ref: str, event_id: str) -> None:
+        """Require exactly one canonical agent reply to a source event."""
+        self.expected_sources[event_id] = logical_ref
+
+    async def wait_until_exact(
+        self,
+        *,
+        deadline_seconds: float,
+        settle_seconds: float,
+    ) -> None:
+        """Wait until all sources have one reply and the room stays quiet."""
+        deadline = time.monotonic() + deadline_seconds
+        settled_after = time.monotonic() + settle_seconds
+        while time.monotonic() < deadline:
+            await self._sync_once(timeout_ms=250)
+            self._assert_no_wrong_replies()
+            if all(len(self.response_ids[source]) == 1 for source in self.expected_sources):
+                settled_after = max(settled_after, self._last_response_at + settle_seconds)
+                if time.monotonic() >= settled_after:
+                    return
+        missing = {
+            logical_ref: len(self.response_ids[event_id])
+            for event_id, logical_ref in self.expected_sources.items()
+            if len(self.response_ids[event_id]) != 1
+        }
+        msg = f"timed out waiting for exact agent replies: {missing}"
+        raise AssertionError(msg)
+
+    def resolve_response_ref(self, response_ref: str) -> str:
+        """Resolve a logical agent-response reference to its real event ID."""
+        event_id = self.response_event_by_ref.get(response_ref)
+        if event_id is None:
+            msg = f"response event not observed for {response_ref!r}"
+            raise KeyError(msg)
+        return event_id
+
+    async def _sync_once(self, *, timeout_ms: int, allow_limited: bool = False) -> None:
+        data = await self.client.sync(self.next_batch, timeout_ms=timeout_ms)
+        next_batch = data.get("next_batch")
+        if not isinstance(next_batch, str):
+            msg = "Matrix sync omitted next_batch"
+            raise TypeError(msg)
+        self.next_batch = next_batch
+        joined = data.get("rooms", {}).get("join", {})
+        room = joined.get(self.client.room_id, {}) if isinstance(joined, dict) else {}
+        timeline = room.get("timeline", {}) if isinstance(room, dict) else {}
+        if timeline.get("limited") is True and not allow_limited:
+            msg = "live fuzz oracle received a limited timeline; reduce batch size"
+            raise AssertionError(msg)
+        events = timeline.get("events", [])
+        if not isinstance(events, list):
+            return
+        for raw_event in events:
+            if isinstance(raw_event, dict):
+                self._ingest_event(raw_event)
+
+    def _ingest_event(self, event: Mapping[str, Any]) -> None:
+        event_id = event.get("event_id")
+        if not isinstance(event_id, str) or event_id in self.seen_event_ids:
+            return
+        self.seen_event_ids.add(event_id)
+        if event.get("sender") != self.agent_id or event.get("type") != "m.room.message":
+            return
+        content = event.get("content")
+        if not isinstance(content, dict):
+            return
+        relation = content.get("m.relates_to")
+        if not isinstance(relation, dict) or relation.get("rel_type") != "m.thread":
+            return
+        reply = relation.get("m.in_reply_to")
+        source_event_id = reply.get("event_id") if isinstance(reply, dict) else None
+        if not isinstance(source_event_id, str):
+            return
+        self.response_ids[source_event_id].add(event_id)
+        logical_ref = self.expected_sources.get(source_event_id)
+        if logical_ref is not None:
+            self.response_event_by_ref[f"response:{logical_ref}"] = event_id
+        self._last_response_at = time.monotonic()
+
+    def _assert_no_wrong_replies(self) -> None:
+        duplicates = {
+            self.expected_sources.get(source, source): sorted(event_ids)
+            for source, event_ids in self.response_ids.items()
+            if len(event_ids) > 1
+        }
+        unexpected = {
+            source: sorted(event_ids)
+            for source, event_ids in self.response_ids.items()
+            if source not in self.expected_sources
+        }
+        if duplicates or unexpected:
+            msg = f"agent reply invariant failed: duplicates={duplicates}, unexpected={unexpected}"
+            raise AssertionError(msg)
+
+
+class LiveFuzzRunner:
+    """Translate logical operations into concurrent real Matrix writes."""
+
+    def __init__(
+        self,
+        stack: ManagedTuwunelStack,
+        clients: tuple[LiveMatrixClient, ...],
+        scenario: LiveFuzzScenario,
+        *,
+        reply_timeout: float,
+        settle_seconds: float,
+    ) -> None:
+        self.stack = stack
+        self.clients = clients
+        self.client = clients[0]
+        self.scenario = scenario
+        self.reply_timeout = reply_timeout
+        self.settle_seconds = settle_seconds
+        self.oracle = ExactReplyOracle(self.client, stack.agent_id)
+        self.event_ids: dict[str, str] = {}
+        self.sent_payloads: dict[str, _SentPayload] = {}
+        self.operation_count = 0
+        self.restart_count = 0
+        self.executed_batches = 0
+
+    async def run(self) -> dict[str, int | str]:
+        """Execute every batch and enforce the reply invariant after each."""
+        await asyncio.gather(*(client.register() for client in self.clients))
+        await asyncio.gather(*(client.join_room() for client in self.clients))
+        if self.scenario.profile == "saturation":
+            await asyncio.gather(
+                *(client.sync_incremental(timeout_ms=0, allow_limited=True) for client in self.clients),
+            )
+            return await self._run_saturation()
+
+        await self.oracle.initialize()
+        await self._send_roots(range(self.scenario.thread_count))
+        return await self._run_batches(
+            self.scenario.batches,
+        )
+
+    async def _run_saturation(self) -> dict[str, int | str]:
+        """Run hot and parallel turns without cross-thread barriers."""
+        parallel_start = self._saturation_parallel_start()
+        expected_sources: set[str] = set()
+
+        hot_root, hot_response = await self._saturation_turn(
+            self.clients[0],
+            label="hot-root",
+            thread_root=None,
+            reply_to=None,
+            expected_sources=expected_sources,
+        )
+        for batch in self.scenario.batches[:parallel_start]:
+            operation = batch[0]
+            _, hot_response = await self._saturation_turn(
+                self.clients[0],
+                label=operation.event_ref,
+                thread_root=hot_root,
+                reply_to=hot_response,
+                expected_sources=expected_sources,
+            )
+            self.operation_count += 1
+            self.executed_batches += 1
+
+        parallel_batches = self.scenario.batches[parallel_start:]
+
+        async def run_parallel_thread(thread: int) -> None:
+            client = self._client_for_thread(thread)
+            root, response = await self._saturation_turn(
+                client,
+                label=f"root:{thread}",
+                thread_root=None,
+                reply_to=None,
+                expected_sources=expected_sources,
+            )
+            for batch in parallel_batches:
+                operation = next(item for item in batch if item.thread == thread)
+                _, response = await self._saturation_turn(
+                    client,
+                    label=operation.event_ref,
+                    thread_root=root,
+                    reply_to=response,
+                    expected_sources=expected_sources,
+                )
+                self.operation_count += 1
+
+        await asyncio.gather(
+            *(run_parallel_thread(thread) for thread in range(1, self.scenario.thread_count)),
+        )
+        self.executed_batches += len(parallel_batches)
+
+        # A duplicate response may finish just after its twin. Let all model
+        # streams settle, then audit the union of every sender's sync history.
+        await asyncio.sleep(max(self.settle_seconds, 1.0))
+        await asyncio.gather(
+            *(client.sync_incremental(timeout_ms=0, allow_limited=True) for client in self.clients),
+        )
+        all_events = {event_id: event for client in self.clients for event_id, event in client.seen_events.items()}
+        response_ids = self._canonical_response_ids(all_events.values())
+        duplicates = {
+            source_event_id: sorted(event_ids)
+            for source_event_id, event_ids in response_ids.items()
+            if source_event_id in expected_sources and len(event_ids) != 1
+        }
+        missing = sorted(expected_sources - response_ids.keys())
+        unexpected = {
+            source_event_id: sorted(event_ids)
+            for source_event_id, event_ids in response_ids.items()
+            if source_event_id not in expected_sources
+        }
+        if duplicates or missing or unexpected:
+            msg = (
+                "saturation reply invariant failed: "
+                f"duplicates={duplicates}, missing={missing}, unexpected={unexpected}"
+            )
+            raise AssertionError(msg)
+
+        return {
+            "batches": self.executed_batches,
+            "canonical_agent_replies": len(expected_sources),
+            "operations": self.operation_count,
+            "restarts": 0,
+            "roots": self.scenario.thread_count,
+            "status": "PASS",
+        }
+
+    async def _saturation_turn(
+        self,
+        client: LiveMatrixClient,
+        *,
+        label: str,
+        thread_root: str | None,
+        reply_to: str | None,
+        expected_sources: set[str],
+    ) -> tuple[str, str]:
+        """Send one old-harness turn and wait for its completed stream."""
+        content = self._message_content(
+            f"Live saturation {label}",
+            relation=(
+                {
+                    "rel_type": "m.thread",
+                    "event_id": thread_root,
+                    "is_falling_back": True,
+                    "m.in_reply_to": {"event_id": reply_to},
+                }
+                if thread_root is not None and reply_to is not None
+                else None
+            ),
+        )
+        txn_id = f"live-saturation-{label}-{secrets.token_hex(4)}"
+        source_event_id = await client.send_event("m.room.message", txn_id, content)
+        expected_sources.add(source_event_id)
+        root_event_id = thread_root or source_event_id
+        response_event_id = await self._wait_for_completed_response(
+            client,
+            root_event_id=root_event_id,
+            source_event_id=source_event_id,
+        )
+        return root_event_id, response_event_id
+
+    async def _wait_for_completed_response(
+        self,
+        client: LiveMatrixClient,
+        *,
+        root_event_id: str,
+        source_event_id: str,
+    ) -> str:
+        """Wait until one source has exactly one fully streamed response."""
+        deadline = time.monotonic() + self.reply_timeout
+        while time.monotonic() < deadline:
+            response_ids = self._canonical_response_ids(
+                client.seen_events.values(),
+                root_event_id=root_event_id,
+            ).get(source_event_id, set())
+            if len(response_ids) > 1:
+                msg = f"duplicate agent replies for {source_event_id}: {sorted(response_ids)}"
+                raise AssertionError(msg)
+            if len(response_ids) == 1:
+                response_event_id = next(iter(response_ids))
+                if "END call=" in self._latest_event_body(client.seen_events.values(), response_event_id):
+                    return response_event_id
+            await client.sync_incremental(timeout_ms=1000, allow_limited=True)
+        msg = f"agent response timeout for {source_event_id}"
+        raise TimeoutError(msg)
+
+    def _canonical_response_ids(
+        self,
+        events: Collection[Mapping[str, Any]],
+        *,
+        root_event_id: str | None = None,
+    ) -> dict[str, set[str]]:
+        """Index canonical agent originals by their direct source event."""
+        response_ids: dict[str, set[str]] = defaultdict(set)
+        for event in events:
+            if event.get("type") != "m.room.message" or event.get("sender") != self.stack.agent_id:
+                continue
+            event_id = event.get("event_id")
+            content = event.get("content")
+            if not isinstance(event_id, str) or not isinstance(content, dict):
+                continue
+            relation = content.get("m.relates_to")
+            if not isinstance(relation, dict) or relation.get("rel_type") != "m.thread":
+                continue
+            if root_event_id is not None and relation.get("event_id") != root_event_id:
+                continue
+            in_reply_to = relation.get("m.in_reply_to")
+            source_event_id = in_reply_to.get("event_id") if isinstance(in_reply_to, dict) else None
+            if isinstance(source_event_id, str):
+                response_ids[source_event_id].add(event_id)
+        return response_ids
+
+    @staticmethod
+    def _latest_event_body(
+        events: Collection[Mapping[str, Any]],
+        response_event_id: str,
+    ) -> str:
+        """Return the newest original or edit body for one response."""
+        candidates: list[tuple[int, str]] = []
+        for event in events:
+            event_id = event.get("event_id")
+            content = event.get("content")
+            if not isinstance(event_id, str) or not isinstance(content, dict):
+                continue
+            relation = content.get("m.relates_to")
+            is_original = event_id == response_event_id
+            is_edit = (
+                isinstance(relation, dict)
+                and relation.get("rel_type") == "m.replace"
+                and relation.get("event_id") == response_event_id
+            )
+            if not is_original and not is_edit:
+                continue
+            new_content = content.get("m.new_content")
+            body_source = new_content if isinstance(new_content, dict) else content
+            body = body_source.get("body")
+            if isinstance(body, str):
+                timestamp = event.get("origin_server_ts")
+                candidates.append((timestamp if isinstance(timestamp, int) else 0, body))
+        return max(candidates, default=(0, ""))[1]
+
+    async def _run_batches(
+        self,
+        batches: tuple[tuple[LiveOperation, ...], ...],
+        *,
+        batch_index_offset: int = 0,
+    ) -> dict[str, int | str]:
+        """Run one contiguous scenario segment against already-created roots."""
+        for relative_batch_index, batch in enumerate(batches):
+            batch_index = batch_index_offset + relative_batch_index
+            if batch[0].kind is LiveOperationKind.RESTART_MINDROOM:
+                self.stack.restart_mindroom()
+                self.restart_count += 1
+            else:
+                results = await asyncio.gather(*(self._apply(operation) for operation in batch))
+                for operation, event_id, payload in results:
+                    self.operation_count += 1
+                    if event_id is not None and operation.kind is not LiveOperationKind.IDEMPOTENT_RETRY:
+                        self.event_ids[operation.event_ref] = event_id
+                    if payload is not None:
+                        self.sent_payloads[operation.event_ref] = payload
+                    if operation.kind in {
+                        LiveOperationKind.THREAD_MESSAGE,
+                        LiveOperationKind.PLAIN_REPLY,
+                    }:
+                        assert event_id is not None
+                        self.oracle.expect(operation.event_ref, event_id)
+            try:
+                await self.oracle.wait_until_exact(
+                    deadline_seconds=self.reply_timeout,
+                    settle_seconds=self.settle_seconds,
+                )
+            except AssertionError as exc:
+                msg = f"{exc} after live batch {batch_index}"
+                raise AssertionError(msg) from exc
+            self.executed_batches += 1
+
+        return {
+            "batches": self.executed_batches,
+            "canonical_agent_replies": len(self.oracle.expected_sources),
+            "operations": self.operation_count,
+            "restarts": self.restart_count,
+            "roots": self.scenario.thread_count,
+            "status": "PASS",
+        }
+
+    def _saturation_parallel_start(self) -> int:
+        """Return the first batch belonging to the parallel saturation phase."""
+        return next(
+            (
+                index
+                for index, batch in enumerate(self.scenario.batches)
+                if any(operation.thread != 0 for operation in batch)
+            ),
+            len(self.scenario.batches),
+        )
+
+    def _client_for_thread(self, thread: int) -> LiveMatrixClient:
+        """Use the original multi-sender mapping for saturation traces."""
+        if self.scenario.profile != "saturation":
+            return self.client
+        client_index = max(thread - 1, 0)
+        return self.clients[client_index]
+
+    async def _send_roots(self, threads: Collection[int]) -> None:
+        async def send_root(thread: int) -> tuple[int, str, _SentPayload]:
+            logical_ref = f"root:{thread}"
+            content = self._message_content(f"Live fuzz root {thread}")
+            payload = _SentPayload("m.room.message", f"live-fuzz-{logical_ref}", content)
+            event_id = await self._client_for_thread(thread).send_event(
+                payload.event_type,
+                payload.txn_id,
+                payload.content,
+            )
+            return thread, event_id, payload
+
+        roots = await asyncio.gather(*(send_root(thread) for thread in threads))
+        for thread, event_id, payload in roots:
+            logical_ref = f"root:{thread}"
+            self.event_ids[logical_ref] = event_id
+            self.sent_payloads[logical_ref] = payload
+            self.oracle.expect(logical_ref, event_id)
+        await self.oracle.wait_until_exact(
+            deadline_seconds=self.reply_timeout,
+            settle_seconds=self.settle_seconds,
+        )
+
+    async def _apply(
+        self,
+        operation: LiveOperation,
+    ) -> tuple[LiveOperation, str | None, _SentPayload | None]:
+        assert operation.target is not None
+        target_event_id = self._resolve_event_ref(operation.target)
+        txn_id = f"live-fuzz-op-{operation.operation_id}"
+        client = self._client_for_thread(operation.thread)
+
+        if operation.kind is LiveOperationKind.THREAD_MESSAGE:
+            root_event_id = self.event_ids[f"root:{operation.thread}"]
+            content = self._message_content(
+                f"Live fuzz thread message {operation.operation_id}",
+                relation={
+                    "rel_type": "m.thread",
+                    "event_id": root_event_id,
+                    "is_falling_back": True,
+                    "m.in_reply_to": {"event_id": target_event_id},
+                },
+            )
+            payload = _SentPayload("m.room.message", txn_id, content)
+            event_id = await client.send_event(payload.event_type, txn_id, content)
+            return operation, event_id, payload
+
+        if operation.kind is LiveOperationKind.PLAIN_REPLY:
+            content = self._message_content(
+                f"Live fuzz plain reply {operation.operation_id}",
+                relation={"m.in_reply_to": {"event_id": target_event_id}},
+            )
+            payload = _SentPayload("m.room.message", txn_id, content)
+            event_id = await client.send_event(payload.event_type, txn_id, content)
+            return operation, event_id, payload
+
+        if operation.kind is LiveOperationKind.EDIT:
+            new_content = self._message_content(f"Live fuzz edited message {operation.operation_id}")
+            content = {
+                **new_content,
+                "m.new_content": new_content,
+                "m.relates_to": {"rel_type": "m.replace", "event_id": target_event_id},
+            }
+            event_id = await client.send_event("m.room.message", txn_id, content)
+            return operation, event_id, None
+
+        if operation.kind is LiveOperationKind.REACTION:
+            content = {
+                "m.relates_to": {
+                    "rel_type": "m.annotation",
+                    "event_id": target_event_id,
+                    "key": f"fuzz-{operation.operation_id % 7}",
+                },
+            }
+            event_id = await client.send_event("m.reaction", txn_id, content)
+            return operation, event_id, None
+
+        if operation.kind is LiveOperationKind.REDACTION:
+            event_id = await client.redact(target_event_id, txn_id)
+            return operation, event_id, None
+
+        payload = self.sent_payloads[operation.target]
+        event_id = await client.send_event(payload.event_type, payload.txn_id, payload.content)
+        if event_id != target_event_id:
+            msg = f"idempotent retry changed event ID for {operation.target}: {target_event_id} -> {event_id}"
+            raise AssertionError(msg)
+        return operation, event_id, None
+
+    def _resolve_event_ref(self, logical_ref: str) -> str:
+        if logical_ref.startswith("response:"):
+            return self.oracle.resolve_response_ref(logical_ref)
+        event_id = self.event_ids.get(logical_ref)
+        if event_id is None:
+            msg = f"event not observed for {logical_ref!r}"
+            raise KeyError(msg)
+        return event_id
+
+    def _message_content(
+        self,
+        body: str,
+        *,
+        relation: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        content: dict[str, Any] = {
+            "msgtype": "m.text",
+            "body": f"{body} {self.stack.agent_id}",
+            "m.mentions": {"user_ids": [self.stack.agent_id]},
+        }
+        if relation is not None:
+            content["m.relates_to"] = dict(relation)
+        return content
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        msg = "must be at least 1"
+        raise argparse.ArgumentTypeError(msg)
+    return parsed
+
+
+def _non_negative_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        msg = "must be non-negative"
+        raise argparse.ArgumentTypeError(msg)
+    return parsed
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", choices=("fuzz", "saturation"), default="fuzz")
+    parser.add_argument("--seed", type=int, default=1)
+    parser.add_argument("--steps", type=_positive_int, default=200)
+    parser.add_argument("--threads", type=_positive_int, default=45)
+    parser.add_argument("--max-batch-size", type=_positive_int, default=16)
+    parser.add_argument("--restart-interval", type=_non_negative_int, default=100)
+    parser.add_argument("--reply-timeout", type=float, default=60)
+    parser.add_argument("--settle-seconds", type=float, default=0.75)
+    parser.add_argument("--trace", type=Path)
+    parser.add_argument("--save-trace", type=Path)
+    parser.add_argument("--failure-log", type=Path)
+    return parser.parse_args()
+
+
+async def _run_live(
+    stack: ManagedTuwunelStack,
+    scenario: LiveFuzzScenario,
+    *,
+    reply_timeout: float,
+    settle_seconds: float,
+) -> dict[str, int | str]:
+    client_count = scenario.thread_count - 1 if scenario.profile == "saturation" else 1
+    clients = tuple(LiveMatrixClient(stack.homeserver, stack.room_id) for _ in range(client_count))
+    try:
+        return await LiveFuzzRunner(
+            stack,
+            clients,
+            scenario,
+            reply_timeout=reply_timeout,
+            settle_seconds=settle_seconds,
+        ).run()
+    finally:
+        await asyncio.gather(*(client.close() for client in clients))
+
+
+def main() -> None:
+    """Run one trace against a fresh disposable real-server stack."""
+    args = _parse_args()
+    scenario = (
+        LiveFuzzScenario.from_json(args.trace.read_text(encoding="utf-8"))
+        if args.trace is not None
+        else (
+            saturation_scenario()
+            if args.profile == "saturation"
+            else live_scenario_from_seed(
+                args.seed,
+                steps=args.steps,
+                thread_count=args.threads,
+                max_batch_size=args.max_batch_size,
+                restart_interval=args.restart_interval,
+            )
+        )
+    )
+    if args.save_trace is not None:
+        args.save_trace.write_text(scenario.to_json() + "\n", encoding="utf-8")
+
+    stack = ManagedTuwunelStack(
+        stream_segments=96 if scenario.profile == "saturation" else 4,
+        stream_delay=0.012 if scenario.profile == "saturation" else 0.001,
+    )
+    try:
+        stack.start()
+        result = asyncio.run(
+            _run_live(
+                stack,
+                scenario,
+                reply_timeout=args.reply_timeout,
+                settle_seconds=args.settle_seconds,
+            ),
+        )
+        result["seed"] = args.seed if args.trace is None else "trace"
+        result.update(stack.diagnostic_counts())
+        print(json.dumps(result, sort_keys=True))
+    except Exception:
+        print("Live Matrix fuzz trace:", file=sys.stderr)
+        print(args.trace or scenario.to_json(), file=sys.stderr)
+        print(json.dumps(stack.diagnostic_counts(), sort_keys=True), file=sys.stderr)
+        if args.failure_log is not None and stack.log_path.exists():
+            args.failure_log.write_text(
+                stack.log_path.read_text(encoding="utf-8", errors="replace"),
+                encoding="utf-8",
+            )
+        log_tail = stack.log_tail()
+        if log_tail:
+            print("MindRoom log tail:", file=sys.stderr)
+            print(log_tail, file=sys.stderr)
+        raise
+    finally:
+        stack.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/testing/fuzz_live_matrix.py
+++ b/scripts/testing/fuzz_live_matrix.py
@@ -602,6 +602,7 @@ class ManagedTuwunelStack:
         self.server_name = ""
         self.room_id = ""
         self.agent_id = ""
+        self.router_id = ""
         self._created = False
         self._model_server: ThreadingHTTPServer | None = None
         self._model_thread: threading.Thread | None = None
@@ -622,6 +623,7 @@ class ManagedTuwunelStack:
         self.homeserver = f"http://127.0.0.1:{matrix_port}"
         self.server_name = f"m-{domain}"
         self.agent_id = f"@mindroom_{AGENT_NAME}_{self.namespace}:{self.server_name}"
+        self.router_id = f"@mindroom_router_{self.namespace}:{self.server_name}"
 
         _run_command("just", "local-instances-start-matrix", self.instance_name)
         self._wait_for_url(f"{self.homeserver}/_matrix/client/versions", timeout=30)
@@ -960,9 +962,17 @@ class LiveMatrixClient:
 class ExactReplyOracle:
     """Track canonical agent replies from real incremental `/sync` responses."""
 
-    def __init__(self, client: LiveMatrixClient, agent_id: str) -> None:
+    def __init__(
+        self,
+        client: LiveMatrixClient,
+        agent_id: str,
+        *,
+        internal_relay_senders: Collection[str] = (),
+    ) -> None:
         self.client = client
         self.agent_id = agent_id
+        self.internal_relay_senders = frozenset(internal_relay_senders)
+        self.internal_source_ids: set[str] = set()
         self.next_batch: str | None = None
         self.expected_sources: dict[str, str] = {}
         self.response_ids: dict[str, set[str]] = defaultdict(set)
@@ -1035,6 +1045,9 @@ class ExactReplyOracle:
         if not isinstance(event_id, str) or event_id in self.seen_event_ids:
             return
         self.seen_event_ids.add(event_id)
+        if event.get("sender") in self.internal_relay_senders:
+            self.internal_source_ids.add(event_id)
+            return
         if event.get("sender") != self.agent_id or event.get("type") != "m.room.message":
             return
         content = event.get("content")
@@ -1062,7 +1075,7 @@ class ExactReplyOracle:
         unexpected = {
             source: sorted(event_ids)
             for source, event_ids in self.response_ids.items()
-            if source not in self.expected_sources
+            if source not in self.expected_sources and source not in self.internal_source_ids
         }
         if duplicates or unexpected:
             msg = f"agent reply invariant failed: duplicates={duplicates}, unexpected={unexpected}"
@@ -1087,7 +1100,11 @@ class LiveFuzzRunner:
         self.scenario = scenario
         self.reply_timeout = reply_timeout
         self.settle_seconds = settle_seconds
-        self.oracle = ExactReplyOracle(self.client, stack.agent_id)
+        self.oracle = ExactReplyOracle(
+            self.client,
+            stack.agent_id,
+            internal_relay_senders=(stack.router_id,),
+        )
         self.event_ids: dict[str, str] = {}
         self.sent_payloads: dict[str, _SentPayload] = {}
         self.operation_count = 0
@@ -1510,7 +1527,11 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--threads", type=_positive_int, default=45)
     parser.add_argument("--max-batch-size", type=_positive_int, default=16)
     parser.add_argument("--restart-interval", type=_non_negative_int, default=100)
-    parser.add_argument("--reply-timeout", type=float, default=60)
+    parser.add_argument(
+        "--reply-timeout",
+        type=float,
+        help="per-reply deadline (default: 60s fuzz, 180s saturation)",
+    )
     parser.add_argument("--settle-seconds", type=float, default=0.75)
     parser.add_argument("--trace", type=Path)
     parser.add_argument("--save-trace", type=Path)
@@ -1559,6 +1580,9 @@ def main() -> None:
     )
     if args.save_trace is not None:
         args.save_trace.write_text(scenario.to_json() + "\n", encoding="utf-8")
+    reply_timeout = args.reply_timeout
+    if reply_timeout is None:
+        reply_timeout = 180 if scenario.profile == "saturation" else 60
 
     stack = ManagedTuwunelStack(
         stream_segments=96 if scenario.profile == "saturation" else 4,
@@ -1570,7 +1594,7 @@ def main() -> None:
             _run_live(
                 stack,
                 scenario,
-                reply_timeout=args.reply_timeout,
+                reply_timeout=reply_timeout,
                 settle_seconds=args.settle_seconds,
             ),
         )

--- a/scripts/testing/fuzz_live_matrix.py
+++ b/scripts/testing/fuzz_live_matrix.py
@@ -173,6 +173,18 @@ class LiveFuzzScenario:
             if restart_operations and len(batch) != 1:
                 msg = "MindRoom restart must be a singleton batch"
                 raise ValueError(msg)
+            reply_threads = [
+                operation.thread
+                for operation in batch
+                if operation.kind
+                in {
+                    LiveOperationKind.THREAD_MESSAGE,
+                    LiveOperationKind.PLAIN_REPLY,
+                }
+            ]
+            if len(reply_threads) != len(set(reply_threads)):
+                msg = "same-thread messages requiring replies must use separate batches"
+                raise ValueError(msg)
 
             new_events: set[str] = set()
             new_responses: set[str] = set()
@@ -358,15 +370,30 @@ def live_scenario_from_seed(
             next_restart += restart_interval
 
         batch_size = min(steps - generated, randomizer.randint(1, max_batch_size))
-        operations = [
-            _choose_operation(
+        operations: list[LiveOperation] = []
+        reply_threads: set[int] = set()
+        for offset in range(batch_size):
+            operation = _choose_operation(
                 randomizer,
                 state,
                 operation_id=operation_id + offset,
                 thread_count=thread_count,
             )
-            for offset in range(batch_size)
-        ]
+            needs_reply = operation.kind in {
+                LiveOperationKind.THREAD_MESSAGE,
+                LiveOperationKind.PLAIN_REPLY,
+            }
+            if needs_reply and operation.thread in reply_threads:
+                operation = LiveOperation(
+                    operation_id=operation.operation_id,
+                    kind=LiveOperationKind.REACTION,
+                    thread=operation.thread,
+                    target=randomizer.choice(state.reaction_targets[operation.thread]),
+                )
+                needs_reply = False
+            operations.append(operation)
+            if needs_reply:
+                reply_threads.add(operation.thread)
         operation_id += batch_size
 
         batches.append(tuple(operations))
@@ -920,7 +947,9 @@ class LiveMatrixClient:
             json=json_body,
             params=params,
         )
-        response.raise_for_status()
+        if response.is_error:
+            msg = f"Matrix {method} {path} failed with HTTP {response.status_code}: {response.text}"
+            raise RuntimeError(msg)
         data = response.json()
         if not isinstance(data, dict):
             msg = f"Matrix {method} {path} returned non-object JSON"
@@ -1415,7 +1444,7 @@ class LiveFuzzRunner:
                 "m.relates_to": {
                     "rel_type": "m.annotation",
                     "event_id": target_event_id,
-                    "key": f"fuzz-{operation.operation_id % 7}",
+                    "key": f"fuzz-{operation.operation_id}",
                 },
             }
             event_id = await client.send_event("m.reaction", txn_id, content)

--- a/scripts/testing/fuzz_matrix_event_cache.py
+++ b/scripts/testing/fuzz_matrix_event_cache.py
@@ -1,0 +1,1020 @@
+"""Replayable state-sequence fuzzing for the durable Matrix event cache.
+
+This module drives realistic joined-timeline writes through ``ThreadSyncWritePolicy``
+while interleaving snapshot replacement, invalidation, redaction, duplicate delivery,
+opaque-event replay, and concurrent thread activity.
+
+The pytest suite uses Hypothesis to generate and shrink traces.
+For longer deterministic runs:
+
+    uv run python scripts/testing/fuzz_matrix_event_cache.py --seed 42 --steps 500
+
+On failure the complete JSON trace is printed and can be replayed with:
+
+    uv run python scripts/testing/fuzz_matrix_event_cache.py --trace trace.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import random
+import tempfile
+import time
+from dataclasses import asdict, dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+import nio
+
+from mindroom.logging_config import get_logger
+from mindroom.matrix.cache import (
+    ConversationEventCache,
+    EventCacheWriteCoordinator,
+    ThreadRevision,
+    thread_cache_rejection_reason,
+)
+from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
+from mindroom.matrix.cache.thread_write_cache_ops import ThreadMutationCacheOps
+from mindroom.matrix.cache.thread_writes import ThreadSyncWritePolicy
+from mindroom.matrix.event_info import EventInfo
+from mindroom.matrix.thread_bookkeeping import ThreadMutationResolver
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable, Sequence
+
+    from mindroom.bot_runtime_view import BotRuntimeView
+
+FUZZ_PRINCIPAL = "@mindroom_cache_fuzz:localhost"
+OTHER_PRINCIPAL = "@mindroom_cache_fuzz_other:localhost"
+_BASE_TIMESTAMP = 1_700_000_000_000
+
+
+def _required_int(value: dict[str, object], key: str) -> int:
+    field = value.get(key)
+    if not isinstance(field, int) or isinstance(field, bool):
+        msg = f"Matrix cache fuzz operation field {key!r} must be an integer"
+        raise TypeError(msg)
+    return field
+
+
+class OperationKind(StrEnum):
+    """One mutation family understood by the cache fuzzer."""
+
+    THREADED_MESSAGE = "threaded_message"
+    PLAIN_REPLY = "plain_reply"
+    EDIT = "edit"
+    REACTION = "reaction"
+    REFERENCE = "reference"
+    REDACTION = "redaction"
+    CIPHERTEXT_REPLAY = "ciphertext_replay"
+    REPLACE_THREAD = "replace_thread"
+    INVALIDATE_THREAD = "invalidate_thread"
+    MARK_THREAD_STALE = "mark_thread_stale"
+    MARK_ROOM_STALE = "mark_room_stale"
+    LIMITED_SYNC = "limited_sync"
+
+
+@dataclass(frozen=True, slots=True)
+class FuzzOperation:
+    """Compact, JSON-serializable mutation description."""
+
+    kind: OperationKind
+    room: int
+    thread: int
+    slot: int
+    target: int
+    variant: int
+
+    @classmethod
+    def from_dict(cls, value: dict[str, object]) -> FuzzOperation:
+        """Parse one serialized operation."""
+        raw_kind = value.get("kind")
+        if not isinstance(raw_kind, str):
+            msg = "Matrix cache fuzz operation kind must be a string"
+            raise TypeError(msg)
+        return cls(
+            kind=OperationKind(raw_kind),
+            room=_required_int(value, "room"),
+            thread=_required_int(value, "thread"),
+            slot=_required_int(value, "slot"),
+            target=_required_int(value, "target"),
+            variant=_required_int(value, "variant"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class FuzzScenario:
+    """Ordered concurrent batches forming one replayable cache history."""
+
+    batches: tuple[tuple[FuzzOperation, ...], ...]
+
+    def to_json(self) -> str:
+        """Serialize the complete trace for exact replay."""
+        payload = {
+            "version": 1,
+            "batches": [[asdict(operation) for operation in batch] for batch in self.batches],
+        }
+        return json.dumps(payload, indent=2, sort_keys=True)
+
+    @classmethod
+    def from_json(cls, value: str) -> FuzzScenario:
+        """Load a trace emitted by :meth:`to_json`."""
+        payload = json.loads(value)
+        if not isinstance(payload, dict) or payload.get("version") != 1:
+            msg = "unsupported Matrix cache fuzz trace"
+            raise ValueError(msg)
+        raw_batches = payload.get("batches")
+        if not isinstance(raw_batches, list):
+            msg = "Matrix cache fuzz trace is missing batches"
+            raise TypeError(msg)
+        return cls(
+            batches=tuple(
+                tuple(FuzzOperation.from_dict(cast("dict[str, object]", operation)) for operation in batch)
+                for batch in raw_batches
+            ),
+        )
+
+
+@dataclass(slots=True)
+class _EventSection:
+    events: list[object]
+
+
+@dataclass(slots=True)
+class _Timeline:
+    events: list[nio.Event]
+    limited: bool
+
+
+@dataclass(slots=True)
+class _RoomSync:
+    timeline: _Timeline
+    state: _EventSection
+    ephemeral: _EventSection
+    account_data: _EventSection
+
+
+@dataclass(slots=True)
+class _SyncRooms:
+    join: dict[str, _RoomSync]
+    invite: dict[str, _RoomSync]
+    leave: dict[str, _RoomSync]
+
+
+@dataclass(slots=True)
+class _DeviceLists:
+    changed: list[str]
+    left: list[str]
+
+
+@dataclass(slots=True)
+class _SyncEnvelope:
+    rooms: _SyncRooms
+    presence: _EventSection
+    account_data: _EventSection
+    to_device: _EventSection
+    device_lists: _DeviceLists
+
+
+@dataclass(slots=True)
+class _CacheRuntime:
+    event_cache: ConversationEventCache
+    event_cache_write_coordinator: EventCacheWriteCoordinator
+
+
+@dataclass(frozen=True, slots=True)
+class ObservableCacheState:
+    """Stable public state used for restart and backend-parity checks."""
+
+    events: tuple[tuple[str, str, str | None], ...]
+    mappings: tuple[tuple[str, str, str | None], ...]
+    threads: tuple[tuple[str, str, tuple[str, ...]], ...]
+    revisions: tuple[tuple[str, str, ThreadRevision | None], ...]
+    invalidation_reasons: tuple[tuple[str, str, str | None, str | None], ...]
+
+
+def room_id(room: int) -> str:
+    """Return one deterministic Matrix room ID."""
+    return f"!fuzz-room-{room}:localhost"
+
+
+def thread_id(room: int, thread: int) -> str:
+    """Return one deterministic thread root ID."""
+    return f"$fuzz-r{room}-t{thread}-root"
+
+
+def message_id(room: int, thread: int, slot: int) -> str:
+    """Return one deterministic explicit thread-message ID."""
+    return f"$fuzz-r{room}-t{thread}-message-{slot}"
+
+
+def reply_id(room: int, thread: int, slot: int) -> str:
+    """Return one deterministic reply-only message ID."""
+    return f"$fuzz-r{room}-t{thread}-reply-{slot}"
+
+
+def edit_id(room: int, thread: int, target: int, slot: int, variant: int) -> str:
+    """Return one deterministic edit ID."""
+    return f"$fuzz-r{room}-t{thread}-message-{target}-edit-{slot}-{variant % 2}"
+
+
+def reaction_id(room: int, thread: int, target: int, slot: int) -> str:
+    """Return one deterministic reaction ID."""
+    return f"$fuzz-r{room}-t{thread}-message-{target}-reaction-{slot}"
+
+
+def reference_id(room: int, thread: int, target: int, slot: int) -> str:
+    """Return one deterministic reference-message ID."""
+    return f"$fuzz-r{room}-t{thread}-message-{target}-reference-{slot}"
+
+
+def _sender(slot: int) -> str:
+    return f"@fuzz-user-{slot % 4}:localhost"
+
+
+def _timestamp(room: int, thread: int, slot: int, offset: int = 0) -> int:
+    return _BASE_TIMESTAMP + room * 1_000_000 + thread * 100_000 + slot * 100 + offset
+
+
+def _event_source(
+    *,
+    event_id: str,
+    event_type: str,
+    room: int,
+    sender: str,
+    timestamp: int,
+    content: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "content": content,
+        "event_id": event_id,
+        "origin_server_ts": timestamp,
+        "room_id": room_id(room),
+        "sender": sender,
+        "type": event_type,
+    }
+
+
+def root_source(room: int, thread: int) -> dict[str, Any]:
+    """Build one thread root."""
+    event_id = thread_id(room, thread)
+    return _event_source(
+        event_id=event_id,
+        event_type="m.room.message",
+        room=room,
+        sender=_sender(thread),
+        timestamp=_timestamp(room, thread, 0),
+        content={"body": event_id, "msgtype": "m.text"},
+    )
+
+
+def threaded_message_source(operation: FuzzOperation) -> dict[str, Any]:
+    """Build one explicit threaded message."""
+    event_id = message_id(operation.room, operation.thread, operation.slot)
+    return _event_source(
+        event_id=event_id,
+        event_type="m.room.message",
+        room=operation.room,
+        sender=_sender(operation.slot),
+        timestamp=_timestamp(operation.room, operation.thread, operation.slot, 10),
+        content={
+            "body": event_id,
+            "msgtype": "m.text",
+            "m.relates_to": {
+                "event_id": thread_id(operation.room, operation.thread),
+                "rel_type": "m.thread",
+            },
+        },
+    )
+
+
+def plain_reply_source(operation: FuzzOperation) -> dict[str, Any]:
+    """Build a reply whose thread must be inferred through its target."""
+    event_id = reply_id(operation.room, operation.thread, operation.slot)
+    target_id = (
+        thread_id(operation.room, operation.thread)
+        if operation.variant % 3 == 0
+        else message_id(operation.room, operation.thread, operation.target)
+    )
+    return _event_source(
+        event_id=event_id,
+        event_type="m.room.message",
+        room=operation.room,
+        sender=_sender(operation.slot),
+        timestamp=_timestamp(operation.room, operation.thread, operation.slot, 20),
+        content={
+            "body": event_id,
+            "msgtype": "m.text",
+            "m.relates_to": {"m.in_reply_to": {"event_id": target_id}},
+        },
+    )
+
+
+def edit_source(operation: FuzzOperation) -> dict[str, Any]:
+    """Build a valid or wrong-sender edit of a deterministic message slot."""
+    target_id = message_id(operation.room, operation.thread, operation.target)
+    event_id = edit_id(
+        operation.room,
+        operation.thread,
+        operation.target,
+        operation.slot,
+        operation.variant,
+    )
+    new_content: dict[str, Any] = {"body": f"edited {target_id}", "msgtype": "m.text"}
+    if operation.variant % 2 == 0:
+        new_content["m.relates_to"] = {
+            "event_id": thread_id(operation.room, operation.thread),
+            "rel_type": "m.thread",
+        }
+    sender_slot = operation.target if operation.variant % 4 != 3 else operation.target + 1
+    return _event_source(
+        event_id=event_id,
+        event_type="m.room.message",
+        room=operation.room,
+        sender=_sender(sender_slot),
+        timestamp=_timestamp(operation.room, operation.thread, operation.slot, 30 + operation.variant % 2),
+        content={
+            "body": f"* edited {target_id}",
+            "msgtype": "m.text",
+            "m.new_content": new_content,
+            "m.relates_to": {"event_id": target_id, "rel_type": "m.replace"},
+        },
+    )
+
+
+def reaction_source(operation: FuzzOperation) -> dict[str, Any]:
+    """Build one annotation that must remain point-only."""
+    target_id = message_id(operation.room, operation.thread, operation.target)
+    return _event_source(
+        event_id=reaction_id(operation.room, operation.thread, operation.target, operation.slot),
+        event_type="m.reaction",
+        room=operation.room,
+        sender=_sender(operation.slot),
+        timestamp=_timestamp(operation.room, operation.thread, operation.slot, 40),
+        content={
+            "m.relates_to": {
+                "event_id": target_id,
+                "key": ("👍", "👎", "🚀")[operation.variant % 3],
+                "rel_type": "m.annotation",
+            },
+        },
+    )
+
+
+def reference_source(operation: FuzzOperation) -> dict[str, Any]:
+    """Build one visible message related by reference."""
+    target_id = message_id(operation.room, operation.thread, operation.target)
+    event_id = reference_id(operation.room, operation.thread, operation.target, operation.slot)
+    return _event_source(
+        event_id=event_id,
+        event_type="m.room.message",
+        room=operation.room,
+        sender=_sender(operation.slot),
+        timestamp=_timestamp(operation.room, operation.thread, operation.slot, 50),
+        content={
+            "body": event_id,
+            "msgtype": "m.text",
+            "m.relates_to": {"event_id": target_id, "rel_type": "m.reference"},
+        },
+    )
+
+
+def ciphertext_source(operation: FuzzOperation) -> dict[str, Any]:
+    """Build an opaque replay sharing an explicit message event ID."""
+    content: dict[str, Any] = {
+        "algorithm": "m.megolm.v1.aes-sha2",
+        "ciphertext": "opaque",
+        "device_id": "FUZZ",
+        "sender_key": "opaque",
+        "session_id": "opaque",
+    }
+    if operation.variant % 2:
+        content["m.relates_to"] = {
+            "event_id": thread_id(operation.room, operation.thread),
+            "rel_type": "m.thread",
+        }
+    return _event_source(
+        event_id=message_id(operation.room, operation.thread, operation.slot),
+        event_type="m.room.encrypted",
+        room=operation.room,
+        sender=_sender(operation.slot),
+        timestamp=_timestamp(operation.room, operation.thread, operation.slot, 10),
+        content=content,
+    )
+
+
+def _raw_event(source: dict[str, Any]) -> nio.Event:
+    event_type = source["type"]
+    assert isinstance(event_type, str)
+    return nio.UnknownEvent(source, event_type)
+
+
+def _redaction_target(operation: FuzzOperation) -> str:
+    target_kind = operation.variant % 4
+    if target_kind == 0:
+        return thread_id(operation.room, operation.thread)
+    if target_kind == 1:
+        return message_id(operation.room, operation.thread, operation.target)
+    if target_kind == 2:
+        return edit_id(
+            operation.room,
+            operation.thread,
+            operation.target,
+            operation.slot,
+            operation.variant,
+        )
+    return reaction_id(operation.room, operation.thread, operation.target, operation.slot)
+
+
+def _redaction_event(operation: FuzzOperation) -> nio.RedactionEvent:
+    target_id = _redaction_target(operation)
+    source = _event_source(
+        event_id=f"$redact-{target_id.removeprefix('$')}-{operation.slot}",
+        event_type="m.room.redaction",
+        room=operation.room,
+        sender=_sender(operation.slot),
+        timestamp=_timestamp(operation.room, operation.thread, operation.slot, 60),
+        content={"reason": "cache fuzz"},
+    )
+    return nio.RedactionEvent(source, target_id)
+
+
+def _sync_response(
+    events: Sequence[nio.Event],
+    *,
+    room: int,
+    limited: bool = False,
+) -> _SyncEnvelope:
+    empty = _EventSection(events=[])
+    return _SyncEnvelope(
+        rooms=_SyncRooms(
+            join={
+                room_id(room): _RoomSync(
+                    timeline=_Timeline(events=list(events), limited=limited),
+                    state=empty,
+                    ephemeral=_EventSection(events=[]),
+                    account_data=_EventSection(events=[]),
+                ),
+            },
+            invite={},
+            leave={},
+        ),
+        presence=_EventSection(events=[]),
+        account_data=_EventSection(events=[]),
+        to_device=_EventSection(events=[]),
+        device_lists=_DeviceLists(changed=[], left=[]),
+    )
+
+
+def _build_sync_policy(cache: ConversationEventCache) -> ThreadSyncWritePolicy:
+    logger = get_logger("scripts.testing.fuzz_matrix_event_cache")
+    coordinator = EventCacheWriteCoordinator(logger=logger)
+    runtime = cast(
+        "BotRuntimeView",
+        _CacheRuntime(
+            event_cache=cache,
+            event_cache_write_coordinator=coordinator,
+        ),
+    )
+
+    async def fetch_event_info(fetched_room_id: str, event_id: str) -> EventInfo | None:
+        event = await cache.get_event(fetched_room_id, event_id)
+        return None if event is None else EventInfo.from_event(event)
+
+    resolver = ThreadMutationResolver(
+        logger_getter=lambda: logger,
+        runtime=runtime,
+        fetch_event_info_for_thread_resolution=fetch_event_info,
+    )
+    cache_ops = ThreadMutationCacheOps(
+        logger_getter=lambda: logger,
+        runtime=runtime,
+    )
+    return ThreadSyncWritePolicy(
+        resolver=resolver,
+        cache_ops=cache_ops,
+    )
+
+
+class CacheFuzzRunner:
+    """Execute one scenario and continuously assert storage invariants."""
+
+    def __init__(
+        self,
+        cache: ConversationEventCache,
+        scenario: FuzzScenario,
+        *,
+        room_count: int,
+        thread_count: int,
+    ) -> None:
+        self.cache = cache.for_principal(FUZZ_PRINCIPAL)
+        self.other_cache = cache.for_principal(OTHER_PRINCIPAL)
+        self.policy = _build_sync_policy(self.cache)
+        self.scenario = scenario
+        self.room_count = room_count
+        self.thread_count = thread_count
+        self.known_ids: set[tuple[str, str]] = set()
+        self.redacted_ids: set[tuple[str, str]] = set()
+        self.reaction_ids: set[tuple[str, str]] = set()
+
+    async def seed(self) -> None:
+        """Create authoritative roots so later operations can race realistically."""
+        for room in range(self.room_count):
+            current_room_id = room_id(room)
+            membership_epoch = await self.cache.room_membership_epoch(current_room_id)
+            assert membership_epoch is not None
+            for thread in range(self.thread_count):
+                root = root_source(room, thread)
+                root_event_id = cast("str", root["event_id"])
+                replaced = await self.cache.replace_thread_if_not_newer(
+                    current_room_id,
+                    thread_id(room, thread),
+                    [root],
+                    expected_membership_epoch=membership_epoch,
+                    fetch_started_at=float("inf"),
+                    validated_at=time.time(),
+                )
+                assert replaced
+                self.known_ids.add((current_room_id, root_event_id))
+
+    async def run(self) -> ObservableCacheState:
+        """Execute all batches and return stable observable state."""
+        await self.seed()
+        await self.assert_invariants()
+        for batch in self.scenario.batches:
+            await asyncio.gather(
+                *(self._apply_operation(operation) for operation in batch),
+            )
+            await self.assert_invariants()
+        return await self.observe()
+
+    async def _apply_sync(self, room: int, events: Sequence[nio.Event], *, limited: bool = False) -> None:
+        result = await self.policy.cache_sync_timeline_for_certification(
+            cast("nio.SyncResponse", _sync_response(events, room=room, limited=limited)),
+        )
+        assert result.complete is not limited
+        assert result.limited_room_ids == ((room_id(room),) if limited else ())
+        assert result.errors == ()
+
+    def _remember_source(self, source: dict[str, Any]) -> None:
+        source_room_id = cast("str", source["room_id"])
+        source_event_id = cast("str", source["event_id"])
+        self.known_ids.add((source_room_id, source_event_id))
+        if source["type"] == "m.reaction":
+            self.reaction_ids.add((source_room_id, source_event_id))
+
+    async def _apply_operation(self, operation: FuzzOperation) -> None:
+        handlers: dict[OperationKind, Callable[[FuzzOperation], Awaitable[None]]] = {
+            OperationKind.THREADED_MESSAGE: self._apply_source_operation,
+            OperationKind.PLAIN_REPLY: self._apply_source_operation,
+            OperationKind.EDIT: self._apply_source_operation,
+            OperationKind.REACTION: self._apply_source_operation,
+            OperationKind.REFERENCE: self._apply_source_operation,
+            OperationKind.REDACTION: self._apply_redaction,
+            OperationKind.CIPHERTEXT_REPLAY: self._apply_source_operation,
+            OperationKind.REPLACE_THREAD: self._apply_thread_replacement,
+            OperationKind.INVALIDATE_THREAD: self._apply_thread_invalidation,
+            OperationKind.MARK_THREAD_STALE: self._apply_thread_stale_marker,
+            OperationKind.MARK_ROOM_STALE: self._apply_room_stale_marker,
+            OperationKind.LIMITED_SYNC: self._apply_limited_sync,
+        }
+        handler = handlers.get(operation.kind)
+        if handler is None:
+            msg = f"unsupported fuzz operation: {operation.kind}"
+            raise AssertionError(msg)
+        await handler(operation)
+
+    async def _apply_source_operation(self, operation: FuzzOperation) -> None:
+        builders: dict[OperationKind, Callable[[FuzzOperation], dict[str, Any]]] = {
+            OperationKind.THREADED_MESSAGE: threaded_message_source,
+            OperationKind.PLAIN_REPLY: plain_reply_source,
+            OperationKind.EDIT: edit_source,
+            OperationKind.REACTION: reaction_source,
+            OperationKind.REFERENCE: reference_source,
+            OperationKind.CIPHERTEXT_REPLAY: ciphertext_source,
+        }
+        source_builder = builders.get(operation.kind)
+        if source_builder is None:
+            msg = f"fuzz operation has no event builder: {operation.kind}"
+            raise AssertionError(msg)
+        source = source_builder(operation)
+        self._remember_source(source)
+        await self._apply_sync(operation.room, [_raw_event(source)])
+
+    async def _apply_redaction(self, operation: FuzzOperation) -> None:
+        current_room_id = room_id(operation.room)
+        target_id = _redaction_target(operation)
+        self.known_ids.add((current_room_id, target_id))
+        self.redacted_ids.add((current_room_id, target_id))
+        await self._apply_sync(operation.room, [_redaction_event(operation)])
+
+    async def _apply_thread_replacement(self, operation: FuzzOperation) -> None:
+        current_room_id = room_id(operation.room)
+        current_thread_id = thread_id(operation.room, operation.thread)
+        upper_slot = operation.variant % 6
+        sources = [
+            root_source(operation.room, operation.thread),
+            *[
+                threaded_message_source(
+                    FuzzOperation(
+                        kind=OperationKind.THREADED_MESSAGE,
+                        room=operation.room,
+                        thread=operation.thread,
+                        slot=slot,
+                        target=0,
+                        variant=0,
+                    ),
+                )
+                for slot in range(upper_slot)
+            ],
+        ]
+        for source in sources:
+            self._remember_source(source)
+        membership_epoch = await self.cache.room_membership_epoch(current_room_id)
+        if membership_epoch is None:
+            return
+        await self.cache.replace_thread_if_not_newer(
+            current_room_id,
+            current_thread_id,
+            sources,
+            expected_membership_epoch=membership_epoch,
+            fetch_started_at=time.time(),
+            validated_at=time.time(),
+        )
+
+    async def _apply_thread_invalidation(self, operation: FuzzOperation) -> None:
+        await self.cache.invalidate_thread(
+            room_id(operation.room),
+            thread_id(operation.room, operation.thread),
+        )
+
+    async def _apply_thread_stale_marker(self, operation: FuzzOperation) -> None:
+        current_room_id = room_id(operation.room)
+        current_thread_id = thread_id(operation.room, operation.thread)
+        reason = "sync_thread_mutation" if operation.variant % 3 else "sync_opaque_encrypted_event"
+        await self.cache.mark_thread_stale(
+            current_room_id,
+            current_thread_id,
+            reason=reason,
+        )
+        if operation.variant % 2:
+            await self.cache.revalidate_thread_after_incremental_update(
+                current_room_id,
+                current_thread_id,
+            )
+
+    async def _apply_room_stale_marker(self, operation: FuzzOperation) -> None:
+        await self.cache.mark_room_threads_stale(
+            room_id(operation.room),
+            reason="sync_thread_lookup_unavailable",
+        )
+
+    async def _apply_limited_sync(self, operation: FuzzOperation) -> None:
+        await self._apply_sync(operation.room, [], limited=True)
+
+    async def _assert_tombstone_invariants(self) -> None:
+        for current_room_id, event_id in sorted(self.redacted_ids):
+            assert await self.cache.get_event(current_room_id, event_id) is None, (
+                f"redacted event resurrected: {current_room_id} {event_id}"
+            )
+            mapping = await self.cache.get_thread_id_for_event(current_room_id, event_id)
+            is_thread_root = any(
+                event_id == thread_id(room, thread)
+                for room in range(self.room_count)
+                for thread in range(self.thread_count)
+            )
+            assert mapping is None or (is_thread_root and mapping == event_id), (
+                f"redacted non-root event retained a thread mapping: {current_room_id} {event_id} -> {mapping}"
+            )
+
+    async def _assert_isolation_and_reaction_invariants(self) -> None:
+        for current_room_id, event_id in sorted(self.known_ids):
+            assert await self.other_cache.get_event(current_room_id, event_id) is None
+            assert await self.other_cache.get_thread_id_for_event(current_room_id, event_id) is None
+
+        for current_room_id, event_id in sorted(self.reaction_ids):
+            assert await self.cache.get_thread_id_for_event(current_room_id, event_id) is None
+
+    async def _assert_thread_invariants(self) -> None:
+        for room in range(self.room_count):
+            current_room_id = room_id(room)
+            for thread in range(self.thread_count):
+                current_thread_id = thread_id(room, thread)
+                events = await self.cache.get_thread_events(current_room_id, current_thread_id)
+                revision = await self.cache.get_thread_revision(current_room_id, current_thread_id)
+                if events is None:
+                    assert revision is None
+                    continue
+                cache_state = await self.cache.get_thread_cache_state(
+                    current_room_id,
+                    current_thread_id,
+                )
+                assert cache_state is not None
+                snapshot_is_reusable = thread_cache_rejection_reason(cache_state) is None
+                event_ids = [cast("str", event["event_id"]) for event in events]
+                timestamps = [cast("int", event["origin_server_ts"]) for event in events]
+                assert len(event_ids) == len(set(event_ids))
+                assert timestamps == sorted(timestamps)
+                assert revision is not None
+                assert revision.event_count == len(events)
+                assert revision.max_origin_server_ts == max(timestamps)
+                for event, event_id in zip(events, event_ids, strict=True):
+                    assert await self.cache.get_event(current_room_id, event_id) == event
+                    mapping = await self.cache.get_thread_id_for_event(current_room_id, event_id)
+                    if snapshot_is_reusable:
+                        assert mapping == current_thread_id, (
+                            f"reusable thread snapshot/index mismatch: {current_room_id} "
+                            f"{current_thread_id} contains {event_id}, mapped to {mapping}"
+                        )
+                    assert (current_room_id, event_id) not in self.redacted_ids
+                    assert (current_room_id, event_id) not in self.reaction_ids
+
+    async def _assert_latest_edit_invariants(self) -> None:
+        for current_room_id, event_id in sorted(self.known_ids):
+            latest_edit = await self.cache.get_latest_edit(current_room_id, event_id)
+            if latest_edit is None:
+                continue
+            latest_edit_id = cast("str", latest_edit["event_id"])
+            relation = cast("dict[str, Any]", latest_edit["content"]).get("m.relates_to")
+            assert isinstance(relation, dict)
+            assert relation.get("rel_type") == "m.replace"
+            assert relation.get("event_id") == event_id
+            assert await self.cache.get_event(current_room_id, latest_edit_id) == latest_edit
+            assert (current_room_id, latest_edit_id) not in self.redacted_ids
+
+    async def assert_invariants(self) -> None:
+        """Assert cache consistency through only the public storage contract."""
+        await self._assert_tombstone_invariants()
+        await self._assert_isolation_and_reaction_invariants()
+        await self._assert_thread_invariants()
+        await self._assert_latest_edit_invariants()
+
+    async def observe(self) -> ObservableCacheState:
+        """Read stable state for restart comparisons."""
+        events: list[tuple[str, str, str | None]] = []
+        mappings: list[tuple[str, str, str | None]] = []
+        for current_room_id, event_id in sorted(self.known_ids):
+            event = await self.cache.get_event(current_room_id, event_id)
+            events.append(
+                (
+                    current_room_id,
+                    event_id,
+                    None if event is None else json.dumps(event, sort_keys=True),
+                ),
+            )
+            mappings.append(
+                (
+                    current_room_id,
+                    event_id,
+                    await self.cache.get_thread_id_for_event(current_room_id, event_id),
+                ),
+            )
+        threads: list[tuple[str, str, tuple[str, ...]]] = []
+        revisions: list[tuple[str, str, ThreadRevision | None]] = []
+        invalidation_reasons: list[tuple[str, str, str | None, str | None]] = []
+        for room in range(self.room_count):
+            current_room_id = room_id(room)
+            for thread in range(self.thread_count):
+                current_thread_id = thread_id(room, thread)
+                thread_events = await self.cache.get_thread_events(current_room_id, current_thread_id)
+                threads.append(
+                    (
+                        current_room_id,
+                        current_thread_id,
+                        ()
+                        if thread_events is None
+                        else tuple(cast("str", event["event_id"]) for event in thread_events),
+                    ),
+                )
+                revisions.append(
+                    (
+                        current_room_id,
+                        current_thread_id,
+                        await self.cache.get_thread_revision(current_room_id, current_thread_id),
+                    ),
+                )
+                state = await self.cache.get_thread_cache_state(current_room_id, current_thread_id)
+                invalidation_reasons.append(
+                    (
+                        current_room_id,
+                        current_thread_id,
+                        None if state is None else state.invalidation_reason,
+                        None if state is None else state.room_invalidation_reason,
+                    ),
+                )
+        return ObservableCacheState(
+            events=tuple(events),
+            mappings=tuple(mappings),
+            threads=tuple(threads),
+            revisions=tuple(revisions),
+            invalidation_reasons=tuple(invalidation_reasons),
+        )
+
+
+async def run_scenario(
+    cache_factory: Callable[[], ConversationEventCache],
+    scenario: FuzzScenario,
+    *,
+    room_count: int = 2,
+    thread_count: int = 4,
+    verify_restart: bool = True,
+) -> ObservableCacheState:
+    """Run one scenario, emitting its exact trace on failure."""
+    root_cache = cache_factory()
+    await root_cache.initialize()
+    runner = CacheFuzzRunner(
+        root_cache,
+        scenario,
+        room_count=room_count,
+        thread_count=thread_count,
+    )
+    try:
+        result = await runner.run()
+        known_ids = set(runner.known_ids)
+        redacted_ids = set(runner.redacted_ids)
+        reaction_ids = set(runner.reaction_ids)
+    except Exception as exc:
+        msg = f"{exc}\nMatrix cache fuzz trace:\n{scenario.to_json()}"
+        raise AssertionError(msg) from exc
+    finally:
+        await root_cache.close()
+
+    if not verify_restart:
+        return result
+
+    reopened_root = cache_factory()
+    await reopened_root.initialize()
+    reopened = CacheFuzzRunner(
+        reopened_root,
+        FuzzScenario(batches=()),
+        room_count=room_count,
+        thread_count=thread_count,
+    )
+    reopened.known_ids = known_ids
+    reopened.redacted_ids = redacted_ids
+    reopened.reaction_ids = reaction_ids
+    try:
+        await reopened.assert_invariants()
+        restarted_result = await reopened.observe()
+        assert restarted_result == result
+    except Exception as exc:
+        msg = f"{exc}\nMatrix cache fuzz trace:\n{scenario.to_json()}"
+        raise AssertionError(msg) from exc
+    finally:
+        await reopened_root.close()
+    return result
+
+
+_WEIGHTED_KINDS = (
+    OperationKind.THREADED_MESSAGE,
+    OperationKind.THREADED_MESSAGE,
+    OperationKind.THREADED_MESSAGE,
+    OperationKind.PLAIN_REPLY,
+    OperationKind.PLAIN_REPLY,
+    OperationKind.EDIT,
+    OperationKind.EDIT,
+    OperationKind.REACTION,
+    OperationKind.REACTION,
+    OperationKind.REFERENCE,
+    OperationKind.REDACTION,
+    OperationKind.CIPHERTEXT_REPLAY,
+    OperationKind.REPLACE_THREAD,
+    OperationKind.INVALIDATE_THREAD,
+    OperationKind.MARK_THREAD_STALE,
+    OperationKind.MARK_ROOM_STALE,
+    OperationKind.LIMITED_SYNC,
+)
+
+
+def scenario_from_seed(
+    seed: int,
+    *,
+    steps: int,
+    room_count: int = 2,
+    thread_count: int = 4,
+    max_batch_size: int = 8,
+) -> FuzzScenario:
+    """Generate a deterministic long-running scenario."""
+    randomizer = random.Random(seed)  # noqa: S311 - deterministic test trace generation
+    batches: list[tuple[FuzzOperation, ...]] = []
+    remaining = steps
+    while remaining:
+        batch_size = min(remaining, randomizer.randint(1, max_batch_size))
+        batch = tuple(
+            FuzzOperation(
+                kind=randomizer.choice(_WEIGHTED_KINDS),
+                room=randomizer.randrange(room_count),
+                thread=randomizer.randrange(thread_count),
+                slot=randomizer.randrange(16),
+                target=randomizer.randrange(16),
+                variant=randomizer.randrange(8),
+            )
+            for _ in range(batch_size)
+        )
+        batches.append(batch)
+        remaining -= batch_size
+    return FuzzScenario(batches=tuple(batches))
+
+
+def concurrent_fanout_scenario(thread_count: int = 45) -> FuzzScenario:
+    """Build the 45-way thread burst plus mixed follow-up mutations."""
+    initial_messages = tuple(
+        FuzzOperation(
+            kind=OperationKind.THREADED_MESSAGE,
+            room=0,
+            thread=thread,
+            slot=0,
+            target=0,
+            variant=0,
+        )
+        for thread in range(thread_count)
+    )
+    mixed_mutations = tuple(
+        operation
+        for thread in range(thread_count)
+        for operation in (
+            FuzzOperation(OperationKind.EDIT, 0, thread, 1, 0, 0),
+            FuzzOperation(OperationKind.REACTION, 0, thread, 2, 0, thread),
+            FuzzOperation(OperationKind.PLAIN_REPLY, 0, thread, 3, 0, 1),
+        )
+    )
+    disruptive_mutations = tuple(
+        FuzzOperation(
+            kind=(OperationKind.REDACTION if thread % 2 else OperationKind.CIPHERTEXT_REPLAY),
+            room=0,
+            thread=thread,
+            slot=0,
+            target=0,
+            variant=1,
+        )
+        for thread in range(0, thread_count, 5)
+    )
+    return FuzzScenario(
+        batches=(initial_messages, mixed_mutations, disruptive_mutations),
+    )
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        msg = "must be at least 1"
+        raise argparse.ArgumentTypeError(msg)
+    return parsed
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--seed", type=int, default=1)
+    parser.add_argument("--steps", type=_positive_int, default=500)
+    parser.add_argument("--rooms", type=_positive_int, default=2)
+    parser.add_argument("--threads", type=_positive_int, default=4)
+    parser.add_argument("--max-batch-size", type=_positive_int, default=8)
+    parser.add_argument("--trace", type=Path)
+    parser.add_argument("--save-trace", type=Path)
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Run a replayable SQLite fuzz scenario."""
+    args = _parse_args()
+    scenario = (
+        FuzzScenario.from_json(args.trace.read_text(encoding="utf-8"))
+        if args.trace is not None
+        else scenario_from_seed(
+            args.seed,
+            steps=args.steps,
+            room_count=args.rooms,
+            thread_count=args.threads,
+            max_batch_size=args.max_batch_size,
+        )
+    )
+    if args.save_trace is not None:
+        args.save_trace.write_text(scenario.to_json() + "\n", encoding="utf-8")
+    with tempfile.TemporaryDirectory(prefix="mindroom-matrix-cache-fuzz-") as temp_dir:
+        db_path = Path(temp_dir) / "event_cache.db"
+        asyncio.run(
+            run_scenario(
+                lambda: SqliteEventCache(db_path),
+                scenario,
+                room_count=args.rooms,
+                thread_count=args.threads,
+            ),
+        )
+    print(
+        json.dumps(
+            {
+                "batches": len(scenario.batches),
+                "operations": sum(len(batch) for batch in scenario.batches),
+                "seed": args.seed if args.trace is None else None,
+                "status": "PASS",
+            },
+            sort_keys=True,
+        ),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mindroom/matrix/cache/postgres_event_cache_events.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache_events.py
@@ -484,25 +484,17 @@ async def _reconcile_thread_root_self_rows(
 ) -> None:
     """Keep root self-mappings exactly while a current row still proves them."""
     for root_id in candidate_root_ids:
-        support_row = await fetchone(
+        surviving_child = await fetchone(
             db,
             """
-            SELECT
-                EXISTS(
-                    SELECT 1
-                    FROM mindroom_event_cache_events
-                    WHERE namespace = %s AND room_id = %s AND event_id = %s
-                )
-                OR EXISTS(
-                    SELECT 1
-                    FROM mindroom_event_cache_event_threads
-                    WHERE namespace = %s AND room_id = %s AND thread_id = %s AND event_id <> %s
-                )
+            SELECT 1
+            FROM mindroom_event_cache_event_threads
+            WHERE namespace = %s AND room_id = %s AND thread_id = %s AND event_id <> %s
+            LIMIT 1
             """,
-            (namespace, room_id, root_id, namespace, room_id, root_id, root_id),
+            (namespace, room_id, root_id, root_id),
         )
-        assert support_row is not None
-        if bool(support_row[0]) or root_id in current_self_root_ids:
+        if surviving_child is not None or root_id in current_self_root_ids:
             await db.execute(
                 """
                 INSERT INTO mindroom_event_cache_event_threads(namespace, room_id, event_id, thread_id)
@@ -707,8 +699,9 @@ async def delete_event_thread_rows(
     room_id: str,
     *,
     event_ids: list[str],
+    current_self_root_ids: Collection[str] = (),
 ) -> int:
-    """Delete event mappings and unsupported roots whose proof was removed."""
+    """Delete event mappings while preserving roots proven by the current snapshot."""
     if not event_ids:
         return 0
     affected_thread_ids = await _thread_ids_for_events(
@@ -730,7 +723,7 @@ async def delete_event_thread_rows(
         namespace,
         room_id,
         candidate_root_ids=affected_thread_ids,
-        current_self_root_ids=set(),
+        current_self_root_ids=set(current_self_root_ids),
     )
     return deleted_rows
 

--- a/src/mindroom/matrix/cache/postgres_event_cache_events.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache_events.py
@@ -484,17 +484,25 @@ async def _reconcile_thread_root_self_rows(
 ) -> None:
     """Keep root self-mappings exactly while a current row still proves them."""
     for root_id in candidate_root_ids:
-        surviving_child = await fetchone(
+        support_row = await fetchone(
             db,
             """
-            SELECT 1
-            FROM mindroom_event_cache_event_threads
-            WHERE namespace = %s AND room_id = %s AND thread_id = %s AND event_id <> %s
-            LIMIT 1
+            SELECT
+                EXISTS(
+                    SELECT 1
+                    FROM mindroom_event_cache_events
+                    WHERE namespace = %s AND room_id = %s AND event_id = %s
+                )
+                OR EXISTS(
+                    SELECT 1
+                    FROM mindroom_event_cache_event_threads
+                    WHERE namespace = %s AND room_id = %s AND thread_id = %s AND event_id <> %s
+                )
             """,
-            (namespace, room_id, root_id, root_id),
+            (namespace, room_id, root_id, namespace, room_id, root_id, root_id),
         )
-        if surviving_child is not None or root_id in current_self_root_ids:
+        assert support_row is not None
+        if bool(support_row[0]) or root_id in current_self_root_ids:
             await db.execute(
                 """
                 INSERT INTO mindroom_event_cache_event_threads(namespace, room_id, event_id, thread_id)

--- a/src/mindroom/matrix/cache/postgres_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache_threads.py
@@ -390,6 +390,7 @@ async def _replace_thread_locked(
             namespace,
             room_id,
             event_ids=removed_event_ids,
+            current_self_root_ids={thread_id} if thread_id in replacement_event_ids else (),
         )
 
 

--- a/src/mindroom/matrix/cache/sqlite_event_cache_events.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache_events.py
@@ -505,16 +505,32 @@ async def _reconcile_thread_root_self_rows(
     for root_id in candidate_root_ids:
         cursor = await db.execute(
             """
-            SELECT 1
-            FROM event_threads
-            WHERE principal_id = ? AND room_id = ? AND thread_id = ? AND event_id <> ?
-            LIMIT 1
+            SELECT
+                EXISTS(
+                    SELECT 1
+                    FROM events
+                    WHERE principal_id = ? AND room_id = ? AND event_id = ?
+                )
+                OR EXISTS(
+                    SELECT 1
+                    FROM event_threads
+                    WHERE principal_id = ? AND room_id = ? AND thread_id = ? AND event_id <> ?
+                )
             """,
-            (principal_id, room_id, root_id, root_id),
+            (
+                principal_id,
+                room_id,
+                root_id,
+                principal_id,
+                room_id,
+                root_id,
+                root_id,
+            ),
         )
-        has_surviving_child = await cursor.fetchone() is not None
+        support_row = await cursor.fetchone()
         await cursor.close()
-        if has_surviving_child or root_id in current_self_root_ids:
+        assert support_row is not None
+        if bool(support_row[0]) or root_id in current_self_root_ids:
             await db.execute(
                 """
                 INSERT OR IGNORE INTO event_threads(principal_id, room_id, event_id, thread_id)

--- a/src/mindroom/matrix/cache/sqlite_event_cache_events.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache_events.py
@@ -505,32 +505,16 @@ async def _reconcile_thread_root_self_rows(
     for root_id in candidate_root_ids:
         cursor = await db.execute(
             """
-            SELECT
-                EXISTS(
-                    SELECT 1
-                    FROM events
-                    WHERE principal_id = ? AND room_id = ? AND event_id = ?
-                )
-                OR EXISTS(
-                    SELECT 1
-                    FROM event_threads
-                    WHERE principal_id = ? AND room_id = ? AND thread_id = ? AND event_id <> ?
-                )
+            SELECT 1
+            FROM event_threads
+            WHERE principal_id = ? AND room_id = ? AND thread_id = ? AND event_id <> ?
+            LIMIT 1
             """,
-            (
-                principal_id,
-                room_id,
-                root_id,
-                principal_id,
-                room_id,
-                root_id,
-                root_id,
-            ),
+            (principal_id, room_id, root_id, root_id),
         )
-        support_row = await cursor.fetchone()
+        has_surviving_child = await cursor.fetchone() is not None
         await cursor.close()
-        assert support_row is not None
-        if bool(support_row[0]) or root_id in current_self_root_ids:
+        if has_surviving_child or root_id in current_self_root_ids:
             await db.execute(
                 """
                 INSERT OR IGNORE INTO event_threads(principal_id, room_id, event_id, thread_id)
@@ -737,8 +721,9 @@ async def delete_event_thread_rows(
     room_id: str,
     *,
     event_ids: list[str],
+    current_self_root_ids: Collection[str] = (),
 ) -> int:
-    """Delete event-to-thread rows within one owner and room."""
+    """Delete event mappings while preserving roots proven by the current snapshot."""
     affected_thread_ids = await _thread_ids_for_events(
         db,
         principal_id,
@@ -758,7 +743,7 @@ async def delete_event_thread_rows(
         principal_id,
         room_id,
         candidate_root_ids=affected_thread_ids,
-        current_self_root_ids=set(),
+        current_self_root_ids=set(current_self_root_ids),
     )
     return deleted_rows
 

--- a/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
@@ -441,6 +441,7 @@ async def _replace_thread_locked(
             principal_id,
             room_id,
             event_ids=removed_event_ids,
+            current_self_root_ids={thread_id} if thread_id in replacement_event_ids else (),
         )
 
 

--- a/src/mindroom/text_ingress_dispatch.py
+++ b/src/mindroom/text_ingress_dispatch.py
@@ -94,7 +94,7 @@ async def dispatch_text_message(
 ) -> None:
     """Run the normal text or command dispatch pipeline for a prepared text event."""
     turn_claim = handled_turn or TurnRecord.create([raw_event.event_id], completed=False)
-    if not controller.deps.turn_store.try_claim_turn(turn_claim):
+    if not _try_claim_turn(controller, turn_claim, queued_notice_reservation):
         return
     claim_transferred = False
 
@@ -154,6 +154,7 @@ async def dispatch_text_message(
             trusted_attachment_ids=trusted_attachment_ids,
             media_events=media_events,
             queued_notice_reservation=queued_notice_reservation,
+            turn_claim=turn_claim,
             mark_claim_transferred=mark_claim_transferred,
         )
     finally:
@@ -163,6 +164,19 @@ async def dispatch_text_message(
             queued_notice_reservation.cancel()
         if timing_scope_token is not None:
             timing_scope_context.reset(timing_scope_token)
+
+
+def _try_claim_turn(
+    controller: TurnController,
+    turn_claim: TurnRecord,
+    queued_notice_reservation: QueuedHumanNoticeReservation | None,
+) -> bool:
+    """Claim dispatch ownership or cancel the reservation that cannot be consumed."""
+    if controller.deps.turn_store.try_claim_turn(turn_claim):
+        return True
+    if queued_notice_reservation is not None:
+        queued_notice_reservation.cancel()
+    return False
 
 
 async def _prepare_text_dispatch(
@@ -373,6 +387,7 @@ async def _apply_turn_plan(
     trusted_attachment_ids: list[str],
     media_events: list[MediaDispatchEvent] | None,
     queued_notice_reservation: QueuedHumanNoticeReservation | None,
+    turn_claim: TurnRecord,
     mark_claim_transferred: Callable[[], None],
 ) -> None:
     if plan.kind == "ignore":
@@ -425,7 +440,7 @@ async def _apply_turn_plan(
     response_task = controller.deps.response_runner.track_inbox_response(
         _run_claimed_response(
             controller,
-            handled_turn,
+            turn_claim,
             controller._execute_response_action(
                 room,
                 prepared.event,
@@ -464,14 +479,14 @@ async def _apply_turn_plan(
 
 async def _run_claimed_response(
     controller: TurnController,
-    handled_turn: TurnRecord,
+    turn_claim: TurnRecord,
     response: Awaitable[None],
 ) -> None:
     """Release exclusive response ownership after every terminal path."""
     try:
         await response
     finally:
-        controller.deps.turn_store.release_pending_turn_claim(handled_turn)
+        controller.deps.turn_store.release_pending_turn_claim(turn_claim)
 
 
 async def _execute_route_plan(

--- a/src/mindroom/text_ingress_dispatch.py
+++ b/src/mindroom/text_ingress_dispatch.py
@@ -40,7 +40,7 @@ from mindroom.timing import (
 from mindroom.timing import timing_scope as timing_scope_context
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Awaitable, Callable, Sequence
 
     import nio
 
@@ -93,6 +93,15 @@ async def dispatch_text_message(
     current_prompt_is_structured: bool = False,
 ) -> None:
     """Run the normal text or command dispatch pipeline for a prepared text event."""
+    turn_claim = handled_turn or TurnRecord.create([raw_event.event_id], completed=False)
+    if not controller.deps.turn_store.try_claim_turn(turn_claim):
+        return
+    claim_transferred = False
+
+    def mark_claim_transferred() -> None:
+        nonlocal claim_transferred
+        claim_transferred = True
+
     timing_scope_token = None
     try:
         dispatch_timing = get_dispatch_pipeline_timing(raw_event.source)
@@ -145,8 +154,11 @@ async def dispatch_text_message(
             trusted_attachment_ids=trusted_attachment_ids,
             media_events=media_events,
             queued_notice_reservation=queued_notice_reservation,
+            mark_claim_transferred=mark_claim_transferred,
         )
     finally:
+        if not claim_transferred:
+            controller.deps.turn_store.release_pending_turn_claim(turn_claim)
         if queued_notice_reservation is not None:
             queued_notice_reservation.cancel()
         if timing_scope_token is not None:
@@ -361,6 +373,7 @@ async def _apply_turn_plan(
     trusted_attachment_ids: list[str],
     media_events: list[MediaDispatchEvent] | None,
     queued_notice_reservation: QueuedHumanNoticeReservation | None,
+    mark_claim_transferred: Callable[[], None],
 ) -> None:
     if plan.kind == "ignore":
         if plan.ignore_reason == "router":
@@ -410,21 +423,29 @@ async def _apply_turn_plan(
     # response lock; the response itself keeps running on a runner-owned task.
     response_started = asyncio.Event()
     response_task = controller.deps.response_runner.track_inbox_response(
-        controller._execute_response_action(
-            room,
-            prepared.event,
-            prepared.dispatch,
-            plan.response_action,
-            payload_inputs,
-            processing_log="Processing",
-            dispatch_started_at=prepared.dispatch_started_at,
-            handled_turn=handled_turn,
-            matrix_run_metadata=controller.deps.turn_store.build_run_metadata(handled_turn),
-            queued_notice_reservation=queued_notice_reservation,
-            on_lifecycle_lock_acquired=response_started.set,
+        _run_claimed_response(
+            controller,
+            handled_turn,
+            controller._execute_response_action(
+                room,
+                prepared.event,
+                prepared.dispatch,
+                plan.response_action,
+                payload_inputs,
+                processing_log="Processing",
+                dispatch_started_at=prepared.dispatch_started_at,
+                handled_turn=handled_turn,
+                matrix_run_metadata=controller.deps.turn_store.build_run_metadata(handled_turn),
+                queued_notice_reservation=queued_notice_reservation,
+                on_lifecycle_lock_acquired=response_started.set,
+            ),
         ),
         name=f"inbox_response:{prepared.event.event_id}",
     )
+    # Ownership moves synchronously after task creation. If this dispatch task
+    # is cancelled while waiting for the lifecycle lock, its finally block must
+    # not reopen the source while the runner-owned response still exists.
+    mark_claim_transferred()
     started_wait = asyncio.ensure_future(response_started.wait())
     try:
         await asyncio.wait({started_wait, response_task}, return_when=asyncio.FIRST_COMPLETED)
@@ -439,6 +460,18 @@ async def _apply_turn_plan(
         # own cancellation state. The queued-notice reservation still cancels
         # in dispatch_text_message's finally, which is the cleanup contract.
         response_task.result()
+
+
+async def _run_claimed_response(
+    controller: TurnController,
+    handled_turn: TurnRecord,
+    response: Awaitable[None],
+) -> None:
+    """Release exclusive response ownership after every terminal path."""
+    try:
+        await response
+    finally:
+        controller.deps.turn_store.release_pending_turn_claim(handled_turn)
 
 
 async def _execute_route_plan(

--- a/src/mindroom/turn_store.py
+++ b/src/mindroom/turn_store.py
@@ -120,7 +120,6 @@ class TurnStore:
             )
 
         self._ledger.update_handled_turn(turn_record.indexed_event_ids, terminal_record)
-        self.release_pending_turn_claim(turn_record)
 
     def is_handled(self, event_id: str) -> bool:
         """Return whether one source event already has a terminal outcome."""

--- a/src/mindroom/turn_store.py
+++ b/src/mindroom/turn_store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+import threading
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -65,6 +66,8 @@ class TurnStore:
 
     deps: TurnStoreDeps
     _ledger: HandledTurnLedger = field(init=False, repr=False)
+    _pending_claim_lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
+    _pending_claimed_event_ids: set[str] = field(default_factory=set, init=False, repr=False)
 
     def __post_init__(self) -> None:
         """Construct the private handled-turn ledger for this runtime entity."""
@@ -117,6 +120,7 @@ class TurnStore:
             )
 
         self._ledger.update_handled_turn(turn_record.indexed_event_ids, terminal_record)
+        self.release_pending_turn_claim(turn_record)
 
     def is_handled(self, event_id: str) -> bool:
         """Return whether one source event already has a terminal outcome."""
@@ -193,6 +197,22 @@ class TurnStore:
             merge_pending,
             wait_for_persist=True,
         )
+
+    def try_claim_turn(self, turn_record: TurnRecord) -> bool:
+        """Claim source processing before any expensive dispatch resolution."""
+        event_ids = turn_record.indexed_event_ids
+        if not turn_record.source_event_ids:
+            return False
+        with self._pending_claim_lock:
+            if self._pending_claimed_event_ids.intersection(event_ids):
+                return False
+            self._pending_claimed_event_ids.update(event_ids)
+        return True
+
+    def release_pending_turn_claim(self, turn_record: TurnRecord) -> None:
+        """Release a response claim after terminal settlement or failure."""
+        with self._pending_claim_lock:
+            self._pending_claimed_event_ids.difference_update(turn_record.indexed_event_ids)
 
     def mark_source_redacted(
         self,

--- a/tests/test_live_matrix_fuzz.py
+++ b/tests/test_live_matrix_fuzz.py
@@ -1,0 +1,158 @@
+"""Tests for replayable real-server Matrix fuzz traces and their oracle."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from scripts.testing.fuzz_live_matrix import (
+    ExactReplyOracle,
+    LiveFuzzScenario,
+    LiveMatrixClient,
+    LiveOperation,
+    LiveOperationKind,
+    live_scenario_from_seed,
+    saturation_scenario,
+)
+
+
+def test_live_scenario_is_deterministic_and_json_replayable() -> None:
+    """A seed must produce a stable trace that survives JSON round-tripping."""
+    scenario = live_scenario_from_seed(
+        42,
+        steps=250,
+        thread_count=12,
+        max_batch_size=10,
+        restart_interval=75,
+    )
+
+    assert scenario == live_scenario_from_seed(
+        42,
+        steps=250,
+        thread_count=12,
+        max_batch_size=10,
+        restart_interval=75,
+    )
+    assert LiveFuzzScenario.from_json(scenario.to_json()) == scenario
+    assert (
+        sum(
+            operation.kind is not LiveOperationKind.RESTART_MINDROOM
+            for batch in scenario.batches
+            for operation in batch
+        )
+        == 250
+    )
+    assert any(
+        operation.kind is LiveOperationKind.RESTART_MINDROOM for batch in scenario.batches for operation in batch
+    )
+
+
+def test_live_scenario_generator_covers_every_matrix_mutation() -> None:
+    """The weighted generator must reach every supported live operation."""
+    seen = {
+        operation.kind
+        for seed in range(5)
+        for batch in live_scenario_from_seed(
+            seed,
+            steps=200,
+            thread_count=8,
+            restart_interval=50,
+        ).batches
+        for operation in batch
+    }
+
+    assert seen == set(LiveOperationKind)
+
+
+def test_saturation_scenario_matches_original_two_phase_workload() -> None:
+    """The regression profile must preserve the old hot-then-parallel ordering."""
+    scenario = saturation_scenario()
+
+    assert scenario.thread_count == 13
+    assert len(scenario.batches) == 108
+    assert all(len(batch) == 1 and batch[0].thread == 0 for batch in scenario.batches[:100])
+    assert all([operation.thread for operation in batch] == list(range(1, 13)) for batch in scenario.batches[100:])
+
+
+def test_live_scenario_rejects_same_batch_dependency() -> None:
+    """Concurrent operations may only target events from completed batches."""
+    scenario = LiveFuzzScenario(
+        thread_count=1,
+        batches=(
+            (
+                LiveOperation(0, LiveOperationKind.THREAD_MESSAGE, 0, "root:0"),
+                LiveOperation(1, LiveOperationKind.REACTION, 0, "op:0"),
+            ),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="unknown or same-batch target"):
+        scenario.validate()
+
+
+@pytest.mark.asyncio
+async def test_exact_reply_oracle_counts_only_canonical_agent_thread_replies() -> None:
+    """Edits and duplicate sync delivery must not inflate canonical counts."""
+    client = LiveMatrixClient("http://matrix.invalid", "!room:example")
+    oracle = ExactReplyOracle(client, "@agent:example")
+    oracle.expect("root:0", "$source")
+
+    canonical: dict[str, Any] = {
+        "event_id": "$response",
+        "sender": "@agent:example",
+        "type": "m.room.message",
+        "content": {
+            "m.relates_to": {
+                "rel_type": "m.thread",
+                "event_id": "$source",
+                "m.in_reply_to": {"event_id": "$source"},
+            },
+        },
+    }
+    oracle._ingest_event(canonical)
+    oracle._ingest_event(canonical)
+    oracle._ingest_event(
+        {
+            **canonical,
+            "event_id": "$edit",
+            "content": {
+                "m.relates_to": {
+                    "rel_type": "m.replace",
+                    "event_id": "$response",
+                },
+            },
+        },
+    )
+
+    assert oracle.response_ids == {"$source": {"$response"}}
+    assert oracle.resolve_response_ref("response:root:0") == "$response"
+    oracle._assert_no_wrong_replies()
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_exact_reply_oracle_rejects_duplicate_canonical_replies() -> None:
+    """Two distinct agent events replying to one input must fail immediately."""
+    client = LiveMatrixClient("http://matrix.invalid", "!room:example")
+    oracle = ExactReplyOracle(client, "@agent:example")
+    oracle.expect("root:0", "$source")
+    for event_id in ("$response-one", "$response-two"):
+        oracle._ingest_event(
+            {
+                "event_id": event_id,
+                "sender": "@agent:example",
+                "type": "m.room.message",
+                "content": {
+                    "m.relates_to": {
+                        "rel_type": "m.thread",
+                        "event_id": "$source",
+                        "m.in_reply_to": {"event_id": "$source"},
+                    },
+                },
+            },
+        )
+
+    with pytest.raises(AssertionError, match="duplicates"):
+        oracle._assert_no_wrong_replies()
+    await client.close()

--- a/tests/test_live_matrix_fuzz.py
+++ b/tests/test_live_matrix_fuzz.py
@@ -194,28 +194,29 @@ async def test_exact_reply_oracle_allows_response_to_internal_restart_relay() ->
         "@agent:example",
         internal_relay_senders=("@router:example",),
     )
-    oracle._ingest_event(
-        {
-            "event_id": "$resume-relay",
-            "sender": "@router:example",
-            "type": "m.room.message",
-            "content": {"body": "resume"},
-        },
-    )
-    oracle._ingest_event(
-        {
-            "event_id": "$response",
-            "sender": "@agent:example",
-            "type": "m.room.message",
-            "content": {
-                "m.relates_to": {
-                    "rel_type": "m.thread",
-                    "event_id": "$root",
-                    "m.in_reply_to": {"event_id": "$resume-relay"},
+    try:
+        oracle._ingest_event(
+            {
+                "event_id": "$resume-relay",
+                "sender": "@router:example",
+                "type": "m.room.message",
+                "content": {"body": "resume"},
+            },
+        )
+        oracle._ingest_event(
+            {
+                "event_id": "$response",
+                "sender": "@agent:example",
+                "type": "m.room.message",
+                "content": {
+                    "m.relates_to": {
+                        "rel_type": "m.thread",
+                        "event_id": "$root",
+                        "m.in_reply_to": {"event_id": "$resume-relay"},
+                    },
                 },
             },
-        },
-    )
-
-    oracle._assert_no_wrong_replies()
-    await client.close()
+        )
+        oracle._assert_no_wrong_replies()
+    finally:
+        await client.close()

--- a/tests/test_live_matrix_fuzz.py
+++ b/tests/test_live_matrix_fuzz.py
@@ -46,6 +46,17 @@ def test_live_scenario_is_deterministic_and_json_replayable() -> None:
     assert any(
         operation.kind is LiveOperationKind.RESTART_MINDROOM for batch in scenario.batches for operation in batch
     )
+    for batch in scenario.batches:
+        reply_threads = [
+            operation.thread
+            for operation in batch
+            if operation.kind
+            in {
+                LiveOperationKind.THREAD_MESSAGE,
+                LiveOperationKind.PLAIN_REPLY,
+            }
+        ]
+        assert len(reply_threads) == len(set(reply_threads))
 
 
 def test_live_scenario_generator_covers_every_matrix_mutation() -> None:
@@ -88,6 +99,22 @@ def test_live_scenario_rejects_same_batch_dependency() -> None:
     )
 
     with pytest.raises(ValueError, match="unknown or same-batch target"):
+        scenario.validate()
+
+
+def test_live_scenario_rejects_ambiguous_same_thread_reply_batch() -> None:
+    """The exact-reply oracle cannot distinguish a valid coalesced turn from loss."""
+    scenario = LiveFuzzScenario(
+        thread_count=1,
+        batches=(
+            (
+                LiveOperation(0, LiveOperationKind.THREAD_MESSAGE, 0, "root:0"),
+                LiveOperation(1, LiveOperationKind.PLAIN_REPLY, 0, "response:root:0"),
+            ),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="same-thread messages"):
         scenario.validate()
 
 

--- a/tests/test_live_matrix_fuzz.py
+++ b/tests/test_live_matrix_fuzz.py
@@ -183,3 +183,39 @@ async def test_exact_reply_oracle_rejects_duplicate_canonical_replies() -> None:
     with pytest.raises(AssertionError, match="duplicates"):
         oracle._assert_no_wrong_replies()
     await client.close()
+
+
+@pytest.mark.asyncio
+async def test_exact_reply_oracle_allows_response_to_internal_restart_relay() -> None:
+    """Restart recovery may validly answer a router-authored resume relay."""
+    client = LiveMatrixClient("http://matrix.invalid", "!room:example")
+    oracle = ExactReplyOracle(
+        client,
+        "@agent:example",
+        internal_relay_senders=("@router:example",),
+    )
+    oracle._ingest_event(
+        {
+            "event_id": "$resume-relay",
+            "sender": "@router:example",
+            "type": "m.room.message",
+            "content": {"body": "resume"},
+        },
+    )
+    oracle._ingest_event(
+        {
+            "event_id": "$response",
+            "sender": "@agent:example",
+            "type": "m.room.message",
+            "content": {
+                "m.relates_to": {
+                    "rel_type": "m.thread",
+                    "event_id": "$root",
+                    "m.in_reply_to": {"event_id": "$resume-relay"},
+                },
+            },
+        },
+    )
+
+    oracle._assert_no_wrong_replies()
+    await client.close()

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -232,6 +232,35 @@ def _make_room(room_id: str = "!room:localhost") -> MagicMock:
     return room
 
 
+@pytest.mark.asyncio
+async def test_duplicate_delivery_is_claimed_before_dispatch_resolution(tmp_path: Path) -> None:
+    """A replay arriving during cache resolution must not repeat that work."""
+    bot = _make_bot(tmp_path, debounce_ms=0)
+    room = _make_room()
+    event = _text_event(event_id="$duplicate", body="@test_agent hello")
+    resolution_started = asyncio.Event()
+    release_resolution = asyncio.Event()
+
+    async def slow_prepare(*_args: object, **_kwargs: object) -> None:
+        resolution_started.set()
+        await release_resolution.wait()
+
+    with patch.object(
+        bot._turn_controller,
+        "_prepare_dispatch",
+        new=AsyncMock(side_effect=slow_prepare),
+    ) as prepare:
+        first = asyncio.create_task(
+            bot._turn_controller._dispatch_text_message(room, event, "@user:localhost"),
+        )
+        await resolution_started.wait()
+        await bot._turn_controller._dispatch_text_message(room, event, "@user:localhost")
+        release_resolution.set()
+        await first
+
+    prepare.assert_awaited_once()
+
+
 async def _wait_for(condition: Callable[[], bool], *, deadline_seconds: float = 0.5) -> None:
     """Poll until a test condition becomes true."""
     ready = asyncio.Event()

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -239,32 +239,30 @@ async def test_duplicate_delivery_is_claimed_before_dispatch_resolution(tmp_path
     room = _make_room()
     event = _text_event(event_id="$duplicate", body="@test_agent hello")
     resolution_started = asyncio.Event()
-    release_resolution = asyncio.Event()
     duplicate_reservation = MagicMock()
 
-    async def slow_prepare(*_args: object, **_kwargs: object) -> None:
+    async def slow_normalize(*_args: object, **_kwargs: object) -> None:
         resolution_started.set()
-        await release_resolution.wait()
+        await asyncio.Event().wait()
 
-    with patch.object(
-        bot._turn_controller,
-        "_prepare_dispatch",
-        new=AsyncMock(side_effect=slow_prepare),
-    ) as prepare:
-        first = asyncio.create_task(
-            bot._turn_controller._dispatch_text_message(room, event, "@user:localhost"),
-        )
-        await resolution_started.wait()
-        await bot._turn_controller._dispatch_text_message(
-            room,
-            event,
-            "@user:localhost",
-            queued_notice_reservation=duplicate_reservation,
-        )
-        release_resolution.set()
+    normalizer = MagicMock()
+    normalizer.resolve_text_event = AsyncMock(side_effect=slow_normalize)
+    controller = replace_turn_controller_deps(bot, normalizer=normalizer)
+    first = asyncio.create_task(
+        controller._dispatch_text_message(room, event, "@user:localhost"),
+    )
+    await resolution_started.wait()
+    await controller._dispatch_text_message(
+        room,
+        event,
+        "@user:localhost",
+        queued_notice_reservation=duplicate_reservation,
+    )
+    first.cancel()
+    with pytest.raises(asyncio.CancelledError):
         await first
 
-    prepare.assert_awaited_once()
+    normalizer.resolve_text_event.assert_awaited_once()
     duplicate_reservation.cancel.assert_called_once_with()
 
 

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -240,6 +240,7 @@ async def test_duplicate_delivery_is_claimed_before_dispatch_resolution(tmp_path
     event = _text_event(event_id="$duplicate", body="@test_agent hello")
     resolution_started = asyncio.Event()
     release_resolution = asyncio.Event()
+    duplicate_reservation = MagicMock()
 
     async def slow_prepare(*_args: object, **_kwargs: object) -> None:
         resolution_started.set()
@@ -254,11 +255,17 @@ async def test_duplicate_delivery_is_claimed_before_dispatch_resolution(tmp_path
             bot._turn_controller._dispatch_text_message(room, event, "@user:localhost"),
         )
         await resolution_started.wait()
-        await bot._turn_controller._dispatch_text_message(room, event, "@user:localhost")
+        await bot._turn_controller._dispatch_text_message(
+            room,
+            event,
+            "@user:localhost",
+            queued_notice_reservation=duplicate_reservation,
+        )
         release_resolution.set()
         await first
 
     prepare.assert_awaited_once()
+    duplicate_reservation.cancel.assert_called_once_with()
 
 
 async def _wait_for(condition: Callable[[], bool], *, deadline_seconds: float = 0.5) -> None:

--- a/tests/test_matrix_event_cache_fuzz.py
+++ b/tests/test_matrix_event_cache_fuzz.py
@@ -1,0 +1,158 @@
+"""Property and replay tests for the Matrix event-cache fuzz framework."""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from hypothesis import HealthCheck, example, given, settings
+from hypothesis import strategies as st
+
+from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
+from scripts.testing.fuzz_matrix_event_cache import (
+    FuzzOperation,
+    FuzzScenario,
+    OperationKind,
+    concurrent_fanout_scenario,
+    run_scenario,
+    scenario_from_seed,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from mindroom.matrix.cache import ConversationEventCache
+
+
+_OPERATION_KINDS = tuple(OperationKind)
+
+
+def _operation_strategy() -> st.SearchStrategy[FuzzOperation]:
+    return st.builds(
+        FuzzOperation,
+        kind=st.sampled_from(_OPERATION_KINDS),
+        room=st.integers(min_value=0, max_value=1),
+        thread=st.integers(min_value=0, max_value=2),
+        slot=st.integers(min_value=0, max_value=7),
+        target=st.integers(min_value=0, max_value=7),
+        variant=st.integers(min_value=0, max_value=7),
+    )
+
+
+def _scenario_strategy() -> st.SearchStrategy[FuzzScenario]:
+    batch = st.lists(
+        _operation_strategy(),
+        min_size=1,
+        max_size=4,
+    ).map(tuple)
+    return st.lists(
+        batch,
+        min_size=1,
+        max_size=4,
+    ).map(lambda batches: FuzzScenario(batches=tuple(batches)))
+
+
+_CONCURRENT_REDACTION_REPLAY = FuzzScenario(
+    batches=(
+        (
+            FuzzOperation(OperationKind.THREADED_MESSAGE, 0, 0, 0, 0, 0),
+            FuzzOperation(OperationKind.THREADED_MESSAGE, 0, 1, 0, 0, 0),
+        ),
+        (
+            FuzzOperation(OperationKind.EDIT, 0, 0, 1, 0, 0),
+            FuzzOperation(OperationKind.REACTION, 0, 0, 1, 0, 0),
+            FuzzOperation(OperationKind.PLAIN_REPLY, 0, 0, 1, 0, 0),
+        ),
+        (
+            FuzzOperation(OperationKind.REDACTION, 0, 0, 0, 0, 1),
+            FuzzOperation(OperationKind.THREADED_MESSAGE, 0, 0, 0, 0, 0),
+            FuzzOperation(OperationKind.CIPHERTEXT_REPLAY, 0, 0, 0, 0, 1),
+            FuzzOperation(OperationKind.REPLACE_THREAD, 0, 0, 0, 0, 4),
+        ),
+    ),
+)
+
+
+@example(_CONCURRENT_REDACTION_REPLAY)
+@settings(
+    deadline=None,
+    derandomize=True,
+    max_examples=8,
+    print_blob=True,
+    suppress_health_check=(HealthCheck.too_slow,),
+)
+@given(scenario=_scenario_strategy())
+def test_hypothesis_matrix_cache_traces_preserve_sqlite_invariants(
+    scenario: FuzzScenario,
+) -> None:
+    """Shrunk concurrent mutation traces preserve public cache invariants."""
+    with tempfile.TemporaryDirectory(prefix="mindroom-hypothesis-cache-") as temp_dir:
+        db_path = Path(temp_dir) / "event_cache.db"
+        asyncio.run(
+            run_scenario(
+                lambda: SqliteEventCache(db_path),
+                scenario,
+                room_count=2,
+                thread_count=3,
+                verify_restart=False,
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_seeded_concurrent_trace_matches_every_cache_backend(
+    event_cache_factory: Callable[[], ConversationEventCache],
+) -> None:
+    """One stable chaos trace guards SQLite and Postgres contract parity."""
+    await run_scenario(
+        event_cache_factory,
+        scenario_from_seed(
+            1637,
+            steps=48,
+            room_count=2,
+            thread_count=4,
+            max_batch_size=6,
+        ),
+        room_count=2,
+        thread_count=4,
+    )
+
+
+@pytest.mark.asyncio
+async def test_forty_five_thread_fanout_matches_every_cache_backend(
+    event_cache_factory: Callable[[], ConversationEventCache],
+) -> None:
+    """The original 45-way load shape survives concurrent edits, replies, and reactions."""
+    await run_scenario(
+        event_cache_factory,
+        concurrent_fanout_scenario(),
+        room_count=1,
+        thread_count=45,
+        verify_restart=False,
+    )
+
+
+def test_fuzz_trace_json_round_trip_is_exact() -> None:
+    """Failure traces remain portable across local runs and CI."""
+    scenario = scenario_from_seed(
+        42,
+        steps=25,
+        room_count=2,
+        thread_count=3,
+        max_batch_size=5,
+    )
+
+    assert FuzzScenario.from_json(scenario.to_json()) == scenario
+    assert (
+        scenario_from_seed(
+            42,
+            steps=25,
+            room_count=2,
+            thread_count=3,
+            max_batch_size=5,
+        )
+        == scenario
+    )

--- a/tests/test_matrix_event_cache_security.py
+++ b/tests/test_matrix_event_cache_security.py
@@ -742,6 +742,34 @@ async def test_restoring_event_without_thread_relation_removes_stale_mapping(
 
 
 @pytest.mark.asyncio
+async def test_removing_last_child_relation_preserves_cached_root_mapping(
+    event_cache_factory: Callable[[], ConversationEventCache],
+) -> None:
+    """A cached root remains sufficient proof after its last child loses the thread relation."""
+    root = _shared_cache(event_cache_factory)
+    await root.initialize()
+    cache = root.for_principal("@alice:localhost")
+    room_id = "!room:localhost"
+    root_event_id = "$thread-root"
+    child_event_id = "$child"
+    threaded_child = _event(child_event_id, 2)
+    threaded_child["content"]["m.relates_to"] = {
+        "rel_type": "m.thread",
+        "event_id": root_event_id,
+    }
+    try:
+        await cache.store_event(root_event_id, room_id, _event(root_event_id, 1))
+        await cache.store_event(child_event_id, room_id, threaded_child)
+
+        await cache.store_event(child_event_id, room_id, _event(child_event_id, 3))
+
+        assert await cache.get_thread_id_for_event(room_id, child_event_id) is None
+        assert await cache.get_thread_id_for_event(room_id, root_event_id) == root_event_id
+    finally:
+        await root.close()
+
+
+@pytest.mark.asyncio
 async def test_storing_thread_root_preserves_child_proven_self_mapping(
     event_cache_factory: Callable[[], ConversationEventCache],
 ) -> None:
@@ -803,6 +831,40 @@ async def test_redacting_last_thread_child_removes_orphan_root_mapping(
         assert await cache.redact_event(room_id, "$second-child")
         assert await cache.get_thread_id_for_event(room_id, "$second-child") is None
         assert await cache.get_thread_id_for_event(room_id, root_event_id) is None
+    finally:
+        await root.close()
+
+
+@pytest.mark.asyncio
+async def test_replacing_thread_without_old_children_preserves_root_mapping(
+    event_cache_factory: Callable[[], ConversationEventCache],
+) -> None:
+    """Removing stale children must not erase the replacement snapshot's root self-mapping."""
+    root = _shared_cache(event_cache_factory)
+    await root.initialize()
+    cache = root.for_principal("@alice:localhost")
+    room_id = "!room:localhost"
+    root_event_id = "$thread-root"
+    root_event = _event(root_event_id, 1)
+    child_event = _event("$old-child", 2)
+    try:
+        await replace_thread_unconditionally(
+            cache,
+            room_id,
+            root_event_id,
+            [root_event, child_event],
+        )
+
+        await replace_thread_unconditionally(
+            cache,
+            room_id,
+            root_event_id,
+            [root_event],
+        )
+
+        assert await cache.get_thread_events(room_id, root_event_id) == [root_event]
+        assert await cache.get_thread_id_for_event(room_id, root_event_id) == root_event_id
+        assert await cache.get_thread_id_for_event(room_id, "$old-child") is None
     finally:
         await root.close()
 

--- a/tests/test_matrix_event_cache_security.py
+++ b/tests/test_matrix_event_cache_security.py
@@ -742,34 +742,6 @@ async def test_restoring_event_without_thread_relation_removes_stale_mapping(
 
 
 @pytest.mark.asyncio
-async def test_removing_last_child_relation_preserves_cached_root_mapping(
-    event_cache_factory: Callable[[], ConversationEventCache],
-) -> None:
-    """A cached root remains sufficient proof after its last child loses the thread relation."""
-    root = _shared_cache(event_cache_factory)
-    await root.initialize()
-    cache = root.for_principal("@alice:localhost")
-    room_id = "!room:localhost"
-    root_event_id = "$thread-root"
-    child_event_id = "$child"
-    threaded_child = _event(child_event_id, 2)
-    threaded_child["content"]["m.relates_to"] = {
-        "rel_type": "m.thread",
-        "event_id": root_event_id,
-    }
-    try:
-        await cache.store_event(root_event_id, room_id, _event(root_event_id, 1))
-        await cache.store_event(child_event_id, room_id, threaded_child)
-
-        await cache.store_event(child_event_id, room_id, _event(child_event_id, 3))
-
-        assert await cache.get_thread_id_for_event(room_id, child_event_id) is None
-        assert await cache.get_thread_id_for_event(room_id, root_event_id) == root_event_id
-    finally:
-        await root.close()
-
-
-@pytest.mark.asyncio
 async def test_storing_thread_root_preserves_child_proven_self_mapping(
     event_cache_factory: Callable[[], ConversationEventCache],
 ) -> None:

--- a/tests/test_turn_store.py
+++ b/tests/test_turn_store.py
@@ -36,6 +36,7 @@ from mindroom.history.storage import (
 from mindroom.history.types import HistoryScope, HistoryScopeState
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
+from mindroom.text_ingress_dispatch import _run_claimed_response
 from mindroom.turn_store import TurnStore, TurnStoreDeps
 from tests.conftest import TEST_PASSWORD, bind_runtime_paths, runtime_paths_for, test_runtime_paths
 
@@ -129,6 +130,46 @@ def _prepare_redaction(
         target=target,
         source_event_ids=("$later",),
     )
+
+
+def test_pending_turn_claim_allows_only_one_concurrent_owner(tmp_path: Path) -> None:
+    """Overlapping delivery of one source event must start one response."""
+    store = _store(tmp_path)
+    turn = TurnRecord.create(["$source"], completed=False)
+    barrier = threading.Barrier(8)
+    claims = [False] * barrier.parties
+
+    def claim(index: int) -> None:
+        barrier.wait()
+        claims[index] = store.try_claim_turn(turn)
+
+    threads = [threading.Thread(target=claim, args=(index,)) for index in range(barrier.parties)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert sum(claims) == 1
+    store.release_pending_turn_claim(turn)
+    assert store.try_claim_turn(turn) is True
+
+
+@pytest.mark.asyncio
+async def test_failed_claimed_response_releases_turn_for_replay(tmp_path: Path) -> None:
+    """A failed owner must not permanently suppress a later delivery."""
+    store = _store(tmp_path)
+    turn = TurnRecord.create(["$source"], completed=False)
+    assert store.try_claim_turn(turn) is True
+
+    async def fail() -> None:
+        msg = "response failed"
+        raise RuntimeError(msg)
+
+    controller = SimpleNamespace(deps=SimpleNamespace(turn_store=store))
+    with pytest.raises(RuntimeError, match="response failed"):
+        await _run_claimed_response(controller, turn, fail())
+
+    assert store.try_claim_turn(turn) is True
 
 
 def test_prepare_redaction_removes_causal_run_suffix(tmp_path: Path) -> None:

--- a/tests/test_turn_store.py
+++ b/tests/test_turn_store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import asyncio
 import threading
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -170,6 +171,34 @@ async def test_failed_claimed_response_releases_turn_for_replay(tmp_path: Path) 
         await _run_claimed_response(controller, turn, fail())
 
     assert store.try_claim_turn(turn) is True
+
+
+@pytest.mark.asyncio
+async def test_terminal_turn_keeps_claim_until_response_task_finishes(tmp_path: Path) -> None:
+    """Terminal persistence must not reopen a source before task cleanup completes."""
+    store = _store(tmp_path)
+    turn = TurnRecord.create(["$source"], completed=False)
+    other_turn = TurnRecord.create(["$discovery"], completed=False)
+    expanded_turn = replace(turn, discovery_event_ids=other_turn.source_event_ids)
+    terminal_recorded = asyncio.Event()
+    release_response = asyncio.Event()
+    assert store.try_claim_turn(turn) is True
+    assert store.try_claim_turn(other_turn) is True
+
+    async def finish_response() -> None:
+        store.record_turn(expanded_turn)
+        terminal_recorded.set()
+        await release_response.wait()
+
+    controller = SimpleNamespace(deps=SimpleNamespace(turn_store=store))
+    response_task = asyncio.create_task(_run_claimed_response(controller, turn, finish_response()))
+    await terminal_recorded.wait()
+
+    assert store.try_claim_turn(turn) is False
+    release_response.set()
+    await response_task
+    assert store.try_claim_turn(turn) is True
+    assert store.try_claim_turn(other_turn) is False
 
 
 def test_prepare_redaction_removes_causal_run_suffix(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ name = "cuda-bindings"
 version = "12.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/c1/dabe88f52c3e3760d861401bb994df08f672ec893b8f7592dc91626adcf3/cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fda147a344e8eaeca0c6ff113d2851ffca8f7dfc0a6c932374ee5c47caa649c8", size = 12151019, upload-time = "2025-10-21T14:51:43.167Z" },
@@ -2853,6 +2853,55 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
+]
+
+[[package]]
+name = "hypothesis"
+version = "6.161.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/1d/f5453faa2dd41890212d858f9dfa2a9e6db643c3037d6758101f38ae3f8a/hypothesis-6.161.1.tar.gz", hash = "sha256:44ee51052b560245676cacf8c88be23f312132cdf29cb08dd092b52fdcf07a5d", size = 486148, upload-time = "2026-07-23T20:37:08.065Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/23/445da79f0847e63f2acfc7ca446d18dc4ddc05a2bd88c70c2a28b3a65510/hypothesis-6.161.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c74cc6f010ac2635591891de8c16a3b5c0576f3661750509cef2487a6c1bee9a", size = 766527, upload-time = "2026-07-23T20:36:38.332Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/da/d7329ec56c2762553ad0f370406af4f47c1a74aed8fc7549f13c007f549c/hypothesis-6.161.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e1584bd873c68847ece7d8310f44c739a465122d94a506c44e9378278838779b", size = 762095, upload-time = "2026-07-23T20:36:14.461Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9e/7ef3091342d7b6445aec7a77b243b5fdf54ca61a6c1a3020f68c16ad52c2/hypothesis-6.161.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed29064e1c5b3062f74c8d073a3b623b33310fa4b13ce168db2c7ecd43caa922", size = 1091343, upload-time = "2026-07-23T20:35:49.161Z" },
+    { url = "https://files.pythonhosted.org/packages/68/41/4b48032eaa17c59e648dfd5224fefcfe9626d7972cd99f89b3632d9dac4d/hypothesis-6.161.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7567f56527cdfe53989fcb99dca46cd805e28ca392c183886757b7f870b90046", size = 1140882, upload-time = "2026-07-23T20:36:09.431Z" },
+    { url = "https://files.pythonhosted.org/packages/47/7e/9be7ae0c525a169eb6e824ea0f9b517a47887d22e379f2ad013cd0ff736f/hypothesis-6.161.1-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:730244719991ab11c1dfb6fe7a40488bdb6a632d4c856d08499d979e71e86c6b", size = 1132968, upload-time = "2026-07-23T20:36:58.457Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/10/f71f3fbb34cf996957d832dad6bec8a34415cd2b9145693bb082c00944b8/hypothesis-6.161.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b9956a4de0d04078791ef0b78f60e160aae205d9c8871b9a23f1db727d099dd7", size = 1265175, upload-time = "2026-07-23T20:35:52.172Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/28/82c4edad608931113d5993fede9fc9b6045f5d1203e538af0726d5b14a79/hypothesis-6.161.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:def1fa012d9d8fce70e8c107e2137b9ab89293884470cc6f565c42c5f07c029e", size = 1307849, upload-time = "2026-07-23T20:36:06.065Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/10/7ad339cdec8df2bd907e3b2a712dd5f36f59f2c1ea2d7d01417436338692/hypothesis-6.161.1-cp310-abi3-win32.whl", hash = "sha256:410e09dff0cc332b4434aa6f1a20f9d6c037ab938f3db4f6adc272b2a7d03fc4", size = 652384, upload-time = "2026-07-23T20:36:12.771Z" },
+    { url = "https://files.pythonhosted.org/packages/68/65/821390df2877ea60e48d028a2659fbfa1a852b393655ce3a99dd04522002/hypothesis-6.161.1-cp310-abi3-win_amd64.whl", hash = "sha256:bba4ea9d1ba5ad6ad93c500ce4f241329de28a91489a9a318f75be8dc79f477d", size = 658547, upload-time = "2026-07-23T20:36:19.407Z" },
+    { url = "https://files.pythonhosted.org/packages/92/06/c724ff585b9e61a2c40500e214f19794a02fe6a48d7587d9fcb27b75cf56/hypothesis-6.161.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:2b12a6bc4f3f6071b9db444c49b387a2f005b53ecb491aa10c4bdac32abc8df4", size = 768144, upload-time = "2026-07-23T20:37:04.462Z" },
+    { url = "https://files.pythonhosted.org/packages/78/3e/35ac6507910eaced5d06dc60b6e3484a718a9cc89791e067f7f17b45ec60/hypothesis-6.161.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:db2d1d564c9a232007e5f1b7e9a4333c3718f2b73dc47d82f2300fb2cfce0840", size = 759714, upload-time = "2026-07-23T20:35:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/3505c465f0e9f611197730561a9c787ff02ce9a7f54cdf2bd32f083af207/hypothesis-6.161.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:12cf495fc49e4e3cee80f50fb0126a0ad99f9d6baa0984f1f5923c62bdd365f8", size = 1090154, upload-time = "2026-07-23T20:35:42.987Z" },
+    { url = "https://files.pythonhosted.org/packages/35/09/720f80ff2daca23e164a133c4102a25d5006a5d00577bdfdf1f7df5045d1/hypothesis-6.161.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cf5a709efe1eb193c340f57110df210d146967a93e7fe611213df43594c59530", size = 1140198, upload-time = "2026-07-23T20:36:33.243Z" },
+    { url = "https://files.pythonhosted.org/packages/72/06/10583f6b185031e0366cdffaeb54a9fa7577799b4017e67381eb309610b2/hypothesis-6.161.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:432f832c52872369c0f9a85bd4d18198944c64a7b4d4f63a133c9837c360f951", size = 1262979, upload-time = "2026-07-23T20:36:45.745Z" },
+    { url = "https://files.pythonhosted.org/packages/98/b2/abd0a1e9e05ba7ce639833eb93ab27ffdb940ffd146ab9b17ba3dcd2a4a7/hypothesis-6.161.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:eb8a90449d2138ef6b82cecf39311e10f30cef89ad792aeb574086193752a8c9", size = 1307159, upload-time = "2026-07-23T20:35:58.162Z" },
+    { url = "https://files.pythonhosted.org/packages/50/7d/03607c3f83c2312cdab52d9ce25054216fcea2c33da483d8d1afb6356d10/hypothesis-6.161.1-cp312-cp312-win_amd64.whl", hash = "sha256:36652bce788e77ccb1bd92a21fd6491980bae5ecdf7686e8943aa70458c873a6", size = 655680, upload-time = "2026-07-23T20:36:40.063Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c7/8295a14fabbfa8ed90bd2c382e8f00b8726e4feb5b94236ff463d5ab2004/hypothesis-6.161.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:b6f3a2eeb3b141c662b572585c903955d41ce6ac1d07ff6b927e658170fab2f8", size = 768018, upload-time = "2026-07-23T20:37:06.242Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/44/88f576f295aec95ff07febabb2029b64db02d392b9d0969cb70d27a5f2ef/hypothesis-6.161.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3f6bc47b4100af38c740cbcd8a1cc5a69b57d67b6c910feeb964a0badad35cdf", size = 759679, upload-time = "2026-07-23T20:36:49.537Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/10/9d757e68d53e5ecd973aa5e09bc16ab3d045f7cc4b409ac69bf2a62c31a0/hypothesis-6.161.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ac69b3f9682b54a8dca79738805301efb6cbdc0645eacbac650992f6571b56a", size = 1090070, upload-time = "2026-07-23T20:35:50.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/eb/1ee79c1f34024738090a1033cd2e3825e590011a310922f4ff88a0730ad5/hypothesis-6.161.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6b3abe32e180cef09772768ec59b2ce9320b03cbc8756a686163582c82ce5056", size = 1140012, upload-time = "2026-07-23T20:36:56.686Z" },
+    { url = "https://files.pythonhosted.org/packages/43/95/cef03067e9d3249893d6c8e2527af7cd0d843729b1d5580734230c00c794/hypothesis-6.161.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3fbcf071b12d7f133f910dde2ddcb820285b4d3549f5c75aa826b8eda6e42768", size = 1263022, upload-time = "2026-07-23T20:36:11.118Z" },
+    { url = "https://files.pythonhosted.org/packages/98/05/6d9732f5052a77eb119784eaf18a19e83a23f0d0aeba8358ccfd6ae53e9a/hypothesis-6.161.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f82837674382a8e03e9389cf3c3444a052420c6e697b7cab4ada2d28448e226f", size = 1306912, upload-time = "2026-07-23T20:36:47.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/9f/e1fd97cd3801782a98d642fc10d9310e4f5c852aee8933d49e50d0265c49/hypothesis-6.161.1-cp313-cp313-win_amd64.whl", hash = "sha256:e688d96fa01816c3205336fc9954c6efa561c9bfbef783b2960ab4ec714ff73e", size = 655638, upload-time = "2026-07-23T20:35:46.164Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/1b/35683d3c1089354ae75d15b4cf4f00900508f8b10100f74f350d9005a7ac/hypothesis-6.161.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:36062ae4cd60fdbcc765edb47b73677c70350d6611cbcec2fdc3069be16479c1", size = 768213, upload-time = "2026-07-23T20:36:54.872Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/92/d85baa4241b2625f012989943bae190d21aead7b7705a0573ec61f8ca152/hypothesis-6.161.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6e59608ad96e2bfb7e4d1eb5adac633a5a2f735b9e368d8b5e0b12d976aacb2c", size = 759815, upload-time = "2026-07-23T20:35:44.516Z" },
+    { url = "https://files.pythonhosted.org/packages/08/4b/08214b62fa1b85d059b71f5401130506c11d35a82d221133b415de19793d/hypothesis-6.161.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4d4249baa5fa38221432318ad692c2bc34b74eee1e8fe3d828c498a27f0545a8", size = 1090571, upload-time = "2026-07-23T20:37:00.529Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a8/3d66569b0fbf8b7be5b2cead898295eb65d5efb0eb298f6552441292cdfc/hypothesis-6.161.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3eb24e5f115de84e089829fd6f904f7c3296d8462560f22b7d9bc04bb7828123", size = 1140198, upload-time = "2026-07-23T20:35:34.489Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1c/8391c5dcb1dcbb41e193dace61092d1311718405b696207d1ba35ae5f3e4/hypothesis-6.161.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2d079ae6ae39fd602393bbf853627aa530fcb467200246ca8700a401e1c1862d", size = 1263355, upload-time = "2026-07-23T20:35:38.905Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/97/40c3a8dccc3a8e6cdb262b846a5de8b8f9792d47645b41b073233f435976/hypothesis-6.161.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:34a95d9684e760fa122194e721b35fe61fc4f792b6f90402fc43ce86ef1e021d", size = 1307192, upload-time = "2026-07-23T20:36:35.121Z" },
+    { url = "https://files.pythonhosted.org/packages/69/7c/8919fcefd596c4fab3d89fbcced9431269edb6e7d3b0fd178949f56d9798/hypothesis-6.161.1-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:13b3523058a8240748f3756d443b2af6dfdca9f741b268e0e5f71fb6fe7f5934", size = 599732, upload-time = "2026-07-23T20:36:29.22Z" },
+    { url = "https://files.pythonhosted.org/packages/86/04/3bda8a4d9f29c0e6225129ce394ebd75a9735f65d91fbd780d559c607acf/hypothesis-6.161.1-cp314-cp314-win_amd64.whl", hash = "sha256:3c5d057b7601801d1aa93070a38b77511e0009e1ccffe6a42cb259e846f50e31", size = 655588, upload-time = "2026-07-23T20:36:36.639Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/b3/cf868c489c28cfd1c293401568a927650ff09dbab92079c322fe49f7ebe3/hypothesis-6.161.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:b79650b1b90806fc06c88ff1963c974678155770bcf488d19fd5e44b8d276893", size = 766790, upload-time = "2026-07-23T20:35:56.734Z" },
+    { url = "https://files.pythonhosted.org/packages/31/a0/d743e0fbfb0f0cb58739890d3d132f605e666419c0b25d96efeffee1b5ea/hypothesis-6.161.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b7dd1963fefcfa6ac5a33abba1e401f03e25fbca57ca9c2c57b121a1bea9d14f", size = 758280, upload-time = "2026-07-23T20:36:02.819Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e9/8a13ff4ecb3582e0bd5c02d68c28ae550cf22c8bd1554ad46a4ba6919ef1/hypothesis-6.161.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84e0d123ef2996ac2025bba9c2b2d51ba44320fb744c4044acb74b8deb95c3d6", size = 1089167, upload-time = "2026-07-23T20:36:44.003Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/3a/e8d950dbea29184aa5863136a6e835f5fccb9ac73be13f555a62c1284b10/hypothesis-6.161.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f736f6ec2081f974cb96a14d2e05b796197e508fca0e6c84f50c163496851eac", size = 1139083, upload-time = "2026-07-23T20:37:02.593Z" },
+    { url = "https://files.pythonhosted.org/packages/49/43/a55b85c185d81214849bb802714d13ca62ee5ecbbbdc6d1417efe313aaf3/hypothesis-6.161.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c2ecc445a73a77f30a7b1c95280d91ec04f674e8c61df86b3f7adbfde4a0ac1b", size = 1261591, upload-time = "2026-07-23T20:36:31.442Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/de/aceb9c110e2f6f995c929827ffae1f21ad85fe9c43dec7ac94619ecd8de1/hypothesis-6.161.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c9e34f122639949dfabe1c2b70c0b06287e2eaf1ce7bc49b14cd4c532a14d25", size = 1305967, upload-time = "2026-07-23T20:35:53.65Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/bd/06a88dfa122e549336c0b48b83f27190822a3702172b987a8448faf1d9bb/hypothesis-6.161.1-cp314-cp314t-win_amd64.whl", hash = "sha256:027367e736255b9cf3ac894bbde4815ebc000396af9d9427f16776f395697159", size = 655718, upload-time = "2026-07-23T20:35:47.721Z" },
 ]
 
 [[package]]
@@ -4350,6 +4399,7 @@ zoom = [
 [package.dev-dependencies]
 dev = [
     { name = "aioresponses" },
+    { name = "hypothesis" },
     { name = "markdown" },
     { name = "markdown-code-runner" },
     { name = "markdown-gfm-admonition" },
@@ -4552,6 +4602,7 @@ provides-extras = ["agent-vault-access", "agentql", "airflow", "apify", "approve
 [package.metadata.requires-dev]
 dev = [
     { name = "aioresponses", specifier = ">=0.7.8" },
+    { name = "hypothesis", specifier = ">=6.161.1" },
     { name = "markdown", specifier = ">=3.10.2" },
     { name = "markdown-code-runner", specifier = ">=2.4" },
     { name = "markdown-gfm-admonition" },
@@ -5070,7 +5121,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -5081,7 +5132,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -5108,9 +5159,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -5121,7 +5172,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -7157,10 +7208,10 @@ name = "pyobjc-framework-applicationservices"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
-    { name = "pyobjc-framework-coretext" },
-    { name = "pyobjc-framework-quartz" },
+    { name = "pyobjc-core", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pyobjc-framework-coretext", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/4d/0ebdd8144aba94b8fe9828ccee5616a4bf53d1f8bc51cff55f3cce86d695/pyobjc_framework_applicationservices-12.2.1.tar.gz", hash = "sha256:048ea663c9ac75c44a15dc7d5b8d78cbb4c97bf1c76e83835e8d5498e184001f", size = 109342, upload-time = "2026-06-19T16:19:46.149Z" }
 wheels = [
@@ -7178,7 +7229,7 @@ name = "pyobjc-framework-cocoa"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
+    { name = "pyobjc-core", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/51/34/fbe38a204643aa4e1b91391cdce07a34da565a69171ebcad08de7438a556/pyobjc_framework_cocoa-12.2.1.tar.gz", hash = "sha256:b94b37fe5730e5ae1fb0052912cd174e6ec329b0bfba4a012ae5db1014b5864b", size = 3125751, upload-time = "2026-06-19T16:20:05.159Z" }
 wheels = [
@@ -7196,9 +7247,9 @@ name = "pyobjc-framework-coretext"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
-    { name = "pyobjc-framework-quartz" },
+    { name = "pyobjc-core", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5a/9c/4c7f452059dc1d3845b8e627b9113c247a997b9b07518e848c2ab7ff3149/pyobjc_framework_coretext-12.2.1.tar.gz", hash = "sha256:af740e784d7c592c34025ec7165f4f6c1a69b5a2d9075f06e41e4f77c212aed2", size = 97349, upload-time = "2026-06-19T16:20:22.508Z" }
 wheels = [
@@ -7216,8 +7267,8 @@ name = "pyobjc-framework-quartz"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/f6/2a8b84dbf1fe7c04dd96ea73d991678d4e09a909f51971ecc51629bb2ab4/pyobjc_framework_quartz-12.2.1.tar.gz", hash = "sha256:b3b8b6f71e66147f8ff9e6213864cc8527e3a0b1ee90835b93ce221f4802d9b0", size = 3215521, upload-time = "2026-06-19T16:21:30.199Z" }
 wheels = [


### PR DESCRIPTION
## Why

The thread-cache regression exposed two gaps in testing: cache mutation correctness was covered mostly by examples, and the historical saturation workload lived only in an ad-hoc harness.

Under real Tuwunel load, duplicate sync delivery could also overlap before the durable pending-turn record existed, allowing two response pipelines for one source event.

## What changed

- Add a replayable direct cache fuzzer with deterministic concurrent traces, Hypothesis coverage, restart checks, and SQLite/Postgres parity.
- Add a disposable real-Tuwunel and real-MindRoom runner covering concurrent threads, replies, edits, reactions, redactions, idempotent retries, restarts, and saved trace replay.
- Preserve the exact historical 100-turn hot-thread plus 12-by-8 saturation profile.
- Make the saturation deadline match its intentionally slow 12-way stream workload.
- Teach the exact-reply oracle that router-owned restart-resume relays are valid internal recovery sources while still rejecting duplicate replies.
- Fix root-index reconciliation when an authoritative replacement snapshot retains a thread root while removing stale children.
- Claim source turns before dispatch/cache resolution and transfer that claim to the runner-owned response task, preventing overlapping duplicate delivery from starting a second pipeline.

Limited-sync gap loss belongs to `mindroom-nio`; no MindRoom runtime workaround is included.
The library fix is in mindroom-ai/mindroom-nio#20.

## Verification

- Full pytest suite passes.
- Tach dependency/interface validation passes.
- Relevant ruff, formatting, ty, vulture, privacy, and documentation hooks pass.
- Direct fuzz: 8,000 random operations, deep restart traces, and 45-way SQLite/Postgres fanout.
- Real Tuwunel mixed fuzz: 500 mutations across 45 threads with four MindRoom restarts; 250/250 expected replies, zero duplicates, zero runtime timeouts or stalls.
- Exact historical saturation trace with fixed `mindroom-nio`: 209/209 canonical replies twice, zero duplicates, zero runtime timeouts or stalls.
- The same saturation trace against the pre-fix library lost a source even with a 180-second reply deadline.
- Real limited-sync flood probe for mindroom-ai/mindroom-nio#20: before 50/300 delivered; after 300/300 exactly once and ordered.

## Size

Most of the diff is test infrastructure: the two fuzz runners and their tests account for roughly 2,750 lines.
Production changes stay narrow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate processing of Matrix messages under concurrent delivery.
  * Improved response claim/release timing so cleanup happens at the correct time.
  * Preserved valid thread-root mappings during thread snapshot replacements while removing stale mappings.
* **New Features**
  * Added live Matrix fuzzing with deterministic replay and an “exact reply” validation oracle.
  * Added Matrix event-cache fuzzing with replayable traces and cache-invariant checks.
* **Testing**
  * Added deterministic, property-based, and saturation-style fuzz tests for cache behavior, security contracts, and trace round-tripping.
* **Documentation**
  * Updated the scripts testing guide with new fuzzing commands and examples.
* **Chores**
  * Added Hypothesis to the development dependency set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->