### PR TITLE
fix(history): bound compaction summary output so it stays generable inside the chunk timeout

### DIFF
--- a/src/mindroom/constants.py
+++ b/src/mindroom/constants.py
@@ -22,6 +22,14 @@ ROUTER_AGENT_NAME = "router"
 VISIBLE_ROUTER_VOICE_ECHO_KEY = "com.mindroom.visible_router_voice_echo"
 DEFAULT_MINDROOM_URL = "http://127.0.0.1:8765"
 MINDROOM_COMPACTION_CHUNK_TIMEOUT_SECONDS = 180.0
+# Compaction summary output must stay generable inside the chunk timeout above:
+# observed Vertex Claude throughput bottoms out around 35-40 output tokens/s, so
+# an uncapped summary (model max_tokens, e.g. 32K) that outgrows ~7K tokens turns
+# into a guaranteed wall-clock timeout instead of a typed truncation error the
+# retry policy can act on. 4096 tokens finishes in ~100-120s at the observed
+# floor, leaving prefill headroom, and sits above the ~2,000-word budget that
+# COMPACTION_SUMMARY_PROMPT asks the model to stay within.
+MINDROOM_COMPACTION_SUMMARY_MAX_OUTPUT_TOKENS = 4096
 DEFAULT_TOOL_OUTPUT_AUTO_SAVE_THRESHOLD_BYTES = 50 * 1024
 _MINDROOM_DISPATCH_THREAD_READ_TIMEOUT_SECONDS = 1.0
 _STANDARD_HISTORY_ROLES = frozenset({"user", "assistant", "tool"})

--- a/src/mindroom/history/summary_call.py
+++ b/src/mindroom/history/summary_call.py
@@ -10,9 +10,13 @@ It enforces the call-side half of the compaction invariants
    at or above max_tokens is a 400 from Anthropic), SDK retries disabled, and
    one SDK timeout coordinated with the outer chunk budget
    (``MINDROOM_COMPACTION_CHUNK_TIMEOUT_SECONDS``) instead of two uncoordinated
-   constants in two modules. Claude summary output uses the loaded model's own
-   max_tokens as the truncation guard. Unknown providers pass through untouched
-   and rely on the outer chunk timeout alone.
+   constants in two modules. Claude summary output is capped at
+   ``MINDROOM_COMPACTION_SUMMARY_MAX_OUTPUT_TOKENS`` (or the model's own smaller
+   max_tokens) so the truncation guard stays reachable inside the chunk timeout:
+   a summary the model cannot finish in time must surface as a typed
+   ``CompactionSummaryOutputLimitError`` the retry policy can shrink on, not as a
+   wall-clock timeout that recurs identically on every attempt. Unknown providers
+   pass through untouched and rely on the outer chunk timeout alone.
 
 4. Retry on provider failure is deterministic.
    ``SummaryRetryPolicy`` decides which error classes warrant a smaller retry
@@ -52,7 +56,10 @@ from agno.session.summary import SessionSummary
 
 from mindroom.cancellation import request_task_cancel
 from mindroom.claude_prompt_cache import as_anthropic_claude
-from mindroom.constants import MINDROOM_COMPACTION_CHUNK_TIMEOUT_SECONDS
+from mindroom.constants import (
+    MINDROOM_COMPACTION_CHUNK_TIMEOUT_SECONDS,
+    MINDROOM_COMPACTION_SUMMARY_MAX_OUTPUT_TOKENS,
+)
 from mindroom.error_handling import TRANSIENT_PROVIDER_STATUS_CODES
 from mindroom.history.types import COMPACTION_SUMMARY_RETRY_FLOOR_TOKENS
 from mindroom.logging_config import get_logger
