### PR TITLE
Recover Matrix cache after cancelled Postgres work

### DIFF
--- a/src/mindroom/matrix/cache/postgres_event_cache.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache.py
@@ -57,6 +57,7 @@ _TRANSIENT_SQLSTATES: frozenset[str] = frozenset(
     },
 )
 _TRANSIENT_ERROR_TEXT: tuple[str, ...] = (
+    "another command is already in progress",
     "connection is closed",
     "connection already closed",
     "connection refused",

--- a/src/mindroom/matrix/client_thread_history.py
+++ b/src/mindroom/matrix/client_thread_history.py
@@ -1088,11 +1088,18 @@ async def refresh_thread_history_from_source(
             expected_membership_epoch=fetch_membership_epoch,
             fetch_started_at=fetch_started_at,
         )
+        cache_store_outcome = (
+            "stored"
+            if cache_store_written
+            else "writes_unavailable"
+            if not event_cache.durable_writes_available
+            else "not_replaced"
+        )
         logger.info(
             "Thread history cache store completed",
             room_id=room_id,
             thread_id=thread_id,
-            cache_store_outcome="stored" if cache_store_written else "not_replaced",
+            cache_store_outcome=cache_store_outcome,
             cache_store_written=cache_store_written,
             event_count=len(fetch_result.event_sources),
             homeserver_scan_pages=fetch_result.room_scan_pages,

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -755,6 +755,13 @@ class MatrixConversationCache(ConversationCacheProtocol):
         is_shutting_down: Callable[[], bool],
     ) -> bool:
         """Warm one room's recent thread roots and report whether the room-level pass finished."""
+        if not self.runtime.event_cache.durable_writes_available:
+            self.logger.warning(
+                "startup_thread_prewarm_skipped",
+                room_id=room_id,
+                reason="event_cache_writes_unavailable",
+            )
+            return False
         started_at = time.perf_counter()
         threads_warmed = 0
         threads_failed = 0
@@ -804,7 +811,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
         is_shutting_down: Callable[[], bool],
     ) -> _StartupThreadPrewarmOutcome:
         """Refresh one startup thread snapshot and return its room-level prewarm outcome."""
-        if is_shutting_down():
+        if is_shutting_down() or not self.runtime.event_cache.durable_writes_available:
             return "aborted"
         if not thread_id:
             self.logger.warning(

--- a/tests/test_bot_ready_hook.py
+++ b/tests/test_bot_ready_hook.py
@@ -984,6 +984,29 @@ async def test_startup_thread_prewarm_refreshes_threads_concurrently(tmp_path: P
 
 
 @pytest.mark.asyncio
+async def test_startup_thread_prewarm_skips_when_cache_writes_are_unavailable(tmp_path: Path) -> None:
+    """Startup prewarm must not scan Matrix when its snapshots cannot be persisted."""
+    bot = _agent_bot(tmp_path)
+    bot._conversation_cache.logger = MagicMock()
+    bot.event_cache.durable_writes_available = False
+    bot._conversation_cache._startup_thread_prewarm_ids = AsyncMock(
+        side_effect=AssertionError("prewarm should not enumerate threads when cache writes are unavailable"),
+    )
+
+    completed = await bot._conversation_cache.prewarm_recent_room_threads(
+        "!room:localhost",
+        is_shutting_down=lambda: False,
+    )
+
+    assert completed is False
+    bot._conversation_cache.logger.warning.assert_called_once_with(
+        "startup_thread_prewarm_skipped",
+        room_id="!room:localhost",
+        reason="event_cache_writes_unavailable",
+    )
+
+
+@pytest.mark.asyncio
 async def test_startup_thread_prewarm_limits_room_work_across_bots(tmp_path: Path) -> None:
     """Startup prewarm should not let many enabled bots warm different rooms at the same time."""
     first_bot = _agent_bot(tmp_path, agent_name="router")

--- a/tests/test_event_cache_backends.py
+++ b/tests/test_event_cache_backends.py
@@ -1524,6 +1524,38 @@ async def test_postgres_runtime_rolls_back_cancelled_advisory_lock() -> None:
     db.rollback.assert_awaited_once()
 
 
+@pytest.mark.asyncio
+async def test_postgres_event_cache_reconnects_and_retries_connection_busy_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A connection poisoned by cancellation must be replaced instead of disabling cache writes."""
+    cache = PostgresEventCache(database_url="postgresql://cache:test@localhost/mindroom", namespace="tenant-a")
+    busy_error = psycopg.OperationalError("sending prepared query failed: another command is already in progress")
+    run_attempt = AsyncMock(
+        side_effect=[
+            busy_error,
+            ("recovered", _FlushedPendingWrites()),
+        ],
+    )
+    handle_transient_failure = AsyncMock()
+    monkeypatch.setattr(cache, "_run_operation_attempt", run_attempt)
+    monkeypatch.setattr(cache._runtime, "handle_transient_failure", handle_transient_failure)
+
+    result = await cache._operation(
+        "!room:example.test",
+        operation="recover_busy_connection",
+        disabled_result=None,
+        callback=AsyncMock(),
+    )
+
+    assert result == "recovered"
+    assert run_attempt.await_count == 2
+    handle_transient_failure.assert_awaited_once_with(
+        busy_error,
+        operation="recover_busy_connection",
+    )
+
+
 def test_build_event_cache_auto_installs_postgres_extra_before_import(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1962,6 +1994,13 @@ def test_postgres_transient_classifier_accepts_startup_connection_refused() -> N
 def test_postgres_transient_classifier_accepts_connection_timeout() -> None:
     """Startup connection timeouts should retry later instead of disabling the cache."""
     assert _is_transient_postgres_failure(psycopg.errors.ConnectionTimeout("connection timeout expired"))
+
+
+def test_postgres_transient_classifier_accepts_connection_busy_after_cancellation() -> None:
+    """A connection left busy by cancellation must be replaced before retrying cache work."""
+    assert _is_transient_postgres_failure(
+        psycopg.OperationalError("sending prepared query failed: another command is already in progress"),
+    )
 
 
 def test_postgres_transient_classifier_accepts_dns_resolution_failure() -> None:


### PR DESCRIPTION
## Why

A cancelled Postgres cache operation can leave its psycopg async connection busy. The transient classifier did not recognize that state, so later cache work kept reusing the poisoned connection and fail-closed invalidation could disable the advisory cache. Startup prewarm then continued fetching snapshots even though none could persist.

## What

- Treat the psycopg connection-busy error as transient so cache work reconnects and retries.
- Skip or abort startup thread prewarm when durable cache writes are unavailable.
- Report writes_unavailable separately from a guarded replacement race.
- Cover reconnect/retry and prewarm-skip behavior with regression tests.

## Validation

- uv run --extra postgres pytest -x --lf tests/test_event_cache_backends.py tests/test_bot_ready_hook.py
- 43 passed, 2 skipped
- Commit-time Python quality, type, boundary, and privacy hooks passed