### PR TITLE
Fix self-targeted subagent session dispatch

### DIFF
--- a/src/mindroom/custom_tools/subagents.py
+++ b/src/mindroom/custom_tools/subagents.py
@@ -14,7 +14,8 @@ from agno.tools import Toolkit
 
 from mindroom.agent_descriptions import describe_agent
 from mindroom.authorization import responder_candidate_entities_for_room, responder_candidate_entities_from_cached_room
-from mindroom.constants import ORIGINAL_SENDER_KEY
+from mindroom.constants import ORIGINAL_SENDER_KEY, SOURCE_KIND_KEY
+from mindroom.dispatch_source import TRUSTED_INTERNAL_RELAY_SOURCE_KIND
 from mindroom.entity_resolution import entity_identity_registry
 from mindroom.matrix.client_delivery import send_message_result
 from mindroom.matrix.mentions import format_message_with_mentions
@@ -384,6 +385,7 @@ async def _send_matrix_text(
     )
     if original_sender:
         content[ORIGINAL_SENDER_KEY] = original_sender
+        content[SOURCE_KIND_KEY] = TRUSTED_INTERNAL_RELAY_SOURCE_KIND
     delivered = await send_message_result(context.client, room_id, content)
     if delivered is not None:
         context.conversation_cache.notify_outbound_message(room_id, delivered.event_id, delivered.content_sent)

--- a/tests/test_ingress_validation.py
+++ b/tests/test_ingress_validation.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import nio
 
 from mindroom.bot_runtime_view import BotRuntimeState
 from mindroom.config.main import Config
@@ -16,12 +19,9 @@ from tests.identity_helpers import entity_ids
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from mindroom.turn_policy import TurnPolicy
-    from mindroom.turn_store import TurnStore
 
-
-def test_auto_resume_relay_resolves_requester_to_original_human(tmp_path: Path) -> None:
-    """Router-authored auto-resume should preserve human requester without trusting outsiders."""
+def test_trusted_relay_resolves_requester_and_allows_self_authored_ingress(tmp_path: Path) -> None:
+    """Trusted relays should preserve human requesters without trusting outsiders."""
     config = bind_runtime_paths(
         Config(
             agents={"test_agent": {"display_name": "Test Agent"}},
@@ -32,6 +32,28 @@ def test_auto_resume_relay_resolves_requester_to_original_human(tmp_path: Path) 
     )
     runtime_paths = runtime_paths_for(config)
     ids = entity_ids(config, runtime_paths)
+    runtime = BotRuntimeState(
+        client=None,
+        config=config,
+        runtime_paths=runtime_paths,
+        enable_streaming=False,
+        orchestrator=None,
+        event_cache=None,
+        event_cache_write_coordinator=None,
+    )
+    turn_store = MagicMock()
+    turn_store.is_handled.return_value = False
+    turn_policy = MagicMock()
+    turn_policy.can_reply_to_sender.return_value = True
+    validator = IngressValidator(
+        IngressValidatorDeps(
+            runtime=runtime,
+            runtime_paths=runtime_paths,
+            matrix_id=ids["test_agent"],
+            turn_store=turn_store,
+            turn_policy=turn_policy,
+        ),
+    )
     human_sender = "@human:localhost"
     content = stale_stream_cleanup._build_auto_resume_content(
         stale_stream_cleanup._InterruptedThread(
@@ -44,24 +66,6 @@ def test_auto_resume_relay_resolves_requester_to_original_human(tmp_path: Path) 
         ),
         config=config,
         runtime_paths=runtime_paths,
-    )
-    runtime = BotRuntimeState(
-        client=None,
-        config=config,
-        runtime_paths=runtime_paths,
-        enable_streaming=False,
-        orchestrator=None,
-        event_cache=None,
-        event_cache_write_coordinator=None,
-    )
-    validator = IngressValidator(
-        IngressValidatorDeps(
-            runtime=runtime,
-            runtime_paths=runtime_paths,
-            matrix_id=ids["test_agent"],
-            turn_store=cast("TurnStore", object()),
-            turn_policy=cast("TurnPolicy", object()),
-        ),
     )
 
     assert content[ORIGINAL_SENDER_KEY] == human_sender
@@ -80,3 +84,21 @@ def test_auto_resume_relay_resolves_requester_to_original_human(tmp_path: Path) 
         )
         == "@untrusted:localhost"
     )
