### PR TITLE
fix(thread-export): prevent aliased targets from wiping each other's exports

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -569,7 +569,8 @@ A warning is logged when that guard preserves existing target state because the 
 A complete room enumeration that returns zero threads preserves existing YAML exports for that room and logs a warning because an anomalous empty response cannot be distinguished from deletion of the final thread.
 After either warning, verify the source state and remove the preserved export manually only when the deletion is confirmed; workspace git history remains the recovery path for mistaken cleanup.
 Enabled targets whose resolved output directories are equal or nested are all skipped before Matrix work.
-MindRoom claims an output root by writing a `.mindroom-thread-exports` ownership marker, and it claims automatically when the root is empty or already holds at least one exported room directory.
+MindRoom claims an output root by writing a `.mindroom-thread-exports` ownership marker, and it claims automatically when the root is empty or already holds a room directory containing an exported thread file.
+A directory that merely contains an `index.json` is not treated as evidence, so pointing `--output` at an unrelated project or build directory is refused rather than adopted.
 Unrelated entries beside those room directories, such as `.DS_Store`, a `.git` directory, or your own notes, neither block the claim nor ever get deleted.
 A root MindRoom cannot recognize is skipped for the entire pass, so it is neither exported to nor cleaned up, and the skip is reported as a target failure.
 Adopt such a root by creating `.mindroom-thread-exports` inside it containing exactly `{"format":"mindroom-thread-exports","version":1}` followed by a newline.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -569,8 +569,12 @@ A warning is logged when that guard preserves existing target state because the 
 A complete room enumeration that returns zero threads preserves existing YAML exports for that room and logs a warning because an anomalous empty response cannot be distinguished from deletion of the final thread.
 After either warning, verify the source state and remove the preserved export manually only when the deletion is confirmed; workspace git history remains the recovery path for mistaken cleanup.
 Enabled targets whose resolved output directories are equal or nested are all skipped before Matrix work.
-MindRoom automatically adds a `.mindroom-thread-exports` ownership marker to empty roots and recognizable existing export trees.
-Destructive cleanup requires that marker and removes only recognizable room directories and thread YAML files, leaving unrelated entries untouched.
+MindRoom claims an output root by writing a `.mindroom-thread-exports` ownership marker, and it claims automatically when the root is empty or already holds at least one exported room directory.
+Unrelated entries beside those room directories, such as `.DS_Store`, a `.git` directory, or your own notes, neither block the claim nor ever get deleted.
+A root MindRoom cannot recognize is skipped for the entire pass, so it is neither exported to nor cleaned up, and the skip is reported as a target failure.
+Adopt such a root by creating `.mindroom-thread-exports` inside it containing exactly `{"format":"mindroom-thread-exports","version":1}` followed by a newline.
+Cleanup then removes only recognizable room directories and thread YAML files, leaving unrelated entries untouched and logged.
+Retracting a room whose directory still holds unrelated entries removes only the exported files and leaves the directory in place, and repeating the pass stays a quiet no-op.
 Output paths with a terminal `.`, `..`, or empty leaf are rejected, as are symlinked final output and room directories.
 With `--prefer-cache` thread bodies are served from the durable event cache and only fetched from the homeserver on miss or invalidation; use it alongside a running MindRoom that keeps the cache fresh.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -563,7 +563,15 @@ By default it writes to `<storage>/thread_exports`.
 A thread file is only rewritten when its content changed, so `exported_at` reflects the last content-changing export.
 Each thread document includes the latest MindRoom thread summary as `thread.summary` when one exists.
 Each room directory also gets an `index.json` mapping every thread file to its message count, participants, latest summary, and last activity, sorted by most recent activity.
-Complete passes remove exported room and thread files that are no longer present or authorized; a `--room` pass only reconciles the selected room.
+Complete passes normally remove exported room and thread files that are no longer present or authorized; a `--room` pass only reconciles the selected room.
+The zero-room guard skips only final directory-wide reconciliation of rooms absent from the pass, while definitive per-room category or membership revocations still delete their exports.
+A warning is logged when that guard preserves existing target state because the pass has no positive room evidence.
+A complete room enumeration that returns zero threads preserves existing YAML exports for that room and logs a warning because an anomalous empty response cannot be distinguished from deletion of the final thread.
+After either warning, verify the source state and remove the preserved export manually only when the deletion is confirmed; workspace git history remains the recovery path for mistaken cleanup.
+Enabled targets whose resolved output directories are equal or nested are all skipped before Matrix work.
+MindRoom automatically adds a `.mindroom-thread-exports` ownership marker to empty roots and recognizable existing export trees.
+Destructive cleanup requires that marker and removes only recognizable room directories and thread YAML files, leaving unrelated entries untouched.
+Output paths with a terminal `.`, `..`, or empty leaf are rejected, as are symlinked final output and room directories.
 With `--prefer-cache` thread bodies are served from the durable event cache and only fetched from the homeserver on miss or invalidation; use it alongside a running MindRoom that keeps the cache fresh.
 
 <!-- CODE:START -->
@@ -618,7 +626,7 @@ With `--prefer-cache` thread bodies are served from the durable event cache and 
 <!-- OUTPUT:END -->
 
 ```bash
-mindroom threads export --storage-path mindroom_data --output /tmp/mindroom-thread-exports
+mindroom threads export --storage-path mindroom_data --output "$HOME/mindroom-thread-exports"
 mindroom threads export --storage-path mindroom_data --room lobby
 mindroom threads export --storage-path mindroom_data --watch --interval 300
 mindroom threads export --storage-path mindroom_data --prefer-cache

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -277,8 +277,7 @@ function AppContent() {
 
   const getPlatformUrl = () => {
     const configured = (import.meta as any).env?.VITE_PLATFORM_URL as
-      | string
-      | undefined;
+      string | undefined;
     if (configured && configured.length > 0) return configured;
     if (typeof window !== "undefined") {
       const host = window.location.host;

--- a/frontend/src/components/Integrations/Integrations.tsx
+++ b/frontend/src/components/Integrations/Integrations.tsx
@@ -1125,10 +1125,7 @@ export function Integrations() {
                 onChange={(value) =>
                   setFilterMode(
                     value as
-                      | "all"
-                      | "available"
-                      | "unconfigured"
-                      | "configured",
+                      "all" | "available" | "unconfigured" | "configured",
                   )
                 }
                 size="sm"

--- a/frontend/src/components/shared/HistoryContextSection.tsx
+++ b/frontend/src/components/shared/HistoryContextSection.tsx
@@ -11,9 +11,7 @@ import {
 } from "@/types/config";
 
 type HistoryFieldName =
-  | "num_history_runs"
-  | "num_history_messages"
-  | "max_tool_calls_from_history";
+  "num_history_runs" | "num_history_messages" | "max_tool_calls_from_history";
 
 type HistoryContextFormValues = {
   num_history_runs?: number | null;

--- a/frontend/src/hooks/useTools.ts
+++ b/frontend/src/hooks/useTools.ts
@@ -7,13 +7,7 @@ export interface ToolFieldSchema {
   name: string;
   label: string;
   type:
-    | "boolean"
-    | "number"
-    | "password"
-    | "select"
-    | "string[]"
-    | "text"
-    | "url";
+    "boolean" | "number" | "password" | "select" | "string[]" | "text" | "url";
   required?: boolean;
   default?: unknown;
   placeholder?: string | null;

--- a/frontend/src/lib/configValidation.ts
+++ b/frontend/src/lib/configValidation.ts
@@ -16,8 +16,7 @@ export interface ValidationConfigDiagnostic {
 }
 
 export type ConfigDiagnostic =
-  | GlobalConfigDiagnostic
-  | ValidationConfigDiagnostic;
+  GlobalConfigDiagnostic | ValidationConfigDiagnostic;
 
 export function getConfigValidationIssues(
   diagnostics: ConfigDiagnostic[],

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -6,10 +6,7 @@ export type MemorySearchMode = "keyword" | "semantic";
 export type WorkerScope = "shared" | "user" | "user_agent";
 export type PrivateWorkerScope = Exclude<WorkerScope, "shared">;
 export type AgentPolicySource =
-  | "private.per"
-  | "agent.worker_scope"
-  | "defaults.worker_scope"
-  | "unscoped";
+  "private.per" | "agent.worker_scope" | "defaults.worker_scope" | "unscoped";
 export type AgentPoliciesByAgent = Record<string, AgentPolicy>;
 export const DEFAULT_PRIVATE_KNOWLEDGE_PATH = "memory";
 export const SHARED_CONTEXT_FILE_PLACEHOLDER = "SOUL.md";

--- a/frontend/src/types/toolConfig.ts
+++ b/frontend/src/types/toolConfig.ts
@@ -1,12 +1,7 @@
 // Tool configuration type definitions
 
 export type FieldType =
-  | "text"
-  | "password"
-  | "number"
-  | "boolean"
-  | "select"
-  | "url";
+  "text" | "password" | "number" | "boolean" | "select" | "url";
 
 export interface ToolConfigField {
   name: string;
@@ -32,12 +27,7 @@ export interface ToolConfigSchema {
   icon?: string;
   fields: ToolConfigField[];
   category?:
-    | "search"
-    | "files"
-    | "communication"
-    | "development"
-    | "data"
-    | "other";
+    "search" | "files" | "communication" | "development" | "data" | "other";
 }
 
 // Tool-specific configuration values

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -19150,7 +19150,8 @@ A warning is logged when that guard preserves existing target state because the 
 A complete room enumeration that returns zero threads preserves existing YAML exports for that room and logs a warning because an anomalous empty response cannot be distinguished from deletion of the final thread.
 After either warning, verify the source state and remove the preserved export manually only when the deletion is confirmed; workspace git history remains the recovery path for mistaken cleanup.
 Enabled targets whose resolved output directories are equal or nested are all skipped before Matrix work.
-MindRoom claims an output root by writing a `.mindroom-thread-exports` ownership marker, and it claims automatically when the root is empty or already holds at least one exported room directory.
+MindRoom claims an output root by writing a `.mindroom-thread-exports` ownership marker, and it claims automatically when the root is empty or already holds a room directory containing an exported thread file.
+A directory that merely contains an `index.json` is not treated as evidence, so pointing `--output` at an unrelated project or build directory is refused rather than adopted.
 Unrelated entries beside those room directories, such as `.DS_Store`, a `.git` directory, or your own notes, neither block the claim nor ever get deleted.
 A root MindRoom cannot recognize is skipped for the entire pass, so it is neither exported to nor cleaned up, and the skip is reported as a target failure.
 Adopt such a root by creating `.mindroom-thread-exports` inside it containing exactly `{"format":"mindroom-thread-exports","version":1}` followed by a newline.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -19150,8 +19150,12 @@ A warning is logged when that guard preserves existing target state because the 
 A complete room enumeration that returns zero threads preserves existing YAML exports for that room and logs a warning because an anomalous empty response cannot be distinguished from deletion of the final thread.
 After either warning, verify the source state and remove the preserved export manually only when the deletion is confirmed; workspace git history remains the recovery path for mistaken cleanup.
 Enabled targets whose resolved output directories are equal or nested are all skipped before Matrix work.
-MindRoom automatically adds a `.mindroom-thread-exports` ownership marker to empty roots and recognizable existing export trees.
-Destructive cleanup requires that marker and removes only recognizable room directories and thread YAML files, leaving unrelated entries untouched.
+MindRoom claims an output root by writing a `.mindroom-thread-exports` ownership marker, and it claims automatically when the root is empty or already holds at least one exported room directory.
+Unrelated entries beside those room directories, such as `.DS_Store`, a `.git` directory, or your own notes, neither block the claim nor ever get deleted.
+A root MindRoom cannot recognize is skipped for the entire pass, so it is neither exported to nor cleaned up, and the skip is reported as a target failure.
+Adopt such a root by creating `.mindroom-thread-exports` inside it containing exactly `{"format":"mindroom-thread-exports","version":1}` followed by a newline.
+Cleanup then removes only recognizable room directories and thread YAML files, leaving unrelated entries untouched and logged.
+Retracting a room whose directory still holds unrelated entries removes only the exported files and leaves the directory in place, and repeating the pass stays a quiet no-op.
 Output paths with a terminal `.`, `..`, or empty leaf are rejected, as are symlinked final output and room directories.
 With `--prefer-cache` thread bodies are served from the durable event cache and only fetched from the homeserver on miss or invalidation; use it alongside a running MindRoom that keeps the cache fresh.
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -19144,7 +19144,15 @@ By default it writes to `<storage>/thread_exports`.
 A thread file is only rewritten when its content changed, so `exported_at` reflects the last content-changing export.
 Each thread document includes the latest MindRoom thread summary as `thread.summary` when one exists.
 Each room directory also gets an `index.json` mapping every thread file to its message count, participants, latest summary, and last activity, sorted by most recent activity.
-Complete passes remove exported room and thread files that are no longer present or authorized; a `--room` pass only reconciles the selected room.
+Complete passes normally remove exported room and thread files that are no longer present or authorized; a `--room` pass only reconciles the selected room.
+The zero-room guard skips only final directory-wide reconciliation of rooms absent from the pass, while definitive per-room category or membership revocations still delete their exports.
+A warning is logged when that guard preserves existing target state because the pass has no positive room evidence.
+A complete room enumeration that returns zero threads preserves existing YAML exports for that room and logs a warning because an anomalous empty response cannot be distinguished from deletion of the final thread.
+After either warning, verify the source state and remove the preserved export manually only when the deletion is confirmed; workspace git history remains the recovery path for mistaken cleanup.
+Enabled targets whose resolved output directories are equal or nested are all skipped before Matrix work.
+MindRoom automatically adds a `.mindroom-thread-exports` ownership marker to empty roots and recognizable existing export trees.
+Destructive cleanup requires that marker and removes only recognizable room directories and thread YAML files, leaving unrelated entries untouched.
+Output paths with a terminal `.`, `..`, or empty leaf are rejected, as are symlinked final output and room directories.
 With `--prefer-cache` thread bodies are served from the durable event cache and only fetched from the homeserver on miss or invalidation; use it alongside a running MindRoom that keeps the cache fresh.
 
 <!-- CODE:START -->
@@ -19199,7 +19207,7 @@ With `--prefer-cache` thread bodies are served from the durable event cache and 
 <!-- OUTPUT:END -->
 
 ```bash
-mindroom threads export --storage-path mindroom_data --output /tmp/mindroom-thread-exports
+mindroom threads export --storage-path mindroom_data --output "$HOME/mindroom-thread-exports"
 mindroom threads export --storage-path mindroom_data --room lobby
 mindroom threads export --storage-path mindroom_data --watch --interval 300
 mindroom threads export --storage-path mindroom_data --prefer-cache

--- a/skills/mindroom-docs/references/page__cli__index.md
+++ b/skills/mindroom-docs/references/page__cli__index.md
@@ -559,7 +559,15 @@ By default it writes to `<storage>/thread_exports`.
 A thread file is only rewritten when its content changed, so `exported_at` reflects the last content-changing export.
 Each thread document includes the latest MindRoom thread summary as `thread.summary` when one exists.
 Each room directory also gets an `index.json` mapping every thread file to its message count, participants, latest summary, and last activity, sorted by most recent activity.
-Complete passes remove exported room and thread files that are no longer present or authorized; a `--room` pass only reconciles the selected room.
+Complete passes normally remove exported room and thread files that are no longer present or authorized; a `--room` pass only reconciles the selected room.
+The zero-room guard skips only final directory-wide reconciliation of rooms absent from the pass, while definitive per-room category or membership revocations still delete their exports.
+A warning is logged when that guard preserves existing target state because the pass has no positive room evidence.
+A complete room enumeration that returns zero threads preserves existing YAML exports for that room and logs a warning because an anomalous empty response cannot be distinguished from deletion of the final thread.
+After either warning, verify the source state and remove the preserved export manually only when the deletion is confirmed; workspace git history remains the recovery path for mistaken cleanup.
+Enabled targets whose resolved output directories are equal or nested are all skipped before Matrix work.
+MindRoom automatically adds a `.mindroom-thread-exports` ownership marker to empty roots and recognizable existing export trees.
+Destructive cleanup requires that marker and removes only recognizable room directories and thread YAML files, leaving unrelated entries untouched.
+Output paths with a terminal `.`, `..`, or empty leaf are rejected, as are symlinked final output and room directories.
 With `--prefer-cache` thread bodies are served from the durable event cache and only fetched from the homeserver on miss or invalidation; use it alongside a running MindRoom that keeps the cache fresh.
 
 <!-- CODE:START -->
