### PR TITLE
Bound startup cache scans and fail open

### DIFF
--- a/src/mindroom/matrix/client_thread_history.py
+++ b/src/mindroom/matrix/client_thread_history.py
@@ -1561,6 +1561,7 @@ class _BulkThreadScanResult:
     unresolved_opaque_event_ids: frozenset[str]
     page_count: int
     scanned_event_count: int
+    scan_truncated: bool
 
 
 @dataclass(frozen=True)
@@ -1572,6 +1573,7 @@ class BulkThreadRefreshStats:
     missing_root_ids: frozenset[str]
     room_scan_pages: int
     scanned_event_count: int
+    scan_truncated: bool = False
 
 
 async def _unresolved_opaque_relation_event_ids(
@@ -1665,16 +1667,24 @@ async def _bulk_scan_thread_event_sources(
     room_id: str,
     *,
     thread_root_ids: Collection[str],
+    max_scan_pages: int | None = None,
 ) -> _BulkThreadScanResult:
     """Walk room history backward once and recover every requested thread's event sources."""
+    if max_scan_pages is not None and max_scan_pages < 1:
+        msg = "max_scan_pages must be at least 1"
+        raise ValueError(msg)
     latest_edits_by_original_event_id: dict[str, tuple[nio.RoomMessageText | nio.RoomMessageNotice, str | None]] = {}
     scanned_message_sources: dict[str, dict[str, Any]] = {}
     remaining_root_ids = set(thread_root_ids)
     from_token: str | None = None
     page_count = 0
     scanned_event_count = 0
+    scan_truncated = False
 
     while remaining_root_ids:
+        if max_scan_pages is not None and page_count >= max_scan_pages:
+            scan_truncated = True
+            break
         response = await client.room_messages(
             room_id,
             start=from_token,
@@ -1716,6 +1726,7 @@ async def _bulk_scan_thread_event_sources(
         unresolved_opaque_event_ids=unresolved_opaque_event_ids,
         page_count=page_count,
         scanned_event_count=scanned_event_count,
+        scan_truncated=scan_truncated,
     )
 
 
@@ -1726,6 +1737,7 @@ async def bulk_refresh_room_thread_histories(
     *,
     thread_root_ids: Collection[str],
     caller_label: str = "unknown",
+    max_scan_pages: int | None = None,
 ) -> BulkThreadRefreshStats:
     """Warm the durable thread cache for many threads with one backward room scan.
 
@@ -1734,13 +1746,19 @@ async def bulk_refresh_room_thread_histories(
     O(history) walk, buckets every scanned event with the same canonical resolution rules as the
     per-thread path, and stores each requested thread through the same guarded
     ``replace_thread_if_not_newer`` path. Threads whose root never appeared in the scan are
-    reported in ``missing_root_ids`` and never stored. Threads whose reconstruction contains
-    still-opaque encrypted evidence are marked stale instead of stored, and a scan holding opaque
-    relations with unresolved impact marks every requested thread stale.
+    reported in ``missing_root_ids`` and never stored. A caller-provided page budget stops the scan
+    with remaining roots reported as missing and ``scan_truncated`` set. Threads whose reconstruction
+    contains still-opaque encrypted evidence are marked stale instead of stored, and a scan holding
+    opaque relations with unresolved impact marks every requested thread stale.
     """
     fetch_started_at = time.time()
     fetch_membership_epoch = await _capture_membership_epoch(event_cache, room_id)
-    scan_result = await _bulk_scan_thread_event_sources(client, room_id, thread_root_ids=thread_root_ids)
+    scan_result = await _bulk_scan_thread_event_sources(
+        client,
+        room_id,
+        thread_root_ids=thread_root_ids,
+        max_scan_pages=max_scan_pages,
+    )
     stored_threads = 0
     opaque_stale_threads = 0
     if scan_result.unresolved_opaque_event_ids:
@@ -1776,6 +1794,7 @@ async def bulk_refresh_room_thread_histories(
         missing_root_ids=scan_result.missing_root_ids,
         room_scan_pages=scan_result.page_count,
         scanned_event_count=scan_result.scanned_event_count,
+        scan_truncated=scan_result.scan_truncated,
     )
     logger.info(
         "Bulk thread cache refresh completed",
@@ -1787,6 +1806,7 @@ async def bulk_refresh_room_thread_histories(
         missing_roots=len(stats.missing_root_ids),
         room_scan_pages=stats.room_scan_pages,
         scanned_event_count=stats.scanned_event_count,
+        scan_truncated=stats.scan_truncated,
     )
     return stats
 

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -90,6 +90,7 @@ __all__ = [
 
 
 _STARTUP_PREWARM_THREAD_LIMIT = 32
+_STARTUP_PREWARM_MAX_SCAN_PAGES = 20
 
 
 async def resolve_thread_root_event_id_for_client(
@@ -706,6 +707,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
                 self.runtime.event_cache,
                 thread_root_ids=thread_ids,
                 caller_label="startup_thread_prewarm",
+                max_scan_pages=_STARTUP_PREWARM_MAX_SCAN_PAGES,
             )
 
         coordinator = self.runtime.event_cache_write_coordinator
@@ -798,14 +800,25 @@ class MatrixConversationCache(ConversationCacheProtocol):
         thread_ids = await self._startup_thread_prewarm_ids(room_id)
         if thread_ids is None or is_shutting_down() or not self.runtime.event_cache.durable_writes_available:
             return False
-        untrusted_thread_ids = await untrusted_cached_thread_ids(
-            self.runtime.event_cache,
-            room_id,
-            thread_ids,
-        )
-        already_warm = len(thread_ids) - len(untrusted_thread_ids)
-        if is_shutting_down() or not self.runtime.event_cache.durable_writes_available:
+        try:
+            untrusted_thread_ids = await untrusted_cached_thread_ids(
+                self.runtime.event_cache,
+                room_id,
+                thread_ids,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            self.logger.warning(
+                "startup_thread_prewarm_cache_probe_failed",
+                room_id=room_id,
+                thread_count=len(thread_ids),
+                error=str(exc),
+            )
+            untrusted_thread_ids = None
+        if untrusted_thread_ids is None or is_shutting_down() or not self.runtime.event_cache.durable_writes_available:
             return False
+        already_warm = len(thread_ids) - len(untrusted_thread_ids)
         if not untrusted_thread_ids:
             self._log_startup_thread_prewarm_complete(
                 room_id,

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -814,6 +814,8 @@ class MatrixConversationCache(ConversationCacheProtocol):
                 room_id=room_id,
                 thread_count=len(thread_ids),
                 error=str(exc),
+                error_type=type(exc).__name__,
+                exc_info=True,
             )
             untrusted_thread_ids = None
         if untrusted_thread_ids is None or is_shutting_down() or not self.runtime.event_cache.durable_writes_available:

--- a/tests/test_bot_ready_hook.py
+++ b/tests/test_bot_ready_hook.py
@@ -1076,6 +1076,8 @@ async def test_startup_thread_prewarm_cache_probe_failure_is_fail_open(tmp_path:
         room_id="!room:localhost",
         thread_count=1,
         error="database unavailable",
+        error_type="RuntimeError",
+        exc_info=True,
     )
 
 

--- a/tests/test_bot_ready_hook.py
+++ b/tests/test_bot_ready_hook.py
@@ -992,6 +992,7 @@ async def test_startup_thread_prewarm_bulk_refreshes_once_under_room_barrier(tmp
         bot.event_cache,
         thread_root_ids=tuple(thread_ids),
         caller_label="startup_thread_prewarm",
+        max_scan_pages=20,
     )
     assert competing_write_started.is_set()
     bot._conversation_cache.logger.info.assert_any_call(
@@ -1038,6 +1039,44 @@ async def test_startup_thread_prewarm_rechecks_shutdown_before_bulk_scan(tmp_pat
 
     assert completed is False
     mock_bulk_refresh.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_startup_thread_prewarm_cache_probe_failure_is_fail_open(tmp_path: Path) -> None:
+    """A cache-state read failure should release the room without aborting the startup loop."""
+    bot = _agent_bot(tmp_path)
+    bot._conversation_cache.logger = MagicMock()
+    thread_ids = ["$thread:localhost"]
+
+    with (
+        patch.object(
+            bot._conversation_cache,
+            "_startup_thread_prewarm_ids",
+            new=AsyncMock(return_value=thread_ids),
+        ),
+        patch(
+            "mindroom.matrix.conversation_cache.untrusted_cached_thread_ids",
+            new=AsyncMock(side_effect=RuntimeError("database unavailable")),
+        ),
+        patch.object(
+            bot._conversation_cache,
+            "_bulk_refresh_startup_threads",
+            new=AsyncMock(),
+        ) as mock_bulk_refresh,
+    ):
+        completed = await bot._conversation_cache.prewarm_recent_room_threads(
+            "!room:localhost",
+            is_shutting_down=lambda: False,
+        )
+
+    assert completed is False
+    mock_bulk_refresh.assert_not_awaited()
+    bot._conversation_cache.logger.warning.assert_called_once_with(
+        "startup_thread_prewarm_cache_probe_failed",
+        room_id="!room:localhost",
+        thread_count=1,
+        error="database unavailable",
+    )
 
 
 @pytest.mark.asyncio
@@ -1163,6 +1202,7 @@ async def test_startup_thread_prewarm_bulk_refresh_waits_for_background_warm(tmp
         bot.event_cache,
         thread_root_ids=["$thread-root"],
         caller_label="startup_thread_prewarm",
+        max_scan_pages=20,
     )
 
 

--- a/tests/test_bulk_thread_backfill.py
+++ b/tests/test_bulk_thread_backfill.py
@@ -158,3 +158,44 @@ async def test_bulk_refresh_reports_missing_roots_without_storing_partial_thread
     assert stats.missing_root_ids == frozenset({"$ghost:localhost"})
     event_cache.replace_thread_if_not_newer.assert_awaited_once()
     assert event_cache.replace_thread_if_not_newer.await_args.args[1] == "$a:localhost"
+
+
+@pytest.mark.asyncio
+async def test_bulk_refresh_page_budget_stores_found_threads_and_reports_remaining_roots() -> None:
+    """A capped startup scan should preserve partial success without reading another page."""
+    client = AsyncMock()
+    client.room_messages = AsyncMock(
+        side_effect=[
+            _messages_response(
+                [
+                    _message_event("$b1:localhost", "reply b", timestamp=3000, thread_root_id="$b:localhost"),
+                    _message_event("$a:localhost", "root a", timestamp=1000),
+                ],
+                end="t1",
+            ),
+            _messages_response(
+                [_message_event("$b:localhost", "root b", timestamp=500)],
+                end=None,
+            ),
+        ],
+    )
+    event_cache = AsyncMock()
+    event_cache.room_membership_epoch = AsyncMock(return_value=7)
+    event_cache.replace_thread_if_not_newer = AsyncMock(return_value=True)
+
+    stats = await bulk_refresh_room_thread_histories(
+        client,
+        _ROOM_ID,
+        event_cache,
+        thread_root_ids=["$a:localhost", "$b:localhost"],
+        caller_label="test",
+        max_scan_pages=1,
+    )
+
+    client.room_messages.assert_awaited_once()
+    assert stats.stored_threads == 1
+    assert stats.missing_root_ids == frozenset({"$b:localhost"})
+    assert stats.room_scan_pages == 1
+    assert stats.scan_truncated is True
+    event_cache.replace_thread_if_not_newer.assert_awaited_once()
+    assert event_cache.replace_thread_if_not_newer.await_args.args[1] == "$a:localhost"

--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -878,6 +878,7 @@ async def test_conversation_cache_startup_prewarm_bulk_refresh_preserves_metadat
             event_cache,
             thread_root_ids=["$thread:localhost"],
             caller_label="startup_thread_prewarm",
+            max_scan_pages=20,
         )
     finally:
         await event_cache.close()


### PR DESCRIPTION
## Why

#1650 correctly serializes startup refill against same-room cache writes, but review found two reliability gaps after it merged: a missing or very old root could hold that barrier through an unlimited room-history walk, and a cache-state probe error could abort prewarming later rooms.

## What

- Cap startup-only bulk scans at 20 pages (at most 2,000 Matrix message events).
- Preserve partial success: roots found before the cap are stored; unresolved roots are reported with `scan_truncated`.
- Leave thread export and normal full-history scans uncapped.
- Catch cache-state probe failures, log them, and return cleanly so the room claim is released and later rooms continue.

## Verification

- `pytest tests/test_bot_ready_hook.py tests/test_event_cache.py tests/test_thread_read_guards.py tests/test_bulk_thread_backfill.py tests/test_thread_export_execution.py -x --lf --cache-clear -n auto --no-cov -q`
- Applicable pre-commit hooks, including ruff, formatting, ty, vulture, Tach, and module privacy