+    agent_id = ids["test_agent"]
+    event = nio.RoomMessageText.from_dict(
+        {
+            "event_id": "$spawn",
+            "sender": agent_id.full_id,
+            "origin_server_ts": 1234567890,
+            "content": {
+                "msgtype": "m.text",
+                "body": f"{agent_id.full_id} do work",
+                "m.mentions": {"user_ids": [agent_id.full_id]},
+                ORIGINAL_SENDER_KEY: human_sender,
+                SOURCE_KIND_KEY: TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
+            },
+        },
+    )
+    room = nio.MatrixRoom("!room:localhost", agent_id.full_id)
+
+    assert validator.precheck_event(room, event) == human_sender

--- a/tests/test_subagents.py
+++ b/tests/test_subagents.py
@@ -14,10 +14,17 @@ import pytest
 import mindroom.tools  # noqa: F401
 from mindroom.agent_descriptions import describe_agent
 from mindroom.config.agent import AgentConfig
-from mindroom.constants import ORIGINAL_SENDER_KEY, ROUTER_AGENT_NAME, RuntimePaths, resolve_runtime_paths
+from mindroom.constants import (
+    ORIGINAL_SENDER_KEY,
+    ROUTER_AGENT_NAME,
+    SOURCE_KIND_KEY,
+    RuntimePaths,
+    resolve_runtime_paths,
+)
 from mindroom.custom_tools import subagents as subagents_module
 from mindroom.custom_tools.delegate import DelegateTools
 from mindroom.custom_tools.subagents import SubAgentsTools
+from mindroom.dispatch_source import TRUSTED_INTERNAL_RELAY_SOURCE_KIND
 from mindroom.entity_resolution import entity_identity_registry
 from mindroom.message_target import MessageTarget
 from mindroom.session_ids import create_session_id, parse_session_id
@@ -686,6 +693,29 @@ async def test_send_matrix_text_uses_latest_thread_event_id_for_fallback(
     assert content["m.relates_to"]["event_id"] == ctx.thread_id
     assert content["m.relates_to"]["m.in_reply_to"]["event_id"] == "$latest:localhost"
     assert content[ORIGINAL_SENDER_KEY] == ctx.requester_id
+
+
+@pytest.mark.asyncio
+async def test_send_matrix_text_marks_original_sender_as_trusted_relay(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Root session messages should carry trusted human-relay metadata."""
+    send_mock = AsyncMock(side_effect=delivered_matrix_side_effect("$evt"))
+    monkeypatch.setattr(subagents_module, "send_message_result", send_mock)
+    ctx = _make_context(tmp_path, requester_id="@user:localhost")
+
+    await subagents_module._send_matrix_text(
+        ctx,
+        room_id=ctx.room_id,
+        text="@actual_openclaw:localhost do work",
+        thread_id=None,
+        original_sender=ctx.requester_id,
+    )
+
+    content = send_mock.await_args.args[2]
+    assert content[ORIGINAL_SENDER_KEY] == ctx.requester_id
+    assert content[SOURCE_KIND_KEY] == TRUSTED_INTERNAL_RELAY_SOURCE_KIND
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Spawned sessions can post work back to their own Matrix identity. Those messages preserved the human sender but lacked trusted-relay provenance, so ingress treated the agent as the requester and discarded the event as self-authored before mention routing.

Mark subagent session messages carrying an original sender as trusted internal relays. This preserves the human requester through ingress validation and lets both session spawn and follow-up send messages reach the addressed agent without weakening the general self-message guard.

Regression coverage verifies relay metadata at send time and the full requester-resolution/precheck behavior for self-authored events.

## Validation

- Focused regression tests
- Related subagent, ingress, turn-dispatch, controller, and policy test suites
- Ruff check and format
- Targeted type check
- Pre-commit hooks (repo-wide type hook skipped because fresh environment lacks optional tool dependencies; targeted changed-file type check passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trusted internal relay handling so messages retain the correct original sender identity.
  * Self-authored messages received through trusted relays are now correctly accepted during ingress validation.

* **Tests**
  * Added coverage verifying relay metadata and requester identity resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->