### PR TITLE
Bulk-fill startup thread cache per room

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -811,7 +811,7 @@ class AgentBot:
                 await self.startup_thread_prewarm_registry.release(self.event_cache.principal_id, room_id)
 
     async def _run_startup_thread_prewarm(self) -> None:
-        """Prewarm recent thread snapshots per joined room without blocking live dispatch behind cache seeding."""
+        """Prewarm recent thread snapshots with one bounded bulk scan per joined room."""
         try:
             joined_rooms = await self._get_startup_thread_prewarm_joined_rooms()
             for room_id in joined_rooms:

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -811,7 +811,7 @@ class AgentBot:
                 await self.startup_thread_prewarm_registry.release(self.event_cache.principal_id, room_id)
 
     async def _run_startup_thread_prewarm(self) -> None:
-        """Prewarm recent thread snapshots with one bounded bulk scan per joined room."""
+        """Prewarm recent thread snapshots with one bulk scan per joined room."""
         try:
             joined_rooms = await self._get_startup_thread_prewarm_joined_rooms()
             for room_id in joined_rooms:

--- a/src/mindroom/matrix/cache/thread_reads.py
+++ b/src/mindroom/matrix/cache/thread_reads.py
@@ -5,8 +5,8 @@ Read-side invariants:
 1. Every thread read through this policy first waits for the room and same-thread write queue to drain
    (``wait_for_thread_idle``), so a read never observes cache state older than mutations already queued
    when the read began.
-   Startup prewarm deliberately bypasses this policy and relies on the write-time replacement guard
-   instead.
+   Startup prewarm bypasses this policy but runs its one bulk room scan through the room write barrier
+   before relying on the backend replacement guard.
 
 2. Dispatch-safe modes (``DISPATCH_SNAPSHOT``, ``DISPATCH_FULL``) bound the whole wait-plus-fetch by one
    shared timeout and return an explicitly degraded empty result

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -717,6 +717,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
                 room_id,
                 refresh_room_threads,
                 name="matrix_cache_bulk_startup_thread_prewarm",
+                log_exceptions=False,
                 coordination_scope=self.runtime.event_cache.principal_id,
             ),
         )

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -18,7 +18,7 @@ import time
 from contextlib import asynccontextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Literal, Protocol, cast
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 import nio
 from nio.responses import RoomGetEventError