@@ -227,6 +234,11 @@ def configure_summary_model(model: Model, *, timeout_seconds: float | None = Non
     claude_model.cache_system_prompt = False
     claude_model.extended_cache_time = False
     claude_model.thinking = None
+    claude_model.max_tokens = (
+        min(claude_model.max_tokens, MINDROOM_COMPACTION_SUMMARY_MAX_OUTPUT_TOKENS)
+        if claude_model.max_tokens
+        else MINDROOM_COMPACTION_SUMMARY_MAX_OUTPUT_TOKENS
+    )
     claude_model.timeout = min(claude_model.timeout, resolved_timeout) if claude_model.timeout else resolved_timeout
     client_params = dict(claude_model.client_params or {})
     client_params["max_retries"] = 0

--- a/src/mindroom/prompts.py
+++ b/src/mindroom/prompts.py
@@ -316,10 +316,12 @@ Your job is to produce one merged handoff summary as plain text.
 Return only the summary text.
 
 Rules:
+- Keep the merged summary under roughly 2,000 words. This budget outranks every preservation rule below: a summary that grows without bound eventually cannot be regenerated within the compaction time budget, and compaction then fails on every attempt.
+- When merging would exceed the budget, condense instead of growing — starting with the oldest and least load-bearing material from <previous_summary>. Collapse finished work into one-line outcomes; drop superseded plans, resolved errors, and exploratory dead ends entirely.
 - Preserve all still-relevant information from <previous_summary>.
 - Add only the new information from <new_conversation>.
-- Keep unchanged wording verbatim when it is still correct so future prompt prefixes remain stable.
-- Never paraphrase away exact technical details such as file paths, function names, class names, commands, Matrix IDs, model names, config keys, numeric thresholds, ports, URLs, or error text.
+- Within the budget, keep unchanged wording verbatim when it is still correct so future prompt prefixes remain stable.
+- Never paraphrase away exact technical details that are still load-bearing, such as file paths, function names, class names, commands, Matrix IDs, model names, config keys, numeric thresholds, ports, URLs, or error text.
 - Preserve tool activity when it matters to current state, especially file edits, commands, and tool results.
 - Do not invent facts.
 - If a section has no content, write `None.`

--- a/tests/test_compaction_invariants.py
+++ b/tests/test_compaction_invariants.py
@@ -37,6 +37,7 @@ from mindroom.config.models import CompactionConfig, CompactionOverrideConfig, D
 from mindroom.constants import (
     MINDROOM_COMPACTION_CHUNK_TIMEOUT_SECONDS,
     MINDROOM_COMPACTION_METADATA_KEY,
+    MINDROOM_COMPACTION_SUMMARY_MAX_OUTPUT_TOKENS,
     RuntimePaths,
     resolve_runtime_paths,
 )
@@ -518,7 +519,7 @@ def test_configure_summary_model_tunes_claude_in_one_place() -> None:
     assert model.cache_system_prompt is False
     assert model.extended_cache_time is False
     assert model.thinking is None
-    assert model.max_tokens == 64_000
+    assert model.max_tokens == MINDROOM_COMPACTION_SUMMARY_MAX_OUTPUT_TOKENS
     assert model.timeout == MINDROOM_COMPACTION_CHUNK_TIMEOUT_SECONDS
     assert model.client_params == {"max_retries": 0, "custom": "keep"}
 
@@ -539,7 +540,7 @@ def test_configure_summary_model_tunes_vertexai_claude() -> None:
     assert model.cache_system_prompt is False
     assert model.extended_cache_time is False
     assert model.thinking is None
-    assert model.max_tokens == 8192
+    assert model.max_tokens == MINDROOM_COMPACTION_SUMMARY_MAX_OUTPUT_TOKENS
     assert model.timeout == MINDROOM_COMPACTION_CHUNK_TIMEOUT_SECONDS
     assert model.client_params == {"max_retries": 0}
 
@@ -583,7 +584,7 @@ async def test_generate_compaction_summary_applies_tuning_and_request_shape() ->
     assert model.cache_system_prompt is False
     assert model.extended_cache_time is False
     assert model.thinking is None
-    assert model.max_tokens == 64_000
+    assert model.max_tokens == MINDROOM_COMPACTION_SUMMARY_MAX_OUTPUT_TOKENS
     assert model.timeout == MINDROOM_COMPACTION_CHUNK_TIMEOUT_SECONDS
     assert model.client_params == {"max_retries": 0}
     assert [(message.role, message.content) for message in model.seen_messages] == [
@@ -631,7 +632,7 @@ async def test_generate_compaction_summary_allows_claude_summary_below_output_ca
             max_tokens=64_000,
             response=ModelResponse(
                 content="durable summary ended cleanly.",
-                output_tokens=63_999,
+                output_tokens=MINDROOM_COMPACTION_SUMMARY_MAX_OUTPUT_TOKENS - 1,
             ),
         ),
         summary_input="conversation payload",
@@ -642,21 +643,24 @@ async def test_generate_compaction_summary_allows_claude_summary_below_output_ca
 
 
 @pytest.mark.asyncio
-async def test_generate_compaction_summary_allows_full_history_summary_above_four_k() -> None:
-    summary = await generate_compaction_summary(
-        model=_RecordingClaude(
-            id="claude-sonnet-5",
-            max_tokens=8192,
-            response=ModelResponse(
-                content="durable full-history summary ended cleanly.",
-                output_tokens=4_097,
+async def test_generate_compaction_summary_caps_output_below_generous_model_max_tokens() -> None:
+    # A model max_tokens far above what the chunk timeout can generate must not
+    # become the truncation guard: a summary that fills the compaction ceiling
+    # raises the typed output-limit error instead of running into the wall-clock
+    # timeout on every attempt.
+    with pytest.raises(CompactionSummaryOutputLimitError):
+        await generate_compaction_summary(
+            model=_RecordingClaude(
+                id="claude-sonnet-5",
+                max_tokens=8192,
+                response=ModelResponse(
+                    content="durable full-history summary ended cleanly.",
+                    output_tokens=MINDROOM_COMPACTION_SUMMARY_MAX_OUTPUT_TOKENS,
+                ),
             ),
-        ),
-        summary_input="conversation payload",
-        summary_prompt="Summarize the conversation.",
-    )
-
-    assert summary.summary == "durable full-history summary ended cleanly."
+            summary_input="conversation payload",
+            summary_prompt="Summarize the conversation.",
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Compaction summaries can grow until summary generation reaches its wall-clock timeout.
Shrinking the new input does not help when the previous summary itself dictates a large output, so the same scope can fail repeatedly.

## Root cause

- The summary prompt required carrying the previous summary forward without a clear output-length budget.
- The serving model output allowance could be much larger than what the configured chunk timeout can generate.
- Input-shrinking retries therefore repeated the same output-bound timeout.

## Fix

- Give the compaction summary prompt an explicit approximate 2,000-word budget that takes precedence over preservation rules.
- Condense the oldest and least load-bearing material when the summary approaches that budget.
- Cap Claude summary output with `MINDROOM_COMPACTION_SUMMARY_MAX_OUTPUT_TOKENS`, defaulting to 4096 while preserving smaller authored caps.
- Surface an output-limit failure as `CompactionSummaryOutputLimitError` so the existing retry policy can handle it instead of waiting for repeated wall-clock timeouts.

This partially restores the output guard removed by #1331 while pairing it with prompt-level condensation, so the guard remains reachable without recreating the earlier truncation-refusal behavior.

## Testing

Focused compaction, summary-call, sizing-log, rewrite, and prompt tests pass locally.
The prior above-4K invariant is replaced with an invariant that the output guard must remain reachable within the chunk timeout.

## Possible follow-ups

- Remember recent compaction failures so a scope does not retry immediately on every turn.
- Consider streaming summary calls with an idle timeout instead of only a wall-clock timeout.