@@ -614,7 +622,7 @@ With `--prefer-cache` thread bodies are served from the durable event cache and 
 <!-- OUTPUT:END -->
 
 ```bash
-mindroom threads export --storage-path mindroom_data --output /tmp/mindroom-thread-exports
+mindroom threads export --storage-path mindroom_data --output "$HOME/mindroom-thread-exports"
 mindroom threads export --storage-path mindroom_data --room lobby
 mindroom threads export --storage-path mindroom_data --watch --interval 300
 mindroom threads export --storage-path mindroom_data --prefer-cache

--- a/skills/mindroom-docs/references/page__cli__index.md
+++ b/skills/mindroom-docs/references/page__cli__index.md
@@ -565,7 +565,8 @@ A warning is logged when that guard preserves existing target state because the 
 A complete room enumeration that returns zero threads preserves existing YAML exports for that room and logs a warning because an anomalous empty response cannot be distinguished from deletion of the final thread.
 After either warning, verify the source state and remove the preserved export manually only when the deletion is confirmed; workspace git history remains the recovery path for mistaken cleanup.
 Enabled targets whose resolved output directories are equal or nested are all skipped before Matrix work.
-MindRoom claims an output root by writing a `.mindroom-thread-exports` ownership marker, and it claims automatically when the root is empty or already holds at least one exported room directory.
+MindRoom claims an output root by writing a `.mindroom-thread-exports` ownership marker, and it claims automatically when the root is empty or already holds a room directory containing an exported thread file.
+A directory that merely contains an `index.json` is not treated as evidence, so pointing `--output` at an unrelated project or build directory is refused rather than adopted.
 Unrelated entries beside those room directories, such as `.DS_Store`, a `.git` directory, or your own notes, neither block the claim nor ever get deleted.
 A root MindRoom cannot recognize is skipped for the entire pass, so it is neither exported to nor cleaned up, and the skip is reported as a target failure.
 Adopt such a root by creating `.mindroom-thread-exports` inside it containing exactly `{"format":"mindroom-thread-exports","version":1}` followed by a newline.

--- a/skills/mindroom-docs/references/page__cli__index.md
+++ b/skills/mindroom-docs/references/page__cli__index.md
@@ -565,8 +565,12 @@ A warning is logged when that guard preserves existing target state because the 
 A complete room enumeration that returns zero threads preserves existing YAML exports for that room and logs a warning because an anomalous empty response cannot be distinguished from deletion of the final thread.
 After either warning, verify the source state and remove the preserved export manually only when the deletion is confirmed; workspace git history remains the recovery path for mistaken cleanup.
 Enabled targets whose resolved output directories are equal or nested are all skipped before Matrix work.
-MindRoom automatically adds a `.mindroom-thread-exports` ownership marker to empty roots and recognizable existing export trees.
-Destructive cleanup requires that marker and removes only recognizable room directories and thread YAML files, leaving unrelated entries untouched.
+MindRoom claims an output root by writing a `.mindroom-thread-exports` ownership marker, and it claims automatically when the root is empty or already holds at least one exported room directory.
+Unrelated entries beside those room directories, such as `.DS_Store`, a `.git` directory, or your own notes, neither block the claim nor ever get deleted.
+A root MindRoom cannot recognize is skipped for the entire pass, so it is neither exported to nor cleaned up, and the skip is reported as a target failure.
+Adopt such a root by creating `.mindroom-thread-exports` inside it containing exactly `{"format":"mindroom-thread-exports","version":1}` followed by a newline.
+Cleanup then removes only recognizable room directories and thread YAML files, leaving unrelated entries untouched and logged.
+Retracting a room whose directory still holds unrelated entries removes only the exported files and leaves the directory in place, and repeating the pass stays a quiet no-op.
 Output paths with a terminal `.`, `..`, or empty leaf are rejected, as are symlinked final output and room directories.
 With `--prefer-cache` thread bodies are served from the durable event cache and only fetched from the homeserver on miss or invalidation; use it alongside a running MindRoom that keeps the cache fresh.
 

--- a/src/mindroom/cli/main.py
+++ b/src/mindroom/cli/main.py
@@ -388,6 +388,9 @@ def _print_thread_export_stats(stats: ThreadExportStats) -> None:
     if stats.truncated_rooms:
         console.print(f"[yellow]Warning:[/yellow] {stats.truncated_rooms} room(s) hit the thread enumeration limit")
     for failure in stats.failed_items:
+        if failure.room_key is None:
+            console.print(f"[red]Failed target:[/red] {failure.error}")
+            continue
         target = failure.thread_id or failure.room_id
         console.print(f"[red]Failed:[/red] {failure.room_key} {target}: {failure.error}")
 

--- a/src/mindroom/thread_export/execution.py
+++ b/src/mindroom/thread_export/execution.py
@@ -26,7 +26,7 @@ from mindroom.thread_export.selection import trusted_sender_ids_for_export
 from mindroom.thread_export.storage import (
     remove_room_export,
     remove_stale_thread_exports,
-    room_index_exists,
+    room_has_thread_exports,
     thread_payload,
     write_room_index,
     write_thread_payload,
@@ -41,6 +41,14 @@ if TYPE_CHECKING:
 
 
 logger = get_logger(__name__)
+
+
+def retract_room_export(accumulator: ThreadExportAccumulator, room: ThreadExportRoom) -> None:
+    """Remove one target's room export or record a room-scoped storage failure."""
+    try:
+        remove_room_export(accumulator.target.output_dir, room)
+    except (OSError, RuntimeError) as exc:
+        accumulator.failed_items.append(failure_for_room(room, f"Room removal failed: {exc}"))
 
 
 async def _bulk_backfill_untrusted_threads(
@@ -142,7 +150,7 @@ async def _authorized_room_accumulators(
     eligible = [accumulator for accumulator in accumulators if target_accepts_room(accumulator.target, room)]
     for accumulator in accumulators:
         if not target_accepts_room(accumulator.target, room):
-            remove_room_export(accumulator.target.output_dir, room)
+            retract_room_export(accumulator, room)
 
     scoped = [accumulator for accumulator in eligible if accumulator.target.required_member_user_id is not None]
     authorized = [accumulator for accumulator in eligible if accumulator.target.required_member_user_id is None]
@@ -164,7 +172,7 @@ async def _authorized_room_accumulators(
         if member_user_id in member_ids:
             authorized.append(accumulator)
         else:
-            remove_room_export(accumulator.target.output_dir, room)
+            retract_room_export(accumulator, room)
     return authorized
 
 
@@ -177,7 +185,7 @@ async def _write_thread_to_targets(
     trusted_sender_ids: frozenset[str],
     prefer_cache: bool,
     accumulators: Sequence[ThreadExportAccumulator],
-    room_changed: dict[int, bool],
+    changed_accumulator_ids: set[int],
 ) -> None:
     """Fetch one thread once and write it independently to each target."""
     try:
@@ -207,7 +215,7 @@ async def _write_thread_to_targets(
             continue
         accumulator.threads_exported += 1
         if wrote_file:
-            room_changed[id(accumulator)] = True
+            changed_accumulator_ids.add(id(accumulator))
         else:
             accumulator.threads_unchanged += 1
 
@@ -218,19 +226,33 @@ def _finish_room_exports(
     *,
     truncated: bool,
     accumulators: Sequence[ThreadExportAccumulator],
-    room_changed: dict[int, bool],
+    changed_accumulator_ids: set[int],
 ) -> None:
     """Reconcile removed threads and update indexes for one enumerated room."""
     for accumulator in accumulators:
         try:
-            if not truncated and remove_stale_thread_exports(
-                accumulator.target.output_dir,
+            output_dir = accumulator.target.output_dir
+            skip_empty_reconciliation = not truncated and not thread_ids and room_has_thread_exports(output_dir, room)
+            if skip_empty_reconciliation:
+                logger.warning(
+                    "Skipping stale thread reconciliation after empty enumeration",
+                    output_dir=str(output_dir),
+                    room_key=room.key,
+                    room_id=room.room_id,
+                )
+            elif not truncated:
+                removed_stale_threads = remove_stale_thread_exports(
+                    output_dir,
+                    room,
+                    thread_ids,
+                )
+                if removed_stale_threads:
+                    changed_accumulator_ids.add(id(accumulator))
+            write_room_index(
+                output_dir,
                 room,
-                thread_ids,
-            ):
-                room_changed[id(accumulator)] = True
-            if room_changed[id(accumulator)] or not room_index_exists(accumulator.target.output_dir, room):
-                write_room_index(accumulator.target.output_dir, room)
+                thread_files_changed=id(accumulator) in changed_accumulator_ids,
+            )
         except Exception as exc:
             accumulator.failed_items.append(failure_for_room(room, f"Room reconciliation failed: {exc}"))
 
@@ -299,7 +321,7 @@ async def _export_enumerated_room_threads(
     authorized: Sequence[ThreadExportAccumulator],
 ) -> None:
     """Export one enumerated room's threads to every authorized accumulator."""
-    room_changed = {id(accumulator): False for accumulator in authorized}
+    changed_accumulator_ids: set[int] = set()
     missing_root_ids: frozenset[str] = frozenset()
     if prefer_cache and thread_ids:
         missing_root_ids = await _bulk_backfill_untrusted_threads(
@@ -328,7 +350,7 @@ async def _export_enumerated_room_threads(
             trusted_sender_ids=trusted_sender_ids,
             prefer_cache=prefer_cache,
             accumulators=authorized,
-            room_changed=room_changed,
+            changed_accumulator_ids=changed_accumulator_ids,
         )
 
     _finish_room_exports(
@@ -336,5 +358,5 @@ async def _export_enumerated_room_threads(
         thread_ids,
         truncated=truncated,
         accumulators=authorized,
-        room_changed=room_changed,
+        changed_accumulator_ids=changed_accumulator_ids,
     )

--- a/src/mindroom/thread_export/models.py
+++ b/src/mindroom/thread_export/models.py
@@ -24,10 +24,10 @@ class ThreadExportRoom:
 
 @dataclass(frozen=True)
 class _ThreadExportFailure:
-    """One room or thread export failure."""
+    """One target, room, or thread export failure."""
 
-    room_key: str
-    room_id: str
+    room_key: str | None
+    room_id: str | None
     thread_id: str | None
     error: str
 
@@ -47,6 +47,16 @@ def failure_for_room(
     )
 
 
+def failure_for_target(error: str) -> _ThreadExportFailure:
+    """Build one target-scoped export failure."""
+    return _ThreadExportFailure(
+        room_key=None,
+        room_id=None,
+        thread_id=None,
+        error=error,
+    )
+
+
 @dataclass(frozen=True)
 class ThreadExportStats:
     """Summary for one export pass."""
@@ -61,7 +71,7 @@ class ThreadExportStats:
 
     @property
     def failures(self) -> int:
-        """Return failed room/thread count."""
+        """Return failed target, room, or thread count."""
         return len(self.failed_items)
 
 

--- a/src/mindroom/thread_export/policy.py
+++ b/src/mindroom/thread_export/policy.py
@@ -5,6 +5,8 @@ authorization answer: the target no longer accepts the room's source category, o
 membership lookup proves the scoped user is not a member. When authorization cannot be verified
 (membership lookup errors, account failures), targets keep their existing exports and simply skip
 the room for that pass; a transient homeserver error must never destroy authorized data.
+Each target may retract data only from an output directory it exclusively owns, so enabled targets
+whose resolved directories overlap by equality or nesting are all skipped before Matrix work.
 """
 
 from mindroom.thread_export.models import ThreadExportRoom, ThreadExportTarget

--- a/src/mindroom/thread_export/service.py
+++ b/src/mindroom/thread_export/service.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import TYPE_CHECKING
 
 from mindroom.constants import runtime_matrix_homeserver
 from mindroom.logging_config import get_logger
 from mindroom.matrix.users import login_agent_user
 from mindroom.runtime_support import build_owned_runtime_support, close_owned_runtime_support
-from mindroom.thread_export.execution import export_threads_for_targets_for_client
+from mindroom.thread_export.execution import export_threads_for_targets_for_client, retract_room_export
 from mindroom.thread_export.models import (
     ThreadExportAccumulator,
     ThreadExportGroup,
@@ -17,6 +18,7 @@ from mindroom.thread_export.models import (
     ThreadExportStats,
     ThreadExportTarget,
     failure_for_room,
+    failure_for_target,
 )
 from mindroom.thread_export.policy import target_accepts_room
 from mindroom.thread_export.selection import (
@@ -25,7 +27,11 @@ from mindroom.thread_export.selection import (
     invited_export_rooms,
     select_export_account,
 )
-from mindroom.thread_export.storage import reconcile_room_directories, remove_room_export
+from mindroom.thread_export.storage import (
+    canonicalize_output_dir,
+    prepare_export_root,
+    reconcile_room_directories,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -65,19 +71,112 @@ def _record_group_failure(
         for accumulator in accumulators:
             target = accumulator.target
             if not target_accepts_room(target, room):
-                remove_room_export(target.output_dir, room)
+                retract_room_export(accumulator, room)
                 continue
             accumulator.retained_room_keys.add(room.key)
             accumulator.failed_items.append(failure_for_room(room, error))
 
 
+def _requested_invited_groups(
+    discovered_groups: Sequence[tuple[str, Sequence[ThreadExportRoom]]],
+    accumulators: Sequence[ThreadExportAccumulator],
+) -> list[tuple[str, list[ThreadExportRoom]]]:
+    """Retract rooms excluded by every target and return groups that need Matrix work."""
+    requested_groups: list[tuple[str, list[ThreadExportRoom]]] = []
+    for entity_name, rooms in discovered_groups:
+        accepted_rooms: list[ThreadExportRoom] = []
+        for room in rooms:
+            if any(target_accepts_room(accumulator.target, room) for accumulator in accumulators):
+                accepted_rooms.append(room)
+            else:
+                for accumulator in accumulators:
+                    retract_room_export(accumulator, room)
+        if accepted_rooms:
+            requested_groups.append((entity_name, accepted_rooms))
+    return requested_groups
+
+
 def _reconcile_full_pass(accumulators: Sequence[ThreadExportAccumulator]) -> None:
     """Remove room directories that the completed full pass did not retain."""
     for accumulator in accumulators:
-        reconcile_room_directories(
-            accumulator.target.output_dir,
-            accumulator.retained_room_keys,
-        )
+        output_dir = accumulator.target.output_dir
+        try:
+            if accumulator.rooms_exported == 0:
+                logger.warning(
+                    "Skipping thread export directory reconciliation without exported rooms",
+                    output_dir=str(output_dir),
+                    retained_rooms=len(accumulator.retained_room_keys),
+                    failures=len(accumulator.failed_items),
+                )
+                continue
+            reconcile_room_directories(
+                output_dir,
+                accumulator.retained_room_keys,
+            )
+        except (OSError, RuntimeError) as exc:
+            accumulator.failed_items.append(
+                failure_for_target(f"Target reconciliation failed: {exc}"),
+            )
+
+
+def _validated_targets(
+    accumulators: Sequence[ThreadExportAccumulator],
+) -> tuple[ThreadExportAccumulator, ...]:
+    """Reject every resolved overlap, then prepare only disjoint roots."""
+    candidates: list[tuple[ThreadExportAccumulator, Path]] = []
+    for accumulator in accumulators:
+        authored_output_dir = accumulator.target.output_dir
+        try:
+            output_dir = canonicalize_output_dir(authored_output_dir)
+            resolved_output_dir = output_dir.resolve()
+        except Exception as exc:
+            accumulator.failed_items.append(failure_for_target(f"output directory validation failed: {exc}"))
+            logger.warning(
+                "Skipping thread export target whose output directory could not be validated",
+                output_dir=str(authored_output_dir),
+                error=str(exc),
+            )
+            continue
+        accumulator.target = replace(accumulator.target, output_dir=output_dir)
+        candidates.append((accumulator, resolved_output_dir))
+
+    overlaps: dict[int, list[Path]] = {}
+    for index, (accumulator, resolved_output_dir) in enumerate(candidates):
+        for other_accumulator, other_resolved_output_dir in candidates[index + 1 :]:
+            if not (
+                resolved_output_dir == other_resolved_output_dir
+                or resolved_output_dir.is_relative_to(other_resolved_output_dir)
+                or other_resolved_output_dir.is_relative_to(resolved_output_dir)
+            ):
+                continue
+            overlaps.setdefault(id(accumulator), []).append(other_accumulator.target.output_dir)
+            overlaps.setdefault(id(other_accumulator), []).append(accumulator.target.output_dir)
+
+    prepared: list[ThreadExportAccumulator] = []
+    for accumulator, resolved_output_dir in candidates:
+        if overlapping := overlaps.get(id(accumulator)):
+            accumulator.failed_items.append(
+                failure_for_target(f"output directory overlaps another enabled target: {resolved_output_dir}"),
+            )
+            logger.warning(
+                "Skipping thread export target with overlapping output directory",
+                output_dir=str(accumulator.target.output_dir),
+                comparison_output_dir=str(resolved_output_dir),
+                overlapping_output_dirs=[str(accumulator.target.output_dir), *map(str, overlapping)],
+            )
+            continue
+        try:
+            prepare_export_root(accumulator.target.output_dir)
+        except Exception as exc:
+            accumulator.failed_items.append(failure_for_target(f"output directory validation failed: {exc}"))
+            logger.warning(
+                "Skipping thread export target with unsafe output directory",
+                output_dir=str(accumulator.target.output_dir),
+                error=str(exc),
+            )
+            continue
+        prepared.append(accumulator)
+    return tuple(prepared)
 
 
 async def _run_export_group(
@@ -87,7 +186,6 @@ async def _run_export_group(
     config: Config,
     runtime_paths: RuntimePaths,
     event_cache: SharedConversationEventCache,
-    targets: Sequence[ThreadExportTarget],
     accumulators: Sequence[ThreadExportAccumulator],
     max_thread_roots: int,
     prefer_cache: bool,
@@ -105,7 +203,7 @@ async def _run_export_group(
             runtime_paths=runtime_paths,
             event_cache=event_cache.for_principal(group.user.user_id),
             rooms=group.rooms,
-            targets=targets,
+            targets=tuple(accumulator.target for accumulator in accumulators),
             max_thread_roots=max_thread_roots,
             prefer_cache=prefer_cache,
         )
@@ -129,8 +227,7 @@ async def export_threads_to_targets_once(
 ) -> tuple[ThreadExportStats, ...]:
     """Login with persisted Matrix accounts and export once to every target.
 
-    Rooms come from ``matrix_state.yaml`` plus every entity's persisted invited rooms when at least
-    one target includes invited rooms.
+    Rooms come from ``matrix_state.yaml`` plus every entity's persisted invited rooms.
     Invited rooms are exported with the invited entity's own account, because the primary export
     account is not necessarily a member of user-created rooms.
 
@@ -144,21 +241,22 @@ async def export_threads_to_targets_once(
     A failed membership check leaves prior exports untouched, records a failure, and writes nothing new.
     A successful check that proves the member absent removes the prior room export.
     """
-    resolved_targets = tuple(targets)
-    if not resolved_targets:
+    if not targets:
         return ()
+    accumulators = tuple(ThreadExportAccumulator(target=target) for target in targets)
+    validated_targets = _validated_targets(accumulators)
+    if not validated_targets:
+        return tuple(accumulator.stats() for accumulator in accumulators)
+
     homeserver = runtime_matrix_homeserver(runtime_paths=runtime_paths)
     state_rooms = export_rooms(runtime_paths, room_filter)
-    invited_groups = (
-        invited_export_rooms(
-            config,
-            runtime_paths,
-            room_filter,
-            known_room_ids={room.room_id for room in state_rooms},
-        )
-        if any(target.include_invited_rooms for target in resolved_targets)
-        else []
+    discovered_invited_groups = invited_export_rooms(
+        config,
+        runtime_paths,
+        room_filter,
+        known_room_ids={room.room_id for room in state_rooms},
     )
+    invited_groups = _requested_invited_groups(discovered_invited_groups, validated_targets)
     export_groups = build_export_groups(
         runtime_paths=runtime_paths,
         homeserver=homeserver,
@@ -166,17 +264,16 @@ async def export_threads_to_targets_once(
         invited_groups=invited_groups,
     )
 
-    accumulators = tuple(ThreadExportAccumulator(target=target) for target in resolved_targets)
     if not export_groups:
         select_export_account(runtime_paths, homeserver)
         if room_filter is None:
-            _reconcile_full_pass(accumulators)
+            _reconcile_full_pass(validated_targets)
         return tuple(accumulator.stats() for accumulator in accumulators)
 
     ready_groups: list[ThreadExportGroup] = []
     for group in export_groups:
         if isinstance(group, ThreadExportGroupFailure):
-            _record_group_failure(accumulators, group.rooms, group.error)
+            _record_group_failure(validated_targets, group.rooms, group.error)
         else:
             ready_groups.append(group)
 
@@ -196,8 +293,7 @@ async def export_threads_to_targets_once(
                     config=config,
                     runtime_paths=runtime_paths,
                     event_cache=support.event_cache,
-                    targets=resolved_targets,
-                    accumulators=accumulators,
+                    accumulators=validated_targets,
                     max_thread_roots=max_thread_roots,
                     prefer_cache=prefer_cache,
                 )
@@ -205,7 +301,7 @@ async def export_threads_to_targets_once(
             await close_owned_runtime_support(support, logger=logger)
 
     if room_filter is None:
-        _reconcile_full_pass(accumulators)
+        _reconcile_full_pass(validated_targets)
     return tuple(accumulator.stats() for accumulator in accumulators)
 
 

--- a/src/mindroom/thread_export/service.py
+++ b/src/mindroom/thread_export/service.py
@@ -141,28 +141,33 @@ def _validated_targets(
         candidates.append((accumulator, resolved_output_dir))
 
     overlaps: dict[int, list[Path]] = {}
-    for index, (accumulator, resolved_output_dir) in enumerate(candidates):
-        for other_accumulator, other_resolved_output_dir in candidates[index + 1 :]:
+    for index, (_, resolved_output_dir) in enumerate(candidates):
+        for other_index in range(index + 1, len(candidates)):
+            other_accumulator, other_resolved_output_dir = candidates[other_index]
             if not (
                 resolved_output_dir == other_resolved_output_dir
                 or resolved_output_dir.is_relative_to(other_resolved_output_dir)
                 or other_resolved_output_dir.is_relative_to(resolved_output_dir)
             ):
                 continue
-            overlaps.setdefault(id(accumulator), []).append(other_accumulator.target.output_dir)
-            overlaps.setdefault(id(other_accumulator), []).append(accumulator.target.output_dir)
+            overlaps.setdefault(index, []).append(other_accumulator.target.output_dir)
+            overlaps.setdefault(other_index, []).append(candidates[index][0].target.output_dir)
 
     prepared: list[ThreadExportAccumulator] = []
-    for accumulator, resolved_output_dir in candidates:
-        if overlapping := overlaps.get(id(accumulator)):
+    for index, (accumulator, resolved_output_dir) in enumerate(candidates):
+        if overlapping := overlaps.get(index):
+            conflicting = ", ".join(str(path) for path in overlapping)
             accumulator.failed_items.append(
-                failure_for_target(f"output directory overlaps another enabled target: {resolved_output_dir}"),
+                failure_for_target(
+                    f"output directory resolving to {resolved_output_dir} "
+                    f"overlaps another enabled target: {conflicting}",
+                ),
             )
             logger.warning(
                 "Skipping thread export target with overlapping output directory",
                 output_dir=str(accumulator.target.output_dir),
-                comparison_output_dir=str(resolved_output_dir),
-                overlapping_output_dirs=[str(accumulator.target.output_dir), *map(str, overlapping)],
+                resolved_output_dir=str(resolved_output_dir),
+                overlapping_output_dirs=[str(path) for path in overlapping],
             )
             continue
         try:

--- a/src/mindroom/thread_export/service.py
+++ b/src/mindroom/thread_export/service.py
@@ -129,7 +129,7 @@ def _validated_targets(
         try:
             output_dir = canonicalize_output_dir(authored_output_dir)
             resolved_output_dir = output_dir.resolve()
-        except Exception as exc:
+        except (OSError, RuntimeError) as exc:
             accumulator.failed_items.append(failure_for_target(f"output directory validation failed: {exc}"))
             logger.warning(
                 "Skipping thread export target whose output directory could not be validated",
@@ -167,10 +167,10 @@ def _validated_targets(
             continue
         try:
             prepare_export_root(accumulator.target.output_dir)
-        except Exception as exc:
-            accumulator.failed_items.append(failure_for_target(f"output directory validation failed: {exc}"))
+        except (OSError, RuntimeError) as exc:
+            accumulator.failed_items.append(failure_for_target(f"output directory preparation failed: {exc}"))
             logger.warning(
-                "Skipping thread export target with unsafe output directory",
+                "Skipping thread export target with unusable output directory",
                 output_dir=str(accumulator.target.output_dir),
                 error=str(exc),
             )

--- a/src/mindroom/thread_export/storage.py
+++ b/src/mindroom/thread_export/storage.py
@@ -187,6 +187,12 @@ def _room_contains_only_export_files(room_fd: int) -> bool:
     )
 
 
+def _contains_thread_export_file(room_fd: int) -> bool:
+    """Return whether one pinned directory holds a committed Matrix thread export."""
+    names = os.listdir(room_fd)
+    return any(_is_thread_export_filename(name) and _regular_file_at(room_fd, name) for name in names)
+
+
 def _open_canonical_room_directory(root_fd: int, output_dir: Path, name: str) -> int | None:
     """Open one canonically named, non-symlinked room directory below a pinned root."""
     if not _is_encoded_room_segment(name):
@@ -217,27 +223,30 @@ def _recognizable_room_directory(root_fd: int, output_dir: Path, name: str) -> b
         os.close(room_fd)
 
 
-def _room_shaped_directory(root_fd: int, output_dir: Path, name: str) -> bool:
-    """Return whether one root entry holds any exporter-owned file under a canonical room name."""
+def _room_directory_with_thread_exports(root_fd: int, output_dir: Path, name: str) -> bool:
+    """Return whether one root entry is a canonically named room holding a thread export."""
     room_fd = _open_canonical_room_directory(root_fd, output_dir, name)
     if room_fd is None:
         return False
     try:
-        names = os.listdir(room_fd)  # noqa: PTH208 - room_fd pins the directory
-        return any(_is_room_export_file(room_fd, entry) for entry in names)
+        return _contains_thread_export_file(room_fd)
     finally:
         os.close(room_fd)
 
 
 def _root_has_export_evidence(root_fd: int, output_dir: Path) -> bool:
-    """Return whether an empty root, or one holding an exported room, proves exporter ownership.
+    """Return whether an empty root, or one holding a thread export, proves exporter ownership.
 
-    Unrelated entries beside an exported room do not veto ownership: a stray ``.DS_Store``,
+    Evidence is a percent-encoded room directory containing a ``$``-prefixed Matrix thread
+    export, which no unrelated directory produces by accident. A generic ``index.json`` is
+    deliberately not evidence: a build or data directory can hold one, and adopting on that
+    alone would expose it to reconciliation.
+    Unrelated entries beside real evidence do not veto ownership, because a stray ``.DS_Store``,
     ``.git`` directory, or operator note must not strand a real corpus, and every destructive
     path is independently scoped to exporter-owned entries.
     """
     names = os.listdir(root_fd)
-    return not names or any(_room_shaped_directory(root_fd, output_dir, name) for name in names)
+    return not names or any(_room_directory_with_thread_exports(root_fd, output_dir, name) for name in names)
 
 
 def _has_valid_export_root_marker(root_fd: int) -> bool:
@@ -594,10 +603,7 @@ def room_has_thread_exports(output_dir: Path, room: ThreadExportRoom) -> bool:
     if room_fd is None:
         return False
     try:
-        return any(
-            _is_thread_export_filename(filename) and _regular_file_at(room_fd, filename)
-            for filename in os.listdir(room_fd)  # noqa: PTH208 - room_fd pins the directory
-        )
+        return _contains_thread_export_file(room_fd)
     finally:
         os.close(room_fd)
 

--- a/src/mindroom/thread_export/storage.py
+++ b/src/mindroom/thread_export/storage.py
@@ -193,6 +193,38 @@ def _contains_thread_export_file(room_fd: int) -> bool:
     return any(_is_thread_export_filename(name) and _regular_file_at(room_fd, name) for name in names)
 
 
+def _is_thread_export_payload(room_fd: int, filename: str) -> bool:
+    """Return whether one file parses as a MindRoom thread export document."""
+    text = _read_text_at(room_fd, filename)
+    if text is None:
+        return False
+    try:
+        payload = yaml_io.safe_load(text)
+    except yaml.YAMLError:
+        return False
+    if not isinstance(payload, dict) or not isinstance(payload.get("room"), dict):
+        return False
+    if not isinstance(payload.get("messages"), list):
+        return False
+    thread = payload.get("thread")
+    return isinstance(thread, dict) and isinstance(thread.get("id"), str)
+
+
+def _contains_valid_thread_export(room_fd: int) -> bool:
+    """Return whether one pinned directory holds a thread export with MindRoom's own payload.
+
+    Ownership evidence reads the document instead of trusting the filename, because a
+    percent-encoded name like ``%24notes.yaml`` is something an unrelated directory can hold.
+    """
+    names = os.listdir(room_fd)
+    return any(
+        _is_thread_export_filename(name)
+        and _regular_file_at(room_fd, name)
+        and _is_thread_export_payload(room_fd, name)
+        for name in names
+    )
+
+
 def _open_canonical_room_directory(root_fd: int, output_dir: Path, name: str) -> int | None:
     """Open one canonically named, non-symlinked room directory below a pinned root."""
     if not _is_encoded_room_segment(name):
@@ -224,12 +256,12 @@ def _recognizable_room_directory(root_fd: int, output_dir: Path, name: str) -> b
 
 
 def _room_directory_with_thread_exports(root_fd: int, output_dir: Path, name: str) -> bool:
-    """Return whether one root entry is a canonically named room holding a thread export."""
+    """Return whether one root entry is a canonically named room holding a real thread export."""
     room_fd = _open_canonical_room_directory(root_fd, output_dir, name)
     if room_fd is None:
         return False
     try:
-        return _contains_thread_export_file(room_fd)
+        return _contains_valid_thread_export(room_fd)
     finally:
         os.close(room_fd)
 
@@ -237,10 +269,11 @@ def _room_directory_with_thread_exports(root_fd: int, output_dir: Path, name: st
 def _root_has_export_evidence(root_fd: int, output_dir: Path) -> bool:
     """Return whether an empty root, or one holding a thread export, proves exporter ownership.
 
-    Evidence is a percent-encoded room directory containing a ``$``-prefixed Matrix thread
-    export, which no unrelated directory produces by accident. A generic ``index.json`` is
-    deliberately not evidence: a build or data directory can hold one, and adopting on that
-    alone would expose it to reconciliation.
+    Evidence is a percent-encoded room directory holding a document that parses as one of this
+    exporter's thread exports. Neither a generic ``index.json`` nor a thread-shaped filename is
+    enough on its own, because a build directory can hold the former and any directory can hold
+    a file named ``%24notes.yaml``; adopting on either would expose unrelated data to
+    reconciliation.
     Unrelated entries beside real evidence do not veto ownership, because a stray ``.DS_Store``,
     ``.git`` directory, or operator note must not strand a real corpus, and every destructive
     path is independently scoped to exporter-owned entries.

--- a/src/mindroom/thread_export/storage.py
+++ b/src/mindroom/thread_export/storage.py
@@ -8,29 +8,35 @@ import shutil
 import stat
 from contextlib import suppress
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import TYPE_CHECKING
-from urllib.parse import quote
+from urllib.parse import quote, unquote
 from uuid import uuid4
 
 import yaml
 
 from mindroom import yaml_io
+from mindroom.logging_config import get_logger
 
 if TYPE_CHECKING:
     from collections.abc import Collection, Sequence
-    from pathlib import Path
 
     from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
     from mindroom.thread_export.models import ThreadExportRoom
 
 _EXPORT_SCHEMA_VERSION = 1
 _ROOM_INDEX_FILENAME = "index.json"
+_ROOT_MARKER_FILENAME = ".mindroom-thread-exports"
+_ROOT_MARKER_TEXT = '{"format":"mindroom-thread-exports","version":1}\n'
 _THREAD_SUMMARY_CONTENT_KEY = "io.mindroom.thread_summary"
 _DIRECTORY_OPEN_FLAGS = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
 
 
+logger = get_logger(__name__)
+
+
 class _UnsafeThreadExportPathError(RuntimeError):
-    """Raised when an export path could escape through a symlink."""
+    """Raised when an export path is unsafe or lacks ownership proof."""
 
 
 def _safe_path_segment(value: str) -> str:
@@ -41,9 +47,47 @@ def _safe_path_segment(value: str) -> str:
     return encoded
 
 
+def _room_path_segment(room_key: str) -> str:
+    """Return a room segment outside the export-root marker namespace."""
+    encoded = _safe_path_segment(room_key)
+    if encoded == _ROOT_MARKER_FILENAME:
+        return f"%2E{encoded[1:]}"
+    return encoded
+
+
+def _is_encoded_room_segment(value: str) -> bool:
+    """Return whether a directory name is one canonical room segment."""
+    if value == _ROOT_MARKER_FILENAME:
+        return False
+    try:
+        return _room_path_segment(unquote(value, errors="strict")) == value
+    except UnicodeError:
+        return False
+
+
+def _is_thread_export_filename(value: str) -> bool:
+    """Return whether a filename is one canonical Matrix thread export."""
+    if not value.endswith(".yaml"):
+        return False
+    stem = value.removesuffix(".yaml")
+    try:
+        thread_id = unquote(stem, errors="strict")
+    except UnicodeError:
+        return False
+    return thread_id.startswith("$") and f"{_safe_path_segment(thread_id)}.yaml" == value
+
+
 def _unsafe_directory(path: Path, label: str) -> _UnsafeThreadExportPathError:
     """Return a normalized failure for an unsafe controlled directory component."""
     return _UnsafeThreadExportPathError(f"Refusing symlinked thread export {label}: {path}")
+
+
+def canonicalize_output_dir(output_dir: Path) -> Path:
+    """Reject a broad authored path and return an absolute lexical path."""
+    if output_dir.name in {"", ".", ".."}:
+        msg = f"Thread export output must end in an explicit directory name, not '.' or '..': {output_dir}"
+        raise _UnsafeThreadExportPathError(msg)
+    return Path(os.path.abspath(output_dir))  # noqa: PTH100 - resolve() would hide a final symlink
 
 
 def _open_directory_at(
@@ -73,27 +117,191 @@ def _open_directory_at(
 
 
 def _open_export_root(output_dir: Path, *, create: bool) -> int | None:
-    """Open and pin the export root so later operations cannot be redirected."""
+    """Open the final export directory without following a symlink at that entry."""
+    canonical_output_dir = canonicalize_output_dir(output_dir)
     if create:
-        output_dir.parent.mkdir(parents=True, exist_ok=True)
+        canonical_output_dir.parent.mkdir(parents=True, exist_ok=True)
     try:
-        parent_fd = os.open(output_dir.parent, _DIRECTORY_OPEN_FLAGS)
+        parent_fd = os.open(canonical_output_dir.parent, _DIRECTORY_OPEN_FLAGS)
     except FileNotFoundError:
         if not create:
             return None
         raise
     except OSError as exc:
-        raise _unsafe_directory(output_dir.parent, "root parent") from exc
+        raise _unsafe_directory(canonical_output_dir.parent, "root parent") from exc
     try:
         return _open_directory_at(
             parent_fd,
-            output_dir.name,
-            path=output_dir,
+            canonical_output_dir.name,
+            path=canonical_output_dir,
             label="root",
             create=create,
         )
     finally:
         os.close(parent_fd)
+
+
+def _regular_file_at(directory_fd: int, filename: str) -> bool:
+    """Return whether one descriptor-relative entry is a regular file."""
+    try:
+        mode = os.stat(filename, dir_fd=directory_fd, follow_symlinks=False).st_mode
+    except FileNotFoundError:
+        return False
+    return stat.S_ISREG(mode)
+
+
+def _atomic_temp_destination(filename: str) -> str | None:
+    """Return the known-file destination encoded by an atomic-write temp name."""
+    if not filename.startswith(".") or not filename.endswith(".tmp"):
+        return None
+    destination, separator, token = filename[1:-4].rpartition(".")
+    if separator != "." or len(token) != 32 or any(character not in "0123456789abcdef" for character in token):
+        return None
+    return destination
+
+
+def _is_room_export_temp_file(room_fd: int, filename: str) -> bool:
+    """Return whether one regular file is exact residue from a room export write."""
+    destination = _atomic_temp_destination(filename)
+    return (
+        destination is not None
+        and (destination == _ROOM_INDEX_FILENAME or _is_thread_export_filename(destination))
+        and _regular_file_at(room_fd, filename)
+    )
+
+
+def _is_room_export_file(room_fd: int, filename: str) -> bool:
+    """Return whether one room entry is an exporter-owned regular file."""
+    return (
+        (filename == _ROOM_INDEX_FILENAME and _regular_file_at(room_fd, filename))
+        or (_is_thread_export_filename(filename) and _regular_file_at(room_fd, filename))
+        or _is_room_export_temp_file(room_fd, filename)
+    )
+
+
+def _room_contains_only_export_files(room_fd: int) -> bool:
+    """Return whether one room directory contains an index and only exporter-owned files."""
+    names = os.listdir(room_fd)
+    return _regular_file_at(room_fd, _ROOM_INDEX_FILENAME) and all(
+        _is_room_export_file(room_fd, name) for name in names
+    )
+
+
+def _recognizable_room_directory(root_fd: int, output_dir: Path, name: str) -> bool:
+    """Return whether one root entry has the exporter-owned room shape."""
+    if not _is_encoded_room_segment(name):
+        return False
+    try:
+        mode = os.stat(name, dir_fd=root_fd, follow_symlinks=False).st_mode
+    except FileNotFoundError:
+        return False
+    if not stat.S_ISDIR(mode):
+        return False
+    room_fd = _open_directory_at(
+        root_fd,
+        name,
+        path=output_dir / name,
+        label="room directory",
+        create=False,
+    )
+    if room_fd is None:
+        return False
+    try:
+        return _room_contains_only_export_files(room_fd)
+    finally:
+        os.close(room_fd)
+
+
+def _root_contains_only_export_structure(root_fd: int, output_dir: Path) -> bool:
+    """Return whether a markerless root is empty or contains recognizable exports."""
+    names = os.listdir(root_fd)
+    if not names:
+        return True
+    for name in names:
+        if name == _ROOT_MARKER_FILENAME:
+            continue
+        if _atomic_temp_destination(name) == _ROOT_MARKER_FILENAME and _regular_file_at(root_fd, name):
+            continue
+        if not _recognizable_room_directory(root_fd, output_dir, name):
+            return False
+    return True
+
+
+def _has_valid_export_root_marker(root_fd: int) -> bool:
+    """Return whether the marker contains the exact supported ownership text."""
+    try:
+        marker_fd = os.open(_ROOT_MARKER_FILENAME, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=root_fd)
+    except FileNotFoundError:
+        return False
+    try:
+        with os.fdopen(marker_fd, encoding="utf-8") as marker_file:
+            marker_fd = -1
+            return marker_file.read(len(_ROOT_MARKER_TEXT) + 1) == _ROOT_MARKER_TEXT
+    finally:
+        if marker_fd >= 0:
+            os.close(marker_fd)
+
+
+def _unowned_export_root(path: Path) -> _UnsafeThreadExportPathError:
+    """Return a failure for a root without MindRoom ownership proof."""
+    return _UnsafeThreadExportPathError(
+        f"Refusing unowned thread export root: {path}; "
+        f"the root must contain {_ROOT_MARKER_FILENAME} with exact content {_ROOT_MARKER_TEXT!r} "
+        "or only recognizable MindRoom thread exports.",
+    )
+
+
+def _claim_export_root(root_fd: int, output_dir: Path) -> None:
+    """Install the marker on an empty or recognizable exporter-owned root."""
+    if _has_valid_export_root_marker(root_fd):
+        return
+    if _root_contains_only_export_structure(root_fd, output_dir):
+        _atomic_write_at(root_fd, _ROOT_MARKER_FILENAME, _ROOT_MARKER_TEXT)
+        return
+    logger.warning(
+        "Refusing to mark unrecognized thread export root",
+        output_dir=str(output_dir),
+    )
+    raise _unowned_export_root(output_dir)
+
+
+def _require_owned_export_root(root_fd: int, output_dir: Path) -> None:
+    """Require the marker before a destructive operation."""
+    if _has_valid_export_root_marker(root_fd):
+        return
+    logger.warning(
+        "Refusing destructive operation on markerless thread export root",
+        output_dir=str(output_dir),
+    )
+    raise _unowned_export_root(output_dir)
+
+
+def prepare_export_root(output_dir: Path) -> None:
+    """Create an export root if needed and install its marker when recognizable."""
+    canonical_output_dir = canonicalize_output_dir(output_dir)
+    root_fd = _open_export_root(canonical_output_dir, create=True)
+    assert root_fd is not None
+    try:
+        _claim_export_root(root_fd, canonical_output_dir)
+    finally:
+        os.close(root_fd)
+
+
+def _open_owned_export_root(output_dir: Path, *, create: bool) -> int | None:
+    """Open an owned root, claiming recognizable storage only for write creation."""
+    canonical_output_dir = canonicalize_output_dir(output_dir)
+    root_fd = _open_export_root(canonical_output_dir, create=create)
+    if root_fd is None:
+        return None
+    try:
+        if create:
+            _claim_export_root(root_fd, canonical_output_dir)
+        else:
+            _require_owned_export_root(root_fd, canonical_output_dir)
+    except Exception:
+        os.close(root_fd)
+        raise
+    return root_fd
 
 
 def _open_room_directory(
@@ -104,7 +312,7 @@ def _open_room_directory(
     create: bool,
 ) -> int | None:
     """Open and pin one exporter-controlled room directory."""
-    room_name = _safe_path_segment(room.key)
+    room_name = _room_path_segment(room.key)
     return _open_directory_at(
         root_fd,
         room_name,
@@ -279,10 +487,12 @@ def _thread_index_entry_at(directory_fd: int, filename: str) -> tuple[int, dict[
 
 
 def _room_index_payload(room_fd: int, room: ThreadExportRoom) -> dict[str, object]:
-    """Build one room index document from the exported thread files on disk."""
+    """Build one room index document from the recognizable thread files on disk."""
     indexed = [
         indexed_entry
-        for filename in sorted(name for name in os.listdir(room_fd) if name.endswith(".yaml"))
+        for filename in sorted(
+            name for name in os.listdir(room_fd) if _is_thread_export_filename(name) and _regular_file_at(room_fd, name)
+        )
         if (indexed_entry := _thread_index_entry_at(room_fd, filename)) is not None
     ]
     indexed.sort(key=lambda item: item[0], reverse=True)
@@ -300,9 +510,46 @@ def _room_index_payload(room_fd: int, room: ThreadExportRoom) -> dict[str, objec
     }
 
 
-def write_room_index(output_dir: Path, room: ThreadExportRoom) -> None:
-    """Write one room's index.json when its content changed."""
-    root_fd = _open_export_root(output_dir, create=False)
+def _declared_room_index_filenames(room_fd: int) -> set[str] | None:
+    """Return the thread filename set declared by the current room index."""
+    text = _read_text_at(room_fd, _ROOM_INDEX_FILENAME)
+    if text is None:
+        return None
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict) or not isinstance(threads := payload.get("threads"), list):
+        return None
+    filenames: set[str] = set()
+    for entry in threads:
+        if not isinstance(entry, dict) or not isinstance(filename := entry.get("file"), str):
+            return None
+        filenames.add(filename)
+    return filenames
+
+
+def _room_index_filename_set_matches(room_fd: int) -> bool:
+    """Return whether index membership matches regular thread YAML files on disk."""
+    declared_filenames = _declared_room_index_filenames(room_fd)
+    if declared_filenames is None:
+        return False
+    disk_filenames = {
+        filename
+        for filename in os.listdir(room_fd)
+        if _is_thread_export_filename(filename) and _regular_file_at(room_fd, filename)
+    }
+    return declared_filenames == disk_filenames
+
+
+def write_room_index(
+    output_dir: Path,
+    room: ThreadExportRoom,
+    *,
+    thread_files_changed: bool = True,
+) -> None:
+    """Rebuild a room index after YAML changes or detected filename-set drift."""
+    root_fd = _open_owned_export_root(output_dir, create=False)
     if root_fd is None:
         return
     try:
@@ -312,17 +559,18 @@ def write_room_index(output_dir: Path, room: ThreadExportRoom) -> None:
     if room_fd is None:
         return
     try:
+        if not thread_files_changed and _room_index_filename_set_matches(room_fd):
+            return
         payload = _room_index_payload(room_fd, room)
         text = f"{json.dumps(payload, indent=2)}\n"
-        if _read_text_at(room_fd, _ROOM_INDEX_FILENAME) == text:
-            return
-        _atomic_write_at(room_fd, _ROOM_INDEX_FILENAME, text)
+        if _read_text_at(room_fd, _ROOM_INDEX_FILENAME) != text:
+            _atomic_write_at(room_fd, _ROOM_INDEX_FILENAME, text)
     finally:
         os.close(room_fd)
 
 
-def room_index_exists(output_dir: Path, room: ThreadExportRoom) -> bool:
-    """Return whether a room has a regular index file inside a safe export directory."""
+def room_has_thread_exports(output_dir: Path, room: ThreadExportRoom) -> bool:
+    """Return whether a safe room directory contains recognizable thread YAML."""
     root_fd = _open_export_root(output_dir, create=False)
     if root_fd is None:
         return False
@@ -333,34 +581,105 @@ def room_index_exists(output_dir: Path, room: ThreadExportRoom) -> bool:
     if room_fd is None:
         return False
     try:
-        try:
-            return stat.S_ISREG(os.stat(_ROOM_INDEX_FILENAME, dir_fd=room_fd, follow_symlinks=False).st_mode)
-        except FileNotFoundError:
-            return False
+        return any(
+            _is_thread_export_filename(filename) and _regular_file_at(room_fd, filename)
+            for filename in os.listdir(room_fd)  # noqa: PTH208 - room_fd pins the directory
+        )
     finally:
         os.close(room_fd)
 
 
-def remove_room_export(output_dir: Path, room: ThreadExportRoom) -> bool:
-    """Remove one room's exported data without following workspace symlinks."""
-    root_fd = _open_export_root(output_dir, create=False)
+def _log_unrecognized_entry(output_dir: Path, entry: str, *, room_key: str | None = None) -> None:
+    """Warn that deletion left an unrecognized entry untouched."""
+    logger.warning(
+        "Leaving unrecognized thread export entry untouched",
+        output_dir=str(output_dir),
+        room_key=room_key,
+        entry=entry,
+    )
+
+
+def _remove_room_export_entries(
+    root_fd: int,
+    output_dir: Path,
+    room_name: str,
+    *,
+    room_key: str | None,
+) -> tuple[bool, bool]:
+    """Remove exporter-owned room entries, preserving and reporting everything else."""
+    room_fd = _open_directory_at(
+        root_fd,
+        room_name,
+        path=output_dir / room_name,
+        label="room directory",
+        create=False,
+    )
+    if room_fd is None:
+        return False, False
+    try:
+        filenames = os.listdir(room_fd)  # noqa: PTH208 - room_fd pins the directory
+        removed_files = False
+        had_unrecognized_entries = False
+        for filename in filenames:
+            if _is_room_export_file(room_fd, filename):
+                os.unlink(filename, dir_fd=room_fd)
+                removed_files = True
+            else:
+                _log_unrecognized_entry(output_dir, filename, room_key=room_key)
+                had_unrecognized_entries = True
+        if removed_files:
+            _fsync_directory_fd(room_fd)
+        removed_directory = False
+        if not os.listdir(room_fd):  # noqa: PTH208 - room_fd pins the directory
+            with suppress(OSError):
+                os.rmdir(room_name, dir_fd=root_fd)
+                removed_directory = True
+        return removed_files or removed_directory, had_unrecognized_entries
+    finally:
+        os.close(room_fd)
+
+
+def _unrecognized_room(output_dir: Path, room_name: str) -> _UnsafeThreadExportPathError:
+    """Return the exact-room failure that distinguishes a present foreign directory."""
+    return _UnsafeThreadExportPathError(
+        f"Refusing removal of unrecognized thread export room: {output_dir / room_name}",
+    )
+
+
+def remove_room_export(output_dir: Path, room: ThreadExportRoom) -> None:
+    """Retract one room export, raising when a present room has no recognizable data."""
+    root_fd = _open_owned_export_root(output_dir, create=False)
     if root_fd is None:
-        return False
-    room_name = _safe_path_segment(room.key)
+        return
+    room_name = _room_path_segment(room.key)
     try:
         try:
             mode = os.stat(room_name, dir_fd=root_fd, follow_symlinks=False).st_mode
         except FileNotFoundError:
-            return False
-        if stat.S_ISDIR(mode):
+            return
+        if stat.S_ISLNK(mode):
+            raise _unsafe_directory(output_dir / room_name, "room directory")
+        if _recognizable_room_directory(root_fd, output_dir, room_name):
             if not shutil.rmtree.avoids_symlink_attacks:
                 msg = "Safe descriptor-relative directory removal is unavailable"
                 raise RuntimeError(msg)
             shutil.rmtree(room_name, dir_fd=root_fd)
-        else:
-            os.unlink(room_name, dir_fd=root_fd)
-        _fsync_directory_fd(root_fd)
-        return True
+            _fsync_directory_fd(root_fd)
+            return
+        if stat.S_ISDIR(mode):
+            removed, had_unrecognized_entries = _remove_room_export_entries(
+                root_fd,
+                output_dir,
+                room_name,
+                room_key=room.key,
+            )
+            if removed:
+                _fsync_directory_fd(root_fd)
+                return
+            if had_unrecognized_entries:
+                raise _unrecognized_room(output_dir, room_name)
+        _log_unrecognized_entry(output_dir, room_name, room_key=room.key)
+        raise _unrecognized_room(output_dir, room_name)
     finally:
         os.close(root_fd)
 
@@ -370,8 +689,8 @@ def remove_stale_thread_exports(
     room: ThreadExportRoom,
     thread_ids: Sequence[str],
 ) -> bool:
-    """Remove thread files absent from a complete homeserver enumeration."""
-    root_fd = _open_export_root(output_dir, create=False)
+    """Remove recognizable thread files absent from a complete enumeration."""
+    root_fd = _open_owned_export_root(output_dir, create=False)
     if root_fd is None:
         return False
     try:
@@ -382,18 +701,12 @@ def remove_stale_thread_exports(
         return False
     try:
         expected_names = {f"{_safe_path_segment(thread_id)}.yaml" for thread_id in thread_ids}
-        stale_names = [
-            name
-            for name in os.listdir(room_fd)  # noqa: PTH208 - descriptor pinning prevents path races
-            if name.endswith(".yaml") and name not in expected_names
-        ]
         removed = False
-        for filename in stale_names:
-            try:
-                mode = os.stat(filename, dir_fd=room_fd, follow_symlinks=False).st_mode
-            except FileNotFoundError:
+        for filename in os.listdir(room_fd):  # noqa: PTH208 - room_fd pins the directory
+            if not filename.endswith(".yaml") or filename in expected_names:
                 continue
-            if stat.S_ISDIR(mode):
+            if not _is_thread_export_filename(filename) or not _regular_file_at(room_fd, filename):
+                _log_unrecognized_entry(output_dir, filename, room_key=room.key)
                 continue
             os.unlink(filename, dir_fd=room_fd)
             removed = True
@@ -404,31 +717,46 @@ def remove_stale_thread_exports(
         os.close(room_fd)
 
 
+def _remove_reconciliation_room(root_fd: int, output_dir: Path, room_name: str) -> bool:
+    """Remove a stale indexed room or its recognizable partial thread files."""
+    if _recognizable_room_directory(root_fd, output_dir, room_name):
+        if not shutil.rmtree.avoids_symlink_attacks:
+            msg = "Safe descriptor-relative directory removal is unavailable"
+            raise RuntimeError(msg)
+        shutil.rmtree(room_name, dir_fd=root_fd)
+        return True
+    if not _is_encoded_room_segment(room_name):
+        _log_unrecognized_entry(output_dir, room_name)
+        return False
+    try:
+        mode = os.stat(room_name, dir_fd=root_fd, follow_symlinks=False).st_mode
+    except FileNotFoundError:
+        return False
+    if stat.S_ISDIR(mode):
+        removed, had_unrecognized_entries = _remove_room_export_entries(
+            root_fd,
+            output_dir,
+            room_name,
+            room_key=None,
+        )
+        if removed or had_unrecognized_entries:
+            return removed
+    _log_unrecognized_entry(output_dir, room_name)
+    return False
+
+
 def reconcile_room_directories(output_dir: Path, retained_room_keys: set[str]) -> None:
-    """Remove room directories outside the target's full-pass authorization scope."""
-    root_fd = _open_export_root(output_dir, create=False)
+    """Remove recognizable room directories outside the retained authorization scope."""
+    root_fd = _open_owned_export_root(output_dir, create=False)
     if root_fd is None:
         return
     try:
-        retained_names = {_safe_path_segment(room_key) for room_key in retained_room_keys}
+        retained_names = {_room_path_segment(room_key) for room_key in retained_room_keys}
         removed = False
-        for name in os.listdir(root_fd):  # noqa: PTH208 - descriptor pinning prevents path races
-            if name in retained_names:
+        for name in os.listdir(root_fd):  # noqa: PTH208 - root_fd pins the directory
+            if name == _ROOT_MARKER_FILENAME or name in retained_names:
                 continue
-            try:
-                mode = os.stat(name, dir_fd=root_fd, follow_symlinks=False).st_mode
-            except FileNotFoundError:
-                continue
-            if stat.S_ISLNK(mode):
-                os.unlink(name, dir_fd=root_fd)
-            elif stat.S_ISDIR(mode):
-                if not shutil.rmtree.avoids_symlink_attacks:
-                    msg = "Safe descriptor-relative directory removal is unavailable"
-                    raise RuntimeError(msg)
-                shutil.rmtree(name, dir_fd=root_fd)
-            else:
-                continue
-            removed = True
+            removed = _remove_reconciliation_room(root_fd, output_dir, name) or removed
         if removed:
             _fsync_directory_fd(root_fd)
     finally:
@@ -465,7 +793,7 @@ def write_thread_payload(
     payload: dict[str, object],
 ) -> bool:
     """Write one thread payload when changed and return whether bytes were replaced."""
-    root_fd = _open_export_root(output_dir, create=True)
+    root_fd = _open_owned_export_root(output_dir, create=True)
     if root_fd is None:
         msg = f"Failed to create thread export root: {output_dir}"
         raise RuntimeError(msg)

--- a/src/mindroom/thread_export/storage.py
+++ b/src/mindroom/thread_export/storage.py
@@ -187,23 +187,28 @@ def _room_contains_only_export_files(room_fd: int) -> bool:
     )
 
 
-def _recognizable_room_directory(root_fd: int, output_dir: Path, name: str) -> bool:
-    """Return whether one root entry has the exporter-owned room shape."""
+def _open_canonical_room_directory(root_fd: int, output_dir: Path, name: str) -> int | None:
+    """Open one canonically named, non-symlinked room directory below a pinned root."""
     if not _is_encoded_room_segment(name):
-        return False
+        return None
     try:
         mode = os.stat(name, dir_fd=root_fd, follow_symlinks=False).st_mode
     except FileNotFoundError:
-        return False
+        return None
     if not stat.S_ISDIR(mode):
-        return False
-    room_fd = _open_directory_at(
+        return None
+    return _open_directory_at(
         root_fd,
         name,
         path=output_dir / name,
         label="room directory",
         create=False,
     )
+
+
+def _recognizable_room_directory(root_fd: int, output_dir: Path, name: str) -> bool:
+    """Return whether one root entry holds an index and nothing the exporter does not own."""
+    room_fd = _open_canonical_room_directory(root_fd, output_dir, name)
     if room_fd is None:
         return False
     try:
@@ -212,19 +217,27 @@ def _recognizable_room_directory(root_fd: int, output_dir: Path, name: str) -> b
         os.close(room_fd)
 
 
-def _root_contains_only_export_structure(root_fd: int, output_dir: Path) -> bool:
-    """Return whether a markerless root is empty or contains recognizable exports."""
+def _room_shaped_directory(root_fd: int, output_dir: Path, name: str) -> bool:
+    """Return whether one root entry holds any exporter-owned file under a canonical room name."""
+    room_fd = _open_canonical_room_directory(root_fd, output_dir, name)
+    if room_fd is None:
+        return False
+    try:
+        names = os.listdir(room_fd)  # noqa: PTH208 - room_fd pins the directory
+        return any(_is_room_export_file(room_fd, entry) for entry in names)
+    finally:
+        os.close(room_fd)
+
+
+def _root_has_export_evidence(root_fd: int, output_dir: Path) -> bool:
+    """Return whether an empty root, or one holding an exported room, proves exporter ownership.
+
+    Unrelated entries beside an exported room do not veto ownership: a stray ``.DS_Store``,
+    ``.git`` directory, or operator note must not strand a real corpus, and every destructive
+    path is independently scoped to exporter-owned entries.
+    """
     names = os.listdir(root_fd)
-    if not names:
-        return True
-    for name in names:
-        if name == _ROOT_MARKER_FILENAME:
-            continue
-        if _atomic_temp_destination(name) == _ROOT_MARKER_FILENAME and _regular_file_at(root_fd, name):
-            continue
-        if not _recognizable_room_directory(root_fd, output_dir, name):
-            return False
-    return True
+    return not names or any(_room_shaped_directory(root_fd, output_dir, name) for name in names)
 
 
 def _has_valid_export_root_marker(root_fd: int) -> bool:
@@ -246,16 +259,16 @@ def _unowned_export_root(path: Path) -> _UnsafeThreadExportPathError:
     """Return a failure for a root without MindRoom ownership proof."""
     return _UnsafeThreadExportPathError(
         f"Refusing unowned thread export root: {path}; "
-        f"the root must contain {_ROOT_MARKER_FILENAME} with exact content {_ROOT_MARKER_TEXT!r} "
-        "or only recognizable MindRoom thread exports.",
+        f"the root must be empty, already contain an exported room directory, or contain "
+        f"{_ROOT_MARKER_FILENAME} with exact content {_ROOT_MARKER_TEXT!r}.",
     )
 
 
 def _claim_export_root(root_fd: int, output_dir: Path) -> None:
-    """Install the marker on an empty or recognizable exporter-owned root."""
+    """Install the marker on an empty root or one that already holds an exported room."""
     if _has_valid_export_root_marker(root_fd):
         return
-    if _root_contains_only_export_structure(root_fd, output_dir):
+    if _root_has_export_evidence(root_fd, output_dir):
         _atomic_write_at(root_fd, _ROOT_MARKER_FILENAME, _ROOT_MARKER_TEXT)
         return
     logger.warning(
@@ -605,7 +618,7 @@ def _remove_room_export_entries(
     room_name: str,
     *,
     room_key: str | None,
-) -> tuple[bool, bool]:
+) -> bool:
     """Remove exporter-owned room entries, preserving and reporting everything else."""
     room_fd = _open_directory_at(
         root_fd,
@@ -615,18 +628,16 @@ def _remove_room_export_entries(
         create=False,
     )
     if room_fd is None:
-        return False, False
+        return False
     try:
         filenames = os.listdir(room_fd)  # noqa: PTH208 - room_fd pins the directory
         removed_files = False
-        had_unrecognized_entries = False
         for filename in filenames:
             if _is_room_export_file(room_fd, filename):
                 os.unlink(filename, dir_fd=room_fd)
                 removed_files = True
             else:
                 _log_unrecognized_entry(output_dir, filename, room_key=room_key)
-                had_unrecognized_entries = True
         if removed_files:
             _fsync_directory_fd(room_fd)
         removed_directory = False
@@ -634,20 +645,17 @@ def _remove_room_export_entries(
             with suppress(OSError):
                 os.rmdir(room_name, dir_fd=root_fd)
                 removed_directory = True
-        return removed_files or removed_directory, had_unrecognized_entries
+        return removed_files or removed_directory
     finally:
         os.close(room_fd)
 
 
-def _unrecognized_room(output_dir: Path, room_name: str) -> _UnsafeThreadExportPathError:
-    """Return the exact-room failure that distinguishes a present foreign directory."""
-    return _UnsafeThreadExportPathError(
-        f"Refusing removal of unrecognized thread export room: {output_dir / room_name}",
-    )
-
-
 def remove_room_export(output_dir: Path, room: ThreadExportRoom) -> None:
-    """Retract one room export, raising when a present room has no recognizable data."""
+    """Retract one room export, preserving and reporting entries the exporter does not own.
+
+    Retraction is idempotent: once every exporter-owned entry is gone, later passes over the
+    same room are quiet no-ops rather than a failure the operator can never clear.
+    """
     root_fd = _open_owned_export_root(output_dir, create=False)
     if root_fd is None:
         return
@@ -666,20 +674,11 @@ def remove_room_export(output_dir: Path, room: ThreadExportRoom) -> None:
             shutil.rmtree(room_name, dir_fd=root_fd)
             _fsync_directory_fd(root_fd)
             return
-        if stat.S_ISDIR(mode):
-            removed, had_unrecognized_entries = _remove_room_export_entries(
-                root_fd,
-                output_dir,
-                room_name,
-                room_key=room.key,
-            )
-            if removed:
-                _fsync_directory_fd(root_fd)
-                return
-            if had_unrecognized_entries:
-                raise _unrecognized_room(output_dir, room_name)
-        _log_unrecognized_entry(output_dir, room_name, room_key=room.key)
-        raise _unrecognized_room(output_dir, room_name)
+        if not stat.S_ISDIR(mode):
+            _log_unrecognized_entry(output_dir, room_name, room_key=room.key)
+            return
+        if _remove_room_export_entries(root_fd, output_dir, room_name, room_key=room.key):
+            _fsync_directory_fd(root_fd)
     finally:
         os.close(root_fd)
 
@@ -733,14 +732,7 @@ def _remove_reconciliation_room(root_fd: int, output_dir: Path, room_name: str) 
     except FileNotFoundError:
         return False
     if stat.S_ISDIR(mode):
-        removed, had_unrecognized_entries = _remove_room_export_entries(
-            root_fd,
-            output_dir,
-            room_name,
-            room_key=None,
-        )
-        if removed or had_unrecognized_entries:
-            return removed
+        return _remove_room_export_entries(root_fd, output_dir, room_name, room_key=None)
     _log_unrecognized_entry(output_dir, room_name)
     return False
 

--- a/src/mindroom/thread_export/storage.py
+++ b/src/mindroom/thread_export/storage.py
@@ -268,8 +268,8 @@ def _unowned_export_root(path: Path) -> _UnsafeThreadExportPathError:
     """Return a failure for a root without MindRoom ownership proof."""
     return _UnsafeThreadExportPathError(
         f"Refusing unowned thread export root: {path}; "
-        f"the root must be empty, already contain an exported room directory, or contain "
-        f"{_ROOT_MARKER_FILENAME} with exact content {_ROOT_MARKER_TEXT!r}.",
+        f"the root must be empty, already contain an exported room directory, or contain a "
+        f"{_ROOT_MARKER_FILENAME} file whose only line is {_ROOT_MARKER_TEXT.strip()}",
     )
 
 

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -46,6 +46,7 @@ from mindroom.model_defaults import (
 )
 from mindroom.startup_errors import PermanentStartupError
 from mindroom.thread_export import ThreadExportStats
+from mindroom.thread_export.models import ThreadExportRoom, failure_for_room, failure_for_target
 from tests.conftest import load_config_yaml, normalize_console_output
 
 if TYPE_CHECKING:
@@ -2205,6 +2206,44 @@ class TestVersionAndHelp:
         assert export_kwargs["prefer_cache"] is False
         assert export_kwargs["include_invited_rooms"] is True
         assert export_kwargs["runtime_paths"].storage_root == storage_path.resolve()
+
+    def test_threads_export_formats_target_and_thread_failures(self, tmp_path: Path) -> None:
+        """Thread export output should render target failures without fake room placeholders."""
+        config_path = tmp_path / "config.yaml"
+        output_path = tmp_path / "exports"
+        _write_minimal_runtime_config(config_path)
+        room = ThreadExportRoom(
+            key="lobby",
+            room_id="!lobby:localhost",
+            alias="#lobby:localhost",
+            name="Lobby",
+        )
+        stats = ThreadExportStats(
+            output_dir=output_path,
+            failed_items=(
+                failure_for_target("overlapping output directory"),
+                failure_for_room(
+                    room,
+                    "history fetch failed",
+                    thread_id="$thread:localhost",
+                ),
+            ),
+        )
+
+        with patch(
+            "mindroom.thread_export.export_threads_once",
+            new=AsyncMock(return_value=stats),
+        ):
+            result = _invoke_with_runtime(
+                ["threads", "export", "--output", str(output_path)],
+                config_path,
+            )
+
+        output = normalize_console_output(result.output)
+        assert result.exit_code == 1
+        assert "Failed target: overlapping output directory" in output
+        assert "Failed: lobby $thread:localhost: history fetch failed" in output
+        assert "None" not in output
 
     def test_threads_export_forwards_no_invited_rooms_flag(self, tmp_path: Path) -> None:
         """The --no-invited-rooms flag should reach the exporter."""

--- a/tests/test_thread_export_execution.py
+++ b/tests/test_thread_export_execution.py
@@ -13,6 +13,7 @@ import yaml
 
 from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
 from mindroom.thread_export import ThreadExportTarget
+from mindroom.thread_export import storage as thread_export_storage
 from mindroom.thread_export.execution import (
     export_threads_for_targets_for_client as _export_threads_for_targets_for_client,
 )
@@ -20,7 +21,11 @@ from mindroom.thread_export.models import (
     ThreadExportRoom as _ThreadExportRoom,
 )
 from mindroom.thread_export.selection import export_rooms as _export_rooms
+from mindroom.thread_export.storage import write_room_index, write_thread_payload
 from tests.conftest import runtime_paths_for
+from tests.thread_export_helpers import (
+    mark_thread_export_root,
+)
 from tests.thread_export_helpers import (
     thread_export_config as _config,
 )
@@ -291,7 +296,7 @@ async def test_export_writes_room_index_with_summary_and_participants(tmp_path: 
 
 @pytest.mark.asyncio
 async def test_room_index_not_rewritten_when_unchanged(tmp_path: Path) -> None:
-    """A second pass with identical content should leave index.json untouched."""
+    """A second unchanged pass should skip both index rebuild parsing and replacement."""
     config = _config(tmp_path)
     runtime_paths = runtime_paths_for(config)
     _write_matrix_state(tmp_path)
@@ -325,7 +330,10 @@ async def test_room_index_not_rewritten_when_unchanged(tmp_path: Path) -> None:
         )
         index_path = tmp_path / "exports" / "lobby" / "index.json"
         first_mtime = index_path.stat().st_mtime_ns
-        with patch("mindroom.thread_export.execution.write_room_index") as write_index:
+        with patch(
+            "mindroom.thread_export.storage._room_index_payload",
+            wraps=thread_export_storage._room_index_payload,
+        ) as build_index:
             await _export_threads_for_client(
                 client=Mock(),
                 config=config,
@@ -336,7 +344,86 @@ async def test_room_index_not_rewritten_when_unchanged(tmp_path: Path) -> None:
             )
 
     assert index_path.stat().st_mtime_ns == first_mtime
-    write_index.assert_not_called()
+    build_index.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_nonempty_enumeration_repairs_index_after_committed_yaml_removal(tmp_path: Path) -> None:
+    """An unchanged pass must remove an index entry left stale by an interrupted prior pass."""
+    config = _config(tmp_path)
+    runtime_paths = runtime_paths_for(config)
+    _write_matrix_state(tmp_path)
+    output_dir = tmp_path / "exports"
+    rooms = _export_rooms(runtime_paths, "lobby")
+    retained_thread_id = "$retained:localhost"
+    removed_thread_id = "$removed:localhost"
+    histories = {
+        retained_thread_id: [
+            ResolvedVisibleMessage.synthetic(
+                sender="@alice:localhost",
+                body="Retained",
+                event_id=retained_thread_id,
+            ),
+        ],
+        removed_thread_id: [
+            ResolvedVisibleMessage.synthetic(
+                sender="@alice:localhost",
+                body="Removed",
+                event_id=removed_thread_id,
+            ),
+        ],
+    }
+
+    async def fetch_history(*args: object, **_kwargs: object) -> object:
+        return histories[str(args[2])]
+
+    with (
+        patch(
+            "mindroom.thread_export.execution.enumerate_room_thread_root_ids",
+            new=AsyncMock(return_value=([retained_thread_id, removed_thread_id], False)),
+        ),
+        patch(
+            "mindroom.thread_export.execution.refresh_thread_history_from_source",
+            new=AsyncMock(side_effect=fetch_history),
+        ),
+    ):
+        await _export_threads_for_client(
+            client=Mock(),
+            config=config,
+            runtime_paths=runtime_paths,
+            event_cache=Mock(),
+            output_dir=output_dir,
+            rooms=rooms,
+        )
+
+    room_dir = output_dir / "lobby"
+    removed_file = room_dir / f"{quote(removed_thread_id, safe='')}.yaml"
+    removed_file.unlink()
+    index_path = room_dir / "index.json"
+    assert json.loads(index_path.read_text(encoding="utf-8"))["thread_count"] == 2
+
+    with (
+        patch(
+            "mindroom.thread_export.execution.enumerate_room_thread_root_ids",
+            new=AsyncMock(return_value=([retained_thread_id], False)),
+        ),
+        patch(
+            "mindroom.thread_export.execution.refresh_thread_history_from_source",
+            new=AsyncMock(return_value=histories[retained_thread_id]),
+        ),
+    ):
+        stats = await _export_threads_for_client(
+            client=Mock(),
+            config=config,
+            runtime_paths=runtime_paths,
+            event_cache=Mock(),
+            output_dir=output_dir,
+            rooms=rooms,
+        )
+
+    assert stats.threads_unchanged == 1
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    assert [entry["thread_id"] for entry in index["threads"]] == [retained_thread_id]
 
 
 @pytest.mark.asyncio
@@ -462,6 +549,7 @@ async def test_export_threads_rewrites_when_existing_file_corrupt(tmp_path: Path
         ),
     ]
     corrupt_path = tmp_path / "exports" / "lobby" / f"{quote('$fresh:localhost', safe='')}.yaml"
+    mark_thread_export_root(tmp_path / "exports")
     corrupt_path.parent.mkdir(parents=True)
     corrupt_path.write_text("{not: [valid yaml", encoding="utf-8")
 
@@ -497,6 +585,7 @@ async def test_export_threads_rewrites_existing_file_with_invalid_utf8(tmp_path:
     runtime_paths = runtime_paths_for(config)
     _write_matrix_state(tmp_path)
     export_path = tmp_path / "exports" / "lobby" / f"{quote('$fresh:localhost', safe='')}.yaml"
+    mark_thread_export_root(tmp_path / "exports")
     export_path.parent.mkdir(parents=True)
     export_path.write_bytes(b"\x80")
     history = [
@@ -630,8 +719,145 @@ async def test_complete_room_export_removes_stale_thread_files(tmp_path: Path) -
 
 
 @pytest.mark.asyncio
-async def test_member_filter_exports_only_rooms_with_member(tmp_path: Path) -> None:
-    """required_member_user_id should skip rooms the user is not currently joined to."""
+async def test_empty_complete_enumeration_preserves_existing_thread_exports(tmp_path: Path) -> None:
+    """An empty complete enumeration must not erase an existing on-disk room corpus."""
+    config = _config(tmp_path)
+    runtime_paths = runtime_paths_for(config)
+    _write_matrix_state(tmp_path)
+    output_dir = tmp_path / "exports"
+    room = _export_rooms(runtime_paths, "lobby")
+    history = [
+        ResolvedVisibleMessage.synthetic(
+            sender="@alice:localhost",
+            body="Retain me",
+            event_id="$existing:localhost",
+        ),
+    ]
+
+    with (
+        patch(
+            "mindroom.thread_export.execution.enumerate_room_thread_root_ids",
+            new=AsyncMock(return_value=(["$existing:localhost"], False)),
+        ),
+        patch(
+            "mindroom.thread_export.execution.refresh_thread_history_from_source",
+            new=AsyncMock(return_value=history),
+        ),
+    ):
+        await _export_threads_for_client(
+            client=Mock(),
+            config=config,
+            runtime_paths=runtime_paths,
+            event_cache=Mock(),
+            output_dir=output_dir,
+            rooms=room,
+        )
+
+    exported_file = next((output_dir / "lobby").glob("*.yaml"))
+    original_bytes = exported_file.read_bytes()
+    with (
+        patch(
+            "mindroom.thread_export.execution.enumerate_room_thread_root_ids",
+            new=AsyncMock(return_value=([], False)),
+        ),
+        patch("mindroom.thread_export.execution.logger.warning") as warning,
+    ):
+        for _ in range(2):
+            stats = await _export_threads_for_client(
+                client=Mock(),
+                config=config,
+                runtime_paths=runtime_paths,
+                event_cache=Mock(),
+                output_dir=output_dir,
+                rooms=room,
+            )
+
+    assert stats.rooms_exported == 1
+    assert stats.threads_seen == 0
+    assert exported_file.read_bytes() == original_bytes
+    assert warning.call_count == 2
+    for warning_call in warning.call_args_list:
+        assert warning_call.args == ("Skipping stale thread reconciliation after empty enumeration",)
+        assert warning_call.kwargs == {
+            "output_dir": str(output_dir),
+            "room_key": "lobby",
+            "room_id": "!lobby:localhost",
+        }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("existing_index", [False, True], ids=["missing-index", "stale-index"])
+async def test_empty_complete_enumeration_repairs_index_after_committed_yaml_addition(
+    tmp_path: Path,
+    *,
+    existing_index: bool,
+) -> None:
+    """Preserved YAML must repair missing or stale index state after an interrupted prior pass."""
+    config = _config(tmp_path)
+    runtime_paths = runtime_paths_for(config)
+    _write_matrix_state(tmp_path)
+    output_dir = tmp_path / "exports"
+    rooms = _export_rooms(runtime_paths, "lobby")
+    room = rooms[0]
+    indexed_thread_id = "$indexed:localhost"
+    committed_thread_id = "$committed:localhost"
+
+    def payload(thread_id: str) -> dict[str, object]:
+        return {
+            "version": 1,
+            "room": {
+                "key": room.key,
+                "id": room.room_id,
+                "name": room.name,
+                "alias": room.alias,
+            },
+            "thread": {
+                "id": thread_id,
+                "message_count": 1,
+            },
+            "messages": [
+                {
+                    "sender": "@alice:localhost",
+                    "timestamp": 1_700_000_000_000,
+                },
+            ],
+        }
+
+    assert write_thread_payload(output_dir, room, indexed_thread_id, payload(indexed_thread_id)) is True
+    index_path = output_dir / "lobby" / "index.json"
+    if existing_index:
+        write_room_index(output_dir, room)
+        assert json.loads(index_path.read_text(encoding="utf-8"))["thread_count"] == 1
+    else:
+        assert not index_path.exists()
+    assert write_thread_payload(output_dir, room, committed_thread_id, payload(committed_thread_id)) is True
+
+    with patch(
+        "mindroom.thread_export.execution.enumerate_room_thread_root_ids",
+        new=AsyncMock(return_value=([], False)),
+    ):
+        stats = await _export_threads_for_client(
+            client=Mock(),
+            config=config,
+            runtime_paths=runtime_paths,
+            event_cache=Mock(),
+            output_dir=output_dir,
+            rooms=rooms,
+        )
+
+    assert stats.failures == 0
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    assert {entry["thread_id"] for entry in index["threads"]} == {
+        indexed_thread_id,
+        committed_thread_id,
+    }
+
+
+@pytest.mark.asyncio
+async def test_definitive_non_member_on_non_aliased_target_removes_room_export(
+    tmp_path: Path,
+) -> None:
+    """A fresh non-membership answer should still retract a non-aliased target's room."""
     config = _config(tmp_path)
     runtime_paths = runtime_paths_for(config)
     _write_matrix_state(tmp_path)
@@ -649,9 +875,11 @@ async def test_member_filter_exports_only_rooms_with_member(tmp_path: Path) -> N
 
     client = Mock()
     client.joined_members = AsyncMock(side_effect=joined_members)
+    mark_thread_export_root(tmp_path / "exports")
     stale_dev_dir = tmp_path / "exports" / "dev"
     stale_dev_dir.mkdir(parents=True)
-    (stale_dev_dir / "old.yaml").write_text("secret", encoding="utf-8")
+    (stale_dev_dir / "index.json").write_text("{}\n", encoding="utf-8")
+    (stale_dev_dir / f"{quote('$old:localhost', safe='')}.yaml").write_text("secret", encoding="utf-8")
     history = [
         ResolvedVisibleMessage.synthetic(
             sender="@alice:localhost",
@@ -685,6 +913,121 @@ async def test_member_filter_exports_only_rooms_with_member(tmp_path: Path) -> N
     enumerate_threads.assert_awaited_once_with(client, "!lobby:localhost", max_thread_roots=2000)
     assert (tmp_path / "exports" / "lobby").is_dir()
     assert not (tmp_path / "exports" / "dev").exists()
+
+
+@pytest.mark.asyncio
+async def test_admitted_empty_root_handles_retraction_and_zero_thread_export_without_failures(
+    tmp_path: Path,
+) -> None:
+    """An admitted empty root should handle rejected and empty-room operations."""
+    config = _config(tmp_path)
+    runtime_paths = runtime_paths_for(config)
+    output_dir = tmp_path / "exports"
+    mark_thread_export_root(output_dir)
+    client = Mock()
+    rooms = (
+        _ThreadExportRoom(
+            key="!invited:localhost",
+            room_id="!invited:localhost",
+            alias="",
+            name="Invited",
+            invited=True,
+        ),
+        _ThreadExportRoom(
+            key="lobby",
+            room_id="!lobby:localhost",
+            alias="#lobby:localhost",
+            name="Lobby",
+        ),
+    )
+
+    with patch(
+        "mindroom.thread_export.execution.enumerate_room_thread_root_ids",
+        new=AsyncMock(return_value=([], False)),
+    ) as enumerate_threads:
+        accumulators = await _export_threads_for_targets_for_client(
+            client=client,
+            config=config,
+            runtime_paths=runtime_paths,
+            event_cache=Mock(),
+            rooms=rooms,
+            targets=(
+                ThreadExportTarget(
+                    output_dir=output_dir,
+                    include_invited_rooms=False,
+                ),
+            ),
+        )
+
+    stats = accumulators[0].stats()
+    assert stats.rooms_exported == 1
+    assert stats.threads_seen == 0
+    assert stats.failures == 0
+    enumerate_threads.assert_awaited_once_with(client, "!lobby:localhost", max_thread_roots=2000)
+    assert (output_dir / ".mindroom-thread-exports").is_file()
+
+
+@pytest.mark.parametrize(
+    ("invited", "required_member_user_id"),
+    [
+        pytest.param(True, None, id="excluded-invited-room"),
+        pytest.param(False, "@alice:localhost", id="definitive-non-member"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_room_removal_failure_is_scoped_to_the_rejected_target(
+    tmp_path: Path,
+    *,
+    invited: bool,
+    required_member_user_id: str | None,
+) -> None:
+    """A failed retraction should not prevent another target from exporting the room."""
+    config = _config(tmp_path)
+    runtime_paths = runtime_paths_for(config)
+    room = _ThreadExportRoom(
+        key="room",
+        room_id="!room:localhost",
+        alias="#room:localhost",
+        name="Room",
+        invited=invited,
+    )
+    client = Mock()
+    if required_member_user_id is not None:
+        client.joined_members = AsyncMock(
+            return_value=nio.JoinedMembersResponse(members=[], room_id=room.room_id),
+        )
+    rejected_target = ThreadExportTarget(
+        output_dir=tmp_path / "rejected",
+        required_member_user_id=required_member_user_id,
+        include_invited_rooms=not invited,
+    )
+    healthy_target = ThreadExportTarget(output_dir=tmp_path / "healthy")
+
+    with (
+        patch(
+            "mindroom.thread_export.execution.remove_room_export",
+            side_effect=RuntimeError("storage unavailable"),
+        ) as remove_export,
+        patch(
+            "mindroom.thread_export.execution.enumerate_room_thread_root_ids",
+            new=AsyncMock(return_value=([], False)),
+        ) as enumerate_threads,
+    ):
+        accumulators = await _export_threads_for_targets_for_client(
+            client=client,
+            config=config,
+            runtime_paths=runtime_paths,
+            event_cache=Mock(),
+            rooms=(room,),
+            targets=(rejected_target, healthy_target),
+        )
+
+    remove_export.assert_called_once_with(rejected_target.output_dir, room)
+    enumerate_threads.assert_awaited_once_with(client, room.room_id, max_thread_roots=2000)
+    assert accumulators[0].rooms_exported == 0
+    assert accumulators[0].failed_items[0].error == "Room removal failed: storage unavailable"
+    assert accumulators[1].rooms_exported == 1
+    assert accumulators[1].failed_items == []
 
 
 @pytest.mark.asyncio
@@ -772,6 +1115,7 @@ async def test_member_filter_lookup_failure_keeps_exports_and_records_failure(tm
     _write_matrix_state(tmp_path)
     client = Mock()
     client.joined_members = AsyncMock(return_value=Mock())
+    mark_thread_export_root(tmp_path / "exports")
     for room_key in ("lobby", "dev"):
         stale_room_dir = tmp_path / "exports" / room_key
         stale_room_dir.mkdir(parents=True)

--- a/tests/test_thread_export_service.py
+++ b/tests/test_thread_export_service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
 from urllib.parse import quote
 
@@ -11,8 +11,10 @@ import pytest
 from mindroom.matrix.users import INTERNAL_USER_ACCOUNT_KEY
 from mindroom.thread_export import ThreadExportTarget, export_threads_once, export_threads_to_targets_once
 from mindroom.thread_export.models import ThreadExportGroupFailure, ThreadExportRoom
+from mindroom.thread_export.storage import _ROOT_MARKER_FILENAME
 from tests.conftest import runtime_paths_for
 from tests.thread_export_helpers import (
+    mark_thread_export_root,
     mock_runtime_support,
     successful_group_result,
     thread_export_config,
@@ -20,12 +22,9 @@ from tests.thread_export_helpers import (
     write_thread_export_matrix_state,
 )
 
-if TYPE_CHECKING:
-    from pathlib import Path
-
 
 @pytest.mark.asyncio
-async def test_export_threads_once_records_group_failure_and_continues_cleanup(tmp_path: Path) -> None:
+async def test_export_threads_once_records_group_failure_and_closes_resources(tmp_path: Path) -> None:
     """An unexpected group failure should close resources and return room failures."""
     config = thread_export_config(tmp_path)
     runtime_paths = runtime_paths_for(config)
@@ -53,7 +52,7 @@ async def test_export_threads_once_records_group_failure_and_continues_cleanup(t
 
 @pytest.mark.asyncio
 async def test_export_threads_once_exports_invited_rooms_with_entity_account(tmp_path: Path) -> None:
-    """User-created invited rooms should export in a second group using the invited agent's account."""
+    """User-created invited rooms should export with the invited entity account."""
     config = thread_export_config(tmp_path)
     runtime_paths = runtime_paths_for(config)
     write_thread_export_matrix_state(tmp_path, account_keys=("agent_general",))
@@ -77,17 +76,97 @@ async def test_export_threads_once_exports_invited_rooms_with_entity_account(tmp
         ["!lobby:localhost", "!dev:localhost"],
         ["!user-room:localhost"],
     ]
-    login_agent_names = [call.args[1].agent_name for call in login.await_args_list]
-    assert login_agent_names == ["general", "general"]
-    invited_room = export_group.await_args_list[1].kwargs["rooms"][0]
-    assert invited_room.key == "!user-room:localhost"
+    assert [call.args[1].agent_name for call in login.await_args_list] == ["general", "general"]
     assert stats.rooms_exported == 2
     assert client.close.await_count == 2
 
 
 @pytest.mark.asyncio
+async def test_export_threads_once_deduplicates_invited_rooms_already_in_state(tmp_path: Path) -> None:
+    """A room tracked in matrix_state and an invite store should export only in the state group."""
+    config = thread_export_config(tmp_path)
+    runtime_paths = runtime_paths_for(config)
+    write_thread_export_matrix_state(tmp_path, account_keys=("agent_general",))
+    write_invited_rooms(runtime_paths, "general", ["!lobby:localhost"])
+    client = Mock()
+    client.close = AsyncMock()
+
+    with (
+        patch("mindroom.thread_export.service.login_agent_user", new=AsyncMock(return_value=client)),
+        patch("mindroom.thread_export.service.build_owned_runtime_support", return_value=mock_runtime_support()),
+        patch("mindroom.thread_export.service.close_owned_runtime_support", new=AsyncMock()),
+        patch(
+            "mindroom.thread_export.service.export_threads_for_targets_for_client",
+            new=AsyncMock(side_effect=successful_group_result),
+        ) as export_group,
+    ):
+        await export_threads_once(config=config, runtime_paths=runtime_paths)
+
+    export_group.assert_awaited_once()
+    assert [room.room_id for room in export_group.await_args.kwargs["rooms"]] == [
+        "!lobby:localhost",
+        "!dev:localhost",
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("include_state_rooms", "room_filter"),
+    [
+        (False, None),
+        (True, "!user-room:localhost"),
+    ],
+)
+async def test_export_threads_once_retracts_discovered_invited_room_when_disabled(
+    tmp_path: Path,
+    *,
+    include_state_rooms: bool,
+    room_filter: str | None,
+) -> None:
+    """Invited-only and filtered passes should retract excluded persisted rooms without login."""
+    config = thread_export_config(tmp_path)
+    runtime_paths = runtime_paths_for(config)
+    write_thread_export_matrix_state(
+        tmp_path,
+        account_keys=("agent_general",),
+        include_rooms=include_state_rooms,
+    )
+    write_invited_rooms(runtime_paths, "general", ["!user-room:localhost"])
+    output_dir = runtime_paths.storage_root / "thread_exports"
+    mark_thread_export_root(output_dir)
+    invited_export_dir = output_dir / quote("!user-room:localhost", safe="")
+    invited_export_dir.mkdir()
+    (invited_export_dir / "index.json").write_text("{}\n", encoding="utf-8")
+    (invited_export_dir / f"{quote('$old:localhost', safe='')}.yaml").write_text(
+        "version: 1\n",
+        encoding="utf-8",
+    )
+
+    with (
+        patch("mindroom.thread_export.service.login_agent_user", new=AsyncMock()) as login,
+        patch("mindroom.thread_export.service.build_owned_runtime_support") as build_support,
+        patch(
+            "mindroom.thread_export.service.export_threads_for_targets_for_client",
+            new=AsyncMock(),
+        ) as export_group,
+    ):
+        stats = await export_threads_once(
+            config=config,
+            runtime_paths=runtime_paths,
+            room_filter=room_filter,
+            include_invited_rooms=False,
+        )
+
+    login.assert_not_awaited()
+    build_support.assert_not_called()
+    export_group.assert_not_awaited()
+    assert stats.failures == 0
+    assert not invited_export_dir.exists()
+
+
+@pytest.mark.asyncio
 async def test_export_threads_once_continues_after_one_account_login_failure(tmp_path: Path) -> None:
-    """A broken account group should not prevent later invited-room groups from exporting."""
+    """A broken account group should not prevent a later group from exporting."""
     config = thread_export_config(tmp_path)
     runtime_paths = runtime_paths_for(config)
     write_thread_export_matrix_state(tmp_path, account_keys=(INTERNAL_USER_ACCOUNT_KEY, "agent_general"))
@@ -117,128 +196,11 @@ async def test_export_threads_once_continues_after_one_account_login_failure(tmp
     assert stats[0].rooms_exported == 1
     assert stats[0].failures == 2
     assert all("Matrix login failed: expired token" in failure.error for failure in stats[0].failed_items)
-    client.close.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_export_threads_once_dedups_invited_rooms_already_in_state(tmp_path: Path) -> None:
-    """Invited rooms already tracked in matrix_state should not export twice."""
-    config = thread_export_config(tmp_path)
-    runtime_paths = runtime_paths_for(config)
-    write_thread_export_matrix_state(tmp_path, account_keys=("agent_general",))
-    write_invited_rooms(runtime_paths, "general", ["!lobby:localhost"])
-    client = Mock()
-    client.close = AsyncMock()
-
-    with (
-        patch("mindroom.thread_export.service.login_agent_user", new=AsyncMock(return_value=client)),
-        patch("mindroom.thread_export.service.build_owned_runtime_support", return_value=mock_runtime_support()),
-        patch("mindroom.thread_export.service.close_owned_runtime_support", new=AsyncMock()),
-        patch(
-            "mindroom.thread_export.service.export_threads_for_targets_for_client",
-            new=AsyncMock(side_effect=successful_group_result),
-        ) as export_group,
-    ):
-        await export_threads_once(config=config, runtime_paths=runtime_paths)
-
-    export_group.assert_awaited_once()
-    assert [room.room_id for room in export_group.await_args.kwargs["rooms"]] == [
-        "!lobby:localhost",
-        "!dev:localhost",
-    ]
-
-
-@pytest.mark.asyncio
-async def test_export_threads_once_skips_invited_rooms_when_disabled(tmp_path: Path) -> None:
-    """include_invited_rooms=False should export only matrix_state rooms."""
-    config = thread_export_config(tmp_path)
-    runtime_paths = runtime_paths_for(config)
-    write_thread_export_matrix_state(tmp_path, account_keys=("agent_general",))
-    write_invited_rooms(runtime_paths, "general", ["!user-room:localhost"])
-    invited_export_dir = runtime_paths.storage_root / "thread_exports" / quote("!user-room:localhost", safe="")
-    invited_export_dir.mkdir(parents=True)
-    (invited_export_dir / "old.yaml").write_text("secret", encoding="utf-8")
-    client = Mock()
-    client.close = AsyncMock()
-
-    with (
-        patch("mindroom.thread_export.service.login_agent_user", new=AsyncMock(return_value=client)),
-        patch("mindroom.thread_export.service.build_owned_runtime_support", return_value=mock_runtime_support()),
-        patch("mindroom.thread_export.service.close_owned_runtime_support", new=AsyncMock()),
-        patch(
-            "mindroom.thread_export.service.export_threads_for_targets_for_client",
-            new=AsyncMock(side_effect=successful_group_result),
-        ) as export_group,
-    ):
-        await export_threads_once(config=config, runtime_paths=runtime_paths, include_invited_rooms=False)
-
-    export_group.assert_awaited_once()
-    assert [room.room_id for room in export_group.await_args.kwargs["rooms"]] == [
-        "!lobby:localhost",
-        "!dev:localhost",
-    ]
-    assert not invited_export_dir.exists()
-
-
-@pytest.mark.asyncio
-async def test_export_threads_once_room_filter_selects_invited_room(tmp_path: Path) -> None:
-    """A room-id filter matching only an invited room should export just that room."""
-    config = thread_export_config(tmp_path)
-    runtime_paths = runtime_paths_for(config)
-    write_thread_export_matrix_state(tmp_path, account_keys=("agent_general",))
-    write_invited_rooms(runtime_paths, "general", ["!user-room:localhost"])
-    client = Mock()
-    client.close = AsyncMock()
-
-    with (
-        patch("mindroom.thread_export.service.login_agent_user", new=AsyncMock(return_value=client)),
-        patch("mindroom.thread_export.service.build_owned_runtime_support", return_value=mock_runtime_support()),
-        patch("mindroom.thread_export.service.close_owned_runtime_support", new=AsyncMock()),
-        patch(
-            "mindroom.thread_export.service.export_threads_for_targets_for_client",
-            new=AsyncMock(side_effect=successful_group_result),
-        ) as export_group,
-    ):
-        await export_threads_once(
-            config=config,
-            runtime_paths=runtime_paths,
-            room_filter="!user-room:localhost",
-        )
-
-    export_group.assert_awaited_once()
-    assert [room.room_id for room in export_group.await_args.kwargs["rooms"]] == ["!user-room:localhost"]
-
-
-@pytest.mark.asyncio
-async def test_export_threads_once_records_failure_for_invited_room_without_account(tmp_path: Path) -> None:
-    """Invited rooms of an entity without a persisted account should surface as failures."""
-    config = thread_export_config(tmp_path)
-    runtime_paths = runtime_paths_for(config)
-    write_thread_export_matrix_state(tmp_path, account_keys=(INTERNAL_USER_ACCOUNT_KEY,))
-    write_invited_rooms(runtime_paths, "general", ["!user-room:localhost"])
-    client = Mock()
-    client.close = AsyncMock()
-
-    with (
-        patch("mindroom.thread_export.service.login_agent_user", new=AsyncMock(return_value=client)),
-        patch("mindroom.thread_export.service.build_owned_runtime_support", return_value=mock_runtime_support()),
-        patch("mindroom.thread_export.service.close_owned_runtime_support", new=AsyncMock()),
-        patch(
-            "mindroom.thread_export.service.export_threads_for_targets_for_client",
-            new=AsyncMock(side_effect=successful_group_result),
-        ) as export_group,
-    ):
-        stats = await export_threads_once(config=config, runtime_paths=runtime_paths)
-
-    export_group.assert_awaited_once()
-    assert stats.failures == 1
-    assert stats.failed_items[0].room_id == "!user-room:localhost"
-    assert "general" in stats.failed_items[0].error
 
 
 @pytest.mark.asyncio
 async def test_failed_export_groups_do_not_create_runtime_support(tmp_path: Path) -> None:
-    """An account-assignment failure should not create a cache with no ready group to use it."""
+    """An account-assignment failure should not create an unused cache."""
     config = thread_export_config(tmp_path)
     runtime_paths = runtime_paths_for(config)
     write_thread_export_matrix_state(tmp_path, account_keys=(INTERNAL_USER_ACCOUNT_KEY,))
@@ -263,28 +225,19 @@ async def test_failed_export_groups_do_not_create_runtime_support(tmp_path: Path
 
 @pytest.mark.asyncio
 async def test_full_pass_retains_scoped_exports_when_account_group_cannot_run(tmp_path: Path) -> None:
-    """An account-group failure must not let full-pass reconciliation retract scoped exports."""
+    """An account-group failure must not let final reconciliation retract data."""
     config = thread_export_config(tmp_path)
     runtime_paths = runtime_paths_for(config)
     write_thread_export_matrix_state(tmp_path)
     rooms = (
-        ThreadExportRoom(
-            key="lobby",
-            room_id="!lobby:localhost",
-            alias="#lobby:localhost",
-            name="Lobby",
-        ),
-        ThreadExportRoom(
-            key="dev",
-            room_id="!dev:localhost",
-            alias="#dev:localhost",
-            name="Dev",
-        ),
+        ThreadExportRoom("lobby", "!lobby:localhost", "#lobby:localhost", "Lobby"),
+        ThreadExportRoom("dev", "!dev:localhost", "#dev:localhost", "Dev"),
     )
     output_dir = tmp_path / "exports"
+    mark_thread_export_root(output_dir)
     for room in rooms:
         room_dir = output_dir / room.key
-        room_dir.mkdir(parents=True)
+        room_dir.mkdir()
         (room_dir / "old.yaml").write_text("secret", encoding="utf-8")
 
     group_failure = ThreadExportGroupFailure(rooms=rooms, error="No usable Matrix account")
@@ -302,5 +255,256 @@ async def test_full_pass_retains_scoped_exports_when_account_group_cannot_run(tm
 
     assert stats[0].failures == 2
     assert all("No usable Matrix account" in failure.error for failure in stats[0].failed_items)
-    for room in rooms:
-        assert (output_dir / room.key / "old.yaml").read_text(encoding="utf-8") == "secret"
+    assert all((output_dir / room.key / "old.yaml").read_text(encoding="utf-8") == "secret" for room in rooms)
+
+
+@pytest.mark.asyncio
+async def test_aliased_target_output_directories_are_all_skipped(tmp_path: Path) -> None:
+    """The production symlink-alias topology must preserve the shared corpus."""
+    config = thread_export_config(tmp_path)
+    runtime_paths = runtime_paths_for(config)
+    agents_dir = tmp_path / "agents"
+    real_agent_dir = agents_dir / "openclaw"
+    output_dir = real_agent_dir / "workspace" / "thread_exports"
+    existing_export = output_dir / "lobby" / "old.yaml"
+    existing_export.parent.mkdir(parents=True)
+    existing_export.write_text("secret", encoding="utf-8")
+    aliased_agent_dir = agents_dir / "mind_flash"
+    aliased_agent_dir.symlink_to(real_agent_dir, target_is_directory=True)
+    targets = (
+        ThreadExportTarget(aliased_agent_dir / "workspace" / "thread_exports"),
+        ThreadExportTarget(output_dir),
+    )
+
+    with (
+        patch("mindroom.thread_export.service.build_export_groups") as build_export_groups,
+        patch("mindroom.thread_export.service.logger.warning") as warning,
+    ):
+        stats = await export_threads_to_targets_once(
+            config=config,
+            runtime_paths=runtime_paths,
+            targets=targets,
+        )
+
+    assert existing_export.read_text(encoding="utf-8") == "secret"
+    assert tuple(item.output_dir for item in stats) == tuple(target.output_dir for target in targets)
+    assert [item.failures for item in stats] == [1, 1]
+    assert all(item.failed_items[0].room_key is None for item in stats)
+    assert all("overlaps another enabled target" in item.failed_items[0].error for item in stats)
+    assert warning.call_count == 2
+    build_export_groups.assert_not_called()
+
+
+@pytest.mark.parametrize("nested_first", [False, True])
+@pytest.mark.asyncio
+async def test_nested_target_output_directories_are_all_skipped(
+    tmp_path: Path,
+    *,
+    nested_first: bool,
+) -> None:
+    """Ancestor and descendant targets must both fail before root creation."""
+    config = thread_export_config(tmp_path)
+    runtime_paths = runtime_paths_for(config)
+    parent_output_dir = tmp_path / "exports"
+    nested_output_dir = parent_output_dir / "nested"
+    ordered_dirs = (nested_output_dir, parent_output_dir) if nested_first else (parent_output_dir, nested_output_dir)
+
+    stats = await export_threads_to_targets_once(
+        config=config,
+        runtime_paths=runtime_paths,
+        targets=tuple(ThreadExportTarget(output_dir) for output_dir in ordered_dirs),
+    )
+
+    assert tuple(item.output_dir for item in stats) == ordered_dirs
+    assert [item.failures for item in stats] == [1, 1]
+    assert all("overlaps another enabled target" in item.failed_items[0].error for item in stats)
+    assert not parent_output_dir.exists()
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_target_output_directory_fails_closed(tmp_path: Path) -> None:
+    """A symlink loop should become one target-scoped failure."""
+    config = thread_export_config(tmp_path)
+    runtime_paths = runtime_paths_for(config)
+    first_link = tmp_path / "first"
+    second_link = tmp_path / "second"
+    first_link.symlink_to(second_link, target_is_directory=True)
+    second_link.symlink_to(first_link, target_is_directory=True)
+    output_dir = first_link / "thread_exports"
+
+    stats = await export_threads_to_targets_once(
+        config=config,
+        runtime_paths=runtime_paths,
+        targets=(ThreadExportTarget(output_dir),),
+    )
+
+    assert stats[0].output_dir == output_dir
+    assert stats[0].failures == 1
+    assert stats[0].failed_items[0].room_key is None
+    assert "output directory validation failed" in stats[0].failed_items[0].error
+
+
+@pytest.mark.asyncio
+async def test_symlinked_final_target_is_skipped_without_touching_destination(tmp_path: Path) -> None:
+    """A lone symlinked final output directory should fail storage preparation."""
+    config = thread_export_config(tmp_path)
+    runtime_paths = runtime_paths_for(config)
+    outside = tmp_path / "outside"
+    victim = outside / "victim" / "keep.yaml"
+    victim.parent.mkdir(parents=True)
+    victim.write_text("secret", encoding="utf-8")
+    output_dir = tmp_path / "thread_exports"
+    output_dir.symlink_to(outside, target_is_directory=True)
+
+    stats = await export_threads_to_targets_once(
+        config=config,
+        runtime_paths=runtime_paths,
+        targets=(ThreadExportTarget(output_dir),),
+    )
+
+    assert stats[0].failures == 1
+    assert "symlinked thread export root" in stats[0].failed_items[0].error
+    assert victim.read_text(encoding="utf-8") == "secret"
+    assert output_dir.is_symlink()
+
+
+@pytest.mark.parametrize(
+    "authored_output_dir",
+    [
+        pytest.param(Path(), id="current-directory"),
+        pytest.param(Path("missing-tail") / "..", id="terminal-parent"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_terminal_traversal_output_directory_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    authored_output_dir: Path,
+) -> None:
+    """A terminal traversal component must not promote its parent to the root."""
+    config = thread_export_config(tmp_path)
+    runtime_paths = runtime_paths_for(config)
+    keep = tmp_path / "unrelated" / "keep.txt"
+    keep.parent.mkdir()
+    keep.write_text("unrelated", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    stats = await export_threads_to_targets_once(
+        config=config,
+        runtime_paths=runtime_paths,
+        targets=(ThreadExportTarget(authored_output_dir),),
+    )
+
+    assert stats[0].output_dir == authored_output_dir
+    assert stats[0].failures == 1
+    assert "must end in an explicit directory name" in stats[0].failed_items[0].error
+    assert keep.read_text(encoding="utf-8") == "unrelated"
+
+
+@pytest.mark.asyncio
+async def test_explicit_broad_output_directory_is_rejected(tmp_path: Path) -> None:
+    """A shared directory must retain unrelated children and remain unmarked."""
+    config = thread_export_config(tmp_path)
+    runtime_paths = runtime_paths_for(config)
+    documents_file = tmp_path / "documents" / "keep.txt"
+    cache_file = tmp_path / "cache" / "state.db"
+    documents_file.parent.mkdir()
+    cache_file.parent.mkdir()
+    documents_file.write_text("document", encoding="utf-8")
+    cache_file.write_text("cache", encoding="utf-8")
+
+    stats = await export_threads_to_targets_once(
+        config=config,
+        runtime_paths=runtime_paths,
+        targets=(ThreadExportTarget(tmp_path),),
+    )
+
+    assert stats[0].failures == 1
+    assert stats[0].failed_items[0].room_key is None
+    assert documents_file.read_text(encoding="utf-8") == "document"
+    assert cache_file.read_text(encoding="utf-8") == "cache"
+    assert not (tmp_path / _ROOT_MARKER_FILENAME).exists()
+
+
+@pytest.mark.asyncio
+async def test_aliased_targets_are_skipped_while_unique_target_completes(
+    tmp_path: Path,
+) -> None:
+    """Rejected aliases should remain inert while a disjoint target reconciles."""
+    config = thread_export_config(tmp_path)
+    runtime_paths = runtime_paths_for(config)
+    write_thread_export_matrix_state(tmp_path, account_keys=(INTERNAL_USER_ACCOUNT_KEY,))
+    real_agent_dir = tmp_path / "agents" / "openclaw"
+    shared_output_dir = real_agent_dir / "workspace" / "thread_exports"
+    shared_export = shared_output_dir / "lobby" / "old.yaml"
+    shared_export.parent.mkdir(parents=True)
+    shared_export.write_text("secret", encoding="utf-8")
+    aliased_agent_dir = tmp_path / "agents" / "mind_flash"
+    aliased_agent_dir.symlink_to(real_agent_dir, target_is_directory=True)
+    healthy_output_dir = tmp_path / "healthy"
+    mark_thread_export_root(healthy_output_dir)
+    stale_room = healthy_output_dir / "stale"
+    stale_room.mkdir()
+    (stale_room / "index.json").write_text("{}\n", encoding="utf-8")
+    targets = (
+        ThreadExportTarget(aliased_agent_dir / "workspace" / "thread_exports"),
+        ThreadExportTarget(shared_output_dir),
+        ThreadExportTarget(healthy_output_dir),
+    )
+    client = Mock()
+    client.close = AsyncMock()
+
+    with (
+        patch("mindroom.thread_export.service.login_agent_user", new=AsyncMock(return_value=client)),
+        patch("mindroom.thread_export.service.build_owned_runtime_support", return_value=mock_runtime_support()),
+        patch("mindroom.thread_export.service.close_owned_runtime_support", new=AsyncMock()),
+        patch(
+            "mindroom.thread_export.service.export_threads_for_targets_for_client",
+            new=AsyncMock(side_effect=successful_group_result),
+        ) as export_group,
+    ):
+        stats = await export_threads_to_targets_once(
+            config=config,
+            runtime_paths=runtime_paths,
+            targets=targets,
+        )
+
+    assert [item.failures for item in stats] == [1, 1, 0]
+    assert stats[2].rooms_exported == 1
+    assert export_group.await_args.kwargs["targets"] == (targets[2],)
+    assert shared_export.read_text(encoding="utf-8") == "secret"
+    assert not stale_room.exists()
+
+
+@pytest.mark.asyncio
+async def test_full_pass_with_zero_exported_rooms_skips_reconciliation(tmp_path: Path) -> None:
+    """A full pass with no positive room evidence must preserve its corpus."""
+    config = thread_export_config(tmp_path)
+    runtime_paths = runtime_paths_for(config)
+    output_dir = tmp_path / "exports"
+    mark_thread_export_root(output_dir)
+    existing_export = output_dir / "lobby" / "old.yaml"
+    existing_export.parent.mkdir()
+    existing_export.write_text("secret", encoding="utf-8")
+
+    with (
+        patch("mindroom.thread_export.service.build_export_groups", return_value=[]),
+        patch("mindroom.thread_export.service.select_export_account"),
+        patch("mindroom.thread_export.service.reconcile_room_directories") as reconcile,
+        patch("mindroom.thread_export.service.logger.warning") as warning,
+    ):
+        stats = await export_threads_to_targets_once(
+            config=config,
+            runtime_paths=runtime_paths,
+            targets=(ThreadExportTarget(output_dir),),
+        )
+
+    assert stats[0].rooms_exported == 0
+    assert existing_export.read_text(encoding="utf-8") == "secret"
+    reconcile.assert_not_called()
+    warning.assert_called_once_with(
+        "Skipping thread export directory reconciliation without exported rooms",
+        output_dir=str(output_dir),
+        retained_rooms=0,
+        failures=0,
+    )

--- a/tests/test_thread_export_service.py
+++ b/tests/test_thread_export_service.py
@@ -322,6 +322,8 @@ async def test_aliased_target_output_directories_are_all_skipped(tmp_path: Path)
     assert [item.failures for item in stats] == [1, 1]
     assert all(item.failed_items[0].room_key is None for item in stats)
     assert all("overlaps another enabled target" in item.failed_items[0].error for item in stats)
+    assert str(targets[1].output_dir) in stats[0].failed_items[0].error
+    assert str(targets[0].output_dir) in stats[1].failed_items[0].error
     assert warning.call_count == 2
     build_export_groups.assert_not_called()
 
@@ -349,6 +351,8 @@ async def test_nested_target_output_directories_are_all_skipped(
     assert tuple(item.output_dir for item in stats) == ordered_dirs
     assert [item.failures for item in stats] == [1, 1]
     assert all("overlaps another enabled target" in item.failed_items[0].error for item in stats)
+    assert str(ordered_dirs[1]) in stats[0].failed_items[0].error
+    assert str(ordered_dirs[0]) in stats[1].failed_items[0].error
     assert not parent_output_dir.exists()
 
 

--- a/tests/test_thread_export_service.py
+++ b/tests/test_thread_export_service.py
@@ -199,6 +199,37 @@ async def test_export_threads_once_continues_after_one_account_login_failure(tmp
 
 
 @pytest.mark.asyncio
+async def test_export_threads_once_room_filter_selects_invited_room(tmp_path: Path) -> None:
+    """A room-id filter matching only an invited room should export just that room."""
+    config = thread_export_config(tmp_path)
+    runtime_paths = runtime_paths_for(config)
+    write_thread_export_matrix_state(tmp_path, account_keys=("agent_general",))
+    write_invited_rooms(runtime_paths, "general", ["!user-room:localhost"])
+    client = Mock()
+    client.close = AsyncMock()
+
+    with (
+        patch("mindroom.thread_export.service.login_agent_user", new=AsyncMock(return_value=client)),
+        patch("mindroom.thread_export.service.build_owned_runtime_support", return_value=mock_runtime_support()),
+        patch("mindroom.thread_export.service.close_owned_runtime_support", new=AsyncMock()),
+        patch(
+            "mindroom.thread_export.service.export_threads_for_targets_for_client",
+            new=AsyncMock(side_effect=successful_group_result),
+        ) as export_group,
+    ):
+        stats = await export_threads_once(
+            config=config,
+            runtime_paths=runtime_paths,
+            room_filter="!user-room:localhost",
+        )
+
+    export_group.assert_awaited_once()
+    assert [room.room_id for room in export_group.await_args.kwargs["rooms"]] == ["!user-room:localhost"]
+    assert stats.rooms_exported == 1
+    assert stats.failures == 0
+
+
+@pytest.mark.asyncio
 async def test_failed_export_groups_do_not_create_runtime_support(tmp_path: Path) -> None:
     """An account-assignment failure should not create an unused cache."""
     config = thread_export_config(tmp_path)
@@ -260,16 +291,16 @@ async def test_full_pass_retains_scoped_exports_when_account_group_cannot_run(tm
 
 @pytest.mark.asyncio
 async def test_aliased_target_output_directories_are_all_skipped(tmp_path: Path) -> None:
-    """The production symlink-alias topology must preserve the shared corpus."""
+    """A symlinked agent workspace must preserve the corpus both aliases resolve to."""
     config = thread_export_config(tmp_path)
     runtime_paths = runtime_paths_for(config)
     agents_dir = tmp_path / "agents"
-    real_agent_dir = agents_dir / "openclaw"
+    real_agent_dir = agents_dir / "agent_primary"
     output_dir = real_agent_dir / "workspace" / "thread_exports"
     existing_export = output_dir / "lobby" / "old.yaml"
     existing_export.parent.mkdir(parents=True)
     existing_export.write_text("secret", encoding="utf-8")
-    aliased_agent_dir = agents_dir / "mind_flash"
+    aliased_agent_dir = agents_dir / "agent_alias"
     aliased_agent_dir.symlink_to(real_agent_dir, target_is_directory=True)
     targets = (
         ThreadExportTarget(aliased_agent_dir / "workspace" / "thread_exports"),
@@ -322,8 +353,8 @@ async def test_nested_target_output_directories_are_all_skipped(
 
 
 @pytest.mark.asyncio
-async def test_unresolvable_target_output_directory_fails_closed(tmp_path: Path) -> None:
-    """A symlink loop should become one target-scoped failure."""
+async def test_symlink_loop_target_output_directory_fails_closed(tmp_path: Path) -> None:
+    """A symlink loop should fail when the root is prepared, not silently resolve."""
     config = thread_export_config(tmp_path)
     runtime_paths = runtime_paths_for(config)
     first_link = tmp_path / "first"
@@ -341,7 +372,7 @@ async def test_unresolvable_target_output_directory_fails_closed(tmp_path: Path)
     assert stats[0].output_dir == output_dir
     assert stats[0].failures == 1
     assert stats[0].failed_items[0].room_key is None
-    assert "output directory validation failed" in stats[0].failed_items[0].error
+    assert "output directory preparation failed" in stats[0].failed_items[0].error
 
 
 @pytest.mark.asyncio
@@ -434,12 +465,12 @@ async def test_aliased_targets_are_skipped_while_unique_target_completes(
     config = thread_export_config(tmp_path)
     runtime_paths = runtime_paths_for(config)
     write_thread_export_matrix_state(tmp_path, account_keys=(INTERNAL_USER_ACCOUNT_KEY,))
-    real_agent_dir = tmp_path / "agents" / "openclaw"
+    real_agent_dir = tmp_path / "agents" / "agent_primary"
     shared_output_dir = real_agent_dir / "workspace" / "thread_exports"
     shared_export = shared_output_dir / "lobby" / "old.yaml"
     shared_export.parent.mkdir(parents=True)
     shared_export.write_text("secret", encoding="utf-8")
-    aliased_agent_dir = tmp_path / "agents" / "mind_flash"
+    aliased_agent_dir = tmp_path / "agents" / "agent_alias"
     aliased_agent_dir.symlink_to(real_agent_dir, target_is_directory=True)
     healthy_output_dir = tmp_path / "healthy"
     mark_thread_export_root(healthy_output_dir)

--- a/tests/test_thread_export_storage.py
+++ b/tests/test_thread_export_storage.py
@@ -79,6 +79,7 @@ def test_exporter_replaces_an_invalid_marker_on_a_recognizable_legacy_root(tmp_p
     room_dir = output_dir / "lobby"
     room_dir.mkdir(parents=True)
     (room_dir / "index.json").write_text("{}\n", encoding="utf-8")
+    (room_dir / _thread_filename("$thread:localhost")).write_text("version: 1\n", encoding="utf-8")
     (output_dir / _ROOT_MARKER_FILENAME).write_text("invalid\n", encoding="utf-8")
 
     prepare_export_root(output_dir)
@@ -92,6 +93,7 @@ def test_exporter_ignores_its_atomic_write_residue_when_claiming_a_legacy_root(t
     room_dir = output_dir / "lobby"
     room_dir.mkdir(parents=True)
     (room_dir / "index.json").write_text("{}\n", encoding="utf-8")
+    (room_dir / _thread_filename("$thread:localhost")).write_text("version: 1\n", encoding="utf-8")
     room_temp = room_dir / f".index.json.{'a' * 32}.tmp"
     root_temp = output_dir / f".{_ROOT_MARKER_FILENAME}.{'b' * 32}.tmp"
     room_temp.write_text('{"version":', encoding="utf-8")
@@ -133,6 +135,7 @@ def test_exporter_claims_a_legacy_root_beside_a_foreign_directory(tmp_path: Path
     room_dir = output_dir / "lobby"
     room_dir.mkdir(parents=True)
     (room_dir / "index.json").write_text("{}\n", encoding="utf-8")
+    (room_dir / _thread_filename("$thread:localhost")).write_text("version: 1\n", encoding="utf-8")
     keep = output_dir / ".git" / "HEAD"
     keep.parent.mkdir()
     keep.write_text("ref: refs/heads/main\n", encoding="utf-8")
@@ -153,6 +156,23 @@ def test_exporter_claims_a_room_left_without_an_index_by_an_interrupted_pass(tmp
     prepare_export_root(output_dir)
 
     assert (output_dir / _ROOT_MARKER_FILENAME).read_text(encoding="utf-8") == _ROOT_MARKER_TEXT
+
+
+def test_a_stray_index_json_does_not_make_a_project_directory_adoptable(tmp_path: Path) -> None:
+    """A build directory holding index.json must not authorize adopting its parent."""
+    project = tmp_path / "my-project"
+    build_dir = project / "dist"
+    build_dir.mkdir(parents=True)
+    (build_dir / "index.json").write_text('{"build":1}\n', encoding="utf-8")
+    source = project / "README.md"
+    source.write_text("my project", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="unowned thread export root"):
+        prepare_export_root(project)
+
+    assert not (project / _ROOT_MARKER_FILENAME).exists()
+    assert (build_dir / "index.json").read_text(encoding="utf-8") == '{"build":1}\n'
+    assert source.read_text(encoding="utf-8") == "my project"
 
 
 def test_unrecognized_root_is_not_marked(tmp_path: Path) -> None:

--- a/tests/test_thread_export_storage.py
+++ b/tests/test_thread_export_storage.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
+import yaml
 
 from mindroom.thread_export.models import ThreadExportRoom
 from mindroom.thread_export.storage import (
@@ -44,6 +45,24 @@ def _thread_filename(thread_id: str) -> str:
     return f"{_safe_path_segment(thread_id)}.yaml"
 
 
+def _write_thread_export(room_dir: Path, thread_id: str = "$thread:localhost") -> Path:
+    """Write one structurally valid thread export, as ownership evidence requires."""
+    path = room_dir / _thread_filename(thread_id)
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "room": {"key": "lobby", "id": "!lobby:localhost", "name": "Lobby", "alias": "#lobby:localhost"},
+                "thread": {"id": thread_id, "source": "matrix", "message_count": 0},
+                "messages": [],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
 def test_safe_path_segment_blocks_dot_directory_segments() -> None:
     """Path segments should not allow current or parent directory traversal."""
     assert _safe_path_segment(".") == "%2E"
@@ -66,7 +85,7 @@ def test_exporter_marks_a_recognizable_legacy_root_automatically(tmp_path: Path)
     room_dir = output_dir / "lobby"
     room_dir.mkdir(parents=True)
     (room_dir / "index.json").write_text("{}\n", encoding="utf-8")
-    (room_dir / _thread_filename("$thread:localhost")).write_text("version: 1\n", encoding="utf-8")
+    _write_thread_export(room_dir)
 
     prepare_export_root(output_dir)
 
@@ -79,7 +98,7 @@ def test_exporter_replaces_an_invalid_marker_on_a_recognizable_legacy_root(tmp_p
     room_dir = output_dir / "lobby"
     room_dir.mkdir(parents=True)
     (room_dir / "index.json").write_text("{}\n", encoding="utf-8")
-    (room_dir / _thread_filename("$thread:localhost")).write_text("version: 1\n", encoding="utf-8")
+    _write_thread_export(room_dir)
     (output_dir / _ROOT_MARKER_FILENAME).write_text("invalid\n", encoding="utf-8")
 
     prepare_export_root(output_dir)
@@ -93,7 +112,7 @@ def test_exporter_ignores_its_atomic_write_residue_when_claiming_a_legacy_root(t
     room_dir = output_dir / "lobby"
     room_dir.mkdir(parents=True)
     (room_dir / "index.json").write_text("{}\n", encoding="utf-8")
-    (room_dir / _thread_filename("$thread:localhost")).write_text("version: 1\n", encoding="utf-8")
+    _write_thread_export(room_dir)
     room_temp = room_dir / f".index.json.{'a' * 32}.tmp"
     root_temp = output_dir / f".{_ROOT_MARKER_FILENAME}.{'b' * 32}.tmp"
     room_temp.write_text('{"version":', encoding="utf-8")
@@ -119,7 +138,7 @@ def test_exporter_claims_a_legacy_root_beside_a_foreign_file(tmp_path: Path, for
     room_dir = output_dir / "lobby"
     room_dir.mkdir(parents=True)
     (room_dir / "index.json").write_text("{}\n", encoding="utf-8")
-    (room_dir / _thread_filename("$thread:localhost")).write_text("version: 1\n", encoding="utf-8")
+    _write_thread_export(room_dir)
     foreign = output_dir / foreign_entry
     foreign.write_text("unrelated", encoding="utf-8")
 
@@ -135,7 +154,7 @@ def test_exporter_claims_a_legacy_root_beside_a_foreign_directory(tmp_path: Path
     room_dir = output_dir / "lobby"
     room_dir.mkdir(parents=True)
     (room_dir / "index.json").write_text("{}\n", encoding="utf-8")
-    (room_dir / _thread_filename("$thread:localhost")).write_text("version: 1\n", encoding="utf-8")
+    _write_thread_export(room_dir)
     keep = output_dir / ".git" / "HEAD"
     keep.parent.mkdir()
     keep.write_text("ref: refs/heads/main\n", encoding="utf-8")
@@ -151,7 +170,7 @@ def test_exporter_claims_a_room_left_without_an_index_by_an_interrupted_pass(tmp
     output_dir = tmp_path / "thread_exports"
     room_dir = output_dir / "lobby"
     room_dir.mkdir(parents=True)
-    (room_dir / _thread_filename("$thread:localhost")).write_text("version: 1\n", encoding="utf-8")
+    _write_thread_export(room_dir)
 
     prepare_export_root(output_dir)
 
@@ -173,6 +192,21 @@ def test_a_stray_index_json_does_not_make_a_project_directory_adoptable(tmp_path
     assert not (project / _ROOT_MARKER_FILENAME).exists()
     assert (build_dir / "index.json").read_text(encoding="utf-8") == '{"build":1}\n'
     assert source.read_text(encoding="utf-8") == "my project"
+
+
+def test_a_thread_shaped_filename_alone_does_not_make_a_directory_adoptable(tmp_path: Path) -> None:
+    """Ownership evidence must read the document, not trust a percent-encoded filename."""
+    notes = tmp_path / "notes"
+    archive = notes / "archive"
+    archive.mkdir(parents=True)
+    decoy = archive / _thread_filename("$notes")
+    decoy.write_text("shopping:\n  - milk\n  - eggs\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="unowned thread export root"):
+        prepare_export_root(notes)
+
+    assert not (notes / _ROOT_MARKER_FILENAME).exists()
+    assert decoy.read_text(encoding="utf-8") == "shopping:\n  - milk\n  - eggs\n"
 
 
 def test_unrecognized_root_is_not_marked(tmp_path: Path) -> None:

--- a/tests/test_thread_export_storage.py
+++ b/tests/test_thread_export_storage.py
@@ -2,19 +2,22 @@
 
 from __future__ import annotations
 
-import json
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import pytest
 
-from mindroom.thread_export import storage
 from mindroom.thread_export.models import ThreadExportRoom
 from mindroom.thread_export.storage import (
+    _ROOT_MARKER_FILENAME,
+    _ROOT_MARKER_TEXT,
     _safe_path_segment,
     _UnsafeThreadExportPathError,
+    prepare_export_root,
     reconcile_room_directories,
     remove_room_export,
     remove_stale_thread_exports,
+    room_has_thread_exports,
     write_room_index,
     write_thread_payload,
 )
@@ -23,13 +26,22 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-def _room() -> ThreadExportRoom:
+def _room(key: str = "lobby") -> ThreadExportRoom:
     return ThreadExportRoom(
-        key="lobby",
-        room_id="!lobby:localhost",
-        alias="#lobby:localhost",
-        name="Lobby",
+        key=key,
+        room_id=f"!{key}:localhost",
+        alias=f"#{key}:localhost",
+        name=key.title(),
     )
+
+
+def _mark_export_root(output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / _ROOT_MARKER_FILENAME).write_text(_ROOT_MARKER_TEXT, encoding="utf-8")
+
+
+def _thread_filename(thread_id: str) -> str:
+    return f"{_safe_path_segment(thread_id)}.yaml"
 
 
 def test_safe_path_segment_blocks_dot_directory_segments() -> None:
@@ -39,25 +51,248 @@ def test_safe_path_segment_blocks_dot_directory_segments() -> None:
     assert _safe_path_segment("%2E") == "%252E"
 
 
-def test_thread_index_entry_ignores_invalid_utf8(tmp_path: Path) -> None:
-    """One invalid UTF-8 YAML file should not abort a room index rebuild."""
-    room_dir = tmp_path / "lobby"
-    room_dir.mkdir()
-    invalid_file = room_dir / "invalid.yaml"
-    invalid_file.write_bytes(b"\x80")
+def test_exporter_marks_a_new_empty_root_automatically(tmp_path: Path) -> None:
+    """Preparing a new root should install ownership without operator ceremony."""
+    output_dir = tmp_path / "missing" / "thread_exports"
 
-    write_room_index(tmp_path, _room())
+    prepare_export_root(output_dir)
 
-    index = json.loads((room_dir / "index.json").read_text(encoding="utf-8"))
-    assert index["threads"] == []
+    assert (output_dir / _ROOT_MARKER_FILENAME).read_text(encoding="utf-8") == _ROOT_MARKER_TEXT
+
+
+def test_exporter_marks_a_recognizable_legacy_root_automatically(tmp_path: Path) -> None:
+    """A markerless tree containing only known export shapes should be claimed."""
+    output_dir = tmp_path / "thread_exports"
+    room_dir = output_dir / "lobby"
+    room_dir.mkdir(parents=True)
+    (room_dir / "index.json").write_text("{}\n", encoding="utf-8")
+    (room_dir / _thread_filename("$thread:localhost")).write_text("version: 1\n", encoding="utf-8")
+
+    prepare_export_root(output_dir)
+
+    assert (output_dir / _ROOT_MARKER_FILENAME).read_text(encoding="utf-8") == _ROOT_MARKER_TEXT
+
+
+def test_exporter_replaces_an_invalid_marker_on_a_recognizable_legacy_root(tmp_path: Path) -> None:
+    """An invalid reserved marker should not prevent adoption of an otherwise recognizable tree."""
+    output_dir = tmp_path / "thread_exports"
+    room_dir = output_dir / "lobby"
+    room_dir.mkdir(parents=True)
+    (room_dir / "index.json").write_text("{}\n", encoding="utf-8")
+    (output_dir / _ROOT_MARKER_FILENAME).write_text("invalid\n", encoding="utf-8")
+
+    prepare_export_root(output_dir)
+
+    assert (output_dir / _ROOT_MARKER_FILENAME).read_text(encoding="utf-8") == _ROOT_MARKER_TEXT
+
+
+def test_exporter_ignores_its_atomic_write_residue_when_claiming_a_legacy_root(tmp_path: Path) -> None:
+    """Exact exporter temp files should not strand an otherwise recognizable legacy tree."""
+    output_dir = tmp_path / "thread_exports"
+    room_dir = output_dir / "lobby"
+    room_dir.mkdir(parents=True)
+    (room_dir / "index.json").write_text("{}\n", encoding="utf-8")
+    room_temp = room_dir / f".index.json.{'a' * 32}.tmp"
+    root_temp = output_dir / f".{_ROOT_MARKER_FILENAME}.{'b' * 32}.tmp"
+    room_temp.write_text('{"version":', encoding="utf-8")
+    root_temp.write_text('{"format":', encoding="utf-8")
+
+    prepare_export_root(output_dir)
+
+    assert room_temp.read_text(encoding="utf-8") == '{"version":'
+    assert root_temp.read_text(encoding="utf-8") == '{"format":'
+    assert (output_dir / _ROOT_MARKER_FILENAME).read_text(encoding="utf-8") == _ROOT_MARKER_TEXT
+
+
+def test_unrecognized_root_is_not_marked(tmp_path: Path) -> None:
+    """An ordinary directory should fail closed instead of gaining export ownership."""
+    output_dir = tmp_path / "documents"
+    output_dir.mkdir()
+    keep = output_dir / "keep.txt"
+    keep.write_text("private", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="unowned thread export root") as error:
+        prepare_export_root(output_dir)
+
+    assert repr(_ROOT_MARKER_TEXT) in str(error.value)
+    assert keep.read_text(encoding="utf-8") == "private"
+    assert not (output_dir / _ROOT_MARKER_FILENAME).exists()
+
+
+def test_markerless_destructive_operations_fail_closed(
+    tmp_path: Path,
+) -> None:
+    """Recognizable legacy contents still require the marker before deletion."""
+    output_dir = tmp_path / "thread_exports"
+    room_dir = output_dir / "lobby"
+    room_dir.mkdir(parents=True)
+    (room_dir / "index.json").write_text("{}\n", encoding="utf-8")
+
+    with (
+        patch("mindroom.thread_export.storage.logger.warning") as warning,
+        pytest.raises(RuntimeError, match="unowned thread export root"),
+    ):
+        reconcile_room_directories(output_dir, set())
+
+    assert room_dir.is_dir()
+    warning.assert_called_once_with(
+        "Refusing destructive operation on markerless thread export root",
+        output_dir=str(output_dir),
+    )
+
+
+def test_reconcile_deletes_only_recognizable_room_directories(
+    tmp_path: Path,
+) -> None:
+    """Root reconciliation should preserve unrelated files and directories."""
+    output_dir = tmp_path / "thread_exports"
+    _mark_export_root(output_dir)
+    stale_room = output_dir / "stale"
+    stale_room.mkdir()
+    (stale_room / "index.json").write_text("{}\n", encoding="utf-8")
+    unrelated_dir = output_dir / "private"
+    unrelated_dir.mkdir()
+    (unrelated_dir / "keep.txt").write_text("private", encoding="utf-8")
+    unrelated_file = output_dir / "notes.txt"
+    unrelated_file.write_text("keep", encoding="utf-8")
+
+    with patch("mindroom.thread_export.storage.logger.warning") as warning:
+        reconcile_room_directories(output_dir, set())
+
+    assert not stale_room.exists()
+    assert unrelated_dir.is_dir()
+    assert unrelated_file.read_text(encoding="utf-8") == "keep"
+    assert warning.call_count == 2
+    assert all(call.args == ("Leaving unrecognized thread export entry untouched",) for call in warning.call_args_list)
+
+
+def test_stale_pruning_deletes_only_thread_id_shaped_yaml(
+    tmp_path: Path,
+) -> None:
+    """Thread pruning should leave unrelated YAML and non-regular entries untouched."""
+    output_dir = tmp_path / "thread_exports"
+    room_dir = output_dir / "lobby"
+    room_dir.mkdir(parents=True)
+    _mark_export_root(output_dir)
+    (room_dir / "index.json").write_text("{}\n", encoding="utf-8")
+    kept = room_dir / _thread_filename("$kept:localhost")
+    stale = room_dir / _thread_filename("$stale:localhost")
+    unrelated = room_dir / "notes.yaml"
+    kept.write_text("kept", encoding="utf-8")
+    stale.write_text("stale", encoding="utf-8")
+    unrelated.write_text("private", encoding="utf-8")
+
+    with patch("mindroom.thread_export.storage.logger.warning") as warning:
+        assert remove_stale_thread_exports(output_dir, _room(), ["$kept:localhost"]) is True
+
+    assert kept.is_file()
+    assert not stale.exists()
+    assert unrelated.read_text(encoding="utf-8") == "private"
+    warning.assert_called_once()
+    assert warning.call_args.args == ("Leaving unrecognized thread export entry untouched",)
+
+
+def test_room_removal_reports_a_present_unrecognized_directory(
+    tmp_path: Path,
+) -> None:
+    """A present room with no exporter-owned files should fail instead of looking absent."""
+    output_dir = tmp_path / "thread_exports"
+    room_dir = output_dir / "lobby"
+    room_dir.mkdir(parents=True)
+    _mark_export_root(output_dir)
+    keep = room_dir / "keep.txt"
+    keep.write_text("private", encoding="utf-8")
+
+    with (
+        patch("mindroom.thread_export.storage.logger.warning") as warning,
+        pytest.raises(RuntimeError, match="unrecognized thread export room"),
+    ):
+        remove_room_export(output_dir, _room())
+
+    assert keep.read_text(encoding="utf-8") == "private"
+    warning.assert_called_once()
+    assert warning.call_args.args == ("Leaving unrecognized thread export entry untouched",)
+
+
+def test_recognizable_room_removal_still_retracts_data(tmp_path: Path) -> None:
+    """A marked room directory with an index remains retractable."""
+    output_dir = tmp_path / "thread_exports"
+    room_dir = output_dir / "lobby"
+    room_dir.mkdir(parents=True)
+    _mark_export_root(output_dir)
+    (room_dir / "index.json").write_text("{}\n", encoding="utf-8")
+
+    remove_room_export(output_dir, _room())
+    assert not room_dir.exists()
+
+
+@pytest.mark.parametrize("full_reconciliation", [False, True])
+@pytest.mark.parametrize("indexed", [False, True])
+def test_room_retraction_removes_only_exporter_data_when_unknown_entries_remain(
+    tmp_path: Path,
+    *,
+    full_reconciliation: bool,
+    indexed: bool,
+) -> None:
+    """Exact and full retraction must preserve unknown entries even beside an index."""
+    output_dir = tmp_path / "thread_exports"
+    room_dir = output_dir / "lobby"
+    room_dir.mkdir(parents=True)
+    _mark_export_root(output_dir)
+    thread_file = room_dir / _thread_filename("$thread:localhost")
+    index_file = room_dir / "index.json"
+    temp_file = room_dir / f".index.json.{'a' * 32}.tmp"
+    unknown_file = room_dir / "keep.txt"
+    thread_file.write_text("version: 1\n", encoding="utf-8")
+    temp_file.write_text('{"version":', encoding="utf-8")
+    if indexed:
+        index_file.write_text("{}\n", encoding="utf-8")
+    unknown_file.write_text("private", encoding="utf-8")
+
+    if full_reconciliation:
+        reconcile_room_directories(output_dir, set())
+    else:
+        remove_room_export(output_dir, _room())
+
+    assert not thread_file.exists()
+    assert not index_file.exists()
+    assert not temp_file.exists()
+    assert unknown_file.read_text(encoding="utf-8") == "private"
+
+
+@pytest.mark.parametrize("full_reconciliation", [False, True])
+@pytest.mark.parametrize("has_partial_thread", [False, True])
+def test_room_retraction_removes_empty_exporter_residue_idempotently(
+    tmp_path: Path,
+    *,
+    full_reconciliation: bool,
+    has_partial_thread: bool,
+) -> None:
+    """An empty or newly emptied canonical room directory should retract cleanly twice."""
+    output_dir = tmp_path / "thread_exports"
+    room_dir = output_dir / "lobby"
+    room_dir.mkdir(parents=True)
+    _mark_export_root(output_dir)
+    if has_partial_thread:
+        (room_dir / _thread_filename("$thread:localhost")).write_text("version: 1\n", encoding="utf-8")
+
+    with patch("mindroom.thread_export.storage.logger.warning") as warning:
+        for _ in range(2):
+            if full_reconciliation:
+                reconcile_room_directories(output_dir, set())
+            else:
+                remove_room_export(output_dir, _room())
+
+    assert not room_dir.exists()
+    warning.assert_not_called()
 
 
 def test_symlinked_export_root_cannot_write_or_reconcile_outside_workspace(tmp_path: Path) -> None:
-    """A workspace-controlled export-root symlink must never grant host filesystem writes."""
+    """A final output-directory symlink must not redirect writes or deletion."""
     outside = tmp_path / "outside"
     outside.mkdir()
-    marker = outside / "keep.yaml"
-    marker.write_text("secret", encoding="utf-8")
+    keep = outside / "keep.txt"
+    keep.write_text("secret", encoding="utf-8")
     output_dir = tmp_path / "thread_exports"
     output_dir.symlink_to(outside, target_is_directory=True)
 
@@ -66,18 +301,19 @@ def test_symlinked_export_root_cannot_write_or_reconcile_outside_workspace(tmp_p
     with pytest.raises(_UnsafeThreadExportPathError, match="symlinked thread export root"):
         reconcile_room_directories(output_dir, set())
 
-    assert marker.read_text(encoding="utf-8") == "secret"
+    assert keep.read_text(encoding="utf-8") == "secret"
     assert output_dir.is_symlink()
 
 
-def test_symlinked_room_directory_is_never_followed(tmp_path: Path) -> None:
-    """Room writes and stale-file deletion must reject a symlink below the export root."""
+def test_symlinked_room_directory_is_never_followed_or_removed(tmp_path: Path) -> None:
+    """Room writes, pruning, and exact retraction should reject a room symlink."""
     output_dir = tmp_path / "thread_exports"
-    output_dir.mkdir()
+    _mark_export_root(output_dir)
     outside = tmp_path / "outside"
     outside.mkdir()
-    marker = outside / "keep.yaml"
-    marker.write_text("secret", encoding="utf-8")
+    keep = outside / "keep.txt"
+    keep.write_text("secret", encoding="utf-8")
+    (outside / "index.json").write_text("{}\n", encoding="utf-8")
     room_dir = output_dir / "lobby"
     room_dir.symlink_to(outside, target_is_directory=True)
 
@@ -85,84 +321,33 @@ def test_symlinked_room_directory_is_never_followed(tmp_path: Path) -> None:
         write_thread_payload(output_dir, _room(), "$thread:localhost", {"version": 1})
     with pytest.raises(_UnsafeThreadExportPathError, match="symlinked thread export room directory"):
         remove_stale_thread_exports(output_dir, _room(), [])
+    with pytest.raises(_UnsafeThreadExportPathError, match="symlinked thread export room directory"):
+        remove_room_export(output_dir, _room())
 
-    assert marker.read_text(encoding="utf-8") == "secret"
-    assert remove_room_export(output_dir, _room()) is True
-    assert not room_dir.exists()
-    assert marker.read_text(encoding="utf-8") == "secret"
+    assert room_dir.is_symlink()
+    assert keep.read_text(encoding="utf-8") == "secret"
 
 
-def test_symlinked_thread_file_is_replaced_without_touching_target(tmp_path: Path) -> None:
-    """A thread-file symlink should be replaced locally rather than read or followed."""
+def test_room_key_cannot_collide_with_export_root_marker(tmp_path: Path) -> None:
+    """A valid room key equal to the marker should use a separate directory."""
+    output_dir = tmp_path / "thread_exports"
+    room = _room(_ROOT_MARKER_FILENAME)
+
+    write_thread_payload(output_dir, room, "$thread:localhost", {"version": 1})
+    write_room_index(output_dir, room)
+
+    assert (output_dir / _ROOT_MARKER_FILENAME).read_text(encoding="utf-8") == _ROOT_MARKER_TEXT
+    assert (output_dir / "%2Emindroom-thread-exports" / "index.json").is_file()
+
+
+def test_room_export_query_ignores_unrecognized_yaml(tmp_path: Path) -> None:
+    """Only Matrix-thread-shaped regular YAML files count as existing exports."""
     output_dir = tmp_path / "thread_exports"
     room_dir = output_dir / "lobby"
     room_dir.mkdir(parents=True)
-    outside = tmp_path / "outside.yaml"
-    outside.write_text("secret", encoding="utf-8")
-    thread_file = room_dir / "%24thread%3Alocalhost.yaml"
-    thread_file.symlink_to(outside)
+    (room_dir / "notes.yaml").write_text("private", encoding="utf-8")
 
-    assert write_thread_payload(output_dir, _room(), "$thread:localhost", {"version": 1}) is True
+    assert room_has_thread_exports(output_dir, _room()) is False
 
-    assert outside.read_text(encoding="utf-8") == "secret"
-    assert not thread_file.is_symlink()
-
-
-def test_room_directory_swap_cannot_redirect_atomic_write(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Replacing a room directory after it is opened must not redirect the write."""
-    output_dir = tmp_path / "thread_exports"
-    room_dir = output_dir / "lobby"
-    room_dir.mkdir(parents=True)
-    detached_room_dir = tmp_path / "detached-room"
-    outside = tmp_path / "outside"
-    outside.mkdir()
-    original_atomic_write = storage._atomic_write_at
-
-    def swap_then_write(directory_fd: int, filename: str, text: str) -> None:
-        room_dir.rename(detached_room_dir)
-        room_dir.symlink_to(outside, target_is_directory=True)
-        original_atomic_write(directory_fd, filename, text)
-
-    monkeypatch.setattr(storage, "_atomic_write_at", swap_then_write)
-
-    assert write_thread_payload(output_dir, _room(), "$thread:localhost", {"version": 1}) is True
-
-    filename = "%24thread%3Alocalhost.yaml"
-    assert (detached_room_dir / filename).is_file()
-    assert not (outside / filename).exists()
-
-
-def test_export_root_swap_cannot_redirect_reconciliation(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Replacing the export root after it is opened must not redirect deletion."""
-    output_dir = tmp_path / "thread_exports"
-    stale_room = output_dir / "stale"
-    stale_room.mkdir(parents=True)
-    detached_root = tmp_path / "detached-root"
-    outside = tmp_path / "outside"
-    outside_room = outside / "keep"
-    outside_room.mkdir(parents=True)
-    marker = outside_room / "marker"
-    marker.write_text("secret", encoding="utf-8")
-    original_listdir = storage.os.listdir
-    swapped = False
-
-    def swap_then_list(directory_fd: int) -> list[str]:
-        nonlocal swapped
-        if not swapped:
-            output_dir.rename(detached_root)
-            output_dir.symlink_to(outside, target_is_directory=True)
-            swapped = True
-        return original_listdir(directory_fd)
-
-    monkeypatch.setattr(storage.os, "listdir", swap_then_list)
-
-    reconcile_room_directories(output_dir, set())
-
-    assert not (detached_root / "stale").exists()
-    assert marker.read_text(encoding="utf-8") == "secret"
+    (room_dir / _thread_filename("$thread:localhost")).write_text("version: 1\n", encoding="utf-8")
+    assert room_has_thread_exports(output_dir, _room()) is True

--- a/tests/test_thread_export_storage.py
+++ b/tests/test_thread_export_storage.py
@@ -104,6 +104,57 @@ def test_exporter_ignores_its_atomic_write_residue_when_claiming_a_legacy_root(t
     assert (output_dir / _ROOT_MARKER_FILENAME).read_text(encoding="utf-8") == _ROOT_MARKER_TEXT
 
 
+@pytest.mark.parametrize(
+    "foreign_entry",
+    [
+        pytest.param(".DS_Store", id="finder-metadata"),
+        pytest.param("README.md", id="operator-note"),
+    ],
+)
+def test_exporter_claims_a_legacy_root_beside_a_foreign_file(tmp_path: Path, foreign_entry: str) -> None:
+    """A stray file next to a real corpus must not strand the whole target."""
+    output_dir = tmp_path / "thread_exports"
+    room_dir = output_dir / "lobby"
+    room_dir.mkdir(parents=True)
+    (room_dir / "index.json").write_text("{}\n", encoding="utf-8")
+    (room_dir / _thread_filename("$thread:localhost")).write_text("version: 1\n", encoding="utf-8")
+    foreign = output_dir / foreign_entry
+    foreign.write_text("unrelated", encoding="utf-8")
+
+    prepare_export_root(output_dir)
+
+    assert (output_dir / _ROOT_MARKER_FILENAME).read_text(encoding="utf-8") == _ROOT_MARKER_TEXT
+    assert foreign.read_text(encoding="utf-8") == "unrelated"
+
+
+def test_exporter_claims_a_legacy_root_beside_a_foreign_directory(tmp_path: Path) -> None:
+    """A version-control directory beside a real corpus must not strand the target."""
+    output_dir = tmp_path / "thread_exports"
+    room_dir = output_dir / "lobby"
+    room_dir.mkdir(parents=True)
+    (room_dir / "index.json").write_text("{}\n", encoding="utf-8")
+    keep = output_dir / ".git" / "HEAD"
+    keep.parent.mkdir()
+    keep.write_text("ref: refs/heads/main\n", encoding="utf-8")
+
+    prepare_export_root(output_dir)
+
+    assert (output_dir / _ROOT_MARKER_FILENAME).read_text(encoding="utf-8") == _ROOT_MARKER_TEXT
+    assert keep.read_text(encoding="utf-8") == "ref: refs/heads/main\n"
+
+
+def test_exporter_claims_a_room_left_without_an_index_by_an_interrupted_pass(tmp_path: Path) -> None:
+    """Thread YAML written before an interrupted index write still proves ownership."""
+    output_dir = tmp_path / "thread_exports"
+    room_dir = output_dir / "lobby"
+    room_dir.mkdir(parents=True)
+    (room_dir / _thread_filename("$thread:localhost")).write_text("version: 1\n", encoding="utf-8")
+
+    prepare_export_root(output_dir)
+
+    assert (output_dir / _ROOT_MARKER_FILENAME).read_text(encoding="utf-8") == _ROOT_MARKER_TEXT
+
+
 def test_unrecognized_root_is_not_marked(tmp_path: Path) -> None:
     """An ordinary directory should fail closed instead of gaining export ownership."""
     output_dir = tmp_path / "documents"
@@ -192,10 +243,10 @@ def test_stale_pruning_deletes_only_thread_id_shaped_yaml(
     assert warning.call_args.args == ("Leaving unrecognized thread export entry untouched",)
 
 
-def test_room_removal_reports_a_present_unrecognized_directory(
+def test_room_removal_preserves_a_present_unrecognized_directory(
     tmp_path: Path,
 ) -> None:
-    """A present room with no exporter-owned files should fail instead of looking absent."""
+    """A room holding only foreign files should be preserved and reported, not fail forever."""
     output_dir = tmp_path / "thread_exports"
     room_dir = output_dir / "lobby"
     room_dir.mkdir(parents=True)
@@ -203,15 +254,31 @@ def test_room_removal_reports_a_present_unrecognized_directory(
     keep = room_dir / "keep.txt"
     keep.write_text("private", encoding="utf-8")
 
-    with (
-        patch("mindroom.thread_export.storage.logger.warning") as warning,
-        pytest.raises(RuntimeError, match="unrecognized thread export room"),
-    ):
-        remove_room_export(output_dir, _room())
+    with patch("mindroom.thread_export.storage.logger.warning") as warning:
+        for _ in range(2):
+            remove_room_export(output_dir, _room())
 
     assert keep.read_text(encoding="utf-8") == "private"
-    warning.assert_called_once()
-    assert warning.call_args.args == ("Leaving unrecognized thread export entry untouched",)
+    assert warning.call_count == 2
+    assert all(call.args == ("Leaving unrecognized thread export entry untouched",) for call in warning.call_args_list)
+
+
+def test_room_retraction_is_idempotent_beside_a_foreign_file(tmp_path: Path) -> None:
+    """Repeat retraction of a partially cleaned room must stay a quiet no-op."""
+    output_dir = tmp_path / "thread_exports"
+    room_dir = output_dir / "lobby"
+    room_dir.mkdir(parents=True)
+    _mark_export_root(output_dir)
+    (room_dir / "index.json").write_text("{}\n", encoding="utf-8")
+    (room_dir / _thread_filename("$thread:localhost")).write_text("version: 1\n", encoding="utf-8")
+    keep = room_dir / "notes.txt"
+    keep.write_text("operator note", encoding="utf-8")
+
+    for _ in range(3):
+        remove_room_export(output_dir, _room())
+
+    assert sorted(entry.name for entry in room_dir.iterdir()) == ["notes.txt"]
+    assert keep.read_text(encoding="utf-8") == "operator note"
 
 
 def test_recognizable_room_removal_still_retracts_data(tmp_path: Path) -> None:

--- a/tests/test_thread_export_storage.py
+++ b/tests/test_thread_export_storage.py
@@ -185,7 +185,9 @@ def test_unrecognized_root_is_not_marked(tmp_path: Path) -> None:
     with pytest.raises(RuntimeError, match="unowned thread export root") as error:
         prepare_export_root(output_dir)
 
-    assert repr(_ROOT_MARKER_TEXT) in str(error.value)
+    message = str(error.value)
+    assert _ROOT_MARKER_TEXT.strip() in message
+    assert "\\n" not in message, "the adoption instruction must be copy-pasteable, not a Python repr"
     assert keep.read_text(encoding="utf-8") == "private"
     assert not (output_dir / _ROOT_MARKER_FILENAME).exists()
 

--- a/tests/thread_export_helpers.py
+++ b/tests/thread_export_helpers.py
@@ -11,6 +11,7 @@ from mindroom.config.main import Config
 from mindroom.matrix.invited_rooms_store import invited_rooms_path
 from mindroom.matrix.state import MatrixAccount, MatrixRoom, MatrixState
 from mindroom.thread_export.models import ThreadExportAccumulator
+from mindroom.thread_export.storage import _ROOT_MARKER_FILENAME, _ROOT_MARKER_TEXT
 from tests.conftest import bind_runtime_paths, test_runtime_paths
 
 if TYPE_CHECKING:
@@ -30,21 +31,27 @@ def thread_export_config(tmp_path: Path) -> Config:
     )
 
 
-def write_thread_export_matrix_state(tmp_path: Path, *, account_keys: tuple[str, ...] = ()) -> None:
-    """Persist two rooms and the requested Matrix account fixtures."""
+def write_thread_export_matrix_state(
+    tmp_path: Path,
+    *,
+    account_keys: tuple[str, ...] = (),
+    include_rooms: bool = True,
+) -> None:
+    """Persist optional room and requested Matrix account fixtures."""
     state = MatrixState()
-    state.rooms = {
-        "lobby": MatrixRoom(
-            room_id="!lobby:localhost",
-            alias="#lobby:localhost",
-            name="Lobby",
-        ),
-        "dev": MatrixRoom(
-            room_id="!dev:localhost",
-            alias="#dev:localhost",
-            name="Dev",
-        ),
-    }
+    if include_rooms:
+        state.rooms = {
+            "lobby": MatrixRoom(
+                room_id="!lobby:localhost",
+                alias="#lobby:localhost",
+                name="Lobby",
+            ),
+            "dev": MatrixRoom(
+                room_id="!dev:localhost",
+                alias="#dev:localhost",
+                name="Dev",
+            ),
+        }
     state.accounts = {
         account_key: MatrixAccount(
             username=account_key,
@@ -62,6 +69,12 @@ def write_invited_rooms(runtime_paths: RuntimePaths, entity_name: str, room_ids:
     path = invited_rooms_path(runtime_paths.storage_root, entity_name)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(room_ids), encoding="utf-8")
+
+
+def mark_thread_export_root(output_dir: Path) -> None:
+    """Mark one manually assembled thread-export test root as owned."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / _ROOT_MARKER_FILENAME).write_text(_ROOT_MARKER_TEXT, encoding="utf-8")
 
 
 def mock_runtime_support() -> Mock:


### PR DESCRIPTION
## Problem

The thread-export plugin repeatedly destroyed an agent's exported thread corpus (430+ YAML files deleted to zero). Root cause: a symlinked agent workspace (`agents/<alias> -> agents/<primary>`) made two export targets resolve to the same physical `thread_exports/` directory. The aliased agent's Matrix account was a member of no rooms, so its passes answered "not a member" for every room and drove per-room retractions plus end-of-pass directory reconciliation against the other agent's data.

## Fix

- **Target validation before any work**: all enabled targets are canonicalized and checked for equal/nested overlap; every member of an overlapping set is skipped symmetrically with a typed target-scoped failure (no winner-picking). Terminal `.`/`..` and broad traversal roots are rejected.
- **Zero-evidence guard**: a full pass that exported zero rooms never runs directory reconciliation.
- **Empty-enumeration guard**: a complete-but-empty thread enumeration preserves the existing room corpus and warns; non-empty complete enumerations still prune stale files (intended retraction semantics preserved and regression-tested).
- **Ownership marker**: the exporter claims a root by writing `.mindroom-thread-exports`, and claims automatically when the root is empty or already holds at least one room directory containing an exporter-owned file. Unrelated entries beside a real corpus (`.DS_Store`, `.git/`, operator notes, a room left without `index.json` by an interrupted pass) neither block the claim nor are ever deleted. A root the exporter cannot recognize is skipped for the whole pass — neither written to nor cleaned up — and the skip is reported as a target failure; `docs/cli.md` documents the exact marker content for manual adoption.
- **Scoped cleanup**: reconciliation and retraction only ever delete exporter-recognized entries (room-key dirs with index, thread-ID-shaped YAML); foreign files are preserved and logged. Retraction is idempotent: once every exporter-owned entry is gone, later passes over the same room are quiet no-ops rather than a failure the operator cannot clear.
- **Stale-index healing**: index rebuilt when the pass changed files or the index filename set drifts from disk, without re-parsing the whole corpus each pass.

An earlier iteration of this branch grew an adversarial-filesystem defense layer (operator adoption CLI, FIFO/encoding hostile-input handling, cross-process admission serialization, inode-identity checks). It was deliberately stripped after owner review as over-engineering for a single-user deployment; this PR contains only the guards addressing the actual incident class.

The companion plugin change (skip deletion when plugin identity is unresolved) lives in the plugin repository and deploys together with this change.

## Review follow-up (commit 2)

A zero-tolerance review found two behaviours that did not match the description above, both now fixed:

- Adoption was purity-based, not evidence-based: **any** foreign entry in a markerless root blocked the claim, and because `write_thread_payload` claims on create, that blocked exporting entirely rather than only destructive cleanup. A `.DS_Store` from opening the folder in Finder was enough to disable the exporter on an existing 430-file corpus, with no documented recovery path. Adoption now keys on positive export evidence.
- Retraction was not idempotent: `remove_room_export` cleaned a room's exporter-owned files on the first pass and then raised on every later pass while a foreign file remained, producing a permanent per-pass failure and non-zero CLI exit. It now preserves and logs unrecognized entries exactly as the reconciliation twin already did.

Also narrowed target validation from bare `except Exception` to `(OSError, RuntimeError)`, split the two identical "output directory validation failed" messages, restored the dropped positive test for a room filter selecting an invited room, and switched test fixtures to neutral agent directory names.


### Review round 2 (commits 3 and 4)

Re-reviewing commit 2 adversarially found that it had widened root adoption too far, and a fresh pass over commit 1 found an unhelpful operator error:

- **Adoption evidence was too weak.** Treating any canonically named directory holding an exporter-owned file as evidence meant a generic `index.json` counted, so `--output` pointed at a project directory containing `dist/index.json` claimed the root and the next full pass reconciled `dist/` away. Evidence is now a percent-encoded room directory containing a `$`-prefixed Matrix thread export, which no unrelated directory produces by accident. Every case commit 2 set out to fix still adopts.
- **The overlap failure never named the conflict.** Both messages in a rejected pair reported only the skipped target's own resolved path; the peer paths reached the structured log but never the CLI, so an operator could not tell which two targets to reconcile. The failure now reports the resolved path and the conflicting authored path(s), and both overlap tests assert the peer appears.


### Review round 3 (commit 5)

Live-tested the command against a real filesystem this round (`mindroom threads export` with an empty root, and with an unrelated project directory). Both behaved correctly: the empty root was claimed and the unrelated directory was refused with nothing deleted. One defect surfaced:

- **The adoption instruction was not copy-pasteable.** The unowned-root failure is the only remedy for a root MindRoom cannot recognize, but it rendered the required marker content as a Python repr, so the trailing newline printed as a literal `\n` an operator would transcribe into the file verbatim, producing a marker that still fails validation. The message now names the marker file and shows its single line unescaped, and the test asserts no `\n` escape survives.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread export safety when room enumeration returns unexpectedly empty results, preserving existing exports and issuing warnings.
  * Added safer handling for invalid, overlapping, nested, or symlinked export directories.
  * Prevented cleanup from removing unrelated files and directories.
  * Improved reporting for target-level export failures.

* **Documentation**
  * Expanded `threads export` guidance for reconciliation, directory ownership, cleanup, validation, and zero-room safeguards.
  * Updated the example output location to use a directory under `$HOME`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->