@@ -35,10 +35,13 @@ from mindroom.matrix.cache.thread_reads import ThreadReadMode, ThreadReadPolicy
 from mindroom.matrix.cache.thread_write_cache_ops import ThreadMutationCacheOps
 from mindroom.matrix.cache.thread_writes import ThreadLiveWritePolicy, ThreadOutboundWritePolicy, ThreadSyncWritePolicy
 from mindroom.matrix.client_thread_history import (
+    BulkThreadRefreshStats,
+    bulk_refresh_room_thread_histories,
     fetch_dispatch_thread_history,
     fetch_dispatch_thread_snapshot,
     fetch_thread_history,
     get_room_threads_page,
+    untrusted_cached_thread_ids,
 )
 from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.media import (
@@ -87,8 +90,6 @@ __all__ = [
 
 
 _STARTUP_PREWARM_THREAD_LIMIT = 32
-_STARTUP_PREWARM_THREAD_CONCURRENCY = 8
-type _StartupThreadPrewarmOutcome = Literal["warmed", "failed", "aborted"]
 
 
 async def resolve_thread_root_event_id_for_client(
@@ -691,19 +692,49 @@ class MatrixConversationCache(ConversationCacheProtocol):
             resolution_reuse=self._thread_resolution_reuse,
         )
 
-    async def _refresh_dispatch_thread_snapshot_for_startup_prewarm(
+    async def _bulk_refresh_startup_threads(
         self,
         room_id: str,
-        thread_id: str,
-    ) -> ThreadHistoryResult:
-        """Refresh one strict thread snapshot for advisory startup prewarm without the live read barrier."""
-        return await self._fetch_thread_from_client(
-            fetch_dispatch_thread_snapshot,
-            room_id,
-            thread_id,
-            caller_label="startup_thread_prewarm",
-            # Startup prewarm bypasses the read coordinator; 0.0 means no coordinator queue was used.
-            coordinator_queue_wait_ms=0.0,
+        thread_ids: Collection[str],
+    ) -> BulkThreadRefreshStats:
+        """Refresh one room's startup threads in one scan under the room write barrier."""
+
+        async def refresh_room_threads() -> BulkThreadRefreshStats:
+            return await bulk_refresh_room_thread_histories(
+                self._require_client(),
+                room_id,
+                self.runtime.event_cache,
+                thread_root_ids=thread_ids,
+                caller_label="startup_thread_prewarm",
+            )
+
+        coordinator = self.runtime.event_cache_write_coordinator
+        if coordinator is None:
+            return await refresh_room_threads()
+        return cast(
+            "BulkThreadRefreshStats",
+            await coordinator.queue_room_update(
+                room_id,
+                refresh_room_threads,
+                name="matrix_cache_bulk_startup_thread_prewarm",
+                coordination_scope=self.runtime.event_cache.principal_id,
+            ),
+        )
+
+    def _log_startup_thread_prewarm_complete(
+        self,
+        room_id: str,
+        *,
+        started_at: float,
+        threads_warmed: int,
+        threads_failed: int,
+    ) -> None:
+        self.logger.info(
+            "startup_thread_prewarm_complete",
+            room_id=room_id,
+            threads_warmed=threads_warmed,
+            threads_failed=threads_failed,
+            elapsed_ms=elapsed_ms_since(started_at, clock=time.perf_counter),
         )
 
     async def _startup_thread_prewarm_ids(
@@ -763,84 +794,51 @@ class MatrixConversationCache(ConversationCacheProtocol):
             )
             return False
         started_at = time.perf_counter()
-        threads_warmed = 0
-        threads_failed = 0
         thread_ids = await self._startup_thread_prewarm_ids(room_id)
-        if thread_ids is None:
+        if thread_ids is None or is_shutting_down() or not self.runtime.event_cache.durable_writes_available:
             return False
-
-        completed = True
-        pending_thread_ids = list(thread_ids)
-
-        async def worker() -> None:
-            nonlocal completed, threads_failed, threads_warmed
-            while pending_thread_ids:
-                if is_shutting_down():
-                    completed = False
-                    return
-                outcome = await self._prewarm_one_startup_thread(
-                    room_id,
-                    pending_thread_ids.pop(0),
-                    is_shutting_down=is_shutting_down,
-                )
-                if outcome == "aborted":
-                    completed = False
-                    return
-                if outcome == "failed":
-                    threads_failed += 1
-                else:
-                    threads_warmed += 1
-
-        worker_count = min(_STARTUP_PREWARM_THREAD_CONCURRENCY, len(pending_thread_ids))
-        await asyncio.gather(*(worker() for _ in range(worker_count)))
-
-        self.logger.info(
-            "startup_thread_prewarm_complete",
-            room_id=room_id,
-            threads_warmed=threads_warmed,
-            threads_failed=threads_failed,
-            elapsed_ms=elapsed_ms_since(started_at, clock=time.perf_counter),
+        untrusted_thread_ids = await untrusted_cached_thread_ids(
+            self.runtime.event_cache,
+            room_id,
+            thread_ids,
         )
-        return completed
-
-    async def _prewarm_one_startup_thread(
-        self,
-        room_id: str,
-        thread_id: str,
-        *,
-        is_shutting_down: Callable[[], bool],
-    ) -> _StartupThreadPrewarmOutcome:
-        """Refresh one startup thread snapshot and return its room-level prewarm outcome."""
-        if is_shutting_down() or not self.runtime.event_cache.durable_writes_available:
-            return "aborted"
-        if not thread_id:
-            self.logger.warning(
-                "startup_thread_prewarm_thread_failed",
-                room_id=room_id,
-                thread_id=thread_id,
-                error="missing_thread_root_event_id",
+        already_warm = len(thread_ids) - len(untrusted_thread_ids)
+        if not untrusted_thread_ids:
+            self._log_startup_thread_prewarm_complete(
+                room_id,
+                started_at=started_at,
+                threads_warmed=already_warm,
+                threads_failed=0,
             )
-            await asyncio.sleep(0)
-            return "failed"
+            return True
 
         try:
-            await self._refresh_dispatch_thread_snapshot_for_startup_prewarm(
+            stats = await self._bulk_refresh_startup_threads(
                 room_id,
-                thread_id,
+                untrusted_thread_ids,
             )
         except asyncio.CancelledError:
             raise
         except Exception as exc:
             self.logger.warning(
-                "startup_thread_prewarm_thread_failed",
+                "startup_thread_prewarm_bulk_failed",
                 room_id=room_id,
-                thread_id=thread_id,
+                thread_count=len(untrusted_thread_ids),
                 error=str(exc),
             )
-            return "failed"
+            return False
+        if is_shutting_down() or not self.runtime.event_cache.durable_writes_available:
+            return False
 
-        await asyncio.sleep(0)
-        return "warmed"
+        threads_warmed = already_warm + stats.stored_threads
+        threads_failed = len(untrusted_thread_ids) - stats.stored_threads
+        self._log_startup_thread_prewarm_complete(
+            room_id,
+            started_at=started_at,
+            threads_warmed=threads_warmed,
+            threads_failed=threads_failed,
+        )
+        return True
 
     async def get_thread_history(
         self,

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -803,6 +803,8 @@ class MatrixConversationCache(ConversationCacheProtocol):
             thread_ids,
         )
         already_warm = len(thread_ids) - len(untrusted_thread_ids)
+        if is_shutting_down() or not self.runtime.event_cache.durable_writes_available:
+            return False
         if not untrusted_thread_ids:
             self._log_startup_thread_prewarm_complete(
                 room_id,
@@ -827,8 +829,6 @@ class MatrixConversationCache(ConversationCacheProtocol):
                 error=str(exc),
             )
             return False
-        if is_shutting_down() or not self.runtime.event_cache.durable_writes_available:
-            return False
 
         threads_warmed = already_warm + stats.stored_threads
         threads_failed = len(untrusted_thread_ids) - stats.stored_threads
@@ -838,7 +838,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
             threads_warmed=threads_warmed,
             threads_failed=threads_failed,
         )
-        return True
+        return not is_shutting_down() and self.runtime.event_cache.durable_writes_available
 
     async def get_thread_history(
         self,

--- a/tests/test_bot_ready_hook.py
+++ b/tests/test_bot_ready_hook.py
@@ -1167,6 +1167,29 @@ async def test_startup_thread_prewarm_bulk_refresh_waits_for_background_warm(tmp
 
 
 @pytest.mark.asyncio
+async def test_startup_thread_prewarm_bulk_failure_is_logged_only_by_caller(tmp_path: Path) -> None:
+    """Awaited bulk failures should not also be logged by the background-task callback."""
+    bot = _agent_bot(tmp_path)
+    bot.client = make_matrix_client_mock(user_id=bot.agent_user.user_id or "@mindroom_code:localhost")
+
+    with (
+        patch(
+            "mindroom.matrix.conversation_cache.bulk_refresh_room_thread_histories",
+            new=AsyncMock(side_effect=RuntimeError("boom")),
+        ),
+        patch("mindroom.background_tasks.logger.exception") as background_task_log,
+        pytest.raises(RuntimeError, match="boom"),
+    ):
+        await bot._conversation_cache._bulk_refresh_startup_threads(
+            "!room:localhost",
+            ["$thread-root"],
+        )
+
+    await asyncio.sleep(0)
+    background_task_log.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_startup_thread_prewarm_joined_rooms_failure_is_fail_open(tmp_path: Path) -> None:
     """Startup thread prewarm should log and stop cleanly when joined room lookup fails."""
     bot = _agent_bot(tmp_path)

--- a/tests/test_bot_ready_hook.py
+++ b/tests/test_bot_ready_hook.py
@@ -1004,6 +1004,43 @@ async def test_startup_thread_prewarm_bulk_refreshes_once_under_room_barrier(tmp
 
 
 @pytest.mark.asyncio
+async def test_startup_thread_prewarm_rechecks_shutdown_before_bulk_scan(tmp_path: Path) -> None:
+    """Startup prewarm should not begin a bulk scan when shutdown starts during the cache probe."""
+    bot = _agent_bot(tmp_path)
+    thread_ids = ["$thread:localhost"]
+    shutting_down = False
+
+    async def probe_untrusted_threads(*_args: object, **_kwargs: object) -> tuple[str, ...]:
+        nonlocal shutting_down
+        shutting_down = True
+        return tuple(thread_ids)
+
+    with (
+        patch.object(
+            bot._conversation_cache,
+            "_startup_thread_prewarm_ids",
+            new=AsyncMock(return_value=thread_ids),
+        ),
+        patch(
+            "mindroom.matrix.conversation_cache.untrusted_cached_thread_ids",
+            new=AsyncMock(side_effect=probe_untrusted_threads),
+        ),
+        patch.object(
+            bot._conversation_cache,
+            "_bulk_refresh_startup_threads",
+            new=AsyncMock(),
+        ) as mock_bulk_refresh,
+    ):
+        completed = await bot._conversation_cache.prewarm_recent_room_threads(
+            "!room:localhost",
+            is_shutting_down=lambda: shutting_down,
+        )
+
+    assert completed is False
+    mock_bulk_refresh.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_startup_thread_prewarm_skips_when_cache_writes_are_unavailable(tmp_path: Path) -> None:
     """Startup prewarm must not scan Matrix when its snapshots cannot be persisted."""
     bot = _agent_bot(tmp_path)
@@ -1334,6 +1371,7 @@ async def test_shutdown_mid_room_prewarm_releases_claim_for_later_joined_bot(tmp
     router_bot = _agent_bot(tmp_path, agent_name="router")
     router_bot.client = make_matrix_client_mock(user_id=router_bot.agent_user.user_id or "@mindroom_router:localhost")
     router_bot.client.joined_rooms.return_value = nio.JoinedRoomsResponse(rooms=["!room:localhost"])
+    router_bot._conversation_cache.logger = MagicMock()
     agent_bot = _agent_bot(tmp_path)
     agent_bot.client = make_matrix_client_mock(user_id=agent_bot.agent_user.user_id or "@mindroom_code:localhost")
     agent_bot.client.joined_rooms.return_value = nio.JoinedRoomsResponse(rooms=["!room:localhost"])
@@ -1373,6 +1411,13 @@ async def test_shutdown_mid_room_prewarm_releases_claim_for_later_joined_bot(tmp
     router_bot._conversation_cache._bulk_refresh_startup_threads.assert_awaited_once_with(
         "!room:localhost",
         ("$thread-a:localhost", "$thread-b:localhost"),
+    )
+    router_bot._conversation_cache.logger.info.assert_any_call(
+        "startup_thread_prewarm_complete",
+        room_id="!room:localhost",
+        threads_warmed=2,
+        threads_failed=0,
+        elapsed_ms=ANY,
     )
     agent_bot._conversation_cache._bulk_refresh_startup_threads.assert_awaited_once_with(
         "!room:localhost",

--- a/tests/test_bot_ready_hook.py
+++ b/tests/test_bot_ready_hook.py
@@ -27,7 +27,7 @@ from mindroom.hooks import (
     HookRegistry,
     hook,
 )
-from mindroom.matrix.cache import ThreadHistoryResult, thread_history_result
+from mindroom.matrix.client_thread_history import BulkThreadRefreshStats
 from mindroom.matrix.sync_certification import SyncCacheWriteResult
 from mindroom.matrix.to_device import AuthenticatedToDeviceEvent
 from mindroom.matrix.users import AgentMatrixUser
@@ -114,6 +114,21 @@ def _thread_root_event(
     )
     assert isinstance(event, nio.RoomMessageText)
     return event
+
+
+def _bulk_refresh_stats(
+    requested_threads: int,
+    *,
+    stored_threads: int | None = None,
+) -> BulkThreadRefreshStats:
+    """Return compact startup-prewarm bulk stats for tests."""
+    return BulkThreadRefreshStats(
+        requested_threads=requested_threads,
+        stored_threads=requested_threads if stored_threads is None else stored_threads,
+        missing_root_ids=frozenset(),
+        room_scan_pages=1,
+        scanned_event_count=requested_threads,
+    )
 
 
 def _sync_response_with_room_membership_section(
@@ -762,9 +777,7 @@ async def test_bot_ready_starts_background_startup_thread_prewarm(tmp_path: Path
     bot.client = make_matrix_client_mock(user_id=bot.agent_user.user_id or "@mindroom_code:localhost")
     bot.client.joined_rooms.return_value = nio.JoinedRoomsResponse(rooms=["!room:localhost"])
     bot._conversation_cache.logger = MagicMock()
-    bot._conversation_cache._refresh_dispatch_thread_snapshot_for_startup_prewarm = AsyncMock(
-        return_value=thread_history_result([], is_full_history=False),
-    )
+    bot._conversation_cache._bulk_refresh_startup_threads = AsyncMock(return_value=_bulk_refresh_stats(2))
 
     thread_roots = [
         _thread_root_event("$thread-a:localhost", body="Thread A", origin_server_ts=1),
@@ -791,13 +804,10 @@ async def test_bot_ready_starts_background_startup_thread_prewarm(tmp_path: Path
         "!room:localhost",
         limit=32,
     )
-    assert [
-        call.args
-        for call in bot._conversation_cache._refresh_dispatch_thread_snapshot_for_startup_prewarm.await_args_list
-    ] == [
-        ("!room:localhost", "$thread-a:localhost"),
-        ("!room:localhost", "$thread-b:localhost"),
-    ]
+    bot._conversation_cache._bulk_refresh_startup_threads.assert_awaited_once_with(
+        "!room:localhost",
+        ("$thread-a:localhost", "$thread-b:localhost"),
+    )
     mock_get_dispatch_thread_snapshot.assert_not_awaited()
     bot._conversation_cache.logger.info.assert_any_call(
         "startup_thread_prewarm_complete",
@@ -818,9 +828,7 @@ async def test_bot_ready_prefers_locally_recent_threads_for_startup_prewarm(tmp_
         "$thread-local-a:localhost",
         "$thread-local-b:localhost",
     ]
-    bot._conversation_cache._refresh_dispatch_thread_snapshot_for_startup_prewarm = AsyncMock(
-        return_value=thread_history_result([], is_full_history=False),
-    )
+    bot._conversation_cache._bulk_refresh_startup_threads = AsyncMock(return_value=_bulk_refresh_stats(4))
 
     thread_roots = [
         _thread_root_event("$thread-local-b:localhost", body="Thread B", origin_server_ts=2),
@@ -844,15 +852,15 @@ async def test_bot_ready_prefers_locally_recent_threads_for_startup_prewarm(tmp_
         "!room:localhost",
         limit=32,
     )
-    assert [
-        call.args
-        for call in bot._conversation_cache._refresh_dispatch_thread_snapshot_for_startup_prewarm.await_args_list
-    ] == [
-        ("!room:localhost", "$thread-local-a:localhost"),
-        ("!room:localhost", "$thread-local-b:localhost"),
-        ("!room:localhost", "$thread-api-c:localhost"),
-        ("!room:localhost", "$thread-api-d:localhost"),
-    ]
+    bot._conversation_cache._bulk_refresh_startup_threads.assert_awaited_once_with(
+        "!room:localhost",
+        (
+            "$thread-local-a:localhost",
+            "$thread-local-b:localhost",
+            "$thread-api-c:localhost",
+            "$thread-api-d:localhost",
+        ),
+    )
 
 
 @pytest.mark.asyncio
@@ -865,9 +873,7 @@ async def test_bot_ready_falls_back_to_local_threads_when_threads_api_fails(tmp_
         "$thread-local-a:localhost",
         "$thread-local-b:localhost",
     ]
-    bot._conversation_cache._refresh_dispatch_thread_snapshot_for_startup_prewarm = AsyncMock(
-        return_value=thread_history_result([], is_full_history=False),
-    )
+    bot._conversation_cache._bulk_refresh_startup_threads = AsyncMock(return_value=_bulk_refresh_stats(2))
     bot._conversation_cache.logger = MagicMock()
 
     with (
@@ -880,13 +886,10 @@ async def test_bot_ready_falls_back_to_local_threads_when_threads_api_fails(tmp_
         await bot._on_sync_response(MagicMock())
         await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
 
-    assert [
-        call.args
-        for call in bot._conversation_cache._refresh_dispatch_thread_snapshot_for_startup_prewarm.await_args_list
-    ] == [
-        ("!room:localhost", "$thread-local-a:localhost"),
-        ("!room:localhost", "$thread-local-b:localhost"),
-    ]
+    bot._conversation_cache._bulk_refresh_startup_threads.assert_awaited_once_with(
+        "!room:localhost",
+        ("$thread-local-a:localhost", "$thread-local-b:localhost"),
+    )
     bot._conversation_cache.logger.warning.assert_any_call(
         "startup_thread_prewarm_room_threads_failed",
         room_id="!room:localhost",
@@ -903,9 +906,7 @@ async def test_bot_ready_skips_threads_api_when_local_recent_cache_is_sufficient
     bot.client.joined_rooms.return_value = nio.JoinedRoomsResponse(rooms=["!room:localhost"])
     local_thread_ids = [f"$thread-{index}:localhost" for index in range(32)]
     bot.event_cache.get_recent_room_thread_ids.return_value = local_thread_ids
-    bot._conversation_cache._refresh_dispatch_thread_snapshot_for_startup_prewarm = AsyncMock(
-        return_value=thread_history_result([], is_full_history=False),
-    )
+    bot._conversation_cache._bulk_refresh_startup_threads = AsyncMock(return_value=_bulk_refresh_stats(32))
 
     with (
         patch("mindroom.bot.mark_matrix_sync_success", return_value=datetime.now(UTC)),
@@ -918,66 +919,85 @@ async def test_bot_ready_skips_threads_api_when_local_recent_cache_is_sufficient
         await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
 
     bot.event_cache.get_recent_room_thread_ids.assert_awaited_once_with("!room:localhost", limit=32)
-    assert [
-        call.args[1]
-        for call in bot._conversation_cache._refresh_dispatch_thread_snapshot_for_startup_prewarm.await_args_list
-    ] == local_thread_ids
+    bot._conversation_cache._bulk_refresh_startup_threads.assert_awaited_once_with(
+        "!room:localhost",
+        tuple(local_thread_ids),
+    )
 
 
 @pytest.mark.asyncio
-async def test_startup_thread_prewarm_refreshes_threads_concurrently(tmp_path: Path) -> None:
-    """Startup prewarm should refresh thread snapshots concurrently up to the configured bound."""
+async def test_startup_thread_prewarm_bulk_refreshes_once_under_room_barrier(tmp_path: Path) -> None:
+    """Startup prewarm should use one room scan and serialize competing local cache writes."""
     bot = _agent_bot(tmp_path)
+    bot.client = make_matrix_client_mock(user_id=bot.agent_user.user_id or "@mindroom_code:localhost")
     bot._conversation_cache.logger = MagicMock()
-    thread_ids = [f"$thread-{index}:localhost" for index in range(40)]
-    expected_concurrency = 8
-    all_concurrent_refreshes_started = asyncio.Event()
-    release_refreshes = asyncio.Event()
-    started_thread_ids: list[str] = []
-    active_refreshes = 0
-    max_active_refreshes = 0
+    thread_ids = [f"$thread-{index}:localhost" for index in range(32)]
+    bulk_refresh_started = asyncio.Event()
+    release_bulk_refresh = asyncio.Event()
+    competing_write_started = asyncio.Event()
 
-    async def refresh_thread(room_id: str, thread_id: str) -> ThreadHistoryResult:
-        nonlocal active_refreshes, max_active_refreshes
-        assert room_id == "!room:localhost"
-        active_refreshes += 1
-        max_active_refreshes = max(max_active_refreshes, active_refreshes)
-        started_thread_ids.append(thread_id)
-        if len(started_thread_ids) == expected_concurrency:
-            all_concurrent_refreshes_started.set()
-        await release_refreshes.wait()
-        active_refreshes -= 1
-        return thread_history_result([], is_full_history=False)
+    async def bulk_refresh(*_args: object, **_kwargs: object) -> BulkThreadRefreshStats:
+        bulk_refresh_started.set()
+        await release_bulk_refresh.wait()
+        return _bulk_refresh_stats(len(thread_ids))
 
-    with patch.object(
-        bot._conversation_cache,
-        "_startup_thread_prewarm_ids",
-        new=AsyncMock(return_value=thread_ids),
+    async def competing_write() -> None:
+        competing_write_started.set()
+
+    with (
+        patch.object(
+            bot._conversation_cache,
+            "_startup_thread_prewarm_ids",
+            new=AsyncMock(return_value=thread_ids),
+        ),
+        patch(
+            "mindroom.matrix.conversation_cache.untrusted_cached_thread_ids",
+            new=AsyncMock(return_value=tuple(thread_ids)),
+        ),
+        patch(
+            "mindroom.matrix.conversation_cache.bulk_refresh_room_thread_histories",
+            new=AsyncMock(side_effect=bulk_refresh),
+        ) as mock_bulk_refresh,
     ):
-        bot._conversation_cache._refresh_dispatch_thread_snapshot_for_startup_prewarm = AsyncMock(
-            side_effect=refresh_thread,
-        )
         prewarm_task = asyncio.create_task(
             bot._conversation_cache.prewarm_recent_room_threads(
                 "!room:localhost",
                 is_shutting_down=lambda: False,
             ),
         )
+        competing_task: asyncio.Task[object] | None = None
         try:
-            await asyncio.wait_for(all_concurrent_refreshes_started.wait(), timeout=1.0)
-            assert started_thread_ids == thread_ids[:expected_concurrency]
-            release_refreshes.set()
+            await asyncio.wait_for(bulk_refresh_started.wait(), timeout=1.0)
+            competing_task = bot.event_cache_write_coordinator.queue_thread_update(
+                "!room:localhost",
+                thread_ids[0],
+                competing_write,
+                name="test_competing_startup_write",
+                coordination_scope=bot.event_cache.principal_id,
+            )
+            await asyncio.sleep(0)
+            assert not competing_write_started.is_set()
+            release_bulk_refresh.set()
             assert await prewarm_task
+            await competing_task
         finally:
-            release_refreshes.set()
+            release_bulk_refresh.set()
             await asyncio.gather(prewarm_task, return_exceptions=True)
+            if competing_task is not None:
+                await asyncio.gather(competing_task, return_exceptions=True)
 
-    assert started_thread_ids == thread_ids
-    assert max_active_refreshes == expected_concurrency
+    mock_bulk_refresh.assert_awaited_once_with(
+        bot.client,
+        "!room:localhost",
+        bot.event_cache,
+        thread_root_ids=tuple(thread_ids),
+        caller_label="startup_thread_prewarm",
+    )
+    assert competing_write_started.is_set()
     bot._conversation_cache.logger.info.assert_any_call(
         "startup_thread_prewarm_complete",
         room_id="!room:localhost",
-        threads_warmed=40,
+        threads_warmed=32,
         threads_failed=0,
         elapsed_ms=ANY,
     )
@@ -1081,28 +1101,32 @@ async def test_startup_thread_prewarm_releases_room_claim_after_failure(tmp_path
 
 
 @pytest.mark.asyncio
-async def test_startup_thread_prewarm_refresh_waits_for_background_warm(tmp_path: Path) -> None:
-    """Startup prewarm should complete a real background refresh instead of timing out quickly."""
+async def test_startup_thread_prewarm_bulk_refresh_waits_for_background_warm(tmp_path: Path) -> None:
+    """Startup prewarm should await the full bulk scan instead of timing it out."""
     bot = _agent_bot(tmp_path)
     bot.client = make_matrix_client_mock(user_id=bot.agent_user.user_id or "@mindroom_code:localhost")
 
-    async def slow_refresh(*_args: object, **_kwargs: object) -> ThreadHistoryResult:
+    async def slow_refresh(*_args: object, **_kwargs: object) -> BulkThreadRefreshStats:
         await asyncio.sleep(0.35)
-        return thread_history_result([], is_full_history=False)
+        return _bulk_refresh_stats(1)
 
     with patch(
-        "mindroom.matrix.conversation_cache.fetch_dispatch_thread_snapshot",
+        "mindroom.matrix.conversation_cache.bulk_refresh_room_thread_histories",
         new=AsyncMock(side_effect=slow_refresh),
-    ) as fetch_dispatch_thread_snapshot:
-        result = await bot._conversation_cache._refresh_dispatch_thread_snapshot_for_startup_prewarm(
+    ) as bulk_refresh:
+        result = await bot._conversation_cache._bulk_refresh_startup_threads(
             "!room:localhost",
-            "$thread-root",
+            ["$thread-root"],
         )
 
-    assert result.messages == []
-    fetch_dispatch_thread_snapshot.assert_awaited_once()
-    assert fetch_dispatch_thread_snapshot.await_args.kwargs["caller_label"] == "startup_thread_prewarm"
-    assert fetch_dispatch_thread_snapshot.await_args.kwargs["coordinator_queue_wait_ms"] == 0.0
+    assert result == _bulk_refresh_stats(1)
+    bulk_refresh.assert_awaited_once_with(
+        bot.client,
+        "!room:localhost",
+        bot.event_cache,
+        thread_root_ids=["$thread-root"],
+        caller_label="startup_thread_prewarm",
+    )
 
 
 @pytest.mark.asyncio
@@ -1197,13 +1221,13 @@ async def test_agent_only_ad_hoc_room_still_prewarms_when_router_exists(tmp_path
             ) as mock_get_room_threads_page,
             patch.object(
                 router_bot._conversation_cache,
-                "get_dispatch_thread_snapshot",
-                new=AsyncMock(return_value=thread_history_result([], is_full_history=False)),
+                "_bulk_refresh_startup_threads",
+                new=AsyncMock(return_value=_bulk_refresh_stats(1)),
             ),
             patch.object(
                 agent_bot._conversation_cache,
-                "get_dispatch_thread_snapshot",
-                new=AsyncMock(return_value=thread_history_result([], is_full_history=False)),
+                "_bulk_refresh_startup_threads",
+                new=AsyncMock(return_value=_bulk_refresh_stats(1)),
             ),
         ):
             await router_bot._on_sync_response(MagicMock())
@@ -1239,13 +1263,13 @@ async def test_each_principal_claims_shared_room_startup_prewarm(tmp_path: Path)
             ) as mock_get_room_threads_page,
             patch.object(
                 router_bot._conversation_cache,
-                "get_dispatch_thread_snapshot",
-                new=AsyncMock(return_value=thread_history_result([], is_full_history=False)),
+                "_bulk_refresh_startup_threads",
+                new=AsyncMock(return_value=_bulk_refresh_stats(1)),
             ),
             patch.object(
                 agent_bot._conversation_cache,
-                "get_dispatch_thread_snapshot",
-                new=AsyncMock(return_value=thread_history_result([], is_full_history=False)),
+                "_bulk_refresh_startup_threads",
+                new=AsyncMock(return_value=_bulk_refresh_stats(1)),
             ),
         ):
             await agent_bot._on_sync_response(MagicMock())
@@ -1270,9 +1294,7 @@ async def test_room_thread_listing_failure_releases_claim_for_later_joined_bot(t
     agent_bot.client = make_matrix_client_mock(user_id=agent_bot.agent_user.user_id or "@mindroom_code:localhost")
     agent_bot.client.joined_rooms.return_value = nio.JoinedRoomsResponse(rooms=["!room:localhost"])
     agent_bot._conversation_cache.logger = MagicMock()
-    agent_bot._conversation_cache._refresh_dispatch_thread_snapshot_for_startup_prewarm = AsyncMock(
-        return_value=thread_history_result([], is_full_history=False),
-    )
+    agent_bot._conversation_cache._bulk_refresh_startup_threads = AsyncMock(return_value=_bulk_refresh_stats(1))
     orchestrator = _MultiAgentOrchestrator(runtime_paths=orchestrator_runtime_paths(tmp_path))
     thread_roots = [_thread_root_event("$thread-a:localhost", body="Thread A", origin_server_ts=1)]
 
@@ -1296,12 +1318,10 @@ async def test_room_thread_listing_failure_releases_claim_for_later_joined_bot(t
         error="boom",
         local_thread_count=0,
     )
-    assert [
-        call.args
-        for call in agent_bot._conversation_cache._refresh_dispatch_thread_snapshot_for_startup_prewarm.await_args_list
-    ] == [
-        ("!room:localhost", "$thread-a:localhost"),
-    ]
+    agent_bot._conversation_cache._bulk_refresh_startup_threads.assert_awaited_once_with(
+        "!room:localhost",
+        ("$thread-a:localhost",),
+    )
     assert (
         agent_bot.event_cache.principal_id,
         "!room:localhost",
@@ -1319,16 +1339,17 @@ async def test_shutdown_mid_room_prewarm_releases_claim_for_later_joined_bot(tmp
     agent_bot.client.joined_rooms.return_value = nio.JoinedRoomsResponse(rooms=["!room:localhost"])
     orchestrator = _MultiAgentOrchestrator(runtime_paths=orchestrator_runtime_paths(tmp_path))
 
-    async def _abort_after_first_refresh(_room_id: str, _thread_id: str) -> ThreadHistoryResult:
+    async def _abort_after_bulk_refresh(
+        _room_id: str,
+        thread_ids: tuple[str, ...],
+    ) -> BulkThreadRefreshStats:
         router_bot._sync_shutting_down = True
-        return thread_history_result([], is_full_history=False)
+        return _bulk_refresh_stats(len(thread_ids))
 
-    router_bot._conversation_cache._refresh_dispatch_thread_snapshot_for_startup_prewarm = AsyncMock(
-        side_effect=_abort_after_first_refresh,
+    router_bot._conversation_cache._bulk_refresh_startup_threads = AsyncMock(
+        side_effect=_abort_after_bulk_refresh,
     )
-    agent_bot._conversation_cache._refresh_dispatch_thread_snapshot_for_startup_prewarm = AsyncMock(
-        return_value=thread_history_result([], is_full_history=False),
-    )
+    agent_bot._conversation_cache._bulk_refresh_startup_threads = AsyncMock(return_value=_bulk_refresh_stats(2))
 
     thread_roots = [
         _thread_root_event("$thread-a:localhost", body="Thread A", origin_server_ts=1),
@@ -1349,14 +1370,14 @@ async def test_shutdown_mid_room_prewarm_releases_claim_for_later_joined_bot(tmp
             await wait_for_background_tasks(timeout=1.0, owner=agent_bot._runtime_view)
 
     assert mock_get_room_threads_page.await_count == 2
-    assert router_bot._conversation_cache._refresh_dispatch_thread_snapshot_for_startup_prewarm.await_count == 1
-    assert [
-        call.args
-        for call in agent_bot._conversation_cache._refresh_dispatch_thread_snapshot_for_startup_prewarm.await_args_list
-    ] == [
-        ("!room:localhost", "$thread-a:localhost"),
-        ("!room:localhost", "$thread-b:localhost"),
-    ]
+    router_bot._conversation_cache._bulk_refresh_startup_threads.assert_awaited_once_with(
+        "!room:localhost",
+        ("$thread-a:localhost", "$thread-b:localhost"),
+    )
+    agent_bot._conversation_cache._bulk_refresh_startup_threads.assert_awaited_once_with(
+        "!room:localhost",
+        ("$thread-a:localhost", "$thread-b:localhost"),
+    )
     assert (
         agent_bot.event_cache.principal_id,
         "!room:localhost",
@@ -1459,8 +1480,8 @@ async def test_disabled_bot_does_not_block_enabled_bot_from_claiming_room(tmp_pa
             ) as mock_get_room_threads_page,
             patch.object(
                 enabled_bot._conversation_cache,
-                "get_dispatch_thread_snapshot",
-                new=AsyncMock(return_value=thread_history_result([], is_full_history=False)),
+                "_bulk_refresh_startup_threads",
+                new=AsyncMock(return_value=_bulk_refresh_stats(1)),
             ),
         ):
             await disabled_bot._on_sync_response(MagicMock())
@@ -1476,18 +1497,13 @@ async def test_disabled_bot_does_not_block_enabled_bot_from_claiming_room(tmp_pa
 
 
 @pytest.mark.asyncio
-async def test_startup_thread_prewarm_skips_failed_threads_and_logs_counts(tmp_path: Path) -> None:
-    """Startup thread prewarm should fail open on individual thread refresh failures."""
+async def test_startup_thread_prewarm_fails_open_when_bulk_refresh_fails(tmp_path: Path) -> None:
+    """Startup thread prewarm should release its room claim after a bulk scan failure."""
     bot = _agent_bot(tmp_path)
     bot.client = make_matrix_client_mock(user_id=bot.agent_user.user_id or "@mindroom_code:localhost")
     bot.client.joined_rooms.return_value = nio.JoinedRoomsResponse(rooms=["!room:localhost"])
     bot._conversation_cache.logger = MagicMock()
-    bot._conversation_cache._refresh_dispatch_thread_snapshot_for_startup_prewarm = AsyncMock(
-        side_effect=[
-            RuntimeError("boom"),
-            thread_history_result([], is_full_history=False),
-        ],
-    )
+    bot._conversation_cache._bulk_refresh_startup_threads = AsyncMock(side_effect=RuntimeError("boom"))
 
     thread_roots = [
         _thread_root_event("$thread-a:localhost", body="Thread A", origin_server_ts=1),
@@ -1504,23 +1520,20 @@ async def test_startup_thread_prewarm_skips_failed_threads_and_logs_counts(tmp_p
         await bot._on_sync_response(MagicMock())
         await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
 
-    assert [
-        call.args[1]
-        for call in bot._conversation_cache._refresh_dispatch_thread_snapshot_for_startup_prewarm.await_args_list
-    ] == ["$thread-a:localhost", "$thread-b:localhost"]
+    bot._conversation_cache._bulk_refresh_startup_threads.assert_awaited_once_with(
+        "!room:localhost",
+        ("$thread-a:localhost", "$thread-b:localhost"),
+    )
     bot._conversation_cache.logger.warning.assert_any_call(
-        "startup_thread_prewarm_thread_failed",
+        "startup_thread_prewarm_bulk_failed",
         room_id="!room:localhost",
-        thread_id="$thread-a:localhost",
+        thread_count=2,
         error="boom",
     )
-    bot._conversation_cache.logger.info.assert_any_call(
-        "startup_thread_prewarm_complete",
-        room_id="!room:localhost",
-        threads_warmed=1,
-        threads_failed=1,
-        elapsed_ms=ANY,
-    )
+    assert (
+        bot.event_cache.principal_id,
+        "!room:localhost",
+    ) not in bot.startup_thread_prewarm_registry._claimed_rooms
 
 
 @pytest.mark.asyncio

--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -33,7 +33,7 @@ from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
 from mindroom.matrix.cache.thread_history_result import thread_history_result
 from mindroom.matrix.cache.thread_reads import ThreadReadMode
 from mindroom.matrix.cache.write_coordinator import EventCacheWriteCoordinator
-from mindroom.matrix.client_thread_history import fetch_thread_history
+from mindroom.matrix.client_thread_history import BulkThreadRefreshStats, fetch_thread_history
 from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
 from mindroom.matrix.conversation_cache import MatrixConversationCache, _cached_room_get_event
 from mindroom.matrix.event_info import EventInfo
@@ -844,39 +844,40 @@ async def test_strict_thread_history_propagates_cache_coordinator_timeout(
 
 
 @pytest.mark.asyncio
-async def test_conversation_cache_startup_prewarm_fetch_preserves_fixed_metadata(
+async def test_conversation_cache_startup_prewarm_bulk_refresh_preserves_metadata(
     tmp_path: Path,
 ) -> None:
-    """Startup prewarm should bypass read coordination while keeping strict fetch metadata."""
+    """Startup prewarm should call the bulk room refresher with fixed metadata."""
     event_cache = SqliteEventCache(tmp_path / "event_cache.db")
     await event_cache.initialize()
     client = MagicMock()
     conversation_cache = _conversation_cache_for_thread_reads(tmp_path, event_cache, client=client)
-    fetch_dispatch_thread_snapshot = AsyncMock(return_value=thread_history_result([], is_full_history=False))
+    stats = BulkThreadRefreshStats(
+        requested_threads=1,
+        stored_threads=1,
+        missing_root_ids=frozenset(),
+        room_scan_pages=1,
+        scanned_event_count=2,
+    )
+    bulk_refresh_room_thread_histories = AsyncMock(return_value=stats)
 
     try:
-        with (
-            patch(
-                "mindroom.matrix.conversation_cache.fetch_dispatch_thread_snapshot",
-                fetch_dispatch_thread_snapshot,
-            ),
-            patch("mindroom.matrix.conversation_cache.time.time", return_value=222.0),
+        with patch(
+            "mindroom.matrix.conversation_cache.bulk_refresh_room_thread_histories",
+            bulk_refresh_room_thread_histories,
         ):
-            await conversation_cache._refresh_dispatch_thread_snapshot_for_startup_prewarm(
+            result = await conversation_cache._bulk_refresh_startup_threads(
                 "!room:localhost",
-                "$thread:localhost",
+                ["$thread:localhost"],
             )
 
-        fetch_dispatch_thread_snapshot.assert_awaited_once_with(
+        assert result == stats
+        bulk_refresh_room_thread_histories.assert_awaited_once_with(
             client,
             "!room:localhost",
-            "$thread:localhost",
-            event_cache=event_cache,
-            cache_write_guard_started_at=222.0,
-            trusted_sender_ids=conversation_cache._trusted_sender_ids(),
+            event_cache,
+            thread_root_ids=["$thread:localhost"],
             caller_label="startup_thread_prewarm",
-            coordinator_queue_wait_ms=0.0,
-            resolution_reuse=conversation_cache._thread_resolution_reuse,
         )
     finally:
         await event_cache.close()

--- a/tests/test_thread_read_guards.py
+++ b/tests/test_thread_read_guards.py
@@ -827,22 +827,22 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         try:
             bot.client.room_messages = AsyncMock(side_effect=room_messages)
             prewarm_task = asyncio.create_task(
-                bot._conversation_cache._refresh_dispatch_thread_snapshot_for_startup_prewarm(
+                bot._conversation_cache._bulk_refresh_startup_threads(
                     room_id,
-                    thread_id,
+                    [thread_id],
                 ),
             )
             await asyncio.wait_for(prewarm_fetch_started.wait(), timeout=1.0)
 
             allow_prewarm_fetch_finish.set()
-            prewarm_history = await asyncio.wait_for(prewarm_task, timeout=1.0)
+            prewarm_stats = await asyncio.wait_for(prewarm_task, timeout=1.0)
 
             history = await bot._conversation_cache.get_dispatch_thread_history(room_id, thread_id)
         finally:
             allow_prewarm_fetch_finish.set()
             await _close_bound_runtime_support(bot, support)
 
-        assert [message.body for message in prewarm_history] == ["Old root", "Old reply"]
+        assert prewarm_stats.stored_threads == 1
         assert [message.body for message in history] == ["Old root", "Old reply"]
         assert history.diagnostics[THREAD_HISTORY_SOURCE_DIAGNOSTIC] == THREAD_HISTORY_SOURCE_CACHE
         assert THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC not in history.diagnostics


### PR DESCRIPTION
## Why

Startup prewarm currently launches one full room-history scan per thread. On active rooms, sync invalidations can advance while those scans are running, so guarded stores lose the race and the per-principal cache remains cold. The repeated scans also turn bootstrap work into O(threads x room history).

## What

- Check which recent thread snapshots are actually untrusted before fetching.
- Refill all missing snapshots with one bulk room scan.
- Run that scan and its durable stores through the principal-room write barrier, while retaining the backend timestamp guard for cross-process safety.
- Keep startup fail-open and report bulk warmed/failed counts.

This addresses the startup refill loop described in #1648. It complements #1649, which restored Postgres writes after cancelled work.

## Verification

- `pytest tests/test_bot_ready_hook.py tests/test_event_cache.py tests/test_thread_read_guards.py tests/test_bulk_thread_backfill.py -x --lf -n auto --no-cov -q`
- Applicable pre-commit hooks, including ruff, formatting, ty, vulture, Tach, and module privacy
